### PR TITLE
refactor: use `noCursorTimeout` to `MongoSnapshotRepository.scrollAggregateId`

### DIFF
--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoSnapshotRepository.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoSnapshotRepository.kt
@@ -56,6 +56,7 @@ class MongoSnapshotRepository(private val database: MongoDatabase) : SnapshotRep
             .projection(Projections.include(Documents.ID_FIELD, MessageRecords.TENANT_ID))
             .sort(Sorts.ascending(Documents.ID_FIELD))
             .limit(limit)
+            .noCursorTimeout(true)
             .toFlux()
             .map {
                 namedAggregate.asAggregateId(


### PR DESCRIPTION


Changes proposed in this pull request:

- refactor: use `noCursorTimeout` to `MongoSnapshotRepository.scrollAggregateId`

