### PR TITLE
test(aggregate): enhance fork test with custom name

### DIFF
--- a/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt
+++ b/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt
@@ -43,7 +43,7 @@ class CartSpec : AggregateSpec<Cart, CartState>(
                 expectStateAggregate {
                     ownerId.assert().isEqualTo(ownerId)
                 }
-                fork {
+                fork("Added") {
                     val removeCartItem = RemoveCartItem(
                         productIds = setOf(addCartItem.productId),
                     )

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/DefaultAggregateDsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/DefaultAggregateDsl.kt
@@ -194,16 +194,23 @@ class DefaultExpectDsl<S : Any>(override val delegate: ExpectStage<S>) :
     Decorator<ExpectStage<S>>,
     AbstractDynamicTestBuilder() {
     override fun fork(
+        name: String,
         verifyError: Boolean,
         block: ForkedVerifiedStageDsl<S>.() -> Unit
     ) {
+        val displayName = buildString {
+            append("Fork")
+            if (name.isNotEmpty()) {
+                append("[$name]")
+            }
+        }
         val forkNode = try {
             val verifiedStage = delegate.verify().fork(verifyError)
             val forkedVerifiedStageDsl = DefaultForkedVerifiedStageDsl(verifiedStage)
             block(forkedVerifiedStageDsl)
-            DynamicContainer.dynamicContainer("Fork", forkedVerifiedStageDsl.dynamicNodes)
+            DynamicContainer.dynamicContainer(displayName, forkedVerifiedStageDsl.dynamicNodes)
         } catch (e: Throwable) {
-            DynamicTest.dynamicTest("Fork Error") {
+            DynamicTest.dynamicTest("$displayName Error") {
                 throw e
             }
         }

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/Dsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/Dsl.kt
@@ -61,6 +61,7 @@ interface WhenDsl<S : Any> : NameSpecCapable {
 
 interface ExpectDsl<S : Any> : AggregateExpecter<S, ExpectDsl<S>> {
     fun fork(
+        name: String = "",
         verifyError: Boolean = false,
         block: ForkedVerifiedStageDsl<S>.() -> Unit
     )


### PR DESCRIPTION
- Add optional name parameter to fork function in Dsl.kt
- Update DefaultAggregateDsl.kt to use custom fork name in test display
- Modify CartSpec.kt to use named fork for better test readability

