### PR TITLE
feat(schema): add support for aggregated query conditions

### DIFF
--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/QueryComponent.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/QueryComponent.kt
@@ -20,6 +20,7 @@ import me.ahoo.wow.api.query.PagedList
 import me.ahoo.wow.api.query.PagedQuery
 import me.ahoo.wow.api.query.SingleQuery
 import me.ahoo.wow.modeling.matedata.AggregateMetadata
+import me.ahoo.wow.modeling.toStringWithAlias
 import me.ahoo.wow.openapi.CommonComponent.Response.withErrorCodeHeader
 import me.ahoo.wow.openapi.QueryComponent.Schema.conditionSchema
 import me.ahoo.wow.openapi.QueryComponent.Schema.listQuerySchema
@@ -27,6 +28,7 @@ import me.ahoo.wow.openapi.QueryComponent.Schema.pagedQuerySchema
 import me.ahoo.wow.openapi.QueryComponent.Schema.singleQuerySchema
 import me.ahoo.wow.openapi.context.OpenAPIComponentContext
 import me.ahoo.wow.schema.typed.AggregatedDomainEventStream
+import me.ahoo.wow.schema.typed.query.AggregatedCondition
 
 object QueryComponent {
 
@@ -57,6 +59,12 @@ object QueryComponent {
         fun OpenAPIComponentContext.singleQueryRequestBody(): io.swagger.v3.oas.models.parameters.RequestBody {
             return requestBody(SINGLE_QUERY_KEY) {
                 content(schema = singleQuerySchema())
+            }
+        }
+
+        fun OpenAPIComponentContext.aggregatedCountQueryRequestBody(aggregateMetadata: AggregateMetadata<*, *>): io.swagger.v3.oas.models.parameters.RequestBody {
+            return requestBody(aggregateMetadata.toStringWithAlias() + ".CountQuery") {
+                content(schema = schema(AggregatedCondition::class.java, aggregateMetadata.command.aggregateType))
             }
         }
 

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/snapshot/CountSnapshotRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/snapshot/CountSnapshotRouteSpec.kt
@@ -19,7 +19,7 @@ import me.ahoo.wow.api.naming.NamedBoundedContext
 import me.ahoo.wow.openapi.CommonComponent.Response.requestTimeoutResponse
 import me.ahoo.wow.openapi.CommonComponent.Response.tooManyRequestsResponse
 import me.ahoo.wow.openapi.Https
-import me.ahoo.wow.openapi.QueryComponent.RequestBody.countQueryRequestBody
+import me.ahoo.wow.openapi.QueryComponent.RequestBody.aggregatedCountQueryRequestBody
 import me.ahoo.wow.openapi.QueryComponent.Response.countQueryResponse
 import me.ahoo.wow.openapi.RouteIdSpec
 import me.ahoo.wow.openapi.aggregate.AbstractTenantOwnerAggregateRouteSpecFactory
@@ -51,7 +51,8 @@ class CountSnapshotRouteSpec(
 
     override val summary: String
         get() = "Count snapshot"
-    override val requestBody: RequestBody = componentContext.countQueryRequestBody()
+    override val requestBody: RequestBody =
+        componentContext.aggregatedCountQueryRequestBody(aggregateRouteMetadata.aggregateMetadata)
 
     override val responses: ApiResponses = ApiResponses().apply {
         addApiResponse(Https.Code.OK, componentContext.countQueryResponse())

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
@@ -123,6 +123,7 @@ object AggregatedFieldPaths {
         return allFieldPaths(
             parentName = StateAggregateRecords.STATE,
             fields = listOf(
+                "",
                 StateAggregateRecords.EVENT_ID,
                 StateAggregateRecords.FIRST_OPERATOR,
                 StateAggregateRecords.OPERATOR,

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
@@ -13,7 +13,10 @@
 
 package me.ahoo.wow.schema
 
+import me.ahoo.wow.modeling.annotation.aggregateMetadata
+import me.ahoo.wow.schema.TypeFieldPaths.allFieldPaths
 import me.ahoo.wow.schema.Types.isStdType
+import me.ahoo.wow.serialization.state.StateAggregateRecords
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
 import kotlin.reflect.KVisibility
@@ -24,7 +27,7 @@ import kotlin.reflect.jvm.jvmErasure
 /**
  * Utility object to handle state field paths.
  */
-object AggregatedFieldPaths {
+object TypeFieldPaths {
     /**
      * Delimiter used to join property names in the path.
      */
@@ -112,5 +115,26 @@ object AggregatedFieldPaths {
             return null
         }
         return nestedType
+    }
+}
+
+object AggregatedFieldPaths {
+    fun KClass<*>.stateAggregatedFieldPaths(): List<String> {
+        return allFieldPaths(
+            parentName = StateAggregateRecords.STATE,
+            fields = listOf(
+                StateAggregateRecords.EVENT_ID,
+                StateAggregateRecords.FIRST_OPERATOR,
+                StateAggregateRecords.OPERATOR,
+                StateAggregateRecords.FIRST_EVENT_TIME,
+                StateAggregateRecords.EVENT_TIME
+            )
+        )
+    }
+
+    fun KClass<*>.commandAggregatedFieldPaths(): List<String> {
+        val aggregateMetadata = this.java.aggregateMetadata<Any, Any>()
+        val stateAggregateType = aggregateMetadata.state.aggregateType.kotlin
+        return stateAggregateType.stateAggregatedFieldPaths()
     }
 }

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowModule.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowModule.kt
@@ -26,6 +26,7 @@ import me.ahoo.wow.schema.typed.DomainEventStreamDefinitionProvider
 import me.ahoo.wow.schema.typed.SnapshotDefinitionProvider
 import me.ahoo.wow.schema.typed.StateAggregateDefinitionProvider
 import me.ahoo.wow.schema.typed.StateEventDefinitionProvider
+import me.ahoo.wow.schema.typed.query.AggregatedConditionDefinitionProvider
 
 class WowModule(
     private val options: Set<WowOption> = WowOption.ALL
@@ -43,6 +44,7 @@ class WowModule(
         generalConfigPart.withCustomDefinitionProvider(DomainEventStreamDefinitionProvider)
         generalConfigPart.withCustomDefinitionProvider(AggregatedDomainEventStreamDefinitionProvider)
         generalConfigPart.withCustomDefinitionProvider(AggregatedFieldsDefinitionProvider)
+        generalConfigPart.withCustomDefinitionProvider(AggregatedConditionDefinitionProvider)
         generalConfigPart.withCustomDefinitionProvider(StateAggregateDefinitionProvider)
         generalConfigPart.withCustomDefinitionProvider(SnapshotDefinitionProvider)
         generalConfigPart.withCustomDefinitionProvider(StateEventDefinitionProvider)

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/query/AggregatedCondition.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/query/AggregatedCondition.kt
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.schema.typed
+package me.ahoo.wow.schema.typed.query
 
-interface AggregatedCondition<StateAggregateType : Any>
+import me.ahoo.wow.api.query.ICondition
+
+interface AggregatedCondition<CommandAggregateType : Any> : ICondition

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
@@ -18,7 +18,9 @@ import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.PagedList
 import me.ahoo.wow.api.query.PagedQuery
 import me.ahoo.wow.example.api.order.ShippingAddress
-import me.ahoo.wow.schema.AggregatedFieldPaths.allFieldPaths
+import me.ahoo.wow.example.domain.order.Order
+import me.ahoo.wow.schema.AggregatedFieldPaths.commandAggregatedFieldPaths
+import me.ahoo.wow.schema.TypeFieldPaths.allFieldPaths
 import org.junit.jupiter.api.Test
 
 class AggregatedFieldPathsTest {
@@ -32,6 +34,13 @@ class AggregatedFieldPathsTest {
     @Test
     fun allPropertyPaths() {
         DemoState::class.allFieldPaths(parentName = "state").forEach {
+            println(it)
+        }
+    }
+
+    @Test
+    fun allCommandAggregatedFieldPaths() {
+        Order::class.commandAggregatedFieldPaths().forEach {
             println(it)
         }
     }

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/JsonSchemaGeneratorTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/JsonSchemaGeneratorTest.kt
@@ -45,6 +45,7 @@ import me.ahoo.wow.schema.kotlin.KotlinModule
 import me.ahoo.wow.schema.naming.SchemaNamingModule
 import me.ahoo.wow.schema.typed.AggregatedDomainEventStream
 import me.ahoo.wow.schema.typed.AggregatedFields
+import me.ahoo.wow.schema.typed.query.AggregatedCondition
 import me.ahoo.wow.serialization.JsonSerializer
 import me.ahoo.wow.tck.mock.MockStateAggregate
 import org.joda.money.CurrencyUnit
@@ -105,6 +106,11 @@ class JsonSchemaGeneratorTest {
                     Order::class.java,
                     "OrderAggregatedFields"
                 ),
+                Arguments.of(
+                    AggregatedCondition::class.java,
+                    Order::class.java,
+                    "OrderAggregatedCondition"
+                ),
             )
         }
     }
@@ -147,6 +153,16 @@ class JsonSchemaGeneratorTest {
         val jsonSchemaGenerator = JsonSchemaGenerator()
         val schema = jsonSchemaGenerator.generate(CommandStage::class.java).asJsonSchema()
         schema.getProperties().assert().isNull()
+    }
+
+    @Test
+    fun aggregatedCondition() {
+        val jsonSchemaGenerator = JsonSchemaGenerator()
+        val schema = jsonSchemaGenerator.generate(
+            AggregatedCondition::class.java,
+            Order::class.java
+        ).asJsonSchema()
+        schema.getProperties().assert().isNotNull()
     }
 
     @Test

--- a/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedCondition.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedCondition.json
@@ -1,0 +1,61 @@
+{
+  "$schema" : "https://json-schema.org/draft/2020-12/schema",
+  "$defs" : {
+    "StringObjectMap" : {
+      "type" : "object"
+    },
+    "wow.api.query.Condition" : {
+      "type" : "object",
+      "properties" : {
+        "children" : {
+          "default" : "[]",
+          "type" : "array",
+          "items" : {
+            "$ref" : "#/$defs/wow.api.query.Condition"
+          }
+        },
+        "field" : {
+          "type" : "string"
+        },
+        "operator" : {
+          "$ref" : "#/$defs/wow.api.query.Operator",
+          "default" : "ALL"
+        },
+        "options" : {
+          "$ref" : "#/$defs/StringObjectMap",
+          "default" : "{}"
+        },
+        "value" : { }
+      },
+      "required" : [ "operator" ]
+    },
+    "wow.api.query.Operator" : {
+      "type" : "string",
+      "enum" : [ "AND", "OR", "NOR", "ID", "IDS", "AGGREGATE_ID", "AGGREGATE_IDS", "TENANT_ID", "OWNER_ID", "DELETED", "ALL", "EQ", "NE", "GT", "LT", "GTE", "LTE", "CONTAINS", "IN", "NOT_IN", "BETWEEN", "ALL_IN", "STARTS_WITH", "ENDS_WITH", "ELEM_MATCH", "NULL", "NOT_NULL", "TRUE", "FALSE", "EXISTS", "TODAY", "BEFORE_TODAY", "TOMORROW", "THIS_WEEK", "NEXT_WEEK", "LAST_WEEK", "THIS_MONTH", "LAST_MONTH", "RECENT_DAYS", "EARLIER_DAYS", "RAW" ]
+    }
+  },
+  "type" : "object",
+  "properties" : {
+    "children" : {
+      "default" : "[]",
+      "type" : "array",
+      "items" : {
+        "$ref" : "#/$defs/wow.api.query.Condition"
+      }
+    },
+    "field" : {
+      "type" : "string",
+      "enum" : [ "eventId", "firstOperator", "operator", "firstEventTime", "eventTime", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount" ]
+    },
+    "operator" : {
+      "$ref" : "#/$defs/wow.api.query.Operator",
+      "default" : "ALL"
+    },
+    "options" : {
+      "$ref" : "#/$defs/StringObjectMap",
+      "default" : "{}"
+    },
+    "value" : { }
+  },
+  "required" : [ "operator" ]
+}

--- a/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedCondition.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedCondition.json
@@ -45,7 +45,7 @@
     },
     "field" : {
       "type" : "string",
-      "enum" : [ "eventId", "firstOperator", "operator", "firstEventTime", "eventTime", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount" ]
+      "enum" : [ "", "eventId", "firstOperator", "operator", "firstEventTime", "eventTime", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount" ]
     },
     "operator" : {
       "$ref" : "#/$defs/wow.api.query.Operator",

--- a/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedFields.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedFields.json
@@ -1,8 +1,5 @@
 {
   "$schema" : "https://json-schema.org/draft/2020-12/schema",
-  "properties" : {
-    "type" : {
-      "enum" : [ "eventId", "firstOperator", "operator", "firstEventTime", "eventTime", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount" ]
-    }
-  }
+  "type" : "string",
+  "enum" : [ "eventId", "firstOperator", "operator", "firstEventTime", "eventTime", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount" ]
 }

--- a/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedFields.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedFields.json
@@ -1,5 +1,5 @@
 {
   "$schema" : "https://json-schema.org/draft/2020-12/schema",
   "type" : "string",
-  "enum" : [ "eventId", "firstOperator", "operator", "firstEventTime", "eventTime", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount" ]
+  "enum" : [ "", "eventId", "firstOperator", "operator", "firstEventTime", "eventTime", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount" ]
 }


### PR DESCRIPTION
- Introduce AggregatedCondition interface for query conditions in aggregated contexts
- Implement AggregatedConditionDefinitionProvider to generate JSON schema for aggregated conditions
- Update AggregatedFieldsDefinitionProvider to use new commandAggregatedFieldPaths method
- Modify OpenAPI component to use new aggregatedCountQueryRequestBody method
- Rename AggregatedFieldPaths to TypeFieldPaths and add new methods for state and command aggregated field paths

