### PR TITLE
refactor(query): apply JsonInclude annotation for non-empty fields

### DIFF
--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/Condition.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/Condition.kt
@@ -20,34 +20,35 @@ import java.time.format.DateTimeFormatter
 
 interface ICondition<C : ICondition<C>> {
 
+    @get:JsonInclude(JsonInclude.Include.NON_EMPTY)
     val field: String
 
     @get:Schema(defaultValue = "ALL")
     val operator: Operator
+
+    @get:JsonInclude(JsonInclude.Include.NON_EMPTY)
     val value: Any
 
     /**
      * When `operator` is `AND` or `OR` or `NOR`, `children` cannot be empty.
      */
     @get:Schema(defaultValue = "[]")
+    @get:JsonInclude(JsonInclude.Include.NON_EMPTY)
     val children: List<C>
 
     @get:Schema(defaultValue = "{}")
+    @get:JsonInclude(JsonInclude.Include.NON_EMPTY)
     val options: Map<String, Any>
 }
 
 data class Condition(
-    @field:JsonInclude(JsonInclude.Include.NON_EMPTY)
     override val field: String = EMPTY_VALUE,
-    override val operator: Operator,
-    @field:JsonInclude(JsonInclude.Include.NON_EMPTY)
+    override val operator: Operator = Operator.ALL,
     override val value: Any = EMPTY_VALUE,
     /**
      * When `operator` is `AND` or `OR` or `NOR`, `children` cannot be empty.
      */
-    @field:JsonInclude(JsonInclude.Include.NON_EMPTY)
     override val children: List<Condition> = emptyList(),
-    @field:JsonInclude(JsonInclude.Include.NON_EMPTY)
     override val options: Map<String, Any> = emptyMap()
 ) : ICondition<Condition>, RewritableCondition<Condition> {
     fun <V> valueAs(): V {

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/ListQuery.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/ListQuery.kt
@@ -13,7 +13,6 @@
 
 package me.ahoo.wow.api.query
 
-import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 
 interface IListQuery : Queryable<IListQuery> {
@@ -24,7 +23,6 @@ interface IListQuery : Queryable<IListQuery> {
 data class ListQuery(
     override val condition: Condition,
     override val projection: Projection = Projection.ALL,
-    @field:JsonInclude(JsonInclude.Include.NON_EMPTY)
     override val sort: List<Sort> = emptyList(),
     override val limit: Int = Pagination.DEFAULT.size
 ) : IListQuery {

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/PagedQuery.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/PagedQuery.kt
@@ -13,8 +13,6 @@
 
 package me.ahoo.wow.api.query
 
-import com.fasterxml.jackson.annotation.JsonInclude
-
 interface IPagedQuery : Queryable<IPagedQuery> {
     val pagination: Pagination
 }
@@ -22,7 +20,6 @@ interface IPagedQuery : Queryable<IPagedQuery> {
 data class PagedQuery(
     override val condition: Condition,
     override val projection: Projection = Projection.ALL,
-    @field:JsonInclude(JsonInclude.Include.NON_EMPTY)
     override val sort: List<Sort> = emptyList(),
     override val pagination: Pagination = Pagination.DEFAULT
 ) : IPagedQuery {

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/SingleQuery.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/SingleQuery.kt
@@ -13,14 +13,11 @@
 
 package me.ahoo.wow.api.query
 
-import com.fasterxml.jackson.annotation.JsonInclude
-
 interface ISingleQuery : Queryable<ISingleQuery>
 
 data class SingleQuery(
     override val condition: Condition,
     override val projection: Projection = Projection.ALL,
-    @field:JsonInclude(JsonInclude.Include.NON_EMPTY)
     override val sort: List<Sort> = emptyList(),
 ) : ISingleQuery {
     override fun withCondition(newCondition: Condition): ISingleQuery {

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/SortCapable.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/SortCapable.kt
@@ -13,9 +13,11 @@
 
 package me.ahoo.wow.api.query
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
 
 interface SortCapable {
     @get:Schema(defaultValue = "[]")
+    @get:JsonInclude(JsonInclude.Include.NON_EMPTY)
     val sort: List<Sort>
 }

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/AggregatedFields.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/AggregatedFields.kt
@@ -13,4 +13,13 @@
 
 package me.ahoo.wow.schema.typed
 
-interface AggregatedFields<CommandAggregateType : Any>
+interface AggregatedFields<CommandAggregateType : Any> {
+    companion object {
+        val EMPTY = object : AggregatedFields<Any> {}
+
+        @Suppress("UNCHECKED_CAST")
+        fun <CommandAggregateType : Any> empty(): AggregatedFields<CommandAggregateType> {
+            return EMPTY as AggregatedFields<CommandAggregateType>
+        }
+    }
+}

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/query/AggregatedCondition.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/query/AggregatedCondition.kt
@@ -13,26 +13,33 @@
 
 package me.ahoo.wow.schema.typed.query
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import io.swagger.v3.oas.annotations.media.Schema
+import me.ahoo.wow.api.query.Condition.Companion.EMPTY_VALUE
 import me.ahoo.wow.api.query.Operator
 import me.ahoo.wow.schema.typed.AggregatedFields
 
 interface IAggregatedCondition<CommandAggregateType : Any> {
+    @get:JsonInclude(JsonInclude.Include.NON_EMPTY)
     val field: AggregatedFields<CommandAggregateType>
 
     @get:Schema(defaultValue = "ALL")
     val operator: Operator
+
+    @get:JsonInclude(JsonInclude.Include.NON_EMPTY)
     val value: Any
 
     @get:Schema(defaultValue = "{}")
+    @get:JsonInclude(JsonInclude.Include.NON_EMPTY)
     val options: Map<String, Any>
 }
 
 data class AggregatedCondition<CommandAggregateType : Any>(
-    override val field: AggregatedFields<CommandAggregateType>,
-    override val operator: Operator,
-    override val value: Any,
+    override val field: AggregatedFields<CommandAggregateType> = AggregatedFields.empty(),
+    override val operator: Operator = Operator.ALL,
+    override val value: Any = EMPTY_VALUE,
     @get:Schema(defaultValue = "[]")
-    val children: List<AggregatedCondition<CommandAggregateType>>,
+    @get:JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val children: List<AggregatedCondition<CommandAggregateType>> = emptyList(),
     override val options: Map<String, Any> = emptyMap()
 ) : IAggregatedCondition<CommandAggregateType>

--- a/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedCondition.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedCondition.json
@@ -23,6 +23,5 @@
       "default" : "{}"
     },
     "value" : { }
-  },
-  "required" : [ "children", "field", "operator", "value" ]
+  }
 }

--- a/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedListQuery.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedListQuery.json
@@ -27,8 +27,7 @@
           "default" : "{}"
         },
         "value" : { }
-      },
-      "required" : [ "children", "field", "operator", "value" ]
+      }
     },
     "wow.api.query.Condition" : {
       "type" : "object",

--- a/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedListQuery.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedListQuery.json
@@ -52,8 +52,7 @@
           "default" : "{}"
         },
         "value" : { }
-      },
-      "required" : [ "operator" ]
+      }
     },
     "wow.api.query.Operator" : {
       "type" : "string",

--- a/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedPagedQuery.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedPagedQuery.json
@@ -27,8 +27,7 @@
           "default" : "{}"
         },
         "value" : { }
-      },
-      "required" : [ "children", "field", "operator", "value" ]
+      }
     },
     "wow.api.query.Condition" : {
       "type" : "object",

--- a/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedPagedQuery.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedPagedQuery.json
@@ -52,8 +52,7 @@
           "default" : "{}"
         },
         "value" : { }
-      },
-      "required" : [ "operator" ]
+      }
     },
     "wow.api.query.Operator" : {
       "type" : "string",

--- a/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedSingleQuery.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedSingleQuery.json
@@ -27,8 +27,7 @@
           "default" : "{}"
         },
         "value" : { }
-      },
-      "required" : [ "children", "field", "operator", "value" ]
+      }
     },
     "wow.api.query.Condition" : {
       "type" : "object",

--- a/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedSingleQuery.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/OrderAggregatedSingleQuery.json
@@ -52,8 +52,7 @@
           "default" : "{}"
         },
         "value" : { }
-      },
-      "required" : [ "operator" ]
+      }
     },
     "wow.api.query.Operator" : {
       "type" : "string",


### PR DESCRIPTION
- Add JsonInclude annotation to Condition class properties
- Remove explicit JsonInclude annotations from ListQuery, PagedQuery, and SingleQuery
- Add JsonInclude annotation to sort property in SortCapable interface