### PR TITLE
feat(schema): generate AggregatedDomainEventStream JSON schema

### DIFF
--- a/.idea/modules/Wow.test.iml
+++ b/.idea/modules/Wow.test.iml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<module version="4">
-  <component name="CheckStyle-IDEA-Module" serialisationVersion="2">
-    <option name="activeLocationsIds" />
-  </component>
-</module>

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/AggregatedDomainEventStreamDefinitionProvider.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/AggregatedDomainEventStreamDefinitionProvider.kt
@@ -14,12 +14,14 @@
 package me.ahoo.wow.schema.typed
 
 import com.fasterxml.classmate.ResolvedType
+import com.fasterxml.jackson.databind.node.ArrayNode
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.github.victools.jsonschema.generator.CustomDefinition
 import com.github.victools.jsonschema.generator.CustomDefinitionProviderV2
 import com.github.victools.jsonschema.generator.SchemaGenerationContext
 import com.github.victools.jsonschema.generator.SchemaKeyword
 import me.ahoo.wow.event.DomainEventStream
+import me.ahoo.wow.event.annotation.toEventMetadata
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.schema.JsonSchema.Companion.asCustomDefinition
 import me.ahoo.wow.schema.JsonSchema.Companion.asJsonSchema
@@ -28,6 +30,7 @@ import me.ahoo.wow.schema.WowSchemaLoader
 import me.ahoo.wow.serialization.MessageRecords
 
 object AggregatedDomainEventStreamDefinitionProvider : CustomDefinitionProviderV2 {
+    private const val DOMAIN_EVENT_STREAM_BODY_RESOURCE_NAME = "DomainEventStreamBody"
     private val type: Class<*> = AggregatedDomainEventStream::class.java
 
     override fun provideCustomSchemaDefinition(
@@ -37,29 +40,35 @@ object AggregatedDomainEventStreamDefinitionProvider : CustomDefinitionProviderV
         if (!javaType.isInstanceOf(type)) {
             return null
         }
-        val rootNode = WowSchemaLoader.load(DomainEventStream::class.java)
+
         if (javaType.typeBindings.isEmpty) {
-            return CustomDefinition(rootNode)
+            return domainEventStreamNode()
         }
+        val schemaVersion = context.generatorConfig.schemaVersion
         val commandAggregateType = javaType.typeBindings.getBoundType(0).erasedType
         val aggregateMetadata = commandAggregateType.aggregateMetadata<Any, Any>()
         val eventTypes = aggregateMetadata.state.sourcingFunctionRegistry.keys.sortedBy { it.name }
         if (eventTypes.isEmpty()) {
-            return CustomDefinition(rootNode)
+            return domainEventStreamNode()
         }
-        val rootSchema = rootNode.asJsonSchema()
+        val rootSchema = WowSchemaLoader.load(type).asJsonSchema(schemaVersion)
         val rootPropertiesNode = rootSchema.requiredGetProperties()
-        val itemsNode =
-            rootPropertiesNode[DomainEventStream::body.name][SchemaKeyword.TAG_ITEMS.toPropertyName()] as ObjectNode
-        val itemsSchema = itemsNode.asJsonSchema()
-        val bodyTypeNode = itemsSchema.requiredGetProperties()[MessageRecords.BODY_TYPE] as ObjectNode
-        val bodyTypeEnumNode = bodyTypeNode.putArray(SchemaKeyword.TAG_ENUM.toPropertyName())
-        val bodyNode = itemsSchema.requiredGetProperties()[MessageRecords.BODY] as ObjectNode
-        val bodyAnyOfNode = bodyNode.putArray(SchemaKeyword.TAG_ANYOF.toPropertyName())
+        val rootPropertiesBodyNode = rootPropertiesNode[DomainEventStream::body.name] as ObjectNode
+        val itemsNode = rootPropertiesBodyNode[SchemaKeyword.TAG_ITEMS.toPropertyName()] as ObjectNode
+        val itemsAnyOfNode = itemsNode[SchemaKeyword.TAG_ANYOF.toPropertyName(schemaVersion)] as ArrayNode
+        val eventBodyNodeTemplate = WowSchemaLoader.load(DOMAIN_EVENT_STREAM_BODY_RESOURCE_NAME)
         eventTypes.forEach { eventType ->
-            bodyTypeEnumNode.add(eventType.name)
+            val eventMetadata = eventType.toEventMetadata()
+            val eventBodySchema = eventBodyNodeTemplate.deepCopy().asJsonSchema(schemaVersion)
+            eventBodySchema.actual.put(SchemaKeyword.TAG_TITLE.toPropertyName(schemaVersion), eventMetadata.name)
+            val eventBodyPropertiesNode = eventBodySchema.requiredGetProperties()
+            val eventBodyNameNode = eventBodyPropertiesNode[MessageRecords.NAME] as ObjectNode
+            eventBodyNameNode.put(SchemaKeyword.TAG_CONST.toPropertyName(), eventMetadata.name)
+            val eventBodyTypeNode = eventBodyPropertiesNode[MessageRecords.BODY_TYPE] as ObjectNode
+            eventBodyTypeNode.put(SchemaKeyword.TAG_CONST.toPropertyName(), eventType.name)
             val eventNode = createEventTypeDefinition(eventType, context)
-            bodyAnyOfNode.add(eventNode)
+            eventBodyPropertiesNode.set<ObjectNode>(MessageRecords.BODY, eventNode)
+            itemsAnyOfNode.add(eventBodySchema.actual)
         }
 
         return rootSchema.asCustomDefinition()
@@ -70,5 +79,9 @@ object AggregatedDomainEventStreamDefinitionProvider : CustomDefinitionProviderV
             return context.createDefinitionReference(context.typeContext.resolve(eventType))
         }
         return context.createStandardDefinition(context.typeContext.resolve(eventType), this)
+    }
+
+    private fun domainEventStreamNode(): CustomDefinition {
+        return CustomDefinition(WowSchemaLoader.load(DomainEventStream::class.java))
     }
 }

--- a/wow-schema/src/main/resources/META-INF/wow-schema/AggregatedDomainEventStream.json
+++ b/wow-schema/src/main/resources/META-INF/wow-schema/AggregatedDomainEventStream.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AggregatedDomainEventStream",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The ID of the domain event stream."
+    },
+    "contextName": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The name of the context to which the domain event stream belongs"
+    },
+    "aggregateName": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The name of the aggregate to which the domain event stream belongs"
+    },
+    "header": {
+      "type": "object",
+      "properties": {
+        "user_agent": {
+          "type": "string",
+          "description": "user agent"
+        },
+        "remote_ip": {
+          "type": "string",
+          "description": "remote ip"
+        },
+        "trace_id": {
+          "type": "string",
+          "description": "trace id"
+        },
+        "command_operator": {
+          "type": "string",
+          "description": "command operator"
+        },
+        "local_first": {
+          "type": "boolean",
+          "description": "local first"
+        },
+        "command_wait_endpoint": {
+          "type": "string",
+          "format": "url",
+          "description": "command wait endpoint"
+        },
+        "command_wait_stage": {
+          "type": "string",
+          "enum": [
+            "SENT",
+            "PROCESSED",
+            "SNAPSHOT",
+            "PROJECTED",
+            "EVENT_HANDLED",
+            "SAGA_HANDLED"
+          ],
+          "default": "PROCESSED"
+        }
+      },
+      "description": "message header",
+      "additionalProperties": true
+    },
+    "tenantId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The tenant id of the aggregate"
+    },
+    "aggregateId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The id of the aggregate"
+    },
+    "ownerId": {
+      "type": "string",
+      "description": "The owner ID of the aggregate resource",
+      "default": ""
+    },
+    "commandId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The ID of the command message."
+    },
+    "requestId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The request ID of the command message, which is used to check the idempotency of the command message"
+    },
+    "version": {
+      "type": "integer",
+      "format": "int32",
+      "description": "The version of the domain event stream"
+    },
+    "body": {
+      "type": "array",
+      "items": {
+        "anyOf": []
+      },
+      "minItems": 1,
+      "description": "A list of domain events for the domain event stream"
+    },
+    "createTime": {
+      "type": "integer",
+      "format": "int64",
+      "description": "The time when the domain event stream was created"
+    }
+  },
+  "required": [
+    "id",
+    "contextName",
+    "aggregateName",
+    "tenantId",
+    "aggregateId",
+    "ownerId",
+    "version",
+    "body",
+    "createTime"
+  ]
+}

--- a/wow-schema/src/main/resources/META-INF/wow-schema/DomainEventStreamBody.json
+++ b/wow-schema/src/main/resources/META-INF/wow-schema/DomainEventStreamBody.json
@@ -1,0 +1,36 @@
+{
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The ID of the domain event."
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "description": "The name of the domain event"
+    },
+    "revision": {
+      "type": "string",
+      "description": "The revision number of the domain event",
+      "default": "0.0.1"
+    },
+    "bodyType": {
+      "type": "string",
+      "description": "The fully qualified name of the domain event body"
+    },
+    "body": {
+      "type": "object",
+      "description": "The message body of the domain event"
+    }
+  },
+  "description": "The body of the domain event",
+  "required": [
+    "id",
+    "name",
+    "revision",
+    "bodyType",
+    "body"
+  ]
+}

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/JsonSchemaGeneratorTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/JsonSchemaGeneratorTest.kt
@@ -85,7 +85,11 @@ class JsonSchemaGeneratorTest {
                 Arguments.of(StateAggregate::class.java, MockStateAggregate::class.java, "MockStateAggregate"),
                 Arguments.of(Snapshot::class.java, MockStateAggregate::class.java, "MockStateAggregateSnapshot"),
                 Arguments.of(StateEvent::class.java, MockStateAggregate::class.java, "MockStateAggregateStateEvent"),
-                Arguments.of(AggregatedDomainEventStream::class.java, Cart::class.java, "AggregatedDomainEventStream"),
+                Arguments.of(
+                    AggregatedDomainEventStream::class.java,
+                    Cart::class.java,
+                    "CartAggregatedDomainEventStream"
+                ),
                 Arguments.of(
                     AggregatedDomainEventStream::class.java,
                     MockEmptyAggregate::class.java,

--- a/wow-schema/src/test/resources/META-INF/wow-schema/CartAggregatedDomainEventStream.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/CartAggregatedDomainEventStream.json
@@ -15,7 +15,7 @@
       "required" : [ "productId" ]
     }
   },
-  "title" : "DomainEventStream",
+  "title" : "AggregatedDomainEventStream",
   "type" : "object",
   "properties" : {
     "id" : {
@@ -103,32 +103,31 @@
     "body" : {
       "type" : "array",
       "items" : {
-        "type" : "object",
-        "properties" : {
-          "id" : {
-            "type" : "string",
-            "minLength" : 1,
-            "description" : "The ID of the domain event."
-          },
-          "name" : {
-            "type" : "string",
-            "minLength" : 1,
-            "description" : "The name of the domain event"
-          },
-          "revision" : {
-            "type" : "string",
-            "description" : "The revision number of the domain event",
-            "default" : "0.0.1"
-          },
-          "bodyType" : {
-            "type" : "string",
-            "description" : "The fully qualified name of the domain event body",
-            "enum" : [ "me.ahoo.wow.example.api.cart.CartItemAdded", "me.ahoo.wow.example.api.cart.CartItemRemoved", "me.ahoo.wow.example.api.cart.CartQuantityChanged" ]
-          },
-          "body" : {
-            "type" : "object",
-            "description" : "The message body of the domain event",
-            "anyOf" : [ {
+        "anyOf" : [ {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "minLength" : 1,
+              "description" : "The ID of the domain event."
+            },
+            "name" : {
+              "type" : "string",
+              "minLength" : 1,
+              "description" : "The name of the domain event",
+              "const" : "cart_item_added"
+            },
+            "revision" : {
+              "type" : "string",
+              "description" : "The revision number of the domain event",
+              "default" : "0.0.1"
+            },
+            "bodyType" : {
+              "type" : "string",
+              "description" : "The fully qualified name of the domain event body",
+              "const" : "me.ahoo.wow.example.api.cart.CartItemAdded"
+            },
+            "body" : {
               "type" : "object",
               "properties" : {
                 "added" : {
@@ -136,7 +135,36 @@
                 }
               },
               "required" : [ "added" ]
-            }, {
+            }
+          },
+          "description" : "The body of the domain event",
+          "required" : [ "id", "name", "revision", "bodyType", "body" ],
+          "title" : "cart_item_added"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "minLength" : 1,
+              "description" : "The ID of the domain event."
+            },
+            "name" : {
+              "type" : "string",
+              "minLength" : 1,
+              "description" : "The name of the domain event",
+              "const" : "cart_item_removed"
+            },
+            "revision" : {
+              "type" : "string",
+              "description" : "The revision number of the domain event",
+              "default" : "0.0.1"
+            },
+            "bodyType" : {
+              "type" : "string",
+              "description" : "The fully qualified name of the domain event body",
+              "const" : "me.ahoo.wow.example.api.cart.CartItemRemoved"
+            },
+            "body" : {
               "type" : "object",
               "properties" : {
                 "productIds" : {
@@ -147,7 +175,36 @@
                 }
               },
               "required" : [ "productIds" ]
-            }, {
+            }
+          },
+          "description" : "The body of the domain event",
+          "required" : [ "id", "name", "revision", "bodyType", "body" ],
+          "title" : "cart_item_removed"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "id" : {
+              "type" : "string",
+              "minLength" : 1,
+              "description" : "The ID of the domain event."
+            },
+            "name" : {
+              "type" : "string",
+              "minLength" : 1,
+              "description" : "The name of the domain event",
+              "const" : "cart_quantity_changed"
+            },
+            "revision" : {
+              "type" : "string",
+              "description" : "The revision number of the domain event",
+              "default" : "0.0.1"
+            },
+            "bodyType" : {
+              "type" : "string",
+              "description" : "The fully qualified name of the domain event body",
+              "const" : "me.ahoo.wow.example.api.cart.CartQuantityChanged"
+            },
+            "body" : {
               "type" : "object",
               "properties" : {
                 "changed" : {
@@ -155,11 +212,12 @@
                 }
               },
               "required" : [ "changed" ]
-            } ]
-          }
-        },
-        "description" : "The body of the domain event",
-        "required" : [ "id", "name", "revision", "bodyType", "body" ]
+            }
+          },
+          "description" : "The body of the domain event",
+          "required" : [ "id", "name", "revision", "bodyType", "body" ],
+          "title" : "cart_quantity_changed"
+        } ]
       },
       "minItems" : 1,
       "description" : "A list of domain events for the domain event stream"


### PR DESCRIPTION
- Add AggregatedDomainEventStream JSON schema definition
- Update AggregatedDomainEventStreamDefinitionProvider to use new schema
- Generate CartAggregatedDomainEventStream JSON schema as an example
- Add DomainEventStreamBody JSON schema as a reusable component
- Update JsonSchemaGeneratorTest to use new schema for Cart aggregate
