### PR TITLE
feat(api): support multiple PathVariable and HeaderVariable annotations

### DIFF
--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/CommandRoute.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/CommandRoute.kt
@@ -38,6 +38,7 @@ annotation class CommandRoute(
         AnnotationTarget.PROPERTY_GETTER,
         AnnotationTarget.ANNOTATION_CLASS
     )
+    @Repeatable
     @Inherited
     annotation class PathVariable(
         val name: String = "",
@@ -51,6 +52,7 @@ annotation class CommandRoute(
         AnnotationTarget.PROPERTY_GETTER,
         AnnotationTarget.ANNOTATION_CLASS
     )
+    @Repeatable
     @Inherited
     annotation class HeaderVariable(
         val name: String = "",

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/route/CommandRouteMetadataParser.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/route/CommandRouteMetadataParser.kt
@@ -30,6 +30,7 @@ import me.ahoo.wow.serialization.toJsonString
 import org.slf4j.LoggerFactory
 import org.springframework.web.util.UriTemplate
 import kotlin.reflect.KProperty1
+import kotlin.reflect.full.findAnnotations
 
 object CommandRouteMetadataParser : CacheableMetadataParser() {
     override fun <TYPE : Any, M : Metadata> parseToMetadata(type: Class<TYPE>): M {
@@ -72,11 +73,11 @@ internal class CommandRouteMetadataVisitor<C : Any>(private val commandType: Cla
     }
 
     override fun visitProperty(property: KProperty1<C, *>) {
-        property.scanAnnotation<CommandRoute.PathVariable>()?.let {
+        property.findAnnotations<CommandRoute.PathVariable>().forEach {
             val variableMetadata = property.toVariableMetadata(it.name, it.nestedPath, it.required)
             pathVariables.add(variableMetadata)
         }
-        property.scanAnnotation<CommandRoute.HeaderVariable>()?.let {
+        property.findAnnotations<CommandRoute.HeaderVariable>().forEach {
             val variableMetadata = property.toVariableMetadata(it.name, it.nestedPath, it.required)
             headerVariables.add(variableMetadata)
         }

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/route/CommandRouteMetadataParserTest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/route/CommandRouteMetadataParserTest.kt
@@ -96,7 +96,7 @@ class CommandRouteMetadataParserTest {
     @Test
     fun decodeNested() {
         val commandRouteMetadata = commandRouteMetadata<NestedMockCommandRoute>()
-        assertThat(commandRouteMetadata.path, equalTo("{customerId}/{id}"))
+        assertThat(commandRouteMetadata.path, equalTo("{customerId}/{id}/{name}"))
         val customerIdPathVariable =
             commandRouteMetadata.pathVariableMetadata.first { it.variableName == "customerId" }
         assertThat(customerIdPathVariable.fieldName, equalTo("id"))
@@ -108,6 +108,7 @@ class CommandRouteMetadataParserTest {
                 mapOf(
                     "id" to "id",
                     "customerId" to "customerId",
+                    "name" to "name",
                 )[it]
             },
             {
@@ -116,6 +117,7 @@ class CommandRouteMetadataParserTest {
         )
         assertThat(command.id, equalTo("id"))
         assertThat(command.customer.id, equalTo("customerId"))
+        assertThat(command.customer.name, equalTo("name"))
     }
 }
 
@@ -130,12 +132,13 @@ data class MockCommandRoute(
     val header: String = "header",
 )
 
-@CommandRoute("{customerId}/{id}")
+@CommandRoute("{customerId}/{id}/{name}")
 data class NestedMockCommandRoute(
     @CommandRoute.PathVariable
     val id: String,
     @CommandRoute.PathVariable(name = "customerId", nestedPath = ["id"])
+    @CommandRoute.PathVariable(name = "name", nestedPath = ["name"])
     val customer: Customer
 ) {
-    data class Customer(val id: String)
+    data class Customer(val id: String, val name: String)
 }


### PR DESCRIPTION
- Add `@Repeatable` annotation to PathVariable and HeaderVariable
- Update CommandRouteMetadataParser to handle multiple annotations
- Add test case for nested PathVariable with multiple fields
