### PR TITLE
feat(api): add appendOwnerPath option for command route

### DIFF
--- a/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/PayOrder.kt
+++ b/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/PayOrder.kt
@@ -23,7 +23,11 @@ import java.math.BigDecimal
  *
  * @author ahoo wang
  */
-@CommandRoute("pay", method = CommandRoute.Method.POST, appendIdPath = CommandRoute.AppendPath.ALWAYS)
+@CommandRoute(
+    "pay",
+    method = CommandRoute.Method.POST,
+    appendOwnerPath = CommandRoute.AppendPath.NEVER
+)
 data class PayOrder(
     @field:NotBlank
     val paymentId: String,

--- a/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/ShipOrder.kt
+++ b/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/ShipOrder.kt
@@ -23,7 +23,7 @@ import me.ahoo.wow.api.annotation.Summary
 @Summary("发货")
 @CommandRoute(
     action = "package",
-    appendIdPath = CommandRoute.AppendPath.ALWAYS,
+    appendOwnerPath = CommandRoute.AppendPath.NEVER,
     method = CommandRoute.Method.POST
 )
 data class ShipOrder(

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/CommandRoute.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/CommandRoute.kt
@@ -30,6 +30,7 @@ annotation class CommandRoute(
     val prefix: String = "",
     val appendIdPath: AppendPath = AppendPath.DEFAULT,
     val appendTenantPath: AppendPath = AppendPath.DEFAULT,
+    val appendOwnerPath: AppendPath = AppendPath.DEFAULT,
     val summary: String = "",
     val description: String = "",
 ) {

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/command/CommandRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/command/CommandRouteSpec.kt
@@ -98,6 +98,13 @@ class CommandRouteSpec(
             val default = super.appendTenantPath
             return commandRouteMetadata.appendTenantPath.resolve(default)
         }
+
+    override val appendOwnerPath: Boolean
+        get() {
+            val default = super.appendOwnerPath
+            return commandRouteMetadata.appendOwnerPath.resolve(default)
+        }
+
     override val appendIdPath: Boolean
         get() {
             if (aggregateRouteMetadata.owner == AggregateRoute.Owner.AGGREGATE_ID) {

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/route/CommandRouteMetadata.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/route/CommandRouteMetadata.kt
@@ -26,6 +26,7 @@ data class CommandRouteMetadata<C>(
     val prefix: String = "",
     val appendIdPath: CommandRoute.AppendPath = CommandRoute.AppendPath.DEFAULT,
     val appendTenantPath: CommandRoute.AppendPath = CommandRoute.AppendPath.DEFAULT,
+    val appendOwnerPath: CommandRoute.AppendPath = CommandRoute.AppendPath.DEFAULT,
     val commandMetadata: CommandMetadata<C>,
     val summary: String = "",
     val description: String = "",

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/route/CommandRouteMetadataParser.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/route/CommandRouteMetadataParser.kt
@@ -112,15 +112,16 @@ internal class CommandRouteMetadataVisitor<C : Any>(private val commandType: Cla
             summary = summary
         )
 
-        val path = parsePath(commandRoute, commandMetadata)
+        val action = parseAction(commandRoute, commandMetadata)
 
         return CommandRouteMetadata(
             enabled = commandRoute.enabled,
-            action = path,
+            action = action,
             method = commandMetadata.toMethod(commandRoute.method),
             prefix = commandRoute.prefix,
             appendIdPath = commandRoute.appendIdPath,
             appendTenantPath = commandRoute.appendTenantPath,
+            appendOwnerPath = commandRoute.appendOwnerPath,
             commandMetadata = commandMetadata,
             pathVariableMetadata = pathVariables,
             headerVariableMetadata = headerVariables,
@@ -129,7 +130,7 @@ internal class CommandRouteMetadataVisitor<C : Any>(private val commandType: Cla
         )
     }
 
-    private fun parsePath(
+    private fun parseAction(
         commandRoute: CommandRoute,
         commandMetadata: CommandMetadata<C>
     ): String {


### PR DESCRIPTION
- Add appendOwnerPath parameter to CommandRoute annotation
- Update CommandRouteMetadata and CommandRouteMetadataParser to support appendOwnerPath
- Modify CommandRouteSpec to handle appendOwnerPath option
- Update example commands to use appendOwnerPath instead of appendIdPath
