### PR TITLE
feat(exception): introduce ErrorInfoCapable interface for unified error handling

### DIFF
--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/exception/ErrorInfoCapable.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/exception/ErrorInfoCapable.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.api.exception
+
+interface ErrorInfoCapable {
+    val errorInfo: ErrorInfo
+}

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandExceptions.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandExceptions.kt
@@ -16,6 +16,7 @@ package me.ahoo.wow.command
 import jakarta.validation.ConstraintViolation
 import me.ahoo.wow.api.exception.BindingError
 import me.ahoo.wow.api.exception.ErrorInfo
+import me.ahoo.wow.api.exception.ErrorInfoCapable
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.exception.ErrorCodes.COMMAND_VALIDATION
@@ -41,7 +42,11 @@ class CommandResultException(val commandResult: CommandResult, cause: Throwable?
         errorMsg = commandResult.errorMsg,
         cause = cause,
         bindingErrors = commandResult.bindingErrors
-    )
+    ),
+    ErrorInfoCapable {
+    override val errorInfo: ErrorInfo
+        get() = commandResult
+}
 
 class CommandValidationException(
     val command: Any,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandResult.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandResult.kt
@@ -21,6 +21,7 @@ import me.ahoo.wow.api.exception.BindingError
 import me.ahoo.wow.api.exception.ErrorInfo
 import me.ahoo.wow.api.messaging.processor.ProcessorInfo
 import me.ahoo.wow.api.modeling.TenantId
+import me.ahoo.wow.api.naming.Materialized
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.NullableAggregateVersionCapable
 import me.ahoo.wow.command.wait.SignalTimeCapable
@@ -52,7 +53,8 @@ data class CommandResult(
     ProcessorInfo,
     CommandResultCapable,
     SignalTimeCapable,
-    NullableAggregateVersionCapable
+    NullableAggregateVersionCapable,
+    Materialized
 
 fun WaitSignal.toResult(commandMessage: CommandMessage<*>): CommandResult {
     return CommandResult(

--- a/wow-core/src/main/kotlin/me/ahoo/wow/exception/ErrorConverter.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/exception/ErrorConverter.kt
@@ -14,6 +14,8 @@
 package me.ahoo.wow.exception
 
 import me.ahoo.wow.api.exception.ErrorInfo
+import me.ahoo.wow.api.exception.ErrorInfo.Companion.materialize
+import me.ahoo.wow.api.exception.ErrorInfoCapable
 import java.lang.reflect.ParameterizedType
 import java.util.concurrent.TimeoutException
 
@@ -36,6 +38,12 @@ abstract class AbstractErrorConverterFactory<E : Throwable> : ErrorConverterFact
 
 object DefaultErrorConverter : ErrorConverter<Throwable> {
     override fun convert(error: Throwable): ErrorInfo {
+        if (error is ErrorInfoCapable) {
+            return error.errorInfo.materialize()
+        }
+        if (error is ErrorInfo) {
+            return error.materialize()
+        }
         val errorCode = when (error) {
             is IllegalArgumentException -> ErrorCodes.ILLEGAL_ARGUMENT
             is IllegalStateException -> ErrorCodes.ILLEGAL_STATE

--- a/wow-core/src/main/kotlin/me/ahoo/wow/exception/ErrorConverterRegistrar.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/exception/ErrorConverterRegistrar.kt
@@ -16,7 +16,6 @@ package me.ahoo.wow.exception
 import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.annotation.sortedByOrder
 import me.ahoo.wow.api.exception.ErrorInfo
-import me.ahoo.wow.api.exception.ErrorInfo.Companion.materialize
 import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 
@@ -60,9 +59,6 @@ object ErrorConverterRegistrar {
 }
 
 fun Throwable.toErrorInfo(): ErrorInfo {
-    if (this is ErrorInfo) {
-        return this.materialize()
-    }
     val errorConverter = ErrorConverterRegistrar.get(this.javaClass) ?: DefaultErrorConverter
     return errorConverter.convert(this)
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/exception/ErrorConverterRegistrarTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/exception/ErrorConverterRegistrarTest.kt
@@ -2,6 +2,10 @@ package me.ahoo.wow.exception
 
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.exception.ErrorInfo
+import me.ahoo.wow.command.CommandResult
+import me.ahoo.wow.command.CommandResultException
+import me.ahoo.wow.command.wait.CommandStage
+import me.ahoo.wow.id.generateGlobalId
 import org.junit.jupiter.api.Test
 
 class ErrorInfoConverterRegistrarTest {
@@ -14,6 +18,22 @@ class ErrorInfoConverterRegistrarTest {
         CustomException().toErrorInfo().errorCode.assert().isEqualTo(ErrorCodes.BAD_REQUEST)
         ErrorConverterRegistrar.register(CustomExceptionErrorConverterFactory()).assert().isNull()
         CustomException().toErrorInfo().errorCode.assert().isEqualTo("CUSTOM_EXCEPTION")
+    }
+
+    @Test
+    fun commandResultExceptionToErrorInfo() {
+        val commandResult = CommandResult(
+            id = generateGlobalId(),
+            stage = CommandStage.SENT,
+            aggregateId = generateGlobalId(),
+            tenantId = generateGlobalId(),
+            requestId = generateGlobalId(),
+            commandId = generateGlobalId(),
+            contextName = "contextName",
+            processorName = "processorName",
+            errorCode = ErrorCodes.NOT_FOUND
+        )
+        CommandResultException(commandResult).toErrorInfo().assert().isEqualTo(commandResult)
     }
 }
 

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/RequestExceptionHandler.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/RequestExceptionHandler.kt
@@ -14,7 +14,6 @@
 package me.ahoo.wow.webflux.exception
 
 import io.github.oshai.kotlinlogging.KotlinLogging
-import me.ahoo.wow.command.CommandResultException
 import me.ahoo.wow.exception.toErrorInfo
 import me.ahoo.wow.webflux.route.toServerResponse
 import org.springframework.web.reactive.function.server.ServerRequest
@@ -34,9 +33,6 @@ object DefaultRequestExceptionHandler : RequestExceptionHandler {
     override fun handle(request: ServerRequest, throwable: Throwable): Mono<ServerResponse> {
         log.warn(throwable) {
             request.formatRequest()
-        }
-        if (throwable is CommandResultException) {
-            return throwable.commandResult.toServerResponse()
         }
         return throwable.toErrorInfo().toServerResponse()
     }

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/DefaultExceptionHandlerTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/DefaultExceptionHandlerTest.kt
@@ -1,11 +1,6 @@
 package me.ahoo.wow.webflux.exception
 
 import me.ahoo.test.asserts.assert
-import me.ahoo.wow.command.CommandResult
-import me.ahoo.wow.command.CommandResultException
-import me.ahoo.wow.command.wait.CommandStage
-import me.ahoo.wow.exception.ErrorCodes
-import me.ahoo.wow.id.generateGlobalId
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
@@ -25,31 +20,6 @@ class DefaultExceptionHandlerTest {
             .test()
             .consumeNextWith {
                 it.statusCode().assert().isEqualTo(HttpStatus.BAD_REQUEST)
-            }
-            .verifyComplete()
-    }
-
-    @Test
-    fun handleCommandResultException() {
-        val request = MockServerRequest.builder()
-            .method(HttpMethod.GET)
-            .uri(URI.create("http://localhost"))
-            .build()
-        val commandResult = CommandResult(
-            id = generateGlobalId(),
-            stage = CommandStage.SENT,
-            aggregateId = generateGlobalId(),
-            tenantId = generateGlobalId(),
-            requestId = generateGlobalId(),
-            commandId = generateGlobalId(),
-            contextName = "contextName",
-            processorName = "processorName",
-            errorCode = ErrorCodes.NOT_FOUND
-        )
-        DefaultRequestExceptionHandler.handle(request, CommandResultException(commandResult))
-            .test()
-            .consumeNextWith {
-                it.statusCode().assert().isEqualTo(HttpStatus.NOT_FOUND)
             }
             .verifyComplete()
     }


### PR DESCRIPTION
- Add ErrorInfoCapable interface to standardize error information retrieval
- Implement ErrorInfoCapable in CommandResultException
- Update ErrorConverter to handle ErrorInfoCapable objects
- Remove redundant error handling logic in RequestExceptionHandler
- Add unit tests for new error handling approach
