### PR TITLE
refactor(wow-core): modify AbstractWaitStrategy for better structure and inheritance

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/AbstractWaitStrategy.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/AbstractWaitStrategy.kt
@@ -29,17 +29,17 @@ abstract class AbstractWaitStrategy : WaitStrategy {
         val DEFAULT_BUSY_LOOPING_DURATION: Duration = Duration.ofMillis(10)
     }
 
-    private val waitSignalSink: Sinks.Many<WaitSignal> = Sinks.many().unicast().onBackpressureBuffer()
+    protected val waitSignalSink: Sinks.Many<WaitSignal> = Sinks.many().unicast().onBackpressureBuffer()
     override val cancelled: Boolean
         get() = Scannable.from(waitSignalSink).scanOrDefault(Scannable.Attr.CANCELLED, false)
 
     override val terminated: Boolean
         get() = Scannable.from(waitSignalSink).scanOrDefault(Scannable.Attr.TERMINATED, false)
 
-    private var onFinallyHook: AtomicReference<Consumer<SignalType>> = AtomicReference(EmptyOnFinally)
+    protected var onFinallyHook: AtomicReference<Consumer<SignalType>> = AtomicReference(EmptyOnFinally)
 
     @Suppress("TooGenericExceptionCaught")
-    private fun safeDoFinally(signalType: SignalType) {
+    protected fun safeDoFinally(signalType: SignalType) {
         val currentHook = onFinallyHook.get()
         try {
             currentHook.accept(signalType)
@@ -54,11 +54,11 @@ abstract class AbstractWaitStrategy : WaitStrategy {
         return waitSignalSink.asFlux().doFinally(this::safeDoFinally)
     }
 
-    private fun busyLooping(): Sinks.EmitFailureHandler {
+    protected fun busyLooping(): Sinks.EmitFailureHandler {
         return Sinks.EmitFailureHandler.busyLooping(DEFAULT_BUSY_LOOPING_DURATION)
     }
 
-    override fun next(signal: WaitSignal) {
+    protected fun nextSignal(signal: WaitSignal) {
         waitSignalSink.emitNext(signal, busyLooping())
     }
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForAfterProcessed.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForAfterProcessed.kt
@@ -47,7 +47,7 @@ abstract class WaitingForAfterProcessed : WaitingFor, AbstractWaitStrategy() {
     }
 
     override fun next(signal: WaitSignal) {
-        super.next(signal)
+        nextSignal(signal)
         if (signal.stage == CommandStage.PROCESSED) {
             processedSignal = signal
             if (!signal.succeeded) {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForStage.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForStage.kt
@@ -18,7 +18,7 @@ import me.ahoo.wow.command.wait.WaitSignal
 
 abstract class WaitingForStage : WaitingFor, AbstractWaitStrategy() {
     override fun next(signal: WaitSignal) {
-        super.next(signal)
+        nextSignal(signal)
         if (signal.stage == stage) {
             complete()
         }


### PR DESCRIPTION

- Change access modifiers from private to protected for key components
- Rename next function to nextSignal for clarity and to avoid overriding issues
- Update child classes to use new function names
- These changes prepare for integrating WaitUntilProcessed in a future commit

