### PR TITLE
refactor(wow-openapi): replace setDefault with direct assignment to default property

### DIFF
--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/Condition.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/Condition.kt
@@ -16,7 +16,7 @@ package me.ahoo.wow.api.query
 import java.time.ZoneId
 
 data class Condition(
-    val field: String,
+    val field: String = "",
     val operator: Operator,
     val value: Any = EMPTY_VALUE,
     /**

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/GlobalRouteSpecFactory.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/GlobalRouteSpecFactory.kt
@@ -15,6 +15,10 @@ package me.ahoo.wow.openapi
 
 import io.swagger.v3.oas.models.Components
 import me.ahoo.wow.api.naming.NamedBoundedContext
+import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.ListQuery
+import me.ahoo.wow.api.query.PagedQuery
+import me.ahoo.wow.api.query.SingleQuery
 import me.ahoo.wow.openapi.ComponentRef.Companion.createComponents
 import me.ahoo.wow.openapi.HeaderRef.Companion.ERROR_CODE_HEADER
 import me.ahoo.wow.openapi.HeaderRef.Companion.with
@@ -28,6 +32,7 @@ import me.ahoo.wow.openapi.RoutePaths.BATCH_AFTER_ID_PARAMETER
 import me.ahoo.wow.openapi.RoutePaths.BATCH_LIMIT_PARAMETER
 import me.ahoo.wow.openapi.RoutePaths.HEAD_VERSION
 import me.ahoo.wow.openapi.RoutePaths.TAIL_VERSION
+import me.ahoo.wow.openapi.SchemaRef.Companion.toSchemaRef
 import me.ahoo.wow.openapi.SchemaRef.Companion.toSchemas
 import me.ahoo.wow.openapi.event.EventCompensateRouteSpecFactory.Companion.COMPENSATION_TARGET_SCHEMA
 import me.ahoo.wow.openapi.event.LoadEventStreamRouteSpecFactory.Companion.DOMAIN_EVENT_STREAM_ARRAY_RESPONSE
@@ -43,6 +48,10 @@ class DefaultGlobalRouteSpecFactory : GlobalRouteSpecFactory {
         SchemaRef.ERROR_INFO.schemas.mergeSchemas()
         BatchResult::class.java.toSchemas().mergeSchemas()
         COMPENSATION_TARGET_SCHEMA.schemas.mergeSchemas()
+        SingleQuery::class.java.toSchemaRef().schemas.mergeSchemas()
+        PagedQuery::class.java.toSchemaRef().schemas.mergeSchemas()
+        ListQuery::class.java.toSchemaRef().schemas.mergeSchemas()
+        Condition::class.java.toSchemaRef().schemas.mergeSchemas()
         components.headers.with(ERROR_CODE_HEADER)
         components.parameters
             .with(HEAD_VERSION)

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/CommandResultConverter.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/CommandResultConverter.kt
@@ -26,7 +26,7 @@ class CommandResultConverter : TargetTypeModifyConverter() {
     override fun modify(resolvedSchema: Schema<*>): Schema<*> {
         val result = checkNotNull(resolvedSchema.properties[CommandResult::result.name])
         result.additionalProperties = null
-        result.setDefault(emptyMap<String, Any>())
+        result.default = emptyMap<String, Any>()
         return resolvedSchema
     }
 }

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/ConditionConverter.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/ConditionConverter.kt
@@ -21,11 +21,11 @@ import me.ahoo.wow.api.query.Operator
 class ConditionConverter : TargetTypeModifyConverter() {
     override val targetType: Class<*> = Condition::class.java
     override fun modify(resolvedSchema: Schema<*>): Schema<*> {
-        resolvedSchema.properties[Condition::field.name]?.setDefault(EMPTY_VALUE)
-        resolvedSchema.properties[Condition::operator.name]?.setDefault(Operator.ALL.name)
-        resolvedSchema.properties[Condition::value.name]?.setDefault(EMPTY_VALUE)
-        resolvedSchema.properties[Condition::children.name]?.setDefault(emptyList<Condition>())
-        resolvedSchema.properties[Condition::options.name]?.setDefault(emptyMap<String, Any>())
+        resolvedSchema.properties[Condition::field.name]?.default = EMPTY_VALUE
+        resolvedSchema.properties[Condition::operator.name]?.default = Operator.ALL.name
+        resolvedSchema.properties[Condition::value.name]?.default = EMPTY_VALUE
+        resolvedSchema.properties[Condition::children.name]?.default = emptyList<Condition>()
+        resolvedSchema.properties[Condition::options.name]?.default = emptyMap<String, Any>()
         return resolvedSchema
     }
 }

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/DomainEventConverter.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/DomainEventConverter.kt
@@ -33,8 +33,8 @@ import me.ahoo.wow.serialization.MessageRecords
 class DomainEventConverter : ModelConverter {
     companion object {
         private val wrapTypes: Set<String> = setOf(
-            DomainEventStream::class.java.toSchemaName()!!,
-            StateEvent::class.java.toSchemaName()!!
+            DomainEventStream::class.java.toSchemaName(),
+            StateEvent::class.java.toSchemaName()
         )
     }
 

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/ListQueryConverter.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/ListQueryConverter.kt
@@ -22,8 +22,8 @@ import me.ahoo.wow.api.query.Sort
 class ListQueryConverter : TargetTypeModifyConverter() {
     override val targetType: Class<*> = ListQuery::class.java
     override fun modify(resolvedSchema: Schema<*>): Schema<*> {
-        resolvedSchema.properties[ListQuery::sort.name]?.setDefault(emptyList<Sort>())
-        resolvedSchema.properties[ListQuery::limit.name]?.setDefault(Pagination.DEFAULT.size)
+        resolvedSchema.properties[ListQuery::sort.name]?.default = emptyList<Sort>()
+        resolvedSchema.properties[ListQuery::limit.name]?.default = Pagination.DEFAULT.size
         resolvedSchema.properties.remove(Projection::isEmpty.name)
         return resolvedSchema
     }

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/PagedQueryConverter.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/PagedQueryConverter.kt
@@ -20,7 +20,7 @@ import me.ahoo.wow.api.query.Sort
 class PagedQueryConverter : TargetTypeModifyConverter() {
     override val targetType: Class<*> = PagedQuery::class.java
     override fun modify(resolvedSchema: Schema<*>): Schema<*> {
-        resolvedSchema.properties[PagedQuery::sort.name]?.setDefault(emptyList<Sort>())
+        resolvedSchema.properties[PagedQuery::sort.name]?.default = emptyList<Sort>()
         return resolvedSchema
     }
 }

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/PaginationConverter.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/PaginationConverter.kt
@@ -19,8 +19,8 @@ import me.ahoo.wow.api.query.Pagination
 class PaginationConverter : TargetTypeModifyConverter() {
     override val targetType: Class<*> = Pagination::class.java
     override fun modify(resolvedSchema: Schema<*>): Schema<*> {
-        resolvedSchema.properties[Pagination::index.name]?.setDefault(Pagination.DEFAULT.index)
-        resolvedSchema.properties[Pagination::size.name]?.setDefault(Pagination.DEFAULT.size)
+        resolvedSchema.properties[Pagination::index.name]?.default = Pagination.DEFAULT.index
+        resolvedSchema.properties[Pagination::size.name]?.default = Pagination.DEFAULT.size
         return resolvedSchema
     }
 }

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/ProjectionConverter.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/ProjectionConverter.kt
@@ -19,9 +19,9 @@ import me.ahoo.wow.api.query.Projection
 class ProjectionConverter : TargetTypeModifyConverter() {
     override val targetType: Class<*> = Projection::class.java
     override fun modify(resolvedSchema: Schema<*>): Schema<*> {
-        resolvedSchema.properties[Projection::include.name]?.setDefault(emptyList<String>())
-        resolvedSchema.properties[Projection::exclude.name]?.setDefault(emptyList<String>())
-        resolvedSchema.properties.remove(Projection::isEmpty.name)
+        resolvedSchema.properties[Projection::include.name]?.default = emptyList<String>()
+        resolvedSchema.properties[Projection::exclude.name]?.default = emptyList<String>()
+        resolvedSchema.properties.remove("empty")
         return resolvedSchema
     }
 }

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/SingleQueryConverter.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/SingleQueryConverter.kt
@@ -20,7 +20,7 @@ import me.ahoo.wow.api.query.Sort
 class SingleQueryConverter : TargetTypeModifyConverter() {
     override val targetType: Class<*> = SingleQuery::class.java
     override fun modify(resolvedSchema: Schema<*>): Schema<*> {
-        resolvedSchema.properties[SingleQuery::sort.name]?.setDefault(emptyList<Sort>())
+        resolvedSchema.properties[SingleQuery::sort.name]?.default = emptyList<Sort>()
         return resolvedSchema
     }
 }

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/event/CountEventStreamRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/event/CountEventStreamRouteSpec.kt
@@ -26,7 +26,6 @@ import me.ahoo.wow.openapi.RequestBodyRef.Companion.toRequestBody
 import me.ahoo.wow.openapi.ResponseRef.Companion.toResponse
 import me.ahoo.wow.openapi.RouteIdSpec
 import me.ahoo.wow.openapi.RouteSpec
-import me.ahoo.wow.openapi.SchemaRef.Companion.toSchemaRef
 
 class CountEventStreamRouteSpec(
     override val currentContext: NamedBoundedContext,
@@ -58,9 +57,6 @@ class CountEventStreamRouteSpec(
 }
 
 class CountEventStreamRouteSpecFactory : AbstractAggregateRouteSpecFactory() {
-    init {
-        Condition::class.java.toSchemaRef().schemas.mergeSchemas()
-    }
 
     override fun create(
         currentContext: NamedBoundedContext,

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/event/ListQueryEventStreamRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/event/ListQueryEventStreamRouteSpec.kt
@@ -25,7 +25,6 @@ import me.ahoo.wow.openapi.RequestBodyRef.Companion.toRequestBody
 import me.ahoo.wow.openapi.ResponseRef.Companion.with
 import me.ahoo.wow.openapi.RouteIdSpec
 import me.ahoo.wow.openapi.RouteSpec
-import me.ahoo.wow.openapi.SchemaRef.Companion.toSchemaRef
 import me.ahoo.wow.openapi.event.LoadEventStreamRouteSpecFactory.Companion.DOMAIN_EVENT_STREAM_ARRAY_RESPONSE
 
 class ListQueryEventStreamRouteSpec(
@@ -55,9 +54,6 @@ class ListQueryEventStreamRouteSpec(
 }
 
 class ListQueryEventStreamRouteSpecFactory : AbstractAggregateRouteSpecFactory() {
-    init {
-        ListQuery::class.java.toSchemaRef().schemas.mergeSchemas()
-    }
 
     override fun create(
         currentContext: NamedBoundedContext,

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/event/PagedQueryEventStreamRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/event/PagedQueryEventStreamRouteSpec.kt
@@ -62,9 +62,6 @@ class PagedQueryEventStreamRouteSpec(
 }
 
 class PagedQueryEventStreamRouteSpecFactory : AbstractAggregateRouteSpecFactory() {
-    init {
-        PagedQuery::class.java.toSchemaRef().schemas.mergeSchemas()
-    }
 
     override fun create(
         currentContext: NamedBoundedContext,

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/snapshot/CountSnapshotRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/snapshot/CountSnapshotRouteSpec.kt
@@ -26,7 +26,6 @@ import me.ahoo.wow.openapi.RequestBodyRef.Companion.toRequestBody
 import me.ahoo.wow.openapi.ResponseRef.Companion.toResponse
 import me.ahoo.wow.openapi.RouteIdSpec
 import me.ahoo.wow.openapi.RouteSpec
-import me.ahoo.wow.openapi.SchemaRef.Companion.toSchemaRef
 
 class CountSnapshotRouteSpec(
     override val currentContext: NamedBoundedContext,
@@ -58,9 +57,6 @@ class CountSnapshotRouteSpec(
 }
 
 class CountSnapshotRouteSpecFactory : AbstractAggregateRouteSpecFactory() {
-    init {
-        Condition::class.java.toSchemaRef().schemas.mergeSchemas()
-    }
 
     override fun create(
         currentContext: NamedBoundedContext,

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/snapshot/ListQuerySnapshotRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/snapshot/ListQuerySnapshotRouteSpec.kt
@@ -63,9 +63,6 @@ class ListQuerySnapshotRouteSpec(
 }
 
 class ListQuerySnapshotRouteSpecFactory : AbstractAggregateRouteSpecFactory() {
-    init {
-        ListQuery::class.java.toSchemaRef().schemas.mergeSchemas()
-    }
 
     override fun create(
         currentContext: NamedBoundedContext,

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/snapshot/ListQuerySnapshotStateRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/snapshot/ListQuerySnapshotStateRouteSpec.kt
@@ -60,9 +60,6 @@ class ListQuerySnapshotStateRouteSpec(
 }
 
 class ListQuerySnapshotStateRouteSpecFactory : AbstractAggregateRouteSpecFactory() {
-    init {
-        ListQuery::class.java.toSchemaRef().schemas.mergeSchemas()
-    }
 
     override fun create(
         currentContext: NamedBoundedContext,

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/snapshot/PagedQuerySnapshotRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/snapshot/PagedQuerySnapshotRouteSpec.kt
@@ -65,9 +65,6 @@ class PagedQuerySnapshotRouteSpec(
 }
 
 class PagedQuerySnapshotRouteSpecFactory : AbstractAggregateRouteSpecFactory() {
-    init {
-        PagedQuery::class.java.toSchemaRef().schemas.mergeSchemas()
-    }
 
     override fun create(
         currentContext: NamedBoundedContext,

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/snapshot/PagedQuerySnapshotStateRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/snapshot/PagedQuerySnapshotStateRouteSpec.kt
@@ -62,9 +62,6 @@ class PagedQuerySnapshotStateRouteSpec(
 }
 
 class PagedQuerySnapshotStateRouteSpecFactory : AbstractAggregateRouteSpecFactory() {
-    init {
-        PagedQuery::class.java.toSchemaRef().schemas.mergeSchemas()
-    }
 
     override fun create(
         currentContext: NamedBoundedContext,

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/snapshot/SingleSnapshotRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/snapshot/SingleSnapshotRouteSpec.kt
@@ -64,10 +64,6 @@ class SingleSnapshotRouteSpec(
 }
 
 class SingleSnapshotRouteSpecFactory : AbstractAggregateRouteSpecFactory() {
-    init {
-        SingleQuery::class.java.toSchemaRef().schemas.mergeSchemas()
-    }
-
     override fun create(
         currentContext: NamedBoundedContext,
         aggregateMetadata: AggregateMetadata<*, *>

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/snapshot/SingleSnapshotStateRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/snapshot/SingleSnapshotStateRouteSpec.kt
@@ -60,9 +60,6 @@ class SingleSnapshotStateRouteSpec(
 }
 
 class SingleSnapshotStateRouteSpecFactory : AbstractAggregateRouteSpecFactory() {
-    init {
-        SingleQuery::class.java.toSchemaRef().schemas.mergeSchemas()
-    }
 
     override fun create(
         currentContext: NamedBoundedContext,


### PR DESCRIPTION

- Update multiple converters to use direct assignment to the 'default' property instead of calling 'setDefault'
- This change simplifies the code and aligns with the OpenAPI library's updated approach

