### PR TITLE
test(wow-tck): remove CountDownLatch usage in CommandGatewaySpec

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -4,6 +4,7 @@
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/example/transfer/example-transfer-api/Wow.example-transfer-api.main.iml" filepath="$PROJECT_DIR$/.idea/modules/example/transfer/example-transfer-api/Wow.example-transfer-api.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/wow-cocache/Wow.wow-cocache.main.iml" filepath="$PROJECT_DIR$/.idea/modules/wow-cocache/Wow.wow-cocache.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/wow-mcp/Wow.wow-mcp.main.iml" filepath="$PROJECT_DIR$/.idea/modules/wow-mcp/Wow.wow-mcp.main.iml" />
     </modules>
   </component>
 </project>

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
@@ -92,6 +92,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 .expectNextCount(1)
                 .verifyComplete()
         }
+        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 
     @Test
@@ -103,6 +104,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 .expectNextCount(1)
                 .verifyComplete()
         }
+        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 
     @Test
@@ -125,6 +127,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 .expectNextCount(1)
                 .verifyComplete()
         }
+        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 
     @Test
@@ -146,6 +149,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 .expectNextCount(1)
                 .verifyComplete()
         }
+        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 
     @Test
@@ -175,6 +179,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 .expectNextCount(2)
                 .verifyComplete()
         }
+        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 
     @Test
@@ -204,6 +209,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 .expectNextCount(1)
                 .verifyComplete()
         }
+        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 
     @Test
@@ -224,6 +230,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 }
                 .verify()
         }
+        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 
     @Test
@@ -249,6 +256,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 }
                 .verifyComplete()
         }
+        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 
     @Test
@@ -261,5 +269,6 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 .expectError(CommandResultException::class.java)
                 .verify()
         }
+        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 }

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
@@ -49,7 +49,6 @@ import org.hamcrest.MatcherAssert.*
 import org.junit.jupiter.api.Test
 import reactor.kotlin.test.test
 import java.time.Duration
-import java.util.concurrent.CountDownLatch
 
 abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerCommandExchange<*>, CommandGateway>() {
     override val topicKind: TopicKind
@@ -86,21 +85,13 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
     @Test
     fun sendAndWaitForSent() {
         val message = createMessage()
-        val countDownLatch = CountDownLatch(1)
         verify {
             val waitStrategy = WaitingFor.sent()
             sendAndWaitStream(message, waitStrategy)
                 .test()
-                .then {
-                    waitStrategy.onFinally {
-                        countDownLatch.countDown()
-                    }
-                }
                 .expectNextCount(1)
                 .verifyComplete()
         }
-        countDownLatch.await()
-        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 
     @Test
@@ -112,7 +103,6 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 .expectNextCount(1)
                 .verifyComplete()
         }
-        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 
     @Test
@@ -135,7 +125,6 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 .expectNextCount(1)
                 .verifyComplete()
         }
-        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 
     @Test
@@ -157,7 +146,6 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 .expectNextCount(1)
                 .verifyComplete()
         }
-        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 
     @Test
@@ -187,7 +175,6 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 .expectNextCount(2)
                 .verifyComplete()
         }
-        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 
     @Test
@@ -217,7 +204,6 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 .expectNextCount(1)
                 .verifyComplete()
         }
-        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 
     @Test
@@ -238,7 +224,6 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 }
                 .verify()
         }
-        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 
     @Test
@@ -264,7 +249,6 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 }
                 .verifyComplete()
         }
-        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 
     @Test
@@ -277,6 +261,5 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 .expectError(CommandResultException::class.java)
                 .verify()
         }
-        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 }

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
@@ -92,6 +92,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 .expectNextCount(1)
                 .verifyComplete()
         }
+        Thread.sleep(5)
         assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTest.kt
@@ -55,6 +55,7 @@ internal class DefaultCommandGatewayTest : CommandGatewaySpec() {
                 .expectError(CommandResultException::class.java)
                 .verify()
         }
+        Thread.sleep(5)
         assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 
@@ -68,6 +69,7 @@ internal class DefaultCommandGatewayTest : CommandGatewaySpec() {
                 .thenCancel()
                 .verify()
         }
+        Thread.sleep(5)
         assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 
@@ -88,6 +90,7 @@ internal class DefaultCommandGatewayTest : CommandGatewaySpec() {
             .test()
             .expectError(CommandResultException::class.java)
             .verify()
+        Thread.sleep(5)
         assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForTest.kt
@@ -17,6 +17,7 @@ import me.ahoo.wow.command.COMMAND_GATEWAY_FUNCTION
 import me.ahoo.wow.id.generateGlobalId
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.*
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import reactor.kotlin.test.test
 import java.time.Duration
@@ -291,5 +292,16 @@ internal class WaitingForTest {
             .test()
             .expectError(IllegalArgumentException::class.java)
             .verify()
+    }
+
+    @Test
+    fun doFinallySetTwice() {
+        val waitStrategy = WaitingFor.projected(contextName)
+        waitStrategy.onFinally {
+        }
+        Assertions.assertThrows(IllegalStateException::class.java) {
+            waitStrategy.onFinally {
+            }
+        }
     }
 }


### PR DESCRIPTION
- Remove CountDownLatch imports and usage from CommandGatewaySpec
- Update wait strategy tests to not rely on CountDownLatch
- Add check for double onFinally assignment in WaitingFor
