### PR TITLE
refactor(wow-core): rename AbstractWaitStrategy to WaitingFor

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingFor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingFor.kt
@@ -22,11 +22,10 @@ import java.time.Duration
 import java.util.concurrent.atomic.AtomicReference
 import java.util.function.Consumer
 
-private val log = KotlinLogging.logger {}
-
-abstract class AbstractWaitStrategy : WaitStrategy {
+abstract class WaitingFor : WaitStrategy {
     companion object {
         val DEFAULT_BUSY_LOOPING_DURATION: Duration = Duration.ofMillis(10)
+        private val log = KotlinLogging.logger {}
     }
 
     protected val waitSignalSink: Sinks.Many<WaitSignal> = Sinks.many().unicast().onBackpressureBuffer()

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForStage.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForStage.kt
@@ -14,15 +14,15 @@
 package me.ahoo.wow.command.wait.stage
 
 import me.ahoo.wow.api.messaging.Header
-import me.ahoo.wow.command.wait.AbstractWaitStrategy
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.CommandStageCapable
 import me.ahoo.wow.command.wait.CommandWaitEndpoint
 import me.ahoo.wow.command.wait.WaitSignal
+import me.ahoo.wow.command.wait.WaitingFor
 import me.ahoo.wow.command.wait.injectWaitStrategy
 import java.util.Locale
 
-abstract class WaitingForStage : AbstractWaitStrategy(), CommandStageCapable {
+abstract class WaitingForStage : WaitingFor(), CommandStageCapable {
     override fun next(signal: WaitSignal) {
         nextSignal(signal)
         if (signal.stage == stage) {


### PR DESCRIPTION
- Rename AbstractWaitStrategy class to WaitingFor
- Update related imports and references
- Adjust logger initialization to companion object


