### PR TITLE
feat(schema): make definition path configurable in OpenAPISchemaBuilder

### DIFF
--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilder.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilder.kt
@@ -48,10 +48,11 @@ class OpenAPISchemaBuilder(
     private val optionPreset: OptionPreset = OptionPreset.PLAIN_JSON,
     override val defaultSchemaNamePrefix: String = "",
     private val customizer: Consumer<SchemaGeneratorConfigBuilder> = DefaultCustomizer(defaultSchemaNamePrefix),
-    private val openapi31: Boolean = true
+    private val openapi31: Boolean = true,
+    private val definitionPath: String = DEFAULT_DEFINITION_PATH
 ) : DefaultSchemaNamePrefixCapable, InlineSchemaCapable {
     companion object {
-        const val DEFINITION_PATH = "components/schemas"
+        const val DEFAULT_DEFINITION_PATH = "components/schemas"
     }
 
     private val openAPIObjectMapper = ObjectMapperFactory.create(null, openapi31)
@@ -88,7 +89,7 @@ class OpenAPISchemaBuilder(
     }
 
     fun build(): Map<String, Schema<*>> {
-        val collectedDefs = schemaBuilder.collectDefinitions(DEFINITION_PATH)
+        val collectedDefs = schemaBuilder.collectDefinitions(definitionPath)
         for (schemaReference in schemaReferences) {
             schemaReference.merge()
         }

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilderTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilderTest.kt
@@ -81,10 +81,13 @@ class OpenAPISchemaBuilderTest {
 
     @Test
     fun condition() {
-        val openAPISchemaBuilder = OpenAPISchemaBuilder()
+        val definitionPath = "${'$'}defs"
+        val openAPISchemaBuilder = OpenAPISchemaBuilder(definitionPath = definitionPath)
         openAPISchemaBuilder.generateSchema(Condition::class.java)
         val componentsSchemas = openAPISchemaBuilder.build()
-        componentsSchemas.assert().containsKey("StringObjectMap")
-        componentsSchemas.assert().hasSize(3)
+        val conditionSchema = componentsSchemas["wow.api.query.Condition"]
+        val childrenItem = conditionSchema?.properties[Condition::children.name]?.items
+        childrenItem.assert().isNotNull()
+        childrenItem?.`$ref`.assert().startsWith("#/$definitionPath")
     }
 }


### PR DESCRIPTION
- Add `definitionPath` parameter to OpenAPISchemaBuilder constructor
- Use `definitionPath` instead of fixed constant in build method
- Update test to use custom definition path and verify its usage
