### PR TITLE
feat(wow-api): add jackson-annotations and optimize JSON serialization

### DIFF
--- a/wow-api/build.gradle.kts
+++ b/wow-api/build.gradle.kts
@@ -1,3 +1,4 @@
 dependencies{
+    compileOnly("com.fasterxml.jackson.core:jackson-annotations")
     compileOnly("io.swagger.core.v3:swagger-annotations-jakarta")
 }

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/Version.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/Version.kt
@@ -12,6 +12,7 @@
  */
 package me.ahoo.wow.api
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import io.swagger.v3.oas.annotations.media.Schema
 
 /**
@@ -28,12 +29,14 @@ interface Version {
     val version: Int
 
     @get:Schema(hidden = true)
+    @get:JsonIgnore
     val initialized: Boolean
         get() {
             return version > UNINITIALIZED_VERSION
         }
 
     @get:Schema(hidden = true)
+    @get:JsonIgnore
     val isInitialVersion: Boolean
         get() {
             return version == INITIAL_VERSION

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/Condition.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/Condition.kt
@@ -13,11 +13,13 @@
 
 package me.ahoo.wow.api.query
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 interface ICondition<C : ICondition<C>> {
+
     val field: String
 
     @get:Schema(defaultValue = "ALL")
@@ -35,13 +37,17 @@ interface ICondition<C : ICondition<C>> {
 }
 
 data class Condition(
+    @field:JsonInclude(JsonInclude.Include.NON_EMPTY)
     override val field: String = EMPTY_VALUE,
     override val operator: Operator,
+    @field:JsonInclude(JsonInclude.Include.NON_EMPTY)
     override val value: Any = EMPTY_VALUE,
     /**
      * When `operator` is `AND` or `OR` or `NOR`, `children` cannot be empty.
      */
+    @field:JsonInclude(JsonInclude.Include.NON_EMPTY)
     override val children: List<Condition> = emptyList(),
+    @field:JsonInclude(JsonInclude.Include.NON_EMPTY)
     override val options: Map<String, Any> = emptyMap()
 ) : ICondition<Condition>, RewritableCondition<Condition> {
     fun <V> valueAs(): V {

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/ListQuery.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/ListQuery.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.api.query
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 
 interface IListQuery : Queryable<IListQuery> {
@@ -23,6 +24,7 @@ interface IListQuery : Queryable<IListQuery> {
 data class ListQuery(
     override val condition: Condition,
     override val projection: Projection = Projection.ALL,
+    @field:JsonInclude(JsonInclude.Include.NON_EMPTY)
     override val sort: List<Sort> = emptyList(),
     override val limit: Int = Pagination.DEFAULT.size
 ) : IListQuery {

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/PagedQuery.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/PagedQuery.kt
@@ -13,6 +13,8 @@
 
 package me.ahoo.wow.api.query
 
+import com.fasterxml.jackson.annotation.JsonInclude
+
 interface IPagedQuery : Queryable<IPagedQuery> {
     val pagination: Pagination
 }
@@ -20,6 +22,7 @@ interface IPagedQuery : Queryable<IPagedQuery> {
 data class PagedQuery(
     override val condition: Condition,
     override val projection: Projection = Projection.ALL,
+    @field:JsonInclude(JsonInclude.Include.NON_EMPTY)
     override val sort: List<Sort> = emptyList(),
     override val pagination: Pagination = Pagination.DEFAULT
 ) : IPagedQuery {

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/Queryable.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/Queryable.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.api.query
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class Sort(val field: String, val direction: Direction) {
@@ -37,8 +38,10 @@ data class Pagination(
 
 data class Projection(
     @field:Schema(defaultValue = "[]")
+    @field:JsonInclude(JsonInclude.Include.NON_EMPTY)
     val include: List<String> = emptyList(),
     @field:Schema(defaultValue = "[]")
+    @field:JsonInclude(JsonInclude.Include.NON_EMPTY)
     val exclude: List<String> = emptyList()
 ) {
     companion object {

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/SingleQuery.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/SingleQuery.kt
@@ -13,11 +13,14 @@
 
 package me.ahoo.wow.api.query
 
+import com.fasterxml.jackson.annotation.JsonInclude
+
 interface ISingleQuery : Queryable<ISingleQuery>
 
 data class SingleQuery(
     override val condition: Condition,
     override val projection: Projection = Projection.ALL,
+    @field:JsonInclude(JsonInclude.Include.NON_EMPTY)
     override val sort: List<Sort> = emptyList(),
 ) : ISingleQuery {
     override fun withCondition(newCondition: Condition): ISingleQuery {


### PR DESCRIPTION
- Add compile-only dependency for jackson-annotations
- Apply JsonInclude annotation to improve JSON serialization efficiency
- Update multiple query-related classes to use JsonInclude for non-empty fields
- Add JsonIgnore annotation to Version class for better API documentation
