### PR TITLE
refactor(wow-core): replace sendAndWaitForSent with send in StatelessSagaFunction

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt
@@ -53,7 +53,7 @@ class StatelessSagaFunction(
                 toCommandFlux(exchange.message, it)
             }
             .concatMap {
-                commandGateway.sendAndWaitForSent(it).thenReturn(it)
+                commandGateway.send(it).thenReturn(it)
             }.collectList()
             .map {
                 val commandStream = DefaultCommandStream(exchange.message.id, it)


### PR DESCRIPTION

- Update commandGateway call in StatelessSagaFunction to use send() instead of sendAndWaitForSent()
- This change improves the performance and responsiveness of the stateless saga function

