### PR TITLE
feat(test): add expect function to VerifiedStage

### DIFF
--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/VerifiedStage.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/VerifiedStage.kt
@@ -28,12 +28,18 @@ import me.ahoo.wow.serialization.deepCody
 import me.ahoo.wow.serialization.toJsonString
 import me.ahoo.wow.serialization.toObject
 
-interface VerifiedStage<S : Any> : GivenStage<S> {
+interface VerifiedStage<S : Any> : GivenStage<S>, AggregateExpecter<S, VerifiedStage<S>> {
     val verifiedResult: ExpectedResult<S>
     val stateAggregate: StateAggregate<S>
         get() = verifiedResult.stateAggregate
     val stateRoot: S
         get() = stateAggregate.state
+
+    override fun expect(expected: ExpectedResult<S>.() -> Unit): VerifiedStage<S> {
+        expected(verifiedResult)
+        return this
+    }
+
     fun then(verifyError: Boolean = false): VerifiedStage<S>
 
     /**


### PR DESCRIPTION
- Implement expect function in VerifiedStage interface
- Allow chaining expect calls for fluent testing
- Improve testability by providing a dedicated method for expectations

