### PR TITLE
feat(serialization): add toObjectNode extension function for String

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/serialization/JsonSerializer.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/serialization/JsonSerializer.kt
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.JavaType
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
 
 object JsonSerializer : ObjectMapper() {
@@ -45,6 +46,10 @@ fun Any.toPrettyJson(): String {
 fun <T : JsonNode> String.toJsonNode(): T {
     @Suppress("UNCHECKED_CAST")
     return JsonSerializer.readTree(this) as T
+}
+
+fun String.toObjectNode(): ObjectNode {
+    return toJsonNode()
 }
 
 fun <T> String.toObject(objectType: JavaType): T {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/serialization/JsonSerializerTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/serialization/JsonSerializerTest.kt
@@ -106,7 +106,7 @@ internal class JsonSerializerTest {
             )
         val mockEventJson = mockEvent.toJsonString()
         val mutableDomainEventRecord =
-            mockEventJson.toJsonNode<ObjectNode>().toDomainEventRecord().toMutableDomainEventRecord()
+            mockEventJson.toObjectNode().toDomainEventRecord().toMutableDomainEventRecord()
         mutableDomainEventRecord.bodyType = "NotFoundClass"
         val failedDomainEvent = mutableDomainEventRecord.actual.toJsonString().toObject<DomainEvent<Any>>()
         assertThat(failedDomainEvent, instanceOf(JsonDomainEvent::class.java))

--- a/wow-core/src/test/kotlin/me/ahoo/wow/serialization/event/StateJsonRecordTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/serialization/event/StateJsonRecordTest.kt
@@ -13,11 +13,10 @@
 
 package me.ahoo.wow.serialization.event
 
-import com.fasterxml.jackson.databind.node.ObjectNode
 import me.ahoo.wow.api.Identifier
 import me.ahoo.wow.id.generateGlobalId
-import me.ahoo.wow.serialization.toJsonNode
 import me.ahoo.wow.serialization.toJsonString
+import me.ahoo.wow.serialization.toObjectNode
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -25,7 +24,7 @@ class StateJsonRecordTest {
     @Test
     fun toState() {
         val state = MockState()
-        val stateNode = state.toJsonString().toJsonNode<ObjectNode>()
+        val stateNode = state.toJsonString().toObjectNode()
         val stateJsonRecord = StateJsonRecord(stateNode)
         assertThat(stateJsonRecord.state<MockState>()).isEqualTo(state)
         assertThat(stateJsonRecord.actual).isEqualTo(stateNode)

--- a/wow-r2dbc/src/main/kotlin/me/ahoo/wow/r2dbc/R2dbcEventStore.kt
+++ b/wow-r2dbc/src/main/kotlin/me/ahoo/wow/r2dbc/R2dbcEventStore.kt
@@ -27,6 +27,7 @@ import me.ahoo.wow.serialization.event.FlatEventStreamRecord
 import me.ahoo.wow.serialization.event.toEventStreamRecord
 import me.ahoo.wow.serialization.toJsonNode
 import me.ahoo.wow.serialization.toJsonString
+import me.ahoo.wow.serialization.toObjectNode
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
@@ -110,7 +111,7 @@ class R2dbcEventStore(
                     id = id,
                     rawAggregateId = aggregateId,
                     ownerId = ownerId,
-                    header = header.toJsonNode() as ObjectNode,
+                    header = header.toObjectNode(),
                     body = body.toJsonNode(),
                     commandId = commandId,
                     requestId = requestId,


### PR DESCRIPTION
- Add toObjectNode extension function to String class for easier conversion to ObjectNode
- Update usage in tests and R2dbcEventStore to use the new function
- Remove redundant type casting when converting JSON string to ObjectNode
