### PR TITLE
refactor(webflux): rename CommandMessageParser to CommandMessageExtractor

### DIFF
--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfiguration.kt
@@ -37,15 +37,15 @@ import me.ahoo.wow.webflux.route.RouteHandlerFunctionRegistrar
 import me.ahoo.wow.webflux.route.RouterFunctionBuilder
 import me.ahoo.wow.webflux.route.command.CommandFacadeHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.command.CommandHandlerFunctionFactory
-import me.ahoo.wow.webflux.route.command.CommandMessageParser
 import me.ahoo.wow.webflux.route.command.DEFAULT_TIME_OUT
-import me.ahoo.wow.webflux.route.command.DefaultCommandMessageParser
 import me.ahoo.wow.webflux.route.command.appender.CommandRequestExtendHeaderAppender
 import me.ahoo.wow.webflux.route.command.appender.CommandRequestHeaderAppender
 import me.ahoo.wow.webflux.route.command.appender.CommandRequestRemoteIpHeaderAppender
 import me.ahoo.wow.webflux.route.command.appender.CommandRequestUserAgentHeaderAppender
 import me.ahoo.wow.webflux.route.command.extractor.CommandBuilderExtractor
+import me.ahoo.wow.webflux.route.command.extractor.CommandMessageExtractor
 import me.ahoo.wow.webflux.route.command.extractor.DefaultCommandBuilderExtractor
+import me.ahoo.wow.webflux.route.command.extractor.DefaultCommandMessageExtractor
 import me.ahoo.wow.webflux.route.event.CountEventStreamHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.event.EventCompensateHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.event.ListQueryEventStreamHandlerFunctionFactory
@@ -181,12 +181,12 @@ class WebFluxAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    fun commandMessageParser(
+    fun commandMessageExtractor(
         commandMessageFactory: CommandMessageFactory,
         commandBuilderExtractor: CommandBuilderExtractor,
         commandRequestHeaderAppenderObjectProvider: ObjectProvider<CommandRequestHeaderAppender>
-    ): CommandMessageParser {
-        return DefaultCommandMessageParser(
+    ): CommandMessageExtractor {
+        return DefaultCommandMessageExtractor(
             commandMessageFactory = commandMessageFactory,
             commandBuilderExtractor = commandBuilderExtractor,
             commandRequestHeaderAppends = commandRequestHeaderAppenderObjectProvider.toList<CommandRequestHeaderAppender>()
@@ -207,12 +207,12 @@ class WebFluxAutoConfiguration {
     @ConditionalOnMissingBean(name = [COMMAND_FACADE_HANDLER_FUNCTION_FACTORY_BEAN_NAME])
     fun commandFacadeHandlerFunctionFactory(
         commandGateway: CommandGateway,
-        commandMessageParser: CommandMessageParser,
+        commandMessageExtractor: CommandMessageExtractor,
         exceptionHandler: RequestExceptionHandler,
     ): CommandFacadeHandlerFunctionFactory {
         return CommandFacadeHandlerFunctionFactory(
             commandGateway = commandGateway,
-            commandMessageParser = commandMessageParser,
+            commandMessageExtractor = commandMessageExtractor,
             exceptionHandler = exceptionHandler
         )
     }
@@ -442,12 +442,12 @@ class WebFluxAutoConfiguration {
     @ConditionalOnMissingBean(name = [COMMAND_HANDLER_FUNCTION_FACTORY_BEAN_NAME])
     fun commandHandlerFunctionFactory(
         commandGateway: CommandGateway,
-        commandMessageParser: CommandMessageParser,
+        commandMessageExtractor: CommandMessageExtractor,
         exceptionHandler: RequestExceptionHandler,
     ): CommandHandlerFunctionFactory {
         return CommandHandlerFunctionFactory(
             commandGateway = commandGateway,
-            commandMessageParser = commandMessageParser,
+            commandMessageExtractor = commandMessageExtractor,
             exceptionHandler = exceptionHandler,
             timeout = DEFAULT_TIME_OUT
         )

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandFacadeHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandFacadeHandlerFunction.kt
@@ -17,6 +17,8 @@ import me.ahoo.wow.command.CommandGateway
 import me.ahoo.wow.openapi.aggregate.command.CommandFacadeRouteSpec
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.route.RouteHandlerFunctionFactory
+import me.ahoo.wow.webflux.route.command.extractor.CommandFacadeBodyExtractor
+import me.ahoo.wow.webflux.route.command.extractor.CommandMessageExtractor
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
@@ -31,14 +33,14 @@ import java.time.Duration
  */
 class CommandFacadeHandlerFunction(
     private val commandGateway: CommandGateway,
-    private val commandMessageParser: CommandMessageParser,
+    private val commandMessageExtractor: CommandMessageExtractor,
     private val exceptionHandler: RequestExceptionHandler,
     private val timeout: Duration = DEFAULT_TIME_OUT
 ) : HandlerFunction<ServerResponse> {
 
     private val handler = CommandHandler(
         commandGateway = commandGateway,
-        commandMessageParser = commandMessageParser,
+        commandMessageExtractor = commandMessageExtractor,
         timeout = timeout
     )
 
@@ -53,7 +55,7 @@ class CommandFacadeHandlerFunction(
 
 class CommandFacadeHandlerFunctionFactory(
     private val commandGateway: CommandGateway,
-    private val commandMessageParser: CommandMessageParser,
+    private val commandMessageExtractor: CommandMessageExtractor,
     private val exceptionHandler: RequestExceptionHandler,
     private val timeout: Duration = DEFAULT_TIME_OUT
 ) : RouteHandlerFunctionFactory<CommandFacadeRouteSpec> {
@@ -63,7 +65,7 @@ class CommandFacadeHandlerFunctionFactory(
     override fun create(spec: CommandFacadeRouteSpec): HandlerFunction<ServerResponse> {
         return CommandFacadeHandlerFunction(
             commandGateway = commandGateway,
-            commandMessageParser = commandMessageParser,
+            commandMessageExtractor = commandMessageExtractor,
             exceptionHandler = exceptionHandler,
             timeout = timeout
         )

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt
@@ -19,6 +19,7 @@ import me.ahoo.wow.command.CommandResult
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.WaitingFor
 import me.ahoo.wow.openapi.metadata.AggregateRouteMetadata
+import me.ahoo.wow.webflux.route.command.extractor.CommandMessageExtractor
 import org.reactivestreams.Publisher
 import org.springframework.web.reactive.function.server.ServerRequest
 import reactor.core.publisher.Flux
@@ -26,7 +27,7 @@ import java.time.Duration
 
 class CommandHandler(
     private val commandGateway: CommandGateway,
-    private val commandMessageParser: CommandMessageParser,
+    private val commandMessageExtractor: CommandMessageExtractor,
     private val timeout: Duration = DEFAULT_TIME_OUT
 ) {
 
@@ -35,7 +36,7 @@ class CommandHandler(
         commandBody: Any,
         aggregateRouteMetadata: AggregateRouteMetadata<*>,
     ): Flux<CommandResult> {
-        return commandMessageParser.parse(
+        return commandMessageExtractor.extract(
             aggregateRouteMetadata = aggregateRouteMetadata,
             request = request,
             commandBody = commandBody

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandBodyExtractor.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandBodyExtractor.kt
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.webflux.route.command
+package me.ahoo.wow.webflux.route.command.extractor
 
 import com.fasterxml.jackson.databind.node.ObjectNode
 import me.ahoo.wow.openapi.metadata.CommandRouteMetadata

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandFacadeBodyExtractor.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandFacadeBodyExtractor.kt
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.webflux.route.command
+package me.ahoo.wow.webflux.route.command.extractor
 
 import com.fasterxml.jackson.databind.node.ObjectNode
 import me.ahoo.wow.configuration.requiredAggregateType

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandMessageExtractor.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandMessageExtractor.kt
@@ -11,30 +11,29 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.webflux.route.command
+package me.ahoo.wow.webflux.route.command.extractor
 
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.command.factory.CommandMessageFactory
 import me.ahoo.wow.openapi.metadata.AggregateRouteMetadata
 import me.ahoo.wow.webflux.route.command.appender.CommandRequestHeaderAppender
-import me.ahoo.wow.webflux.route.command.extractor.CommandBuilderExtractor
 import org.springframework.web.reactive.function.server.ServerRequest
 import reactor.core.publisher.Mono
 
-interface CommandMessageParser {
-    fun parse(
+interface CommandMessageExtractor {
+    fun extract(
         aggregateRouteMetadata: AggregateRouteMetadata<*>,
         commandBody: Any,
         request: ServerRequest
     ): Mono<CommandMessage<Any>>
 }
 
-class DefaultCommandMessageParser(
+class DefaultCommandMessageExtractor(
     private val commandMessageFactory: CommandMessageFactory,
     private val commandBuilderExtractor: CommandBuilderExtractor,
     private val commandRequestHeaderAppends: List<CommandRequestHeaderAppender> = listOf()
-) : CommandMessageParser {
-    override fun parse(
+) : CommandMessageExtractor {
+    override fun extract(
         aggregateRouteMetadata: AggregateRouteMetadata<*>,
         commandBody: Any,
         request: ServerRequest

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandFacadeHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandFacadeHandlerFunctionTest.kt
@@ -20,6 +20,7 @@ import me.ahoo.wow.tck.mock.MockCreateAggregate
 import me.ahoo.wow.test.SagaVerifier
 import me.ahoo.wow.webflux.exception.DefaultRequestExceptionHandler
 import me.ahoo.wow.webflux.route.command.extractor.DefaultCommandBuilderExtractor
+import me.ahoo.wow.webflux.route.command.extractor.DefaultCommandMessageExtractor
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
@@ -36,7 +37,7 @@ class CommandFacadeHandlerFunctionTest {
 
         val handlerFunction = CommandFacadeHandlerFunctionFactory(
             commandGateway = commandGateway,
-            commandMessageParser = DefaultCommandMessageParser(
+            commandMessageExtractor = DefaultCommandMessageExtractor(
                 SimpleCommandMessageFactory(
                     NoOpValidator,
                     SimpleCommandBuilderRewriterRegistry()

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunctionTest.kt
@@ -32,6 +32,7 @@ import me.ahoo.wow.tck.mock.MockCreateAggregate
 import me.ahoo.wow.test.SagaVerifier
 import me.ahoo.wow.webflux.exception.DefaultRequestExceptionHandler
 import me.ahoo.wow.webflux.route.command.extractor.DefaultCommandBuilderExtractor
+import me.ahoo.wow.webflux.route.command.extractor.DefaultCommandMessageExtractor
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
@@ -49,7 +50,7 @@ class CommandHandlerFunctionTest {
             MOCK_AGGREGATE_METADATA.command.aggregateType.aggregateRouteMetadata(),
             commandRouteMetadata,
             commandGateway,
-            DefaultCommandMessageParser(
+            DefaultCommandMessageExtractor(
                 SimpleCommandMessageFactory(
                     NoOpValidator,
                     SimpleCommandBuilderRewriterRegistry()

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerTest.kt
@@ -1,4 +1,17 @@
-package me.ahoo.wow.webflux.handler
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.route.command
 
 import com.sun.security.auth.UserPrincipal
 import me.ahoo.test.asserts.assert
@@ -13,9 +26,8 @@ import me.ahoo.wow.serialization.toJsonString
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import me.ahoo.wow.tck.mock.MockCreateAggregate
 import me.ahoo.wow.test.SagaVerifier
-import me.ahoo.wow.webflux.route.command.CommandHandler
-import me.ahoo.wow.webflux.route.command.DefaultCommandMessageParser
 import me.ahoo.wow.webflux.route.command.extractor.DefaultCommandBuilderExtractor
+import me.ahoo.wow.webflux.route.command.extractor.DefaultCommandMessageExtractor
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
@@ -40,13 +52,13 @@ class CommandHandlerTest {
             .principal(UserPrincipal(generateGlobalId()))
             .body(MockCreateAggregate(generateGlobalId(), generateGlobalId()).toJsonString())
         val commandHandler = CommandHandler(
-            SagaVerifier.defaultCommandGateway(),
-            DefaultCommandMessageParser(
-                SimpleCommandMessageFactory(
-                    NoOpValidator,
-                    SimpleCommandBuilderRewriterRegistry()
+            commandGateway = SagaVerifier.defaultCommandGateway(),
+            commandMessageExtractor = DefaultCommandMessageExtractor(
+                commandMessageFactory = SimpleCommandMessageFactory(
+                    validator = NoOpValidator,
+                    commandBuilderRewriterRegistry = SimpleCommandBuilderRewriterRegistry()
                 ),
-                DefaultCommandBuilderExtractor
+                commandBuilderExtractor = DefaultCommandBuilderExtractor
             )
         )
         commandHandler.handle(
@@ -74,7 +86,7 @@ class CommandHandlerTest {
             .body(MockCreateAggregate(generateGlobalId(), generateGlobalId()).toJsonString())
         val commandHandler = CommandHandler(
             SagaVerifier.defaultCommandGateway(),
-            DefaultCommandMessageParser(
+            DefaultCommandMessageExtractor(
                 commandMessageFactory = SimpleCommandMessageFactory(
                     validator = NoOpValidator,
                     commandBuilderRewriterRegistry = SimpleCommandBuilderRewriterRegistry()
@@ -107,7 +119,7 @@ class CommandHandlerTest {
             .body(MockCreateAggregate(generateGlobalId(), generateGlobalId()).toJsonString())
         val commandHandler = CommandHandler(
             commandGateway = SagaVerifier.defaultCommandGateway(),
-            commandMessageParser = DefaultCommandMessageParser(
+            commandMessageExtractor = DefaultCommandMessageExtractor(
                 commandMessageFactory = SimpleCommandMessageFactory(
                     NoOpValidator,
                     SimpleCommandBuilderRewriterRegistry()

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandBodyExtractorTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandBodyExtractorTest.kt
@@ -1,4 +1,17 @@
-package me.ahoo.wow.webflux.route.command
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.route.command.extractor
 
 import com.fasterxml.jackson.databind.node.ObjectNode
 import io.mockk.every

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandFacadeBodyExtractorTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandFacadeBodyExtractorTest.kt
@@ -1,4 +1,17 @@
-package me.ahoo.wow.webflux.route.command
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.route.command.extractor
 
 import com.fasterxml.jackson.databind.node.ObjectNode
 import io.mockk.every

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/extractor/DefaultCommandMessageExtractorTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/extractor/DefaultCommandMessageExtractorTest.kt
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.webflux.route.command
+package me.ahoo.wow.webflux.route.command.extractor
 
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.command.factory.SimpleCommandBuilderRewriterRegistry
@@ -25,12 +25,11 @@ import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import me.ahoo.wow.tck.mock.MockCreateAggregate
 import me.ahoo.wow.webflux.route.command.appender.CommandRequestExtendHeaderAppender
-import me.ahoo.wow.webflux.route.command.extractor.DefaultCommandBuilderExtractor
 import org.junit.jupiter.api.Test
 import org.springframework.mock.web.reactive.function.server.MockServerRequest
 import reactor.kotlin.test.test
 
-class DefaultCommandMessageParserTest {
+class DefaultCommandMessageExtractorTest {
 
     @Test
     fun parse() {
@@ -41,15 +40,15 @@ class DefaultCommandMessageParserTest {
             .header(CommandComponent.Header.WAIT_STAGE, CommandStage.SENT.toString())
             .header(CommandComponent.Header.LOCAL_FIRST, false.toString())
             .build()
-        val commandMessageParser =
-            DefaultCommandMessageParser(
+        val commandMessageExtractor =
+            DefaultCommandMessageExtractor(
                 commandMessageFactory = SimpleCommandMessageFactory(
                     NoOpValidator,
                     SimpleCommandBuilderRewriterRegistry()
                 ),
                 commandBuilderExtractor = DefaultCommandBuilderExtractor
             )
-        commandMessageParser.parse(
+        commandMessageExtractor.extract(
             aggregateRouteMetadata = MOCK_AGGREGATE_METADATA.command.aggregateType.aggregateRouteMetadata(),
             commandBody = MockCreateAggregate(
                 id = generateGlobalId(),
@@ -75,8 +74,8 @@ class DefaultCommandMessageParserTest {
             .header(CommandComponent.Header.LOCAL_FIRST, false.toString())
             .header(key, value)
             .build()
-        val commandMessageParser =
-            DefaultCommandMessageParser(
+        val commandMessageExtractor =
+            DefaultCommandMessageExtractor(
                 commandMessageFactory = SimpleCommandMessageFactory(
                     validator = NoOpValidator,
                     commandBuilderRewriterRegistry = SimpleCommandBuilderRewriterRegistry()
@@ -86,7 +85,7 @@ class DefaultCommandMessageParserTest {
                     CommandRequestExtendHeaderAppender
                 )
             )
-        commandMessageParser.parse(
+        commandMessageExtractor.extract(
             aggregateRouteMetadata = MOCK_AGGREGATE_METADATA.command.aggregateType.aggregateRouteMetadata(),
             commandBody = MockCreateAggregate(
                 id = generateGlobalId(),


### PR DESCRIPTION
- Rename CommandMessageParser to CommandMessageExtractor
- Rename DefaultCommandMessageParser to DefaultCommandMessageExtractor
- Update related test classes
- Adjust package structure

