### PR TITLE
refactor(command): use extension functions for default ID handling

### DIFF
--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/TenantId.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/TenantId.kt
@@ -18,5 +18,8 @@ interface TenantId {
 
     companion object {
         const val DEFAULT_TENANT_ID = "(0)"
+        fun String?.orDefaultTenantId(): String {
+            return this ?: DEFAULT_TENANT_ID
+        }
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandFactory.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandFactory.kt
@@ -18,8 +18,8 @@ import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.event.DomainEvent
 import me.ahoo.wow.api.messaging.Header
 import me.ahoo.wow.api.modeling.NamedAggregate
-import me.ahoo.wow.api.modeling.OwnerId
-import me.ahoo.wow.api.modeling.TenantId
+import me.ahoo.wow.api.modeling.OwnerId.Companion.orDefaultOwnerId
+import me.ahoo.wow.api.modeling.TenantId.Companion.orDefaultTenantId
 import me.ahoo.wow.command.annotation.commandMetadata
 import me.ahoo.wow.command.factory.CommandBuilder
 import me.ahoo.wow.id.generateGlobalId
@@ -51,8 +51,8 @@ fun <C : Any> C.toCommandMessage(
         "The command[$javaClass] must be associated with a named aggregate!"
     }
     val commandAggregateId = metadata.aggregateIdGetter?.get(this) ?: aggregateId ?: commandNamedAggregate.generateId()
-    val commandTenantId = metadata.tenantIdGetter?.get(this) ?: tenantId ?: TenantId.DEFAULT_TENANT_ID
-    val commandOwnerId = metadata.ownerIdGetter?.get(this) ?: ownerId ?: OwnerId.DEFAULT_OWNER_ID
+    val commandTenantId = metadata.tenantIdGetter?.get(this) ?: tenantId.orDefaultTenantId()
+    val commandOwnerId = metadata.ownerIdGetter?.get(this) ?: ownerId.orDefaultOwnerId()
     val targetAggregateId = commandNamedAggregate.aggregateId(id = commandAggregateId, tenantId = commandTenantId)
     val expectedAggregateVersion = if (metadata.isCreate) {
         Version.UNINITIALIZED_VERSION

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/CommandFactoryTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/CommandFactoryTest.kt
@@ -12,6 +12,8 @@
  */
 package me.ahoo.wow.command
 
+import me.ahoo.wow.api.modeling.OwnerId
+import me.ahoo.wow.api.modeling.TenantId
 import me.ahoo.wow.command.factory.CommandBuilder.Companion.commandBuilder
 import me.ahoo.wow.id.generateGlobalId
 import org.hamcrest.MatcherAssert.*
@@ -93,6 +95,26 @@ internal class CommandFactoryTest {
         val commandMessage = command.toCommandMessage()
         assertThat(commandMessage.body, equalTo(command))
         assertThat(commandMessage.name, equalTo(NAMED_COMMAND))
+        assertThat(commandMessage.aggregateId.tenantId, equalTo(TenantId.DEFAULT_TENANT_ID))
+        assertThat(commandMessage.ownerId, equalTo(OwnerId.DEFAULT_OWNER_ID))
+        assertThat(commandMessage.aggregateId.id, equalTo(command.id))
+        assertThat(commandMessage.aggregateVersion, nullValue())
+        assertThat(
+            commandMessage.createTime.toDouble(),
+            closeTo(System.currentTimeMillis().toDouble(), 5000.toDouble())
+        )
+    }
+
+    @Test
+    fun createGivenTenantIdAndOwnerId() {
+        val command = MockNamedCommand(generateGlobalId())
+        val tenantId = "tenantId"
+        val ownerId = "ownerId"
+        val commandMessage = command.toCommandMessage(tenantId = tenantId, ownerId = ownerId)
+        assertThat(commandMessage.body, equalTo(command))
+        assertThat(commandMessage.name, equalTo(NAMED_COMMAND))
+        assertThat(commandMessage.aggregateId.tenantId, equalTo(tenantId))
+        assertThat(commandMessage.ownerId, equalTo(ownerId))
         assertThat(commandMessage.aggregateId.id, equalTo(command.id))
         assertThat(commandMessage.aggregateVersion, nullValue())
         assertThat(

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/CommandFactoryTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/CommandFactoryTest.kt
@@ -16,6 +16,7 @@ import me.ahoo.wow.command.factory.CommandBuilder.Companion.commandBuilder
 import me.ahoo.wow.id.generateGlobalId
 import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 internal class CommandFactoryTest {
@@ -114,5 +115,16 @@ internal class CommandFactoryTest {
         val commandMessage = command.toCommandMessage()
         assertThat(commandMessage.aggregateId.id, equalTo(command.id))
         assertThat(commandMessage.ownerId, equalTo(command.ownerId))
+    }
+
+    @Test
+    fun anyCommand() {
+        Assertions.assertThrows(
+            IllegalArgumentException::class.java,
+            {
+                Any().toCommandMessage()
+            },
+            "The command[${Any().javaClass}] must be associated with a named aggregate!"
+        )
     }
 }


### PR DESCRIPTION
- Replace direct default ID usage with new extension functions
- Add orDefaultTenantId() function to TenantId companion object
- Use orDefaultOwnerId() function from OwnerId companion object
- Improve code readability and reduce repetition

