### PR TITLE
refactor(wow-elasticsearch): replace single() with next() for dynamicSingle

### DIFF
--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryService.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryService.kt
@@ -50,7 +50,7 @@ abstract class AbstractElasticsearchQueryService<R : Any> : QueryService<R> {
             limit = 1,
             sort = singleQuery.sort
         )
-        return dynamicList(listQuery).single()
+        return dynamicList(listQuery).next()
     }
 
     override fun list(listQuery: IListQuery): Flux<R> {


### PR DESCRIPTION
- Update AbstractElasticsearchQueryService to use next() instead of single()
- This change improves the handling of single element queries in Elasticsearch
