### PR TITLE
refactor(wow-openapi): extract load aggregate responses to common component

### DIFF
--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/event/CountEventStreamRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/event/CountEventStreamRouteSpec.kt
@@ -52,7 +52,7 @@ class CountEventStreamRouteSpec(
     override val requestBody: RequestBody = componentContext.countQueryRequestBody()
 
     override val responses: ApiResponses = ApiResponses().apply {
-        addApiResponse("200", componentContext.countQueryResponse())
+        addApiResponse(Https.Code.OK, componentContext.countQueryResponse())
     }
 }
 

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/state/LoadAggregateComponent.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/state/LoadAggregateComponent.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.openapi.aggregate.state
+
+import io.swagger.v3.oas.models.responses.ApiResponses
+import me.ahoo.wow.modeling.matedata.AggregateMetadata
+import me.ahoo.wow.openapi.ApiResponseBuilder
+import me.ahoo.wow.openapi.CommonComponent.Header
+import me.ahoo.wow.openapi.CommonComponent.Header.errorCodeHeader
+import me.ahoo.wow.openapi.CommonComponent.Response.badRequestResponse
+import me.ahoo.wow.openapi.CommonComponent.Response.notFoundResponse
+import me.ahoo.wow.openapi.Https
+import me.ahoo.wow.openapi.context.OpenAPIComponentContext
+
+object LoadAggregateComponent {
+    object Response {
+        fun OpenAPIComponentContext.loadAggregateResponses(
+            summary: String,
+            aggregateMetadata: AggregateMetadata<*, *>
+        ): ApiResponses = ApiResponses().apply {
+            ApiResponseBuilder()
+                .description(summary)
+                .header(Header.WOW_ERROR_CODE, errorCodeHeader())
+                .content(schema = schema(aggregateMetadata.state.aggregateType))
+                .build()
+                .let {
+                    addApiResponse(Https.Code.OK, it)
+                }
+            addApiResponse(Https.Code.BAD_REQUEST, badRequestResponse())
+            addApiResponse(Https.Code.NOT_FOUND, notFoundResponse())
+        }
+    }
+}

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/state/LoadAggregateRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/state/LoadAggregateRouteSpec.kt
@@ -17,16 +17,12 @@ import io.swagger.v3.oas.models.parameters.RequestBody
 import io.swagger.v3.oas.models.responses.ApiResponses
 import me.ahoo.wow.api.annotation.AggregateRoute
 import me.ahoo.wow.api.naming.NamedBoundedContext
-import me.ahoo.wow.openapi.ApiResponseBuilder
-import me.ahoo.wow.openapi.CommonComponent.Header
-import me.ahoo.wow.openapi.CommonComponent.Header.errorCodeHeader
-import me.ahoo.wow.openapi.CommonComponent.Response.badRequestResponse
-import me.ahoo.wow.openapi.CommonComponent.Response.notFoundResponse
 import me.ahoo.wow.openapi.Https
 import me.ahoo.wow.openapi.RouteIdSpec
 import me.ahoo.wow.openapi.RouteSpec
 import me.ahoo.wow.openapi.aggregate.AbstractAggregateRouteSpecFactory
 import me.ahoo.wow.openapi.aggregate.AggregateRouteSpec
+import me.ahoo.wow.openapi.aggregate.state.LoadAggregateComponent.Response.loadAggregateResponses
 import me.ahoo.wow.openapi.context.OpenAPIComponentContext
 import me.ahoo.wow.openapi.metadata.AggregateRouteMetadata
 
@@ -54,18 +50,7 @@ class LoadAggregateRouteSpec(
         get() = "Load state aggregate"
 
     override val requestBody: RequestBody? = null
-    override val responses: ApiResponses = ApiResponses().apply {
-        ApiResponseBuilder()
-            .description(summary)
-            .header(Header.WOW_ERROR_CODE, componentContext.errorCodeHeader())
-            .content(schema = componentContext.schema(aggregateMetadata.state.aggregateType))
-            .build()
-            .let {
-                addApiResponse(Https.Code.OK, it)
-            }
-        addApiResponse(Https.Code.BAD_REQUEST, componentContext.badRequestResponse())
-        addApiResponse(Https.Code.NOT_FOUND, componentContext.notFoundResponse())
-    }
+    override val responses: ApiResponses = componentContext.loadAggregateResponses(summary, aggregateMetadata)
 }
 
 class LoadAggregateRouteSpecFactory : AbstractAggregateRouteSpecFactory() {

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/state/LoadTimeBasedAggregateRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/state/LoadTimeBasedAggregateRouteSpec.kt
@@ -18,17 +18,13 @@ import io.swagger.v3.oas.models.parameters.RequestBody
 import io.swagger.v3.oas.models.responses.ApiResponses
 import me.ahoo.wow.api.annotation.AggregateRoute
 import me.ahoo.wow.api.naming.NamedBoundedContext
-import me.ahoo.wow.openapi.ApiResponseBuilder
-import me.ahoo.wow.openapi.CommonComponent.Header
-import me.ahoo.wow.openapi.CommonComponent.Header.errorCodeHeader
 import me.ahoo.wow.openapi.CommonComponent.Parameter.createTimePathParameter
-import me.ahoo.wow.openapi.CommonComponent.Response.badRequestResponse
-import me.ahoo.wow.openapi.CommonComponent.Response.notFoundResponse
 import me.ahoo.wow.openapi.Https
 import me.ahoo.wow.openapi.RouteIdSpec
 import me.ahoo.wow.openapi.RouteSpec
 import me.ahoo.wow.openapi.aggregate.AbstractAggregateRouteSpecFactory
 import me.ahoo.wow.openapi.aggregate.AggregateRouteSpec
+import me.ahoo.wow.openapi.aggregate.state.LoadAggregateComponent.Response.loadAggregateResponses
 import me.ahoo.wow.openapi.context.OpenAPIComponentContext
 import me.ahoo.wow.openapi.metadata.AggregateRouteMetadata
 import me.ahoo.wow.serialization.MessageRecords
@@ -59,18 +55,7 @@ class LoadTimeBasedAggregateRouteSpec(
     override val parameters: List<Parameter>
         get() = super.parameters + componentContext.createTimePathParameter()
     override val requestBody: RequestBody? = null
-    override val responses: ApiResponses = ApiResponses().apply {
-        ApiResponseBuilder()
-            .description(summary)
-            .header(Header.WOW_ERROR_CODE, componentContext.errorCodeHeader())
-            .content(schema = componentContext.schema(aggregateMetadata.state.aggregateType))
-            .build()
-            .let {
-                addApiResponse(Https.Code.OK, it)
-            }
-        addApiResponse(Https.Code.BAD_REQUEST, componentContext.badRequestResponse())
-        addApiResponse(Https.Code.NOT_FOUND, componentContext.notFoundResponse())
-    }
+    override val responses: ApiResponses = componentContext.loadAggregateResponses(summary, aggregateMetadata)
 }
 
 class LoadTimeBasedAggregateRouteSpecFactory : AbstractAggregateRouteSpecFactory() {

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/state/LoadVersionedAggregateRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/state/LoadVersionedAggregateRouteSpec.kt
@@ -18,17 +18,13 @@ import io.swagger.v3.oas.models.parameters.RequestBody
 import io.swagger.v3.oas.models.responses.ApiResponses
 import me.ahoo.wow.api.annotation.AggregateRoute
 import me.ahoo.wow.api.naming.NamedBoundedContext
-import me.ahoo.wow.openapi.ApiResponseBuilder
-import me.ahoo.wow.openapi.CommonComponent.Header
-import me.ahoo.wow.openapi.CommonComponent.Header.errorCodeHeader
 import me.ahoo.wow.openapi.CommonComponent.Parameter.versionPathParameter
-import me.ahoo.wow.openapi.CommonComponent.Response.badRequestResponse
-import me.ahoo.wow.openapi.CommonComponent.Response.notFoundResponse
 import me.ahoo.wow.openapi.Https
 import me.ahoo.wow.openapi.RouteIdSpec
 import me.ahoo.wow.openapi.RouteSpec
 import me.ahoo.wow.openapi.aggregate.AbstractAggregateRouteSpecFactory
 import me.ahoo.wow.openapi.aggregate.AggregateRouteSpec
+import me.ahoo.wow.openapi.aggregate.state.LoadAggregateComponent.Response.loadAggregateResponses
 import me.ahoo.wow.openapi.context.OpenAPIComponentContext
 import me.ahoo.wow.openapi.metadata.AggregateRouteMetadata
 import me.ahoo.wow.serialization.MessageRecords
@@ -59,18 +55,7 @@ class LoadVersionedAggregateRouteSpec(
     override val parameters: List<Parameter>
         get() = super.parameters + componentContext.versionPathParameter()
     override val requestBody: RequestBody? = null
-    override val responses: ApiResponses = ApiResponses().apply {
-        ApiResponseBuilder()
-            .description(summary)
-            .header(Header.WOW_ERROR_CODE, componentContext.errorCodeHeader())
-            .content(schema = componentContext.schema(aggregateMetadata.state.aggregateType))
-            .build()
-            .let {
-                addApiResponse(Https.Code.OK, it)
-            }
-        addApiResponse(Https.Code.BAD_REQUEST, componentContext.badRequestResponse())
-        addApiResponse(Https.Code.NOT_FOUND, componentContext.notFoundResponse())
-    }
+    override val responses: ApiResponses = componentContext.loadAggregateResponses(summary, aggregateMetadata)
 }
 
 class LoadVersionedAggregateRouteSpecFactory : AbstractAggregateRouteSpecFactory() {


### PR DESCRIPTION
- Create LoadAggregateComponent object to centralize response handling
- Update CountEventStreamRouteSpec to use Https.Code.OK for consistency
- Refactor LoadAggregateRouteSpec, LoadTimeBasedAggregateRouteSpec, and LoadVersionedAggregateRouteSpec to use the new LoadAggregateComponent
- Remove redundant response building code from individual route specs
