### PR TITLE
refactor(wow-schema): Simplify and optimize IgnoreCommandRouteVariableCheck

### DIFF
--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/IgnoreCommandRouteVariableCheck.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/IgnoreCommandRouteVariableCheck.kt
@@ -22,12 +22,11 @@ import kotlin.reflect.jvm.kotlinProperty
 object IgnoreCommandRouteVariableCheck : Predicate<FieldScope> {
     override fun test(fieldScope: FieldScope): Boolean {
         val property = fieldScope.rawMember.kotlinProperty!!
-        if (property.scanAnnotation<CommandRoute.PathVariable>() != null) {
+        val pathVariable = property.scanAnnotation<CommandRoute.PathVariable>()
+        if (pathVariable != null && pathVariable.nestedPath.isEmpty()) {
             return true
         }
-        if (property.scanAnnotation<CommandRoute.HeaderVariable>() != null) {
-            return true
-        }
-        return false
+        val headerVariable = property.scanAnnotation<CommandRoute.HeaderVariable>()
+        return headerVariable != null && headerVariable.nestedPath.isEmpty()
     }
 }


### PR DESCRIPTION
- Combine conditions for checking `CommandRoute.PathVariable` and `CommandRoute.HeaderVariable`.
- Remove redundant return statements.
- Ensure `nestedPath` is empty before returning true.


