### PR TITLE
refactor(command): redesign WaitStrategy and related components

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt
@@ -50,23 +50,7 @@ interface CommandGateway : CommandBus {
     fun <C : Any> sendAndWait(
         command: CommandMessage<C>,
         waitStrategy: WaitStrategy
-    ): Mono<CommandResult> {
-        return send(command, waitStrategy)
-            .onErrorMap {
-                CommandResultException(it.toResult(command, processorName = COMMAND_GATEWAY_PROCESSOR_NAME), it)
-            }
-            .flatMap {
-                waitStrategy.waiting()
-                    .map { waitSignal ->
-                        waitSignal.toResult(it.message)
-                            .apply {
-                                if (!succeeded) {
-                                    throw CommandResultException(this)
-                                }
-                            }
-                    }
-            }
-    }
+    ): Mono<CommandResult>
 
     fun <C : Any> sendAndWaitForSent(
         command: CommandMessage<C>

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategy.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategy.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.command.wait
 
 import me.ahoo.wow.api.messaging.processor.ProcessorInfo
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 /**
@@ -21,7 +22,12 @@ import reactor.core.publisher.Mono
  * @see WaitingFor
  */
 interface WaitStrategy : ProcessorInfo {
-    fun waiting(): Mono<WaitSignal>
+    val cancelled: Boolean
+    val terminated: Boolean
+    fun waiting(): Flux<WaitSignal>
+    fun waitingLast(): Mono<WaitSignal> {
+        return waiting().last()
+    }
 
     fun error(throwable: Throwable)
 
@@ -29,4 +35,6 @@ interface WaitStrategy : ProcessorInfo {
      * 由下游(CommandBus or Aggregate or Projector)发送处理结果信号.
      */
     fun next(signal: WaitSignal)
+
+    fun complete()
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingForProcessed.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingForProcessed.kt
@@ -19,9 +19,9 @@ class WaitingForProcessed : AbstractWaitingFor() {
     override val contextName: String = ""
     override val processorName: String = ""
     override fun next(signal: WaitSignal) {
-        if (signal.stage != CommandStage.PROCESSED) {
-            return
+        super.next(signal)
+        if (signal.stage == CommandStage.PROCESSED) {
+            complete()
         }
-        sink.tryEmitValue(signal)
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/SimpleWaitStrategyRegistrarTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/SimpleWaitStrategyRegistrarTest.kt
@@ -15,6 +15,7 @@ package me.ahoo.wow.command.wait
 
 import me.ahoo.wow.command.COMMAND_GATEWAY_FUNCTION
 import me.ahoo.wow.id.GlobalIdGenerator
+import me.ahoo.wow.id.generateGlobalId
 import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
@@ -60,12 +61,13 @@ internal class SimpleWaitStrategyRegistrarTest {
     @Test
     fun next() {
         val registrar = SimpleWaitStrategyRegistrar
-        val commandId = GlobalIdGenerator.generateAsString()
+        val commandId = generateGlobalId()
 
         val waitSignal = SimpleWaitSignal(commandId, CommandStage.PROCESSED, COMMAND_GATEWAY_FUNCTION)
         var nextResult = registrar.next(waitSignal)
         assertThat(nextResult, equalTo(false))
         val waitStrategy = WaitingFor.processed()
+        waitStrategy.waiting().subscribe()
         registrar.register(commandId, waitStrategy)
         nextResult = registrar.next(waitSignal)
         assertThat(nextResult, equalTo(true))


### PR DESCRIPTION
- Update CommandGateway to use new WaitStrategy interface
- Refactor DefaultCommandGateway to implement new sendAndWait method
- Modify SimpleWaitStrategyRegistrar to handle command completion
- Update WaitingFor and related classes to use Flux instead of Mono
- Improve test coverage for new WaitStrategy behavior