### PR TITLE
feat(wow-schema): Support `Map` class in `WowSchemaNamingStrategy`

### DIFF
--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowSchemaNamingStrategy.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowSchemaNamingStrategy.kt
@@ -73,9 +73,14 @@ object WowSchemaNamingStrategy : SchemaDefinitionNamingStrategy {
         val flatTypes = flattenType()
         val namePrefix = flatTypes.firstNotNullOfOrNull {
             it.resolveNamePrefix()
-        } ?: return null
+        }
+        if (namePrefix == null && !this.isInstanceOf(Map::class.java)) {
+            return null
+        }
         return buildString {
-            append(namePrefix)
+            if (!namePrefix.isNullOrBlank()) {
+                append(namePrefix)
+            }
             flatTypes.forEach {
                 append(it.toSchemaName())
             }

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/WowSchemaNamingStrategyTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/WowSchemaNamingStrategyTest.kt
@@ -13,6 +13,7 @@ import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.api.query.MaterializedSnapshot
 import me.ahoo.wow.api.query.PagedList
+import me.ahoo.wow.configuration.BoundedContext
 import me.ahoo.wow.example.api.ExampleService
 import me.ahoo.wow.example.api.order.CreateOrder
 import me.ahoo.wow.example.domain.cart.CartState
@@ -68,6 +69,22 @@ class WowSchemaNamingStrategyTest {
                         arrayOf(mockk<CreateOrder>()).javaClass
                     ),
                     "example.order.CreateOrderArray"
+                ),
+                Arguments.of(
+                    typeContext.resolve(
+                        Map::class.java,
+                        String::class.java,
+                        Object::class.java
+                    ),
+                    "StringObjectMap"
+                ),
+                Arguments.of(
+                    typeContext.resolve(
+                        Map::class.java,
+                        String::class.java,
+                        BoundedContext::class.java
+                    ),
+                    "wow.configuration.StringBoundedContextMap"
                 )
             )
         }

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilderTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilderTest.kt
@@ -84,6 +84,7 @@ class OpenAPISchemaBuilderTest {
         val openAPISchemaBuilder = OpenAPISchemaBuilder()
         openAPISchemaBuilder.generateSchema(Condition::class.java)
         val componentsSchemas = openAPISchemaBuilder.build()
+        componentsSchemas.assert().containsKey("StringObjectMap")
         componentsSchemas.assert().hasSize(3)
     }
 }


### PR DESCRIPTION
- Enhanced `namePrefix` null check and append logic in `WowSchemaNamingStrategy`.
- Added a test case to verify the presence of "StringObjectMap" in `OpenAPISchemaBuilderTest`.
- Included additional test cases for map types in `WowSchemaNamingStrategyTest`.
