### PR TITLE
refactor(wow-openapi): extract common header parameters for command

### DIFF
--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/command/CommandComponent.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/command/CommandComponent.kt
@@ -160,6 +160,19 @@ object CommandComponent {
                 schema = StringSchema()
                 `in`(ParameterIn.HEADER.toString())
             }
+
+        fun OpenAPIComponentContext.commandCommonHeaderParameters(): List<io.swagger.v3.oas.models.parameters.Parameter> {
+            return listOf(
+                waitStageHeaderParameter(),
+                waitContextHeaderParameter(),
+                waitProcessorHeaderParameter(),
+                waitTimeOutHeaderParameter(),
+                aggregateIdHeaderParameter(),
+                aggregateVersionHeaderParameter(),
+                requestIdHeaderParameter(),
+                localFirstHeaderParameter()
+            )
+        }
     }
 
     object Response {

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/command/CommandFacadeRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/command/CommandFacadeRouteSpec.kt
@@ -24,19 +24,12 @@ import me.ahoo.wow.openapi.Https
 import me.ahoo.wow.openapi.RequestBodyBuilder
 import me.ahoo.wow.openapi.RouteIdSpec
 import me.ahoo.wow.openapi.RouteSpec
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.aggregateIdHeaderParameter
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.aggregateVersionHeaderParameter
 import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.commandAggregateContextHeaderParameter
 import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.commandAggregateNameHeaderParameter
+import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.commandCommonHeaderParameters
 import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.commandTypeHeaderParameter
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.localFirstHeaderParameter
 import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.ownerIdHeaderParameter
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.requestIdHeaderParameter
 import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.tenantIdHeaderParameter
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.waitContextHeaderParameter
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.waitProcessorHeaderParameter
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.waitStageHeaderParameter
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.waitTimeOutHeaderParameter
 import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Response.commandResponses
 import me.ahoo.wow.openapi.aggregate.command.CommandFacadeRouteSpecFactory.Companion.PATH
 import me.ahoo.wow.openapi.context.OpenAPIComponentContext
@@ -58,16 +51,9 @@ class CommandFacadeRouteSpec(override val componentContext: OpenAPIComponentCont
     override val summary: String = "send command"
     override val parameters: List<Parameter> = buildList {
         add(componentContext.commandTypeHeaderParameter())
-        add(componentContext.waitStageHeaderParameter())
-        add(componentContext.waitContextHeaderParameter())
-        add(componentContext.waitProcessorHeaderParameter())
-        add(componentContext.waitTimeOutHeaderParameter())
+        addAll(componentContext.commandCommonHeaderParameters())
         add(componentContext.tenantIdHeaderParameter())
         add(componentContext.ownerIdHeaderParameter())
-        add(componentContext.aggregateIdHeaderParameter())
-        add(componentContext.aggregateVersionHeaderParameter())
-        add(componentContext.requestIdHeaderParameter())
-        add(componentContext.localFirstHeaderParameter())
         add(componentContext.commandAggregateContextHeaderParameter())
         add(componentContext.commandAggregateNameHeaderParameter())
     }

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/command/CommandRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/command/CommandRouteSpec.kt
@@ -31,14 +31,7 @@ import me.ahoo.wow.openapi.RouteSpec
 import me.ahoo.wow.openapi.Tags.toTags
 import me.ahoo.wow.openapi.aggregate.AbstractAggregateRouteSpecFactory
 import me.ahoo.wow.openapi.aggregate.AggregateRouteSpec
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.aggregateIdHeaderParameter
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.aggregateVersionHeaderParameter
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.localFirstHeaderParameter
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.requestIdHeaderParameter
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.waitContextHeaderParameter
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.waitProcessorHeaderParameter
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.waitStageHeaderParameter
-import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.waitTimeOutHeaderParameter
+import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Parameter.commandCommonHeaderParameters
 import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Response.commandResponses
 import me.ahoo.wow.openapi.context.OpenAPIComponentContext
 import me.ahoo.wow.openapi.metadata.AggregateRouteMetadata
@@ -146,14 +139,7 @@ class CommandRouteSpec(
         addAll(super.parameters)
         addAll(pathParameters)
         addAll(headerParameters)
-        add(componentContext.waitStageHeaderParameter())
-        add(componentContext.waitContextHeaderParameter())
-        add(componentContext.waitProcessorHeaderParameter())
-        add(componentContext.waitTimeOutHeaderParameter())
-        add(componentContext.aggregateIdHeaderParameter())
-        add(componentContext.aggregateVersionHeaderParameter())
-        add(componentContext.requestIdHeaderParameter())
-        add(componentContext.localFirstHeaderParameter())
+        addAll(componentContext.commandCommonHeaderParameters())
     }
     override val requestBody: RequestBody = RequestBodyBuilder().description(summary)
         .content(schema = componentContext.schema(commandRouteMetadata.commandMetadata.commandType)).build()


### PR DESCRIPTION
- Extract commandCommonHeaderParameters() function in CommandComponent
- Update CommandFacadeRouteSpec and CommandRouteSpec to use the new function
- Remove duplicate header parameter imports and additions in route specs

