### PR TITLE
feat(exception): support auto register ErrorConverterFactory to ErrorConverterRegistrar

### DIFF
--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/WowAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/WowAutoConfiguration.kt
@@ -12,11 +12,15 @@
  */
 package me.ahoo.wow.spring.boot.starter
 
+import me.ahoo.wow.annotation.sortedByOrder
 import me.ahoo.wow.api.naming.NamedBoundedContext
+import me.ahoo.wow.exception.ErrorConverterFactory
+import me.ahoo.wow.exception.ErrorConverterRegistrar
 import me.ahoo.wow.ioc.ServiceProvider
 import me.ahoo.wow.naming.CurrentBoundedContext
 import me.ahoo.wow.naming.MaterializedNamedBoundedContext
 import me.ahoo.wow.spring.SpringServiceProvider
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
@@ -54,5 +58,15 @@ class WowAutoConfiguration(private val wowProperties: WowProperties) {
         val currentContext = MaterializedNamedBoundedContext(contextName)
         CurrentBoundedContext.current = currentContext
         return currentContext
+    }
+
+    @Bean
+    fun errorConverterRegistrar(
+        errorConverterFactoryProvider: ObjectProvider<ErrorConverterFactory<*>>
+    ): ErrorConverterRegistrar {
+        errorConverterFactoryProvider.sortedByOrder().forEach {
+            ErrorConverterRegistrar.register(it)
+        }
+        return ErrorConverterRegistrar
     }
 }

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/WowAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/WowAutoConfigurationTest.kt
@@ -14,6 +14,10 @@
 package me.ahoo.wow.spring.boot.starter
 
 import me.ahoo.wow.api.naming.NamedBoundedContext
+import me.ahoo.wow.exception.DefaultErrorConverter
+import me.ahoo.wow.exception.ErrorConverter
+import me.ahoo.wow.exception.ErrorConverterFactory
+import me.ahoo.wow.exception.ErrorConverterRegistrar
 import me.ahoo.wow.ioc.ServiceProvider
 import me.ahoo.wow.spring.boot.starter.WowAutoConfiguration.Companion.SPRING_APPLICATION_NAME
 import org.assertj.core.api.AssertionsForInterfaceTypes
@@ -28,11 +32,22 @@ internal class WowAutoConfigurationTest {
     fun contextLoads() {
         contextRunner
             .enableWow()
+            .withBean(ErrorConverterFactory::class.java, {
+                return@withBean object : ErrorConverterFactory<Throwable> {
+                    override val supportedType: Class<Throwable>
+                        get() = Throwable::class.java
+
+                    override fun create(): ErrorConverter<Throwable> {
+                        return DefaultErrorConverter
+                    }
+                }
+            })
             .run { context: AssertableApplicationContext ->
                 AssertionsForInterfaceTypes.assertThat(context)
                     .hasSingleBean(WowProperties::class.java)
                     .hasSingleBean(ServiceProvider::class.java)
                     .hasSingleBean(NamedBoundedContext::class.java)
+                    .hasSingleBean(ErrorConverterRegistrar::class.java)
             }
     }
 


### PR DESCRIPTION
- Add ErrorConverterRegistrar bean creation in WowAutoConfiguration
- Implement and test ErrorConverterFactory with Throwable support
- Update WowAutoConfigurationTest to include new ErrorConverterRegistrar bean
