### PR TITLE
test(wow-spring-boot-starter): add unit tests for PrepareAutoConfiguration and ServerCommandWaitEndpoint

### DIFF
--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/command/ServerCommandWaitEndpointTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/command/ServerCommandWaitEndpointTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.spring.boot.starter.command
+
+import io.mockk.every
+import io.mockk.mockk
+import me.ahoo.cosid.machine.HostAddressSupplier
+import me.ahoo.wow.openapi.command.CommandWaitRouteSpecFactory
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.*
+import org.junit.jupiter.api.Test
+import org.springframework.boot.web.context.WebServerInitializedEvent
+
+class ServerCommandWaitEndpointTest {
+
+    @Test
+    fun endpoint() {
+        val hostAddress = "127.0.0.1"
+        val serverCommandWaitEndpoint = ServerCommandWaitEndpoint(object : HostAddressSupplier {
+            override fun getHostAddress(): String? {
+                return hostAddress
+            }
+        })
+        val event = mockk<WebServerInitializedEvent> {
+            every { webServer.port } returns 8080
+        }
+        serverCommandWaitEndpoint.onApplicationEvent(event)
+        assertThat(
+            serverCommandWaitEndpoint.endpoint,
+            equalTo("http://$hostAddress:8080${CommandWaitRouteSpecFactory.PATH}")
+        )
+    }
+}

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareAutoConfigurationTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.spring.boot.starter.prepare
+
+import me.ahoo.wow.spring.boot.starter.enableWow
+import org.assertj.core.api.AssertionsForInterfaceTypes
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+class PrepareAutoConfigurationTest {
+    private val contextRunner = ApplicationContextRunner()
+
+    @Test
+    fun contextLoads() {
+        contextRunner
+            .enableWow()
+            .withUserConfiguration(PrepareAutoConfiguration::class.java)
+            .run { context: AssertableApplicationContext ->
+                AssertionsForInterfaceTypes.assertThat(context)
+                    .hasSingleBean(PrepareProperties::class.java)
+            }
+    }
+}


### PR DESCRIPTION

- Add PrepareAutoConfigurationTest to verify the loading of PrepareProperties bean
- Add ServerCommandWaitEndpointTest to test the endpoint URL construction
