### PR TITLE
feat(query): Support `TODAY` & `TOMORROW` & `THIS_WEEK` & `NEXT_WEEK` & `LAST_WEEK` & `THIS_MONTH` & `LAST_MONTH` & `RECENT_DAYS` Operator.

### DIFF
--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/Query.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/Query.kt
@@ -142,7 +142,26 @@ enum class Operator {
     /**
      * 原始操作符，将条件值直接作为原始的数据库查询条件
      */
-    RAW
+    RAW,
+
+    // #region 日期类型筛选条件
+    /**
+     * 匹配数值类型字段在指定值今天范围区间的所有文档
+     * 字段要求:以毫秒为单位的`long` 类型时间戳
+     */
+    TODAY,
+    TOMORROW,
+    THIS_WEEK,
+    NEXT_WEEK,
+    LAST_WEEK,
+    THIS_MONTH,
+    LAST_MONTH,
+
+    /**
+     * 匹配数值类型字段在指定值最近天数范围区间的所有文档
+     */
+    RECENT_DAYS
+    // #endregion
 }
 
 data class Condition(
@@ -202,6 +221,16 @@ data class Condition(
         fun ids(vararg value: String) = Condition(field = EMPTY_VALUE, operator = Operator.IDS, value = value.toList())
         fun tenantId(value: String) = Condition(field = EMPTY_VALUE, operator = Operator.TENANT_ID, value = value)
         fun deleted(value: Boolean) = Condition(field = EMPTY_VALUE, operator = Operator.DELETED, value = value)
+        fun today(field: String) = Condition(field = field, operator = Operator.TODAY)
+        fun tomorrow(field: String) = Condition(field = field, operator = Operator.TOMORROW)
+        fun thisWeek(field: String) = Condition(field = field, operator = Operator.THIS_WEEK)
+        fun nextWeek(field: String) = Condition(field = field, operator = Operator.NEXT_WEEK)
+        fun lastWeek(field: String) = Condition(field = field, operator = Operator.LAST_WEEK)
+        fun thisMonth(field: String) = Condition(field = field, operator = Operator.THIS_MONTH)
+        fun lastMonth(field: String) = Condition(field = field, operator = Operator.LAST_MONTH)
+        fun recentDays(field: String, days: Int) =
+            Condition(field = field, operator = Operator.RECENT_DAYS, value = days)
+
         fun raw(value: Any) = Condition(field = EMPTY_VALUE, operator = Operator.RAW, value = value)
     }
 }

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/MongoConditionConverter.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/MongoConditionConverter.kt
@@ -21,6 +21,11 @@ import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.serialization.state.StateAggregateRecords
 import org.bson.Document
 import org.bson.conversions.Bson
+import java.time.DayOfWeek
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.ZoneOffset
+import java.time.temporal.TemporalAdjusters
 
 object MongoConditionConverter : ConditionConverter<Bson> {
     override fun and(condition: Condition): Bson {
@@ -136,6 +141,85 @@ object MongoConditionConverter : ConditionConverter<Bson> {
 
     override fun deleted(condition: Condition): Bson {
         return Filters.eq(StateAggregateRecords.DELETED, condition.value)
+    }
+
+    override fun today(condition: Condition): Bson {
+        val startOfDay = LocalDateTime.now().with(LocalTime.MIN)
+        val endOfDay = LocalDateTime.now().with(LocalTime.MAX)
+        return Filters.and(
+            Filters.gte(condition.field, startOfDay.toInstant(ZoneOffset.UTC).toEpochMilli()),
+            Filters.lte(condition.field, endOfDay.toInstant(ZoneOffset.UTC).toEpochMilli())
+        )
+    }
+
+    override fun tomorrow(condition: Condition): Bson {
+        val startOfTomorrow = LocalDateTime.now().plusDays(1).with(LocalTime.MIN)
+        val endOfTomorrow = LocalDateTime.now().plusDays(1).with(LocalTime.MAX)
+        return Filters.and(
+            Filters.gte(condition.field, startOfTomorrow.toInstant(ZoneOffset.UTC).toEpochMilli()),
+            Filters.lte(condition.field, endOfTomorrow.toInstant(ZoneOffset.UTC).toEpochMilli())
+        )
+    }
+
+    override fun thisWeek(condition: Condition): Bson {
+        val startOfWeek =
+            LocalDateTime.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)).with(LocalTime.MIN)
+        val endOfWeek = LocalDateTime.now().with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY)).with(LocalTime.MAX)
+        return Filters.and(
+            Filters.gte(condition.field, startOfWeek.toInstant(ZoneOffset.UTC).toEpochMilli()),
+            Filters.lte(condition.field, endOfWeek.toInstant(ZoneOffset.UTC).toEpochMilli())
+        )
+    }
+
+    override fun nextWeek(condition: Condition): Bson {
+        val startOfNextWeek = LocalDateTime.now().plusWeeks(1).with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+            .with(LocalTime.MIN)
+        val endOfNextWeek =
+            LocalDateTime.now().plusWeeks(1).with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY)).with(LocalTime.MAX)
+        return Filters.and(
+            Filters.gte(condition.field, startOfNextWeek.toInstant(ZoneOffset.UTC).toEpochMilli()),
+            Filters.lte(condition.field, endOfNextWeek.toInstant(ZoneOffset.UTC).toEpochMilli())
+        )
+    }
+
+    override fun lastWeek(condition: Condition): Bson {
+        val startOfLastWeek = LocalDateTime.now().minusWeeks(1).with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+            .with(LocalTime.MIN)
+        val endOfLastWeek =
+            LocalDateTime.now().minusWeeks(1).with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY)).with(LocalTime.MAX)
+        return Filters.and(
+            Filters.gte(condition.field, startOfLastWeek.toInstant(ZoneOffset.UTC).toEpochMilli()),
+            Filters.lte(condition.field, endOfLastWeek.toInstant(ZoneOffset.UTC).toEpochMilli())
+        )
+    }
+
+    override fun thisMonth(condition: Condition): Bson {
+        val startOfMonth = LocalDateTime.now().withDayOfMonth(1).with(LocalTime.MIN)
+        val endOfMonth = LocalDateTime.now().with(TemporalAdjusters.lastDayOfMonth()).with(LocalTime.MAX)
+        return Filters.and(
+            Filters.gte(condition.field, startOfMonth.toInstant(ZoneOffset.UTC).toEpochMilli()),
+            Filters.lte(condition.field, endOfMonth.toInstant(ZoneOffset.UTC).toEpochMilli())
+        )
+    }
+
+    override fun lastMonth(condition: Condition): Bson {
+        val startOfLastMonth = LocalDateTime.now().minusMonths(1).withDayOfMonth(1).with(LocalTime.MIN)
+        val endOfLastMonth =
+            LocalDateTime.now().minusMonths(1).with(TemporalAdjusters.lastDayOfMonth()).with(LocalTime.MAX)
+        return Filters.and(
+            Filters.gte(condition.field, startOfLastMonth.toInstant(ZoneOffset.UTC).toEpochMilli()),
+            Filters.lte(condition.field, endOfLastMonth.toInstant(ZoneOffset.UTC).toEpochMilli())
+        )
+    }
+
+    override fun recentDays(condition: Condition): Bson {
+        val days = condition.value as Number
+        val startOfRecentDays = LocalDateTime.now().minusDays(days.toLong()).with(LocalTime.MIN)
+        val endOfRecentDays = LocalDateTime.now().with(LocalTime.MAX)
+        return Filters.and(
+            Filters.gte(condition.field, startOfRecentDays.toInstant(ZoneOffset.UTC).toEpochMilli()),
+            Filters.lte(condition.field, endOfRecentDays.toInstant(ZoneOffset.UTC).toEpochMilli())
+        )
     }
 
     override fun raw(condition: Condition): Bson {

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/ConditionConverter.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/ConditionConverter.kt
@@ -45,6 +45,14 @@ interface ConditionConverter<T> {
             Operator.TRUE -> isTrue(condition)
             Operator.FALSE -> isFalse(condition)
             Operator.DELETED -> deleted(condition)
+            Operator.TODAY -> today(condition)
+            Operator.TOMORROW -> tomorrow(condition)
+            Operator.THIS_WEEK -> thisWeek(condition)
+            Operator.NEXT_WEEK -> nextWeek(condition)
+            Operator.LAST_WEEK -> lastWeek(condition)
+            Operator.THIS_MONTH -> thisMonth(condition)
+            Operator.LAST_MONTH -> lastMonth(condition)
+            Operator.RECENT_DAYS -> recentDays(condition)
             Operator.RAW -> raw(condition)
         }
         return not(condition.not, target)
@@ -75,6 +83,14 @@ interface ConditionConverter<T> {
     fun isTrue(condition: Condition): T
     fun isFalse(condition: Condition): T
     fun deleted(condition: Condition): T
+    fun today(condition: Condition): T
+    fun tomorrow(condition: Condition): T
+    fun thisWeek(condition: Condition): T
+    fun nextWeek(condition: Condition): T
+    fun lastWeek(condition: Condition): T
+    fun thisMonth(condition: Condition): T
+    fun lastMonth(condition: Condition): T
+    fun recentDays(condition: Condition): T
     fun raw(condition: Condition): T
     fun not(not: Boolean, target: T): T
 }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/ConditionDsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/ConditionDsl.kt
@@ -182,6 +182,38 @@ class ConditionDsl {
         condition(Condition.isFalse(this))
     }
 
+    fun String.today() {
+        condition(Condition.today(this))
+    }
+
+    fun String.tomorrow() {
+        condition(Condition.tomorrow(this))
+    }
+
+    fun String.thisWeek() {
+        condition(Condition.thisWeek(this))
+    }
+
+    fun String.nextWeek() {
+        condition(Condition.nextWeek(this))
+    }
+
+    fun String.lastWeek() {
+        condition(Condition.lastWeek(this))
+    }
+
+    fun String.thisMonth() {
+        condition(Condition.thisMonth(this))
+    }
+
+    fun String.lastMonth() {
+        condition(Condition.lastMonth(this))
+    }
+
+    infix fun String.recentDays(days: Int) {
+        condition(Condition.recentDays(this, days))
+    }
+
     fun raw(value: Any) {
         condition(Condition.raw(value))
     }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/ConditionDslTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/ConditionDslTest.kt
@@ -53,6 +53,14 @@ class ConditionDslTest {
                 "field3" eq "value3"
                 "field4" eq "value4"
             }
+            "field19".today()
+            "field20".tomorrow()
+            "field21".thisWeek()
+            "field22".nextWeek()
+            "field23".lastWeek()
+            "field24".thisMonth()
+            "field25".lastMonth()
+            "field26".recentDays(1)
             raw("1=1")
         }
         assertThat(
@@ -95,6 +103,14 @@ class ConditionDslTest {
                                 Condition.eq("field4", "value4")
                             )
                         ),
+                        Condition.today("field19"),
+                        Condition.tomorrow("field20"),
+                        Condition.thisWeek("field21"),
+                        Condition.nextWeek("field22"),
+                        Condition.lastWeek("field23"),
+                        Condition.thisMonth("field24"),
+                        Condition.lastMonth("field25"),
+                        Condition.recentDays("field26", 1),
                         Condition.raw("1=1")
                     )
                 )


### PR DESCRIPTION
Support `TODAY` & `TOMORROW` & `THIS_WEEK` & `NEXT_WEEK` & `LAST_WEEK` & `THIS_MONTH` & `LAST_MONTH` & `RECENT_DAYS` Operator.