### PR TITLE
refactor(api): update CommandRoute annotation and deprecate a property

### DIFF
--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/CommandRoute.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/CommandRoute.kt
@@ -15,18 +15,22 @@ package me.ahoo.wow.api.annotation
 
 import java.lang.annotation.Inherited
 
-const val DEFAULT_COMMAND_PATH = "__{command_name}__"
+const val DEFAULT_COMMAND_ACTION = "__{command_name}__"
 
 @Target(AnnotationTarget.CLASS, AnnotationTarget.ANNOTATION_CLASS)
 @Inherited
 @MustBeDocumented
 annotation class CommandRoute(
-    val path: String = DEFAULT_COMMAND_PATH,
+    /**
+     * action name or sub resource name
+     */
+    val path: String = DEFAULT_COMMAND_ACTION,
     val enabled: Boolean = true,
     val method: Method = Method.DEFAULT,
     val prefix: String = "",
     val appendIdPath: AppendPath = AppendPath.DEFAULT,
     val appendTenantPath: AppendPath = AppendPath.DEFAULT,
+    @Deprecated("Will be removed in version 5.3")
     val ignoreAggregateNamePrefix: Boolean = false,
     val summary: String = "",
     val description: String = "",

--- a/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/ReactiveSnapshotQueryApi.kt
+++ b/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/ReactiveSnapshotQueryApi.kt
@@ -38,7 +38,7 @@ interface ReactiveSnapshotQueryApi<S : Any> : SnapshotQueryApi {
     fun singleState(@RequestBody singleQuery: ISingleQuery): Mono<S>
 
     fun getById(id: String): Mono<MaterializedSnapshot<S>> {
-        return singleQuery {
+        singleQuery {
             condition {
                 id(id)
             }

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/route/CommandRouteMetadataParser.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/route/CommandRouteMetadataParser.kt
@@ -15,7 +15,7 @@ package me.ahoo.wow.openapi.route
 
 import com.fasterxml.jackson.annotation.JsonProperty
 import me.ahoo.wow.api.annotation.CommandRoute
-import me.ahoo.wow.api.annotation.DEFAULT_COMMAND_PATH
+import me.ahoo.wow.api.annotation.DEFAULT_COMMAND_ACTION
 import me.ahoo.wow.api.annotation.Summary
 import me.ahoo.wow.command.annotation.commandMetadata
 import me.ahoo.wow.command.metadata.CommandMetadata
@@ -135,7 +135,7 @@ internal class CommandRouteMetadataVisitor<C : Any>(private val commandType: Cla
         commandRoute: CommandRoute,
         commandMetadata: CommandMetadata<C>
     ): String {
-        if (commandRoute.path == DEFAULT_COMMAND_PATH) {
+        if (commandRoute.path == DEFAULT_COMMAND_ACTION) {
             return commandMetadata.name
         }
         if (commandRoute.path.isBlank()) {


### PR DESCRIPTION
- Rename DEFAULT_COMMAND_PATH to DEFAULT_COMMAND_ACTION for better clarity
- Add JavaDoc for the 'path' property
- Deprecate 'ignoreAggregateNamePrefix' property