### PR TITLE
ci: remove paths-ignore for push event and simplify workflow configurations

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,11 +1,5 @@
 name: Codecov
 on:
-  push:
-    paths-ignore:
-      - 'document/**'
-      - 'documentation/**'
-      - 'schema/**'
-      - 'wow-example/**'
   pull_request:
     paths-ignore:
       - 'document/**'

--- a/.github/workflows/compensation-test.yml
+++ b/.github/workflows/compensation-test.yml
@@ -13,13 +13,6 @@
 
 name: Compensation Test
 on:
-  push:
-    paths-ignore:
-      - 'document/**'
-      - 'documentation/**'
-      - 'schema/**'
-      - 'wow-example/**'
-
   pull_request:
     paths-ignore:
       - 'document/**'

--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -20,11 +20,6 @@ on:
       - main
     paths:
       - 'documentation/**'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - 'documentation/**'
   workflow_dispatch:
 permissions:
   contents: write

--- a/.github/workflows/example-java-test.yml
+++ b/.github/workflows/example-java-test.yml
@@ -13,11 +13,6 @@
 
 name: Java compatibility Test
 on:
-  push:
-    paths-ignore:
-      - 'document/**'
-      - 'documentation/**'
-      - 'schema/**'
   pull_request:
     paths-ignore:
       - 'document/**'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -13,12 +13,6 @@
 
 name: Integration Test
 on:
-  push:
-    paths-ignore:
-      - 'document/**'
-      - 'documentation/**'
-      - 'schema/**'
-      - 'wow-example/**'
   pull_request:
     paths-ignore:
       - 'document/**'


### PR DESCRIPTION
- Remove paths-ignore configuration for push event across multiple workflow files
- Simplify workflow configurations by removing redundant sections
- This change allows all CI jobs to run on all pushes, improving test coverage and ensuring comprehensive validation of changes

