### PR TITLE
refactor(test): simplify service injection in test verifiers

### DIFF
--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/DefaultAggregateVerifier.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/DefaultAggregateVerifier.kt
@@ -37,7 +37,6 @@ import reactor.kotlin.core.publisher.switchIfEmpty
 import reactor.kotlin.core.publisher.toMono
 import reactor.kotlin.test.test
 import java.util.function.Consumer
-import kotlin.reflect.KType
 
 internal class DefaultGivenStage<C : Any, S : Any>(
     private val aggregateId: AggregateId,
@@ -48,8 +47,8 @@ internal class DefaultGivenStage<C : Any, S : Any>(
 ) : GivenStage<S> {
     private var ownerId: String = OwnerId.DEFAULT_OWNER_ID
 
-    override fun <SERVICE : Any> inject(service: SERVICE, serviceName: String, serviceType: KType): GivenStage<S> {
-        serviceProvider.register(service, serviceName, serviceType)
+    override fun inject(inject: ServiceProvider.() -> Unit): GivenStage<S> {
+        inject(serviceProvider)
         return this
     }
 
@@ -240,8 +239,8 @@ internal class DefaultVerifiedStage<C : Any, S : Any>(
 ) : VerifiedStage<S>, GivenStage<S> {
     private var ownerId: String = verifiedResult.stateAggregate.ownerId
 
-    override fun <SERVICE : Any> inject(service: SERVICE, serviceName: String, serviceType: KType): GivenStage<S> {
-        serviceProvider.register(service, serviceName, serviceType)
+    override fun inject(inject: ServiceProvider.() -> Unit): GivenStage<S> {
+        inject(serviceProvider)
         return this
     }
 

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/Stages.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/Stages.kt
@@ -38,7 +38,14 @@ interface GivenStage<S : Any> {
         service: SERVICE,
         serviceName: String = service.javaClass.toName(),
         serviceType: KType = service.javaClass.kotlin.defaultType
-    ): GivenStage<S>
+    ): GivenStage<S> {
+        inject {
+            register(service, serviceName, serviceType)
+        }
+        return this
+    }
+
+    fun inject(inject: ServiceProvider.() -> Unit): GivenStage<S>
 
     fun givenOwnerId(ownerId: String): GivenStage<S>
 

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/DefaultStatelessSagaVerifier.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/DefaultStatelessSagaVerifier.kt
@@ -36,7 +36,6 @@ import reactor.kotlin.core.publisher.switchIfEmpty
 import reactor.kotlin.test.test
 import java.lang.reflect.Constructor
 import java.util.function.Consumer
-import kotlin.reflect.KType
 
 internal class DefaultWhenStage<T : Any>(
     private val sagaMetadata: ProcessorMetadata<T, DomainEventExchange<*>>,
@@ -62,8 +61,8 @@ internal class DefaultWhenStage<T : Any>(
         )
     }
 
-    override fun <SERVICE : Any> inject(service: SERVICE, serviceName: String, serviceType: KType): WhenStage<T> {
-        serviceProvider.register(service, serviceName, serviceType)
+    override fun inject(inject: ServiceProvider.() -> Unit): WhenStage<T> {
+        inject(serviceProvider)
         return this
     }
 

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/Stages.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/Stages.kt
@@ -18,6 +18,7 @@ import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.modeling.OwnerId
 import me.ahoo.wow.event.DomainEventExchange
 import me.ahoo.wow.infra.Decorator
+import me.ahoo.wow.ioc.ServiceProvider
 import me.ahoo.wow.messaging.function.MessageFunction
 import me.ahoo.wow.naming.annotation.toName
 import me.ahoo.wow.saga.stateless.CommandStream
@@ -36,8 +37,14 @@ interface WhenStage<T : Any> {
         service: SERVICE,
         serviceName: String = service.javaClass.toName(),
         serviceType: KType = service.javaClass.kotlin.defaultType
-    ): WhenStage<T>
+    ): WhenStage<T> {
+        inject {
+            register(service, serviceName, serviceType)
+        }
+        return this
+    }
 
+    fun inject(inject: ServiceProvider.() -> Unit): WhenStage<T>
     fun functionFilter(filter: (MessageFunction<*, *, *>) -> Boolean): WhenStage<T>
 
     fun functionName(functionName: String): WhenStage<T> {


### PR DESCRIPTION
- Replace complex inject method with a simpler extension function
- Update DefaultAggregateVerifier and DefaultStatelessSagaVerifier to use new inject method
- Modify Stages.kt files to include new inject extension function
- Remove unused KType import

