### PR TITLE
refactor(test): replace assertion libraries with custom assert functions

### DIFF
--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/JsonSchemaTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/JsonSchemaTest.kt
@@ -2,12 +2,11 @@ package me.ahoo.wow.schema
 
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.github.victools.jsonschema.generator.SchemaVersion
+import me.ahoo.test.asserts.assert
+import me.ahoo.test.asserts.assertThrownBy
 import me.ahoo.wow.example.api.order.CreateOrder
 import me.ahoo.wow.schema.JsonSchema.Companion.asJsonSchema
 import me.ahoo.wow.serialization.toObject
-import org.hamcrest.CoreMatchers.notNullValue
-import org.hamcrest.MatcherAssert.*
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class JsonSchemaTest {
@@ -17,13 +16,13 @@ class JsonSchemaTest {
     fun get() {
         val schema = jsonSchemaGenerator.generate(CreateOrder::class.java)
             .asJsonSchema(schemaVersion = SchemaVersion.DRAFT_2020_12)
-        assertThat(schema.getProperties(), notNullValue())
+        schema.getProperties().assert().isNotNull()
     }
 
     @Test
     fun requiredGetPropertiesIfEmpty() {
         val emptySchema = "{}".toObject<ObjectNode>().asJsonSchema()
-        Assertions.assertThrows(IllegalArgumentException::class.java) {
+        assertThrownBy<IllegalArgumentException> {
             emptySchema.requiredGetProperties()
         }
     }

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/JsonSchemaValidatorTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/JsonSchemaValidatorTest.kt
@@ -7,6 +7,7 @@ import com.networknt.schema.JsonSchemaFactory
 import com.networknt.schema.SchemaLocation
 import com.networknt.schema.SchemaValidatorsConfig
 import com.networknt.schema.SpecVersion.VersionFlag
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.event.DomainEvent
 import me.ahoo.wow.api.modeling.AggregateId
@@ -31,8 +32,6 @@ import me.ahoo.wow.modeling.state.StateAggregate
 import me.ahoo.wow.serialization.toPrettyJson
 import me.ahoo.wow.tck.event.MockDomainEventStreams
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.*
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -151,6 +150,6 @@ class JsonSchemaValidatorTest {
         val assertions = schema.validate(input, InputFormat.JSON) { executionContext ->
             executionContext.executionConfig.formatAssertionsEnabled = true
         }
-        assertThat(assertions.firstOrNull()?.error.orEmpty(), assertions.isEmpty(), equalTo(true))
+        assertions.assert().isEmpty()
     }
 }

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/TypesTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/TypesTest.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.schema
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.event.DomainEvent
 import me.ahoo.wow.api.modeling.AggregateId
@@ -22,77 +23,76 @@ import me.ahoo.wow.eventsourcing.state.StateEvent
 import me.ahoo.wow.modeling.state.StateAggregate
 import me.ahoo.wow.schema.Types.isStdType
 import me.ahoo.wow.schema.Types.isWowType
-import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
 class TypesTest {
     @Test
     fun `isWowType should return true for AggregateId`() {
-        assertTrue(AggregateId::class.java.isWowType())
+        AggregateId::class.java.isWowType().assert().isTrue()
     }
 
     @Test
     fun `isWowType should return true for CommandMessage`() {
-        assertTrue(CommandMessage::class.java.isWowType())
+        CommandMessage::class.java.isWowType().assert().isTrue()
     }
 
     @Test
     fun `isWowType should return true for DomainEvent`() {
-        assertTrue(DomainEvent::class.java.isWowType())
+        DomainEvent::class.java.isWowType().assert().isTrue()
     }
 
     @Test
     fun `isWowType should return true for DomainEventStream`() {
-        assertTrue(DomainEventStream::class.java.isWowType())
+        DomainEventStream::class.java.isWowType().assert().isTrue()
     }
 
     @Test
     fun `isWowType should return true for Snapshot`() {
-        assertTrue(Snapshot::class.java.isWowType())
+        Snapshot::class.java.isWowType().assert().isTrue()
     }
 
     @Test
     fun `isWowType should return true for StateAggregate`() {
-        assertTrue(StateAggregate::class.java.isWowType())
+        StateAggregate::class.java.isWowType().assert().isTrue()
     }
 
     @Test
     fun `isWowType should return true for StateEvent`() {
-        assertTrue(StateEvent::class.java.isWowType())
+        StateEvent::class.java.isWowType().assert().isTrue()
     }
 
     @Test
     fun `isWowType should return false for String`() {
-        assertFalse(String::class.java.isWowType())
+        String::class.java.isWowType().assert().isFalse()
     }
 
     @Test
     fun `isWowType should return false for Int`() {
-        assertFalse(Int::class.java.isWowType())
+        Int::class.java.isWowType().assert().isFalse()
     }
 
     @Test
     fun `isWowType should return false for List`() {
-        assertFalse(List::class.java.isWowType())
+        List::class.java.isWowType().assert().isFalse()
     }
 
     @Test
     fun `isStdType should return true for String`() {
-        assertTrue(String::class.java.isStdType())
+        String::class.java.isStdType().assert().isTrue()
     }
 
     @Test
     fun `isStdType should return true for Int`() {
-        assertTrue(Int::class.java.isStdType())
+        Int::class.java.isStdType().assert().isTrue()
     }
 
     @Test
     fun `isStdType should return true for List`() {
-        assertTrue(List::class.java.isStdType())
+        List::class.java.isStdType().assert().isTrue()
     }
 
     @Test
     fun `isStdType should return false for AggregateId`() {
-        assertFalse(AggregateId::class.java.isStdType())
+        AggregateId::class.java.isStdType().assert().isFalse()
     }
 }

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/WowSchemaLoaderTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/WowSchemaLoaderTest.kt
@@ -1,6 +1,6 @@
 package me.ahoo.wow.schema
 
-import org.junit.jupiter.api.Assertions
+import me.ahoo.test.asserts.assertThrownBy
 import org.junit.jupiter.api.Test
 
 class WowSchemaLoaderTest {
@@ -8,7 +8,7 @@ class WowSchemaLoaderTest {
     @Test
     fun loadAsStringNotFound() {
         val resourceName = "not_found.json"
-        Assertions.assertThrows(IllegalArgumentException::class.java) {
+        assertThrownBy<IllegalArgumentException> {
             WowSchemaLoader.loadAsString(resourceName)
         }
     }

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/WowSchemaNamingStrategyTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/WowSchemaNamingStrategyTest.kt
@@ -9,6 +9,7 @@ import com.github.victools.jsonschema.generator.TypeContext
 import com.github.victools.jsonschema.generator.impl.TypeContextFactory
 import io.mockk.mockk
 import io.swagger.v3.oas.annotations.media.Schema
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.api.query.MaterializedSnapshot
 import me.ahoo.wow.api.query.PagedList
@@ -18,8 +19,6 @@ import me.ahoo.wow.example.domain.cart.CartState
 import me.ahoo.wow.example.domain.order.OrderState
 import me.ahoo.wow.schema.WowSchemaNamingStrategy.toSchemaName
 import me.ahoo.wow.serialization.JsonSerializer
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.MatcherAssert.*
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -78,6 +77,6 @@ class WowSchemaNamingStrategyTest {
     @MethodSource("parametersForToSchemaName")
     fun toSchemaName(type: ResolvedType, expectedSchemaName: String?) {
         val schemaName = type.toSchemaName()
-        assertThat(schemaName, equalTo(expectedSchemaName))
+        schemaName.assert().isEqualTo(expectedSchemaName)
     }
 }

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilderTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilderTest.kt
@@ -1,5 +1,7 @@
 package me.ahoo.wow.schema.openapi
 
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.MaterializedSnapshot
 import me.ahoo.wow.api.query.PagedList
 import me.ahoo.wow.command.wait.SimpleWaitSignal
@@ -7,8 +9,6 @@ import me.ahoo.wow.example.api.cart.AddCartItem
 import me.ahoo.wow.example.api.order.CreateOrder
 import me.ahoo.wow.example.domain.order.OrderState
 import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.CoreMatchers.notNullValue
-import org.hamcrest.CoreMatchers.nullValue
 import org.hamcrest.MatcherAssert.*
 import org.junit.jupiter.api.Test
 
@@ -17,18 +17,18 @@ class OpenAPISchemaBuilderTest {
     @Test
     fun build() {
         val openAPISchemaBuilder = OpenAPISchemaBuilder()
-        assertThat(openAPISchemaBuilder.inline, equalTo(false))
+        openAPISchemaBuilder.inline.assert().isFalse()
         val stringSchema = openAPISchemaBuilder.generateSchema(String::class.java)
-        assertThat(stringSchema.types.first(), equalTo("string"))
+        stringSchema.types.assert().contains("string")
         val createOderSchema = openAPISchemaBuilder.generateSchema(CreateOrder::class.java)
-        assertThat(createOderSchema.`$ref`, nullValue())
+        createOderSchema.`$ref`.assert().isNull()
         val addCartItemSchema = openAPISchemaBuilder.generateSchema(AddCartItem::class.java)
-        assertThat(addCartItemSchema.`$ref`, nullValue())
+        addCartItemSchema.`$ref`.assert().isNull()
         val orderStateSnapshotSchema = openAPISchemaBuilder.generateSchema(
             MaterializedSnapshot::class.java,
             OrderState::class.java
         )
-        assertThat(orderStateSnapshotSchema.`$ref`, nullValue())
+        orderStateSnapshotSchema.`$ref`.assert().isNull()
         val orderStateSnapshotPagedListSchema = openAPISchemaBuilder.generateSchema(
             PagedList::class.java,
             openAPISchemaBuilder.resolveType(
@@ -36,11 +36,11 @@ class OpenAPISchemaBuilderTest {
                 OrderState::class.java
             )
         )
-        assertThat(orderStateSnapshotPagedListSchema.`$ref`, nullValue())
+        orderStateSnapshotPagedListSchema.`$ref`.assert().isNull()
         val componentsSchemas = openAPISchemaBuilder.build()
-        assertThat(createOderSchema.`$ref`, notNullValue())
-        assertThat(addCartItemSchema.`$ref`, notNullValue())
-        assertThat(componentsSchemas.size, equalTo(9))
+        createOderSchema.`$ref`.assert().isNotNull()
+        addCartItemSchema.`$ref`.assert().isNotNull()
+        componentsSchemas.assert().hasSize(9)
     }
 
     @Test
@@ -48,16 +48,16 @@ class OpenAPISchemaBuilderTest {
         val openAPISchemaBuilder = OpenAPISchemaBuilder(
             customizer = OpenAPISchemaBuilder.InlineCustomizer
         )
-        assertThat(openAPISchemaBuilder.inline, equalTo(true))
+        openAPISchemaBuilder.inline.assert().isTrue()
         val createOderSchema = openAPISchemaBuilder.generateSchema(CreateOrder::class.java)
-        assertThat(createOderSchema.`$ref`, nullValue())
+        createOderSchema.`$ref`.assert().isNull()
         val addCartItemSchema = openAPISchemaBuilder.generateSchema(AddCartItem::class.java)
-        assertThat(addCartItemSchema.`$ref`, nullValue())
+        addCartItemSchema.`$ref`.assert().isNull()
         val orderStateSnapshotSchema = openAPISchemaBuilder.generateSchema(
             MaterializedSnapshot::class.java,
             OrderState::class.java
         )
-        assertThat(orderStateSnapshotSchema.`$ref`, nullValue())
+        orderStateSnapshotSchema.`$ref`.assert().isNull()
         val orderStateSnapshotPagedListSchema = openAPISchemaBuilder.generateSchema(
             PagedList::class.java,
             openAPISchemaBuilder.resolveType(
@@ -65,9 +65,9 @@ class OpenAPISchemaBuilderTest {
                 OrderState::class.java
             )
         )
-        assertThat(orderStateSnapshotPagedListSchema.`$ref`, nullValue())
+        orderStateSnapshotPagedListSchema.`$ref`.assert().isNull()
         val componentsSchemas = openAPISchemaBuilder.build()
-        assertThat(componentsSchemas.size, equalTo(0))
+        componentsSchemas.assert().isEmpty()
     }
 
     @Test
@@ -76,6 +76,14 @@ class OpenAPISchemaBuilderTest {
         assertThat(openAPISchemaBuilder.inline, equalTo(false))
         openAPISchemaBuilder.generateSchema(SimpleWaitSignal::class.java)
         val componentsSchemas = openAPISchemaBuilder.build()
-        assertThat(componentsSchemas.size, equalTo(6))
+        componentsSchemas.assert().hasSize(6)
+    }
+
+    @Test
+    fun condition() {
+        val openAPISchemaBuilder = OpenAPISchemaBuilder()
+        openAPISchemaBuilder.generateSchema(Condition::class.java)
+        val componentsSchemas = openAPISchemaBuilder.build()
+        componentsSchemas.assert().hasSize(3)
     }
 }


### PR DESCRIPTION
Replaced the use of Hamcrest and JUnit assertions with custom assert functions from `me.ahoo.test.asserts` for consistency and improved readability. This change affects multiple test files including `JsonSchemaTest`, `WowSchemaLoaderTest`, `JsonSchemaGeneratorTest`, `JsonSchemaValidatorTest`, `TypesTest`, and `OpenAPISchemaBuilderTest`.

- Updated imports to include `assert` and `assertThrownBy` where necessary.
- Replaced `assertThat` and `Assertions.assert*` calls with equivalent `assert` and `assertThrownBy` methods.

