### PR TITLE
refactor(cache): optimize StateToCacheDataConverter.identity() method

### DIFF
--- a/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/StateToCacheDataConverter.kt
+++ b/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/StateToCacheDataConverter.kt
@@ -19,9 +19,9 @@ fun interface StateToCacheDataConverter<S, D> {
     companion object {
         private val IDENTITY = StateToCacheDataConverter<Any, Any> { state -> state }
 
-        fun <S, D> identity(): StateToCacheDataConverter<S, D> {
+        fun <D> identity(): StateToCacheDataConverter<D, D> {
             @Suppress("UNCHECKED_CAST")
-            return IDENTITY as StateToCacheDataConverter<S, D>
+            return IDENTITY as StateToCacheDataConverter<D, D>
         }
     }
 }

--- a/wow-cocache/src/test/kotlin/me/ahoo/wow/cache/StateToCacheDataConverterTest.kt
+++ b/wow-cocache/src/test/kotlin/me/ahoo/wow/cache/StateToCacheDataConverterTest.kt
@@ -21,7 +21,7 @@ class StateToCacheDataConverterTest {
     @Test
     fun stateToCacheData() {
         val state = Any()
-        val data = StateToCacheDataConverter.identity<Any, Any>().stateToCacheData(state)
+        val data = StateToCacheDataConverter.identity<Any>().stateToCacheData(state)
         assertThat(state, sameInstance(data))
     }
 }


### PR DESCRIPTION
- Update the identity() method in StateToCacheDataConverter to use a single type parameter
- Adjust the corresponding test case to use the new method signature
- This change improves type safety and reduces unnecessary type casting