### PR TITLE
refactor(ioc): simplify ServiceProvider interface and update related classes

### DIFF
--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/DefaultAggregateVerifier.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/DefaultAggregateVerifier.kt
@@ -49,7 +49,7 @@ internal class DefaultGivenStage<C : Any, S : Any>(
     private var ownerId: String = OwnerId.DEFAULT_OWNER_ID
 
     override fun <SERVICE : Any> inject(service: SERVICE, serviceName: String, serviceType: KType): GivenStage<S> {
-        serviceProvider.register(serviceName, serviceType, service)
+        serviceProvider.register(service, serviceName, serviceType)
         return this
     }
 
@@ -241,7 +241,7 @@ internal class DefaultVerifiedStage<C : Any, S : Any>(
     private var ownerId: String = verifiedResult.stateAggregate.ownerId
 
     override fun <SERVICE : Any> inject(service: SERVICE, serviceName: String, serviceType: KType): GivenStage<S> {
-        serviceProvider.register(serviceName, serviceType, service)
+        serviceProvider.register(service, serviceName, serviceType)
         return this
     }
 

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/DefaultStatelessSagaVerifier.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/DefaultStatelessSagaVerifier.kt
@@ -63,7 +63,7 @@ internal class DefaultWhenStage<T : Any>(
     }
 
     override fun <SERVICE : Any> inject(service: SERVICE, serviceName: String, serviceType: KType): WhenStage<T> {
-        serviceProvider.register(serviceName, serviceType, service)
+        serviceProvider.register(service, serviceName, serviceType)
         return this
     }
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/ioc/ServiceProvider.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/ioc/ServiceProvider.kt
@@ -55,7 +55,5 @@ fun <S : Any> ServiceProvider.getRequiredService(serviceType: Class<S>): S {
 }
 
 inline fun <reified S : Any> ServiceProvider.getRequiredService(): S {
-    return requireNotNull(getService()) {
-        "Service[${S::class}] not found."
-    }
+    return getRequiredService(typeOf<S>())
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/ioc/ServiceProvider.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/ioc/ServiceProvider.kt
@@ -23,16 +23,13 @@ import kotlin.reflect.typeOf
  * @author ahoo wang
  */
 interface ServiceProvider {
-    fun register(serviceName: String, serviceType: KType, service: Any)
-    fun register(serviceType: KType, service: Any)
-    fun register(serviceName: String, service: Any)
+    fun register(
+        service: Any,
+        serviceName: String = service.javaClass.toName(),
+        serviceType: KType = service.javaClass.kotlin.defaultType
+    )
 
     fun <S : Any> getService(serviceType: KType): S?
-
-    fun <S : Any> register(service: S) {
-        val serviceName = service.javaClass.toName()
-        register(serviceName, service)
-    }
 
     fun <S : Any> getService(serviceName: String): S?
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/ioc/SimpleServiceProvider.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/ioc/SimpleServiceProvider.kt
@@ -21,17 +21,9 @@ class SimpleServiceProvider : ServiceProvider {
     private val typedServices: ConcurrentHashMap<KType, Any> = ConcurrentHashMap<KType, Any>()
     private val namedServices: ConcurrentHashMap<String, Any> = ConcurrentHashMap<String, Any>()
 
-    override fun register(serviceName: String, serviceType: KType, service: Any) {
+    override fun register(service: Any, serviceName: String, serviceType: KType) {
         typedServices[serviceType] = service
         namedServices[serviceName] = service
-    }
-
-    override fun register(serviceType: KType, service: Any) {
-        typedServices[serviceType] = service
-    }
-
-    override fun register(serviceName: String, service: Any) {
-        register(serviceName, service.javaClass.kotlin.defaultType, service)
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/wow-core/src/test/kotlin/me/ahoo/wow/ioc/SimpleServiceProviderTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/ioc/SimpleServiceProviderTest.kt
@@ -1,9 +1,11 @@
 package me.ahoo.wow.ioc
 
 import me.ahoo.test.asserts.assert
+import me.ahoo.test.asserts.assertThrownBy
 import me.ahoo.wow.api.annotation.Name
 import me.ahoo.wow.ioc.SimpleServiceProviderTest.Companion.SERVICE_NAME
 import org.junit.jupiter.api.Test
+import kotlin.reflect.typeOf
 
 @Name(SERVICE_NAME)
 class SimpleServiceProviderTest {
@@ -18,8 +20,26 @@ class SimpleServiceProviderTest {
         serviceProvider.getRequiredService<SimpleServiceProviderTest>().assert().isSameAs(this)
         serviceProvider.getRequiredService<SimpleServiceProviderTest>(SERVICE_NAME).assert().isSameAs(this)
 
+        assertThrownBy<IllegalArgumentException> {
+            serviceProvider.getRequiredService<SimpleServiceProviderTest>("notExist")
+        }
+
+        assertThrownBy<IllegalArgumentException> {
+            serviceProvider.getRequiredService<SimpleServiceProviderTest>(typeOf<MockService>())
+        }
+
+        assertThrownBy<IllegalArgumentException> {
+            serviceProvider.getRequiredService<MockService>()
+        }
+
+        assertThrownBy<IllegalArgumentException> {
+            serviceProvider.getRequiredService(MockService::class.java)
+        }
+
         val copiedServiceProvider = serviceProvider.copy()
         copiedServiceProvider.getRequiredService<SimpleServiceProviderTest>().assert().isSameAs(this)
         copiedServiceProvider.getRequiredService<SimpleServiceProviderTest>(SERVICE_NAME).assert().isSameAs(this)
     }
+
+    object MockService
 }

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/SpringServiceProvider.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/SpringServiceProvider.kt
@@ -24,15 +24,7 @@ class SpringServiceProvider(override val delegate: ConfigurableBeanFactory) :
     ServiceProvider,
     Decorator<ConfigurableBeanFactory> {
 
-    override fun register(serviceName: String, serviceType: KType, service: Any) {
-        register(serviceName, service)
-    }
-
-    override fun register(serviceType: KType, service: Any) {
-        register(service)
-    }
-
-    override fun register(serviceName: String, service: Any) {
+    override fun register(service: Any, serviceName: String, serviceType: KType) {
         delegate.registerSingleton(serviceName, service)
     }
 

--- a/wow-spring/src/test/kotlin/me/ahoo/wow/spring/SpringServiceProviderTest.kt
+++ b/wow-spring/src/test/kotlin/me/ahoo/wow/spring/SpringServiceProviderTest.kt
@@ -15,7 +15,7 @@ class SpringServiceProviderTest {
         val beanFactory = DefaultListableBeanFactory()
         val serviceProvider = SpringServiceProvider(beanFactory)
         serviceProvider.getService<SpringServiceProviderTest>().assert().isNull()
-        serviceProvider.register(typeOf<SpringServiceProviderTest>(), this)
+        serviceProvider.register(this, serviceType = typeOf<SpringServiceProviderTest>())
         serviceProvider.getRequiredService<SpringServiceProviderTest>().assert().isSameAs(this)
         serviceProvider.getOriginalDelegate().assert().isSameAs(beanFactory)
     }


### PR DESCRIPTION
- Simplified ServiceProvider interface with a single register method
- Updated register method signature to be more intuitive
- Modified implementations in SimpleServiceProvider and SpringServiceProvider
- Adjusted usage in DefaultAggregateVerifier and DefaultStatelessSagaVerifier
