### PR TITLE
refactor(wow-core): optimize command gateway and introduce reactive extensions

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/reactor/Monos.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/reactor/Monos.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.reactor
+
+import reactor.core.publisher.Mono
+
+fun <R> Mono<*>.thenDefer(defer: () -> Mono<R>): Mono<R> {
+    return this.then(Mono.defer { defer() })
+}
+
+fun Mono<*>.thenRunnable(runnable: () -> Unit): Mono<Void> {
+    return this.then(Mono.fromRunnable(runnable))
+}


### PR DESCRIPTION


- Simplify check function using thenRunnable
- Refactor send function to use thenDefer and thenRunnable
- Introduce new reactive extensions in Monos.kt for better code organization

