### PR TITLE
feat(schema): add enum support and simplify enum definitions

### DIFF
--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/kotlin/KotlinCustomDefinitionProvider.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/kotlin/KotlinCustomDefinitionProvider.kt
@@ -33,7 +33,8 @@ object KotlinCustomDefinitionProvider : CustomDefinitionProviderV2 {
         context: SchemaGenerationContext
     ): CustomDefinition? {
         javaType.erasedType.getAnnotation(Metadata::class.java) ?: return null
-        if (javaType.erasedType.packageName.startsWith("kotlin") ||
+        if (javaType.erasedType.isEnum ||
+            javaType.erasedType.packageName.startsWith("kotlin") ||
             javaType.erasedType.packageName.startsWith("kotlinx")
         ) {
             return null

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilder.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilder.kt
@@ -108,6 +108,7 @@ class OpenAPISchemaBuilder(
                     .with(openApiModule)
                     .with(wowModule)
                     .with(Option.PLAIN_DEFINITION_KEYS)
+                    .with(Option.SIMPLIFIED_ENUMS)
 
                 forFields()
                     .withInstanceAttributeOverride(OpenAPICompatibilityAttributeOverride(schemaVersion))

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/JsonSchemaGeneratorTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/JsonSchemaGeneratorTest.kt
@@ -16,6 +16,7 @@ import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.event.DomainEvent
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.command.SimpleCommandMessage
+import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.event.SimpleDomainEvent
 import me.ahoo.wow.event.SimpleDomainEventStream
@@ -93,21 +94,28 @@ class JsonSchemaGeneratorTest {
 
     @Test
     fun ignoreCommandPathRouteVariable() {
-        val schema = jsonSchemaGenerator.generate(Patch::class.java)
-        assertThat(schema.get("properties"), nullValue())
+        val schema = jsonSchemaGenerator.generate(Patch::class.java).asJsonSchema()
+        assertThat(schema.getProperties(), nullValue())
     }
 
     @Test
     fun ignoreCommandHeaderRouteVariable() {
-        val schema = jsonSchemaGenerator.generate(Header::class.java)
-        assertThat(schema.get("properties"), nullValue())
+        val schema = jsonSchemaGenerator.generate(Header::class.java).asJsonSchema()
+        assertThat(schema.getProperties(), nullValue())
     }
 
     @Test
     fun notIgnoreCommandPathRouteVariable() {
         val jsonSchemaGenerator = JsonSchemaGenerator(setOf())
-        val schema = jsonSchemaGenerator.generate(Patch::class.java)
-        assertThat(schema.get("properties"), notNullValue())
+        val schema = jsonSchemaGenerator.generate(Patch::class.java).asJsonSchema()
+        assertThat(schema.getProperties(), notNullValue())
+    }
+
+    @Test
+    fun enum() {
+        val jsonSchemaGenerator = JsonSchemaGenerator()
+        val schema = jsonSchemaGenerator.generate(CommandStage::class.java).asJsonSchema()
+        assertThat(schema.getProperties(), nullValue())
     }
 
     @Test


### PR DESCRIPTION
- Update KotlinCustomDefinitionProvider to exclude enum types
- Enable simplified enums option in OpenAPISchemaBuilder
- Add test case for enum type generation
- Refactor test cases to use asJsonSchema() method

