### PR TITLE
feat(openapi): add description to OpenAPI info

### DIFF
--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RouterSpecs.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RouterSpecs.kt
@@ -76,6 +76,10 @@ class RouterSpecs(
         return firstLocalAggregateType.`package`.implementationVersion
     }
 
+    private fun description(): String? {
+        return MetadataSearcher.metadata.contexts[currentContext.contextName]?.description
+    }
+
     private fun OpenAPI.ensureInfo() {
         val info = this.info ?: Info()
         if (info.title.isNullOrBlank() || info.title == DEFAULT_OPENAPI_INFO_TITLE) {
@@ -83,6 +87,9 @@ class RouterSpecs(
         }
         serviceVersion()?.let {
             info.version = it
+        }
+        if (info.description.isNullOrBlank()) {
+            info.description = description()
         }
         this.info = info
     }

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/RouterSpecsTest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/RouterSpecsTest.kt
@@ -44,7 +44,7 @@ class RouterSpecsTest {
 
     @Test
     fun mergeOpenAPIWithInfoDefault() {
-        val info = Info().title(DEFAULT_OPENAPI_INFO_TITLE)
+        val info = Info().title(DEFAULT_OPENAPI_INFO_TITLE).description("hello")
         val openAPI = OpenAPI().info(info)
         RouterSpecs(materializedNamedBoundedContext).build()
             .mergeOpenAPI(openAPI)


### PR DESCRIPTION
- Retrieve description from MetadataSearcher for the current context
- Set the description in the OpenAPI info if not already provided
- Update test case to include description in the expected Info object

