### PR TITLE
refactor(test): introduce InjectPublicServiceCapable interface

### DIFF
--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/DefaultAggregateDsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/DefaultAggregateDsl.kt
@@ -20,6 +20,7 @@ import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.eventsourcing.EventStore
 import me.ahoo.wow.infra.Decorator
 import me.ahoo.wow.ioc.ServiceProvider
+import me.ahoo.wow.ioc.SimpleServiceProvider
 import me.ahoo.wow.modeling.state.StateAggregate
 import me.ahoo.wow.modeling.state.StateAggregateFactory
 import me.ahoo.wow.test.AggregateVerifier.aggregateVerifier
@@ -37,6 +38,7 @@ import kotlin.reflect.KClass
 
 class DefaultAggregateDsl<C : Any, S : Any>(private val commandAggregateType: Class<C>) :
     AggregateDsl<S>, AbstractDynamicTestBuilder() {
+    override val publicServiceProvider: ServiceProvider = SimpleServiceProvider()
     override fun on(
         aggregateId: String,
         tenantId: String,
@@ -45,6 +47,10 @@ class DefaultAggregateDsl<C : Any, S : Any>(private val commandAggregateType: Cl
         serviceProvider: ServiceProvider,
         block: GivenDsl<S>.() -> Unit
     ) {
+        publicServiceProvider.serviceNames.forEach { serviceName ->
+            val publicService = serviceProvider.getService<Any>(serviceName)!!
+            serviceProvider.register(publicService, serviceName = serviceName)
+        }
         val givenStage = commandAggregateType.aggregateVerifier<C, S>(
             aggregateId = aggregateId,
             tenantId = tenantId,

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/Dsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/Dsl.kt
@@ -28,8 +28,9 @@ import me.ahoo.wow.modeling.state.StateAggregateFactory
 import me.ahoo.wow.test.aggregate.AggregateExpecter
 import me.ahoo.wow.test.aggregate.ExpectedResult
 import me.ahoo.wow.test.dsl.NameSpecCapable
+import me.ahoo.wow.test.saga.stateless.dsl.InjectPublicServiceCapable
 
-interface AggregateDsl<S : Any> {
+interface AggregateDsl<S : Any> : InjectPublicServiceCapable {
     fun on(
         aggregateId: String = generateGlobalId(),
         tenantId: String = TenantId.DEFAULT_TENANT_ID,

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/DefaultStatelessSagaDsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/DefaultStatelessSagaDsl.kt
@@ -34,10 +34,7 @@ import kotlin.reflect.KClass
 
 class DefaultStatelessSagaDsl<T : Any>(private val processorType: Class<T>) : StatelessSagaDsl<T>,
     AbstractDynamicTestBuilder() {
-    private val publicServiceProvider: ServiceProvider = SimpleServiceProvider()
-    override fun inject(inject: ServiceProvider.() -> Unit) {
-        inject(publicServiceProvider)
-    }
+    override val publicServiceProvider: ServiceProvider = SimpleServiceProvider()
 
     override fun on(
         serviceProvider: ServiceProvider,

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/Dsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/Dsl.kt
@@ -27,7 +27,7 @@ import me.ahoo.wow.test.dsl.NameSpecCapable
 import me.ahoo.wow.test.saga.stateless.StatelessSagaExpecter
 import me.ahoo.wow.test.validation.TestValidator
 
-interface StatelessSagaDsl<T : Any> : InjectServiceCapable<Unit> {
+interface StatelessSagaDsl<T : Any> : InjectPublicServiceCapable {
     fun on(
         serviceProvider: ServiceProvider = SimpleServiceProvider(),
         commandGateway: CommandGateway = defaultCommandGateway(),

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/InjectPublicServiceCapable.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/InjectPublicServiceCapable.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.test.saga.stateless.dsl
+
+import me.ahoo.wow.ioc.ServiceProvider
+import me.ahoo.wow.test.dsl.InjectServiceCapable
+
+interface InjectPublicServiceCapable : InjectServiceCapable<Unit> {
+    val publicServiceProvider: ServiceProvider
+
+    override fun inject(inject: ServiceProvider.() -> Unit) {
+        inject(publicServiceProvider)
+    }
+}


### PR DESCRIPTION
- Add InjectPublicServiceCapable interface for injecting public services
- Implement the interface in DefaultAggregateDsl and DefaultStatelessSagaDsl
- Update AggregateDsl and StatelessSagaDsl to extend InjectPublicServiceCapable
- Simplify service injection logic by using publicServiceProvider

