### PR TITLE
test: update context name to wow.event or wow.messaging in metadata tests

### DIFF
--- a/wow-core/src/test/kotlin/me/ahoo/wow/event/annotation/EventProcessorParserTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/event/annotation/EventProcessorParserTest.kt
@@ -25,7 +25,7 @@ internal class EventProcessorParserTest {
     @Test
     fun eventProcessorMetadata() {
         val eventProcessorMetadata = eventProcessorMetadata<MockEventProcessor>()
-        assertThat(eventProcessorMetadata.contextName, equalTo("wow-core-test"))
+        assertThat(eventProcessorMetadata.contextName, equalTo("wow.event"))
         assertThat(eventProcessorMetadata.processorType, equalTo(MockEventProcessor::class.java))
         assertThat(
             eventProcessorMetadata.functionRegistry.map { it.supportedType }.toSet(),

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/function/FunctionMetadataParserTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/function/FunctionMetadataParserTest.kt
@@ -74,8 +74,8 @@ class FunctionMetadataParserTest {
         assertThat(
             metadata.supportedTopics,
             hasItems(
-                MaterializedNamedAggregate("wow-core-test", "aggregate1"),
-                MaterializedNamedAggregate("wow-core-test", "aggregate2"),
+                MaterializedNamedAggregate("wow.messaging", "aggregate1"),
+                MaterializedNamedAggregate("wow.messaging", "aggregate2"),
             ),
         )
         assertThat(
@@ -92,7 +92,7 @@ class FunctionMetadataParserTest {
         assertThat(
             metadata.supportedTopics,
             hasItems(
-                MaterializedNamedAggregate("wow-core-test", "aggregate1")
+                MaterializedNamedAggregate("wow.messaging", "aggregate1")
             ),
         )
         assertThat(

--- a/wow-core/src/test/kotlin/me/ahoo/wow/projection/annotation/ProjectionProcessorMetadataParserTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/projection/annotation/ProjectionProcessorMetadataParserTest.kt
@@ -32,7 +32,7 @@ internal class ProjectionProcessorMetadataParserTest {
     fun projectorMetadata() {
         val metadata = projectionProcessorMetadata<MockProjector>()
         assertThat(metadata.processorType, equalTo(MockProjector::class.java))
-        assertThat(metadata.contextName, equalTo("wow-core-test"))
+        assertThat(metadata.contextName, equalTo("wow"))
         assertThat(metadata.name, equalTo("MockProjector"))
         assertThat(metadata.functionRegistry.size, equalTo(3))
         assertThat(


### PR DESCRIPTION
- Change contextName from 'wow-core-test' to 'wow.event' in EventProcessorParserTest
- Update contextName from 'wow-core-test' to 'wow.messaging' in FunctionMetadataParserTest
- Modify contextName from 'wow-core-test' to 'wow' in ProjectionProcessorMetadataParserTest
