### PR TITLE
feat(metadata): add field information to VariableMetadata

### DIFF
--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/metadata/CommandRouteMetadata.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/metadata/CommandRouteMetadata.kt
@@ -20,6 +20,7 @@ import me.ahoo.wow.api.naming.SummaryCapable
 import me.ahoo.wow.command.metadata.CommandMetadata
 import me.ahoo.wow.serialization.JsonSerializer
 import me.ahoo.wow.serialization.toObject
+import java.lang.reflect.Field
 
 data class CommandRouteMetadata<C>(
     val enabled: Boolean,
@@ -95,6 +96,7 @@ data class CommandRouteMetadata<C>(
 }
 
 data class VariableMetadata(
+    val field: Field?,
     val fieldPath: List<String>,
     /**
      * variable name

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/metadata/CommandRouteMetadataParser.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/metadata/CommandRouteMetadataParser.kt
@@ -32,6 +32,7 @@ import me.ahoo.wow.openapi.PathBuilder
 import me.ahoo.wow.serialization.toJsonString
 import org.springframework.web.util.UriTemplate
 import kotlin.reflect.KProperty1
+import kotlin.reflect.jvm.javaField
 
 object CommandRouteMetadataParser : CacheableMetadataParser() {
     override fun <TYPE : Any, M : Metadata> parseToMetadata(type: Class<TYPE>): M {
@@ -67,6 +68,7 @@ internal class CommandRouteMetadataVisitor<C : Any>(private val commandType: Cla
             addAll(nestedPath)
         }
         return VariableMetadata(
+            field = javaField,
             fieldPath = fieldPath,
             variableName = variableName,
             required = required,
@@ -153,6 +155,7 @@ internal class CommandRouteMetadataVisitor<C : Any>(private val commandType: Cla
             }
             missedVariableNames.forEach {
                 val missedVariable = VariableMetadata(
+                    field = null,
                     fieldPath = listOf(it),
                     variableName = it,
                     required = true,

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/route/CommandRouteMetadataParserTest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/route/CommandRouteMetadataParserTest.kt
@@ -24,6 +24,7 @@ import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import kotlin.reflect.jvm.javaField
 
 class CommandRouteMetadataParserTest {
 
@@ -36,6 +37,7 @@ class CommandRouteMetadataParserTest {
         assertThat(commandRouteMetadata.prefix, equalTo(""))
         assertThat(commandRouteMetadata.appendIdPath, equalTo(CommandRoute.AppendPath.DEFAULT))
         val idPathVariable = commandRouteMetadata.pathVariableMetadata.first { it.variableName == "id" }
+        assertThat(idPathVariable.field, equalTo(MockCommandRouteNotRequired::id.javaField))
         assertThat(idPathVariable.fieldName, equalTo("id"))
         assertThat(idPathVariable.variableName, equalTo("id"))
         assertThat(idPathVariable.required, equalTo(true))


### PR DESCRIPTION
- Add 'field' property to VariableMetadata to store Java Field reference
- Update CommandRouteMetadataParser to populate 'field' in VariableMetadata
- Add test case to verify 'field' property in VariableMetadata
