### PR TITLE
refactor(test): enhance AggregateDsl with additional parameters

### DIFF
--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/DefaultAggregateDsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/DefaultAggregateDsl.kt
@@ -17,9 +17,11 @@ import me.ahoo.wow.api.event.DomainEvent
 import me.ahoo.wow.api.messaging.Header
 import me.ahoo.wow.api.naming.Named
 import me.ahoo.wow.event.DomainEventStream
+import me.ahoo.wow.eventsourcing.EventStore
 import me.ahoo.wow.infra.Decorator
 import me.ahoo.wow.ioc.ServiceProvider
 import me.ahoo.wow.modeling.state.StateAggregate
+import me.ahoo.wow.modeling.state.StateAggregateFactory
 import me.ahoo.wow.test.AggregateVerifier.aggregateVerifier
 import me.ahoo.wow.test.aggregate.EventIterator
 import me.ahoo.wow.test.aggregate.ExpectStage
@@ -35,8 +37,21 @@ import kotlin.reflect.KClass
 
 class DefaultAggregateDsl<C : Any, S : Any>(private val commandAggregateType: Class<C>) :
     AggregateDsl<S>, AbstractDynamicTestBuilder() {
-    override fun on(block: GivenDsl<S>.() -> Unit) {
-        val givenStage = commandAggregateType.aggregateVerifier<C, S>()
+    override fun on(
+        aggregateId: String,
+        tenantId: String,
+        stateAggregateFactory: StateAggregateFactory,
+        eventStore: EventStore,
+        serviceProvider: ServiceProvider,
+        block: GivenDsl<S>.() -> Unit
+    ) {
+        val givenStage = commandAggregateType.aggregateVerifier<C, S>(
+            aggregateId = aggregateId,
+            tenantId = tenantId,
+            stateAggregateFactory = stateAggregateFactory,
+            eventStore = eventStore,
+            serviceProvider = serviceProvider
+        )
         val givenDsl = DefaultGivenDsl(givenStage)
         block(givenDsl)
         dynamicNodes.addAll(givenDsl.dynamicNodes)

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/Dsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/Dsl.kt
@@ -15,15 +15,29 @@ package me.ahoo.wow.test.aggregate.dsl
 
 import me.ahoo.wow.api.messaging.Header
 import me.ahoo.wow.api.modeling.OwnerId
+import me.ahoo.wow.api.modeling.TenantId
+import me.ahoo.wow.eventsourcing.EventStore
+import me.ahoo.wow.eventsourcing.InMemoryEventStore
+import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.ioc.ServiceProvider
+import me.ahoo.wow.ioc.SimpleServiceProvider
 import me.ahoo.wow.messaging.DefaultHeader
+import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory
 import me.ahoo.wow.modeling.state.StateAggregate
+import me.ahoo.wow.modeling.state.StateAggregateFactory
 import me.ahoo.wow.test.aggregate.AggregateExpecter
 import me.ahoo.wow.test.aggregate.ExpectedResult
 import me.ahoo.wow.test.dsl.NameSpecCapable
 
 interface AggregateDsl<S : Any> {
-    fun on(block: GivenDsl<S>.() -> Unit)
+    fun on(
+        aggregateId: String = generateGlobalId(),
+        tenantId: String = TenantId.DEFAULT_TENANT_ID,
+        stateAggregateFactory: StateAggregateFactory = ConstructorStateAggregateFactory,
+        eventStore: EventStore = InMemoryEventStore(),
+        serviceProvider: ServiceProvider = SimpleServiceProvider(),
+        block: GivenDsl<S>.() -> Unit
+    )
 }
 
 interface GivenDsl<S : Any> : WhenDsl<S>, NameSpecCapable {


### PR DESCRIPTION
- Add parameters to on() method: aggregateId, tenantId, stateAggregateFactory, eventStore, serviceProvider
- Update DefaultAggregateDsl to use new parameters in aggregateVerifier
- Modify Dsl to include new parameters in AggregateDsl interface

