### PR TITLE
refactor(webflux): optimize route response handling 

### DIFF
--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/Responses.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/Responses.kt
@@ -23,12 +23,12 @@ import me.ahoo.wow.webflux.exception.DefaultRequestExceptionHandler
 import me.ahoo.wow.webflux.exception.ErrorHttpStatusMapping.toHttpStatus
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.route.command.isSse
-import org.reactivestreams.Publisher
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.http.codec.ServerSentEvent
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toFlux
 import reactor.kotlin.core.publisher.toMono
@@ -67,12 +67,12 @@ fun Mono<*>.toServerResponse(
     }
 }
 
-fun Publisher<CommandResult>.toCommandResponse(
+fun Flux<CommandResult>.toCommandResponse(
     request: ServerRequest,
     exceptionHandler: RequestExceptionHandler = DefaultRequestExceptionHandler
 ): Mono<ServerResponse> {
     if (!request.isSse()) {
-        return this.toMono().toServerResponse(request, exceptionHandler)
+        return this.next().toServerResponse(request, exceptionHandler)
     }
 
     val serverSentEventStream = this.toFlux().map {

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/Responses.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/Responses.kt
@@ -30,7 +30,6 @@ import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
-import reactor.kotlin.core.publisher.toFlux
 import reactor.kotlin.core.publisher.toMono
 
 fun Throwable.toResponseEntity(): ResponseEntity<ErrorInfo> {
@@ -75,7 +74,7 @@ fun Flux<CommandResult>.toCommandResponse(
         return this.next().toServerResponse(request, exceptionHandler)
     }
 
-    val serverSentEventStream = this.toFlux().map {
+    val serverSentEventStream = this.map {
         ServerSentEvent.builder<String>()
             .id(it.id)
             .event(it.stage.name)

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/ResponsesKtTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/ResponsesKtTest.kt
@@ -34,6 +34,7 @@ import org.springframework.mock.http.server.reactive.MockServerHttpRequest
 import org.springframework.mock.web.reactive.function.server.MockServerRequest
 import org.springframework.mock.web.server.MockServerWebExchange
 import org.springframework.web.reactive.function.server.ServerResponse
+import reactor.kotlin.core.publisher.toFlux
 import reactor.kotlin.core.publisher.toMono
 import reactor.kotlin.test.test
 import java.util.concurrent.TimeoutException
@@ -98,6 +99,7 @@ class ResponsesKtTest {
             contextName = "contextName",
             processorName = "processorName",
         ).toMono()
+            .toFlux()
             .toCommandResponse(serverRequest, DefaultRequestExceptionHandler)
             .test()
             .consumeNextWith {
@@ -130,6 +132,7 @@ class ResponsesKtTest {
             contextName = "contextName",
             processorName = "processorName",
         ).toMono()
+            .toFlux()
             .toCommandResponse(serverRequest, DefaultRequestExceptionHandler)
             .flatMap {
                 it.writeTo(serverWebExchange, responseContext)
@@ -160,6 +163,7 @@ class ResponsesKtTest {
             contextName = "contextName",
             processorName = "processorName",
         ).toMono()
+            .toFlux()
             .doOnNext {
                 throw TimeoutException()
             }
@@ -187,6 +191,7 @@ class ResponsesKtTest {
             contextName = "contextName",
             processorName = "processorName",
         ).toMono()
+            .toFlux()
             .toCommandResponse(mockRequest, DefaultRequestExceptionHandler)
             .test()
             .consumeNextWith {


### PR DESCRIPTION
- Remove unused import of toFlux() extension function
- Replace toFlux() with map() in serverSentEventStream creation