### PR TITLE
refactor(webflux): rename `isEventStream` to `isSse`

### DIFF
--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/Responses.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/Responses.kt
@@ -20,7 +20,7 @@ import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.openapi.command.CommandRequestHeaders.WOW_ERROR_CODE
 import me.ahoo.wow.serialization.toJsonString
 import me.ahoo.wow.webflux.exception.ErrorHttpStatusMapping.toHttpStatus
-import me.ahoo.wow.webflux.route.command.isEventStream
+import me.ahoo.wow.webflux.route.command.isSse
 import org.reactivestreams.Publisher
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -69,7 +69,7 @@ fun Publisher<CommandResult>.toCommandResponse(
     request: ServerRequest,
     exceptionHandler: RequestExceptionHandler = DefaultRequestExceptionHandler
 ): Mono<ServerResponse> {
-    if (!request.isEventStream()) {
+    if (!request.isSse()) {
         return this.toMono().toServerResponse(request, exceptionHandler)
     }
 

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/AggregateRequest.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/AggregateRequest.kt
@@ -104,6 +104,6 @@ fun ServerRequest.getWaitTimeout(default: Duration = DEFAULT_TIME_OUT): Duration
     } ?: default
 }
 
-fun ServerRequest.isEventStream(): Boolean {
+fun ServerRequest.isSse(): Boolean {
     return headers().accept().contains(MediaType.TEXT_EVENT_STREAM)
 }

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt
@@ -55,7 +55,7 @@ class CommandHandler(
             contextName = waitContext,
             processorName = request.getWaitProcessor()
         )
-        if (request.isEventStream()) {
+        if (request.isSse()) {
             return commandGateway.sendAndWaitStream(
                 command = commandMessage,
                 waitStrategy = waitStrategy


### PR DESCRIPTION
- Rename the `isEventStream` function to `isSse` for better readability and consistency
- Update function calls in `CommandHandler` and `Responses` to use the new `isSse` name