### PR TITLE
feat(cosec): add request ID extraction for CoSec

### DIFF
--- a/wow-cosec/src/main/kotlin/me/ahoo/wow/cosec/extractor/CoSecCommandBuilderExtractor.kt
+++ b/wow-cosec/src/main/kotlin/me/ahoo/wow/cosec/extractor/CoSecCommandBuilderExtractor.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.cosec.extractor
+
+import me.ahoo.wow.command.factory.CommandBuilder
+import me.ahoo.wow.openapi.metadata.AggregateRouteMetadata
+import me.ahoo.wow.webflux.route.command.extractor.CommandBuilderExtractor
+import me.ahoo.wow.webflux.route.command.extractor.DefaultCommandBuilderExtractor
+import org.springframework.web.reactive.function.server.ServerRequest
+import reactor.core.publisher.Mono
+
+object CoSecCommandBuilderExtractor : CommandBuilderExtractor {
+    const val REQUEST_ID_KEY = "CoSec-Request-Id"
+    override fun extract(
+        aggregateRouteMetadata: AggregateRouteMetadata<*>,
+        commandBody: Any,
+        request: ServerRequest
+    ): Mono<CommandBuilder> {
+        return DefaultCommandBuilderExtractor.extract(aggregateRouteMetadata, commandBody, request)
+            .map { commandBuilder ->
+                request.headers().firstHeader(REQUEST_ID_KEY)?.let {
+                    commandBuilder.requestIdIfAbsent(it)
+                }
+                commandBuilder
+            }
+    }
+}

--- a/wow-cosec/src/test/kotlin/me/ahoo/wow/cosec/extractor/CoSecCommandBuilderExtractorTest.kt
+++ b/wow-cosec/src/test/kotlin/me/ahoo/wow/cosec/extractor/CoSecCommandBuilderExtractorTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.cosec.extractor
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.command.wait.CommandStage
+import me.ahoo.wow.cosec.extractor.CoSecCommandBuilderExtractor.REQUEST_ID_KEY
+import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.openapi.aggregate.command.CommandComponent
+import me.ahoo.wow.openapi.metadata.aggregateRouteMetadata
+import me.ahoo.wow.serialization.MessageRecords
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
+import me.ahoo.wow.tck.mock.MockCreateAggregate
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.reactive.function.server.MockServerRequest
+
+class CoSecCommandBuilderExtractorTest {
+    @Test
+    fun extract() {
+        val request = MockServerRequest.builder()
+            .pathVariable(MessageRecords.TENANT_ID, generateGlobalId())
+            .pathVariable(MessageRecords.OWNER_ID, generateGlobalId())
+            .pathVariable(CommandComponent.Header.AGGREGATE_VERSION, 1.toString())
+            .header(CommandComponent.Header.WAIT_STAGE, CommandStage.SENT.toString())
+            .header(CommandComponent.Header.LOCAL_FIRST, false.toString())
+            .header(REQUEST_ID_KEY, generateGlobalId())
+            .build()
+        val commandBuilder = CoSecCommandBuilderExtractor.extract(
+            aggregateRouteMetadata = MOCK_AGGREGATE_METADATA.command.aggregateType.aggregateRouteMetadata(),
+            commandBody = MockCreateAggregate(
+                id = generateGlobalId(),
+                data = generateGlobalId(),
+            ),
+            request
+        ).block()
+        commandBuilder!!.requestId.assert()
+            .isEqualTo(request.headers().firstHeader(REQUEST_ID_KEY))
+    }
+}

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/cosec/CoSecAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/cosec/CoSecAutoConfiguration.kt
@@ -14,8 +14,10 @@
 package me.ahoo.wow.spring.boot.starter.cosec
 
 import me.ahoo.wow.cosec.appender.CoSecCommandRequestHeaderAppender
+import me.ahoo.wow.cosec.extractor.CoSecCommandBuilderExtractor
 import me.ahoo.wow.spring.boot.starter.ConditionalOnWowEnabled
 import me.ahoo.wow.webflux.route.command.appender.CommandRequestHeaderAppender
+import me.ahoo.wow.webflux.route.command.extractor.CommandBuilderExtractor
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.context.annotation.Bean
@@ -28,5 +30,10 @@ class CoSecAutoConfiguration {
     @Bean
     fun coSecCommandRequestHeaderAppender(): CommandRequestHeaderAppender {
         return CoSecCommandRequestHeaderAppender
+    }
+
+    @Bean
+    fun coSecCommandBuilderExtractor(): CommandBuilderExtractor {
+        return CoSecCommandBuilderExtractor
     }
 }


### PR DESCRIPTION
- Implement CoSecCommandBuilderExtractor to extract request ID from headers
- Add request ID to command builder if present
- Update CoSecAutoConfiguration to include new extractor
- Add unit tests for CoSecCommandBuilderExtractor

