### PR TITLE
feat(core): add support for extracting command aggregate in CommandExchange

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandExchange.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandExchange.kt
@@ -21,6 +21,7 @@ import me.ahoo.wow.event.DomainEventException.Companion.toException
 import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.messaging.handler.MessageExchange
 import me.ahoo.wow.modeling.command.AggregateProcessor
+import me.ahoo.wow.modeling.command.getCommandAggregate
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -93,6 +94,10 @@ interface ServerCommandExchange<C : Any> : CommandExchange<ServerCommandExchange
         val extracted = super.extractDeclared(type)
         if (extracted != null) {
             return extracted
+        }
+        val commandAggregate = getCommandAggregate<Any, Any>()
+        if (type.isInstance(commandAggregate)) {
+            return type.cast(commandAggregate)
         }
         val eventStream = getEventStream()
         if (type.isInstance(eventStream)) {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/SimpleServerCommandExchangeTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/SimpleServerCommandExchangeTest.kt
@@ -5,6 +5,8 @@ import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.modeling.command.CommandAggregate
+import me.ahoo.wow.modeling.command.setCommandAggregate
 import org.junit.jupiter.api.Test
 
 class SimpleServerCommandExchangeTest {
@@ -24,6 +26,14 @@ class SimpleServerCommandExchangeTest {
         val command = MockCreateCommand(generateGlobalId()).toCommandMessage()
         val commandExchange = SimpleServerCommandExchange(command)
         commandExchange.extractDeclared(CommandMessage::class.java).assert().isNotNull()
+    }
+
+    @Test
+    fun extractDeclaredCommandAggregate() {
+        val command = MockCreateCommand(generateGlobalId()).toCommandMessage()
+        val commandExchange = SimpleServerCommandExchange(command)
+        commandExchange.setCommandAggregate(mockk())
+        commandExchange.extractDeclared(CommandAggregate::class.java).assert().isNotNull()
     }
 
     @Test


### PR DESCRIPTION


- Implement getCommandAggregate() method in CommandExchange
- Add unit test for extracting command aggregate
- Update extractDeclared() method to handle CommandAggregate type

