### PR TITLE
feat(core): add aggregate version support

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandExchange.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandExchange.kt
@@ -43,6 +43,7 @@ class SimpleClientCommandExchange<C : Any>(
 const val COMMAND_INVOKE_RESULT_KEY = "__COMMAND_INVOKE_RESULT__"
 const val EVENT_STREAM_KEY = "__EVENT_STREAM__"
 const val AGGREGATE_PROCESSOR_KEY = "__AGGREGATE_PROCESSOR__"
+const val AGGREGATE_VERSION_KEY = "__AGGREGATE_VERSION__"
 
 interface ServerCommandExchange<C : Any> : CommandExchange<ServerCommandExchange<C>, C> {
 
@@ -68,6 +69,14 @@ interface ServerCommandExchange<C : Any> : CommandExchange<ServerCommandExchange
 
     fun getEventStream(): DomainEventStream? {
         return getAttribute(EVENT_STREAM_KEY)
+    }
+
+    fun setAggregateVersion(aggregateVersion: Int): ServerCommandExchange<C> {
+        return setAttribute(AGGREGATE_VERSION_KEY, aggregateVersion)
+    }
+
+    override fun getAggregateVersion(): Int? {
+        return getAttribute(AGGREGATE_VERSION_KEY)
     }
 
     override fun getError(): Throwable? {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/handler/MessageExchange.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/handler/MessageExchange.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.messaging.handler
 
+import me.ahoo.wow.api.Version
 import me.ahoo.wow.api.command.CommandResultAccessor
 import me.ahoo.wow.api.messaging.Message
 import me.ahoo.wow.api.messaging.function.FunctionInfo
@@ -83,6 +84,13 @@ interface MessageExchange<SOURCE : MessageExchange<SOURCE, M>, out M : Message<*
 
     fun getServiceProvider(): ServiceProvider? {
         return getAttribute(SERVICE_PROVIDER_KEY)
+    }
+
+    fun getAggregateVersion(): Int? {
+        if (message is Version) {
+            return (message as Version).version
+        }
+        return null
     }
 
     override fun getCommandResult(): Map<String, Any> {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt
@@ -51,6 +51,7 @@ class SimpleCommandAggregate<C : Any, S : Any>(
 
     override fun process(exchange: ServerCommandExchange<*>): Mono<DomainEventStream> {
         exchange.setFunction(processorFunction)
+        exchange.setAggregateVersion(version)
         val message = exchange.message
         val commandType = message.body.javaClass
         return Mono.defer {
@@ -96,6 +97,7 @@ class SimpleCommandAggregate<C : Any, S : Any>(
                 /**
                  * 持久化事件存储,完成持久化领域事件意味着命令已经完成.
                  */
+                exchange.setAggregateVersion(eventStream.version)
                 commandState.onStore(eventStore, eventStream).doOnNext { commandState = it }
                     .doOnError { commandState = CommandState.EXPIRED }.thenReturn(eventStream)
             }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/SimpleClientCommandExchangeTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/SimpleClientCommandExchangeTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.command
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.command.wait.WaitingFor
+import me.ahoo.wow.id.generateGlobalId
+import org.junit.jupiter.api.Test
+
+class SimpleClientCommandExchangeTest {
+
+    @Test
+    fun main() {
+        val waitingFor = WaitingFor.sent()
+        val command = MockCreateCommand(generateGlobalId()).toCommandMessage()
+        val commandExchange = SimpleClientCommandExchange(command, waitingFor)
+        commandExchange.message.assert().isEqualTo(command)
+        commandExchange.waitStrategy.assert().isEqualTo(waitingFor)
+        commandExchange.attributes.assert().isEmpty()
+        commandExchange.getAggregateVersion().assert().isNull()
+    }
+}

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/SimpleServerCommandExchangeTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/SimpleServerCommandExchangeTest.kt
@@ -10,11 +10,13 @@ import org.junit.jupiter.api.Test
 class SimpleServerCommandExchangeTest {
 
     @Test
-    fun set() {
+    fun main() {
         val command = MockCreateCommand(generateGlobalId()).toCommandMessage()
         val commandExchange = SimpleServerCommandExchange(command)
         commandExchange.setAggregateProcessor(mockk()).getAggregateProcessor().assert().isNotNull()
         commandExchange.setEventStream(mockk()).getEventStream().assert().isNotNull()
+        commandExchange.getAggregateVersion().assert().isNull()
+        commandExchange.setAggregateVersion(1).getAggregateVersion().assert().isEqualTo(1)
     }
 
     @Test

--- a/wow-core/src/test/kotlin/me/ahoo/wow/event/SimpleDomainEventExchangeTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/event/SimpleDomainEventExchangeTest.kt
@@ -1,5 +1,6 @@
 package me.ahoo.wow.event
 
+import io.mockk.every
 import io.mockk.mockk
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.event.DomainEvent
@@ -9,14 +10,19 @@ import me.ahoo.wow.messaging.function.MessageFunction
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Mono
 
-class ExchangeEventFunctionKtTest {
+class SimpleDomainEventExchangeTest {
 
     @Test
-    fun setEventFunction() {
-        val exchange = SimpleDomainEventExchange(mockk<DomainEvent<Any>>())
+    fun main() {
+        val exchange = SimpleDomainEventExchange(
+            mockk<DomainEvent<Any>> {
+                every { version } returns 1
+            }
+        )
         val mockEventFunction = MockEventFunction()
         exchange.setFunction(mockEventFunction).getEventFunction().assert().isNotNull()
         exchange.getFunction().assert().isNotNull()
+        exchange.getAggregateVersion().assert().isOne()
     }
 
     class MockEventFunction : MessageFunction<Any, DomainEventExchange<*>, Mono<Void>> {


### PR DESCRIPTION
- Add AGGREGATE_VERSION_KEY constant in CommandExchange
- Implement setAggregateVersion and getAggregateVersion methods in ServerCommandExchange
- Update MessageExchange to support getting aggregate version from Version message
- Add unit tests for SimpleClientCommandExchange and SimpleDomainEventExchange
- Update SimpleCommandAggregate to set and update aggregate version
