### PR TITLE
refactor(test): optimize stateless saga verification logic

### DIFF
--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/DefaultStatelessSagaVerifier.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/DefaultStatelessSagaVerifier.kt
@@ -151,6 +151,9 @@ internal class DefaultExpectStage<T : Any>(private val expectedResultMono: Mono<
     }
 
     override fun verify(immediately: Boolean): ExpectedResult<T> {
+        if (immediately.not()) {
+            return expectedResult
+        }
         val expectErrors = mutableListOf<AssertionError>()
         for (expectState in expectStates) {
             try {
@@ -158,9 +161,6 @@ internal class DefaultExpectStage<T : Any>(private val expectedResultMono: Mono<
             } catch (e: AssertionError) {
                 expectErrors.add(e)
             }
-        }
-        if (immediately.not()) {
-            return expectedResult
         }
         if (expectErrors.isNotEmpty()) {
             throw MultipleAssertionsError(expectErrors)


### PR DESCRIPTION
- Move the immediate verification check to the beginning of the verify function
- Simplify the code structure by removing unnecessary nested conditional

