### PR TITLE
refactor(query): split ReactiveSnapshotQueryApi into separate interfaces

### DIFF
--- a/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/ReactiveSnapshotQueryApi.kt
+++ b/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/ReactiveSnapshotQueryApi.kt
@@ -20,24 +20,17 @@ import me.ahoo.wow.api.query.ISingleQuery
 import me.ahoo.wow.api.query.MaterializedSnapshot
 import me.ahoo.wow.api.query.PagedList
 import me.ahoo.wow.query.dsl.singleQuery
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.reactive.function.client.WebClientResponseException
-import org.springframework.web.service.annotation.PostExchange
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
-interface ReactiveSnapshotQueryApi<S : Any> : SnapshotQueryApi {
+interface ReactiveSnapshotQueryApi<S : Any> :
+    SnapshotSingleQueryApi<Mono<MaterializedSnapshot<S>>, Mono<Map<String, Any>>, Mono<S>>,
+    SnapshotListQueryApi<Flux<MaterializedSnapshot<S>>, Flux<Map<String, Any>>, Flux<S>>,
+    SnapshotPagedQueryApi<Mono<PagedList<MaterializedSnapshot<S>>>, Mono<PagedList<Map<String, Any>>>, Mono<PagedList<S>>>,
+    SnapshotCountQueryApi<Mono<Long>> {
 
-    @PostExchange(SNAPSHOT_SINGLE_RESOURCE_NAME)
-    fun single(@RequestBody singleQuery: ISingleQuery): Mono<MaterializedSnapshot<S>>
-
-    @PostExchange(SNAPSHOT_SINGLE_RESOURCE_NAME)
-    fun dynamicSingle(@RequestBody singleQuery: ISingleQuery): Mono<Map<String, Any>>
-
-    @PostExchange(SNAPSHOT_SINGLE_STATE_RESOURCE_NAME)
-    fun singleState(@RequestBody singleQuery: ISingleQuery): Mono<S>
-
-    fun getById(id: String): Mono<MaterializedSnapshot<S>> {
+    override fun getById(id: String): Mono<MaterializedSnapshot<S>> {
         singleQuery {
             condition {
                 id(id)
@@ -47,7 +40,7 @@ interface ReactiveSnapshotQueryApi<S : Any> : SnapshotQueryApi {
         }
     }
 
-    fun getStateById(id: String): Mono<S> {
+    override fun getStateById(id: String): Mono<S> {
         singleQuery {
             condition {
                 id(id)
@@ -56,27 +49,6 @@ interface ReactiveSnapshotQueryApi<S : Any> : SnapshotQueryApi {
             return singleState(it).switchNotFoundToEmpty()
         }
     }
-
-    @PostExchange(SNAPSHOT_LIST_RESOURCE_NAME)
-    fun list(@RequestBody query: IListQuery): Flux<MaterializedSnapshot<S>>
-
-    @PostExchange(SNAPSHOT_LIST_RESOURCE_NAME)
-    fun dynamicList(@RequestBody query: IListQuery): Flux<Map<String, Any>>
-
-    @PostExchange(SNAPSHOT_LIST_STATE_RESOURCE_NAME)
-    fun listState(@RequestBody query: IListQuery): Flux<S>
-
-    @PostExchange(SNAPSHOT_PAGED_QUERY_RESOURCE_NAME)
-    fun paged(@RequestBody pagedQuery: IPagedQuery): Mono<PagedList<MaterializedSnapshot<S>>>
-
-    @PostExchange(SNAPSHOT_PAGED_QUERY_RESOURCE_NAME)
-    fun dynamicPaged(@RequestBody pagedQuery: IPagedQuery): Mono<PagedList<Map<String, Any>>>
-
-    @PostExchange(SNAPSHOT_PAGED_QUERY_STATE_RESOURCE_NAME)
-    fun pagedState(@RequestBody pagedQuery: IPagedQuery): Mono<PagedList<S>>
-
-    @PostExchange(SNAPSHOT_COUNT_RESOURCE_NAME)
-    fun count(@RequestBody condition: Condition): Mono<Long>
 }
 
 fun <T> Mono<T>.switchNotFoundToEmpty(): Mono<T> {

--- a/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SnapshotCountQueryApi.kt
+++ b/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SnapshotCountQueryApi.kt
@@ -13,6 +13,13 @@
 
 package me.ahoo.wow.apiclient.query
 
-const val SNAPSHOT_RESOURCE_NAME = "snapshot"
+import me.ahoo.wow.api.query.Condition
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.service.annotation.PostExchange
 
-interface SnapshotQueryApi
+const val SNAPSHOT_COUNT_RESOURCE_NAME = "$SNAPSHOT_RESOURCE_NAME/count"
+
+interface SnapshotCountQueryApi<R> : SnapshotQueryApi {
+    @PostExchange(SNAPSHOT_COUNT_RESOURCE_NAME)
+    fun count(@RequestBody condition: Condition): R
+}

--- a/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SnapshotListQueryApi.kt
+++ b/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SnapshotListQueryApi.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.apiclient.query
+
+import me.ahoo.wow.api.query.IListQuery
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.service.annotation.PostExchange
+
+const val SNAPSHOT_LIST_RESOURCE_NAME = "$SNAPSHOT_RESOURCE_NAME/list"
+const val SNAPSHOT_LIST_STATE_RESOURCE_NAME = "$SNAPSHOT_LIST_RESOURCE_NAME/state"
+
+interface SnapshotListQueryApi<R, RD, RS> : SnapshotQueryApi {
+    @PostExchange(SNAPSHOT_LIST_RESOURCE_NAME)
+    fun list(@RequestBody query: IListQuery): R
+
+    @PostExchange(SNAPSHOT_LIST_RESOURCE_NAME)
+    fun dynamicList(@RequestBody query: IListQuery): RD
+
+    @PostExchange(SNAPSHOT_LIST_STATE_RESOURCE_NAME)
+    fun listState(@RequestBody query: IListQuery): RS
+}

--- a/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SnapshotPagedQueryApi.kt
+++ b/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SnapshotPagedQueryApi.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.apiclient.query
+
+import me.ahoo.wow.api.query.IPagedQuery
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.service.annotation.PostExchange
+
+const val SNAPSHOT_PAGED_QUERY_RESOURCE_NAME = "$SNAPSHOT_RESOURCE_NAME/paged"
+const val SNAPSHOT_PAGED_QUERY_STATE_RESOURCE_NAME = "$SNAPSHOT_PAGED_QUERY_RESOURCE_NAME/state"
+
+interface SnapshotPagedQueryApi<R, RD, RS> : SnapshotQueryApi {
+    @PostExchange(SNAPSHOT_PAGED_QUERY_RESOURCE_NAME)
+    fun paged(@RequestBody pagedQuery: IPagedQuery): R
+
+    @PostExchange(SNAPSHOT_PAGED_QUERY_RESOURCE_NAME)
+    fun dynamicPaged(@RequestBody pagedQuery: IPagedQuery): RD
+
+    @PostExchange(SNAPSHOT_PAGED_QUERY_STATE_RESOURCE_NAME)
+    fun pagedState(@RequestBody pagedQuery: IPagedQuery): RS
+}

--- a/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SnapshotSingleQueryApi.kt
+++ b/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SnapshotSingleQueryApi.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.apiclient.query
+
+import me.ahoo.wow.api.query.ISingleQuery
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.service.annotation.PostExchange
+
+const val SNAPSHOT_SINGLE_RESOURCE_NAME = "$SNAPSHOT_RESOURCE_NAME/single"
+const val SNAPSHOT_SINGLE_STATE_RESOURCE_NAME = "$SNAPSHOT_SINGLE_RESOURCE_NAME/state"
+
+interface SnapshotSingleQueryApi<R, RD, RS> : SnapshotQueryApi {
+    @PostExchange(SNAPSHOT_SINGLE_RESOURCE_NAME)
+    fun single(@RequestBody singleQuery: ISingleQuery): R
+
+    @PostExchange(SNAPSHOT_SINGLE_RESOURCE_NAME)
+    fun dynamicSingle(@RequestBody singleQuery: ISingleQuery): RD
+
+    @PostExchange(SNAPSHOT_SINGLE_STATE_RESOURCE_NAME)
+    fun singleState(@RequestBody singleQuery: ISingleQuery): RS
+    fun getById(id: String): R
+    fun getStateById(id: String): RS
+}

--- a/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SyncSnapshotQueryApi.kt
+++ b/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SyncSnapshotQueryApi.kt
@@ -20,23 +20,16 @@ import me.ahoo.wow.api.query.ISingleQuery
 import me.ahoo.wow.api.query.MaterializedSnapshot
 import me.ahoo.wow.api.query.PagedList
 import me.ahoo.wow.query.dsl.singleQuery
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.client.HttpClientErrorException
 import org.springframework.web.reactive.function.client.WebClientResponseException
-import org.springframework.web.service.annotation.PostExchange
 
-interface SyncSnapshotQueryApi<S : Any> : SnapshotQueryApi {
+interface SyncSnapshotQueryApi<S : Any> :
+    SnapshotSingleQueryApi<MaterializedSnapshot<S>?, Map<String, Any>?, S?>,
+    SnapshotListQueryApi<List<MaterializedSnapshot<S>>, List<Map<String, Any>>, List<S>>,
+    SnapshotPagedQueryApi<PagedList<MaterializedSnapshot<S>>, PagedList<Map<String, Any>>, PagedList<S>>,
+    SnapshotCountQueryApi<Long> {
 
-    @PostExchange(SNAPSHOT_SINGLE_RESOURCE_NAME)
-    fun single(@RequestBody singleQuery: ISingleQuery): MaterializedSnapshot<S>?
-
-    @PostExchange(SNAPSHOT_SINGLE_RESOURCE_NAME)
-    fun dynamicSingle(@RequestBody singleQuery: ISingleQuery): Map<String, Any>?
-
-    @PostExchange(SNAPSHOT_SINGLE_STATE_RESOURCE_NAME)
-    fun singleState(@RequestBody singleQuery: ISingleQuery): S?
-
-    fun getById(id: String): MaterializedSnapshot<S>? {
+    override fun getById(id: String): MaterializedSnapshot<S>? {
         singleQuery {
             condition {
                 id(id)
@@ -46,7 +39,7 @@ interface SyncSnapshotQueryApi<S : Any> : SnapshotQueryApi {
         }
     }
 
-    fun getStateById(id: String): S? {
+    override fun getStateById(id: String): S? {
         singleQuery {
             condition {
                 id(id)
@@ -55,27 +48,6 @@ interface SyncSnapshotQueryApi<S : Any> : SnapshotQueryApi {
             return switchNotFoundToNull { singleState(it) }
         }
     }
-
-    @PostExchange(SNAPSHOT_LIST_RESOURCE_NAME)
-    fun list(@RequestBody query: IListQuery): List<MaterializedSnapshot<S>>
-
-    @PostExchange(SNAPSHOT_LIST_RESOURCE_NAME)
-    fun dynamicList(@RequestBody query: IListQuery): List<Map<String, Any>>
-
-    @PostExchange(SNAPSHOT_LIST_STATE_RESOURCE_NAME)
-    fun listState(@RequestBody query: IListQuery): List<S>
-
-    @PostExchange(SNAPSHOT_PAGED_QUERY_RESOURCE_NAME)
-    fun paged(@RequestBody pagedQuery: IPagedQuery): PagedList<MaterializedSnapshot<S>>
-
-    @PostExchange(SNAPSHOT_PAGED_QUERY_RESOURCE_NAME)
-    fun dynamicPaged(@RequestBody pagedQuery: IPagedQuery): PagedList<Map<String, Any>>
-
-    @PostExchange(SNAPSHOT_PAGED_QUERY_STATE_RESOURCE_NAME)
-    fun pagedState(@RequestBody pagedQuery: IPagedQuery): PagedList<S>
-
-    @PostExchange(SNAPSHOT_COUNT_RESOURCE_NAME)
-    fun count(@RequestBody condition: Condition): Long
 }
 
 fun <T> switchNotFoundToNull(query: () -> T): T? {


### PR DESCRIPTION
- Divide ReactiveSnapshotQueryApi into SnapshotSingleQueryApi, SnapshotListQueryApi, SnapshotPagedQueryApi, and SnapshotCountQueryApi
- Update SyncSnapshotQueryApi to implement new interfaces
- Remove redundant method declarations and annotations
- Improve code organization and readability
