### PR TITLE
refactor(naming): introduce CurrentContextCapable interface for context management

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/naming/CurrentContextCapable.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/naming/CurrentContextCapable.kt
@@ -13,9 +13,6 @@
 
 package me.ahoo.wow.naming
 
-import me.ahoo.wow.api.naming.NamedBoundedContext
-
-object CurrentBoundedContext : CurrentContextCapable<NamedBoundedContext> {
-    @Volatile
-    override var current: NamedBoundedContext = MaterializedNamedBoundedContext("")
+interface CurrentContextCapable<CONTEXT> {
+    val current: CONTEXT
 }

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/context/CurrentOpenAPIComponentContext.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/context/CurrentOpenAPIComponentContext.kt
@@ -13,7 +13,9 @@
 
 package me.ahoo.wow.openapi.context
 
-object CurrentOpenAPIComponentContext {
+import me.ahoo.wow.naming.CurrentContextCapable
+
+object CurrentOpenAPIComponentContext : CurrentContextCapable<OpenAPIComponentContext?> {
     @Volatile
-    var current: OpenAPIComponentContext? = null
+    override var current: OpenAPIComponentContext? = null
 }

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/BoundedContextSchemaNameConverter.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/BoundedContextSchemaNameConverter.kt
@@ -35,7 +35,7 @@ class BoundedContextSchemaNameConverter : ModelConverter {
             if (rawClass.isStdType()) {
                 return
             }
-            val namePrefix = rawClass.resolveNamePrefix() ?: CurrentBoundedContext.context.getContextAliasPrefix()
+            val namePrefix = rawClass.resolveNamePrefix() ?: CurrentBoundedContext.current.getContextAliasPrefix()
             name = namePrefix + rawClass.toSchemaName()
         }
 
@@ -45,7 +45,7 @@ class BoundedContextSchemaNameConverter : ModelConverter {
         }
 
         fun AnnotatedType.resolveName(resolvedType: ResolvedType) {
-            name = resolvedType.toSchemaName(CurrentBoundedContext.context.getContextAliasPrefix())
+            name = resolvedType.toSchemaName(CurrentBoundedContext.current.getContextAliasPrefix())
         }
 
         fun AnnotatedType.resolveName() {

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/WowAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/WowAutoConfiguration.kt
@@ -52,7 +52,7 @@ class WowAutoConfiguration(private val wowProperties: WowProperties) {
         val contextName =
             wowProperties.contextName ?: applicationContext.environment.getRequiredProperty(SPRING_APPLICATION_NAME)
         val currentContext = MaterializedNamedBoundedContext(contextName)
-        CurrentBoundedContext.context = currentContext
+        CurrentBoundedContext.current = currentContext
         return currentContext
     }
 }

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/openapi/OpenAPIAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/openapi/OpenAPIAutoConfigurationTest.kt
@@ -1,6 +1,5 @@
 package me.ahoo.wow.spring.boot.starter.openapi
 
-import io.swagger.v3.oas.models.OpenAPI
 import me.ahoo.wow.openapi.RouterSpecs
 import me.ahoo.wow.spring.boot.starter.enableWow
 import org.assertj.core.api.AssertionsForInterfaceTypes
@@ -8,7 +7,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 
-class CompensationAutoConfigurationTest {
+class OpenAPIAutoConfigurationTest {
     private val contextRunner = ApplicationContextRunner()
 
     @Test
@@ -21,7 +20,7 @@ class CompensationAutoConfigurationTest {
             .run { context: AssertableApplicationContext ->
                 AssertionsForInterfaceTypes.assertThat(context)
                     .hasSingleBean(RouterSpecs::class.java)
-                    .hasSingleBean(OpenAPI::class.java)
+                    .hasSingleBean(WowOpenApiCustomizer::class.java)
             }
     }
 }


### PR DESCRIPTION
- Extract CurrentContextCapable interface for managing current context
- Refactor CurrentBoundedContext and CurrentOpenAPIComponentContext to implement CurrentContextCapable
- Update BoundedContextSchemaNameConverter to use new current property
- Modify WowAutoConfiguration to set current context using CurrentBoundedContext
