### PR TITLE
refactor(webflux): move command response handling to new file

### DIFF
--- a/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt
+++ b/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt
@@ -67,10 +67,11 @@ class Cart(private val state: CartState) {
     }
 
     fun onCommand(command: ChangeQuantity): CartQuantityChanged {
+        val item = state.items.firstOrNull {
+            it.productId == command.productId
+        } ?: throw IllegalArgumentException("商品[${command.productId}]不存在.")
         return CartQuantityChanged(
-            changed = state.items.first {
-                it.productId == command.productId
-            }.copy(quantity = command.quantity),
+            changed = item.copy(quantity = command.quantity),
         )
     }
 }

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/RequestExceptionHandler.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/RequestExceptionHandler.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.webflux.exception
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import me.ahoo.wow.command.CommandResultException
 import me.ahoo.wow.exception.toErrorInfo
 import me.ahoo.wow.webflux.route.toServerResponse
 import org.springframework.web.reactive.function.server.ServerRequest
@@ -26,13 +27,16 @@ interface RequestExceptionHandler {
 
 object DefaultRequestExceptionHandler : RequestExceptionHandler {
     private val log = KotlinLogging.logger {}
-    private fun ServerRequest.formatRequest(): String {
+    fun ServerRequest.formatRequest(): String {
         return "HTTP ${method()} ${uri()}"
     }
 
     override fun handle(request: ServerRequest, throwable: Throwable): Mono<ServerResponse> {
         log.warn(throwable) {
             request.formatRequest()
+        }
+        if (throwable is CommandResultException) {
+            return throwable.commandResult.toServerResponse()
         }
         return throwable.toErrorInfo().toServerResponse()
     }

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/Responses.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/Responses.kt
@@ -14,7 +14,6 @@
 package me.ahoo.wow.webflux.route
 
 import me.ahoo.wow.api.exception.ErrorInfo
-import me.ahoo.wow.command.CommandResult
 import me.ahoo.wow.exception.toErrorInfo
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.openapi.CommonComponent.Header.WOW_ERROR_CODE
@@ -77,25 +76,6 @@ fun <T : Any> Flux<T>.toServerResponse(
             .data(it.toJsonString())
             .build()
     }.toEventStreamResponse(request, exceptionHandler)
-}
-
-fun Flux<CommandResult>.toCommandResponse(
-    request: ServerRequest,
-    exceptionHandler: RequestExceptionHandler
-): Mono<ServerResponse> {
-    if (!request.isSse()) {
-        return this.next().toServerResponse(request, exceptionHandler)
-    }
-
-    val serverSentEventStream = this.map {
-        ServerSentEvent.builder<String>()
-            .id(it.id)
-            .event(it.stage.name)
-            .data(it.toJsonString())
-            .build()
-    }.errorResume(request, exceptionHandler)
-
-    return serverSentEventStream.toEventStreamResponse(request, exceptionHandler)
 }
 
 fun Flux<ServerSentEvent<String>>.toEventStreamResponse(

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandFacadeHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandFacadeHandlerFunction.kt
@@ -17,7 +17,6 @@ import me.ahoo.wow.command.CommandGateway
 import me.ahoo.wow.openapi.aggregate.command.CommandFacadeRouteSpec
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
-import me.ahoo.wow.webflux.route.toCommandResponse
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt
@@ -19,7 +19,6 @@ import me.ahoo.wow.openapi.metadata.AggregateRouteMetadata
 import me.ahoo.wow.openapi.metadata.CommandRouteMetadata
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
-import me.ahoo.wow.webflux.route.toCommandResponse
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.RouterFunctions
 import org.springframework.web.reactive.function.server.ServerRequest

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandResponses.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandResponses.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.route.command
+
+import me.ahoo.wow.command.CommandResult
+import me.ahoo.wow.serialization.toJsonString
+import me.ahoo.wow.webflux.exception.RequestExceptionHandler
+import me.ahoo.wow.webflux.route.errorResume
+import me.ahoo.wow.webflux.route.toEventStreamResponse
+import me.ahoo.wow.webflux.route.toServerResponse
+import org.springframework.http.codec.ServerSentEvent
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+fun Flux<CommandResult>.toCommandResponse(
+    request: ServerRequest,
+    exceptionHandler: RequestExceptionHandler
+): Mono<ServerResponse> {
+    if (!request.isSse()) {
+        return this.next().toServerResponse(request, exceptionHandler)
+    }
+
+    val serverSentEventStream = this.map {
+        ServerSentEvent.builder<String>()
+            .id(it.id)
+            .event(it.stage.name)
+            .data(it.toJsonString())
+            .build()
+    }.errorResume(request, exceptionHandler)
+
+    return serverSentEventStream.toEventStreamResponse(request, exceptionHandler)
+}

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/DefaultExceptionHandlerTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/DefaultExceptionHandlerTest.kt
@@ -1,6 +1,11 @@
 package me.ahoo.wow.webflux.exception
 
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.command.CommandResult
+import me.ahoo.wow.command.CommandResultException
+import me.ahoo.wow.command.wait.CommandStage
+import me.ahoo.wow.exception.ErrorCodes
+import me.ahoo.wow.id.generateGlobalId
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
@@ -20,6 +25,31 @@ class DefaultExceptionHandlerTest {
             .test()
             .consumeNextWith {
                 it.statusCode().assert().isEqualTo(HttpStatus.BAD_REQUEST)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun handleCommandResultException() {
+        val request = MockServerRequest.builder()
+            .method(HttpMethod.GET)
+            .uri(URI.create("http://localhost"))
+            .build()
+        val commandResult = CommandResult(
+            id = generateGlobalId(),
+            stage = CommandStage.SENT,
+            aggregateId = generateGlobalId(),
+            tenantId = generateGlobalId(),
+            requestId = generateGlobalId(),
+            commandId = generateGlobalId(),
+            contextName = "contextName",
+            processorName = "processorName",
+            errorCode = ErrorCodes.NOT_FOUND
+        )
+        DefaultRequestExceptionHandler.handle(request, CommandResultException(commandResult))
+            .test()
+            .consumeNextWith {
+                it.statusCode().assert().isEqualTo(HttpStatus.NOT_FOUND)
             }
             .verifyComplete()
     }


### PR DESCRIPTION
- Extract command response handling logic to new CommandResponses.kt file
- Add unit tests for command response handling in CommandResponsesTest.kt
- Update DefaultRequestExceptionHandler to handle CommandResultException
- Remove redundant code from Responses.kt

