### PR TITLE
refactor(wow-openapi): extract command responses into a single function

### DIFF
--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/command/CommandComponent.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/command/CommandComponent.kt
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.models.media.IntegerSchema
 import io.swagger.v3.oas.models.media.StringSchema
 import io.swagger.v3.oas.models.responses.ApiResponse
+import io.swagger.v3.oas.models.responses.ApiResponses
 import me.ahoo.wow.api.Wow
 import me.ahoo.wow.command.CommandResult
 import me.ahoo.wow.command.wait.CommandStage
@@ -211,5 +212,15 @@ object CommandComponent {
                 header(CommonComponent.Header.WOW_ERROR_CODE, errorCodeHeader())
                 content(schema = commandResultSchema())
             }
+
+        fun OpenAPIComponentContext.commandResponses(): ApiResponses = ApiResponses().apply {
+            addApiResponse(Https.Code.OK, okCommandResponse())
+            addApiResponse(Https.Code.BAD_REQUEST, badRequestCommandResponse())
+            addApiResponse(Https.Code.NOT_FOUND, notFoundCommandResponse())
+            addApiResponse(Https.Code.CONFLICT, versionConflictCommandResponse())
+            addApiResponse(Https.Code.TOO_MANY_REQUESTS, tooManyRequestsCommandResponse())
+            addApiResponse(Https.Code.REQUEST_TIMEOUT, requestTimeoutCommandResponse())
+            addApiResponse(Https.Code.GONE, illegalAccessDeletedAggregateCommandResponse())
+        }
     }
 }

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/command/CommandFacadeRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/command/CommandFacadeRouteSpec.kt
@@ -37,13 +37,7 @@ import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.waitCont
 import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.waitProcessorHeaderParameter
 import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.waitStageHeaderParameter
 import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.waitTimeOutHeaderParameter
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Response.badRequestCommandResponse
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Response.illegalAccessDeletedAggregateCommandResponse
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Response.notFoundCommandResponse
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Response.okCommandResponse
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Response.requestTimeoutCommandResponse
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Response.tooManyRequestsCommandResponse
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Response.versionConflictCommandResponse
+import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Response.commandResponses
 import me.ahoo.wow.openapi.aggregate.command.CommandFacadeRouteSpecFactory.Companion.PATH
 import me.ahoo.wow.openapi.context.OpenAPIComponentContext
 import me.ahoo.wow.openapi.context.OpenAPIComponentContextCapable
@@ -84,15 +78,7 @@ class CommandFacadeRouteSpec(override val componentContext: OpenAPIComponentCont
             schema = ObjectSchema()
         )
         .build()
-    override val responses: ApiResponses = ApiResponses().apply {
-        addApiResponse(Https.Code.OK, componentContext.okCommandResponse())
-        addApiResponse(Https.Code.BAD_REQUEST, componentContext.badRequestCommandResponse())
-        addApiResponse(Https.Code.NOT_FOUND, componentContext.notFoundCommandResponse())
-        addApiResponse(Https.Code.CONFLICT, componentContext.versionConflictCommandResponse())
-        addApiResponse(Https.Code.TOO_MANY_REQUESTS, componentContext.tooManyRequestsCommandResponse())
-        addApiResponse(Https.Code.REQUEST_TIMEOUT, componentContext.requestTimeoutCommandResponse())
-        addApiResponse(Https.Code.GONE, componentContext.illegalAccessDeletedAggregateCommandResponse())
-    }
+    override val responses: ApiResponses = componentContext.commandResponses()
 }
 
 class CommandFacadeRouteSpecFactory : GlobalRouteSpecFactory, AbstractRouteSpecFactory() {

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/command/CommandRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/command/CommandRouteSpec.kt
@@ -39,13 +39,7 @@ import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.waitCont
 import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.waitProcessorHeaderParameter
 import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.waitStageHeaderParameter
 import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.waitTimeOutHeaderParameter
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Response.badRequestCommandResponse
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Response.illegalAccessDeletedAggregateCommandResponse
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Response.notFoundCommandResponse
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Response.okCommandResponse
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Response.requestTimeoutCommandResponse
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Response.tooManyRequestsCommandResponse
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Response.versionConflictCommandResponse
+import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Response.commandResponses
 import me.ahoo.wow.openapi.context.OpenAPIComponentContext
 import me.ahoo.wow.openapi.metadata.AggregateRouteMetadata
 import me.ahoo.wow.openapi.metadata.CommandRouteMetadata
@@ -163,15 +157,7 @@ class CommandRouteSpec(
     }
     override val requestBody: RequestBody = RequestBodyBuilder().description(summary)
         .content(schema = componentContext.schema(commandRouteMetadata.commandMetadata.commandType)).build()
-    override val responses: ApiResponses = ApiResponses().apply {
-        addApiResponse(Https.Code.OK, componentContext.okCommandResponse())
-        addApiResponse(Https.Code.BAD_REQUEST, componentContext.badRequestCommandResponse())
-        addApiResponse(Https.Code.NOT_FOUND, componentContext.notFoundCommandResponse())
-        addApiResponse(Https.Code.CONFLICT, componentContext.versionConflictCommandResponse())
-        addApiResponse(Https.Code.TOO_MANY_REQUESTS, componentContext.tooManyRequestsCommandResponse())
-        addApiResponse(Https.Code.REQUEST_TIMEOUT, componentContext.requestTimeoutCommandResponse())
-        addApiResponse(Https.Code.GONE, componentContext.illegalAccessDeletedAggregateCommandResponse())
-    }
+    override val responses: ApiResponses = componentContext.commandResponses()
 }
 
 class CommandRouteSpecFactory : AbstractAggregateRouteSpecFactory() {


### PR DESCRIPTION
- Extracted commandResponses() function in CommandComponent to centralize response creation
- Updated CommandFacadeRouteSpec and CommandRouteSpec to use the new centralized function
- Removed duplicate response creation code from individual route specs