### PR TITLE
refactor(compiler): extract GeneratedFile class for code generation

### DIFF
--- a/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/GeneratedFile.kt
+++ b/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/GeneratedFile.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.compiler
+
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.Dependencies
+import me.ahoo.wow.api.naming.Named
+
+data class GeneratedFile(
+    val dependencies: Dependencies,
+    val packageName: String,
+    override val name: String,
+    val code: String,
+    val extensionName: String = "kt"
+) : Named {
+    fun writeFile(codeGenerator: CodeGenerator) {
+        val file = codeGenerator
+            .createNewFile(
+                dependencies = this.dependencies,
+                packageName = this.packageName,
+                fileName = this.name,
+                extensionName = this.extensionName,
+            )
+        file.write(this.code.toByteArray())
+        file.close()
+    }
+}

--- a/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/aggregate/metadata/AggregatesMetadataProcessor.kt
+++ b/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/aggregate/metadata/AggregatesMetadataProcessor.kt
@@ -21,7 +21,6 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.validate
 import me.ahoo.wow.compiler.AggregateRootResolver.AGGREGATE_ROOT_NAME
 import me.ahoo.wow.compiler.aggregate.metadata.AggregatesMetadataResolver.resolveNamedAggregates
-import me.ahoo.wow.compiler.aggregate.metadata.AggregatesMetadataResolver.writeFile
 import me.ahoo.wow.compiler.metadata.MetadataSymbolProcessor.Companion.BOUNDED_CONTEXT_NAME
 
 class AggregatesMetadataProcessor(environment: SymbolProcessorEnvironment) :

--- a/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/query/QuerySymbolProcessor.kt
+++ b/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/query/QuerySymbolProcessor.kt
@@ -21,7 +21,6 @@ import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.validate
 import me.ahoo.wow.compiler.AggregateRootResolver.AGGREGATE_ROOT_NAME
 import me.ahoo.wow.compiler.query.StateAggregateRootResolver.resolveStateAggregateRoot
-import me.ahoo.wow.compiler.query.StateAggregateRootResolver.writeFile
 
 class QuerySymbolProcessor(environment: SymbolProcessorEnvironment) :
     SymbolProcessor {


### PR DESCRIPTION
- Create a new GeneratedFile class to encapsulate generated file information
- Update AggregatesMetadataResolver and StateAggregateRootResolver to use GeneratedFile
- Remove redundant writeFile functions from AggregatesMetadataFile and StateAggregateRootPropertyNavigationFile
- Simplify code structure and improve reusability

