### PR TITLE
feat(ioc): add serviceNames property to ServiceProvider

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/ioc/ServiceProvider.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/ioc/ServiceProvider.kt
@@ -24,6 +24,8 @@ import kotlin.reflect.typeOf
  * @author ahoo wang
  */
 interface ServiceProvider : Copyable<ServiceProvider> {
+    val serviceNames: Set<String>
+
     fun register(
         service: Any,
         serviceName: String = service.javaClass.toName(),
@@ -31,7 +33,6 @@ interface ServiceProvider : Copyable<ServiceProvider> {
     )
 
     fun <S : Any> getService(serviceType: KType): S?
-
     fun <S : Any> getService(serviceName: String): S?
 }
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/ioc/SimpleServiceProvider.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/ioc/SimpleServiceProvider.kt
@@ -20,6 +20,8 @@ import kotlin.reflect.full.isSubtypeOf
 class SimpleServiceProvider : ServiceProvider {
     private val typedServices: ConcurrentHashMap<KType, Any> = ConcurrentHashMap<KType, Any>()
     private val namedServices: ConcurrentHashMap<String, Any> = ConcurrentHashMap<String, Any>()
+    override val serviceNames: Set<String>
+        get() = namedServices.keys
 
     override fun register(service: Any, serviceName: String, serviceType: KType) {
         typedServices[serviceType] = service

--- a/wow-core/src/test/kotlin/me/ahoo/wow/ioc/SimpleServiceProviderTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/ioc/SimpleServiceProviderTest.kt
@@ -17,6 +17,7 @@ class SimpleServiceProviderTest {
     fun getService() {
         val serviceProvider = SimpleServiceProvider()
         serviceProvider.register<SimpleServiceProviderTest>(this)
+        serviceProvider.serviceNames.assert().contains(SERVICE_NAME)
         serviceProvider.getRequiredService<SimpleServiceProviderTest>().assert().isSameAs(this)
         serviceProvider.getRequiredService<SimpleServiceProviderTest>(SERVICE_NAME).assert().isSameAs(this)
 

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/SpringServiceProvider.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/SpringServiceProvider.kt
@@ -25,6 +25,9 @@ class SpringServiceProvider(override val delegate: ConfigurableBeanFactory) :
     ServiceProvider,
     Decorator<ConfigurableBeanFactory> {
 
+    override val serviceNames: Set<String>
+        get() = delegate.singletonNames.toSet()
+
     override fun register(service: Any, serviceName: String, serviceType: KType) {
         delegate.registerSingleton(serviceName, service)
     }

--- a/wow-spring/src/test/kotlin/me/ahoo/wow/spring/SpringServiceProviderTest.kt
+++ b/wow-spring/src/test/kotlin/me/ahoo/wow/spring/SpringServiceProviderTest.kt
@@ -4,6 +4,7 @@ import me.ahoo.test.asserts.assert
 import me.ahoo.wow.infra.Decorator.Companion.getOriginalDelegate
 import me.ahoo.wow.ioc.getRequiredService
 import me.ahoo.wow.ioc.getService
+import me.ahoo.wow.naming.annotation.toName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.support.DefaultListableBeanFactory
 import kotlin.reflect.typeOf
@@ -16,6 +17,7 @@ class SpringServiceProviderTest {
         val serviceProvider = SpringServiceProvider(beanFactory)
         serviceProvider.getService<SpringServiceProviderTest>().assert().isNull()
         serviceProvider.register(this, serviceType = typeOf<SpringServiceProviderTest>())
+        serviceProvider.serviceNames.assert().contains(SpringServiceProviderTest::class.java.toName())
         serviceProvider.getRequiredService<SpringServiceProviderTest>().assert().isSameAs(this)
         serviceProvider.getOriginalDelegate().assert().isSameAs(beanFactory)
 


### PR DESCRIPTION
- Add serviceNames property to ServiceProvider interface
- Implement serviceNames in SimpleServiceProvider and SpringServiceProvider
- Add unit tests for serviceNames in both SimpleServiceProvider and SpringServiceProvider

