### PR TITLE
build: update Gradle project configurations and dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,8 +19,8 @@ import org.jetbrains.dokka.gradle.DokkaPlugin
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 
 plugins {
-    alias(libs.plugins.testRetry)
-    alias(libs.plugins.publishPlugin)
+    alias(libs.plugins.test.retry)
+    alias(libs.plugins.publish.plugin)
     alias(libs.plugins.detekt)
     alias(libs.plugins.kotlin)
     alias(libs.plugins.dokka)

--- a/compensation/wow-compensation-server/build.gradle.kts
+++ b/compensation/wow-compensation-server/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
     alias(libs.plugins.ksp)
     application
     alias(libs.plugins.kotlin)
-    alias(libs.plugins.kotlinSpring)
+    alias(libs.plugins.kotlin.spring)
     kotlin("kapt")
 }
 

--- a/example/example-server/build.gradle.kts
+++ b/example/example-server/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
     alias(libs.plugins.ksp)
     application
     alias(libs.plugins.kotlin)
-    alias(libs.plugins.kotlinSpring)
+    alias(libs.plugins.kotlin.spring)
     kotlin("kapt")
 }
 

--- a/example/transfer/example-transfer-server/build.gradle.kts
+++ b/example/transfer/example-transfer-server/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
     alias(libs.plugins.ksp)
     application
     alias(libs.plugins.kotlin)
-    alias(libs.plugins.kotlinSpring)
+    alias(libs.plugins.kotlin.spring)
     kotlin("kapt")
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,57 +1,57 @@
 [versions]
 # libraries
-springBoot = "3.4.1"
+spring-boot = "3.4.1"
 cosid = "2.10.2"
 simba = "2.6.2"
 coapi="1.9.2"
 testcontainers = "1.20.4"
 opentelemetry = "1.45.0"
-opentelemetryInstrumentation = "2.11.0"
-opentelemetrySemconv = "1.29.0-alpha"
+opentelemetry-instrumentation = "2.11.0"
+opentelemetry-semconv = "1.29.0-alpha"
 guava = "33.4.0-jre"
 hamcrest = "3.0"
 mockk = "1.13.14"
-kotlinCompileTesting = "0.7.0"
+kotlin-compile-testing = "0.7.0"
 swagger = "2.2.27"
-springDoc = "2.8.1"
+springdoc = "2.8.1"
 jte = "3.1.15"
 # plugins
-testRetry = "1.6.0"
+test-retry = "1.6.0"
 detekt = "1.23.7"
 dokka = "2.0.0"
 kotlin = "2.0.21"
-publishPlugin = "2.0.0"
+publish-plugin = "2.0.0"
 ksp = "2.0.21-1.0.28"
 
 [libraries]
-springBootDependencies = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "springBoot" }
-cosidBom = { module = "me.ahoo.cosid:cosid-bom", version.ref = "cosid" }
-simbaBom = { module = "me.ahoo.simba:simba-bom", version.ref = "simba" }
-coapiBom = { module = "me.ahoo.coapi:coapi-bom", version.ref = "coapi" }
-opentelemetryBom = { module = "io.opentelemetry:opentelemetry-bom", version.ref = "opentelemetry" }
-opentelemetryInstrumentationBom = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom", version.ref = "opentelemetryInstrumentation" }
-opentelemetrySemconv = { module = "io.opentelemetry:opentelemetry-semconv", version.ref = "opentelemetrySemconv" }
-testcontainersBom = { module = "org.testcontainers:testcontainers-bom", version.ref = "testcontainers" }
-kspSymbolProcessingApi = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
-kspSymbolProcessing = { module = "com.google.devtools.ksp:symbol-processing", version.ref = "ksp" }
-kotlinCompileTesting = { module = "dev.zacsweers.kctfork:ksp", version.ref = "kotlinCompileTesting" }
+spring-boot-dependencies = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot" }
+cosid-bom = { module = "me.ahoo.cosid:cosid-bom", version.ref = "cosid" }
+simba-bom = { module = "me.ahoo.simba:simba-bom", version.ref = "simba" }
+coapi-bom = { module = "me.ahoo.coapi:coapi-bom", version.ref = "coapi" }
+opentelemetry-bom = { module = "io.opentelemetry:opentelemetry-bom", version.ref = "opentelemetry" }
+opentelemetry-instrumentation-bom = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom", version.ref = "opentelemetry-instrumentation" }
+opentelemetry-semconv = { module = "io.opentelemetry:opentelemetry-semconv", version.ref = "opentelemetry-semconv" }
+testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version.ref = "testcontainers" }
+ksp-symbol-processing-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }
+ksp-symbol-processing = { module = "com.google.devtools.ksp:symbol-processing", version.ref = "ksp" }
+kotlin-compile-testing = { module = "dev.zacsweers.kctfork:ksp", version.ref = "kotlin-compile-testing" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
 swagger = { module = "io.swagger.core.v3:swagger-core-jakarta", version.ref = "swagger" }
-springDocStarterCommon = { module = "org.springdoc:springdoc-openapi-starter-common", version.ref = "springDoc" }
-springDocStarterWebfluxApi = { module = "org.springdoc:springdoc-openapi-starter-webflux-api", version.ref = "springDoc" }
-springDocStarterWebfluxUi = { module = "org.springdoc:springdoc-openapi-starter-webflux-ui", version.ref = "springDoc" }
+springdoc-starter-common = { module = "org.springdoc:springdoc-openapi-starter-common", version.ref = "springdoc" }
+springdoc-openapi-starter-webflux-api = { module = "org.springdoc:springdoc-openapi-starter-webflux-api", version.ref = "springdoc" }
+springdoc-openapi-starter-webflux-ui = { module = "org.springdoc:springdoc-openapi-starter-webflux-ui", version.ref = "springdoc" }
 jte = { module = "gg.jte:jte", version.ref = "jte" }
 jte-kotlin = { module = "gg.jte:jte-kotlin", version.ref = "jte" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
-detektFormatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
+detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 [plugins]
-testRetry = { id = "org.gradle.test-retry", version.ref = "testRetry" }
+test-retry = { id = "org.gradle.test-retry", version.ref = "test-retry" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-kotlinSpring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
-kotlinkapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
-publishPlugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "publishPlugin" }
+kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "publish-plugin" }
 

--- a/wow-compiler/build.gradle.kts
+++ b/wow-compiler/build.gradle.kts
@@ -2,9 +2,9 @@ description = "Wow Symbol Processing"
 
 dependencies {
     implementation(project(":wow-core"))
-    implementation(libs.kspSymbolProcessingApi)
-    testImplementation(libs.kotlinCompileTesting)
-    testImplementation(libs.kspSymbolProcessing)
+    implementation(libs.ksp.symbol.processing.api)
+    testImplementation(libs.kotlin.compile.testing)
+    testImplementation(libs.ksp.symbol.processing )
     testImplementation(project(":wow-api"))
     testImplementation(project(":wow-apiclient"))
     testImplementation(project(":wow-core"))

--- a/wow-dependencies/build.gradle.kts
+++ b/wow-dependencies/build.gradle.kts
@@ -12,22 +12,22 @@
  */
 
 dependencies {
-    api(platform(libs.springBootDependencies))
-    api(platform(libs.cosidBom))
-    api(platform(libs.simbaBom))
-    api(platform(libs.coapiBom))
-    api(platform(libs.opentelemetryBom))
-    api(platform(libs.opentelemetryInstrumentationBom))
-    api(platform(libs.testcontainersBom))
+    api(platform(libs.spring.boot.dependencies))
+    api(platform(libs.cosid.bom))
+    api(platform(libs.simba.bom))
+    api(platform(libs.coapi.bom))
+    api(platform(libs.opentelemetry.bom))
+    api(platform(libs.opentelemetry.instrumentation.bom))
+    api(platform(libs.testcontainers.bom))
     constraints {
         api(libs.guava)
-        api(libs.opentelemetrySemconv)
+        api(libs.opentelemetry.semconv)
         api(libs.swagger)
-        api(libs.springDocStarterCommon)
-        api(libs.springDocStarterWebfluxApi)
-        api(libs.springDocStarterWebfluxUi)
+        api(libs.springdoc.starter.common)
+        api(libs.springdoc.openapi.starter.webflux.api)
+        api(libs.springdoc.openapi.starter.webflux.ui)
         api(libs.hamcrest)
         api(libs.mockk)
-        api(libs.detektFormatting)
+        api(libs.detekt.formatting)
     }
 }

--- a/wow-spring-boot-starter/build.gradle.kts
+++ b/wow-spring-boot-starter/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    alias(libs.plugins.kotlinSpring)
+    alias(libs.plugins.kotlin.spring)
     kotlin("kapt")
 }
 java {


### PR DESCRIPTION
- Update Gradle plugins and dependencies across multiple project modules
- Refactor import statements to use updated dependency versions
- Replace deprecated plugins with their latest equivalents
- Update version references in libs.versions.toml to follow new naming conventions