### PR TITLE
test(wow-core): update StateJsonRecordTest to use state() method

### DIFF
--- a/wow-core/src/test/kotlin/me/ahoo/wow/serialization/event/StateJsonRecordTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/serialization/event/StateJsonRecordTest.kt
@@ -27,7 +27,7 @@ class StateJsonRecordTest {
         val state = MockState()
         val stateNode = state.toJsonString().toJsonNode<ObjectNode>()
         val stateJsonRecord = StateJsonRecord(stateNode)
-        assertThat(stateJsonRecord.toState<MockState>()).isEqualTo(state)
+        assertThat(stateJsonRecord.state<MockState>()).isEqualTo(state)
         assertThat(stateJsonRecord.actual).isEqualTo(stateNode)
     }
 


### PR DESCRIPTION
- Replace toState<MockState>() with state<MockState>() in StateJsonRecordTest
- This change improves code readability and follows the recent refactoring