### PR TITLE
feat(schema): support OpenAPI schema annotations for Kotlin

### DIFF
--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/kotlin/KotlinNullableCheck.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/kotlin/KotlinNullableCheck.kt
@@ -15,6 +15,8 @@ package me.ahoo.wow.schema.kotlin
 
 import com.github.victools.jsonschema.generator.ConfigFunction
 import com.github.victools.jsonschema.generator.FieldScope
+import io.swagger.v3.oas.annotations.media.Schema
+import me.ahoo.wow.infra.reflection.AnnotationScanner.scanAnnotation
 import me.ahoo.wow.schema.Types.isKotlinElement
 import kotlin.reflect.jvm.kotlinProperty
 
@@ -24,7 +26,9 @@ object KotlinNullableCheck : ConfigFunction<FieldScope, Boolean> {
         if (!fieldScope.declaringType.erasedType.isKotlinElement()) {
             return false
         }
+
         val property = fieldScope.rawMember.kotlinProperty ?: return false
-        return property.returnType.isMarkedNullable
+        val schemaAnnotation = property.scanAnnotation<Schema>() ?: return property.returnType.isMarkedNullable
+        return schemaAnnotation.nullable
     }
 }

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/kotlin/KotlinReadOnlyCheck.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/kotlin/KotlinReadOnlyCheck.kt
@@ -14,6 +14,8 @@
 package me.ahoo.wow.schema.kotlin
 
 import com.github.victools.jsonschema.generator.FieldScope
+import io.swagger.v3.oas.annotations.media.Schema
+import me.ahoo.wow.infra.reflection.AnnotationScanner.scanAnnotation
 import me.ahoo.wow.schema.Types.isKotlinElement
 import java.util.function.Predicate
 import kotlin.reflect.KFunction
@@ -28,6 +30,10 @@ object KotlinReadOnlyCheck : Predicate<FieldScope> {
             return false
         }
         val property = fieldScope.rawMember.kotlinProperty ?: return false
+        val schemaAnnotation = property.scanAnnotation<Schema>()
+        if (schemaAnnotation != null && schemaAnnotation.accessMode != Schema.AccessMode.AUTO) {
+            return schemaAnnotation.accessMode == Schema.AccessMode.READ_ONLY
+        }
         if (property.isLateinit) {
             return true
         }

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/kotlin/KotlinRequiredCheck.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/kotlin/KotlinRequiredCheck.kt
@@ -14,6 +14,8 @@
 package me.ahoo.wow.schema.kotlin
 
 import com.github.victools.jsonschema.generator.FieldScope
+import io.swagger.v3.oas.annotations.media.Schema
+import me.ahoo.wow.infra.reflection.AnnotationScanner.scanAnnotation
 import me.ahoo.wow.schema.Types.isKotlinElement
 import me.ahoo.wow.schema.kotlin.KotlinReadOnlyCheck.primaryConstructor
 import java.util.function.Predicate
@@ -25,7 +27,13 @@ object KotlinRequiredCheck : Predicate<FieldScope> {
         if (!fieldScope.declaringType.erasedType.isKotlinElement()) {
             return false
         }
-        fieldScope.rawMember.kotlinProperty ?: return false
+        val property = fieldScope.rawMember.kotlinProperty ?: return false
+        val schemaAnnotation = property.scanAnnotation<Schema>()
+
+        if (schemaAnnotation != null && schemaAnnotation.requiredMode != Schema.RequiredMode.AUTO) {
+            return schemaAnnotation.requiredMode == Schema.RequiredMode.REQUIRED
+        }
+
         if (KotlinReadOnlyCheck.test(fieldScope)) {
             return false
         }

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/kotlin/KotlinWriteOnlyCheck.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/kotlin/KotlinWriteOnlyCheck.kt
@@ -14,6 +14,8 @@
 package me.ahoo.wow.schema.kotlin
 
 import com.github.victools.jsonschema.generator.FieldScope
+import io.swagger.v3.oas.annotations.media.Schema
+import me.ahoo.wow.infra.reflection.AnnotationScanner.scanAnnotation
 import me.ahoo.wow.schema.Types.isKotlinElement
 import java.util.function.Predicate
 import kotlin.reflect.KVisibility
@@ -26,6 +28,8 @@ object KotlinWriteOnlyCheck : Predicate<FieldScope> {
             return false
         }
         val property = fieldScope.rawMember.kotlinProperty ?: return false
-        return property.getter.visibility == KVisibility.PRIVATE
+        val schemaAnnotation = property.scanAnnotation<Schema>()
+            ?: return property.getter.visibility == KVisibility.PRIVATE
+        return schemaAnnotation.accessMode == Schema.AccessMode.WRITE_ONLY
     }
 }

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilder.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilder.kt
@@ -106,7 +106,11 @@ class OpenAPISchemaBuilder(
         Consumer<SchemaGeneratorConfigBuilder> {
 
         fun SchemaGeneratorConfigBuilder.defaultConfig(): SchemaGeneratorConfigBuilder {
-            val jacksonModule: Module = JacksonModule(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED)
+            val jacksonModule: Module = JacksonModule(
+                JacksonOption.RESPECT_JSONPROPERTY_ORDER,
+                JacksonOption.RESPECT_JSONPROPERTY_REQUIRED,
+                JacksonOption.INLINE_TRANSFORMED_SUBTYPES
+            )
             val jakartaModule = JakartaValidationModule(
                 JakartaValidationOption.PREFER_IDN_EMAIL_FORMAT,
                 JakartaValidationOption.INCLUDE_PATTERN_EXPRESSIONS


### PR DESCRIPTION
- Add support for @Schema annotation in Kotlin classes
- Implement nullable, readOnly, required, and writeOnly checks using @Schema
- Update JsonSchemaGenerator to handle new schema annotations
- Modify existing checks to respect @Schema when present
