### PR TITLE
feat(wow-openapi): add empty class converter for Swagger

### DIFF
--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/EmptyClassConverter.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/EmptyClassConverter.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.openapi.converter
+
+import io.swagger.v3.core.converter.AnnotatedType
+import io.swagger.v3.core.converter.ModelConverter
+import io.swagger.v3.core.converter.ModelConverterContext
+import io.swagger.v3.oas.models.media.Schema
+
+class EmptyClassConverter : ModelConverter {
+    override fun resolve(
+        type: AnnotatedType,
+        context: ModelConverterContext,
+        chain: Iterator<ModelConverter>
+    ): Schema<*>? {
+        if (!chain.hasNext()) {
+            return null
+        }
+        val resolvedSchema = chain.next().resolve(type, context, chain) ?: return null
+        if (!resolvedSchema.`$ref`.isNullOrBlank() || resolvedSchema.properties != null) {
+            return resolvedSchema
+        }
+        resolvedSchema.properties = HashMap()
+        return resolvedSchema
+    }
+}

--- a/wow-openapi/src/main/resources/META-INF/services/io.swagger.v3.core.converter.ModelConverter
+++ b/wow-openapi/src/main/resources/META-INF/services/io.swagger.v3.core.converter.ModelConverter
@@ -25,3 +25,4 @@ me.ahoo.wow.openapi.converter.ListQueryConverter
 me.ahoo.wow.openapi.converter.PaginationConverter
 me.ahoo.wow.openapi.converter.PagedQueryConverter
 me.ahoo.wow.openapi.converter.SingleQueryConverter
+me.ahoo.wow.openapi.converter.EmptyClassConverter


### PR DESCRIPTION
- Implement EmptyClassConverter to handle empty classes in Swagger
- Register EmptyClassConverter in META-INF/services/io.swagger.v3.core.converter.ModelConverter