### PR TITLE
refactor(core): introduce createAsMono method in StateAggregateFactory

### DIFF
--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/DefaultAggregateVerifier.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/DefaultAggregateVerifier.kt
@@ -104,10 +104,10 @@ internal class DefaultWhenStage<C : Any, S : Any>(
         )
         serverCommandExchange.setServiceProvider(serviceProvider)
         val commandAggregateId = commandMessage.aggregateId
-        val expectedResultMono = stateAggregateFactory.create(
+        val expectedResultMono = stateAggregateFactory.createAsMono(
             metadata.state,
             commandAggregateId,
-        ).toMono().map {
+        ).map {
             try {
                 commandMessage.body.validate()
             } catch (throwable: Throwable) {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStoreStateAggregateRepository.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStoreStateAggregateRepository.kt
@@ -40,12 +40,13 @@ class EventStoreStateAggregateRepository(
         metadata: StateAggregateMetadata<S>,
         loadEventStream: (StateAggregate<S>) -> Flux<DomainEventStream>
     ): Mono<StateAggregate<S>> {
-        val stateAggregate = stateAggregateFactory.create(metadata, aggregateId)
-        return loadEventStream(stateAggregate)
-            .map {
-                stateAggregate.onSourcing(it)
-            }
-            .then(Mono.just(stateAggregate))
+        return stateAggregateFactory.createAsMono(metadata, aggregateId).flatMap { stateAggregate ->
+            loadEventStream(stateAggregate)
+                .map {
+                    stateAggregate.onSourcing(it)
+                }
+                .then(Mono.just(stateAggregate))
+        }
     }
 
     override fun <S : Any> load(

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/RetryableAggregateProcessor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/RetryableAggregateProcessor.kt
@@ -58,9 +58,7 @@ class RetryableAggregateProcessor<C : Any, S : Any>(
 
     override fun process(exchange: ServerCommandExchange<*>): Mono<DomainEventStream> {
         val stateAggregateMono = if (exchange.message.isCreate) {
-            Mono.fromCallable {
-                aggregateFactory.create(aggregateMetadata.state, exchange.message.aggregateId)
-            }
+            aggregateFactory.createAsMono(aggregateMetadata.state, exchange.message.aggregateId)
         } else {
             stateAggregateRepository.load(aggregateId, aggregateMetadata.state)
         }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/state/StateAggregateFactory.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/state/StateAggregateFactory.kt
@@ -22,6 +22,7 @@ import me.ahoo.wow.modeling.matedata.AggregateMetadata
 import me.ahoo.wow.modeling.matedata.StateAggregateMetadata
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import reactor.core.publisher.Mono
 
 /**
  * Aggregate Factory .
@@ -31,6 +32,11 @@ import org.slf4j.LoggerFactory
  */
 interface StateAggregateFactory {
     fun <S : Any> create(metadata: StateAggregateMetadata<S>, aggregateId: AggregateId): StateAggregate<S>
+    fun <S : Any> createAsMono(metadata: StateAggregateMetadata<S>, aggregateId: AggregateId): Mono<StateAggregate<S>> {
+        return Mono.fromCallable {
+            create(metadata, aggregateId)
+        }
+    }
 }
 
 object ConstructorStateAggregateFactory : StateAggregateFactory {


### PR DESCRIPTION
- Add createAsMono method to StateAggregateFactory interface
- Update implementations to use createAsMono instead of create
- Remove unnecessary toMono conversions
- Simplify code in various classes by using the new method
