### PR TITLE
feat(api): add resource name customization for aggregate routes

### DIFF
--- a/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/Order.kt
+++ b/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/Order.kt
@@ -52,7 +52,7 @@ import reactor.kotlin.core.publisher.toMono
  * @see me.ahoo.wow.modeling.state.StateAggregate
  */
 @AggregateRoot
-@AggregateRoute(owner = AggregateRoute.Owner.ALWAYS)
+@AggregateRoute(resourceName = "sales-order", owner = AggregateRoute.Owner.ALWAYS)
 class Order(private val state: OrderState) {
     companion object {
         private val log = LoggerFactory.getLogger(Order::class.java)

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AggregateRoute.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AggregateRoute.kt
@@ -19,6 +19,7 @@ import java.lang.annotation.Inherited
 @Inherited
 @MustBeDocumented
 annotation class AggregateRoute(
+    val resourceName: String = "",
     val owner: Owner = Owner.NEVER
 ) {
 

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/AggregateRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/AggregateRouteSpec.kt
@@ -73,7 +73,7 @@ interface AggregateRouteSpec : RouteSpec {
             if (appendOwnerPath) {
                 pathBuilder.append(OWNER_PATH_PREFIX)
             }
-            pathBuilder.append(namedAggregate.aggregateName)
+            pathBuilder.append(aggregateRouteMetadata.resourceName)
             if (appendIdPath) {
                 pathBuilder.append(ID_PATH_VARIABLE)
             }

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/route/AggregateRouteMetadata.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/route/AggregateRouteMetadata.kt
@@ -18,6 +18,7 @@ import me.ahoo.wow.modeling.matedata.AggregateMetadata
 
 data class AggregateRouteMetadata<C : Any>(
     val aggregateMetadata: AggregateMetadata<C, *>,
+    val resourceName: String,
     val owner: AggregateRoute.Owner
 ) : me.ahoo.wow.metadata.Metadata {
 

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/route/AggregateRouteMetadataParser.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/route/AggregateRouteMetadataParser.kt
@@ -35,10 +35,16 @@ internal class AggregateRouteMetadataVisitor<C : Any>(private val aggregateType:
 
     fun toMetadata(): AggregateRouteMetadata<C> {
         val aggregateMetadata = aggregateType.aggregateMetadata<C, Any>()
-        val ownerRoute = aggregateType.kotlin.scanAnnotation<AggregateRoute>()?.owner ?: AggregateRoute.Owner.NEVER
+        val aggregateRoute = aggregateType.kotlin.scanAnnotation<AggregateRoute>() ?: return AggregateRouteMetadata(
+            aggregateMetadata = aggregateMetadata,
+            resourceName = aggregateMetadata.aggregateName,
+            owner = AggregateRoute.Owner.NEVER
+        )
+
         return AggregateRouteMetadata(
             aggregateMetadata = aggregateMetadata,
-            owner = ownerRoute
+            resourceName = aggregateRoute.resourceName.ifBlank { aggregateMetadata.aggregateName },
+            owner = aggregateRoute.owner
         )
     }
 }


### PR DESCRIPTION
- Add resourceName property to AggregateRoute annotation
- Update AggregateRouteMetadata to include resourceName
- Modify AggregateRouteMetadataParser to handle new resourceName property
- Adjust AggregateRouteSpec to use customized resource name
- Update example to demonstrate new resourceName usage

