### PR TITLE
test: replace Hamcrest with AssertJ for unit testing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -120,6 +120,7 @@ configure(libraryProjects) {
         testImplementation("ch.qos.logback:logback-classic")
         testImplementation("org.junit.jupiter:junit-jupiter-api")
         testImplementation("org.junit.jupiter:junit-jupiter-params")
+        testImplementation("org.assertj:assertj-core")
         testImplementation("org.hamcrest:hamcrest")
         testImplementation("io.mockk:mockk") {
             exclude(group = "org.slf4j", module = "slf4j-api")

--- a/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSagaTest.kt
+++ b/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSagaTest.kt
@@ -7,8 +7,7 @@ import me.ahoo.wow.example.api.order.OrderCreated
 import me.ahoo.wow.example.api.order.OrderItem
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.test.SagaVerifier.sagaVerifier
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 
@@ -36,9 +35,9 @@ class CartSagaTest {
                 ownerId = ownerId
             )
             .expectCommand<RemoveCartItem> {
-                assertThat(it.aggregateId.id, equalTo(ownerId))
-                assertThat(it.body.productIds, hasSize(1))
-                assertThat(it.body.productIds.first(), equalTo(orderItem.productId))
+                assertThat(it.aggregateId.id).isEqualTo(ownerId)
+                assertThat(it.body.productIds).hasSize(1)
+                assertThat(it.body.productIds).first().isEqualTo(orderItem.productId)
             }
             .verify()
     }

--- a/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartTest.kt
+++ b/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartTest.kt
@@ -28,8 +28,7 @@ import me.ahoo.wow.modeling.command.IllegalAccessDeletedAggregateException
 import me.ahoo.wow.test.aggregate.`when`
 import me.ahoo.wow.test.aggregate.whenCommand
 import me.ahoo.wow.test.aggregateVerifier
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 class CartTest {
@@ -48,9 +47,9 @@ class CartTest {
             .expectNoError()
             .expectEventType(CartItemAdded::class.java)
             .expectState {
-                assertThat(it.items, hasSize(1))
+                assertThat(it.items).hasSize(1)
             }.expectStateAggregate {
-                assertThat(it.ownerId, equalTo(ownerId))
+                assertThat(it.ownerId).isEqualTo(ownerId)
             }
             .verify()
     }
@@ -68,7 +67,7 @@ class CartTest {
             .expectNoError()
             .expectEventType(CartItemAdded::class.java)
             .expectState {
-                assertThat(it.items, hasSize(1))
+                assertThat(it.items).hasSize(1)
             }
             .verify()
     }
@@ -93,7 +92,8 @@ class CartTest {
             .expectNoError()
             .expectEventType(CartQuantityChanged::class.java)
             .expectState {
-                assertThat(it.items.first().quantity, equalTo(2))
+                assertThat(it.items).hasSize(1)
+                assertThat(it.items.first().quantity).isEqualTo(2)
             }
             .verify()
     }
@@ -110,10 +110,10 @@ class CartTest {
             .expectNoError()
             .expectEventType(CartItemAdded::class.java)
             .expectState {
-                assertThat(it.items, hasSize(1))
+                assertThat(it.items).hasSize(1)
             }
             .expectStateAggregate {
-                assertThat(it.version, equalTo(1))
+                assertThat(it.version).isEqualTo(1)
             }
             .verify()
     }
@@ -142,7 +142,7 @@ class CartTest {
             .`when`(addCartItem)
             .expectErrorType(IllegalArgumentException::class.java)
             .expectState {
-                assertThat(it.items, hasSize(MAX_CART_ITEM_SIZE))
+                assertThat(it.items).hasSize(MAX_CART_ITEM_SIZE)
             }
             .verify()
     }
@@ -166,7 +166,7 @@ class CartTest {
             .`when`(removeCartItem)
             .expectEventType(CartItemRemoved::class.java)
             .expectState {
-                assertThat(it.items, hasSize(0))
+                assertThat(it.items).isEmpty()
             }
             .verify()
     }
@@ -190,8 +190,8 @@ class CartTest {
             .`when`(changeQuantity)
             .expectEventType(CartQuantityChanged::class.java)
             .expectState {
-                assertThat(it.items, hasSize(1))
-                assertThat(it.items.first().quantity, equalTo(changeQuantity.quantity))
+                assertThat(it.items).hasSize(1)
+                assertThat(it.items.first().quantity).isEqualTo(changeQuantity.quantity)
             }
             .verify()
     }
@@ -208,14 +208,14 @@ class CartTest {
             .expectNoError()
             .expectEventType(CartItemAdded::class.java)
             .expectState {
-                assertThat(it.items, hasSize(1))
+                assertThat(it.items).hasSize(1)
             }
             .verify()
             .then()
             .whenCommand(DefaultDeleteAggregate)
             .expectEventType(DefaultAggregateDeleted::class.java)
             .expectStateAggregate {
-                assertThat(it.deleted, equalTo(true))
+                assertThat(it.deleted).isTrue()
             }.verify()
             .then()
             .whenCommand(DefaultDeleteAggregate::class.java)
@@ -224,7 +224,7 @@ class CartTest {
             .then()
             .whenCommand(DefaultRecoverAggregate)
             .expectStateAggregate {
-                assertThat(it.deleted, equalTo(false))
+                assertThat(it.deleted).isFalse()
             }.verify()
             .then()
             .whenCommand(DefaultRecoverAggregate)

--- a/example/transfer/example-transfer-domain/src/test/kotlin/me/ahoo/wow/example/transfer/domain/AccountKTest.kt
+++ b/example/transfer/example-transfer-domain/src/test/kotlin/me/ahoo/wow/example/transfer/domain/AccountKTest.kt
@@ -31,8 +31,7 @@ import me.ahoo.wow.example.transfer.api.UnfreezeAccount
 import me.ahoo.wow.example.transfer.api.UnlockAmount
 import me.ahoo.wow.id.GlobalIdGenerator
 import me.ahoo.wow.test.aggregateVerifier
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 internal class AccountKTest {
@@ -43,8 +42,8 @@ internal class AccountKTest {
             .`when`(CreateAccount("name", 100))
             .expectEventType(AccountCreated::class.java)
             .expectState {
-                assertThat(it.name, equalTo("name"))
-                assertThat(it.balanceAmount, equalTo(100))
+                assertThat(it.name).isEqualTo("name")
+                assertThat(it.balanceAmount).isEqualTo(100)
             }
             .verify()
     }
@@ -56,8 +55,8 @@ internal class AccountKTest {
             .`when`(Prepare("name", 100))
             .expectEventType(AmountLocked::class.java, Prepared::class.java)
             .expectState {
-                assertThat(it.name, equalTo("name"))
-                assertThat(it.balanceAmount, equalTo(0))
+                assertThat(it.name).isEqualTo("name")
+                assertThat(it.balanceAmount).isEqualTo(0)
             }
             .verify()
     }
@@ -68,12 +67,12 @@ internal class AccountKTest {
             .given(AccountCreated("name", 100), AccountFrozen(""))
             .`when`(Prepare("name", 100))
             .expectError<IllegalStateException> {
-                assertThat(it.message, equalTo("账号已冻结无法转账."))
+                assertThat(it).hasMessage("账号已冻结无法转账.")
             }
             .expectState {
-                assertThat(it.name, equalTo("name"))
-                assertThat(it.balanceAmount, equalTo(100))
-                assertThat(it.isFrozen, equalTo(true))
+                assertThat(it.name).isEqualTo("name")
+                assertThat(it.balanceAmount).isEqualTo(100)
+                assertThat(it.isFrozen).isTrue()
             }
             .verify()
     }
@@ -84,11 +83,11 @@ internal class AccountKTest {
             .given(AccountCreated("name", 100))
             .`when`(Prepare("name", 200))
             .expectError<IllegalStateException> {
-                assertThat(it.message, equalTo("账号余额不足."))
+                assertThat(it).hasMessage("账号余额不足.")
             }
             .expectState {
-                assertThat(it.name, equalTo("name"))
-                assertThat(it.balanceAmount, equalTo(100))
+                assertThat(it.name).isEqualTo("name")
+                assertThat(it.balanceAmount).isEqualTo(100)
             }
             .verify()
     }
@@ -101,8 +100,8 @@ internal class AccountKTest {
             .`when`(Entry(aggregateId, "sourceId", 100))
             .expectEventType(AmountEntered::class.java)
             .expectState {
-                assertThat(it.name, equalTo("name"))
-                assertThat(it.balanceAmount, equalTo(200))
+                assertThat(it.name).isEqualTo("name")
+                assertThat(it.balanceAmount).isEqualTo(200)
             }
             .verify()
     }
@@ -115,9 +114,9 @@ internal class AccountKTest {
             .`when`(Entry(aggregateId, "sourceId", 100))
             .expectEventType(EntryFailed::class.java)
             .expectState {
-                assertThat(it.name, equalTo("name"))
-                assertThat(it.balanceAmount, equalTo(100))
-                assertThat(it.isFrozen, equalTo(true))
+                assertThat(it.name).isEqualTo("name")
+                assertThat(it.balanceAmount).isEqualTo(100)
+                assertThat(it.isFrozen).isTrue()
             }
             .verify()
     }
@@ -130,10 +129,10 @@ internal class AccountKTest {
             .`when`(Confirm(aggregateId, 100))
             .expectEventType(Confirmed::class.java)
             .expectState {
-                assertThat(it.name, equalTo("name"))
-                assertThat(it.balanceAmount, equalTo(0))
-                assertThat(it.lockedAmount, equalTo(0))
-                assertThat(it.isFrozen, equalTo(false))
+                assertThat(it.name).isEqualTo("name")
+                assertThat(it.balanceAmount).isEqualTo(0)
+                assertThat(it.lockedAmount).isEqualTo(0)
+                assertThat(it.isFrozen).isFalse()
             }
             .verify()
     }
@@ -146,10 +145,10 @@ internal class AccountKTest {
             .`when`(UnlockAmount(aggregateId, 100))
             .expectEventType(AmountUnlocked::class.java)
             .expectState {
-                assertThat(it.name, equalTo("name"))
-                assertThat(it.balanceAmount, equalTo(100))
-                assertThat(it.lockedAmount, equalTo(0))
-                assertThat(it.isFrozen, equalTo(false))
+                assertThat(it.name).isEqualTo("name")
+                assertThat(it.balanceAmount).isEqualTo(100)
+                assertThat(it.lockedAmount).isEqualTo(0)
+                assertThat(it.isFrozen).isFalse()
             }
             .verify()
     }
@@ -162,10 +161,10 @@ internal class AccountKTest {
             .`when`(FreezeAccount(""))
             .expectEventType(AccountFrozen::class.java)
             .expectState {
-                assertThat(it.name, equalTo("name"))
-                assertThat(it.balanceAmount, equalTo(100))
-                assertThat(it.lockedAmount, equalTo(0))
-                assertThat(it.isFrozen, equalTo(true))
+                assertThat(it.name).isEqualTo("name")
+                assertThat(it.balanceAmount).isEqualTo(100)
+                assertThat(it.lockedAmount).isEqualTo(0)
+                assertThat(it.isFrozen).isTrue()
             }
             .verify()
     }
@@ -177,13 +176,13 @@ internal class AccountKTest {
             .given(AccountCreated("name", 100), AccountFrozen(""))
             .`when`(FreezeAccount(""))
             .expectError<IllegalStateException> {
-                assertThat(it.message, equalTo("账号已冻结无需再次冻结."))
+                assertThat(it).hasMessage("账号已冻结无需再次冻结.")
             }
             .expectState {
-                assertThat(it.name, equalTo("name"))
-                assertThat(it.balanceAmount, equalTo(100))
-                assertThat(it.lockedAmount, equalTo(0))
-                assertThat(it.isFrozen, equalTo(true))
+                assertThat(it.name).isEqualTo("name")
+                assertThat(it.balanceAmount).isEqualTo(100)
+                assertThat(it.lockedAmount).isEqualTo(0)
+                assertThat(it.isFrozen).isTrue()
             }
             .verify()
     }
@@ -195,10 +194,10 @@ internal class AccountKTest {
             .given(AccountCreated("name", 100), AccountFrozen(""))
             .`when`(UnfreezeAccount(""))
             .expectState {
-                assertThat(it.name, equalTo("name"))
-                assertThat(it.balanceAmount, equalTo(100))
-                assertThat(it.lockedAmount, equalTo(0))
-                assertThat(it.isFrozen, equalTo(false))
+                assertThat(it.name).isEqualTo("name")
+                assertThat(it.balanceAmount).isEqualTo(100)
+                assertThat(it.lockedAmount).isEqualTo(0)
+                assertThat(it.isFrozen).isFalse()
             }
             .verify()
     }
@@ -210,10 +209,10 @@ internal class AccountKTest {
             .given(AccountCreated("name", 100), AccountUnfrozen(""))
             .`when`(UnfreezeAccount(""))
             .expectState {
-                assertThat(it.name, equalTo("name"))
-                assertThat(it.balanceAmount, equalTo(100))
-                assertThat(it.lockedAmount, equalTo(0))
-                assertThat(it.isFrozen, equalTo(false))
+                assertThat(it.name).isEqualTo("name")
+                assertThat(it.balanceAmount).isEqualTo(100)
+                assertThat(it.lockedAmount).isEqualTo(0)
+                assertThat(it.isFrozen).isFalse()
             }
             .verify()
     }
@@ -226,10 +225,10 @@ internal class AccountKTest {
             .`when`(LockAmount(10))
             .expectEventType(AmountLocked::class.java)
             .expectState {
-                assertThat(it.name, equalTo("name"))
-                assertThat(it.balanceAmount, equalTo(90L))
-                assertThat(it.lockedAmount, equalTo(10L))
-                assertThat(it.isFrozen, equalTo(false))
+                assertThat(it.name).isEqualTo("name")
+                assertThat(it.balanceAmount).isEqualTo(90)
+                assertThat(it.lockedAmount).isEqualTo(10)
+                assertThat(it.isFrozen).isFalse()
             }
             .verify()
     }

--- a/example/transfer/example-transfer-domain/src/test/kotlin/me/ahoo/wow/example/transfer/domain/TransferSagaKTest.kt
+++ b/example/transfer/example-transfer-domain/src/test/kotlin/me/ahoo/wow/example/transfer/domain/TransferSagaKTest.kt
@@ -20,8 +20,7 @@ import me.ahoo.wow.example.transfer.api.EntryFailed
 import me.ahoo.wow.example.transfer.api.Prepared
 import me.ahoo.wow.example.transfer.api.UnlockAmount
 import me.ahoo.wow.test.SagaVerifier.sagaVerifier
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
 internal class TransferSagaKTest {
@@ -32,8 +31,8 @@ internal class TransferSagaKTest {
         sagaVerifier<TransferSaga>()
             .`when`(event)
             .expectCommandBody<Entry> {
-                assertThat(it.id, equalTo(event.to))
-                assertThat(it.amount, equalTo(event.amount))
+                assertThat(it.id).isEqualTo(event.to)
+                assertThat(it.amount).isEqualTo(event.amount)
             }
             .verify()
     }
@@ -44,8 +43,8 @@ internal class TransferSagaKTest {
         sagaVerifier<TransferSaga>()
             .`when`(event)
             .expectCommandBody<Confirm> {
-                assertThat(it.id, equalTo(event.sourceId))
-                assertThat(it.amount, equalTo(event.amount))
+                assertThat(it.id).isEqualTo(event.sourceId)
+                assertThat(it.amount).isEqualTo(event.amount)
             }
             .verify()
     }
@@ -56,8 +55,8 @@ internal class TransferSagaKTest {
         sagaVerifier<TransferSaga>()
             .`when`(event)
             .expectCommandBody<UnlockAmount> {
-                assertThat(it.id, equalTo(event.sourceId))
-                assertThat(it.amount, equalTo(event.amount))
+                assertThat(it.id).isEqualTo(event.sourceId)
+                assertThat(it.amount).isEqualTo(event.amount)
             }
             .verify()
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ jte = "3.2.0"
 jsonschema-generator = "4.38.0"
 json-schema-validator = "1.5.6"
 # testing
+assertj = "3.27.3"
 hamcrest = "3.0"
 mockk = "1.14.0"
 kotlin-compile-testing = "0.7.0"
@@ -51,6 +52,7 @@ springdoc-openapi-starter-webflux-api = { module = "org.springdoc:springdoc-open
 springdoc-openapi-starter-webflux-ui = { module = "org.springdoc:springdoc-openapi-starter-webflux-ui", version.ref = "springdoc" }
 jte = { module = "gg.jte:jte", version.ref = "jte" }
 jte-kotlin = { module = "gg.jte:jte-kotlin", version.ref = "jte" }
+assertj-bom = { module = "org.assertj:assertj-bom", version.ref = "assertj" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }

--- a/test/wow-test/build.gradle.kts
+++ b/test/wow-test/build.gradle.kts
@@ -4,7 +4,7 @@ dependencies {
     api(project(":wow-core"))
     api("io.projectreactor:reactor-test")
     api("me.ahoo.cosid:cosid-test")
-    api("org.hamcrest:hamcrest")
+    api("org.assertj:assertj-core")
     api("org.hibernate.validator:hibernate-validator")
     implementation("org.junit.jupiter:junit-jupiter-api")
     implementation("com.fasterxml.jackson.core:jackson-databind")

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/DefaultAggregateVerifier.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/DefaultAggregateVerifier.kt
@@ -31,8 +31,7 @@ import me.ahoo.wow.serialization.deepCody
 import me.ahoo.wow.serialization.toJsonString
 import me.ahoo.wow.serialization.toObject
 import me.ahoo.wow.test.validation.validate
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
+import org.assertj.core.api.Assertions.assertThat
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.switchIfEmpty
 import reactor.kotlin.core.publisher.toMono
@@ -331,7 +330,7 @@ private fun <S : Any> verifyStateAggregateSerializable(stateAggregate: StateAggr
     }
     val serialized = stateAggregate.toJsonString()
     val deserialized = serialized.toObject<StateAggregate<S>>()
-    assertThat(deserialized, equalTo(stateAggregate))
+    assertThat(deserialized).isEqualTo(stateAggregate)
     return deserialized
 }
 

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/Stages.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/Stages.kt
@@ -20,8 +20,7 @@ import me.ahoo.wow.infra.Decorator
 import me.ahoo.wow.messaging.function.MessageFunction
 import me.ahoo.wow.naming.annotation.toName
 import me.ahoo.wow.saga.stateless.CommandStream
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
+import org.assertj.core.api.Assertions.assertThat
 import java.util.function.Consumer
 
 /**
@@ -63,7 +62,7 @@ interface ExpectStage<T : Any> {
 
     fun expectCommandStream(expected: Consumer<CommandStream>): ExpectStage<T> {
         return expectNoError().expect {
-            assertThat("Expect the command stream is not null.", it.commandStream, notNullValue())
+            assertThat(it.commandStream).describedAs { "Expect the command stream is not null." }.isNotNull
             expected.accept(it.commandStream!!)
         }
     }
@@ -87,7 +86,9 @@ interface ExpectStage<T : Any> {
      */
     fun <C : Any> expectCommand(expected: Consumer<CommandMessage<C>>): ExpectStage<T> {
         return expectCommandStream {
-            assertThat("Expect the command stream size to be greater than 1.", it.size, greaterThanOrEqualTo(1))
+            assertThat(
+                it
+            ).describedAs { "Expect the command stream size to be greater than 1." }.hasSizeGreaterThanOrEqualTo(1)
             @Suppress("UNCHECKED_CAST")
             expected.accept(it.first() as CommandMessage<C>)
         }
@@ -101,7 +102,7 @@ interface ExpectStage<T : Any> {
 
     fun expectCommandCount(expected: Int): ExpectStage<T> {
         return expectCommandStream {
-            assertThat("Expect the command stream size.", it.size, equalTo(expected))
+            assertThat(it).describedAs { "Expect the command stream size." }.hasSize(expected)
         }
     }
 
@@ -109,20 +110,20 @@ interface ExpectStage<T : Any> {
         return expectCommandCount(expected.size).expectCommandStream {
             val itr = it.iterator()
             for (eventType in expected) {
-                assertThat(itr.next().body, instanceOf(eventType))
+                assertThat(itr.next().body).isInstanceOf(eventType)
             }
         }
     }
 
     fun expectNoError(): ExpectStage<T> {
         return expect {
-            assertThat("Expect no error", it.error, nullValue())
+            assertThat(it.error).describedAs { "Expect no error." }.isNull()
         }
     }
 
     fun expectError(): ExpectStage<T> {
         return expect {
-            assertThat("Expect an error.", it.error, notNullValue())
+            assertThat(it.error).describedAs { "Expect an error." }.isNotNull()
         }
     }
 
@@ -134,7 +135,9 @@ interface ExpectStage<T : Any> {
     }
 
     fun <E : Throwable> expectErrorType(expected: Class<E>): ExpectStage<T> {
-        return expectError<E> { assertThat(it, instanceOf(expected)) }
+        return expectError<E> {
+            assertThat(it).isInstanceOf(expected)
+        }
     }
 
     /**
@@ -158,9 +161,9 @@ class CommandIterator(override val delegate: Iterator<CommandMessage<*>>) :
 
     @Suppress("UNCHECKED_CAST")
     fun <C : Any> nextCommand(commandType: Class<C>): CommandMessage<C> {
-        assertThat("Expect the next command.", hasNext(), equalTo(true))
+        assertThat(hasNext()).describedAs { "Expect the next command." }.isEqualTo(true)
         val nextCommand = next()
-        assertThat("Expect the command body type.", nextCommand.body, instanceOf(commandType))
+        assertThat(nextCommand.body).describedAs { "Expect the command body type." }.isInstanceOf(commandType)
         return nextCommand as CommandMessage<C>
     }
 

--- a/wow-dependencies/build.gradle.kts
+++ b/wow-dependencies/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     api(platform(libs.cocache.bom))
     api(platform(libs.opentelemetry.bom))
     api(platform(libs.opentelemetry.instrumentation.bom))
+    api(platform(libs.assertj.bom))
     api(platform(libs.testcontainers.bom))
     constraints {
         api(libs.guava)


### PR DESCRIPTION
- Remove Hamcrest dependency from various test configurations
- Add AssertJ dependency to testImplementation configuration
- Update test code to use AssertJ assertions instead of Hamcrest
- Refactor test expectations to use AssertJ's fluent API
- Remove redundant Hamcrest imports and replace with AssertJ

