### PR TITLE
feat(core): implement Copyable interface for SimpleServiceProvider

### DIFF
--- a/.idea/modules/compensation/wow-compensation-server/Wow.wow-compensation-server.main.iml
+++ b/.idea/modules/compensation/wow-compensation-server/Wow.wow-compensation-server.main.iml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="CheckStyle-IDEA-Module" serialisationVersion="2">
+    <option name="activeLocationsIds" />
+  </component>
+</module>

--- a/.idea/modules/test/wow-test/Wow.wow-test.main.iml
+++ b/.idea/modules/test/wow-test/Wow.wow-test.main.iml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="CheckStyle-IDEA-Module" serialisationVersion="2">
+    <option name="activeLocationsIds" />
+  </component>
+</module>

--- a/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/order/OrchestrationTest.kt
+++ b/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/order/OrchestrationTest.kt
@@ -25,8 +25,7 @@ import me.ahoo.wow.example.domain.order.OrderFixture.SHIPPING_ADDRESS
 import me.ahoo.wow.example.domain.order.infra.InventoryService
 import me.ahoo.wow.example.domain.order.infra.PricingService
 import me.ahoo.wow.id.generateGlobalId
-import me.ahoo.wow.test.aggregate.ExpectedResult
-import me.ahoo.wow.test.aggregate.GivenStage
+import me.ahoo.wow.test.aggregate.VerifiedStage
 import me.ahoo.wow.test.aggregate.whenCommand
 import me.ahoo.wow.test.aggregateVerifier
 import org.junit.jupiter.api.Test
@@ -80,16 +79,16 @@ class OrchestrationTest {
             }
             .verify()
             .fork {
-                changeAddress(it)
+                changeAddress()
             }.fork {
-                payOrder(it)
+                payOrder()
             }
     }
 
-    private fun GivenStage<OrderState>.payOrder(it: ExpectedResult<OrderState>) {
+    private fun VerifiedStage<OrderState>.payOrder() {
         val payOrder = PayOrder(
-            it.stateAggregate.aggregateId.id,
-            it.stateAggregate.state.payable
+            stateAggregate.aggregateId.id,
+            stateAggregate.state.payable
         )
         whenCommand(payOrder)
             .expectEventType(OrderPaid::class)
@@ -100,7 +99,7 @@ class OrchestrationTest {
             .verify()
     }
 
-    private fun GivenStage<OrderState>.changeAddress(it: ExpectedResult<OrderState>) {
+    private fun VerifiedStage<OrderState>.changeAddress() {
         val changeAddress = ChangeAddress(
             ShippingAddress(
                 country = "China",

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/VerifiedStage.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/VerifiedStage.kt
@@ -14,11 +14,11 @@
 package me.ahoo.wow.test.aggregate
 
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.Copyable
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.eventsourcing.InMemoryEventStore
 import me.ahoo.wow.ioc.ServiceProvider
-import me.ahoo.wow.ioc.SimpleServiceProvider
 import me.ahoo.wow.modeling.command.CommandAggregateFactory
 import me.ahoo.wow.modeling.command.SimpleCommandAggregateFactory
 import me.ahoo.wow.modeling.matedata.AggregateMetadata
@@ -44,8 +44,8 @@ interface VerifiedStage<S : Any> : GivenStage<S> {
     fun fork(
         verifyError: Boolean = false,
         serviceProviderSupplier: (ServiceProvider) -> ServiceProvider = {
-            require(it is SimpleServiceProvider)
-            it.copy()
+            require(it is Copyable<*>)
+            it.copy() as ServiceProvider
         },
         commandAggregateFactorySupplier: () -> CommandAggregateFactory = {
             SimpleCommandAggregateFactory(InMemoryEventStore())

--- a/wow-core/src/main/kotlin/me/ahoo/wow/ioc/SimpleServiceProvider.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/ioc/SimpleServiceProvider.kt
@@ -12,12 +12,13 @@
  */
 package me.ahoo.wow.ioc
 
+import me.ahoo.wow.api.Copyable
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KType
 import kotlin.reflect.full.defaultType
 import kotlin.reflect.full.isSubtypeOf
 
-class SimpleServiceProvider : ServiceProvider {
+class SimpleServiceProvider : ServiceProvider, Copyable<SimpleServiceProvider> {
     private val typedServices: ConcurrentHashMap<KType, Any> = ConcurrentHashMap<KType, Any>()
     private val namedServices: ConcurrentHashMap<String, Any> = ConcurrentHashMap<String, Any>()
 
@@ -43,7 +44,7 @@ class SimpleServiceProvider : ServiceProvider {
         return namedServices[serviceName] as S?
     }
 
-    fun copy(): SimpleServiceProvider {
+    override fun copy(): SimpleServiceProvider {
         val copy = SimpleServiceProvider()
         copy.typedServices.putAll(typedServices)
         copy.namedServices.putAll(namedServices)


### PR DESCRIPTION
- Add Copyable<SimpleServiceProvider> implementation to SimpleServiceProvider class
- Override copy() function to create a deep copy of the service provider
- Update VerifiedStage interface to extend GivenStage
- Modify then() function signatures to return VerifiedStage instead of GivenStage
- Update handle function parameters to use VerifiedStage instead of GivenStage

