### PR TITLE
build: update import on demand settings for Kotlin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,4 +5,4 @@ charset = utf-8
 
 [*.{kt,kts}]
 ij_kotlin_allow_trailing_comma = false
-ij_kotlin_packages_to_use_import_on_demand = java.util.*,org.hamcrest.Matchers.*,org.hamcrest.MatcherAssert.*,org.junit.jupiter.api.Assertions.*
+ij_kotlin_packages_to_use_import_on_demand = java.util.*,org.assertj.core.api.Assertions.*


### PR DESCRIPTION
- Replace JUnit and Hamcrest imports with AssertJ for cleaner and more fluent assertions
- This change improves code readability and simplifies imports

