### PR TITLE
refactor(wow-openapi): replace COMMAND_OWNER_PARAMETER with OWNER_ID_PARAMETER ref

### DIFF
--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/command/CommandFacadeRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/command/CommandFacadeRouteSpec.kt
@@ -32,7 +32,6 @@ import me.ahoo.wow.openapi.RouteIdSpec
 import me.ahoo.wow.openapi.RouteSpec
 import me.ahoo.wow.openapi.command.CommandFacadeRouteSpecFactory.Companion.COMMAND_AGGREGATE_CONTEXT_PARAMETER
 import me.ahoo.wow.openapi.command.CommandFacadeRouteSpecFactory.Companion.COMMAND_AGGREGATE_NAME_PARAMETER
-import me.ahoo.wow.openapi.command.CommandFacadeRouteSpecFactory.Companion.COMMAND_OWNER_PARAMETER
 import me.ahoo.wow.openapi.command.CommandFacadeRouteSpecFactory.Companion.COMMAND_TYPE_PARAMETER
 import me.ahoo.wow.openapi.command.CommandFacadeRouteSpecFactory.Companion.PATH
 import me.ahoo.wow.openapi.command.CommandRouteSpecFactory.Companion.AGGREGATE_ID_PARAMETER
@@ -42,6 +41,7 @@ import me.ahoo.wow.openapi.command.CommandRouteSpecFactory.Companion.COMMAND_RES
 import me.ahoo.wow.openapi.command.CommandRouteSpecFactory.Companion.ILLEGAL_ACCESS_DELETED_AGGREGATE_RESPONSE
 import me.ahoo.wow.openapi.command.CommandRouteSpecFactory.Companion.LOCAL_FIRST_PARAMETER
 import me.ahoo.wow.openapi.command.CommandRouteSpecFactory.Companion.NOT_FOUND_RESPONSE
+import me.ahoo.wow.openapi.command.CommandRouteSpecFactory.Companion.OWNER_ID_PARAMETER
 import me.ahoo.wow.openapi.command.CommandRouteSpecFactory.Companion.REQUEST_ID_PARAMETER
 import me.ahoo.wow.openapi.command.CommandRouteSpecFactory.Companion.TENANT_ID_PARAMETER
 import me.ahoo.wow.openapi.command.CommandRouteSpecFactory.Companion.VERSION_CONFLICT_RESPONSE
@@ -71,7 +71,7 @@ object CommandFacadeRouteSpec : RouteSpec {
                 add(WAIT_PROCESSOR_PARAMETER.ref)
                 add(WAIT_TIME_OUT_PARAMETER.ref)
                 add(TENANT_ID_PARAMETER.ref)
-                add(COMMAND_OWNER_PARAMETER)
+                add(OWNER_ID_PARAMETER.ref)
                 add(AGGREGATE_ID_PARAMETER.ref)
                 add(AGGREGATE_VERSION_PARAMETER.ref)
                 add(REQUEST_ID_PARAMETER.ref)
@@ -114,11 +114,6 @@ class CommandFacadeRouteSpecFactory : GlobalRouteSpecFactory {
             .`in`(ParameterIn.HEADER.toString())
             .schema(StringSchema())
             .description("Command Aggregate Name")
-        val COMMAND_OWNER_PARAMETER: Parameter = Parameter()
-            .name(CommandRequestHeaders.OWNER_ID)
-            .`in`(ParameterIn.HEADER.toString())
-            .schema(StringSchema())
-            .description("Resource Owner Id")
         const val PATH = "/${Wow.WOW}/command/send"
     }
 

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/command/CommandRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/command/CommandRouteSpec.kt
@@ -211,6 +211,13 @@ class CommandRouteSpecFactory : AbstractAggregateRouteSpecFactory() {
             .schema(StringSchema()).let {
                 ParameterRef("${Wow.WOW_PREFIX}${it.name}", it)
             }
+        val OWNER_ID_PARAMETER = Parameter()
+            .name(CommandRequestHeaders.OWNER_ID)
+            .`in`(ParameterIn.HEADER.toString())
+            .description("Resource Owner Id")
+            .schema(StringSchema()).let {
+                ParameterRef("${Wow.WOW_PREFIX}${it.name}", it)
+            }
         val AGGREGATE_ID_PARAMETER = Parameter()
             .name(CommandRequestHeaders.AGGREGATE_ID)
             .`in`(ParameterIn.HEADER.toString())
@@ -283,6 +290,7 @@ class CommandRouteSpecFactory : AbstractAggregateRouteSpecFactory() {
             .with(WAIT_PROCESSOR_PARAMETER)
             .with(WAIT_TIME_OUT_PARAMETER)
             .with(TENANT_ID_PARAMETER)
+            .with(OWNER_ID_PARAMETER)
             .with(AGGREGATE_ID_PARAMETER)
             .with(AGGREGATE_VERSION_PARAMETER)
             .with(REQUEST_ID_PARAMETER)


### PR DESCRIPTION
- Remove COMMAND_OWNER_PARAMETER from CommandFacadeRouteSpec
- Add OWNER_ID_PARAMETER ref to CommandFacadeRouteSpec- Update CommandRouteSpec to include OWNER_ID_PARAMETER
- Refactor code to use ParameterRef for better reusability

