### PR TITLE
refactor(test): add service type parameter for inject functions

### DIFF
--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/DefaultAggregateVerifier.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/DefaultAggregateVerifier.kt
@@ -37,6 +37,7 @@ import reactor.kotlin.core.publisher.switchIfEmpty
 import reactor.kotlin.core.publisher.toMono
 import reactor.kotlin.test.test
 import java.util.function.Consumer
+import kotlin.reflect.KType
 
 internal class DefaultGivenStage<C : Any, S : Any>(
     private val aggregateId: AggregateId,
@@ -46,8 +47,9 @@ internal class DefaultGivenStage<C : Any, S : Any>(
     private val serviceProvider: ServiceProvider
 ) : GivenStage<S> {
     private var ownerId: String = OwnerId.DEFAULT_OWNER_ID
-    override fun <SERVICE : Any> inject(service: SERVICE, serviceName: String): GivenStage<S> {
-        serviceProvider.register(serviceName, service)
+
+    override fun <SERVICE : Any> inject(service: SERVICE, serviceName: String, serviceType: KType): GivenStage<S> {
+        serviceProvider.register(serviceName, serviceType, service)
         return this
     }
 
@@ -237,8 +239,9 @@ internal class DefaultVerifiedStage<C : Any, S : Any>(
     private val serviceProvider: ServiceProvider
 ) : VerifiedStage<S>, GivenStage<S> {
     private var ownerId: String = verifiedResult.stateAggregate.ownerId
-    override fun <SERVICE : Any> inject(service: SERVICE, serviceName: String): GivenStage<S> {
-        serviceProvider.register(serviceName, service)
+
+    override fun <SERVICE : Any> inject(service: SERVICE, serviceName: String, serviceType: KType): GivenStage<S> {
+        serviceProvider.register(serviceName, serviceType, service)
         return this
     }
 

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/Stages.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/Stages.kt
@@ -30,12 +30,15 @@ import me.ahoo.wow.modeling.state.StateAggregate
 import me.ahoo.wow.naming.annotation.toName
 import java.util.function.Consumer
 import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.full.defaultType
 
 interface GivenStage<S : Any> {
-    fun <SERVICE : Any> inject(service: SERVICE, serviceName: String): GivenStage<S>
-    fun <SERVICE : Any> inject(service: SERVICE): GivenStage<S> {
-        return inject(service = service, serviceName = service.javaClass.toName())
-    }
+    fun <SERVICE : Any> inject(
+        service: SERVICE,
+        serviceName: String = service.javaClass.toName(),
+        serviceType: KType = service.javaClass.kotlin.defaultType
+    ): GivenStage<S>
 
     fun givenOwnerId(ownerId: String): GivenStage<S>
 

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/DefaultStatelessSagaVerifier.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/DefaultStatelessSagaVerifier.kt
@@ -36,6 +36,7 @@ import reactor.kotlin.core.publisher.switchIfEmpty
 import reactor.kotlin.test.test
 import java.lang.reflect.Constructor
 import java.util.function.Consumer
+import kotlin.reflect.KType
 
 internal class DefaultWhenStage<T : Any>(
     private val sagaMetadata: ProcessorMetadata<T, DomainEventExchange<*>>,
@@ -61,8 +62,8 @@ internal class DefaultWhenStage<T : Any>(
         )
     }
 
-    override fun <SERVICE : Any> inject(service: SERVICE, serviceName: String): WhenStage<T> {
-        serviceProvider.register(serviceName, service)
+    override fun <SERVICE : Any> inject(service: SERVICE, serviceName: String, serviceType: KType): WhenStage<T> {
+        serviceProvider.register(serviceName, serviceType, service)
         return this
     }
 

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/Stages.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/Stages.kt
@@ -23,6 +23,8 @@ import me.ahoo.wow.naming.annotation.toName
 import me.ahoo.wow.saga.stateless.CommandStream
 import java.util.function.Consumer
 import kotlin.reflect.KClass
+import kotlin.reflect.KType
+import kotlin.reflect.full.defaultType
 
 /**
  * Stateless Saga:
@@ -30,11 +32,12 @@ import kotlin.reflect.KClass
  * 2. expect commands
  */
 interface WhenStage<T : Any> {
-    fun <SERVICE : Any> inject(service: SERVICE, serviceName: String): WhenStage<T>
+    fun <SERVICE : Any> inject(
+        service: SERVICE,
+        serviceName: String = service.javaClass.toName(),
+        serviceType: KType = service.javaClass.kotlin.defaultType
+    ): WhenStage<T>
 
-    fun <SERVICE : Any> inject(service: SERVICE): WhenStage<T> {
-        return inject(service, service.javaClass.toName())
-    }
 
     fun functionFilter(filter: (MessageFunction<*, *, *>) -> Boolean): WhenStage<T>
 

--- a/wow-core/build.gradle.kts
+++ b/wow-core/build.gradle.kts
@@ -9,6 +9,7 @@ dependencies {
     api("com.google.guava:guava")
     api("com.fasterxml.jackson.core:jackson-databind")
     api("io.github.oshai:kotlin-logging-jvm")
+    api(kotlin("reflect"))
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
     testImplementation(project(":wow-tck"))

--- a/wow-core/src/main/kotlin/me/ahoo/wow/ioc/ServiceProvider.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/ioc/ServiceProvider.kt
@@ -13,6 +13,7 @@
 package me.ahoo.wow.ioc
 
 import me.ahoo.wow.naming.annotation.toName
+import kotlin.reflect.KType
 
 /**
  * ServiceProvider .
@@ -20,13 +21,17 @@ import me.ahoo.wow.naming.annotation.toName
  * @author ahoo wang
  */
 interface ServiceProvider {
+    fun register(serviceName: String, serviceType: KType, service: Any)
+    fun register(serviceType: KType, service: Any)
+    fun register(serviceName: String, service: Any)
+
+    fun <S : Any> getService(serviceType: KType): S?
+
     fun <S : Any> register(service: S) {
         val serviceName = service.javaClass.toName()
         register(serviceName, service)
     }
-
     fun <S : Any> register(serviceType: Class<S>, service: S)
-    fun <S : Any> register(serviceName: String, service: S)
     fun <S : Any> getService(serviceType: Class<S>): S?
     fun <S : Any> getService(serviceName: String): S?
     fun <S : Any> getRequiredService(serviceType: Class<S>): S {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/ioc/SimpleServiceProvider.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/ioc/SimpleServiceProvider.kt
@@ -46,7 +46,7 @@ class SimpleServiceProvider : ServiceProvider {
         }
         return typedServices.values.firstOrNull {
             val instanceType = it.javaClass.kotlin.defaultType
-            serviceType.isSubtypeOf(instanceType)
+            instanceType.isSubtypeOf(serviceType)
         } as S?
     }
 

--- a/wow-core/src/test/kotlin/me/ahoo/wow/ioc/SimpleServiceProviderTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/ioc/SimpleServiceProviderTest.kt
@@ -1,9 +1,8 @@
 package me.ahoo.wow.ioc
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.annotation.Name
 import me.ahoo.wow.ioc.SimpleServiceProviderTest.Companion.SERVICE_NAME
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 
 @Name(SERVICE_NAME)
@@ -16,11 +15,11 @@ class SimpleServiceProviderTest {
     fun getService() {
         val serviceProvider = SimpleServiceProvider()
         serviceProvider.register(this)
-        assertThat(serviceProvider.getRequiredService<SimpleServiceProviderTest>(), equalTo(this))
-        assertThat(serviceProvider.getRequiredService(SERVICE_NAME), equalTo(this))
+        serviceProvider.getRequiredService<SimpleServiceProviderTest>().assert().isSameAs(this)
+        serviceProvider.getRequiredService<SimpleServiceProviderTest>(SERVICE_NAME).assert().isSameAs(this)
 
         val copiedServiceProvider = serviceProvider.copy()
-        assertThat(copiedServiceProvider.getRequiredService<SimpleServiceProviderTest>(), equalTo(this))
-        assertThat(copiedServiceProvider.getRequiredService(SERVICE_NAME), equalTo(this))
+        copiedServiceProvider.getRequiredService<SimpleServiceProviderTest>().assert().isSameAs(this)
+        copiedServiceProvider.getRequiredService<SimpleServiceProviderTest>(SERVICE_NAME).assert().isSameAs(this)
     }
 }

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/SpringServiceProvider.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/SpringServiceProvider.kt
@@ -17,6 +17,9 @@ import me.ahoo.wow.infra.Decorator
 import me.ahoo.wow.ioc.ServiceProvider
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
+import org.springframework.core.ResolvableType
+import kotlin.reflect.KType
+import kotlin.reflect.jvm.javaType
 
 class SpringServiceProvider(override val delegate: ConfigurableBeanFactory) :
     ServiceProvider,
@@ -26,8 +29,21 @@ class SpringServiceProvider(override val delegate: ConfigurableBeanFactory) :
         register(service)
     }
 
-    override fun <S : Any> register(serviceName: String, service: S) {
+    override fun register(serviceName: String, serviceType: KType, service: Any) {
+        register(serviceName, service)
+    }
+
+    override fun register(serviceType: KType, service: Any) {
+        register(service)
+    }
+
+    override fun register(serviceName: String, service: Any) {
         delegate.registerSingleton(serviceName, service)
+    }
+
+    override fun <S : Any> getService(serviceType: KType): S? {
+        val resolvableType = ResolvableType.forType(serviceType.javaType)
+        return delegate.getBeanProvider<S>(resolvableType).getIfAvailable { null }
     }
 
     @Suppress("UNCHECKED_CAST")


### PR DESCRIPTION
- Update inject functions in DefaultAggregateVerifier and DefaultStatelessSagaVerifier to include serviceType parameter
- Modify Stages.kt files to add serviceType parameter with default value
- These changes allow for more flexible service registration in tests