### PR TITLE
refactor(cocache): update StateCacheRefresher to use Mono.fromRunnable<Void>

### DIFF
--- a/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/refresh/StateCacheRefresher.kt
+++ b/wow-cocache/src/main/kotlin/me/ahoo/wow/cache/refresh/StateCacheRefresher.kt
@@ -45,7 +45,7 @@ abstract class StateCacheRefresher<S : Any, D, M : DomainEventExchange<*>>(
     }
 
     override fun invoke(exchange: M): Mono<Void> {
-        return Mono.fromRunnable<Void?> {
+        return Mono.fromRunnable<Void> {
             if (log.isDebugEnabled) {
                 log.debug("[${this.javaClass.simpleName}] Refresh {} Cache.", exchange.message.aggregateId)
             }


### PR DESCRIPTION

- Change Mono.fromRunnable<Void?> to Mono.fromRunnable<Void> for better type safety
- Improve type handling in the StateCacheRefresher class
