### PR TITLE
feat(cache): implement StateCacheRefresher for proactive cache refreshing

### DIFF
--- a/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/CacheValueTtlConfiguration.kt
+++ b/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/CacheValueTtlConfiguration.kt
@@ -13,14 +13,13 @@
 
 package me.ahoo.wow.cache
 
-import java.time.Duration
-
-data class LoadCacheSourceConfiguration(
-    val timeout: Duration = Duration.ofSeconds(10),
-    override val ttl: Long? = null,
-    val amplitude: Long = 0
-) : CacheValueTtlConfiguration {
-    companion object {
-        val DEFAULT = LoadCacheSourceConfiguration()
-    }
+interface CacheValueTtlConfiguration {
+    /**
+     * 缓存过期时间，单位：秒
+     *
+     * 当为 `null` 时，表示不设置过期时间。
+     *
+     * @see me.ahoo.cache.api.TtlAt
+     */
+    val ttl: Long?
 }

--- a/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/RefreshMode.kt
+++ b/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/RefreshMode.kt
@@ -13,14 +13,7 @@
 
 package me.ahoo.wow.cache
 
-import java.time.Duration
-
-data class LoadCacheSourceConfiguration(
-    val timeout: Duration = Duration.ofSeconds(10),
-    override val ttl: Long? = null,
-    val amplitude: Long = 0
-) : CacheValueTtlConfiguration {
-    companion object {
-        val DEFAULT = LoadCacheSourceConfiguration()
-    }
+enum class RefreshMode {
+    AUTO,
+    EVICT
 }

--- a/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/StateCacheRefresher.kt
+++ b/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/StateCacheRefresher.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.cache
+
+import me.ahoo.cache.DefaultCacheValue
+import me.ahoo.cache.api.Cache
+import me.ahoo.wow.api.messaging.function.FunctionKind
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.modeling.NamedAggregateDecorator
+import me.ahoo.wow.event.StateDomainEventExchange
+import me.ahoo.wow.messaging.function.MessageFunction
+import me.ahoo.wow.modeling.materialize
+import reactor.core.publisher.Mono
+
+/**
+ * 主动刷新缓存.
+ */
+@JvmDefaultWithoutCompatibility
+open class StateCacheRefresher<S : Any, D>(
+    override val namedAggregate: NamedAggregate,
+    private val stateToCacheDataConverter: StateToCacheDataConverter<S, D>,
+    private val cache: Cache<String, D>,
+    override val ttl: Long? = null,
+    private val mode: RefreshMode = RefreshMode.AUTO
+) : NamedAggregateDecorator,
+    CacheValueTtlConfiguration,
+    MessageFunction<StateCacheRefresher<S, D>, StateDomainEventExchange<S, Any>, Mono<Void>> {
+    companion object {
+        private val log = org.slf4j.LoggerFactory.getLogger(StateCacheRefresher::class.java)
+    }
+
+    override val functionKind: FunctionKind = FunctionKind.STATE_EVENT
+    override val name: String = StateCacheRefresher<*, *>::invoke.name
+    override val processor: StateCacheRefresher<S, D> = this
+    override val supportedTopics: Set<NamedAggregate> = setOf(namedAggregate.materialize())
+    override val supportedType: Class<*> = Any::class.java
+
+    override fun <A : Annotation> getAnnotation(annotationClass: Class<A>): A? {
+        return null
+    }
+
+    override fun invoke(exchange: StateDomainEventExchange<S, Any>): Mono<Void> {
+        return Mono.fromRunnable {
+            if (log.isDebugEnabled) {
+                log.debug("[$mode]Refresh {} Cache.", exchange.state.aggregateId)
+            }
+            when (mode) {
+                RefreshMode.AUTO -> autoRefresh(exchange)
+                RefreshMode.EVICT -> evictRefresh(exchange)
+            }
+        }
+    }
+
+    private fun evictRefresh(exchange: StateDomainEventExchange<S, Any>) {
+        cache.evict(exchange.state.aggregateId.id)
+    }
+
+    private fun autoRefresh(exchange: StateDomainEventExchange<S, Any>) {
+        if (exchange.state.deleted) {
+            cache.evict(exchange.state.aggregateId.id)
+            return
+        }
+        val cacheData = stateToCacheDataConverter.stateToCacheData(exchange.state.state)
+        val ttl = ttl
+        val cacheValue = if (ttl == null) {
+            DefaultCacheValue.forever(cacheData)
+        } else {
+            DefaultCacheValue.ttlAt(cacheData, ttl)
+        }
+        cache.setCache(exchange.state.aggregateId.id, cacheValue)
+    }
+}

--- a/wow-cocache/src/test/kotlin/me/ahoo/wow/cache/StateCacheRefresherTest.kt
+++ b/wow-cocache/src/test/kotlin/me/ahoo/wow/cache/StateCacheRefresherTest.kt
@@ -1,0 +1,121 @@
+package me.ahoo.wow.cache
+
+import io.mockk.every
+import io.mockk.spyk
+import me.ahoo.cache.client.MapClientSideCache
+import me.ahoo.wow.api.annotation.OnEvent
+import me.ahoo.wow.api.messaging.function.FunctionKind
+import me.ahoo.wow.event.StateDomainEventExchange
+import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.modeling.materialize
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
+import me.ahoo.wow.tck.mock.MockStateAggregate
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.nullValue
+import org.hamcrest.MatcherAssert.*
+import org.junit.jupiter.api.Test
+import reactor.kotlin.test.test
+
+class StateCacheRefresherTest {
+    private val stateCacheRefresher = StateCacheRefresher<MockStateAggregate, MockStateAggregate>(
+        namedAggregate = MOCK_AGGREGATE_METADATA,
+        stateToCacheDataConverter = StateToCacheDataConverter.identity(),
+        cache = MapClientSideCache()
+    )
+
+    @Test
+    fun getFunctionKind() {
+        assertThat(stateCacheRefresher.functionKind, equalTo(FunctionKind.STATE_EVENT))
+    }
+
+    @Test
+    fun getName() {
+        assertThat(stateCacheRefresher.name, equalTo(StateCacheRefresher<*, *>::invoke.name))
+    }
+
+    @Test
+    fun getProcessor() {
+        assertThat(stateCacheRefresher.processor, equalTo(stateCacheRefresher))
+    }
+
+    @Test
+    fun getSupportedTopics() {
+        assertThat(stateCacheRefresher.supportedTopics, equalTo(setOf(MOCK_AGGREGATE_METADATA.materialize())))
+    }
+
+    @Test
+    fun getSupportedType() {
+        assertThat(stateCacheRefresher.supportedType, equalTo(Any::class.java))
+    }
+
+    @Test
+    fun getAnnotation() {
+        assertThat(stateCacheRefresher.getAnnotation(OnEvent::class.java), nullValue())
+    }
+
+    @Test
+    fun getNamedAggregate() {
+        assertThat(stateCacheRefresher.namedAggregate, equalTo(MOCK_AGGREGATE_METADATA))
+    }
+
+    @Test
+    fun getTtl() {
+        assertThat(stateCacheRefresher.ttl, nullValue())
+    }
+
+    @Test
+    fun invoke() {
+        val exchange = spyk<StateDomainEventExchange<MockStateAggregate, Any>> {
+            every { state.state } returns MockStateAggregate(generateGlobalId())
+            every { state.aggregateId } returns MOCK_AGGREGATE_METADATA.aggregateId()
+            every { state.deleted } returns false
+        }
+
+        stateCacheRefresher.invoke(exchange).test().verifyComplete()
+    }
+
+    @Test
+    fun invokeIfDeleted() {
+        val exchange = spyk<StateDomainEventExchange<MockStateAggregate, Any>> {
+            every { state.aggregateId } returns MOCK_AGGREGATE_METADATA.aggregateId()
+            every { state.deleted } returns true
+        }
+
+        stateCacheRefresher.invoke(exchange).test().verifyComplete()
+    }
+
+    @Test
+    fun invokeIfWithTtl() {
+        val stateCacheRefresher = StateCacheRefresher<MockStateAggregate, MockStateAggregate>(
+            namedAggregate = MOCK_AGGREGATE_METADATA,
+            stateToCacheDataConverter = StateToCacheDataConverter.identity(),
+            cache = MapClientSideCache(),
+            ttl = 600
+        )
+
+        val exchange = spyk<StateDomainEventExchange<MockStateAggregate, Any>> {
+            every { state.state } returns MockStateAggregate(generateGlobalId())
+            every { state.aggregateId } returns MOCK_AGGREGATE_METADATA.aggregateId()
+            every { state.deleted } returns false
+        }
+
+        stateCacheRefresher.invoke(exchange).test().verifyComplete()
+    }
+
+    @Test
+    fun invokeIfEvictMode() {
+        val stateCacheRefresher = StateCacheRefresher<MockStateAggregate, MockStateAggregate>(
+            namedAggregate = MOCK_AGGREGATE_METADATA,
+            stateToCacheDataConverter = StateToCacheDataConverter.identity(),
+            cache = MapClientSideCache(),
+            mode = RefreshMode.EVICT
+        )
+
+        val exchange = spyk<StateDomainEventExchange<MockStateAggregate, Any>> {
+            every { state.aggregateId } returns MOCK_AGGREGATE_METADATA.aggregateId()
+        }
+
+        stateCacheRefresher.invoke(exchange).test().verifyComplete()
+    }
+}


### PR DESCRIPTION
- Add CacheValueTtlConfiguration interface for cache TTL configuration
- Update LoadCacheSourceConfiguration to implement CacheValueTtlConfiguration
- Introduce RefreshMode enum for different cache refreshing strategies
- Implement StateCacheRefresher class for proactive cache refreshing
- Add unit tests for StateCacheRefresher functionality
