### PR TITLE
feat(openapi): add converters for various types to handle additional properties

### DIFF
--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/BoundedContextConverter.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/BoundedContextConverter.kt
@@ -14,21 +14,19 @@
 package me.ahoo.wow.openapi.converter
 
 import io.swagger.v3.oas.models.media.Schema
-import me.ahoo.wow.api.query.Condition
-import me.ahoo.wow.api.query.Condition.Companion.EMPTY_VALUE
-import me.ahoo.wow.api.query.Operator
+import me.ahoo.wow.configuration.BoundedContext
 
-class ConditionConverter : TargetTypeModifyConverter() {
-    override val targetType: Class<*> = Condition::class.java
+/**
+ * BoundedContext Converter
+ */
+class BoundedContextConverter : TargetTypeModifyConverter() {
+
+    override val targetType: Class<*> = BoundedContext::class.java
+
     override fun modify(resolvedSchema: Schema<*>): Schema<*> {
-        resolvedSchema.properties[Condition::field.name]?.default = EMPTY_VALUE
-        resolvedSchema.properties[Condition::operator.name]?.default = Operator.ALL.name
-        resolvedSchema.properties[Condition::value.name]?.default = EMPTY_VALUE
-        resolvedSchema.properties[Condition::children.name]?.default = emptyList<Condition>()
-        resolvedSchema.properties[Condition::options.name]?.let {
-            it.default = emptyMap<String, Any>()
-            it.additionalProperties(true)
-        }
+        val result = checkNotNull(resolvedSchema.properties[BoundedContext::aggregates.name])
+        result.additionalProperties = true
+        result.default = emptyMap<String, Any>()
         return resolvedSchema
     }
 }

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/CommandResultConverter.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/CommandResultConverter.kt
@@ -15,6 +15,7 @@ package me.ahoo.wow.openapi.converter
 
 import io.swagger.v3.oas.models.media.Schema
 import me.ahoo.wow.command.CommandResult
+import me.ahoo.wow.command.CommandResultCapable
 
 /**
  * CommandResult Converter
@@ -24,8 +25,8 @@ class CommandResultConverter : TargetTypeModifyConverter() {
     override val targetType: Class<*> = CommandResult::class.java
 
     override fun modify(resolvedSchema: Schema<*>): Schema<*> {
-        val result = checkNotNull(resolvedSchema.properties[CommandResult::result.name])
-        result.additionalProperties = null
+        val result = checkNotNull(resolvedSchema.properties[CommandResultCapable::result.name])
+        result.additionalProperties = true
         result.default = emptyMap<String, Any>()
         return resolvedSchema
     }

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/MessageHeaderConverter.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/MessageHeaderConverter.kt
@@ -14,21 +14,17 @@
 package me.ahoo.wow.openapi.converter
 
 import io.swagger.v3.oas.models.media.Schema
-import me.ahoo.wow.api.query.Condition
-import me.ahoo.wow.api.query.Condition.Companion.EMPTY_VALUE
-import me.ahoo.wow.api.query.Operator
+import me.ahoo.wow.api.messaging.Header
 
-class ConditionConverter : TargetTypeModifyConverter() {
-    override val targetType: Class<*> = Condition::class.java
+/**
+ * Header Converter
+ */
+class MessageHeaderConverter : TargetTypeModifyConverter() {
+
+    override val targetType: Class<*> = Header::class.java
+
     override fun modify(resolvedSchema: Schema<*>): Schema<*> {
-        resolvedSchema.properties[Condition::field.name]?.default = EMPTY_VALUE
-        resolvedSchema.properties[Condition::operator.name]?.default = Operator.ALL.name
-        resolvedSchema.properties[Condition::value.name]?.default = EMPTY_VALUE
-        resolvedSchema.properties[Condition::children.name]?.default = emptyList<Condition>()
-        resolvedSchema.properties[Condition::options.name]?.let {
-            it.default = emptyMap<String, Any>()
-            it.additionalProperties(true)
-        }
+        resolvedSchema.additionalProperties = true
         return resolvedSchema
     }
 }

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/WaitSignalConverter.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/WaitSignalConverter.kt
@@ -14,21 +14,20 @@
 package me.ahoo.wow.openapi.converter
 
 import io.swagger.v3.oas.models.media.Schema
-import me.ahoo.wow.api.query.Condition
-import me.ahoo.wow.api.query.Condition.Companion.EMPTY_VALUE
-import me.ahoo.wow.api.query.Operator
+import me.ahoo.wow.command.CommandResultCapable
+import me.ahoo.wow.command.wait.WaitSignal
 
-class ConditionConverter : TargetTypeModifyConverter() {
-    override val targetType: Class<*> = Condition::class.java
+/**
+ * WaitSignal Converter
+ */
+class WaitSignalConverter : TargetTypeModifyConverter() {
+
+    override val targetType: Class<*> = WaitSignal::class.java
+
     override fun modify(resolvedSchema: Schema<*>): Schema<*> {
-        resolvedSchema.properties[Condition::field.name]?.default = EMPTY_VALUE
-        resolvedSchema.properties[Condition::operator.name]?.default = Operator.ALL.name
-        resolvedSchema.properties[Condition::value.name]?.default = EMPTY_VALUE
-        resolvedSchema.properties[Condition::children.name]?.default = emptyList<Condition>()
-        resolvedSchema.properties[Condition::options.name]?.let {
-            it.default = emptyMap<String, Any>()
-            it.additionalProperties(true)
-        }
+        val result = checkNotNull(resolvedSchema.properties[CommandResultCapable::result.name])
+        result.additionalProperties = true
+        result.default = emptyMap<String, Any>()
         return resolvedSchema
     }
 }

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/WowMetadataConverter.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/WowMetadataConverter.kt
@@ -14,21 +14,19 @@
 package me.ahoo.wow.openapi.converter
 
 import io.swagger.v3.oas.models.media.Schema
-import me.ahoo.wow.api.query.Condition
-import me.ahoo.wow.api.query.Condition.Companion.EMPTY_VALUE
-import me.ahoo.wow.api.query.Operator
+import me.ahoo.wow.configuration.WowMetadata
 
-class ConditionConverter : TargetTypeModifyConverter() {
-    override val targetType: Class<*> = Condition::class.java
+/**
+ * WowMetadata Converter
+ */
+class WowMetadataConverter : TargetTypeModifyConverter() {
+
+    override val targetType: Class<*> = WowMetadata::class.java
+
     override fun modify(resolvedSchema: Schema<*>): Schema<*> {
-        resolvedSchema.properties[Condition::field.name]?.default = EMPTY_VALUE
-        resolvedSchema.properties[Condition::operator.name]?.default = Operator.ALL.name
-        resolvedSchema.properties[Condition::value.name]?.default = EMPTY_VALUE
-        resolvedSchema.properties[Condition::children.name]?.default = emptyList<Condition>()
-        resolvedSchema.properties[Condition::options.name]?.let {
-            it.default = emptyMap<String, Any>()
-            it.additionalProperties(true)
-        }
+        val result = checkNotNull(resolvedSchema.properties[WowMetadata::contexts.name])
+        result.additionalProperties = true
+        result.default = emptyMap<String, Any>()
         return resolvedSchema
     }
 }

--- a/wow-openapi/src/main/resources/META-INF/services/io.swagger.v3.core.converter.ModelConverter
+++ b/wow-openapi/src/main/resources/META-INF/services/io.swagger.v3.core.converter.ModelConverter
@@ -20,6 +20,10 @@ me.ahoo.wow.openapi.converter.EventStreamConverter
 me.ahoo.wow.openapi.converter.DomainEventConverter
 me.ahoo.wow.openapi.converter.StateEventConverter
 me.ahoo.wow.openapi.converter.CommandResultConverter
+me.ahoo.wow.openapi.converter.WaitSignalConverter
+me.ahoo.wow.openapi.converter.BoundedContextConverter
+me.ahoo.wow.openapi.converter.WowMetadataConverter
+me.ahoo.wow.openapi.converter.MessageHeaderConverter
 me.ahoo.wow.openapi.converter.ConditionConverter
 me.ahoo.wow.openapi.converter.ProjectionConverter
 me.ahoo.wow.openapi.converter.ListQueryConverter


### PR DESCRIPTION
- Add BoundedContextConverter to allow additional properties for aggregates
- Update CommandResultConverter to use CommandResultCapable and allow additional properties
- Modify ConditionConverter to set additional properties for options
- Add new converters for WaitSignal, WowMetadata, and MessageHeader
- Update BoundedContextSchemaNameConverter to resolve schema names for non-standard library classes

