### PR TITLE
refactor(wow-test): make DefaultStatelessSagaDsl name property read-only

### DIFF
--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/DefaultStatelessSagaDsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/DefaultStatelessSagaDsl.kt
@@ -41,6 +41,7 @@ class DefaultWhenDsl<T : Any>(override val delegate: WhenStage<T>) :
     AbstractDynamicTestBuilder(),
     Named {
     override var name: String = ""
+        private set
     override fun name(name: String) {
         this.name = name
     }


### PR DESCRIPTION
- Add private setter to the name property in DefaultStatelessSagaDsl
- This change ensures that the name property can only be modified through the name() function, improving encapsulation and data integrity
