### PR TITLE
feat(core): add aggregate version to CommandResult and WaitSignal

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandResult.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandResult.kt
@@ -22,6 +22,7 @@ import me.ahoo.wow.api.exception.ErrorInfo
 import me.ahoo.wow.api.messaging.processor.ProcessorInfo
 import me.ahoo.wow.api.modeling.TenantId
 import me.ahoo.wow.command.wait.CommandStage
+import me.ahoo.wow.command.wait.NullableAggregateVersionCapable
 import me.ahoo.wow.command.wait.SignalTimeCapable
 import me.ahoo.wow.command.wait.WaitSignal
 import me.ahoo.wow.exception.ErrorCodes
@@ -31,6 +32,7 @@ import me.ahoo.wow.id.generateGlobalId
 data class CommandResult(
     val stage: CommandStage,
     val aggregateId: String,
+    override val aggregateVersion: Int? = null,
     override val id: String,
     override val contextName: String,
     override val processorName: String,
@@ -42,13 +44,22 @@ data class CommandResult(
     override val bindingErrors: List<BindingError> = emptyList(),
     override val result: Map<String, Any> = emptyMap(),
     override val signalTime: Long = System.currentTimeMillis()
-) : Identifier, CommandId, TenantId, RequestId, ErrorInfo, ProcessorInfo, CommandResultCapable, SignalTimeCapable
+) : Identifier,
+    CommandId,
+    TenantId,
+    RequestId,
+    ErrorInfo,
+    ProcessorInfo,
+    CommandResultCapable,
+    SignalTimeCapable,
+    NullableAggregateVersionCapable
 
 fun WaitSignal.toResult(commandMessage: CommandMessage<*>): CommandResult {
     return CommandResult(
         id = this.id,
         stage = this.stage,
         aggregateId = commandMessage.aggregateId.id,
+        aggregateVersion = aggregateVersion,
         contextName = function.contextName,
         processorName = function.processorName,
         tenantId = commandMessage.aggregateId.tenantId,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifier.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifier.kt
@@ -104,6 +104,7 @@ class CommandWaitNotifierSubscriber<E, M>(
             id = messageExchange.message.id,
             commandId = messageExchange.message.commandId,
             stage = processingStage,
+            aggregateVersion = messageExchange.getAggregateVersion(),
             isLastProjection = isLastProjection,
             errorCode = error.errorCode,
             errorMsg = error.errorMsg,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitSignal.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitSignal.kt
@@ -28,16 +28,20 @@ interface SignalTimeCapable {
     val signalTime: Long
 }
 
+interface NullableAggregateVersionCapable {
+    val aggregateVersion: Int?
+}
+
 interface WaitSignal :
     Identifier,
     CommandId,
+    NullableAggregateVersionCapable,
     ErrorInfo,
     SignalTimeCapable,
     CommandResultCapable,
     FunctionInfoCapable<FunctionInfoData> {
     val stage: CommandStage
     val isLastProjection: Boolean
-
     fun copyResult(result: Map<String, Any>): WaitSignal
 }
 
@@ -46,6 +50,7 @@ data class SimpleWaitSignal(
     override val commandId: String,
     override val stage: CommandStage,
     override val function: FunctionInfoData,
+    override val aggregateVersion: Int? = null,
     override val isLastProjection: Boolean = false,
     override val errorCode: String = ErrorCodes.SUCCEEDED,
     override val errorMsg: String = ErrorCodes.SUCCEEDED_MESSAGE,
@@ -59,6 +64,7 @@ data class SimpleWaitSignal(
             commandId: String,
             stage: CommandStage,
             isLastProjection: Boolean = false,
+            aggregateVersion: Int? = null,
             errorCode: String = ErrorCodes.SUCCEEDED,
             errorMsg: String = ErrorCodes.SUCCEEDED_MESSAGE,
             bindingErrors: List<BindingError> = emptyList(),
@@ -70,6 +76,7 @@ data class SimpleWaitSignal(
                 commandId = commandId,
                 stage = stage,
                 function = this.materialize(),
+                aggregateVersion = aggregateVersion,
                 isLastProjection = isLastProjection,
                 errorCode = errorCode,
                 errorMsg = errorMsg,


### PR DESCRIPTION
- Add aggregateVersion property to CommandResult and WaitSignal classes
- Implement NullableAggregateVersionCapable interface in WaitSignal
- Update MonoCommandWaitNotifier to handle aggregate version
- Modify WaitSignalData and its builder to include aggregate version

