### PR TITLE
Update Test Assertions and Deprecation Warnings

### DIFF
--- a/wow-core/src/test/kotlin/me/ahoo/wow/annotation/SortedByOrderKtTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/annotation/SortedByOrderKtTest.kt
@@ -1,5 +1,6 @@
 package me.ahoo.wow.annotation
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.annotation.ORDER_FIRST
 import me.ahoo.wow.api.annotation.ORDER_LAST
 import me.ahoo.wow.api.annotation.Order
@@ -13,14 +14,14 @@ class SortedByOrderKtTest {
     @Test
     fun sortAny() {
         val sortedList = listOf(Any(), Any()).sortedByOrder()
-        assertThat(sortedList, hasSize(2))
+        sortedList.assert().hasSize(2)
     }
 
     @Test
     fun sortOrderValue() {
         val sortedList = listOf(OrderLast, OrderFirst).sortedByOrder()
-        assertThat(sortedList, hasSize(2))
-        assertThat(sortedList, contains(OrderFirst, OrderLast))
+        sortedList.assert().hasSize(2)
+        sortedList.assert().contains(OrderFirst, OrderLast)
     }
 
     @Test

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/stereotype/EventProcessor.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/stereotype/EventProcessor.kt
@@ -18,8 +18,11 @@ import org.springframework.stereotype.Component
 @Component
 @me.ahoo.wow.api.annotation.EventProcessor
 @Deprecated(
-    "Use EventProcessorComponent instead.",
-    ReplaceWith("EventProcessorComponent")
+    message = "Use EventProcessorComponent instead.",
+    replaceWith = ReplaceWith(
+        expression = "EventProcessorComponent",
+        imports = ["me.ahoo.wow.spring.stereotype.EventProcessorComponent"]
+    )
 )
 annotation class EventProcessor
 

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/stereotype/ProjectionProcessor.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/stereotype/ProjectionProcessor.kt
@@ -21,8 +21,11 @@ import org.springframework.stereotype.Component
 @Component
 @me.ahoo.wow.api.annotation.ProjectionProcessor
 @Deprecated(
-    "Use ProjectionProcessorComponent instead.",
-    ReplaceWith("ProjectionProcessorComponent")
+    message = "Use ProjectionProcessorComponent instead.",
+    ReplaceWith(
+        expression = "ProjectionProcessorComponent",
+        imports = ["me.ahoo.wow.spring.stereotype.ProjectionProcessorComponent"]
+    )
 )
 annotation class ProjectionProcessor
 

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/stereotype/StatelessSaga.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/stereotype/StatelessSaga.kt
@@ -18,8 +18,11 @@ import org.springframework.stereotype.Component
 @Component
 @me.ahoo.wow.api.annotation.StatelessSaga
 @Deprecated(
-    "Use StatelessSagaComponent instead.",
-    ReplaceWith("StatelessSagaComponent")
+    message = "Use StatelessSagaComponent instead.",
+    ReplaceWith(
+        expression = "StatelessSagaComponent",
+        imports = ["me.ahoo.wow.spring.stereotype.StatelessSagaComponent"]
+    )
 )
 annotation class StatelessSaga
 

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/DefaultExceptionHandlerTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/DefaultExceptionHandlerTest.kt
@@ -1,7 +1,6 @@
 package me.ahoo.wow.webflux.exception
 
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
@@ -20,7 +19,7 @@ class DefaultExceptionHandlerTest {
         DefaultRequestExceptionHandler.handle(request, IllegalArgumentException("error"))
             .test()
             .consumeNextWith {
-                assertThat(it.statusCode(), equalTo(HttpStatus.BAD_REQUEST))
+                it.statusCode().assert().isEqualTo(HttpStatus.BAD_REQUEST)
             }
             .verifyComplete()
     }

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/ErrorHttpStatusMappingTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/ErrorHttpStatusMappingTest.kt
@@ -1,10 +1,10 @@
 package me.ahoo.wow.webflux.exception
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.exception.ErrorInfo
+import me.ahoo.wow.exception.ErrorCodes
 import me.ahoo.wow.exception.toErrorInfo
 import me.ahoo.wow.webflux.exception.ErrorHttpStatusMapping.toHttpStatus
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 
@@ -13,28 +13,40 @@ class ErrorHttpStatusMappingTest {
     @Test
     fun register() {
         ErrorHttpStatusMapping.register("register", HttpStatus.BAD_REQUEST)
-        assertThat(ErrorHttpStatusMapping.getHttpStatus("register"), equalTo(HttpStatus.BAD_REQUEST))
+        ErrorHttpStatusMapping.getHttpStatus("register").assert().isEqualTo(HttpStatus.BAD_REQUEST)
     }
 
     @Test
     fun unregister() {
         ErrorHttpStatusMapping.register("unregister", HttpStatus.BAD_REQUEST)
-        assertThat(ErrorHttpStatusMapping.getHttpStatus("unregister"), equalTo(HttpStatus.BAD_REQUEST))
+        ErrorHttpStatusMapping.getHttpStatus("unregister").assert().isEqualTo(HttpStatus.BAD_REQUEST)
         ErrorHttpStatusMapping.unregister("unregister")
-        assertThat(ErrorHttpStatusMapping.getHttpStatus("unregister"), nullValue())
+        ErrorHttpStatusMapping.getHttpStatus("unregister").assert().isNull()
     }
 
     @Test
     fun toHttpStatus() {
         IllegalArgumentException().toErrorInfo().toHttpStatus().let {
-            assertThat(it, equalTo(HttpStatus.BAD_REQUEST))
+            it.assert().isEqualTo(HttpStatus.BAD_REQUEST)
         }
     }
 
     @Test
     fun toHttpStatusIfMissing() {
         ErrorInfo.of("asHttpStatusIfMissing", "").toHttpStatus().let {
-            assertThat(it, equalTo(HttpStatus.BAD_REQUEST))
+            it.assert().isEqualTo(HttpStatus.BAD_REQUEST)
         }
+    }
+
+    @Test
+    fun getHttpStatus_validErrorCode() {
+        val httpStatus = ErrorHttpStatusMapping.getHttpStatus(ErrorCodes.NOT_FOUND)
+        httpStatus.assert().isEqualTo(HttpStatus.NOT_FOUND)
+    }
+
+    @Test
+    fun getHttpStatus_invalidErrorCode() {
+        val httpStatus = ErrorHttpStatusMapping.getHttpStatus("invalidErrorCode")
+        httpStatus.assert().isNull()
     }
 }

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/bi/GenerateBIScriptHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/bi/GenerateBIScriptHandlerFunctionTest.kt
@@ -1,12 +1,11 @@
 package me.ahoo.wow.webflux.route.bi
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.bi.MessageHeaderSqlType
 import me.ahoo.wow.openapi.context.OpenAPIComponentContext
 import me.ahoo.wow.openapi.global.GenerateBIScriptRouteSpec
 import me.ahoo.wow.openapi.global.GenerateBIScriptRouteSpecFactory.Companion.BI_HEADER_TYPE_HEADER
 import me.ahoo.wow.webflux.route.global.GenerateBIScriptHandlerFunctionFactory
-import org.hamcrest.MatcherAssert
-import org.hamcrest.Matchers
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.springframework.mock.web.reactive.function.server.MockServerRequest
@@ -27,7 +26,7 @@ class GenerateBIScriptHandlerFunctionTest {
         handlerFunction.handle(request)
             .test()
             .consumeNextWith {
-                MatcherAssert.assertThat(it.statusCode(), Matchers.equalTo(HttpStatus.OK))
+                it.statusCode().assert().isEqualTo(HttpStatus.OK)
             }.verifyComplete()
     }
 
@@ -41,7 +40,7 @@ class GenerateBIScriptHandlerFunctionTest {
         handlerFunction.handle(request)
             .test()
             .consumeNextWith {
-                MatcherAssert.assertThat(it.statusCode(), Matchers.equalTo(HttpStatus.OK))
+                it.statusCode().assert().isEqualTo(HttpStatus.OK)
             }.verifyComplete()
     }
 }

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/wait/CommandWaitHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/wait/CommandWaitHandlerFunctionTest.kt
@@ -2,13 +2,12 @@ package me.ahoo.wow.webflux.wait
 
 import io.mockk.every
 import io.mockk.mockk
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.command.COMMAND_GATEWAY_FUNCTION
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.SimpleWaitSignal
 import me.ahoo.wow.command.wait.SimpleWaitStrategyRegistrar
 import me.ahoo.wow.id.generateGlobalId
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 import org.springframework.web.reactive.function.server.ServerRequest
 import reactor.kotlin.core.publisher.toMono
@@ -30,7 +29,7 @@ class CommandWaitHandlerFunctionTest {
         val response = commandWaitHandlerFunction.handle(request)
         response.test()
             .consumeNextWith {
-                assertThat(it.statusCode().is2xxSuccessful, equalTo(true))
+                it.statusCode().is2xxSuccessful.assert().isTrue()
             }
             .verifyComplete()
     }


### PR DESCRIPTION
Changes proposed in this pull request:
- Switched from using `assertThat` to `assert` for test assertions, improving readability and consistency.
- Updated the `@Deprecated` annotations in `StatelessSaga`, `ProjectionProcessor`, and `EventProcessor` to include detailed messages and import statements, making deprecation warnings more informative.