### PR TITLE
test(wow-schema): Add TypesTest for isWowType and isStdType methods

### DIFF
--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowSchemaNamingStrategy.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowSchemaNamingStrategy.kt
@@ -45,6 +45,9 @@ object WowSchemaNamingStrategy : SchemaDefinitionNamingStrategy {
                 return it.name
             }
         }
+        if (this.isArray) {
+            return "Array"
+        }
         return simpleName
     }
 

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowSchemaNamingStrategy.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowSchemaNamingStrategy.kt
@@ -18,7 +18,6 @@ import com.github.victools.jsonschema.generator.SchemaGenerationContext
 import com.github.victools.jsonschema.generator.impl.DefinitionKey
 import com.github.victools.jsonschema.generator.naming.DefaultSchemaDefinitionNamingStrategy
 import com.github.victools.jsonschema.generator.naming.SchemaDefinitionNamingStrategy
-import me.ahoo.wow.api.Wow
 import me.ahoo.wow.configuration.namedAggregate
 import me.ahoo.wow.configuration.namedBoundedContext
 import me.ahoo.wow.infra.reflection.AnnotationScanner.scanAnnotation
@@ -36,9 +35,6 @@ object WowSchemaNamingStrategy : SchemaDefinitionNamingStrategy {
             it.getContextAlias().let { alias ->
                 return "$alias."
             }
-        }
-        if (name.startsWith("me.ahoo.wow.")) {
-            return Wow.WOW_PREFIX
         }
         return null
     }

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/TypesTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/TypesTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.schema
+
+import me.ahoo.wow.api.command.CommandMessage
+import me.ahoo.wow.api.event.DomainEvent
+import me.ahoo.wow.api.modeling.AggregateId
+import me.ahoo.wow.event.DomainEventStream
+import me.ahoo.wow.eventsourcing.snapshot.Snapshot
+import me.ahoo.wow.eventsourcing.state.StateEvent
+import me.ahoo.wow.modeling.state.StateAggregate
+import me.ahoo.wow.schema.Types.isStdType
+import me.ahoo.wow.schema.Types.isWowType
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class TypesTest {
+    @Test
+    fun `isWowType should return true for AggregateId`() {
+        assertTrue(AggregateId::class.java.isWowType())
+    }
+
+    @Test
+    fun `isWowType should return true for CommandMessage`() {
+        assertTrue(CommandMessage::class.java.isWowType())
+    }
+
+    @Test
+    fun `isWowType should return true for DomainEvent`() {
+        assertTrue(DomainEvent::class.java.isWowType())
+    }
+
+    @Test
+    fun `isWowType should return true for DomainEventStream`() {
+        assertTrue(DomainEventStream::class.java.isWowType())
+    }
+
+    @Test
+    fun `isWowType should return true for Snapshot`() {
+        assertTrue(Snapshot::class.java.isWowType())
+    }
+
+    @Test
+    fun `isWowType should return true for StateAggregate`() {
+        assertTrue(StateAggregate::class.java.isWowType())
+    }
+
+    @Test
+    fun `isWowType should return true for StateEvent`() {
+        assertTrue(StateEvent::class.java.isWowType())
+    }
+
+    @Test
+    fun `isWowType should return false for String`() {
+        assertFalse(String::class.java.isWowType())
+    }
+
+    @Test
+    fun `isWowType should return false for Int`() {
+        assertFalse(Int::class.java.isWowType())
+    }
+
+    @Test
+    fun `isWowType should return false for List`() {
+        assertFalse(List::class.java.isWowType())
+    }
+
+    @Test
+    fun `isStdType should return true for String`() {
+        assertTrue(String::class.java.isStdType())
+    }
+
+    @Test
+    fun `isStdType should return true for Int`() {
+        assertTrue(Int::class.java.isStdType())
+    }
+
+    @Test
+    fun `isStdType should return true for List`() {
+        assertTrue(List::class.java.isStdType())
+    }
+
+    @Test
+    fun `isStdType should return false for AggregateId`() {
+        assertFalse(AggregateId::class.java.isStdType())
+    }
+}

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/WowSchemaNamingStrategyTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/WowSchemaNamingStrategyTest.kt
@@ -7,6 +7,7 @@ import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder
 import com.github.victools.jsonschema.generator.SchemaVersion
 import com.github.victools.jsonschema.generator.TypeContext
 import com.github.victools.jsonschema.generator.impl.TypeContextFactory
+import io.mockk.mockk
 import io.swagger.v3.oas.annotations.media.Schema
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.api.query.MaterializedSnapshot
@@ -63,6 +64,12 @@ class WowSchemaNamingStrategyTest {
                     ),
                     "example.CartStateMaterializedSnapshotPagedList"
                 ),
+                Arguments.of(
+                    typeContext.resolve(
+                        arrayOf(mockk<CreateOrder>()).javaClass
+                    ),
+                    "example.order.CreateOrderObject[]"
+                )
             )
         }
     }

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/WowSchemaNamingStrategyTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/WowSchemaNamingStrategyTest.kt
@@ -68,7 +68,7 @@ class WowSchemaNamingStrategyTest {
                     typeContext.resolve(
                         arrayOf(mockk<CreateOrder>()).javaClass
                     ),
-                    "example.order.CreateOrderObject[]"
+                    "example.order.CreateOrderArray"
                 )
             )
         }


### PR DESCRIPTION
Add a new test class `TypesTest` to verify the behavior of `isWowType` and `isStdType` methods. The tests cover various types to ensure that the methods correctly identify WoW-specific and standard types.

- Added tests for `AggregateId`, `CommandMessage`, `DomainEvent`, `DomainEventStream`, `Snapshot`, `StateAggregate`, and `StateEvent` to check `isWowType`.
- Added tests for `String`, `Int`, and `List` to check both `isWowType` and `isStdType`.

Also, removed an unused import and a redundant condition in `WowSchemaNamingStrategy`.


