### PR TITLE
feat(schema): support Jackson @JsonIgnore annotation

### DIFF
--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
@@ -13,6 +13,8 @@
 
 package me.ahoo.wow.schema
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import me.ahoo.wow.infra.reflection.AnnotationScanner.scanAnnotation
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.schema.TypeFieldPaths.allFieldPaths
 import me.ahoo.wow.schema.Types.isStdType
@@ -72,7 +74,7 @@ object TypeFieldPaths {
             return
         }
         memberProperties.filter {
-            it.visibility == KVisibility.PUBLIC
+            it.visibility == KVisibility.PUBLIC && it.scanAnnotation<JsonIgnore>()?.value != true
         }.forEach { property ->
             val fullName = property.resolveFieldName(parentName)
             fieldPaths.add(fullName)

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
@@ -13,6 +13,8 @@
 
 package me.ahoo.wow.schema
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.Identifier
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.PagedList
@@ -25,21 +27,22 @@ import org.junit.jupiter.api.Test
 
 class AggregatedFieldPathsTest {
     @Test
-    fun allPropertyPathsForCondition() {
+    fun allFieldPathsForCondition() {
         Condition::class.allFieldPaths().forEach {
             println(it)
         }
     }
 
     @Test
-    fun allPropertyPaths() {
-        DemoState::class.allFieldPaths(parentName = "state").forEach {
-            println(it)
-        }
+    fun allFieldPaths() {
+        val allFieldPaths = DemoState::class.allFieldPaths(parentName = "state")
+        allFieldPaths.assert().contains("state.address")
+        allFieldPaths.assert().doesNotContain("addresses")
+        allFieldPaths.assert().contains("state.pagedQuery")
     }
 
     @Test
-    fun allCommandAggregatedFieldPaths() {
+    fun commandAggregatedFieldPaths() {
         Order::class.commandAggregatedFieldPaths().forEach {
             println(it)
         }
@@ -47,8 +50,11 @@ class AggregatedFieldPathsTest {
 
     class DemoState(override val id: String) : Identifier {
         var address: ShippingAddress = ShippingAddress("CN", "GD", "SZ", "YT", "YT")
+
+        @JsonIgnore
         var addresses: List<ShippingAddress> = emptyList()
         var addressArray: Array<ShippingAddress> = emptyArray()
+        @JsonIgnore(false)
         var pagedQuery: PagedQuery = PagedQuery(Condition.all())
         var pagedList: PagedList<DemoState> = PagedList.empty()
     }

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
@@ -54,6 +54,7 @@ class AggregatedFieldPathsTest {
         @JsonIgnore
         var addresses: List<ShippingAddress> = emptyList()
         var addressArray: Array<ShippingAddress> = emptyArray()
+
         @JsonIgnore(false)
         var pagedQuery: PagedQuery = PagedQuery(Condition.all())
         var pagedList: PagedList<DemoState> = PagedList.empty()


### PR DESCRIPTION
- Add support for Jackson's @JsonIgnore annotation in TypeFieldPaths
- Filter out properties annotated with @JsonIgnore when building field paths
- Improve compatibility with Jackson-based serialization/deserialization

