### PR TITLE
feat(command-gateway): Support WaitingForSent

### DIFF
--- a/example/example-server/src/main/kotlin/me/ahoo/wow/example/server/cart/CartController.kt
+++ b/example/example-server/src/main/kotlin/me/ahoo/wow/example/server/cart/CartController.kt
@@ -18,6 +18,7 @@ import me.ahoo.wow.apiclient.query.queryState
 import me.ahoo.wow.command.CommandGateway
 import me.ahoo.wow.command.CommandResult
 import me.ahoo.wow.command.toCommandMessage
+import me.ahoo.wow.command.wait.WaitingFor
 import me.ahoo.wow.example.api.cart.AddCartItem
 import me.ahoo.wow.example.api.cart.CartData
 import me.ahoo.wow.example.api.client.CartQueryClient
@@ -27,6 +28,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.service.annotation.GetExchange
 import org.springframework.web.service.annotation.PostExchange
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.core.scheduler.Schedulers
 
@@ -61,5 +63,14 @@ class CartController(
             quantity = 1
         )
         return commandGateway.sendAndWaitForSnapshot(addCartItem.toCommandMessage(ownerId = userId))
+    }
+
+    @PostExchange("/cart/{userId}/add-cart-item", accept = ["text/event-stream"])
+    fun addCartItem(@PathVariable userId: String): Flux<CommandResult> {
+        val addCartItem = AddCartItem(
+            productId = "productId",
+            quantity = 1
+        )
+        return commandGateway.sendAndWaitStream(addCartItem.toCommandMessage(ownerId = userId), waitStrategy = WaitingFor.processed())
     }
 }

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/mock/MockAggregate.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/mock/MockAggregate.kt
@@ -33,7 +33,6 @@ object WrongCommandMessage : CommandValidator {
     override fun validate() {
         throw RuntimeException("wrong command message")
     }
-
 }
 
 data class MockChangeAggregate(val id: String, val data: String)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt
@@ -59,7 +59,8 @@ interface CommandGateway : CommandBus {
 
     fun <C : Any> sendAndWaitForSent(
         command: CommandMessage<C>
-    ): Mono<CommandResult>
+    ): Mono<CommandResult> =
+        sendAndWait(command, WaitingFor.sent())
 
     fun <C : Any> sendAndWaitForProcessed(
         command: CommandMessage<C>

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategyRegistrar.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategyRegistrar.kt
@@ -41,9 +41,6 @@ interface WaitStrategyRegistrar {
     fun next(signal: WaitSignal): Boolean {
         val waitStrategy = get(signal.commandId) ?: return false
         waitStrategy.next(signal)
-        if (waitStrategy.cancelled || waitStrategy.terminated) {
-            unregister(signal.commandId)
-        }
         return true
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingFor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingFor.kt
@@ -22,7 +22,7 @@ interface WaitingFor : WaitStrategy {
     val stage: CommandStage
 
     companion object {
-
+        fun sent(): WaitingFor = WaitingForSent()
         fun processed(): WaitingFor = WaitingForProcessed()
 
         fun snapshot(): WaitingFor = WaitingForSnapshot()
@@ -47,6 +47,7 @@ interface WaitingFor : WaitStrategy {
 
         fun stage(stage: CommandStage, contextName: String, processorName: String = ""): WaitingFor {
             return when (stage) {
+                CommandStage.SENT -> sent()
                 CommandStage.PROCESSED -> processed()
                 CommandStage.SNAPSHOT -> snapshot()
                 CommandStage.PROJECTED -> projected(contextName, processorName)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingForSent.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingForSent.kt
@@ -13,9 +13,9 @@
 
 package me.ahoo.wow.command.wait
 
-class WaitingForProcessed : AbstractWaitingFor() {
+class WaitingForSent : AbstractWaitingFor() {
     override val stage: CommandStage
-        get() = CommandStage.PROCESSED
+        get() = CommandStage.SENT
     override val contextName: String = ""
     override val processorName: String = ""
     override fun next(signal: WaitSignal) {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTest.kt
@@ -13,17 +13,21 @@
 
 package me.ahoo.wow.command
 
-import io.mockk.every
 import io.mockk.mockk
-import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.command.validation.CommandValidator
 import me.ahoo.wow.command.wait.CommandStage
+import me.ahoo.wow.command.wait.SimpleCommandWaitEndpoint
 import me.ahoo.wow.command.wait.WaitingFor
 import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.infra.idempotency.DefaultAggregateIdempotencyCheckerProvider
 import me.ahoo.wow.tck.command.CommandGatewaySpec
 import me.ahoo.wow.tck.mock.MockVoidCommand
+import me.ahoo.wow.test.validation.TestValidator
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.*
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import reactor.kotlin.test.test
 
 internal class DefaultCommandGatewayTest : CommandGatewaySpec() {
     override fun createCommandBus(): CommandBus {
@@ -31,32 +35,42 @@ internal class DefaultCommandGatewayTest : CommandGatewaySpec() {
     }
 
     @Test
-    fun sendWithSent() {
-        val messageGateway = createMessageBus()
-        val commandMessage: CommandMessage<Any> = mockk()
-        Assertions.assertThrows(IllegalArgumentException::class.java) {
-            messageGateway.send(commandMessage, WaitingFor.stage(CommandStage.SENT, "", ""))
-        }
-    }
-
-    @Test
     fun sendVoidCommand() {
         val messageGateway = createMessageBus()
-        val commandMessage = MockVoidCommand(generateGlobalId()).toCommandMessage()
+        val message = MockVoidCommand(generateGlobalId()).toCommandMessage()
         Assertions.assertThrows(IllegalArgumentException::class.java) {
-            messageGateway.send(commandMessage, WaitingFor.stage(CommandStage.PROCESSED, "", ""))
+            messageGateway.send(message, WaitingFor.stage(CommandStage.PROCESSED, "", ""))
         }
     }
 
     @Test
     fun validateCommandBody() {
-        val messageGateway = createMessageBus()
-        val commandMessage: CommandMessage<CommandValidator> = mockk {
-            every { body } returns MockCommandBody()
+        val message = MockCommandBody().toCommandMessage()
+        verify {
+            sendAndWaitForSent(message)
+                .test()
+                .expectError(CommandResultException::class.java)
+                .verify()
         }
-        Assertions.assertThrows(IllegalArgumentException::class.java) {
-            messageGateway.send(commandMessage, WaitingFor.stage(CommandStage.SENT, "", ""))
-        }
+        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
+    }
+
+    @Test
+    fun validateCommandBodyWhenValidateError() {
+        val commandBus = mockk<CommandBus>()
+        val commandGateway = DefaultCommandGateway(
+            commandWaitEndpoint = SimpleCommandWaitEndpoint(""),
+            commandBus = commandBus,
+            validator = TestValidator,
+            idempotencyCheckerProvider = DefaultAggregateIdempotencyCheckerProvider { idempotencyChecker },
+            waitStrategyRegistrar = waitStrategyRegistrar,
+        )
+        val message = createMessage()
+        commandGateway.sendAndWaitForProcessed(message)
+            .test()
+            .expectError(CommandResultException::class.java)
+            .verify()
+        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 
     class MockCommandBody : CommandValidator {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/SimpleWaitStrategyRegistrarTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/SimpleWaitStrategyRegistrarTest.kt
@@ -71,6 +71,7 @@ internal class SimpleWaitStrategyRegistrarTest {
         registrar.register(commandId, waitStrategy)
         nextResult = registrar.next(waitSignal)
         assertThat(nextResult, equalTo(true))
+        registrar.unregister(commandId)
         val containsResult = registrar.contains(commandId)
         assertThat(containsResult, equalTo(false))
     }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForTest.kt
@@ -17,7 +17,6 @@ import me.ahoo.wow.command.COMMAND_GATEWAY_FUNCTION
 import me.ahoo.wow.id.generateGlobalId
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.*
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import reactor.kotlin.test.test
 import java.time.Duration
@@ -257,8 +256,11 @@ internal class WaitingForTest {
 
     @Test
     fun waitingForSent() {
-        Assertions.assertThrows<IllegalArgumentException>(IllegalArgumentException::class.java) {
-            WaitingFor.stage("SENT", contextName)
-        }
+        val waitStrategy = WaitingFor.stage("SENT", contextName)
+        waitStrategy.error(IllegalArgumentException())
+        waitStrategy.waitingLast()
+            .test()
+            .expectError(IllegalArgumentException::class.java)
+            .verify()
     }
 }

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt
@@ -46,9 +46,6 @@ class CommandHandler(
 
     private fun sendCommand(commandMessage: CommandMessage<Any>, request: ServerRequest): Mono<CommandResult> {
         val stage: CommandStage = request.getCommandStage()
-        if (commandMessage.isVoid || CommandStage.SENT == stage) {
-            return commandGateway.sendAndWaitForSent(commandMessage)
-        }
         val waitContext = request.getWaitContext().ifBlank {
             commandMessage.contextName
         }

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/handler/CommandHandlerTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/handler/CommandHandlerTest.kt
@@ -11,7 +11,6 @@ import me.ahoo.wow.openapi.route.aggregateRouteMetadata
 import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import me.ahoo.wow.tck.mock.MockCreateAggregate
-import me.ahoo.wow.tck.mock.MockVoidCommand
 import me.ahoo.wow.test.SagaVerifier
 import me.ahoo.wow.webflux.route.command.CommandHandler
 import me.ahoo.wow.webflux.route.command.DefaultCommandMessageParser
@@ -51,39 +50,6 @@ class CommandHandlerTest {
         commandHandler.handle(
             request,
             MockCreateAggregate(generateGlobalId(), generateGlobalId()),
-            MOCK_AGGREGATE_METADATA.command.aggregateType.aggregateRouteMetadata()
-        ).test()
-            .expectNextCount(1)
-            .verifyComplete()
-    }
-
-    @Test
-    fun handleVoidCommand() {
-        val request = mockk<ServerRequest> {
-            every { headers().firstHeader(CommandRequestHeaders.WAIT_STAGE) } returns "PROCESSED"
-            every { headers().firstHeader(CommandRequestHeaders.WAIT_CONTEXT) } returns "test"
-            every { headers().firstHeader(CommandRequestHeaders.WAIT_PROCESSOR) } returns "test"
-            every { headers().firstHeader(CommandRequestHeaders.WAIT_TIME_OUT) } returns null
-            every { pathVariables()[MessageRecords.TENANT_ID] } returns generateGlobalId()
-            every { pathVariables()[MessageRecords.OWNER_ID] } returns null
-            every { pathVariables()[RoutePaths.ID_KEY] } returns generateGlobalId()
-            every { headers().firstHeader(CommandRequestHeaders.AGGREGATE_ID) } returns null
-            every { headers().firstHeader(CommandRequestHeaders.OWNER_ID) } returns null
-            every { headers().firstHeader(CommandRequestHeaders.AGGREGATE_VERSION) } returns null
-            every { headers().firstHeader(CommandRequestHeaders.REQUEST_ID) } returns null
-            every { headers().firstHeader(CommandRequestHeaders.LOCAL_FIRST) } returns true.toString()
-            every { principal() } returns mockk<Principal> {
-                every { name } returns generateGlobalId()
-            }.toMono()
-            every { headers().asHttpHeaders() } returns HttpHeaders()
-        }
-        val commandHandler = CommandHandler(
-            SagaVerifier.defaultCommandGateway(),
-            DefaultCommandMessageParser(SimpleCommandMessageFactory(SimpleCommandBuilderRewriterRegistry()))
-        )
-        commandHandler.handle(
-            request,
-            MockVoidCommand(generateGlobalId()),
             MOCK_AGGREGATE_METADATA.command.aggregateType.aggregateRouteMetadata()
         ).test()
             .expectNextCount(1)

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandFacadeHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandFacadeHandlerFunctionTest.kt
@@ -22,11 +22,13 @@ import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.web.reactive.function.server.ServerRequest
 import reactor.kotlin.core.publisher.toMono
 import reactor.kotlin.test.test
 import reactor.util.function.Tuples
+import java.net.URI
 import java.security.Principal
 
 class CommandFacadeHandlerFunctionTest {
@@ -49,6 +51,8 @@ class CommandFacadeHandlerFunctionTest {
                 ) as Any,
                 MockCommandAggregate::class.java.aggregateRouteMetadata() as AggregateRouteMetadata<Any>
             ).toMono()
+            every { method() } returns HttpMethod.POST
+            every { uri() } returns URI.create("http://localhost:8080")
             every { headers().firstHeader(CommandRequestHeaders.WAIT_TIME_OUT) } returns null
             every { pathVariables()[MessageRecords.TENANT_ID] } returns generateGlobalId()
             every { pathVariables()[MessageRecords.OWNER_ID] } returns null
@@ -58,6 +62,8 @@ class CommandFacadeHandlerFunctionTest {
             every { headers().firstHeader(CommandRequestHeaders.OWNER_ID) } returns null
             every { headers().firstHeader(CommandRequestHeaders.REQUEST_ID) } returns null
             every { headers().firstHeader(CommandRequestHeaders.LOCAL_FIRST) } returns true.toString()
+            every { headers().firstHeader(CommandRequestHeaders.WAIT_CONTEXT) } returns null
+            every { headers().firstHeader(CommandRequestHeaders.WAIT_PROCESSOR) } returns null
             every { headers().firstHeader(CommandRequestHeaders.COMMAND_TYPE) } returns MockCreateAggregate::class.java.name
             every { principal() } returns mockk<Principal> {
                 every { name } returns generateGlobalId()
@@ -72,7 +78,7 @@ class CommandFacadeHandlerFunctionTest {
             }.verifyComplete()
 
         verify {
-            commandGateway.sendAndWaitForSent<Any>(any())
+            commandGateway.sendAndWait<Any>(any(), any())
         }
     }
 }

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunctionTest.kt
@@ -35,10 +35,12 @@ import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.web.reactive.function.server.ServerRequest
 import reactor.kotlin.core.publisher.toMono
 import reactor.kotlin.test.test
+import java.net.URI
 import java.security.Principal
 
 class CommandHandlerFunctionTest {
@@ -59,6 +61,8 @@ class CommandHandlerFunctionTest {
                 id = generateGlobalId(),
                 data = generateGlobalId(),
             ).toMono()
+            every { method() } returns HttpMethod.POST
+            every { uri() } returns URI.create("http://localhost:8080")
             every { headers().firstHeader(CommandRequestHeaders.WAIT_TIME_OUT) } returns null
             every { pathVariables()[MessageRecords.TENANT_ID] } returns generateGlobalId()
             every { pathVariables()[MessageRecords.OWNER_ID] } returns generateGlobalId()
@@ -67,6 +71,8 @@ class CommandHandlerFunctionTest {
             every { headers().firstHeader(CommandRequestHeaders.AGGREGATE_ID) } returns null
             every { headers().firstHeader(CommandRequestHeaders.REQUEST_ID) } returns null
             every { headers().firstHeader(CommandRequestHeaders.LOCAL_FIRST) } returns null
+            every { headers().firstHeader(CommandRequestHeaders.WAIT_CONTEXT) } returns null
+            every { headers().firstHeader(CommandRequestHeaders.WAIT_PROCESSOR) } returns null
             every { principal() } returns mockk<Principal> {
                 every { name } returns generateGlobalId()
             }.toMono()
@@ -80,7 +86,7 @@ class CommandHandlerFunctionTest {
             }.verifyComplete()
 
         verify {
-            commandGateway.sendAndWaitForSent<Any>(any())
+            commandGateway.sendAndWait<Any>(any(), any())
         }
     }
 }


### PR DESCRIPTION
- Add new WaitingForSent class to handle the SENT stage of commands
- Update the stage() function in WaitingFor companion object to include SENT stage
- Refactor WaitingForProcessed class to use a more generic approach for stage comparison
- Add new function sendAndWaitStream with waitStrategy CommandStage.SENT
- Implement thenEmitSentSignal to emit sent signal after command sent
- Update existing sendAndWaitForSent to use new waitStrategy
- Update CommandHandler to handle void commands with SENT wait strategy
- Modify DefaultCommandGateway to unregister wait strategy after completion
- Update tests to cover void command scenarios and wait strategy registration