### PR TITLE
build(wow-compiler): update Generated annotation import

### DIFF
--- a/wow-compiler/src/test/kotlin/me/ahoo/wow/compiler/query/QuerySymbolProcessorTest.kt
+++ b/wow-compiler/src/test/kotlin/me/ahoo/wow/compiler/query/QuerySymbolProcessorTest.kt
@@ -44,7 +44,7 @@ class QuerySymbolProcessorTest {
                 """
                 package me.ahoo.wow.compiler
                 
-                import javax.annotation.processing.Generated
+                import me.ahoo.wow.api.annotation.Generated
                 
                 object MockCompilerAggregateProperties {
                     const val ID = "id"
@@ -87,7 +87,7 @@ class QuerySymbolProcessorTest {
                 """
                     package me.ahoo.wow.compiler
                     
-                    import javax.annotation.processing.Generated
+                    import me.ahoo.wow.api.annotation.Generated
                     
                     object MockJavaCompilerAggregateProperties {
                         const val ID = "id"


### PR DESCRIPTION
- Replace javax.annotation.processing.Generated with me.ahoo.wow.api.annotation.Generated
- Update import statements in both Kotlin and Java test files


