### PR TITLE
refactor(command): remove void command checks in DefaultCommandGateway

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandResult.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandResult.kt
@@ -23,6 +23,7 @@ import me.ahoo.wow.api.messaging.processor.ProcessorInfo
 import me.ahoo.wow.api.modeling.TenantId
 import me.ahoo.wow.api.naming.Materialized
 import me.ahoo.wow.command.wait.CommandStage
+import me.ahoo.wow.command.wait.CommandStageCapable
 import me.ahoo.wow.command.wait.NullableAggregateVersionCapable
 import me.ahoo.wow.command.wait.SignalTimeCapable
 import me.ahoo.wow.command.wait.WaitSignal
@@ -31,7 +32,7 @@ import me.ahoo.wow.exception.toErrorInfo
 import me.ahoo.wow.id.generateGlobalId
 
 data class CommandResult(
-    val stage: CommandStage,
+    override val stage: CommandStage,
     val aggregateId: String,
     override val aggregateVersion: Int? = null,
     override val id: String,
@@ -45,7 +46,8 @@ data class CommandResult(
     override val bindingErrors: List<BindingError> = emptyList(),
     override val result: Map<String, Any> = emptyMap(),
     override val signalTime: Long = System.currentTimeMillis()
-) : Identifier,
+) : CommandStageCapable,
+    Identifier,
     CommandId,
     TenantId,
     RequestId,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
@@ -19,6 +19,7 @@ import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.command.validation.CommandValidator
 import me.ahoo.wow.command.validation.validateCommand
 import me.ahoo.wow.command.wait.CommandStage
+import me.ahoo.wow.command.wait.CommandStageCapable
 import me.ahoo.wow.command.wait.CommandWaitEndpoint
 import me.ahoo.wow.command.wait.SimpleWaitSignal.Companion.toWaitSignal
 import me.ahoo.wow.command.wait.WaitStrategy
@@ -107,6 +108,12 @@ class DefaultCommandGateway(
         command: CommandMessage<C>,
         waitStrategy: WaitStrategy
     ): Mono<out ClientCommandExchange<C>> {
+        if (command.isVoid && waitStrategy is CommandStageCapable) {
+            require(
+                waitStrategy.stage == CommandStage.SENT
+            ) { "The wait strategy for the void command must be SENT." }
+        }
+
         return check(command).thenDefer {
             waitStrategy.inject(commandWaitEndpoint, command.header)
             waitStrategyRegistrar.register(command.commandId, waitStrategy)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
@@ -23,7 +23,6 @@ import me.ahoo.wow.command.wait.CommandWaitEndpoint
 import me.ahoo.wow.command.wait.SimpleWaitSignal.Companion.toWaitSignal
 import me.ahoo.wow.command.wait.WaitStrategy
 import me.ahoo.wow.command.wait.WaitStrategyRegistrar
-import me.ahoo.wow.command.wait.stage.WaitingFor
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.infra.idempotency.AggregateIdempotencyCheckerProvider
 import me.ahoo.wow.modeling.materialize
@@ -108,10 +107,6 @@ class DefaultCommandGateway(
         command: CommandMessage<C>,
         waitStrategy: WaitStrategy
     ): Mono<out ClientCommandExchange<C>> {
-        require(waitStrategy is WaitingFor) { "waitStrategy must be WaitingFor." }
-        if (command.isVoid) {
-            require(waitStrategy.stage == CommandStage.SENT) { "The wait strategy for the void command must be SENT." }
-        }
         return check(command).thenDefer {
             waitStrategy.inject(commandWaitEndpoint, command.header)
             waitStrategyRegistrar.register(command.commandId, waitStrategy)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt
@@ -83,3 +83,7 @@ enum class CommandStage {
         return processingStage in previous
     }
 }
+
+interface CommandStageCapable {
+    val stage: CommandStage
+}

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingFor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingFor.kt
@@ -16,6 +16,7 @@ package me.ahoo.wow.command.wait.stage
 import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.messaging.Header
 import me.ahoo.wow.command.wait.CommandStage
+import me.ahoo.wow.command.wait.CommandStageCapable
 import me.ahoo.wow.command.wait.CommandWaitEndpoint
 import me.ahoo.wow.command.wait.WaitSignal
 import me.ahoo.wow.command.wait.WaitStrategy
@@ -29,8 +30,7 @@ import java.util.*
 import java.util.concurrent.atomic.AtomicReference
 import java.util.function.Consumer
 
-interface WaitingFor : WaitStrategy {
-    val stage: CommandStage
+interface WaitingFor : WaitStrategy, CommandStageCapable {
 
     companion object {
         fun sent(): WaitingFor = WaitingForSent()

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTest.kt
@@ -17,10 +17,15 @@ import io.mockk.every
 import io.mockk.mockk
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.command.validation.CommandValidator
+import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.SimpleCommandWaitEndpoint
+import me.ahoo.wow.command.wait.stage.WaitingFor
+import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.infra.idempotency.DefaultAggregateIdempotencyCheckerProvider
 import me.ahoo.wow.tck.command.CommandGatewaySpec
+import me.ahoo.wow.tck.mock.MockVoidCommand
 import me.ahoo.wow.test.validation.TestValidator
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import reactor.kotlin.core.publisher.toMono
 import reactor.kotlin.test.test
@@ -29,6 +34,15 @@ import java.time.Duration
 internal class DefaultCommandGatewayTest : CommandGatewaySpec() {
     override fun createCommandBus(): CommandBus {
         return InMemoryCommandBus()
+    }
+
+    @Test
+    fun sendVoidCommand() {
+        val messageGateway = createMessageBus()
+        val message = MockVoidCommand(generateGlobalId()).toCommandMessage()
+        Assertions.assertThrows(IllegalArgumentException::class.java) {
+            messageGateway.send(message, WaitingFor.stage(CommandStage.PROCESSED, "", ""))
+        }
     }
 
     @Test

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTest.kt
@@ -17,15 +17,10 @@ import io.mockk.every
 import io.mockk.mockk
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.command.validation.CommandValidator
-import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.SimpleCommandWaitEndpoint
-import me.ahoo.wow.command.wait.stage.WaitingFor
-import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.infra.idempotency.DefaultAggregateIdempotencyCheckerProvider
 import me.ahoo.wow.tck.command.CommandGatewaySpec
-import me.ahoo.wow.tck.mock.MockVoidCommand
 import me.ahoo.wow.test.validation.TestValidator
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import reactor.kotlin.core.publisher.toMono
 import reactor.kotlin.test.test
@@ -34,15 +29,6 @@ import java.time.Duration
 internal class DefaultCommandGatewayTest : CommandGatewaySpec() {
     override fun createCommandBus(): CommandBus {
         return InMemoryCommandBus()
-    }
-
-    @Test
-    fun sendVoidCommand() {
-        val messageGateway = createMessageBus()
-        val message = MockVoidCommand(generateGlobalId()).toCommandMessage()
-        Assertions.assertThrows(IllegalArgumentException::class.java) {
-            messageGateway.send(message, WaitingFor.stage(CommandStage.PROCESSED, "", ""))
-        }
     }
 
     @Test


### PR DESCRIPTION
- Remove requirement for waitStrategy to be WaitingFor
- Remove special handling for void commands
- Delete related test case for void command validation
