### PR TITLE
refactor(webflux): introduce CommandMessageParser and remove CommandParser

### DIFF
--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfiguration.kt
@@ -37,7 +37,9 @@ import me.ahoo.wow.webflux.route.RouterFunctionBuilder
 import me.ahoo.wow.webflux.route.bi.GenerateBIScriptHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.command.CommandFacadeHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.command.CommandHandlerFunctionFactory
+import me.ahoo.wow.webflux.route.command.CommandMessageParser
 import me.ahoo.wow.webflux.route.command.DEFAULT_TIME_OUT
+import me.ahoo.wow.webflux.route.command.DefaultCommandMessageParser
 import me.ahoo.wow.webflux.route.event.CountEventStreamHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.event.EventCompensateHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.event.ListQueryEventStreamHandlerFunctionFactory
@@ -139,6 +141,13 @@ class WebFluxAutoConfiguration {
         return GlobalExceptionHandler
     }
 
+
+    @Bean
+    @ConditionalOnWebfluxGlobalErrorEnabled
+    fun commandMessageParser(commandMessageFactory: CommandMessageFactory,): CommandMessageParser {
+        return DefaultCommandMessageParser(commandMessageFactory)
+    }
+
     @Bean
     @Order(Ordered.HIGHEST_PRECEDENCE)
     @ConditionalOnMissingBean(name = [COMMAND_WAIT_HANDLER_FUNCTION_FACTORY_BEAN_NAME])
@@ -153,12 +162,12 @@ class WebFluxAutoConfiguration {
     @ConditionalOnMissingBean(name = [COMMAND_FACADE_HANDLER_FUNCTION_FACTORY_BEAN_NAME])
     fun commandFacadeHandlerFunctionFactory(
         commandGateway: CommandGateway,
-        commandMessageFactory: CommandMessageFactory,
+        commandMessageParser: CommandMessageParser,
         exceptionHandler: RequestExceptionHandler,
     ): CommandFacadeHandlerFunctionFactory {
         return CommandFacadeHandlerFunctionFactory(
             commandGateway = commandGateway,
-            commandMessageFactory = commandMessageFactory,
+            commandMessageParser = commandMessageParser,
             exceptionHandler = exceptionHandler
         )
     }
@@ -401,12 +410,12 @@ class WebFluxAutoConfiguration {
     @ConditionalOnMissingBean(name = [COMMAND_HANDLER_FUNCTION_FACTORY_BEAN_NAME])
     fun commandHandlerFunctionFactory(
         commandGateway: CommandGateway,
-        commandMessageFactory: CommandMessageFactory,
+        commandMessageParser: CommandMessageParser,
         exceptionHandler: RequestExceptionHandler,
     ): CommandHandlerFunctionFactory {
         return CommandHandlerFunctionFactory(
             commandGateway = commandGateway,
-            commandMessageFactory = commandMessageFactory,
+            commandMessageParser = commandMessageParser,
             exceptionHandler = exceptionHandler,
             timeout = DEFAULT_TIME_OUT
         )

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/AggregateRequest.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/AggregateRequest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.route.command
+
+import me.ahoo.wow.api.modeling.TenantId
+import me.ahoo.wow.command.wait.CommandStage
+import me.ahoo.wow.infra.ifNotBlank
+import me.ahoo.wow.modeling.matedata.AggregateMetadata
+import me.ahoo.wow.openapi.RoutePaths
+import me.ahoo.wow.openapi.command.CommandHeaders
+import me.ahoo.wow.serialization.MessageRecords
+import org.springframework.web.reactive.function.server.ServerRequest
+import java.time.Duration
+import java.util.*
+
+fun ServerRequest.getTenantId(aggregateMetadata: AggregateMetadata<*, *>): String? {
+    aggregateMetadata.staticTenantId.ifNotBlank<String> {
+        return it
+    }
+    pathVariables()[MessageRecords.TENANT_ID].ifNotBlank<String> {
+        return it
+    }
+    headers().firstHeader(CommandHeaders.TENANT_ID).ifNotBlank<String> {
+        return it
+    }
+    return null
+}
+
+fun ServerRequest.getTenantIdOrDefault(aggregateMetadata: AggregateMetadata<*, *>): String {
+    return getTenantId(aggregateMetadata) ?: return TenantId.DEFAULT_TENANT_ID
+}
+
+fun ServerRequest.getAggregateId(): String? {
+    headers().firstHeader(CommandHeaders.AGGREGATE_ID).ifNotBlank<String> {
+        return it
+    }
+    pathVariables()[RoutePaths.ID_KEY].ifNotBlank<String> {
+        return it
+    }
+    return null
+}
+
+fun ServerRequest.getLocalFirst(): Boolean? {
+    headers().firstHeader(CommandHeaders.LOCAL_FIRST).ifNotBlank<String> {
+        return it.toBoolean()
+    }
+    return null
+}
+
+fun ServerRequest.getCommandStage(): CommandStage {
+    return headers().firstHeader(CommandHeaders.WAIT_STAGE).ifNotBlank { stage ->
+        CommandStage.valueOf(stage.uppercase(Locale.getDefault()))
+    } ?: CommandStage.PROCESSED
+}
+
+fun ServerRequest.getWaitContext(): String {
+    return headers().firstHeader(CommandHeaders.WAIT_CONTEXT).orEmpty()
+}
+
+fun ServerRequest.getWaitProcessor(): String {
+    return headers().firstHeader(CommandHeaders.WAIT_PROCESSOR).orEmpty()
+}
+
+fun ServerRequest.getWaitTimeout(default: Duration = DEFAULT_TIME_OUT): Duration {
+    return headers().firstHeader(CommandHeaders.WAIT_TIME_OUT)?.toLongOrNull()?.let {
+        Duration.ofMillis(it)
+    } ?: default
+}

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandFacadeHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandFacadeHandlerFunction.kt
@@ -14,7 +14,6 @@
 package me.ahoo.wow.webflux.route.command
 
 import me.ahoo.wow.command.CommandGateway
-import me.ahoo.wow.command.factory.CommandMessageFactory
 import me.ahoo.wow.openapi.command.CommandFacadeRouteSpec
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.exception.toServerResponse
@@ -33,14 +32,14 @@ import java.time.Duration
  */
 class CommandFacadeHandlerFunction(
     private val commandGateway: CommandGateway,
-    private val commandMessageFactory: CommandMessageFactory,
+    private val commandMessageParser: CommandMessageParser,
     private val exceptionHandler: RequestExceptionHandler,
     private val timeout: Duration = DEFAULT_TIME_OUT
 ) : HandlerFunction<ServerResponse> {
 
     private val handler = CommandHandler(
         commandGateway = commandGateway,
-        commandMessageFactory = commandMessageFactory,
+        commandMessageParser = commandMessageParser,
         timeout = timeout
     )
 
@@ -55,7 +54,7 @@ class CommandFacadeHandlerFunction(
 
 class CommandFacadeHandlerFunctionFactory(
     private val commandGateway: CommandGateway,
-    private val commandMessageFactory: CommandMessageFactory,
+    private val commandMessageParser: CommandMessageParser,
     private val exceptionHandler: RequestExceptionHandler,
     private val timeout: Duration = DEFAULT_TIME_OUT
 ) : RouteHandlerFunctionFactory<CommandFacadeRouteSpec> {
@@ -65,7 +64,7 @@ class CommandFacadeHandlerFunctionFactory(
     override fun create(spec: CommandFacadeRouteSpec): HandlerFunction<ServerResponse> {
         return CommandFacadeHandlerFunction(
             commandGateway = commandGateway,
-            commandMessageFactory = commandMessageFactory,
+            commandMessageParser = commandMessageParser,
             exceptionHandler = exceptionHandler,
             timeout = timeout
         )

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt
@@ -14,7 +14,6 @@
 package me.ahoo.wow.webflux.route.command
 
 import me.ahoo.wow.command.CommandGateway
-import me.ahoo.wow.command.factory.CommandMessageFactory
 import me.ahoo.wow.modeling.matedata.AggregateMetadata
 import me.ahoo.wow.openapi.command.CommandRouteSpec
 import me.ahoo.wow.openapi.route.CommandRouteMetadata
@@ -40,12 +39,12 @@ class CommandHandlerFunction(
     private val aggregateMetadata: AggregateMetadata<*, *>,
     private val commandRouteMetadata: CommandRouteMetadata<out Any>,
     private val commandGateway: CommandGateway,
-    private val commandMessageFactory: CommandMessageFactory,
+    private val commandMessageParser: CommandMessageParser,
     private val exceptionHandler: RequestExceptionHandler,
     private val timeout: Duration = DEFAULT_TIME_OUT
 ) : HandlerFunction<ServerResponse> {
     private val bodyExtractor = CommandBodyExtractor(commandRouteMetadata)
-    private val handler = CommandHandler(commandGateway, commandMessageFactory, timeout)
+    private val handler = CommandHandler(commandGateway, commandMessageParser, timeout)
     override fun handle(request: ServerRequest): Mono<ServerResponse> {
         return if (commandRouteMetadata.pathVariableMetadata.isEmpty() && commandRouteMetadata.headerVariableMetadata.isEmpty()) {
             request.bodyToMono(commandRouteMetadata.commandMetadata.commandType)
@@ -64,7 +63,7 @@ class CommandHandlerFunction(
 
 class CommandHandlerFunctionFactory(
     private val commandGateway: CommandGateway,
-    private val commandMessageFactory: CommandMessageFactory,
+    private val commandMessageParser: CommandMessageParser,
     private val exceptionHandler: RequestExceptionHandler,
     private val timeout: Duration = DEFAULT_TIME_OUT
 ) : RouteHandlerFunctionFactory<CommandRouteSpec> {
@@ -77,7 +76,7 @@ class CommandHandlerFunctionFactory(
             aggregateMetadata = spec.aggregateMetadata,
             commandRouteMetadata = spec.commandRouteMetadata as CommandRouteMetadata<Any>,
             commandGateway = commandGateway,
-            commandMessageFactory = commandMessageFactory,
+            commandMessageParser = commandMessageParser,
             exceptionHandler = exceptionHandler,
             timeout = timeout
         )

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandMessageParser.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandMessageParser.kt
@@ -14,75 +14,46 @@
 package me.ahoo.wow.webflux.route.command
 
 import me.ahoo.wow.api.command.CommandMessage
-import me.ahoo.wow.api.modeling.TenantId
 import me.ahoo.wow.command.CommandOperator.withOperator
 import me.ahoo.wow.command.factory.CommandBuilder.Companion.commandBuilder
 import me.ahoo.wow.command.factory.CommandMessageFactory
 import me.ahoo.wow.infra.ifNotBlank
 import me.ahoo.wow.messaging.withLocalFirst
 import me.ahoo.wow.modeling.matedata.AggregateMetadata
-import me.ahoo.wow.openapi.RoutePaths
 import me.ahoo.wow.openapi.command.CommandHeaders
-import me.ahoo.wow.serialization.MessageRecords
 import org.springframework.web.reactive.function.server.ServerRequest
 import reactor.core.publisher.Mono
 
-object CommandParser {
-    fun ServerRequest.getTenantId(aggregateMetadata: AggregateMetadata<*, *>): String? {
-        aggregateMetadata.staticTenantId.ifNotBlank<String> {
-            return it
-        }
-        pathVariables()[MessageRecords.TENANT_ID].ifNotBlank<String> {
-            return it
-        }
-        headers().firstHeader(CommandHeaders.TENANT_ID).ifNotBlank<String> {
-            return it
-        }
-        return null
-    }
-
-    fun ServerRequest.getTenantIdOrDefault(aggregateMetadata: AggregateMetadata<*, *>): String {
-        return getTenantId(aggregateMetadata) ?: return TenantId.DEFAULT_TENANT_ID
-    }
-
-    fun ServerRequest.getAggregateId(): String? {
-        headers().firstHeader(CommandHeaders.AGGREGATE_ID).ifNotBlank<String> {
-            return it
-        }
-        pathVariables()[RoutePaths.ID_KEY].ifNotBlank<String> {
-            return it
-        }
-        return null
-    }
-
-    fun ServerRequest.getLocalFirst(): Boolean? {
-        headers().firstHeader(CommandHeaders.LOCAL_FIRST).ifNotBlank<String> {
-            return it.toBoolean()
-        }
-        return null
-    }
-
-    fun ServerRequest.parse(
+interface CommandMessageParser {
+    fun parse(
         aggregateMetadata: AggregateMetadata<*, *>,
         commandBody: Any,
-        commandMessageFactory: CommandMessageFactory
+        request: ServerRequest
+    ): Mono<CommandMessage<Any>>
+}
+
+class DefaultCommandMessageParser(private val commandMessageFactory: CommandMessageFactory) : CommandMessageParser {
+    override fun parse(
+        aggregateMetadata: AggregateMetadata<*, *>,
+        commandBody: Any,
+        request: ServerRequest
     ): Mono<CommandMessage<Any>> {
-        val aggregateId = getAggregateId()
-        val tenantId = getTenantId(aggregateMetadata)
-        val aggregateVersion = headers().firstHeader(CommandHeaders.AGGREGATE_VERSION)?.toIntOrNull()
-        val requestId = headers().firstHeader(CommandHeaders.REQUEST_ID).ifNotBlank { it }
+        val aggregateId = request.getAggregateId()
+        val tenantId = request.getTenantId(aggregateMetadata)
+        val aggregateVersion = request.headers().firstHeader(CommandHeaders.AGGREGATE_VERSION)?.toIntOrNull()
+        val requestId = request.headers().firstHeader(CommandHeaders.REQUEST_ID).ifNotBlank { it }
         val commandBuilder = commandBody.commandBuilder()
             .aggregateId(aggregateId)
             .tenantId(tenantId)
             .aggregateVersion(aggregateVersion)
             .requestId(requestId)
             .namedAggregate(aggregateMetadata.namedAggregate)
-        getLocalFirst()?.let {
+        request.getLocalFirst()?.let {
             commandBuilder.header { header ->
                 header.withLocalFirst(it)
             }
         }
-        return principal().map {
+        return request.principal().map {
             commandBuilder.header { header ->
                 header.withOperator(it.name)
             }

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/event/EventCompensateHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/event/EventCompensateHandlerFunction.kt
@@ -23,7 +23,7 @@ import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
-import me.ahoo.wow.webflux.route.command.CommandParser.getTenantIdOrDefault
+import me.ahoo.wow.webflux.route.command.getTenantIdOrDefault
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/event/LoadEventStreamHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/event/LoadEventStreamHandlerFunction.kt
@@ -22,7 +22,7 @@ import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
-import me.ahoo.wow.webflux.route.command.CommandParser.getTenantIdOrDefault
+import me.ahoo.wow.webflux.route.command.getTenantIdOrDefault
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/CountQueryHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/CountQueryHandlerFunction.kt
@@ -21,7 +21,7 @@ import me.ahoo.wow.query.filter.QueryHandler
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
-import me.ahoo.wow.webflux.route.command.CommandParser.getTenantId
+import me.ahoo.wow.webflux.route.command.getTenantId
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/ListQueryHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/ListQueryHandlerFunction.kt
@@ -21,7 +21,7 @@ import me.ahoo.wow.query.filter.QueryHandler
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
-import me.ahoo.wow.webflux.route.command.CommandParser.getTenantId
+import me.ahoo.wow.webflux.route.command.getTenantId
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/PagedQueryHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/PagedQueryHandlerFunction.kt
@@ -21,7 +21,7 @@ import me.ahoo.wow.query.filter.QueryHandler
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
-import me.ahoo.wow.webflux.route.command.CommandParser.getTenantId
+import me.ahoo.wow.webflux.route.command.getTenantId
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/ListQuerySnapshotStateHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/ListQuerySnapshotStateHandlerFunction.kt
@@ -22,7 +22,7 @@ import me.ahoo.wow.query.snapshot.toStateDocument
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
-import me.ahoo.wow.webflux.route.command.CommandParser.getTenantId
+import me.ahoo.wow.webflux.route.command.getTenantId
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/LoadSnapshotHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/LoadSnapshotHandlerFunction.kt
@@ -22,7 +22,7 @@ import me.ahoo.wow.query.snapshot.filter.SnapshotQueryHandler
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
-import me.ahoo.wow.webflux.route.command.CommandParser.getTenantIdOrDefault
+import me.ahoo.wow.webflux.route.command.getTenantIdOrDefault
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/PagedQuerySnapshotStateHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/PagedQuerySnapshotStateHandlerFunction.kt
@@ -22,7 +22,7 @@ import me.ahoo.wow.query.snapshot.toStateDocumentPagedList
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
-import me.ahoo.wow.webflux.route.command.CommandParser.getTenantId
+import me.ahoo.wow.webflux.route.command.getTenantId
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/RegenerateSnapshotHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/RegenerateSnapshotHandlerFunction.kt
@@ -24,7 +24,7 @@ import me.ahoo.wow.openapi.snapshot.RegenerateSnapshotRouteSpec
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
-import me.ahoo.wow.webflux.route.command.CommandParser.getTenantIdOrDefault
+import me.ahoo.wow.webflux.route.command.getTenantIdOrDefault
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/SingleSnapshotHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/SingleSnapshotHandlerFunction.kt
@@ -22,7 +22,7 @@ import me.ahoo.wow.query.snapshot.filter.SnapshotQueryHandler
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
-import me.ahoo.wow.webflux.route.command.CommandParser.getTenantId
+import me.ahoo.wow.webflux.route.command.getTenantId
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/SingleSnapshotStateHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/SingleSnapshotStateHandlerFunction.kt
@@ -23,7 +23,7 @@ import me.ahoo.wow.query.snapshot.toStateDocument
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
-import me.ahoo.wow.webflux.route.command.CommandParser.getTenantId
+import me.ahoo.wow.webflux.route.command.getTenantId
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/AbstractLoadAggregateHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/AbstractLoadAggregateHandlerFunction.kt
@@ -22,7 +22,7 @@ import me.ahoo.wow.openapi.RoutePaths
 import me.ahoo.wow.query.mask.tryMask
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.exception.toServerResponse
-import me.ahoo.wow.webflux.route.command.CommandParser.getTenantIdOrDefault
+import me.ahoo.wow.webflux.route.command.getTenantIdOrDefault
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/AggregateTracingHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/AggregateTracingHandlerFunction.kt
@@ -28,7 +28,7 @@ import me.ahoo.wow.serialization.deepCody
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
-import me.ahoo.wow.webflux.route.command.CommandParser.getTenantIdOrDefault
+import me.ahoo.wow.webflux.route.command.getTenantIdOrDefault
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/IdsQueryAggregateHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/IdsQueryAggregateHandlerFunction.kt
@@ -21,7 +21,7 @@ import me.ahoo.wow.query.mask.tryMask
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
-import me.ahoo.wow.webflux.route.command.CommandParser.getTenantIdOrDefault
+import me.ahoo.wow.webflux.route.command.getTenantIdOrDefault
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/LoadTimeBasedAggregateHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/LoadTimeBasedAggregateHandlerFunction.kt
@@ -24,7 +24,7 @@ import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
-import me.ahoo.wow.webflux.route.command.CommandParser.getTenantIdOrDefault
+import me.ahoo.wow.webflux.route.command.getTenantIdOrDefault
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/handler/CommandHandlerTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/handler/CommandHandlerTest.kt
@@ -12,6 +12,7 @@ import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import me.ahoo.wow.tck.mock.MockCreateAggregate
 import me.ahoo.wow.test.SagaVerifier
 import me.ahoo.wow.webflux.route.command.CommandHandler
+import me.ahoo.wow.webflux.route.command.DefaultCommandMessageParser
 import org.junit.jupiter.api.Test
 import org.springframework.web.reactive.function.server.ServerRequest
 import reactor.kotlin.core.publisher.toMono
@@ -40,7 +41,7 @@ class CommandHandlerTest {
         }
         val commandHandler = CommandHandler(
             SagaVerifier.defaultCommandGateway(),
-            SimpleCommandMessageFactory(SimpleCommandBuilderRewriterRegistry())
+            DefaultCommandMessageParser(SimpleCommandMessageFactory(SimpleCommandBuilderRewriterRegistry()))
         )
         commandHandler.handle(
             request,
@@ -70,7 +71,7 @@ class CommandHandlerTest {
         }
         val commandHandler = CommandHandler(
             SagaVerifier.defaultCommandGateway(),
-            SimpleCommandMessageFactory(SimpleCommandBuilderRewriterRegistry())
+            DefaultCommandMessageParser(SimpleCommandMessageFactory(SimpleCommandBuilderRewriterRegistry()))
         )
         commandHandler.handle(
             request,

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandFacadeHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandFacadeHandlerFunctionTest.kt
@@ -37,7 +37,7 @@ class CommandFacadeHandlerFunctionTest {
         val commandGateway = spyk<CommandGateway>(SagaVerifier.defaultCommandGateway())
         val handlerFunction = CommandFacadeHandlerFunction(
             commandGateway,
-            SimpleCommandMessageFactory((SimpleCommandBuilderRewriterRegistry())),
+            DefaultCommandMessageParser(SimpleCommandMessageFactory((SimpleCommandBuilderRewriterRegistry()))),
             DefaultRequestExceptionHandler
         )
         val request = mockk<ServerRequest> {

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunctionTest.kt
@@ -49,7 +49,7 @@ class CommandHandlerFunctionTest {
             MOCK_AGGREGATE_METADATA,
             commandRouteMetadata,
             commandGateway,
-            SimpleCommandMessageFactory((SimpleCommandBuilderRewriterRegistry())),
+            DefaultCommandMessageParser(SimpleCommandMessageFactory((SimpleCommandBuilderRewriterRegistry()))),
             DefaultRequestExceptionHandler,
         )
         val request = mockk<ServerRequest> {

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/DefaultCommandMessageParserTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/DefaultCommandMessageParserTest.kt
@@ -11,13 +11,12 @@ import me.ahoo.wow.openapi.command.CommandHeaders
 import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import me.ahoo.wow.tck.mock.MockCreateAggregate
-import me.ahoo.wow.webflux.route.command.CommandParser.parse
 import org.junit.jupiter.api.Test
 import org.springframework.web.reactive.function.server.ServerRequest
 import reactor.core.publisher.Mono
 import reactor.kotlin.test.test
 
-class CommandParserTest {
+class DefaultCommandMessageParserTest {
 
     @Test
     fun parse() {
@@ -33,13 +32,15 @@ class CommandParserTest {
             every { headers().firstHeader(CommandHeaders.WAIT_STAGE) } returns CommandStage.SENT.toString()
             every { headers().firstHeader(CommandHeaders.LOCAL_FIRST) } returns false.toString()
         }
-        request.parse(
+        val commandMessageParser =
+            DefaultCommandMessageParser(SimpleCommandMessageFactory((SimpleCommandBuilderRewriterRegistry())))
+        commandMessageParser.parse(
             aggregateMetadata = MOCK_AGGREGATE_METADATA,
             commandBody = MockCreateAggregate(
                 id = GlobalIdGenerator.generateAsString(),
                 data = GlobalIdGenerator.generateAsString(),
             ),
-            SimpleCommandMessageFactory(SimpleCommandBuilderRewriterRegistry())
+            request
         ).test()
             .expectNextCount(1)
             .verifyComplete()


### PR DESCRIPTION
- Introduce new CommandMessageParser interface and DefaultCommandMessageParser implementation
- Remove static methods from CommandParser object
- Update related classes to use the new CommandMessageParser
- Rename CommandParserTest to DefaultCommandMessageParserTest

