### PR TITLE
fix(openapi): correct schema for list content in API responses

### DIFF
--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/ApiResponseBuilder.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/ApiResponseBuilder.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.openapi
 
 import io.swagger.v3.oas.models.headers.Header
+import io.swagger.v3.oas.models.media.ArraySchema
 import io.swagger.v3.oas.models.media.Content
 import io.swagger.v3.oas.models.media.MediaType
 import io.swagger.v3.oas.models.media.Schema
@@ -46,8 +47,9 @@ class ApiResponseBuilder {
     }
 
     fun listContent(schema: Schema<*>): ApiResponseBuilder {
-        apiResponse.content.addMediaType(Https.MediaType.APPLICATION_JSON, MediaType().schema(schema))
-        apiResponse.content.addMediaType(Https.MediaType.TEXT_EVENT_STREAM, MediaType().schema(schema))
+        val arraySchema = ArraySchema().items(schema)
+        apiResponse.content.addMediaType(Https.MediaType.APPLICATION_JSON, MediaType().schema(arraySchema))
+        apiResponse.content.addMediaType(Https.MediaType.TEXT_EVENT_STREAM, MediaType().schema(arraySchema))
         return this
     }
 

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/QueryComponent.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/QueryComponent.kt
@@ -126,7 +126,7 @@ object QueryComponent {
         fun OpenAPIComponentContext.loadEventStreamResponse(aggregateMetadata: AggregateMetadata<*, *>): io.swagger.v3.oas.models.responses.ApiResponse {
             return ApiResponseBuilder().withErrorCodeHeader(this)
                 .listContent(
-                    schema = arraySchema(
+                    schema = schema(
                         AggregatedDomainEventStream::class.java,
                         aggregateMetadata.command.aggregateType
                     )

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/snapshot/ListQuerySnapshotRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/snapshot/ListQuerySnapshotRouteSpec.kt
@@ -58,7 +58,7 @@ class ListQuerySnapshotRouteSpec(
     override val responses: ApiResponses = ApiResponses().apply {
         ApiResponseBuilder().header(CommonComponent.Header.WOW_ERROR_CODE, componentContext.errorCodeHeader())
             .listContent(
-                schema = componentContext.arraySchema(
+                schema = componentContext.schema(
                     MaterializedSnapshot::class.java,
                     aggregateMetadata.state.aggregateType
                 )

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/snapshot/ListQuerySnapshotStateRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/snapshot/ListQuerySnapshotStateRouteSpec.kt
@@ -57,7 +57,7 @@ class ListQuerySnapshotStateRouteSpec(
 
     override val responses: ApiResponses = ApiResponses().apply {
         ApiResponseBuilder().header(CommonComponent.Header.WOW_ERROR_CODE, componentContext.errorCodeHeader())
-            .listContent(schema = componentContext.arraySchema(aggregateMetadata.state.aggregateType))
+            .listContent(schema = componentContext.schema(aggregateMetadata.state.aggregateType))
             .build()
             .let {
                 addApiResponse(Https.Code.OK, it)


### PR DESCRIPTION
- Update ApiResponseBuilder to use ArraySchema for list content
- Modify ListQuerySnapshotRouteSpec and ListQuerySnapshotStateRouteSpec to use new schema method
- Adjust QueryComponent to use schema method for event stream response
