### PR TITLE
refactor(wow-openapi): improve schema name handling and add aggregate naming support

### DIFF
--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/schema/AggregateIdSchema.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/schema/AggregateIdSchema.kt
@@ -29,7 +29,7 @@ import me.ahoo.wow.serialization.MessageRecords
  */
 object AggregateIdSchema {
 
-    val SCHEMA_NAME = requireNotNull(AggregateId::class.java.toSchemaName())
+    val SCHEMA_NAME = AggregateId::class.java.toSchemaName()
     val REF_SCHEMA_NAME = SCHEMA_NAME.toRefSchema()
     val SCHEMA = Schema<AggregateId>()
 


### PR DESCRIPTION
- Remove unnecessary non-null assertions for schema names
- Add support for naming schemas based on named aggregates
- Use simple class name as fallback schema name
- Refactor schema name generation logic for better readability and performance
