### PR TITLE
refactor(ioc): implement Copyable interface for ServiceProvider

### DIFF
--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/VerifiedStage.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/VerifiedStage.kt
@@ -14,7 +14,6 @@
 package me.ahoo.wow.test.aggregate
 
 import me.ahoo.test.asserts.assert
-import me.ahoo.wow.api.Copyable
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.eventsourcing.InMemoryEventStore
@@ -98,11 +97,7 @@ internal class DefaultVerifiedStage<C : Any, S : Any>(
             stateAggregate = forkedStateAggregate,
             domainEventStream = forkedEventStream
         )
-        val forkedServiceProvider = if (serviceProvider is Copyable<*>) {
-            serviceProvider.copy() as ServiceProvider
-        } else {
-            serviceProvider
-        }
+        val forkedServiceProvider = serviceProvider.copy()
         val forkedCommandAggregateFactory = SimpleCommandAggregateFactory(InMemoryEventStore())
         val forkedVerifiedStage = DefaultVerifiedStage(
             verifiedResult = forkedResult,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/ioc/ServiceProvider.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/ioc/ServiceProvider.kt
@@ -12,6 +12,7 @@
  */
 package me.ahoo.wow.ioc
 
+import me.ahoo.wow.api.Copyable
 import me.ahoo.wow.naming.annotation.toName
 import kotlin.reflect.KType
 import kotlin.reflect.full.defaultType
@@ -22,7 +23,7 @@ import kotlin.reflect.typeOf
  *
  * @author ahoo wang
  */
-interface ServiceProvider {
+interface ServiceProvider : Copyable<ServiceProvider> {
     fun register(
         service: Any,
         serviceName: String = service.javaClass.toName(),

--- a/wow-core/src/main/kotlin/me/ahoo/wow/ioc/SimpleServiceProvider.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/ioc/SimpleServiceProvider.kt
@@ -12,13 +12,12 @@
  */
 package me.ahoo.wow.ioc
 
-import me.ahoo.wow.api.Copyable
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KType
 import kotlin.reflect.full.defaultType
 import kotlin.reflect.full.isSubtypeOf
 
-class SimpleServiceProvider : ServiceProvider, Copyable<SimpleServiceProvider> {
+class SimpleServiceProvider : ServiceProvider {
     private val typedServices: ConcurrentHashMap<KType, Any> = ConcurrentHashMap<KType, Any>()
     private val namedServices: ConcurrentHashMap<String, Any> = ConcurrentHashMap<String, Any>()
 

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/SpringServiceProvider.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/SpringServiceProvider.kt
@@ -16,6 +16,7 @@ package me.ahoo.wow.spring
 import me.ahoo.wow.infra.Decorator
 import me.ahoo.wow.ioc.ServiceProvider
 import org.springframework.beans.factory.config.ConfigurableBeanFactory
+import org.springframework.beans.factory.support.DefaultListableBeanFactory
 import org.springframework.core.ResolvableType
 import kotlin.reflect.KType
 import kotlin.reflect.jvm.javaType
@@ -36,5 +37,16 @@ class SpringServiceProvider(override val delegate: ConfigurableBeanFactory) :
     @Suppress("UNCHECKED_CAST")
     override fun <S : Any> getService(serviceName: String): S? {
         return delegate.getBean(serviceName) as S?
+    }
+
+    override fun copy(): ServiceProvider {
+        val newBeanFactory = DefaultListableBeanFactory()
+        newBeanFactory.copyConfigurationFrom(delegate)
+        delegate.copyConfigurationFrom(delegate)
+        delegate.singletonNames.forEach {
+            val bean = delegate.getBean(it)
+            newBeanFactory.registerSingleton(it, bean)
+        }
+        return SpringServiceProvider(newBeanFactory)
     }
 }

--- a/wow-spring/src/test/kotlin/me/ahoo/wow/spring/SpringServiceProviderTest.kt
+++ b/wow-spring/src/test/kotlin/me/ahoo/wow/spring/SpringServiceProviderTest.kt
@@ -18,5 +18,8 @@ class SpringServiceProviderTest {
         serviceProvider.register(this, serviceType = typeOf<SpringServiceProviderTest>())
         serviceProvider.getRequiredService<SpringServiceProviderTest>().assert().isSameAs(this)
         serviceProvider.getOriginalDelegate().assert().isSameAs(beanFactory)
+
+        val copiedServiceProvider = serviceProvider.copy()
+        copiedServiceProvider.getRequiredService<SpringServiceProviderTest>().assert().isSameAs(this)
     }
 }


### PR DESCRIPTION
- Add Copyable<ServiceProvider> interface to ServiceProvider
- Remove Copyable implementation from SimpleServiceProvider
- Implement copy() method in SpringServiceProvider
- Update test cases to cover new copy functionality
- Simplify serviceProvider copying in VerifiedStage

