### PR TITLE
refactor(test): enhance stateless saga DSL with command handling capabilities

### DIFF
--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/DefaultStatelessSagaDsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/DefaultStatelessSagaDsl.kt
@@ -15,6 +15,8 @@ package me.ahoo.wow.test.saga.stateless.dsl
 
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.naming.Named
+import me.ahoo.wow.command.CommandGateway
+import me.ahoo.wow.command.factory.CommandMessageFactory
 import me.ahoo.wow.infra.Decorator
 import me.ahoo.wow.ioc.ServiceProvider
 import me.ahoo.wow.messaging.function.MessageFunction
@@ -31,8 +33,17 @@ import kotlin.reflect.KClass
 
 class DefaultStatelessSagaDsl<T : Any>(private val processorType: Class<T>) : StatelessSagaDsl<T>,
     AbstractDynamicTestBuilder() {
-    override fun on(block: WhenDsl<T>.() -> Unit) {
-        val whenStage = processorType.sagaVerifier()
+    override fun on(
+        serviceProvider: ServiceProvider,
+        commandGateway: CommandGateway,
+        commandMessageFactory: CommandMessageFactory,
+        block: WhenDsl<T>.() -> Unit
+    ) {
+        val whenStage = processorType.sagaVerifier(
+            serviceProvider = serviceProvider,
+            commandGateway = commandGateway,
+            commandMessageFactory = commandMessageFactory
+        )
         val whenDsl = DefaultWhenDsl(whenStage)
         block(whenDsl)
         dynamicNodes.addAll(whenDsl.dynamicNodes)

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/Dsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/Dsl.kt
@@ -14,13 +14,28 @@
 package me.ahoo.wow.test.saga.stateless.dsl
 
 import me.ahoo.wow.api.modeling.OwnerId
+import me.ahoo.wow.command.CommandGateway
+import me.ahoo.wow.command.factory.CommandMessageFactory
+import me.ahoo.wow.command.factory.SimpleCommandBuilderRewriterRegistry
+import me.ahoo.wow.command.factory.SimpleCommandMessageFactory
 import me.ahoo.wow.ioc.ServiceProvider
+import me.ahoo.wow.ioc.SimpleServiceProvider
 import me.ahoo.wow.messaging.function.MessageFunction
+import me.ahoo.wow.test.SagaVerifier.defaultCommandGateway
 import me.ahoo.wow.test.dsl.NameSpecCapable
 import me.ahoo.wow.test.saga.stateless.StatelessSagaExpecter
+import me.ahoo.wow.test.validation.TestValidator
 
 interface StatelessSagaDsl<T : Any> {
-    fun on(block: WhenDsl<T>.() -> Unit)
+    fun on(
+        serviceProvider: ServiceProvider = SimpleServiceProvider(),
+        commandGateway: CommandGateway = defaultCommandGateway(),
+        commandMessageFactory: CommandMessageFactory = SimpleCommandMessageFactory(
+            validator = TestValidator,
+            commandBuilderRewriterRegistry = SimpleCommandBuilderRewriterRegistry()
+        ),
+        block: WhenDsl<T>.() -> Unit
+    )
 }
 
 interface WhenDsl<T : Any> : NameSpecCapable {


### PR DESCRIPTION
- Add commandGateway and commandMessageFactory parameters to on() function
- Update DefaultStatelessSagaDsl to use these new parameters
- Modify Dsl.kt to include default implementations for command handling

