### PR TITLE
fix(command): add validation for void command wait strategy

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
@@ -79,6 +79,9 @@ class DefaultCommandGateway(
         require(waitStrategy.stage != CommandStage.SENT) {
             "waitStrategy.stage must not be CommandStage.SENT. Use sendAndWaitForSent instead."
         }
+        require(!command.isVoid) {
+            "The wait strategy for the void command must be SENT."
+        }
         return check(command).then(
             Mono.defer {
                 command.header.injectWaitStrategy(

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/LocalFirstCommandBus.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/LocalFirstCommandBus.kt
@@ -14,10 +14,8 @@
 package me.ahoo.wow.command
 
 import me.ahoo.wow.api.command.CommandMessage
-import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.messaging.LocalFirstMessageBus
 import me.ahoo.wow.messaging.withLocalFirst
-import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 class LocalFirstCommandBus(
@@ -29,11 +27,5 @@ class LocalFirstCommandBus(
             message.withLocalFirst(false)
         }
         return super.send(message)
-    }
-
-    override fun receive(namedAggregates: Set<NamedAggregate>): Flux<ServerCommandExchange<*>> {
-        return super.receive(namedAggregates).filter {
-            !it.message.isVoid
-        }
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/CommandDispatcher.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/CommandDispatcher.kt
@@ -48,6 +48,9 @@ class CommandDispatcher(
     override fun receiveMessage(namedAggregate: NamedAggregate): Flux<ServerCommandExchange<*>> {
         return commandBus
             .receive(setOf(namedAggregate))
+            .filter {
+                !it.message.isVoid
+            }
             .writeReceiverGroup(name)
             .writeMetricsSubscriber(name)
     }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTest.kt
@@ -19,7 +19,9 @@ import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.command.validation.CommandValidator
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.WaitingFor
+import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.tck.command.CommandGatewaySpec
+import me.ahoo.wow.tck.mock.MockVoidCommand
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
@@ -29,11 +31,20 @@ internal class DefaultCommandGatewayTest : CommandGatewaySpec() {
     }
 
     @Test
-    fun sendWithSend() {
+    fun sendWithSent() {
         val messageGateway = createMessageBus()
         val commandMessage: CommandMessage<Any> = mockk()
         Assertions.assertThrows(IllegalArgumentException::class.java) {
             messageGateway.send(commandMessage, WaitingFor.stage(CommandStage.SENT, "", ""))
+        }
+    }
+
+    @Test
+    fun sendVoidCommand() {
+        val messageGateway = createMessageBus()
+        val commandMessage = MockVoidCommand(generateGlobalId()).toCommandMessage()
+        Assertions.assertThrows(IllegalArgumentException::class.java) {
+            messageGateway.send(commandMessage, WaitingFor.stage(CommandStage.PROCESSED, "", ""))
         }
     }
 

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/LocalFirstCommandBusTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/LocalFirstCommandBusTest.kt
@@ -33,7 +33,7 @@ class LocalFirstCommandBusTest : CommandBusSpec() {
                 .doOnSubscribe {
                     onReady.asMono()
                         .then(send(message))
-                        .delaySubscription(Duration.ofMillis(1000))
+                        .delaySubscription(Duration.ofMillis(100))
                         .subscribe()
                 }
                 .test()
@@ -56,7 +56,7 @@ class LocalFirstCommandBusTest : CommandBusSpec() {
                 .doOnSubscribe {
                     onReady.asMono()
                         .then(send(message))
-                        .delaySubscription(Duration.ofMillis(1000))
+                        .delaySubscription(Duration.ofMillis(10))
                         .subscribe()
                 }
                 .test()


### PR DESCRIPTION
- Add check to prevent using PROCESSED stage with void commands
- Update test cases to cover the new validation
- Improve test readability by renaming and reorganizing test methods
