### PR TITLE
refactor(wow-core): rename `isAfter` to `isPrevious` for CommandStage comparison

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt
@@ -70,16 +70,16 @@ enum class CommandStage {
      * @return 如果当前阶段等于或在处理阶段之后则返回true，否则返回false
      */
     fun shouldNotify(processingStage: CommandStage): Boolean {
-        return this == processingStage || isAfter(processingStage)
+        return this == processingStage || isPrevious(processingStage)
     }
 
     /**
-     * 判断当前处理阶段是否在指定处理阶段之后
+     * 判断给定的处理阶段是否为当前阶段的前置阶段
      *
-     * @param processingStage 要比较的处理阶段
-     * @return 如果当前阶段在指定阶段之后则返回true，否则返回false
+     * @param processingStage 待判断的处理阶段
+     * @return 如果给定阶段是当前阶段的前置阶段则返回true，否则返回false
      */
-    fun isAfter(processingStage: CommandStage): Boolean {
+    fun isPrevious(processingStage: CommandStage): Boolean {
         return processingStage in previous
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/CommandStageTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/CommandStageTest.kt
@@ -17,7 +17,7 @@ class CommandStageTest {
     @ParameterizedTest
     @MethodSource("isAfterArgsProvider")
     fun isAfter(commandStage: CommandStage, processingStage: CommandStage, expected: Boolean) {
-        commandStage.isAfter(processingStage).assert().isEqualTo(expected)
+        commandStage.isPrevious(processingStage).assert().isEqualTo(expected)
     }
 
     companion object {


### PR DESCRIPTION


- Rename `isAfter` function to `isPrevious` in CommandStage class
- Update related test cases in CommandStageTest
- This change improves clarity in stage comparison logic

