### PR TITLE
add kotlin-logging to wow-dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,7 +117,6 @@ configure(libraryProjects) {
         api(platform(dependenciesProject))
         detektPlugins(platform(dependenciesProject))
         implementation("org.slf4j:slf4j-api")
-        implementation("io.github.oshai:kotlin-logging-jvm")
         testImplementation("ch.qos.logback:logback-classic")
         testImplementation("org.junit.jupiter:junit-jupiter-api")
         testImplementation("org.junit.jupiter:junit-jupiter-params")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,6 +117,7 @@ configure(libraryProjects) {
         api(platform(dependenciesProject))
         detektPlugins(platform(dependenciesProject))
         implementation("org.slf4j:slf4j-api")
+        implementation("io.github.oshai:kotlin-logging-jvm")
         testImplementation("ch.qos.logback:logback-classic")
         testImplementation("org.junit.jupiter:junit-jupiter-api")
         testImplementation("org.junit.jupiter:junit-jupiter-params")

--- a/documentation/docs/guide/projection.md
+++ b/documentation/docs/guide/projection.md
@@ -13,12 +13,12 @@
 在一般场景中，聚合根的最新状态快照可以当做读模型，比如 [事件补偿控制台](./event-compensation) 就没有定义投影处理器，直接使用了最新状态快照作为读模型。
 :::
 
-- 投影处理器需要标记 `@ProjectionProcessor` 注解，以便框架能够自动发现。
+- 投影处理器需要标记 `@ProjectionProcessorComponent` 注解，以便框架能够自动发现。
 - 领域事件处理函数需要添加 `@OnEvent` 注解，但该注解不是必须的，默认情况下命名为 `onEvent` 即表明该函数为领域事件处理函数。
 - 领域事件处理函数接受的参数为：具体领域事件 (`OrderCreated`)、领域事件 (`DomainEvent<OrderCreated>`)。
 
 ```kotlin
-@ProjectionProcessor
+@ProjectionProcessorComponent
 class OrderProjector {
 
     fun onEvent(orderCreated: OrderCreated) {

--- a/documentation/docs/guide/saga.md
+++ b/documentation/docs/guide/saga.md
@@ -79,7 +79,7 @@ _Saga_ 通过订阅事件完成处理逻辑后返回聚合命令。
 - `onEvent(EntryFailed)`: 订阅转账入账失败事件（`EntryFailed`），并生成解锁金额命令(`UnlockAmount`)。
 
 ```java
-@StatelessSaga
+@StatelessSagaComponent
 public class TransferSaga {
 
     Entry onEvent(Prepared prepared, AggregateId aggregateId) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ opentelemetry = "1.48.0"
 opentelemetry-instrumentation = "2.14.0"
 opentelemetry-semconv = "1.29.0-alpha"
 guava = "33.4.5-jre"
+kotlin-logging = "7.0.5"
 hamcrest = "3.0"
 mockk = "1.13.17"
 kotlin-compile-testing = "0.7.0"
@@ -42,6 +43,7 @@ ksp-symbol-processing-api = { module = "com.google.devtools.ksp:symbol-processin
 ksp-symbol-processing = { module = "com.google.devtools.ksp:symbol-processing", version.ref = "ksp" }
 kotlin-compile-testing = { module = "dev.zacsweers.kctfork:ksp", version.ref = "kotlin-compile-testing" }
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
+kotlin-logging = { module = "io.github.oshai:kotlin-logging-jvm", version.ref = "kotlin-logging" }
 swagger = { module = "io.swagger.core.v3:swagger-core-jakarta", version.ref = "swagger" }
 springdoc-starter-common = { module = "org.springdoc:springdoc-openapi-starter-common", version.ref = "springdoc" }
 springdoc-openapi-starter-webflux-api = { module = "org.springdoc:springdoc-openapi-starter-webflux-api", version.ref = "springdoc" }

--- a/wow-core/build.gradle.kts
+++ b/wow-core/build.gradle.kts
@@ -8,6 +8,7 @@ dependencies {
     api("jakarta.validation:jakarta.validation-api")
     api("com.google.guava:guava")
     api("com.fasterxml.jackson.core:jackson-databind")
+    api("io.github.oshai:kotlin-logging-jvm")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     testImplementation(project(":wow-tck"))

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.command
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.validation.Validator
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.command.validation.CommandValidator
@@ -27,7 +28,6 @@ import me.ahoo.wow.command.wait.injectWaitStrategy
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.infra.idempotency.AggregateIdempotencyCheckerProvider
 import me.ahoo.wow.modeling.materialize
-import org.slf4j.LoggerFactory
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.core.publisher.Sinks
@@ -41,7 +41,7 @@ class DefaultCommandGateway(
 ) : CommandGateway, CommandBus by commandBus {
 
     companion object {
-        private val log = LoggerFactory.getLogger(DefaultCommandGateway::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     private fun <C : Any> validate(commandBody: C) {
@@ -164,11 +164,8 @@ class DefaultCommandGateway(
             // 防止基于内存的消息总线聚合处理信号早于命令发送完成而抛出异常。
             waitStrategy.next(waitSignal)
         } catch (emissionError: Sinks.EmissionException) {
-            if (log.isWarnEnabled) {
-                log.warn(
-                    "The wait strategy [${command.commandId}] is cancelled or terminated, so the signal is not sent.",
-                    emissionError
-                )
+            log.warn(emissionError) {
+                "The wait strategy [${command.commandId}] is cancelled or terminated, so the signal is not sent."
             }
         }
     }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/annotation/CommandMetadataParser.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/annotation/CommandMetadataParser.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.command.annotation
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.annotation.AnnotationPropertyAccessorParser.toAggregateIdGetterIfAnnotated
 import me.ahoo.wow.annotation.AnnotationPropertyAccessorParser.toAggregateNameGetterIfAnnotated
 import me.ahoo.wow.annotation.AnnotationPropertyAccessorParser.toAggregateVersionGetterIfAnnotated
@@ -39,12 +40,9 @@ import me.ahoo.wow.modeling.matedata.NamedAggregateGetter
 import me.ahoo.wow.modeling.matedata.SelfNamedAggregateGetter
 import me.ahoo.wow.modeling.matedata.toNamedAggregateGetter
 import me.ahoo.wow.naming.annotation.toName
-import org.slf4j.LoggerFactory
 import kotlin.reflect.KProperty1
 import kotlin.reflect.KType
 import kotlin.reflect.jvm.jvmErasure
-
-private val LOG = LoggerFactory.getLogger(CommandMetadataParser::class.java)
 
 /**
  * Command Metadata Parser .
@@ -62,6 +60,10 @@ object CommandMetadataParser : CacheableMetadataParser() {
 }
 
 internal class CommandMetadataVisitor<C>(private val commandType: Class<C>) : ClassVisitor<C> {
+    companion object {
+        private val log = KotlinLogging.logger {}
+    }
+
     private val commandName: String = commandType.toName()
     private val isCreate = commandType.isAnnotationPresent(CreateAggregate::class.java)
     private val isVoid = commandType.isAnnotationPresent(VoidCommand::class.java)
@@ -127,10 +129,8 @@ internal class CommandMetadataVisitor<C>(private val commandType: Class<C>) : Cl
 
     fun toMetadata(): CommandMetadata<C> {
         if (aggregateIdGetter == null && !isCreate) {
-            if (LOG.isWarnEnabled) {
-                LOG.warn(
-                    "Command[$commandType] does not define an aggregate ID field and is not a create aggregate command.",
-                )
+            log.warn {
+                "Command[$commandType] does not define an aggregate ID field and is not a create aggregate command."
             }
         }
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/factory/CommandBuilderRewriter.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/factory/CommandBuilderRewriter.kt
@@ -13,7 +13,7 @@
 
 package me.ahoo.wow.command.factory
 
-import org.slf4j.LoggerFactory
+import io.github.oshai.kotlinlogging.KotlinLogging
 import reactor.core.publisher.Mono
 import java.util.concurrent.ConcurrentHashMap
 
@@ -34,26 +34,21 @@ interface CommandBuilderRewriterRegistry {
 
 class SimpleCommandBuilderRewriterRegistry : CommandBuilderRewriterRegistry {
     companion object {
-        private val log = LoggerFactory.getLogger(SimpleCommandBuilderRewriterRegistry::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     private val registrar = ConcurrentHashMap<Class<*>, CommandBuilderRewriter>()
     override fun register(extractor: CommandBuilderRewriter) {
         val previous = registrar.put(extractor.supportedCommandType, extractor)
-        if (log.isInfoEnabled) {
-            log.info(
-                "Register - supportedCommandType:[{}] - previous:[{}],current:[{}].",
-                extractor.supportedCommandType,
-                previous,
-                extractor
-            )
+        log.info {
+            "Register - supportedCommandType:[${extractor.supportedCommandType}] - previous:[$previous],current:[$extractor]."
         }
     }
 
     override fun unregister(commandType: Class<*>) {
         val removed = registrar.remove(commandType)
-        if (log.isInfoEnabled) {
-            log.info("Unregister - commandType:[{}] - removed:[{}].", commandType, removed)
+        log.info {
+            "Unregister - commandType:[$commandType] - removed:[$removed]."
         }
     }
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWaitNotifier.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWaitNotifier.kt
@@ -13,10 +13,10 @@
 
 package me.ahoo.wow.command.wait
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.messaging.Header
 import me.ahoo.wow.api.messaging.processor.ProcessorInfo
 import me.ahoo.wow.id.GlobalIdGenerator
-import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
 import reactor.core.scheduler.Schedulers
 
@@ -82,25 +82,19 @@ class LocalCommandWaitNotifier(
     private val waitStrategyRegistrar: WaitStrategyRegistrar
 ) : CommandWaitNotifier {
     companion object {
-        private val log = LoggerFactory.getLogger(LocalCommandWaitNotifier::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     override fun notify(commandWaitEndpoint: String, waitSignal: WaitSignal): Mono<Void> {
         return Mono.fromRunnable {
             if (isLocalCommand(waitSignal.commandId)) {
-                if (log.isDebugEnabled) {
-                    log.debug(
-                        "Notify Local - waitSignal: {}",
-                        waitSignal,
-                    )
+                log.debug {
+                    "Notify Local - waitSignal: $waitSignal"
                 }
                 waitStrategyRegistrar.next(waitSignal)
             } else {
-                if (log.isWarnEnabled) {
-                    log.warn(
-                        "Ignore Notify - waitSignal: {}",
-                        waitSignal,
-                    )
+                log.warn {
+                    "Ignore Notify - waitSignal: $waitSignal"
                 }
             }
         }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategyRegistrar.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategyRegistrar.kt
@@ -13,7 +13,7 @@
 
 package me.ahoo.wow.command.wait
 
-import org.slf4j.LoggerFactory
+import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -46,20 +46,20 @@ interface WaitStrategyRegistrar {
 }
 
 object SimpleWaitStrategyRegistrar : WaitStrategyRegistrar {
-    private val log = LoggerFactory.getLogger(SimpleWaitStrategyRegistrar::class.java)
+    private val log = KotlinLogging.logger {}
     private val waitStrategies: ConcurrentHashMap<String, WaitStrategy> = ConcurrentHashMap()
 
     override fun register(commandId: String, waitStrategy: WaitStrategy): WaitStrategy? {
-        if (log.isDebugEnabled) {
-            log.debug("Register - command[{}] WaitStrategy.", commandId)
+        log.debug {
+            "Register - command[$commandId] WaitStrategy."
         }
         return waitStrategies.putIfAbsent(commandId, waitStrategy)
     }
 
     override fun unregister(commandId: String): WaitStrategy? {
         val value = waitStrategies.remove(commandId)
-        if (log.isDebugEnabled) {
-            log.debug("Unregister - remove command[{}] WaitStrategy - [{}].", commandId, value != null)
+        log.debug {
+            "Unregister - remove command[$commandId] WaitStrategy - [${value != null}]."
         }
         return value
     }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingFor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingFor.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.command.wait
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import reactor.core.Scannable
 import reactor.core.publisher.Flux
 import reactor.core.publisher.SignalType
@@ -69,10 +70,11 @@ interface WaitingFor : WaitStrategy {
     }
 }
 
-private val LOG = org.slf4j.LoggerFactory.getLogger(WaitingFor::class.java)
+private val log = KotlinLogging.logger {}
 
 abstract class AbstractWaitingFor : WaitingFor {
     companion object {
+
         val DEFAULT_BUSY_LOOPING_DURATION: Duration = Duration.ofMillis(10)
     }
 
@@ -91,7 +93,9 @@ abstract class AbstractWaitingFor : WaitingFor {
         try {
             currentHook.accept(signalType)
         } catch (error: Throwable) {
-            LOG.error("Finally hook execution failed", error)
+            log.error(error) {
+                "Finally hook execution failed"
+            }
         }
     }
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/configuration/MetadataSearcher.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/configuration/MetadataSearcher.kt
@@ -13,23 +13,23 @@
 
 package me.ahoo.wow.configuration
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.api.naming.NamedBoundedContext
 import me.ahoo.wow.modeling.materialize
 import me.ahoo.wow.serialization.JsonSerializer
-import org.slf4j.LoggerFactory
 
 const val WOW_METADATA_RESOURCE_NAME = "META-INF/wow-metadata.json"
 
 object MetadataSearcher {
-    private val log = LoggerFactory.getLogger(MetadataSearcher::class.java)
+    private val log = KotlinLogging.logger {}
     val metadata: WowMetadata by lazy {
         var current = WowMetadata()
         ClassLoader.getSystemResources(WOW_METADATA_RESOURCE_NAME)
             .iterator()
             .forEach { resource ->
-                if (log.isDebugEnabled) {
-                    log.debug("Load metadata [{}].", resource)
+                log.debug {
+                    "Load metadata [$resource]."
                 }
                 @Suppress("TooGenericExceptionCaught")
                 resource.openStream().use {
@@ -37,9 +37,7 @@ object MetadataSearcher {
                         val next = JsonSerializer.readValue(it, WowMetadata::class.java)
                         current = current.merge(next)
                     } catch (e: Throwable) {
-                        if (log.isErrorEnabled) {
-                            log.error(e.message, e)
-                        }
+                        log.error(e) { e.message }
                     }
                 }
             }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/event/AbstractAggregateEventDispatcher.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/event/AbstractAggregateEventDispatcher.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.event
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.event.DomainEvent
 import me.ahoo.wow.messaging.compensation.CompensationMatcher.match
 import me.ahoo.wow.messaging.dispatcher.AggregateMessageDispatcher
@@ -22,15 +23,13 @@ import me.ahoo.wow.messaging.function.MessageFunctionRegistrar
 import me.ahoo.wow.messaging.handler.ExchangeAck.finallyAck
 import me.ahoo.wow.messaging.handler.MessageExchange
 import me.ahoo.wow.serialization.toJsonString
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 abstract class AbstractAggregateEventDispatcher<E : MessageExchange<*, DomainEventStream>> :
     AggregateMessageDispatcher<E>() {
     companion object {
-        private val log: Logger = LoggerFactory.getLogger(AbstractAggregateEventDispatcher::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     abstract val functionRegistrar:
@@ -56,8 +55,8 @@ abstract class AbstractAggregateEventDispatcher<E : MessageExchange<*, DomainEve
                 event.match(it)
             }.toSet()
         if (functions.isEmpty()) {
-            if (log.isDebugEnabled) {
-                log.debug("Not find any functions.Ignore this event:[{}].", event.toJsonString())
+            log.debug {
+                "Not find any functions.Ignore this event:[${event.toJsonString()}]."
             }
             return Mono.empty()
         }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/event/AbstractEventDispatcher.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/event/AbstractEventDispatcher.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.event
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.messaging.TopicKind
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.eventsourcing.state.StateEventBus
@@ -29,14 +30,13 @@ import me.ahoo.wow.modeling.MaterializedNamedAggregate
 import me.ahoo.wow.modeling.materialize
 import me.ahoo.wow.scheduler.AggregateSchedulerSupplier
 import me.ahoo.wow.serialization.toJsonString
-import org.slf4j.LoggerFactory
 import reactor.core.publisher.Flux
 import reactor.core.publisher.GroupedFlux
 import reactor.core.publisher.Mono
 
 abstract class AbstractEventDispatcher<R : Mono<*>> : MessageDispatcher {
     companion object {
-        private val log = LoggerFactory.getLogger(AbstractEventDispatcher::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     abstract val parallelism: Int
@@ -123,25 +123,25 @@ abstract class AbstractEventDispatcher<R : Mono<*>> : MessageDispatcher {
     }
 
     override fun run() {
-        if (log.isInfoEnabled) {
-            log.info("[$name] Run subscribe to Event:${eventStreamTopics.toJsonString()}.")
+        log.info {
+            "[$name] Run subscribe to Event:${eventStreamTopics.toJsonString()}."
         }
         if (eventStreamTopics.isEmpty()) {
-            if (log.isWarnEnabled) {
-                log.warn("[$name] Ignore start [DomainEventDistributionSubscriber] because namedAggregates is empty.")
+            log.warn {
+                "[$name] Ignore start [DomainEventDistributionSubscriber] because namedAggregates is empty."
             }
         } else {
             receiveEventStream(eventStreamTopics)
                 .groupBy { it.message.materialize() }
                 .subscribe(domainEventDistributionSubscriber)
         }
-        if (log.isInfoEnabled) {
-            log.info("[$name] Run subscribe to State Event:${stateEventTopics.toJsonString()}.")
+        log.info {
+            "[$name] Run subscribe to State Event:${stateEventTopics.toJsonString()}."
         }
 
         if (stateEventTopics.isEmpty()) {
-            if (log.isWarnEnabled) {
-                log.warn("[$name] Ignore start [StateEventDistributionSubscriber] because namedAggregates is empty.")
+            log.warn {
+                "[$name] Ignore start [StateEventDistributionSubscriber] because namedAggregates is empty."
             }
         } else {
             receiveStateEventStream(stateEventTopics)
@@ -151,8 +151,8 @@ abstract class AbstractEventDispatcher<R : Mono<*>> : MessageDispatcher {
     }
 
     override fun close() {
-        if (log.isInfoEnabled) {
-            log.info("[$name] Close.")
+        log.info {
+            "[$name] Close."
         }
         domainEventDistributionSubscriber.cancel()
         stateEventDistributionSubscriber.cancel()

--- a/wow-core/src/main/kotlin/me/ahoo/wow/event/upgrader/EventUpgraderFactory.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/event/upgrader/EventUpgraderFactory.kt
@@ -13,33 +13,31 @@
 
 package me.ahoo.wow.event.upgrader
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.annotation.sortedByOrder
 import me.ahoo.wow.event.upgrader.EventNamedAggregate.Companion.toEventNamedAggregate
 import me.ahoo.wow.event.upgrader.MutableDomainEventRecord.Companion.toMutableDomainEventRecord
 import me.ahoo.wow.modeling.materialize
 import me.ahoo.wow.serialization.event.DomainEventRecord
-import org.slf4j.LoggerFactory
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 
 object EventUpgraderFactory {
-    private val log = LoggerFactory.getLogger(EventUpgraderFactory::class.java)
+    private val log = KotlinLogging.logger {}
     private val eventUpgraderFactories: ConcurrentHashMap<EventNamedAggregate, List<EventUpgrader>> =
         ConcurrentHashMap()
 
     init {
         ServiceLoader.load(EventUpgrader::class.java)
             .forEach {
-                if (log.isInfoEnabled) {
-                    log.info("Load $it to register.")
-                }
+                log.info { "Load $it to register." }
                 register(it)
             }
     }
 
     fun register(eventUpgrader: EventUpgrader) {
-        if (log.isInfoEnabled) {
-            log.info("Register $eventUpgrader.")
+        log.info {
+            "Register $eventUpgrader."
         }
         eventUpgraderFactories.compute(eventUpgrader.eventNamedAggregate) { _, value ->
             if (value == null) {
@@ -63,8 +61,8 @@ object EventUpgraderFactory {
         }
         var mutableDomainEventRecord = domainEventRecord.toMutableDomainEventRecord()
         eventUpgraders.forEach {
-            if (log.isDebugEnabled) {
-                log.debug("Upgrade [${domainEventRecord.id}]@[$eventNamedAggregate] by $it.")
+            log.debug {
+                "Upgrade [${domainEventRecord.id}]@[$eventNamedAggregate] by $it."
             }
             mutableDomainEventRecord = it.upgrade(mutableDomainEventRecord).toMutableDomainEventRecord()
         }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/AbstractEventStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/AbstractEventStore.kt
@@ -12,26 +12,21 @@
  */
 package me.ahoo.wow.eventsourcing
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.Version
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.event.DomainEventStream
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 abstract class AbstractEventStore : EventStore {
     private companion object {
-        private val log: Logger = LoggerFactory.getLogger(AbstractEventStore::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     override fun append(eventStream: DomainEventStream): Mono<Void> {
-        if (log.isDebugEnabled) {
-            log.debug(
-                "Append {} - version[{}]",
-                eventStream.aggregateId,
-                eventStream.version,
-            )
+        log.debug {
+            "Append ${eventStream.aggregateId} - version[${eventStream.version}]"
         }
         return appendStream(eventStream)
             .onErrorMap(EventVersionConflictException::class.java) {
@@ -49,13 +44,8 @@ abstract class AbstractEventStore : EventStore {
         headVersion: Int,
         tailVersion: Int
     ): Flux<DomainEventStream> {
-        if (log.isDebugEnabled) {
-            log.debug(
-                "Load {} - headVersion[{}] - tailVersion[{}].",
-                aggregateId,
-                headVersion,
-                tailVersion,
-            )
+        log.debug {
+            "Load $aggregateId - headVersion[$headVersion] - tailVersion[$tailVersion]."
         }
         require(headVersion > -1) {
             "$aggregateId headVersion[$headVersion] must be greater than -1!"

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventSourcingStateAggregateRepository.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventSourcingStateAggregateRepository.kt
@@ -12,6 +12,7 @@
  */
 package me.ahoo.wow.eventsourcing
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.eventsourcing.snapshot.SnapshotRepository
 import me.ahoo.wow.modeling.matedata.StateAggregateMetadata
@@ -19,7 +20,6 @@ import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory.toStateAggreg
 import me.ahoo.wow.modeling.state.StateAggregate
 import me.ahoo.wow.modeling.state.StateAggregateFactory
 import me.ahoo.wow.modeling.state.StateAggregateRepository
-import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
 
 /**
@@ -33,7 +33,7 @@ class EventSourcingStateAggregateRepository(
     private val eventStore: EventStore
 ) : StateAggregateRepository {
     companion object {
-        private val log = LoggerFactory.getLogger(EventSourcingStateAggregateRepository::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     override fun <S : Any> load(
@@ -41,8 +41,8 @@ class EventSourcingStateAggregateRepository(
         metadata: StateAggregateMetadata<S>,
         tailVersion: Int
     ): Mono<StateAggregate<S>> {
-        if (log.isDebugEnabled) {
-            log.debug("Load {} version:{}.", aggregateId, tailVersion)
+        log.debug {
+            "Load $aggregateId version:$tailVersion."
         }
         val loadStateAggregate = if (tailVersion == Int.MAX_VALUE) {
             snapshotRepository.load<S>(aggregateId)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStoreStateAggregateRepository.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStoreStateAggregateRepository.kt
@@ -12,13 +12,13 @@
  */
 package me.ahoo.wow.eventsourcing
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.modeling.matedata.StateAggregateMetadata
 import me.ahoo.wow.modeling.state.StateAggregate
 import me.ahoo.wow.modeling.state.StateAggregateFactory
 import me.ahoo.wow.modeling.state.StateAggregateRepository
-import org.slf4j.LoggerFactory
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
@@ -32,7 +32,7 @@ class EventStoreStateAggregateRepository(
     private val eventStore: EventStore
 ) : StateAggregateRepository {
     companion object {
-        private val log = LoggerFactory.getLogger(EventStoreStateAggregateRepository::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     private fun <S : Any> loadStateAggregate(
@@ -54,8 +54,8 @@ class EventStoreStateAggregateRepository(
         metadata: StateAggregateMetadata<S>,
         tailVersion: Int
     ): Mono<StateAggregate<S>> {
-        if (log.isDebugEnabled) {
-            log.debug("Load {} version:{}.", aggregateId, tailVersion)
+        log.debug {
+            "Load $aggregateId version:$tailVersion."
         }
         return loadStateAggregate(aggregateId, metadata) {
             eventStore

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/VersionOffsetSnapshotStrategy.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/VersionOffsetSnapshotStrategy.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.eventsourcing.snapshot
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.eventsourcing.state.StateEventExchange
 import reactor.core.publisher.Mono
 
@@ -23,7 +24,7 @@ class VersionOffsetSnapshotStrategy(
     private val snapshotRepository: SnapshotRepository
 ) : SnapshotStrategy {
     companion object {
-        private val log = org.slf4j.LoggerFactory.getLogger(VersionOffsetSnapshotStrategy::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     override fun onEvent(stateEventExchange: StateEventExchange<*>): Mono<Void> {
@@ -32,14 +33,8 @@ class VersionOffsetSnapshotStrategy(
             .flatMap { currentVersion ->
                 val currentVersionOffset = (stateEvent.version - currentVersion)
                 val matched = currentVersionOffset >= versionOffset
-                if (log.isDebugEnabled) {
-                    log.debug(
-                        "[{}] Current version offset:[{}] - expected offset:[{}] matched:[{}].",
-                        stateEvent.aggregateId,
-                        currentVersionOffset,
-                        versionOffset,
-                        matched,
-                    )
+                log.debug {
+                    "[${stateEvent.aggregateId}] Current version offset:[$currentVersionOffset] - expected offset:[$versionOffset] matched:[$matched]."
                 }
                 if (!matched) {
                     return@flatMap Mono.empty<Void>()

--- a/wow-core/src/main/kotlin/me/ahoo/wow/exception/ErrorCodeMapping.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/exception/ErrorCodeMapping.kt
@@ -13,29 +13,24 @@
 
 package me.ahoo.wow.exception
 
-import org.slf4j.LoggerFactory
+import io.github.oshai.kotlinlogging.KotlinLogging
 import java.util.concurrent.ConcurrentHashMap
 
 object ErrorCodeMapping {
-    private val log = LoggerFactory.getLogger(ErrorCodeMapping::class.java)
+    private val log = KotlinLogging.logger {}
     private val registrar = ConcurrentHashMap<Class<out Throwable>, String>()
 
     fun register(throwableClass: Class<out Throwable>, errorCode: String) {
         val previous = registrar.put(throwableClass, errorCode)
-        if (log.isInfoEnabled) {
-            log.info(
-                "Register - throwableClass:[{}] - previous:[{}],current:[{}].",
-                throwableClass,
-                previous,
-                errorCode
-            )
+        log.info {
+            "Register - throwableClass:[$throwableClass] - previous:[$previous],current:[$errorCode]."
         }
     }
 
     fun unregister(throwableClass: Class<out Throwable>) {
         val removed = registrar.remove(throwableClass)
-        if (log.isInfoEnabled) {
-            log.info("Unregister - throwableClass:[{}] - removed:[{}].", throwableClass, removed)
+        log.info {
+            "Unregister - throwableClass:[$throwableClass] - removed:[$removed]."
         }
     }
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/exception/RecoverableExceptionRegistrar.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/exception/RecoverableExceptionRegistrar.kt
@@ -13,30 +13,25 @@
 
 package me.ahoo.wow.exception
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.exception.RecoverableType
-import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 
 object RecoverableExceptionRegistrar {
-    private val log = LoggerFactory.getLogger(RecoverableExceptionRegistrar::class.java)
+    private val log = KotlinLogging.logger {}
     private val registrar = ConcurrentHashMap<Class<out Throwable>, RecoverableType>()
 
     fun register(throwableClass: Class<out Throwable>, recoverableType: RecoverableType) {
         val previous = registrar.put(throwableClass, recoverableType)
-        if (log.isInfoEnabled) {
-            log.info(
-                "Register - throwableClass:[{}] - previous:[{}],current:[{}].",
-                throwableClass,
-                previous,
-                recoverableType
-            )
+        log.info {
+            "Register - throwableClass:[$throwableClass] - previous:[$previous],current:[$recoverableType]."
         }
     }
 
     fun unregister(throwableClass: Class<out Throwable>) {
         val removed = registrar.remove(throwableClass)
-        if (log.isInfoEnabled) {
-            log.info("Unregister - throwableClass:[{}] - removed:[{}].", throwableClass, removed)
+        log.info {
+            "Unregister - throwableClass:[$throwableClass] - removed:[$removed]."
         }
     }
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/filter/FilterChainBuilder.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/filter/FilterChainBuilder.kt
@@ -13,9 +13,9 @@
 
 package me.ahoo.wow.filter
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.annotation.sortedByOrder
 import me.ahoo.wow.infra.reflection.AnnotationScanner.scanAnnotation
-import org.slf4j.LoggerFactory
 import kotlin.reflect.KClass
 
 fun interface FilterCondition {
@@ -48,7 +48,7 @@ class TypedFilterCondition(private val filterType: KClass<*>) :
 
 class FilterChainBuilder<T> {
     companion object {
-        private val log = LoggerFactory.getLogger(FilterChainBuilder::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     private var filterCondition: FilterCondition = FilterCondition.ALL
@@ -90,7 +90,7 @@ class FilterChainBuilder<T> {
         for (i in sortedFilters.size - 1 downTo 0) {
             next = chainFactory(sortedFilters[i], next)
         }
-        if (log.isInfoEnabled) {
+        log.info {
             buildString {
                 sortedFilters.forEachIndexed { index, filter ->
                     append(filter.javaClass.name)
@@ -99,7 +99,7 @@ class FilterChainBuilder<T> {
                     }
                 }
             }.let {
-                log.info("Build - Condition:[{}] - FilterChain: {}", filterCondition, it)
+                "Build - Condition:[$filterCondition] - FilterChain: $it"
             }
         }
         return next

--- a/wow-core/src/main/kotlin/me/ahoo/wow/id/AggregateIdGenerator.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/id/AggregateIdGenerator.kt
@@ -13,11 +13,11 @@
 
 package me.ahoo.wow.id
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.cosid.IdGenerator
 import me.ahoo.wow.annotation.sortedByOrder
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.modeling.materialize
-import org.slf4j.LoggerFactory
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 
@@ -26,7 +26,7 @@ private val AGGREGATE_ID_GENERATORS: MutableMap<NamedAggregate, IdGenerator> =
 
 object AggregateIdGeneratorRegistrar :
     Map<NamedAggregate, IdGenerator> by AGGREGATE_ID_GENERATORS {
-    private val log = LoggerFactory.getLogger(AggregateIdGeneratorRegistrar::class.java)
+    private val log = KotlinLogging.logger {}
     private val factories: List<AggregateIdGeneratorFactory> by lazy {
         return@lazy ServiceLoader.load(AggregateIdGeneratorFactory::class.java)
             .sortedByOrder()
@@ -35,17 +35,17 @@ object AggregateIdGeneratorRegistrar :
     fun getOrInitialize(key: NamedAggregate): IdGenerator {
         return AGGREGATE_ID_GENERATORS.computeIfAbsent(key) { _ ->
             factories.firstNotNullOfOrNull {
-                if (log.isInfoEnabled) {
-                    log.info("Load $it to create [$key]'s AggregateIdGenerator.")
+                log.info {
+                    "Load $it to create [$key]'s AggregateIdGenerator."
                 }
                 val idGenerator = it.create(key)
                 if (idGenerator == null) {
-                    if (log.isInfoEnabled) {
-                        log.info("Ignore: $it create [$key]'s AggregateIdGenerator is null.")
+                    log.info {
+                        "Ignore: $it create [$key]'s AggregateIdGenerator is null."
                     }
                 } else {
-                    if (log.isInfoEnabled) {
-                        log.info("Setup $idGenerator to [$key]'s AggregateIdGenerator.")
+                    log.info {
+                        "Setup $idGenerator to [$key]'s AggregateIdGenerator."
                     }
                 }
                 idGenerator

--- a/wow-core/src/main/kotlin/me/ahoo/wow/id/CosIdAggregateIdGeneratorFactory.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/id/CosIdAggregateIdGeneratorFactory.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.id
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.cosid.IdGenerator
 import me.ahoo.cosid.cosid.ClockSyncCosIdGenerator
 import me.ahoo.cosid.cosid.Radix62CosIdGenerator
@@ -22,7 +23,6 @@ import me.ahoo.wow.api.annotation.ORDER_LAST
 import me.ahoo.wow.api.annotation.Order
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.configuration.MetadataSearcher
-import org.slf4j.LoggerFactory
 
 @Order(ORDER_LAST)
 class CosIdAggregateIdGeneratorFactory(
@@ -30,7 +30,7 @@ class CosIdAggregateIdGeneratorFactory(
 ) :
     AggregateIdGeneratorFactory {
     companion object {
-        private val log = LoggerFactory.getLogger(CosIdAggregateIdGeneratorFactory::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     override fun create(namedAggregate: NamedAggregate): IdGenerator {
@@ -44,16 +44,16 @@ class CosIdAggregateIdGeneratorFactory(
         val idGeneratorOp = idProvider.get(idGenName)
         if (idGeneratorOp.isPresent) {
             val idGenerator = idGeneratorOp.get()
-            if (log.isInfoEnabled) {
-                log.info("Create $idGenerator to $namedAggregate from DefaultIdGeneratorProvider[$idGenName].")
+            log.info {
+                "Create $idGenerator to $namedAggregate from DefaultIdGeneratorProvider[$idGenName]."
             }
             return idGenerator
         }
 
         val idGenerator = Radix62CosIdGenerator(GlobalIdGenerator.machineId)
         val clockSyncCosIdGenerator = ClockSyncCosIdGenerator(idGenerator)
-        if (log.isInfoEnabled) {
-            log.info("Create $clockSyncCosIdGenerator to $namedAggregate.")
+        log.info {
+            "Create $clockSyncCosIdGenerator to $namedAggregate."
         }
         return clockSyncCosIdGenerator
     }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/id/CosIdGlobalIdGeneratorFactory.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/id/CosIdGlobalIdGeneratorFactory.kt
@@ -13,13 +13,13 @@
 
 package me.ahoo.wow.id
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.cosid.CosId
 import me.ahoo.cosid.cosid.CosIdGenerator
 import me.ahoo.cosid.provider.DefaultIdGeneratorProvider
 import me.ahoo.cosid.provider.IdGeneratorProvider
 import me.ahoo.wow.api.annotation.ORDER_FIRST
 import me.ahoo.wow.api.annotation.Order
-import org.slf4j.LoggerFactory
 
 @Order(ORDER_FIRST)
 class CosIdGlobalIdGeneratorFactory(
@@ -27,7 +27,7 @@ class CosIdGlobalIdGeneratorFactory(
 ) :
     GlobalIdGeneratorFactory {
     companion object {
-        private val log = LoggerFactory.getLogger(CosIdGlobalIdGeneratorFactory::class.java)
+        private val log = KotlinLogging.logger {}
         const val ID_KEY = "wow.cosid"
         val ID_NAME: String = System.getProperty(ID_KEY, CosId.COSID)
     }
@@ -35,14 +35,14 @@ class CosIdGlobalIdGeneratorFactory(
     override fun create(): CosIdGenerator? {
         val idGenOp = idProvider.get(ID_NAME)
         if (idGenOp.isEmpty) {
-            if (log.isInfoEnabled) {
-                log.info("Create - Not found Id name[$ID_NAME] from DefaultIdGeneratorProvider.")
+            log.info {
+                "Create - Not found Id name[$ID_NAME] from DefaultIdGeneratorProvider."
             }
             return null
         }
         val idGenerator = idGenOp.get()
-        if (log.isInfoEnabled) {
-            log.info("Create - Found Id name[$ID_NAME] [$idGenerator] from DefaultIdGeneratorProvider.")
+        log.info {
+            "Create - Found Id name[$ID_NAME] [$idGenerator] from DefaultIdGeneratorProvider."
         }
         return idGenerator as CosIdGenerator
     }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/id/GlobalIdGenerator.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/id/GlobalIdGenerator.kt
@@ -12,20 +12,20 @@
  */
 package me.ahoo.wow.id
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.cosid.cosid.CosIdGenerator
 import me.ahoo.cosid.cosid.CosIdIdStateParser
 import me.ahoo.cosid.cosid.CosIdState
 import me.ahoo.wow.annotation.sortedByOrder
 import me.ahoo.wow.exception.WowException
 import me.ahoo.wow.infra.Decorator
-import org.slf4j.LoggerFactory
 import java.util.*
 
 /**
  * Global Id Generator
  */
 object GlobalIdGenerator : CosIdGenerator, Decorator<CosIdGenerator> {
-    private val log = LoggerFactory.getLogger(GlobalIdGenerator::class.java)
+    private val log = KotlinLogging.logger {}
 
     override val delegate: CosIdGenerator by lazy {
         return@lazy loadGlobalIdGenerator() ?: throw NotInitializedGlobalIdGeneratorError()
@@ -35,17 +35,17 @@ object GlobalIdGenerator : CosIdGenerator, Decorator<CosIdGenerator> {
         return ServiceLoader.load(GlobalIdGeneratorFactory::class.java)
             .sortedByOrder()
             .firstNotNullOfOrNull {
-                if (log.isInfoEnabled) {
-                    log.info("Load $it to create GlobalIdGenerator.")
+                log.info {
+                    "Load $it to create GlobalIdGenerator."
                 }
                 val idGenerator = it.create()
                 if (idGenerator == null) {
-                    if (log.isInfoEnabled) {
-                        log.info("$it create GlobalIdGenerator is null.")
+                    log.info {
+                        "$it create GlobalIdGenerator is null."
                     }
                 } else {
-                    if (log.isInfoEnabled) {
-                        log.info("Setup $idGenerator to GlobalIdGenerator.")
+                    log.info {
+                        "Setup $idGenerator to GlobalIdGenerator."
                     }
                 }
                 idGenerator

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/Strings.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/Strings.kt
@@ -13,7 +13,7 @@
 
 package me.ahoo.wow.infra
 
-inline fun <R> String?.ifNotBlank(func: (String) -> R): R? {
+public inline fun <R> String?.ifNotBlank(func: (String) -> R): R? {
     if (this.isNullOrBlank()) {
         return null
     }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/Strings.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/Strings.kt
@@ -13,7 +13,7 @@
 
 package me.ahoo.wow.infra
 
-public inline fun <R> String?.ifNotBlank(func: (String) -> R): R? {
+inline fun <R> String?.ifNotBlank(func: (String) -> R): R? {
     if (this.isNullOrBlank()) {
         return null
     }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/idempotency/BloomFilterIdempotencyChecker.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/idempotency/BloomFilterIdempotencyChecker.kt
@@ -13,7 +13,7 @@
 package me.ahoo.wow.infra.idempotency
 
 import com.google.common.hash.BloomFilter
-import org.slf4j.LoggerFactory
+import io.github.oshai.kotlinlogging.KotlinLogging
 import reactor.core.publisher.Mono
 import java.time.Duration
 
@@ -30,12 +30,12 @@ class BloomFilterIdempotencyChecker(
 ) :
     IdempotencyChecker {
     companion object {
-        private val log = LoggerFactory.getLogger(BloomFilterIdempotencyChecker::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     private val bloomFilterCache = Mono.fromCallable {
-        if (log.isInfoEnabled) {
-            log.info("Create new BloomFilter.")
+        log.info {
+            "Create new BloomFilter."
         }
         bloomFilterSupplier()
     }.cache(ttl)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/reflection/AnnotationScanner.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/reflection/AnnotationScanner.kt
@@ -23,7 +23,6 @@ import kotlin.reflect.full.hasAnnotation
 import kotlin.reflect.jvm.javaField
 
 object AnnotationScanner {
-    val repeatableClass = java.lang.annotation.Repeatable::class
     const val REPEATABLE_CONTAINER_SIMPLE_NAME = "Container"
     const val REPEATABLE_CONTAINER_ENDS_WITH = "${'$'}$REPEATABLE_CONTAINER_SIMPLE_NAME"
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/AbstractDispatcher.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/AbstractDispatcher.kt
@@ -13,17 +13,17 @@
 
 package me.ahoo.wow.messaging.dispatcher
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.messaging.MessageDispatcher
 import me.ahoo.wow.messaging.writeReceiverGroup
 import me.ahoo.wow.metrics.Metrics.writeMetricsSubscriber
 import me.ahoo.wow.serialization.toJsonString
-import org.slf4j.LoggerFactory
 import reactor.core.publisher.Flux
 
 abstract class AbstractDispatcher<T : Any> : MessageDispatcher {
     companion object {
-        private val log = LoggerFactory.getLogger(AbstractDispatcher::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     /**
@@ -44,12 +44,12 @@ abstract class AbstractDispatcher<T : Any> : MessageDispatcher {
     }
 
     override fun run() {
-        if (log.isInfoEnabled) {
-            log.info("[$name] Run subscribe to namedAggregates:${namedAggregates.toJsonString()}.")
+        log.info {
+            "[$name] Run subscribe to namedAggregates:${namedAggregates.toJsonString()}."
         }
         if (namedAggregates.isEmpty()) {
-            if (log.isWarnEnabled) {
-                log.warn("[$name] Ignore start because namedAggregates is empty.")
+            log.warn {
+                "[$name] Ignore start because namedAggregates is empty."
             }
             return
         }
@@ -57,8 +57,8 @@ abstract class AbstractDispatcher<T : Any> : MessageDispatcher {
     }
 
     override fun close() {
-        if (log.isInfoEnabled) {
-            log.info("[$name] Close.")
+        log.info {
+            "[$name] Close."
         }
         aggregateDispatchers.forEach { it.close() }
     }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/AbstractMessageDispatcher.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/AbstractMessageDispatcher.kt
@@ -13,24 +13,24 @@
 
 package me.ahoo.wow.messaging.dispatcher
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.messaging.MessageDispatcher
 import me.ahoo.wow.serialization.toJsonString
-import org.slf4j.LoggerFactory
 
 abstract class AbstractMessageDispatcher<T : Any> : MessageDispatcher, SafeSubscriber<T>() {
     companion object {
-        private val log = LoggerFactory.getLogger(AbstractMessageDispatcher::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     abstract val topics: Set<Any>
 
     override fun run() {
-        if (log.isInfoEnabled) {
-            log.info("[$name] Run subscribe to topics:${topics.toJsonString()}.")
+        log.info {
+            "[$name] Run subscribe to topics:${topics.toJsonString()}."
         }
         if (topics.isEmpty()) {
-            if (log.isWarnEnabled) {
-                log.warn("[$name] Ignore start because topics is empty.")
+            log.warn {
+                "[$name] Ignore start because topics is empty."
             }
             return
         }
@@ -40,8 +40,8 @@ abstract class AbstractMessageDispatcher<T : Any> : MessageDispatcher, SafeSubsc
     abstract fun start()
 
     override fun close() {
-        if (log.isInfoEnabled) {
-            log.info("[$name] Close.")
+        log.info {
+            "[$name] Close."
         }
         cancel()
     }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/AggregateMessageDispatcher.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/AggregateMessageDispatcher.kt
@@ -13,12 +13,12 @@
 
 package me.ahoo.wow.messaging.dispatcher
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.Wow
 import me.ahoo.wow.api.modeling.NamedAggregateDecorator
 import me.ahoo.wow.messaging.MessageDispatcher
 import me.ahoo.wow.messaging.handler.MessageExchange
 import me.ahoo.wow.metrics.Metrics
-import org.slf4j.LoggerFactory
 import reactor.core.publisher.Flux
 import reactor.core.publisher.GroupedFlux
 import reactor.core.publisher.Mono
@@ -27,15 +27,15 @@ import reactor.core.scheduler.Scheduler
 abstract class AggregateMessageDispatcher<T : MessageExchange<*, *>> : MessageDispatcher, NamedAggregateDecorator,
     SafeSubscriber<Void>() {
     companion object {
-        private val log = LoggerFactory.getLogger(AggregateMessageDispatcher::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     abstract val parallelism: Int
     abstract val scheduler: Scheduler
     abstract val messageFlux: Flux<T>
     override fun run() {
-        if (log.isInfoEnabled) {
-            log.info("[$name] Run subscribe to $namedAggregate.")
+        log.info {
+            "[$name] Run subscribe to $namedAggregate."
         }
         messageFlux
             .groupBy { it.toGroupKey() }
@@ -61,8 +61,8 @@ abstract class AggregateMessageDispatcher<T : MessageExchange<*, *>> : MessageDi
     abstract fun handleExchange(exchange: T): Mono<Void>
 
     override fun close() {
-        if (log.isInfoEnabled) {
-            log.info("[$name] Close.")
+        log.info {
+            "[$name] Close."
         }
         cancel()
     }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/SafeSubscriber.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/SafeSubscriber.kt
@@ -13,27 +13,27 @@
 
 package me.ahoo.wow.messaging.dispatcher
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.naming.Named
 import org.reactivestreams.Subscription
-import org.slf4j.LoggerFactory
 import reactor.core.publisher.BaseSubscriber
 import reactor.core.publisher.SignalType
 
 abstract class SafeSubscriber<T : Any> : BaseSubscriber<T>(), Named {
     companion object {
-        private val log = LoggerFactory.getLogger(SafeSubscriber::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     @Suppress("TooGenericExceptionCaught")
     override fun hookOnNext(value: T) {
-        if (log.isDebugEnabled) {
-            log.debug("[$name] OnNext $value")
+        log.debug {
+            "[$name] OnNext $value."
         }
         try {
             safeOnNext(value)
         } catch (e: Throwable) {
-            if (log.isErrorEnabled) {
-                log.error("[$name] OnNext handle error.", e)
+            log.error(e) {
+                "[$name] OnNext handle error."
             }
             safeOnNextError(value, throwable = e)
         }
@@ -43,21 +43,21 @@ abstract class SafeSubscriber<T : Any> : BaseSubscriber<T>(), Named {
     open fun safeOnNextError(value: T, throwable: Throwable) {}
 
     override fun hookOnSubscribe(subscription: Subscription) {
-        if (log.isDebugEnabled) {
-            log.debug("[$name] OnSubscribe.")
+        log.debug {
+            "[$name] OnSubscribe."
         }
         super.hookOnSubscribe(subscription)
     }
 
     override fun hookOnError(throwable: Throwable) {
-        if (log.isErrorEnabled) {
-            log.error("[$name] OnError.", throwable)
+        log.error(throwable) {
+            "[$name] OnError."
         }
     }
 
     override fun hookFinally(type: SignalType) {
-        if (log.isInfoEnabled) {
-            log.info("[$name] Finally $type.")
+        log.info {
+            "[$name] Finally $type."
         }
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/function/SimpleMessageFunctionRegistrar.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/function/SimpleMessageFunctionRegistrar.kt
@@ -13,30 +13,29 @@
 
 package me.ahoo.wow.messaging.function
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.messaging.Message
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.api.naming.NamedBoundedContext
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import java.util.concurrent.CopyOnWriteArraySet
 
 class SimpleMessageFunctionRegistrar<F : MessageFunction<*, *, *>> : MessageFunctionRegistrar<F> {
     private companion object {
-        private val log: Logger = LoggerFactory.getLogger(SimpleMessageFunctionRegistrar::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     private val registrar: CopyOnWriteArraySet<F> = CopyOnWriteArraySet()
 
     override fun register(function: F) {
-        if (log.isInfoEnabled) {
-            log.info("Register {}.", function)
+        log.info {
+            "Register $function."
         }
         registrar.add(function)
     }
 
     override fun unregister(function: F) {
-        if (log.isInfoEnabled) {
-            log.info("Unregister {}.", function)
+        log.info {
+            "Unregister $function."
         }
         registrar.remove(function)
     }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/MessagePropagatorProvider.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/MessagePropagatorProvider.kt
@@ -13,21 +13,21 @@
 
 package me.ahoo.wow.messaging.propagation
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.annotation.sortedByOrder
 import me.ahoo.wow.api.messaging.Header
 import me.ahoo.wow.api.messaging.Message
-import org.slf4j.LoggerFactory
 import java.util.*
 
 object MessagePropagatorProvider : MessagePropagator {
-    private val log = LoggerFactory.getLogger(MessagePropagatorProvider::class.java)
+    private val log = KotlinLogging.logger {}
 
     private val messagePropagators: List<MessagePropagator> by lazy {
         ServiceLoader.load(MessagePropagator::class.java)
             .sortedByOrder()
             .map {
-                if (log.isInfoEnabled) {
-                    log.info("Load MessagePropagator: [{}]", it.javaClass.name)
+                log.info {
+                    "Load MessagePropagator: [${it.javaClass.name}]"
                 }
                 it
             }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/annotation/AggregateMetadataParser.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/annotation/AggregateMetadataParser.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.modeling.annotation
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.annotation.sortedByOrder
 import me.ahoo.wow.api.annotation.AfterCommand
 import me.ahoo.wow.api.annotation.AggregateRoot
@@ -37,7 +38,6 @@ import me.ahoo.wow.modeling.command.after.AfterCommandFunctionMetadata.Companion
 import me.ahoo.wow.modeling.matedata.AggregateMetadata
 import me.ahoo.wow.modeling.matedata.CommandAggregateMetadata
 import me.ahoo.wow.modeling.matedata.StateAggregateMetadata
-import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
 import java.lang.reflect.Constructor
 import kotlin.reflect.KFunction
@@ -45,8 +45,6 @@ import kotlin.reflect.full.hasAnnotation
 import kotlin.reflect.full.valueParameters
 import kotlin.reflect.jvm.javaConstructor
 import kotlin.reflect.jvm.javaType
-
-private val log = LoggerFactory.getLogger(AggregateMetadataParser::class.java)
 
 /**
  * Aggregate Metadata Parser .
@@ -63,6 +61,10 @@ object AggregateMetadataParser : CacheableMetadataParser() {
 
     private class AggregateMetadataVisitor<C : Any, S : Any>(commandAggregateType: Class<C>) :
         ClassVisitor<C> {
+        companion object {
+            private val log = KotlinLogging.logger {}
+        }
+
         private val commandAggregateType: Class<C>
         private val stateAggregateType: Class<S>
         private val stateAggregateMetadata: StateAggregateMetadata<S>
@@ -129,8 +131,8 @@ object AggregateMetadataParser : CacheableMetadataParser() {
 
         fun toMetadata(): AggregateMetadata<C, S> {
             if (commandFunctionRegistry.isEmpty()) {
-                if (log.isWarnEnabled) {
-                    log.warn("CommandAggregate[$commandAggregateType] requires at least one OnCommand function!")
+                log.warn {
+                    "CommandAggregate[$commandAggregateType] requires at least one OnCommand function!"
                 }
             }
             val namedAggregate = MetadataSearcher.typeNamedAggregate[commandAggregateType]

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/annotation/StateAggregateMetadataParser.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/annotation/StateAggregateMetadataParser.kt
@@ -12,6 +12,7 @@
  */
 package me.ahoo.wow.modeling.annotation
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.annotation.AnnotationPropertyAccessorParser.toAggregateIdGetterIfAnnotated
 import me.ahoo.wow.annotation.AnnotationPropertyAccessorParser.toStringGetter
 import me.ahoo.wow.api.annotation.DEFAULT_AGGREGATE_ID_NAME
@@ -26,7 +27,6 @@ import me.ahoo.wow.messaging.function.FunctionMetadataParser.toFunctionMetadata
 import me.ahoo.wow.metadata.CacheableMetadataParser
 import me.ahoo.wow.metadata.Metadata
 import me.ahoo.wow.modeling.matedata.StateAggregateMetadata
-import org.slf4j.LoggerFactory
 import java.lang.reflect.Constructor
 import kotlin.reflect.KFunction
 import kotlin.reflect.KProperty1
@@ -34,8 +34,6 @@ import kotlin.reflect.full.hasAnnotation
 import kotlin.reflect.full.valueParameters
 import kotlin.reflect.jvm.javaConstructor
 import kotlin.reflect.jvm.javaType
-
-private val log = LoggerFactory.getLogger(StateAggregateMetadataParser::class.java)
 
 /**
  * State Aggregate Metadata Parser .
@@ -54,6 +52,10 @@ object StateAggregateMetadataParser : CacheableMetadataParser() {
 
 internal class StateAggregateMetadataVisitor<S : Any>(private val stateAggregateType: Class<S>) :
     ClassVisitor<S> {
+    companion object {
+        private val log = KotlinLogging.logger {}
+    }
+
     private val constructor: Constructor<S>
     private var aggregateIdGetter: PropertyGetter<S, String>? = null
     private val sourcingFunctionRegistry: MutableMap<Class<*>, FunctionAccessorMetadata<S, Void>> = HashMap()
@@ -106,8 +108,8 @@ internal class StateAggregateMetadataVisitor<S : Any>(private val stateAggregate
 
     fun toMetadata(): StateAggregateMetadata<S> {
         if (sourcingFunctionRegistry.isEmpty()) {
-            if (log.isWarnEnabled) {
-                log.warn("StateAggregate[$stateAggregateType] requires at least one OnSourcing function!")
+            log.warn {
+                "StateAggregate[$stateAggregateType] requires at least one OnSourcing function!"
             }
         }
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/RetryableAggregateProcessor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/RetryableAggregateProcessor.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.modeling.command
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.exception.RecoverableType
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.api.modeling.NamedTypedAggregate
@@ -22,7 +23,6 @@ import me.ahoo.wow.exception.recoverable
 import me.ahoo.wow.modeling.matedata.AggregateMetadata
 import me.ahoo.wow.modeling.state.StateAggregateFactory
 import me.ahoo.wow.modeling.state.StateAggregateRepository
-import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
 import reactor.util.retry.Retry
 import java.time.Duration
@@ -35,7 +35,7 @@ class RetryableAggregateProcessor<C : Any, S : Any>(
     private val commandAggregateFactory: CommandAggregateFactory
 ) : AggregateProcessor<C>, NamedTypedAggregate<C> by aggregateMetadata.command {
     private companion object {
-        private val log = LoggerFactory.getLogger(RetryableAggregateProcessor::class.java)
+        private val log = KotlinLogging.logger {}
         private const val MAX_RETRIES = 3L
         private val MIN_BACKOFF = Duration.ofMillis(500)
     }
@@ -46,13 +46,8 @@ class RetryableAggregateProcessor<C : Any, S : Any>(
         .filter {
             it.recoverable == RecoverableType.RECOVERABLE
         }.doBeforeRetry {
-            if (log.isWarnEnabled) {
-                log.warn(
-                    "[BeforeRetry] {} totalRetries[{}].",
-                    aggregateId,
-                    it.totalRetries(),
-                    it.failure()
-                )
+            log.warn(it.failure()) {
+                "[BeforeRetry] $aggregateId totalRetries[${it.totalRetries()}]."
             }
         }
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt
@@ -12,6 +12,7 @@
  */
 package me.ahoo.wow.modeling.command
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.command.RecoverAggregate
 import me.ahoo.wow.api.messaging.function.FunctionInfoData
 import me.ahoo.wow.api.messaging.function.FunctionKind
@@ -22,8 +23,6 @@ import me.ahoo.wow.eventsourcing.EventStore
 import me.ahoo.wow.exception.NotFoundResourceException
 import me.ahoo.wow.modeling.matedata.CommandAggregateMetadata
 import me.ahoo.wow.modeling.state.StateAggregate
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
 
@@ -34,7 +33,7 @@ class SimpleCommandAggregate<C : Any, S : Any>(
     private val metadata: CommandAggregateMetadata<C>
 ) : CommandAggregate<C, S>, NamedTypedAggregate<C> by metadata {
     private companion object {
-        private val log: Logger = LoggerFactory.getLogger(SimpleCommandAggregate::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     override val processorName: String = metadata.processorName
@@ -56,8 +55,8 @@ class SimpleCommandAggregate<C : Any, S : Any>(
         val commandType = message.body.javaClass
         return Mono.defer {
             exchange.setCommandAggregate(this)
-            if (log.isDebugEnabled) {
-                log.debug("Process {}.", message)
+            log.debug {
+                "Process $message."
             }
             if (message.aggregateVersion != null && message.aggregateVersion != version) {
                 return@defer CommandExpectVersionConflictException(

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/state/SimpleStateAggregate.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/state/SimpleStateAggregate.kt
@@ -12,6 +12,7 @@
  */
 package me.ahoo.wow.modeling.state
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.Version
 import me.ahoo.wow.api.event.AggregateDeleted
 import me.ahoo.wow.api.event.AggregateRecovered
@@ -24,8 +25,6 @@ import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.event.SimpleDomainEventExchange
 import me.ahoo.wow.event.ignoreSourcing
 import me.ahoo.wow.modeling.matedata.StateAggregateMetadata
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 
 class SimpleStateAggregate<S : Any>(
     override val aggregateId: AggregateId,
@@ -45,12 +44,12 @@ class SimpleStateAggregate<S : Any>(
     private val sourcingRegistry = metadata.toMessageFunctionRegistry(state)
 
     companion object {
-        private val log: Logger = LoggerFactory.getLogger(SimpleStateAggregate::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     override fun onSourcing(eventStream: DomainEventStream): StateAggregate<S> {
-        if (log.isDebugEnabled) {
-            log.debug("onSourcing {}.", eventStream)
+        log.debug {
+            "onSourcing $eventStream."
         }
 
         if (eventStream.ignoreSourcing()) {
@@ -96,11 +95,8 @@ class SimpleStateAggregate<S : Any>(
         if (sourcingFunction != null) {
             sourcingFunction.invoke(SimpleDomainEventExchange(domainEvent))
         } else {
-            if (log.isDebugEnabled) {
-                log.debug(
-                    "Sourcing {} Ignore this domain event because onSourcing does not exist.",
-                    domainEvent,
-                )
+            log.debug {
+                "Sourcing $domainEvent Ignore this domain event because onSourcing does not exist."
             }
         }
     }

--- a/wow-dependencies/build.gradle.kts
+++ b/wow-dependencies/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     api(platform(libs.testcontainers.bom))
     constraints {
         api(libs.guava)
+        api(libs.kotlin.logging)
         api(libs.opentelemetry.semconv)
         api(libs.swagger)
         api(libs.springdoc.starter.common)

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/IndexTemplateInitializer.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/IndexTemplateInitializer.kt
@@ -15,6 +15,7 @@ package me.ahoo.wow.elasticsearch
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.google.common.io.Resources
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.messaging.dispatcher.SafeSubscriber
 import me.ahoo.wow.serialization.toJsonString
 import me.ahoo.wow.serialization.toObject
@@ -27,7 +28,7 @@ import reactor.core.publisher.Mono
 
 class IndexTemplateInitializer(private val elasticsearchOperations: ReactiveElasticsearchOperations) {
     companion object {
-        private val log = org.slf4j.LoggerFactory.getLogger(IndexTemplateInitializer::class.java)
+        private val log = KotlinLogging.logger {}
         private const val EVENT_STREAM_TEMPLATE_NAME = "wow-event-stream-template"
         private const val SNAPSHOT_TEMPLATE_NAME = "wow-snapshot-template"
         private const val INDEX_PATTERNS_KEY = "index_patterns"
@@ -53,8 +54,8 @@ class IndexTemplateInitializer(private val elasticsearchOperations: ReactiveElas
     }
 
     fun initTemplate(name: String, template: JsonNode): Mono<Boolean> {
-        if (log.isInfoEnabled) {
-            log.info("initTemplate - name:$name .")
+        log.info {
+            "initTemplate - name:$name ."
         }
         val indexPatterns = template.get(INDEX_PATTERNS_KEY).map {
             it.asText()

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/AggregateSchemaInitializer.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/AggregateSchemaInitializer.kt
@@ -17,16 +17,16 @@ import com.mongodb.client.model.IndexOptions
 import com.mongodb.client.model.Indexes
 import com.mongodb.reactivestreams.client.MongoCollection
 import com.mongodb.reactivestreams.client.MongoDatabase
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.infra.accessor.function.reactive.toBlockable
 import me.ahoo.wow.serialization.MessageRecords
 import org.bson.Document
-import org.slf4j.LoggerFactory
 import reactor.kotlin.core.publisher.toFlux
 import reactor.kotlin.core.publisher.toMono
 
 object AggregateSchemaInitializer {
-    private val log = LoggerFactory.getLogger(AggregateSchemaInitializer::class.java)
+    private val log = KotlinLogging.logger {}
     const val AGGREGATE_ID_AND_VERSION_UNIQUE_INDEX_NAME = "aggregateId_1_version_1"
     const val REQUEST_ID_UNIQUE_INDEX_NAME = "requestId_1"
     private val uniqueIndexOptions = IndexOptions().unique(true)
@@ -43,17 +43,17 @@ object AggregateSchemaInitializer {
     fun MongoDatabase.ensureCollection(collectionName: String): Boolean {
         listCollectionNames().toFlux().collectList().toBlockable().block()!!.let {
             if (it.contains(collectionName)) {
-                if (log.isInfoEnabled) {
-                    log.info("Ensure Collection {} already exists,ignore create.", collectionName)
+                log.info {
+                    "Ensure Collection [$collectionName already exists,ignore create."
                 }
                 return false
             }
-            if (log.isInfoEnabled) {
-                log.info("Ensure Collection {} Creating.", collectionName)
+            log.info {
+                "Ensure Collection [$collectionName] Creating."
             }
             this.createCollection(collectionName).toMono().block()
-            if (log.isInfoEnabled) {
-                log.info("Ensure Collection {} Created.", collectionName)
+            log.info {
+                "Ensure Collection [$collectionName] Creating."
             }
             return true
         }
@@ -83,6 +83,7 @@ object AggregateSchemaInitializer {
         createIndex(Indexes.hashed(MessageRecords.TENANT_ID))
             .toMono().toBlockable().block()
     }
+
     fun MongoCollection<Document>.createOwnerIdIndex() {
         createIndex(Indexes.hashed(MessageRecords.OWNER_ID))
             .toMono().toBlockable().block()

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/EventStreamSchemaInitializer.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/EventStreamSchemaInitializer.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.mongo
 
 import com.mongodb.reactivestreams.client.MongoDatabase
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.configuration.MetadataSearcher
 import me.ahoo.wow.mongo.AggregateSchemaInitializer.createAggregateIdAndRequestIdUniqueIndex
@@ -24,7 +25,6 @@ import me.ahoo.wow.mongo.AggregateSchemaInitializer.createRequestIdUniqueIndex
 import me.ahoo.wow.mongo.AggregateSchemaInitializer.createTenantIdIndex
 import me.ahoo.wow.mongo.AggregateSchemaInitializer.ensureCollection
 import me.ahoo.wow.mongo.AggregateSchemaInitializer.toEventStreamCollectionName
-import org.slf4j.LoggerFactory
 
 class EventStreamSchemaInitializer(
     private val database: MongoDatabase,
@@ -39,7 +39,7 @@ class EventStreamSchemaInitializer(
     private val enableRequestIdUniqueIndex: Boolean = false
 ) {
     companion object {
-        private val log = LoggerFactory.getLogger(EventStreamSchemaInitializer::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     fun initAll() {
@@ -50,13 +50,8 @@ class EventStreamSchemaInitializer(
 
     fun initSchema(namedAggregate: NamedAggregate) {
         val collectionName = namedAggregate.toEventStreamCollectionName()
-        if (log.isInfoEnabled) {
-            log.info(
-                "Init NamedAggregate Schema [{}] to Database:[{}] CollectionName [{}]",
-                namedAggregate,
-                database.name,
-                collectionName,
-            )
+        log.info {
+            "Init NamedAggregate Schema [$namedAggregate] to Database:[${database.name}] CollectionName [$collectionName]"
         }
         if (!database.ensureCollection(collectionName)) {
             return

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/SnapshotSchemaInitializer.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/SnapshotSchemaInitializer.kt
@@ -15,6 +15,7 @@ package me.ahoo.wow.mongo
 
 import com.mongodb.client.model.Indexes
 import com.mongodb.reactivestreams.client.MongoDatabase
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.configuration.MetadataSearcher
 import me.ahoo.wow.infra.accessor.function.reactive.toBlockable
@@ -23,12 +24,11 @@ import me.ahoo.wow.mongo.AggregateSchemaInitializer.createTenantIdIndex
 import me.ahoo.wow.mongo.AggregateSchemaInitializer.ensureCollection
 import me.ahoo.wow.mongo.AggregateSchemaInitializer.toSnapshotCollectionName
 import me.ahoo.wow.serialization.state.StateAggregateRecords
-import org.slf4j.LoggerFactory
 import reactor.kotlin.core.publisher.toMono
 
 class SnapshotSchemaInitializer(private val database: MongoDatabase) {
     companion object {
-        private val log = LoggerFactory.getLogger(SnapshotSchemaInitializer::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     fun initAll() {
@@ -39,13 +39,8 @@ class SnapshotSchemaInitializer(private val database: MongoDatabase) {
 
     fun initSchema(namedAggregate: NamedAggregate) {
         val collectionName = namedAggregate.toSnapshotCollectionName()
-        if (log.isInfoEnabled) {
-            log.info(
-                "Init NamedAggregate Schema [{}] to Database:[{}] CollectionName [{}]",
-                namedAggregate,
-                database.name,
-                collectionName,
-            )
+        log.info {
+            "Init NamedAggregate Schema [$namedAggregate] to Database:[${database.name}] CollectionName [$collectionName]"
         }
         if (!database.ensureCollection(collectionName)) {
             return

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/route/CommandRouteMetadataParser.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/route/CommandRouteMetadataParser.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.openapi.route
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.annotation.CommandRoute
 import me.ahoo.wow.api.annotation.DEFAULT_COMMAND_ACTION
 import me.ahoo.wow.api.annotation.Summary
@@ -28,7 +29,6 @@ import me.ahoo.wow.metadata.Metadata
 import me.ahoo.wow.openapi.Https
 import me.ahoo.wow.openapi.PathBuilder
 import me.ahoo.wow.serialization.toJsonString
-import org.slf4j.LoggerFactory
 import org.springframework.web.util.UriTemplate
 import kotlin.reflect.KProperty1
 
@@ -44,7 +44,7 @@ object CommandRouteMetadataParser : CacheableMetadataParser() {
 internal class CommandRouteMetadataVisitor<C : Any>(private val commandType: Class<C>) :
     ClassVisitor<C> {
     companion object {
-        private val log = LoggerFactory.getLogger(CommandRouteMetadataVisitor::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     private var pathVariables: MutableSet<VariableMetadata> = mutableSetOf()
@@ -145,12 +145,8 @@ internal class CommandRouteMetadataVisitor<C : Any>(private val commandType: Cla
         val pathVariableNames = pathVariables.map { it.variableName }.toSet()
         val missedVariableNames = uriPathVariables - pathVariableNames
         if (missedVariableNames.isNotEmpty()) {
-            if (log.isWarnEnabled) {
-                log.warn(
-                    "Command[{}] Route PathVariables{} is not bound to fields.",
-                    commandMetadata.commandType,
-                    missedVariableNames.toJsonString(),
-                )
+            log.warn {
+                "Command[${commandMetadata.commandType}] Route PathVariables [${missedVariableNames.toJsonString()}] is not bound to fields."
             }
             missedVariableNames.forEach {
                 val missedVariable = VariableMetadata(

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/messaging/MessageTextMapSetter.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/messaging/MessageTextMapSetter.kt
@@ -13,13 +13,13 @@
 
 package me.ahoo.wow.opentelemetry.messaging
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.opentelemetry.context.propagation.TextMapSetter
 import me.ahoo.wow.api.messaging.Message
-import org.slf4j.LoggerFactory
 
 class MessageTextMapSetter<M : Message<*, *>> : TextMapSetter<M> {
     companion object {
-        private val log = LoggerFactory.getLogger(MessageTextMapSetter::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     override fun set(carrier: M?, key: String, value: String) {
@@ -27,8 +27,8 @@ class MessageTextMapSetter<M : Message<*, *>> : TextMapSetter<M> {
             return
         }
         if (carrier.isReadOnly) {
-            if (log.isWarnEnabled) {
-                log.warn("carrier is read only. key:[{}],value:[{}]", key, value)
+            log.warn {
+                "carrier is read only. key:[$key],value:[$value]"
             }
             return
         }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/filter/MaskingDynamicDocumentQueryFilter.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/filter/MaskingDynamicDocumentQueryFilter.kt
@@ -20,7 +20,6 @@ import me.ahoo.wow.query.mask.DataMaskerRegistry
 import me.ahoo.wow.query.mask.mask
 import reactor.core.publisher.Mono
 
-@Suppress("UNCHECKED_CAST")
 abstract class MaskingDynamicDocumentQueryFilter<MASKER : AggregateDynamicDocumentMasker>(
     protected val maskerRegistry: DataMaskerRegistry<MASKER>
 ) :

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/filter/QueryHandler.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/filter/QueryHandler.kt
@@ -37,7 +37,6 @@ interface QueryHandler<R : Any> : Handler<QueryContext<*, *>> {
     fun count(namedAggregate: NamedAggregate, condition: Condition): Mono<Long>
 }
 
-@Suppress("UNCHECKED_CAST")
 abstract class AbstractQueryHandler<R : Any>(
     private val chain: FilterChain<QueryContext<*, *>>,
     private val errorHandler: ErrorHandler<QueryContext<*, *>>

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/AggregateDataMasker.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/AggregateDataMasker.kt
@@ -48,7 +48,7 @@ class DefaultAggregateDataMasker<MASKER : DynamicDocumentMasker>(override val ma
     }
 
     companion object {
-        val EMPTY = DefaultAggregateDataMasker<DynamicDocumentMasker>(emptyList())
+        private val EMPTY = DefaultAggregateDataMasker<DynamicDocumentMasker>(emptyList())
 
         @Suppress("UNCHECKED_CAST")
         fun <MASKER : DynamicDocumentMasker> empty(): DefaultAggregateDataMasker<MASKER> =

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/AggregateDataMasker.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/AggregateDataMasker.kt
@@ -48,7 +48,7 @@ class DefaultAggregateDataMasker<MASKER : DynamicDocumentMasker>(override val ma
     }
 
     companion object {
-        private val EMPTY = DefaultAggregateDataMasker<DynamicDocumentMasker>(emptyList())
+        val EMPTY = DefaultAggregateDataMasker<DynamicDocumentMasker>(emptyList())
 
         @Suppress("UNCHECKED_CAST")
         fun <MASKER : DynamicDocumentMasker> empty(): DefaultAggregateDataMasker<MASKER> =

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/DataMaskerRegistry.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/DataMaskerRegistry.kt
@@ -13,9 +13,9 @@
 
 package me.ahoo.wow.query.mask
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.modeling.materialize
-import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 
 interface DataMaskerRegistry<MASKER : AggregateDynamicDocumentMasker> {
@@ -26,14 +26,14 @@ interface DataMaskerRegistry<MASKER : AggregateDynamicDocumentMasker> {
 
 abstract class AbstractDataMaskerRegistry<MASKER : AggregateDynamicDocumentMasker> : DataMaskerRegistry<MASKER> {
     companion object {
-        private val log = LoggerFactory.getLogger(AbstractDataMaskerRegistry::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     private val maskers = ConcurrentHashMap<NamedAggregate, AggregateDataMasker<MASKER>>()
 
     override fun register(masker: MASKER) {
-        if (log.isInfoEnabled) {
-            log.info("Register - masker:[{}].", masker)
+        log.info {
+            "Register - masker:[$masker]."
         }
         maskers.compute(masker.namedAggregate.materialize()) { _, aggregateDataMasker ->
             aggregateDataMasker?.addMasker(masker) ?: DefaultAggregateDataMasker(listOf(masker))
@@ -41,8 +41,8 @@ abstract class AbstractDataMaskerRegistry<MASKER : AggregateDynamicDocumentMaske
     }
 
     override fun unregister(masker: MASKER) {
-        if (log.isInfoEnabled) {
-            log.info("Unregister - masker:[{}].", masker)
+        log.info {
+            "Unregister - masker:[$masker]."
         }
         maskers.compute(masker.namedAggregate.materialize()) { _, aggregateDataMasker ->
             aggregateDataMasker?.removeMasker(masker) ?: DefaultAggregateDataMasker.empty()

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/metrics/MetricsBeanPostProcessor.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/metrics/MetricsBeanPostProcessor.kt
@@ -13,22 +13,24 @@
 
 package me.ahoo.wow.spring.boot.starter.metrics
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.metrics.Metrics.metrizable
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.config.BeanPostProcessor
 import org.springframework.core.Ordered
 
 class MetricsBeanPostProcessor : BeanPostProcessor, Ordered {
     companion object {
-        private val log = LoggerFactory.getLogger(MetricsBeanPostProcessor::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     override fun postProcessAfterInitialization(bean: Any, beanName: String): Any {
-        val metrizableBean = bean.metrizable()
-        if (metrizableBean !== bean && log.isInfoEnabled) {
-            log.info("Metrizable bean [{}] [{}] -> [{}]", beanName, bean.javaClass.name, metrizableBean.javaClass.name)
+        val metatableBean = bean.metrizable()
+        if (metatableBean !== bean) {
+            log.info {
+                "Magnetizable bean [$beanName] [${bean.javaClass.name}] -> [${metatableBean.javaClass.name}]"
+            }
         }
-        return metrizableBean
+        return metatableBean
     }
 
     override fun getOrder(): Int {

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/TracingBeanPostProcessor.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/TracingBeanPostProcessor.kt
@@ -13,20 +13,22 @@
 
 package me.ahoo.wow.spring.boot.starter.opentelemetry
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.opentelemetry.Tracing.tracing
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.config.BeanPostProcessor
 import org.springframework.core.Ordered
 
 class TracingBeanPostProcessor : BeanPostProcessor, Ordered {
     companion object {
-        private val log = LoggerFactory.getLogger(TracingBeanPostProcessor::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     override fun postProcessAfterInitialization(bean: Any, beanName: String): Any {
         val tracingBean = bean.tracing()
-        if (tracingBean !== bean && log.isInfoEnabled) {
-            log.info("Tracing bean [{}] [{}] -> [{}]", beanName, bean.javaClass.name, tracingBean.javaClass.name)
+        if (tracingBean !== bean) {
+            log.info {
+                "Tracing bean [$beanName] [${bean.javaClass.name}] -> [${tracingBean.javaClass.name}]"
+            }
         }
         return tracingBean
     }

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/AutoRegistrar.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/AutoRegistrar.kt
@@ -13,7 +13,7 @@
 
 package me.ahoo.wow.spring
 
-import org.slf4j.LoggerFactory
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.context.ApplicationContext
 import org.springframework.context.SmartLifecycle
 import org.springframework.context.SmartLifecycle.DEFAULT_PHASE
@@ -30,14 +30,14 @@ abstract class AutoRegistrar<CM : Annotation>(
     private val applicationContext: ApplicationContext
 ) : SmartLifecycle {
     companion object {
-        private val log = LoggerFactory.getLogger(AutoRegistrar::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     private val running = AtomicBoolean(false)
 
     override fun start() {
-        if (log.isInfoEnabled) {
-            log.info("Start registering component:${componentType.simpleName}.")
+        log.info {
+            "Start registering component:${componentType.simpleName}."
         }
         if (!running.compareAndSet(false, true)) {
             return
@@ -45,8 +45,8 @@ abstract class AutoRegistrar<CM : Annotation>(
         val components = applicationContext.getBeansWithAnnotation(componentType)
         components.forEach { entry ->
             val component = entry.value
-            if (log.isDebugEnabled) {
-                log.debug("Registering Component {}.", component)
+            log.debug {
+                "Registering Component [$component]."
             }
             register(component)
         }
@@ -55,8 +55,8 @@ abstract class AutoRegistrar<CM : Annotation>(
     abstract fun register(component: Any)
 
     override fun stop() {
-        if (log.isInfoEnabled) {
-            log.info("Stop ${componentType.simpleName}.")
+        log.info {
+            "Stop ${componentType.simpleName}."
         }
         if (!running.compareAndSet(true, false)) {
             return

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/EventStreamQueryServiceRegistrar.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/EventStreamQueryServiceRegistrar.kt
@@ -13,19 +13,19 @@
 
 package me.ahoo.wow.spring.query
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.modeling.MaterializedNamedAggregate
 import me.ahoo.wow.modeling.toStringWithAlias
 import me.ahoo.wow.query.event.EventStreamQueryService
 import me.ahoo.wow.query.event.EventStreamQueryServiceFactory
 import me.ahoo.wow.query.event.NoOpEventStreamQueryServiceFactory
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.support.BeanDefinitionBuilder
 import org.springframework.beans.factory.support.BeanDefinitionRegistry
 
 class EventStreamQueryServiceRegistrar : QueryServiceRegistrar() {
     companion object {
-        private val log = LoggerFactory.getLogger(EventStreamQueryServiceRegistrar::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     override fun registerQueryService(
@@ -34,12 +34,12 @@ class EventStreamQueryServiceRegistrar : QueryServiceRegistrar() {
     ) {
         val namedAggregate = entry.key
         val beanName = "${namedAggregate.toStringWithAlias()}.EventStreamQueryService"
-        if (log.isInfoEnabled) {
-            log.info("Register EventStreamQueryService [$beanName].")
+        log.info {
+            "Register EventStreamQueryService [$beanName]."
         }
         if (registry.containsBeanDefinition(beanName)) {
-            if (log.isWarnEnabled) {
-                log.warn("EventStreamQueryService [$beanName] already exists - Ignore.")
+            log.warn {
+                "EventStreamQueryService [$beanName] already exists - Ignore."
             }
             return
         }

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/SnapshotQueryServiceRegistrar.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/SnapshotQueryServiceRegistrar.kt
@@ -13,13 +13,13 @@
 
 package me.ahoo.wow.spring.query
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.modeling.MaterializedNamedAggregate
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.modeling.toStringWithAlias
 import me.ahoo.wow.query.snapshot.NoOpSnapshotQueryServiceFactory
 import me.ahoo.wow.query.snapshot.SnapshotQueryService
 import me.ahoo.wow.query.snapshot.SnapshotQueryServiceFactory
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.support.BeanDefinitionBuilder
 import org.springframework.beans.factory.support.BeanDefinitionRegistry
@@ -27,7 +27,7 @@ import org.springframework.core.ResolvableType
 
 class SnapshotQueryServiceRegistrar : QueryServiceRegistrar() {
     companion object {
-        private val log = LoggerFactory.getLogger(SnapshotQueryServiceRegistrar::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     override fun registerQueryService(
@@ -36,12 +36,12 @@ class SnapshotQueryServiceRegistrar : QueryServiceRegistrar() {
     ) {
         val namedAggregate = entry.key
         val beanName = "${namedAggregate.toStringWithAlias()}.SnapshotQueryService"
-        if (log.isInfoEnabled) {
-            log.info("Register SnapshotQueryService [$beanName].")
+        log.info {
+            "Register SnapshotQueryService [$beanName]."
         }
         if (registry.containsBeanDefinition(beanName)) {
-            if (log.isWarnEnabled) {
-                log.warn("SnapshotQueryService [$beanName] already exists - Ignore.")
+            log.warn {
+                "SnapshotQueryService [$beanName] already exists - Ignore."
             }
             return
         }

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/ErrorHttpStatusMapping.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/ErrorHttpStatusMapping.kt
@@ -13,14 +13,14 @@
 
 package me.ahoo.wow.webflux.exception
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.exception.ErrorInfo
 import me.ahoo.wow.exception.ErrorCodes
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import java.util.concurrent.ConcurrentHashMap
 
 object ErrorHttpStatusMapping {
-    private val log = LoggerFactory.getLogger(ErrorHttpStatusMapping::class.java)
+    private val log = KotlinLogging.logger {}
     private val registrar = ConcurrentHashMap<String, HttpStatus>()
 
     init {
@@ -44,15 +44,15 @@ object ErrorHttpStatusMapping {
 
     fun register(errorCode: String, httpStatus: HttpStatus) {
         val previous = registrar.put(errorCode, httpStatus)
-        if (log.isInfoEnabled) {
-            log.info("Register - errorCode:[{}] - previous:[{}],current:[{}].", errorCode, previous, httpStatus)
+        log.info {
+            "Register - errorCode:[$errorCode] - previous:[$previous],current:[$httpStatus]."
         }
     }
 
     fun unregister(errorCode: String) {
         val removed = registrar.remove(errorCode)
-        if (log.isInfoEnabled) {
-            log.info("Unregister - errorCode:[{}] - removed:[{}].", errorCode, removed)
+        log.info {
+            "Unregister - errorCode:[$errorCode] - removed:[$removed]."
         }
     }
 

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/GlobalExceptionHandler.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/GlobalExceptionHandler.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.webflux.exception
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.exception.BindingError
 import me.ahoo.wow.api.exception.ErrorInfo
 import me.ahoo.wow.exception.ErrorCodes
@@ -20,7 +21,6 @@ import me.ahoo.wow.exception.toErrorInfo
 import me.ahoo.wow.openapi.command.CommandRequestHeaders
 import me.ahoo.wow.serialization.toJsonString
 import me.ahoo.wow.webflux.exception.ErrorHttpStatusMapping.toHttpStatus
-import org.slf4j.LoggerFactory
 import org.springframework.core.Ordered
 import org.springframework.http.MediaType
 import org.springframework.http.server.reactive.ServerHttpRequest
@@ -32,11 +32,11 @@ import org.springframework.web.server.WebExceptionHandler
 import reactor.core.publisher.Mono
 
 object GlobalExceptionHandler : WebExceptionHandler, Ordered {
-    private val log = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
+    private val log = KotlinLogging.logger {}
 
     override fun handle(exchange: ServerWebExchange, ex: Throwable): Mono<Void> {
-        if (log.isWarnEnabled) {
-            log.warn(exchange.request.formatRequest(), ex)
+        log.warn(ex) {
+            exchange.request.formatRequest()
         }
 
         val errorInfo = when (ex) {

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/RequestExceptionHandler.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/RequestExceptionHandler.kt
@@ -13,10 +13,10 @@
 
 package me.ahoo.wow.webflux.exception
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.command.CommandResultException
 import me.ahoo.wow.exception.toErrorInfo
 import me.ahoo.wow.webflux.route.toServerResponse
-import org.slf4j.LoggerFactory
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
 import reactor.core.publisher.Mono
@@ -26,14 +26,14 @@ interface RequestExceptionHandler {
 }
 
 object DefaultRequestExceptionHandler : RequestExceptionHandler {
-    private val log = LoggerFactory.getLogger(DefaultRequestExceptionHandler::class.java)
+    private val log = KotlinLogging.logger {}
     private fun ServerRequest.formatRequest(): String {
         return "HTTP ${method()} ${uri()}"
     }
 
     override fun handle(request: ServerRequest, throwable: Throwable): Mono<ServerResponse> {
-        if (log.isWarnEnabled) {
-            log.warn(request.formatRequest(), throwable)
+        log.warn(throwable) {
+            request.formatRequest()
         }
         if (throwable is CommandResultException) {
             return throwable.commandResult.toServerResponse()

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/RouteHandlerFunctionRegistrar.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/RouteHandlerFunctionRegistrar.kt
@@ -13,25 +13,20 @@
 
 package me.ahoo.wow.webflux.route
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.openapi.RouteSpec
-import org.slf4j.LoggerFactory
 import java.util.concurrent.ConcurrentHashMap
 
 class RouteHandlerFunctionRegistrar {
     companion object {
-        private val log = LoggerFactory.getLogger(RouteHandlerFunctionRegistrar::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     private val factories = ConcurrentHashMap<Class<out RouteSpec>, RouteHandlerFunctionFactory<*>>()
     fun register(routeHandlerFunctionFactory: RouteHandlerFunctionFactory<*>) {
         val previous = factories.put(routeHandlerFunctionFactory.supportedSpec, routeHandlerFunctionFactory)
-        if (log.isInfoEnabled) {
-            log.info(
-                "Register - supportedSpec:[{}] - previous:[{}],current:[{}].",
-                routeHandlerFunctionFactory.supportedSpec,
-                previous,
-                routeHandlerFunctionFactory
-            )
+        log.info {
+            "Register - supportedSpec:[${routeHandlerFunctionFactory.supportedSpec}] - previous:[$previous],current:[$routeHandlerFunctionFactory]."
         }
     }
 

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/wait/WebClientCommandWaitNotifier.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/wait/WebClientCommandWaitNotifier.kt
@@ -13,12 +13,12 @@
 
 package me.ahoo.wow.webflux.wait
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.command.wait.CommandWaitNotifier
 import me.ahoo.wow.command.wait.WaitSignal
 import me.ahoo.wow.command.wait.WaitStrategyRegistrar
 import me.ahoo.wow.command.wait.isLocalCommand
 import me.ahoo.wow.messaging.handler.DEFAULT_RETRY_SPEC
-import org.slf4j.LoggerFactory
 import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
@@ -28,27 +28,20 @@ class WebClientCommandWaitNotifier(
     private val webClient: WebClient
 ) : CommandWaitNotifier {
     companion object {
-        private val log = LoggerFactory.getLogger(WebClientCommandWaitNotifier::class.java)
+        private val log = KotlinLogging.logger {}
     }
 
     override fun notify(commandWaitEndpoint: String, waitSignal: WaitSignal): Mono<Void> {
         return Mono.defer {
             if (isLocalCommand(waitSignal.commandId)) {
-                if (log.isDebugEnabled) {
-                    log.debug(
-                        "Notify Local - waitSignal: {}",
-                        waitSignal,
-                    )
+                log.debug {
+                    "Notify Local - waitSignal: $waitSignal."
                 }
                 waitStrategyRegistrar.next(waitSignal)
                 return@defer Mono.empty()
             }
-            if (log.isDebugEnabled) {
-                log.debug(
-                    "Notify remote: endpoint: [{}] - waitSignal: {}",
-                    commandWaitEndpoint,
-                    waitSignal,
-                )
+            log.debug {
+                "Notify remote: endpoint: [$commandWaitEndpoint] - waitSignal: $waitSignal."
             }
             webClient
                 .post()


### PR DESCRIPTION
- Add kotlin-logging as an API dependency in wow-dependencies/build.gradle.kts
- Update logging implementation across multiple source files to use KotlinLogging
- Remove redundant SLF4J logger declarations and imports