### PR TITLE
feat(schema): add extra OpenAPI format values support

### DIFF
--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilder.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilder.kt
@@ -138,6 +138,7 @@ class OpenAPISchemaBuilder(
                     .with(jodaMoneyModule)
                     .with(wowModule)
                     .with(schemaNamingModule)
+                    .with(Option.EXTRA_OPEN_API_FORMAT_VALUES)
                     .with(Option.PLAIN_DEFINITION_KEYS)
                     .with(Option.SIMPLIFIED_ENUMS)
                     .with(Option.MAP_VALUES_AS_ADDITIONAL_PROPERTIES)


### PR DESCRIPTION
- Enable Option.EXTRA_OPEN_API_FORMAT_VALUES in OpenAPISchemaBuilder