### PR TITLE
feat: add `NamedBoundedContext` metadata to `MessageFunction`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ ksp.incremental=true
 ksp.incremental.log=true
 
 group=me.ahoo.wow
-version=1.18.3
+version=1.18.4
 description=A Modern Reactive CQRS Architecture Microservice development framework based on DDD and EventSourcing.
 website=https://github.com/Ahoo-Wang/Wow
 issues=https://github.com/Ahoo-Wang/Wow/issues

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/function/MessageFunction.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/function/MessageFunction.kt
@@ -14,10 +14,9 @@ package me.ahoo.wow.messaging.function
 
 import me.ahoo.wow.api.messaging.FunctionKindCapable
 import me.ahoo.wow.api.naming.NamedBoundedContext
-import me.ahoo.wow.configuration.asRequiredNamedBoundedContext
 import me.ahoo.wow.messaging.handler.MessageExchange
 
-interface MessageFunction<P : Any, in M : MessageExchange<*, *>, out R> : FunctionKindCapable {
+interface MessageFunction<P : Any, in M : MessageExchange<*, *>, out R> : FunctionKindCapable, NamedBoundedContext {
 
     /**
      * Message body types supported by the message function.
@@ -51,8 +50,3 @@ fun <P : Any, M : MessageExchange<*, *>, R> MethodFunctionMetadata<P, R>.asMessa
         InjectableMethodMessageFunction(processor, this)
     }
 }
-
-val <P : Any, M : MessageExchange<*, *>, R> MessageFunction<P, M, R>.namedBoundedContext: NamedBoundedContext
-    get() {
-        return processor.javaClass.asRequiredNamedBoundedContext()
-    }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/function/MethodFunctionMetadata.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/function/MethodFunctionMetadata.kt
@@ -15,6 +15,8 @@ package me.ahoo.wow.messaging.function
 
 import me.ahoo.wow.api.messaging.FunctionKind
 import me.ahoo.wow.api.messaging.FunctionKindCapable
+import me.ahoo.wow.api.naming.NamedBoundedContext
+import me.ahoo.wow.configuration.asRequiredNamedBoundedContext
 import me.ahoo.wow.infra.accessor.method.MethodAccessor
 import me.ahoo.wow.messaging.handler.MessageExchange
 
@@ -25,12 +27,11 @@ data class MethodFunctionMetadata<P, out R>(
     val supportedTopics: Set<Any>,
     val firstParameterKind: FirstParameterKind,
     val injectParameterTypes: Array<Class<*>>
-) : FunctionKindCapable {
-    val injectParameterLength: Int
-        get() = injectParameterTypes.size
+) : FunctionKindCapable, NamedBoundedContext {
+    val injectParameterLength: Int = injectParameterTypes.size
 
-    val processorType: Class<P>
-        get() = accessor.targetType
+    val processorType: Class<P> = accessor.targetType
+    override val contextName: String = processorType.asRequiredNamedBoundedContext().contextName
 
     fun extractFirstArgument(exchange: MessageExchange<*, *>): Any {
         return when (firstParameterKind) {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/function/MethodMessageHandler.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/function/MethodMessageHandler.kt
@@ -20,10 +20,11 @@ data class SimpleMethodMessageFunction<P : Any, in M : MessageExchange<*, *>, ou
     override val metadata: MethodFunctionMetadata<P, R>
 ) :
     MethodMessageFunction<P, M, R> {
-    override val supportedTopics: Set<Any>
-        get() = metadata.supportedTopics
-    override val functionKind: FunctionKind
-        get() = metadata.functionKind
+    override val contextName: String
+        get() = metadata.contextName
+    override val supportedTopics: Set<Any> = metadata.supportedTopics
+    override val functionKind: FunctionKind = metadata.functionKind
+
     override fun handle(exchange: M): R {
         val firstArgument = metadata.extractFirstArgument(exchange)
         return metadata.accessor.invoke(processor, arrayOf(firstArgument))
@@ -39,10 +40,9 @@ data class InjectableMethodMessageFunction<P : Any, in M : MessageExchange<*, *>
     override val metadata: MethodFunctionMetadata<P, R>
 ) :
     MethodMessageFunction<P, M, R> {
-    override val supportedTopics: Set<Any>
-        get() = metadata.supportedTopics
-    override val functionKind: FunctionKind
-        get() = metadata.functionKind
+    override val contextName: String = metadata.contextName
+    override val supportedTopics: Set<Any> = metadata.supportedTopics
+    override val functionKind: FunctionKind = metadata.functionKind
 
     override fun handle(exchange: M): R {
         val args = arrayOfNulls<Any>(1 + metadata.injectParameterLength)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/CommandFunction.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/CommandFunction.kt
@@ -25,12 +25,10 @@ class CommandFunction<C : Any>(
     private val commandAggregate: CommandAggregate<C, *>
 ) :
     MessageFunction<C, ServerCommandExchange<*>, Mono<DomainEventStream>> {
-    override val supportedType: Class<*>
-        get() = delegate.supportedType
-    override val processor: C
-        get() = delegate.processor
-    override val functionKind: FunctionKind
-        get() = delegate.functionKind
+    override val contextName: String = delegate.contextName
+    override val supportedType: Class<*> = delegate.supportedType
+    override val processor: C = delegate.processor
+    override val functionKind: FunctionKind = delegate.functionKind
     override fun handle(exchange: ServerCommandExchange<*>): Mono<DomainEventStream> {
         return delegate
             .handle(exchange)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/DefaultDeleteAggregateFunction.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/DefaultDeleteAggregateFunction.kt
@@ -26,12 +26,10 @@ import reactor.kotlin.core.publisher.toMono
 class DefaultDeleteAggregateFunction<C : Any>(
     private val commandAggregate: CommandAggregate<C, *>
 ) : MessageFunction<C, ServerCommandExchange<*>, Mono<DomainEventStream>> {
-    override val supportedType: Class<*>
-        get() = DefaultDeleteAggregate::class.java
-    override val processor: C
-        get() = commandAggregate.commandRoot
-    override val functionKind: FunctionKind
-        get() = FunctionKind.COMMAND
+    override val contextName: String = commandAggregate.contextName
+    override val supportedType: Class<*> = DefaultDeleteAggregate::class.java
+    override val processor: C = commandAggregate.commandRoot
+    override val functionKind: FunctionKind = FunctionKind.COMMAND
 
     override fun handle(
         exchange: ServerCommandExchange<*>

--- a/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt
@@ -28,15 +28,11 @@ class StatelessSagaFunction(
     private val commandGateway: CommandGateway
 ) :
     MessageFunction<Any, DomainEventExchange<*>, Mono<CommandStream>> {
-
-    override val processor: Any
-        get() = actual.processor
-    override val supportedType: Class<*>
-        get() = actual.supportedType
-    override val supportedTopics: Set<Any>
-        get() = actual.supportedTopics
-    override val functionKind: FunctionKind
-        get() = actual.functionKind
+    override val contextName: String = actual.contextName
+    override val processor: Any = actual.processor
+    override val supportedType: Class<*> = actual.supportedType
+    override val supportedTopics: Set<Any> = actual.supportedTopics
+    override val functionKind: FunctionKind = actual.functionKind
 
     override fun handle(exchange: DomainEventExchange<*>): Mono<CommandStream> {
         return actual.handle(exchange)

--- a/wow-core/src/test/kotlin/me/ahoo/wow/event/DomainEventDispatcherTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/event/DomainEventDispatcherTest.kt
@@ -40,6 +40,8 @@ internal class DomainEventDispatcherTest {
     fun run() {
         val sink = Sinks.empty<Void>()
         handlerRegistrar.register(object : MessageFunction<Any, DomainEventExchange<*>, Mono<*>> {
+            override val contextName: String
+                get() = "test"
             override val supportedType: Class<*>
                 get() = MockAggregateCreated::class.java
             override val processor: Any

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/function/MethodFunctionMetadataTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/function/MethodFunctionMetadataTest.kt
@@ -55,6 +55,8 @@ internal class MethodFunctionMetadataTest {
         )
         assertThat(metadata.firstParameterKind, equalTo(FirstParameterKind.MESSAGE_BODY))
         assertThat(metadata.supportedTopics, hasSize(0))
+        assertThat(metadata.processorType, equalTo(MockCommandAggregate::class.java))
+        assertThat(metadata.contextName, equalTo("wow-tck"))
     }
 
     @Test


### PR DESCRIPTION


Changes proposed in this pull request:
- feat: add `NamedBoundedContext` metadata to `MessageFunction`

