### PR TITLE
refactor(instrumentation): update instrumentation version to Wow.VERSION

### DIFF
--- a/compensation/wow-compensation-server/src/main/kotlin/me/ahoo/wow/compensation/server/configuration/SwaggerConfiguration.kt
+++ b/compensation/wow-compensation-server/src/main/kotlin/me/ahoo/wow/compensation/server/configuration/SwaggerConfiguration.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.wow.compensation.server.configuration
+
+import io.swagger.v3.oas.models.info.Contact
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.info.License
+import me.ahoo.wow.api.Wow
+import org.springdoc.core.customizers.OpenApiCustomizer
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Swagger Config.
+ *
+ * @author ahoo wang
+ */
+@Configuration
+class SwaggerConfiguration {
+    companion object {
+        val API_INFO: Info = Info()
+            .title("Wow Compensation Service")
+            .description("A Modern Reactive CQRS Architecture Microservice development framework based on DDD and EventSourcing.")
+            .contact(Contact().name("Ahoo Wang").url("https://github.com/Ahoo-Wang/Wow"))
+            .license(License().url("https://github.com/Ahoo-Wang/Wow/blob/main/LICENSE").name("Apache 2.0"))
+            .version(Wow.VERSION)
+    }
+
+    @Bean
+    fun wowCompensationOpenApiCustomizer(): OpenApiCustomizer {
+        return OpenApiCustomizer {
+            it.info(API_INFO)
+        }
+    }
+}

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/Wow.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/Wow.kt
@@ -21,4 +21,5 @@ package me.ahoo.wow.api
 object Wow {
     const val WOW: String = "wow"
     const val WOW_PREFIX: String = "$WOW."
+    val VERSION: String = Wow.javaClass.`package`.implementationVersion ?: "5.19.2"
 }

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/WowInstrumenter.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/WowInstrumenter.kt
@@ -25,7 +25,6 @@ import me.ahoo.wow.serialization.MessageRecords
 
 object WowInstrumenter {
     private const val INSTRUMENTATION_NAME = "me.ahoo.wow"
-    val INSTRUMENTATION_VERSION: String = WowInstrumenter.javaClass.`package`.implementationVersion ?: "5.12.3"
     const val INSTRUMENTATION_NAME_PREFIX = "$INSTRUMENTATION_NAME-"
 
     private const val MESSAGE_PREFIX = Wow.WOW_PREFIX + "message."

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/aggregate/AggregateInstrumenter.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/aggregate/AggregateInstrumenter.kt
@@ -16,10 +16,10 @@ package me.ahoo.wow.opentelemetry.aggregate
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor
+import me.ahoo.wow.api.Wow
 import me.ahoo.wow.command.ServerCommandExchange
 import me.ahoo.wow.opentelemetry.ExchangeAttributesExtractor
 import me.ahoo.wow.opentelemetry.WowInstrumenter.INSTRUMENTATION_NAME_PREFIX
-import me.ahoo.wow.opentelemetry.WowInstrumenter.INSTRUMENTATION_VERSION
 import me.ahoo.wow.opentelemetry.messaging.MessageExchangeTextMapGetter
 
 object AggregateInstrumenter {
@@ -30,7 +30,7 @@ object AggregateInstrumenter {
             INSTRUMENTATION_NAME,
             AggregateSpanNameExtractor,
         ).addAttributesExtractor(ExchangeAttributesExtractor())
-            .setInstrumentationVersion(INSTRUMENTATION_VERSION)
+            .setInstrumentationVersion(Wow.VERSION)
             .buildConsumerInstrumenter(MessageExchangeTextMapGetter())
 }
 

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/eventprocessor/EventProcessorInstrumenter.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/eventprocessor/EventProcessorInstrumenter.kt
@@ -16,9 +16,9 @@ package me.ahoo.wow.opentelemetry.eventprocessor
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor
+import me.ahoo.wow.api.Wow
 import me.ahoo.wow.event.DomainEventExchange
 import me.ahoo.wow.opentelemetry.ExchangeAttributesExtractor
-import me.ahoo.wow.opentelemetry.WowInstrumenter
 import me.ahoo.wow.opentelemetry.WowInstrumenter.INSTRUMENTATION_NAME_PREFIX
 import me.ahoo.wow.opentelemetry.messaging.MessageExchangeTextMapGetter
 
@@ -30,7 +30,7 @@ object EventProcessorInstrumenter {
             INSTRUMENTATION_NAME,
             EventProcessorSpanNameExtractor,
         ).addAttributesExtractor(ExchangeAttributesExtractor())
-            .setInstrumentationVersion(WowInstrumenter.INSTRUMENTATION_VERSION)
+            .setInstrumentationVersion(Wow.VERSION)
             .buildConsumerInstrumenter(MessageExchangeTextMapGetter())
 }
 

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/eventsourcing/EventStoreInstrumenter.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/eventsourcing/EventStoreInstrumenter.kt
@@ -16,12 +16,12 @@ package me.ahoo.wow.opentelemetry.eventsourcing
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor
+import me.ahoo.wow.api.Wow
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.opentelemetry.AggregateIdAttributesExtractor
 import me.ahoo.wow.opentelemetry.MessageAttributesExtractor
 import me.ahoo.wow.opentelemetry.WowInstrumenter.INSTRUMENTATION_NAME_PREFIX
-import me.ahoo.wow.opentelemetry.WowInstrumenter.INSTRUMENTATION_VERSION
 
 object EventStoreInstrumenter {
     private const val INSTRUMENTATION_NAME = "${INSTRUMENTATION_NAME_PREFIX}eventStore"
@@ -31,7 +31,7 @@ object EventStoreInstrumenter {
             INSTRUMENTATION_NAME,
             EventStoreAppendSpanNameExtractor,
         ).addAttributesExtractor(MessageAttributesExtractor())
-            .setInstrumentationVersion(INSTRUMENTATION_VERSION)
+            .setInstrumentationVersion(Wow.VERSION)
             .buildInstrumenter()
 
     val LOAD_INSTRUMENTER: Instrumenter<AggregateId, Unit> =
@@ -40,7 +40,7 @@ object EventStoreInstrumenter {
             INSTRUMENTATION_NAME,
             EventStoreLoadSpanNameExtractor,
         ).addAttributesExtractor(AggregateIdAttributesExtractor)
-            .setInstrumentationVersion(INSTRUMENTATION_VERSION)
+            .setInstrumentationVersion(Wow.VERSION)
             .buildInstrumenter()
 }
 

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/messaging/CommandProducerInstrumenter.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/messaging/CommandProducerInstrumenter.kt
@@ -16,9 +16,9 @@ package me.ahoo.wow.opentelemetry.messaging
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor
+import me.ahoo.wow.api.Wow
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.opentelemetry.MessageAttributesExtractor
-import me.ahoo.wow.opentelemetry.WowInstrumenter
 import me.ahoo.wow.opentelemetry.WowInstrumenter.INSTRUMENTATION_NAME_PREFIX
 
 object CommandProducerInstrumenter {
@@ -29,7 +29,7 @@ object CommandProducerInstrumenter {
             INSTRUMENTATION_NAME,
             CommandProducerSpanNameExtractor,
         ).addAttributesExtractor(MessageAttributesExtractor())
-            .setInstrumentationVersion(WowInstrumenter.INSTRUMENTATION_VERSION)
+            .setInstrumentationVersion(Wow.VERSION)
             .buildProducerInstrumenter(MessageTextMapSetter())
 }
 

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/messaging/EventProducerInstrumenter.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/messaging/EventProducerInstrumenter.kt
@@ -16,9 +16,9 @@ package me.ahoo.wow.opentelemetry.messaging
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor
+import me.ahoo.wow.api.Wow
 import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.opentelemetry.MessageAttributesExtractor
-import me.ahoo.wow.opentelemetry.WowInstrumenter
 import me.ahoo.wow.opentelemetry.WowInstrumenter.INSTRUMENTATION_NAME_PREFIX
 
 object EventProducerInstrumenter {
@@ -29,7 +29,7 @@ object EventProducerInstrumenter {
             INSTRUMENTATION_NAME,
             EventProducerSpanNameExtractor,
         ).addAttributesExtractor(MessageAttributesExtractor())
-            .setInstrumentationVersion(WowInstrumenter.INSTRUMENTATION_VERSION)
+            .setInstrumentationVersion(Wow.VERSION)
             .buildProducerInstrumenter(MessageTextMapSetter())
 }
 

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/messaging/StateEventProducerInstrumenter.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/messaging/StateEventProducerInstrumenter.kt
@@ -16,9 +16,9 @@ package me.ahoo.wow.opentelemetry.messaging
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor
+import me.ahoo.wow.api.Wow
 import me.ahoo.wow.eventsourcing.state.StateEvent
 import me.ahoo.wow.opentelemetry.MessageAttributesExtractor
-import me.ahoo.wow.opentelemetry.WowInstrumenter
 import me.ahoo.wow.opentelemetry.WowInstrumenter.INSTRUMENTATION_NAME_PREFIX
 
 object StateEventProducerInstrumenter {
@@ -29,7 +29,7 @@ object StateEventProducerInstrumenter {
             INSTRUMENTATION_NAME,
             StateEventProducerProducerSpanNameExtractor,
         ).addAttributesExtractor(MessageAttributesExtractor())
-            .setInstrumentationVersion(WowInstrumenter.INSTRUMENTATION_VERSION)
+            .setInstrumentationVersion(Wow.VERSION)
             .buildProducerInstrumenter(MessageTextMapSetter())
 }
 

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/projection/ProjectionInstrumenter.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/projection/ProjectionInstrumenter.kt
@@ -15,9 +15,9 @@ package me.ahoo.wow.opentelemetry.projection
 
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
+import me.ahoo.wow.api.Wow
 import me.ahoo.wow.event.DomainEventExchange
 import me.ahoo.wow.opentelemetry.ExchangeAttributesExtractor
-import me.ahoo.wow.opentelemetry.WowInstrumenter
 import me.ahoo.wow.opentelemetry.WowInstrumenter.INSTRUMENTATION_NAME_PREFIX
 import me.ahoo.wow.opentelemetry.eventprocessor.EventProcessorSpanNameExtractor
 import me.ahoo.wow.opentelemetry.messaging.MessageExchangeTextMapGetter
@@ -30,6 +30,6 @@ object ProjectionInstrumenter {
             INSTRUMENTATION_NAME,
             EventProcessorSpanNameExtractor,
         ).addAttributesExtractor(ExchangeAttributesExtractor())
-            .setInstrumentationVersion(WowInstrumenter.INSTRUMENTATION_VERSION)
+            .setInstrumentationVersion(Wow.VERSION)
             .buildConsumerInstrumenter(MessageExchangeTextMapGetter())
 }

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/saga/StatelessSagaInstrumenter.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/saga/StatelessSagaInstrumenter.kt
@@ -15,9 +15,9 @@ package me.ahoo.wow.opentelemetry.saga
 
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
+import me.ahoo.wow.api.Wow
 import me.ahoo.wow.event.DomainEventExchange
 import me.ahoo.wow.opentelemetry.ExchangeAttributesExtractor
-import me.ahoo.wow.opentelemetry.WowInstrumenter
 import me.ahoo.wow.opentelemetry.WowInstrumenter.INSTRUMENTATION_NAME_PREFIX
 import me.ahoo.wow.opentelemetry.eventprocessor.EventProcessorSpanNameExtractor
 import me.ahoo.wow.opentelemetry.messaging.MessageExchangeTextMapGetter
@@ -30,6 +30,6 @@ object StatelessSagaInstrumenter {
             INSTRUMENTATION_NAME,
             EventProcessorSpanNameExtractor,
         ).addAttributesExtractor(ExchangeAttributesExtractor())
-            .setInstrumentationVersion(WowInstrumenter.INSTRUMENTATION_VERSION)
+            .setInstrumentationVersion(Wow.VERSION)
             .buildConsumerInstrumenter(MessageExchangeTextMapGetter())
 }

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/snapshot/SnapshotInstrumenter.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/snapshot/SnapshotInstrumenter.kt
@@ -16,9 +16,9 @@ package me.ahoo.wow.opentelemetry.snapshot
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor
+import me.ahoo.wow.api.Wow
 import me.ahoo.wow.eventsourcing.state.StateEventExchange
 import me.ahoo.wow.opentelemetry.ExchangeAttributesExtractor
-import me.ahoo.wow.opentelemetry.WowInstrumenter
 import me.ahoo.wow.opentelemetry.WowInstrumenter.INSTRUMENTATION_NAME_PREFIX
 import me.ahoo.wow.opentelemetry.messaging.MessageExchangeTextMapGetter
 
@@ -30,7 +30,7 @@ object SnapshotInstrumenter {
             INSTRUMENTATION_NAME,
             SnapshotSpanNameExtractor,
         ).addAttributesExtractor(ExchangeAttributesExtractor())
-            .setInstrumentationVersion(WowInstrumenter.INSTRUMENTATION_VERSION)
+            .setInstrumentationVersion(Wow.VERSION)
             .buildConsumerInstrumenter(MessageExchangeTextMapGetter())
 }
 

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/snapshot/SnapshotRepositoryInstrumenter.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/snapshot/SnapshotRepositoryInstrumenter.kt
@@ -16,10 +16,10 @@ package me.ahoo.wow.opentelemetry.snapshot
 import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
 import io.opentelemetry.instrumentation.api.instrumenter.SpanNameExtractor
+import me.ahoo.wow.api.Wow
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.opentelemetry.AggregateIdAttributesExtractor
 import me.ahoo.wow.opentelemetry.WowInstrumenter.INSTRUMENTATION_NAME_PREFIX
-import me.ahoo.wow.opentelemetry.WowInstrumenter.INSTRUMENTATION_VERSION
 
 object SnapshotRepositoryInstrumenter {
     private const val INSTRUMENTATION_NAME = "${INSTRUMENTATION_NAME_PREFIX}snapshotRepository"
@@ -29,7 +29,7 @@ object SnapshotRepositoryInstrumenter {
             INSTRUMENTATION_NAME,
             SnapshotRepositorySaveSpanNameExtractor,
         ).addAttributesExtractor(AggregateIdAttributesExtractor)
-            .setInstrumentationVersion(INSTRUMENTATION_VERSION)
+            .setInstrumentationVersion(Wow.VERSION)
             .buildInstrumenter()
 
     val LOAD_INSTRUMENTER: Instrumenter<AggregateId, Unit> =
@@ -38,7 +38,7 @@ object SnapshotRepositoryInstrumenter {
             INSTRUMENTATION_NAME,
             SnapshotRepositoryLoadSpanNameExtractor,
         ).addAttributesExtractor(AggregateIdAttributesExtractor)
-            .setInstrumentationVersion(INSTRUMENTATION_VERSION)
+            .setInstrumentationVersion(Wow.VERSION)
             .buildInstrumenter()
 }
 


### PR DESCRIPTION
- Remove INSTRUMENTATION_VERSION from WowInstrumenter
- Use Wow.VERSION in all instrumenters instead of WowInstrumenter.INSTRUMENTATION_VERSION
- Update ApplyRetrySpecComponent to use non-nullable formBuilder
- Add SwaggerConfiguration for Wow Compensation Service
- Update Wow object to use javaClass.`package`.implementationVersion for VERSION
