### PR TITLE
refactor(test): replace hamcrest with fluent-assert

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -124,7 +124,6 @@ configure(libraryProjects) {
         testImplementation("io.micrometer:micrometer-core")
         testImplementation("ch.qos.logback:logback-classic")
         testImplementation("me.ahoo.test:fluent-assert-core")
-        testImplementation("org.hamcrest:hamcrest")
         testImplementation("io.mockk:mockk") {
             exclude(group = "org.slf4j", module = "slf4j-api")
         }

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -25,6 +25,7 @@ style:
   WildcardImport:
     excludeImports:
       - java.util.*
+      - org.assertj.core.api.Assertions.*
 naming:
   MemberNameEqualsClassName:
     active: false
@@ -40,7 +41,7 @@ performance:
     active: false
 formatting:
   NoWildcardImports:
-    packagesToUseImportOnDemandProperty: "java.util.*"
+    packagesToUseImportOnDemandProperty: "java.util.*,org.assertj.core.api.Assertions.*"
   MaximumLineLength:
     active: false
   Filename:

--- a/example/transfer/example-transfer-domain/src/test/java/me/ahoo/wow/example/transfer/domain/AccountTest.java
+++ b/example/transfer/example-transfer-domain/src/test/java/me/ahoo/wow/example/transfer/domain/AccountTest.java
@@ -18,8 +18,7 @@ import me.ahoo.wow.example.transfer.api.CreateAccount;
 import org.junit.jupiter.api.Test;
 
 import static me.ahoo.wow.test.AggregateVerifier.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.assertj.core.api.Assertions.*;
 
 class AccountTest {
 
@@ -30,15 +29,15 @@ class AccountTest {
                 .when(new CreateAccount("name", 100L))
                 .expectEventType(AccountCreated.class)
                 .expectEventIterator(eventIterator -> {
-                    assertThat(eventIterator.hasNext(), equalTo(true));
+                    assertThat(eventIterator.hasNext()).isTrue();
                     var eventBody = eventIterator.nextEventBody(AccountCreated.class);
-                    assertThat(eventBody.name(), equalTo("name"));
-                    assertThat(eventBody.balance(), equalTo(100L));
-                    assertThat(eventIterator.hasNext(), equalTo(false));
+                    assertThat(eventBody.name()).isEqualTo("name");
+                    assertThat(eventBody.balance()).isEqualTo(100L);
+                    assertThat(eventIterator.hasNext()).isFalse();
                 })
                 .expectState(account -> {
-                    assertThat(account.getName(), equalTo("name"));
-                    assertThat(account.getBalanceAmount(), equalTo(100L));
+                    assertThat(account.getName()).isEqualTo("name");
+                    assertThat(account.getBalanceAmount()).isEqualTo(100L);
                 })
                 .verify();
     }

--- a/example/transfer/example-transfer-domain/src/test/java/me/ahoo/wow/example/transfer/domain/TransferBoundedContextTest.java
+++ b/example/transfer/example-transfer-domain/src/test/java/me/ahoo/wow/example/transfer/domain/TransferBoundedContextTest.java
@@ -15,14 +15,13 @@ package me.ahoo.wow.example.transfer.domain;
 
 import org.junit.jupiter.api.Test;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.assertj.core.api.Assertions.*;
 
 class TransferBoundedContextTest {
 
     @Test
     void ctor() {
         var boundedContext = new TransferBoundedContext();
-        assertThat(boundedContext, notNullValue());
+        assertThat(boundedContext).isNotNull();
     }
 }

--- a/example/transfer/example-transfer-domain/src/test/java/me/ahoo/wow/example/transfer/domain/TransferSagaTest.java
+++ b/example/transfer/example-transfer-domain/src/test/java/me/ahoo/wow/example/transfer/domain/TransferSagaTest.java
@@ -18,8 +18,7 @@ import me.ahoo.wow.example.transfer.api.Prepared;
 import org.junit.jupiter.api.Test;
 
 import static me.ahoo.wow.test.SagaVerifier.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.assertj.core.api.Assertions.*;
 
 public class TransferSagaTest {
 
@@ -29,8 +28,8 @@ public class TransferSagaTest {
         sagaVerifier(TransferSaga.class)
                 .when(event)
                 .expectCommandBody((Entry entry) -> {
-                    assertThat(entry.id(), equalTo(event.to()));
-                    assertThat(entry.amount(), equalTo(event.amount()));
+                    assertThat(entry.id()).isEqualTo(event.to());
+                    assertThat(entry.amount()).isEqualTo(event.amount());
                 })
                 .verify();
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,6 @@ json-schema-validator = "1.5.7"
 # testing
 junit = "5.13.2"
 fluent-assert = "0.2.0"
-hamcrest = "3.0"
 mockk = "1.14.4"
 kotlin-compile-testing = "0.7.1"
 # plugins
@@ -54,7 +53,6 @@ jte = { module = "gg.jte:jte", version.ref = "jte" }
 jte-kotlin = { module = "gg.jte:jte-kotlin", version.ref = "jte" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 fluent-assert-bom = { module = "me.ahoo.test:fluent-assert-bom", version.ref = "fluent-assert" }
-hamcrest = { module = "org.hamcrest:hamcrest", version.ref = "hamcrest" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 [plugins]

--- a/test/wow-it/build.gradle.kts
+++ b/test/wow-it/build.gradle.kts
@@ -4,7 +4,6 @@ dependencies {
     testImplementation(project(":wow-core"))
     testImplementation("io.projectreactor:reactor-test")
     testImplementation("me.ahoo.cosid:cosid-test")
-    testImplementation("org.hamcrest:hamcrest")
     testImplementation(project(":wow-mongo"))
     testImplementation(project(":wow-kafka"))
     testImplementation(project(":wow-tck"))

--- a/test/wow-mock/build.gradle.kts
+++ b/test/wow-mock/build.gradle.kts
@@ -4,6 +4,5 @@ dependencies {
     api(project(":wow-core"))
     testImplementation("io.projectreactor:reactor-test")
     testImplementation("me.ahoo.cosid:cosid-test")
-    testImplementation("org.hamcrest:hamcrest")
     testImplementation(project(":wow-tck"))
 }

--- a/test/wow-tck/build.gradle.kts
+++ b/test/wow-tck/build.gradle.kts
@@ -5,7 +5,6 @@ dependencies {
     api(project(":wow-query"))
     api("io.projectreactor:reactor-test")
     api("me.ahoo.cosid:cosid-test")
-    api("org.hamcrest:hamcrest")
     api(project(":wow-test"))
     implementation("org.junit.jupiter:junit-jupiter-api")
     implementation("com.fasterxml.jackson.core:jackson-databind")

--- a/wow-core/src/test/java/me/ahoo/wow/infra/accessor/function/FastInvokeTest.java
+++ b/wow-core/src/test/java/me/ahoo/wow/infra/accessor/function/FastInvokeTest.java
@@ -20,8 +20,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 class FastInvokeTest {
 
@@ -49,7 +48,7 @@ class FastInvokeTest {
         String[] args = {"1", "2", "3"};
         Object[] invokeArgs = {args};
         Object result = FastInvoke.invoke(method, this, invokeArgs);
-        assertThat(result, equalTo(args));
+        assertThat(result).isEqualTo(args);
     }
 
     @Test
@@ -57,6 +56,6 @@ class FastInvokeTest {
         Constructor<Ctor> ctor = Ctor.class.getDeclaredConstructor(String.class);
         ctor.trySetAccessible();
         Ctor instance = FastInvoke.newInstance(ctor, new Object[]{"1"});
-        assertThat(instance.getId(), equalTo("1"));
+        assertThat(instance.getId()).isEqualTo("1");
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/VersionTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/VersionTest.kt
@@ -13,9 +13,8 @@
 
 package me.ahoo.wow
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.Version
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 
 class VersionTest {
@@ -26,7 +25,7 @@ class VersionTest {
             override val version: Int
                 get() = Version.UNINITIALIZED_VERSION
         }
-        assertThat(version.initialized, equalTo(false))
+        version.initialized.assert().isFalse()
     }
 
     @Test
@@ -35,6 +34,6 @@ class VersionTest {
             override val version: Int
                 get() = Version.INITIAL_VERSION
         }
-        assertThat(version.initialized, equalTo(true))
+        version.initialized.assert().isTrue()
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/WowTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/WowTest.kt
@@ -13,16 +13,15 @@
 
 package me.ahoo.wow
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.Wow
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 
 internal class WowTest {
 
     @Test
     fun test() {
-        assertThat(Wow.WOW, equalTo("wow"))
-        assertThat(Wow.WOW_PREFIX, equalTo("wow."))
+        Wow.WOW.assert().isEqualTo("wow")
+        Wow.WOW_PREFIX.assert().isEqualTo("wow.")
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/id/AggregateIdGeneratorRegistrarTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/id/AggregateIdGeneratorRegistrarTest.kt
@@ -13,9 +13,8 @@
 
 package me.ahoo.wow.id
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.modeling.MaterializedNamedAggregate
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.notNullValue
 import org.junit.jupiter.api.Test
 
 internal class AggregateIdGeneratorRegistrarTest {
@@ -24,7 +23,7 @@ internal class AggregateIdGeneratorRegistrarTest {
     fun generateId() {
         val namedAggregate = MaterializedNamedAggregate("test", "test")
         val id = namedAggregate.generateId()
-        assertThat(id, notNullValue())
-        assertThat(AggregateIdGeneratorRegistrar[namedAggregate], notNullValue())
+        id.assert().isNotNull()
+        AggregateIdGeneratorRegistrar[namedAggregate].assert().isNotNull
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/infra/accessor/constructor/InjectableObjectFactoryTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/infra/accessor/constructor/InjectableObjectFactoryTest.kt
@@ -13,10 +13,8 @@
 
 package me.ahoo.wow.infra.accessor.constructor
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.ioc.SimpleServiceProvider
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
-import org.hamcrest.Matchers.notNullValue
 import org.junit.jupiter.api.Test
 
 internal class InjectableObjectFactoryTest {
@@ -25,7 +23,7 @@ internal class InjectableObjectFactoryTest {
     fun newInstance() {
         val injectableObjectFactory =
             InjectableObjectFactory(MockServiceWithoutParameter::class.java.getConstructor(), SimpleServiceProvider())
-        assertThat(injectableObjectFactory.newInstance(), notNullValue())
+        injectableObjectFactory.newInstance().assert().isNotNull()
     }
 
     @Test
@@ -40,8 +38,8 @@ internal class InjectableObjectFactoryTest {
                 serviceProvider,
             )
         val mockServiceWithInject = injectableObjectFactory.newInstance()
-        assertThat(mockServiceWithInject, notNullValue())
-        assertThat(mockServiceWithInject.injectService, equalTo(injectService))
+        mockServiceWithInject.assert().isNotNull()
+        mockServiceWithInject.injectService.assert().isEqualTo(injectService)
     }
 }
 

--- a/wow-core/src/test/kotlin/me/ahoo/wow/infra/accessor/function/reactive/MonoFunctionAccessorFactoryTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/infra/accessor/function/reactive/MonoFunctionAccessorFactoryTest.kt
@@ -14,8 +14,7 @@
 
 package me.ahoo.wow.infra.accessor.function.reactive
 
-import org.hamcrest.MatcherAssert
-import org.hamcrest.Matchers
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
@@ -29,12 +28,7 @@ internal class MonoFunctionAccessorFactoryTest {
             "onCommand",
             ChangeStateReturnMono::class.java,
         ).kotlinFunction!!.toMonoFunctionAccessor<MockAggregate, Any>()
-        MatcherAssert.assertThat(
-            methodAccessor,
-            Matchers.instanceOf(
-                SimpleMonoFunctionAccessor::class.java,
-            ),
-        )
+        methodAccessor.assert().isInstanceOf(SimpleMonoFunctionAccessor::class.java)
     }
 
     @Test
@@ -44,12 +38,7 @@ internal class MonoFunctionAccessorFactoryTest {
                 "onCommand",
                 ChangeStateReturnFlux::class.java,
             ).kotlinFunction!!.toMonoFunctionAccessor<MockAggregate, Any>()
-        MatcherAssert.assertThat(
-            methodAccessor,
-            Matchers.instanceOf(
-                FluxMonoFunctionAccessor::class.java,
-            ),
-        )
+        methodAccessor.assert().isInstanceOf(FluxMonoFunctionAccessor::class.java)
     }
 
     @Test
@@ -59,12 +48,7 @@ internal class MonoFunctionAccessorFactoryTest {
                 "onCommand",
                 ChangeStateReturnPublisher::class.java,
             ).kotlinFunction!!.toMonoFunctionAccessor<MockAggregate, Any>()
-        MatcherAssert.assertThat(
-            methodAccessor,
-            Matchers.instanceOf(
-                PublisherMonoFunctionAccessor::class.java,
-            ),
-        )
+        methodAccessor.assert().isInstanceOf(PublisherMonoFunctionAccessor::class.java)
     }
 
     @Test
@@ -74,12 +58,7 @@ internal class MonoFunctionAccessorFactoryTest {
                 "onCommand",
                 ChangeStateReturnSync::class.java,
             ).kotlinFunction!!.toMonoFunctionAccessor<MockAggregate, Any>()
-        MatcherAssert.assertThat(
-            methodAccessor,
-            Matchers.instanceOf(
-                SyncMonoFunctionAccessor::class.java,
-            ),
-        )
+        methodAccessor.assert().isInstanceOf(SyncMonoFunctionAccessor::class.java)
     }
 
     @Suppress("FunctionOnlyReturningConstant")

--- a/wow-core/src/test/kotlin/me/ahoo/wow/infra/idempotency/BloomFilterIdempotencyCheckerTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/infra/idempotency/BloomFilterIdempotencyCheckerTest.kt
@@ -14,8 +14,7 @@ package me.ahoo.wow.infra.idempotency
 
 import com.google.common.hash.BloomFilter
 import com.google.common.hash.Funnels
-import org.hamcrest.MatcherAssert
-import org.hamcrest.Matchers
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import java.time.Duration
 
@@ -28,7 +27,7 @@ class BloomFilterIdempotencyCheckerTest {
 
     @Test
     fun check() {
-        MatcherAssert.assertThat(idempotencyChecker.check("hi").block(), Matchers.equalTo(true))
-        MatcherAssert.assertThat(idempotencyChecker.check("hi").block(), Matchers.equalTo(false))
+        idempotencyChecker.check("hi").block().assert().isTrue()
+        idempotencyChecker.check("hi").block().assert().isFalse()
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/HeaderTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/HeaderTest.kt
@@ -12,20 +12,18 @@
  */
 package me.ahoo.wow.messaging
 
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.aMapWithSize
-import org.hamcrest.Matchers.equalTo
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 internal class HeaderTest {
     @Test
     fun ofWhenNull() {
-        assertThat(null.toHeader(), equalTo(DefaultHeader.empty()))
+        null.toHeader().assert().isEqualTo(DefaultHeader.empty())
     }
 
     @Test
     fun ofWhenEmpty() {
-        assertThat(HashMap<String, String>().toHeader(), equalTo(DefaultHeader.empty()))
+        HashMap<String, String>().toHeader().assert().isEqualTo(DefaultHeader.empty())
     }
 
     @Test
@@ -33,13 +31,13 @@ internal class HeaderTest {
         val values = HashMap<String, String>()
         values["KEY"] = "VALUE"
         val header = DefaultHeader(values)
-        assertThat(header.toHeader(), equalTo(header))
+        header.toHeader().assert().isEqualTo(header)
     }
 
     @Test
     fun ofWhenNotEmpty() {
         val values = HashMap<String, String>()
         values["KEY"] = "VALUE"
-        assertThat(values.toHeader(), aMapWithSize(1))
+        values.toHeader().assert().hasSize(1)
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/naming/AppendPrefixNamingConverterTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/naming/AppendPrefixNamingConverterTest.kt
@@ -13,8 +13,7 @@
 
 package me.ahoo.wow.naming
 
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 internal class AppendPrefixNamingConverterTest {
@@ -25,9 +24,9 @@ internal class AppendPrefixNamingConverterTest {
 
     @Test
     fun convert() {
-        assertThat(CONVERTER.prefix, equalTo(PREFIX))
+        CONVERTER.prefix.assert().isEqualTo(PREFIX)
         val phrase = "wow"
         val actual = CONVERTER.convert(phrase)
-        assertThat(actual, equalTo("${PREFIX}$phrase"))
+        actual.assert().isEqualTo("${PREFIX}$phrase")
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/naming/AppendSuffixNamingConverterTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/naming/AppendSuffixNamingConverterTest.kt
@@ -13,8 +13,7 @@
 
 package me.ahoo.wow.naming
 
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 internal class AppendSuffixNamingConverterTest {
@@ -26,9 +25,9 @@ internal class AppendSuffixNamingConverterTest {
 
     @Test
     fun convert() {
-        assertThat(CONVERTER.suffix, equalTo(SUFFIX))
+        CONVERTER.suffix.assert().isEqualTo(SUFFIX)
         val phrase = "wow"
         val actual = CONVERTER.convert(phrase)
-        assertThat(actual, equalTo("${phrase}$SUFFIX"))
+        actual.assert().isEqualTo("${phrase}$SUFFIX")
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/naming/CamelCaseStrategyTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/naming/CamelCaseStrategyTest.kt
@@ -13,8 +13,7 @@
 
 package me.ahoo.wow.naming
 
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 internal class CamelCaseStrategyTest {
@@ -26,12 +25,12 @@ internal class CamelCaseStrategyTest {
     @Test
     fun segment() {
         val actual = CamelCaseStrategy.segment(PHRASE)
-        assertThat(actual, equalTo(WORDS))
+        actual.assert().isEqualTo(WORDS)
     }
 
     @Test
     fun transform() {
         val actual = CamelCaseStrategy.transform(WORDS)
-        assertThat(actual, equalTo(PHRASE))
+        actual.assert().isEqualTo(PHRASE)
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/naming/CompositeNamingConverterTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/naming/CompositeNamingConverterTest.kt
@@ -13,8 +13,7 @@
 
 package me.ahoo.wow.naming
 
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 internal class CompositeNamingConverterTest {
@@ -28,13 +27,13 @@ internal class CompositeNamingConverterTest {
     fun convert() {
         val phrase = PREFIX + PascalCaseStrategyTest.PHRASE
         val actual = CONVERTER.convert(phrase)
-        assertThat(actual, equalTo(SnakeCaseStrategyTest.PHRASE))
+        actual.assert().isEqualTo(SnakeCaseStrategyTest.PHRASE)
     }
 
     @Test
     fun convertWhenMismatch() {
         val phrase = "prefix" + PascalCaseStrategyTest.PHRASE
         val actual = CONVERTER.convert(phrase)
-        assertThat(actual, equalTo("prefix_wow_is_great"))
+        actual.assert().isEqualTo("prefix_wow_is_great")
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/naming/IgnorePrefixNamingConverterTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/naming/IgnorePrefixNamingConverterTest.kt
@@ -13,8 +13,7 @@
 
 package me.ahoo.wow.naming
 
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 internal class IgnorePrefixNamingConverterTest {
@@ -25,15 +24,15 @@ internal class IgnorePrefixNamingConverterTest {
 
     @Test
     fun convert() {
-        assertThat(CONVERTER.prefix, equalTo(PREFIX))
+        CONVERTER.prefix.assert().isEqualTo(PREFIX)
         val actual = CONVERTER.convert(PREFIX)
-        assertThat(actual, equalTo(""))
+        actual.assert().isEqualTo("")
     }
 
     @Test
     fun convertWhenMismatch() {
         val phrase = "prefix"
         val actual = CONVERTER.convert(phrase)
-        assertThat(actual, equalTo(phrase))
+        actual.assert().isEqualTo(phrase)
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/naming/IgnoreSuffixNamingConverterTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/naming/IgnoreSuffixNamingConverterTest.kt
@@ -13,8 +13,7 @@
 
 package me.ahoo.wow.naming
 
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 internal class IgnoreSuffixNamingConverterTest {
@@ -26,15 +25,15 @@ internal class IgnoreSuffixNamingConverterTest {
 
     @Test
     fun convert() {
-        assertThat(CONVERTER.suffix, equalTo(SUFFIX))
+        CONVERTER.suffix.assert().isEqualTo(SUFFIX)
         val actual = CONVERTER.convert(SUFFIX)
-        assertThat(actual, equalTo(""))
+        actual.assert().isEqualTo("")
     }
 
     @Test
     fun convertWhenMismatch() {
         val phrase = "suffix"
         val actual = CONVERTER.convert(phrase)
-        assertThat(actual, equalTo(phrase))
+        actual.assert().isEqualTo(phrase)
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/naming/KebabCaseStrategyTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/naming/KebabCaseStrategyTest.kt
@@ -13,8 +13,7 @@
 
 package me.ahoo.wow.naming
 
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 internal class KebabCaseStrategyTest {
@@ -27,12 +26,12 @@ internal class KebabCaseStrategyTest {
     @Test
     fun segment() {
         val actual = KebabCaseStrategy.segment(PHRASE)
-        assertThat(actual, equalTo(WORDS))
+        actual.assert().isEqualTo(WORDS)
     }
 
     @Test
     fun transform() {
         val actual = KebabCaseStrategy.transform(WORDS)
-        assertThat(actual, equalTo(PHRASE))
+        actual.assert().isEqualTo(PHRASE)
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/naming/LowerDotCaseStrategyTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/naming/LowerDotCaseStrategyTest.kt
@@ -13,8 +13,7 @@
 
 package me.ahoo.wow.naming
 
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 internal class LowerDotCaseStrategyTest {
@@ -26,12 +25,12 @@ internal class LowerDotCaseStrategyTest {
     @Test
     fun segment() {
         val actual = LowerDotCaseStrategy.segment(PHRASE)
-        assertThat(actual, equalTo(WORDS))
+        actual.assert().isEqualTo(WORDS)
     }
 
     @Test
     fun transform() {
         val actual = LowerDotCaseStrategy.transform(WORDS)
-        assertThat(actual, equalTo(PHRASE))
+        actual.assert().isEqualTo(PHRASE)
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/naming/NamingConverterTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/naming/NamingConverterTest.kt
@@ -13,14 +13,13 @@
 
 package me.ahoo.wow.naming
 
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 internal class NamingConverterTest {
     @Test
     fun convert() {
         val actual = NamingConverter.PASCAL_TO_SNAKE.convert(PascalCaseStrategyTest.PHRASE)
-        assertThat(actual, equalTo(SnakeCaseStrategyTest.PHRASE))
+        actual.assert().isEqualTo(SnakeCaseStrategyTest.PHRASE)
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/naming/PascalCaseStrategyTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/naming/PascalCaseStrategyTest.kt
@@ -13,8 +13,7 @@
 
 package me.ahoo.wow.naming
 
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 internal class PascalCaseStrategyTest {
@@ -27,12 +26,12 @@ internal class PascalCaseStrategyTest {
     @Test
     fun segment() {
         val actual = PascalCaseStrategy.segment(PHRASE)
-        assertThat(actual, equalTo(WORDS))
+        actual.assert().isEqualTo(WORDS)
     }
 
     @Test
     fun transform() {
         val actual = PascalCaseStrategy.transform(WORDS)
-        assertThat(actual, equalTo(PHRASE))
+        actual.assert().isEqualTo(PHRASE)
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/naming/SnakeCaseStrategyTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/naming/SnakeCaseStrategyTest.kt
@@ -13,8 +13,7 @@
 
 package me.ahoo.wow.naming
 
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 
 internal class SnakeCaseStrategyTest {
@@ -27,12 +26,12 @@ internal class SnakeCaseStrategyTest {
     @Test
     fun segment() {
         val actual = SnakeCaseStrategy.segment(PHRASE)
-        assertThat(actual, equalTo(WORDS))
+        actual.assert().isEqualTo(WORDS)
     }
 
     @Test
     fun transform() {
         val actual = SnakeCaseStrategy.transform(WORDS)
-        assertThat(actual, equalTo(PHRASE))
+        actual.assert().isEqualTo(PHRASE)
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/sharding/CompositeAggregateIdShardingTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/sharding/CompositeAggregateIdShardingTest.kt
@@ -1,13 +1,12 @@
 package me.ahoo.wow.sharding
 
 import me.ahoo.cosid.sharding.ModCycle
+import me.ahoo.test.asserts.assert
+import me.ahoo.test.asserts.assertThrownBy
 import me.ahoo.wow.modeling.MaterializedNamedAggregate
 import me.ahoo.wow.modeling.aggregateId
 import me.ahoo.wow.modeling.materialize
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
-import org.hamcrest.MatcherAssert
-import org.hamcrest.Matchers
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 
 class CompositeAggregateIdShardingTest {
@@ -21,13 +20,13 @@ class CompositeAggregateIdShardingTest {
     @Test
     fun sharding() {
         val actual = sharding.sharding(MOCK_AGGREGATE_METADATA.aggregateId("0TEDamtj0001001"))
-        MatcherAssert.assertThat(actual, Matchers.equalTo("sharding_1"))
+        actual.assert().isEqualTo("sharding_1")
     }
 
     @Test
     fun shardingIfMissing() {
         val aggregateId = MaterializedNamedAggregate("test", "test").aggregateId()
-        Assertions.assertThrows(IllegalStateException::class.java) {
+        assertThrownBy<IllegalStateException> {
             sharding.sharding(aggregateId)
         }
     }

--- a/wow-dependencies/build.gradle.kts
+++ b/wow-dependencies/build.gradle.kts
@@ -29,7 +29,6 @@ dependencies {
         api(libs.opentelemetry.semconv)
         api(libs.swagger.annotations)
         api(libs.swagger.core)
-        api(libs.hamcrest)
         api(libs.mockk)
         api(libs.detekt.formatting)
     }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/context/ContextsTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/context/ContextsTest.kt
@@ -13,10 +13,9 @@
 
 package me.ahoo.wow.query.context
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.query.filter.Contexts.getRawRequest
 import me.ahoo.wow.query.filter.Contexts.writeRawRequest
-import org.hamcrest.CoreMatchers
-import org.hamcrest.MatcherAssert
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Mono
 import reactor.kotlin.test.test
@@ -26,7 +25,7 @@ class ContextsTest {
     @Test
     fun writeRawRequest() {
         Mono.deferContextual {
-            MatcherAssert.assertThat(it.getRawRequest<ContextsTest>(), CoreMatchers.equalTo(this))
+            it.getRawRequest<ContextsTest>().assert().isEqualTo(this)
             Mono.empty<Void>()
         }.writeRawRequest(this)
             .test()

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/DefaultCommandMessageParserTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/DefaultCommandMessageParserTest.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.webflux.route.command
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.command.factory.SimpleCommandBuilderRewriterRegistry
 import me.ahoo.wow.command.factory.SimpleCommandMessageFactory
 import me.ahoo.wow.command.validation.NoOpValidator
@@ -24,8 +25,6 @@ import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import me.ahoo.wow.tck.mock.MockCreateAggregate
 import me.ahoo.wow.webflux.route.command.appender.CommandRequestExtendHeaderAppender
-import org.hamcrest.CoreMatchers
-import org.hamcrest.MatcherAssert
 import org.junit.jupiter.api.Test
 import org.springframework.mock.web.reactive.function.server.MockServerRequest
 import reactor.kotlin.test.test
@@ -87,7 +86,7 @@ class DefaultCommandMessageParserTest {
             request
         ).test()
             .consumeNextWith {
-                MatcherAssert.assertThat(it.header[headerKey], CoreMatchers.equalTo(value))
+                it.header[headerKey].assert().isEqualTo(value)
             }
             .verifyComplete()
     }

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/event/LoadEventStreamHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/event/LoadEventStreamHandlerFunctionTest.kt
@@ -1,5 +1,6 @@
 package me.ahoo.wow.webflux.route.event
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.openapi.BatchComponent
 import me.ahoo.wow.openapi.aggregate.event.LoadEventStreamRouteSpec
@@ -8,8 +9,6 @@ import me.ahoo.wow.openapi.metadata.aggregateRouteMetadata
 import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import me.ahoo.wow.webflux.exception.DefaultRequestExceptionHandler
-import org.hamcrest.MatcherAssert
-import org.hamcrest.Matchers
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.springframework.mock.web.reactive.function.server.MockServerRequest
@@ -40,7 +39,7 @@ class LoadEventStreamHandlerFunctionTest {
         handlerFunction.handle(request)
             .test()
             .consumeNextWith {
-                MatcherAssert.assertThat(it.statusCode(), Matchers.equalTo(HttpStatus.OK))
+                it.statusCode().assert().isEqualTo(HttpStatus.OK)
             }.verifyComplete()
     }
 }

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/id/GlobalIdHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/id/GlobalIdHandlerFunctionTest.kt
@@ -1,10 +1,9 @@
 package me.ahoo.wow.webflux.route.id
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.openapi.context.OpenAPIComponentContext
 import me.ahoo.wow.openapi.global.GenerateGlobalIdRouteSpec
 import me.ahoo.wow.webflux.route.global.GlobalIdHandlerFunctionFactory
-import org.hamcrest.MatcherAssert
-import org.hamcrest.Matchers
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.springframework.mock.web.reactive.function.server.MockServerRequest
@@ -22,7 +21,7 @@ class GlobalIdHandlerFunctionTest {
         handlerFunction.handle(request)
             .test()
             .consumeNextWith {
-                MatcherAssert.assertThat(it.statusCode(), Matchers.equalTo(HttpStatus.OK))
+                it.statusCode().assert().isEqualTo(HttpStatus.OK)
             }.verifyComplete()
     }
 }

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/metadata/GetWowMetadataHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/metadata/GetWowMetadataHandlerFunctionTest.kt
@@ -1,10 +1,9 @@
 package me.ahoo.wow.webflux.route.metadata
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.openapi.context.OpenAPIComponentContext
 import me.ahoo.wow.openapi.global.GetWowMetadataRouteSpec
 import me.ahoo.wow.webflux.route.global.GetWowMetadataHandlerFunctionFactory
-import org.hamcrest.MatcherAssert
-import org.hamcrest.Matchers
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.springframework.mock.web.reactive.function.server.MockServerRequest
@@ -22,7 +21,7 @@ class GetWowMetadataHandlerFunctionTest {
         handlerFunction.handle(request)
             .test()
             .consumeNextWith {
-                MatcherAssert.assertThat(it.statusCode(), Matchers.equalTo(HttpStatus.OK))
+                it.statusCode().assert().isEqualTo(HttpStatus.OK)
             }.verifyComplete()
     }
 }

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/snapshot/CountSnapshotHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/snapshot/CountSnapshotHandlerFunctionTest.kt
@@ -1,5 +1,6 @@
 package me.ahoo.wow.webflux.route.snapshot
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.openapi.aggregate.snapshot.CountSnapshotRouteSpec
@@ -8,8 +9,6 @@ import me.ahoo.wow.openapi.metadata.aggregateRouteMetadata
 import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import me.ahoo.wow.webflux.exception.DefaultRequestExceptionHandler
-import org.hamcrest.MatcherAssert
-import org.hamcrest.Matchers
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import org.springframework.mock.web.reactive.function.server.MockServerRequest
@@ -39,7 +38,7 @@ class CountSnapshotHandlerFunctionTest {
         handlerFunction.handle(request)
             .test()
             .consumeNextWith {
-                MatcherAssert.assertThat(it.statusCode(), Matchers.equalTo(HttpStatus.OK))
+                it.statusCode().assert().isEqualTo(HttpStatus.OK)
             }.verifyComplete()
     }
 }

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/snapshot/LoadSnapshotHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/snapshot/LoadSnapshotHandlerFunctionTest.kt
@@ -2,6 +2,7 @@ package me.ahoo.wow.webflux.route.snapshot
 
 import io.mockk.every
 import io.mockk.mockk
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.openapi.aggregate.snapshot.LoadSnapshotRouteSpec
 import me.ahoo.wow.openapi.context.OpenAPIComponentContext
@@ -9,8 +10,6 @@ import me.ahoo.wow.openapi.metadata.aggregateRouteMetadata
 import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import me.ahoo.wow.webflux.exception.DefaultRequestExceptionHandler
-import org.hamcrest.MatcherAssert
-import org.hamcrest.Matchers
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
@@ -43,7 +42,7 @@ class LoadSnapshotHandlerFunctionTest {
         handlerFunction.handle(request)
             .test()
             .consumeNextWith {
-                MatcherAssert.assertThat(it.statusCode(), Matchers.equalTo(HttpStatus.NOT_FOUND))
+                it.statusCode().assert().isEqualTo(HttpStatus.NOT_FOUND)
             }.verifyComplete()
     }
 }

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/state/LoadVersionedAggregateHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/state/LoadVersionedAggregateHandlerFunctionTest.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.webflux.route.state
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.eventsourcing.EventSourcingStateAggregateRepository
 import me.ahoo.wow.eventsourcing.InMemoryEventStore
 import me.ahoo.wow.eventsourcing.snapshot.NoOpSnapshotRepository
@@ -24,8 +25,6 @@ import me.ahoo.wow.openapi.metadata.aggregateRouteMetadata
 import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import me.ahoo.wow.webflux.exception.DefaultRequestExceptionHandler
-import org.hamcrest.MatcherAssert
-import org.hamcrest.Matchers
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
@@ -62,7 +61,7 @@ class LoadVersionedAggregateHandlerFunctionTest {
         handlerFunction.handle(request)
             .test()
             .consumeNextWith {
-                MatcherAssert.assertThat(it.statusCode(), Matchers.equalTo(HttpStatus.NOT_FOUND))
+                it.statusCode().assert().isEqualTo(HttpStatus.NOT_FOUND)
             }.verifyComplete()
     }
 }


### PR DESCRIPTION
- Remove hamcrest dependency from various test files and build configurations
- Replace hamcrest assertions with assertj assertions across multiple test
- Update import statements and assertion syntax accordingly
