### PR TITLE
feat: support `doubleSend` for `LocalFirstCommandBus`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ ksp.incremental=true
 ksp.incremental.log=true
 
 group=me.ahoo.wow
-version=1.9.10
+version=1.10.0
 description=A Modern Reactive CQRS Architecture Microservice development framework based on DDD and EventSourcing.
 website=https://github.com/Ahoo-Wang/Wow
 issues=https://github.com/Ahoo-Wang/Wow/issues

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/modeling/command/CommandDispatcherSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/modeling/command/CommandDispatcherSpec.kt
@@ -142,7 +142,7 @@ abstract class CommandDispatcherSpec {
 
     @Test
     fun run() {
-        val chain = FilterChainBuilder<ServerCommandExchange<Any>>()
+        val chain = FilterChainBuilder<ServerCommandExchange<*>>()
             .addFilter(AggregateProcessorFilter)
             .addFilter(SendDomainEventStreamFilter(domainEventBus))
             .addFilter(ProcessedNotifierFilter(LocalCommandWaitNotifier(waitStrategyRegistrar)))

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/DefaultStatelessSagaVerifier.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/DefaultStatelessSagaVerifier.kt
@@ -15,7 +15,7 @@ package me.ahoo.wow.test.saga.stateless
 
 import me.ahoo.wow.api.event.DomainEvent
 import me.ahoo.wow.api.modeling.TenantId
-import me.ahoo.wow.command.CommandBus
+import me.ahoo.wow.command.CommandGateway
 import me.ahoo.wow.event.DomainEventExchange
 import me.ahoo.wow.event.SimpleDomainEventExchange
 import me.ahoo.wow.event.asDomainEvent
@@ -33,7 +33,7 @@ import java.lang.reflect.Constructor
 internal class DefaultWhenStage<T : Any>(
     private val sagaMetadata: ProcessorMetadata<T, DomainEventExchange<*>>,
     private val serviceProvider: ServiceProvider,
-    private val commandBus: CommandBus
+    private val commandGateway: CommandGateway
 ) : WhenStage<T> {
     companion object {
         const val STATELESS_SAGA_COMMAND_ID = "__StatelessSagaVerifier__"
@@ -60,7 +60,7 @@ internal class DefaultWhenStage<T : Any>(
         val sagaCtor = sagaMetadata.processorType.constructors.first() as Constructor<T>
         val processor: T = InjectableObjectFactory(sagaCtor, serviceProvider).newInstance()
         val handlerRegistrar = StatelessSagaFunctionRegistrar()
-        handlerRegistrar.registerStatelessSaga(processor, commandBus)
+        handlerRegistrar.registerStatelessSaga(processor, commandGateway)
 
         val domainEvent = asDomainEvent(event)
         val eventExchange = SimpleDomainEventExchange(message = domainEvent).setServiceProvider(serviceProvider)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandBus.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandBus.kt
@@ -14,8 +14,9 @@
 package me.ahoo.wow.command
 
 import me.ahoo.wow.api.command.CommandMessage
-import me.ahoo.wow.messaging.ReceiveMessageBus
-import me.ahoo.wow.messaging.SendMessageBus
+import me.ahoo.wow.messaging.DistributedMessageBus
+import me.ahoo.wow.messaging.LocalMessageBus
+import me.ahoo.wow.messaging.MessageBus
 
 /**
  * Command Bus .
@@ -24,4 +25,8 @@ import me.ahoo.wow.messaging.SendMessageBus
  * @see InMemoryCommandBus
  *
  */
-interface CommandBus : SendMessageBus<CommandMessage<*>>, ReceiveMessageBus<ServerCommandExchange<Any>>
+interface CommandBus : MessageBus<CommandMessage<*>, ServerCommandExchange<*>>
+
+interface LocalCommandBus : CommandBus, LocalMessageBus<CommandMessage<*>, ServerCommandExchange<*>>
+
+interface DistributedCommandBus : CommandBus, DistributedMessageBus<CommandMessage<*>, ServerCommandExchange<*>>

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt
@@ -18,7 +18,6 @@ import me.ahoo.wow.api.exception.asErrorInfo
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.WaitStrategy
 import me.ahoo.wow.command.wait.WaitingFor
-import me.ahoo.wow.messaging.MessageGateway
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
 
@@ -30,7 +29,7 @@ import reactor.kotlin.core.publisher.toMono
  * @see CommandBus
  *
  */
-interface CommandGateway : MessageGateway, CommandBus {
+interface CommandGateway : CommandBus {
 
     fun <C : Any> send(
         command: CommandMessage<C>,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/NotifierFilters.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/NotifierFilters.kt
@@ -44,7 +44,7 @@ abstract class AbstractNotifierFilter<T : MessageExchange<*, *>>(
 @Order(ORDER_FIRST)
 class ProcessedNotifierFilter(
     commandWaitNotifier: CommandWaitNotifier
-) : AbstractNotifierFilter<ServerCommandExchange<Any>>(CommandStage.PROCESSED, commandWaitNotifier)
+) : AbstractNotifierFilter<ServerCommandExchange<*>>(CommandStage.PROCESSED, commandWaitNotifier)
 
 @FilterType(SnapshotDispatcher::class)
 @Order(ORDER_FIRST)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventBus.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventBus.kt
@@ -12,8 +12,9 @@
  */
 package me.ahoo.wow.event
 
-import me.ahoo.wow.messaging.ReceiveMessageBus
-import me.ahoo.wow.messaging.SendMessageBus
+import me.ahoo.wow.messaging.DistributedMessageBus
+import me.ahoo.wow.messaging.LocalMessageBus
+import me.ahoo.wow.messaging.MessageBus
 
 /**
  * Domain Event Bus.
@@ -22,4 +23,8 @@ import me.ahoo.wow.messaging.SendMessageBus
  * 2. 领域事件处理有序性
  *
  */
-interface DomainEventBus : SendMessageBus<DomainEventStream>, ReceiveMessageBus<EventStreamExchange>
+interface DomainEventBus : MessageBus<DomainEventStream, EventStreamExchange>
+
+interface LocalDomainEventBus : DomainEventBus, LocalMessageBus<DomainEventStream, EventStreamExchange>
+
+interface DistributedDomainEventBus : DomainEventBus, DistributedMessageBus<DomainEventStream, EventStreamExchange>

--- a/wow-core/src/main/kotlin/me/ahoo/wow/event/InMemoryDomainEventBus.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/event/InMemoryDomainEventBus.kt
@@ -14,7 +14,6 @@ package me.ahoo.wow.event
 
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.command.BUSY_LOOPING_DURATION
-import me.ahoo.wow.messaging.LocalSendMessageBus
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.core.publisher.Sinks
@@ -23,7 +22,7 @@ import reactor.core.publisher.Sinks.Many
 class InMemoryDomainEventBus(
     private val sink: Many<EventStreamExchange> = Sinks.many()
         .multicast().onBackpressureBuffer()
-) : DomainEventBus, LocalSendMessageBus<DomainEventStream, EventStreamExchange> {
+) : LocalDomainEventBus {
 
     override fun sendExchange(exchange: EventStreamExchange): Mono<Void> {
         return Mono.fromRunnable {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/MessageBus.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/MessageBus.kt
@@ -21,29 +21,17 @@ import reactor.core.publisher.Mono
 import reactor.util.context.Context
 import reactor.util.context.ContextView
 
-interface MessageBus : AutoCloseable {
+interface MessageBus<M : Message<*>, E : MessageExchange<*, M>> : AutoCloseable {
     override fun close() = Unit
-}
-
-interface LocalMessageBus : MessageBus
-
-interface DistributedMessageBus : MessageBus
-
-interface MessageGateway : MessageBus
-interface SendMessageBus<M : Message<*>> : MessageBus {
     fun send(message: M): Mono<Void>
+    fun receive(namedAggregates: Set<NamedAggregate>): Flux<E>
 }
 
-interface LocalSendMessageBus<M : Message<*>, E : MessageExchange<*, M>> :
-    LocalMessageBus,
-    MessageBus,
-    SendMessageBus<M> {
+interface LocalMessageBus<M : Message<*>, E : MessageExchange<*, M>> : MessageBus<M, E> {
     fun sendExchange(exchange: E): Mono<Void>
 }
 
-interface ReceiveMessageBus<E : MessageExchange<*, *>> : MessageBus {
-    fun receive(namedAggregates: Set<NamedAggregate>): Flux<E>
-}
+interface DistributedMessageBus<M : Message<*>, E : MessageExchange<*, M>> : MessageBus<M, E>
 
 const val RECEIVER_GROUP = "(ReceiverGroup)"
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricCommandHandler.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricCommandHandler.kt
@@ -20,7 +20,7 @@ import me.ahoo.wow.modeling.command.CommandHandler
 import reactor.core.publisher.Mono
 
 class MetricCommandHandler(override val delegate: CommandHandler) : CommandHandler, Decorator<CommandHandler> {
-    override fun handle(exchange: ServerCommandExchange<Any>): Mono<Void> {
+    override fun handle(exchange: ServerCommandExchange<*>): Mono<Void> {
         return delegate.handle(exchange)
             .name(Wow.WOW_PREFIX + "command.handle")
             .tag(Metrics.AGGREGATE_KEY, exchange.message.aggregateName)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricDomainEventBus.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricDomainEventBus.kt
@@ -15,16 +15,18 @@ package me.ahoo.wow.metrics
 
 import me.ahoo.wow.api.Wow
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.event.DistributedDomainEventBus
 import me.ahoo.wow.event.DomainEventBus
 import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.event.EventStreamExchange
+import me.ahoo.wow.event.LocalDomainEventBus
 import me.ahoo.wow.metrics.Metrics.tagMetricsSubscriber
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
-class MetricDomainEventBus(delegate: DomainEventBus) :
+open class MetricDomainEventBus<T : DomainEventBus>(delegate: T) :
     DomainEventBus,
-    AbstractMetricDecorator<DomainEventBus>(delegate),
+    AbstractMetricDecorator<T>(delegate),
     Metrizable {
 
     override fun send(message: DomainEventStream): Mono<Void> {
@@ -47,3 +49,15 @@ class MetricDomainEventBus(delegate: DomainEventBus) :
         delegate.close()
     }
 }
+
+class MetricLocalDomainEventBus(delegate: LocalDomainEventBus) :
+    LocalDomainEventBus,
+    MetricDomainEventBus<LocalDomainEventBus>(delegate) {
+    override fun sendExchange(exchange: EventStreamExchange): Mono<Void> {
+        return delegate.sendExchange(exchange)
+    }
+}
+
+class MetricDistributedDomainEventBus(delegate: DistributedDomainEventBus) :
+    DistributedDomainEventBus,
+    MetricDomainEventBus<DistributedDomainEventBus>(delegate)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/AggregateCommandDispatcher.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/AggregateCommandDispatcher.kt
@@ -37,18 +37,18 @@ class AggregateCommandDispatcher<C : Any, S : Any>(
     val aggregateMetadata: AggregateMetadata<C, S>,
     override val parallelism: Int = MessageParallelism.DEFAULT_PARALLELISM,
     override val scheduler: Scheduler,
-    override val messageFlux: Flux<ServerCommandExchange<Any>>,
+    override val messageFlux: Flux<ServerCommandExchange<*>>,
     override val name: String =
         "${aggregateMetadata.aggregateName}-${AggregateCommandDispatcher::class.simpleName!!}",
     private val aggregateProcessorFactory: AggregateProcessorFactory,
     private val commandHandler: CommandHandler,
     private val serviceProvider: ServiceProvider
-) : AggregateMessageDispatcher<ServerCommandExchange<Any>>() {
+) : AggregateMessageDispatcher<ServerCommandExchange<*>>() {
 
     override val namedAggregate: NamedAggregate
         get() = aggregateMetadata.namedAggregate
 
-    override fun handleExchange(exchange: ServerCommandExchange<Any>): Mono<Void> {
+    override fun handleExchange(exchange: ServerCommandExchange<*>): Mono<Void> {
         val aggregateId = exchange.message.aggregateId
         val aggregateProcessor = aggregateProcessorFactory.create(aggregateId, aggregateMetadata)
         exchange.setServiceProvider(serviceProvider)
@@ -57,7 +57,7 @@ class AggregateCommandDispatcher<C : Any, S : Any>(
         return commandHandler.handle(exchange)
     }
 
-    override fun ServerCommandExchange<Any>.asGroupKey(): Int {
+    override fun ServerCommandExchange<*>.asGroupKey(): Int {
         return message.asGroupKey(parallelism)
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/AggregateProcessorFilter.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/AggregateProcessorFilter.kt
@@ -23,10 +23,10 @@ import reactor.core.publisher.Mono
 
 @FilterType(CommandDispatcher::class)
 @Order(ORDER_LAST)
-object AggregateProcessorFilter : Filter<ServerCommandExchange<Any>> {
+object AggregateProcessorFilter : Filter<ServerCommandExchange<*>> {
     override fun filter(
-        exchange: ServerCommandExchange<Any>,
-        next: FilterChain<ServerCommandExchange<Any>>
+        exchange: ServerCommandExchange<*>,
+        next: FilterChain<ServerCommandExchange<*>>
     ): Mono<Void> {
         return checkNotNull(exchange.aggregateProcessor)
             .process(exchange)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/CommandDispatcher.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/CommandDispatcher.kt
@@ -44,8 +44,8 @@ class CommandDispatcher(
     private val serviceProvider: ServiceProvider,
     private val schedulerSupplier: AggregateSchedulerSupplier =
         DefaultAggregateSchedulerSupplier("CommandDispatcher")
-) : AbstractDispatcher<ServerCommandExchange<Any>>() {
-    override fun receiveMessage(namedAggregate: NamedAggregate): Flux<ServerCommandExchange<Any>> {
+) : AbstractDispatcher<ServerCommandExchange<*>>() {
+    override fun receiveMessage(namedAggregate: NamedAggregate): Flux<ServerCommandExchange<*>> {
         return commandBus
             .receive(setOf(namedAggregate))
             .writeReceiverGroup(name)
@@ -54,7 +54,7 @@ class CommandDispatcher(
 
     override fun newAggregateDispatcher(
         namedAggregate: NamedAggregate,
-        messageFlux: Flux<ServerCommandExchange<Any>>
+        messageFlux: Flux<ServerCommandExchange<*>>
     ): MessageDispatcher {
         val aggregateMetadata = namedAggregate
             .asRequiredAggregateType<Any>()

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/CommandHandler.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/CommandHandler.kt
@@ -20,9 +20,9 @@ import me.ahoo.wow.messaging.handler.FilterChain
 import me.ahoo.wow.messaging.handler.Handler
 import me.ahoo.wow.messaging.handler.LogResumeErrorHandler
 
-interface CommandHandler : Handler<ServerCommandExchange<Any>>
+interface CommandHandler : Handler<ServerCommandExchange<*>>
 
 class DefaultCommandHandler(
-    chain: FilterChain<ServerCommandExchange<Any>>,
-    errorHandler: ErrorHandler<ServerCommandExchange<Any>> = LogResumeErrorHandler()
-) : CommandHandler, AbstractHandler<ServerCommandExchange<Any>>(chain, errorHandler)
+    chain: FilterChain<ServerCommandExchange<*>>,
+    errorHandler: ErrorHandler<ServerCommandExchange<*>> = LogResumeErrorHandler()
+) : CommandHandler, AbstractHandler<ServerCommandExchange<*>>(chain, errorHandler)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SendDomainEventStreamFilter.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SendDomainEventStreamFilter.kt
@@ -25,10 +25,10 @@ import reactor.core.publisher.Mono
 
 @FilterType(CommandDispatcher::class)
 @Order(ORDER_LAST, after = [AggregateProcessorFilter::class])
-class SendDomainEventStreamFilter(private val domainEventBus: DomainEventBus) : Filter<ServerCommandExchange<Any>> {
+class SendDomainEventStreamFilter(private val domainEventBus: DomainEventBus) : Filter<ServerCommandExchange<*>> {
     override fun filter(
-        exchange: ServerCommandExchange<Any>,
-        next: FilterChain<ServerCommandExchange<Any>>
+        exchange: ServerCommandExchange<*>,
+        next: FilterChain<ServerCommandExchange<*>>
     ): Mono<Void> {
         return Mono.defer {
             val eventStream = exchange.eventStream ?: return@defer next.filter(exchange)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt
@@ -15,7 +15,7 @@ package me.ahoo.wow.saga.stateless
 
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.event.DomainEvent
-import me.ahoo.wow.command.CommandBus
+import me.ahoo.wow.command.CommandGateway
 import me.ahoo.wow.command.asCommandMessage
 import me.ahoo.wow.event.DomainEventExchange
 import me.ahoo.wow.messaging.function.MessageFunction
@@ -24,7 +24,7 @@ import reactor.kotlin.core.publisher.toFlux
 
 class StatelessSagaFunction(
     val actual: MessageFunction<Any, DomainEventExchange<*>, Mono<*>>,
-    private val commandBus: CommandBus
+    private val commandGateway: CommandGateway
 ) :
     MessageFunction<Any, DomainEventExchange<*>, Mono<CommandStream>> {
 
@@ -44,7 +44,7 @@ class StatelessSagaFunction(
                 commandStream
                     .toFlux()
                     .concatMap {
-                        commandBus.send(it)
+                        commandGateway.send(it)
                     }
                     .then(Mono.just(commandStream))
             }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunctionRegistrar.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunctionRegistrar.kt
@@ -13,7 +13,7 @@
 
 package me.ahoo.wow.saga.stateless
 
-import me.ahoo.wow.command.CommandBus
+import me.ahoo.wow.command.CommandGateway
 import me.ahoo.wow.event.AbstractEventFunctionRegistrar
 import me.ahoo.wow.event.DomainEventExchange
 import me.ahoo.wow.messaging.function.MessageFunction
@@ -27,12 +27,12 @@ class StatelessSagaFunctionRegistrar(
         SimpleMultipleMessageFunctionRegistrar()
 ) : AbstractEventFunctionRegistrar<Mono<*>>(actual) {
 
-    fun registerStatelessSaga(statelessSaga: Any, commandBus: CommandBus) {
+    fun registerStatelessSaga(statelessSaga: Any, commandGateway: CommandGateway) {
         statelessSaga.javaClass
             .asStatelessSagaMetadata()
             .asMessageFunctionRegistry(statelessSaga)
             .forEach {
-                val statelessSagaHandler = StatelessSagaFunction(it, commandBus)
+                val statelessSagaHandler = StatelessSagaFunction(it, commandGateway)
                 register(statelessSagaHandler)
             }
     }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/LocalFirstCommandBusTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/LocalFirstCommandBusTest.kt
@@ -1,9 +1,37 @@
 package me.ahoo.wow.command
 
+import me.ahoo.wow.api.command.CommandMessage
+import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.tck.command.CommandBusSpec
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.core.publisher.Sinks
 
 class LocalFirstCommandBusTest : CommandBusSpec() {
     override fun createCommandBus(): CommandBus {
-        return LocalFirstCommandBus(distributedCommandBus = InMemoryCommandBus())
+        return LocalFirstCommandBus(distributedCommandBus = MockDistributedCommandBus())
+    }
+}
+
+class MockDistributedCommandBus : DistributedCommandBus {
+    private val sink: Sinks.Many<ServerCommandExchange<*>> = Sinks.many().unicast().onBackpressureBuffer()
+
+    override fun send(message: CommandMessage<*>): Mono<Void> {
+        val exchange = SimpleServerCommandExchange(message)
+        return Mono.fromRunnable {
+            @Suppress("UNCHECKED_CAST")
+            sink.emitNext(
+                exchange as ServerCommandExchange<Any>,
+                Sinks.EmitFailureHandler.busyLooping(BUSY_LOOPING_DURATION),
+            )
+        }
+    }
+
+    override fun receive(namedAggregates: Set<NamedAggregate>): Flux<ServerCommandExchange<*>> {
+        return sink.asFlux().filter {
+            namedAggregates.any { namedAggregate ->
+                namedAggregate.isSameAggregateName(it.message)
+            }
+        }
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/ProcessedNotifierFilterTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/ProcessedNotifierFilterTest.kt
@@ -29,9 +29,9 @@ internal class ProcessedNotifierFilterTest {
     fun filter() {
         val processedNotifierFilter = ProcessedNotifierFilter(LocalCommandWaitNotifier(SimpleWaitStrategyRegistrar))
         val command = CreateAggregate("", "")
-            .asCommandMessage() as CommandMessage<Any>
+            .asCommandMessage() as CommandMessage<*>
         val exchange = SimpleServerCommandExchange(command)
-        val chain = FilterChainBuilder<ServerCommandExchange<Any>>().build()
+        val chain = FilterChainBuilder<ServerCommandExchange<*>>().build()
         processedNotifierFilter.filter(exchange, chain)
             .test()
             .verifyComplete()

--- a/wow-kafka/src/main/kotlin/me/ahoo/wow/kafka/AbstractKafkaBus.kt
+++ b/wow-kafka/src/main/kotlin/me/ahoo/wow/kafka/AbstractKafkaBus.kt
@@ -16,7 +16,7 @@ package me.ahoo.wow.kafka
 import me.ahoo.wow.api.messaging.Message
 import me.ahoo.wow.api.modeling.AggregateIdCapable
 import me.ahoo.wow.api.modeling.NamedAggregate
-import me.ahoo.wow.messaging.MessageBus
+import me.ahoo.wow.messaging.DistributedMessageBus
 import me.ahoo.wow.messaging.getReceiverGroup
 import me.ahoo.wow.messaging.handler.MessageExchange
 import me.ahoo.wow.serialization.asJsonString
@@ -40,7 +40,8 @@ abstract class AbstractKafkaBus<M, E>(
     private val senderOptions: SenderOptions<String, String>,
     private val receiverOptions: ReceiverOptions<String, String>,
     private val receiverOptionsCustomizer: ReceiverOptionsCustomizer = NoOpReceiverOptionsCustomizer
-) : MessageBus where M : Message<*>, M : AggregateIdCapable, M : NamedAggregate, E : MessageExchange<*, *> {
+) : DistributedMessageBus<M, E>
+    where M : Message<*>, M : AggregateIdCapable, M : NamedAggregate, E : MessageExchange<*, M> {
     companion object {
         private val log = LoggerFactory.getLogger(AbstractKafkaBus::class.java)
     }

--- a/wow-kafka/src/main/kotlin/me/ahoo/wow/kafka/KafkaCommandBus.kt
+++ b/wow-kafka/src/main/kotlin/me/ahoo/wow/kafka/KafkaCommandBus.kt
@@ -15,9 +15,8 @@ package me.ahoo.wow.kafka
 import me.ahoo.wow.api.Wow
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.modeling.NamedAggregate
-import me.ahoo.wow.command.CommandBus
+import me.ahoo.wow.command.DistributedCommandBus
 import me.ahoo.wow.command.ServerCommandExchange
-import me.ahoo.wow.messaging.DistributedMessageBus
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.kafka.receiver.ReceiverOffset
@@ -34,21 +33,21 @@ class KafkaCommandBus(
     receiverOptions: ReceiverOptions<String, String>,
     private val topicPrefix: String = Wow.WOW_PREFIX,
     receiverOptionsCustomizer: ReceiverOptionsCustomizer = NoOpReceiverOptionsCustomizer
-) : CommandBus, DistributedMessageBus, AbstractKafkaBus<CommandMessage<Any>, ServerCommandExchange<Any>>(
+) : DistributedCommandBus, AbstractKafkaBus<CommandMessage<*>, ServerCommandExchange<*>>(
     senderOptions,
     receiverOptions,
     receiverOptionsCustomizer,
 ) {
 
     @Suppress("UNCHECKED_CAST")
-    override val messageType: Class<CommandMessage<Any>>
-        get() = CommandMessage::class.java as Class<CommandMessage<Any>>
+    override val messageType: Class<CommandMessage<*>>
+        get() = CommandMessage::class.java
 
     override fun NamedAggregate.asTopic(): String {
         return asCommandTopic(topicPrefix)
     }
 
-    override fun CommandMessage<Any>.asExchange(receiverOffset: ReceiverOffset): ServerCommandExchange<Any> {
+    override fun CommandMessage<*>.asExchange(receiverOffset: ReceiverOffset): ServerCommandExchange<*> {
         return KafkaServerCommandExchange(this, receiverOffset)
     }
 
@@ -57,7 +56,7 @@ class KafkaCommandBus(
         return super.sendMessage(message as CommandMessage<Any>)
     }
 
-    override fun receive(namedAggregates: Set<NamedAggregate>): Flux<ServerCommandExchange<Any>> {
+    override fun receive(namedAggregates: Set<NamedAggregate>): Flux<ServerCommandExchange<*>> {
         return super.receiveMessage(namedAggregates)
     }
 }

--- a/wow-kafka/src/main/kotlin/me/ahoo/wow/kafka/KafkaDomainEventBus.kt
+++ b/wow-kafka/src/main/kotlin/me/ahoo/wow/kafka/KafkaDomainEventBus.kt
@@ -14,10 +14,9 @@ package me.ahoo.wow.kafka
 
 import me.ahoo.wow.api.Wow
 import me.ahoo.wow.api.modeling.NamedAggregate
-import me.ahoo.wow.event.DomainEventBus
+import me.ahoo.wow.event.DistributedDomainEventBus
 import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.event.EventStreamExchange
-import me.ahoo.wow.messaging.DistributedMessageBus
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.kafka.receiver.ReceiverOffset
@@ -29,7 +28,7 @@ class KafkaDomainEventBus(
     receiverOptions: ReceiverOptions<String, String>,
     private val topicPrefix: String = Wow.WOW_PREFIX,
     receiverOptionsCustomizer: ReceiverOptionsCustomizer = NoOpReceiverOptionsCustomizer
-) : DomainEventBus, DistributedMessageBus,
+) : DistributedDomainEventBus,
     AbstractKafkaBus<DomainEventStream, EventStreamExchange>(
         senderOptions,
         receiverOptions,

--- a/wow-spring-boot-starter/build.gradle.kts
+++ b/wow-spring-boot-starter/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     api("org.springframework.cloud:spring-cloud-commons")
     kapt("org.springframework.boot:spring-boot-configuration-processor")
     kapt("org.springframework.boot:spring-boot-autoconfigure-processor")
+    testImplementation(project(":wow-test"))
     testImplementation(project(":wow-tck"))
     testImplementation("org.mariadb:r2dbc-mariadb")
     testImplementation(project(":wow-r2dbc"))

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandAutoConfiguration.kt
@@ -20,6 +20,7 @@ import me.ahoo.wow.command.LocalFirstCommandBus
 import me.ahoo.wow.spring.boot.starter.ConditionalOnWowEnabled
 import me.ahoo.wow.spring.boot.starter.MessageBusType
 import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
@@ -45,6 +46,7 @@ class CommandAutoConfiguration(val commandProperties: CommandProperties) {
     @ConditionalOnProperty(
         CommandProperties.LocalFirst.ENABLED_KEY,
         havingValue = "true",
+        matchIfMissing = true
     )
     fun localCommandBus(): LocalCommandBus {
         return InMemoryCommandBus()
@@ -52,10 +54,11 @@ class CommandAutoConfiguration(val commandProperties: CommandProperties) {
 
     @Bean
     @Primary
-    @ConditionalOnMissingBean(value = [LocalCommandBus::class, DistributedCommandBus::class])
+    @ConditionalOnBean(value = [LocalCommandBus::class, DistributedCommandBus::class])
     @ConditionalOnProperty(
         CommandProperties.LocalFirst.ENABLED_KEY,
         havingValue = "true",
+        matchIfMissing = true
     )
     fun localFirstCommandBus(
         localCommandBus: LocalCommandBus,

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandAutoConfiguration.kt
@@ -13,26 +13,54 @@
 
 package me.ahoo.wow.spring.boot.starter.command
 
-import me.ahoo.wow.command.CommandBus
+import me.ahoo.wow.command.DistributedCommandBus
 import me.ahoo.wow.command.InMemoryCommandBus
+import me.ahoo.wow.command.LocalCommandBus
+import me.ahoo.wow.command.LocalFirstCommandBus
 import me.ahoo.wow.spring.boot.starter.ConditionalOnWowEnabled
 import me.ahoo.wow.spring.boot.starter.MessageBusType
 import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
 
 @AutoConfiguration
 @ConditionalOnWowEnabled
 @EnableConfigurationProperties(CommandProperties::class)
-class CommandAutoConfiguration {
+class CommandAutoConfiguration(val commandProperties: CommandProperties) {
 
     @Bean
     @ConditionalOnProperty(
         CommandProperties.Bus.TYPE,
         havingValue = MessageBusType.IN_MEMORY_NAME,
     )
-    fun inMemoryCommandBus(): CommandBus {
+    fun inMemoryCommandBus(): LocalCommandBus {
         return InMemoryCommandBus()
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(LocalCommandBus::class)
+    @ConditionalOnProperty(
+        CommandProperties.LocalFirst.ENABLED_KEY,
+        havingValue = "true",
+    )
+    fun localCommandBus(): LocalCommandBus {
+        return InMemoryCommandBus()
+    }
+
+    @Bean
+    @Primary
+    @ConditionalOnMissingBean(value = [LocalCommandBus::class, DistributedCommandBus::class])
+    @ConditionalOnProperty(
+        CommandProperties.LocalFirst.ENABLED_KEY,
+        havingValue = "true",
+    )
+    fun localFirstCommandBus(
+        localCommandBus: LocalCommandBus,
+        distributedCommandBus: DistributedCommandBus
+    ): LocalFirstCommandBus {
+        return LocalFirstCommandBus(distributedCommandBus, commandProperties.bus.localFirst.doubleSend, localCommandBus)
     }
 }

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandProperties.kt
@@ -39,8 +39,14 @@ data class CommandProperties(
     }
 
     data class LocalFirst(
-        val enabled: Boolean = true
-    )
+        val enabled: Boolean = true,
+        val doubleSend: Boolean = false
+    ) {
+        companion object {
+            const val PREFIX = "${CommandProperties.PREFIX}.local-first"
+            const val ENABLED_KEY = "$PREFIX.enabled"
+        }
+    }
 
     data class Idempotency(
         val enable: Boolean = false,

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/event/EventAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/event/EventAutoConfiguration.kt
@@ -17,6 +17,7 @@ import me.ahoo.wow.event.DefaultEventCompensator
 import me.ahoo.wow.event.DomainEventBus
 import me.ahoo.wow.event.EventCompensator
 import me.ahoo.wow.event.InMemoryDomainEventBus
+import me.ahoo.wow.event.LocalDomainEventBus
 import me.ahoo.wow.eventsourcing.EventStore
 import me.ahoo.wow.spring.boot.starter.ConditionalOnWowEnabled
 import me.ahoo.wow.spring.boot.starter.MessageBusType
@@ -34,7 +35,7 @@ class EventAutoConfiguration {
         EventProperties.Bus.TYPE,
         havingValue = MessageBusType.IN_MEMORY_NAME,
     )
-    fun inMemoryDomainEventBus(): DomainEventBus {
+    fun inMemoryDomainEventBus(): LocalDomainEventBus {
         return InMemoryDomainEventBus()
     }
 

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/kafka/KafkaAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/kafka/KafkaAutoConfiguration.kt
@@ -13,8 +13,8 @@
 
 package me.ahoo.wow.spring.boot.starter.kafka
 
-import me.ahoo.wow.command.CommandBus
-import me.ahoo.wow.event.DomainEventBus
+import me.ahoo.wow.command.DistributedCommandBus
+import me.ahoo.wow.event.DistributedDomainEventBus
 import me.ahoo.wow.kafka.KafkaCommandBus
 import me.ahoo.wow.kafka.KafkaDomainEventBus
 import me.ahoo.wow.kafka.NoOpReceiverOptionsCustomizer
@@ -52,7 +52,7 @@ class KafkaAutoConfiguration(private val kafkaProperties: KafkaProperties) {
     )
     fun kafkaCommandBus(
         receiverOptionsCustomizer: ReceiverOptionsCustomizer
-    ): CommandBus {
+    ): DistributedCommandBus {
         return KafkaCommandBus(
             senderOptions = kafkaProperties.buildSenderOptions(),
             receiverOptions = kafkaProperties.buildReceiverOptions(),
@@ -69,7 +69,7 @@ class KafkaAutoConfiguration(private val kafkaProperties: KafkaProperties) {
     )
     fun kafkaDomainEventBus(
         receiverOptionsCustomizer: ReceiverOptionsCustomizer
-    ): DomainEventBus {
+    ): DistributedDomainEventBus {
         return KafkaDomainEventBus(
             senderOptions = kafkaProperties.buildSenderOptions(),
             receiverOptions = kafkaProperties.buildReceiverOptions(),

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/modeling/AggregateAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/modeling/AggregateAutoConfiguration.kt
@@ -14,7 +14,7 @@
 package me.ahoo.wow.spring.boot.starter.modeling
 
 import me.ahoo.wow.api.naming.NamedBoundedContext
-import me.ahoo.wow.command.CommandBus
+import me.ahoo.wow.command.CommandGateway
 import me.ahoo.wow.command.ServerCommandExchange
 import me.ahoo.wow.event.DomainEventBus
 import me.ahoo.wow.eventsourcing.EventSourcingStateAggregateRepository
@@ -103,9 +103,9 @@ class AggregateAutoConfiguration {
 
     @Bean
     fun commandFilterChain(
-        filters: List<Filter<ServerCommandExchange<Any>>>
-    ): FilterChain<ServerCommandExchange<Any>> {
-        return FilterChainBuilder<ServerCommandExchange<Any>>()
+        filters: List<Filter<ServerCommandExchange<*>>>
+    ): FilterChain<ServerCommandExchange<*>> {
+        return FilterChainBuilder<ServerCommandExchange<*>>()
             .addFilters(filters)
             .filterCondition(CommandDispatcher::class)
             .build()
@@ -113,15 +113,15 @@ class AggregateAutoConfiguration {
 
     @Bean("commandErrorHandler")
     @ConditionalOnMissingBean(name = ["commandErrorHandler"])
-    fun commandErrorHandler(): ErrorHandler<ServerCommandExchange<Any>> {
+    fun commandErrorHandler(): ErrorHandler<ServerCommandExchange<*>> {
         return LogResumeErrorHandler()
     }
 
     @Bean
     @ConditionalOnMissingBean
     fun commandHandler(
-        commandFilterChain: FilterChain<ServerCommandExchange<Any>>,
-        @Qualifier("commandErrorHandler") commandErrorHandler: ErrorHandler<ServerCommandExchange<Any>>
+        commandFilterChain: FilterChain<ServerCommandExchange<*>>,
+        @Qualifier("commandErrorHandler") commandErrorHandler: ErrorHandler<ServerCommandExchange<*>>
     ): CommandHandler {
         return DefaultCommandHandler(
             chain = commandFilterChain,
@@ -133,7 +133,7 @@ class AggregateAutoConfiguration {
     @ConditionalOnMissingBean
     fun aggregateDispatcher(
         namedBoundedContext: NamedBoundedContext,
-        commandBus: CommandBus,
+        commandBus: CommandGateway,
         aggregateProcessorFactory: AggregateProcessorFactory,
         commandHandler: CommandHandler,
         serviceProvider: ServiceProvider

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/WowOpenTelemetryAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/WowOpenTelemetryAutoConfiguration.kt
@@ -18,7 +18,6 @@ import me.ahoo.wow.opentelemetry.projection.TraceProjectionFilter
 import me.ahoo.wow.opentelemetry.saga.TraceStatelessSagaFilter
 import me.ahoo.wow.opentelemetry.snapshot.TraceSnapshotFilter
 import me.ahoo.wow.spring.boot.starter.ConditionalOnWowEnabled
-import me.ahoo.wow.spring.boot.starter.command.CommandProperties
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
@@ -61,7 +60,7 @@ class WowOpenTelemetryAutoConfiguration {
     }
 
     @Bean
-    fun tracingBeanPostProcessor(commandProperties: CommandProperties?): TracingBeanPostProcessor {
-        return TracingBeanPostProcessor(commandProperties?.bus?.localFirst?.enabled ?: false)
+    fun tracingBeanPostProcessor(): TracingBeanPostProcessor {
+        return TracingBeanPostProcessor()
     }
 }

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/modeling/AggregateAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/modeling/AggregateAutoConfigurationTest.kt
@@ -13,8 +13,7 @@
 
 package me.ahoo.wow.spring.boot.starter.modeling
 
-import me.ahoo.wow.command.CommandBus
-import me.ahoo.wow.command.InMemoryCommandBus
+import me.ahoo.wow.command.CommandGateway
 import me.ahoo.wow.event.DomainEventBus
 import me.ahoo.wow.event.InMemoryDomainEventBus
 import me.ahoo.wow.eventsourcing.EventStore
@@ -33,6 +32,7 @@ import me.ahoo.wow.modeling.state.StateAggregateRepository
 import me.ahoo.wow.spring.boot.starter.enableWow
 import me.ahoo.wow.spring.boot.starter.opentelemetry.WowOpenTelemetryAutoConfiguration
 import me.ahoo.wow.spring.command.CommandDispatcherLauncher
+import me.ahoo.wow.test.StatelessSagaVerifier.TEST_COMMAND_GATEWAY
 import org.assertj.core.api.AssertionsForInterfaceTypes
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
@@ -50,7 +50,7 @@ internal class AggregateAutoConfigurationTest {
             .withBean(SnapshotRepository::class.java, { NoOpSnapshotRepository })
             .withBean(EventStore::class.java, { InMemoryEventStore() })
             .withBean(DomainEventBus::class.java, { InMemoryDomainEventBus() })
-            .withBean(CommandBus::class.java, { InMemoryCommandBus() })
+            .withBean(CommandGateway::class.java, { TEST_COMMAND_GATEWAY })
             .withUserConfiguration(
                 WowOpenTelemetryAutoConfiguration::class.java,
                 AggregateAutoConfiguration::class.java,

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/WowOpenTelemetryAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/WowOpenTelemetryAutoConfigurationTest.kt
@@ -18,7 +18,6 @@ import me.ahoo.wow.opentelemetry.eventprocessor.TraceEventProcessorFilter
 import me.ahoo.wow.opentelemetry.projection.TraceProjectionFilter
 import me.ahoo.wow.opentelemetry.saga.TraceStatelessSagaFilter
 import me.ahoo.wow.opentelemetry.snapshot.TraceSnapshotFilter
-import me.ahoo.wow.spring.boot.starter.command.CommandAutoConfiguration
 import me.ahoo.wow.spring.boot.starter.enableWow
 import org.assertj.core.api.AssertionsForInterfaceTypes
 import org.junit.jupiter.api.Test
@@ -33,7 +32,6 @@ internal class WowOpenTelemetryAutoConfigurationTest {
         contextRunner
             .enableWow()
             .withUserConfiguration(
-                CommandAutoConfiguration::class.java,
                 WowOpenTelemetryAutoConfiguration::class.java,
             )
             .run { context: AssertableApplicationContext ->

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
@@ -14,9 +14,7 @@
 package me.ahoo.wow.spring.boot.starter.webflux
 
 import io.mockk.mockk
-import me.ahoo.wow.command.CommandBus
 import me.ahoo.wow.command.CommandGateway
-import me.ahoo.wow.command.InMemoryCommandBus
 import me.ahoo.wow.command.wait.CommandWaitNotifier
 import me.ahoo.wow.event.DomainEventBus
 import me.ahoo.wow.event.EventCompensator
@@ -32,6 +30,7 @@ import me.ahoo.wow.spring.boot.starter.command.CommandGatewayAutoConfiguration
 import me.ahoo.wow.spring.boot.starter.enableWow
 import me.ahoo.wow.spring.boot.starter.eventsourcing.EventSourcingAutoConfiguration
 import me.ahoo.wow.spring.boot.starter.modeling.AggregateAutoConfiguration
+import me.ahoo.wow.test.StatelessSagaVerifier
 import me.ahoo.wow.webflux.ExceptionHandler
 import org.assertj.core.api.AssertionsForInterfaceTypes
 import org.junit.jupiter.api.Test
@@ -47,12 +46,11 @@ internal class WebFluxAutoConfigurationTest {
         contextRunner
             .enableWow()
             .withBean(CommandWaitNotifier::class.java, { mockk() })
-            .withBean(CommandGateway::class.java, { mockk() })
+            .withBean(CommandGateway::class.java, { StatelessSagaVerifier.TEST_COMMAND_GATEWAY })
             .withBean(StateAggregateFactory::class.java, { ConstructorStateAggregateFactory })
             .withBean(SnapshotRepository::class.java, { NoOpSnapshotRepository })
             .withBean(EventStore::class.java, { InMemoryEventStore() })
             .withBean(DomainEventBus::class.java, { InMemoryDomainEventBus() })
-            .withBean(CommandBus::class.java, { InMemoryCommandBus() })
             .withBean(EventCompensator::class.java, { mockk() })
             .withUserConfiguration(
                 UtilAutoConfiguration::class.java,


### PR DESCRIPTION


Changes proposed in this pull request:
- feat: support `doubleSend` for `LocalFirstCommandBus`
- feat: support `LocalCommandBus` / `DistributedCommandBus`
- feat: support `LocalDomainEventBus` / `DistributedDomainEventBus`
