### PR TITLE
test(wow-test): enhance stateless saga dsl with naming capability

### DIFF
--- a/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSagaSpec.kt
+++ b/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSagaSpec.kt
@@ -51,4 +51,26 @@ class CartSagaSpec : SagaSpec<CartSaga>({
             }
         }
     }
+    on {
+        name("NotFromCart")
+        val orderItem = OrderItem(
+            id = generateGlobalId(),
+            productId = generateGlobalId(),
+            price = BigDecimal.valueOf(10),
+            quantity = 10,
+        )
+        whenEvent(
+            event = mockk<OrderCreated> {
+                every {
+                    items
+                } returns listOf(orderItem)
+                every {
+                    fromCart
+                } returns false
+            },
+            ownerId = generateGlobalId()
+        ) {
+            expectNoCommand()
+        }
+    }
 })

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/SagaSpec.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/SagaSpec.kt
@@ -31,7 +31,7 @@ abstract class SagaSpec<T : Any>(private val block: StatelessSagaDsl<T>.() -> Un
 
     @TestFactory
     fun execute(): Stream<DynamicNode> {
-        val statelessSagaDsl = DefaultStatelessSagaDsl<T>(processorType)
+        val statelessSagaDsl = DefaultStatelessSagaDsl(processorType)
         block(statelessSagaDsl)
         return statelessSagaDsl.dynamicNodes.stream()
     }

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/dsl/NameSpecCapable.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/dsl/NameSpecCapable.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.test.dsl
+
+interface NameSpecCapable {
+    fun name(name: String)
+}

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/DefaultStatelessSagaDsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/DefaultStatelessSagaDsl.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.test.saga.stateless.dsl
 
+import me.ahoo.wow.api.naming.Named
 import me.ahoo.wow.infra.Decorator
 import me.ahoo.wow.ioc.ServiceProvider
 import me.ahoo.wow.messaging.function.MessageFunction
@@ -34,8 +35,16 @@ class DefaultStatelessSagaDsl<T : Any>(private val processorType: Class<T>) : St
     }
 }
 
-class DefaultWhenDsl<T : Any>(override val delegate: WhenStage<T>) : Decorator<WhenStage<T>>, WhenDsl<T>,
-    AbstractDynamicTestBuilder() {
+class DefaultWhenDsl<T : Any>(override val delegate: WhenStage<T>) :
+    Decorator<WhenStage<T>>,
+    WhenDsl<T>,
+    AbstractDynamicTestBuilder(),
+    Named {
+    override var name: String = ""
+    override fun name(name: String) {
+        this.name = name
+    }
+
     override fun inject(inject: ServiceProvider.() -> Unit) {
         delegate.inject(inject)
     }
@@ -60,6 +69,9 @@ class DefaultWhenDsl<T : Any>(override val delegate: WhenStage<T>) : Decorator<W
             }
             append(" Event")
             append("[${event.javaClass.toName()}]")
+            if (name.isNotEmpty()) {
+                append("[$name]")
+            }
         }
         val dynamicTest = DynamicTest.dynamicTest(displayName) {
             expectStage.verify()

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/Dsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/Dsl.kt
@@ -16,13 +16,14 @@ package me.ahoo.wow.test.saga.stateless.dsl
 import me.ahoo.wow.api.modeling.OwnerId
 import me.ahoo.wow.ioc.ServiceProvider
 import me.ahoo.wow.messaging.function.MessageFunction
+import me.ahoo.wow.test.dsl.NameSpecCapable
 import me.ahoo.wow.test.saga.stateless.StatelessSagaExpecter
 
 interface StatelessSagaDsl<T : Any> {
     fun on(block: WhenDsl<T>.() -> Unit)
 }
 
-interface WhenDsl<T : Any> {
+interface WhenDsl<T : Any> : NameSpecCapable {
     fun inject(inject: ServiceProvider.() -> Unit)
     fun functionFilter(filter: (MessageFunction<*, *, *>) -> Boolean)
     fun functionName(functionName: String) {


### PR DESCRIPTION
- Add NameSpecCapable interface to WhenDsl
- Implement name property and name function in DefaultWhenDsl
- Update SagaSpec and CartSagaSpec to use new naming feature
- Add test case for non-cart origin in CartSagaSpec
