### PR TITLE
fix(event-store): ensure events are ordered by version when loading

### DIFF
--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoEventStore.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoEventStore.kt
@@ -16,6 +16,7 @@ package me.ahoo.wow.mongo
 import com.mongodb.ErrorCategory
 import com.mongodb.MongoWriteException
 import com.mongodb.client.model.Filters
+import com.mongodb.client.model.Sorts
 import com.mongodb.reactivestreams.client.MongoDatabase
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.command.DuplicateRequestIdException
@@ -79,6 +80,7 @@ class MongoEventStore(private val database: MongoDatabase) : AbstractEventStore(
         val eventStreamCollectionName = aggregateId.toEventStreamCollectionName()
         return database.getCollection(eventStreamCollectionName)
             .find(filter)
+            .sort(Sorts.ascending(MessageRecords.VERSION))
             .toFlux()
             .map {
                 val domainEventStream = it.replacePrimaryKeyToId().toJson().toObject<DomainEventStream>()

--- a/wow-r2dbc/src/main/kotlin/me/ahoo/wow/r2dbc/EventStreamSchema.kt
+++ b/wow-r2dbc/src/main/kotlin/me/ahoo/wow/r2dbc/EventStreamSchema.kt
@@ -36,11 +36,11 @@ object EventStreamStatementGenerator {
     }
 
     private fun loadByVersionSql(tableName: String): String {
-        return "select * from $tableName where aggregate_id=? and version between ? and ?"
+        return "select * from $tableName where aggregate_id=? and version between ? and ? order by version"
     }
 
     private fun loadByEventTimeSql(tableName: String): String {
-        return "select * from $tableName where aggregate_id=? and create_time between ? and ?"
+        return "select * from $tableName where aggregate_id=? and create_time between ? and ? order by version"
     }
 
     private fun appendSql(tableName: String): String {

--- a/wow-r2dbc/src/test/kotlin/me/ahoo/wow/r2dbc/ShardingEventStreamSchemaTest.kt
+++ b/wow-r2dbc/src/test/kotlin/me/ahoo/wow/r2dbc/ShardingEventStreamSchemaTest.kt
@@ -33,7 +33,9 @@ internal class ShardingEventStreamSchemaTest {
     fun load() {
         assertThat(
             eventStreamSchema.load(namedAggregate.aggregateId("0TEC7cEx0001001")),
-            equalTo("select * from test_event_stream_1 where aggregate_id=? and version between ? and ?"),
+            equalTo(
+                "select * from test_event_stream_1 where aggregate_id=? and version between ? and ? order by version"
+            ),
         )
     }
 

--- a/wow-r2dbc/src/test/kotlin/me/ahoo/wow/r2dbc/SimpleEventStreamSchemaTest.kt
+++ b/wow-r2dbc/src/test/kotlin/me/ahoo/wow/r2dbc/SimpleEventStreamSchemaTest.kt
@@ -27,7 +27,9 @@ internal class SimpleEventStreamSchemaTest {
     fun loadEventStream() {
         assertThat(
             eventStreamSchema.load(namedAggregate.aggregateId("")),
-            equalTo("select * from test_event_stream where aggregate_id=? and version between ? and ?"),
+            equalTo(
+                "select * from test_event_stream where aggregate_id=? and version between ? and ? order by version"
+            ),
         )
     }
 


### PR DESCRIPTION
- Add 'order by version' clause to SQL queries in EventStreamSchema
- Implement sorting by version in MongoEventStore
- Update tests to reflect the new ordering behavior

This change ensures that events are always returned in the correct order, which is crucial for event sourcing and replay functionality.