### PR TITLE
feat(mongodb): add owner ID index and remove aggregate ID collection

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/naming/NamingConverter.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/naming/NamingConverter.kt
@@ -19,7 +19,7 @@ import me.ahoo.wow.infra.Decorator
  *
  * @author ahoo wang
  */
-interface NamingConverter {
+fun interface NamingConverter {
     fun convert(phrase: String): String
 
     companion object {

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/AggregateSchemaInitializer.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/AggregateSchemaInitializer.kt
@@ -32,17 +32,12 @@ object AggregateSchemaInitializer {
     private val uniqueIndexOptions = IndexOptions().unique(true)
     private const val EVENT_STREAM_COLLECTION_SUFFIX = "_event_stream"
     private const val SNAPSHOT_COLLECTION_SUFFIX = "_snapshot"
-    private const val AGGREGATE_ID_COLLECTION_SUFFIX = "_aggregate_id"
     fun NamedAggregate.toEventStreamCollectionName(): String {
         return "${this.aggregateName}$EVENT_STREAM_COLLECTION_SUFFIX"
     }
 
     fun NamedAggregate.toSnapshotCollectionName(): String {
         return "${this.aggregateName}$SNAPSHOT_COLLECTION_SUFFIX"
-    }
-
-    fun NamedAggregate.toAggregateIdCollectionName(): String {
-        return "${this.aggregateName}$AGGREGATE_ID_COLLECTION_SUFFIX"
     }
 
     fun MongoDatabase.ensureCollection(collectionName: String): Boolean {
@@ -86,6 +81,10 @@ object AggregateSchemaInitializer {
 
     fun MongoCollection<Document>.createTenantIdIndex() {
         createIndex(Indexes.hashed(MessageRecords.TENANT_ID))
+            .toMono().toBlockable().block()
+    }
+    fun MongoCollection<Document>.createOwnerIdIndex() {
+        createIndex(Indexes.hashed(MessageRecords.OWNER_ID))
             .toMono().toBlockable().block()
     }
 }

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/EventStreamSchemaInitializer.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/EventStreamSchemaInitializer.kt
@@ -19,6 +19,7 @@ import me.ahoo.wow.configuration.MetadataSearcher
 import me.ahoo.wow.mongo.AggregateSchemaInitializer.createAggregateIdAndRequestIdUniqueIndex
 import me.ahoo.wow.mongo.AggregateSchemaInitializer.createAggregateIdAndVersionUniqueIndex
 import me.ahoo.wow.mongo.AggregateSchemaInitializer.createAggregateIdIndex
+import me.ahoo.wow.mongo.AggregateSchemaInitializer.createOwnerIdIndex
 import me.ahoo.wow.mongo.AggregateSchemaInitializer.createRequestIdUniqueIndex
 import me.ahoo.wow.mongo.AggregateSchemaInitializer.createTenantIdIndex
 import me.ahoo.wow.mongo.AggregateSchemaInitializer.ensureCollection
@@ -69,5 +70,6 @@ class EventStreamSchemaInitializer(
             eventStreamCollection.createAggregateIdAndRequestIdUniqueIndex()
         }
         eventStreamCollection.createTenantIdIndex()
+        eventStreamCollection.createOwnerIdIndex()
     }
 }

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/SnapshotSchemaInitializer.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/SnapshotSchemaInitializer.kt
@@ -18,6 +18,7 @@ import com.mongodb.reactivestreams.client.MongoDatabase
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.configuration.MetadataSearcher
 import me.ahoo.wow.infra.accessor.function.reactive.toBlockable
+import me.ahoo.wow.mongo.AggregateSchemaInitializer.createOwnerIdIndex
 import me.ahoo.wow.mongo.AggregateSchemaInitializer.createTenantIdIndex
 import me.ahoo.wow.mongo.AggregateSchemaInitializer.ensureCollection
 import me.ahoo.wow.mongo.AggregateSchemaInitializer.toSnapshotCollectionName
@@ -51,6 +52,7 @@ class SnapshotSchemaInitializer(private val database: MongoDatabase) {
         }
         val snapshotCollection = database.getCollection(collectionName)
         snapshotCollection.createTenantIdIndex()
+        snapshotCollection.createOwnerIdIndex()
         snapshotCollection.createIndex(Indexes.hashed(Documents.ID_FIELD))
             .toMono().toBlockable().block()
         snapshotCollection.createIndex(Indexes.hashed(StateAggregateRecords.DELETED))


### PR DESCRIPTION
- Add createOwnerIdIndex function to AggregateSchemaInitializer
- Implement createOwnerIdIndex in EventStreamSchemaInitializer and SnapshotSchemaInitializer
- Remove toAggregateIdCollectionName function and related collections
- Update NamingConverter to use functional interface
