### PR TITLE
feat(core): add support for VoidCommand

### DIFF
--- a/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/ViewCart.kt
+++ b/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/ViewCart.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.example.api.cart
+
+import me.ahoo.wow.api.annotation.VoidCommand
+
+@VoidCommand
+data class ViewCart(val userAgent: String)

--- a/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt
+++ b/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt
@@ -25,11 +25,12 @@ import me.ahoo.wow.example.api.cart.CartQuantityChanged
 import me.ahoo.wow.example.api.cart.ChangeQuantity
 import me.ahoo.wow.example.api.cart.MountedCommand
 import me.ahoo.wow.example.api.cart.RemoveCartItem
+import me.ahoo.wow.example.api.cart.ViewCart
 
 const val MAX_CART_ITEM_SIZE = 100
 
 @StaticTenantId
-@AggregateRoot(commands = [MountedCommand::class])
+@AggregateRoot(commands = [MountedCommand::class, ViewCart::class])
 @Tag(name = "customer")
 class Cart(private val state: CartState) {
 

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/GivenInitializationCommand.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/GivenInitializationCommand.kt
@@ -28,6 +28,7 @@ data class GivenInitializationCommand(
     override val requestId: String = GlobalIdGenerator.generateAsString(),
     override val isCreate: Boolean = true,
     override val allowCreate: Boolean = false,
+    override val isVoid: Boolean = false,
     override val header: Header = DefaultHeader.empty()
 ) : CommandMessage<GivenInitialization>, NamedAggregate by aggregateId {
     override val body: GivenInitialization = GivenInitialization

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/VoidCommand.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/VoidCommand.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.api.annotation
+
+import java.lang.annotation.Inherited
+
+/**
+ * 标记命令为虚空命令（Void Command）。
+ *
+ * 使用需要命令需要将命令通过 [AggregateRoot.commands] 挂载到聚合根。
+ *
+ * 虚空命令的特点是：
+ * - 只需要将命令发送到命令总线（Command Bus），而不需要聚合根（Aggregate Root）进行处理。
+ * - 通常用于那些不需要返回结果或状态更新的命令操作。
+ *
+ * 使用场景：
+ * - 记录用户的查询操作。
+ *
+ * @see AggregateRoot
+ **/
+@Target(AnnotationTarget.CLASS, AnnotationTarget.ANNOTATION_CLASS)
+@Inherited
+@MustBeDocumented
+annotation class VoidCommand

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt
@@ -46,8 +46,17 @@ interface CommandMessage<C : Any> :
 
     /**
      * is the create aggregate command
+     * @see me.ahoo.wow.api.annotation.CreateAggregate
      */
     val isCreate: Boolean
 
+    /**
+     * @see me.ahoo.wow.api.annotation.AllowCreate
+     */
     val allowCreate: Boolean
+
+    /**
+     * @see me.ahoo.wow.api.annotation.VoidCommand
+     */
+    val isVoid: Boolean
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandFactory.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandFactory.kt
@@ -68,6 +68,7 @@ fun <C : Any> C.toCommandMessage(
         name = metadata.name,
         isCreate = metadata.isCreate,
         allowCreate = metadata.allowCreate,
+        isVoid = metadata.isVoid,
     ).ensureTraceId()
 }
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/SimpleCommandMessage.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/SimpleCommandMessage.kt
@@ -31,6 +31,7 @@ data class SimpleCommandMessage<C : Any>(
     override val name: String = body.javaClass.toName(),
     override val isCreate: Boolean = false,
     override val allowCreate: Boolean = false,
+    override val isVoid: Boolean = false,
     override val createTime: Long = System.currentTimeMillis()
 ) : CommandMessage<C>, NamedAggregate by aggregateId {
     override fun copy(): CommandMessage<C> {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/annotation/CommandMetadataParser.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/annotation/CommandMetadataParser.kt
@@ -23,6 +23,7 @@ import me.ahoo.wow.annotation.AnnotationPropertyAccessorParser.toTenantIdGetterI
 import me.ahoo.wow.api.annotation.AllowCreate
 import me.ahoo.wow.api.annotation.CreateAggregate
 import me.ahoo.wow.api.annotation.DEFAULT_AGGREGATE_ID_NAME
+import me.ahoo.wow.api.annotation.VoidCommand
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.command.metadata.CommandMetadata
 import me.ahoo.wow.configuration.MetadataSearcher
@@ -61,7 +62,8 @@ object CommandMetadataParser : CacheableMetadataParser() {
 
 internal class CommandMetadataVisitor<C>(private val commandType: Class<C>) : ClassVisitor<C> {
     private val commandName: String = commandType.toName()
-    private val isCreateAggregate = commandType.isAnnotationPresent(CreateAggregate::class.java)
+    private val isCreate = commandType.isAnnotationPresent(CreateAggregate::class.java)
+    private val isVoid = commandType.isAnnotationPresent(VoidCommand::class.java)
     private var allowCreate: Boolean = commandType.isAnnotationPresent(AllowCreate::class.java)
     private var namedAggregateGetter: NamedAggregateGetter<C>? = null
     private var aggregateNameGetter: PropertyGetter<C, String>? = null
@@ -119,7 +121,7 @@ internal class CommandMetadataVisitor<C>(private val commandType: Class<C>) : Cl
     }
 
     fun toMetadata(): CommandMetadata<C> {
-        if (aggregateIdGetter == null && !isCreateAggregate) {
+        if (aggregateIdGetter == null && !isCreate) {
             if (LOG.isWarnEnabled) {
                 LOG.warn(
                     "Command[$commandType] does not define an aggregate ID field and is not a create aggregate command.",
@@ -138,11 +140,12 @@ internal class CommandMetadataVisitor<C>(private val commandType: Class<C>) : Cl
             commandType = commandType,
             namedAggregateGetter = namedAggregateGetter,
             name = commandName,
-            isCreate = isCreateAggregate,
+            isCreate = isCreate,
             allowCreate = allowCreate,
+            isVoid = isVoid,
             aggregateIdGetter = aggregateIdGetter,
             aggregateVersionGetter = aggregateVersionGetter,
-            tenantIdGetter = tenantIdGetter,
+            tenantIdGetter = tenantIdGetter
         )
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/metadata/CommandMetadata.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/metadata/CommandMetadata.kt
@@ -30,6 +30,7 @@ data class CommandMetadata<C>(
     override val name: String,
     val isCreate: Boolean,
     val allowCreate: Boolean,
+    val isVoid: Boolean,
     /**
      * Aggregate ID can be null if it is a create aggregate command.
      */

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/CommandDispatcher.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/CommandDispatcher.kt
@@ -48,6 +48,7 @@ class CommandDispatcher(
     override fun receiveMessage(namedAggregate: NamedAggregate): Flux<ServerCommandExchange<*>> {
         return commandBus
             .receive(setOf(namedAggregate))
+            .filter { !it.message.isVoid }
             .writeReceiverGroup(name)
             .writeMetricsSubscriber(name)
     }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt
@@ -78,11 +78,7 @@ class StatelessSagaFunction(
             singleResult.header.inject(domainEvent)
             return singleResult.toMono()
         }
-        val commandBuilder = if (singleResult is CommandBuilder) {
-            singleResult
-        } else {
-            singleResult.commandBuilder()
-        }
+        val commandBuilder = singleResult as? CommandBuilder ?: singleResult.commandBuilder()
         commandBuilder
             .requestIfIfAbsent("${domainEvent.id}-$index")
             .tenantIdIfAbsent(domainEvent.aggregateId.tenantId)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/serialization/command/CommandJsonSerializer.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/serialization/command/CommandJsonSerializer.kt
@@ -28,6 +28,7 @@ import me.ahoo.wow.serialization.MessageSerializer
 import me.ahoo.wow.serialization.command.CommandRecords.AGGREGATE_VERSION
 import me.ahoo.wow.serialization.command.CommandRecords.ALLOW_CREATE
 import me.ahoo.wow.serialization.command.CommandRecords.IS_CREATE
+import me.ahoo.wow.serialization.command.CommandRecords.IS_VOID
 import me.ahoo.wow.serialization.toObject
 
 object CommandJsonSerializer : MessageSerializer<CommandMessage<*>>(CommandMessage::class.java) {
@@ -40,6 +41,7 @@ object CommandJsonSerializer : MessageSerializer<CommandMessage<*>>(CommandMessa
             generator.writeNumberField(AGGREGATE_VERSION, it)
         }
         generator.writeBooleanField(IS_CREATE, value.isCreate)
+        generator.writeBooleanField(IS_VOID, value.isVoid)
         generator.writeBooleanField(ALLOW_CREATE, value.allowCreate)
     }
 }
@@ -65,6 +67,7 @@ object CommandJsonDeserializer : StdDeserializer<CommandMessage<*>>(CommandMessa
             name = commandRecord.name,
             isCreate = commandRecord.isCreate,
             allowCreate = commandRecord.allowCreate,
+            isVoid = commandRecord.isVoid,
             createTime = commandRecord.createTime,
         )
     }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/serialization/command/CommandRecord.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/serialization/command/CommandRecord.kt
@@ -24,6 +24,7 @@ import me.ahoo.wow.serialization.NamedBoundedContextMessageRecord
 object CommandRecords {
     const val AGGREGATE_VERSION = "aggregateVersion"
     const val IS_CREATE = "isCreate"
+    const val IS_VOID = "isVoid"
     const val ALLOW_CREATE = "allowCreate"
 }
 
@@ -39,7 +40,9 @@ interface CommandRecord :
     val isCreate: Boolean
         get() = actual[CommandRecords.IS_CREATE].asBoolean()
     val allowCreate: Boolean
-        get() = actual.get(CommandRecords.ALLOW_CREATE)?.asBoolean() ?: false
+        get() = actual.get(CommandRecords.ALLOW_CREATE)?.asBoolean() == true
+    val isVoid: Boolean
+        get() = actual.get(CommandRecords.IS_VOID)?.asBoolean() == true
 }
 
 class DelegatingCommandRecord(override val actual: ObjectNode) : CommandRecord


### PR DESCRIPTION
- Implement VoidCommand annotation to mark commands that don't require aggregate processing
- Add isVoid property to CommandMetadata and CommandMessage
- Update CommandDispatcher to filter out void commands
- Serialize and deserialize isVoid flag in CommandRecord

