### PR TITLE
refactor(CommandRouteSpec): Update variableType usage

### DIFF
--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/command/CommandRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/command/CommandRouteSpec.kt
@@ -142,7 +142,7 @@ class CommandRouteSpec(
         }
 
     private fun VariableMetadata.variableSchema(): Schema<*> {
-        return field?.type?.let {
+        return variableType?.let {
             componentContext.schema(it)
         } ?: StringSchema()
     }

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/BatchResultTest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/BatchResultTest.kt
@@ -1,14 +1,13 @@
 package me.ahoo.wow.openapi
 
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 class BatchResultTest {
     @Test
     fun test() {
         val batchResult = BatchResult("cursorId", 1)
-        assertThat(batchResult.afterId, equalTo("cursorId"))
-        assertThat(batchResult.size, equalTo(1))
+        batchResult.afterId.assert().isEqualTo("cursorId")
+        batchResult.size.assert().isEqualTo(1)
     }
 }

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/RouterSpecsTest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/RouterSpecsTest.kt
@@ -1,14 +1,13 @@
 package me.ahoo.wow.openapi
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.naming.MaterializedNamedBoundedContext
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 
 class RouterSpecsTest {
     @Test
     fun build() {
         val routerSpecs = RouterSpecs(MaterializedNamedBoundedContext("test")).build()
-        assertThat(routerSpecs, notNullValue())
+        routerSpecs.assert().isNotEmpty()
     }
 }

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/TagsTest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/TagsTest.kt
@@ -1,9 +1,8 @@
 package me.ahoo.wow.openapi
 
 import io.swagger.v3.oas.annotations.tags.Tag
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.openapi.Tags.toTags
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 
 @Tag(name = "test")
@@ -13,6 +12,6 @@ class TagsTest {
     @Test
     fun asTags() {
         val tags = TagsTest::class.java.toTags()
-        assertThat(tags, equalTo(setOf("test", "test2")))
+        tags.assert().contains("test", "test2")
     }
 }

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/converter/BoundedContextSchemaNameConverterTest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/converter/BoundedContextSchemaNameConverterTest.kt
@@ -2,10 +2,9 @@ package me.ahoo.wow.openapi.converter
 
 import io.swagger.v3.core.converter.ModelConverters
 import me.ahoo.cosid.stat.generator.CosIdGeneratorStat
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.openapi.BatchResult
 import me.ahoo.wow.tck.mock.MockCommandAggregate
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.*
 import org.junit.jupiter.api.Test
 
 class BoundedContextSchemaNameConverterTest {
@@ -13,24 +12,24 @@ class BoundedContextSchemaNameConverterTest {
     @Test
     fun resolveAggregate() {
         val schemas = ModelConverters.getInstance(true).read(MockCommandAggregate::class.java)
-        assertThat(schemas.containsKey("tck.mock_aggregate.MockCommandAggregate"), equalTo(true))
+        schemas.assert().containsKey("tck.mock_aggregate.MockCommandAggregate")
     }
 
     @Test
     fun resolveJavaLib() {
         val schemas = ModelConverters.getInstance(true).read(String::class.java)
-        assertThat(schemas.size, equalTo(0))
+        schemas.assert().hasSize(0)
     }
 
     @Test
     fun resolveJavaClass() {
         val schemas = ModelConverters.getInstance(true).read(CosIdGeneratorStat::class.java)
-        assertThat(schemas.containsKey("CosIdGeneratorStat"), equalTo(true))
+        schemas.assert().containsKey("CosIdGeneratorStat")
     }
 
     @Test
     fun resolveBatchResult() {
         val schemas = ModelConverters.getInstance(true).read(BatchResult::class.java)
-        assertThat(schemas.containsKey("wow.openapi.BatchResult"), equalTo(true))
+        schemas.assert().containsKey("wow.openapi.BatchResult")
     }
 }


### PR DESCRIPTION
- Replaced `field?.type` with `variableType` for clarity and consistency.

