### PR TITLE
feat(schema): add Joda Money support

### DIFF
--- a/wow-schema/build.gradle.kts
+++ b/wow-schema/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     api("com.github.victools:jsonschema-module-jackson")
     api("com.github.victools:jsonschema-module-jakarta-validation")
     api("com.github.victools:jsonschema-module-swagger-2")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-joda-money")
     testImplementation(libs.json.schema.validator)
     testImplementation("io.swagger.core.v3:swagger-core-jakarta")
     testImplementation(project(":wow-tck"))

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowModule.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowModule.kt
@@ -18,6 +18,8 @@ import com.github.victools.jsonschema.generator.Module
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigPart
 import com.github.victools.jsonschema.generator.SchemaGeneratorGeneralConfigPart
+import me.ahoo.wow.schema.joda.money.CurrencyUnitDefinitionProvider
+import me.ahoo.wow.schema.joda.money.MoneyDefinitionProvider
 import me.ahoo.wow.schema.kotlin.KotlinCustomDefinitionProvider
 import me.ahoo.wow.schema.kotlin.KotlinNullableCheck
 import me.ahoo.wow.schema.kotlin.KotlinReadOnlyCheck
@@ -45,6 +47,7 @@ class WowModule(private val options: Set<WowOption> = WowOption.ALL) : Module {
         generalConfigPart.withCustomDefinitionProvider(SnapshotDefinitionProvider)
         generalConfigPart.withCustomDefinitionProvider(StateEventDefinitionProvider)
         wowNamingStrategy(generalConfigPart)
+        jodaMoney(generalConfigPart)
     }
 
     private fun ignoreCommandRouteVariable(configPart: SchemaGeneratorConfigPart<FieldScope>) {
@@ -74,5 +77,13 @@ class WowModule(private val options: Set<WowOption> = WowOption.ALL) : Module {
             return
         }
         generalConfigPart.withDefinitionNamingStrategy(WowSchemaNamingStrategy)
+    }
+
+    private fun jodaMoney(generalConfigPart: SchemaGeneratorGeneralConfigPart) {
+        if (options.contains(WowOption.JODA_MONEY).not()) {
+            return
+        }
+        generalConfigPart.withCustomDefinitionProvider(CurrencyUnitDefinitionProvider)
+        generalConfigPart.withCustomDefinitionProvider(MoneyDefinitionProvider)
     }
 }

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/joda/money/CurrencyUnitDefinitionProvider.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/joda/money/CurrencyUnitDefinitionProvider.kt
@@ -11,20 +11,12 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.schema
+package me.ahoo.wow.schema.joda.money
 
-enum class WowOption {
-    /**
-     *
-     * @see me.ahoo.wow.api.annotation.CommandRoute.PathVariable
-     * @see me.ahoo.wow.api.annotation.CommandRoute.HeaderVariable
-     */
-    IGNORE_COMMAND_ROUTE_VARIABLE,
-    KOTLIN,
-    WOW_NAMING_STRATEGY,
-    JODA_MONEY;
+import me.ahoo.wow.schema.typed.TypedCustomDefinitionProvider
+import org.joda.money.CurrencyUnit
 
-    companion object {
-        val ALL: Set<WowOption> = setOf(IGNORE_COMMAND_ROUTE_VARIABLE, KOTLIN, WOW_NAMING_STRATEGY, JODA_MONEY)
-    }
+object CurrencyUnitDefinitionProvider : TypedCustomDefinitionProvider() {
+    override val type: Class<*>
+        get() = CurrencyUnit::class.java
 }

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/joda/money/MoneyDefinitionProvider.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/joda/money/MoneyDefinitionProvider.kt
@@ -11,20 +11,12 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.schema
+package me.ahoo.wow.schema.joda.money
 
-enum class WowOption {
-    /**
-     *
-     * @see me.ahoo.wow.api.annotation.CommandRoute.PathVariable
-     * @see me.ahoo.wow.api.annotation.CommandRoute.HeaderVariable
-     */
-    IGNORE_COMMAND_ROUTE_VARIABLE,
-    KOTLIN,
-    WOW_NAMING_STRATEGY,
-    JODA_MONEY;
+import me.ahoo.wow.schema.typed.TypedCustomDefinitionProvider
+import org.joda.money.Money
 
-    companion object {
-        val ALL: Set<WowOption> = setOf(IGNORE_COMMAND_ROUTE_VARIABLE, KOTLIN, WOW_NAMING_STRATEGY, JODA_MONEY)
-    }
+object MoneyDefinitionProvider : TypedCustomDefinitionProvider() {
+    override val type: Class<*>
+        get() = Money::class.java
 }

--- a/wow-schema/src/main/resources/META-INF/wow-schema/CurrencyUnit.json
+++ b/wow-schema/src/main/resources/META-INF/wow-schema/CurrencyUnit.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "CurrencyUnit",
+  "type": "string",
+  "format": "currency",
+  "default": "CNY",
+  "examples": [
+    "CNY",
+    "USD",
+    "EUR"
+  ]
+}

--- a/wow-schema/src/main/resources/META-INF/wow-schema/Money.json
+++ b/wow-schema/src/main/resources/META-INF/wow-schema/Money.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Money",
+  "type": "object",
+  "properties": {
+    "currency": {
+      "type": "string",
+      "format": "currency",
+      "default": "CNY",
+      "examples": [
+        "CNY",
+        "USD",
+        "EUR"
+      ]
+    },
+    "amount": {
+      "type": "number"
+    }
+  },
+  "required": [
+    "currency",
+    "amount"
+  ]
+}

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/JsonSchemaGeneratorTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/JsonSchemaGeneratorTest.kt
@@ -36,6 +36,8 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.notNullValue
 import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*
+import org.joda.money.CurrencyUnit
+import org.joda.money.Money
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
@@ -43,7 +45,8 @@ import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
 
 class JsonSchemaGeneratorTest {
-    private val jsonSchemaGenerator = JsonSchemaGenerator(setOf(WowOption.IGNORE_COMMAND_ROUTE_VARIABLE))
+    private val jsonSchemaGenerator =
+        JsonSchemaGenerator(setOf(WowOption.IGNORE_COMMAND_ROUTE_VARIABLE, WowOption.JODA_MONEY))
 
     companion object {
         @JvmStatic
@@ -63,6 +66,8 @@ class JsonSchemaGeneratorTest {
                 Arguments.of(Snapshot::class.java, SimpleSnapshot::class.java),
                 Arguments.of(StateEvent::class.java, StateEvent::class.java),
                 Arguments.of(StateEvent::class.java, StateEventData::class.java),
+                Arguments.of(CurrencyUnit::class.java, CurrencyUnit::class.java),
+                Arguments.of(Money::class.java, Money::class.java),
             )
         }
 


### PR DESCRIPTION
- Add CurrencyUnitDefinitionProvider and MoneyDefinitionProvider for Joda Money
- Update WowModule to include Joda Money support
- Add JODA_MONEY option to WowOption
- Create JSON schemas for CurrencyUnit and Money
- Update JsonSchemaGeneratorTest to include Joda Money classes
- Add jackson-datatype-joda-money as an implementation dependency
