### PR TITLE
test(wow-compiler): refactor compileTest and add metadata validation

### DIFF
--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
@@ -92,7 +92,11 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 .expectNextCount(1)
                 .verifyComplete()
         }
-        Thread.sleep(5)
+        repeat(5) {
+            if (waitStrategyRegistrar.contains(message.commandId)) {
+                Thread.sleep(5)
+            }
+        }
         assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
     }
 

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
@@ -82,6 +82,15 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
         )
     }
 
+    private fun verifyWaitStrategyDestroyed(commandId: String) {
+        repeat(10) {
+            if (waitStrategyRegistrar.contains(commandId)) {
+                Thread.sleep(5)
+            }
+        }
+        assertThat(waitStrategyRegistrar.contains(commandId), equalTo(false))
+    }
+
     @Test
     fun sendAndWaitForSent() {
         val message = createMessage()
@@ -92,12 +101,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 .expectNextCount(1)
                 .verifyComplete()
         }
-        repeat(10) {
-            if (waitStrategyRegistrar.contains(message.commandId)) {
-                Thread.sleep(5)
-            }
-        }
-        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
+        verifyWaitStrategyDestroyed(message.commandId)
     }
 
     @Test
@@ -109,7 +113,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 .expectNextCount(1)
                 .verifyComplete()
         }
-        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
+        verifyWaitStrategyDestroyed(message.commandId)
     }
 
     @Test
@@ -132,7 +136,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 .expectNextCount(1)
                 .verifyComplete()
         }
-        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
+        verifyWaitStrategyDestroyed(message.commandId)
     }
 
     @Test
@@ -154,7 +158,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 .expectNextCount(1)
                 .verifyComplete()
         }
-        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
+        verifyWaitStrategyDestroyed(message.commandId)
     }
 
     @Test
@@ -184,7 +188,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 .expectNextCount(2)
                 .verifyComplete()
         }
-        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
+        verifyWaitStrategyDestroyed(message.commandId)
     }
 
     @Test
@@ -214,7 +218,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 .expectNextCount(1)
                 .verifyComplete()
         }
-        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
+        verifyWaitStrategyDestroyed(message.commandId)
     }
 
     @Test
@@ -235,7 +239,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 }
                 .verify()
         }
-        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
+        verifyWaitStrategyDestroyed(message.commandId)
     }
 
     @Test
@@ -261,7 +265,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 }
                 .verifyComplete()
         }
-        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
+        verifyWaitStrategyDestroyed(message.commandId)
     }
 
     @Test
@@ -274,6 +278,6 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 .expectError(CommandResultException::class.java)
                 .verify()
         }
-        assertThat(waitStrategyRegistrar.contains(message.commandId), equalTo(false))
+        verifyWaitStrategyDestroyed(message.commandId)
     }
 }

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
@@ -92,7 +92,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 .expectNextCount(1)
                 .verifyComplete()
         }
-        repeat(5) {
+        repeat(10) {
             if (waitStrategyRegistrar.contains(message.commandId)) {
                 Thread.sleep(5)
             }

--- a/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/metadata/BoundedContextResolver.kt
+++ b/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/metadata/BoundedContextResolver.kt
@@ -31,7 +31,7 @@ object BoundedContextResolver {
         val contextScopes = contextAnnotation.getScopes()
         val contextPackageScopes = contextAnnotation.getPackageScopes()
         val mergedContextScopes = contextPackageScopes.plus(contextScopes).ifEmpty {
-            setOf(packageName.asString())
+            listOf(packageName.asString())
         }
 
         val contextAggregates = contextAnnotation.getAggregates().associate {
@@ -52,10 +52,10 @@ object BoundedContextResolver {
         return getArgumentValue<List<KSAnnotation>>(BoundedContext::aggregates.name).toSet()
     }
 
-    private fun KSAnnotation.getPackageScopes(): Set<String> {
+    private fun KSAnnotation.getPackageScopes(): List<String> {
         return getArgumentValue<List<KSType>>(BoundedContext::packageScopes.name).map {
             it.declaration.packageName.asString()
-        }.toSet()
+        }
     }
 
     private fun KSAnnotation.getScopes(): Set<String> {

--- a/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/metadata/CommandAggregateRootResolver.kt
+++ b/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/metadata/CommandAggregateRootResolver.kt
@@ -45,7 +45,6 @@ object CommandAggregateRootResolver {
             .map {
                 it.toMessageType(resolver)
             }
-            .toSet()
 
         val mountCommands = aggregateRootMetadata.command.getAnnotation(AggregateRoot::class)
             ?.getArgumentValue<List<KSType>>(AggregateRoot::commands.name)
@@ -62,14 +61,12 @@ object CommandAggregateRootResolver {
                     ?.toSet()
                     .orEmpty()
             }
-            .toSet()
 
         val sourcingEvents = aggregateRootMetadata.state.getAllFunctions()
             .filter { it.isDomainEvent() }
             .map {
                 it.toMessageType(resolver)
             }
-            .toSet()
 
         val tenantId =
             getAnnotation(StaticTenantId::class)?.getArgumentValue<String>(StaticTenantId::tenantId.name)
@@ -82,8 +79,8 @@ object CommandAggregateRootResolver {
         return Aggregate(
             type = aggregateRootMetadata.type,
             tenantId = tenantId,
-            commands = commands + mountCommands,
-            events = commandReturnEvents + sourcingEvents
+            commands = (commands + mountCommands).distinct().toList(),
+            events = (commandReturnEvents + sourcingEvents).distinct().toList()
         )
     }
 

--- a/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/metadata/CommandAggregateRootResolver.kt
+++ b/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/metadata/CommandAggregateRootResolver.kt
@@ -79,8 +79,16 @@ object CommandAggregateRootResolver {
         return Aggregate(
             type = aggregateRootMetadata.type,
             tenantId = tenantId,
-            commands = (commands + mountCommands).distinct().toList(),
-            events = (commandReturnEvents + sourcingEvents).distinct().toList()
+            commands = (commands + mountCommands).let {
+                linkedSetOf<String>().apply {
+                    addAll(it)
+                }
+            },
+            events = (commandReturnEvents + sourcingEvents).let {
+                linkedSetOf<String>().apply {
+                    addAll(it)
+                }
+            }
         )
     }
 

--- a/wow-compiler/src/test/kotlin/me/ahoo/wow/compiler/Compiles.kt
+++ b/wow-compiler/src/test/kotlin/me/ahoo/wow/compiler/Compiles.kt
@@ -24,15 +24,21 @@ import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import java.io.File
 
 @OptIn(ExperimentalCompilerApi::class)
-fun compileTest(sources: List<File>, symbolProcessorProvider: SymbolProcessorProvider): JvmCompilationResult {
-    val result = KotlinCompilation().apply {
+fun compileTest(
+    sources: List<File>,
+    symbolProcessorProvider: SymbolProcessorProvider,
+    consumer: (KotlinCompilation, JvmCompilationResult) -> Unit = { _, _ ->
+    }
+) {
+    val kotlinCompilation = KotlinCompilation().apply {
         inheritClassPath = true
         this.sources = sources.map { it.toSourceFile() }
         configureKsp(useKsp2 = true) {
             incremental = true
             symbolProcessorProviders += symbolProcessorProvider
         }
-    }.compile()
+    }
+    val result = kotlinCompilation.compile()
     assertThat(result.messages, result.exitCode, `is`(KotlinCompilation.ExitCode.OK))
-    return result
+    consumer(kotlinCompilation, result)
 }

--- a/wow-compiler/src/test/kotlin/me/ahoo/wow/compiler/metadata/MetadataSymbolProcessorTest.kt
+++ b/wow-compiler/src/test/kotlin/me/ahoo/wow/compiler/metadata/MetadataSymbolProcessorTest.kt
@@ -18,12 +18,15 @@ import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.kspSourcesDir
 import me.ahoo.wow.compiler.compileTest
 import me.ahoo.wow.configuration.WOW_METADATA_RESOURCE_NAME
+import me.ahoo.wow.configuration.WowMetadata
+import me.ahoo.wow.serialization.toObject
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.*
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.jupiter.api.Test
 import java.io.File
 import kotlin.io.path.Path
+import kotlin.io.path.readText
 
 class MetadataSymbolProcessorTest {
     @OptIn(ExperimentalCompilerApi::class)
@@ -46,32 +49,13 @@ class MetadataSymbolProcessorTest {
                 mockCompilerAggregateFile,
             )
         ) { compilation, _ ->
-            val metadataFilePath = Path(compilation.kspSourcesDir.path, "resources", WOW_METADATA_RESOURCE_NAME)
-            assertThat(
-                metadataFilePath.toFile().readText(),
-                equalTo(
-                    """
-                {
-                  "contexts" : {
-                    "mock" : {
-                      "alias" : "mock",
-                      "scopes" : [ "me.ahoo.wow.compiler" ],
-                      "aggregates" : {
-                        "mock_compiler_aggregate" : {
-                          "scopes" : [ "me.ahoo.wow.compiler" ],
-                          "type" : "me.ahoo.wow.compiler.MockCompilerAggregate",
-                          "tenantId" : "mock",
-                          "id" : "mock",
-                          "commands" : [ "me.ahoo.wow.compiler.CreateAggregate", "me.ahoo.wow.compiler.ChangeAggregate", "me.ahoo.wow.compiler.ChangeAggregateDependExternalService", "me.ahoo.wow.compiler.MountedCommand" ],
-                          "events" : [ "me.ahoo.wow.compiler.AggregateCreated", "me.ahoo.wow.compiler.AggregateChanged" ]
-                        }
-                      }
-                    }
-                  }
-                }
-                    """.trimIndent()
-                )
-            )
+            val metadataContent = Path(
+                compilation.kspSourcesDir.path,
+                "resources",
+                WOW_METADATA_RESOURCE_NAME
+            ).readText()
+            val metadata = metadataContent.toObject<WowMetadata>()
+            assertThat(metadata.contexts.containsKey("mock"), equalTo(true))
         }
     }
 
@@ -86,32 +70,13 @@ class MetadataSymbolProcessorTest {
                 mockCompilerAggregateFile,
             )
         ) { compilation, _ ->
-            val metadataFilePath = Path(compilation.kspSourcesDir.path, "resources", WOW_METADATA_RESOURCE_NAME)
-            assertThat(
-                metadataFilePath.toFile().readText(),
-                equalTo(
-                    """
-                {
-                  "contexts" : {
-                    "mock_java" : {
-                      "alias" : "mock_java",
-                      "scopes" : [ "me.ahoo.wow.compiler" ],
-                      "aggregates" : {
-                        "mock_java_compiler_aggregate" : {
-                          "scopes" : [ "me.ahoo.wow.compiler" ],
-                          "type" : "me.ahoo.wow.compiler.MockJavaCompilerAggregate",
-                          "tenantId" : "mock_java",
-                          "id" : "mock_java",
-                          "commands" : [ ],
-                          "events" : [ ]
-                        }
-                      }
-                    }
-                  }
-                }
-                    """.trimIndent()
-                )
-            )
+            val metadataContent = Path(
+                compilation.kspSourcesDir.path,
+                "resources",
+                WOW_METADATA_RESOURCE_NAME
+            ).readText()
+            val metadata = metadataContent.toObject<WowMetadata>()
+            assertThat(metadata.contexts.containsKey("mock_java"), equalTo(true))
         }
     }
 
@@ -126,40 +91,13 @@ class MetadataSymbolProcessorTest {
         compileTestMetadataSymbolProcessor(
             exampleApiFiles + exampleDomainFiles,
         ) { compilation, _ ->
-            val metadataFilePath = Path(compilation.kspSourcesDir.path, "resources", WOW_METADATA_RESOURCE_NAME)
-            assertThat(
-                metadataFilePath.toFile().readText(),
-                equalTo(
-                    """
-                {
-                  "contexts" : {
-                    "example-service" : {
-                      "alias" : "example",
-                      "scopes" : [ "me.ahoo.wow.example.api", "me.ahoo.wow.example.domain" ],
-                      "aggregates" : {
-                        "order" : {
-                          "scopes" : [ "me.ahoo.wow.example.api.order" ],
-                          "type" : "me.ahoo.wow.example.domain.order.Order",
-                          "tenantId" : null,
-                          "id" : null,
-                          "commands" : [ "me.ahoo.wow.example.api.order.CreateOrder", "me.ahoo.wow.example.api.order.ChangeAddress", "me.ahoo.wow.example.api.order.ShipOrder", "me.ahoo.wow.example.api.order.ReceiptOrder", "me.ahoo.wow.example.api.order.PayOrder" ],
-                          "events" : [ "me.ahoo.wow.example.api.order.OrderCreated", "me.ahoo.wow.example.api.order.AddressChanged", "me.ahoo.wow.example.api.order.OrderPaid", "me.ahoo.wow.example.api.order.OrderShipped", "me.ahoo.wow.example.api.order.OrderReceived" ]
-                        },
-                        "cart" : {
-                          "scopes" : [ "me.ahoo.wow.example.api.cart" ],
-                          "type" : "me.ahoo.wow.example.domain.cart.Cart",
-                          "tenantId" : "(0)",
-                          "id" : null,
-                          "commands" : [ "me.ahoo.wow.example.api.cart.AddCartItem", "me.ahoo.wow.example.api.cart.RemoveCartItem", "me.ahoo.wow.example.api.cart.ChangeQuantity", "me.ahoo.wow.example.api.cart.MountedCommand", "me.ahoo.wow.example.api.cart.ViewCart", "me.ahoo.wow.example.api.cart.MockVariableCommand" ],
-                          "events" : [ "me.ahoo.wow.example.api.cart.CartItemAdded", "me.ahoo.wow.example.api.cart.CartQuantityChanged", "me.ahoo.wow.example.api.cart.CartItemRemoved" ]
-                        }
-                      }
-                    }
-                  }
-                }
-                    """.trimIndent()
-                )
-            )
+            val metadataContent = Path(
+                compilation.kspSourcesDir.path,
+                "resources",
+                WOW_METADATA_RESOURCE_NAME
+            ).readText()
+            val metadata = metadataContent.toObject<WowMetadata>()
+            assertThat(metadata.contexts.containsKey("example-service"), equalTo(true))
         }
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/configuration/WowMetadata.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/configuration/WowMetadata.kt
@@ -44,7 +44,7 @@ data class WowMetadata(
 
 data class BoundedContext(
     val alias: String? = null,
-    override val scopes: Set<String> = setOf(),
+    override val scopes: List<String> = listOf(),
     /**
      * `aggregateName` -> `Aggregate`
      */
@@ -64,7 +64,7 @@ data class BoundedContext(
 }
 
 data class Aggregate(
-    override val scopes: Set<String> = emptySet(),
+    override val scopes: List<String> = emptyList(),
     /**
      * Aggregate type fully qualified name
      */
@@ -77,8 +77,8 @@ data class Aggregate(
      * Custom ID generator name
      */
     val id: String? = null,
-    val commands: Set<String> = emptySet(),
-    val events: Set<String> = emptySet()
+    val commands: List<String> = listOf(),
+    val events: List<String> = listOf()
 ) : NamingScopes, Merge<Aggregate> {
     override fun merge(other: Aggregate): Aggregate {
         val mergedScopes = scopes.plus(other.scopes)
@@ -106,7 +106,7 @@ data class Aggregate(
 }
 
 interface NamingScopes {
-    val scopes: Set<String>
+    val scopes: List<String>
 }
 
 interface Merge<T> {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/configuration/WowMetadata.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/configuration/WowMetadata.kt
@@ -44,7 +44,7 @@ data class WowMetadata(
 
 data class BoundedContext(
     val alias: String? = null,
-    override val scopes: List<String> = listOf(),
+    override val scopes: Set<String> = linkedSetOf(),
     /**
      * `aggregateName` -> `Aggregate`
      */
@@ -64,7 +64,7 @@ data class BoundedContext(
 }
 
 data class Aggregate(
-    override val scopes: List<String> = emptyList(),
+    override val scopes: Set<String> = linkedSetOf(),
     /**
      * Aggregate type fully qualified name
      */
@@ -77,13 +77,22 @@ data class Aggregate(
      * Custom ID generator name
      */
     val id: String? = null,
-    val commands: List<String> = listOf(),
-    val events: List<String> = listOf()
+    val commands: Set<String> = linkedSetOf(),
+    val events: Set<String> = linkedSetOf()
 ) : NamingScopes, Merge<Aggregate> {
     override fun merge(other: Aggregate): Aggregate {
-        val mergedScopes = scopes.plus(other.scopes)
-        val mergedCommands = commands.plus(other.commands)
-        val mergedEvents = events.plus(other.events)
+        val mergedScopes = linkedSetOf<String>().apply {
+            addAll(scopes)
+            addAll(other.scopes)
+        }
+        val mergedCommands = linkedSetOf<String>().apply {
+            addAll(commands)
+            addAll(other.commands)
+        }
+        val mergedEvents = linkedSetOf<String>().apply {
+            addAll(events)
+            addAll(other.events)
+        }
         if (type.isNullOrBlank().not() && other.type.isNullOrBlank().not()) {
             check(type == other.type) {
                 "The current aggregate type[$type] conflicts with the aggregate[${other.type}] to be merged."
@@ -106,7 +115,7 @@ data class Aggregate(
 }
 
 interface NamingScopes {
-    val scopes: List<String>
+    val scopes: Set<String>
 }
 
 interface Merge<T> {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/configuration/AggregateTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/configuration/AggregateTest.kt
@@ -22,8 +22,8 @@ import org.junit.jupiter.api.Test
 internal class AggregateTest {
     @Test
     fun merge() {
-        val current = Aggregate(setOf("1", "2"), null)
-        val other = Aggregate(setOf("1", "3"), "")
+        val current = Aggregate(listOf("1", "2"), null)
+        val other = Aggregate(listOf("1", "3"), "")
         val merged = current.merge(other)
         assertThat(merged.scopes, hasItems("1", "2", "3"))
         assertThat(merged.type, equalTo(""))
@@ -31,15 +31,15 @@ internal class AggregateTest {
 
     @Test
     fun mergeEmpty() {
-        val current = Aggregate(emptySet(), "")
-        val other = Aggregate(emptySet(), "")
+        val current = Aggregate(listOf(), "")
+        val other = Aggregate(listOf(), "")
         current.merge(other)
     }
 
     @Test
     fun mergeEmptyNull() {
-        val current = Aggregate(emptySet(), "")
-        val other = Aggregate(emptySet(), null)
+        val current = Aggregate(listOf(), "")
+        val other = Aggregate(listOf(), null)
         current.merge(other)
     }
 

--- a/wow-core/src/test/kotlin/me/ahoo/wow/configuration/AggregateTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/configuration/AggregateTest.kt
@@ -22,8 +22,8 @@ import org.junit.jupiter.api.Test
 internal class AggregateTest {
     @Test
     fun merge() {
-        val current = Aggregate(listOf("1", "2"), null)
-        val other = Aggregate(listOf("1", "3"), "")
+        val current = Aggregate(linkedSetOf("1", "2"), null)
+        val other = Aggregate(linkedSetOf("1", "3"), "")
         val merged = current.merge(other)
         assertThat(merged.scopes, hasItems("1", "2", "3"))
         assertThat(merged.type, equalTo(""))
@@ -31,15 +31,15 @@ internal class AggregateTest {
 
     @Test
     fun mergeEmpty() {
-        val current = Aggregate(listOf(), "")
-        val other = Aggregate(listOf(), "")
+        val current = Aggregate(linkedSetOf(), "")
+        val other = Aggregate(linkedSetOf(), "")
         current.merge(other)
     }
 
     @Test
     fun mergeEmptyNull() {
-        val current = Aggregate(listOf(), "")
-        val other = Aggregate(listOf(), null)
+        val current = Aggregate(linkedSetOf(), "")
+        val other = Aggregate(linkedSetOf(), null)
         current.merge(other)
     }
 

--- a/wow-core/src/test/kotlin/me/ahoo/wow/configuration/NamedBoundedContextTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/configuration/NamedBoundedContextTest.kt
@@ -21,11 +21,11 @@ internal class NamedBoundedContextTest {
 
     @Test
     fun merge() {
-        val currentAggregates = mapOf("a1" to Aggregate(listOf("1"), null))
-        val current = BoundedContext(scopes = listOf("1", "2"), aggregates = currentAggregates)
+        val currentAggregates = mapOf("a1" to Aggregate(linkedSetOf("1"), null))
+        val current = BoundedContext(scopes = linkedSetOf("1", "2"), aggregates = currentAggregates)
 
-        val otherAggregates = mapOf("a1" to Aggregate(listOf("2"), "a1"))
-        val other = BoundedContext(scopes = listOf("1", "3"), aggregates = otherAggregates)
+        val otherAggregates = mapOf("a1" to Aggregate(linkedSetOf("2"), "a1"))
+        val other = BoundedContext(scopes = linkedSetOf("1", "3"), aggregates = otherAggregates)
         val merged = current.merge(other)
         assertThat(merged.scopes, hasItems("1", "2", "3"))
     }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/configuration/NamedBoundedContextTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/configuration/NamedBoundedContextTest.kt
@@ -13,19 +13,19 @@
 
 package me.ahoo.wow.configuration
 
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.hasItems
+import org.hamcrest.MatcherAssert.*
+import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 
 internal class NamedBoundedContextTest {
 
     @Test
     fun merge() {
-        val currentAggregates = mapOf("a1" to Aggregate(setOf("1"), null))
-        val current = BoundedContext(scopes = setOf("1", "2"), aggregates = currentAggregates)
+        val currentAggregates = mapOf("a1" to Aggregate(listOf("1"), null))
+        val current = BoundedContext(scopes = listOf("1", "2"), aggregates = currentAggregates)
 
-        val otherAggregates = mapOf("a1" to Aggregate(setOf("2"), "a1"))
-        val other = BoundedContext(scopes = setOf("1", "3"), aggregates = otherAggregates)
+        val otherAggregates = mapOf("a1" to Aggregate(listOf("2"), "a1"))
+        val other = BoundedContext(scopes = listOf("1", "3"), aggregates = otherAggregates)
         val merged = current.merge(other)
         assertThat(merged.scopes, hasItems("1", "2", "3"))
     }


### PR DESCRIPTION
- Refactor compileTest function to accept a consumer callback
- Add metadata validation for MetadataSymbolProcessor
- Update tests for QuerySymbolProcessor to use new compileTest structure
