### PR TITLE
refactor: Replace dots in header names with underscores for `MessagePropagator`

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandOperator.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandOperator.kt
@@ -16,7 +16,7 @@ package me.ahoo.wow.command
 import me.ahoo.wow.api.messaging.Header
 
 object CommandOperator {
-    private const val OPERATOR_HEADER = "command.operator"
+    private const val OPERATOR_HEADER = "command_operator"
     val Header.operator: String?
         get() {
             return this[OPERATOR_HEADER]

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWaitNotifier.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWaitNotifier.kt
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
 import reactor.core.scheduler.Schedulers
 
-const val COMMAND_WAIT_PREFIX = "command.wait."
+const val COMMAND_WAIT_PREFIX = "command_wait_"
 const val COMMAND_WAIT_ENDPOINT = "${COMMAND_WAIT_PREFIX}endpoint"
 const val COMMAND_WAIT_STAGE = "${COMMAND_WAIT_PREFIX}stage"
 const val COMMAND_WAIT_CONTEXT = "${COMMAND_WAIT_PREFIX}context"

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/LocalFirstMessageBus.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/LocalFirstMessageBus.kt
@@ -24,7 +24,7 @@ import org.slf4j.LoggerFactory
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
-const val LOCAL_FIRST_HEADER = "local.first"
+const val LOCAL_FIRST_HEADER = "local_first"
 
 fun Header.withLocalFirst(localFirst: Boolean = true): Header {
     return with(LOCAL_FIRST_HEADER, localFirst.toString())

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/TraceMessagePropagator.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/TraceMessagePropagator.kt
@@ -20,9 +20,9 @@ import me.ahoo.wow.api.naming.Named
 
 class TraceMessagePropagator : MessagePropagator {
     companion object {
-        private const val TRACE_ID = "trace.id"
-        private const val UPSTREAM_ID = "upstream.id"
-        private const val UPSTREAM_NAME = "upstream.name"
+        private const val TRACE_ID = "trace_id"
+        private const val UPSTREAM_ID = "upstream_id"
+        private const val UPSTREAM_NAME = "upstream_name"
 
         val Header.traceId: String?
             get() {


### PR DESCRIPTION
- `command.wait.*` -> `command_wait_*`
- `command.operator` -> `command_operator`
- `trace.id` -> `trace_id`
- `upstream.id` -> `upstream_id`
- `upstream.name` -> `upstream_name`

In order to better adapt to the queries of MongoDB / Elasticsearch