### PR TITLE
feat(query): add `SnapshotQueryServiceRegistrar` to auto register `SnapshotQueryService`

### DIFF
--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/query/QueryAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/query/QueryAutoConfiguration.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.wow.spring.boot.starter.query
+
+import me.ahoo.wow.spring.boot.starter.ConditionalOnWowEnabled
+import me.ahoo.wow.spring.query.SnapshotQueryServiceRegistrar
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.context.annotation.Import
+
+/**
+ * Query AutoConfiguration .
+ *
+ * @author ahoo wang
+ */
+@AutoConfiguration
+@Import(SnapshotQueryServiceRegistrar::class)
+@ConditionalOnWowEnabled
+class QueryAutoConfiguration

--- a/wow-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/wow-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -26,3 +26,4 @@ me.ahoo.wow.spring.boot.starter.openapi.OpenAPIAutoConfiguration
 me.ahoo.wow.spring.boot.starter.webflux.WebFluxAutoConfiguration
 me.ahoo.wow.spring.boot.starter.webflux.WowWebClientAutoConfiguration
 me.ahoo.wow.spring.boot.starter.compensation.CompensationAutoConfiguration
+me.ahoo.wow.spring.boot.starter.query.QueryAutoConfiguration

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/query/QueryAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/query/QueryAutoConfigurationTest.kt
@@ -1,0 +1,25 @@
+package me.ahoo.wow.spring.boot.starter.query
+
+import me.ahoo.wow.query.NoOpSnapshotQueryServiceFactory
+import me.ahoo.wow.query.SnapshotQueryServiceFactory
+import me.ahoo.wow.spring.boot.starter.enableWow
+import org.assertj.core.api.AssertionsForInterfaceTypes
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+class QueryAutoConfigurationTest {
+    private val contextRunner = ApplicationContextRunner()
+
+    @Test
+    fun contextLoads() {
+        contextRunner
+            .enableWow()
+            .withUserConfiguration(QueryAutoConfiguration::class.java)
+            .withBean(SnapshotQueryServiceFactory::class.java, { NoOpSnapshotQueryServiceFactory })
+            .run { context: AssertableApplicationContext ->
+                AssertionsForInterfaceTypes.assertThat(context)
+                    .hasBean("example.order.SnapshotQueryService")
+            }
+    }
+}

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/query/QueryAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/query/QueryAutoConfigurationTest.kt
@@ -19,7 +19,28 @@ class QueryAutoConfigurationTest {
             .withBean(SnapshotQueryServiceFactory::class.java, { NoOpSnapshotQueryServiceFactory })
             .run { context: AssertableApplicationContext ->
                 AssertionsForInterfaceTypes.assertThat(context)
-                    .hasBean("example.order.SnapshotQueryService")
+                    .hasBean(ExistsBeanName.SNAPSHOT_QUERY_SERVICE)
             }
+    }
+
+    @Test
+    fun contextLoadsWhensExists() {
+        contextRunner
+            .enableWow()
+            .withUserConfiguration(QueryAutoConfiguration::class.java)
+            .withBean(SnapshotQueryServiceFactory::class.java, { NoOpSnapshotQueryServiceFactory })
+            .withBean(ExistsBeanName.SNAPSHOT_QUERY_SERVICE, ExistsBeanName::class.java)
+            .run { context: AssertableApplicationContext ->
+                AssertionsForInterfaceTypes.assertThat(context)
+                    .hasBean("example.order.SnapshotQueryService")
+                    .hasSingleBean(ExistsBeanName::class.java)
+            }
+    }
+}
+
+@Suppress("UtilityClassWithPublicConstructor")
+class ExistsBeanName {
+    companion object {
+        const val SNAPSHOT_QUERY_SERVICE = "example.order.SnapshotQueryService"
     }
 }

--- a/wow-spring/build.gradle.kts
+++ b/wow-spring/build.gradle.kts
@@ -1,4 +1,5 @@
 dependencies {
     api(project(":wow-core"))
+    implementation(project(":wow-query"))
     implementation("org.springframework:spring-context")
 }

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/SnapshotQueryServiceFactoryBean.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/SnapshotQueryServiceFactoryBean.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.spring.query
+
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.query.SnapshotQueryService
+import me.ahoo.wow.query.SnapshotQueryServiceFactory
+import org.springframework.beans.factory.BeanFactory
+import org.springframework.beans.factory.FactoryBean
+import org.springframework.context.ApplicationContext
+import org.springframework.context.ApplicationContextAware
+
+class SnapshotQueryServiceFactoryBean(private val namedAggregate: NamedAggregate) :
+    FactoryBean<Any>,
+    ApplicationContextAware {
+    private lateinit var appContext: BeanFactory
+    override fun setApplicationContext(applicationContext: ApplicationContext) {
+        this.appContext = applicationContext
+    }
+
+    override fun getObject(): Any {
+        val queryServiceFactory: SnapshotQueryServiceFactory =
+            appContext.getBean(SnapshotQueryServiceFactory::class.java)
+        return queryServiceFactory.create<Any>(namedAggregate)
+    }
+
+    override fun getObjectType(): Class<*> {
+        return SnapshotQueryService::class.java
+    }
+}

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/SnapshotQueryServiceRegistrar.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/SnapshotQueryServiceRegistrar.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.spring.query
+
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.configuration.MetadataSearcher
+import me.ahoo.wow.modeling.toStringWithAlias
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.BeanFactory
+import org.springframework.beans.factory.BeanFactoryAware
+import org.springframework.beans.factory.support.BeanDefinitionBuilder
+import org.springframework.beans.factory.support.BeanDefinitionRegistry
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar
+import org.springframework.core.type.AnnotationMetadata
+
+class SnapshotQueryServiceRegistrar : ImportBeanDefinitionRegistrar, BeanFactoryAware {
+    companion object {
+        private val log = LoggerFactory.getLogger(SnapshotQueryServiceRegistrar::class.java)
+    }
+
+    protected lateinit var appContext: BeanFactory
+    override fun setBeanFactory(beanFactory: BeanFactory) {
+        this.appContext = beanFactory
+    }
+
+    override fun registerBeanDefinitions(importingClassMetadata: AnnotationMetadata, registry: BeanDefinitionRegistry) {
+        MetadataSearcher.localAggregates.forEach {
+            registerSnapshotQueryService(it, registry)
+        }
+    }
+
+    private fun registerSnapshotQueryService(
+        namedAggregate: NamedAggregate,
+        registry: BeanDefinitionRegistry
+    ) {
+        val beanName = "${namedAggregate.toStringWithAlias()}.SnapshotQueryService"
+        if (log.isInfoEnabled) {
+            log.info("Register SnapshotQueryService [$beanName].")
+        }
+        if (registry.containsBeanDefinition(beanName)) {
+            if (log.isWarnEnabled) {
+                log.warn(
+                    "SnapshotQueryService [$beanName] already exists - Ignore."
+                )
+            }
+            return
+        }
+        val beanDefinitionBuilder =
+            BeanDefinitionBuilder.genericBeanDefinition(SnapshotQueryServiceFactoryBean::class.java)
+        beanDefinitionBuilder.addConstructorArgValue(namedAggregate)
+        registry.registerBeanDefinition(beanName, beanDefinitionBuilder.beanDefinition)
+    }
+}

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/SnapshotQueryServiceRegistrar.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/SnapshotQueryServiceRegistrar.kt
@@ -29,7 +29,7 @@ class SnapshotQueryServiceRegistrar : ImportBeanDefinitionRegistrar, BeanFactory
         private val log = LoggerFactory.getLogger(SnapshotQueryServiceRegistrar::class.java)
     }
 
-    protected lateinit var appContext: BeanFactory
+    private lateinit var appContext: BeanFactory
     override fun setBeanFactory(beanFactory: BeanFactory) {
         this.appContext = beanFactory
     }

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/SnapshotQueryServiceRegistrar.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/SnapshotQueryServiceRegistrar.kt
@@ -50,9 +50,7 @@ class SnapshotQueryServiceRegistrar : ImportBeanDefinitionRegistrar, BeanFactory
         }
         if (registry.containsBeanDefinition(beanName)) {
             if (log.isWarnEnabled) {
-                log.warn(
-                    "SnapshotQueryService [$beanName] already exists - Ignore."
-                )
+                log.warn("SnapshotQueryService [$beanName] already exists - Ignore.")
             }
             return
         }


### PR DESCRIPTION
```kotlin
@RestController
@RequestMapping("/order")
class OrderQueryController(
    @Qualifier("example.order.SnapshotQueryService")
    private val queryService: SnapshotQueryService<OrderState>
) {
    @GetMapping("{tenantId}/{orderId}")
    fun getById(@PathVariable tenantId: String, @PathVariable orderId: String): Mono<OrderState> {
        return condition {
            tenantId(tenantId)
            id(orderId)
        }.single(queryService).toState().throwNotFoundIfEmpty()
    }
}
```