### PR TITLE
test: add assert extension functions for common JDK types

### DIFF
--- a/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSagaTest.kt
+++ b/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSagaTest.kt
@@ -7,7 +7,7 @@ import me.ahoo.wow.example.api.order.OrderCreated
 import me.ahoo.wow.example.api.order.OrderItem
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.test.SagaVerifier.sagaVerifier
-import org.assertj.core.api.Assertions.assertThat
+import me.ahoo.wow.test.assert.assert
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 
@@ -35,9 +35,9 @@ class CartSagaTest {
                 ownerId = ownerId
             )
             .expectCommand<RemoveCartItem> {
-                assertThat(it.aggregateId.id).isEqualTo(ownerId)
-                assertThat(it.body.productIds).hasSize(1)
-                assertThat(it.body.productIds).first().isEqualTo(orderItem.productId)
+                it.aggregateId.id.assert().isEqualTo(ownerId)
+                it.body.productIds.assert().hasSize(1)
+                it.body.productIds.assert().first().isEqualTo(orderItem.productId)
             }
             .verify()
     }

--- a/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartTest.kt
+++ b/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartTest.kt
@@ -28,7 +28,7 @@ import me.ahoo.wow.modeling.command.IllegalAccessDeletedAggregateException
 import me.ahoo.wow.test.aggregate.`when`
 import me.ahoo.wow.test.aggregate.whenCommand
 import me.ahoo.wow.test.aggregateVerifier
-import org.assertj.core.api.Assertions.assertThat
+import me.ahoo.wow.test.assert.assert
 import org.junit.jupiter.api.Test
 
 class CartTest {
@@ -47,9 +47,9 @@ class CartTest {
             .expectNoError()
             .expectEventType(CartItemAdded::class.java)
             .expectState {
-                assertThat(it.items).hasSize(1)
+                it.items.assert().hasSize(1)
             }.expectStateAggregate {
-                assertThat(it.ownerId).isEqualTo(ownerId)
+                it.ownerId.assert().isEqualTo(ownerId)
             }
             .verify()
     }
@@ -67,7 +67,7 @@ class CartTest {
             .expectNoError()
             .expectEventType(CartItemAdded::class.java)
             .expectState {
-                assertThat(it.items).hasSize(1)
+                it.items.assert().hasSize(1)
             }
             .verify()
     }
@@ -92,8 +92,8 @@ class CartTest {
             .expectNoError()
             .expectEventType(CartQuantityChanged::class.java)
             .expectState {
-                assertThat(it.items).hasSize(1)
-                assertThat(it.items.first().quantity).isEqualTo(2)
+                it.items.assert().hasSize(1)
+                it.items.first().quantity.assert().isEqualTo(2)
             }
             .verify()
     }
@@ -110,10 +110,10 @@ class CartTest {
             .expectNoError()
             .expectEventType(CartItemAdded::class.java)
             .expectState {
-                assertThat(it.items).hasSize(1)
+                it.items.assert().hasSize(1)
             }
             .expectStateAggregate {
-                assertThat(it.version).isEqualTo(1)
+                it.version.assert().isEqualTo(1)
             }
             .verify()
     }
@@ -142,7 +142,7 @@ class CartTest {
             .`when`(addCartItem)
             .expectErrorType(IllegalArgumentException::class.java)
             .expectState {
-                assertThat(it.items).hasSize(MAX_CART_ITEM_SIZE)
+                it.items.assert().hasSize(MAX_CART_ITEM_SIZE)
             }
             .verify()
     }
@@ -166,7 +166,7 @@ class CartTest {
             .`when`(removeCartItem)
             .expectEventType(CartItemRemoved::class.java)
             .expectState {
-                assertThat(it.items).isEmpty()
+                it.items.assert().isEmpty()
             }
             .verify()
     }
@@ -190,8 +190,8 @@ class CartTest {
             .`when`(changeQuantity)
             .expectEventType(CartQuantityChanged::class.java)
             .expectState {
-                assertThat(it.items).hasSize(1)
-                assertThat(it.items.first().quantity).isEqualTo(changeQuantity.quantity)
+                it.items.assert().hasSize(1)
+                it.items.first().quantity.assert().isEqualTo(changeQuantity.quantity)
             }
             .verify()
     }
@@ -208,14 +208,14 @@ class CartTest {
             .expectNoError()
             .expectEventType(CartItemAdded::class.java)
             .expectState {
-                assertThat(it.items).hasSize(1)
+                it.items.assert().hasSize(1)
             }
             .verify()
             .then()
             .whenCommand(DefaultDeleteAggregate)
             .expectEventType(DefaultAggregateDeleted::class.java)
             .expectStateAggregate {
-                assertThat(it.deleted).isTrue()
+                it.deleted.assert().isTrue()
             }.verify()
             .then()
             .whenCommand(DefaultDeleteAggregate::class.java)
@@ -224,7 +224,7 @@ class CartTest {
             .then()
             .whenCommand(DefaultRecoverAggregate)
             .expectStateAggregate {
-                assertThat(it.deleted).isFalse()
+                it.deleted.assert().isFalse()
             }.verify()
             .then()
             .whenCommand(DefaultRecoverAggregate)

--- a/example/transfer/example-transfer-domain/src/test/kotlin/me/ahoo/wow/example/transfer/domain/AccountKTest.kt
+++ b/example/transfer/example-transfer-domain/src/test/kotlin/me/ahoo/wow/example/transfer/domain/AccountKTest.kt
@@ -31,6 +31,7 @@ import me.ahoo.wow.example.transfer.api.UnfreezeAccount
 import me.ahoo.wow.example.transfer.api.UnlockAmount
 import me.ahoo.wow.id.GlobalIdGenerator
 import me.ahoo.wow.test.aggregateVerifier
+import me.ahoo.wow.test.assert.assert
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -42,8 +43,8 @@ internal class AccountKTest {
             .`when`(CreateAccount("name", 100))
             .expectEventType(AccountCreated::class.java)
             .expectState {
-                assertThat(it.name).isEqualTo("name")
-                assertThat(it.balanceAmount).isEqualTo(100)
+                it.name.assert().isEqualTo("name")
+                it.balanceAmount.assert().isEqualTo(100)
             }
             .verify()
     }
@@ -55,8 +56,8 @@ internal class AccountKTest {
             .`when`(Prepare("name", 100))
             .expectEventType(AmountLocked::class.java, Prepared::class.java)
             .expectState {
-                assertThat(it.name).isEqualTo("name")
-                assertThat(it.balanceAmount).isEqualTo(0)
+                it.name.assert().isEqualTo("name")
+                it.balanceAmount.assert().isEqualTo(0)
             }
             .verify()
     }
@@ -70,9 +71,9 @@ internal class AccountKTest {
                 assertThat(it).hasMessage("账号已冻结无法转账.")
             }
             .expectState {
-                assertThat(it.name).isEqualTo("name")
-                assertThat(it.balanceAmount).isEqualTo(100)
-                assertThat(it.isFrozen).isTrue()
+                it.name.assert().isEqualTo("name")
+                it.balanceAmount.assert().isEqualTo(100)
+                it.isFrozen.assert().isTrue()
             }
             .verify()
     }
@@ -86,8 +87,8 @@ internal class AccountKTest {
                 assertThat(it).hasMessage("账号余额不足.")
             }
             .expectState {
-                assertThat(it.name).isEqualTo("name")
-                assertThat(it.balanceAmount).isEqualTo(100)
+                it.name.assert().isEqualTo("name")
+                it.balanceAmount.assert().isEqualTo(100)
             }
             .verify()
     }
@@ -100,8 +101,8 @@ internal class AccountKTest {
             .`when`(Entry(aggregateId, "sourceId", 100))
             .expectEventType(AmountEntered::class.java)
             .expectState {
-                assertThat(it.name).isEqualTo("name")
-                assertThat(it.balanceAmount).isEqualTo(200)
+                it.name.assert().isEqualTo("name")
+                it.balanceAmount.assert().isEqualTo(200)
             }
             .verify()
     }
@@ -114,9 +115,9 @@ internal class AccountKTest {
             .`when`(Entry(aggregateId, "sourceId", 100))
             .expectEventType(EntryFailed::class.java)
             .expectState {
-                assertThat(it.name).isEqualTo("name")
-                assertThat(it.balanceAmount).isEqualTo(100)
-                assertThat(it.isFrozen).isTrue()
+                it.name.assert().isEqualTo("name")
+                it.balanceAmount.assert().isEqualTo(100)
+                it.isFrozen.assert().isTrue()
             }
             .verify()
     }
@@ -129,10 +130,10 @@ internal class AccountKTest {
             .`when`(Confirm(aggregateId, 100))
             .expectEventType(Confirmed::class.java)
             .expectState {
-                assertThat(it.name).isEqualTo("name")
-                assertThat(it.balanceAmount).isEqualTo(0)
-                assertThat(it.lockedAmount).isEqualTo(0)
-                assertThat(it.isFrozen).isFalse()
+                it.name.assert().isEqualTo("name")
+                it.balanceAmount.assert().isEqualTo(0)
+                it.lockedAmount.assert().isEqualTo(0)
+                it.isFrozen.assert().isFalse()
             }
             .verify()
     }
@@ -145,10 +146,10 @@ internal class AccountKTest {
             .`when`(UnlockAmount(aggregateId, 100))
             .expectEventType(AmountUnlocked::class.java)
             .expectState {
-                assertThat(it.name).isEqualTo("name")
-                assertThat(it.balanceAmount).isEqualTo(100)
-                assertThat(it.lockedAmount).isEqualTo(0)
-                assertThat(it.isFrozen).isFalse()
+                it.name.assert().isEqualTo("name")
+                it.balanceAmount.assert().isEqualTo(100)
+                it.lockedAmount.assert().isEqualTo(0)
+                it.isFrozen.assert().isFalse()
             }
             .verify()
     }
@@ -161,10 +162,10 @@ internal class AccountKTest {
             .`when`(FreezeAccount(""))
             .expectEventType(AccountFrozen::class.java)
             .expectState {
-                assertThat(it.name).isEqualTo("name")
-                assertThat(it.balanceAmount).isEqualTo(100)
-                assertThat(it.lockedAmount).isEqualTo(0)
-                assertThat(it.isFrozen).isTrue()
+                it.name.assert().isEqualTo("name")
+                it.balanceAmount.assert().isEqualTo(100)
+                it.lockedAmount.assert().isEqualTo(0)
+                it.isFrozen.assert().isTrue()
             }
             .verify()
     }
@@ -179,10 +180,10 @@ internal class AccountKTest {
                 assertThat(it).hasMessage("账号已冻结无需再次冻结.")
             }
             .expectState {
-                assertThat(it.name).isEqualTo("name")
-                assertThat(it.balanceAmount).isEqualTo(100)
-                assertThat(it.lockedAmount).isEqualTo(0)
-                assertThat(it.isFrozen).isTrue()
+                it.name.assert().isEqualTo("name")
+                it.balanceAmount.assert().isEqualTo(100)
+                it.lockedAmount.assert().isEqualTo(0)
+                it.isFrozen.assert().isTrue()
             }
             .verify()
     }
@@ -194,10 +195,10 @@ internal class AccountKTest {
             .given(AccountCreated("name", 100), AccountFrozen(""))
             .`when`(UnfreezeAccount(""))
             .expectState {
-                assertThat(it.name).isEqualTo("name")
-                assertThat(it.balanceAmount).isEqualTo(100)
-                assertThat(it.lockedAmount).isEqualTo(0)
-                assertThat(it.isFrozen).isFalse()
+                it.name.assert().isEqualTo("name")
+                it.balanceAmount.assert().isEqualTo(100)
+                it.lockedAmount.assert().isEqualTo(0)
+                it.isFrozen.assert().isFalse()
             }
             .verify()
     }
@@ -209,10 +210,10 @@ internal class AccountKTest {
             .given(AccountCreated("name", 100), AccountUnfrozen(""))
             .`when`(UnfreezeAccount(""))
             .expectState {
-                assertThat(it.name).isEqualTo("name")
-                assertThat(it.balanceAmount).isEqualTo(100)
-                assertThat(it.lockedAmount).isEqualTo(0)
-                assertThat(it.isFrozen).isFalse()
+                it.name.assert().isEqualTo("name")
+                it.balanceAmount.assert().isEqualTo(100)
+                it.lockedAmount.assert().isEqualTo(0)
+                it.isFrozen.assert().isFalse()
             }
             .verify()
     }
@@ -225,10 +226,10 @@ internal class AccountKTest {
             .`when`(LockAmount(10))
             .expectEventType(AmountLocked::class.java)
             .expectState {
-                assertThat(it.name).isEqualTo("name")
-                assertThat(it.balanceAmount).isEqualTo(90)
-                assertThat(it.lockedAmount).isEqualTo(10)
-                assertThat(it.isFrozen).isFalse()
+                it.name.assert().isEqualTo("name")
+                it.balanceAmount.assert().isEqualTo(90)
+                it.lockedAmount.assert().isEqualTo(10)
+                it.isFrozen.assert().isFalse()
             }
             .verify()
     }

--- a/example/transfer/example-transfer-domain/src/test/kotlin/me/ahoo/wow/example/transfer/domain/TransferSagaKTest.kt
+++ b/example/transfer/example-transfer-domain/src/test/kotlin/me/ahoo/wow/example/transfer/domain/TransferSagaKTest.kt
@@ -20,7 +20,7 @@ import me.ahoo.wow.example.transfer.api.EntryFailed
 import me.ahoo.wow.example.transfer.api.Prepared
 import me.ahoo.wow.example.transfer.api.UnlockAmount
 import me.ahoo.wow.test.SagaVerifier.sagaVerifier
-import org.assertj.core.api.Assertions.assertThat
+import me.ahoo.wow.test.assert.assert
 import org.junit.jupiter.api.Test
 
 internal class TransferSagaKTest {
@@ -31,8 +31,8 @@ internal class TransferSagaKTest {
         sagaVerifier<TransferSaga>()
             .`when`(event)
             .expectCommandBody<Entry> {
-                assertThat(it.id).isEqualTo(event.to)
-                assertThat(it.amount).isEqualTo(event.amount)
+                it.id.assert().isEqualTo(event.to)
+                it.amount.assert().isEqualTo(event.amount)
             }
             .verify()
     }
@@ -43,8 +43,8 @@ internal class TransferSagaKTest {
         sagaVerifier<TransferSaga>()
             .`when`(event)
             .expectCommandBody<Confirm> {
-                assertThat(it.id).isEqualTo(event.sourceId)
-                assertThat(it.amount).isEqualTo(event.amount)
+                it.id.assert().isEqualTo(event.sourceId)
+                it.amount.assert().isEqualTo(event.amount)
             }
             .verify()
     }
@@ -55,8 +55,8 @@ internal class TransferSagaKTest {
         sagaVerifier<TransferSaga>()
             .`when`(event)
             .expectCommandBody<UnlockAmount> {
-                assertThat(it.id).isEqualTo(event.sourceId)
-                assertThat(it.amount).isEqualTo(event.amount)
+                it.id.assert().isEqualTo(event.sourceId)
+                it.amount.assert().isEqualTo(event.amount)
             }
             .verify()
     }

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
@@ -42,10 +42,8 @@ import me.ahoo.wow.infra.idempotency.IdempotencyChecker
 import me.ahoo.wow.tck.messaging.MessageBusSpec
 import me.ahoo.wow.tck.mock.MockCreateAggregate
 import me.ahoo.wow.tck.mock.WrongCommandMessage
+import me.ahoo.wow.test.assert.assert
 import me.ahoo.wow.test.validation.TestValidator
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.CoreMatchers.instanceOf
-import org.hamcrest.MatcherAssert.*
 import org.junit.jupiter.api.Test
 import reactor.kotlin.test.test
 import java.time.Duration
@@ -88,7 +86,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                 Thread.sleep(5)
             }
         }
-        assertThat(waitStrategyRegistrar.contains(commandId), equalTo(false))
+        waitStrategyRegistrar.contains(commandId).assert().isFalse()
     }
 
     @Test
@@ -232,10 +230,10 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
             sendAndWaitForSent(message)
                 .test()
                 .consumeErrorWith {
-                    assertThat(it, instanceOf(CommandResultException::class.java))
+                    it.assert().isInstanceOf(CommandResultException::class.java)
                     val commandResultException = it as CommandResultException
-                    assertThat(commandResultException.commandResult.errorCode, equalTo(ErrorCodes.DUPLICATE_REQUEST_ID))
-                    assertThat(commandResultException.cause, instanceOf(DuplicateRequestIdException::class.java))
+                    commandResultException.commandResult.errorCode.assert().isEqualTo(ErrorCodes.DUPLICATE_REQUEST_ID)
+                    commandResultException.cause.assert().isInstanceOf(DuplicateRequestIdException::class.java)
                 }
                 .verify()
         }
@@ -261,7 +259,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
                     waitStrategyRegistrar.next(errorSignal)
                 }
                 .consumeNextWith {
-                    assertThat(it.errorCode, equalTo(errorSignal.errorCode))
+                    it.errorCode.assert().isEqualTo(errorSignal.errorCode)
                 }
                 .verifyComplete()
         }

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/event/DomainEventStreamSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/event/DomainEventStreamSpec.kt
@@ -19,8 +19,7 @@ import me.ahoo.wow.id.GlobalIdGenerator
 import me.ahoo.wow.modeling.aggregateId
 import me.ahoo.wow.tck.mock.MockAggregateChanged
 import me.ahoo.wow.tck.mock.MockAggregateCreated
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
+import me.ahoo.wow.test.assert.assert
 import org.junit.jupiter.api.Test
 
 /**
@@ -45,33 +44,33 @@ abstract class DomainEventStreamSpec {
     @Test
     fun aggregateId() {
         val domainEventStream = createDomainEventStream(testEvents, testAggregateId, 0)
-        assertThat(domainEventStream.aggregateId, equalTo(testAggregateId))
-        assertThat(domainEventStream.contextName, equalTo(testAggregateId.contextName))
-        assertThat(domainEventStream.aggregateName, equalTo(testAggregateId.aggregateName))
+        domainEventStream.aggregateId.assert().isEqualTo(testAggregateId)
+        domainEventStream.contextName.assert().isEqualTo(testAggregateId.contextName)
+        domainEventStream.aggregateName.assert().isEqualTo(testAggregateId.aggregateName)
     }
 
     @Test
     fun size() {
         val domainEventStream = createDomainEventStream(testEvents, testAggregateId, 0)
-        assertThat(domainEventStream.aggregateId, equalTo(testAggregateId))
-        assertThat(domainEventStream.size, equalTo(testEvents.size))
+        domainEventStream.aggregateId.assert().isEqualTo(testAggregateId)
+        domainEventStream.size.assert().isEqualTo(testEvents.size)
     }
 
     @Test
     fun version() {
         val domainEventStream = createDomainEventStream(testEvents, testAggregateId, 0)
-        assertThat(domainEventStream.aggregateId, equalTo(testAggregateId))
-        assertThat(domainEventStream.version, equalTo(1))
-        assertThat(domainEventStream.size, equalTo(2))
+        domainEventStream.aggregateId.assert().isEqualTo(testAggregateId)
+        domainEventStream.version.assert().isEqualTo(1)
+        domainEventStream.size.assert().isEqualTo(2)
     }
 
     @Test
     fun whenEquals() {
         val domainEventStream = createDomainEventStream(testEvents, testAggregateId, 0)
-        assertThat(domainEventStream, equalTo(domainEventStream))
-        assertThat(domainEventStream, not(Any()))
+        domainEventStream.assert().isEqualTo(domainEventStream)
+        domainEventStream.assert().isNotEqualTo(Any())
         val other = createDomainEventStream(testEvents, testAggregateId, 0)
-        assertThat(domainEventStream, not(other))
+        domainEventStream.assert().isNotEqualTo(other)
     }
 
     @Test

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/assert/Jdk.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/assert/Jdk.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.test.assert
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.BigDecimalAssert
+import org.assertj.core.api.BooleanAssert
+import org.assertj.core.api.ByteAssert
+import org.assertj.core.api.CollectionAssert
+import org.assertj.core.api.DoubleAssert
+import org.assertj.core.api.FloatAssert
+import org.assertj.core.api.IntegerAssert
+import org.assertj.core.api.IteratorAssert
+import org.assertj.core.api.ListAssert
+import org.assertj.core.api.LongAssert
+import org.assertj.core.api.MapAssert
+import org.assertj.core.api.ObjectArrayAssert
+import org.assertj.core.api.ObjectAssert
+import org.assertj.core.api.OptionalAssert
+import org.assertj.core.api.ShortAssert
+import org.assertj.core.api.StringAssert
+import org.assertj.core.api.ThrowableAssert
+import java.math.BigDecimal
+import java.util.*
+import java.util.stream.Stream
+
+fun Boolean.assert(): BooleanAssert {
+    return BooleanAssert(this)
+}
+
+fun Byte.assert(): ByteAssert {
+    return ByteAssert(this)
+}
+
+fun Short.assert(): ShortAssert {
+    return ShortAssert(this)
+}
+
+fun Int.assert(): IntegerAssert {
+    return IntegerAssert(this)
+}
+
+fun Long.assert(): LongAssert {
+    return LongAssert(this)
+}
+
+fun Float.assert(): FloatAssert {
+    return FloatAssert(this)
+}
+
+fun Double.assert(): DoubleAssert {
+    return DoubleAssert(this)
+}
+
+fun BigDecimal.assert(): BigDecimalAssert {
+    return BigDecimalAssert(this)
+}
+
+fun String.assert(): StringAssert {
+    return StringAssert(this)
+}
+
+fun <T> T.assert(): ObjectAssert<T> {
+    return assertThat(this)
+}
+
+fun <T> Iterator<T>.assert(): IteratorAssert<T> {
+    return assertThat(this)
+}
+
+fun <T> Collection<T>.assert(): CollectionAssert<T> {
+    return CollectionAssert(this)
+}
+
+fun <T> Array<T>.assert(): ObjectArrayAssert<T> {
+    return assertThat(this)
+}
+
+fun <T> List<T>.assert(): ListAssert<T> {
+    return ListAssert(this)
+}
+
+fun <T : Throwable> T.assert(): ThrowableAssert<T> {
+    return ThrowableAssert(this)
+}
+
+fun <T> Optional<T>.assert(): OptionalAssert<T> {
+    return assertThat<T>(this)
+}
+
+fun <K, V> Map<K, V>.assert(): MapAssert<K, V> {
+    return MapAssert(this)
+}
+
+fun <T> Stream<T>.assert(): ListAssert<T> {
+    return assertThat(this)
+}

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/assert/JdkConcurrent.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/assert/JdkConcurrent.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.test.assert
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.FutureAssert
+import java.util.concurrent.Future
+
+fun <V> Future<V>.assert(): FutureAssert<V> {
+    return assertThat(this)
+}

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/assert/JdkFunction.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/assert/JdkFunction.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.test.assert
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.PredicateAssert
+import java.util.function.Predicate
+
+fun <T> Predicate<T>.assert(): PredicateAssert<T> {
+    return assertThat(this)
+}

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/assert/JdkIO.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/assert/JdkIO.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.test.assert
+
+import org.assertj.core.api.FileAssert
+import org.assertj.core.api.PathAssert
+import org.assertj.core.api.UriAssert
+import org.assertj.core.api.UrlAssert
+import java.io.File
+import java.net.URI
+import java.net.URL
+import java.nio.file.Path
+
+fun Path.assert(): PathAssert {
+    return PathAssert(this)
+}
+
+fun File.assert(): FileAssert {
+    return FileAssert(this)
+}
+
+fun URL.assert(): UrlAssert {
+    return UrlAssert(this)
+}
+
+fun URI.assert(): UriAssert {
+    return UriAssert(this)
+}

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/assert/JdkTime.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/assert/JdkTime.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.test.assert
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatTemporal
+import org.assertj.core.api.DateAssert
+import org.assertj.core.api.DurationAssert
+import org.assertj.core.api.InstantAssert
+import org.assertj.core.api.LocalDateAssert
+import org.assertj.core.api.LocalDateTimeAssert
+import org.assertj.core.api.LocalTimeAssert
+import org.assertj.core.api.OffsetDateTimeAssert
+import org.assertj.core.api.OffsetTimeAssert
+import org.assertj.core.api.PeriodAssert
+import org.assertj.core.api.TemporalAssert
+import org.assertj.core.api.YearMonthAssert
+import org.assertj.core.api.ZonedDateTimeAssert
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.OffsetTime
+import java.time.Period
+import java.time.YearMonth
+import java.time.ZonedDateTime
+import java.time.temporal.Temporal
+import java.util.*
+
+fun Date.assert(): DateAssert {
+    return assertThat(this) as DateAssert
+}
+
+fun ZonedDateTime.assert(): ZonedDateTimeAssert {
+    return assertThat(this) as ZonedDateTimeAssert
+}
+
+fun Temporal.assertTemporal(): TemporalAssert {
+    return assertThatTemporal(this)
+}
+
+fun LocalDateTime.assert(): LocalDateTimeAssert {
+    return assertThat(this) as LocalDateTimeAssert
+}
+
+fun OffsetDateTime.assert(): OffsetDateTimeAssert {
+    return assertThat(this) as OffsetDateTimeAssert
+}
+
+fun OffsetTime.assert(): OffsetTimeAssert {
+    return assertThat(this) as OffsetTimeAssert
+}
+
+fun LocalTime.assert(): LocalTimeAssert {
+    return assertThat(this) as LocalTimeAssert
+}
+
+fun LocalDate.assert(): LocalDateAssert {
+    return assertThat(this) as LocalDateAssert
+}
+
+fun YearMonth.assert(): YearMonthAssert {
+    return assertThat(this) as YearMonthAssert
+}
+
+fun Instant.assert(): InstantAssert {
+    return assertThat(this) as InstantAssert
+}
+
+fun Duration.assert(): DurationAssert {
+    return assertThat(this) as DurationAssert
+}
+
+fun Period.assert(): PeriodAssert {
+    return assertThat(this) as PeriodAssert
+}

--- a/wow-core/src/test/kotlin/me/ahoo/wow/annotation/AnnotationPropertyAccessorParserTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/annotation/AnnotationPropertyAccessorParserTest.kt
@@ -13,6 +13,7 @@ import me.ahoo.wow.api.annotation.AggregateVersion
 import me.ahoo.wow.api.annotation.StaticAggregateId
 import me.ahoo.wow.api.annotation.StaticTenantId
 import me.ahoo.wow.api.annotation.TenantId
+import me.ahoo.wow.test.assert.assert
 import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Assertions
@@ -21,8 +22,7 @@ import org.junit.jupiter.api.Test
 class AnnotationPropertyAccessorParserTest {
     @Test
     fun toStringGetter() {
-        val propertyGetter = Mock::stringField.toStringGetter()
-        assertThat(propertyGetter, notNullValue())
+        Mock::stringField.toStringGetter().assert().isNotNull()
     }
 
     @Test


### PR DESCRIPTION
- Add assert extension functions for Boolean, Byte, Short, Int, Long, Float, Double, BigDecimal, String, Collection, List, Map, Optional, Future, Predicate, File, Path, URL, URI, Date, ZonedDateTime, Temporal, LocalDateTime, OffsetDateTime, OffsetTime, LocalTime, LocalDate, YearMonth, Instant, Duration, and Period types
- Update existing test files to use new assert extension functions
- Remove redundant imports of Assertions class in test files
