### PR TITLE
refactor(wow-spring): optimize AutoRegistrar stop logic and add test coverage

### DIFF
--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/saga/StatelessSagaAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/saga/StatelessSagaAutoConfigurationTest.kt
@@ -20,6 +20,7 @@ import me.ahoo.wow.event.DomainEventBus
 import me.ahoo.wow.event.InMemoryDomainEventBus
 import me.ahoo.wow.eventsourcing.state.InMemoryStateEventBus
 import me.ahoo.wow.eventsourcing.state.StateEventBus
+import me.ahoo.wow.example.domain.cart.CartSaga
 import me.ahoo.wow.saga.stateless.StatelessSagaDispatcher
 import me.ahoo.wow.saga.stateless.StatelessSagaFunctionFilter
 import me.ahoo.wow.saga.stateless.StatelessSagaFunctionRegistrar
@@ -43,6 +44,7 @@ internal class StatelessSagaAutoConfigurationTest {
             .withBean(CommandMessageFactory::class.java, { mockk() })
             .withBean(DomainEventBus::class.java, { InMemoryDomainEventBus() })
             .withBean(StateEventBus::class.java, { InMemoryStateEventBus() })
+            .withBean(CartSaga::class.java, { CartSaga() })
             .withUserConfiguration(
                 StatelessSagaAutoConfiguration::class.java,
             )
@@ -55,6 +57,10 @@ internal class StatelessSagaAutoConfigurationTest {
                     .hasSingleBean(StatelessSagaHandler::class.java)
                     .hasSingleBean(StatelessSagaDispatcher::class.java)
                     .hasSingleBean(StatelessSagaDispatcherLauncher::class.java)
+
+                val processorAutoRegistrar = context.getBean(StatelessSagaProcessorAutoRegistrar::class.java)
+                processorAutoRegistrar.start()
+                processorAutoRegistrar.stop()
             }
     }
 }

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/AutoRegistrar.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/AutoRegistrar.kt
@@ -58,9 +58,7 @@ abstract class AutoRegistrar<CM : Annotation>(
         log.info {
             "Stop ${componentType.simpleName}."
         }
-        if (!running.compareAndSet(true, false)) {
-            return
-        }
+        running.compareAndSet(true, false)
     }
 
     override fun isRunning(): Boolean {


### PR DESCRIPTION
- Simplify the stop logic in AutoRegistrar by removing unnecessary if statement
- Add test coverage for AutoRegistrar start and stop operations in StatelessSagaAutoConfigurationTest
