### PR TITLE
refactor(wow-core): extract AbstractWaitStrategy and simplify Waiting For implementations

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/AbstractWaitStrategy.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/AbstractWaitStrategy.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.command.wait
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import reactor.core.Scannable
+import reactor.core.publisher.Flux
+import reactor.core.publisher.SignalType
+import reactor.core.publisher.Sinks
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicReference
+import java.util.function.Consumer
+
+private val log = KotlinLogging.logger {}
+
+abstract class AbstractWaitStrategy : WaitStrategy {
+    companion object {
+        val DEFAULT_BUSY_LOOPING_DURATION: Duration = Duration.ofMillis(10)
+    }
+
+    private val waitSignalSink: Sinks.Many<WaitSignal> = Sinks.many().unicast().onBackpressureBuffer()
+    override val cancelled: Boolean
+        get() = Scannable.from(waitSignalSink).scanOrDefault(Scannable.Attr.CANCELLED, false)
+
+    override val terminated: Boolean
+        get() = Scannable.from(waitSignalSink).scanOrDefault(Scannable.Attr.TERMINATED, false)
+
+    private var onFinallyHook: AtomicReference<Consumer<SignalType>> = AtomicReference(EmptyOnFinally)
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun safeDoFinally(signalType: SignalType) {
+        val currentHook = onFinallyHook.get()
+        try {
+            currentHook.accept(signalType)
+        } catch (error: Throwable) {
+            log.error(error) {
+                "Finally hook execution failed"
+            }
+        }
+    }
+
+    override fun waiting(): Flux<WaitSignal> {
+        return waitSignalSink.asFlux().doFinally(this::safeDoFinally)
+    }
+
+    private fun busyLooping(): Sinks.EmitFailureHandler {
+        return Sinks.EmitFailureHandler.busyLooping(DEFAULT_BUSY_LOOPING_DURATION)
+    }
+
+    override fun next(signal: WaitSignal) {
+        waitSignalSink.emitNext(signal, busyLooping())
+    }
+
+    override fun error(throwable: Throwable) {
+        waitSignalSink.emitError(throwable, busyLooping())
+    }
+
+    override fun complete() {
+        waitSignalSink.emitComplete(busyLooping())
+    }
+
+    override fun onFinally(doFinally: Consumer<SignalType>) {
+        check(this.onFinallyHook.compareAndSet(EmptyOnFinally, doFinally)) {
+            "Finally hook already set [${this.onFinallyHook.get()}]"
+        }
+    }
+
+    object EmptyOnFinally : Consumer<SignalType> {
+        override fun accept(t: SignalType) = Unit
+    }
+}

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForAfterProcessed.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForAfterProcessed.kt
@@ -13,11 +13,12 @@
 
 package me.ahoo.wow.command.wait.stage
 
+import me.ahoo.wow.command.wait.AbstractWaitStrategy
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.WaitSignal
 import reactor.core.publisher.Mono
 
-abstract class WaitingForAfterProcessed : AbstractWaitingFor() {
+abstract class WaitingForAfterProcessed : WaitingFor, AbstractWaitStrategy() {
     @Volatile
     private var processedSignal: WaitSignal? = null
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForStage.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForStage.kt
@@ -13,9 +13,10 @@
 
 package me.ahoo.wow.command.wait.stage
 
+import me.ahoo.wow.command.wait.AbstractWaitStrategy
 import me.ahoo.wow.command.wait.WaitSignal
 
-abstract class WaitingForStage : AbstractWaitingFor() {
+abstract class WaitingForStage : WaitingFor, AbstractWaitStrategy() {
     override fun next(signal: WaitSignal) {
         super.next(signal)
         if (signal.stage == stage) {


### PR DESCRIPTION

- Extract common wait strategy logic into AbstractWaitStrategy class
- Simplify WaitingFor interface and remove duplicate code
- Update WaitingForAfterProcessed and WaitingForStage to extend AbstractWaitStrategy
- Remove redundant methods and properties from WaitingFor implementations


