### PR TITLE
refactor: remove Deprecated `SnapshotRepository.load`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ ksp.incremental=true
 ksp.incremental.log=true
 
 group=me.ahoo.wow
-version=1.11.0
+version=1.11.1
 description=A Modern Reactive CQRS Architecture Microservice development framework based on DDD and EventSourcing.
 website=https://github.com/Ahoo-Wang/Wow
 issues=https://github.com/Ahoo-Wang/Wow/issues

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/event/MockEvent.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/event/MockEvent.kt
@@ -11,4 +11,5 @@
  * limitations under the License.
  */
 package me.ahoo.wow.tck.event
+
 data class MockEvent(val state: String)

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/StatelessSagaVerifier.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/StatelessSagaVerifier.kt
@@ -33,18 +33,21 @@ import me.ahoo.wow.test.saga.stateless.WhenStage
  * @author ahoo wang
  */
 object StatelessSagaVerifier {
-    val TEST_COMMAND_GATEWAY: CommandGateway = DefaultCommandGateway(
-        SimpleCommandWaitEndpoint("test"),
-        InMemoryCommandBus(),
-        NoOpIdempotencyChecker,
-        SimpleWaitStrategyRegistrar,
-        NoOpValidator
-    )
+    @JvmStatic
+    fun defaultCommandGateway(): CommandGateway {
+        return DefaultCommandGateway(
+            SimpleCommandWaitEndpoint("__StatelessSagaVerifier__"),
+            InMemoryCommandBus(),
+            NoOpIdempotencyChecker,
+            SimpleWaitStrategyRegistrar,
+            NoOpValidator
+        )
+    }
 
     @JvmStatic
     fun <T : Any> Class<T>.asSagaVerifier(
         serviceProvider: ServiceProvider = SimpleServiceProvider(),
-        commandGateway: CommandGateway = TEST_COMMAND_GATEWAY
+        commandGateway: CommandGateway = defaultCommandGateway()
     ): WhenStage<T> {
         val sagaMetadata: ProcessorMetadata<T, DomainEventExchange<*>> = asEventProcessorMetadata()
         return DefaultWhenStage(
@@ -57,7 +60,7 @@ object StatelessSagaVerifier {
     @JvmStatic
     inline fun <reified T : Any> sagaVerifier(
         serviceProvider: ServiceProvider = SimpleServiceProvider(),
-        commandGateway: CommandGateway = TEST_COMMAND_GATEWAY
+        commandGateway: CommandGateway = defaultCommandGateway()
     ): WhenStage<T> {
         return T::class.java.asSagaVerifier(serviceProvider, commandGateway)
     }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotRepository.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotRepository.kt
@@ -14,7 +14,6 @@ package me.ahoo.wow.eventsourcing.snapshot
 
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.api.modeling.NamedAggregate
-import me.ahoo.wow.modeling.matedata.StateAggregateMetadata
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
@@ -24,14 +23,6 @@ const val FIRST_CURSOR_ID = "(0)"
  * Snapshot Repository.
  */
 interface SnapshotRepository {
-    @Deprecated(
-        "use load(aggregateId: AggregateId): Mono<Snapshot<S>> instead.",
-        ReplaceWith("load(aggregateId)"),
-    )
-    fun <S : Any> load(metadata: StateAggregateMetadata<S>, aggregateId: AggregateId): Mono<Snapshot<S>> {
-        return load(aggregateId)
-    }
-
     fun <S : Any> load(aggregateId: AggregateId): Mono<Snapshot<S>>
     fun <S : Any> save(snapshot: Snapshot<S>): Mono<Void>
     fun scrollAggregateId(

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/modeling/AggregateAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/modeling/AggregateAutoConfigurationTest.kt
@@ -32,7 +32,7 @@ import me.ahoo.wow.modeling.state.StateAggregateRepository
 import me.ahoo.wow.spring.boot.starter.enableWow
 import me.ahoo.wow.spring.boot.starter.opentelemetry.WowOpenTelemetryAutoConfiguration
 import me.ahoo.wow.spring.command.CommandDispatcherLauncher
-import me.ahoo.wow.test.StatelessSagaVerifier.TEST_COMMAND_GATEWAY
+import me.ahoo.wow.test.StatelessSagaVerifier
 import org.assertj.core.api.AssertionsForInterfaceTypes
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
@@ -50,7 +50,7 @@ internal class AggregateAutoConfigurationTest {
             .withBean(SnapshotRepository::class.java, { NoOpSnapshotRepository })
             .withBean(EventStore::class.java, { InMemoryEventStore() })
             .withBean(DomainEventBus::class.java, { InMemoryDomainEventBus() })
-            .withBean(CommandGateway::class.java, { TEST_COMMAND_GATEWAY })
+            .withBean(CommandGateway::class.java, { StatelessSagaVerifier.defaultCommandGateway() })
             .withUserConfiguration(
                 WowOpenTelemetryAutoConfiguration::class.java,
                 AggregateAutoConfiguration::class.java,

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
@@ -46,7 +46,7 @@ internal class WebFluxAutoConfigurationTest {
         contextRunner
             .enableWow()
             .withBean(CommandWaitNotifier::class.java, { mockk() })
-            .withBean(CommandGateway::class.java, { StatelessSagaVerifier.TEST_COMMAND_GATEWAY })
+            .withBean(CommandGateway::class.java, { StatelessSagaVerifier.defaultCommandGateway() })
             .withBean(StateAggregateFactory::class.java, { ConstructorStateAggregateFactory })
             .withBean(SnapshotRepository::class.java, { NoOpSnapshotRepository })
             .withBean(EventStore::class.java, { InMemoryEventStore() })


### PR DESCRIPTION


Changes proposed in this pull request:
- refactor: remove Deprecated `SnapshotRepository.load`
