### PR TITLE
refactor(webflux): replace mockk with MockServerRequest in unit tests

### DIFF
--- a/wow-webflux/build.gradle.kts
+++ b/wow-webflux/build.gradle.kts
@@ -4,6 +4,8 @@ dependencies {
     implementation(project(":wow-bi"))
     implementation("org.springframework:spring-context")
     implementation("org.springframework:spring-webflux")
+    testImplementation("org.springframework:spring-test")
     testImplementation(project(":wow-tck"))
     testImplementation(project(":example-domain"))
+
 }

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/RequestExceptionHandler.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/RequestExceptionHandler.kt
@@ -15,6 +15,7 @@ package me.ahoo.wow.webflux.exception
 
 import me.ahoo.wow.command.CommandResultException
 import me.ahoo.wow.exception.toErrorInfo
+import me.ahoo.wow.webflux.route.toServerResponse
 import org.slf4j.LoggerFactory
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
@@ -26,7 +27,7 @@ interface RequestExceptionHandler {
 
 object DefaultRequestExceptionHandler : RequestExceptionHandler {
     private val log = LoggerFactory.getLogger(DefaultRequestExceptionHandler::class.java)
-    fun ServerRequest.formatRequest(): String {
+    private fun ServerRequest.formatRequest(): String {
         return "HTTP ${method()} ${uri()}"
     }
 

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/Responses.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/Responses.kt
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.webflux.exception
+package me.ahoo.wow.webflux.route
 
 import me.ahoo.wow.api.exception.ErrorInfo
 import me.ahoo.wow.command.CommandResult
@@ -19,7 +19,9 @@ import me.ahoo.wow.exception.toErrorInfo
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.openapi.command.CommandRequestHeaders.WOW_ERROR_CODE
 import me.ahoo.wow.serialization.toJsonString
+import me.ahoo.wow.webflux.exception.DefaultRequestExceptionHandler
 import me.ahoo.wow.webflux.exception.ErrorHttpStatusMapping.toHttpStatus
+import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.route.command.isSse
 import org.reactivestreams.Publisher
 import org.springframework.http.MediaType

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandFacadeHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandFacadeHandlerFunction.kt
@@ -16,8 +16,8 @@ package me.ahoo.wow.webflux.route.command
 import me.ahoo.wow.command.CommandGateway
 import me.ahoo.wow.openapi.command.CommandFacadeRouteSpec
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
-import me.ahoo.wow.webflux.exception.toCommandResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
+import me.ahoo.wow.webflux.route.toCommandResponse
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt
@@ -18,8 +18,8 @@ import me.ahoo.wow.openapi.command.CommandRouteSpec
 import me.ahoo.wow.openapi.route.AggregateRouteMetadata
 import me.ahoo.wow.openapi.route.CommandRouteMetadata
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
-import me.ahoo.wow.webflux.exception.toCommandResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
+import me.ahoo.wow.webflux.route.toCommandResponse
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.RouterFunctions
 import org.springframework.web.reactive.function.server.ServerRequest

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/event/EventCompensateHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/event/EventCompensateHandlerFunction.kt
@@ -21,9 +21,9 @@ import me.ahoo.wow.openapi.RoutePaths
 import me.ahoo.wow.openapi.event.EventCompensateRouteSpec
 import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
-import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.command.getTenantIdOrDefault
+import me.ahoo.wow.webflux.route.toServerResponse
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/event/LoadEventStreamHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/event/LoadEventStreamHandlerFunction.kt
@@ -20,9 +20,9 @@ import me.ahoo.wow.query.dsl.listQuery
 import me.ahoo.wow.query.event.filter.EventStreamQueryHandler
 import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
-import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.command.getTenantIdOrDefault
+import me.ahoo.wow.webflux.route.toServerResponse
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/event/state/ResendStateEventFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/event/state/ResendStateEventFunction.kt
@@ -19,8 +19,8 @@ import me.ahoo.wow.modeling.matedata.AggregateMetadata
 import me.ahoo.wow.openapi.RoutePaths
 import me.ahoo.wow.openapi.event.state.ResendStateEventRouteSpec
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
-import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
+import me.ahoo.wow.webflux.route.toServerResponse
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/CountQueryHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/CountQueryHandlerFunction.kt
@@ -19,8 +19,8 @@ import me.ahoo.wow.openapi.AggregateRouteSpec
 import me.ahoo.wow.query.filter.Contexts.writeRawRequest
 import me.ahoo.wow.query.filter.QueryHandler
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
-import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
+import me.ahoo.wow.webflux.route.toServerResponse
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/ListQueryHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/ListQueryHandlerFunction.kt
@@ -20,8 +20,8 @@ import me.ahoo.wow.openapi.AggregateRouteSpec
 import me.ahoo.wow.query.filter.Contexts.writeRawRequest
 import me.ahoo.wow.query.filter.QueryHandler
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
-import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
+import me.ahoo.wow.webflux.route.toServerResponse
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/PagedQueryHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/PagedQueryHandlerFunction.kt
@@ -21,8 +21,8 @@ import me.ahoo.wow.openapi.AggregateRouteSpec
 import me.ahoo.wow.query.filter.Contexts.writeRawRequest
 import me.ahoo.wow.query.filter.QueryHandler
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
-import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
+import me.ahoo.wow.webflux.route.toServerResponse
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/SingleQueryHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/SingleQueryHandlerFunction.kt
@@ -21,8 +21,8 @@ import me.ahoo.wow.openapi.AggregateRouteSpec
 import me.ahoo.wow.query.filter.Contexts.writeRawRequest
 import me.ahoo.wow.query.filter.QueryHandler
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
-import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
+import me.ahoo.wow.webflux.route.toServerResponse
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/BatchRegenerateSnapshotHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/BatchRegenerateSnapshotHandlerFunction.kt
@@ -21,9 +21,9 @@ import me.ahoo.wow.openapi.RoutePaths
 import me.ahoo.wow.openapi.snapshot.BatchRegenerateSnapshotRouteSpec
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.exception.onErrorMapBatchTaskException
-import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.toBatchResult
+import me.ahoo.wow.webflux.route.toServerResponse
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/LoadSnapshotHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/LoadSnapshotHandlerFunction.kt
@@ -19,11 +19,11 @@ import me.ahoo.wow.openapi.snapshot.LoadSnapshotRouteSpec
 import me.ahoo.wow.query.dsl.singleQuery
 import me.ahoo.wow.query.snapshot.filter.SnapshotQueryHandler
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
-import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.command.getAggregateId
 import me.ahoo.wow.webflux.route.command.getOwnerId
 import me.ahoo.wow.webflux.route.command.getTenantIdOrDefault
+import me.ahoo.wow.webflux.route.toServerResponse
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/RegenerateSnapshotHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/RegenerateSnapshotHandlerFunction.kt
@@ -22,9 +22,9 @@ import me.ahoo.wow.modeling.state.StateAggregateFactory
 import me.ahoo.wow.openapi.RoutePaths
 import me.ahoo.wow.openapi.snapshot.RegenerateSnapshotRouteSpec
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
-import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.command.getTenantIdOrDefault
+import me.ahoo.wow.webflux.route.toServerResponse
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/AbstractLoadAggregateHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/AbstractLoadAggregateHandlerFunction.kt
@@ -20,9 +20,9 @@ import me.ahoo.wow.modeling.state.StateAggregateRepository
 import me.ahoo.wow.openapi.route.AggregateRouteMetadata
 import me.ahoo.wow.query.mask.tryMask
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
-import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.command.getAggregateId
 import me.ahoo.wow.webflux.route.command.getTenantIdOrDefault
+import me.ahoo.wow.webflux.route.toServerResponse
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/AggregateTracingHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/AggregateTracingHandlerFunction.kt
@@ -26,9 +26,9 @@ import me.ahoo.wow.openapi.RoutePaths
 import me.ahoo.wow.openapi.state.AggregateTracingRouteSpec
 import me.ahoo.wow.serialization.deepCody
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
-import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.command.getTenantIdOrDefault
+import me.ahoo.wow.webflux.route.toServerResponse
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/LoadTimeBasedAggregateHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/LoadTimeBasedAggregateHandlerFunction.kt
@@ -21,10 +21,10 @@ import me.ahoo.wow.openapi.state.LoadTimeBasedAggregateRouteSpec
 import me.ahoo.wow.query.mask.tryMask
 import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
-import me.ahoo.wow.webflux.exception.toServerResponse
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.command.getAggregateId
 import me.ahoo.wow.webflux.route.command.getTenantIdOrDefault
+import me.ahoo.wow.webflux.route.toServerResponse
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/DefaultExceptionHandlerTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/DefaultExceptionHandlerTest.kt
@@ -1,13 +1,11 @@
 package me.ahoo.wow.webflux.exception
 
-import io.mockk.every
-import io.mockk.mockk
 import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
-import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.mock.web.reactive.function.server.MockServerRequest
 import reactor.kotlin.test.test
 import java.net.URI
 
@@ -15,11 +13,11 @@ class DefaultExceptionHandlerTest {
 
     @Test
     fun handle() {
-        val serverRequest = mockk<ServerRequest> {
-            every { method() } returns HttpMethod.GET
-            every { uri() } returns URI.create("http://localhost")
-        }
-        DefaultRequestExceptionHandler.handle(serverRequest, IllegalArgumentException("error"))
+        val request = MockServerRequest.builder()
+            .method(HttpMethod.GET)
+            .uri(URI.create("http://localhost"))
+            .build()
+        DefaultRequestExceptionHandler.handle(request, IllegalArgumentException("error"))
             .test()
             .consumeNextWith {
                 assertThat(it.statusCode(), equalTo(HttpStatus.BAD_REQUEST))

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/ResponsesKtTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/ResponsesKtTest.kt
@@ -8,6 +8,9 @@ import me.ahoo.wow.exception.ErrorCodes
 import me.ahoo.wow.exception.toErrorInfo
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.openapi.command.CommandRequestHeaders.WOW_ERROR_CODE
+import me.ahoo.wow.webflux.route.toCommandResponse
+import me.ahoo.wow.webflux.route.toResponseEntity
+import me.ahoo.wow.webflux.route.toServerResponse
 import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/handler/CommandHandlerTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/handler/CommandHandlerTest.kt
@@ -1,15 +1,13 @@
 package me.ahoo.wow.webflux.handler
 
-import io.mockk.every
-import io.mockk.mockk
+import com.sun.security.auth.UserPrincipal
 import me.ahoo.wow.command.factory.SimpleCommandBuilderRewriterRegistry
 import me.ahoo.wow.command.factory.SimpleCommandMessageFactory
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.id.generateGlobalId
-import me.ahoo.wow.openapi.RoutePaths
 import me.ahoo.wow.openapi.command.CommandRequestHeaders
 import me.ahoo.wow.openapi.route.aggregateRouteMetadata
-import me.ahoo.wow.serialization.MessageRecords
+import me.ahoo.wow.serialization.toJsonString
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import me.ahoo.wow.tck.mock.MockCreateAggregate
 import me.ahoo.wow.test.SagaVerifier
@@ -20,34 +18,26 @@ import org.hamcrest.MatcherAssert.*
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
-import org.springframework.web.reactive.function.server.ServerRequest
-import reactor.kotlin.core.publisher.toMono
+import org.springframework.mock.web.reactive.function.server.MockServerRequest
 import reactor.kotlin.test.test
-import java.security.Principal
 import java.time.Duration
 
 class CommandHandlerTest {
 
     @Test
     fun handleSent() {
-        val request = mockk<ServerRequest> {
-            every { headers().firstHeader(CommandRequestHeaders.WAIT_STAGE) } returns "SENT"
-            every { headers().firstHeader(CommandRequestHeaders.WAIT_CONTEXT) } returns null
-            every { headers().firstHeader(CommandRequestHeaders.WAIT_PROCESSOR) } returns "test"
-            every { headers().firstHeader(CommandRequestHeaders.WAIT_TIME_OUT) } returns null
-            every { pathVariables()[MessageRecords.TENANT_ID] } returns generateGlobalId()
-            every { pathVariables()[MessageRecords.OWNER_ID] } returns generateGlobalId()
-            every { pathVariables()[RoutePaths.ID_KEY] } returns generateGlobalId()
-            every { headers().firstHeader(CommandRequestHeaders.AGGREGATE_ID) } returns null
-            every { headers().firstHeader(CommandRequestHeaders.AGGREGATE_VERSION) } returns null
-            every { headers().firstHeader(CommandRequestHeaders.REQUEST_ID) } returns null
-            every { headers().firstHeader(CommandRequestHeaders.LOCAL_FIRST) } returns true.toString()
-            every { headers().accept().contains(MediaType.TEXT_EVENT_STREAM) } returns false
-            every { principal() } returns mockk<Principal> {
-                every { name } returns generateGlobalId()
-            }.toMono()
-            every { headers().asHttpHeaders() } returns HttpHeaders()
-        }
+        val request = MockServerRequest.builder()
+            .header(CommandRequestHeaders.WAIT_STAGE, CommandStage.SENT.name)
+            .header(CommandRequestHeaders.WAIT_CONTEXT, "test")
+            .header(CommandRequestHeaders.WAIT_PROCESSOR, "test")
+            .header(CommandRequestHeaders.WAIT_TIME_OUT, "1000")
+            .header(CommandRequestHeaders.TENANT_ID, generateGlobalId())
+            .header(CommandRequestHeaders.OWNER_ID, generateGlobalId())
+            .header(CommandRequestHeaders.LOCAL_FIRST, true.toString())
+            .header(CommandRequestHeaders.AGGREGATE_ID, generateGlobalId())
+            .header(CommandRequestHeaders.REQUEST_ID, generateGlobalId())
+            .principal(UserPrincipal(generateGlobalId()))
+            .body(MockCreateAggregate(generateGlobalId(), generateGlobalId()).toJsonString())
         val commandHandler = CommandHandler(
             SagaVerifier.defaultCommandGateway(),
             DefaultCommandMessageParser(SimpleCommandMessageFactory(SimpleCommandBuilderRewriterRegistry()))
@@ -63,24 +53,18 @@ class CommandHandlerTest {
 
     @Test
     fun handleProcessed() {
-        val request = mockk<ServerRequest> {
-            every { headers().firstHeader(CommandRequestHeaders.WAIT_STAGE) } returns "PROCESSED"
-            every { headers().firstHeader(CommandRequestHeaders.WAIT_CONTEXT) } returns "test"
-            every { headers().firstHeader(CommandRequestHeaders.WAIT_PROCESSOR) } returns "test"
-            every { headers().firstHeader(CommandRequestHeaders.WAIT_TIME_OUT) } returns 10.toString()
-            every { pathVariables()[MessageRecords.TENANT_ID] } returns generateGlobalId()
-            every { pathVariables()[MessageRecords.OWNER_ID] } returns generateGlobalId()
-            every { pathVariables()[RoutePaths.ID_KEY] } returns null
-            every { headers().firstHeader(CommandRequestHeaders.AGGREGATE_ID) } returns null
-            every { headers().firstHeader(CommandRequestHeaders.AGGREGATE_VERSION) } returns null
-            every { headers().firstHeader(CommandRequestHeaders.REQUEST_ID) } returns null
-            every { headers().firstHeader(CommandRequestHeaders.LOCAL_FIRST) } returns null
-            every { headers().accept().contains(MediaType.TEXT_EVENT_STREAM) } returns false
-            every { principal() } returns mockk<Principal> {
-                every { name } returns generateGlobalId()
-            }.toMono()
-            every { headers().asHttpHeaders() } returns HttpHeaders()
-        }
+        val request = MockServerRequest.builder()
+            .header(CommandRequestHeaders.WAIT_STAGE, CommandStage.PROCESSED.name)
+            .header(CommandRequestHeaders.WAIT_CONTEXT, "test")
+            .header(CommandRequestHeaders.WAIT_PROCESSOR, "test")
+            .header(CommandRequestHeaders.WAIT_TIME_OUT, "1000")
+            .header(CommandRequestHeaders.TENANT_ID, generateGlobalId())
+            .header(CommandRequestHeaders.OWNER_ID, generateGlobalId())
+            .header(CommandRequestHeaders.LOCAL_FIRST, true.toString())
+            .header(CommandRequestHeaders.AGGREGATE_ID, generateGlobalId())
+            .header(CommandRequestHeaders.REQUEST_ID, generateGlobalId())
+            .principal(UserPrincipal(generateGlobalId()))
+            .body(MockCreateAggregate(generateGlobalId(), generateGlobalId()).toJsonString())
         val commandHandler = CommandHandler(
             SagaVerifier.defaultCommandGateway(),
             DefaultCommandMessageParser(SimpleCommandMessageFactory(SimpleCommandBuilderRewriterRegistry()))
@@ -95,24 +79,19 @@ class CommandHandlerTest {
 
     @Test
     fun handleEventStream() {
-        val request = mockk<ServerRequest> {
-            every { headers().firstHeader(CommandRequestHeaders.WAIT_STAGE) } returns "PROCESSED"
-            every { headers().firstHeader(CommandRequestHeaders.WAIT_CONTEXT) } returns "test"
-            every { headers().firstHeader(CommandRequestHeaders.WAIT_PROCESSOR) } returns "test"
-            every { headers().firstHeader(CommandRequestHeaders.WAIT_TIME_OUT) } returns 1000.toString()
-            every { pathVariables()[MessageRecords.TENANT_ID] } returns generateGlobalId()
-            every { pathVariables()[MessageRecords.OWNER_ID] } returns generateGlobalId()
-            every { pathVariables()[RoutePaths.ID_KEY] } returns null
-            every { headers().firstHeader(CommandRequestHeaders.AGGREGATE_ID) } returns null
-            every { headers().firstHeader(CommandRequestHeaders.AGGREGATE_VERSION) } returns null
-            every { headers().firstHeader(CommandRequestHeaders.REQUEST_ID) } returns null
-            every { headers().firstHeader(CommandRequestHeaders.LOCAL_FIRST) } returns null
-            every { headers().accept().contains(MediaType.TEXT_EVENT_STREAM) } returns true
-            every { principal() } returns mockk<Principal> {
-                every { name } returns generateGlobalId()
-            }.toMono()
-            every { headers().asHttpHeaders() } returns HttpHeaders()
-        }
+        val request = MockServerRequest.builder()
+            .header(CommandRequestHeaders.WAIT_STAGE, CommandStage.PROCESSED.name)
+            .header(CommandRequestHeaders.WAIT_CONTEXT, "test")
+            .header(CommandRequestHeaders.WAIT_PROCESSOR, "test")
+            .header(CommandRequestHeaders.WAIT_TIME_OUT, "1000")
+            .header(CommandRequestHeaders.TENANT_ID, generateGlobalId())
+            .header(CommandRequestHeaders.OWNER_ID, generateGlobalId())
+            .header(CommandRequestHeaders.LOCAL_FIRST, true.toString())
+            .header(CommandRequestHeaders.AGGREGATE_ID, generateGlobalId())
+            .header(CommandRequestHeaders.REQUEST_ID, generateGlobalId())
+            .header(HttpHeaders.ACCEPT, MediaType.TEXT_EVENT_STREAM.toString())
+            .principal(UserPrincipal(generateGlobalId()))
+            .body(MockCreateAggregate(generateGlobalId(), generateGlobalId()).toJsonString())
         val commandHandler = CommandHandler(
             SagaVerifier.defaultCommandGateway(),
             DefaultCommandMessageParser(SimpleCommandMessageFactory(SimpleCommandBuilderRewriterRegistry()))

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/bi/GenerateBIScriptHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/bi/GenerateBIScriptHandlerFunctionTest.kt
@@ -1,23 +1,23 @@
 package me.ahoo.wow.webflux.route.bi
 
-import io.mockk.every
-import io.mockk.mockk
+import me.ahoo.wow.bi.MessageHeaderSqlType
 import me.ahoo.wow.openapi.bi.GenerateBIScriptRouteSpec
 import me.ahoo.wow.openapi.bi.GenerateBIScriptRouteSpecFactory.Companion.BI_HEADER_TYPE_HEADER
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
-import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.mock.web.reactive.function.server.MockServerRequest
 import reactor.kotlin.test.test
 
 class GenerateBIScriptHandlerFunctionTest {
     @Test
     fun handle() {
         val handlerFunction = GenerateBIScriptHandlerFunctionFactory().create(GenerateBIScriptRouteSpec)
-        val request = mockk<ServerRequest> {
-            every { headers().firstHeader(BI_HEADER_TYPE_HEADER) } returns "STRING"
-        }
+        val request = MockServerRequest.builder()
+            .header(BI_HEADER_TYPE_HEADER, MessageHeaderSqlType.STRING.name)
+            .build()
+
         handlerFunction.handle(request)
             .test()
             .consumeNextWith {
@@ -28,9 +28,7 @@ class GenerateBIScriptHandlerFunctionTest {
     @Test
     fun handleEmpty() {
         val handlerFunction = GenerateBIScriptHandlerFunctionFactory().create(GenerateBIScriptRouteSpec)
-        val request = mockk<ServerRequest> {
-            every { headers().firstHeader(BI_HEADER_TYPE_HEADER) } returns null
-        }
+        val request = MockServerRequest.builder().build()
         handlerFunction.handle(request)
             .test()
             .consumeNextWith {

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/AggregateRequestTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/AggregateRequestTest.kt
@@ -13,8 +13,6 @@
 
 package me.ahoo.wow.webflux.route.command
 
-import io.mockk.every
-import io.mockk.mockk
 import me.ahoo.wow.api.annotation.AggregateRoute
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.id.generateGlobalId
@@ -24,83 +22,71 @@ import me.ahoo.wow.serialization.MessageRecords
 import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
-import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.mock.web.reactive.function.server.MockServerRequest
 
 class AggregateRequestTest {
     @Test
     fun getOwnerIdFromPathVariable() {
         val ownerId = generateGlobalId()
-        val request = mockk<ServerRequest> {
-            every { pathVariables()[MessageRecords.OWNER_ID] } returns ownerId
-        }
+        val request = MockServerRequest.builder().pathVariable(MessageRecords.OWNER_ID, ownerId).build()
+
         assertThat(request.getOwnerId(), equalTo(ownerId))
     }
 
     @Test
     fun getOwnerIdFromHeader() {
         val ownerId = generateGlobalId()
-        val request = mockk<ServerRequest> {
-            every { pathVariables()[MessageRecords.OWNER_ID] } returns null
-            every { headers().firstHeader(CommandRequestHeaders.OWNER_ID) } returns ownerId
-        }
+        val request = MockServerRequest.builder().header(CommandRequestHeaders.OWNER_ID, ownerId).build()
         assertThat(request.getOwnerId(), equalTo(ownerId))
     }
 
     @Test
     fun getAggregateIdWithOwnerIdFromPathVariable() {
         val ownerId = generateGlobalId()
-        val request = mockk<ServerRequest>()
+        val request = MockServerRequest.builder().build()
         assertThat(request.getAggregateId(AggregateRoute.Owner.AGGREGATE_ID, ownerId), equalTo(ownerId))
     }
 
     @Test
     fun getAggregateIdWithOwnerIdIsNullFromPathVariable() {
         val aggregateId = generateGlobalId()
-        val request = mockk<ServerRequest> {
-            every { pathVariables()[MessageRecords.OWNER_ID] } returns null
-            every { pathVariables()[RoutePaths.ID_KEY] } returns aggregateId
-        }
+        val request = MockServerRequest.builder()
+            .pathVariable(RoutePaths.ID_KEY, aggregateId)
+            .build()
         assertThat(request.getAggregateId(AggregateRoute.Owner.AGGREGATE_ID, null), equalTo(aggregateId))
     }
 
     @Test
     fun getAggregateIdWithOwner() {
         val ownerId = generateGlobalId()
-        val request = mockk<ServerRequest> {
-            every { pathVariables()[MessageRecords.OWNER_ID] } returns ownerId
-        }
+        val request = MockServerRequest.builder().pathVariable(MessageRecords.OWNER_ID, ownerId).build()
         assertThat(request.getAggregateId(AggregateRoute.Owner.AGGREGATE_ID), equalTo(ownerId))
     }
 
     @Test
     fun getCommandStage() {
-        val request = mockk<ServerRequest> {
-            every { headers().firstHeader(CommandRequestHeaders.WAIT_STAGE) } returns "SENT"
-        }
+        val request = MockServerRequest.builder()
+            .header(CommandRequestHeaders.WAIT_STAGE, CommandStage.SENT.name).build()
         assertThat(request.getCommandStage(), equalTo(CommandStage.SENT))
     }
 
     @Test
     fun getCommandStageIfNull() {
-        val request = mockk<ServerRequest> {
-            every { headers().firstHeader(CommandRequestHeaders.WAIT_STAGE) } returns null
-        }
+        val request = MockServerRequest.builder().build()
         assertThat(request.getCommandStage(), equalTo(CommandStage.PROCESSED))
     }
 
     @Test
     fun getWaitContext() {
-        val request = mockk<ServerRequest> {
-            every { headers().firstHeader(CommandRequestHeaders.WAIT_CONTEXT) } returns "test"
-        }
+        val request = MockServerRequest.builder()
+            .header(CommandRequestHeaders.WAIT_CONTEXT, "test").build()
         assertThat(request.getWaitContext(), equalTo("test"))
     }
 
     @Test
     fun getWaitProcessor() {
-        val request = mockk<ServerRequest> {
-            every { headers().firstHeader(CommandRequestHeaders.WAIT_PROCESSOR) } returns "test"
-        }
+        val request = MockServerRequest.builder()
+            .header(CommandRequestHeaders.WAIT_PROCESSOR, "test").build()
         assertThat(request.getWaitProcessor(), equalTo("test"))
     }
 }


### PR DESCRIPTION
- Replace mockk<ServerRequest> with MockServerRequest in multiple test files
- Update import statements to use MockServerRequest and other related classes
- Adjust test setup to use MockServerRequest.builder() for creating request objects
- Remove unnecessary mockk-related code and simplify test cases
- Update exception handling to use new RequestExceptionHandler methods
