### PR TITLE
refactor(wow-core): WaitStrategy

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 spring-boot = "3.4.1"
 cosid = "2.10.2"
 simba = "2.6.2"
-coapi="1.9.2"
+coapi = "1.9.2"
 testcontainers = "1.20.4"
 opentelemetry = "1.46.0"
 opentelemetry-instrumentation = "2.11.0"

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt
@@ -91,10 +91,10 @@ interface CommandGateway : CommandBus {
     fun <C : Any> sendAndWaitForProcessed(
         command: CommandMessage<C>
     ): Mono<CommandResult> =
-        sendAndWait(command, WaitingFor.processed(command.contextName))
+        sendAndWait(command, WaitingFor.processed())
 
     fun <C : Any> sendAndWaitForSnapshot(
         command: CommandMessage<C>
     ): Mono<CommandResult> =
-        sendAndWait(command, WaitingFor.snapshot(command.contextName))
+        sendAndWait(command, WaitingFor.snapshot())
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingFor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingFor.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.command.wait
+
+import reactor.core.publisher.Mono
+import reactor.core.publisher.Sinks
+import java.util.*
+
+interface WaitingFor : WaitStrategy {
+    val stage: CommandStage
+
+    companion object {
+
+        fun processed(): WaitingFor = WaitingForProcessed()
+
+        fun snapshot(): WaitingFor = WaitingForSnapshot()
+
+        fun projected(contextName: String, processorName: String = ""): WaitingFor =
+            WaitingForProjected(
+                contextName = contextName,
+                processorName = processorName
+            )
+
+        fun eventHandled(contextName: String, processorName: String = ""): WaitingFor =
+            WaitingForEventHandled(
+                contextName = contextName,
+                processorName = processorName
+            )
+
+        fun sagaHandled(contextName: String, processorName: String = ""): WaitingFor =
+            WaitingForSagaHandled(
+                contextName = contextName,
+                processorName = processorName
+            )
+
+        fun stage(stage: CommandStage, contextName: String, processorName: String = ""): WaitingFor {
+            return when (stage) {
+                CommandStage.PROCESSED -> processed()
+                CommandStage.SNAPSHOT -> snapshot()
+                CommandStage.PROJECTED -> projected(contextName, processorName)
+                CommandStage.EVENT_HANDLED -> eventHandled(contextName, processorName)
+                CommandStage.SAGA_HANDLED -> sagaHandled(contextName, processorName)
+                CommandStage.SENT -> throw IllegalArgumentException("Unsupported stage: $stage")
+            }
+        }
+
+        fun stage(stage: String, contextName: String, processorName: String = ""): WaitingFor =
+            stage(
+                stage = CommandStage.valueOf(stage.uppercase(Locale.getDefault())),
+                contextName = contextName,
+                processorName = processorName
+            )
+    }
+}
+
+abstract class AbstractWaitingFor : WaitingFor {
+
+    protected val sink: Sinks.One<WaitSignal> = Sinks.one()
+
+    override fun waiting(): Mono<WaitSignal> {
+        return sink.asMono()
+    }
+
+    override fun error(throwable: Throwable) {
+        sink.tryEmitError(throwable)
+    }
+}

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingForAfterProcessed.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingForAfterProcessed.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.command.wait
+
+abstract class WaitingForAfterProcessed : AbstractWaitingFor() {
+    @Volatile
+    private var processedSignal: WaitSignal? = null
+
+    @Volatile
+    private var waitingForSignal: WaitSignal? = null
+    private val result: MutableMap<String, Any> = mutableMapOf()
+    protected fun nextSignal() {
+        val waitingForSignal = waitingForSignal
+        if (processedSignal == null || waitingForSignal == null) {
+            return
+        }
+        val mergedSignal = waitingForSignal.copyResult(result)
+        sink.tryEmitValue(mergedSignal)
+    }
+
+    open fun isWaitingForSignal(signal: WaitSignal): Boolean {
+        if (signal.stage != stage || !isSameBoundedContext(signal.function)) {
+            return false
+        }
+        if (processorName.isBlank()) {
+            return true
+        }
+        return signal.function.processorName == processorName
+    }
+
+    override fun next(signal: WaitSignal) {
+        result.putAll(signal.result)
+        if (signal.stage == CommandStage.PROCESSED) {
+            processedSignal = signal
+            if (!signal.succeeded) {
+                sink.tryEmitValue(signal)
+                return
+            }
+        }
+        if (isWaitingForSignal(signal)) {
+            waitingForSignal = signal
+        }
+        nextSignal()
+    }
+}

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingForEventHandled.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingForEventHandled.kt
@@ -13,20 +13,10 @@
 
 package me.ahoo.wow.command.wait
 
-import me.ahoo.wow.api.messaging.processor.ProcessorInfo
-import reactor.core.publisher.Mono
-
-/**
- * Command Wait Strategy
- * @see WaitingFor
- */
-interface WaitStrategy : ProcessorInfo {
-    fun waiting(): Mono<WaitSignal>
-
-    fun error(throwable: Throwable)
-
-    /**
-     * 由下游(CommandBus or Aggregate or Projector)发送处理结果信号.
-     */
-    fun next(signal: WaitSignal)
+class WaitingForEventHandled(
+    override val contextName: String,
+    override val processorName: String = ""
+) : WaitingForAfterProcessed() {
+    override val stage: CommandStage
+        get() = CommandStage.EVENT_HANDLED
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingForProcessed.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingForProcessed.kt
@@ -13,20 +13,15 @@
 
 package me.ahoo.wow.command.wait
 
-import me.ahoo.wow.api.messaging.processor.ProcessorInfo
-import reactor.core.publisher.Mono
-
-/**
- * Command Wait Strategy
- * @see WaitingFor
- */
-interface WaitStrategy : ProcessorInfo {
-    fun waiting(): Mono<WaitSignal>
-
-    fun error(throwable: Throwable)
-
-    /**
-     * 由下游(CommandBus or Aggregate or Projector)发送处理结果信号.
-     */
-    fun next(signal: WaitSignal)
+class WaitingForProcessed : AbstractWaitingFor() {
+    override val stage: CommandStage
+        get() = CommandStage.PROCESSED
+    override val contextName: String = ""
+    override val processorName: String = ""
+    override fun next(signal: WaitSignal) {
+        if (signal.stage != CommandStage.PROCESSED) {
+            return
+        }
+        sink.tryEmitValue(signal)
+    }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingForProjected.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingForProjected.kt
@@ -13,20 +13,14 @@
 
 package me.ahoo.wow.command.wait
 
-import me.ahoo.wow.api.messaging.processor.ProcessorInfo
-import reactor.core.publisher.Mono
+class WaitingForProjected(
+    override val contextName: String,
+    override val processorName: String = ""
+) : WaitingForAfterProcessed() {
+    override val stage: CommandStage
+        get() = CommandStage.PROJECTED
 
-/**
- * Command Wait Strategy
- * @see WaitingFor
- */
-interface WaitStrategy : ProcessorInfo {
-    fun waiting(): Mono<WaitSignal>
-
-    fun error(throwable: Throwable)
-
-    /**
-     * 由下游(CommandBus or Aggregate or Projector)发送处理结果信号.
-     */
-    fun next(signal: WaitSignal)
+    override fun isWaitingForSignal(signal: WaitSignal): Boolean {
+        return super.isWaitingForSignal(signal) && signal.isLastProjection
+    }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingForSagaHandled.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingForSagaHandled.kt
@@ -13,20 +13,10 @@
 
 package me.ahoo.wow.command.wait
 
-import me.ahoo.wow.api.messaging.processor.ProcessorInfo
-import reactor.core.publisher.Mono
-
-/**
- * Command Wait Strategy
- * @see WaitingFor
- */
-interface WaitStrategy : ProcessorInfo {
-    fun waiting(): Mono<WaitSignal>
-
-    fun error(throwable: Throwable)
-
-    /**
-     * 由下游(CommandBus or Aggregate or Projector)发送处理结果信号.
-     */
-    fun next(signal: WaitSignal)
+class WaitingForSagaHandled(
+    override val contextName: String,
+    override val processorName: String = ""
+) : WaitingForAfterProcessed() {
+    override val stage: CommandStage
+        get() = CommandStage.SAGA_HANDLED
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingForSnapshot.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingForSnapshot.kt
@@ -13,20 +13,13 @@
 
 package me.ahoo.wow.command.wait
 
-import me.ahoo.wow.api.messaging.processor.ProcessorInfo
-import reactor.core.publisher.Mono
+class WaitingForSnapshot : WaitingForAfterProcessed() {
+    override val stage: CommandStage
+        get() = CommandStage.SNAPSHOT
+    override val contextName: String = ""
+    override val processorName: String = ""
 
-/**
- * Command Wait Strategy
- * @see WaitingFor
- */
-interface WaitStrategy : ProcessorInfo {
-    fun waiting(): Mono<WaitSignal>
-
-    fun error(throwable: Throwable)
-
-    /**
-     * 由下游(CommandBus or Aggregate or Projector)发送处理结果信号.
-     */
-    fun next(signal: WaitSignal)
+    override fun isWaitingForSignal(signal: WaitSignal): Boolean {
+        return signal.stage == stage
+    }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/SimpleWaitStrategyRegistrarTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/SimpleWaitStrategyRegistrarTest.kt
@@ -20,13 +20,12 @@ import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 
 internal class SimpleWaitStrategyRegistrarTest {
-    private val contextName = "SimpleWaitStrategyRegistrarTest"
 
     @Test
     fun register() {
         val registrar = SimpleWaitStrategyRegistrar
         val commandId = GlobalIdGenerator.generateAsString()
-        val waitStrategy = WaitingFor.processed(contextName)
+        val waitStrategy = WaitingFor.processed()
         var registerResult = registrar.register(commandId, waitStrategy)
         assertThat(registerResult, nullValue())
         registerResult = registrar.register(commandId, waitStrategy)
@@ -37,7 +36,7 @@ internal class SimpleWaitStrategyRegistrarTest {
     fun unregister() {
         val registrar = SimpleWaitStrategyRegistrar
         val commandId = GlobalIdGenerator.generateAsString()
-        val waitStrategy = WaitingFor.processed(contextName)
+        val waitStrategy = WaitingFor.processed()
         var registerResult = registrar.unregister(commandId)
         assertThat(registerResult, nullValue())
         registerResult = registrar.register(commandId, waitStrategy)
@@ -52,7 +51,7 @@ internal class SimpleWaitStrategyRegistrarTest {
         val commandId = GlobalIdGenerator.generateAsString()
         var containsResult = registrar.contains(commandId)
         assertThat(containsResult, equalTo(false))
-        val waitStrategy = WaitingFor.processed(contextName)
+        val waitStrategy = WaitingFor.processed()
         registrar.register(commandId, waitStrategy)
         containsResult = registrar.contains(commandId)
         assertThat(containsResult, equalTo(true))
@@ -66,7 +65,7 @@ internal class SimpleWaitStrategyRegistrarTest {
         val waitSignal = SimpleWaitSignal(commandId, CommandStage.PROCESSED, COMMAND_GATEWAY_FUNCTION)
         var nextResult = registrar.next(waitSignal)
         assertThat(nextResult, equalTo(false))
-        val waitStrategy = WaitingFor.processed(contextName)
+        val waitStrategy = WaitingFor.processed()
         registrar.register(commandId, waitStrategy)
         nextResult = registrar.next(waitSignal)
         assertThat(nextResult, equalTo(true))


### PR DESCRIPTION
- Remove the static methods in the WaitingFor class and implement them in the companion object instead
- Add multiple waiting strategy implementation classes to handle different command stages
- Optimize the registration and handling logic of waiting strategies
- Update relevant test cases