### PR TITLE
feat(api): enhance AfterCommand with include/exclude functionality

### DIFF
--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AfterCommand.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AfterCommand.kt
@@ -24,12 +24,13 @@ const val DEFAULT_AFTER_COMMAND_NAME = "afterCommand"
  *
  * - 当返回值不为空时将作为领域事件追加到事件流中。
  *
- * @param commands 需要监听的命令类型。
+ * @param include 需要监听的命令类型。
  */
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
 @Inherited
 @MustBeDocumented
 @OnMessage(FunctionKind.COMMAND, defaultFunctionName = DEFAULT_AFTER_COMMAND_NAME)
 annotation class AfterCommand(
-    val commands: Array<KClass<*>> = []
+    val include: Array<KClass<*>> = [],
+    val exclude: Array<KClass<*>> = []
 )

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AfterCommand.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AfterCommand.kt
@@ -25,6 +25,7 @@ const val DEFAULT_AFTER_COMMAND_NAME = "afterCommand"
  * - 当返回值不为空时将作为领域事件追加到事件流中。
  *
  * @param include 需要监听的命令类型。
+ * @param exclude 排除监听的命令类型。
  */
 @Target(AnnotationTarget.FUNCTION, AnnotationTarget.ANNOTATION_CLASS)
 @Inherited

--- a/wow-core/src/test/kotlin/me/ahoo/wow/modeling/annotation/MockAggregates.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/modeling/annotation/MockAggregates.kt
@@ -51,7 +51,7 @@ class MockAfterCommandAggregate(val id: String) {
         return CmdUpdated
     }
 
-    @AfterCommand(commands = [CreateCmd::class])
+    @AfterCommand(include = [CreateCmd::class], exclude = [UpdateCmd::class])
     fun onAfterCommand(exchange: ServerCommandExchange<Any>): CmdAfter {
         require(exchange.getCommandInvokeResult<CmdCreated>() == CmdCreated)
         return CmdAfter

--- a/wow-core/src/test/kotlin/me/ahoo/wow/modeling/command/AfterCommandFunctionTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/modeling/command/AfterCommandFunctionTest.kt
@@ -5,6 +5,8 @@ import me.ahoo.wow.messaging.function.FunctionMetadataParser.toMonoFunctionMetad
 import me.ahoo.wow.messaging.function.toMessageFunction
 import me.ahoo.wow.modeling.annotation.CreateCmd
 import me.ahoo.wow.modeling.annotation.MockAfterCommandAggregate
+import me.ahoo.wow.modeling.annotation.MockDefaultAfterCommandAggregate
+import me.ahoo.wow.modeling.annotation.UpdateCmd
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.sameInstance
 import org.hamcrest.MatcherAssert.*
@@ -18,6 +20,16 @@ class AfterCommandFunctionTest {
 
     @Test
     fun matchCommand() {
+        assertThat(afterCommandFunction.matchCommand(CreateCmd::class.java), equalTo(true))
+        assertThat(afterCommandFunction.matchCommand(UpdateCmd::class.java), equalTo(false))
+    }
+
+    @Test
+    fun matchCommandEmpty() {
+        val funMetadata =
+            MockDefaultAfterCommandAggregate::afterCommand.toMonoFunctionMetadata<MockDefaultAfterCommandAggregate, Any>()
+        val messageFunction = funMetadata.toMessageFunction(MockDefaultAfterCommandAggregate(generateGlobalId()))
+        val afterCommandFunction = AfterCommandFunction(messageFunction)
         assertThat(afterCommandFunction.matchCommand(CreateCmd::class.java), equalTo(true))
     }
 


### PR DESCRIPTION
- Update AfterCommand annotation to use include/exclude instead of commands
- Modify AfterCommandFunction to handle new include/exclude logic
- Add tests for new AfterCommand matching behavior
- Update MockAggregates to demonstrate new AfterCommand usage