### PR TITLE
refactor(test): replace service registration loop with copyTo function

### DIFF
--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/DefaultAggregateDsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/DefaultAggregateDsl.kt
@@ -47,10 +47,7 @@ class DefaultAggregateDsl<C : Any, S : Any>(private val commandAggregateType: Cl
         serviceProvider: ServiceProvider,
         block: GivenDsl<S>.() -> Unit
     ) {
-        publicServiceProvider.serviceNames.forEach { serviceName ->
-            val publicService = serviceProvider.getService<Any>(serviceName)!!
-            serviceProvider.register(publicService, serviceName = serviceName)
-        }
+        publicServiceProvider.copyTo(serviceProvider)
         val givenStage = commandAggregateType.aggregateVerifier<C, S>(
             aggregateId = aggregateId,
             tenantId = tenantId,

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/DefaultStatelessSagaDsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/DefaultStatelessSagaDsl.kt
@@ -42,10 +42,7 @@ class DefaultStatelessSagaDsl<T : Any>(private val processorType: Class<T>) : St
         commandMessageFactory: CommandMessageFactory,
         block: WhenDsl<T>.() -> Unit
     ) {
-        publicServiceProvider.serviceNames.forEach { serviceName ->
-            val publicService = serviceProvider.getService<Any>(serviceName)!!
-            serviceProvider.register(publicService, serviceName = serviceName)
-        }
+        publicServiceProvider.copyTo(serviceProvider)
         val whenStage = processorType.sagaVerifier(
             serviceProvider = serviceProvider,
             commandGateway = commandGateway,


### PR DESCRIPTION
- Simplify service registration by using copyTo function in DefaultAggregateDsl and DefaultStatelessSagaDsl
- Remove redundant forEach loop that registered each service individually
- Improve code readability and reduce boilerplate

