### PR TITLE
refactor(api): update version retrieval and default value

### DIFF
--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/Wow.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/Wow.kt
@@ -21,5 +21,5 @@ package me.ahoo.wow.api
 object Wow {
     const val WOW: String = "wow"
     const val WOW_PREFIX: String = "$WOW."
-    val VERSION: String = Wow.javaClass.`package`.implementationVersion ?: "5.19.2"
+    val VERSION: String = Wow.javaClass.`package`.implementationVersion.orEmpty()
 }


### PR DESCRIPTION
- Change VERSION property to use orEmpty() instead of providing a best practices
