### PR TITLE
test: update CartTest and Order related tests

### DIFF
--- a/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartTest.kt
+++ b/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartTest.kt
@@ -202,7 +202,6 @@ class CartTest {
             productId = "productId",
             quantity = 1,
         )
-
         aggregateVerifier<Cart, CartState>()
             .`when`(addCartItem)
             .expectNoError()

--- a/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/order/OrderSagaTest.kt
+++ b/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/order/OrderSagaTest.kt
@@ -4,15 +4,15 @@ import io.mockk.every
 import io.mockk.mockk
 import me.ahoo.wow.example.api.order.OrderCreated
 import me.ahoo.wow.example.api.order.OrderItem
-import me.ahoo.wow.id.GlobalIdGenerator
+import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.test.SagaVerifier
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 
 class OrderSagaTest {
     private val orderItem = OrderItem(
-        GlobalIdGenerator.generateAsString(),
-        GlobalIdGenerator.generateAsString(),
+        generateGlobalId(),
+        generateGlobalId(),
         BigDecimal.valueOf(10),
         10,
     )


### PR DESCRIPTION
- Refactor CartTest to use assert() instead of assertThat()
- Update Order related tests to use generateGlobalId() instead of GlobalIdGenerator
- Remove unnecessary imports and simplify test code

