### PR TITLE
docs(guide): update project template version in getting started guide

### DIFF
--- a/documentation/docs/guide/getting-started.md
+++ b/documentation/docs/guide/getting-started.md
@@ -13,7 +13,7 @@
     - _Mac OS_:`~/Library/Application\ Support/JetBrains/<PRODUCT><VERSION/projectTemplates/`
     - _Linux_: `~/.config/JetBrains/<PRODUCT><VERSION>/projectTemplates/`
 - 将模板压缩包放到 _IDEA_ 项目模板目录下
-    - 模板压缩包: [wow-project-template.zip](https://gitee.com/AhooWang/wow-project-template/releases/download/v5.13.5/wow-project-template.zip)
+    - 模板压缩包: [wow-project-template.zip](https://gitee.com/AhooWang/wow-project-template/releases/download/v5.18.6/wow-project-template.zip)
 
 ## 创建项目
 


### PR DESCRIPTION
- Update the project template version from v5.13.5 to v5.18.6 in the getting started guide
- Ensure users download the correct template version for their IDE
