### PR TITLE
refactor(schema): create typed package for typed classes

### DIFF
--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowModule.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowModule.kt
@@ -23,6 +23,13 @@ import me.ahoo.wow.schema.kotlin.KotlinNullableCheck
 import me.ahoo.wow.schema.kotlin.KotlinReadOnlyCheck
 import me.ahoo.wow.schema.kotlin.KotlinRequiredCheck
 import me.ahoo.wow.schema.kotlin.KotlinWriteOnlyCheck
+import me.ahoo.wow.schema.typed.AggregateIdDefinitionProvider
+import me.ahoo.wow.schema.typed.CommandDefinitionProvider
+import me.ahoo.wow.schema.typed.DomainEventDefinitionProvider
+import me.ahoo.wow.schema.typed.DomainEventStreamDefinitionProvider
+import me.ahoo.wow.schema.typed.SnapshotDefinitionProvider
+import me.ahoo.wow.schema.typed.StateAggregateDefinitionProvider
+import me.ahoo.wow.schema.typed.StateEventDefinitionProvider
 
 class WowModule(private val options: Set<WowOption> = WowOption.ALL) : Module {
     override fun applyToConfigBuilder(builder: SchemaGeneratorConfigBuilder) {

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/AbstractStateAggregate.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/AbstractStateAggregate.kt
@@ -11,32 +11,33 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.schema
+package me.ahoo.wow.schema.typed
 
 import com.fasterxml.classmate.ResolvedType
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.github.victools.jsonschema.generator.CustomDefinition
 import com.github.victools.jsonschema.generator.SchemaGenerationContext
 import com.github.victools.jsonschema.generator.SchemaKeyword
-import me.ahoo.wow.api.command.CommandMessage
-import me.ahoo.wow.api.event.DomainEvent
-import me.ahoo.wow.api.messaging.Message
+import me.ahoo.wow.eventsourcing.snapshot.Snapshot
+import me.ahoo.wow.eventsourcing.state.StateEvent
+import me.ahoo.wow.modeling.state.ReadOnlyStateAggregate
+import me.ahoo.wow.modeling.state.StateAggregate
 import me.ahoo.wow.schema.JsonSchema.Companion.asCustomDefinition
 import me.ahoo.wow.schema.JsonSchema.Companion.asJsonSchema
 import me.ahoo.wow.schema.JsonSchema.Companion.toPropertyName
-import me.ahoo.wow.serialization.MessageRecords
+import me.ahoo.wow.serialization.state.StateAggregateRecords
 import java.lang.reflect.ParameterizedType
 
-abstract class MessageDefinitionProvider<M : Message<*, *>> :
+abstract class AbstractStateAggregate<S : ReadOnlyStateAggregate<*>> :
     TypedCustomDefinitionProvider() {
     @Suppress("UNCHECKED_CAST")
     override val type: Class<*> by lazy {
         val superType = javaClass.genericSuperclass as ParameterizedType
         val messageType = superType.actualTypeArguments[0] as ParameterizedType
-        messageType.rawType as Class<M>
+        messageType.rawType as Class<S>
     }
 
-    open fun getBodyType(javaType: ResolvedType): ResolvedType {
+    open fun getStateType(javaType: ResolvedType): ResolvedType {
         return javaType.typeBindings.getBoundType(0)
     }
 
@@ -47,22 +48,17 @@ abstract class MessageDefinitionProvider<M : Message<*, *>> :
 
         val typedSchema = getTypedSchema().asJsonSchema()
         typedSchema.remove(SchemaKeyword.TAG_TITLE)
-        val bodyType = getBodyType(javaType)
+        val stateType = getStateType(javaType)
         val propertiesNode = typedSchema.requiredGetProperties()
-        val bodyTypeNode = propertiesNode[MessageRecords.BODY_TYPE] as ObjectNode
-        val typeKey = SchemaKeyword.TAG_TYPE.toPropertyName()
-        bodyTypeNode.remove(typeKey)
-        val constKey = SchemaKeyword.TAG_CONST.toPropertyName()
-        bodyTypeNode.put(constKey, bodyType.erasedType.name)
-        val bodyOriginalNode = propertiesNode[MessageRecords.BODY] as ObjectNode
-        val bodySchema = context.createStandardDefinition(bodyType, this).asJsonSchema()
+        val stateOriginalNode = propertiesNode[StateAggregateRecords.STATE] as ObjectNode
+        val stateSchema = context.createStandardDefinition(stateType, this).asJsonSchema()
         val descriptionKey = SchemaKeyword.TAG_DESCRIPTION.toPropertyName()
-        bodySchema.set(SchemaKeyword.TAG_DESCRIPTION, bodyOriginalNode[descriptionKey])
-        propertiesNode.set<ObjectNode>(MessageRecords.BODY, bodySchema.actual)
+        stateSchema.set(SchemaKeyword.TAG_DESCRIPTION, stateOriginalNode[descriptionKey])
+        propertiesNode.set<ObjectNode>(StateAggregateRecords.STATE, stateSchema.actual)
         return typedSchema.asCustomDefinition()
     }
 }
 
-object CommandDefinitionProvider : MessageDefinitionProvider<CommandMessage<*>>()
-
-object DomainEventDefinitionProvider : MessageDefinitionProvider<DomainEvent<*>>()
+object StateAggregateDefinitionProvider : AbstractStateAggregate<StateAggregate<*>>()
+object SnapshotDefinitionProvider : AbstractStateAggregate<Snapshot<*>>()
+object StateEventDefinitionProvider : AbstractStateAggregate<StateEvent<*>>()

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/AggregateIdDefinitionProvider.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/AggregateIdDefinitionProvider.kt
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.schema
+package me.ahoo.wow.schema.typed
 
 import me.ahoo.wow.api.modeling.AggregateId
 

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/DomainEventStreamDefinitionProvider.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/DomainEventStreamDefinitionProvider.kt
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.schema
+package me.ahoo.wow.schema.typed
 
 import com.fasterxml.classmate.ResolvedType
 import com.github.victools.jsonschema.generator.CustomDefinition

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/TypedCustomDefinitionProvider.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/TypedCustomDefinitionProvider.kt
@@ -11,13 +11,14 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.schema
+package me.ahoo.wow.schema.typed
 
 import com.fasterxml.classmate.ResolvedType
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.github.victools.jsonschema.generator.CustomDefinition
 import com.github.victools.jsonschema.generator.CustomDefinitionProviderV2
 import com.github.victools.jsonschema.generator.SchemaGenerationContext
+import me.ahoo.wow.schema.WowSchemaLoader
 
 abstract class TypedCustomDefinitionProvider : CustomDefinitionProviderV2 {
     abstract val type: Class<*>


### PR DESCRIPTION
- Move AbstractStateAggregate, AggregateIdDefinitionProvider, DomainEventStreamDefinitionProvider, MessageDefinitionProvider, and TypedCustomDefinitionProvider to new typed package
- Update package name from me.ahoo.wow.schema to me.ahoo.wow.schema.typed
- Add imports for new typed classes in WowModule.kt
