### PR TITLE
feat(command): add support for blocking command builder rewriter

### DIFF
--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/factory/BlockingCommandBuilderRewriterTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/factory/BlockingCommandBuilderRewriterTest.kt
@@ -1,5 +1,6 @@
 package me.ahoo.wow.command.factory
 
+import me.ahoo.wow.api.annotation.Blocking
 import me.ahoo.wow.command.MockCreateCommand
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Mono
@@ -21,11 +22,10 @@ class BlockingCommandBuilderRewriterTest {
 }
 
 class MockBlockingCommandBuilderRewriter : CommandBuilderRewriter {
-    override val blocked: Boolean
-        get() = true
     override val supportedCommandType: Class<MockCreateCommand>
         get() = MockCreateCommand::class.java
 
+    @Blocking
     override fun rewrite(commandBuilder: CommandBuilder): Mono<CommandBuilder> {
         check(!Schedulers.isInNonBlockingThread())
         return Mono.empty()

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/factory/BlockingCommandBuilderRewriterTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/factory/BlockingCommandBuilderRewriterTest.kt
@@ -1,0 +1,33 @@
+package me.ahoo.wow.command.factory
+
+import me.ahoo.wow.command.MockCreateCommand
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
+import reactor.kotlin.test.test
+
+class BlockingCommandBuilderRewriterTest {
+
+    @Test
+    fun rewrite() {
+        val commandBuilder = MutableCommandBuilder(Any())
+        val commandBuilderRewriter = BlockingCommandBuilderRewriter(
+            MockBlockingCommandBuilderRewriter()
+        )
+        commandBuilderRewriter.rewrite(commandBuilder)
+            .test()
+            .verifyComplete()
+    }
+}
+
+class MockBlockingCommandBuilderRewriter : CommandBuilderRewriter {
+    override val blocked: Boolean
+        get() = true
+    override val supportedCommandType: Class<MockCreateCommand>
+        get() = MockCreateCommand::class.java
+
+    override fun rewrite(commandBuilder: CommandBuilder): Mono<CommandBuilder> {
+        check(!Schedulers.isInNonBlockingThread())
+        return Mono.empty()
+    }
+}

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/factory/SimpleCommandBuilderRewriterRegistryTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/factory/SimpleCommandBuilderRewriterRegistryTest.kt
@@ -22,9 +22,34 @@ class SimpleCommandBuilderRewriterRegistryTest {
             nullValue()
         )
     }
+
+    @Test
+    fun registerBlocked() {
+        val registry = SimpleCommandBuilderRewriterRegistry()
+        registry.register(MockBlockedCommandBuilderRewriter())
+        assertThat(
+            registry.getRewriter(MockCreateCommand::class.java),
+            instanceOf(BlockingCommandBuilderRewriter::class.java)
+        )
+        assertThat(
+            (registry.getRewriter(MockCreateCommand::class.java) as BlockingCommandBuilderRewriter).delegate,
+            instanceOf(MockBlockedCommandBuilderRewriter::class.java)
+        )
+    }
 }
 
 class MockCommandBuilderRewriter : CommandBuilderRewriter {
+    override val supportedCommandType: Class<MockCreateCommand>
+        get() = MockCreateCommand::class.java
+
+    override fun rewrite(commandBuilder: CommandBuilder): Mono<CommandBuilder> {
+        return Mono.just(commandBuilder)
+    }
+}
+
+class MockBlockedCommandBuilderRewriter : CommandBuilderRewriter {
+    override val blocked: Boolean
+        get() = true
     override val supportedCommandType: Class<MockCreateCommand>
         get() = MockCreateCommand::class.java
 

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/factory/SimpleCommandBuilderRewriterRegistryTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/factory/SimpleCommandBuilderRewriterRegistryTest.kt
@@ -26,30 +26,19 @@ class SimpleCommandBuilderRewriterRegistryTest {
     @Test
     fun registerBlocked() {
         val registry = SimpleCommandBuilderRewriterRegistry()
-        registry.register(MockBlockedCommandBuilderRewriter())
+        registry.register(MockBlockingCommandBuilderRewriter())
         assertThat(
             registry.getRewriter(MockCreateCommand::class.java),
             instanceOf(BlockingCommandBuilderRewriter::class.java)
         )
         assertThat(
             (registry.getRewriter(MockCreateCommand::class.java) as BlockingCommandBuilderRewriter).delegate,
-            instanceOf(MockBlockedCommandBuilderRewriter::class.java)
+            instanceOf(MockBlockingCommandBuilderRewriter::class.java)
         )
     }
 }
 
 class MockCommandBuilderRewriter : CommandBuilderRewriter {
-    override val supportedCommandType: Class<MockCreateCommand>
-        get() = MockCreateCommand::class.java
-
-    override fun rewrite(commandBuilder: CommandBuilder): Mono<CommandBuilder> {
-        return Mono.just(commandBuilder)
-    }
-}
-
-class MockBlockedCommandBuilderRewriter : CommandBuilderRewriter {
-    override val blocked: Boolean
-        get() = true
     override val supportedCommandType: Class<MockCreateCommand>
         get() = MockCreateCommand::class.java
 

--- a/wow-core/src/test/kotlin/me/ahoo/wow/reactor/SchedulerTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/reactor/SchedulerTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.reactor
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
+
+class SchedulerTest {
+    companion object {
+        private val log = KotlinLogging.logger { }
+    }
+
+    @Test
+    fun test() {
+        val firstScheduler = Schedulers.newSingle("firstScheduler")
+        val secondScheduler = Schedulers.newSingle("secondScheduler")
+        val thirdScheduler = Schedulers.newSingle("thirdScheduler")
+        val fourthScheduler = Schedulers.newSingle("fourthScheduler")
+        Flux.fromIterable(listOf(1, 2, 3, 4, 5))
+            .publishOn(firstScheduler)
+            .doOnSubscribe {
+                log.info { "subscribe" } // fourthScheduler
+            }
+            .doOnNext {
+                log.info { "<1> $it" } // firstScheduler
+            }
+            .publishOn(secondScheduler)
+            .doOnNext {
+                log.info { "<2> $it" } // secondScheduler
+            }
+            .flatMap {
+                Mono.fromCallable {
+                    log.info { "<3> $it" } // thirdScheduler
+                    it * 2
+                }.publishOn(thirdScheduler)
+            }
+            .doOnNext {
+                log.info { "<4> $it" } // thirdScheduler
+            }
+            .subscribeOn(fourthScheduler)
+            .blockLast()
+    }
+}


### PR DESCRIPTION
- Introduce BlockingCommandBuilderRewriter to handle blocking operations
- Update CommandBuilderRewriter interface to include blocked property
- Modify CommandBuilderRewriterRegistry to support registration of blocking rewriters
- Add test case for registering blocked command builder rewriter

