### PR TITLE
fix(webflux): handle read-only headers in GlobalExceptionHandler

### DIFF
--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/GlobalExceptionHandler.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/GlobalExceptionHandler.kt
@@ -44,8 +44,9 @@ object GlobalExceptionHandler : WebExceptionHandler, Ordered {
         val status = errorInfo.toHttpStatus()
         val response = exchange.response
         response.statusCode = status
-        response.headers.set(CommonComponent.Header.WOW_ERROR_CODE, errorInfo.errorCode)
-        response.headers.contentType = MediaType.APPLICATION_JSON
+        if (response.headers.trySet(CommonComponent.Header.WOW_ERROR_CODE, errorInfo.errorCode)) {
+            response.headers.contentType = MediaType.APPLICATION_JSON
+        }
         return response.writeWith(Mono.just(response.bufferFactory().wrap(errorInfo.toJsonString().toByteArray())))
     }
 

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/HttpHeadersGuard.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/HttpHeadersGuard.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.exception
+
+import org.springframework.http.HttpHeaders
+
+fun HttpHeaders.trySet(key: String, value: String): Boolean {
+    try {
+        set(key, value)
+        return true
+    } catch (_: UnsupportedOperationException) {
+        return false
+    }
+}

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/HttpHeadersGuardTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/HttpHeadersGuardTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.exception
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.exception.ErrorCodes
+import me.ahoo.wow.openapi.CommonComponent
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+
+class HttpHeadersGuardTest {
+    @Test
+    fun trySet() {
+        val httpHeaders = HttpHeaders()
+        httpHeaders.trySet(CommonComponent.Header.WOW_ERROR_CODE, ErrorCodes.ILLEGAL_ARGUMENT).assert().isTrue()
+        httpHeaders.getFirst(CommonComponent.Header.WOW_ERROR_CODE).assert().isEqualTo(ErrorCodes.ILLEGAL_ARGUMENT)
+    }
+
+    @Test
+    fun trySetIfReadOnly() {
+        val httpHeaders = HttpHeaders()
+        val readOnlyHttpHeaders = HttpHeaders.readOnlyHttpHeaders(httpHeaders)
+        readOnlyHttpHeaders.trySet(
+            CommonComponent.Header.WOW_ERROR_CODE,
+            ErrorCodes.ILLEGAL_ARGUMENT
+        ).assert().isFalse()
+        readOnlyHttpHeaders.getFirst(CommonComponent.Header.WOW_ERROR_CODE).assert().isNull()
+    }
+}


### PR DESCRIPTION
- Add trySet extension function for HttpHeaders to handle read-only headers
- Update GlobalExceptionHandler to use trySet when setting error code header
- Add unit test for handling read-only headers in GlobalExceptionHandler
- Add unit tests for HttpHeadersGuard trySet function


