### PR TITLE
refactor(wow-core): improve wait strategy injection in command gateway

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
@@ -23,7 +23,6 @@ import me.ahoo.wow.command.wait.CommandWaitEndpoint
 import me.ahoo.wow.command.wait.SimpleWaitSignal.Companion.toWaitSignal
 import me.ahoo.wow.command.wait.WaitStrategy
 import me.ahoo.wow.command.wait.WaitStrategyRegistrar
-import me.ahoo.wow.command.wait.injectWaitStrategy
 import me.ahoo.wow.command.wait.stage.WaitingFor
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.infra.idempotency.AggregateIdempotencyCheckerProvider
@@ -114,10 +113,7 @@ class DefaultCommandGateway(
             require(waitStrategy.stage == CommandStage.SENT) { "The wait strategy for the void command must be SENT." }
         }
         return check(command).thenDefer {
-            command.header.injectWaitStrategy(
-                commandWaitEndpoint = commandWaitEndpoint.endpoint,
-                waitingFor = waitStrategy
-            )
+            waitStrategy.inject(commandWaitEndpoint, command.header)
             waitStrategyRegistrar.register(command.commandId, waitStrategy)
             waitStrategy.onFinally {
                 waitStrategyRegistrar.unregister(command.commandId)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategy.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategy.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.command.wait
 
+import me.ahoo.wow.api.messaging.Header
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.core.publisher.SignalType
@@ -40,4 +41,6 @@ interface WaitStrategy {
     fun complete()
 
     fun onFinally(doFinally: Consumer<SignalType>)
+
+    fun inject(commandWaitEndpoint: CommandWaitEndpoint, header: Header)
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingFor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingFor.kt
@@ -14,9 +14,12 @@
 package me.ahoo.wow.command.wait.stage
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import me.ahoo.wow.api.messaging.Header
 import me.ahoo.wow.command.wait.CommandStage
+import me.ahoo.wow.command.wait.CommandWaitEndpoint
 import me.ahoo.wow.command.wait.WaitSignal
 import me.ahoo.wow.command.wait.WaitStrategy
+import me.ahoo.wow.command.wait.injectWaitStrategy
 import reactor.core.Scannable
 import reactor.core.publisher.Flux
 import reactor.core.publisher.SignalType
@@ -140,6 +143,10 @@ abstract class AbstractWaitingFor : WaitingFor {
         check(this.onFinallyHook.compareAndSet(EmptyOnFinally, doFinally)) {
             "Finally hook already set [${this.onFinallyHook.get()}]"
         }
+    }
+
+    override fun inject(commandWaitEndpoint: CommandWaitEndpoint, header: Header) {
+        header.injectWaitStrategy(commandWaitEndpoint.endpoint, this)
     }
 
     object EmptyOnFinally : Consumer<SignalType> {


### PR DESCRIPTION
- Move wait strategy injection from DefaultCommandGateway to WaitingFor class
- Add inject method to WaitStrategy interface
- Implement inject method in WaitingFor class
- Update command processing logic in DefaultCommandGateway

