### PR TITLE
Add skip method and improve assertions in Stages

### DIFF
--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/Stages.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/Stages.kt
@@ -220,11 +220,23 @@ class EventIterator(override val delegate: Iterator<DomainEvent<*>>) :
     Iterator<DomainEvent<*>> by delegate,
     Decorator<Iterator<DomainEvent<*>>> {
 
+    fun skip(skip: Int) {
+        require(skip >= 0) { "Skip value must be non-negative, but was: $skip" }
+        repeat(skip) {
+            hasNext().assert()
+                .describedAs { "Not enough events to skip $skip times. Current skip times: $it" }
+                .isTrue()
+            next()
+        }
+    }
+
     @Suppress("UNCHECKED_CAST")
     fun <E : Any> nextEvent(eventType: Class<E>): DomainEvent<E> {
-        hasNext().assert().describedAs { "Expect the next command." }.isTrue()
+        hasNext().assert().describedAs { "Expect there to be a next event." }.isTrue()
         val nextEvent = next()
-        nextEvent.body.assert().describedAs { "Expect the event body type." }.isInstanceOf(eventType)
+        nextEvent.body.assert()
+            .describedAs { "Expect the next event body to be an instance of ${eventType.simpleName}." }
+            .isInstanceOf(eventType)
         return nextEvent as DomainEvent<E>
     }
 

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/Stages.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/Stages.kt
@@ -220,7 +220,7 @@ class EventIterator(override val delegate: Iterator<DomainEvent<*>>) :
     Iterator<DomainEvent<*>> by delegate,
     Decorator<Iterator<DomainEvent<*>>> {
 
-    fun skip(skip: Int) {
+    fun skip(skip: Int): EventIterator {
         require(skip >= 0) { "Skip value must be non-negative, but was: $skip" }
         repeat(skip) {
             hasNext().assert()
@@ -228,6 +228,7 @@ class EventIterator(override val delegate: Iterator<DomainEvent<*>>) :
                 .isTrue()
             next()
         }
+        return this
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/Stages.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/Stages.kt
@@ -159,7 +159,7 @@ class CommandIterator(override val delegate: Iterator<CommandMessage<*>>) :
     Iterator<CommandMessage<*>> by delegate,
     Decorator<Iterator<CommandMessage<*>>> {
 
-    fun skip(skip: Int) {
+    fun skip(skip: Int): CommandIterator {
         require(skip >= 0) { "Skip value must be non-negative, but was: $skip" }
         repeat(skip) {
             hasNext().assert()
@@ -167,6 +167,7 @@ class CommandIterator(override val delegate: Iterator<CommandMessage<*>>) :
                 .isTrue()
             next()
         }
+        return this
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/Stages.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/Stages.kt
@@ -159,11 +159,23 @@ class CommandIterator(override val delegate: Iterator<CommandMessage<*>>) :
     Iterator<CommandMessage<*>> by delegate,
     Decorator<Iterator<CommandMessage<*>>> {
 
+    fun skip(skip: Int) {
+        require(skip >= 0) { "Skip value must be non-negative, but was: $skip" }
+        repeat(skip) {
+            hasNext().assert()
+                .describedAs { "Not enough commands to skip $skip times. Current skip times: $it" }
+                .isTrue()
+            next()
+        }
+    }
+
     @Suppress("UNCHECKED_CAST")
     fun <C : Any> nextCommand(commandType: Class<C>): CommandMessage<C> {
-        hasNext().assert().describedAs { "Expect the next command." }.isEqualTo(true)
+        hasNext().assert().describedAs { "Expect there to be a next command." }.isTrue()
         val nextCommand = next()
-        nextCommand.body.assert().describedAs { "Expect the command body type." }.isInstanceOf(commandType)
+        nextCommand.body.assert()
+            .describedAs { "Expect the next command body to be an instance of ${commandType.simpleName}." }
+            .isInstanceOf(commandType)
         return nextCommand as CommandMessage<C>
     }
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Added `skip` method to `Stages` in both `aggregate` and `saga/stateless` packages.
- Improved assertion messages for better clarity and readability.