### PR TITLE
refactor(wow-core): move wait strategy constants and logic to WaitingForStage

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWaitNotifier.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWaitNotifier.kt
@@ -15,41 +15,22 @@ package me.ahoo.wow.command.wait
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.messaging.Header
-import me.ahoo.wow.api.messaging.function.FunctionNameCapable
-import me.ahoo.wow.api.messaging.processor.ProcessorInfo
-import me.ahoo.wow.command.wait.stage.WaitingForStage
+import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_CONTEXT
+import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_FUNCTION
+import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_PROCESSOR
+import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_STAGE
 import me.ahoo.wow.id.GlobalIdGenerator
 import reactor.core.publisher.Mono
 import reactor.core.scheduler.Schedulers
 
 const val COMMAND_WAIT_PREFIX = "command_wait_"
 const val COMMAND_WAIT_ENDPOINT = "${COMMAND_WAIT_PREFIX}endpoint"
-const val COMMAND_WAIT_STAGE = "${COMMAND_WAIT_PREFIX}stage"
-const val COMMAND_WAIT_CONTEXT = "${COMMAND_WAIT_PREFIX}context"
-const val COMMAND_WAIT_PROCESSOR = "${COMMAND_WAIT_PREFIX}processor"
-const val COMMAND_WAIT_FUNCTION = "${COMMAND_WAIT_PREFIX}function"
 
 interface CommandWaitEndpoint {
     val endpoint: String
 }
 
 data class SimpleCommandWaitEndpoint(override val endpoint: String) : CommandWaitEndpoint
-
-fun Header.injectWaitStrategy(
-    commandWaitEndpoint: String,
-    waitingFor: WaitingForStage
-): Header {
-    with(COMMAND_WAIT_ENDPOINT, commandWaitEndpoint)
-        .with(COMMAND_WAIT_STAGE, waitingFor.stage.name)
-    if (waitingFor is ProcessorInfo) {
-        with(COMMAND_WAIT_CONTEXT, waitingFor.contextName)
-            .with(COMMAND_WAIT_PROCESSOR, waitingFor.processorName)
-    }
-    if (waitingFor is FunctionNameCapable) {
-        with(COMMAND_WAIT_FUNCTION, waitingFor.functionName)
-    }
-    return this
-}
 
 fun Header.extractWaitStrategy(): WaitStrategyInfo? {
     val commandWaitEndpoint = this[COMMAND_WAIT_ENDPOINT] ?: return null

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForStage.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForStage.kt
@@ -14,12 +14,15 @@
 package me.ahoo.wow.command.wait.stage
 
 import me.ahoo.wow.api.messaging.Header
+import me.ahoo.wow.api.messaging.function.FunctionNameCapable
+import me.ahoo.wow.api.messaging.processor.ProcessorInfo
+import me.ahoo.wow.command.wait.COMMAND_WAIT_ENDPOINT
+import me.ahoo.wow.command.wait.COMMAND_WAIT_PREFIX
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.CommandStageCapable
 import me.ahoo.wow.command.wait.CommandWaitEndpoint
 import me.ahoo.wow.command.wait.WaitSignal
 import me.ahoo.wow.command.wait.WaitingFor
-import me.ahoo.wow.command.wait.injectWaitStrategy
 import java.util.Locale
 
 abstract class WaitingForStage : WaitingFor(), CommandStageCapable {
@@ -29,11 +32,25 @@ abstract class WaitingForStage : WaitingFor(), CommandStageCapable {
             complete()
         }
     }
+
     override fun inject(commandWaitEndpoint: CommandWaitEndpoint, header: Header) {
-        header.injectWaitStrategy(commandWaitEndpoint.endpoint, this)
+        val waitingFor = this
+        header.with(COMMAND_WAIT_ENDPOINT, commandWaitEndpoint.endpoint)
+            .with(COMMAND_WAIT_STAGE, waitingFor.stage.name)
+        if (waitingFor is ProcessorInfo) {
+            header.with(COMMAND_WAIT_CONTEXT, waitingFor.contextName)
+                .with(COMMAND_WAIT_PROCESSOR, waitingFor.processorName)
+        }
+        if (waitingFor is FunctionNameCapable) {
+            header.with(COMMAND_WAIT_FUNCTION, waitingFor.functionName)
+        }
     }
 
     companion object {
+        const val COMMAND_WAIT_STAGE = "${COMMAND_WAIT_PREFIX}stage"
+        const val COMMAND_WAIT_CONTEXT = "${COMMAND_WAIT_PREFIX}context"
+        const val COMMAND_WAIT_PROCESSOR = "${COMMAND_WAIT_PREFIX}processor"
+        const val COMMAND_WAIT_FUNCTION = "${COMMAND_WAIT_PREFIX}function"
         fun sent(): WaitingForStage = WaitingForSent()
         fun processed(): WaitingForStage = WaitingForProcessed()
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/WaitStrategyMessagePropagator.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/WaitStrategyMessagePropagator.kt
@@ -16,11 +16,11 @@ package me.ahoo.wow.messaging.propagation
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.messaging.Header
 import me.ahoo.wow.api.messaging.Message
-import me.ahoo.wow.command.wait.COMMAND_WAIT_CONTEXT
 import me.ahoo.wow.command.wait.COMMAND_WAIT_ENDPOINT
-import me.ahoo.wow.command.wait.COMMAND_WAIT_FUNCTION
-import me.ahoo.wow.command.wait.COMMAND_WAIT_PROCESSOR
-import me.ahoo.wow.command.wait.COMMAND_WAIT_STAGE
+import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_CONTEXT
+import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_FUNCTION
+import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_PROCESSOR
+import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_STAGE
 
 class WaitStrategyMessagePropagator : MessagePropagator {
     override fun inject(header: Header, upstream: Message<*, *>) {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifierTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifierTest.kt
@@ -43,8 +43,7 @@ internal class MonoCommandWaitNotifierTest {
     @Test
     fun notifyAndForgetWrap() {
         val command = MockCreateCommand("").toCommandMessage()
-
-        command.header.injectWaitStrategy("", WaitingForStage.processed())
+        WaitingForStage.processed().inject(SimpleCommandWaitEndpoint(""), command.header)
 
         val commandWaitNotifier = LocalCommandWaitNotifier(SimpleWaitStrategyRegistrar)
         Mono.empty<Void>()
@@ -65,7 +64,7 @@ internal class MonoCommandWaitNotifierTest {
     @Test
     fun notifyAndForgetWrapError() {
         val command = MockCreateCommand("").toCommandMessage()
-        command.header.injectWaitStrategy("", WaitingForStage.processed())
+        WaitingForStage.processed().inject(SimpleCommandWaitEndpoint(""), command.header)
         val commandWaitNotifier = LocalCommandWaitNotifier(SimpleWaitStrategyRegistrar)
         RuntimeException("error")
             .toMono<Void>()
@@ -81,7 +80,7 @@ internal class MonoCommandWaitNotifierTest {
     @Test
     fun notifyAndForgetWrapAndStageIsEarly() {
         val command = MockCreateCommand("").toCommandMessage()
-        command.header.injectWaitStrategy("", WaitingForStage.processed())
+        WaitingForStage.processed().inject(SimpleCommandWaitEndpoint(""), command.header)
         val commandWaitNotifier = LocalCommandWaitNotifier(SimpleWaitStrategyRegistrar)
         Mono.empty<Void>()
             .thenNotifyAndForget(commandWaitNotifier, CommandStage.PROCESSED, SimpleServerCommandExchange(command))

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/propagation/WaitStrategyMessagePropagatorTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/propagation/WaitStrategyMessagePropagatorTest.kt
@@ -2,14 +2,14 @@ package me.ahoo.wow.messaging.propagation
 
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.command.toCommandMessage
-import me.ahoo.wow.command.wait.COMMAND_WAIT_CONTEXT
 import me.ahoo.wow.command.wait.COMMAND_WAIT_ENDPOINT
-import me.ahoo.wow.command.wait.COMMAND_WAIT_FUNCTION
-import me.ahoo.wow.command.wait.COMMAND_WAIT_PROCESSOR
-import me.ahoo.wow.command.wait.COMMAND_WAIT_STAGE
-import me.ahoo.wow.command.wait.injectWaitStrategy
+import me.ahoo.wow.command.wait.SimpleCommandWaitEndpoint
 import me.ahoo.wow.command.wait.stage.WaitingForStage
-import me.ahoo.wow.id.GlobalIdGenerator
+import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_CONTEXT
+import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_FUNCTION
+import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_PROCESSOR
+import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_STAGE
+import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.messaging.DefaultHeader
 import me.ahoo.wow.tck.mock.MockCreateAggregate
 import org.junit.jupiter.api.Test
@@ -20,13 +20,9 @@ class WaitStrategyMessagePropagatorTest {
     fun inject() {
         val header = DefaultHeader.empty()
         val upstreamMessage =
-            MockCreateAggregate(GlobalIdGenerator.generateAsString(), GlobalIdGenerator.generateAsString())
+            MockCreateAggregate(generateGlobalId(), generateGlobalId())
                 .toCommandMessage()
-
-        upstreamMessage.header.injectWaitStrategy(
-            "wait-endpoint",
-            WaitingForStage.projected("context", "processor", "function")
-        )
+        WaitingForStage.processed().inject(SimpleCommandWaitEndpoint("wait-endpoint"), upstreamMessage.header)
         WaitStrategyMessagePropagator().inject(header, upstreamMessage)
         header[COMMAND_WAIT_ENDPOINT].assert().isEqualTo("wait-endpoint")
         header[COMMAND_WAIT_STAGE].assert().isEqualTo("PROJECTED")
@@ -39,9 +35,9 @@ class WaitStrategyMessagePropagatorTest {
     fun injectIfBlank() {
         val header = DefaultHeader.empty()
         val upstreamMessage =
-            MockCreateAggregate(GlobalIdGenerator.generateAsString(), GlobalIdGenerator.generateAsString())
+            MockCreateAggregate(generateGlobalId(), generateGlobalId())
                 .toCommandMessage()
-        upstreamMessage.header.injectWaitStrategy("wait-endpoint", WaitingForStage.sent())
+        WaitingForStage.sent().inject(SimpleCommandWaitEndpoint("wait-endpoint"), upstreamMessage.header)
         WaitStrategyMessagePropagator().inject(header, upstreamMessage)
         header[COMMAND_WAIT_ENDPOINT].assert().isEqualTo(upstreamMessage.header[COMMAND_WAIT_ENDPOINT])
         header[COMMAND_WAIT_STAGE].assert().isEqualTo(upstreamMessage.header[COMMAND_WAIT_STAGE])


### PR DESCRIPTION


- Move COMMAND_WAIT constants to WaitingForStage companion object
- Extract injectWaitStrategy logic into WaitingForStage
- Update related tests and classes to use new WaitingForStage.inject method
- Remove redundant injectWaitStrategy function from Header


