### PR TITLE
fix(wow-core): improve WaitStrategy to handle multiple onFinally hooks

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
@@ -122,7 +122,7 @@ class DefaultCommandGateway(
                     processor = waitStrategy.processorName
                 )
                 waitStrategyRegistrar.register(command.commandId, waitStrategy)
-                waitStrategy.doFinally {
+                waitStrategy.onFinally {
                     waitStrategyRegistrar.unregister(command.commandId)
                 }
                 val commandExchange: ClientCommandExchange<C> = SimpleClientCommandExchange(command, waitStrategy)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategy.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategy.kt
@@ -40,5 +40,5 @@ interface WaitStrategy : ProcessorInfo {
 
     fun complete()
 
-    fun doFinally(doFinally: Consumer<SignalType>)
+    fun onFinally(doFinally: Consumer<SignalType>)
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForTest.kt
@@ -279,4 +279,17 @@ internal class WaitingForTest {
             .expectError(IllegalArgumentException::class.java)
             .verify()
     }
+
+    @Test
+    fun doFinallyError() {
+        val waitStrategy = WaitingFor.projected(contextName)
+        waitStrategy.onFinally {
+            throw IllegalArgumentException()
+        }
+        waitStrategy.error(IllegalArgumentException())
+        waitStrategy.waitingLast()
+            .test()
+            .expectError(IllegalArgumentException::class.java)
+            .verify()
+    }
 }


### PR DESCRIPTION
- Rename doFinally to onFinally for better clarity
- Allow multiple onFinally hooks to be registered
- Implement safeDoFinally to handle exceptions in onFinally hooks
- Update DefaultCommandGateway to use new onFinally method
- Modify CommandGatewaySpec to demonstrate usage of onFinally
