### PR TITLE
perf: add transient hash codes to improve performance

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/DefaultAggregateId.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/DefaultAggregateId.kt
@@ -26,6 +26,7 @@ data class DefaultAggregateId(
     override val id: String,
     override val tenantId: String = TenantId.DEFAULT_TENANT_ID
 ) : AggregateId {
+    @Transient
     private val hashCode: Int = hash()
     override fun equals(other: Any?): Boolean = equalTo(other)
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/MaterializedNamedAggregate.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/MaterializedNamedAggregate.kt
@@ -24,6 +24,7 @@ data class MaterializedNamedAggregate(
     override val contextName: String,
     override val aggregateName: String
 ) : NamedAggregate, Materialized {
+    @Transient
     private val hashCode = Objects.hash(contextName, aggregateName)
     override fun hashCode(): Int = hashCode
     override fun equals(other: Any?): Boolean {


### PR DESCRIPTION
- Add transient hashCode property to DefaultAggregateId
- Add transient hashCode property to MaterializedNamedAggregate
- These changes can enhance performance by avoiding repeated hash calculations
