### PR TITLE
refactor(webflux): introduce CommandBuilderExtractor for command parsing

### DIFF
--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfiguration.kt
@@ -44,6 +44,8 @@ import me.ahoo.wow.webflux.route.command.appender.CommandRequestExtendHeaderAppe
 import me.ahoo.wow.webflux.route.command.appender.CommandRequestHeaderAppender
 import me.ahoo.wow.webflux.route.command.appender.CommandRequestRemoteIpHeaderAppender
 import me.ahoo.wow.webflux.route.command.appender.CommandRequestUserAgentHeaderAppender
+import me.ahoo.wow.webflux.route.command.extractor.CommandBuilderExtractor
+import me.ahoo.wow.webflux.route.command.extractor.DefaultCommandBuilderExtractor
 import me.ahoo.wow.webflux.route.event.CountEventStreamHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.event.EventCompensateHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.event.ListQueryEventStreamHandlerFunctionFactory
@@ -152,6 +154,12 @@ class WebFluxAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean
+    fun commandBuilderExtractor(): CommandBuilderExtractor {
+        return DefaultCommandBuilderExtractor
+    }
+
+    @Bean
     @ConditionalOnProperty(
         value = ["${WebFluxProperties.COMMAND_REQUEST_APPENDER_PREFIX}.agent$ENABLED_SUFFIX_KEY"],
         matchIfMissing = true,
@@ -175,10 +183,12 @@ class WebFluxAutoConfiguration {
     @ConditionalOnMissingBean
     fun commandMessageParser(
         commandMessageFactory: CommandMessageFactory,
+        commandBuilderExtractor: CommandBuilderExtractor,
         commandRequestHeaderAppenderObjectProvider: ObjectProvider<CommandRequestHeaderAppender>
     ): CommandMessageParser {
         return DefaultCommandMessageParser(
             commandMessageFactory = commandMessageFactory,
+            commandBuilderExtractor = commandBuilderExtractor,
             commandRequestHeaderAppends = commandRequestHeaderAppenderObjectProvider.toList<CommandRequestHeaderAppender>()
         )
     }

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt
@@ -37,8 +37,8 @@ class CommandHandler(
     ): Flux<CommandResult> {
         return commandMessageParser.parse(
             aggregateRouteMetadata = aggregateRouteMetadata,
-            commandBody = commandBody,
-            request = request
+            request = request,
+            commandBody = commandBody
         ).flatMapMany {
             sendCommand(it, request)
         }

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandBuilderExtractor.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandBuilderExtractor.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.route.command.extractor
+
+import me.ahoo.wow.command.factory.CommandBuilder
+import me.ahoo.wow.openapi.metadata.AggregateRouteMetadata
+import org.springframework.web.reactive.function.server.ServerRequest
+import reactor.core.publisher.Mono
+
+fun interface CommandBuilderExtractor {
+    fun extract(
+        aggregateRouteMetadata: AggregateRouteMetadata<*>,
+        commandBody: Any,
+        request: ServerRequest
+    ): Mono<CommandBuilder>
+}

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/extractor/DefaultCommandBuilderExtractor.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/extractor/DefaultCommandBuilderExtractor.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.route.command.extractor
+
+import me.ahoo.wow.command.CommandOperator.withOperator
+import me.ahoo.wow.command.factory.CommandBuilder
+import me.ahoo.wow.command.factory.CommandBuilder.Companion.commandBuilder
+import me.ahoo.wow.infra.ifNotBlank
+import me.ahoo.wow.messaging.withLocalFirst
+import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Header.AGGREGATE_VERSION
+import me.ahoo.wow.openapi.aggregate.command.CommandComponent.Header.REQUEST_ID
+import me.ahoo.wow.openapi.metadata.AggregateRouteMetadata
+import me.ahoo.wow.webflux.route.command.getAggregateId
+import me.ahoo.wow.webflux.route.command.getLocalFirst
+import me.ahoo.wow.webflux.route.command.getOwnerId
+import me.ahoo.wow.webflux.route.command.getTenantId
+import org.springframework.web.reactive.function.server.ServerRequest
+import reactor.core.publisher.Mono
+import reactor.kotlin.core.publisher.toMono
+
+object DefaultCommandBuilderExtractor : CommandBuilderExtractor {
+    override fun extract(
+        aggregateRouteMetadata: AggregateRouteMetadata<*>,
+        commandBody: Any,
+        request: ServerRequest
+    ): Mono<CommandBuilder> {
+        val aggregateMetadata = aggregateRouteMetadata.aggregateMetadata
+        val tenantId = request.getTenantId(aggregateMetadata)
+        val ownerId = request.getOwnerId()
+        val aggregateId = request.getAggregateId(aggregateRouteMetadata.owner, ownerId)
+        val aggregateVersion = request.headers().firstHeader(AGGREGATE_VERSION)?.toIntOrNull()
+        val requestId = request.headers().firstHeader(REQUEST_ID).ifNotBlank { it }
+        val commandBuilder = commandBody.commandBuilder()
+            .aggregateId(aggregateId)
+            .tenantId(tenantId)
+            .ownerId(ownerId)
+            .aggregateVersion(aggregateVersion)
+            .requestId(requestId)
+            .namedAggregate(aggregateMetadata.namedAggregate)
+        request.getLocalFirst()?.let {
+            commandBuilder.header { header ->
+                header.withLocalFirst(it)
+            }
+        }
+        return request.principal().map {
+            commandBuilder.header { header ->
+                header.withOperator(it.name)
+            }
+        }.switchIfEmpty(commandBuilder.toMono())
+    }
+}

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/handler/CommandHandlerTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/handler/CommandHandlerTest.kt
@@ -15,6 +15,7 @@ import me.ahoo.wow.tck.mock.MockCreateAggregate
 import me.ahoo.wow.test.SagaVerifier
 import me.ahoo.wow.webflux.route.command.CommandHandler
 import me.ahoo.wow.webflux.route.command.DefaultCommandMessageParser
+import me.ahoo.wow.webflux.route.command.extractor.DefaultCommandBuilderExtractor
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
@@ -44,7 +45,8 @@ class CommandHandlerTest {
                 SimpleCommandMessageFactory(
                     NoOpValidator,
                     SimpleCommandBuilderRewriterRegistry()
-                )
+                ),
+                DefaultCommandBuilderExtractor
             )
         )
         commandHandler.handle(
@@ -73,10 +75,11 @@ class CommandHandlerTest {
         val commandHandler = CommandHandler(
             SagaVerifier.defaultCommandGateway(),
             DefaultCommandMessageParser(
-                SimpleCommandMessageFactory(
-                    NoOpValidator,
-                    SimpleCommandBuilderRewriterRegistry()
-                )
+                commandMessageFactory = SimpleCommandMessageFactory(
+                    validator = NoOpValidator,
+                    commandBuilderRewriterRegistry = SimpleCommandBuilderRewriterRegistry()
+                ),
+                commandBuilderExtractor = DefaultCommandBuilderExtractor
             )
         )
         commandHandler.handle(
@@ -103,12 +106,13 @@ class CommandHandlerTest {
             .principal(UserPrincipal(generateGlobalId()))
             .body(MockCreateAggregate(generateGlobalId(), generateGlobalId()).toJsonString())
         val commandHandler = CommandHandler(
-            SagaVerifier.defaultCommandGateway(),
-            DefaultCommandMessageParser(
-                SimpleCommandMessageFactory(
+            commandGateway = SagaVerifier.defaultCommandGateway(),
+            commandMessageParser = DefaultCommandMessageParser(
+                commandMessageFactory = SimpleCommandMessageFactory(
                     NoOpValidator,
                     SimpleCommandBuilderRewriterRegistry()
-                )
+                ),
+                commandBuilderExtractor = DefaultCommandBuilderExtractor
             )
         )
         commandHandler.handle(

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandFacadeHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandFacadeHandlerFunctionTest.kt
@@ -19,6 +19,7 @@ import me.ahoo.wow.tck.mock.MockCommandAggregate
 import me.ahoo.wow.tck.mock.MockCreateAggregate
 import me.ahoo.wow.test.SagaVerifier
 import me.ahoo.wow.webflux.exception.DefaultRequestExceptionHandler
+import me.ahoo.wow.webflux.route.command.extractor.DefaultCommandBuilderExtractor
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
@@ -39,7 +40,8 @@ class CommandFacadeHandlerFunctionTest {
                 SimpleCommandMessageFactory(
                     NoOpValidator,
                     SimpleCommandBuilderRewriterRegistry()
-                )
+                ),
+                DefaultCommandBuilderExtractor
             ),
             exceptionHandler = DefaultRequestExceptionHandler
         ).create(CommandFacadeRouteSpec(OpenAPIComponentContext.default()))

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunctionTest.kt
@@ -31,6 +31,7 @@ import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import me.ahoo.wow.tck.mock.MockCreateAggregate
 import me.ahoo.wow.test.SagaVerifier
 import me.ahoo.wow.webflux.exception.DefaultRequestExceptionHandler
+import me.ahoo.wow.webflux.route.command.extractor.DefaultCommandBuilderExtractor
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
@@ -52,7 +53,8 @@ class CommandHandlerFunctionTest {
                 SimpleCommandMessageFactory(
                     NoOpValidator,
                     SimpleCommandBuilderRewriterRegistry()
-                )
+                ),
+                DefaultCommandBuilderExtractor
             ),
             DefaultRequestExceptionHandler,
         )

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/DefaultCommandMessageParserTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/DefaultCommandMessageParserTest.kt
@@ -25,6 +25,7 @@ import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import me.ahoo.wow.tck.mock.MockCreateAggregate
 import me.ahoo.wow.webflux.route.command.appender.CommandRequestExtendHeaderAppender
+import me.ahoo.wow.webflux.route.command.extractor.DefaultCommandBuilderExtractor
 import org.junit.jupiter.api.Test
 import org.springframework.mock.web.reactive.function.server.MockServerRequest
 import reactor.kotlin.test.test
@@ -42,7 +43,11 @@ class DefaultCommandMessageParserTest {
             .build()
         val commandMessageParser =
             DefaultCommandMessageParser(
-                SimpleCommandMessageFactory(NoOpValidator, SimpleCommandBuilderRewriterRegistry())
+                commandMessageFactory = SimpleCommandMessageFactory(
+                    NoOpValidator,
+                    SimpleCommandBuilderRewriterRegistry()
+                ),
+                commandBuilderExtractor = DefaultCommandBuilderExtractor
             )
         commandMessageParser.parse(
             aggregateRouteMetadata = MOCK_AGGREGATE_METADATA.command.aggregateType.aggregateRouteMetadata(),
@@ -72,8 +77,12 @@ class DefaultCommandMessageParserTest {
             .build()
         val commandMessageParser =
             DefaultCommandMessageParser(
-                SimpleCommandMessageFactory(NoOpValidator, SimpleCommandBuilderRewriterRegistry()),
-                listOf(
+                commandMessageFactory = SimpleCommandMessageFactory(
+                    validator = NoOpValidator,
+                    commandBuilderRewriterRegistry = SimpleCommandBuilderRewriterRegistry()
+                ),
+                commandBuilderExtractor = DefaultCommandBuilderExtractor,
+                commandRequestHeaderAppends = listOf(
                     CommandRequestExtendHeaderAppender
                 )
             )


### PR DESCRIPTION
- Add CommandBuilderExtractor interface and DefaultCommandBuilderExtractor implementation
- Update CommandMessageParser to use CommandBuilderExtractor
- Modify related tests to incorporate new command builder extraction logic
- Add commandBuilderExtractor bean in WebFluxAutoConfiguration

