### PR TITLE
refactor(openapi): improve Server-Sent Events support

### DIFF
--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/QueryComponent.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/QueryComponent.kt
@@ -126,10 +126,9 @@ object QueryComponent {
         fun OpenAPIComponentContext.loadEventStreamResponse(aggregateMetadata: AggregateMetadata<*, *>): io.swagger.v3.oas.models.responses.ApiResponse {
             return ApiResponseBuilder().withErrorCodeHeader(this)
                 .listContent(
-                    schema = schema(
-                        AggregatedDomainEventStream::class.java,
-                        aggregateMetadata.command.aggregateType
-                    )
+                    this,
+                    AggregatedDomainEventStream::class.java,
+                    aggregateMetadata.command.aggregateType
                 ).build()
         }
     }

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/snapshot/ListQuerySnapshotRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/snapshot/ListQuerySnapshotRouteSpec.kt
@@ -58,10 +58,9 @@ class ListQuerySnapshotRouteSpec(
     override val responses: ApiResponses = ApiResponses().apply {
         ApiResponseBuilder().header(CommonComponent.Header.WOW_ERROR_CODE, componentContext.errorCodeHeader())
             .listContent(
-                schema = componentContext.schema(
-                    MaterializedSnapshot::class.java,
-                    aggregateMetadata.state.aggregateType
-                )
+                componentContext,
+                MaterializedSnapshot::class.java,
+                aggregateMetadata.state.aggregateType
             )
             .build()
             .let {

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/snapshot/ListQuerySnapshotStateRouteSpec.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/snapshot/ListQuerySnapshotStateRouteSpec.kt
@@ -57,7 +57,7 @@ class ListQuerySnapshotStateRouteSpec(
 
     override val responses: ApiResponses = ApiResponses().apply {
         ApiResponseBuilder().header(CommonComponent.Header.WOW_ERROR_CODE, componentContext.errorCodeHeader())
-            .listContent(schema = componentContext.schema(aggregateMetadata.state.aggregateType))
+            .listContent(componentContext, aggregateMetadata.state.aggregateType)
             .build()
             .let {
                 addApiResponse(Https.Code.OK, it)

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/web/ServerSentEvent.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/web/ServerSentEvent.kt
@@ -13,11 +13,23 @@
 
 package me.ahoo.wow.schema.web
 
-import java.time.Duration
+interface IServerSentEvent<DATA> {
+    val id: String?
+    val event: String?
+    val data: DATA?
+    val retry: Int?
+}
 
 data class ServerSentEvent<DATA>(
-    val id: String? = null,
-    val event: String? = null,
-    val data: DATA? = null,
-    val retry: Duration? = null
-)
+    override val id: String? = null,
+    override val event: String? = null,
+    override val data: DATA? = null,
+    override val retry: Int? = null
+) : IServerSentEvent<DATA>
+
+data class ServerSentEventNonNullData<DATA>(
+    override val id: String? = null,
+    override val event: String? = null,
+    override val data: DATA,
+    override val retry: Int? = null
+) : IServerSentEvent<DATA>

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/web/ServerSentEventTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/web/ServerSentEventTest.kt
@@ -15,16 +15,26 @@ package me.ahoo.wow.schema.web
 
 import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
-import java.time.Duration
 
 class ServerSentEventTest {
 
     @Test
-    fun `should create ServerSentEvent`() {
-        val serverSentEvent = ServerSentEvent(id = "1", event = "event", data = "data", retry = Duration.ofSeconds(1))
+    fun `should create ServerSentEventData`() {
+        val serverSentEvent =
+            ServerSentEvent(id = "1", event = "event", data = "data", retry = 1000)
         serverSentEvent.id.assert().isEqualTo("1")
         serverSentEvent.event.assert().isEqualTo("event")
         serverSentEvent.data.assert().isEqualTo("data")
-        serverSentEvent.retry.assert().isEqualTo(Duration.ofSeconds(1))
+        serverSentEvent.retry.assert().isEqualTo(1000)
+    }
+
+    @Test
+    fun `should create ServerSentEventNonNullData`() {
+        val serverSentEvent =
+            ServerSentEventNonNullData(id = "1", event = "event", data = "data", retry = 1000)
+        serverSentEvent.id.assert().isEqualTo("1")
+        serverSentEvent.event.assert().isEqualTo("event")
+        serverSentEvent.data.assert().isEqualTo("data")
+        serverSentEvent.retry.assert().isEqualTo(1000)
     }
 }


### PR DESCRIPTION
- Update ApiResponseBuilder to handle list content with proper type resolution
- Add support for ServerSentEventNonNullData in API responses
- Modify listContent method to use OpenAPIComponentContext for type resolution
- Update related route specs to use new listContent method with context
- Refactor ServerSentEvent to use Int for retry instead of Duration
- Add ServerSentEventNonNullData class for non-null data representation

