### PR TITLE
feat(event-store): add load event stream by event time functionality

### DIFF
--- a/test/wow-mock/src/main/kotlin/me/ahoo/wow/eventsourcing/mock/DelayEventStore.kt
+++ b/test/wow-mock/src/main/kotlin/me/ahoo/wow/eventsourcing/mock/DelayEventStore.kt
@@ -34,4 +34,8 @@ class DelayEventStore(
     override fun load(aggregateId: AggregateId, headVersion: Int, tailVersion: Int): Flux<DomainEventStream> {
         return delegate.load(aggregateId, headVersion, tailVersion).delaySubscription(delaySupplier())
     }
+
+    override fun load(aggregateId: AggregateId, headEventTime: Long, tailEventTime: Long): Flux<DomainEventStream> {
+        return delegate.load(aggregateId, headEventTime, tailEventTime).delaySubscription(delaySupplier())
+    }
 }

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/eventsourcing/EventStoreSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/eventsourcing/EventStoreSpec.kt
@@ -263,6 +263,24 @@ abstract class EventStoreSpec {
     }
 
     @Test
+    open fun loadEventStreamByEventTime() {
+        val eventStore = createEventStore().metrizable()
+        val eventStream = generateEventStream()
+        eventStore.append(eventStream)
+            .test()
+            .verifyComplete()
+        eventStore.load(eventStream.aggregateId, 0, eventStream.createTime)
+            .test()
+            .expectNextMatches { actualStream: DomainEventStream ->
+                assertThat(actualStream.aggregateId, equalTo(eventStream.aggregateId))
+                assertThat(actualStream.version, equalTo(1))
+                assertThat(actualStream.size, equalTo(10))
+                true
+            }
+            .verifyComplete()
+    }
+
+    @Test
     open fun loadEventStreamGivenWrongVersion() {
         val eventStore = createEventStore().metrizable()
         val eventStream = generateEventStream()

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/AbstractEventStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/AbstractEventStore.kt
@@ -61,14 +61,31 @@ abstract class AbstractEventStore : EventStore {
             "$aggregateId headVersion[$headVersion] must be greater than -1!"
         }
         require(tailVersion >= headVersion) {
-            "$aggregateId headVersion[$headVersion] must be greater than or equal to 0!"
+            "$aggregateId headEventTime[$tailVersion] must be greater than or equal to headEventTime[$headVersion]!"
         }
         return loadStream(aggregateId, headVersion, tailVersion)
+    }
+
+    override fun load(
+        aggregateId: AggregateId,
+        headEventTime: Long,
+        tailEventTime: Long
+    ): Flux<DomainEventStream> {
+        require(tailEventTime >= headEventTime) {
+            "$aggregateId headEventTime[$headEventTime] must be greater than or equal to headEventTime[$headEventTime]!"
+        }
+        return loadStream(aggregateId, headEventTime, tailEventTime)
     }
 
     protected abstract fun loadStream(
         aggregateId: AggregateId,
         headVersion: Int,
         tailVersion: Int
+    ): Flux<DomainEventStream>
+
+    protected abstract fun loadStream(
+        aggregateId: AggregateId,
+        headEventTime: Long,
+        tailEventTime: Long
     ): Flux<DomainEventStream>
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt
@@ -36,7 +36,7 @@ interface EventStore {
     fun append(eventStream: DomainEventStream): Mono<Void>
 
     /**
-     * 根据聚合ID加载事件流.
+     * 根据聚合ID和事件版本号加载事件流.
      * ``` kotlin
      *  val offset=headVersion-1;
      *  val limit=tailVersion-headVersion+1;
@@ -53,6 +53,11 @@ interface EventStore {
         headVersion: Int = DEFAULT_HEAD_VERSION,
         tailVersion: Int = Int.MAX_VALUE
     ): Flux<DomainEventStream>
+
+    /**
+     * 根据聚合ID和事件发生时间戳加载事件流.
+     */
+    fun load(aggregateId: AggregateId, headEventTime: Long, tailEventTime: Long): Flux<DomainEventStream>
 
     companion object {
         const val DEFAULT_HEAD_VERSION: Int = 1

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/InMemoryEventStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/InMemoryEventStore.kt
@@ -71,4 +71,18 @@ class InMemoryEventStore : AbstractEventStore() {
                 .toFlux()
         }
     }
+
+    public override fun loadStream(
+        aggregateId: AggregateId,
+        headEventTime: Long,
+        tailEventTime: Long
+    ): Flux<DomainEventStream> {
+        return Flux.defer {
+            val eventsOfAgg: CopyOnWriteArrayList<DomainEventStream> = events[aggregateId] ?: return@defer Flux.empty()
+            eventsOfAgg
+                .filter { it.createTime in headEventTime..tailEventTime }
+                .map { it.copy() }
+                .toFlux()
+        }
+    }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricEventStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricEventStore.kt
@@ -36,4 +36,12 @@ class MetricEventStore(delegate: EventStore) : EventStore, AbstractMetricDecorat
             .tag(Metrics.AGGREGATE_KEY, aggregateId.aggregateName)
             .metrics()
     }
+
+    override fun load(aggregateId: AggregateId, headEventTime: Long, tailEventTime: Long): Flux<DomainEventStream> {
+        return delegate.load(aggregateId, headEventTime, tailEventTime)
+            .name(Wow.WOW_PREFIX + "eventstore.load")
+            .tagSource()
+            .tag(Metrics.AGGREGATE_KEY, aggregateId.aggregateName)
+            .metrics()
+    }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/modeling/command/MockDelayEventStoreCommandDispatcherTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/modeling/command/MockDelayEventStoreCommandDispatcherTest.kt
@@ -36,4 +36,8 @@ internal class MockDelayEventStoreCommandDispatcherTest : CommandDispatcherSpec(
     override fun load(aggregateId: AggregateId, headVersion: Int, tailVersion: Int): Flux<DomainEventStream> {
         return delegate.load(aggregateId, headVersion, tailVersion).delaySubscription(delayDuration)
     }
+
+    override fun load(aggregateId: AggregateId, headEventTime: Long, tailEventTime: Long): Flux<DomainEventStream> {
+        return delegate.load(aggregateId, headEventTime, tailEventTime).delaySubscription(delayDuration)
+    }
 }

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoEventStore.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoEventStore.kt
@@ -91,7 +91,8 @@ class MongoEventStore(private val database: MongoDatabase) : AbstractEventStore(
 
     override fun loadStream(aggregateId: AggregateId, headVersion: Int, tailVersion: Int): Flux<DomainEventStream> {
         return findStream(
-            aggregateId = aggregateId, filter = Filters.and(
+            aggregateId = aggregateId,
+            filter = Filters.and(
                 Filters.eq(MessageRecords.AGGREGATE_ID, aggregateId.id),
                 Filters.gte(MessageRecords.VERSION, headVersion),
                 Filters.lte(MessageRecords.VERSION, tailVersion),
@@ -105,7 +106,8 @@ class MongoEventStore(private val database: MongoDatabase) : AbstractEventStore(
         tailEventTime: Long
     ): Flux<DomainEventStream> {
         return findStream(
-            aggregateId = aggregateId, filter = Filters.and(
+            aggregateId = aggregateId,
+            filter = Filters.and(
                 Filters.eq(MessageRecords.AGGREGATE_ID, aggregateId.id),
                 Filters.gte(MessageRecords.CREATE_TIME, headEventTime),
                 Filters.lte(MessageRecords.CREATE_TIME, tailEventTime),

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoEventStore.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoEventStore.kt
@@ -31,6 +31,7 @@ import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.serialization.toJsonString
 import me.ahoo.wow.serialization.toObject
 import org.bson.Document
+import org.bson.conversions.Bson
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toFlux
@@ -74,26 +75,41 @@ class MongoEventStore(private val database: MongoDatabase) : AbstractEventStore(
             }.then()
     }
 
-    override fun loadStream(aggregateId: AggregateId, headVersion: Int, tailVersion: Int): Flux<DomainEventStream> {
+    private fun findStream(aggregateId: AggregateId, filter: Bson): Flux<DomainEventStream> {
         val eventStreamCollectionName = aggregateId.toEventStreamCollectionName()
-        val limit = tailVersion - headVersion + 1
         return database.getCollection(eventStreamCollectionName)
-            .find(
-                Filters.and(
-                    Filters.eq(MessageRecords.AGGREGATE_ID, aggregateId.id),
-                    Filters.gte(MessageRecords.VERSION, headVersion),
-                    Filters.lte(MessageRecords.VERSION, tailVersion),
-                ),
-            )
-            .limit(limit)
+            .find(filter)
             .toFlux()
             .map {
                 val domainEventStream = it.replacePrimaryKeyToId().toJson().toObject<DomainEventStream>()
                 require(domainEventStream.aggregateId == aggregateId) {
                     "aggregateId is not match! aggregateId: $aggregateId, domainEventStream: ${domainEventStream.aggregateId}"
                 }
-
                 domainEventStream
             }
+    }
+
+    override fun loadStream(aggregateId: AggregateId, headVersion: Int, tailVersion: Int): Flux<DomainEventStream> {
+        return findStream(
+            aggregateId = aggregateId, filter = Filters.and(
+                Filters.eq(MessageRecords.AGGREGATE_ID, aggregateId.id),
+                Filters.gte(MessageRecords.VERSION, headVersion),
+                Filters.lte(MessageRecords.VERSION, tailVersion),
+            )
+        )
+    }
+
+    override fun loadStream(
+        aggregateId: AggregateId,
+        headEventTime: Long,
+        tailEventTime: Long
+    ): Flux<DomainEventStream> {
+        return findStream(
+            aggregateId = aggregateId, filter = Filters.and(
+                Filters.eq(MessageRecords.AGGREGATE_ID, aggregateId.id),
+                Filters.gte(MessageRecords.CREATE_TIME, headEventTime),
+                Filters.lte(MessageRecords.CREATE_TIME, tailEventTime),
+            )
+        )
     }
 }

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/eventsourcing/TracingEventStore.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/eventsourcing/TracingEventStore.kt
@@ -39,4 +39,12 @@ class TracingEventStore(override val delegate: EventStore) : EventStore, Decorat
             TraceFlux(parentContext, EventStoreInstrumenter.LOAD_INSTRUMENTER, aggregateId, source)
         }
     }
+
+    override fun load(aggregateId: AggregateId, headEventTime: Long, tailEventTime: Long): Flux<DomainEventStream> {
+        return Flux.defer {
+            val parentContext = Context.current()
+            val source = delegate.load(aggregateId, headEventTime, tailEventTime)
+            TraceFlux(parentContext, EventStoreInstrumenter.LOAD_INSTRUMENTER, aggregateId, source)
+        }
+    }
 }

--- a/wow-r2dbc/src/main/kotlin/me/ahoo/wow/r2dbc/R2dbcEventStore.kt
+++ b/wow-r2dbc/src/main/kotlin/me/ahoo/wow/r2dbc/R2dbcEventStore.kt
@@ -142,5 +142,4 @@ class R2dbcEventStore(
                 .bind(2, tailEventTime)
         }
     }
-
 }

--- a/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStore.kt
+++ b/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStore.kt
@@ -72,4 +72,12 @@ class RedisEventStore(
                 it.toObject<DomainEventStream>()
             }
     }
+
+    override fun loadStream(
+        aggregateId: AggregateId,
+        headEventTime: Long,
+        tailEventTime: Long
+    ): Flux<DomainEventStream> {
+        throw UnsupportedOperationException()
+    }
 }

--- a/wow-redis/src/test/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStoreTest.kt
+++ b/wow-redis/src/test/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStoreTest.kt
@@ -36,4 +36,6 @@ class RedisEventStoreTest : EventStoreSpec() {
     override fun createEventStore(): EventStore {
         return RedisEventStore(redisInitializer.redisTemplate)
     }
+
+    override fun loadEventStreamByEventTime() = Unit
 }


### PR DESCRIPTION

- Implement loadStream method for retrieving events by event time range
- Add support for event time-based loading in Elasticsearch, R2DBC, MongoDB, and Redis event stores
- Update test cases to cover new functionality