### PR TITLE
fix(wow-openapi): remove unnecessary schema finish call

### DIFF
--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/WowSchemaConverter.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/WowSchemaConverter.kt
@@ -55,7 +55,6 @@ class WowSchemaConverter : ModelConverter {
                 schema = current.schema(resolvedType)
             }
         }
-        current.finish()
         if (schema != null) {
             schema.name = annotatedType.name
         }


### PR DESCRIPTION
- Remove `current.finish()` call which is not required when using `schema()` method
