### PR TITLE
feat(schema): add common fields to OrderAggregated query schemas

### DIFF
--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
@@ -16,6 +16,7 @@ package me.ahoo.wow.schema
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.schema.TypeFieldPaths.allFieldPaths
 import me.ahoo.wow.schema.Types.isStdType
+import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.serialization.state.StateAggregateRecords
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
@@ -124,11 +125,17 @@ object AggregatedFieldPaths {
             parentName = StateAggregateRecords.STATE,
             fields = listOf(
                 "",
+                MessageRecords.AGGREGATE_ID,
+                MessageRecords.TENANT_ID,
+                MessageRecords.OWNER_ID,
+                MessageRecords.VERSION,
                 StateAggregateRecords.EVENT_ID,
                 StateAggregateRecords.FIRST_OPERATOR,
                 StateAggregateRecords.OPERATOR,
                 StateAggregateRecords.FIRST_EVENT_TIME,
-                StateAggregateRecords.EVENT_TIME
+                StateAggregateRecords.EVENT_TIME,
+                StateAggregateRecords.DELETED,
+                StateAggregateRecords.STATE
             )
         )
     }

--- a/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedCondition.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedCondition.json
@@ -45,7 +45,7 @@
     },
     "field" : {
       "type" : "string",
-      "enum" : [ "", "eventId", "firstOperator", "operator", "firstEventTime", "eventTime", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount" ]
+      "enum" : [ "", "aggregateId", "tenantId", "ownerId", "version", "eventId", "firstOperator", "operator", "firstEventTime", "eventTime", "deleted", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount" ]
     },
     "operator" : {
       "$ref" : "#/$defs/wow.api.query.Operator",

--- a/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedFields.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedFields.json
@@ -1,5 +1,5 @@
 {
   "$schema" : "https://json-schema.org/draft/2020-12/schema",
   "type" : "string",
-  "enum" : [ "", "eventId", "firstOperator", "operator", "firstEventTime", "eventTime", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount" ]
+  "enum" : [ "", "aggregateId", "tenantId", "ownerId", "version", "eventId", "firstOperator", "operator", "firstEventTime", "eventTime", "deleted", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount" ]
 }

--- a/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedListQuery.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedListQuery.json
@@ -48,7 +48,7 @@
         },
         "field" : {
           "type" : "string",
-          "enum" : [ "", "eventId", "firstOperator", "operator", "firstEventTime", "eventTime", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount" ]
+          "enum" : [ "", "aggregateId", "tenantId", "ownerId", "version", "eventId", "firstOperator", "operator", "firstEventTime", "eventTime", "deleted", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount" ]
         },
         "operator" : {
           "$ref" : "#/$defs/wow.api.query.Operator",

--- a/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedPagedQuery.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedPagedQuery.json
@@ -48,7 +48,7 @@
         },
         "field" : {
           "type" : "string",
-          "enum" : [ "", "eventId", "firstOperator", "operator", "firstEventTime", "eventTime", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount" ]
+          "enum" : [ "", "aggregateId", "tenantId", "ownerId", "version", "eventId", "firstOperator", "operator", "firstEventTime", "eventTime", "deleted", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount" ]
         },
         "operator" : {
           "$ref" : "#/$defs/wow.api.query.Operator",

--- a/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedSingleQuery.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedSingleQuery.json
@@ -48,7 +48,7 @@
         },
         "field" : {
           "type" : "string",
-          "enum" : [ "", "eventId", "firstOperator", "operator", "firstEventTime", "eventTime", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount" ]
+          "enum" : [ "", "aggregateId", "tenantId", "ownerId", "version", "eventId", "firstOperator", "operator", "firstEventTime", "eventTime", "deleted", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount" ]
         },
         "operator" : {
           "$ref" : "#/$defs/wow.api.query.Operator",


### PR DESCRIPTION
- Add aggregateId, tenantId, ownerId, version, deleted, and state fields to the enum lists in OrderAggregatedCondition, OrderAggregatedFields, and related query schemas
- Update TypeFieldPaths to include new fields in the ALL_FIELD_PATHS list for OrderAggregated
