### PR TITLE
feat(test): add name specification capability to Aggregate DSL stages

### DIFF
--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/Dsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/Dsl.kt
@@ -20,12 +20,13 @@ import me.ahoo.wow.messaging.DefaultHeader
 import me.ahoo.wow.modeling.state.StateAggregate
 import me.ahoo.wow.test.aggregate.AggregateExpecter
 import me.ahoo.wow.test.aggregate.ExpectedResult
+import me.ahoo.wow.test.dsl.NameSpecCapable
 
 interface AggregateDsl<S : Any> {
     fun given(block: GivenDsl<S>.() -> Unit)
 }
 
-interface GivenDsl<S : Any> : WhenDsl<S> {
+interface GivenDsl<S : Any> : WhenDsl<S>, NameSpecCapable {
     fun inject(inject: ServiceProvider.() -> Unit)
 
     fun givenOwnerId(ownerId: String)
@@ -35,7 +36,7 @@ interface GivenDsl<S : Any> : WhenDsl<S> {
     fun givenState(state: S, version: Int, block: WhenDsl<S>.() -> Unit)
 }
 
-interface WhenDsl<S : Any> {
+interface WhenDsl<S : Any> : NameSpecCapable {
     fun whenCommand(
         command: Any,
         header: Header = DefaultHeader.Companion.empty(),


### PR DESCRIPTION
- Implement NameSpecCapable interface for GivenDsl and WhenDsl
- Add name property and name function to AbstractGivenStageDsl and DefaultWhenDsl
- Update dynamic test and container names to include specified names
- Improve test readability by displaying custom names in test structure
