### PR TITLE
refactor(schema): rename schema naming strategy and update related tests

### DIFF
--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowModule.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowModule.kt
@@ -66,6 +66,6 @@ class WowModule(private val options: Set<WowOption> = WowOption.ALL) : Module {
         if (options.contains(WowOption.WOW_NAMING_STRATEGY).not()) {
             return
         }
-        generalConfigPart.withDefinitionNamingStrategy(WowSchemaDefinitionNamingStrategy)
+        generalConfigPart.withDefinitionNamingStrategy(WowSchemaNamingStrategy)
     }
 }

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowSchemaNamingStrategy.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowSchemaNamingStrategy.kt
@@ -25,7 +25,7 @@ import me.ahoo.wow.infra.reflection.AnnotationScanner.scanAnnotation
 import me.ahoo.wow.modeling.toStringWithAlias
 import me.ahoo.wow.naming.getContextAlias
 
-object WowSchemaDefinitionNamingStrategy : SchemaDefinitionNamingStrategy {
+object WowSchemaNamingStrategy : SchemaDefinitionNamingStrategy {
     private val baseStrategy: SchemaDefinitionNamingStrategy = DefaultSchemaDefinitionNamingStrategy()
 
     private fun Class<*>.resolveNamePrefix(): String? {

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/WowSchemaNamingStrategyTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/WowSchemaNamingStrategyTest.kt
@@ -15,7 +15,7 @@ import me.ahoo.wow.example.api.ExampleService
 import me.ahoo.wow.example.api.order.CreateOrder
 import me.ahoo.wow.example.domain.cart.CartState
 import me.ahoo.wow.example.domain.order.OrderState
-import me.ahoo.wow.schema.WowSchemaDefinitionNamingStrategy.toSchemaName
+import me.ahoo.wow.schema.WowSchemaNamingStrategy.toSchemaName
 import me.ahoo.wow.serialization.JsonSerializer
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.*
@@ -25,7 +25,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 
 @Schema(name = "SchemaDefinitionNamingStrategyTest")
-class WowSchemaDefinitionNamingStrategyTest {
+class WowSchemaNamingStrategyTest {
     companion object {
         private val generatorConfig: SchemaGeneratorConfig =
             SchemaGeneratorConfigBuilder(JsonSerializer, SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON)
@@ -39,7 +39,7 @@ class WowSchemaDefinitionNamingStrategyTest {
                 Arguments.of(typeContext.resolve(CreateOrder::class.java), "example.order.CreateOrder"),
                 Arguments.of(typeContext.resolve(Any::class.java), null),
                 Arguments.of(
-                    typeContext.resolve(WowSchemaDefinitionNamingStrategyTest::class.java),
+                    typeContext.resolve(WowSchemaNamingStrategyTest::class.java),
                     "wow.SchemaDefinitionNamingStrategyTest"
                 ),
                 Arguments.of(typeContext.resolve(ExampleService::class.java), "example.ExampleService"),


### PR DESCRIPTION
- Rename WowSchemaDefinitionNamingStrategy to WowSchemaNamingStrategy
- Update WowModule to use the new naming strategy
- Rename related test files and update test content to match the new strategy

