### PR TITLE
test.openapi: add unit tests for BoundedContextSchemaNameConverter

### DIFF
--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/converter/BoundedContextSchemaNameConverterTest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/converter/BoundedContextSchemaNameConverterTest.kt
@@ -1,0 +1,29 @@
+package me.ahoo.wow.openapi.converter
+
+import io.swagger.v3.core.converter.ModelConverters
+import me.ahoo.cosid.stat.generator.CosIdGeneratorStat
+import me.ahoo.wow.tck.mock.MockCommandAggregate
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.*
+import org.junit.jupiter.api.Test
+
+class BoundedContextSchemaNameConverterTest {
+
+    @Test
+    fun resolveAggregate() {
+        val schemas = ModelConverters.getInstance(true).read(MockCommandAggregate::class.java)
+        assertThat(schemas.containsKey("tck.mock_aggregate.MockCommandAggregate"), equalTo(true))
+    }
+
+    @Test
+    fun resolveJavaLib() {
+        val schemas = ModelConverters.getInstance(true).read(String::class.java)
+        assertThat(schemas.size, equalTo(0))
+    }
+
+    @Test
+    fun resolveJavaClass() {
+        val schemas = ModelConverters.getInstance(true).read(CosIdGeneratorStat::class.java)
+        assertThat(schemas.containsKey("CosIdGeneratorStat"), equalTo(true))
+    }
+}


### PR DESCRIPTION
- Add test cases to verify schema name conversion for different types of classes
- Test coverage includes aggregate, Java library, and custom Java class
- Ensure proper schema name resolution for bounded context

