### PR TITLE
docs(wow-openapi): update summary for CommandWaitRouteSpec

### DIFF
--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/global/CommandWaitRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/global/CommandWaitRouteSpec.kt
@@ -42,7 +42,7 @@ class CommandWaitRouteSpec(override val componentContext: OpenAPIComponentContex
         get() = PATH
     override val method: String
         get() = Https.Method.POST
-    override val summary: String = "command wait handler"
+    override val summary: String = "The receiving endpoint of the wait signal"
     override val parameters: List<Parameter> = listOf()
     override val requestBody: RequestBody =
         RequestBodyBuilder().content(schema = componentContext.schema(SimpleWaitSignal::class.java))


### PR DESCRIPTION
- Change summary from "command wait handler" to "The receiving endpoint of the wait signal"
- Improve clarity and consistency in API documentation