### PR TITLE
refactor(ioc): add register function with reified type parameter

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/ioc/ServiceProvider.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/ioc/ServiceProvider.kt
@@ -34,6 +34,13 @@ interface ServiceProvider {
     fun <S : Any> getService(serviceName: String): S?
 }
 
+inline fun <reified S : Any> ServiceProvider.register(
+    service: Any,
+    serviceName: String = service.javaClass.toName()
+) {
+    register(service, serviceName, typeOf<S>())
+}
+
 inline fun <reified S : Any> ServiceProvider.getService(): S? {
     return getService(typeOf<S>())
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/ioc/SimpleServiceProviderTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/ioc/SimpleServiceProviderTest.kt
@@ -16,7 +16,7 @@ class SimpleServiceProviderTest {
     @Test
     fun getService() {
         val serviceProvider = SimpleServiceProvider()
-        serviceProvider.register(this)
+        serviceProvider.register<SimpleServiceProviderTest>(this)
         serviceProvider.getRequiredService<SimpleServiceProviderTest>().assert().isSameAs(this)
         serviceProvider.getRequiredService<SimpleServiceProviderTest>(SERVICE_NAME).assert().isSameAs(this)
 


### PR DESCRIPTION
- Add an inline register function with reified type parameter to ServiceProvider
- Update test case to use the new register function
- This change improves type safety and eliminates the need for explicit type casts

