### PR TITLE
feat(CommandRouteSpec): enhance summary with fallback to command name

### DIFF
--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/command/CommandRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/command/CommandRouteSpec.kt
@@ -106,7 +106,7 @@ class CommandRouteSpec(
                 .append(commandRouteMetadata.action).build()
         }
     override val summary: String
-        get() = commandRouteMetadata.summary
+        get() = commandRouteMetadata.summary.ifBlank { commandRouteMetadata.commandMetadata.name }
     override val description: String
         get() = commandRouteMetadata.description
     override val tags: List<String>


### PR DESCRIPTION
- Update summary property to use command name if summary is blank
- Improve documentation clarity for command route summaries


