### PR TITLE
feat(command): support void command and optimize command dispatching

### DIFF
--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/mock/MockAggregate.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/mock/MockAggregate.kt
@@ -14,8 +14,10 @@
 package me.ahoo.wow.tck.mock
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import me.ahoo.wow.api.annotation.AggregateRoot
 import me.ahoo.wow.api.annotation.CreateAggregate
 import me.ahoo.wow.api.annotation.OnCommand
+import me.ahoo.wow.api.annotation.VoidCommand
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.modeling.state.ReadOnlyStateAggregate
 import me.ahoo.wow.modeling.state.ReadOnlyStateAggregateAware
@@ -30,6 +32,10 @@ data class MockChangeAggregate(val id: String, val data: String)
 data class MockAggregateCreated(val data: String)
 data class MockAggregateChanged(val data: String)
 
+@VoidCommand
+data class MockVoidCommand(val data: String)
+
+@AggregateRoot(commands = [MockVoidCommand::class])
 class MockCommandAggregate(val state: MockStateAggregate) {
 
     @OnCommand

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/CommandDispatcher.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/CommandDispatcher.kt
@@ -48,7 +48,6 @@ class CommandDispatcher(
     override fun receiveMessage(namedAggregate: NamedAggregate): Flux<ServerCommandExchange<*>> {
         return commandBus
             .receive(setOf(namedAggregate))
-            .filter { !it.message.isVoid }
             .writeReceiverGroup(name)
             .writeMetricsSubscriber(name)
     }


### PR DESCRIPTION
- Add support for void commands in LocalFirstCommandBus
- Implement optimized receive method in CommandDispatcher
- Add test case for void command handling
- Update MockAggregate to include void command example
