### PR TITLE
refactor(tests): update test methods to use whenEvent and whenCommand

### DIFF
--- a/documentation/docs/guide/getting-started.md
+++ b/documentation/docs/guide/getting-started.md
@@ -225,39 +225,39 @@ class DemoState(override val id: String) : Identifier {
 ```kotlin
 class DemoTest {
 
-    @Test
-    fun onCreate() {
-        val command = CreateDemo(
-            data = "data"
-        )
+  @Test
+  fun onCreate() {
+    val command = CreateDemo(
+      data = "data"
+    )
 
-        aggregateVerifier<Demo, DemoState>()
-            .`when`(command)
-            .expectNoError()
-            .expectEventType(DemoCreated::class.java)
-            .expectState {
-                assertThat(it.data, equalTo(command.data))
-            }
-            .verify()
-    }
+    aggregateVerifier<Demo, DemoState>()
+      .whenCommand(command)
+      .expectNoError()
+      .expectEventType(DemoCreated::class.java)
+      .expectState {
+        it.data.assert().isEqualTo(command.data)
+      }
+      .verify()
+  }
 
-    @Test
-    fun onUpdate() {
-        val command = UpdateDemo(
-            id = GlobalIdGenerator.generateAsString(),
-            data = "data"
-        )
+  @Test
+  fun onUpdate() {
+    val command = UpdateDemo(
+      id = generateGlobalId(),
+      data = "data"
+    )
 
-        aggregateVerifier<Demo, DemoState>()
-            .given(DemoCreated("old"))
-            .`when`(command)
-            .expectNoError()
-            .expectEventType(DemoUpdated::class.java)
-            .expectState {
-                assertThat(it.data, equalTo(command.data))
-            }
-            .verify()
-    }
+    aggregateVerifier<Demo, DemoState>()
+      .given(DemoCreated("old"))
+      .whenCommand(command)
+      .expectNoError()
+      .expectEventType(DemoUpdated::class.java)
+      .expectState {
+        it.data.assert().isEqualTo(command.data)
+      }
+      .verify()
+  }
 }
 ```
 

--- a/documentation/docs/guide/saga.md
+++ b/documentation/docs/guide/saga.md
@@ -109,10 +109,10 @@ internal class TransferSagaTest {
     fun onPrepared() {
         val event = Prepared("to", 1)
         sagaVerifier<TransferSaga>()
-            .`when`(event)
+            .whenEvent(event)
             .expectCommandBody<Entry> {
-                assertThat(it.id, equalTo(event.to))
-                assertThat(it.amount, equalTo(event.amount))
+                it.id.assert().isEqualTo(event.to)
+                it.amount.assert().isEqualTo(event.amount)
             }
             .verify()
     }
@@ -121,10 +121,10 @@ internal class TransferSagaTest {
     fun onAmountEntered() {
         val event = AmountEntered("sourceId", 1)
         sagaVerifier<TransferSaga>()
-            .`when`(event)
+            .whenEvent(event)
             .expectCommandBody<Confirm> {
-                assertThat(it.id, equalTo(event.sourceId))
-                assertThat(it.amount, equalTo(event.amount))
+                it.id.assert().isEqualTo(event.sourceId)
+                it.amount.assert().isEqualTo(event.amount)
             }
             .verify()
     }
@@ -133,10 +133,10 @@ internal class TransferSagaTest {
     fun onEntryFailed() {
         val event = EntryFailed("sourceId", 1)
         sagaVerifier<TransferSaga>()
-            .`when`(event)
+            .whenEvent(event)
             .expectCommandBody<UnlockAmount> {
-                assertThat(it.id, equalTo(event.sourceId))
-                assertThat(it.amount, equalTo(event.amount))
+                it.id.assert().isEqualTo(event.sourceId)
+                it.amount.assert().isEqualTo(event.amount)
             }
             .verify()
     }

--- a/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartTest.kt
+++ b/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartTest.kt
@@ -26,7 +26,6 @@ import me.ahoo.wow.example.api.cart.ChangeQuantity
 import me.ahoo.wow.example.api.cart.RemoveCartItem
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.modeling.command.IllegalAccessDeletedAggregateException
-import me.ahoo.wow.test.aggregate.`when`
 import me.ahoo.wow.test.aggregate.whenCommand
 import me.ahoo.wow.test.aggregateVerifier
 import org.junit.jupiter.api.Test
@@ -55,7 +54,7 @@ class CartTest {
     }
 
     @Test
-    fun testGivenState() {
+    fun givenStateWhenAdd() {
         val addCartItem = AddCartItem(
             productId = "productId",
             quantity = 1,
@@ -63,7 +62,7 @@ class CartTest {
 
         aggregateVerifier<Cart, CartState>()
             .givenState(CartState(generateGlobalId()), 1)
-            .`when`(addCartItem)
+            .whenCommand(addCartItem)
             .expectNoError()
             .expectEventType(CartItemAdded::class.java)
             .expectState {
@@ -88,7 +87,7 @@ class CartTest {
                     ),
                 ),
             )
-            .`when`(addCartItem)
+            .whenCommand(addCartItem)
             .expectNoError()
             .expectEventType(CartQuantityChanged::class.java)
             .expectState {
@@ -106,7 +105,7 @@ class CartTest {
         )
         aggregateVerifier<Cart, CartState>()
             .given()
-            .`when`(addCartItem)
+            .whenCommand(addCartItem)
             .expectNoError()
             .expectEventType(CartItemAdded::class.java)
             .expectState {
@@ -139,7 +138,7 @@ class CartTest {
 
         aggregateVerifier<Cart, CartState>()
             .given(*events)
-            .`when`(addCartItem)
+            .whenCommand(addCartItem)
             .expectErrorType(IllegalArgumentException::class.java)
             .expectState {
                 it.items.assert().hasSize(MAX_CART_ITEM_SIZE)
@@ -163,7 +162,7 @@ class CartTest {
                     added = added,
                 ),
             )
-            .`when`(removeCartItem)
+            .whenCommand(removeCartItem)
             .expectEventType(CartItemRemoved::class.java)
             .expectState {
                 it.items.assert().isEmpty()
@@ -187,7 +186,7 @@ class CartTest {
                     added = added,
                 ),
             )
-            .`when`(changeQuantity)
+            .whenCommand(changeQuantity)
             .expectEventType(CartQuantityChanged::class.java)
             .expectState {
                 it.items.assert().hasSize(1)
@@ -203,7 +202,7 @@ class CartTest {
             quantity = 1,
         )
         aggregateVerifier<Cart, CartState>()
-            .`when`(addCartItem)
+            .whenCommand(addCartItem)
             .expectNoError()
             .expectEventType(CartItemAdded::class.java)
             .expectState {

--- a/example/transfer/example-transfer-domain/src/test/kotlin/me/ahoo/wow/example/transfer/domain/TransferSagaKTest.kt
+++ b/example/transfer/example-transfer-domain/src/test/kotlin/me/ahoo/wow/example/transfer/domain/TransferSagaKTest.kt
@@ -29,7 +29,7 @@ internal class TransferSagaKTest {
     fun onPrepared() {
         val event = Prepared("to", 1)
         sagaVerifier<TransferSaga>()
-            .`when`(event)
+            .whenEvent(event)
             .expectCommandBody<Entry> {
                 it.id.assert().isEqualTo(event.to)
                 it.amount.assert().isEqualTo(event.amount)
@@ -41,7 +41,7 @@ internal class TransferSagaKTest {
     fun onAmountEntered() {
         val event = AmountEntered("sourceId", 1)
         sagaVerifier<TransferSaga>()
-            .`when`(event)
+            .whenEvent(event)
             .expectCommandBody<Confirm> {
                 it.id.assert().isEqualTo(event.sourceId)
                 it.amount.assert().isEqualTo(event.amount)
@@ -53,7 +53,7 @@ internal class TransferSagaKTest {
     fun onEntryFailed() {
         val event = EntryFailed("sourceId", 1)
         sagaVerifier<TransferSaga>()
-            .`when`(event)
+            .whenEvent(event)
             .expectCommandBody<UnlockAmount> {
                 it.id.assert().isEqualTo(event.sourceId)
                 it.amount.assert().isEqualTo(event.amount)

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/CommandResultTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/CommandResultTest.kt
@@ -2,7 +2,7 @@ package me.ahoo.wow.command
 
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.exception.ErrorCodes
-import me.ahoo.wow.id.GlobalIdGenerator
+import me.ahoo.wow.id.generateGlobalId
 import org.hamcrest.MatcherAssert.*
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test
 class CommandResultTest {
     @Test
     fun throwableAsResult() {
-        val command = MockCreateCommand(GlobalIdGenerator.generateAsString()).toCommandMessage()
+        val command = MockCreateCommand(generateGlobalId()).toCommandMessage()
         val actual = IllegalStateException("test").toResult(
             command,
             processorName = "processorName"


### PR DESCRIPTION
- Updated test methods in `TransferSagaKTest` to use `whenEvent`.
- Updated test methods in `CartTest` and `DemoTest` to use `whenCommand`.
- Updated documentation to reflect these changes.
