### PR TITLE
feat(schema): integrate Kotlin support into JSON schema generation

### DIFF
--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/JsonSchemaGenerator.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/JsonSchemaGenerator.kt
@@ -24,6 +24,7 @@ import com.github.victools.jsonschema.module.jackson.JacksonModule
 import com.github.victools.jsonschema.module.jackson.JacksonOption
 import com.github.victools.jsonschema.module.jakarta.validation.JakartaValidationModule
 import com.github.victools.jsonschema.module.swagger2.Swagger2Module
+import me.ahoo.wow.schema.kotlin.KotlinModule
 import me.ahoo.wow.serialization.JsonSerializer
 import java.lang.reflect.Type
 
@@ -34,6 +35,7 @@ class JsonSchemaGenerator(private val options: Set<WowOption> = WowOption.ALL) {
         val jacksonModule: Module = JacksonModule(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED)
         val jakartaModule = JakartaValidationModule()
         val openApiModule: Module = Swagger2Module()
+        val kotlinModule = KotlinModule()
         val wowModule = WowModule(options)
         val schemaGeneratorConfigBuilder = SchemaGeneratorConfigBuilder(
             JsonSerializer,
@@ -43,6 +45,7 @@ class JsonSchemaGenerator(private val options: Set<WowOption> = WowOption.ALL) {
             .with(jakartaModule)
             .with(openApiModule)
             .with(wowModule)
+            .with(kotlinModule)
             .with(Option.EXTRA_OPEN_API_FORMAT_VALUES)
         schemaGenerator = SchemaGenerator(schemaGeneratorConfigBuilder.build())
     }

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowModule.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowModule.kt
@@ -20,11 +20,6 @@ import com.github.victools.jsonschema.generator.SchemaGeneratorConfigPart
 import com.github.victools.jsonschema.generator.SchemaGeneratorGeneralConfigPart
 import me.ahoo.wow.schema.joda.money.CurrencyUnitDefinitionProvider
 import me.ahoo.wow.schema.joda.money.MoneyDefinitionProvider
-import me.ahoo.wow.schema.kotlin.KotlinCustomDefinitionProvider
-import me.ahoo.wow.schema.kotlin.KotlinNullableCheck
-import me.ahoo.wow.schema.kotlin.KotlinReadOnlyCheck
-import me.ahoo.wow.schema.kotlin.KotlinRequiredCheck
-import me.ahoo.wow.schema.kotlin.KotlinWriteOnlyCheck
 import me.ahoo.wow.schema.typed.AggregateIdDefinitionProvider
 import me.ahoo.wow.schema.typed.AggregatedDomainEventStreamDefinitionProvider
 import me.ahoo.wow.schema.typed.CommandDefinitionProvider
@@ -41,7 +36,6 @@ class WowModule(private val options: Set<WowOption> = WowOption.ALL) : Module {
         fieldConfigPart.withDescriptionResolver(DescriptionResolver)
         ignoreCommandRouteVariable(fieldConfigPart)
         val generalConfigPart = builder.forTypesInGeneral()
-        kotlinNullable(fieldConfigPart, generalConfigPart)
         generalConfigPart.withCustomDefinitionProvider(AggregateIdDefinitionProvider)
         generalConfigPart.withCustomDefinitionProvider(CommandDefinitionProvider)
         generalConfigPart.withCustomDefinitionProvider(DomainEventDefinitionProvider)
@@ -60,20 +54,6 @@ class WowModule(private val options: Set<WowOption> = WowOption.ALL) : Module {
         }
 
         configPart.withIgnoreCheck(IgnoreCommandRouteVariableCheck)
-    }
-
-    private fun kotlinNullable(
-        fieldConfigPart: SchemaGeneratorConfigPart<FieldScope>,
-        generalConfigPart: SchemaGeneratorGeneralConfigPart
-    ) {
-        if (options.contains(WowOption.KOTLIN).not()) {
-            return
-        }
-        fieldConfigPart.withNullableCheck(KotlinNullableCheck)
-        fieldConfigPart.withReadOnlyCheck(KotlinReadOnlyCheck)
-        fieldConfigPart.withRequiredCheck(KotlinRequiredCheck)
-        fieldConfigPart.withWriteOnlyCheck(KotlinWriteOnlyCheck)
-        generalConfigPart.withCustomDefinitionProvider(KotlinCustomDefinitionProvider)
     }
 
     private fun wowNamingStrategy(generalConfigPart: SchemaGeneratorGeneralConfigPart) {

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/kotlin/KotlinIgnoreCheck.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/kotlin/KotlinIgnoreCheck.kt
@@ -11,19 +11,13 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.schema
+package me.ahoo.wow.schema.kotlin
 
-enum class WowOption {
-    /**
-     *
-     * @see me.ahoo.wow.api.annotation.CommandRoute.PathVariable
-     * @see me.ahoo.wow.api.annotation.CommandRoute.HeaderVariable
-     */
-    IGNORE_COMMAND_ROUTE_VARIABLE,
-    WOW_NAMING_STRATEGY,
-    JODA_MONEY;
+import com.github.victools.jsonschema.generator.FieldScope
+import java.util.function.Predicate
 
-    companion object {
-        val ALL: Set<WowOption> = setOf(IGNORE_COMMAND_ROUTE_VARIABLE, WOW_NAMING_STRATEGY, JODA_MONEY)
+object KotlinIgnoreCheck : Predicate<FieldScope> {
+    override fun test(member: FieldScope): Boolean {
+        return member.rawMember.isSynthetic
     }
 }

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/kotlin/KotlinModule.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/kotlin/KotlinModule.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.schema.kotlin
+
+import com.github.victools.jsonschema.generator.Module
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder
+
+class KotlinModule : Module {
+    override fun applyToConfigBuilder(builder: SchemaGeneratorConfigBuilder) {
+        val fieldConfigPart = builder.forFields()
+        fieldConfigPart.withNullableCheck(KotlinNullableCheck)
+        fieldConfigPart.withReadOnlyCheck(KotlinReadOnlyCheck)
+        fieldConfigPart.withRequiredCheck(KotlinRequiredCheck)
+        fieldConfigPart.withWriteOnlyCheck(KotlinWriteOnlyCheck)
+        fieldConfigPart.withIgnoreCheck(KotlinIgnoreCheck)
+        val generalConfigPart = builder.forTypesInGeneral()
+        generalConfigPart.withCustomDefinitionProvider(KotlinCustomDefinitionProvider)
+    }
+}

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilder.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilder.kt
@@ -35,6 +35,7 @@ import io.swagger.v3.core.util.ObjectMapperFactory
 import io.swagger.v3.oas.models.media.Schema
 import me.ahoo.wow.schema.JsonSchema.Companion.toPropertyName
 import me.ahoo.wow.schema.WowModule
+import me.ahoo.wow.schema.kotlin.KotlinModule
 import me.ahoo.wow.schema.openapi.OpenAPISchemaBuilder.DefaultCustomizer.defaultConfig
 import java.lang.reflect.Type
 import java.util.function.Consumer
@@ -116,10 +117,12 @@ class OpenAPISchemaBuilder(
                 JakartaValidationOption.INCLUDE_PATTERN_EXPRESSIONS
             )
             val openApiModule: Module = Swagger2Module()
+            val kotlinModule = KotlinModule()
             val wowModule = WowModule()
             with(jacksonModule)
                 .with(jakartaModule)
                 .with(openApiModule)
+                .with(kotlinModule)
                 .with(wowModule)
                 .with(Option.PLAIN_DEFINITION_KEYS)
                 .with(Option.SIMPLIFIED_ENUMS)

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/JsonSchemaGeneratorTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/JsonSchemaGeneratorTest.kt
@@ -37,6 +37,7 @@ import me.ahoo.wow.modeling.DefaultAggregateId
 import me.ahoo.wow.modeling.state.SimpleStateAggregate
 import me.ahoo.wow.modeling.state.StateAggregate
 import me.ahoo.wow.schema.JsonSchema.Companion.asJsonSchema
+import me.ahoo.wow.schema.kotlin.KotlinModule
 import me.ahoo.wow.schema.typed.AggregatedDomainEventStream
 import me.ahoo.wow.serialization.JsonSerializer
 import me.ahoo.wow.tck.mock.MockStateAggregate
@@ -146,7 +147,7 @@ class JsonSchemaGeneratorTest {
         val jacksonModule: Module = JacksonModule(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED)
         val jakartaModule = JakartaValidationModule()
         val openApiModule: Module = Swagger2Module()
-        val wowModule = WowModule(setOf(WowOption.KOTLIN, WowOption.WOW_NAMING_STRATEGY))
+        val wowModule = WowModule(setOf(WowOption.WOW_NAMING_STRATEGY))
         val schemaGeneratorConfigBuilder = SchemaGeneratorConfigBuilder(
             JsonSerializer,
             SchemaVersion.DRAFT_2020_12,
@@ -155,6 +156,7 @@ class JsonSchemaGeneratorTest {
             .with(jakartaModule)
             .with(openApiModule)
             .with(wowModule)
+            .with(KotlinModule())
             .with(Option.EXTRA_OPEN_API_FORMAT_VALUES)
             .with(Option.DEFINITIONS_FOR_ALL_OBJECTS)
             .with(Option.PLAIN_DEFINITION_KEYS)
@@ -205,17 +207,8 @@ class JsonSchemaGeneratorTest {
 
     @Test
     fun javaType() {
-        val jsonSchemaGenerator = JsonSchemaGenerator(setOf(WowOption.KOTLIN))
+        val jsonSchemaGenerator = JsonSchemaGenerator()
         jsonSchemaGenerator.generate(CosIdGeneratorStat::class.java)
-    }
-
-    @Test
-    fun kotlin_ignore() {
-        val jsonSchemaGenerator = JsonSchemaGenerator(setOf())
-        val schema = jsonSchemaGenerator.generate(KotlinData::class.java)
-        val type = schema.get("properties").get("nullableField").get("type")
-        assertThat(type.isArray, equalTo(false))
-        assertThat(type.textValue(), equalTo("string"))
     }
 
     @Test

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/JsonSchemaValidatorTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/JsonSchemaValidatorTest.kt
@@ -124,10 +124,10 @@ class JsonSchemaValidatorTest {
                 Arguments.of(
                     typeResolver.resolve(StateEvent::class.java, OrderState::class.java),
                     StateEventData(
-                        MockDomainEventStreams.generateEventStream(
+                        delegate = MockDomainEventStreams.generateEventStream(
                             MOCK_AGGREGATE_METADATA.aggregateId()
                         ),
-                        stateAggregate
+                        state = stateAggregate.state
                     )
                 )
             )


### PR DESCRIPTION
- Add KotlinModule to handle Kotlin-specific schema generation
- Introduce KotlinIgnoreCheck to filter out synthetic fields
- Update JsonSchemaGenerator and OpenAPISchemaBuilder to include KotlinModule
- Remove redundant Kotlin-related code from WowModule
- Adjust unit tests to reflect new Kotlin integration

