### PR TITLE
feat(webflux): add user agent and remote IP to command header

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/CommandRequestHeaderPropagator.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/CommandRequestHeaderPropagator.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.messaging.propagation
+
+import me.ahoo.wow.api.messaging.Header
+import me.ahoo.wow.api.messaging.Message
+
+class CommandRequestHeaderPropagator : MessagePropagator {
+    companion object {
+        private const val USER_AGENT = "user_agent"
+        private const val REMOTE_IP = "remote_ip"
+        val Header.userAgent: String?
+            get() {
+                return this[USER_AGENT]
+            }
+
+        fun Header.withUserAgent(userAgent: String): Header {
+            return this.with(USER_AGENT, userAgent)
+        }
+
+        val Header.remoteIp: String?
+            get() {
+                return this[REMOTE_IP]
+            }
+
+        fun Header.withRemoteIp(remoteIp: String): Header {
+            return this.with(REMOTE_IP, remoteIp)
+        }
+    }
+
+    override fun inject(header: Header, upstream: Message<*, *>) {
+        upstream.header.userAgent?.let {
+            header.withUserAgent(it)
+        }
+        upstream.header.remoteIp?.let {
+            header.withRemoteIp(it)
+        }
+    }
+}

--- a/wow-core/src/main/resources/META-INF/services/me.ahoo.wow.messaging.propagation.MessagePropagator
+++ b/wow-core/src/main/resources/META-INF/services/me.ahoo.wow.messaging.propagation.MessagePropagator
@@ -13,3 +13,4 @@
 me.ahoo.wow.messaging.propagation.WaitStrategyMessagePropagator
 me.ahoo.wow.messaging.propagation.CommandOperatorMessagePropagator
 me.ahoo.wow.messaging.propagation.TraceMessagePropagator
+me.ahoo.wow.messaging.propagation.CommandRequestHeaderPropagator

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/propagation/CommandRequestHeaderPropagatorTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/propagation/CommandRequestHeaderPropagatorTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.messaging.propagation
+
+import me.ahoo.wow.command.toCommandMessage
+import me.ahoo.wow.id.GlobalIdGenerator
+import me.ahoo.wow.messaging.DefaultHeader
+import me.ahoo.wow.messaging.propagation.CommandRequestHeaderPropagator.Companion.remoteIp
+import me.ahoo.wow.messaging.propagation.CommandRequestHeaderPropagator.Companion.userAgent
+import me.ahoo.wow.messaging.propagation.CommandRequestHeaderPropagator.Companion.withRemoteIp
+import me.ahoo.wow.messaging.propagation.CommandRequestHeaderPropagator.Companion.withUserAgent
+import me.ahoo.wow.tck.mock.MockCreateAggregate
+import org.hamcrest.MatcherAssert.*
+import org.hamcrest.Matchers.*
+import org.junit.jupiter.api.Test
+
+class CommandRequestHeaderPropagatorTest {
+    @Test
+    fun inject() {
+        val injectedHeader = DefaultHeader.empty()
+        val upstreamMessage =
+            MockCreateAggregate(GlobalIdGenerator.generateAsString(), GlobalIdGenerator.generateAsString())
+                .toCommandMessage()
+        upstreamMessage.header.withUserAgent("userAgent").withRemoteIp("remoteIp")
+        CommandRequestHeaderPropagator().inject(injectedHeader, upstreamMessage)
+        assertThat(injectedHeader.userAgent, equalTo(upstreamMessage.header.userAgent))
+        assertThat(injectedHeader.remoteIp, equalTo(upstreamMessage.header.remoteIp))
+    }
+
+    @Test
+    fun injectIfNull() {
+        val injectedHeader = DefaultHeader.empty()
+        val upstreamMessage =
+            MockCreateAggregate(GlobalIdGenerator.generateAsString(), GlobalIdGenerator.generateAsString())
+                .toCommandMessage()
+        CommandRequestHeaderPropagator().inject(injectedHeader, upstreamMessage)
+        assertThat(injectedHeader.userAgent, equalTo(null))
+        assertThat(injectedHeader.remoteIp, equalTo(null))
+    }
+}

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfiguration.kt
@@ -40,6 +40,7 @@ import me.ahoo.wow.webflux.route.command.CommandHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.command.CommandMessageParser
 import me.ahoo.wow.webflux.route.command.CommandRequestExtendHeaderAppender
 import me.ahoo.wow.webflux.route.command.CommandRequestHeaderAppender
+import me.ahoo.wow.webflux.route.command.CommandRequestUserAgentHeaderAppender
 import me.ahoo.wow.webflux.route.command.DEFAULT_TIME_OUT
 import me.ahoo.wow.webflux.route.command.DefaultCommandMessageParser
 import me.ahoo.wow.webflux.route.event.CountEventStreamHandlerFunctionFactory
@@ -146,6 +147,11 @@ class WebFluxAutoConfiguration {
     @Bean
     fun commandRequestExtendHeaderAppender(): CommandRequestExtendHeaderAppender {
         return CommandRequestExtendHeaderAppender
+    }
+
+    @Bean
+    fun commandRequestUserAgentHeaderAppender(): CommandRequestUserAgentHeaderAppender {
+        return CommandRequestUserAgentHeaderAppender
     }
 
     @Bean

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfiguration.kt
@@ -25,6 +25,7 @@ import me.ahoo.wow.openapi.RouterSpecs
 import me.ahoo.wow.query.event.filter.EventStreamQueryHandler
 import me.ahoo.wow.query.snapshot.filter.SnapshotQueryHandler
 import me.ahoo.wow.spring.boot.starter.ConditionalOnWowEnabled
+import me.ahoo.wow.spring.boot.starter.ENABLED_SUFFIX_KEY
 import me.ahoo.wow.spring.boot.starter.command.CommandAutoConfiguration
 import me.ahoo.wow.spring.boot.starter.kafka.KafkaProperties
 import me.ahoo.wow.spring.boot.starter.openapi.OpenAPIAutoConfiguration
@@ -71,6 +72,7 @@ import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.core.Ordered
@@ -150,6 +152,11 @@ class WebFluxAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnProperty(
+        value = ["${WebFluxProperties.PREFIX}.command.request.appender.user$ENABLED_SUFFIX_KEY"],
+        matchIfMissing = true,
+        havingValue = "true"
+    )
     fun commandRequestUserAgentHeaderAppender(): CommandRequestUserAgentHeaderAppender {
         return CommandRequestUserAgentHeaderAppender
     }

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandMessageParser.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandMessageParser.kt
@@ -53,7 +53,7 @@ class DefaultCommandMessageParser(
             .requestId(requestId)
             .namedAggregate(aggregateMetadata.namedAggregate)
         commandRequestHeaderAppends.forEach {
-            it.append(request, commandBuilder)
+            it.append(request, commandBuilder.header)
         }
         request.getLocalFirst()?.let {
             commandBuilder.header { header ->

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandRequestUserAgentHeaderAppenderTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandRequestUserAgentHeaderAppenderTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.route.command
+
+import io.mockk.every
+import io.mockk.mockk
+import me.ahoo.wow.messaging.DefaultHeader
+import me.ahoo.wow.messaging.propagation.CommandRequestHeaderPropagator.Companion.remoteIp
+import me.ahoo.wow.messaging.propagation.CommandRequestHeaderPropagator.Companion.userAgent
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.*
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.web.reactive.function.server.ServerRequest
+import java.net.InetSocketAddress
+import java.util.*
+
+class CommandRequestUserAgentHeaderAppenderTest {
+    @Test
+    fun appendUserAgent() {
+        val userAgent = "test"
+        val request = mockk<ServerRequest> {
+            every { headers().firstHeader(HttpHeaders.USER_AGENT) } returns userAgent
+            every { remoteAddress() } returns Optional.empty()
+        }
+        val commandHeader = DefaultHeader.empty()
+        CommandRequestUserAgentHeaderAppender.append(request, commandHeader)
+
+        assertThat(commandHeader.userAgent, equalTo(userAgent))
+    }
+
+    @Test
+    fun appendRemoteIp() {
+        val hostName = "test"
+        val request = mockk<ServerRequest> {
+            every { headers().firstHeader(HttpHeaders.USER_AGENT) } returns null
+            every { remoteAddress() } returns Optional.of(InetSocketAddress(hostName, 8080))
+        }
+        val commandHeader = DefaultHeader.empty()
+        CommandRequestUserAgentHeaderAppender.append(request, commandHeader)
+
+        assertThat(commandHeader.remoteIp, equalTo(hostName))
+    }
+}


### PR DESCRIPTION
- Implement CommandRequestUserAgentHeaderAppender to add user agent and remote IP to command header
- Update CommandMessageParser to use the new appender
- Add CommandRequestHeaderPropagator to handle user agent and remote IP propagation
- Include new propagator in META-INF/services
- Add unit tests for new functionality
