### PR TITLE
feat(api): adjust default owner value

### DIFF
--- a/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/Order.kt
+++ b/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/Order.kt
@@ -52,7 +52,7 @@ import reactor.kotlin.core.publisher.toMono
  * @see me.ahoo.wow.modeling.state.StateAggregate
  */
 @AggregateRoot
-@AggregateRoute
+@AggregateRoute(owner = AggregateRoute.Owner.ALWAYS)
 class Order(private val state: OrderState) {
     companion object {
         private val log = LoggerFactory.getLogger(Order::class.java)

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AggregateRoute.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AggregateRoute.kt
@@ -19,7 +19,7 @@ import java.lang.annotation.Inherited
 @Inherited
 @MustBeDocumented
 annotation class AggregateRoute(
-    val owner: Owner = Owner.ALWAYS
+    val owner: Owner = Owner.NEVER
 ) {
 
     enum class Owner(val owned: Boolean) {


### PR DESCRIPTION
- Change the default value of AggregateRoute's owner parameter to Owner.NEVER
- Explicitly set Owner.ALWAYS for the Order aggregate


