### PR TITLE
build(deps): update JUnit and reorganize test dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -115,17 +115,19 @@ configure(libraryProjects) {
     }
     dependencies {
         api(platform(dependenciesProject))
+        testImplementation(platform(rootProject.libs.junit.bom))
         detektPlugins(platform(dependenciesProject))
         implementation("org.slf4j:slf4j-api")
+        testImplementation("io.micrometer:micrometer-core")
         testImplementation("ch.qos.logback:logback-classic")
-        testImplementation("org.junit.jupiter:junit-jupiter-api")
-        testImplementation("org.junit.jupiter:junit-jupiter-params")
         testImplementation("me.ahoo.test:fluent-assert-core")
         testImplementation("org.hamcrest:hamcrest")
         testImplementation("io.mockk:mockk") {
             exclude(group = "org.slf4j", module = "slf4j-api")
         }
-        testImplementation("io.micrometer:micrometer-core")
+        testImplementation("org.junit.jupiter:junit-jupiter-api")
+        testImplementation("org.junit.jupiter:junit-jupiter-params")
+        testRuntimeOnly("org.junit.platform:junit-platform-launcher")
         testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
         detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting")
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ jte = "3.2.1"
 jsonschema-generator = "4.38.0"
 json-schema-validator = "1.5.7"
 # testing
+junit = "5.13.0"
 fluent-assert = "0.1.2"
 hamcrest = "3.0"
 mockk = "1.14.2"
@@ -51,6 +52,7 @@ swagger-core = { module = "io.swagger.core.v3:swagger-core-jakarta", version.ref
 springdoc-bom = { module = "org.springdoc:springdoc-openapi-bom", version.ref = "springdoc" }
 jte = { module = "gg.jte:jte", version.ref = "jte" }
 jte-kotlin = { module = "gg.jte:jte-kotlin", version.ref = "jte" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 fluent-assert-bom = { module = "me.ahoo.test:fluent-assert-bom", version.ref = "fluent-assert" }
 hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }


### PR DESCRIPTION
- Add JUnit BOM (Bill of Materials) to manage test dependencies
- Update JUnit version to 5.13.0
- Reorganize test dependencies to use JUnit BOM
- Add junit-platform-launcher as a testRuntimeOnly dependency
