### PR TITLE
feat(test): add service injection functionality to StatelessSagaDsl

### DIFF
--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/Dsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/Dsl.kt
@@ -27,6 +27,7 @@ import me.ahoo.wow.test.saga.stateless.StatelessSagaExpecter
 import me.ahoo.wow.test.validation.TestValidator
 
 interface StatelessSagaDsl<T : Any> {
+    fun inject(inject: ServiceProvider.() -> Unit)
     fun on(
         serviceProvider: ServiceProvider = SimpleServiceProvider(),
         commandGateway: CommandGateway = defaultCommandGateway(),


### PR DESCRIPTION
- Implement inject() function in StatelessSagaDsl interface
- Add publicServiceProvider to DefaultStatelessSagaDsl class
- Update on() function to merge public and private service providers

