### PR TITLE
refactor(command): improve wait strategy and unregister command

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
@@ -124,7 +124,7 @@ class DefaultCommandGateway(
                     processor = waitStrategy.processorName
                 )
                 waitStrategyRegistrar.register(command.commandId, waitStrategy)
-                waitStrategy.onFinally {
+                waitStrategy.doFinally {
                     waitStrategyRegistrar.unregister(command.commandId)
                 }
                 val commandExchange: ClientCommandExchange<C> = SimpleClientCommandExchange(command, waitStrategy)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategy.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategy.kt
@@ -40,5 +40,5 @@ interface WaitStrategy : ProcessorInfo {
 
     fun complete()
 
-    fun onFinally(onFinally: Consumer<SignalType>)
+    fun doFinally(doFinally: Consumer<SignalType>)
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategy.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategy.kt
@@ -16,6 +16,8 @@ package me.ahoo.wow.command.wait
 import me.ahoo.wow.api.messaging.processor.ProcessorInfo
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import reactor.core.publisher.SignalType
+import java.util.function.Consumer
 
 /**
  * Command Wait Strategy
@@ -37,4 +39,6 @@ interface WaitStrategy : ProcessorInfo {
     fun next(signal: WaitSignal)
 
     fun complete()
+
+    fun onFinally(onFinally: Consumer<SignalType>)
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingFor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingFor.kt
@@ -15,9 +15,11 @@ package me.ahoo.wow.command.wait
 
 import reactor.core.Scannable
 import reactor.core.publisher.Flux
+import reactor.core.publisher.SignalType
 import reactor.core.publisher.Sinks
 import java.time.Duration
 import java.util.*
+import java.util.function.Consumer
 
 interface WaitingFor : WaitStrategy {
     val stage: CommandStage
@@ -78,8 +80,11 @@ abstract class AbstractWaitingFor : WaitingFor {
     override val terminated: Boolean
         get() = Scannable.from(waitSignalSink).scanOrDefault(Scannable.Attr.TERMINATED, false)
 
+    private var onFinally: Consumer<SignalType> = EmptyOnFinally
     override fun waiting(): Flux<WaitSignal> {
-        return waitSignalSink.asFlux()
+        return waitSignalSink.asFlux().doFinally {
+            onFinally.accept(it)
+        }
     }
 
     private fun busyLooping(): Sinks.EmitFailureHandler {
@@ -96,5 +101,13 @@ abstract class AbstractWaitingFor : WaitingFor {
 
     override fun complete() {
         waitSignalSink.emitComplete(busyLooping())
+    }
+
+    override fun onFinally(onFinally: Consumer<SignalType>) {
+        this.onFinally = onFinally
+    }
+
+    object EmptyOnFinally : Consumer<SignalType> {
+        override fun accept(t: SignalType) = Unit
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingFor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingFor.kt
@@ -80,11 +80,9 @@ abstract class AbstractWaitingFor : WaitingFor {
     override val terminated: Boolean
         get() = Scannable.from(waitSignalSink).scanOrDefault(Scannable.Attr.TERMINATED, false)
 
-    private var onFinally: Consumer<SignalType> = EmptyOnFinally
+    private var doFinally: (Consumer<SignalType>) = EmptyOnFinally
     override fun waiting(): Flux<WaitSignal> {
-        return waitSignalSink.asFlux().doFinally {
-            onFinally.accept(it)
-        }
+        return waitSignalSink.asFlux().doFinally(doFinally)
     }
 
     private fun busyLooping(): Sinks.EmitFailureHandler {
@@ -103,8 +101,8 @@ abstract class AbstractWaitingFor : WaitingFor {
         waitSignalSink.emitComplete(busyLooping())
     }
 
-    override fun onFinally(onFinally: Consumer<SignalType>) {
-        this.onFinally = onFinally
+    override fun doFinally(doFinally: Consumer<SignalType>) {
+        this.doFinally = doFinally
     }
 
     object EmptyOnFinally : Consumer<SignalType> {


### PR DESCRIPTION
- Remove duplicate unregister logic in DefaultCommandGateway
- Add onFinally method to WaitingFor interface
- Implement onFinally in WaitStrategy
- Update wait strategy registration and unregistration process
