### PR TITLE
refactor(wow-core): refactor CommandStage with chain structure

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt
@@ -57,7 +57,9 @@ enum class CommandStage {
     };
 
     /**
-     * 前置阶段
+     * 前置阶段列表
+     *
+     * 定义了当前命令阶段之前必须完成的所有阶段。用于确定阶段之间的依赖关系和执行顺序。
      */
     abstract val previous: List<CommandStage>
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt
@@ -18,88 +18,66 @@ enum class CommandStage {
      * 当命令发布到命令总线/队列后，生成完成信号.
      */
     SENT {
-        override fun shouldNotify(processingStage: CommandStage): Boolean {
-            return this == processingStage
-        }
-
-        override fun isAfter(processingStage: CommandStage): Boolean {
-            return false
-        }
+        override val previous: List<CommandStage> = listOf()
     },
 
     /**
      * 当命令被聚合根处理完成后，生成完成信号.
      */
     PROCESSED {
-        override fun shouldNotify(processingStage: CommandStage): Boolean {
-            return this == processingStage || SENT == processingStage
-        }
-
-        override fun isAfter(processingStage: CommandStage): Boolean {
-            return SENT == processingStage
-        }
+        override val previous: List<CommandStage> = listOf(SENT)
     },
 
     /**
      * 当快照被生成后，生成完成信号.
      */
     SNAPSHOT {
-        override fun shouldNotify(processingStage: CommandStage): Boolean {
-            return this == processingStage ||
-                SENT == processingStage ||
-                PROCESSED == processingStage
-        }
-
-        override fun isAfter(processingStage: CommandStage): Boolean {
-            return SENT == processingStage || PROCESSED == processingStage
-        }
+        override val previous: List<CommandStage> = listOf(SENT, PROCESSED)
     },
 
     /**
      * 当命令产生的事件*投影*完成后，生成完成信号.
      */
     PROJECTED {
-        override fun shouldNotify(processingStage: CommandStage): Boolean {
-            return this == processingStage ||
-                SENT == processingStage ||
-                PROCESSED == processingStage
-        }
-
-        override fun isAfter(processingStage: CommandStage): Boolean {
-            return SENT == processingStage || PROCESSED == processingStage
-        }
+        override val previous: List<CommandStage> = listOf(SENT, PROCESSED)
     },
 
     /**
      * 当命令产生的事件被*事件处理器*处理完成后，生成完成信号.
      */
     EVENT_HANDLED {
-        override fun shouldNotify(processingStage: CommandStage): Boolean {
-            return this == processingStage ||
-                SENT == processingStage ||
-                PROCESSED == processingStage
-        }
-
-        override fun isAfter(processingStage: CommandStage): Boolean {
-            return SENT == processingStage || PROCESSED == processingStage
-        }
+        override val previous: List<CommandStage> = listOf(SENT, PROCESSED)
     },
 
     /**
      * 当命令产生的事件被*Saga*处理完成后，生成完成信号.
      */
     SAGA_HANDLED {
-        override fun shouldNotify(processingStage: CommandStage): Boolean {
-            return this == processingStage ||
-                SENT == processingStage ||
-                PROCESSED == processingStage
-        }
-
-        override fun isAfter(processingStage: CommandStage): Boolean {
-            return SENT == processingStage || PROCESSED == processingStage
-        }
+        override val previous: List<CommandStage> = listOf(SENT, PROCESSED)
     };
 
-    abstract fun shouldNotify(processingStage: CommandStage): Boolean
-    abstract fun isAfter(processingStage: CommandStage): Boolean
+    /**
+     * 前置阶段
+     */
+    abstract val previous: List<CommandStage>
+
+    /**
+     * 判断是否应该发送通知
+     *
+     * @param processingStage 处理阶段
+     * @return 如果当前阶段等于或在处理阶段之后则返回true，否则返回false
+     */
+    fun shouldNotify(processingStage: CommandStage): Boolean {
+        return this == processingStage || isAfter(processingStage)
+    }
+
+    /**
+     * 判断当前处理阶段是否在指定处理阶段之后
+     *
+     * @param processingStage 要比较的处理阶段
+     * @return 如果当前阶段在指定阶段之后则返回true，否则返回false
+     */
+    fun isAfter(processingStage: CommandStage): Boolean {
+        return processingStage in previous
+    }
 }


### PR DESCRIPTION
- Replace inheritance with composition to simplify the class hierarchy
- Introduce 'previous' property to represent prerequisite stages
- Update logic for shouldNotify and isAfter methods to use the new chain structure
- Remove redundant code and improve readability
