### PR TITLE
test(compensation): update ExecutionFailedTest to use IRetrySpec and NextRetryAtCalculator

### DIFF
--- a/compensation/wow-compensation-domain/src/test/kotlin/me/ahoo/wow/compensation/domain/ExecutionFailedTest.kt
+++ b/compensation/wow-compensation-domain/src/test/kotlin/me/ahoo/wow/compensation/domain/ExecutionFailedTest.kt
@@ -31,12 +31,14 @@ import me.ahoo.wow.compensation.api.ExecutionFailedStatus
 import me.ahoo.wow.compensation.api.ExecutionSuccessApplied
 import me.ahoo.wow.compensation.api.ForcePrepareCompensation
 import me.ahoo.wow.compensation.api.FunctionChanged
+import me.ahoo.wow.compensation.api.IRetrySpec
 import me.ahoo.wow.compensation.api.MarkRecoverable
 import me.ahoo.wow.compensation.api.PrepareCompensation
 import me.ahoo.wow.compensation.api.RecoverableMarked
 import me.ahoo.wow.compensation.api.RetrySpec
 import me.ahoo.wow.compensation.api.RetrySpecApplied
 import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.ioc.register
 import me.ahoo.wow.modeling.aggregateId
 import me.ahoo.wow.modeling.toNamedAggregate
 import me.ahoo.wow.test.aggregate.whenCommand
@@ -104,8 +106,10 @@ class ExecutionFailedTest {
         )
 
         aggregateVerifier<ExecutionFailed, ExecutionFailedState>()
-            .inject(DefaultNextRetryAtCalculatorTest.testRetrySpec)
-            .inject(DefaultNextRetryAtCalculator)
+            .inject {
+                register<IRetrySpec>(DefaultNextRetryAtCalculatorTest.testRetrySpec)
+                register<NextRetryAtCalculator>(DefaultNextRetryAtCalculator)
+            }
             .whenCommand(createExecutionFailed)
             .expectNoError()
             .expectEventType(ExecutionFailedCreated::class.java)


### PR DESCRIPTION
- Inject IRetrySpec and NextRetryAtCalculator using wow.ioc.register
- Remove direct instantiation of DefaultNextRetryAtCalculator
- Update test to use new dependency injection approach
