### PR TITLE
refactor(ioc): improve ServiceProvider with reified type support

### DIFF
--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/Stages.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/Stages.kt
@@ -38,7 +38,6 @@ interface WhenStage<T : Any> {
         serviceType: KType = service.javaClass.kotlin.defaultType
     ): WhenStage<T>
 
-
     fun functionFilter(filter: (MessageFunction<*, *, *>) -> Boolean): WhenStage<T>
 
     fun functionName(functionName: String): WhenStage<T> {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/constructor/ObjectFactory.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/constructor/ObjectFactory.kt
@@ -13,6 +13,7 @@
 package me.ahoo.wow.infra.accessor.constructor
 
 import me.ahoo.wow.ioc.ServiceProvider
+import me.ahoo.wow.ioc.getRequiredService
 import java.lang.reflect.Constructor
 
 interface ObjectFactory<T : Any> {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/ioc/ServiceProvider.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/ioc/ServiceProvider.kt
@@ -14,6 +14,8 @@ package me.ahoo.wow.ioc
 
 import me.ahoo.wow.naming.annotation.toName
 import kotlin.reflect.KType
+import kotlin.reflect.full.defaultType
+import kotlin.reflect.typeOf
 
 /**
  * ServiceProvider .
@@ -31,22 +33,32 @@ interface ServiceProvider {
         val serviceName = service.javaClass.toName()
         register(serviceName, service)
     }
-    fun <S : Any> register(serviceType: Class<S>, service: S)
-    fun <S : Any> getService(serviceType: Class<S>): S?
-    fun <S : Any> getService(serviceName: String): S?
-    fun <S : Any> getRequiredService(serviceType: Class<S>): S {
-        return requireNotNull(getService(serviceType)) { "ServiceType[$serviceType] not found." }
-    }
 
-    fun <S : Any> getRequiredService(serviceName: String): S {
-        return requireNotNull(getService(serviceName)) { "ServiceName[$serviceName] not found." }
-    }
+    fun <S : Any> getService(serviceName: String): S?
 }
 
 inline fun <reified S : Any> ServiceProvider.getService(): S? {
-    return getService(S::class.java)
+    return getService(typeOf<S>())
+}
+
+fun <S : Any> ServiceProvider.getRequiredService(serviceName: String): S {
+    return requireNotNull(getService(serviceName)) {
+        "Service[$serviceName] not found."
+    }
+}
+
+fun <S : Any> ServiceProvider.getRequiredService(serviceType: KType): S {
+    return requireNotNull(getService(serviceType)) {
+        "Service[$serviceType] not found."
+    }
+}
+
+fun <S : Any> ServiceProvider.getRequiredService(serviceType: Class<S>): S {
+    return getRequiredService(serviceType.kotlin.defaultType)
 }
 
 inline fun <reified S : Any> ServiceProvider.getRequiredService(): S {
-    return getRequiredService(S::class.java)
+    return requireNotNull(getService()) {
+        "Service[${S::class}] not found."
+    }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/ioc/SimpleServiceProvider.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/ioc/SimpleServiceProvider.kt
@@ -34,10 +34,6 @@ class SimpleServiceProvider : ServiceProvider {
         register(serviceName, service.javaClass.kotlin.defaultType, service)
     }
 
-    override fun <S : Any> register(serviceType: Class<S>, service: S) {
-        register(serviceType.kotlin.defaultType, service)
-    }
-
     @Suppress("UNCHECKED_CAST")
     override fun <S : Any> getService(serviceType: KType): S? {
         val service = typedServices[serviceType] as S?
@@ -48,10 +44,6 @@ class SimpleServiceProvider : ServiceProvider {
             val instanceType = it.javaClass.kotlin.defaultType
             instanceType.isSubtypeOf(serviceType)
         } as S?
-    }
-
-    override fun <S : Any> getService(serviceType: Class<S>): S? {
-        return getService(serviceType.kotlin.defaultType)
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/wow-spring/build.gradle.kts
+++ b/wow-spring/build.gradle.kts
@@ -2,4 +2,5 @@ dependencies {
     api(project(":wow-core"))
     implementation(project(":wow-query"))
     api("org.springframework:spring-context")
+    testImplementation("me.ahoo.test:fluent-assert-core")
 }

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/SpringServiceProvider.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/SpringServiceProvider.kt
@@ -15,7 +15,6 @@ package me.ahoo.wow.spring
 
 import me.ahoo.wow.infra.Decorator
 import me.ahoo.wow.ioc.ServiceProvider
-import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
 import org.springframework.core.ResolvableType
 import kotlin.reflect.KType
@@ -24,10 +23,6 @@ import kotlin.reflect.jvm.javaType
 class SpringServiceProvider(override val delegate: ConfigurableBeanFactory) :
     ServiceProvider,
     Decorator<ConfigurableBeanFactory> {
-
-    override fun <S : Any> register(serviceType: Class<S>, service: S) {
-        register(service)
-    }
 
     override fun register(serviceName: String, serviceType: KType, service: Any) {
         register(serviceName, service)
@@ -49,13 +44,5 @@ class SpringServiceProvider(override val delegate: ConfigurableBeanFactory) :
     @Suppress("UNCHECKED_CAST")
     override fun <S : Any> getService(serviceName: String): S? {
         return delegate.getBean(serviceName) as S?
-    }
-
-    override fun <S : Any> getService(serviceType: Class<S>): S? {
-        return try {
-            delegate.getBean(serviceType)
-        } catch (e: NoSuchBeanDefinitionException) {
-            null
-        }
     }
 }

--- a/wow-spring/src/test/kotlin/me/ahoo/wow/spring/SpringServiceProviderTest.kt
+++ b/wow-spring/src/test/kotlin/me/ahoo/wow/spring/SpringServiceProviderTest.kt
@@ -1,10 +1,12 @@
 package me.ahoo.wow.spring
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.infra.Decorator.Companion.getOriginalDelegate
-import org.hamcrest.MatcherAssert.*
-import org.hamcrest.Matchers.*
+import me.ahoo.wow.ioc.getRequiredService
+import me.ahoo.wow.ioc.getService
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.support.DefaultListableBeanFactory
+import kotlin.reflect.typeOf
 
 class SpringServiceProviderTest {
 
@@ -12,9 +14,9 @@ class SpringServiceProviderTest {
     fun register() {
         val beanFactory = DefaultListableBeanFactory()
         val serviceProvider = SpringServiceProvider(beanFactory)
-        assertThat(serviceProvider.getService(SpringServiceProviderTest::class.java), nullValue())
-        serviceProvider.register(SpringServiceProviderTest::class.java, this)
-        assertThat(serviceProvider.getService(SpringServiceProviderTest::class.java), equalTo(this))
-        assertThat(serviceProvider.getOriginalDelegate(), equalTo(beanFactory))
+        serviceProvider.getService<SpringServiceProviderTest>().assert().isNull()
+        serviceProvider.register(typeOf<SpringServiceProviderTest>(), this)
+        serviceProvider.getRequiredService<SpringServiceProviderTest>().assert().isSameAs(this)
+        serviceProvider.getOriginalDelegate().assert().isSameAs(beanFactory)
     }
 }


### PR DESCRIPTION
- Add support for reified types in ServiceProvider
- Implement new getRequiredService methods with better error messages
- Update ObjectFactory to use new reified type methods
- Refactor SimpleServiceProvider to use KType instead of Class
