### PR TITLE
refactor(test): replace Consumer with lambda in expect methods

### DIFF
--- a/compensation/wow-compensation-domain/src/test/kotlin/me/ahoo/wow/compensation/domain/ExecutionFailedTest.kt
+++ b/compensation/wow-compensation-domain/src/test/kotlin/me/ahoo/wow/compensation/domain/ExecutionFailedTest.kt
@@ -78,18 +78,18 @@ class ExecutionFailedTest {
             .expectNoError()
             .expectEventType(ExecutionFailedCreated::class.java)
             .expectState {
-                it.eventId.assert().isEqualTo(createExecutionFailed.eventId)
-                it.function.assert().isEqualTo(createExecutionFailed.function)
-                it.error.assert().isEqualTo(createExecutionFailed.error)
-                it.executeAt.assert().isEqualTo(createExecutionFailed.executeAt)
-                it.status.assert().isEqualTo(ExecutionFailedStatus.FAILED)
-                it.retryState.retries.assert().isZero()
-                it.isRetryable.assert().isTrue()
-                it.retryState.timeout().assert().isFalse()
-                it.retrySpec.assert().isEqualTo(DefaultNextRetryAtCalculatorTest.testRetrySpec)
-                it.canRetry().assert().isTrue()
-                it.canNextRetry().assert().isFalse()
-                it.recoverable.assert().isEqualTo(createExecutionFailed.recoverable)
+                eventId.assert().isEqualTo(createExecutionFailed.eventId)
+                function.assert().isEqualTo(createExecutionFailed.function)
+                error.assert().isEqualTo(createExecutionFailed.error)
+                executeAt.assert().isEqualTo(createExecutionFailed.executeAt)
+                status.assert().isEqualTo(ExecutionFailedStatus.FAILED)
+                retryState.retries.assert().isZero()
+                isRetryable.assert().isTrue()
+                retryState.timeout().assert().isFalse()
+                retrySpec.assert().isEqualTo(DefaultNextRetryAtCalculatorTest.testRetrySpec)
+                canRetry().assert().isTrue()
+                canNextRetry().assert().isFalse()
+                recoverable.assert().isEqualTo(createExecutionFailed.recoverable)
             }
             .verify()
     }
@@ -114,18 +114,18 @@ class ExecutionFailedTest {
             .expectNoError()
             .expectEventType(ExecutionFailedCreated::class.java)
             .expectState {
-                it.eventId.assert().isEqualTo(createExecutionFailed.eventId)
-                it.function.assert().isEqualTo(createExecutionFailed.function)
-                it.error.assert().isEqualTo(createExecutionFailed.error)
-                it.executeAt.assert().isEqualTo(createExecutionFailed.executeAt)
-                it.status.assert().isEqualTo(ExecutionFailedStatus.FAILED)
-                it.retryState.retries.assert().isZero()
-                it.isRetryable.assert().isTrue()
-                it.retryState.timeout().assert().isFalse()
-                it.retrySpec.assert().isEqualTo(createExecutionFailed.retrySpec)
-                it.canRetry().assert().isTrue()
-                it.canNextRetry().assert().isFalse()
-                it.recoverable.assert().isEqualTo(createExecutionFailed.recoverable)
+                eventId.assert().isEqualTo(createExecutionFailed.eventId)
+                function.assert().isEqualTo(createExecutionFailed.function)
+                error.assert().isEqualTo(createExecutionFailed.error)
+                executeAt.assert().isEqualTo(createExecutionFailed.executeAt)
+                status.assert().isEqualTo(ExecutionFailedStatus.FAILED)
+                retryState.retries.assert().isZero()
+                isRetryable.assert().isTrue()
+                retryState.timeout().assert().isFalse()
+                retrySpec.assert().isEqualTo(createExecutionFailed.retrySpec)
+                canRetry().assert().isTrue()
+                canNextRetry().assert().isFalse()
+                recoverable.assert().isEqualTo(createExecutionFailed.recoverable)
             }
             .verify()
     }
@@ -149,24 +149,24 @@ class ExecutionFailedTest {
             .expectNoError()
             .expectEventType(CompensationPrepared::class.java)
             .expectEventBody<CompensationPrepared> {
-                it.eventId.assert().isEqualTo(executionFailedCreated.eventId)
-                it.function.assert().isEqualTo(executionFailedCreated.function)
-                it.retryState.retries.assert().isEqualTo(executionFailedCreated.retryState.retries + 1)
+                eventId.assert().isEqualTo(executionFailedCreated.eventId)
+                function.assert().isEqualTo(executionFailedCreated.function)
+                retryState.retries.assert().isEqualTo(executionFailedCreated.retryState.retries + 1)
             }
             .expectState {
-                it.id.assert().isEqualTo(prepareCompensation.id)
-                it.status.assert().isEqualTo(ExecutionFailedStatus.PREPARED)
-                it.retryState.retries.assert().isEqualTo(executionFailedCreated.retryState.retries + 1)
-                it.eventId.assert().isEqualTo(executionFailedCreated.eventId)
-                it.function.assert().isEqualTo(executionFailedCreated.function)
-                it.canRetry().assert().isFalse()
+                id.assert().isEqualTo(prepareCompensation.id)
+                status.assert().isEqualTo(ExecutionFailedStatus.PREPARED)
+                retryState.retries.assert().isEqualTo(executionFailedCreated.retryState.retries + 1)
+                eventId.assert().isEqualTo(executionFailedCreated.eventId)
+                function.assert().isEqualTo(executionFailedCreated.function)
+                canRetry().assert().isFalse()
             }
             .verify()
             .fork {
                 whenCommand(prepareCompensation)
                     .expectErrorType(IllegalStateException::class.java)
                     .expectState {
-                        it.status.assert().isEqualTo(ExecutionFailedStatus.PREPARED)
+                        status.assert().isEqualTo(ExecutionFailedStatus.PREPARED)
                     }
                     .verify()
             }
@@ -193,10 +193,10 @@ class ExecutionFailedTest {
             .whenCommand(prepareCompensation)
             .expectErrorType(IllegalStateException::class.java)
             .expectState {
-                it.id.assert().isEqualTo(prepareCompensation.id)
-                it.status.assert().isEqualTo(ExecutionFailedStatus.FAILED)
-                it.retryState.retries.assert().isEqualTo(10)
-                it.canRetry().assert().isFalse()
+                id.assert().isEqualTo(prepareCompensation.id)
+                status.assert().isEqualTo(ExecutionFailedStatus.FAILED)
+                retryState.retries.assert().isEqualTo(10)
+                canRetry().assert().isFalse()
             }
             .verify()
     }
@@ -223,10 +223,10 @@ class ExecutionFailedTest {
             .expectNoError()
             .expectEventType(CompensationPrepared::class.java)
             .expectState {
-                it.id.assert().isEqualTo(prepareCompensation.id)
-                it.status.assert().isEqualTo(ExecutionFailedStatus.PREPARED)
-                it.retryState.retries.assert().isEqualTo(11)
-                it.canNextRetry().assert().isFalse()
+                id.assert().isEqualTo(prepareCompensation.id)
+                status.assert().isEqualTo(ExecutionFailedStatus.PREPARED)
+                retryState.retries.assert().isEqualTo(11)
+                canNextRetry().assert().isFalse()
             }
             .verify()
     }
@@ -264,22 +264,22 @@ class ExecutionFailedTest {
             .expectNoError()
             .expectEventType(ExecutionFailedApplied::class.java)
             .expectState {
-                it.id.assert().isEqualTo(applyExecutionFailed.id)
-                it.status.assert().isEqualTo(ExecutionFailedStatus.FAILED)
-                it.error.assert().isEqualTo(applyExecutionFailed.error)
-                it.executeAt.assert().isEqualTo(applyExecutionFailed.executeAt)
-                it.recoverable.assert().isEqualTo(applyExecutionFailed.recoverable)
-                it.retryState.retries.assert().isEqualTo(1)
-                it.canRetry().assert().isTrue()
-                it.canNextRetry().assert().isFalse()
+                id.assert().isEqualTo(applyExecutionFailed.id)
+                status.assert().isEqualTo(ExecutionFailedStatus.FAILED)
+                error.assert().isEqualTo(applyExecutionFailed.error)
+                executeAt.assert().isEqualTo(applyExecutionFailed.executeAt)
+                recoverable.assert().isEqualTo(applyExecutionFailed.recoverable)
+                retryState.retries.assert().isEqualTo(1)
+                canRetry().assert().isTrue()
+                canNextRetry().assert().isFalse()
             }
             .verify()
             .fork {
                 whenCommand(applyExecutionFailed)
                     .expectErrorType(IllegalStateException::class.java)
                     .expectState {
-                        it.status.assert().isEqualTo(ExecutionFailedStatus.FAILED)
-                        it.retryState.retries.assert().isEqualTo(1)
+                        status.assert().isEqualTo(ExecutionFailedStatus.FAILED)
+                        retryState.retries.assert().isEqualTo(1)
                     }
                     .verify()
             }
@@ -316,21 +316,21 @@ class ExecutionFailedTest {
             .expectNoError()
             .expectEventType(ExecutionSuccessApplied::class.java)
             .expectState {
-                it.id.assert().isEqualTo(applyExecutionSuccess.id)
-                it.status.assert().isEqualTo(ExecutionFailedStatus.SUCCEEDED)
-                it.error.assert().isEqualTo(executionFailedCreated.error)
-                it.recoverable.assert().isEqualTo(executionFailedCreated.recoverable)
-                it.retryState.retries.assert().isEqualTo(1)
-                it.canRetry().assert().isFalse()
-                it.canNextRetry().assert().isFalse()
+                id.assert().isEqualTo(applyExecutionSuccess.id)
+                status.assert().isEqualTo(ExecutionFailedStatus.SUCCEEDED)
+                error.assert().isEqualTo(executionFailedCreated.error)
+                recoverable.assert().isEqualTo(executionFailedCreated.recoverable)
+                retryState.retries.assert().isEqualTo(1)
+                canRetry().assert().isFalse()
+                canNextRetry().assert().isFalse()
             }
             .verify()
             .fork {
                 whenCommand(applyExecutionSuccess)
                     .expectErrorType(IllegalStateException::class.java)
                     .expectState {
-                        it.status.assert().isEqualTo(ExecutionFailedStatus.SUCCEEDED)
-                        it.retryState.retries.assert().isEqualTo(1)
+                        status.assert().isEqualTo(ExecutionFailedStatus.SUCCEEDED)
+                        retryState.retries.assert().isEqualTo(1)
                     }
                     .verify()
             }
@@ -360,11 +360,11 @@ class ExecutionFailedTest {
             .expectNoError()
             .expectEventType(RetrySpecApplied::class.java)
             .expectState {
-                it.id.assert().isEqualTo(applyRetrySpec.id)
-                it.error.assert().isEqualTo(executionFailedCreated.error)
-                it.retrySpec.maxRetries.assert().isEqualTo(applyRetrySpec.maxRetries)
-                it.retrySpec.minBackoff.assert().isEqualTo(applyRetrySpec.minBackoff)
-                it.retrySpec.executionTimeout.assert().isEqualTo(applyRetrySpec.executionTimeout)
+                id.assert().isEqualTo(applyRetrySpec.id)
+                error.assert().isEqualTo(executionFailedCreated.error)
+                retrySpec.maxRetries.assert().isEqualTo(applyRetrySpec.maxRetries)
+                retrySpec.minBackoff.assert().isEqualTo(applyRetrySpec.minBackoff)
+                retrySpec.executionTimeout.assert().isEqualTo(applyRetrySpec.executionTimeout)
             }
             .verify()
     }
@@ -392,8 +392,8 @@ class ExecutionFailedTest {
             .expectNoError()
             .expectEventType(RecoverableMarked::class.java)
             .expectState {
-                it.id.assert().isEqualTo(markRecoverable.id)
-                it.recoverable.assert().isEqualTo(markRecoverable.recoverable)
+                id.assert().isEqualTo(markRecoverable.id)
+                recoverable.assert().isEqualTo(markRecoverable.recoverable)
             }
             .verify()
             .fork {
@@ -429,9 +429,9 @@ class ExecutionFailedTest {
             .expectNoError()
             .expectEventType(FunctionChanged::class.java)
             .expectState {
-                it.id.assert().isEqualTo(changeFunction.id)
-                it.recoverable.assert().isEqualTo(executionFailedCreated.recoverable)
-                it.function.isSameFunction(changeFunction).assert().isTrue()
+                id.assert().isEqualTo(changeFunction.id)
+                recoverable.assert().isEqualTo(executionFailedCreated.recoverable)
+                function.isSameFunction(changeFunction).assert().isTrue()
             }
             .verify()
             .fork {

--- a/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSagaTest.kt
+++ b/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSagaTest.kt
@@ -36,9 +36,9 @@ class CartSagaTest {
             )
             .expectCommandType(RemoveCartItem::class)
             .expectCommand<RemoveCartItem> {
-                it.aggregateId.id.assert().isEqualTo(ownerId)
-                it.body.productIds.assert().hasSize(1)
-                it.body.productIds.assert().first().isEqualTo(orderItem.productId)
+                aggregateId.id.assert().isEqualTo(ownerId)
+                body.productIds.assert().hasSize(1)
+                body.productIds.assert().first().isEqualTo(orderItem.productId)
             }
             .verify()
     }

--- a/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartTest.kt
+++ b/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartTest.kt
@@ -46,9 +46,9 @@ class CartTest {
             .expectNoError()
             .expectEventType(CartItemAdded::class)
             .expectState {
-                it.items.assert().hasSize(1)
+                items.assert().hasSize(1)
             }.expectStateAggregate {
-                it.ownerId.assert().isEqualTo(ownerId)
+                ownerId.assert().isEqualTo(ownerId)
             }
             .verify()
     }
@@ -66,7 +66,7 @@ class CartTest {
             .expectNoError()
             .expectEventType(CartItemAdded::class)
             .expectState {
-                it.items.assert().hasSize(1)
+                items.assert().hasSize(1)
             }
             .verify()
     }
@@ -91,8 +91,8 @@ class CartTest {
             .expectNoError()
             .expectEventType(CartQuantityChanged::class)
             .expectState {
-                it.items.assert().hasSize(1)
-                it.items.first().quantity.assert().isEqualTo(2)
+                items.assert().hasSize(1)
+                items.first().quantity.assert().isEqualTo(2)
             }
             .verify()
     }
@@ -109,10 +109,10 @@ class CartTest {
             .expectNoError()
             .expectEventType(CartItemAdded::class)
             .expectState {
-                it.items.assert().hasSize(1)
+                items.assert().hasSize(1)
             }
             .expectStateAggregate {
-                it.version.assert().isEqualTo(1)
+                version.assert().isEqualTo(1)
             }
             .verify()
     }
@@ -141,7 +141,7 @@ class CartTest {
             .whenCommand(addCartItem)
             .expectErrorType(IllegalArgumentException::class)
             .expectState {
-                it.items.assert().hasSize(MAX_CART_ITEM_SIZE)
+                items.assert().hasSize(MAX_CART_ITEM_SIZE)
             }
             .verify()
     }
@@ -165,7 +165,7 @@ class CartTest {
             .whenCommand(removeCartItem)
             .expectEventType(CartItemRemoved::class)
             .expectState {
-                it.items.assert().isEmpty()
+                items.assert().isEmpty()
             }
             .verify()
     }
@@ -189,8 +189,8 @@ class CartTest {
             .whenCommand(changeQuantity)
             .expectEventType(CartQuantityChanged::class)
             .expectState {
-                it.items.assert().hasSize(1)
-                it.items.first().quantity.assert().isEqualTo(changeQuantity.quantity)
+                items.assert().hasSize(1)
+                items.first().quantity.assert().isEqualTo(changeQuantity.quantity)
             }
             .verify()
     }
@@ -206,14 +206,14 @@ class CartTest {
             .expectNoError()
             .expectEventType(CartItemAdded::class)
             .expectState {
-                it.items.assert().hasSize(1)
+                items.assert().hasSize(1)
             }
             .verify()
             .then()
             .whenCommand(DefaultDeleteAggregate)
             .expectEventType(DefaultAggregateDeleted::class)
             .expectStateAggregate {
-                it.deleted.assert().isTrue()
+                deleted.assert().isTrue()
             }.verify()
             .then()
             .whenCommand(DefaultDeleteAggregate::class)
@@ -222,7 +222,7 @@ class CartTest {
             .then()
             .whenCommand(DefaultRecoverAggregate)
             .expectStateAggregate {
-                it.deleted.assert().isFalse()
+                deleted.assert().isFalse()
             }.verify()
             .then()
             .whenCommand(DefaultRecoverAggregate)

--- a/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/order/OrchestrationTest.kt
+++ b/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/order/OrchestrationTest.kt
@@ -61,20 +61,20 @@ class OrchestrationTest {
             .whenCommand(CreateOrder(orderItems, SHIPPING_ADDRESS, false))
             .expectEventType(OrderCreated::class)
             .expectStateAggregate {
-                it.aggregateId.tenantId.assert().isEqualTo(tenantId)
+                aggregateId.tenantId.assert().isEqualTo(tenantId)
             }
             .expectState {
-                it.id.assert().isNotNull()
-                it.address.assert().isEqualTo(SHIPPING_ADDRESS)
-                it.items.assert().hasSize(1)
-                val item = it.items.first()
+                id.assert().isNotNull()
+                address.assert().isEqualTo(SHIPPING_ADDRESS)
+                items.assert().hasSize(1)
+                val item = items.first()
                 item.productId.assert().isEqualTo(orderItem.productId)
                 item.price.assert().isEqualTo(orderItem.price)
                 item.quantity.assert().isEqualTo(orderItem.quantity)
-                it.status.assert().isEqualTo(OrderStatus.CREATED)
+                status.assert().isEqualTo(OrderStatus.CREATED)
             }.expect {
-                it.exchange.getCommandResult().assert().hasSize(1)
-                val result = it.exchange.getCommandResult<BigDecimal>(OrderState::totalAmount.name)
+                exchange.getCommandResult().assert().hasSize(1)
+                val result = exchange.getCommandResult<BigDecimal>(OrderState::totalAmount.name)
                 result.assert().isEqualTo(orderItem.price.multiply(BigDecimal.valueOf(orderItem.quantity.toLong())))
             }
             .verify()
@@ -93,8 +93,8 @@ class OrchestrationTest {
         whenCommand(payOrder)
             .expectEventType(OrderPaid::class)
             .expectState {
-                it.paidAmount.assert().isEqualTo(it.totalAmount)
-                it.status.assert().isEqualTo(OrderStatus.PAID)
+                paidAmount.assert().isEqualTo(totalAmount)
+                status.assert().isEqualTo(OrderStatus.PAID)
             }
             .verify()
     }
@@ -113,7 +113,7 @@ class OrchestrationTest {
             .expectNoError()
             .expectEventType(AddressChanged::class)
             .expectState {
-                it.address.assert().isEqualTo(changeAddress.shippingAddress)
+                address.assert().isEqualTo(changeAddress.shippingAddress)
             }
             .verify()
     }

--- a/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/order/OrderTest.kt
+++ b/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/order/OrderTest.kt
@@ -73,18 +73,18 @@ internal class OrderTest {
             .whenCommand(CreateOrder(orderItems, SHIPPING_ADDRESS, false))
             .expectEventType(OrderCreated::class)
             .expectStateAggregate {
-                it.aggregateId.tenantId.assert().isEqualTo(tenantId)
+                aggregateId.tenantId.assert().isEqualTo(tenantId)
             }
             .expectState {
-                it.id.assert().isNotNull()
-                it.assert().isNotNull()
-                it.address.assert().isEqualTo(SHIPPING_ADDRESS)
-                verifyItems(it.items, orderItems)
-                it.status.assert().isEqualTo(OrderStatus.CREATED)
+                id.assert().isNotNull()
+                assert().isNotNull()
+                address.assert().isEqualTo(SHIPPING_ADDRESS)
+                verifyItems(items, orderItems)
+                status.assert().isEqualTo(OrderStatus.CREATED)
             }.expect {
-                it.exchange.getCommandResult().size.assert().isOne()
-                it.exchange.getCommandResult().assert().hasSize(1)
-                val result = it.exchange.getCommandResult<BigDecimal>(OrderState::totalAmount.name)
+                exchange.getCommandResult().size.assert().isOne()
+                exchange.getCommandResult().assert().hasSize(1)
+                val result = exchange.getCommandResult<BigDecimal>(OrderState::totalAmount.name)
                 result.assert().isEqualTo(orderItem.price.multiply(BigDecimal.valueOf(orderItem.quantity.toLong())))
             }
             .verify()
@@ -135,7 +135,7 @@ internal class OrderTest {
             .whenCommand(CreateOrder(orderItems, ShippingAddress("US", "US", "US", "US", ""), false))
             .expectErrorType(IllegalArgumentException::class)
             .expectStateAggregate {
-                it.initialized.assert().isFalse()
+                initialized.assert().isFalse()
             }.verify()
     }
 
@@ -153,7 +153,7 @@ internal class OrderTest {
                 /*
                  * 该聚合对象处于未初始化状态，即该聚合未创建成功.
                  */
-                it.initialized.assert().isFalse()
+                initialized.assert().isFalse()
             }.verify()
     }
 
@@ -195,7 +195,7 @@ internal class OrderTest {
                 /*
                  * 该聚合对象处于未初始化状态，即该聚合未创建成功.
                  */
-                it.initialized.assert().isFalse()
+                initialized.assert().isFalse()
             }.verify()
     }
 
@@ -261,15 +261,15 @@ internal class OrderTest {
              * 3.3 期望产生的事件状态
              */
             .expectEventBody<OrderPaid> {
-                it.amount.assert().isEqualTo(payOrder.amount)
+                amount.assert().isEqualTo(payOrder.amount)
             }
             /*
              * 4. 期望当前聚合状态
              */
             .expectState {
-                it.address.assert().isEqualTo(SHIPPING_ADDRESS)
-                it.paidAmount.assert().isEqualTo(payOrder.amount)
-                it.status.assert().isEqualTo(OrderStatus.PAID)
+                address.assert().isEqualTo(SHIPPING_ADDRESS)
+                paidAmount.assert().isEqualTo(payOrder.amount)
+                status.assert().isEqualTo(OrderStatus.PAID)
             }
             /*
              * 完成测试编排后，验证期望.
@@ -303,7 +303,7 @@ internal class OrderTest {
             .expectErrorType(DomainEventException::class)
             .expectEventType(OrderPayDuplicated::class)
             .expectEventBody<OrderPayDuplicated> {
-                it.paymentId.assert().isEqualTo(payOrder.paymentId)
+                paymentId.assert().isEqualTo(payOrder.paymentId)
             }
             .verify()
     }
@@ -336,17 +336,17 @@ internal class OrderTest {
              * 3.2 期望产生的事件状态
              */
             .expectEventIterator {
-                val orderPaid = it.nextEventBody<OrderPaid>()
+                val orderPaid = nextEventBody<OrderPaid>()
                 orderPaid.paid.assert().isTrue()
-                val orderOverPaid = it.nextEventBody<OrderOverPaid>()
+                val orderOverPaid = nextEventBody<OrderOverPaid>()
                 orderOverPaid.overPay.assert().isEqualTo(payOrder.amount.minus(previousState.totalAmount))
             }
             /*
              * 4. 期望当前聚合状态
              */
             .expectState {
-                it.paidAmount.assert().isEqualTo(previousState.totalAmount)
-                it.status.assert().isEqualTo(OrderStatus.PAID)
+                paidAmount.assert().isEqualTo(previousState.totalAmount)
+                status.assert().isEqualTo(OrderStatus.PAID)
             }
             .verify()
     }
@@ -362,7 +362,7 @@ internal class OrderTest {
              * 4. 期望当前聚合状态
              */
             .expectState {
-                it.status.assert().isEqualTo(OrderStatus.SHIPPED)
+                status.assert().isEqualTo(OrderStatus.SHIPPED)
             }
             .verify()
     }
@@ -383,7 +383,7 @@ internal class OrderTest {
             .expectNoError()
             .expectEventType(OrderReceived::class)
             .expectState {
-                it.status.assert().isEqualTo(OrderStatus.RECEIVED)
+                status.assert().isEqualTo(OrderStatus.RECEIVED)
             }
             .verify()
     }
@@ -399,8 +399,8 @@ internal class OrderTest {
                 /*
                  * 验证聚合状态[未]发生变更.
                  */
-                it.paidAmount.assert().isEqualTo(BigDecimal.ZERO)
-                it.status.assert().isEqualTo(OrderStatus.CREATED)
+                paidAmount.assert().isEqualTo(BigDecimal.ZERO)
+                status.assert().isEqualTo(OrderStatus.CREATED)
             }
             .verify()
     }
@@ -415,7 +415,7 @@ internal class OrderTest {
             .whenCommand(changeAddress)
             .expectEventType(AddressChanged::class)
             .expectState {
-                it.address.assert().isEqualTo(changeAddress.shippingAddress)
+                address.assert().isEqualTo(changeAddress.shippingAddress)
             }
             .verify()
     }
@@ -425,7 +425,7 @@ internal class OrderTest {
             .whenCommand(DefaultDeleteAggregate)
             .expectEventType(AggregateDeleted::class)
             .expectStateAggregate {
-                it.deleted.assert().isTrue()
+                deleted.assert().isTrue()
             }
             .verify()
     }
@@ -442,9 +442,9 @@ internal class OrderTest {
             .whenCommand(DefaultDeleteAggregate)
             .expectErrorType(IllegalAccessDeletedAggregateException::class)
             .expectError<IllegalAccessDeletedAggregateException> {
-                it.aggregateId.assert().isEqualTo(verifiedStageAfterDelete.stateAggregate.aggregateId)
+                aggregateId.assert().isEqualTo(verifiedStageAfterDelete.stateAggregate.aggregateId)
             }.expectStateAggregate {
-                it.deleted.assert().isTrue()
+                deleted.assert().isTrue()
             }
             .verify()
     }

--- a/example/transfer/example-transfer-domain/src/test/java/me/ahoo/wow/example/transfer/domain/AccountTest.java
+++ b/example/transfer/example-transfer-domain/src/test/java/me/ahoo/wow/example/transfer/domain/AccountTest.java
@@ -34,10 +34,12 @@ class AccountTest {
                     assertThat(eventBody.name()).isEqualTo("name");
                     assertThat(eventBody.balance()).isEqualTo(100L);
                     assertThat(eventIterator.hasNext()).isFalse();
+                    return null;
                 })
                 .expectState(account -> {
                     assertThat(account.getName()).isEqualTo("name");
                     assertThat(account.getBalanceAmount()).isEqualTo(100L);
+                    return null;
                 })
                 .verify();
     }

--- a/example/transfer/example-transfer-domain/src/test/java/me/ahoo/wow/example/transfer/domain/TransferSagaTest.java
+++ b/example/transfer/example-transfer-domain/src/test/java/me/ahoo/wow/example/transfer/domain/TransferSagaTest.java
@@ -30,6 +30,7 @@ public class TransferSagaTest {
                 .expectCommandBody((Entry entry) -> {
                     assertThat(entry.id()).isEqualTo(event.to());
                     assertThat(entry.amount()).isEqualTo(event.amount());
+                    return null;
                 })
                 .verify();
     }

--- a/example/transfer/example-transfer-domain/src/test/java/me/ahoo/wow/example/transfer/domain/TransferSagaTest.java
+++ b/example/transfer/example-transfer-domain/src/test/java/me/ahoo/wow/example/transfer/domain/TransferSagaTest.java
@@ -30,7 +30,6 @@ public class TransferSagaTest {
                 .expectCommandBody((Entry entry) -> {
                     assertThat(entry.id()).isEqualTo(event.to());
                     assertThat(entry.amount()).isEqualTo(event.amount());
-                    return null;
                 })
                 .verify();
     }

--- a/example/transfer/example-transfer-domain/src/test/kotlin/me/ahoo/wow/example/transfer/domain/AccountKTest.kt
+++ b/example/transfer/example-transfer-domain/src/test/kotlin/me/ahoo/wow/example/transfer/domain/AccountKTest.kt
@@ -32,7 +32,7 @@ import me.ahoo.wow.example.transfer.api.UnfreezeAccount
 import me.ahoo.wow.example.transfer.api.UnlockAmount
 import me.ahoo.wow.id.GlobalIdGenerator
 import me.ahoo.wow.test.aggregateVerifier
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Test
 
 internal class AccountKTest {
@@ -43,8 +43,8 @@ internal class AccountKTest {
             .whenCommand(CreateAccount("name", 100))
             .expectEventType(AccountCreated::class)
             .expectState {
-                it.name.assert().isEqualTo("name")
-                it.balanceAmount.assert().isEqualTo(100)
+                name.assert().isEqualTo("name")
+                balanceAmount.assert().isEqualTo(100)
             }
             .verify()
     }
@@ -56,8 +56,8 @@ internal class AccountKTest {
             .whenCommand(Prepare("name", 100))
             .expectEventType(AmountLocked::class, Prepared::class)
             .expectState {
-                it.name.assert().isEqualTo("name")
-                it.balanceAmount.assert().isEqualTo(0)
+                name.assert().isEqualTo("name")
+                balanceAmount.assert().isEqualTo(0)
             }
             .verify()
     }
@@ -68,12 +68,12 @@ internal class AccountKTest {
             .given(AccountCreated("name", 100), AccountFrozen(""))
             .whenCommand(Prepare("name", 100))
             .expectError<IllegalStateException> {
-                assertThat(it).hasMessage("账号已冻结无法转账.")
+                assertThat(this).hasMessage("账号已冻结无法转账.")
             }
             .expectState {
-                it.name.assert().isEqualTo("name")
-                it.balanceAmount.assert().isEqualTo(100)
-                it.isFrozen.assert().isTrue()
+                name.assert().isEqualTo("name")
+                balanceAmount.assert().isEqualTo(100)
+                isFrozen.assert().isTrue()
             }
             .verify()
     }
@@ -84,11 +84,11 @@ internal class AccountKTest {
             .given(AccountCreated("name", 100))
             .whenCommand(Prepare("name", 200))
             .expectError<IllegalStateException> {
-                assertThat(it).hasMessage("账号余额不足.")
+                assertThat(this).hasMessage("账号余额不足.")
             }
             .expectState {
-                it.name.assert().isEqualTo("name")
-                it.balanceAmount.assert().isEqualTo(100)
+                name.assert().isEqualTo("name")
+                balanceAmount.assert().isEqualTo(100)
             }
             .verify()
     }
@@ -101,8 +101,8 @@ internal class AccountKTest {
             .whenCommand(Entry(aggregateId, "sourceId", 100))
             .expectEventType(AmountEntered::class)
             .expectState {
-                it.name.assert().isEqualTo("name")
-                it.balanceAmount.assert().isEqualTo(200)
+                name.assert().isEqualTo("name")
+                balanceAmount.assert().isEqualTo(200)
             }
             .verify()
     }
@@ -115,9 +115,9 @@ internal class AccountKTest {
             .whenCommand(Entry(aggregateId, "sourceId", 100))
             .expectEventType(EntryFailed::class)
             .expectState {
-                it.name.assert().isEqualTo("name")
-                it.balanceAmount.assert().isEqualTo(100)
-                it.isFrozen.assert().isTrue()
+                name.assert().isEqualTo("name")
+                balanceAmount.assert().isEqualTo(100)
+                isFrozen.assert().isTrue()
             }
             .verify()
     }
@@ -130,10 +130,10 @@ internal class AccountKTest {
             .whenCommand(Confirm(aggregateId, 100))
             .expectEventType(Confirmed::class)
             .expectState {
-                it.name.assert().isEqualTo("name")
-                it.balanceAmount.assert().isEqualTo(0)
-                it.lockedAmount.assert().isEqualTo(0)
-                it.isFrozen.assert().isFalse()
+                name.assert().isEqualTo("name")
+                balanceAmount.assert().isEqualTo(0)
+                lockedAmount.assert().isEqualTo(0)
+                isFrozen.assert().isFalse()
             }
             .verify()
     }
@@ -146,10 +146,10 @@ internal class AccountKTest {
             .whenCommand(UnlockAmount(aggregateId, 100))
             .expectEventType(AmountUnlocked::class)
             .expectState {
-                it.name.assert().isEqualTo("name")
-                it.balanceAmount.assert().isEqualTo(100)
-                it.lockedAmount.assert().isEqualTo(0)
-                it.isFrozen.assert().isFalse()
+                name.assert().isEqualTo("name")
+                balanceAmount.assert().isEqualTo(100)
+                lockedAmount.assert().isEqualTo(0)
+                isFrozen.assert().isFalse()
             }
             .verify()
     }
@@ -162,10 +162,10 @@ internal class AccountKTest {
             .whenCommand(FreezeAccount(""))
             .expectEventType(AccountFrozen::class)
             .expectState {
-                it.name.assert().isEqualTo("name")
-                it.balanceAmount.assert().isEqualTo(100)
-                it.lockedAmount.assert().isEqualTo(0)
-                it.isFrozen.assert().isTrue()
+                name.assert().isEqualTo("name")
+                balanceAmount.assert().isEqualTo(100)
+                lockedAmount.assert().isEqualTo(0)
+                isFrozen.assert().isTrue()
             }
             .verify()
     }
@@ -177,13 +177,13 @@ internal class AccountKTest {
             .given(AccountCreated("name", 100), AccountFrozen(""))
             .whenCommand(FreezeAccount(""))
             .expectError<IllegalStateException> {
-                assertThat(it).hasMessage("账号已冻结无需再次冻结.")
+                assertThat(this).hasMessage("账号已冻结无需再次冻结.")
             }
             .expectState {
-                it.name.assert().isEqualTo("name")
-                it.balanceAmount.assert().isEqualTo(100)
-                it.lockedAmount.assert().isEqualTo(0)
-                it.isFrozen.assert().isTrue()
+                name.assert().isEqualTo("name")
+                balanceAmount.assert().isEqualTo(100)
+                lockedAmount.assert().isEqualTo(0)
+                isFrozen.assert().isTrue()
             }
             .verify()
     }
@@ -195,10 +195,10 @@ internal class AccountKTest {
             .given(AccountCreated("name", 100), AccountFrozen(""))
             .whenCommand(UnfreezeAccount(""))
             .expectState {
-                it.name.assert().isEqualTo("name")
-                it.balanceAmount.assert().isEqualTo(100)
-                it.lockedAmount.assert().isEqualTo(0)
-                it.isFrozen.assert().isFalse()
+                name.assert().isEqualTo("name")
+                balanceAmount.assert().isEqualTo(100)
+                lockedAmount.assert().isEqualTo(0)
+                isFrozen.assert().isFalse()
             }
             .verify()
     }
@@ -210,10 +210,10 @@ internal class AccountKTest {
             .given(AccountCreated("name", 100), AccountUnfrozen(""))
             .whenCommand(UnfreezeAccount(""))
             .expectState {
-                it.name.assert().isEqualTo("name")
-                it.balanceAmount.assert().isEqualTo(100)
-                it.lockedAmount.assert().isEqualTo(0)
-                it.isFrozen.assert().isFalse()
+                name.assert().isEqualTo("name")
+                balanceAmount.assert().isEqualTo(100)
+                lockedAmount.assert().isEqualTo(0)
+                isFrozen.assert().isFalse()
             }
             .verify()
     }
@@ -226,10 +226,10 @@ internal class AccountKTest {
             .whenCommand(LockAmount(10))
             .expectEventType(AmountLocked::class)
             .expectState {
-                it.name.assert().isEqualTo("name")
-                it.balanceAmount.assert().isEqualTo(90)
-                it.lockedAmount.assert().isEqualTo(10)
-                it.isFrozen.assert().isFalse()
+                name.assert().isEqualTo("name")
+                balanceAmount.assert().isEqualTo(90)
+                lockedAmount.assert().isEqualTo(10)
+                isFrozen.assert().isFalse()
             }
             .verify()
     }

--- a/example/transfer/example-transfer-domain/src/test/kotlin/me/ahoo/wow/example/transfer/domain/TransferSagaKTest.kt
+++ b/example/transfer/example-transfer-domain/src/test/kotlin/me/ahoo/wow/example/transfer/domain/TransferSagaKTest.kt
@@ -31,8 +31,8 @@ internal class TransferSagaKTest {
         sagaVerifier<TransferSaga>()
             .whenEvent(event)
             .expectCommandBody<Entry> {
-                it.id.assert().isEqualTo(event.to)
-                it.amount.assert().isEqualTo(event.amount)
+                id.assert().isEqualTo(event.to)
+                amount.assert().isEqualTo(event.amount)
             }
             .verify()
     }
@@ -43,8 +43,8 @@ internal class TransferSagaKTest {
         sagaVerifier<TransferSaga>()
             .whenEvent(event)
             .expectCommandBody<Confirm> {
-                it.id.assert().isEqualTo(event.sourceId)
-                it.amount.assert().isEqualTo(event.amount)
+                id.assert().isEqualTo(event.sourceId)
+                amount.assert().isEqualTo(event.amount)
             }
             .verify()
     }
@@ -55,8 +55,8 @@ internal class TransferSagaKTest {
         sagaVerifier<TransferSaga>()
             .whenEvent(event)
             .expectCommandBody<UnlockAmount> {
-                it.id.assert().isEqualTo(event.sourceId)
-                it.amount.assert().isEqualTo(event.amount)
+               id.assert().isEqualTo(event.sourceId)
+               amount.assert().isEqualTo(event.amount)
             }
             .verify()
     }

--- a/example/transfer/example-transfer-domain/src/test/kotlin/me/ahoo/wow/example/transfer/domain/TransferSagaKTest.kt
+++ b/example/transfer/example-transfer-domain/src/test/kotlin/me/ahoo/wow/example/transfer/domain/TransferSagaKTest.kt
@@ -55,8 +55,8 @@ internal class TransferSagaKTest {
         sagaVerifier<TransferSaga>()
             .whenEvent(event)
             .expectCommandBody<UnlockAmount> {
-               id.assert().isEqualTo(event.sourceId)
-               amount.assert().isEqualTo(event.amount)
+                id.assert().isEqualTo(event.sourceId)
+                amount.assert().isEqualTo(event.amount)
             }
             .verify()
     }

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/ExpectStage.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/ExpectStage.kt
@@ -39,6 +39,10 @@ interface ExpectStage<S : Any> {
         return expectStateAggregate { expected(state) }
     }
 
+    fun expectState(expected: Consumer<S>): ExpectStage<S> {
+        return expectState { expected.accept(this) }
+    }
+
     /**
      * 3.2 期望领域事件.
      */
@@ -57,9 +61,22 @@ interface ExpectStage<S : Any> {
         }
     }
 
+    fun expectEventStream(expected: Consumer<DomainEventStream>): ExpectStage<S> {
+        return expectEventStream {
+            expected.accept(this)
+        }
+    }
+
     fun expectEventIterator(expected: EventIterator.() -> Unit): ExpectStage<S> {
         return expectEventStream {
             expected(EventIterator((iterator())))
+        }
+    }
+
+
+    fun expectEventIterator(expected: Consumer<EventIterator>): ExpectStage<S> {
+        return expectEventIterator {
+            expected.accept(this)
         }
     }
 
@@ -75,9 +92,21 @@ interface ExpectStage<S : Any> {
         }
     }
 
+    fun <E : Any> expectEvent(expected: Consumer<DomainEvent<E>>): ExpectStage<S> {
+        return expectEvent {
+            expected.accept(this)
+        }
+    }
+
     fun <E : Any> expectEventBody(expected: E.() -> Unit): ExpectStage<S> {
         return expectEvent {
             expected(body)
+        }
+    }
+
+    fun <E : Any> expectEventBody(expected: Consumer<E>): ExpectStage<S> {
+        return expectEventBody<E> {
+            expected.accept(this)
         }
     }
 
@@ -125,6 +154,12 @@ interface ExpectStage<S : Any> {
         return expectError().expect {
             @Suppress("UNCHECKED_CAST")
             expected(error as E)
+        }
+    }
+
+    fun <E : Throwable> expectError(expected: Consumer<E>): ExpectStage<S> {
+        return expectError<E> {
+            expected.accept(this)
         }
     }
 

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/DefaultStatelessSagaVerifier.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/DefaultStatelessSagaVerifier.kt
@@ -136,7 +136,7 @@ internal class DefaultWhenStage<T : Any>(
 internal class DefaultExpectStage<T : Any>(private val expectedResult: Mono<ExpectedResult<T>>) : ExpectStage<T> {
     private val expectStates: MutableList<Consumer<ExpectedResult<T>>> = mutableListOf()
 
-    override fun expect(expected: Consumer<ExpectedResult<T>>): ExpectStage<T> {
+    override fun expect(expected: ExpectedResult<T>.() -> Unit): ExpectStage<T> {
         expectStates.add(expected)
         return this
     }

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/Stages.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/Stages.kt
@@ -22,6 +22,7 @@ import me.ahoo.wow.ioc.ServiceProvider
 import me.ahoo.wow.messaging.function.MessageFunction
 import me.ahoo.wow.naming.annotation.toName
 import me.ahoo.wow.saga.stateless.CommandStream
+import java.util.function.Consumer
 import kotlin.reflect.KClass
 import kotlin.reflect.KType
 import kotlin.reflect.full.defaultType
@@ -76,9 +77,21 @@ interface ExpectStage<T : Any> {
         }
     }
 
+    fun expectCommandStream(expected: Consumer<CommandStream>): ExpectStage<T> {
+        return expectCommandStream {
+            expected.accept(this)
+        }
+    }
+
     fun expectCommandIterator(expected: CommandIterator.() -> Unit): ExpectStage<T> {
         return expectCommandStream {
             expected(CommandIterator(iterator()))
+        }
+    }
+
+    fun expectCommandIterator(expected: Consumer<CommandIterator>): ExpectStage<T> {
+        return expectCommandIterator {
+            expected.accept(this)
         }
     }
 
@@ -103,9 +116,19 @@ interface ExpectStage<T : Any> {
         }
     }
 
+    fun <C : Any> expectCommand(expected: Consumer<CommandMessage<C>>): ExpectStage<T> {
+        return expectCommand { expected.accept(this) }
+    }
+
     fun <C : Any> expectCommandBody(expected: C.() -> Unit): ExpectStage<T> {
         return expectCommand {
             expected(body)
+        }
+    }
+
+    fun <C : Any> expectCommandBody(expected: Consumer<C>): ExpectStage<T> {
+        return expectCommandBody<C> {
+            expected.accept(this)
         }
     }
 

--- a/wow-core/src/test/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunctionTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunctionTest.kt
@@ -63,7 +63,7 @@ class StatelessSagaFunctionTest {
             .`when`(MockAggregateCreated("data"))
             .expectNoError()
             .expectCommand<MockCreateAggregate> {
-                it.requestId.assert().isEqualTo(it.id)
+                requestId.assert().isEqualTo(id)
             }
             .verify()
     }
@@ -74,7 +74,7 @@ class StatelessSagaFunctionTest {
             .`when`(MockAggregateCreated("data"))
             .expectNoError()
             .expectCommand<MockCreateAggregate> {
-                it.requestId.assert().isNotEqualTo(it.id)
+                requestId.assert().isNotEqualTo(id)
             }
             .verify()
     }

--- a/wow-models/src/test/kotlin/me/ahoo/wow/models/tree/test/CategoryTest.kt
+++ b/wow-models/src/test/kotlin/me/ahoo/wow/models/tree/test/CategoryTest.kt
@@ -41,13 +41,13 @@ class CategoryTest {
             .expectNoError()
             .expectEventType(CategoryCreated::class.java)
             .expectEventBody<CategoryCreated> {
-                it.name.assert().isEqualTo(command.name)
-                it.level.assert().isOne()
-                it.sortId.assert().isZero()
+                name.assert().isEqualTo(command.name)
+                level.assert().isOne()
+                sortId.assert().isZero()
             }
             .expect {
-                it.exchange.getCommandResult().assert().hasSize(1)
-                val result = it.exchange.getCommandResult<String>(Flat::code.name)
+                exchange.getCommandResult().assert().hasSize(1)
+                val result = exchange.getCommandResult<String>(Flat::code.name)
                 result.assert().isNotNull()
             }
             .verify()
@@ -71,10 +71,10 @@ class CategoryTest {
             .expectNoError()
             .expectEventType(CategoryCreated::class.java)
             .expectEventBody<CategoryCreated> {
-                it.name.assert().isEqualTo("name")
-                l1Category.isDirectChild(it).assert().isTrue()
-                it.level.assert().isEqualTo(2)
-                it.sortId.assert().isEqualTo(l2Category.sortId + 1)
+                name.assert().isEqualTo("name")
+                l1Category.isDirectChild(this).assert().isTrue()
+                level.assert().isEqualTo(2)
+                sortId.assert().isEqualTo(l2Category.sortId + 1)
             }
             .verify()
     }
@@ -100,10 +100,10 @@ class CategoryTest {
             .expectNoError()
             .expectEventType(CategoryDeleted::class.java)
             .expectEventBody<CategoryDeleted> {
-                it.code.assert().isEqualTo(category.code)
+                code.assert().isEqualTo(category.code)
             }
             .expectState {
-                it.children.assert().isEmpty()
+                children.assert().isEmpty()
             }
             .verify()
     }
@@ -138,8 +138,8 @@ class CategoryTest {
             .`when`(command)
             .expectEventType(CategoryUpdated::class.java)
             .expectEventBody<CategoryUpdated> {
-                it.name.assert().isEqualTo(command.name)
-                it.code.assert().isEqualTo(command.code)
+                name.assert().isEqualTo(command.name)
+                code.assert().isEqualTo(command.code)
             }
             .verify()
     }
@@ -165,10 +165,10 @@ class CategoryTest {
             .`when`(command)
             .expectEventType(CategoryMoved::class.java)
             .expectEventBody<CategoryMoved> {
-                it.codes.assert().contains("l11", "l1")
+                codes.assert().contains("l11", "l1")
             }
             .expectState {
-                it.children.map { it.code }.assert().contains("l11", "l1")
+                children.map { it.code }.assert().contains("l11", "l1")
             }
             .verify()
     }

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/state/AggregateTracingHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/state/AggregateTracingHandlerFunctionTest.kt
@@ -36,7 +36,7 @@ class AggregateTracingHandlerFunctionTest {
             .expectNoError()
             .expectEventType(CartItemAdded::class.java)
             .expectState {
-                it.items.assert().hasSize(1)
+                items.assert().hasSize(1)
             }
             .verify()
         val handlerFunction = AggregateTracingHandlerFunctionFactory(

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/state/LoadAggregateHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/state/LoadAggregateHandlerFunctionTest.kt
@@ -54,7 +54,7 @@ class LoadAggregateHandlerFunctionTest {
             .expectNoError()
             .expectEventType(CartItemAdded::class.java)
             .expectState {
-                it.items.assert().hasSize(1)
+                items.assert().hasSize(1)
             }
             .verify()
 

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/state/LoadTimeBasedAggregateHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/state/LoadTimeBasedAggregateHandlerFunctionTest.kt
@@ -53,7 +53,7 @@ class LoadTimeBasedAggregateHandlerFunctionTest {
             .expectNoError()
             .expectEventType(CartItemAdded::class.java)
             .expectState {
-                it.items.assert().hasSize(1)
+                items.assert().hasSize(1)
             }
             .verify()
 


### PR DESCRIPTION
- Replace Consumer functional interface with Kotlin lambda in expect methods
- Update test files to use new lambda-based expect methods
- Remove unnecessary 'it' references in lambda expressions
