### PR TITLE
build: update Gradle plugins and dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 
 plugins {
     alias(libs.plugins.test.retry)
-    alias(libs.plugins.publish.plugin)
+    alias(libs.plugins.publish)
     alias(libs.plugins.detekt)
     alias(libs.plugins.kotlin)
     alias(libs.plugins.dokka)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,5 +53,5 @@ dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
-publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "publish-plugin" }
+publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "publish-plugin" }
 


### PR DESCRIPTION
- Update `publish-plugin` to `publish` in build.gradle.kts
- Update `publish-plugin` to `publish` in gradle/libs.versions.toml