### PR TITLE
refactor(openapi): update default tail version example in API documentation

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt
@@ -51,7 +51,7 @@ interface EventStore {
     fun load(
         aggregateId: AggregateId,
         headVersion: Int = DEFAULT_HEAD_VERSION,
-        tailVersion: Int = Int.MAX_VALUE
+        tailVersion: Int = DEFAULT_TAIL_VERSION
     ): Flux<DomainEventStream>
 
     /**
@@ -61,5 +61,6 @@ interface EventStore {
 
     companion object {
         const val DEFAULT_HEAD_VERSION: Int = 1
+        const val DEFAULT_TAIL_VERSION: Int = Int.MAX_VALUE - 1
     }
 }

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/BatchComponent.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/BatchComponent.kt
@@ -52,7 +52,7 @@ object BatchComponent {
         fun OpenAPIComponentContext.tailVersionPathParameter(): io.swagger.v3.oas.models.parameters.Parameter =
             parameter {
                 name = PathVariable.TAIL_VERSION
-                schema = IntegerSchema().description("The tail version of the aggregate.").example(Int.MAX_VALUE)
+                schema = IntegerSchema().description("The tail version of the aggregate.").example(EventStore.DEFAULT_TAIL_VERSION)
                 `in`(ParameterIn.PATH.toString())
             }
 
@@ -67,7 +67,7 @@ object BatchComponent {
         fun OpenAPIComponentContext.batchLimitPathParameter(): io.swagger.v3.oas.models.parameters.Parameter =
             parameter {
                 name = PathVariable.BATCH_LIMIT
-                schema = IntegerSchema().description("The size of batch.").example(Int.MAX_VALUE)
+                schema = IntegerSchema().description("The size of batch.").example(EventStore.DEFAULT_TAIL_VERSION)
                 `in`(ParameterIn.PATH.toString())
             }
     }

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/CommonComponent.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/CommonComponent.kt
@@ -19,6 +19,7 @@ import io.swagger.v3.oas.models.media.StringSchema
 import me.ahoo.wow.api.Wow
 import me.ahoo.wow.api.exception.DefaultErrorInfo
 import me.ahoo.wow.api.modeling.TenantId
+import me.ahoo.wow.eventsourcing.EventStore
 import me.ahoo.wow.exception.ErrorCodes
 import me.ahoo.wow.openapi.CommonComponent.Header.errorCodeHeader
 import me.ahoo.wow.openapi.CommonComponent.Schema.errorInfoSchema
@@ -67,7 +68,7 @@ object CommonComponent {
         fun OpenAPIComponentContext.versionPathParameter(): io.swagger.v3.oas.models.parameters.Parameter =
             parameter {
                 name = MessageRecords.VERSION
-                schema = IntegerSchema().description("aggregate version").example(Int.MAX_VALUE)
+                schema = IntegerSchema().description("aggregate version").example(EventStore.DEFAULT_TAIL_VERSION)
                 `in`(ParameterIn.PATH.toString())
             }
 


### PR DESCRIPTION
- Replace Int.MAX_VALUE with EventStore.DEFAULT_TAIL_VERSION in OpenAPI parameters
- Add DEFAULT_TAIL_VERSION constant in EventStore companion object
- Update related components to use the new default tail version constant
