### PR TITLE
refactor(query): rename SlimMaterializedSnapshot to SmallMaterializedSnapshot

### DIFF
--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/SmallMaterializedSnapshot.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/SmallMaterializedSnapshot.kt
@@ -26,7 +26,7 @@ import me.ahoo.wow.api.naming.Materialized
  * @param firstEventTime The timestamp of the first event, used to record when the state was first changed.
  * @param state The current state, with a generic type.
  */
-data class SlimMaterializedSnapshot<S : Any>(
+data class SmallMaterializedSnapshot<S : Any>(
     override val version: Int,
     override val firstEventTime: Long,
     override val state: S
@@ -41,8 +41,8 @@ data class SlimMaterializedSnapshot<S : Any>(
  * @param materialize A function that transforms the original state into a new state.
  * @return Returns a transformed simplified materialized snapshot.
  */
-fun <S : Any, D : Any> MaterializedSnapshot<S>.toSlim(materialize: (S) -> D): SlimMaterializedSnapshot<D> {
-    return SlimMaterializedSnapshot(
+fun <S : Any, D : Any> MaterializedSnapshot<S>.toSmall(materialize: (S) -> D): SmallMaterializedSnapshot<D> {
+    return SmallMaterializedSnapshot(
         version = version,
         firstEventTime = firstEventTime,
         state = materialize(state)

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/query/SmallMaterializedSnapshotTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/query/SmallMaterializedSnapshotTest.kt
@@ -3,7 +3,7 @@ package me.ahoo.wow.api.query
 import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
-class SlimMaterializedSnapshotTest {
+class SmallMaterializedSnapshotTest {
     val snapshot = MaterializedSnapshot(
         contextName = "contextName",
         aggregateName = "aggregateName",
@@ -22,8 +22,8 @@ class SlimMaterializedSnapshotTest {
     )
 
     @Test
-    fun toSlim() {
-        val slimSnapshot = snapshot.toSlim { it }
+    fun toSmall() {
+        val slimSnapshot = snapshot.toSmall { it }
         slimSnapshot.version.assert().isEqualTo(snapshot.version)
         slimSnapshot.firstEventTime.assert().isEqualTo(snapshot.firstEventTime)
         slimSnapshot.state.assert().isEqualTo(snapshot.state)


### PR DESCRIPTION
- Rename SlimMaterializedSnapshot to SmallMaterializedSnapshot
- Update related test file name and content
- Modify function name from toSlim to toSmall

