### PR TITLE
test: replace Hamcrest with me.ahoo.test.asserts in test cases

### DIFF
--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/eventsourcing/EventStoreSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/eventsourcing/EventStoreSpec.kt
@@ -12,6 +12,7 @@
  */
 package me.ahoo.wow.tck.eventsourcing
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.Version
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.command.DuplicateRequestIdException
@@ -29,7 +30,6 @@ import me.ahoo.wow.tck.metrics.LoggingMeterRegistryInitializer
 import me.ahoo.wow.tck.mock.MockAggregateCreated
 import me.ahoo.wow.test.aggregate.GivenInitializationCommand
 import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.CoreMatchers.instanceOf
 import org.hamcrest.MatcherAssert.*
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
@@ -74,9 +74,9 @@ abstract class EventStoreSpec {
         eventStore.load(eventStream.aggregateId)
             .test()
             .expectNextMatches {
-                assertThat(it.aggregateId, equalTo(eventStream.aggregateId))
-                assertThat(it.version, equalTo(eventStream.version))
-                assertThat(it.size, equalTo(eventStream.size))
+                it.aggregateId.assert().isEqualTo(eventStream.aggregateId)
+                it.version.assert().isEqualTo(eventStream.version)
+                it.size.assert().isEqualTo(eventStream.size)
                 true
             }
             .verifyComplete()
@@ -94,24 +94,16 @@ abstract class EventStoreSpec {
         eventStore.append(conflictingStream)
             .test()
             .expectErrorMatches {
-                assertThat(
-                    it,
-                    instanceOf(
-                        DuplicateAggregateIdException::class.java,
-                    ),
-                )
+                it.assert().isInstanceOf(DuplicateAggregateIdException::class.java)
                 val conflictException = it as DuplicateAggregateIdException
-                assertThat(conflictException.eventStream, equalTo(conflictingStream))
+                conflictException.eventStream.assert().isEqualTo(conflictingStream)
                 true
             }
             .verify()
         eventStore.load(aggregateId)
             .test()
             .consumeNextWith {
-                assertThat(
-                    it.size,
-                    equalTo(eventStream.size),
-                )
+                it.size.assert().isEqualTo(eventStream.size)
             }
             .verifyComplete()
     }
@@ -147,14 +139,9 @@ abstract class EventStoreSpec {
         eventStore.append(conflictingStream)
             .test()
             .expectErrorMatches {
-                assertThat(
-                    it,
-                    instanceOf(
-                        EventVersionConflictException::class.java,
-                    ),
-                )
+                it.assert().isInstanceOf(EventVersionConflictException::class.java)
                 val conflictException = it as EventVersionConflictException
-                assertThat(conflictException.eventStream, equalTo(conflictingStream))
+                conflictException.eventStream.assert().isEqualTo(conflictingStream)
                 true
             }
             .verify()
@@ -180,24 +167,16 @@ abstract class EventStoreSpec {
         eventStore.append(conflictingStream)
             .test()
             .expectErrorMatches {
-                assertThat(
-                    it,
-                    instanceOf(
-                        DuplicateRequestIdException::class.java,
-                    ),
-                )
+                it.assert().isInstanceOf(DuplicateRequestIdException::class.java)
                 val duplicateRequestIdException = it as DuplicateRequestIdException
-                assertThat(duplicateRequestIdException.requestId, equalTo(conflictingStream.requestId))
+                duplicateRequestIdException.requestId.assert().isEqualTo(conflictingStream.requestId)
                 true
             }
             .verify()
         eventStore.load(aggregateId)
             .test()
             .consumeNextWith {
-                assertThat(
-                    it.size,
-                    equalTo(eventStream.size),
-                )
+                it.size.assert().isEqualTo(eventStream.size)
             }
             .verifyComplete()
     }
@@ -254,9 +233,9 @@ abstract class EventStoreSpec {
         eventStore.load(eventStream.aggregateId, headVersion)
             .test()
             .expectNextMatches { actualStream: DomainEventStream ->
-                assertThat(actualStream.aggregateId, equalTo(eventStream.aggregateId))
-                assertThat(actualStream.version, equalTo(1))
-                assertThat(actualStream.size, equalTo(10))
+                actualStream.aggregateId.assert().isEqualTo(eventStream.aggregateId)
+                actualStream.version.assert().isEqualTo(1)
+                actualStream.size.assert().isEqualTo(10)
                 true
             }
             .verifyComplete()
@@ -272,9 +251,9 @@ abstract class EventStoreSpec {
         eventStore.load(eventStream.aggregateId, 0, eventStream.createTime)
             .test()
             .expectNextMatches { actualStream: DomainEventStream ->
-                assertThat(actualStream.aggregateId, equalTo(eventStream.aggregateId))
-                assertThat(actualStream.version, equalTo(1))
-                assertThat(actualStream.size, equalTo(10))
+                actualStream.aggregateId.assert().isEqualTo(eventStream.aggregateId)
+                actualStream.version.assert().isEqualTo(1)
+                actualStream.size.assert().isEqualTo(10)
                 true
             }
             .verifyComplete()

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/eventsourcing/StateAggregateRepositorySpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/eventsourcing/StateAggregateRepositorySpec.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.tck.eventsourcing
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.event.DomainEvent
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.event.toDomainEventStream
@@ -57,8 +58,8 @@ abstract class StateAggregateRepositorySpec {
         val eventStream = stateChanged.toDomainEventStream(upstream = command, aggregateVersion = 0)
         TEST_EVENT_STORE.append(eventStream).block()
         val stateAggregate = aggregateRepository.load(aggregateId, aggregateMetadata.state).block()!!
-        MatcherAssert.assertThat(stateAggregate, Matchers.notNullValue())
-        MatcherAssert.assertThat(stateAggregate.aggregateId, Matchers.equalTo(aggregateId))
+        stateAggregate.assert().isNotNull()
+        stateAggregate.aggregateId.assert().isEqualTo(aggregateId)
         val domainEventMessage = eventStream.iterator().next() as DomainEvent<MockAggregateChanged>
         MatcherAssert.assertThat(stateAggregate.version, Matchers.equalTo(domainEventMessage.version))
         MatcherAssert.assertThat(

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/messaging/MessageBusSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/messaging/MessageBusSpec.kt
@@ -12,6 +12,7 @@
  */
 package me.ahoo.wow.tck.messaging
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.messaging.Message
 import me.ahoo.wow.api.messaging.TopicKindCapable
 import me.ahoo.wow.api.modeling.NamedAggregate
@@ -72,7 +73,7 @@ abstract class MessageBusSpec<M : Message<*, *>, E : MessageExchange<*, M>, BUS 
                 }
                 .test()
                 .consumeNextWith {
-                    assertThat(it.message.id, equalTo(message.id))
+                    it.message.id.assert().isEqualTo(message.id)
                 }
                 .thenCancel()
                 .verify()

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/modeling/command/CommandDispatcherSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/modeling/command/CommandDispatcherSpec.kt
@@ -14,6 +14,7 @@ package me.ahoo.wow.tck.modeling.command
 
 import com.google.common.hash.BloomFilter
 import com.google.common.hash.Funnels
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.command.CommandBus
 import me.ahoo.wow.command.CommandGateway
 import me.ahoo.wow.command.DefaultCommandGateway
@@ -58,8 +59,6 @@ import me.ahoo.wow.tck.mock.MockCommandAggregate
 import me.ahoo.wow.tck.mock.MockCreateAggregate
 import me.ahoo.wow.tck.mock.MockStateAggregate
 import me.ahoo.wow.test.validation.TestValidator
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -194,10 +193,7 @@ abstract class CommandDispatcherSpec {
                 )
             }
         }
-        assertThat(
-            creates.distinctBy { it.id }.size,
-            equalTo(aggregateCount),
-        )
+        creates.distinctBy { it.id }.size.assert().isEqualTo(aggregateCount)
         println("------------- CreateAggregate -------------")
         val createdDuration = creates.toFlux()
             .subscribeOn(Schedulers.single())
@@ -208,7 +204,7 @@ abstract class CommandDispatcherSpec {
                 commandGateway
                     .sendAndWaitForProcessed(it!!.toCommandMessage())
             }, Int.MAX_VALUE).doOnNext {
-                assertThat(it.succeeded, equalTo(true))
+                it.succeeded.assert().isTrue()
             }
             .timeout(Duration.ofMinutes(1))
             .then()
@@ -237,7 +233,7 @@ abstract class CommandDispatcherSpec {
                 commandGateway.sendAndWaitForProcessed(it.toCommandMessage())
             }, Int.MAX_VALUE)
             .doOnNext {
-                assertThat(it.succeeded, equalTo(true))
+                it.succeeded.assert().isTrue()
             }
             .timeout(Duration.ofSeconds(30))
             .then()

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/modeling/state/StateAggregateFactorySpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/modeling/state/StateAggregateFactorySpec.kt
@@ -12,6 +12,7 @@
  */
 package me.ahoo.wow.tck.modeling.state
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.Identifier
 import me.ahoo.wow.api.modeling.TenantId
 import me.ahoo.wow.id.GlobalIdGenerator
@@ -22,8 +23,6 @@ import me.ahoo.wow.modeling.state.StateAggregate
 import me.ahoo.wow.modeling.state.StateAggregateFactory
 import me.ahoo.wow.tck.mock.MockCommandAggregate
 import me.ahoo.wow.tck.mock.MockStateAggregate
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 import reactor.kotlin.test.test
 
@@ -40,8 +39,8 @@ abstract class StateAggregateFactorySpec {
         aggregateFactory.createAsMono(aggregateMetadata.state, aggregateId)
             .test()
             .consumeNextWith { stateAggregate: StateAggregate<S> ->
-                assertThat(stateAggregate, notNullValue())
-                assertThat(stateAggregate.aggregateId.id, equalTo(aggregateId.id))
+                stateAggregate.assert().isNotNull()
+                stateAggregate.aggregateId.id.assert().isEqualTo(aggregateId.id)
                 verify(stateAggregate)
             }
             .verifyComplete()
@@ -51,7 +50,7 @@ abstract class StateAggregateFactorySpec {
     fun create() {
         val aggregateMetadata = aggregateMetadata<MockCommandAggregate, MockStateAggregate>()
         createStateAggregate(aggregateMetadata) {
-            assertThat(it.state.id, equalTo(it.aggregateId.id))
+            it.state.id.assert().isEqualTo(it.aggregateId.id)
         }
     }
 
@@ -59,8 +58,8 @@ abstract class StateAggregateFactorySpec {
     fun createWithTenantId() {
         val aggregateMetadata = aggregateMetadata<MockCommandAggregateWithTenantId, MockStateAggregateWithTenantId>()
         createStateAggregate(aggregateMetadata) {
-            assertThat(it.state.id, equalTo(it.aggregateId.id))
-            assertThat(it.state.tenantId, equalTo(it.aggregateId.tenantId))
+            it.state.id.assert().isEqualTo(it.aggregateId.id)
+            it.state.tenantId.assert().isEqualTo(it.aggregateId.tenantId)
         }
     }
 }

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/prepare/PrepareKeySpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/prepare/PrepareKeySpec.kt
@@ -13,12 +13,11 @@
 
 package me.ahoo.wow.tck.prepare
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.id.GlobalIdGenerator
 import me.ahoo.wow.infra.prepare.PrepareKey
 import me.ahoo.wow.infra.prepare.PrepareKeyFactory
 import me.ahoo.wow.infra.prepare.PreparedValue.Companion.toTtlAt
-import org.hamcrest.MatcherAssert
-import org.hamcrest.Matchers
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -252,6 +251,6 @@ abstract class PrepareKeySpec<V : Any> {
 
     @Test
     fun getName() {
-        MatcherAssert.assertThat(prepareKey.name, Matchers.equalTo(name))
+        prepareKey.name.assert().isEqualTo(name)
     }
 }


### PR DESCRIPTION
- Remove import statements for Hamcrest
- Add import statement for me.ahoo.test.asserts.assert
- Replace assertThat() with assert().isEqualTo() for equality checks
- Replace equalTo() with isTrue() for boolean checks
- Use isNotNull() instead of notNullValue()
- Remove unnecessary MatcherAssert and Matchers imports
