### PR TITLE
refactor(test): improve expectation verification in stateless sagas

### DIFF
--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/Stages.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/Stages.kt
@@ -68,10 +68,15 @@ interface WhenStage<T : Any> {
 
 interface ExpectStage<T : Any> : StatelessSagaExpecter<T, ExpectStage<T>> {
 
+
+    fun verify(): ExpectedResult<T> {
+        return verify(immediately = true)
+    }
+
     /**
      * 完成流程编排后，执行验证逻辑.
      */
-    fun verify()
+    fun verify(immediately: Boolean): ExpectedResult<T>
 }
 
 data class ExpectedResult<T>(


### PR DESCRIPTION
- Add ability to verify expectations without immediately throwing errors
- Implement lazy evaluation of expected results
- Handle multiple assertion errors using MultipleAssertionsError
- Enhance testability by allowing more flexible verification options


