### PR TITLE
feat(schema): add OpenAPI compatibility and improve schema generation

### DIFF
--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/JsonSchemaGenerator.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/JsonSchemaGenerator.kt
@@ -44,7 +44,6 @@ class JsonSchemaGenerator(private val options: Set<WowOption> = WowOption.ALL) {
             .with(openApiModule)
             .with(wowModule)
             .with(Option.EXTRA_OPEN_API_FORMAT_VALUES)
-
         schemaGenerator = SchemaGenerator(schemaGeneratorConfigBuilder.build())
     }
 

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowModule.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowModule.kt
@@ -27,6 +27,7 @@ import me.ahoo.wow.schema.kotlin.KotlinWriteOnlyCheck
 class WowModule(private val options: Set<WowOption> = WowOption.ALL) : Module {
     override fun applyToConfigBuilder(builder: SchemaGeneratorConfigBuilder) {
         val fieldConfigPart = builder.forFields()
+        fieldConfigPart.withInstanceAttributeOverride { collectedMemberAttributes, member, context -> }
         ignoreCommandRouteVariable(fieldConfigPart)
         val generalConfigPart = builder.forTypesInGeneral()
         kotlinNullable(fieldConfigPart, generalConfigPart)

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowSchemaDefinitionNamingStrategy.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowSchemaDefinitionNamingStrategy.kt
@@ -15,6 +15,7 @@ package me.ahoo.wow.schema
 
 import com.github.victools.jsonschema.generator.SchemaGenerationContext
 import com.github.victools.jsonschema.generator.impl.DefinitionKey
+import com.github.victools.jsonschema.generator.naming.DefaultSchemaDefinitionNamingStrategy
 import com.github.victools.jsonschema.generator.naming.SchemaDefinitionNamingStrategy
 import me.ahoo.wow.api.Wow
 import me.ahoo.wow.configuration.namedAggregate
@@ -24,7 +25,8 @@ import me.ahoo.wow.modeling.toStringWithAlias
 import me.ahoo.wow.naming.getContextAlias
 
 object WowSchemaDefinitionNamingStrategy : SchemaDefinitionNamingStrategy {
-    fun Class<*>.toSchemaName(): String {
+    private val baseStrategy: SchemaDefinitionNamingStrategy = DefaultSchemaDefinitionNamingStrategy()
+    fun Class<*>.toSchemaName(): String? {
         kotlin.scanAnnotation<io.swagger.v3.oas.annotations.media.Schema>()?.let {
             if (it.name.isNotBlank()) {
                 return it.name
@@ -41,10 +43,10 @@ object WowSchemaDefinitionNamingStrategy : SchemaDefinitionNamingStrategy {
         if (name.startsWith("me.ahoo.wow.")) {
             return Wow.WOW_PREFIX + simpleName
         }
-        return simpleName
+        return null
     }
 
     override fun getDefinitionNameForKey(key: DefinitionKey, generationContext: SchemaGenerationContext): String {
-        return key.type.erasedType.toSchemaName()
+        return key.type.erasedType.toSchemaName() ?: baseStrategy.getDefinitionNameForKey(key, generationContext)
     }
 }

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/openapi/OpenAPICompatibilityAttributeOverride.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/openapi/OpenAPICompatibilityAttributeOverride.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.schema.openapi
+
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.github.victools.jsonschema.generator.InstanceAttributeOverrideV2
+import com.github.victools.jsonschema.generator.MemberScope
+import com.github.victools.jsonschema.generator.SchemaGenerationContext
+import com.github.victools.jsonschema.generator.SchemaKeyword
+import com.github.victools.jsonschema.generator.SchemaVersion
+import io.swagger.v3.oas.models.media.Schema
+import me.ahoo.wow.schema.JsonSchema.Companion.toPropertyName
+
+class OpenAPICompatibilityAttributeOverride<M : MemberScope<*, *>?>(private val schemaVersion: SchemaVersion) :
+    InstanceAttributeOverrideV2<M> {
+    override fun overrideInstanceAttributes(
+        collectedMemberAttributes: ObjectNode,
+        member: M,
+        context: SchemaGenerationContext
+    ) {
+        collectedMemberAttributes.replaceAttributes()
+    }
+
+    private fun ObjectNode.replaceAttributes() {
+        replaceAttribute(
+            SchemaKeyword.TAG_MINIMUM_EXCLUSIVE.toPropertyName(schemaVersion),
+            Schema<*>::exclusiveMaximumValue.name
+        )
+        replaceAttribute(
+            SchemaKeyword.TAG_MAXIMUM_EXCLUSIVE.toPropertyName(schemaVersion),
+            Schema<*>::exclusiveMinimumValue.name
+        )
+    }
+
+    private fun ObjectNode.replaceAttribute(from: String, to: String) {
+        if (has(from)) {
+            val value = get(from)
+            remove(from)
+            set<ObjectNode>(to, value)
+        }
+    }
+}

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilder.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilder.kt
@@ -1,0 +1,105 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.schema.openapi
+
+import com.fasterxml.classmate.ResolvedType
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.github.victools.jsonschema.generator.Module
+import com.github.victools.jsonschema.generator.Option
+import com.github.victools.jsonschema.generator.OptionPreset
+import com.github.victools.jsonschema.generator.SchemaGenerator
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfig
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder
+import com.github.victools.jsonschema.generator.SchemaKeyword
+import com.github.victools.jsonschema.generator.SchemaVersion
+import com.github.victools.jsonschema.generator.impl.TypeContextFactory
+import com.github.victools.jsonschema.module.jackson.JacksonModule
+import com.github.victools.jsonschema.module.jackson.JacksonOption
+import com.github.victools.jsonschema.module.jakarta.validation.JakartaValidationModule
+import com.github.victools.jsonschema.module.swagger2.Swagger2Module
+import io.swagger.v3.oas.models.media.Schema
+import me.ahoo.wow.schema.JsonSchema.Companion.toPropertyName
+import me.ahoo.wow.schema.WowModule
+import me.ahoo.wow.serialization.JsonSerializer
+import me.ahoo.wow.serialization.toObject
+import java.lang.reflect.Type
+import java.util.function.Consumer
+
+class OpenAPISchemaBuilder(
+    private val schemaVersion: SchemaVersion = SchemaVersion.DRAFT_2019_09,
+    private val optionPreset: OptionPreset = OptionPreset.PLAIN_JSON,
+    private val customizer: Consumer<SchemaGeneratorConfigBuilder> = Consumer {
+        val jacksonModule: Module = JacksonModule(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED)
+        val jakartaModule = JakartaValidationModule()
+        val openApiModule: Module = Swagger2Module()
+        val wowModule = WowModule()
+        it.with(jacksonModule)
+            .with(jakartaModule)
+            .with(openApiModule)
+            .with(wowModule)
+            .with(Option.DEFINITIONS_FOR_ALL_OBJECTS)
+            .with(Option.PLAIN_DEFINITION_KEYS)
+
+        it.forFields().withInstanceAttributeOverride(OpenAPICompatibilityAttributeOverride(schemaVersion))
+        it.forMethods().withInstanceAttributeOverride(OpenAPICompatibilityAttributeOverride(schemaVersion))
+    }
+) {
+    companion object {
+        const val DEFINITION_PATH = "components/schemas"
+    }
+
+    private val configBuilder: SchemaGeneratorConfig =
+        SchemaGeneratorConfigBuilder(JsonSerializer, schemaVersion, optionPreset)
+            .also {
+                customizer.accept(it)
+            }.build()
+    private val typeContext = TypeContextFactory.createDefaultTypeContext(configBuilder)
+    private val schemaGenerator: SchemaGenerator = SchemaGenerator(configBuilder, typeContext)
+
+    private val inline: Boolean
+        get() = configBuilder.shouldInlineAllSchemas()
+    private val schemaBuilder = schemaGenerator.buildMultipleSchemaDefinitions()
+    private val schemaReferences: MutableList<SchemaReference> = mutableListOf()
+
+    fun generateSchema(mainTargetType: Type, vararg typeParameters: Type): Schema<*> {
+        val resolvedType = typeContext.resolve(mainTargetType, *typeParameters)
+        if (inline) {
+            return schemaGenerator.generateSchema(resolvedType).toObject()
+        }
+        val refSchemaNode = schemaBuilder.createSchemaReference(resolvedType)
+        val schemaReference = SchemaReference(resolvedType, refSchemaNode.toObject(), refSchemaNode)
+        schemaReferences.add(schemaReference)
+        return schemaReference.schema
+    }
+
+    fun build(): Map<String, Schema<*>> {
+        val collectedDefs = schemaBuilder.collectDefinitions(DEFINITION_PATH)
+        for (schemaReference in schemaReferences) {
+            schemaReference.merge()
+        }
+        return collectedDefs.properties().associate { (name, node) ->
+            name to node.toObject()
+        }
+    }
+
+    data class SchemaReference(val type: ResolvedType, val schema: Schema<*>, val node: ObjectNode) {
+
+        fun merge() {
+            val schemaRef = node.get(SchemaKeyword.TAG_REF.toPropertyName())?.textValue()
+            if (schemaRef != null) {
+                schema.`$ref` = schemaRef
+            }
+        }
+    }
+}

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/JsonSchemaGeneratorTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/JsonSchemaGeneratorTest.kt
@@ -129,6 +129,7 @@ class JsonSchemaGeneratorTest {
             .with(Option.PLAIN_DEFINITION_KEYS)
 
         val schemaGenerator = SchemaGenerator(schemaGeneratorConfigBuilder.build())
+
         val openAPISchemaBuilder = schemaGenerator.buildMultipleSchemaDefinitions()
         val schema = openAPISchemaBuilder.createSchemaReference(CreateOrder::class.java).asJsonSchema()
         val componentsSchemas = openAPISchemaBuilder.collectDefinitions("components/schemas")

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/WowSchemaDefinitionNamingStrategyTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/WowSchemaDefinitionNamingStrategyTest.kt
@@ -20,7 +20,7 @@ class WowSchemaDefinitionNamingStrategyTest {
             return Stream.of(
                 Arguments.of(AggregateId::class.java, "wow.AggregateId"),
                 Arguments.of(CreateOrder::class.java, "example.order.CreateOrder"),
-                Arguments.of(Any::class.java, "Object"),
+                Arguments.of(Any::class.java, null),
                 Arguments.of(WowSchemaDefinitionNamingStrategyTest::class.java, "SchemaDefinitionNamingStrategyTest"),
                 Arguments.of(ExampleService::class.java, "example.ExampleService")
             )
@@ -29,7 +29,7 @@ class WowSchemaDefinitionNamingStrategyTest {
 
     @ParameterizedTest
     @MethodSource("parametersForToSchemaName")
-    fun toSchemaName(clazz: Class<*>, expectedSchemaName: String) {
+    fun toSchemaName(clazz: Class<*>, expectedSchemaName: String?) {
         val schemaName = clazz.toSchemaName()
         assertThat(schemaName, equalTo(expectedSchemaName))
     }

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilderTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilderTest.kt
@@ -1,0 +1,25 @@
+package me.ahoo.wow.schema.openapi
+
+import me.ahoo.wow.example.api.cart.AddCartItem
+import me.ahoo.wow.example.api.order.CreateOrder
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.CoreMatchers.notNullValue
+import org.hamcrest.CoreMatchers.nullValue
+import org.hamcrest.MatcherAssert.*
+import org.junit.jupiter.api.Test
+
+class OpenAPISchemaBuilderTest {
+
+    @Test
+    fun build() {
+        val openAPISchemaBuilder = OpenAPISchemaBuilder()
+        val createOderSchema = openAPISchemaBuilder.generateSchema(CreateOrder::class.java)
+        assertThat(createOderSchema.`$ref`, nullValue())
+        val addCartItemSchema = openAPISchemaBuilder.generateSchema(AddCartItem::class.java)
+        assertThat(addCartItemSchema.`$ref`, nullValue())
+        val componentsSchemas = openAPISchemaBuilder.build()
+        assertThat(createOderSchema.`$ref`, notNullValue())
+        assertThat(addCartItemSchema.`$ref`, notNullValue())
+        assertThat(componentsSchemas.size, equalTo(4))
+    }
+}


### PR DESCRIPTION
- Add OpenAPICompatibilityAttributeOverride to replace exclusive min/max attributes
- Implement OpenAPISchemaBuilder for generating OpenAPI-compatible schemas
- Update WowModule to include empty instance attribute override
- Modify WowSchemaDefinitionNamingStrategy to fall back to default strategy
- Add tests for new OpenAPI schema builder and naming strategy
