### PR TITLE
refactor(wow-spring-boot-starter): remove duplicate EnabledCapable interface

### DIFF
--- a/compensation/wow-compensation-server/src/main/kotlin/me/ahoo/wow/compensation/server/scheduler/SchedulerProperties.kt
+++ b/compensation/wow-compensation-server/src/main/kotlin/me/ahoo/wow/compensation/server/scheduler/SchedulerProperties.kt
@@ -13,8 +13,8 @@
 
 package me.ahoo.wow.compensation.server.scheduler
 
+import me.ahoo.wow.api.naming.EnabledCapable
 import me.ahoo.wow.compensation.server.configuration.CompensationProperties
-import me.ahoo.wow.spring.boot.starter.EnabledCapable
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.bind.DefaultValue
 import java.time.Duration

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/BusProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/BusProperties.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.spring.boot.starter
 
+import me.ahoo.wow.api.naming.EnabledCapable
 import me.ahoo.wow.spring.boot.starter.BusType.Companion.KAFKA_NAME
 import org.springframework.boot.context.properties.NestedConfigurationProperty
 import org.springframework.boot.context.properties.bind.DefaultValue

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/WowProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/WowProperties.kt
@@ -14,14 +14,11 @@
 package me.ahoo.wow.spring.boot.starter
 
 import me.ahoo.wow.api.Wow
+import me.ahoo.wow.api.naming.EnabledCapable
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.bind.DefaultValue
 
 const val ENABLED_SUFFIX_KEY = ".enabled"
-
-interface EnabledCapable {
-    val enabled: Boolean
-}
 
 @ConfigurationProperties(prefix = Wow.WOW)
 class WowProperties(

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandProperties.kt
@@ -14,8 +14,8 @@
 package me.ahoo.wow.spring.boot.starter.command
 
 import me.ahoo.wow.api.Wow
+import me.ahoo.wow.api.naming.EnabledCapable
 import me.ahoo.wow.spring.boot.starter.BusProperties
-import me.ahoo.wow.spring.boot.starter.EnabledCapable
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.NestedConfigurationProperty
 import org.springframework.boot.context.properties.bind.DefaultValue

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/compensation/CompensationProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/compensation/CompensationProperties.kt
@@ -14,7 +14,7 @@
 package me.ahoo.wow.spring.boot.starter.compensation
 
 import me.ahoo.wow.api.Wow
-import me.ahoo.wow.spring.boot.starter.EnabledCapable
+import me.ahoo.wow.api.naming.EnabledCapable
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.bind.DefaultValue
 

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchProperties.kt
@@ -14,7 +14,7 @@
 package me.ahoo.wow.spring.boot.starter.elasticsearch
 
 import me.ahoo.wow.api.Wow
-import me.ahoo.wow.spring.boot.starter.EnabledCapable
+import me.ahoo.wow.api.naming.EnabledCapable
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.bind.DefaultValue
 

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/snapshot/SnapshotProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/snapshot/SnapshotProperties.kt
@@ -13,8 +13,8 @@
 
 package me.ahoo.wow.spring.boot.starter.eventsourcing.snapshot
 
+import me.ahoo.wow.api.naming.EnabledCapable
 import me.ahoo.wow.eventsourcing.snapshot.DEFAULT_VERSION_OFFSET
-import me.ahoo.wow.spring.boot.starter.EnabledCapable
 import me.ahoo.wow.spring.boot.starter.eventsourcing.EventSourcingProperties
 import me.ahoo.wow.spring.boot.starter.eventsourcing.StorageType
 import org.springframework.boot.context.properties.ConfigurationProperties

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/kafka/KafkaProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/kafka/KafkaProperties.kt
@@ -14,7 +14,7 @@
 package me.ahoo.wow.spring.boot.starter.kafka
 
 import me.ahoo.wow.api.Wow
-import me.ahoo.wow.spring.boot.starter.EnabledCapable
+import me.ahoo.wow.api.naming.EnabledCapable
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.common.serialization.StringDeserializer

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoProperties.kt
@@ -14,7 +14,7 @@
 package me.ahoo.wow.spring.boot.starter.mongo
 
 import me.ahoo.wow.api.Wow
-import me.ahoo.wow.spring.boot.starter.EnabledCapable
+import me.ahoo.wow.api.naming.EnabledCapable
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.bind.DefaultValue
 

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/openapi/OpenAPIProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/openapi/OpenAPIProperties.kt
@@ -14,7 +14,7 @@
 package me.ahoo.wow.spring.boot.starter.openapi
 
 import me.ahoo.wow.api.Wow
-import me.ahoo.wow.spring.boot.starter.EnabledCapable
+import me.ahoo.wow.api.naming.EnabledCapable
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.bind.DefaultValue
 

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareProperties.kt
@@ -14,7 +14,7 @@
 package me.ahoo.wow.spring.boot.starter.prepare
 
 import me.ahoo.wow.api.Wow
-import me.ahoo.wow.spring.boot.starter.EnabledCapable
+import me.ahoo.wow.api.naming.EnabledCapable
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.bind.DefaultValue
 

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/r2dbc/R2dbcProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/r2dbc/R2dbcProperties.kt
@@ -14,7 +14,7 @@
 package me.ahoo.wow.spring.boot.starter.r2dbc
 
 import me.ahoo.wow.api.Wow
-import me.ahoo.wow.spring.boot.starter.EnabledCapable
+import me.ahoo.wow.api.naming.EnabledCapable
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.bind.DefaultValue
 

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/redis/RedisProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/redis/RedisProperties.kt
@@ -14,7 +14,7 @@
 package me.ahoo.wow.spring.boot.starter.redis
 
 import me.ahoo.wow.api.Wow
-import me.ahoo.wow.spring.boot.starter.EnabledCapable
+import me.ahoo.wow.api.naming.EnabledCapable
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.bind.DefaultValue
 

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxProperties.kt
@@ -14,8 +14,8 @@
 package me.ahoo.wow.spring.boot.starter.webflux
 
 import me.ahoo.wow.api.Wow
+import me.ahoo.wow.api.naming.EnabledCapable
 import me.ahoo.wow.spring.boot.starter.ENABLED_SUFFIX_KEY
-import me.ahoo.wow.spring.boot.starter.EnabledCapable
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.bind.DefaultValue
 


### PR DESCRIPTION
- Remove EnabledCapable interface from wow-spring-boot-starter
- Use EnabledCapable interface from wow-api-naming instead
- Update import statements in multiple files to use the new interface

