### PR TITLE
refactor(command): add global ID to CommandResult and WaitSignal

### DIFF
--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
@@ -111,6 +111,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
     fun sendAndWaitForProcessed() {
         val message = createMessage()
         val processedSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
             commandId = message.commandId,
             stage = CommandStage.PROCESSED,
             function = COMMAND_GATEWAY_FUNCTION,
@@ -133,6 +134,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
     fun sendAndWaitForProcessedDefault() {
         val message = createMessage()
         val processedSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
             commandId = message.commandId,
             stage = CommandStage.PROCESSED,
             function = COMMAND_GATEWAY_FUNCTION,
@@ -154,11 +156,13 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
     fun sendAndWaitForSnapshot() {
         val message = createMessage()
         val processedSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
             commandId = message.commandId,
             stage = CommandStage.PROCESSED,
             function = COMMAND_GATEWAY_FUNCTION,
         )
         val waitSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
             commandId = message.commandId,
             stage = CommandStage.SNAPSHOT,
             function = COMMAND_GATEWAY_FUNCTION,
@@ -182,11 +186,13 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
     fun sendAndWaitForSnapshotDefault() {
         val message = createMessage()
         val processedSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
             commandId = message.commandId,
             stage = CommandStage.PROCESSED,
             function = COMMAND_GATEWAY_FUNCTION,
         )
         val waitSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
             commandId = message.commandId,
             stage = CommandStage.SNAPSHOT,
             function = COMMAND_GATEWAY_FUNCTION,
@@ -231,6 +237,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
     fun sendThenWaitingForProcessedWhenError() {
         val message = createMessage()
         val errorSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
             commandId = message.commandId,
             stage = CommandStage.PROCESSED,
             function = FunctionInfoData(FunctionKind.COMMAND, message.contextName, "", ""),

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt
@@ -28,7 +28,7 @@ val COMMAND_GATEWAY_FUNCTION = FunctionInfoData(
     functionKind = FunctionKind.COMMAND,
     contextName = Wow.WOW,
     processorName = COMMAND_GATEWAY_PROCESSOR_NAME,
-    name = "send",
+    name = "Send",
 )
 
 /**

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandResult.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandResult.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.command
 
+import me.ahoo.wow.api.Identifier
 import me.ahoo.wow.api.command.CommandId
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.command.RequestId
@@ -25,10 +26,12 @@ import me.ahoo.wow.command.wait.SignalTimeCapable
 import me.ahoo.wow.command.wait.WaitSignal
 import me.ahoo.wow.exception.ErrorCodes
 import me.ahoo.wow.exception.toErrorInfo
+import me.ahoo.wow.id.generateGlobalId
 
 data class CommandResult(
     val stage: CommandStage,
     val aggregateId: String,
+    override val id: String,
     override val contextName: String,
     override val processorName: String,
     override val tenantId: String,
@@ -39,10 +42,11 @@ data class CommandResult(
     override val bindingErrors: List<BindingError> = emptyList(),
     override val result: Map<String, Any> = emptyMap(),
     override val signalTime: Long = System.currentTimeMillis()
-) : CommandId, TenantId, RequestId, ErrorInfo, ProcessorInfo, CommandResultCapable, SignalTimeCapable
+) : Identifier, CommandId, TenantId, RequestId, ErrorInfo, ProcessorInfo, CommandResultCapable, SignalTimeCapable
 
 fun WaitSignal.toResult(commandMessage: CommandMessage<*>): CommandResult {
     return CommandResult(
+        id = this.id,
         stage = this.stage,
         aggregateId = commandMessage.aggregateId.id,
         contextName = function.contextName,
@@ -62,12 +66,14 @@ fun Throwable.toResult(
     commandMessage: CommandMessage<*>,
     contextName: String = commandMessage.contextName,
     processorName: String,
+    id: String = generateGlobalId(),
     stage: CommandStage = CommandStage.SENT,
     result: Map<String, Any> = emptyMap(),
     signalTime: Long = System.currentTimeMillis()
 ): CommandResult {
     val errorInfo = toErrorInfo()
     return CommandResult(
+        id = id,
         stage = stage,
         aggregateId = commandMessage.aggregateId.id,
         contextName = contextName,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
@@ -24,6 +24,7 @@ import me.ahoo.wow.command.wait.WaitStrategy
 import me.ahoo.wow.command.wait.WaitStrategyRegistrar
 import me.ahoo.wow.command.wait.WaitingFor
 import me.ahoo.wow.command.wait.injectWaitStrategy
+import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.infra.idempotency.AggregateIdempotencyCheckerProvider
 import me.ahoo.wow.modeling.materialize
 import org.slf4j.LoggerFactory
@@ -158,6 +159,7 @@ class DefaultCommandGateway(
 
     private fun safeEmitSentSignal(command: CommandMessage<*>, waitStrategy: WaitStrategy) {
         val waitSignal = COMMAND_GATEWAY_FUNCTION.toWaitSignal(
+            id = generateGlobalId(),
             commandId = command.commandId,
             stage = CommandStage.SENT,
         )

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifier.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifier.kt
@@ -48,7 +48,6 @@ class MonoCommandWaitNotifier<E, M>(
                 commandWaitNotifier = commandWaitNotifier,
                 processingStage = processingStage,
                 waitStrategy = waitStrategy,
-                commandId = message.commandId,
                 messageExchange = messageExchange,
                 actual = actual,
             ),
@@ -60,7 +59,6 @@ class CommandWaitNotifierSubscriber<E, M>(
     private val commandWaitNotifier: CommandWaitNotifier,
     private val processingStage: CommandStage,
     private val waitStrategy: WaitStrategyInfo,
-    private val commandId: String,
     private val messageExchange: E,
     private val actual: CoreSubscriber<in Void>
 ) : BaseSubscriber<Void>() where E : MessageExchange<*, M>, M : Message<*, *>, M : CommandId, M : NamedBoundedContext {
@@ -101,8 +99,10 @@ class CommandWaitNotifierSubscriber<E, M>(
                 functionKind = FunctionKind.ERROR,
                 contextName = messageExchange.message.contextName
             )
+
         val waitSignal = functionInfo.toWaitSignal(
-            commandId = commandId,
+            id = messageExchange.message.id,
+            commandId = messageExchange.message.commandId,
             stage = processingStage,
             isLastProjection = isLastProjection,
             errorCode = error.errorCode,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitSignal.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitSignal.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.command.wait
 
+import me.ahoo.wow.api.Identifier
 import me.ahoo.wow.api.command.CommandId
 import me.ahoo.wow.api.exception.BindingError
 import me.ahoo.wow.api.exception.ErrorInfo
@@ -28,6 +29,7 @@ interface SignalTimeCapable {
 }
 
 interface WaitSignal :
+    Identifier,
     CommandId,
     ErrorInfo,
     SignalTimeCapable,
@@ -40,6 +42,7 @@ interface WaitSignal :
 }
 
 data class SimpleWaitSignal(
+    override val id: String,
     override val commandId: String,
     override val stage: CommandStage,
     override val function: FunctionInfoData,
@@ -52,6 +55,7 @@ data class SimpleWaitSignal(
 ) : WaitSignal {
     companion object {
         fun FunctionInfo.toWaitSignal(
+            id: String,
             commandId: String,
             stage: CommandStage,
             isLastProjection: Boolean = false,
@@ -62,6 +66,7 @@ data class SimpleWaitSignal(
             signalTime: Long = System.currentTimeMillis()
         ): WaitSignal {
             return SimpleWaitSignal(
+                id = id,
                 commandId = commandId,
                 stage = stage,
                 function = this.materialize(),

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/CommandResultTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/CommandResultTest.kt
@@ -15,6 +15,7 @@ class CommandResultTest {
             command,
             processorName = "processorName"
         )
+        assertThat(actual.id, not(""))
         assertThat(actual.stage, equalTo(CommandStage.SENT))
         assertThat(actual.aggregateId, equalTo(command.aggregateId.id))
         assertThat(actual.tenantId, equalTo(command.aggregateId.tenantId))

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/LocalCommandWaitNotifierTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/LocalCommandWaitNotifierTest.kt
@@ -14,7 +14,7 @@
 package me.ahoo.wow.command.wait
 
 import me.ahoo.wow.command.COMMAND_GATEWAY_FUNCTION
-import me.ahoo.wow.id.GlobalIdGenerator
+import me.ahoo.wow.id.generateGlobalId
 import org.junit.jupiter.api.Test
 import reactor.kotlin.test.test
 
@@ -25,9 +25,10 @@ internal class LocalCommandWaitNotifierTest {
         commandWaitNotifier.notify(
             "endpoint",
             SimpleWaitSignal(
-                GlobalIdGenerator.generateAsString(),
-                CommandStage.SENT,
-                COMMAND_GATEWAY_FUNCTION
+                id = generateGlobalId(),
+                commandId = generateGlobalId(),
+                stage = CommandStage.SENT,
+                function = COMMAND_GATEWAY_FUNCTION
             ),
         )
             .test()
@@ -39,7 +40,12 @@ internal class LocalCommandWaitNotifierTest {
         val commandWaitNotifier = LocalCommandWaitNotifier(SimpleWaitStrategyRegistrar)
         commandWaitNotifier.notifyAndForget(
             "endpoint",
-            SimpleWaitSignal(GlobalIdGenerator.generateAsString(), CommandStage.SENT, COMMAND_GATEWAY_FUNCTION),
+            SimpleWaitSignal(
+                id = generateGlobalId(),
+                commandId = generateGlobalId(),
+                stage = CommandStage.SENT,
+                function = COMMAND_GATEWAY_FUNCTION
+            ),
         )
     }
 
@@ -48,7 +54,12 @@ internal class LocalCommandWaitNotifierTest {
         val commandWaitNotifier = LocalCommandWaitNotifier(SimpleWaitStrategyRegistrar)
         commandWaitNotifier.notify(
             "endpoint",
-            SimpleWaitSignal("0THbs0sW0066001", CommandStage.SENT, COMMAND_GATEWAY_FUNCTION)
+            SimpleWaitSignal(
+                id = generateGlobalId(),
+                commandId = "0THbs0sW0066001",
+                stage = CommandStage.SENT,
+                function = COMMAND_GATEWAY_FUNCTION
+            )
         )
             .test()
             .verifyComplete()

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/SimpleWaitStrategyRegistrarTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/SimpleWaitStrategyRegistrarTest.kt
@@ -63,7 +63,12 @@ internal class SimpleWaitStrategyRegistrarTest {
         val registrar = SimpleWaitStrategyRegistrar
         val commandId = generateGlobalId()
 
-        val waitSignal = SimpleWaitSignal(commandId, CommandStage.PROCESSED, COMMAND_GATEWAY_FUNCTION)
+        val waitSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
+            commandId = commandId,
+            stage = CommandStage.PROCESSED,
+            function = COMMAND_GATEWAY_FUNCTION
+        )
         var nextResult = registrar.next(waitSignal)
         assertThat(nextResult, equalTo(false))
         val waitStrategy = WaitingFor.processed()

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForTest.kt
@@ -30,6 +30,7 @@ internal class WaitingForTest {
         assertThat(waitStrategy.cancelled, equalTo(false))
         assertThat(waitStrategy.terminated, equalTo(false))
         val waitSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
             commandId = "commandId",
             stage = CommandStage.PROCESSED,
             function = COMMAND_GATEWAY_FUNCTION,
@@ -48,6 +49,7 @@ internal class WaitingForTest {
     fun processedIfSnapshot() {
         val waitStrategy = WaitingFor.stage("PROCESSED", contextName)
         val waitSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
             commandId = "commandId",
             stage = CommandStage.SNAPSHOT,
             function = COMMAND_GATEWAY_FUNCTION,
@@ -66,11 +68,13 @@ internal class WaitingForTest {
     fun snapshot() {
         val waitStrategy = WaitingFor.stage("SNAPSHOT", contextName)
         val processedSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROCESSED,
             function = COMMAND_GATEWAY_FUNCTION,
         )
         val waitSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.SNAPSHOT,
             function = COMMAND_GATEWAY_FUNCTION,
@@ -91,6 +95,7 @@ internal class WaitingForTest {
     fun snapshotFailFast() {
         val waitStrategy = WaitingFor.snapshot()
         val waitSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROCESSED,
             function = COMMAND_GATEWAY_FUNCTION,
@@ -109,11 +114,13 @@ internal class WaitingForTest {
     fun projected() {
         val waitStrategy = WaitingFor.stage("PROJECTED", contextName)
         val processedSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROCESSED,
             function = COMMAND_GATEWAY_FUNCTION,
         )
         val waitSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROJECTED,
             function = COMMAND_GATEWAY_FUNCTION.copy(contextName = contextName),
@@ -133,11 +140,13 @@ internal class WaitingForTest {
     fun waitingForProjectedProcessor() {
         val waitStrategy = WaitingFor.projected(contextName, "processor")
         val processedSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROCESSED,
             function = COMMAND_GATEWAY_FUNCTION,
         )
         val waitSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROJECTED,
             function = COMMAND_GATEWAY_FUNCTION.copy(contextName = contextName, processorName = "processor"),
@@ -157,11 +166,13 @@ internal class WaitingForTest {
     fun waitingForProjectedWhenNotLast() {
         val waitStrategy = WaitingFor.projected(contextName)
         val processedSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROCESSED,
             function = COMMAND_GATEWAY_FUNCTION,
         )
         val waitSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROJECTED,
             function = COMMAND_GATEWAY_FUNCTION.copy(contextName = contextName),
@@ -182,11 +193,13 @@ internal class WaitingForTest {
     fun waitingForEventHandled() {
         val waitStrategy = WaitingFor.stage("EVENT_HANDLED", contextName)
         val processedSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROCESSED,
             function = COMMAND_GATEWAY_FUNCTION,
         )
         val waitSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.EVENT_HANDLED,
             function = COMMAND_GATEWAY_FUNCTION.copy(contextName = contextName),
@@ -206,11 +219,13 @@ internal class WaitingForTest {
     fun waitingForSagaHandled() {
         val waitStrategy = WaitingFor.stage("SAGA_HANDLED", contextName)
         val processedSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROCESSED,
             function = COMMAND_GATEWAY_FUNCTION,
         )
         val waitSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.SAGA_HANDLED,
             function = COMMAND_GATEWAY_FUNCTION.copy(contextName = contextName)
@@ -233,8 +248,9 @@ internal class WaitingForTest {
             .consumeSubscriptionWith {
                 waitStrategy.next(
                     SimpleWaitSignal(
-                        generateGlobalId(),
-                        CommandStage.PROJECTED,
+                        id = generateGlobalId(),
+                        commandId = generateGlobalId(),
+                        stage = CommandStage.PROJECTED,
                         function = COMMAND_GATEWAY_FUNCTION,
                     )
                 )

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/Responses.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/Responses.kt
@@ -77,7 +77,7 @@ fun Publisher<CommandResult>.toCommandResponse(
 
     val serverSentEventStream = this.toFlux().map {
         ServerSentEvent.builder<String>()
-            .id(generateGlobalId())
+            .id(it.id)
             .event(it.stage.name)
             .data(it.toJsonString())
             .build()

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/ResponsesKtTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/ResponsesKtTest.kt
@@ -66,6 +66,7 @@ class ResponsesKtTest {
     @Test
     fun commandResultToServerResponse() {
         CommandResult(
+            id = generateGlobalId(),
             stage = CommandStage.SENT,
             aggregateId = generateGlobalId(),
             tenantId = generateGlobalId(),
@@ -88,6 +89,7 @@ class ResponsesKtTest {
     fun toCommandResponse() {
         val serverRequest = MockServerRequest.builder().build()
         CommandResult(
+            id= generateGlobalId(),
             stage = CommandStage.SENT,
             aggregateId = generateGlobalId(),
             tenantId = generateGlobalId(),
@@ -119,6 +121,7 @@ class ResponsesKtTest {
             } returns listOf(ServerSentEventHttpMessageWriter())
         }
         CommandResult(
+            id= generateGlobalId(),
             stage = CommandStage.SENT,
             aggregateId = generateGlobalId(),
             tenantId = generateGlobalId(),
@@ -148,6 +151,7 @@ class ResponsesKtTest {
             } returns listOf(ServerSentEventHttpMessageWriter())
         }
         CommandResult(
+            id= generateGlobalId(),
             stage = CommandStage.SENT,
             aggregateId = generateGlobalId(),
             tenantId = generateGlobalId(),
@@ -174,6 +178,7 @@ class ResponsesKtTest {
             .build()
 
         CommandResult(
+            id= generateGlobalId(),
             stage = CommandStage.SENT,
             aggregateId = generateGlobalId(),
             tenantId = generateGlobalId(),

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/ResponsesKtTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/ResponsesKtTest.kt
@@ -89,7 +89,7 @@ class ResponsesKtTest {
     fun toCommandResponse() {
         val serverRequest = MockServerRequest.builder().build()
         CommandResult(
-            id= generateGlobalId(),
+            id = generateGlobalId(),
             stage = CommandStage.SENT,
             aggregateId = generateGlobalId(),
             tenantId = generateGlobalId(),
@@ -121,7 +121,7 @@ class ResponsesKtTest {
             } returns listOf(ServerSentEventHttpMessageWriter())
         }
         CommandResult(
-            id= generateGlobalId(),
+            id = generateGlobalId(),
             stage = CommandStage.SENT,
             aggregateId = generateGlobalId(),
             tenantId = generateGlobalId(),
@@ -151,7 +151,7 @@ class ResponsesKtTest {
             } returns listOf(ServerSentEventHttpMessageWriter())
         }
         CommandResult(
-            id= generateGlobalId(),
+            id = generateGlobalId(),
             stage = CommandStage.SENT,
             aggregateId = generateGlobalId(),
             tenantId = generateGlobalId(),
@@ -178,7 +178,7 @@ class ResponsesKtTest {
             .build()
 
         CommandResult(
-            id= generateGlobalId(),
+            id = generateGlobalId(),
             stage = CommandStage.SENT,
             aggregateId = generateGlobalId(),
             tenantId = generateGlobalId(),

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/wait/CommandWaitHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/wait/CommandWaitHandlerFunctionTest.kt
@@ -21,7 +21,7 @@ class CommandWaitHandlerFunctionTest {
         val commandWaitHandlerFunction = CommandWaitHandlerFunction(SimpleWaitStrategyRegistrar)
         val request = mockk<ServerRequest> {
             every { bodyToMono(SimpleWaitSignal::class.java) } returns SimpleWaitSignal(
-                id= generateGlobalId(),
+                id = generateGlobalId(),
                 commandId = "commandId",
                 stage = CommandStage.SENT,
                 function = COMMAND_GATEWAY_FUNCTION,

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/wait/CommandWaitHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/wait/CommandWaitHandlerFunctionTest.kt
@@ -6,6 +6,7 @@ import me.ahoo.wow.command.COMMAND_GATEWAY_FUNCTION
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.SimpleWaitSignal
 import me.ahoo.wow.command.wait.SimpleWaitStrategyRegistrar
+import me.ahoo.wow.id.generateGlobalId
 import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
@@ -20,6 +21,7 @@ class CommandWaitHandlerFunctionTest {
         val commandWaitHandlerFunction = CommandWaitHandlerFunction(SimpleWaitStrategyRegistrar)
         val request = mockk<ServerRequest> {
             every { bodyToMono(SimpleWaitSignal::class.java) } returns SimpleWaitSignal(
+                id= generateGlobalId(),
                 commandId = "commandId",
                 stage = CommandStage.SENT,
                 function = COMMAND_GATEWAY_FUNCTION,

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/wait/WebClientCommandWaitNotifierTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/wait/WebClientCommandWaitNotifierTest.kt
@@ -7,6 +7,7 @@ import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.SimpleWaitSignal
 import me.ahoo.wow.command.wait.SimpleWaitStrategyRegistrar
 import me.ahoo.wow.id.GlobalIdGenerator
+import me.ahoo.wow.id.generateGlobalId
 import org.junit.jupiter.api.Test
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
@@ -20,6 +21,7 @@ class WebClientCommandWaitNotifierTest {
         val commandWaitNotifier = WebClientCommandWaitNotifier(SimpleWaitStrategyRegistrar, webClient)
         val commandWaitEndpoint = "http://localhost:8080/command/wait"
         val waitSignal = SimpleWaitSignal(
+            id= generateGlobalId(),
             commandId = GlobalIdGenerator.generateAsString(),
             stage = CommandStage.SENT,
             function = COMMAND_GATEWAY_FUNCTION,
@@ -46,6 +48,7 @@ class WebClientCommandWaitNotifierTest {
         val commandWaitNotifier = WebClientCommandWaitNotifier(SimpleWaitStrategyRegistrar, webClient)
 
         val waitSignal = SimpleWaitSignal(
+            id= generateGlobalId(),
             commandId = "0ToC0Bez003X00Z",
             stage = CommandStage.SENT,
             function = COMMAND_GATEWAY_FUNCTION,

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/wait/WebClientCommandWaitNotifierTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/wait/WebClientCommandWaitNotifierTest.kt
@@ -21,7 +21,7 @@ class WebClientCommandWaitNotifierTest {
         val commandWaitNotifier = WebClientCommandWaitNotifier(SimpleWaitStrategyRegistrar, webClient)
         val commandWaitEndpoint = "http://localhost:8080/command/wait"
         val waitSignal = SimpleWaitSignal(
-            id= generateGlobalId(),
+            id = generateGlobalId(),
             commandId = GlobalIdGenerator.generateAsString(),
             stage = CommandStage.SENT,
             function = COMMAND_GATEWAY_FUNCTION,
@@ -48,7 +48,7 @@ class WebClientCommandWaitNotifierTest {
         val commandWaitNotifier = WebClientCommandWaitNotifier(SimpleWaitStrategyRegistrar, webClient)
 
         val waitSignal = SimpleWaitSignal(
-            id= generateGlobalId(),
+            id = generateGlobalId(),
             commandId = "0ToC0Bez003X00Z",
             stage = CommandStage.SENT,
             function = COMMAND_GATEWAY_FUNCTION,


### PR DESCRIPTION
- Add global ID generation to CommandResult and WaitSignal
- Update related tests to include new ID field
- Adjust CommandGateway and wait notifier implementations