### PR TITLE
feat(api): introduce IMaterializedSnapshot interface and simplify snapshots

### DIFF
--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/MaterializedSnapshot.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/MaterializedSnapshot.kt
@@ -27,6 +27,8 @@ import me.ahoo.wow.api.modeling.StateCapable
 import me.ahoo.wow.api.modeling.TenantId
 import me.ahoo.wow.api.naming.Materialized
 
+interface IMaterializedSnapshot<S : Any> : Materialized, StateCapable<S>
+
 data class MaterializedSnapshot<S : Any>(
     override val contextName: String,
     override val aggregateName: String,
@@ -42,16 +44,15 @@ data class MaterializedSnapshot<S : Any>(
     override val state: S,
     override val snapshotTime: Long,
     override val deleted: Boolean
-) : NamedAggregate,
+) : IMaterializedSnapshot<S>,
+    NamedAggregate,
     TenantId,
     OwnerId,
     Version,
     EventIdCapable,
-    Materialized,
     FirstOperatorCapable,
     OperatorCapable,
     FirstEventTimeCapable,
     EventTimeCapable,
-    StateCapable<S>,
     SnapshotTimeCapable,
     DeletedCapable

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/SmallMaterializedSnapshot.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/SmallMaterializedSnapshot.kt
@@ -15,8 +15,6 @@ package me.ahoo.wow.api.query
 
 import me.ahoo.wow.api.Version
 import me.ahoo.wow.api.modeling.FirstEventTimeCapable
-import me.ahoo.wow.api.modeling.StateCapable
-import me.ahoo.wow.api.naming.Materialized
 
 /**
  * Represents a simplified materialized snapshot with generic state.
@@ -30,7 +28,7 @@ data class SmallMaterializedSnapshot<S : Any>(
     override val version: Int,
     override val firstEventTime: Long,
     override val state: S
-) : Version, Materialized, FirstEventTimeCapable, StateCapable<S>
+) : Version, FirstEventTimeCapable, IMaterializedSnapshot<S>
 
 /**
  * Converts a materialized snapshot into a simplified snapshot form.


### PR DESCRIPTION
- Add IMaterializedSnapshot interface to define materialized snapshot behavior
- Implement IMaterializedSnapshot in MaterializedSnapshot and SmallMaterializedSnapshot
- Remove direct implementation of StateCapable and Materialized from snapshots
- This change improves code organization and enables more flexible snapshot handling
