### PR TITLE
feat(query): add field conversion for MongoDB conditions

### DIFF
--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoConditionConverter.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoConditionConverter.kt
@@ -18,6 +18,7 @@ import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.DeletionState
 import me.ahoo.wow.mongo.Documents
 import me.ahoo.wow.query.converter.AbstractConditionConverter
+import me.ahoo.wow.query.converter.FieldConverter
 import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.serialization.state.StateAggregateRecords
 import me.ahoo.wow.serialization.toJsonString
@@ -25,6 +26,19 @@ import org.bson.Document
 import org.bson.conversions.Bson
 
 abstract class AbstractMongoConditionConverter : AbstractConditionConverter<Bson>() {
+    protected abstract val fieldConverter: FieldConverter
+    protected open fun convertCondition(condition: Condition): Condition {
+        val convertedField = fieldConverter.convert(condition.field)
+        if (convertedField == condition.field) {
+            return condition
+        }
+        return condition.copy(field = convertedField)
+    }
+
+    override fun convert(condition: Condition): Bson {
+        val convertedCondition = convertCondition(condition)
+        return super.convert(convertedCondition)
+    }
 
     override fun and(condition: Condition): Bson {
         require(condition.children.isNotEmpty()) {

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/event/EventStreamConditionConverter.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/event/EventStreamConditionConverter.kt
@@ -16,12 +16,16 @@ package me.ahoo.wow.mongo.query.event
 import com.mongodb.client.model.Filters
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.mongo.query.AbstractMongoConditionConverter
+import me.ahoo.wow.query.converter.FieldConverter
 import me.ahoo.wow.serialization.MessageRecords
 import org.bson.conversions.Bson
 
 object EventStreamConditionConverter : AbstractMongoConditionConverter() {
-
-    override fun convert(condition: Condition): Bson = internalConvert(condition)
+    override val fieldConverter: FieldConverter = EventStreamFieldConverter
+    override fun convert(condition: Condition): Bson {
+        val convertedCondition = convertCondition(condition)
+        return internalConvert(convertedCondition)
+    }
 
     override fun aggregateId(condition: Condition): Bson {
         return Filters.eq(MessageRecords.AGGREGATE_ID, condition.value)

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/SnapshotConditionConverter.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/SnapshotConditionConverter.kt
@@ -15,9 +15,11 @@ package me.ahoo.wow.mongo.query.snapshot
 
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.mongo.query.AbstractMongoConditionConverter
+import me.ahoo.wow.query.converter.FieldConverter
 import org.bson.conversions.Bson
 
 object SnapshotConditionConverter : AbstractMongoConditionConverter() {
+    override val fieldConverter: FieldConverter = SnapshotFieldConverter
     override fun aggregateId(condition: Condition): Bson {
         return id(condition)
     }

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/SnapshotConditionConverterTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/SnapshotConditionConverterTest.kt
@@ -1,10 +1,12 @@
 package me.ahoo.wow.mongo.query
 
 import com.mongodb.client.model.Filters
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.Operator
 import me.ahoo.wow.mongo.Documents
 import me.ahoo.wow.mongo.query.snapshot.SnapshotConditionConverter
+import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.serialization.state.StateAggregateRecords
 import org.bson.conversions.Bson
 import org.hamcrest.MatcherAssert.*
@@ -29,7 +31,7 @@ class SnapshotConditionConverterTest {
             Filters.eq(StateAggregateRecords.DELETED, false),
             expected
         )
-        assertThat(actual.toBsonDocument(), equalTo(deletionBson.toBsonDocument()))
+        actual.toBsonDocument().assert().isEqualTo(deletionBson.toBsonDocument())
     }
 
     @Test
@@ -380,6 +382,7 @@ class SnapshotConditionConverterTest {
         @JvmStatic
         fun toMongoFilterParameters(): Stream<Arguments> {
             return Stream.of(
+                Arguments.of(Condition.eq(MessageRecords.AGGREGATE_ID, "1"), Filters.eq(Documents.ID_FIELD, "1")),
                 Arguments.of(Condition.deleted(false), Filters.eq("deleted", false)),
                 Arguments.of(Condition.tenantId("tenantId"), Filters.eq("tenantId", "tenantId")),
                 Arguments.of(Condition.ownerId("ownerId"), Filters.eq("ownerId", "ownerId")),

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/event/EventStreamConditionConverterTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/event/EventStreamConditionConverterTest.kt
@@ -15,11 +15,20 @@ package me.ahoo.wow.mongo.query.event
 
 import com.mongodb.client.model.Filters
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.mongo.Documents
 import me.ahoo.wow.query.dsl.condition
 import me.ahoo.wow.serialization.MessageRecords
 import org.junit.jupiter.api.Test
 
 class EventStreamConditionConverterTest {
+    @Test
+    fun id() {
+        val condition = condition { MessageRecords.ID.eq("test") }
+        val actual = EventStreamConditionConverter.convert(condition)
+        val expected = Filters.eq(Documents.ID_FIELD, condition.valueAs<String>())
+        actual.assert().isEqualTo(expected)
+    }
+
     @Test
     fun aggregateId() {
         val condition = condition { aggregateId("aggregateId") }


### PR DESCRIPTION
- Introduce FieldConverter interface and implementations for event stream and snapshot
- Add convertCondition method to AbstractMongoConditionConverter
- Update EventStreamConditionConverter and SnapshotConditionConverter to use field converters
- Add test cases for ID field conversion in EventStreamConditionConverter
- Update existing tests to cover new field conversion functionality

