### PR TITLE
ci: ignore additional folders in Codecov workflow

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,5 +1,11 @@
 name: Codecov
 on:
+  push:
+    paths-ignore:
+      - 'document/**'
+      - 'documentation/**'
+      - 'schema/**'
+      - 'wow-example/**'
   pull_request:
     paths-ignore:
       - 'document/**'


### PR DESCRIPTION
- Add paths-ignore for push event
- Ignore 'document', 'documentation', 'schema', and 'wow-example' folders
- Improve workflow efficiency by excluding unnecessary files
