### PR TITLE
refactor(query): extract delete condition guard logic

### DIFF
--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/converter/AbstractConditionConverter.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/converter/AbstractConditionConverter.kt
@@ -15,6 +15,7 @@ package me.ahoo.wow.query.converter
 
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.Operator
+import me.ahoo.wow.query.converter.DeleteConditionGuard.guard
 import java.time.DayOfWeek
 import java.time.LocalTime
 import java.time.OffsetDateTime
@@ -24,21 +25,7 @@ import java.time.temporal.TemporalAdjusters
 
 abstract class AbstractConditionConverter<T> : ConditionConverter<T> {
     override fun convert(condition: Condition): T {
-        val convertedCondition = when (condition.operator) {
-            Operator.ALL -> Condition.ACTIVE
-            Operator.DELETED -> condition
-            Operator.AND -> {
-                if (!condition.children.any { it.operator == Operator.DELETED }) {
-                    Condition.ACTIVE.appendCondition(condition)
-                } else {
-                    condition
-                }
-            }
-
-            else -> {
-                Condition.ACTIVE.appendCondition(condition)
-            }
-        }
+        val convertedCondition = condition.guard()
         return internalConvert(convertedCondition)
     }
 

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/converter/DeleteConditionGuard.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/converter/DeleteConditionGuard.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.converter
+
+import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.Operator
+
+object DeleteConditionGuard {
+    fun Condition.guard(): Condition {
+        return when (this.operator) {
+            Operator.ALL -> Condition.ACTIVE
+            Operator.DELETED -> this
+            Operator.AND -> {
+                if (!this.children.any { it.operator == Operator.DELETED }) {
+                    Condition.ACTIVE.appendCondition(this)
+                } else {
+                    this
+                }
+            }
+
+            else -> {
+                Condition.ACTIVE.appendCondition(this)
+            }
+        }
+    }
+}

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/converter/DeleteConditionGuardTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/converter/DeleteConditionGuardTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.converter
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.DeletionState
+import me.ahoo.wow.query.converter.DeleteConditionGuard.guard
+import me.ahoo.wow.query.dsl.condition
+import org.junit.jupiter.api.Test
+
+class DeleteConditionGuardTest {
+
+    @Test
+    fun guardAll() {
+        val condition = condition { }
+        val converted = condition.guard()
+        converted.assert().isEqualTo(Condition.ACTIVE)
+    }
+
+    @Test
+    fun guardDeleted() {
+        val condition = condition { deleted(DeletionState.DELETED) }
+        val converted = condition.guard()
+        converted.assert().isEqualTo(condition)
+    }
+
+    @Test
+    fun guardAndWithDeleted() {
+        val condition = condition {
+            deleted(DeletionState.DELETED)
+            "field" eq "hi"
+        }
+        val converted = condition.guard()
+        converted.assert().isEqualTo(condition)
+    }
+
+    @Test
+    fun guardAndWithOutDeleted() {
+        val condition = condition {
+            "field1" eq "hi"
+            "field2" eq "hi"
+        }
+        val converted = condition.guard()
+        converted.children.first().assert().isEqualTo(Condition.ACTIVE)
+    }
+
+    @Test
+    fun guardEq() {
+        val condition = condition {
+            "field" eq "hi"
+        }
+        val converted = condition.guard()
+        converted.children.first().assert().isEqualTo(Condition.ACTIVE)
+    }
+}


### PR DESCRIPTION
- Extract delete condition guard logic into a separate object DeleteConditionGuard
- Add unit tests for DeleteConditionGuard to ensure correct behavior
- Simplify the convert function in AbstractConditionConverter by using the new guard method
