### PR TITLE
fix(schema): support array type in JSON Schema generation

### DIFF
--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/BoundedContextSchemaNameConverter.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/converter/BoundedContextSchemaNameConverter.kt
@@ -45,7 +45,7 @@ class BoundedContextSchemaNameConverter : ModelConverter {
         }
 
         fun AnnotatedType.resolveName(resolvedType: ResolvedType) {
-            if (resolvedType.typeBindings.isEmpty) {
+            if (!resolvedType.isArray && resolvedType.typeBindings.isEmpty) {
                 return resolveName(resolvedType.erasedType)
             }
             name = resolvedType.toSchemaName(CurrentBoundedContext.current.getContextAliasPrefix())

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilder.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilder.kt
@@ -99,12 +99,16 @@ class OpenAPISchemaBuilder(
     }
 
     data class SchemaReference(val type: ResolvedType, val schema: Schema<*>, val node: ObjectNode) {
-
         fun merge() {
             val schemaRef = node.get(SchemaKeyword.TAG_REF.toPropertyName())?.textValue()
             if (schemaRef != null) {
                 schema.`$ref` = schemaRef
             }
+            val itemsArrayRef =
+                node.get(SchemaKeyword.TAG_ITEMS.toPropertyName())?.get(SchemaKeyword.TAG_REF.toPropertyName())
+                    ?.textValue() ?: return
+            val itemsSchema = schema.items ?: return
+            itemsSchema.`$ref` = itemsArrayRef
         }
     }
 

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/JsonSchemaGeneratorTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/JsonSchemaGeneratorTest.kt
@@ -1,5 +1,6 @@
 package me.ahoo.wow.schema
 
+import com.fasterxml.classmate.TypeResolver
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.databind.JsonNode
 import com.github.victools.jsonschema.generator.Module
@@ -275,6 +276,14 @@ class JsonSchemaGeneratorTest {
     fun javaType() {
         val jsonSchemaGenerator = JsonSchemaGenerator()
         jsonSchemaGenerator.generate(CosIdGeneratorStat::class.java)
+    }
+
+    @Test
+    fun arrayType() {
+        val jsonSchemaGenerator = JsonSchemaGenerator()
+        val arrayType = TypeResolver().arrayType(SchemaData::class.java)
+        val arrayTypeSchema = jsonSchemaGenerator.generate(arrayType)
+        arrayTypeSchema.get("type").asText().assert().isEqualTo("array")
     }
 
     @Test

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilderTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilderTest.kt
@@ -1,5 +1,6 @@
 package me.ahoo.wow.schema.openapi
 
+import com.fasterxml.classmate.TypeResolver
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.MaterializedSnapshot
@@ -9,6 +10,7 @@ import me.ahoo.wow.example.api.cart.AddCartItem
 import me.ahoo.wow.example.api.order.CreateOrder
 import me.ahoo.wow.example.domain.order.OrderState
 import me.ahoo.wow.models.tree.Leaf
+import me.ahoo.wow.schema.JsonSchemaGeneratorTest.SchemaData
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.*
 import org.junit.jupiter.api.Test
@@ -101,7 +103,18 @@ class OpenAPISchemaBuilderTest {
         val childrenItem = schema?.properties[LeafCategory::children.name]?.items
         childrenItem.assert().isNotNull()
     }
+
+    @Test
+    fun arrayType() {
+        val openAPISchemaBuilder = OpenAPISchemaBuilder()
+        val arrayType = TypeResolver().arrayType(SchemaData::class.java)
+        val arrayTypeSchema = openAPISchemaBuilder.generateSchema(arrayType)
+        val componentsSchemas = openAPISchemaBuilder.build()
+        val schema = componentsSchemas["wow.schema.JsonSchemaGeneratorTest.SchemaData"]
+        arrayTypeSchema.types.assert().contains("array")
+    }
 }
+
 data class LeafCategory(
     override val children: List<LeafCategory>,
     override val sortId: Int,


### PR DESCRIPTION
- Update BoundedContextSchemaNameConverter to handle non-array types
- Add test case for array type in JsonSchemaGenerator
- Improve SchemaReference merge function to support array references
- Add test case for array type in OpenAPISchemaBuilder