### PR TITLE
Update project template download link in guide

### DIFF
--- a/documentation/docs/guide/getting-started.md
+++ b/documentation/docs/guide/getting-started.md
@@ -13,7 +13,7 @@
     - _Mac OS_:`~/Library/Application\ Support/JetBrains/<PRODUCT><VERSION/projectTemplates/`
     - _Linux_: `~/.config/JetBrains/<PRODUCT><VERSION>/projectTemplates/`
 - 将模板压缩包放到 _IDEA_ 项目模板目录下
-    - 模板压缩包: [wow-project-template.zip](https://gitee.com/AhooWang/wow-project-template/releases/download/v5.10.1/wow-project-template.zip)
+    - 模板压缩包: [wow-project-template.zip](https://gitee.com/AhooWang/wow-project-template/releases/download/v5.11.0/wow-project-template.zip)
 
 ## 创建项目
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Update the download link for the project template to point to the latest version (v5.11.0).