### PR TITLE
etl: Replace the time-based partition with the `sipHash64` partition to prevent the same aggregate ID from being distributed to different partitions and causing the merge to fail

### DIFF
--- a/deploy/script/clickhouse.sql
+++ b/deploy/script/clickhouse.sql
@@ -95,7 +95,8 @@ CREATE TABLE bi_db.order_order_state_last_local on cluster '{cluster}'
 ) ENGINE = ReplicatedReplacingMergeTree(
            '/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}', '{replica}',
            version)
-      PARTITION BY toYYYYMM(createTime)
+--    分区算法为 `sipHash64(aggregateId) % 8`,防止相同聚合ID的状态被放置在不同分区从而导致 `Replacing` 合并失效。
+      PARTITION BY sipHash64(aggregateId) % 8
       ORDER BY (aggregateId)
 ;
 


### PR DESCRIPTION
Replace the time-based partition with the `sipHash64` partition to prevent the same aggregate ID from being distributed to different partitions and causing the merge to fail