### PR TITLE
refactor(wow-openapi): improve RouterSpecs.mergeOpenAPI() null handling

### DIFF
--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RouterSpecs.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RouterSpecs.kt
@@ -68,9 +68,13 @@ class RouterSpecs(
     fun mergeOpenAPI(openAPI: OpenAPI) {
         openAPI.apply {
             specVersion(SpecVersion.V31)
-            info = Info()
-                .title(currentContext.getContextAlias())
-                .description(currentContext.contextName)
+            if (info == null) {
+                info(
+                    Info()
+                        .title(currentContext.getContextAlias())
+                        .description(currentContext.contextName)
+                )
+            }
             if (paths == null) {
                 paths = Paths()
             }

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/RouterSpecsTest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/RouterSpecsTest.kt
@@ -1,22 +1,52 @@
 package me.ahoo.wow.openapi
 
+import io.swagger.v3.oas.models.Components
 import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.Paths
+import io.swagger.v3.oas.models.info.Info
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.naming.MaterializedNamedBoundedContext
 import org.junit.jupiter.api.Test
 
 class RouterSpecsTest {
+    val materializedNamedBoundedContext = MaterializedNamedBoundedContext("test")
+
     @Test
     fun build() {
-        val routerSpecs = RouterSpecs(MaterializedNamedBoundedContext("test")).build()
+        val routerSpecs = RouterSpecs(materializedNamedBoundedContext).build()
         routerSpecs.assert().isNotEmpty()
     }
 
     @Test
     fun mergeOpenAPI() {
         val openAPI = OpenAPI()
-        RouterSpecs(MaterializedNamedBoundedContext("test")).build()
+        RouterSpecs(materializedNamedBoundedContext).build()
             .mergeOpenAPI(openAPI)
+        openAPI.info?.title.assert().isEqualTo(materializedNamedBoundedContext.contextName)
+        openAPI.components.schemas.assert().isNotEmpty()
+    }
+
+    @Test
+    fun mergeOpenAPIWithInfo() {
+        val info = Info()
+        val openAPI = OpenAPI().info(info)
+        RouterSpecs(materializedNamedBoundedContext).build()
+            .mergeOpenAPI(openAPI)
+        openAPI.info.assert().isSameAs(info)
+        openAPI.components.schemas.assert().isNotEmpty()
+    }
+
+    @Test
+    fun mergeOpenAPIWithNotNull() {
+        val info = Info()
+        val paths = Paths()
+        val components = Components()
+        val openAPI = OpenAPI().info(info).paths(paths).components(components)
+        RouterSpecs(materializedNamedBoundedContext).build()
+            .mergeOpenAPI(openAPI)
+        openAPI.info.assert().isSameAs(info)
+        openAPI.paths.assert().isSameAs(paths)
+        openAPI.components.assert().isSameAs(components)
         openAPI.components.schemas.assert().isNotEmpty()
     }
 }


### PR DESCRIPTION
- Add null check for OpenAPI.info and initialize if null
- Update RouterSpecsTest with new test cases for mergeOpenAPI scenarios
- Ensure existing info, paths, and components are preserved when merging

