### PR TITLE
feat(command): add sendAndWaitStream method and improve wait strategy handling

### DIFF
--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/mock/MockAggregate.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/mock/MockAggregate.kt
@@ -18,6 +18,7 @@ import me.ahoo.wow.api.annotation.AggregateRoot
 import me.ahoo.wow.api.annotation.CreateAggregate
 import me.ahoo.wow.api.annotation.OnCommand
 import me.ahoo.wow.api.annotation.VoidCommand
+import me.ahoo.wow.api.command.validation.CommandValidator
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.modeling.state.ReadOnlyStateAggregate
 import me.ahoo.wow.modeling.state.ReadOnlyStateAggregateAware
@@ -26,6 +27,14 @@ val MOCK_AGGREGATE_METADATA = aggregateMetadata<MockCommandAggregate, MockStateA
 
 @CreateAggregate
 data class MockCreateAggregate(val id: String, val data: String)
+
+object WrongCommandMessage : CommandValidator {
+    @Suppress("TooGenericExceptionThrown")
+    override fun validate() {
+        throw RuntimeException("wrong command message")
+    }
+
+}
 
 data class MockChangeAggregate(val id: String, val data: String)
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt
@@ -19,6 +19,7 @@ import me.ahoo.wow.api.messaging.function.FunctionInfoData
 import me.ahoo.wow.api.messaging.function.FunctionKind
 import me.ahoo.wow.command.wait.WaitStrategy
 import me.ahoo.wow.command.wait.WaitingFor
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 const val COMMAND_GATEWAY_PROCESSOR_NAME = "CommandGateway"
@@ -44,6 +45,11 @@ interface CommandGateway : CommandBus {
         command: CommandMessage<C>,
         waitStrategy: WaitStrategy
     ): Mono<out ClientCommandExchange<C>>
+
+    fun <C : Any> sendAndWaitStream(
+        command: CommandMessage<C>,
+        waitStrategy: WaitStrategy
+    ): Flux<CommandResult>
 
     @Throws(CommandResultException::class)
     fun <C : Any> sendAndWait(


### PR DESCRIPTION

- Add sendAndWaitStream method to CommandGateway interface
- Implement sendAndWaitStream in DefaultCommandGateway class
- Update CommandGatewaySpec to include tests for new and existing functionality
- Add WrongCommandMessage object for testing validation errors
- Improve error handling and registration of wait strategies
