### PR TITLE
refactor(infra-reflection): redesign annotation scanning mechanism

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/reflection/IntimateAnnotationElement.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/reflection/IntimateAnnotationElement.kt
@@ -38,19 +38,20 @@ class IntimateAnnotationElement(
     val field: Field? = property?.javaField
 
     val intimatedAnnotations: LinkedHashSet<Annotation> by lazy {
-        val merged = linkedSetOf<Annotation>()
-        merged.addAll(element.annotations)
+        val annotations = linkedSetOf<Annotation>()
+        annotations.addAll(element.annotations)
         if (getter != null) {
-            merged.addAll(getter.annotations)
+            annotations.addAll(getter.annotations)
         }
         if (setter != null) {
-            merged.addAll(setter.annotations)
+            annotations.addAll(setter.annotations)
         }
         if (field != null) {
-            merged.addAll(field.annotations)
+            annotations.addAll(field.annotations)
         }
-        merged.flatMap {
-            it.flatRepeatableAnnotation()
+        val merged = linkedSetOf<Annotation>()
+        annotations.forEach {
+            merged.addAll(it.flatRepeatableAnnotation())
         }
         merged
     }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/reflection/IntimateAnnotationElement.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/reflection/IntimateAnnotationElement.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.infra.reflection
+
+import java.lang.reflect.Field
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.reflect.KAnnotatedElement
+import kotlin.reflect.KMutableProperty
+import kotlin.reflect.KProperty
+import kotlin.reflect.full.hasAnnotation
+import kotlin.reflect.jvm.javaField
+
+/**
+ * IntimateAnnotationElement.
+ *
+ */
+class IntimateAnnotationElement(
+    val element: KAnnotatedElement,
+) {
+    val property: KProperty<*>? = element as? KProperty<*>
+    val getter: KProperty.Getter<*>? = property?.getter
+    val setter: KMutableProperty.Setter<*>? = if (property is KMutableProperty<*>) {
+        property.setter
+    } else {
+        null
+    }
+    val field: Field? = property?.javaField
+
+    val intimatedAnnotations: LinkedHashSet<Annotation> by lazy {
+        val merged = linkedSetOf<Annotation>()
+        merged.addAll(element.annotations)
+        if (getter != null) {
+            merged.addAll(getter.annotations)
+        }
+        if (setter != null) {
+            merged.addAll(setter.annotations)
+        }
+        if (field != null) {
+            merged.addAll(field.annotations)
+        }
+        merged.flatMap {
+            it.flatRepeatableAnnotation()
+        }
+        merged
+    }
+
+    val mergedAnnotations: Set<Annotation> by lazy {
+        val merged = linkedSetOf<Annotation>()
+        intimatedAnnotations.forEach {
+            it.inheritedAnnotations(merged)
+        }
+        merged
+    }
+
+    companion object {
+        private const val REPEATABLE_CONTAINER_SIMPLE_NAME = "Container"
+        private const val REPEATABLE_CONTAINER_ENDS_WITH = "${'$'}$REPEATABLE_CONTAINER_SIMPLE_NAME"
+
+        private val cache: ConcurrentHashMap<KAnnotatedElement, IntimateAnnotationElement> = ConcurrentHashMap()
+
+        fun KAnnotatedElement.toIntimateAnnotationElement(): IntimateAnnotationElement {
+            return cache.computeIfAbsent(this) {
+                IntimateAnnotationElement(it)
+            }
+        }
+
+        fun Annotation.flatRepeatableAnnotation(): List<Annotation> {
+            val containerClass = this.annotationClass.java
+            if (containerClass.simpleName == REPEATABLE_CONTAINER_SIMPLE_NAME &&
+                containerClass.name.endsWith(REPEATABLE_CONTAINER_ENDS_WITH)
+            ) {
+                try {
+                    @Suppress("UNCHECKED_CAST")
+                    val value = this.annotationClass.java.getMethod("value").invoke(this) as Array<Annotation>
+                    return value.toList()
+                } catch (ignore: Exception) {
+                    // ignore
+                }
+            }
+            return listOf(this)
+        }
+
+        fun Annotation.inheritedAnnotations(scanned: LinkedHashSet<Annotation> = linkedSetOf()): Set<Annotation> {
+            val existed = scanned.any { it == this }
+            if (existed) {
+                return scanned
+            }
+            scanned.add(this)
+            this.annotationClass.annotations.filter {
+                it.annotationClass.hasAnnotation<java.lang.annotation.Inherited>()
+            }.flatMap {
+                it.inheritedAnnotations(scanned)
+            }
+            return scanned
+        }
+    }
+}

--- a/wow-core/src/test/java/me/ahoo/wow/infra/reflection/JvmRepeatableTag.java
+++ b/wow-core/src/test/java/me/ahoo/wow/infra/reflection/JvmRepeatableTag.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.infra.reflection;
+
+import java.lang.annotation.*;
+
+@Repeatable(JvmRepeatableTags.class)
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JvmRepeatableTag {
+    String value();
+}

--- a/wow-core/src/test/java/me/ahoo/wow/infra/reflection/JvmRepeatableTags.java
+++ b/wow-core/src/test/java/me/ahoo/wow/infra/reflection/JvmRepeatableTags.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.infra.reflection;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface JvmRepeatableTags {
+    JvmRepeatableTag[] value();
+}
+

--- a/wow-core/src/test/java/me/ahoo/wow/infra/reflection/MockRepeatableClass.java
+++ b/wow-core/src/test/java/me/ahoo/wow/infra/reflection/MockRepeatableClass.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.infra.reflection;
+
+public class MockRepeatableClass {
+    @JvmRepeatableTag(value = "tag1")
+    @JvmRepeatableTag(value = "tag2")
+    private String field;
+    @JvmRepeatableTags(
+            {
+                    @JvmRepeatableTag("tag3"),
+                    @JvmRepeatableTag("tag4")
+            }
+    )
+    private String field2;
+}

--- a/wow-core/src/test/kotlin/me/ahoo/wow/infra/reflection/AnnotationScannerTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/infra/reflection/AnnotationScannerTest.kt
@@ -1,9 +1,5 @@
 package me.ahoo.wow.infra.reflection
 
-import me.ahoo.wow.api.annotation.OnMessage
-import me.ahoo.wow.api.messaging.function.FunctionKind
-import me.ahoo.wow.infra.reflection.AnnotationScanner.allAnnotations
-import me.ahoo.wow.infra.reflection.AnnotationScanner.intimateAnnotations
 import me.ahoo.wow.infra.reflection.AnnotationScanner.scanAnnotation
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.notNullValue
@@ -14,33 +10,10 @@ import org.junit.jupiter.api.Test
 class AnnotationScannerTest {
 
     @Test
-    fun intimateAnnotations() {
-        val annotations = Data::property.intimateAnnotations()
-        assertThat(annotations.any { it.annotationClass == MockAnnotation::class }, equalTo(true))
-
-        val getAnnotations = Data::getProperty.intimateAnnotations()
-        assertThat(getAnnotations.any { it.annotationClass == MockAnnotation::class }, equalTo(true))
-
-        val fieldAnnotations = Data::fieldProperty.intimateAnnotations()
-        assertThat(fieldAnnotations.any { it.annotationClass == MockAnnotation::class }, equalTo(true))
-
-        val setAnnotations = Data::setProperty.intimateAnnotations()
-        assertThat(setAnnotations.any { it.annotationClass == MockAnnotation::class }, equalTo(true))
-    }
-
-    @Test
-    fun allAnnotations() {
-        val annotations = Data::property.allAnnotations()
-        assertThat(annotations.any { it.annotationClass == MockAnnotation::class }, equalTo(true))
-        assertThat(annotations.any { it.annotationClass == OnMessage::class }, equalTo(true))
-    }
-
-    @Test
     fun scanAnnotation() {
         val propertyAnnotation = Data::property.scanAnnotation<MockAnnotation>()
         assertThat(propertyAnnotation, notNullValue())
         assertThat(propertyAnnotation!!.annotationClass, equalTo(MockAnnotation::class))
-
         val propertyAnnotation2 = Data::property.scanAnnotation<MockAnnotation>()
         assertThat(propertyAnnotation2, notNullValue())
         assertThat(propertyAnnotation2!!.annotationClass, equalTo(MockAnnotation::class))
@@ -53,25 +26,4 @@ class AnnotationScannerTest {
         val propertyAnnotation2 = Data::class.scanAnnotation<MockAnnotation>()
         assertThat(propertyAnnotation, nullValue())
     }
-
-    data class Data(
-        @MockAnnotation
-        val property: String,
-        @field:MockAnnotation
-        val fieldProperty: String,
-        @get:MockAnnotation
-        val getProperty: String,
-        @set:MockAnnotation
-        var setProperty: String
-    )
-
-    @Target(
-        AnnotationTarget.FIELD,
-        AnnotationTarget.PROPERTY,
-        AnnotationTarget.FUNCTION,
-        AnnotationTarget.PROPERTY_GETTER,
-        AnnotationTarget.PROPERTY_SETTER
-    )
-    @OnMessage(FunctionKind.EVENT, "hi")
-    annotation class MockAnnotation
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/infra/reflection/IntimateAnnotationElementTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/infra/reflection/IntimateAnnotationElementTest.kt
@@ -1,0 +1,184 @@
+package me.ahoo.wow.infra.reflection
+
+import me.ahoo.wow.api.annotation.OnMessage
+import me.ahoo.wow.api.messaging.function.FunctionKind
+import me.ahoo.wow.infra.reflection.IntimateAnnotationElement.Companion.toIntimateAnnotationElement
+import org.hamcrest.CoreMatchers.equalTo
+import org.hamcrest.MatcherAssert.*
+import org.junit.jupiter.api.Test
+import kotlin.reflect.jvm.javaField
+import kotlin.reflect.jvm.kotlinProperty
+
+class IntimateAnnotationElementTest {
+
+    @Test
+    fun getElement() {
+        val element = Data::property.toIntimateAnnotationElement()
+        assertThat(element.element, equalTo(Data::property))
+    }
+
+    @Test
+    fun getProperty() {
+        val element = Data::fieldProperty.toIntimateAnnotationElement()
+        assertThat(element.property, equalTo(Data::fieldProperty))
+    }
+
+    @Test
+    fun getGetter() {
+        val element = Data::fieldProperty.toIntimateAnnotationElement()
+        assertThat(element.getter, equalTo(Data::fieldProperty.getter))
+    }
+
+    @Test
+    fun getSetter() {
+        val element = Data::setProperty.toIntimateAnnotationElement()
+        assertThat(element.setter, equalTo(Data::setProperty.setter))
+    }
+
+    @Test
+    fun getField() {
+        val element = Data::fieldProperty.toIntimateAnnotationElement()
+        assertThat(element.field, equalTo(Data::fieldProperty.javaField))
+    }
+
+    @Test
+    fun getIntimatedAnnotations() {
+        val element = Data::property.toIntimateAnnotationElement()
+        assertThat(
+            element.intimatedAnnotations,
+            equalTo(linkedSetOf(MockAnnotation(), MockAnnotation(), MockAnnotation()))
+        )
+    }
+
+    @Test
+    fun getMergedAnnotations() {
+        val element = Data::fieldProperty.toIntimateAnnotationElement()
+        assertThat(
+            element.mergedAnnotations,
+            equalTo(linkedSetOf(MockAnnotation(), OnMessage(FunctionKind.EVENT, "hi")))
+        )
+    }
+
+    @Test
+    fun getIntimatedAnnotationsRepeatable() {
+        val element = Data::repeatable.toIntimateAnnotationElement()
+        assertThat(element.intimatedAnnotations, equalTo(linkedSetOf(MockAnnotation(), MockAnnotation())))
+    }
+
+    @Test
+    fun getJvmIntimatedAnnotationsRepeatable() {
+        val element = Data::jvmRepeatable.toIntimateAnnotationElement()
+        assertThat(
+            element.intimatedAnnotations,
+            equalTo(
+                linkedSetOf(
+                    JvmRepeatableTags(
+                        value = arrayOf(
+                            JvmRepeatableTag(value = "tag1"),
+                            JvmRepeatableTag(value = "tag2")
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun getJvm2IntimatedAnnotationsRepeatable() {
+        val element = Data::jvmRepeatable2.toIntimateAnnotationElement()
+        assertThat(
+            element.intimatedAnnotations,
+            equalTo(
+                linkedSetOf(
+                    JvmRepeatableTags(
+                        value = arrayOf(
+                            JvmRepeatableTag(value = "tag3"),
+                            JvmRepeatableTag(value = "tag4")
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun getJvmClassIntimatedAnnotationsRepeatable() {
+        val element =
+            MockRepeatableClass::class.java.getDeclaredField("field").kotlinProperty!!.toIntimateAnnotationElement()
+        assertThat(
+            element.intimatedAnnotations,
+            equalTo(
+                linkedSetOf(
+                    JvmRepeatableTags(
+                        value = arrayOf(
+                            JvmRepeatableTag(value = "tag1"),
+                            JvmRepeatableTag(value = "tag2")
+                        )
+                    )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun getJvmClassIntimatedAnnotationsRepeatable2() {
+        val element =
+            MockRepeatableClass::class.java.getDeclaredField("field2").kotlinProperty!!.toIntimateAnnotationElement()
+        assertThat(
+            element.intimatedAnnotations,
+            equalTo(
+                linkedSetOf(
+                    JvmRepeatableTags(
+                        value = arrayOf(
+                            JvmRepeatableTag(value = "tag3"),
+                            JvmRepeatableTag(value = "tag4")
+                        )
+                    )
+                )
+            )
+        )
+    }
+}
+
+data class Data(
+    @MockAnnotation
+    @get:MockAnnotation
+    @field:MockAnnotation
+    val property: String,
+    @field:MockAnnotation
+    val fieldProperty: String,
+    @get:MockAnnotation
+    val getProperty: String,
+    @set:MockAnnotation
+    var setProperty: String,
+    @MockAnnotation
+    @MockAnnotation
+    val repeatable: String,
+    @field:JvmRepeatableTag("tag1")
+    @field:JvmRepeatableTag("tag2")
+    val jvmRepeatable: String,
+    @field:JvmRepeatableTags(
+        value = [
+            JvmRepeatableTag("tag3"),
+            JvmRepeatableTag("tag4")
+        ]
+    )
+    val jvmRepeatable2: String,
+    override val parentProperty: String,
+) : InterfaceAnnotation
+
+@Target(
+    AnnotationTarget.FIELD,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY_GETTER,
+    AnnotationTarget.PROPERTY_SETTER
+)
+@Repeatable
+@OnMessage(FunctionKind.EVENT, "hi")
+annotation class MockAnnotation
+
+interface InterfaceAnnotation {
+    @get:MockAnnotation
+    val parentProperty: String
+}

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/route/CommandRouteMetadataParserTest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/route/CommandRouteMetadataParserTest.kt
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.node.ObjectNode
 import me.ahoo.wow.api.annotation.CommandRoute
 import me.ahoo.wow.api.command.DefaultDeleteAggregate
+import me.ahoo.wow.infra.reflection.IntimateAnnotationElement.Companion.toIntimateAnnotationElement
 import me.ahoo.wow.openapi.Https
 import me.ahoo.wow.openapi.metadata.commandRouteMetadata
 import me.ahoo.wow.serialization.JsonSerializer
@@ -160,6 +161,7 @@ class CommandRouteMetadataParserTest {
 
     @Test
     fun decodeFieldNested() {
+        NestedFieldMockCommandRoute::customer.toIntimateAnnotationElement()
         val commandRouteMetadata = commandRouteMetadata<NestedFieldMockCommandRoute>()
         assertThat(commandRouteMetadata.action, equalTo("{customerId}/{id}/{name}"))
         val customerIdPathVariable =


### PR DESCRIPTION
- Introduce IntimateAnnotationElement class to encapsulate annotation scanning logic
- Refactor AnnotationScanner to use the new IntimateAnnotationElement
- Add support for repeatable annotations in Java
- Improve performance by caching IntimateAnnotationElement instances
- Remove redundant tests and simplify existing ones
