### PR TITLE
feat(wow-schema): Simplify SchemaNamingStrategy and update tests

### DIFF
--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowSchemaNamingStrategy.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowSchemaNamingStrategy.kt
@@ -16,7 +16,6 @@ package me.ahoo.wow.schema
 import com.fasterxml.classmate.ResolvedType
 import com.github.victools.jsonschema.generator.SchemaGenerationContext
 import com.github.victools.jsonschema.generator.impl.DefinitionKey
-import com.github.victools.jsonschema.generator.naming.DefaultSchemaDefinitionNamingStrategy
 import com.github.victools.jsonschema.generator.naming.SchemaDefinitionNamingStrategy
 import me.ahoo.wow.configuration.namedAggregate
 import me.ahoo.wow.configuration.namedBoundedContext
@@ -25,7 +24,6 @@ import me.ahoo.wow.modeling.toStringWithAlias
 import me.ahoo.wow.naming.getContextAlias
 
 object WowSchemaNamingStrategy : SchemaDefinitionNamingStrategy {
-    private val baseStrategy: SchemaDefinitionNamingStrategy = DefaultSchemaDefinitionNamingStrategy()
 
     fun Class<*>.resolveNamePrefix(): String? {
         this.namedAggregate()?.let {
@@ -69,13 +67,10 @@ object WowSchemaNamingStrategy : SchemaDefinitionNamingStrategy {
      * `me.ahoo.wow.api.query.PagedList<me.ahoo.wow.api.query.MaterializedSnapshot<me.ahoo.wow.example.domain.order.OrderState>>`
      *  >> `order.order.OrderStateMaterializedSnapshotPagedList`
      */
-    fun ResolvedType.toSchemaName(): String? {
+    fun ResolvedType.toSchemaName(): String {
         val flatTypes = flattenType()
         val namePrefix = flatTypes.firstNotNullOfOrNull {
             it.resolveNamePrefix()
-        }
-        if (namePrefix == null && !this.isInstanceOf(Map::class.java)) {
-            return null
         }
         return buildString {
             if (!namePrefix.isNullOrBlank()) {
@@ -88,6 +83,6 @@ object WowSchemaNamingStrategy : SchemaDefinitionNamingStrategy {
     }
 
     override fun getDefinitionNameForKey(key: DefinitionKey, generationContext: SchemaGenerationContext): String {
-        return key.type.toSchemaName() ?: baseStrategy.getDefinitionNameForKey(key, generationContext)
+        return key.type.toSchemaName()
     }
 }

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/WowSchemaNamingStrategyTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/WowSchemaNamingStrategyTest.kt
@@ -38,7 +38,7 @@ class WowSchemaNamingStrategyTest {
             return Stream.of(
                 Arguments.of(typeContext.resolve(AggregateId::class.java), "wow.api.modeling.AggregateId"),
                 Arguments.of(typeContext.resolve(CreateOrder::class.java), "example.order.CreateOrder"),
-                Arguments.of(typeContext.resolve(Any::class.java), null),
+                Arguments.of(typeContext.resolve(Any::class.java), "Object"),
                 Arguments.of(
                     typeContext.resolve(WowSchemaNamingStrategyTest::class.java),
                     "wow.schema.SchemaDefinitionNamingStrategyTest"
@@ -92,7 +92,7 @@ class WowSchemaNamingStrategyTest {
 
     @ParameterizedTest
     @MethodSource("parametersForToSchemaName")
-    fun toSchemaName(type: ResolvedType, expectedSchemaName: String?) {
+    fun toSchemaName(type: ResolvedType, expectedSchemaName: String) {
         val schemaName = type.toSchemaName()
         schemaName.assert().isEqualTo(expectedSchemaName)
     }


### PR DESCRIPTION
- Removed unused import and `baseStrategy` field.
- Updated `toSchemaName` method to always return a string.
- Adjusted test cases to reflect the changes in `toSchemaName`.
