### PR TITLE
refactor(api): adjust queries and remove unused initial queries

### DIFF
--- a/compensation/wow-compensation-dashboard/src/app/api/EventStreamQuery.ts
+++ b/compensation/wow-compensation-dashboard/src/app/api/EventStreamQuery.ts
@@ -6,7 +6,7 @@ export const MAX_VERSION = 666666666;
 
 function eventStreamVersionedNextQuery(aggregateId: string, endVersion: number = MAX_VERSION, limit: number = 0): ListQuery {
   return {
-    projection: {include: ["_id", "id", VERSION, "createTime", "body.id", "body.name"], exclude: []},
+    projection: {include: ["id", VERSION, "createTime", "body.id", "body.name"], exclude: []},
     condition: Conditions.and(
       [
         Conditions.aggregateId(aggregateId),

--- a/compensation/wow-compensation-dashboard/src/app/api/ListQuery.ts
+++ b/compensation/wow-compensation-dashboard/src/app/api/ListQuery.ts
@@ -12,7 +12,7 @@
  */
 
 
-import {Condition, Conditions, Pagination, Projection, Projections, Sort, SortDirection} from "./Query";
+import {Condition, Projection, Sort} from "./Query";
 
 export interface ListQuery {
   projection: Projection
@@ -20,10 +20,3 @@ export interface ListQuery {
   sort: Sort[];
   limit: number;
 }
-
-export const initialListQuery: ListQuery = {
-  projection: Projections.all(),
-  condition: Conditions.all(),
-  sort: [{field: "_id", direction: SortDirection.DESC}],
-  limit: 10,
-};

--- a/compensation/wow-compensation-dashboard/src/app/api/PagedQuery.ts
+++ b/compensation/wow-compensation-dashboard/src/app/api/PagedQuery.ts
@@ -21,9 +21,9 @@ export interface PagedQuery {
   pagination: Pagination;
 }
 
-export const initialPagedQuery: PagedQuery = {
+export const initialSnapshotPagedQuery: PagedQuery = {
   projection: Projections.all(),
   condition: Conditions.all(),
-  sort: [{field: "firstEventTime", direction: SortDirection.DESC}],
+  sort: [{field: "aggregateId", direction: SortDirection.DESC}],
   pagination: {index: 1, size: 10},
 };

--- a/compensation/wow-compensation-dashboard/src/app/failed-list/failed-list.component.ts
+++ b/compensation/wow-compensation-dashboard/src/app/failed-list/failed-list.component.ts
@@ -12,7 +12,7 @@ import {NzButtonModule} from 'ng-zorro-antd/button';
 import {NzPopconfirmDirective} from "ng-zorro-antd/popconfirm";
 import {NzDrawerComponent, NzDrawerContentDirective, NzDrawerModule, NzDrawerService} from "ng-zorro-antd/drawer";
 import {NzTypographyComponent} from "ng-zorro-antd/typography";
-import {initialPagedQuery, PagedQuery} from "../api/PagedQuery";
+import {initialSnapshotPagedQuery, PagedQuery} from "../api/PagedQuery";
 import {PagedList} from "../api/PagedList";
 import {NzCountdownComponent} from "ng-zorro-antd/statistic";
 import {ErrorComponent} from "../error/error.component";
@@ -68,7 +68,7 @@ import {NzFlexModule} from 'ng-zorro-antd/flex';
   styleUrls: ['./failed-list.component.scss']
 })
 export class FailedListComponent implements OnInit {
-  pagedQuery: PagedQuery = initialPagedQuery;
+  pagedQuery: PagedQuery = initialSnapshotPagedQuery;
   pagedList: PagedList<ExecutionFailedState> = {total: 0, list: []};
   @Input({required: true}) category: FindCategory = FindCategory.TO_RETRY;
   loading = false;
@@ -186,13 +186,13 @@ export class FailedListComponent implements OnInit {
         return {field: sort.key, direction: direction}
       });
     if (sort.length == 0) {
-      sort = initialPagedQuery.sort
+      sort = initialSnapshotPagedQuery.sort
     }
     this.pagedQuery = {
       projection: Projections.all(),
       sort: sort,
       pagination: {index: params.pageIndex, size: params.pageSize},
-      condition: initialPagedQuery.condition
+      condition: initialSnapshotPagedQuery.condition
     }
     this.load()
   }


### PR DESCRIPTION
- Remove `_id` from EventStreamQuery projection
- Replace `initialPagedQuery` with `initialSnapshotPagedQuery` in failed-list component
- Remove unused `initialListQuery` from ListQuery.ts
- Update `initialSnapshotPagedQuery` in PagedQuery.ts
