### PR TITLE
refactor(test): remove unnecessary blank line in ExpectStage interface

### DIFF
--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/Stages.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/Stages.kt
@@ -68,7 +68,6 @@ interface WhenStage<T : Any> {
 
 interface ExpectStage<T : Any> : StatelessSagaExpecter<T, ExpectStage<T>> {
 
-
     fun verify(): ExpectedResult<T> {
         return verify(immediately = true)
     }


### PR DESCRIPTION
- Deleted an extra blank line before the verify() function in the ExpectStage interface

