### PR TITLE
refactor(wow-openapi): adjust media types for query responses and route acceptance

### DIFF
--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/QueryComponent.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/QueryComponent.kt
@@ -84,7 +84,7 @@ object QueryComponent {
         fun OpenAPIComponentContext.countQueryResponse(): io.swagger.v3.oas.models.responses.ApiResponse {
             return response(COUNT_QUERY_KEY) {
                 withErrorCodeHeader(this@countQueryResponse)
-                content(Https.MediaType.TEXT_PLAIN, schema = schema(Long::class.java))
+                content(Https.MediaType.APPLICATION_JSON, schema = schema(Long::class.java))
             }
         }
 

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RouteSpec.kt
@@ -35,7 +35,7 @@ interface RouteSpec : Identifier, SummaryCapable, DescriptionCapable {
     val tags: List<String>
         get() = listOf(Wow.WOW)
     val accept: List<String>
-        get() = listOf(Https.MediaType.APPLICATION_JSON, Https.MediaType.TEXT_PLAIN)
+        get() = listOf(Https.MediaType.APPLICATION_JSON)
     val parameters: List<Parameter>
     val requestBody: RequestBody?
         get() = null

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RouteSpec.kt
@@ -35,7 +35,7 @@ interface RouteSpec : Identifier, SummaryCapable, DescriptionCapable {
     val tags: List<String>
         get() = listOf(Wow.WOW)
     val accept: List<String>
-        get() = listOf(Https.MediaType.APPLICATION_JSON)
+        get() = listOf(Https.MediaType.APPLICATION_JSON, Https.MediaType.TEXT_PLAIN)
     val parameters: List<Parameter>
     val requestBody: RequestBody?
         get() = null


### PR DESCRIPTION
- Change countQueryResponse media type from TEXT_PLAIN to APPLICATION_JSON
- Add TEXT_PLAIN to accepted media types in RouteSpec

