### PR TITLE
refactor(wow-core): rename and implement WaitSignalShouldNotifyPredicate

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForAfterProcessed.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForAfterProcessed.kt
@@ -15,9 +15,10 @@ package me.ahoo.wow.command.wait.stage
 
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.WaitSignal
+import me.ahoo.wow.command.wait.WaitSignalShouldNotifyPredicate
 import reactor.core.publisher.Mono
 
-abstract class WaitingForAfterProcessed : WaitingForStage() {
+abstract class WaitingForAfterProcessed : WaitingForStage(), WaitSignalShouldNotifyPredicate {
     @Volatile
     private var processedSignal: WaitSignal? = null
 
@@ -31,7 +32,7 @@ abstract class WaitingForAfterProcessed : WaitingForStage() {
         super.complete()
     }
 
-    open fun isWaitingForSignal(signal: WaitSignal): Boolean {
+    override fun shouldNotify(signal: WaitSignal): Boolean {
         return signal.stage == stage
     }
 
@@ -54,7 +55,7 @@ abstract class WaitingForAfterProcessed : WaitingForStage() {
                 return
             }
         }
-        if (isWaitingForSignal(signal)) {
+        if (shouldNotify(signal)) {
             waitingForSignal = signal
         }
         tryComplete()

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForFunction.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForFunction.kt
@@ -18,8 +18,8 @@ import me.ahoo.wow.api.messaging.processor.ProcessorInfo
 import me.ahoo.wow.command.wait.WaitSignal
 
 abstract class WaitingForFunction : WaitingForAfterProcessed(), ProcessorInfo, FunctionNameCapable {
-    override fun isWaitingForSignal(signal: WaitSignal): Boolean {
-        if (!super.isWaitingForSignal(signal) || !isSameBoundedContext(signal.function)) {
+    override fun shouldNotify(signal: WaitSignal): Boolean {
+        if (!super.shouldNotify(signal) || !isSameBoundedContext(signal.function)) {
             return false
         }
         if (processorName.isBlank()) {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForProjected.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForProjected.kt
@@ -24,7 +24,7 @@ class WaitingForProjected(
     override val stage: CommandStage
         get() = CommandStage.PROJECTED
 
-    override fun isWaitingForSignal(signal: WaitSignal): Boolean {
-        return super.isWaitingForSignal(signal) && signal.isLastProjection
+    override fun shouldNotify(signal: WaitSignal): Boolean {
+        return super.shouldNotify(signal) && signal.isLastProjection
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForSnapshot.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForSnapshot.kt
@@ -20,7 +20,7 @@ class WaitingForSnapshot : WaitingForAfterProcessed() {
     override val stage: CommandStage
         get() = CommandStage.SNAPSHOT
 
-    override fun isWaitingForSignal(signal: WaitSignal): Boolean {
+    override fun shouldNotify(signal: WaitSignal): Boolean {
         return signal.stage == stage
     }
 }


### PR DESCRIPTION
- Rename isWaitingForSignal to shouldNotify for better clarity
- Implement WaitSignalShouldNotifyPredicate in WaitingForAfterProcessed
- Update related classes to use the new method name
- Improve code readability and maintainability

