### PR TITLE
feat(prepare): auto discover and register PrepareKey

### DIFF
--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareAutoConfiguration.kt
@@ -20,11 +20,13 @@ import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
 
 @AutoConfiguration
 @ConditionalOnWowEnabled
 @ConditionalOnPrepareEnabled
 @EnableConfigurationProperties(PrepareProperties::class)
+@Import(PrepareKeyAutoRegistrar::class)
 class PrepareAutoConfiguration {
     @Bean
     @ConditionalOnBean(PrepareKeyFactory::class)

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareKeyAutoRegistrar.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareKeyAutoRegistrar.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.spring.boot.starter.prepare
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import me.ahoo.wow.api.annotation.PreparableKey
+import me.ahoo.wow.infra.prepare.proxy.prepareKeyMetadata
+import me.ahoo.wow.spring.prepare.PrepareKeyFactoryBean
+import org.springframework.beans.factory.BeanFactory
+import org.springframework.beans.factory.BeanFactoryAware
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition
+import org.springframework.beans.factory.support.BeanDefinitionBuilder
+import org.springframework.beans.factory.support.BeanDefinitionRegistry
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages
+import org.springframework.context.EnvironmentAware
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
+import org.springframework.context.annotation.ImportBeanDefinitionRegistrar
+import org.springframework.core.env.Environment
+import org.springframework.core.type.AnnotationMetadata
+import org.springframework.core.type.filter.AnnotationTypeFilter
+
+class PrepareKeyAutoRegistrar : ImportBeanDefinitionRegistrar, EnvironmentAware, BeanFactoryAware {
+    companion object {
+        private val logger = KotlinLogging.logger { }
+    }
+
+    private lateinit var env: Environment
+    private lateinit var beanFactory: BeanFactory
+    override fun setEnvironment(environment: Environment) {
+        this.env = environment
+    }
+
+    override fun setBeanFactory(beanFactory: BeanFactory) {
+        this.beanFactory = beanFactory
+    }
+
+    override fun registerBeanDefinitions(importingClassMetadata: AnnotationMetadata, registry: BeanDefinitionRegistry) {
+        if (!AutoConfigurationPackages.has(beanFactory)) {
+            logger.info { "Auto-configuration packages have not been registered" }
+            return
+        }
+        val basePackages = AutoConfigurationPackages.get(this.beanFactory)
+        val scanner = Scanner(false, env)
+        for (basePackage in basePackages) {
+            val candidates = scanner.findCandidateComponents(basePackage)
+            for (candidate in candidates) {
+                val beanClass = Class.forName(candidate.beanClassName)
+                val prepareKeyMetadata = beanClass.kotlin.prepareKeyMetadata()
+                val beanDefinitionBuilder =
+                    BeanDefinitionBuilder.genericBeanDefinition(PrepareKeyFactoryBean::class.java)
+                        .addConstructorArgValue(prepareKeyMetadata)
+                registry.registerBeanDefinition(prepareKeyMetadata.name, beanDefinitionBuilder.beanDefinition)
+                logger.info { "Register PrepareKey: ${prepareKeyMetadata.name}" }
+            }
+        }
+    }
+
+    class Scanner(useDefaultFilters: Boolean, environment: Environment) :
+        ClassPathScanningCandidateComponentProvider(useDefaultFilters, environment) {
+        init {
+            addIncludeFilter(AnnotationTypeFilter(PreparableKey::class.java))
+        }
+
+        override fun isCandidateComponent(beanDefinition: AnnotatedBeanDefinition): Boolean {
+            return beanDefinition.metadata.isInterface
+        }
+    }
+}

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareAutoConfigurationTest.kt
@@ -14,11 +14,37 @@
 package me.ahoo.wow.spring.boot.starter.prepare
 
 import io.mockk.mockk
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.annotation.PreparableKey
+import me.ahoo.wow.infra.prepare.PrepareKey
 import me.ahoo.wow.infra.prepare.PrepareKeyFactory
 import me.ahoo.wow.infra.prepare.proxy.PrepareKeyProxyFactory
+import me.ahoo.wow.spring.boot.starter.command.CommandAutoConfiguration
+import me.ahoo.wow.spring.boot.starter.command.CommandGatewayAutoConfiguration
+import me.ahoo.wow.spring.boot.starter.compensation.CompensationAutoConfiguration
 import me.ahoo.wow.spring.boot.starter.enableWow
+import me.ahoo.wow.spring.boot.starter.event.EventAutoConfiguration
+import me.ahoo.wow.spring.boot.starter.event.EventDispatcherAutoConfiguration
+import me.ahoo.wow.spring.boot.starter.eventsourcing.EventSourcingAutoConfiguration
+import me.ahoo.wow.spring.boot.starter.eventsourcing.snapshot.SnapshotAutoConfiguration
+import me.ahoo.wow.spring.boot.starter.eventsourcing.state.StateAutoConfiguration
+import me.ahoo.wow.spring.boot.starter.eventsourcing.store.EventStoreAutoConfiguration
+import me.ahoo.wow.spring.boot.starter.kafka.KafkaAutoConfiguration
+import me.ahoo.wow.spring.boot.starter.metrics.MetricsAutoConfiguration
+import me.ahoo.wow.spring.boot.starter.modeling.AggregateAutoConfiguration
+import me.ahoo.wow.spring.boot.starter.mongo.MongoEventSourcingAutoConfiguration
+import me.ahoo.wow.spring.boot.starter.openapi.OpenAPIAutoConfiguration
+import me.ahoo.wow.spring.boot.starter.opentelemetry.WowOpenTelemetryAutoConfiguration
+import me.ahoo.wow.spring.boot.starter.projection.ProjectionDispatcherAutoConfiguration
+import me.ahoo.wow.spring.boot.starter.query.QueryAutoConfiguration
+import me.ahoo.wow.spring.boot.starter.r2dbc.R2dbcAutoConfiguration
+import me.ahoo.wow.spring.boot.starter.saga.StatelessSagaAutoConfiguration
+import me.ahoo.wow.spring.boot.starter.webflux.WebFluxAutoConfiguration
+import me.ahoo.wow.spring.boot.starter.webflux.WowWebClientAutoConfiguration
 import org.assertj.core.api.AssertionsForInterfaceTypes
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.getBean
+import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 
@@ -39,4 +65,63 @@ class PrepareAutoConfigurationTest {
                     .hasSingleBean(PrepareProperties::class.java)
             }
     }
+
+    @Test
+    fun contextLoadsWithAutoConfiguration() {
+        val prepareKeyFactory = object : PrepareKeyFactory {
+            override fun <V : Any> create(
+                name: String,
+                valueClass: Class<V>
+            ): PrepareKey<V> {
+                return mockk()
+            }
+        }
+        contextRunner
+            .enableWow()
+            .withBean(PrepareKeyFactory::class.java, {
+                prepareKeyFactory
+            })
+            .withUserConfiguration(EnablePrepareConfiguration::class.java)
+            .withUserConfiguration(PrepareAutoConfiguration::class.java)
+            .withClassLoader(this.javaClass.classLoader)
+            .run { context: AssertableApplicationContext ->
+                AssertionsForInterfaceTypes.assertThat(context)
+                    .hasSingleBean(PrepareKeyProxyFactory::class.java)
+                    .hasSingleBean(PrepareProperties::class.java)
+                    .hasSingleBean(MockPrepareKey::class.java)
+                val mockPrepareKey = context.getBean<MockPrepareKey>()
+                mockPrepareKey.assert().isNotNull()
+            }
+    }
 }
+
+@SpringBootApplication(
+    exclude = [
+        CommandAutoConfiguration::class,
+        EventAutoConfiguration::class,
+        EventDispatcherAutoConfiguration::class,
+        AggregateAutoConfiguration::class,
+        EventSourcingAutoConfiguration::class,
+        EventStoreAutoConfiguration::class,
+        StateAutoConfiguration::class,
+        SnapshotAutoConfiguration::class,
+        MongoEventSourcingAutoConfiguration::class,
+        KafkaAutoConfiguration::class,
+        ProjectionDispatcherAutoConfiguration::class,
+        StatelessSagaAutoConfiguration::class,
+        MetricsAutoConfiguration::class,
+        CommandGatewayAutoConfiguration::class,
+        WowOpenTelemetryAutoConfiguration::class,
+        R2dbcAutoConfiguration::class,
+        org.springframework.boot.autoconfigure.r2dbc.R2dbcAutoConfiguration::class,
+        OpenAPIAutoConfiguration::class,
+        WebFluxAutoConfiguration::class,
+        WowWebClientAutoConfiguration::class,
+        CompensationAutoConfiguration::class,
+        QueryAutoConfiguration::class,
+    ]
+)
+class EnablePrepareConfiguration
+
+@PreparableKey
+interface MockPrepareKey : PrepareKey<String>

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/prepare/PrepareKeyFactoryBean.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/prepare/PrepareKeyFactoryBean.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.spring.prepare
+
+import me.ahoo.wow.infra.prepare.PrepareKey
+import me.ahoo.wow.infra.prepare.proxy.PrepareKeyMetadata
+import me.ahoo.wow.infra.prepare.proxy.PrepareKeyProxyFactory
+import org.springframework.beans.factory.FactoryBean
+import org.springframework.beans.factory.getBean
+import org.springframework.context.ApplicationContext
+import org.springframework.context.ApplicationContextAware
+
+class PrepareKeyFactoryBean<P : PrepareKey<*>>(private val metadata: PrepareKeyMetadata<P>) :
+    FactoryBean<P>,
+    ApplicationContextAware {
+    private lateinit var appContext: ApplicationContext
+    override fun setApplicationContext(applicationContext: ApplicationContext) {
+        this.appContext = applicationContext
+    }
+
+    override fun getObject(): P? {
+        val prepareKeyProxyFactory = appContext.getBean<PrepareKeyProxyFactory>()
+        return prepareKeyProxyFactory.create(metadata)
+    }
+
+    override fun getObjectType(): Class<*> {
+        return metadata.proxyInterface.java
+    }
+}


### PR DESCRIPTION
- Add PrepareKeyAutoRegistrar to scan for PrepareKey interfaces
- Implement PrepareKeyFactoryBean to create PrepareKey instances
- Update PrepareAutoConfiguration to import PrepareKeyAutoRegistrar
- Add tests for PrepareAutoConfiguration with new auto-registration functionality
