### PR TITLE
refactor(test): introduce InjectServiceCapable interface

### DIFF
--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/GivenStage.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/GivenStage.kt
@@ -25,10 +25,11 @@ import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory.toStateAggreg
 import me.ahoo.wow.modeling.state.StateAggregate
 import me.ahoo.wow.modeling.state.StateAggregateFactory
 import me.ahoo.wow.naming.annotation.toName
+import me.ahoo.wow.test.dsl.InjectServiceCapable
 import kotlin.reflect.KType
 import kotlin.reflect.full.defaultType
 
-interface GivenStage<S : Any> {
+interface GivenStage<S : Any> : InjectServiceCapable<GivenStage<S>> {
     fun <SERVICE : Any> inject(
         service: SERVICE,
         serviceName: String = service.javaClass.toName(),
@@ -39,8 +40,6 @@ interface GivenStage<S : Any> {
         }
         return this
     }
-
-    fun inject(inject: ServiceProvider.() -> Unit): GivenStage<S>
 
     fun givenOwnerId(ownerId: String): GivenStage<S>
 

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/dsl/InjectServiceCapable.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/dsl/InjectServiceCapable.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.test.dsl
+
+import me.ahoo.wow.ioc.ServiceProvider
+
+interface InjectServiceCapable<R> {
+    fun inject(inject: ServiceProvider.() -> Unit): R
+}

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/WhenStage.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/WhenStage.kt
@@ -14,9 +14,9 @@
 package me.ahoo.wow.test.saga.stateless
 
 import me.ahoo.wow.api.modeling.OwnerId
-import me.ahoo.wow.ioc.ServiceProvider
 import me.ahoo.wow.messaging.function.MessageFunction
 import me.ahoo.wow.naming.annotation.toName
+import me.ahoo.wow.test.dsl.InjectServiceCapable
 import kotlin.reflect.KType
 import kotlin.reflect.full.defaultType
 
@@ -25,7 +25,7 @@ import kotlin.reflect.full.defaultType
  * 1. when event
  * 2. expect commands
  */
-interface WhenStage<T : Any> {
+interface WhenStage<T : Any> : InjectServiceCapable<WhenStage<T>> {
     fun <SERVICE : Any> inject(
         service: SERVICE,
         serviceName: String = service.javaClass.toName(),
@@ -37,7 +37,6 @@ interface WhenStage<T : Any> {
         return this
     }
 
-    fun inject(inject: ServiceProvider.() -> Unit): WhenStage<T>
     fun functionFilter(filter: (MessageFunction<*, *, *>) -> Boolean): WhenStage<T>
 
     fun functionName(functionName: String): WhenStage<T> {

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/Dsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/Dsl.kt
@@ -22,12 +22,12 @@ import me.ahoo.wow.ioc.ServiceProvider
 import me.ahoo.wow.ioc.SimpleServiceProvider
 import me.ahoo.wow.messaging.function.MessageFunction
 import me.ahoo.wow.test.SagaVerifier.defaultCommandGateway
+import me.ahoo.wow.test.dsl.InjectServiceCapable
 import me.ahoo.wow.test.dsl.NameSpecCapable
 import me.ahoo.wow.test.saga.stateless.StatelessSagaExpecter
 import me.ahoo.wow.test.validation.TestValidator
 
-interface StatelessSagaDsl<T : Any> {
-    fun inject(inject: ServiceProvider.() -> Unit)
+interface StatelessSagaDsl<T : Any> : InjectServiceCapable<Unit> {
     fun on(
         serviceProvider: ServiceProvider = SimpleServiceProvider(),
         commandGateway: CommandGateway = defaultCommandGateway(),
@@ -39,8 +39,7 @@ interface StatelessSagaDsl<T : Any> {
     )
 }
 
-interface WhenDsl<T : Any> : NameSpecCapable {
-    fun inject(inject: ServiceProvider.() -> Unit)
+interface WhenDsl<T : Any> : NameSpecCapable, InjectServiceCapable<Unit> {
     fun functionFilter(filter: (MessageFunction<*, *, *>) -> Boolean)
     fun functionName(functionName: String) {
         functionFilter {


### PR DESCRIPTION
- Extract InjectServiceCapable interface for injecting services into test stages
- Implement InjectServiceCapable in GivenStage and WhenStage
- Remove redundant inject functions from interfaces
- Update imports to use the new InjectServiceCapable interface


