### PR TITLE
test(wow-core): add unit test for waiting for projected function

### DIFF
--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForTest.kt
@@ -163,6 +163,36 @@ internal class WaitingForTest {
     }
 
     @Test
+    fun waitingForProjectedFunction() {
+        val waitStrategy = WaitingFor.projected(contextName, "processor", "function")
+        val processedSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
+            commandId = generateGlobalId(),
+            stage = CommandStage.PROCESSED,
+            function = COMMAND_GATEWAY_FUNCTION,
+        )
+        val waitSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
+            commandId = generateGlobalId(),
+            stage = CommandStage.PROJECTED,
+            function = COMMAND_GATEWAY_FUNCTION.copy(
+                contextName = contextName,
+                processorName = "processor",
+                name = "function"
+            ),
+            isLastProjection = true
+        )
+        waitStrategy.waitingLast()
+            .test()
+            .consumeSubscriptionWith {
+                waitStrategy.next(processedSignal)
+                waitStrategy.next(waitSignal)
+            }
+            .expectNext(waitSignal)
+            .verifyComplete()
+    }
+
+    @Test
     fun waitingForProjectedWhenNotLast() {
         val waitStrategy = WaitingFor.projected(contextName)
         val processedSignal = SimpleWaitSignal(

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForTest.kt
@@ -163,6 +163,31 @@ internal class WaitingForTest {
     }
 
     @Test
+    fun waitingForProjectedProcessorNotEq() {
+        val waitStrategy = WaitingFor.projected(contextName, "processor")
+        val processedSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
+            commandId = generateGlobalId(),
+            stage = CommandStage.PROCESSED,
+            function = COMMAND_GATEWAY_FUNCTION,
+        )
+        val waitSignal = SimpleWaitSignal(
+            id = generateGlobalId(),
+            commandId = generateGlobalId(),
+            stage = CommandStage.PROJECTED,
+            function = COMMAND_GATEWAY_FUNCTION.copy(contextName = contextName, processorName = "hi"),
+            isLastProjection = true
+        )
+        waitStrategy.waitingLast()
+            .test()
+            .consumeSubscriptionWith {
+                waitStrategy.next(processedSignal)
+                waitStrategy.next(waitSignal)
+            }
+            .verifyTimeout(Duration.ofMillis(500))
+    }
+
+    @Test
     fun waitingForProjectedFunction() {
         val waitStrategy = WaitingFor.projected(contextName, "processor", "function")
         val processedSignal = SimpleWaitSignal(


### PR DESCRIPTION
- Implement a new test case for waiting for a projected function
- Verify that the wait strategy correctly handles projected signals
- Ensure that the last projection is properly identified and returned
