### PR TITLE
test: simplify and standardize test assertions

### DIFF
--- a/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSagaTest.kt
+++ b/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSagaTest.kt
@@ -34,6 +34,7 @@ class CartSagaTest {
                 },
                 ownerId = ownerId
             )
+            .expectCommandType(RemoveCartItem::class)
             .expectCommand<RemoveCartItem> {
                 it.aggregateId.id.assert().isEqualTo(ownerId)
                 it.body.productIds.assert().hasSize(1)

--- a/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartTest.kt
+++ b/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartTest.kt
@@ -64,7 +64,7 @@ class CartTest {
             .givenState(CartState(generateGlobalId()), 1)
             .whenCommand(addCartItem)
             .expectNoError()
-            .expectEventType(CartItemAdded::class.java)
+            .expectEventType(CartItemAdded::class)
             .expectState {
                 it.items.assert().hasSize(1)
             }
@@ -89,7 +89,7 @@ class CartTest {
             )
             .whenCommand(addCartItem)
             .expectNoError()
-            .expectEventType(CartQuantityChanged::class.java)
+            .expectEventType(CartQuantityChanged::class)
             .expectState {
                 it.items.assert().hasSize(1)
                 it.items.first().quantity.assert().isEqualTo(2)
@@ -107,7 +107,7 @@ class CartTest {
             .given()
             .whenCommand(addCartItem)
             .expectNoError()
-            .expectEventType(CartItemAdded::class.java)
+            .expectEventType(CartItemAdded::class)
             .expectState {
                 it.items.assert().hasSize(1)
             }
@@ -139,7 +139,7 @@ class CartTest {
         aggregateVerifier<Cart, CartState>()
             .given(*events)
             .whenCommand(addCartItem)
-            .expectErrorType(IllegalArgumentException::class.java)
+            .expectErrorType(IllegalArgumentException::class)
             .expectState {
                 it.items.assert().hasSize(MAX_CART_ITEM_SIZE)
             }
@@ -163,7 +163,7 @@ class CartTest {
                 ),
             )
             .whenCommand(removeCartItem)
-            .expectEventType(CartItemRemoved::class.java)
+            .expectEventType(CartItemRemoved::class)
             .expectState {
                 it.items.assert().isEmpty()
             }
@@ -187,7 +187,7 @@ class CartTest {
                 ),
             )
             .whenCommand(changeQuantity)
-            .expectEventType(CartQuantityChanged::class.java)
+            .expectEventType(CartQuantityChanged::class)
             .expectState {
                 it.items.assert().hasSize(1)
                 it.items.first().quantity.assert().isEqualTo(changeQuantity.quantity)
@@ -204,20 +204,20 @@ class CartTest {
         aggregateVerifier<Cart, CartState>()
             .whenCommand(addCartItem)
             .expectNoError()
-            .expectEventType(CartItemAdded::class.java)
+            .expectEventType(CartItemAdded::class)
             .expectState {
                 it.items.assert().hasSize(1)
             }
             .verify()
             .then()
             .whenCommand(DefaultDeleteAggregate)
-            .expectEventType(DefaultAggregateDeleted::class.java)
+            .expectEventType(DefaultAggregateDeleted::class)
             .expectStateAggregate {
                 it.deleted.assert().isTrue()
             }.verify()
             .then()
-            .whenCommand(DefaultDeleteAggregate::class.java)
-            .expectErrorType(IllegalAccessDeletedAggregateException::class.java)
+            .whenCommand(DefaultDeleteAggregate::class)
+            .expectErrorType(IllegalAccessDeletedAggregateException::class)
             .verify()
             .then()
             .whenCommand(DefaultRecoverAggregate)
@@ -226,7 +226,7 @@ class CartTest {
             }.verify()
             .then()
             .whenCommand(DefaultRecoverAggregate)
-            .expectErrorType(IllegalStateException::class.java)
+            .expectErrorType(IllegalStateException::class)
             .verify()
     }
 }

--- a/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/order/OrchestrationTest.kt
+++ b/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/order/OrchestrationTest.kt
@@ -60,7 +60,7 @@ class OrchestrationTest {
         aggregateVerifier<Order, OrderState>(tenantId = tenantId)
             .inject(DefaultCreateOrderSpec(inventoryService, pricingService))
             .whenCommand(CreateOrder(orderItems, SHIPPING_ADDRESS, false))
-            .expectEventType(OrderCreated::class.java)
+            .expectEventType(OrderCreated::class)
             .expectStateAggregate {
                 it.aggregateId.tenantId.assert().isEqualTo(tenantId)
             }
@@ -92,7 +92,7 @@ class OrchestrationTest {
             it.stateAggregate.state.payable
         )
         whenCommand(payOrder)
-            .expectEventType(OrderPaid::class.java)
+            .expectEventType(OrderPaid::class)
             .expectState {
                 it.paidAmount.assert().isEqualTo(it.totalAmount)
                 it.status.assert().isEqualTo(OrderStatus.PAID)
@@ -110,9 +110,9 @@ class OrchestrationTest {
                 detail = "002"
             )
         )
-        whenCommand(changeAddress).expectNoError()
-            .expectEventCount(1)
-            .expectEventType(AddressChanged::class.java)
+        whenCommand(changeAddress)
+            .expectNoError()
+            .expectEventType(AddressChanged::class)
             .expectState {
                 it.address.assert().isEqualTo(changeAddress.shippingAddress)
             }

--- a/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/order/OrderSagaTest.kt
+++ b/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/order/OrderSagaTest.kt
@@ -11,10 +11,10 @@ import java.math.BigDecimal
 
 class OrderSagaTest {
     private val orderItem = OrderItem(
-        generateGlobalId(),
-        generateGlobalId(),
-        BigDecimal.valueOf(10),
-        10,
+        id = generateGlobalId(),
+        productId = generateGlobalId(),
+        price = BigDecimal.valueOf(10),
+        quantity = 10,
     )
 
     @Test


### PR DESCRIPTION
- Remove unnecessary expectEventCount() calls
- Use expectEventType() instead of expectEventType() for consistency
- Add missing expectCommandType() assertion in CartSagaTest
- Simplify object initialization in OrderSagaTest
- Standardize error type assertions across multiple test files
