### PR TITLE
fix: mongodb missing cursor when `scanAggregateId`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ ksp.incremental=true
 ksp.incremental.log=true
 
 group=me.ahoo.wow
-version=1.16.3
+version=1.16.4
 description=A Modern Reactive CQRS Architecture Microservice development framework based on DDD and EventSourcing.
 website=https://github.com/Ahoo-Wang/Wow
 issues=https://github.com/Ahoo-Wang/Wow/issues

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt
@@ -38,9 +38,10 @@ interface EventStore : AggregateIdScanner {
     /**
      * 根据聚合ID加载事件流.
      * ``` kotlin
-     *  var offset=headVersion-1;
-     *  var limit=tailVersion-headVersion;
+     *  val offset=headVersion-1;
+     *  val limit=tailVersion-headVersion+1;
      * ```
+     * [headVersion~tailVersion]
      *
      * @param aggregateId 聚合ID
      * @param headVersion 事件流的第一个事件版本号，当 `headVersion`=H 时，即从事件版本号 H (包括)开始加载事件流。

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/handler/RegenerateStateEventHandler.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/handler/RegenerateStateEventHandler.kt
@@ -31,7 +31,7 @@ class RegenerateStateEventHandler(
 ) {
     fun handle(config: CompensationConfig, cursorId: String, limit: Int): Mono<BatchResult> {
         return eventStore.scanAggregateId(aggregateMetadata.namedAggregate, cursorId, limit)
-            .flatMap({ aggregateId ->
+            .flatMap { aggregateId ->
                 stateAggregateFactory.create(aggregateMetadata.state, aggregateId)
                     .flatMapMany { stateAggregate ->
                         eventStore
@@ -47,7 +47,7 @@ class RegenerateStateEventHandler(
                                 stateEventBus.send(it).thenReturn(it.aggregateId)
                             }
                     }
-            }, limit, limit)
+            }
             .reduce(BatchResult(cursorId, 0)) { acc, aggregateId ->
                 val nextCursorId = if (aggregateId.id > acc.cursorId) {
                     aggregateId.id

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/BatchRegenerateSnapshotHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/BatchRegenerateSnapshotHandlerFunction.kt
@@ -53,9 +53,9 @@ class BatchRegenerateSnapshotHandlerFunction(
             cursorId = cursorId,
             limit = limit
         )
-            .flatMap({ aggregateId ->
+            .flatMap { aggregateId ->
                 handler.handle(aggregateId)
-            }, limit, limit)
+            }
             .reduce(BatchResult(cursorId, 0)) { acc, snapshot ->
                 val nextCursorId = if (snapshot.aggregateId.id > acc.cursorId) {
                     snapshot.aggregateId.id


### PR DESCRIPTION

Changes proposed in this pull request:
- fix: mongodb missing cursor when `scanAggregateId`
