### PR TITLE
refactor(annotations): migrate annotations to wow-api and deprecate wow-spring stereotypes

### DIFF
--- a/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartSaga.kt
+++ b/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartSaga.kt
@@ -15,12 +15,12 @@ package me.ahoo.wow.example.domain.cart
 
 import me.ahoo.wow.api.annotation.OnEvent
 import me.ahoo.wow.api.annotation.Retry
+import me.ahoo.wow.api.annotation.StatelessSaga
 import me.ahoo.wow.api.event.DomainEvent
 import me.ahoo.wow.command.factory.CommandBuilder
 import me.ahoo.wow.command.factory.CommandBuilder.Companion.commandBuilder
 import me.ahoo.wow.example.api.cart.RemoveCartItem
 import me.ahoo.wow.example.api.order.OrderCreated
-import me.ahoo.wow.spring.stereotype.StatelessSaga
 
 @StatelessSaga
 class CartSaga {

--- a/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/OrderSaga.kt
+++ b/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/OrderSaga.kt
@@ -13,8 +13,8 @@
 
 package me.ahoo.wow.example.domain.order
 
+import me.ahoo.wow.api.annotation.StatelessSaga
 import me.ahoo.wow.example.api.order.OrderCreated
-import me.ahoo.wow.spring.stereotype.StatelessSaga
 import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
 

--- a/example/example-server/src/main/kotlin/me/ahoo/wow/example/server/order/OrderEventProcessor.kt
+++ b/example/example-server/src/main/kotlin/me/ahoo/wow/example/server/order/OrderEventProcessor.kt
@@ -13,14 +13,14 @@
 
 package me.ahoo.wow.example.server.order
 
+import me.ahoo.wow.api.annotation.EventProcessor
 import me.ahoo.wow.example.api.order.AddressChanged
 import me.ahoo.wow.example.api.order.OrderCreated
 import me.ahoo.wow.example.api.order.OrderPaid
-import me.ahoo.wow.spring.stereotype.EventProcessorComponent
 import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
 
-@EventProcessorComponent
+@EventProcessor
 class OrderEventProcessor {
     companion object {
         private val log = LoggerFactory.getLogger(OrderEventProcessor::class.java)

--- a/example/example-server/src/main/kotlin/me/ahoo/wow/example/server/order/OrderMessageFunction.kt
+++ b/example/example-server/src/main/kotlin/me/ahoo/wow/example/server/order/OrderMessageFunction.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.example.server.order
 
+import me.ahoo.wow.api.annotation.EventProcessor
 import me.ahoo.wow.api.messaging.Message
 import me.ahoo.wow.api.messaging.function.FunctionKind
 import me.ahoo.wow.api.modeling.NamedAggregate
@@ -24,11 +25,10 @@ import me.ahoo.wow.example.domain.order.OrderState
 import me.ahoo.wow.messaging.function.MessageFunction
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.modeling.materialize
-import me.ahoo.wow.spring.stereotype.EventProcessorComponent
 import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
 
-@EventProcessorComponent
+@EventProcessor
 class OrderMessageFunction : MessageFunction<Any, DomainEventExchange<Any>, Mono<Void>> {
     companion object {
         private val log = LoggerFactory.getLogger(OrderMessageFunction::class.java)

--- a/example/example-server/src/main/kotlin/me/ahoo/wow/example/server/order/OrderProjector.kt
+++ b/example/example-server/src/main/kotlin/me/ahoo/wow/example/server/order/OrderProjector.kt
@@ -14,17 +14,17 @@
 package me.ahoo.wow.example.server.order
 
 import me.ahoo.wow.api.annotation.Blocking
+import me.ahoo.wow.api.annotation.ProjectionProcessor
 import me.ahoo.wow.example.api.order.AddressChanged
 import me.ahoo.wow.example.api.order.OrderCreated
 import me.ahoo.wow.example.api.order.OrderPaid
 import me.ahoo.wow.example.domain.order.OrderState
 import me.ahoo.wow.modeling.state.ReadOnlyStateAggregate
 import me.ahoo.wow.serialization.toJsonString
-import me.ahoo.wow.spring.stereotype.ProjectionProcessorComponent
 import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
 
-@ProjectionProcessorComponent
+@ProjectionProcessor
 class OrderProjector {
     companion object {
         private val log = LoggerFactory.getLogger(OrderProjector::class.java)

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/EventProcessor.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/EventProcessor.kt
@@ -13,9 +13,11 @@
 
 package me.ahoo.wow.api.annotation
 
+import org.springframework.stereotype.Component
 import java.lang.annotation.Inherited
 
 @Target(AnnotationTarget.CLASS, AnnotationTarget.ANNOTATION_CLASS)
 @Inherited
 @MustBeDocumented
+@Component
 annotation class EventProcessor

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/ProjectionProcessor.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/ProjectionProcessor.kt
@@ -13,9 +13,11 @@
 
 package me.ahoo.wow.api.annotation
 
+import org.springframework.stereotype.Component
 import java.lang.annotation.Inherited
 
 @Target(AnnotationTarget.CLASS, AnnotationTarget.ANNOTATION_CLASS)
 @Inherited
 @MustBeDocumented
+@Component
 annotation class ProjectionProcessor

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/StatelessSaga.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/StatelessSaga.kt
@@ -13,9 +13,11 @@
 
 package me.ahoo.wow.api.annotation
 
+import org.springframework.stereotype.Component
 import java.lang.annotation.Inherited
 
 @Target(AnnotationTarget.CLASS, AnnotationTarget.ANNOTATION_CLASS)
 @Inherited
 @MustBeDocumented
+@Component
 annotation class StatelessSaga

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/stereotype/EventProcessor.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/stereotype/EventProcessor.kt
@@ -26,6 +26,13 @@ import org.springframework.stereotype.Component
 )
 annotation class EventProcessor
 
+@Deprecated(
+    message = "Use EventProcessor instead.",
+    replaceWith = ReplaceWith(
+        expression = "EventProcessor",
+        imports = ["me.ahoo.wow.api.annotation.EventProcessor"]
+    )
+)
 @Component
 @me.ahoo.wow.api.annotation.EventProcessor
 annotation class EventProcessorComponent

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/stereotype/ProjectionProcessor.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/stereotype/ProjectionProcessor.kt
@@ -29,6 +29,13 @@ import org.springframework.stereotype.Component
 )
 annotation class ProjectionProcessor
 
+@Deprecated(
+    message = "Use ProjectionProcessor instead.",
+    replaceWith = ReplaceWith(
+        expression = "ProjectionProcessor",
+        imports = ["me.ahoo.wow.api.annotation.ProjectionProcessor"]
+    )
+)
 @Component
 @me.ahoo.wow.api.annotation.ProjectionProcessor
 annotation class ProjectionProcessorComponent

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/stereotype/StatelessSaga.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/stereotype/StatelessSaga.kt
@@ -26,6 +26,13 @@ import org.springframework.stereotype.Component
 )
 annotation class StatelessSaga
 
+@Deprecated(
+    message = "Use StatelessSaga instead.",
+    replaceWith = ReplaceWith(
+        expression = "StatelessSaga",
+        imports = ["me.ahoo.wow.api.annotation.StatelessSaga"]
+    )
+)
 @Component
 @me.ahoo.wow.api.annotation.StatelessSaga
 annotation class StatelessSagaComponent


### PR DESCRIPTION
- Move @EventProcessor, @ProjectionProcessor, and @StatelessSaga annotations to wow-api
- Add @Component annotation to wow-api annotations for automatic component scanning
- Deprecate corresponding annotations in wow-spring, marking them for removal
- Update example usage to use new wow-api annotations
- Remove redundant spring.stereotype imports in example files

