### PR TITLE
feat(aggregate): add metadata generation for aggregates

### DIFF
--- a/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/AggregateRootResolver.kt
+++ b/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/AggregateRootResolver.kt
@@ -17,6 +17,7 @@ import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.getAnnotationsByType
 import com.google.devtools.ksp.getConstructors
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFile
 import me.ahoo.wow.api.annotation.AggregateRoot
 import me.ahoo.wow.api.annotation.Name
 import me.ahoo.wow.api.naming.Named
@@ -49,6 +50,17 @@ object AggregateRootResolver {
         }
 
         return AggregateRootMetadata(this.toName(), this, stateAggregateDeclaration)
+    }
+
+    fun AggregateRootMetadata.resolveDependencies(): List<KSFile> {
+        return buildList {
+            command.containingFile?.let {
+                add(it)
+            }
+            state.containingFile?.let {
+                add(it)
+            }
+        }.distinct()
     }
 }
 

--- a/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/aggregate/metadata/AggregatesMetadataResolver.kt
+++ b/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/aggregate/metadata/AggregatesMetadataResolver.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.compiler.aggregate.metadata
+
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import me.ahoo.wow.compiler.AggregateRootResolver.resolveAggregateRootMetadata
+import me.ahoo.wow.compiler.AggregateRootResolver.resolveDependencies
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+object AggregatesMetadataResolver {
+    fun KSClassDeclaration.resolveNamedAggregates(
+        commandAggregates: List<KSClassDeclaration>
+    ): AggregatesMetadataFile? {
+        val packageName = packageName.asString()
+        val aggregateMetadata = commandAggregates.filter {
+            it.packageName.asString().startsWith(packageName)
+        }.map {
+            it.resolveAggregateRootMetadata()
+        }
+        if (aggregateMetadata.isEmpty()) {
+            return null
+        }
+        val codeGenerator = StringBuilder()
+        codeGenerator.appendLine("package $packageName")
+        codeGenerator.appendLine()
+        aggregateMetadata.forEach {
+            codeGenerator.appendLine("import ${it.command.qualifiedName!!.asString()}")
+            if (it.command.qualifiedName!!.asString() != it.state.qualifiedName!!.asString()) {
+                codeGenerator.appendLine("import ${it.state.qualifiedName!!.asString()}")
+            }
+        }
+        codeGenerator.appendLine("import me.ahoo.wow.modeling.annotation.aggregateMetadata")
+        codeGenerator.appendLine("import javax.annotation.processing.Generated")
+        codeGenerator.appendLine()
+        val generatedDate = LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        codeGenerator.appendLine(
+            "@Generated(\"${AggregatesMetadataFile.Companion.GENERATOR_NAME}\", date = \"$generatedDate\")"
+        )
+        codeGenerator.appendLine("object ${AggregatesMetadataFile.Companion.FILE_NAME} {")
+        aggregateMetadata.forEach {
+            codeGenerator.appendLine(
+                "    val ${it.command.simpleName.asString()}AggregateMetadata = aggregateMetadata<${it.command.simpleName.asString()}, ${it.state.simpleName.asString()}>()"
+            )
+        }
+        codeGenerator.appendLine("}")
+
+        val dependencies =
+            Dependencies(
+                aggregating = true,
+                sources = aggregateMetadata.flatMap {
+                    it.resolveDependencies()
+                }.toTypedArray()
+            )
+        return AggregatesMetadataFile(
+            dependencies = dependencies,
+            packageName = packageName,
+            code = codeGenerator.toString(),
+        )
+    }
+
+    fun AggregatesMetadataFile.writeFile(codeGenerator: CodeGenerator) {
+        val file = codeGenerator
+            .createNewFile(
+                dependencies = this.dependencies,
+                packageName = this.packageName,
+                fileName = AggregatesMetadataFile.Companion.FILE_NAME,
+                extensionName = this.extensionName,
+            )
+        file.write(this.code.toByteArray())
+        file.close()
+    }
+}
+
+data class AggregatesMetadataFile(
+    val dependencies: Dependencies,
+    val packageName: String,
+    val code: String,
+    val extensionName: String = "kt"
+) {
+
+    companion object {
+        const val FILE_NAME = "AggregatesMetadata"
+        const val GENERATOR_NAME = "me.ahoo.wow.compiler.aggregate.metadata.AggregatesMetadataResolver"
+    }
+}

--- a/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/aggregate/metadata/AggregatesMetadataSymbolProcessorProvider.kt
+++ b/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/aggregate/metadata/AggregatesMetadataSymbolProcessorProvider.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.compiler.aggregate.metadata
+
+import com.google.devtools.ksp.processing.SymbolProcessor
+import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
+import com.google.devtools.ksp.processing.SymbolProcessorProvider
+
+class AggregatesMetadataSymbolProcessorProvider :
+    SymbolProcessorProvider {
+    override fun create(environment: SymbolProcessorEnvironment): SymbolProcessor {
+        return AggregatesMetadataProcessor(environment)
+    }
+}

--- a/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/query/StateAggregateRootResolver.kt
+++ b/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/query/StateAggregateRootResolver.kt
@@ -17,10 +17,9 @@ import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.Dependencies
 import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSClassDeclaration
-import com.google.devtools.ksp.symbol.KSFile
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
-import me.ahoo.wow.compiler.AggregateRootMetadata
 import me.ahoo.wow.compiler.AggregateRootResolver.resolveAggregateRootMetadata
+import me.ahoo.wow.compiler.AggregateRootResolver.resolveDependencies
 import me.ahoo.wow.compiler.query.PropertyNav.Companion.NAV_DELIMITER
 import me.ahoo.wow.compiler.query.PropertyNav.Companion.PROPERTY_DELIMITER
 import me.ahoo.wow.compiler.query.StateAggregateRootPropertyNavigationFile.Companion.FILE_SUFFIX
@@ -36,8 +35,7 @@ object StateAggregateRootResolver {
     fun KSClassDeclaration.resolveStateAggregateRoot(): StateAggregateRootPropertyNavigationFile {
         val aggregateRootMetadata = this.resolveAggregateRootMetadata()
         val stateAggregateDeclaration = aggregateRootMetadata.state
-        val dependencies =
-            Dependencies(aggregating = true, sources = aggregateRootMetadata.resolveDependencies().toTypedArray())
+
         val packageName = stateAggregateDeclaration.packageName.asString()
         val fileName = stateAggregateDeclaration.simpleName.asString() + FILE_SUFFIX
         val codeGenerator = StringBuilder()
@@ -53,18 +51,9 @@ object StateAggregateRootResolver {
             it.resolvePropertyNavigationCode(codeGenerator, added)
         }
         codeGenerator.appendLine("}")
+        val dependencies =
+            Dependencies(aggregating = true, sources = aggregateRootMetadata.resolveDependencies().toTypedArray())
         return StateAggregateRootPropertyNavigationFile(dependencies, packageName, fileName, codeGenerator.toString())
-    }
-
-    private fun AggregateRootMetadata.resolveDependencies(): List<KSFile> {
-        return buildList {
-            command.containingFile?.let {
-                add(it)
-            }
-            state.containingFile?.let {
-                add(it)
-            }
-        }.distinct()
     }
 
     private fun String.toPropertyNav(parent: PropertyNav? = null): PropertyNav {

--- a/wow-compiler/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
+++ b/wow-compiler/src/main/resources/META-INF/services/com.google.devtools.ksp.processing.SymbolProcessorProvider
@@ -13,3 +13,4 @@
 
 me.ahoo.wow.compiler.metadata.MetadataSymbolProcessorProvider
 me.ahoo.wow.compiler.query.QuerySymbolProcessorProvider
+me.ahoo.wow.compiler.aggregate.metadata.AggregatesMetadataSymbolProcessorProvider

--- a/wow-compiler/src/test/kotlin/me/ahoo/wow/compiler/Compiles.kt
+++ b/wow-compiler/src/test/kotlin/me/ahoo/wow/compiler/Compiles.kt
@@ -36,6 +36,7 @@ fun compileTest(
             incremental = true
             symbolProcessorProviders += symbolProcessorProvider
         }
+        jvmTarget = "17"
     }
     val result = kotlinCompilation.compile()
     result.exitCode.assert().withFailMessage { result.messages }.isEqualTo(KotlinCompilation.ExitCode.OK)

--- a/wow-compiler/src/test/kotlin/me/ahoo/wow/compiler/aggregate/metadata/AggregatesMetadataSymbolProcessorTest.kt
+++ b/wow-compiler/src/test/kotlin/me/ahoo/wow/compiler/aggregate/metadata/AggregatesMetadataSymbolProcessorTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.compiler.aggregate.metadata
+
+import com.tschuchort.compiletesting.JvmCompilationResult
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.kspSourcesDir
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.compiler.compileTest
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.io.path.Path
+
+class AggregatesMetadataSymbolProcessorTest {
+    @OptIn(ExperimentalCompilerApi::class)
+    fun compileNamedAggregatesSymbolProcessor(
+        sources: List<File>,
+        consumer: (KotlinCompilation, JvmCompilationResult) -> Unit = { _, _ ->
+        }
+    ) {
+        compileTest(sources, AggregatesMetadataSymbolProcessorProvider(), consumer)
+    }
+
+    @OptIn(ExperimentalCompilerApi::class)
+    @Test
+    fun process() {
+        val mockBoundedContextFile = File("src/test/kotlin/me/ahoo/wow/compiler/MockBoundedContext.kt")
+        val mockCompilerAggregateFile = File("src/test/kotlin/me/ahoo/wow/compiler/MockCompilerAggregate.kt")
+        compileNamedAggregatesSymbolProcessor(
+            listOf(mockBoundedContextFile, mockCompilerAggregateFile),
+        ) { compilation, _ ->
+            val navFile = Path(
+                compilation.kspSourcesDir.path,
+                "kotlin/me/ahoo/wow/compiler",
+                "AggregatesMetadata.kt"
+            )
+            val navFileContent = navFile.toFile().readText()
+            navFileContent.assert().contains(
+                "val MockCompilerAggregateAggregateMetadata = aggregateMetadata<MockCompilerAggregate, MockCompilerAggregate>()"
+            )
+        }
+    }
+
+    @OptIn(ExperimentalCompilerApi::class)
+    @Test
+    fun processExample() {
+        val exampleApiDir = File("../example/example-api/src/main/kotlin/me/ahoo/wow/example/api")
+        val exampleApiFiles = exampleApiDir.walkTopDown().filter { it.isFile }.toList()
+        val exampleDomainDir = File("../example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain")
+        val exampleDomainFiles = exampleDomainDir.walkTopDown().filter { it.isFile }.toList()
+        compileNamedAggregatesSymbolProcessor(exampleApiFiles + exampleDomainFiles)
+    }
+
+    @OptIn(ExperimentalCompilerApi::class)
+    @Test
+    fun processJava() {
+        val mockBoundedContextFile = File("src/test/java/me/ahoo/wow/compiler/MockJavaBoundedContext.java")
+        val mockCompilerAggregateFile = File("src/test/java/me/ahoo/wow/compiler/MockJavaCompilerAggregate.java")
+        compileNamedAggregatesSymbolProcessor(listOf(mockBoundedContextFile, mockCompilerAggregateFile))
+    }
+}


### PR DESCRIPTION
- Add AggregatesMetadataProcessor to handle aggregate metadata generation
- Implement AggregatesMetadataResolver for resolving aggregate metadata
- Create AggregatesMetadataSymbolProcessorProvider for KSP integration
- Add unit tests for aggregate metadata generation
- Update QuerySymbolProcessor to remove dependency file tracking
