### PR TITLE
refactor(cache): split StateCacheRefresher into separate classes

### DIFF
--- a/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/refresh/EvictStateCacheRefresher.kt
+++ b/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/refresh/EvictStateCacheRefresher.kt
@@ -11,16 +11,21 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.cache
+package me.ahoo.wow.cache.refresh
 
-import java.time.Duration
+import me.ahoo.cache.api.Cache
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.event.StateDomainEventExchange
 
-data class LoadCacheSourceConfiguration(
-    val timeout: Duration = Duration.ofSeconds(10),
-    override val ttl: Long? = null,
-    override val amplitude: Long = 0
-) : CacheValueConfiguration {
-    companion object {
-        val DEFAULT = LoadCacheSourceConfiguration()
+/**
+ * 主动逐出缓存.
+ */
+open class EvictStateCacheRefresher<S : Any, D>(
+    namedAggregate: NamedAggregate,
+    override val cache: Cache<String, D>
+) : StateCacheRefresher<S, D> (namedAggregate) {
+
+    override fun refresh(exchange: StateDomainEventExchange<S, Any>) {
+        cache.evict(exchange.state.aggregateId.id)
     }
 }

--- a/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/refresh/SetStateCacheRefresher.kt
+++ b/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/refresh/SetStateCacheRefresher.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.cache.refresh
+
+import me.ahoo.cache.DefaultCacheValue
+import me.ahoo.cache.api.Cache
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.cache.CacheValueConfiguration
+import me.ahoo.wow.cache.StateToCacheDataConverter
+import me.ahoo.wow.event.StateDomainEventExchange
+
+/**
+ * 主动刷新缓存.
+ */
+@JvmDefaultWithoutCompatibility
+open class SetStateCacheRefresher<S : Any, D>(
+    namedAggregate: NamedAggregate,
+    private val stateToCacheDataConverter: StateToCacheDataConverter<S, D>,
+    override val cache: Cache<String, D>,
+    override val ttl: Long? = null,
+    override val amplitude: Long = 0
+) : CacheValueConfiguration, StateCacheRefresher<S, D>(namedAggregate) {
+
+    override fun refresh(exchange: StateDomainEventExchange<S, Any>) {
+        if (exchange.state.deleted) {
+            cache.evict(exchange.state.aggregateId.id)
+            return
+        }
+        val cacheData = stateToCacheDataConverter.stateToCacheData(exchange.state.state)
+        val ttl = ttl
+        val cacheValue = if (ttl == null) {
+            DefaultCacheValue.forever(cacheData)
+        } else {
+            DefaultCacheValue.ttlAt(cacheData, ttl, amplitude)
+        }
+        cache.setCache(exchange.state.aggregateId.id, cacheValue)
+    }
+}

--- a/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/refresh/StateCacheRefresher.kt
+++ b/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/refresh/StateCacheRefresher.kt
@@ -11,9 +11,8 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.cache
+package me.ahoo.wow.cache.refresh
 
-import me.ahoo.cache.DefaultCacheValue
 import me.ahoo.cache.api.Cache
 import me.ahoo.wow.api.messaging.function.FunctionKind
 import me.ahoo.wow.api.modeling.NamedAggregate
@@ -27,24 +26,19 @@ import reactor.core.publisher.Mono
  * 主动刷新缓存.
  */
 @JvmDefaultWithoutCompatibility
-open class StateCacheRefresher<S : Any, D>(
-    override val namedAggregate: NamedAggregate,
-    private val stateToCacheDataConverter: StateToCacheDataConverter<S, D>,
-    private val cache: Cache<String, D>,
-    override val ttl: Long? = null,
-    override val amplitude: Long = 0,
-    private val mode: RefreshMode = RefreshMode.EVICT
-) : NamedAggregateDecorator,
-    CacheValueConfiguration,
+abstract class StateCacheRefresher<S : Any, D>(final override val namedAggregate: NamedAggregate) :
+    NamedAggregateDecorator,
     MessageFunction<StateCacheRefresher<S, D>, StateDomainEventExchange<S, Any>, Mono<Void>> {
     companion object {
         private val log = org.slf4j.LoggerFactory.getLogger(StateCacheRefresher::class.java)
     }
 
+    abstract val cache: Cache<String, D>
     override val functionKind: FunctionKind = FunctionKind.STATE_EVENT
     override val name: String = StateCacheRefresher<*, *>::invoke.name
-    override val processor: StateCacheRefresher<S, D> = this
-    override val supportedTopics: Set<NamedAggregate> = setOf(namedAggregate.materialize())
+    override val processor: StateCacheRefresher<S, D>
+        get() = this
+    final override val supportedTopics: Set<NamedAggregate> = setOf(namedAggregate.materialize())
     override val supportedType: Class<*> = Any::class.java
 
     override fun <A : Annotation> getAnnotation(annotationClass: Class<A>): A? {
@@ -54,31 +48,11 @@ open class StateCacheRefresher<S : Any, D>(
     override fun invoke(exchange: StateDomainEventExchange<S, Any>): Mono<Void> {
         return Mono.fromRunnable {
             if (log.isDebugEnabled) {
-                log.debug("[$mode] Refresh {} Cache.", exchange.state.aggregateId)
+                log.debug("[${this.javaClass.simpleName}] Refresh {} Cache.", exchange.state.aggregateId)
             }
-            when (mode) {
-                RefreshMode.EVICT -> evictRefresh(exchange)
-                RefreshMode.SET -> setRefresh(exchange)
-            }
+            refresh(exchange)
         }
     }
 
-    private fun evictRefresh(exchange: StateDomainEventExchange<S, Any>) {
-        cache.evict(exchange.state.aggregateId.id)
-    }
-
-    private fun setRefresh(exchange: StateDomainEventExchange<S, Any>) {
-        if (exchange.state.deleted) {
-            evictRefresh(exchange)
-            return
-        }
-        val cacheData = stateToCacheDataConverter.stateToCacheData(exchange.state.state)
-        val ttl = ttl
-        val cacheValue = if (ttl == null) {
-            DefaultCacheValue.forever(cacheData)
-        } else {
-            DefaultCacheValue.ttlAt(cacheData, ttl, amplitude)
-        }
-        cache.setCache(exchange.state.aggregateId.id, cacheValue)
-    }
+    abstract fun refresh(exchange: StateDomainEventExchange<S, Any>)
 }

--- a/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/source/LoadCacheSourceConfiguration.kt
+++ b/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/source/LoadCacheSourceConfiguration.kt
@@ -11,16 +11,17 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.cache
+package me.ahoo.wow.cache.source
 
-import me.ahoo.wow.apiclient.query.ReactiveSnapshotQueryApi
-import reactor.core.publisher.Mono
+import me.ahoo.wow.cache.CacheValueConfiguration
+import java.time.Duration
 
-interface QueryApiCacheSource<S : Any> : ReactiveSnapshotQueryApi<S>, StateCacheSource<S, S> {
-    override val stateToCacheDataConverter: StateToCacheDataConverter<S, S>
-        get() = StateToCacheDataConverter.identity()
-
-    override fun loadState(key: String): Mono<S> {
-        return getStateById(key)
+data class LoadCacheSourceConfiguration(
+    val timeout: Duration = Duration.ofSeconds(10),
+    override val ttl: Long? = null,
+    override val amplitude: Long = 0
+) : CacheValueConfiguration {
+    companion object {
+        val DEFAULT = LoadCacheSourceConfiguration()
     }
 }

--- a/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/source/QueryApiCacheSource.kt
+++ b/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/source/QueryApiCacheSource.kt
@@ -11,9 +11,17 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.cache
+package me.ahoo.wow.cache.source
 
-enum class RefreshMode {
-    EVICT,
-    SET
+import me.ahoo.wow.apiclient.query.ReactiveSnapshotQueryApi
+import me.ahoo.wow.cache.StateToCacheDataConverter
+import reactor.core.publisher.Mono
+
+interface QueryApiCacheSource<S : Any> : ReactiveSnapshotQueryApi<S>, StateCacheSource<S, S> {
+    override val stateToCacheDataConverter: StateToCacheDataConverter<S, S>
+        get() = StateToCacheDataConverter.identity()
+
+    override fun loadState(key: String): Mono<S> {
+        return getStateById(key)
+    }
 }

--- a/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/source/QueryServiceCacheSource.kt
+++ b/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/source/QueryServiceCacheSource.kt
@@ -11,8 +11,9 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.cache
+package me.ahoo.wow.cache.source
 
+import me.ahoo.wow.cache.StateToCacheDataConverter
 import me.ahoo.wow.query.dsl.singleQuery
 import me.ahoo.wow.query.snapshot.SnapshotQueryService
 import me.ahoo.wow.query.snapshot.query

--- a/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/source/StateCacheSource.kt
+++ b/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/source/StateCacheSource.kt
@@ -11,11 +11,12 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.cache
+package me.ahoo.wow.cache.source
 
 import me.ahoo.cache.DefaultCacheValue
 import me.ahoo.cache.api.CacheValue
 import me.ahoo.cache.api.source.CacheSource
+import me.ahoo.wow.cache.StateToCacheDataConverter
 import reactor.core.publisher.Mono
 import java.util.concurrent.TimeUnit
 

--- a/wow-cocache/src/test/kotlin/me/ahoo/wow/cache/refresh/EvictStateCacheRefresherTest.kt
+++ b/wow-cocache/src/test/kotlin/me/ahoo/wow/cache/refresh/EvictStateCacheRefresherTest.kt
@@ -1,0 +1,35 @@
+package me.ahoo.wow.cache.refresh
+
+import io.mockk.every
+import io.mockk.spyk
+import me.ahoo.cache.client.MapClientSideCache
+import me.ahoo.wow.event.StateDomainEventExchange
+import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
+import me.ahoo.wow.tck.mock.MockStateAggregate
+import org.hamcrest.CoreMatchers.instanceOf
+import org.hamcrest.MatcherAssert.*
+import org.junit.jupiter.api.Test
+import reactor.kotlin.test.test
+
+class EvictStateCacheRefresherTest {
+    private val stateCacheRefresher = EvictStateCacheRefresher<MockStateAggregate, MockStateAggregate>(
+        namedAggregate = MOCK_AGGREGATE_METADATA,
+        cache = MapClientSideCache()
+    )
+
+    @Test
+    fun getCache() {
+        assertThat(stateCacheRefresher.cache, instanceOf(MapClientSideCache::class.java))
+    }
+
+    @Test
+    fun invoke() {
+        val exchange = spyk<StateDomainEventExchange<MockStateAggregate, Any>> {
+            every { state.aggregateId } returns MOCK_AGGREGATE_METADATA.aggregateId()
+            every { state.deleted } returns true
+        }
+
+        stateCacheRefresher.invoke(exchange).test().verifyComplete()
+    }
+}

--- a/wow-cocache/src/test/kotlin/me/ahoo/wow/cache/refresh/SetStateCacheRefresherTest.kt
+++ b/wow-cocache/src/test/kotlin/me/ahoo/wow/cache/refresh/SetStateCacheRefresherTest.kt
@@ -109,4 +109,22 @@ class SetStateCacheRefresherTest {
 
         stateCacheRefresher.invoke(exchange).test().verifyComplete()
     }
+
+    @Test
+    fun invokeIfWithTtl() {
+        val stateCacheRefresher = SetStateCacheRefresher<MockStateAggregate, MockStateAggregate>(
+            namedAggregate = MOCK_AGGREGATE_METADATA,
+            stateToCacheDataConverter = StateToCacheDataConverter.identity(),
+            cache = MapClientSideCache(),
+            ttl = 600
+        )
+
+        val exchange = spyk<StateDomainEventExchange<MockStateAggregate, Any>> {
+            every { state.state } returns MockStateAggregate(generateGlobalId())
+            every { state.aggregateId } returns MOCK_AGGREGATE_METADATA.aggregateId()
+            every { state.deleted } returns false
+        }
+
+        stateCacheRefresher.invoke(exchange).test().verifyComplete()
+    }
 }

--- a/wow-cocache/src/test/kotlin/me/ahoo/wow/cache/refresh/SetStateCacheRefresherTest.kt
+++ b/wow-cocache/src/test/kotlin/me/ahoo/wow/cache/refresh/SetStateCacheRefresherTest.kt
@@ -1,10 +1,24 @@
-package me.ahoo.wow.cache
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.cache.refresh
 
 import io.mockk.every
 import io.mockk.spyk
 import me.ahoo.cache.client.MapClientSideCache
 import me.ahoo.wow.api.annotation.OnEvent
 import me.ahoo.wow.api.messaging.function.FunctionKind
+import me.ahoo.wow.cache.StateToCacheDataConverter
 import me.ahoo.wow.event.StateDomainEventExchange
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.modeling.aggregateId
@@ -12,17 +26,17 @@ import me.ahoo.wow.modeling.materialize
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import me.ahoo.wow.tck.mock.MockStateAggregate
 import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.instanceOf
 import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.*
 import org.junit.jupiter.api.Test
 import reactor.kotlin.test.test
 
-class StateCacheRefresherTest {
-    private val stateCacheRefresher = StateCacheRefresher<MockStateAggregate, MockStateAggregate>(
+class SetStateCacheRefresherTest {
+    private val stateCacheRefresher = SetStateCacheRefresher<MockStateAggregate, MockStateAggregate>(
         namedAggregate = MOCK_AGGREGATE_METADATA,
         stateToCacheDataConverter = StateToCacheDataConverter.identity(),
-        cache = MapClientSideCache(),
-        mode = RefreshMode.SET
+        cache = MapClientSideCache()
     )
 
     @Test
@@ -61,8 +75,18 @@ class StateCacheRefresherTest {
     }
 
     @Test
+    fun getCache() {
+        assertThat(stateCacheRefresher.cache, instanceOf(MapClientSideCache::class.java))
+    }
+
+    @Test
     fun getTtl() {
         assertThat(stateCacheRefresher.ttl, nullValue())
+    }
+
+    @Test
+    fun getAmplitude() {
+        assertThat(stateCacheRefresher.amplitude, equalTo(0))
     }
 
     @Test
@@ -81,40 +105,6 @@ class StateCacheRefresherTest {
         val exchange = spyk<StateDomainEventExchange<MockStateAggregate, Any>> {
             every { state.aggregateId } returns MOCK_AGGREGATE_METADATA.aggregateId()
             every { state.deleted } returns true
-        }
-
-        stateCacheRefresher.invoke(exchange).test().verifyComplete()
-    }
-
-    @Test
-    fun invokeIfWithTtl() {
-        val stateCacheRefresher = StateCacheRefresher<MockStateAggregate, MockStateAggregate>(
-            namedAggregate = MOCK_AGGREGATE_METADATA,
-            stateToCacheDataConverter = StateToCacheDataConverter.identity(),
-            cache = MapClientSideCache(),
-            ttl = 600
-        )
-
-        val exchange = spyk<StateDomainEventExchange<MockStateAggregate, Any>> {
-            every { state.state } returns MockStateAggregate(generateGlobalId())
-            every { state.aggregateId } returns MOCK_AGGREGATE_METADATA.aggregateId()
-            every { state.deleted } returns false
-        }
-
-        stateCacheRefresher.invoke(exchange).test().verifyComplete()
-    }
-
-    @Test
-    fun invokeIfEvictMode() {
-        val stateCacheRefresher = StateCacheRefresher<MockStateAggregate, MockStateAggregate>(
-            namedAggregate = MOCK_AGGREGATE_METADATA,
-            stateToCacheDataConverter = StateToCacheDataConverter.identity(),
-            cache = MapClientSideCache(),
-            mode = RefreshMode.EVICT
-        )
-
-        val exchange = spyk<StateDomainEventExchange<MockStateAggregate, Any>> {
-            every { state.aggregateId } returns MOCK_AGGREGATE_METADATA.aggregateId()
         }
 
         stateCacheRefresher.invoke(exchange).test().verifyComplete()

--- a/wow-cocache/src/test/kotlin/me/ahoo/wow/cache/source/QueryApiCacheSourceTest.kt
+++ b/wow-cocache/src/test/kotlin/me/ahoo/wow/cache/source/QueryApiCacheSourceTest.kt
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.cache
+package me.ahoo.wow.cache.source
 
 import io.mockk.every
 import io.mockk.spyk

--- a/wow-cocache/src/test/kotlin/me/ahoo/wow/cache/source/QueryServiceCacheSourceTest.kt
+++ b/wow-cocache/src/test/kotlin/me/ahoo/wow/cache/source/QueryServiceCacheSourceTest.kt
@@ -1,4 +1,17 @@
-package me.ahoo.wow.cache
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.cache.source
 
 import io.mockk.every
 import io.mockk.mockk


### PR DESCRIPTION
- Rename StateCacheRefresher to EvictStateCacheRefresher
- Create new SetStateCacheRefresher class
- Update related test files
- Refactor StateCacheRefresher into an abstract class
- Rename other cache-related classes for better organization
