### PR TITLE
docs(wow-api): add AfterCommand annotation documentation

### DIFF
--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AfterCommand.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AfterCommand.kt
@@ -19,6 +19,13 @@ import kotlin.reflect.KClass
 
 const val DEFAULT_AFTER_COMMAND_NAME = "afterCommand"
 
+/**
+ * 在命令函数完成执行后执行的函数。
+ *
+ * - 当返回值不为空时将作为领域事件追加到事件流中。
+ *
+ * @param commands 需要监听的命令类型。
+ */
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
 @Inherited
 @MustBeDocumented


### PR DESCRIPTION
- Add KotlinDoc comment for the AfterCommand annotation
- Explain the purpose and usage of the annotation
- Mention the behavior when the return value is not null
