### PR TITLE
refactor(exception): optimize error handling and response header setting

### DIFF
--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/GlobalExceptionHandler.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/GlobalExceptionHandler.kt
@@ -44,7 +44,7 @@ object GlobalExceptionHandler : WebExceptionHandler, Ordered {
         val status = errorInfo.toHttpStatus()
         val response = exchange.response
         response.statusCode = status
-        if (response.headers.trySet(CommonComponent.Header.WOW_ERROR_CODE, errorInfo.errorCode)) {
+        if (response.trySetHeader(CommonComponent.Header.WOW_ERROR_CODE, errorInfo.errorCode)) {
             response.headers.contentType = MediaType.APPLICATION_JSON
         }
         return response.writeWith(Mono.just(response.bufferFactory().wrap(errorInfo.toJsonString().toByteArray())))

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/HttpHeadersGuard.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/HttpHeadersGuard.kt
@@ -14,6 +14,14 @@
 package me.ahoo.wow.webflux.exception
 
 import org.springframework.http.HttpHeaders
+import org.springframework.http.server.reactive.ServerHttpResponse
+
+fun ServerHttpResponse.trySetHeader(key: String, value: String): Boolean {
+    if (this.isCommitted) {
+        return false
+    }
+    return this.headers.trySet(key, value)
+}
 
 fun HttpHeaders.trySet(key: String, value: String): Boolean {
     try {

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/GlobalExceptionHandlerTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/GlobalExceptionHandlerTest.kt
@@ -39,6 +39,7 @@ class GlobalExceptionHandlerTest {
             every { setStatusCode(any()) } returns true
             every { headers.set(CommonComponent.Header.WOW_ERROR_CODE, ErrorCodes.ILLEGAL_ARGUMENT) } returns Unit
             every { headers.contentType = MediaType.APPLICATION_JSON } returns Unit
+            every { isCommitted } returns false
             every { bufferFactory() } returns DefaultDataBufferFactory()
             every { writeWith(any()) } returns Mono.empty()
         }
@@ -69,9 +70,7 @@ class GlobalExceptionHandlerTest {
 
         val response = mockk<ServerHttpResponse> {
             every { setStatusCode(any()) } returns true
-            every {
-                headers.set(CommonComponent.Header.WOW_ERROR_CODE, ErrorCodes.ILLEGAL_ARGUMENT)
-            } throws UnsupportedOperationException()
+            every { isCommitted } returns true
             every { bufferFactory() } returns DefaultDataBufferFactory()
             every { writeWith(any()) } returns Mono.empty()
         }
@@ -87,7 +86,6 @@ class GlobalExceptionHandlerTest {
 
         verify {
             response.setStatusCode(HttpStatus.BAD_REQUEST)
-            response.headers.set(CommonComponent.Header.WOW_ERROR_CODE, ErrorCodes.ILLEGAL_ARGUMENT)
             response.writeWith(any())
         }
     }
@@ -103,6 +101,7 @@ class GlobalExceptionHandlerTest {
             every { setStatusCode(any()) } returns true
             every { headers.set(CommonComponent.Header.WOW_ERROR_CODE, ErrorCodes.ILLEGAL_ARGUMENT) } returns Unit
             every { headers.contentType = MediaType.APPLICATION_JSON } returns Unit
+            every { isCommitted } returns false
             every { bufferFactory() } returns DefaultDataBufferFactory()
             every { writeWith(any()) } returns Mono.empty()
         }

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/HttpHeadersGuardTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/HttpHeadersGuardTest.kt
@@ -18,8 +18,22 @@ import me.ahoo.wow.exception.ErrorCodes
 import me.ahoo.wow.openapi.CommonComponent
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
+import org.springframework.mock.http.server.reactive.MockServerHttpResponse
 
 class HttpHeadersGuardTest {
+
+    @Test
+    fun trySetHeader() {
+        val response = MockServerHttpResponse()
+        response.trySetHeader(CommonComponent.Header.WOW_ERROR_CODE, ErrorCodes.ILLEGAL_ARGUMENT).assert().isTrue()
+        response.headers.getFirst(CommonComponent.Header.WOW_ERROR_CODE).assert().isEqualTo(ErrorCodes.ILLEGAL_ARGUMENT)
+        response.isCommitted.assert().isFalse()
+        response.setComplete().block()
+        response.isCommitted.assert().isTrue()
+        response.trySetHeader(CommonComponent.Header.WOW_ERROR_CODE, ErrorCodes.NOT_FOUND).assert().isFalse()
+        response.headers.getFirst(CommonComponent.Header.WOW_ERROR_CODE).assert().isEqualTo(ErrorCodes.ILLEGAL_ARGUMENT)
+    }
+
     @Test
     fun trySet() {
         val httpHeaders = HttpHeaders()


### PR DESCRIPTION
- Introduce trySetHeader extension function for ServerHttpResponse
- Update GlobalExceptionHandler to use trySetHeader
- Add unit tests for trySetHeader behavior
- Refactor HttpHeadersGuard to use trySet instead of set

