### PR TITLE
refactor(wow-test): move DynamicTestBuilder to root package

### DIFF
--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/AggregateSpec.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/AggregateSpec.kt
@@ -13,9 +13,9 @@
 
 package me.ahoo.wow.test
 
-import me.ahoo.wow.test.aggregate.dsl.AbstractDynamicTestBuilder
 import me.ahoo.wow.test.aggregate.dsl.AggregateDsl
 import me.ahoo.wow.test.aggregate.dsl.DefaultAggregateDsl
+import me.ahoo.wow.test.dsl.AbstractDynamicTestBuilder
 import org.junit.jupiter.api.DynamicNode
 import org.junit.jupiter.api.TestFactory
 import java.lang.reflect.ParameterizedType

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/DefaultAggregateDsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/DefaultAggregateDsl.kt
@@ -23,6 +23,7 @@ import me.ahoo.wow.test.aggregate.ExpectedResult
 import me.ahoo.wow.test.aggregate.GivenStage
 import me.ahoo.wow.test.aggregate.VerifiedStage
 import me.ahoo.wow.test.aggregate.WhenStage
+import me.ahoo.wow.test.dsl.AbstractDynamicTestBuilder
 import org.junit.jupiter.api.DynamicContainer
 import org.junit.jupiter.api.DynamicTest
 

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/Dsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/Dsl.kt
@@ -20,15 +20,6 @@ import me.ahoo.wow.messaging.DefaultHeader
 import me.ahoo.wow.modeling.state.StateAggregate
 import me.ahoo.wow.test.aggregate.AggregateExpecter
 import me.ahoo.wow.test.aggregate.ExpectedResult
-import org.junit.jupiter.api.DynamicNode
-
-interface DynamicTestBuilder {
-    val dynamicNodes: List<DynamicNode>
-}
-
-abstract class AbstractDynamicTestBuilder : DynamicTestBuilder {
-    override val dynamicNodes: MutableList<DynamicNode> = mutableListOf()
-}
 
 interface AggregateDsl<S : Any> {
     fun given(block: GivenDsl<S>.() -> Unit)

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/dsl/DynamicTestBuilder.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/dsl/DynamicTestBuilder.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.test.dsl
+
+import org.junit.jupiter.api.DynamicNode
+
+interface DynamicTestBuilder {
+    val dynamicNodes: List<DynamicNode>
+}
+
+abstract class AbstractDynamicTestBuilder : DynamicTestBuilder {
+    override val dynamicNodes: MutableList<DynamicNode> = mutableListOf()
+}


### PR DESCRIPTION
- Move DynamicTestBuilder interface and AbstractDynamicTestBuilder class to me.ahoo.wow.test.dsl package
- Update imports in affected files
- Remove redundant code from Dsl.kt

