### PR TITLE
refactor(api): remove CommandRoute.ignoreAggregateNamePrefix

### DIFF
--- a/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/ChangeAddress.kt
+++ b/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/ChangeAddress.kt
@@ -22,7 +22,7 @@ import me.ahoo.wow.api.annotation.Summary
  */
 @Summary("修改收货地址")
 @CommandRoute(
-    path = "address",
+    action = "address",
     method = CommandRoute.Method.PUT,
     appendIdPath = CommandRoute.AppendPath.ALWAYS
 )

--- a/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/CreateOrder.kt
+++ b/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/CreateOrder.kt
@@ -28,7 +28,7 @@ import java.math.BigDecimal
  */
 @Summary("下单")
 @CommandRoute(
-    path = ""
+    action = ""
 )
 @CreateAggregate
 data class CreateOrder(

--- a/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/ReceiptOrder.kt
+++ b/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/ReceiptOrder.kt
@@ -23,7 +23,7 @@ import me.ahoo.wow.api.annotation.Summary
  */
 @Summary("收货")
 @CommandRoute(
-    path = "package",
+    action = "package",
     appendIdPath = CommandRoute.AppendPath.ALWAYS,
     method = CommandRoute.Method.PATCH
 )

--- a/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/ShipOrder.kt
+++ b/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/ShipOrder.kt
@@ -22,7 +22,7 @@ import me.ahoo.wow.api.annotation.Summary
  */
 @Summary("发货")
 @CommandRoute(
-    path = "package",
+    action = "package",
     appendIdPath = CommandRoute.AppendPath.ALWAYS,
     method = CommandRoute.Method.POST
 )

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/CommandRoute.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/CommandRoute.kt
@@ -15,19 +15,21 @@ package me.ahoo.wow.api.annotation
 
 import java.lang.annotation.Inherited
 
-const val DEFAULT_COMMAND_PATH = "__{command_name}__"
+const val DEFAULT_COMMAND_ACTION = "__{command_name}__"
 
 @Target(AnnotationTarget.CLASS, AnnotationTarget.ANNOTATION_CLASS)
 @Inherited
 @MustBeDocumented
 annotation class CommandRoute(
-    val path: String = DEFAULT_COMMAND_PATH,
+    /**
+     * action name or sub resource name
+     */
+    val action: String = DEFAULT_COMMAND_ACTION,
     val enabled: Boolean = true,
     val method: Method = Method.DEFAULT,
     val prefix: String = "",
     val appendIdPath: AppendPath = AppendPath.DEFAULT,
     val appendTenantPath: AppendPath = AppendPath.DEFAULT,
-    val ignoreAggregateNamePrefix: Boolean = false,
     val summary: String = "",
     val description: String = "",
 ) {

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/command/DeleteAggregate.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/command/DeleteAggregate.kt
@@ -23,5 +23,5 @@ import me.ahoo.wow.api.annotation.Summary
 interface DeleteAggregate
 
 @Summary("Delete aggregate")
-@CommandRoute(path = "", method = CommandRoute.Method.DELETE, appendIdPath = CommandRoute.AppendPath.ALWAYS)
+@CommandRoute(action = "", method = CommandRoute.Method.DELETE, appendIdPath = CommandRoute.AppendPath.ALWAYS)
 object DefaultDeleteAggregate : DeleteAggregate

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/command/RecoverAggregate.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/command/RecoverAggregate.kt
@@ -23,5 +23,5 @@ import me.ahoo.wow.api.annotation.Summary
 interface RecoverAggregate
 
 @Summary("Recover deleted aggregate")
-@CommandRoute(path = "recover", method = CommandRoute.Method.PUT, appendIdPath = CommandRoute.AppendPath.ALWAYS)
+@CommandRoute(action = "recover", method = CommandRoute.Method.PUT, appendIdPath = CommandRoute.AppendPath.ALWAYS)
 object DefaultRecoverAggregate : RecoverAggregate

--- a/wow-models/src/main/kotlin/me/ahoo/wow/models/tree/command/Create.kt
+++ b/wow-models/src/main/kotlin/me/ahoo/wow/models/tree/command/Create.kt
@@ -22,7 +22,7 @@ import me.ahoo.wow.models.tree.Flat
 @CommandRoute(
     method = CommandRoute.Method.POST,
     appendIdPath = CommandRoute.AppendPath.ALWAYS,
-    path = "",
+    action = "",
     summary = "Create tree node",
     description = "Id is the tenant ID."
 )

--- a/wow-models/src/main/kotlin/me/ahoo/wow/models/tree/command/Delete.kt
+++ b/wow-models/src/main/kotlin/me/ahoo/wow/models/tree/command/Delete.kt
@@ -21,7 +21,7 @@ import me.ahoo.wow.models.tree.TreeCoded
 @CommandRoute(
     method = CommandRoute.Method.DELETE,
     appendIdPath = CommandRoute.AppendPath.ALWAYS,
-    path = "{code}",
+    action = "{code}",
     summary = "Delete tree node",
     description = "Id is the tenant ID."
 )

--- a/wow-models/src/main/kotlin/me/ahoo/wow/models/tree/command/Move.kt
+++ b/wow-models/src/main/kotlin/me/ahoo/wow/models/tree/command/Move.kt
@@ -18,7 +18,7 @@ import me.ahoo.wow.api.annotation.CommandRoute
 @CommandRoute(
     method = CommandRoute.Method.PUT,
     appendIdPath = CommandRoute.AppendPath.ALWAYS,
-    path = "sort",
+    action = "sort",
     summary = "Move tree node order",
     description = "Only sibling moves are allowed."
 )

--- a/wow-models/src/main/kotlin/me/ahoo/wow/models/tree/command/Update.kt
+++ b/wow-models/src/main/kotlin/me/ahoo/wow/models/tree/command/Update.kt
@@ -21,7 +21,7 @@ import me.ahoo.wow.models.tree.TreeCoded
 @CommandRoute(
     method = CommandRoute.Method.PUT,
     appendIdPath = CommandRoute.AppendPath.ALWAYS,
-    path = "",
+    action = "",
     summary = "Update tree node"
 )
 interface Update<E : Updated> : TreeCoded {

--- a/wow-models/src/test/kotlin/me/ahoo/wow/models/tree/command/CreateCategory.kt
+++ b/wow-models/src/test/kotlin/me/ahoo/wow/models/tree/command/CreateCategory.kt
@@ -20,7 +20,7 @@ import me.ahoo.wow.api.annotation.CommandRoute
 @CommandRoute(
     method = CommandRoute.Method.POST,
     appendIdPath = CommandRoute.AppendPath.ALWAYS,
-    path = "",
+    action = "",
     summary = "添加树节点",
     description = "Id 为租户ID."
 )

--- a/wow-models/src/test/kotlin/me/ahoo/wow/models/tree/command/DeleteCategory.kt
+++ b/wow-models/src/test/kotlin/me/ahoo/wow/models/tree/command/DeleteCategory.kt
@@ -20,7 +20,7 @@ import me.ahoo.wow.models.tree.Flat
 @CommandRoute(
     method = CommandRoute.Method.DELETE,
     appendIdPath = CommandRoute.AppendPath.ALWAYS,
-    path = "{code}",
+    action = "{code}",
     summary = "删除树节点",
     description = "Id 为租户ID."
 )

--- a/wow-models/src/test/kotlin/me/ahoo/wow/models/tree/command/MoveCategory.kt
+++ b/wow-models/src/test/kotlin/me/ahoo/wow/models/tree/command/MoveCategory.kt
@@ -18,7 +18,7 @@ import me.ahoo.wow.api.annotation.CommandRoute
 @CommandRoute(
     method = CommandRoute.Method.PUT,
     appendIdPath = CommandRoute.AppendPath.ALWAYS,
-    path = "sort",
+    action = "sort",
     summary = "移动分类节点",
     description = "只允许同级移动."
 )

--- a/wow-models/src/test/kotlin/me/ahoo/wow/models/tree/command/UpdateCategory.kt
+++ b/wow-models/src/test/kotlin/me/ahoo/wow/models/tree/command/UpdateCategory.kt
@@ -20,7 +20,7 @@ import me.ahoo.wow.models.tree.Flat
 @CommandRoute(
     method = CommandRoute.Method.PUT,
     appendIdPath = CommandRoute.AppendPath.ALWAYS,
-    path = "",
+    action = "",
     summary = "更新分类名称",
     description = "Id 为租户ID."
 )

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/command/CommandRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/command/CommandRouteSpec.kt
@@ -95,17 +95,11 @@ class CommandRouteSpec(
 
     override val appendTenantPath: Boolean
         get() {
-            if (commandRouteMetadata.ignoreAggregateNamePrefix) {
-                return false
-            }
             val default = super.appendTenantPath
             return commandRouteMetadata.appendTenantPath.resolve(default)
         }
     override val appendIdPath: Boolean
         get() {
-            if (commandRouteMetadata.ignoreAggregateNamePrefix) {
-                return false
-            }
             if (aggregateRouteMetadata.owner == AggregateRoute.Owner.AGGREGATE_ID) {
                 return false
             }
@@ -121,13 +115,10 @@ class CommandRouteSpec(
 
     override val path: String
         get() {
-            if (commandRouteMetadata.ignoreAggregateNamePrefix) {
-                return PathBuilder().append(commandRouteMetadata.prefix).append(commandRouteMetadata.path).build()
-            }
             return PathBuilder()
                 .append(commandRouteMetadata.prefix)
                 .append(super.path)
-                .append(commandRouteMetadata.path).build()
+                .append(commandRouteMetadata.action).build()
         }
     override val summary: String
         get() = commandRouteMetadata.summary

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/route/CommandRouteMetadata.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/route/CommandRouteMetadata.kt
@@ -21,12 +21,11 @@ import me.ahoo.wow.serialization.toObject
 
 data class CommandRouteMetadata<C>(
     val enabled: Boolean,
-    val path: String,
+    val action: String,
     val method: String,
     val prefix: String = "",
     val appendIdPath: CommandRoute.AppendPath = CommandRoute.AppendPath.DEFAULT,
     val appendTenantPath: CommandRoute.AppendPath = CommandRoute.AppendPath.DEFAULT,
-    val ignoreAggregateNamePrefix: Boolean = false,
     val commandMetadata: CommandMetadata<C>,
     val summary: String = "",
     val description: String = "",

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/route/CommandRouteMetadataParser.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/route/CommandRouteMetadataParser.kt
@@ -15,7 +15,7 @@ package me.ahoo.wow.openapi.route
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import me.ahoo.wow.api.annotation.CommandRoute
-import me.ahoo.wow.api.annotation.DEFAULT_COMMAND_PATH
+import me.ahoo.wow.api.annotation.DEFAULT_COMMAND_ACTION
 import me.ahoo.wow.api.annotation.Summary
 import me.ahoo.wow.command.annotation.commandMetadata
 import me.ahoo.wow.command.metadata.CommandMetadata
@@ -102,11 +102,10 @@ internal class CommandRouteMetadataVisitor<C : Any>(private val commandType: Cla
         val summary = commandType.kotlin.scanAnnotation<Summary>()?.value ?: ""
         val commandRoute = commandType.kotlin.scanAnnotation<CommandRoute>() ?: return CommandRouteMetadata(
             enabled = true,
-            path = commandMetadata.name,
+            action = commandMetadata.name,
             method = commandMetadata.toMethod(),
             appendIdPath = CommandRoute.AppendPath.DEFAULT,
             appendTenantPath = CommandRoute.AppendPath.DEFAULT,
-            ignoreAggregateNamePrefix = false,
             commandMetadata = commandMetadata,
             pathVariableMetadata = pathVariables,
             headerVariableMetadata = headerVariables,
@@ -117,12 +116,11 @@ internal class CommandRouteMetadataVisitor<C : Any>(private val commandType: Cla
 
         return CommandRouteMetadata(
             enabled = commandRoute.enabled,
-            path = path,
+            action = path,
             method = commandMetadata.toMethod(commandRoute.method),
             prefix = commandRoute.prefix,
             appendIdPath = commandRoute.appendIdPath,
             appendTenantPath = commandRoute.appendTenantPath,
-            ignoreAggregateNamePrefix = commandRoute.ignoreAggregateNamePrefix,
             commandMetadata = commandMetadata,
             pathVariableMetadata = pathVariables,
             headerVariableMetadata = headerVariables,
@@ -135,13 +133,13 @@ internal class CommandRouteMetadataVisitor<C : Any>(private val commandType: Cla
         commandRoute: CommandRoute,
         commandMetadata: CommandMetadata<C>
     ): String {
-        if (commandRoute.path == DEFAULT_COMMAND_PATH) {
+        if (commandRoute.action == DEFAULT_COMMAND_ACTION) {
             return commandMetadata.name
         }
-        if (commandRoute.path.isBlank()) {
-            return commandRoute.path
+        if (commandRoute.action.isBlank()) {
+            return commandRoute.action
         }
-        val fullPath = PathBuilder().append(commandRoute.prefix).append(commandRoute.path).build()
+        val fullPath = PathBuilder().append(commandRoute.prefix).append(commandRoute.action).build()
         val uriPathVariables = UriTemplate(fullPath).variableNames.toSet()
         val pathVariableNames = pathVariables.map { it.variableName }.toSet()
         val missedVariableNames = uriPathVariables - pathVariableNames
@@ -164,7 +162,7 @@ internal class CommandRouteMetadataVisitor<C : Any>(private val commandType: Cla
             }
         }
 
-        return commandRoute.path
+        return commandRoute.action
     }
 }
 

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/route/CommandRouteMetadataParserTest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/route/CommandRouteMetadataParserTest.kt
@@ -29,11 +29,10 @@ class CommandRouteMetadataParserTest {
     fun asCommandRouteMetadata() {
         val commandRouteMetadata = commandRouteMetadata<MockCommandRoute>()
         assertThat(commandRouteMetadata.enabled, equalTo(true))
-        assertThat(commandRouteMetadata.path, equalTo("{id}/{name}"))
+        assertThat(commandRouteMetadata.action, equalTo("{id}/{name}"))
         assertThat(commandRouteMetadata.method, equalTo(Https.Method.PATCH))
         assertThat(commandRouteMetadata.prefix, equalTo(""))
         assertThat(commandRouteMetadata.appendIdPath, equalTo(CommandRoute.AppendPath.DEFAULT))
-        assertThat(commandRouteMetadata.ignoreAggregateNamePrefix, equalTo(false))
         val idPathVariable = commandRouteMetadata.pathVariableMetadata.first { it.variableName == "id" }
         assertThat(idPathVariable.fieldName, equalTo("id"))
         assertThat(idPathVariable.variableName, equalTo("id"))
@@ -96,7 +95,7 @@ class CommandRouteMetadataParserTest {
     @Test
     fun decodeNested() {
         val commandRouteMetadata = commandRouteMetadata<NestedMockCommandRoute>()
-        assertThat(commandRouteMetadata.path, equalTo("{customerId}/{id}/{name}"))
+        assertThat(commandRouteMetadata.action, equalTo("{customerId}/{id}/{name}"))
         val customerIdPathVariable =
             commandRouteMetadata.pathVariableMetadata.first { it.variableName == "customerId" }
         assertThat(customerIdPathVariable.fieldName, equalTo("id"))
@@ -123,7 +122,7 @@ class CommandRouteMetadataParserTest {
     @Test
     fun decodeFieldNested() {
         val commandRouteMetadata = commandRouteMetadata<NestedFieldMockCommandRoute>()
-        assertThat(commandRouteMetadata.path, equalTo("{customerId}/{id}/{name}"))
+        assertThat(commandRouteMetadata.action, equalTo("{customerId}/{id}/{name}"))
         val customerIdPathVariable =
             commandRouteMetadata.pathVariableMetadata.first { it.variableName == "customerId" }
         assertThat(customerIdPathVariable.fieldName, equalTo("id"))


### PR DESCRIPTION
- Rename CommandRoute.path to CommandRoute.action
- Update related metadata and parser to use new action property
- Adjust path generation logic to use action instead of path
- Update example and test cases to reflect the new changes