### PR TITLE
feat(route): add owner aggregate precondition check

### DIFF
--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AggregateRoute.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AggregateRoute.kt
@@ -22,13 +22,13 @@ annotation class AggregateRoute(
     val owner: Owner = Owner.ALWAYS
 ) {
 
-    enum class Owner {
-        NEVER,
-        ALWAYS,
+    enum class Owner(val owned: Boolean) {
+        NEVER(false),
+        ALWAYS(true),
 
         /**
          * owner id is aggregate Id
          */
-        AGGREGATE_ID
+        AGGREGATE_ID(true)
     }
 }

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/LoadSnapshotHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/LoadSnapshotHandlerFunction.kt
@@ -22,6 +22,7 @@ import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.command.getAggregateId
+import me.ahoo.wow.webflux.route.command.getOwnerId
 import me.ahoo.wow.webflux.route.command.getTenantIdOrDefault
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
@@ -37,10 +38,14 @@ class LoadSnapshotHandlerFunction(
     override fun handle(request: ServerRequest): Mono<ServerResponse> {
         val tenantId = request.getTenantIdOrDefault(aggregateMetadata)
         val id = requireNotNull(request.getAggregateId(aggregateRouteMetadata.owner))
+        val ownerId = request.getOwnerId()
         val singleQuery = singleQuery {
             condition {
                 tenantId(tenantId)
                 id(id)
+                if (!ownerId.isNullOrBlank()) {
+                    ownerId(ownerId)
+                }
             }
         }
         return snapshotQueryHandler.dynamicSingle(aggregateMetadata, singleQuery)

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/AbstractLoadAggregateHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/AbstractLoadAggregateHandlerFunction.kt
@@ -50,6 +50,7 @@ abstract class AbstractLoadAggregateHandlerFunction(
             .map {
                 checkVersion(version, it)
                 it.state.tryMask()
+                OwnerAggregatePrecondition(request, aggregateRouteMetadata.owner).check(it)
             }
             .throwNotFoundIfEmpty()
             .toServerResponse(request, exceptionHandler)

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/AbstractLoadAggregateHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/AbstractLoadAggregateHandlerFunction.kt
@@ -49,8 +49,8 @@ abstract class AbstractLoadAggregateHandlerFunction(
             }
             .map {
                 checkVersion(version, it)
-                it.state.tryMask()
                 OwnerAggregatePrecondition(request, aggregateRouteMetadata.owner).check(it)
+                it.state.tryMask()
             }
             .throwNotFoundIfEmpty()
             .toServerResponse(request, exceptionHandler)

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/LoadTimeBasedAggregateHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/LoadTimeBasedAggregateHandlerFunction.kt
@@ -48,8 +48,8 @@ class LoadTimeBasedAggregateHandlerFunction(
                 it.initialized && !it.deleted
             }
             .map {
-                it.state.tryMask()
                 OwnerAggregatePrecondition(request, aggregateRouteMetadata.owner).check(it)
+                it.state.tryMask()
             }
             .throwNotFoundIfEmpty()
             .toServerResponse(request, exceptionHandler)

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/LoadTimeBasedAggregateHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/LoadTimeBasedAggregateHandlerFunction.kt
@@ -36,6 +36,7 @@ class LoadTimeBasedAggregateHandlerFunction(
     private val exceptionHandler: RequestExceptionHandler
 ) : HandlerFunction<ServerResponse> {
     private val aggregateMetadata = aggregateRouteMetadata.aggregateMetadata
+
     override fun handle(request: ServerRequest): Mono<ServerResponse> {
         val tenantId = request.getTenantIdOrDefault(aggregateMetadata)
         val id = requireNotNull(request.getAggregateId(aggregateRouteMetadata.owner))
@@ -48,6 +49,7 @@ class LoadTimeBasedAggregateHandlerFunction(
             }
             .map {
                 it.state.tryMask()
+                OwnerAggregatePrecondition(request, aggregateRouteMetadata.owner).check(it)
             }
             .throwNotFoundIfEmpty()
             .toServerResponse(request, exceptionHandler)

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/OwnerAggregatePrecondition.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/OwnerAggregatePrecondition.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.route.state
+
+import me.ahoo.wow.api.annotation.AggregateRoute
+import me.ahoo.wow.modeling.command.IllegalAccessOwnerAggregateException
+import me.ahoo.wow.modeling.state.StateAggregate
+import me.ahoo.wow.webflux.route.command.getOwnerId
+import org.springframework.web.reactive.function.server.ServerRequest
+
+internal class OwnerAggregatePrecondition(
+    private val request: ServerRequest,
+    private val owner: AggregateRoute.Owner
+) {
+    fun <S : Any> check(stateAggregate: StateAggregate<S>) {
+        if (!owner.owned) {
+            return
+        }
+        val ownerId = requireNotNull(request.getOwnerId())
+        if (stateAggregate.ownerId != ownerId) {
+            throw IllegalAccessOwnerAggregateException(stateAggregate.aggregateId)
+        }
+    }
+}

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/snapshot/LoadSnapshotHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/snapshot/LoadSnapshotHandlerFunctionTest.kt
@@ -36,6 +36,7 @@ class LoadSnapshotHandlerFunctionTest {
             every { uri() } returns URI.create("http://localhost")
             every { pathVariables()[RoutePaths.ID_KEY] } returns generateGlobalId()
             every { pathVariables()[MessageRecords.TENANT_ID] } returns generateGlobalId()
+            every { pathVariables()[MessageRecords.OWNER_ID] } returns generateGlobalId()
         }
         handlerFunction.handle(request)
             .test()

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/state/LoadAggregateHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/state/LoadAggregateHandlerFunctionTest.kt
@@ -15,6 +15,7 @@ package me.ahoo.wow.webflux.route.state
 
 import io.mockk.every
 import io.mockk.mockk
+import me.ahoo.wow.configuration.requiredNamedBoundedContext
 import me.ahoo.wow.eventsourcing.EventSourcingStateAggregateRepository
 import me.ahoo.wow.eventsourcing.InMemoryEventStore
 import me.ahoo.wow.eventsourcing.snapshot.NoOpSnapshotRepository
@@ -28,7 +29,6 @@ import me.ahoo.wow.openapi.RoutePaths
 import me.ahoo.wow.openapi.route.aggregateRouteMetadata
 import me.ahoo.wow.openapi.state.LoadAggregateRouteSpec
 import me.ahoo.wow.serialization.MessageRecords
-import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import me.ahoo.wow.test.aggregate.`when`
 import me.ahoo.wow.test.aggregateVerifier
 import me.ahoo.wow.webflux.exception.DefaultRequestExceptionHandler
@@ -70,7 +70,7 @@ class LoadAggregateHandlerFunctionTest {
             exceptionHandler = DefaultRequestExceptionHandler,
         ).create(
             LoadAggregateRouteSpec(
-                MOCK_AGGREGATE_METADATA,
+                Cart::class.java.requiredNamedBoundedContext(),
                 aggregateRouteMetadata = Cart::class.java.aggregateRouteMetadata()
             )
         )

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/state/OwnerAggregatePreconditionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/state/OwnerAggregatePreconditionTest.kt
@@ -1,0 +1,53 @@
+package me.ahoo.wow.webflux.route.state
+
+import io.mockk.every
+import io.mockk.mockk
+import me.ahoo.wow.api.annotation.AggregateRoute
+import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.modeling.command.IllegalAccessOwnerAggregateException
+import me.ahoo.wow.modeling.state.StateAggregate
+import me.ahoo.wow.modeling.toNamedAggregate
+import me.ahoo.wow.serialization.MessageRecords
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.web.reactive.function.server.ServerRequest
+
+class OwnerAggregatePreconditionTest {
+
+    @Test
+    fun checkNever() {
+        val request = mockk<ServerRequest>()
+        val stateAggregate = mockk<StateAggregate<Any>>()
+        OwnerAggregatePrecondition(request, AggregateRoute.Owner.NEVER).check(stateAggregate)
+    }
+
+    @Test
+    fun check() {
+        val customerId = generateGlobalId()
+        val request = mockk<ServerRequest> {
+            every { pathVariables()[MessageRecords.OWNER_ID] } returns customerId
+        }
+
+        val stateAggregate = mockk<StateAggregate<Any>> {
+            every { ownerId } returns customerId
+        }
+
+        OwnerAggregatePrecondition(request, AggregateRoute.Owner.ALWAYS).check(stateAggregate)
+    }
+
+    @Test
+    fun checkFailed() {
+        val request = mockk<ServerRequest> {
+            every { pathVariables()[MessageRecords.OWNER_ID] } returns generateGlobalId()
+        }
+
+        val stateAggregate = mockk<StateAggregate<Any>> {
+            every { ownerId } returns generateGlobalId()
+            every { aggregateId } returns "test.test".toNamedAggregate().aggregateId()
+        }
+        Assertions.assertThrows(IllegalAccessOwnerAggregateException::class.java) {
+            OwnerAggregatePrecondition(request, AggregateRoute.Owner.ALWAYS).check(stateAggregate)
+        }
+    }
+}


### PR DESCRIPTION
- Implement OwnerAggregatePrecondition to check owner access for aggregates
- Add owner check in LoadSnapshotHandlerFunction and LoadTimeBasedAggregateHandlerFunction
- Update AggregateRoute.Owner to use boolean value for owned status
- Add tests for OwnerAggregatePrecondition

