### PR TITLE
refactor(tests): update assertions to use custom assert methods

### DIFF
--- a/compensation/wow-compensation-api/src/test/kotlin/me/ahoo/wow/compensation/api/query/RetrySpecTest.kt
+++ b/compensation/wow-compensation-api/src/test/kotlin/me/ahoo/wow/compensation/api/query/RetrySpecTest.kt
@@ -13,13 +13,12 @@
 
 package me.ahoo.wow.compensation.api.query
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.annotation.Retry
 import me.ahoo.wow.compensation.api.IRetrySpec
 import me.ahoo.wow.compensation.api.RetrySpec
 import me.ahoo.wow.compensation.api.RetrySpec.Companion.materialize
 import me.ahoo.wow.compensation.api.RetrySpec.Companion.toSpec
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 
 class RetrySpecTest {
@@ -28,7 +27,7 @@ class RetrySpecTest {
     fun materializeSelf() {
         val retrySpec = RetrySpec(1, 2, 3)
         val materialized = retrySpec.materialize()
-        assertThat(retrySpec, sameInstance(materialized))
+        retrySpec.assert().isEqualTo(materialized)
     }
 
     @Test
@@ -42,18 +41,18 @@ class RetrySpecTest {
                 get() = 3
         }
         val materialized = retrySpec.materialize()
-        assertThat(retrySpec, not(sameInstance(materialized)))
-        assertThat(materialized.maxRetries, equalTo(retrySpec.maxRetries))
-        assertThat(materialized.minBackoff, equalTo(retrySpec.minBackoff))
-        assertThat(materialized.executionTimeout, equalTo(retrySpec.executionTimeout))
+        retrySpec.assert().isNotEqualTo(materialized)
+        retrySpec.maxRetries.assert().isEqualTo(materialized.maxRetries)
+        retrySpec.minBackoff.assert().isEqualTo(materialized.minBackoff)
+        retrySpec.executionTimeout.assert().isEqualTo(materialized.executionTimeout)
     }
 
     @Test
     fun toSpec() {
         val retry = Retry()
         val retrySpec = retry.toSpec()
-        assertThat(retrySpec.maxRetries, equalTo(retry.maxRetries))
-        assertThat(retrySpec.minBackoff, equalTo(retry.minBackoff))
-        assertThat(retrySpec.executionTimeout, equalTo(retry.executionTimeout))
+        retrySpec.maxRetries.assert().isEqualTo(retry.maxRetries)
+        retry.minBackoff.assert().isEqualTo(retry.minBackoff)
+        retry.executionTimeout.assert().isEqualTo(retry.executionTimeout)
     }
 }

--- a/compensation/wow-compensation-domain/src/test/kotlin/me/ahoo/wow/compensation/domain/CommandSortTest.kt
+++ b/compensation/wow-compensation-domain/src/test/kotlin/me/ahoo/wow/compensation/domain/CommandSortTest.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.compensation.domain
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.compensation.api.ApplyExecutionFailed
 import me.ahoo.wow.compensation.api.ApplyExecutionSuccess
 import me.ahoo.wow.compensation.api.ApplyRetrySpec
@@ -22,8 +23,6 @@ import me.ahoo.wow.compensation.api.ForcePrepareCompensation
 import me.ahoo.wow.compensation.api.MarkRecoverable
 import me.ahoo.wow.compensation.api.PrepareCompensation
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 
 class CommandSortTest {
@@ -31,19 +30,15 @@ class CommandSortTest {
     fun sort() {
         val aggregateMetadata = aggregateMetadata<ExecutionFailed, ExecutionFailedState>()
         val sortedCommands = aggregateMetadata.command.registeredCommands
-
-        assertThat(
-            sortedCommands,
-            contains(
-                CreateExecutionFailed::class.java,
-                PrepareCompensation::class.java,
-                ForcePrepareCompensation::class.java,
-                ApplyExecutionSuccess::class.java,
-                ApplyExecutionFailed::class.java,
-                ApplyRetrySpec::class.java,
-                ChangeFunction::class.java,
-                MarkRecoverable::class.java
-            )
+        sortedCommands.assert().contains(
+            CreateExecutionFailed::class.java,
+            PrepareCompensation::class.java,
+            ForcePrepareCompensation::class.java,
+            ApplyExecutionSuccess::class.java,
+            ApplyExecutionFailed::class.java,
+            ApplyRetrySpec::class.java,
+            ChangeFunction::class.java,
+            MarkRecoverable::class.java
         )
     }
 }

--- a/compensation/wow-compensation-domain/src/test/kotlin/me/ahoo/wow/compensation/domain/CommandSortTest.kt
+++ b/compensation/wow-compensation-domain/src/test/kotlin/me/ahoo/wow/compensation/domain/CommandSortTest.kt
@@ -30,7 +30,7 @@ class CommandSortTest {
     fun sort() {
         val aggregateMetadata = aggregateMetadata<ExecutionFailed, ExecutionFailedState>()
         val sortedCommands = aggregateMetadata.command.registeredCommands
-        sortedCommands.assert().contains(
+        sortedCommands.assert().containsExactly(
             CreateExecutionFailed::class.java,
             PrepareCompensation::class.java,
             ForcePrepareCompensation::class.java,

--- a/compensation/wow-compensation-domain/src/test/kotlin/me/ahoo/wow/compensation/domain/DefaultNextRetryAtCalculatorTest.kt
+++ b/compensation/wow-compensation-domain/src/test/kotlin/me/ahoo/wow/compensation/domain/DefaultNextRetryAtCalculatorTest.kt
@@ -1,8 +1,7 @@
 package me.ahoo.wow.compensation.domain
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.compensation.api.RetrySpec
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 
 class DefaultNextRetryAtCalculatorTest {
@@ -17,33 +16,27 @@ class DefaultNextRetryAtCalculatorTest {
     @Test
     fun nextRetryAt0() {
         val nextRetryAt = DefaultNextRetryAtCalculator.nextRetryAt(testRetrySpec.minBackoff, 0, 0)
-        assertThat(nextRetryAt, equalTo(testRetrySpec.minBackoff * 1000L))
+        nextRetryAt.assert().isEqualTo(testRetrySpec.minBackoff * 1000L)
     }
 
     @Test
     fun nextRetryAt1() {
         val nextRetryAt = DefaultNextRetryAtCalculator.nextRetryAt(testRetrySpec.minBackoff, 1, 0)
-        assertThat(nextRetryAt, equalTo(testRetrySpec.minBackoff * 1000L * 2))
+        nextRetryAt.assert().isEqualTo(testRetrySpec.minBackoff * 1000L * 2)
     }
 
     @Test
     fun nextRetryAt2() {
         val nextRetryAt = DefaultNextRetryAtCalculator.nextRetryAt(testRetrySpec.minBackoff, 2, 0)
-        assertThat(nextRetryAt, equalTo(testRetrySpec.minBackoff * 1000L * 4))
+        nextRetryAt.assert().isEqualTo(testRetrySpec.minBackoff * 1000L * 4)
     }
 
     @Test
     fun nextRetryState() {
         val retryState = DefaultNextRetryAtCalculator.nextRetryState(testRetrySpec, 1, 0)
-        assertThat(retryState.retries, equalTo(1))
-        assertThat(retryState.retryAt, equalTo(0))
-        assertThat(
-            retryState.timeoutAt,
-            equalTo(testRetrySpec.executionTimeout * 1000L)
-        )
-        assertThat(
-            retryState.nextRetryAt,
-            equalTo(testRetrySpec.minBackoff * 1000L * 2)
-        )
+        retryState.retries.assert().isEqualTo(1)
+        retryState.retryAt.assert().isEqualTo(0)
+        retryState.timeoutAt.assert().isEqualTo(testRetrySpec.executionTimeout * 1000L)
+        retryState.nextRetryAt.assert().isEqualTo(testRetrySpec.minBackoff * 1000L * 2)
     }
 }

--- a/compensation/wow-compensation-domain/src/test/kotlin/me/ahoo/wow/compensation/domain/ExecutionFailedStateTest.kt
+++ b/compensation/wow-compensation-domain/src/test/kotlin/me/ahoo/wow/compensation/domain/ExecutionFailedStateTest.kt
@@ -13,22 +13,22 @@
 
 package me.ahoo.wow.compensation.domain
 
-import me.ahoo.wow.id.GlobalIdGenerator
-import org.junit.jupiter.api.Assertions
+import me.ahoo.test.asserts.assertThrownBy
+import me.ahoo.wow.id.generateGlobalId
 import org.junit.jupiter.api.Test
 
 class ExecutionFailedStateTest {
     @Test
     fun ctor() {
-        val state = ExecutionFailedState(GlobalIdGenerator.generateAsString())
-        Assertions.assertThrows(UninitializedPropertyAccessException::class.java) {
+        val state = ExecutionFailedState(generateGlobalId())
+        assertThrownBy<UninitializedPropertyAccessException> {
             state.eventId
         }
-        Assertions.assertThrows(UninitializedPropertyAccessException::class.java) {
+        assertThrownBy<UninitializedPropertyAccessException> {
             state.function
         }
-        Assertions.assertThrows(UninitializedPropertyAccessException::class.java) {
-            state.error
+        assertThrownBy<UninitializedPropertyAccessException> {
+            state.eventId
         }
     }
 }

--- a/compensation/wow-compensation-domain/src/test/kotlin/me/ahoo/wow/compensation/domain/ExecutionFailedTest.kt
+++ b/compensation/wow-compensation-domain/src/test/kotlin/me/ahoo/wow/compensation/domain/ExecutionFailedTest.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.compensation.domain
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.exception.RecoverableType
 import me.ahoo.wow.api.messaging.function.FunctionInfoData
 import me.ahoo.wow.api.messaging.function.FunctionKind
@@ -35,20 +36,17 @@ import me.ahoo.wow.compensation.api.PrepareCompensation
 import me.ahoo.wow.compensation.api.RecoverableMarked
 import me.ahoo.wow.compensation.api.RetrySpec
 import me.ahoo.wow.compensation.api.RetrySpecApplied
-import me.ahoo.wow.id.GlobalIdGenerator
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.modeling.aggregateId
 import me.ahoo.wow.modeling.toNamedAggregate
 import me.ahoo.wow.test.aggregate.whenCommand
 import me.ahoo.wow.test.aggregateVerifier
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 
 class ExecutionFailedTest {
     companion object {
         val EVENT_AGGREGATE = "order.order".toNamedAggregate()
-        val EVENT_ID = EventId(GlobalIdGenerator.generateAsString(), EVENT_AGGREGATE.aggregateId(), 1)
+        val EVENT_ID = EventId(generateGlobalId(), EVENT_AGGREGATE.aggregateId(), 1)
         val function = FunctionInfoData(
             functionKind = FunctionKind.EVENT,
             contextName = "order",
@@ -57,7 +55,7 @@ class ExecutionFailedTest {
         )
 
         private fun newError(): ErrorDetails {
-            return ErrorDetails(GlobalIdGenerator.generateAsString(), "errorMsg", "stackTrace")
+            return ErrorDetails(generateGlobalId(), "errorMsg", "stackTrace")
         }
     }
 
@@ -78,18 +76,18 @@ class ExecutionFailedTest {
             .expectNoError()
             .expectEventType(ExecutionFailedCreated::class.java)
             .expectState {
-                assertThat(it.eventId, equalTo(createExecutionFailed.eventId))
-                assertThat(it.function, equalTo(createExecutionFailed.function))
-                assertThat(it.error, equalTo(createExecutionFailed.error))
-                assertThat(it.executeAt, equalTo(createExecutionFailed.executeAt))
-                assertThat(it.status, equalTo(ExecutionFailedStatus.FAILED))
-                assertThat(it.retryState.retries, equalTo(0))
-                assertThat(it.isRetryable, equalTo(true))
-                assertThat(it.retryState.timeout(), equalTo(false))
-                assertThat(it.retrySpec, equalTo(DefaultNextRetryAtCalculatorTest.testRetrySpec))
-                assertThat(it.canRetry(), equalTo(true))
-                assertThat(it.canNextRetry(), equalTo(false))
-                assertThat(it.recoverable, equalTo(createExecutionFailed.recoverable))
+                it.eventId.assert().isEqualTo(createExecutionFailed.eventId)
+                it.function.assert().isEqualTo(createExecutionFailed.function)
+                it.error.assert().isEqualTo(createExecutionFailed.error)
+                it.executeAt.assert().isEqualTo(createExecutionFailed.executeAt)
+                it.status.assert().isEqualTo(ExecutionFailedStatus.FAILED)
+                it.retryState.retries.assert().isZero()
+                it.isRetryable.assert().isTrue()
+                it.retryState.timeout().assert().isFalse()
+                it.retrySpec.assert().isEqualTo(DefaultNextRetryAtCalculatorTest.testRetrySpec)
+                it.canRetry().assert().isTrue()
+                it.canNextRetry().assert().isFalse()
+                it.recoverable.assert().isEqualTo(createExecutionFailed.recoverable)
             }
             .verify()
     }
@@ -112,25 +110,25 @@ class ExecutionFailedTest {
             .expectNoError()
             .expectEventType(ExecutionFailedCreated::class.java)
             .expectState {
-                assertThat(it.eventId, equalTo(createExecutionFailed.eventId))
-                assertThat(it.function, equalTo(createExecutionFailed.function))
-                assertThat(it.error, equalTo(createExecutionFailed.error))
-                assertThat(it.executeAt, equalTo(createExecutionFailed.executeAt))
-                assertThat(it.status, equalTo(ExecutionFailedStatus.FAILED))
-                assertThat(it.retryState.retries, equalTo(0))
-                assertThat(it.isRetryable, equalTo(true))
-                assertThat(it.retryState.timeout(), equalTo(false))
-                assertThat(it.retrySpec, equalTo(createExecutionFailed.retrySpec))
-                assertThat(it.canRetry(), equalTo(true))
-                assertThat(it.canNextRetry(), equalTo(false))
-                assertThat(it.recoverable, equalTo(createExecutionFailed.recoverable))
+                it.eventId.assert().isEqualTo(createExecutionFailed.eventId)
+                it.function.assert().isEqualTo(createExecutionFailed.function)
+                it.error.assert().isEqualTo(createExecutionFailed.error)
+                it.executeAt.assert().isEqualTo(createExecutionFailed.executeAt)
+                it.status.assert().isEqualTo(ExecutionFailedStatus.FAILED)
+                it.retryState.retries.assert().isZero()
+                it.isRetryable.assert().isTrue()
+                it.retryState.timeout().assert().isFalse()
+                it.retrySpec.assert().isEqualTo(createExecutionFailed.retrySpec)
+                it.canRetry().assert().isTrue()
+                it.canNextRetry().assert().isFalse()
+                it.recoverable.assert().isEqualTo(createExecutionFailed.recoverable)
             }
             .verify()
     }
 
     @Test
     fun onPrepare() {
-        val prepareCompensation = PrepareCompensation(id = GlobalIdGenerator.generateAsString())
+        val prepareCompensation = PrepareCompensation(id = generateGlobalId())
         val executionFailedCreated = ExecutionFailedCreated(
             eventId = EVENT_ID,
             function = function,
@@ -147,24 +145,24 @@ class ExecutionFailedTest {
             .expectNoError()
             .expectEventType(CompensationPrepared::class.java)
             .expectEventBody<CompensationPrepared> {
-                assertThat(it.eventId, equalTo(executionFailedCreated.eventId))
-                assertThat(it.function, equalTo(executionFailedCreated.function))
-                assertThat(it.retryState.retries, equalTo(executionFailedCreated.retryState.retries + 1))
+                it.eventId.assert().isEqualTo(executionFailedCreated.eventId)
+                it.function.assert().isEqualTo(executionFailedCreated.function)
+                it.retryState.retries.assert().isEqualTo(executionFailedCreated.retryState.retries + 1)
             }
             .expectState {
-                assertThat(it.id, equalTo(prepareCompensation.id))
-                assertThat(it.status, equalTo(ExecutionFailedStatus.PREPARED))
-                assertThat(it.retryState.retries, equalTo(executionFailedCreated.retryState.retries + 1))
-                assertThat(it.eventId, equalTo(executionFailedCreated.eventId))
-                assertThat(it.function, equalTo(executionFailedCreated.function))
-                assertThat(it.canNextRetry(), equalTo(false))
+                it.id.assert().isEqualTo(prepareCompensation.id)
+                it.status.assert().isEqualTo(ExecutionFailedStatus.PREPARED)
+                it.retryState.retries.assert().isEqualTo(executionFailedCreated.retryState.retries + 1)
+                it.eventId.assert().isEqualTo(executionFailedCreated.eventId)
+                it.function.assert().isEqualTo(executionFailedCreated.function)
+                it.canRetry().assert().isFalse()
             }
             .verify()
             .fork {
                 whenCommand(prepareCompensation)
                     .expectErrorType(IllegalStateException::class.java)
                     .expectState {
-                        assertThat(it.status, equalTo(ExecutionFailedStatus.PREPARED))
+                        it.status.assert().isEqualTo(ExecutionFailedStatus.PREPARED)
                     }
                     .verify()
             }
@@ -172,7 +170,7 @@ class ExecutionFailedTest {
 
     @Test
     fun onPrepareGivenMaxRetry() {
-        val prepareCompensation = PrepareCompensation(id = GlobalIdGenerator.generateAsString())
+        val prepareCompensation = PrepareCompensation(id = generateGlobalId())
         val executionFailedCreated = ExecutionFailedCreated(
             eventId = EVENT_ID,
             function = function,
@@ -191,17 +189,17 @@ class ExecutionFailedTest {
             .whenCommand(prepareCompensation)
             .expectErrorType(IllegalStateException::class.java)
             .expectState {
-                assertThat(it.id, equalTo(prepareCompensation.id))
-                assertThat(it.status, equalTo(ExecutionFailedStatus.FAILED))
-                assertThat(it.retryState.retries, equalTo(10))
-                assertThat(it.canNextRetry(), equalTo(false))
+                it.id.assert().isEqualTo(prepareCompensation.id)
+                it.status.assert().isEqualTo(ExecutionFailedStatus.FAILED)
+                it.retryState.retries.assert().isEqualTo(10)
+                it.canRetry().assert().isFalse()
             }
             .verify()
     }
 
     @Test
     fun onForcePrepare() {
-        val prepareCompensation = ForcePrepareCompensation(id = GlobalIdGenerator.generateAsString())
+        val prepareCompensation = ForcePrepareCompensation(id = generateGlobalId())
         val executionFailedCreated = ExecutionFailedCreated(
             eventId = EVENT_ID,
             function = function,
@@ -221,10 +219,10 @@ class ExecutionFailedTest {
             .expectNoError()
             .expectEventType(CompensationPrepared::class.java)
             .expectState {
-                assertThat(it.id, equalTo(prepareCompensation.id))
-                assertThat(it.status, equalTo(ExecutionFailedStatus.PREPARED))
-                assertThat(it.retryState.retries, equalTo(11))
-                assertThat(it.canNextRetry(), equalTo(false))
+                it.id.assert().isEqualTo(prepareCompensation.id)
+                it.status.assert().isEqualTo(ExecutionFailedStatus.PREPARED)
+                it.retryState.retries.assert().isEqualTo(11)
+                it.canNextRetry().assert().isFalse()
             }
             .verify()
     }
@@ -232,7 +230,7 @@ class ExecutionFailedTest {
     @Test
     fun onApplyExecutionFailed() {
         val applyExecutionFailed = ApplyExecutionFailed(
-            id = GlobalIdGenerator.generateAsString(),
+            id = generateGlobalId(),
             error = newError(),
             executeAt = System.currentTimeMillis(),
             recoverable = RecoverableType.RECOVERABLE
@@ -262,22 +260,22 @@ class ExecutionFailedTest {
             .expectNoError()
             .expectEventType(ExecutionFailedApplied::class.java)
             .expectState {
-                assertThat(it.id, equalTo(applyExecutionFailed.id))
-                assertThat(it.status, equalTo(ExecutionFailedStatus.FAILED))
-                assertThat(it.error, equalTo(applyExecutionFailed.error))
-                assertThat(it.executeAt, equalTo(applyExecutionFailed.executeAt))
-                assertThat(it.recoverable, equalTo(applyExecutionFailed.recoverable))
-                assertThat(it.retryState.retries, equalTo(1))
-                assertThat(it.canRetry(), equalTo(true))
-                assertThat(it.canNextRetry(), equalTo(false))
+                it.id.assert().isEqualTo(applyExecutionFailed.id)
+                it.status.assert().isEqualTo(ExecutionFailedStatus.FAILED)
+                it.error.assert().isEqualTo(applyExecutionFailed.error)
+                it.executeAt.assert().isEqualTo(applyExecutionFailed.executeAt)
+                it.recoverable.assert().isEqualTo(applyExecutionFailed.recoverable)
+                it.retryState.retries.assert().isEqualTo(1)
+                it.canRetry().assert().isTrue()
+                it.canNextRetry().assert().isFalse()
             }
             .verify()
             .fork {
                 whenCommand(applyExecutionFailed)
                     .expectErrorType(IllegalStateException::class.java)
                     .expectState {
-                        assertThat(it.status, equalTo(ExecutionFailedStatus.FAILED))
-                        assertThat(it.retryState.retries, equalTo(1))
+                        it.status.assert().isEqualTo(ExecutionFailedStatus.FAILED)
+                        it.retryState.retries.assert().isEqualTo(1)
                     }
                     .verify()
             }
@@ -286,7 +284,7 @@ class ExecutionFailedTest {
     @Test
     fun onSucceed() {
         val applyExecutionSuccess = ApplyExecutionSuccess(
-            id = GlobalIdGenerator.generateAsString(),
+            id = generateGlobalId(),
             executeAt = System.currentTimeMillis()
         )
         val executionFailedCreated = ExecutionFailedCreated(
@@ -314,21 +312,21 @@ class ExecutionFailedTest {
             .expectNoError()
             .expectEventType(ExecutionSuccessApplied::class.java)
             .expectState {
-                assertThat(it.id, equalTo(applyExecutionSuccess.id))
-                assertThat(it.status, equalTo(ExecutionFailedStatus.SUCCEEDED))
-                assertThat(it.error, equalTo(executionFailedCreated.error))
-                assertThat(it.recoverable, equalTo(executionFailedCreated.recoverable))
-                assertThat(it.retryState.retries, equalTo(1))
-                assertThat(it.canRetry(), equalTo(false))
-                assertThat(it.canNextRetry(), equalTo(false))
+                it.id.assert().isEqualTo(applyExecutionSuccess.id)
+                it.status.assert().isEqualTo(ExecutionFailedStatus.SUCCEEDED)
+                it.error.assert().isEqualTo(executionFailedCreated.error)
+                it.recoverable.assert().isEqualTo(executionFailedCreated.recoverable)
+                it.retryState.retries.assert().isEqualTo(1)
+                it.canRetry().assert().isFalse()
+                it.canNextRetry().assert().isFalse()
             }
             .verify()
             .fork {
                 whenCommand(applyExecutionSuccess)
                     .expectErrorType(IllegalStateException::class.java)
                     .expectState {
-                        assertThat(it.status, equalTo(ExecutionFailedStatus.SUCCEEDED))
-                        assertThat(it.retryState.retries, equalTo(1))
+                        it.status.assert().isEqualTo(ExecutionFailedStatus.SUCCEEDED)
+                        it.retryState.retries.assert().isEqualTo(1)
                     }
                     .verify()
             }
@@ -337,7 +335,7 @@ class ExecutionFailedTest {
     @Test
     fun onApplyRetrySpec() {
         val applyRetrySpec = ApplyRetrySpec(
-            id = GlobalIdGenerator.generateAsString(),
+            id = generateGlobalId(),
             maxRetries = 20,
             minBackoff = 180,
             executionTimeout = 100
@@ -358,11 +356,11 @@ class ExecutionFailedTest {
             .expectNoError()
             .expectEventType(RetrySpecApplied::class.java)
             .expectState {
-                assertThat(it.id, equalTo(applyRetrySpec.id))
-                assertThat(it.error, equalTo(executionFailedCreated.error))
-                assertThat(it.retrySpec.maxRetries, equalTo(applyRetrySpec.maxRetries))
-                assertThat(it.retrySpec.minBackoff, equalTo(applyRetrySpec.minBackoff))
-                assertThat(it.retrySpec.executionTimeout, equalTo(applyRetrySpec.executionTimeout))
+                it.id.assert().isEqualTo(applyRetrySpec.id)
+                it.error.assert().isEqualTo(executionFailedCreated.error)
+                it.retrySpec.maxRetries.assert().isEqualTo(applyRetrySpec.maxRetries)
+                it.retrySpec.minBackoff.assert().isEqualTo(applyRetrySpec.minBackoff)
+                it.retrySpec.executionTimeout.assert().isEqualTo(applyRetrySpec.executionTimeout)
             }
             .verify()
     }
@@ -370,7 +368,7 @@ class ExecutionFailedTest {
     @Test
     fun onMarkRecoverable() {
         val markRecoverable = MarkRecoverable(
-            id = GlobalIdGenerator.generateAsString(),
+            id = generateGlobalId(),
             recoverable = RecoverableType.RECOVERABLE
         )
         val executionFailedCreated = ExecutionFailedCreated(
@@ -390,8 +388,8 @@ class ExecutionFailedTest {
             .expectNoError()
             .expectEventType(RecoverableMarked::class.java)
             .expectState {
-                assertThat(it.id, equalTo(markRecoverable.id))
-                assertThat(it.recoverable, equalTo(markRecoverable.recoverable))
+                it.id.assert().isEqualTo(markRecoverable.id)
+                it.recoverable.assert().isEqualTo(markRecoverable.recoverable)
             }
             .verify()
             .fork {
@@ -404,7 +402,7 @@ class ExecutionFailedTest {
     @Test
     fun onChangeFunction() {
         val changeFunction = ChangeFunction(
-            id = GlobalIdGenerator.generateAsString(),
+            id = generateGlobalId(),
             contextName = generateGlobalId(),
             processorName = generateGlobalId(),
             name = generateGlobalId(),
@@ -427,9 +425,9 @@ class ExecutionFailedTest {
             .expectNoError()
             .expectEventType(FunctionChanged::class.java)
             .expectState {
-                assertThat(it.id, equalTo(changeFunction.id))
-                assertThat(it.recoverable, equalTo(executionFailedCreated.recoverable))
-                assertThat(it.function.isSameFunction(changeFunction), equalTo(true))
+                it.id.assert().isEqualTo(changeFunction.id)
+                it.recoverable.assert().isEqualTo(executionFailedCreated.recoverable)
+                it.function.isSameFunction(changeFunction).assert().isTrue()
             }
             .verify()
             .fork {

--- a/compensation/wow-compensation-server/src/test/kotlin/me/ahoo/wow/compensation/server/failed/SnapshotFindNextRetryTest.kt
+++ b/compensation/wow-compensation-server/src/test/kotlin/me/ahoo/wow/compensation/server/failed/SnapshotFindNextRetryTest.kt
@@ -1,12 +1,11 @@
 package me.ahoo.wow.compensation.server.failed
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.exception.RecoverableType
 import me.ahoo.wow.compensation.api.ExecutionFailedStatus
 import me.ahoo.wow.compensation.domain.ExecutionFailedStateProperties
 import me.ahoo.wow.query.dsl.condition
 import me.ahoo.wow.query.snapshot.nestedState
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 
 class SnapshotFindNextRetryTest {
@@ -50,6 +49,6 @@ class SnapshotFindNextRetryTest {
                 }
             }
         }
-        assertThat(nextCondition, equalTo(originalCondition))
+        nextCondition.assert().isEqualTo(originalCondition)
     }
 }

--- a/compensation/wow-compensation-server/src/test/kotlin/me/ahoo/wow/compensation/server/webhook/TemplateEngineTest.kt
+++ b/compensation/wow-compensation-server/src/test/kotlin/me/ahoo/wow/compensation/server/webhook/TemplateEngineTest.kt
@@ -2,6 +2,7 @@ package me.ahoo.wow.compensation.server.webhook
 
 import io.mockk.every
 import io.mockk.mockk
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.messaging.function.FunctionInfoData
 import me.ahoo.wow.api.messaging.function.FunctionKind
 import me.ahoo.wow.compensation.api.CompensationPrepared
@@ -59,7 +60,7 @@ class TemplateEngineTest {
         }
 
         val rendered = TemplateEngine.renderOnEvent(domainEvent, stateAggregate, host)
-        assertThat(rendered, notNullValue())
+        rendered.assert().isNotNull()
     }
 
     @Test
@@ -73,7 +74,7 @@ class TemplateEngineTest {
         }
 
         val rendered = TemplateEngine.renderOnEvent(domainEvent, stateAggregate, host)
-        assertThat(rendered, notNullValue())
+        rendered.assert().isNotNull()
     }
 
     @Test
@@ -85,7 +86,7 @@ class TemplateEngineTest {
         }
 
         val rendered = TemplateEngine.renderOnEvent(domainEvent, stateAggregate, host)
-        assertThat(rendered, notNullValue())
+        rendered.assert().isNotNull()
     }
 
     @Test
@@ -97,7 +98,7 @@ class TemplateEngineTest {
         }
 
         val rendered = TemplateEngine.renderOnEvent(domainEvent, stateAggregate, host)
-        assertThat(rendered, notNullValue())
+        rendered.assert().isNotNull()
     }
 
     @Test
@@ -109,7 +110,7 @@ class TemplateEngineTest {
         }
 
         val rendered = TemplateEngine.renderOnEvent(domainEvent, stateAggregate, host)
-        assertThat(rendered, notNullValue())
+        rendered.assert().isNotNull()
     }
 
     @Test
@@ -117,6 +118,6 @@ class TemplateEngineTest {
         val emptyHostNav = stateAggregate.state.toNavAsMarkdown("")
         assertThat(emptyHostNav, equalTo("`${executionFailedState.id}`"))
         val hostNav = stateAggregate.state.toNavAsMarkdown(host)
-        assertThat(hostNav, equalTo("[${executionFailedState.id}](${host}/to-retry?id=${executionFailedState.id})"))
+        hostNav.assert().isEqualTo("[${executionFailedState.id}](${host}/to-retry?id=${executionFailedState.id})")
     }
 }

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/OnStateEvent.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/OnStateEvent.kt
@@ -37,7 +37,7 @@ const val DEFAULT_ON_STATE_EVENT_NAME = "onStateEvent"
  * ``` kotlin
  *    @OnStateEvent
  *    fun onStateEvent(changed: Changed, stateRecord: StateRecord) {
- *      val state = stateRecord.toObject<StateData>()
+ *      val state = stateRecord.toState<StateData>()
  *         //...
  *     }
  * ```

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/command/DefaultDeleteAggregateTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/command/DefaultDeleteAggregateTest.kt
@@ -13,16 +13,12 @@
 
 package me.ahoo.wow.api.command
 
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 class DefaultDeleteAggregateTest {
     @Test
     fun isAssignableFrom() {
-        assertThat(
-            DeleteAggregate::class.java.isAssignableFrom(DefaultDeleteAggregate::class.java),
-            equalTo(true),
-        )
+        DeleteAggregate::class.java.isAssignableFrom(DefaultDeleteAggregate::class.java).assert().isTrue()
     }
 }

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/messaging/function/FunctionInfoDataKtTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/messaging/function/FunctionInfoDataKtTest.kt
@@ -1,7 +1,6 @@
 package me.ahoo.wow.api.messaging.function
 
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 class FunctionInfoDataKtTest {
@@ -10,6 +9,6 @@ class FunctionInfoDataKtTest {
     fun materialize() {
         val functionInfoData = FunctionInfoData(FunctionKind.COMMAND, "contextName", "processorName", "functionName")
         val materialized = functionInfoData.materialize()
-        assertThat(functionInfoData, sameInstance(materialized))
+        functionInfoData.assert().isSameAs(materialized)
     }
 }

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/query/MaterializedSnapshotTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/query/MaterializedSnapshotTest.kt
@@ -1,7 +1,6 @@
 package me.ahoo.wow.api.query
 
-import org.hamcrest.CoreMatchers.notNullValue
-import org.hamcrest.MatcherAssert.*
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 class MaterializedSnapshotTest {
@@ -24,6 +23,6 @@ class MaterializedSnapshotTest {
             snapshotTime = 1,
             deleted = false
         )
-        assertThat(snapshot, notNullValue())
+        snapshot.assert().isNotNull()
     }
 }

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/query/PagedListTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/query/PagedListTest.kt
@@ -1,12 +1,11 @@
 package me.ahoo.wow.api.query
 
-import org.hamcrest.CoreMatchers.sameInstance
-import org.hamcrest.MatcherAssert.*
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 class PagedListTest {
     @Test
-    fun emtpy() {
-        assertThat(PagedList.empty(), sameInstance(PagedList.empty<String>()))
+    fun empty() {
+        PagedList.empty<String>().assert().isSameAs(PagedList.empty<String>())
     }
 }

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ScriptEngineTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ScriptEngineTest.kt
@@ -1,8 +1,7 @@
 package me.ahoo.wow.bi
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.configuration.MetadataSearcher
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 
 class ScriptEngineTest {
@@ -10,7 +9,7 @@ class ScriptEngineTest {
     @Test
     fun generate() {
         val syncScript = ScriptEngine.generate(MetadataSearcher.localAggregates)
-        assertThat(syncScript, notNullValue())
+        syncScript.assert().isNotNull()
     }
 
     @Test
@@ -21,6 +20,6 @@ class ScriptEngineTest {
             "topicPrefix",
             MessageHeaderSqlType.STRING
         )
-        assertThat(syncScript, notNullValue())
+        syncScript.assert().isNotNull()
     }
 }

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/expansion/StateExpansionScriptGeneratorTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/expansion/StateExpansionScriptGeneratorTest.kt
@@ -13,14 +13,13 @@
 
 package me.ahoo.wow.bi.expansion
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.Identifier
 import me.ahoo.wow.api.annotation.AggregateRoot
 import me.ahoo.wow.bi.expansion.StateExpansionScriptGenerator.Companion.toScriptGenerator
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.serialization.toJsonString
 import me.ahoo.wow.serialization.toObject
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 import java.util.*
 
@@ -33,17 +32,14 @@ class StateExpansionMetadataVisitorTest {
         val biAggregateMetadata = aggregateMetadata<BIAggregate, BIAggregateState>()
         val scriptGenerator = biAggregateMetadata.toScriptGenerator()
         val sql = scriptGenerator.toString()
-        assertThat(sql, equalTo(expectedBiAggregateScript))
-        assertThat(
-            scriptGenerator.targetTables,
-            containsInAnyOrder(
-                "bi_aggregate_state_last_root",
-                "bi_aggregate_state_last_root_items",
-                "bi_aggregate_state_last_root_set",
-                "bi_aggregate_state_last_root_like_list_item",
-                "bi_aggregate_state_last_root_nested_list",
-                "bi_aggregate_state_last_root_nested_list_list"
-            )
+        sql.assert().isEqualTo(expectedBiAggregateScript)
+        scriptGenerator.targetTables.assert().containsExactly(
+            "bi_aggregate_state_last_root",
+            "bi_aggregate_state_last_root_items",
+            "bi_aggregate_state_last_root_set",
+            "bi_aggregate_state_last_root_like_list_item",
+            "bi_aggregate_state_last_root_nested_list",
+            "bi_aggregate_state_last_root_nested_list_list"
         )
     }
 
@@ -52,41 +48,39 @@ class StateExpansionMetadataVisitorTest {
         val state = BIAggregateState(UUID.randomUUID().toString())
         val json = state.toJsonString()
         val stateObj = json.toObject<BIAggregateState>()
-        assertThat(stateObj.id, equalTo(state.id))
-        assertThat(stateObj.string, equalTo(state.string))
-        assertThat(stateObj.int, equalTo(state.int))
-        assertThat(stateObj.long, equalTo(state.long))
-        assertThat(stateObj.double, equalTo(state.double))
-        assertThat(stateObj.float, equalTo(state.float))
-        assertThat(stateObj.boolean, equalTo(state.boolean))
-        assertThat(stateObj.byte, equalTo(state.byte))
-        assertThat(stateObj.short, equalTo(state.short))
-        assertThat(stateObj.char, equalTo(state.char))
-        assertThat(stateObj.item, equalTo(state.item))
-        assertThat(stateObj.uuid, equalTo(state.uuid))
-        assertThat(stateObj.duration, equalTo(state.duration))
-        assertThat(stateObj.kotlinDuration, equalTo(state.kotlinDuration))
-        assertThat(stateObj.date, equalTo(state.date))
-        assertThat(stateObj.sqlDate, equalTo(state.sqlDate))
-        assertThat(stateObj.localDate, equalTo(state.localDate))
-        assertThat(stateObj.localDateTime, equalTo(state.localDateTime))
-        assertThat(stateObj.localTime, equalTo(state.localTime))
-        assertThat(stateObj.instant, equalTo(state.instant))
-        // assertThat(stateObj.zonedDateTime, equalTo(state.zonedDateTime))
-        // assertThat(stateObj.offsetDateTime, equalTo(state.offsetDateTime))
-        assertThat(stateObj.offsetTime, equalTo(state.offsetTime))
-        assertThat(stateObj.yearMonth, equalTo(state.yearMonth))
-        assertThat(stateObj.monthDay, equalTo(state.monthDay))
-        assertThat(stateObj.period, equalTo(state.period))
-        assertThat(stateObj.year, equalTo(state.year))
-        assertThat(stateObj.month, equalTo(state.month))
-        assertThat(stateObj.dayOfWeek, equalTo(state.dayOfWeek))
-        assertThat(stateObj.nested, equalTo(state.nested))
-        assertThat(stateObj.stringList, equalTo(state.stringList))
-        assertThat(stateObj.intArray, equalTo(state.intArray))
-        assertThat(stateObj.map, equalTo(state.map))
-        assertThat(stateObj.items, equalTo(state.items))
-        assertThat(stateObj.nestedList, equalTo(state.nestedList))
+        stateObj.id.assert().isEqualTo(state.id)
+        stateObj.string.assert().isEqualTo(state.string)
+        stateObj.int.assert().isEqualTo(state.int)
+        stateObj.long.assert().isEqualTo(state.long)
+        stateObj.double.assert().isEqualTo(state.double)
+        stateObj.float.assert().isEqualTo(state.float)
+        stateObj.boolean.assert().isEqualTo(state.boolean)
+        stateObj.byte.assert().isEqualTo(state.byte)
+        stateObj.short.assert().isEqualTo(state.short)
+        stateObj.char.assert().isEqualTo(state.char)
+        stateObj.item.assert().isEqualTo(state.item)
+        stateObj.uuid.assert().isEqualTo(state.uuid)
+        stateObj.duration.assert().isEqualTo(state.duration)
+        stateObj.kotlinDuration.assert().isEqualTo(state.kotlinDuration)
+        stateObj.date.assert().isEqualTo(state.date)
+        stateObj.sqlDate.assert().isEqualTo(state.sqlDate)
+        stateObj.localDate.assert().isEqualTo(state.localDate)
+        stateObj.localDateTime.assert().isEqualTo(state.localDateTime)
+        stateObj.localTime.assert().isEqualTo(state.localTime)
+        stateObj.instant.assert().isEqualTo(state.instant)
+        stateObj.offsetTime.assert().isEqualTo(state.offsetTime)
+        stateObj.yearMonth.assert().isEqualTo(state.yearMonth)
+        stateObj.monthDay.assert().isEqualTo(state.monthDay)
+        stateObj.period.assert().isEqualTo(state.period)
+        stateObj.year.assert().isEqualTo(state.year)
+        stateObj.month.assert().isEqualTo(state.month)
+        stateObj.dayOfWeek.assert().isEqualTo(state.dayOfWeek)
+        stateObj.nested.assert().isEqualTo(state.nested)
+        stateObj.stringList.assert().isEqualTo(state.stringList)
+        stateObj.intArray.assert().isEqualTo(state.intArray)
+        stateObj.map.assert().isEqualTo(state.map)
+        stateObj.items.assert().isEqualTo(state.items)
+        stateObj.nestedList.assert().isEqualTo(state.nestedList)
     }
 }
 


### PR DESCRIPTION
- Replaced `org.hamcrest.MatcherAssert` and `org.junit.jupiter.api.Assertions` with `me.ahoo.test.asserts.assert`
- Updated the `ExecutionFailedStateTest`, `DefaultNextRetryAtCalculatorTest`, `ExecutionFailedTest`, and `CommandSortTest` to use the new assertion methods
- Simplified some test cases by removing redundant assertions

- This change aims to standardize the way assertions are handled in the tests, making them more consistent and readable.