### PR TITLE
refactor(cache-refresh): generalize StateCacheRefresher and update related tests

### DIFF
--- a/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/refresh/EvictStateCacheRefresher.kt
+++ b/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/refresh/EvictStateCacheRefresher.kt
@@ -14,8 +14,9 @@
 package me.ahoo.wow.cache.refresh
 
 import me.ahoo.cache.api.Cache
+import me.ahoo.wow.api.messaging.function.FunctionKind
 import me.ahoo.wow.api.modeling.NamedAggregate
-import me.ahoo.wow.event.StateDomainEventExchange
+import me.ahoo.wow.event.DomainEventExchange
 
 /**
  * 主动逐出缓存.
@@ -23,9 +24,10 @@ import me.ahoo.wow.event.StateDomainEventExchange
 open class EvictStateCacheRefresher<S : Any, D>(
     namedAggregate: NamedAggregate,
     override val cache: Cache<String, D>
-) : StateCacheRefresher<S, D> (namedAggregate) {
+) : StateCacheRefresher<S, D, DomainEventExchange<Any>>(namedAggregate) {
 
-    override fun refresh(exchange: StateDomainEventExchange<S, Any>) {
-        cache.evict(exchange.state.aggregateId.id)
+    override val functionKind: FunctionKind = FunctionKind.EVENT
+    override fun refresh(exchange: DomainEventExchange<Any>) {
+        cache.evict(exchange.message.aggregateId.id)
     }
 }

--- a/wow-cocache/src/test/kotlin/me/ahoo/wow/cache/refresh/EvictStateCacheRefresherTest.kt
+++ b/wow-cocache/src/test/kotlin/me/ahoo/wow/cache/refresh/EvictStateCacheRefresherTest.kt
@@ -3,10 +3,12 @@ package me.ahoo.wow.cache.refresh
 import io.mockk.every
 import io.mockk.spyk
 import me.ahoo.cache.client.MapClientSideCache
-import me.ahoo.wow.event.StateDomainEventExchange
+import me.ahoo.wow.api.messaging.function.FunctionKind
+import me.ahoo.wow.event.DomainEventExchange
 import me.ahoo.wow.modeling.aggregateId
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import me.ahoo.wow.tck.mock.MockStateAggregate
+import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.instanceOf
 import org.hamcrest.MatcherAssert.*
 import org.junit.jupiter.api.Test
@@ -19,15 +21,19 @@ class EvictStateCacheRefresherTest {
     )
 
     @Test
+    fun getFunctionKind() {
+        assertThat(stateCacheRefresher.functionKind, equalTo(FunctionKind.EVENT))
+    }
+
+    @Test
     fun getCache() {
         assertThat(stateCacheRefresher.cache, instanceOf(MapClientSideCache::class.java))
     }
 
     @Test
     fun invoke() {
-        val exchange = spyk<StateDomainEventExchange<MockStateAggregate, Any>> {
-            every { state.aggregateId } returns MOCK_AGGREGATE_METADATA.aggregateId()
-            every { state.deleted } returns true
+        val exchange = spyk<DomainEventExchange<Any>> {
+            every { message.aggregateId } returns MOCK_AGGREGATE_METADATA.aggregateId()
         }
 
         stateCacheRefresher.invoke(exchange).test().verifyComplete()

--- a/wow-cocache/src/test/kotlin/me/ahoo/wow/cache/refresh/SetStateCacheRefresherTest.kt
+++ b/wow-cocache/src/test/kotlin/me/ahoo/wow/cache/refresh/SetStateCacheRefresherTest.kt
@@ -46,7 +46,7 @@ class SetStateCacheRefresherTest {
 
     @Test
     fun getName() {
-        assertThat(stateCacheRefresher.name, equalTo(StateCacheRefresher<*, *>::invoke.name))
+        assertThat(stateCacheRefresher.name, equalTo(StateCacheRefresher<*, *, *>::invoke.name))
     }
 
     @Test
@@ -93,7 +93,7 @@ class SetStateCacheRefresherTest {
     fun invoke() {
         val exchange = spyk<StateDomainEventExchange<MockStateAggregate, Any>> {
             every { state.state } returns MockStateAggregate(generateGlobalId())
-            every { state.aggregateId } returns MOCK_AGGREGATE_METADATA.aggregateId()
+            every { message.aggregateId } returns MOCK_AGGREGATE_METADATA.aggregateId()
             every { state.deleted } returns false
         }
 
@@ -103,7 +103,7 @@ class SetStateCacheRefresherTest {
     @Test
     fun invokeIfDeleted() {
         val exchange = spyk<StateDomainEventExchange<MockStateAggregate, Any>> {
-            every { state.aggregateId } returns MOCK_AGGREGATE_METADATA.aggregateId()
+            every { message.aggregateId } returns MOCK_AGGREGATE_METADATA.aggregateId()
             every { state.deleted } returns true
         }
 
@@ -121,7 +121,7 @@ class SetStateCacheRefresherTest {
 
         val exchange = spyk<StateDomainEventExchange<MockStateAggregate, Any>> {
             every { state.state } returns MockStateAggregate(generateGlobalId())
-            every { state.aggregateId } returns MOCK_AGGREGATE_METADATA.aggregateId()
+            every { message.aggregateId } returns MOCK_AGGREGATE_METADATA.aggregateId()
             every { state.deleted } returns false
         }
 


### PR DESCRIPTION
- Abstract StateCacheRefresher now supports generic DomainEventExchange
- Update EvictStateCacheRefresher and SetStateCacheRefresher to use new generic type
- Modify related test cases to accommodate the new generic structure
- Add functionKind property to StateCacheRefresher implementations
