### PR TITLE
refactor(query): add isEmpty extension function for Projection

### DIFF
--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/Queryable.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/Queryable.kt
@@ -44,8 +44,10 @@ data class Projection(
     companion object {
         val ALL = Projection()
     }
+}
 
-    fun isEmpty(): Boolean = include.isEmpty() && exclude.isEmpty()
+fun Projection.isEmpty(): Boolean {
+    return include.isEmpty() && exclude.isEmpty()
 }
 
 interface Queryable<Q : Queryable<Q>> : ConditionCapable<Q>, ProjectionCapable<Q>, SortCapable

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryService.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryService.kt
@@ -25,6 +25,7 @@ import me.ahoo.wow.api.query.PagedList
 import me.ahoo.wow.api.query.PagedQuery
 import me.ahoo.wow.api.query.Pagination
 import me.ahoo.wow.api.query.SimpleDynamicDocument.Companion.toDynamicDocument
+import me.ahoo.wow.api.query.isEmpty
 import me.ahoo.wow.elasticsearch.query.ElasticsearchProjectionConverter.toSourceFilter
 import me.ahoo.wow.elasticsearch.query.ElasticsearchSortConverter.toSortOptions
 import me.ahoo.wow.query.QueryService

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/MongoProjectionConverter.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/MongoProjectionConverter.kt
@@ -15,6 +15,7 @@ package me.ahoo.wow.mongo.query
 
 import com.mongodb.client.model.Projections
 import me.ahoo.wow.api.query.Projection
+import me.ahoo.wow.api.query.isEmpty
 import me.ahoo.wow.query.converter.ProjectionConverter
 import org.bson.conversions.Bson
 


### PR DESCRIPTION
- Add isEmpty extension function to Projection class
- Use the new isEmpty function in Elasticsearch and Mongo query services
- Remove redundant isEmpty function from Queryable interface
