### PR TITLE
refactor(wow-openapi): remove redundant Unit return type in RouteSpecFactory.initialize

### DIFF
--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RouteSpecFactory.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RouteSpecFactory.kt
@@ -17,7 +17,7 @@ import me.ahoo.wow.openapi.context.OpenAPIComponentContext
 import me.ahoo.wow.openapi.context.OpenAPIComponentContextCapable
 
 interface RouteSpecFactory {
-    fun initialize(componentContext: OpenAPIComponentContext) = Unit
+    fun initialize(componentContext: OpenAPIComponentContext)
 }
 
 abstract class AbstractRouteSpecFactory : RouteSpecFactory, OpenAPIComponentContextCapable {


### PR DESCRIPTION
- Changed the initialize method in RouteSpecFactory interface to not explicitly return Unit
- This change simplifies the method signature and improves code readability