### PR TITLE
feat(prepare): support customize base packages for prepare key scan

### DIFF
--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareKeyAutoRegistrar.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareKeyAutoRegistrar.kt
@@ -84,6 +84,10 @@ class PrepareKeyAutoRegistrar : ImportBeanDefinitionRegistrar, EnvironmentAware,
             for (candidate in candidates) {
                 val beanClass = Class.forName(candidate.beanClassName)
                 val prepareKeyMetadata = beanClass.kotlin.prepareKeyMetadata()
+                if (registry.containsBeanDefinition(prepareKeyMetadata.name)) {
+                    logger.info { "PrepareKey: ${prepareKeyMetadata.name} already exists" }
+                    continue
+                }
                 val beanDefinitionBuilder =
                     BeanDefinitionBuilder.genericBeanDefinition(PrepareKeyFactoryBean::class.java)
                         .addConstructorArgValue(prepareKeyMetadata)

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareProperties.kt
@@ -21,11 +21,13 @@ import org.springframework.boot.context.properties.bind.DefaultValue
 @ConfigurationProperties(prefix = PrepareProperties.PREFIX)
 class PrepareProperties(
     @DefaultValue("true") override var enabled: Boolean = true,
-    var storage: PrepareStorage = PrepareStorage.MONGO
+    var storage: PrepareStorage = PrepareStorage.MONGO,
+    var basePackages: List<String> = emptyList(),
 ) : EnabledCapable {
     companion object {
         const val PREFIX = "${Wow.WOW_PREFIX}prepare"
         const val STORAGE = "$PREFIX.storage"
+        const val BASE_PACKAGES = "$PREFIX.base-packages"
     }
 }
 

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareAutoConfigurationTest.kt
@@ -78,6 +78,44 @@ class PrepareAutoConfigurationTest {
         }
         contextRunner
             .enableWow()
+            .withPropertyValues(
+                "${PrepareProperties.BASE_PACKAGES}=me.ahoo.wow.spring.boot.starter.prepare" +
+                    ",me.ahoo.wow.spring.boot.starter.prepare"
+            )
+            .withBean(PrepareKeyFactory::class.java, {
+                prepareKeyFactory
+            })
+            .withUserConfiguration(EnablePrepareConfiguration::class.java)
+            .withUserConfiguration(PrepareAutoConfiguration::class.java)
+            .withClassLoader(this.javaClass.classLoader)
+            .run { context: AssertableApplicationContext ->
+                AssertionsForInterfaceTypes.assertThat(context)
+                    .hasSingleBean(PrepareKeyProxyFactory::class.java)
+                    .hasSingleBean(PrepareProperties::class.java)
+                    .hasSingleBean(MockPrepareKey::class.java)
+                val mockPrepareKey = context.getBean<MockPrepareKey>()
+                mockPrepareKey.assert().isNotNull()
+            }
+    }
+
+    @Test
+    fun contextLoadsWithAutoConfigurationArray() {
+        val prepareKeyFactory = object : PrepareKeyFactory {
+            override fun <V : Any> create(
+                name: String,
+                valueClass: Class<V>
+            ): PrepareKey<V> {
+                return mockk()
+            }
+        }
+        contextRunner
+            .enableWow()
+            .withPropertyValues(
+                "${PrepareProperties.BASE_PACKAGES}[0]=me.ahoo.wow.spring.boot.starter.prepare"
+            )
+            .withPropertyValues(
+                "${PrepareProperties.BASE_PACKAGES}[1]=me.ahoo.wow.spring.boot.starter.prepare"
+            )
             .withBean(PrepareKeyFactory::class.java, {
                 prepareKeyFactory
             })


### PR DESCRIPTION
- Add `basePackages` property to `PrepareProperties` class
- Implement logic to read base packages from properties in `PrepareKeyAutoRegistrar`
- Update test cases to cover new functionality

