### PR TITLE
build(wow-spring-boot-starter): integrate springdoc-openapi for OpenAPI customization

### DIFF
--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/RouterSpecsTest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/RouterSpecsTest.kt
@@ -1,5 +1,6 @@
 package me.ahoo.wow.openapi
 
+import io.swagger.v3.oas.models.OpenAPI
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.naming.MaterializedNamedBoundedContext
 import org.junit.jupiter.api.Test
@@ -9,5 +10,13 @@ class RouterSpecsTest {
     fun build() {
         val routerSpecs = RouterSpecs(MaterializedNamedBoundedContext("test")).build()
         routerSpecs.assert().isNotEmpty()
+    }
+
+    @Test
+    fun mergeOpenAPI() {
+        val openAPI = OpenAPI()
+        RouterSpecs(MaterializedNamedBoundedContext("test")).build()
+            .mergeOpenAPI(openAPI)
+        openAPI.components.schemas.assert().isNotEmpty()
     }
 }

--- a/wow-spring-boot-starter/build.gradle.kts
+++ b/wow-spring-boot-starter/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
     "elasticsearchSupportImplementation"(project(":wow-elasticsearch"))
     "opentelemetrySupportImplementation"(project(":wow-opentelemetry"))
     "openapiSupportImplementation"(project(":wow-openapi"))
+    "openapiSupportImplementation"("org.springdoc:springdoc-openapi-starter-common")
     api("org.springframework:spring-webflux")
     api("org.springframework.boot:spring-boot-starter")
     kapt("org.springframework.boot:spring-boot-configuration-processor")

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/openapi/OpenAPIAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/openapi/OpenAPIAutoConfiguration.kt
@@ -13,7 +13,6 @@
 
 package me.ahoo.wow.spring.boot.starter.openapi
 
-import io.swagger.v3.oas.models.OpenAPI
 import me.ahoo.wow.api.naming.NamedBoundedContext
 import me.ahoo.wow.modeling.getContextAliasPrefix
 import me.ahoo.wow.openapi.RouterSpecs
@@ -54,7 +53,7 @@ class OpenAPIAutoConfiguration {
     }
 
     @Bean
-    fun openAPI(routerSpecs: RouterSpecs): OpenAPI {
-        return routerSpecs.openAPI()
+    fun wowOpenApiCustomizer(routerSpecs: RouterSpecs): WowOpenApiCustomizer {
+        return WowOpenApiCustomizer(routerSpecs)
     }
 }

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/openapi/WowOpenApiCustomizer.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/openapi/WowOpenApiCustomizer.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.spring.boot.starter.openapi
+
+import io.swagger.v3.oas.models.OpenAPI
+import me.ahoo.wow.openapi.RouterSpecs
+import org.springdoc.core.customizers.OpenApiCustomizer
+
+class WowOpenApiCustomizer(private var routerSpecs: RouterSpecs) : OpenApiCustomizer {
+    override fun customise(openApi: OpenAPI) {
+        routerSpecs.mergeOpenAPI(openApi)
+    }
+}


### PR DESCRIPTION
- Add springdoc-openapi-starter-common dependency
- Refactor OpenAPIAutoConfiguration to use WowOpenApiCustomizer
- Update RouterSpecs to support merging OpenAPI
- Create WowOpenApiCustomizer to customize OpenAPI using RouterSpecs
