### PR TITLE
fix(webflux): update error message serialization in server-sent events

### DIFF
--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/Responses.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/Responses.kt
@@ -98,7 +98,7 @@ fun Flux<ServerSentEvent<String>>.errorResume(
         val serverSendEventMono = ServerSentEvent.builder<String>()
             .id(generateGlobalId())
             .event(errorInfo.errorCode)
-            .data(errorInfo.errorMsg)
+            .data(errorInfo.toJsonString())
             .build().toMono()
 
         exceptionHandler.handle(request, it).then(serverSendEventMono)


### PR DESCRIPTION
- Change error message serialization to use toJsonString() instead of errorMsg
- This modification ensures proper JSON formatting of error messages in server-sent events


