### PR TITLE
refactor(command): dynamic command gateway function info

### DIFF
--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
@@ -21,7 +21,6 @@ import me.ahoo.wow.api.messaging.TopicKind
 import me.ahoo.wow.api.messaging.function.FunctionInfoData
 import me.ahoo.wow.api.messaging.function.FunctionKind
 import me.ahoo.wow.api.modeling.NamedAggregate
-import me.ahoo.wow.command.COMMAND_GATEWAY_FUNCTION
 import me.ahoo.wow.command.CommandBus
 import me.ahoo.wow.command.CommandGateway
 import me.ahoo.wow.command.CommandResultException
@@ -61,6 +60,12 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
         ).toCommandMessage()
     }
 
+    private val functionInfo = FunctionInfoData(
+        functionKind = FunctionKind.COMMAND,
+        contextName = namedAggregate.contextName,
+        processorName = namedAggregate.aggregateName,
+        name = CommandGatewaySpec::class.simpleName!!,
+    )
     protected val waitStrategyRegistrar = SimpleWaitStrategyRegistrar
     protected val idempotencyChecker: IdempotencyChecker = BloomFilterIdempotencyChecker(
         Duration.ofSeconds(1),
@@ -121,7 +126,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
             id = generateGlobalId(),
             commandId = message.commandId,
             stage = CommandStage.PROCESSED,
-            function = COMMAND_GATEWAY_FUNCTION,
+            function = functionInfo,
         )
         verify {
             val waitStrategy = WaitingForStage.processed()
@@ -144,7 +149,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
             id = generateGlobalId(),
             commandId = message.commandId,
             stage = CommandStage.PROCESSED,
-            function = COMMAND_GATEWAY_FUNCTION,
+            function = functionInfo,
         )
         verify {
             sendAndWaitForProcessed(message)
@@ -166,13 +171,13 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
             id = generateGlobalId(),
             commandId = message.commandId,
             stage = CommandStage.PROCESSED,
-            function = COMMAND_GATEWAY_FUNCTION,
+            function = functionInfo,
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = message.commandId,
             stage = CommandStage.SNAPSHOT,
-            function = COMMAND_GATEWAY_FUNCTION,
+            function = functionInfo,
         )
         verify {
             val waitStrategy = WaitingForStage.snapshot()
@@ -196,13 +201,13 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
             id = generateGlobalId(),
             commandId = message.commandId,
             stage = CommandStage.PROCESSED,
-            function = COMMAND_GATEWAY_FUNCTION,
+            function = functionInfo,
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = message.commandId,
             stage = CommandStage.SNAPSHOT,
-            function = COMMAND_GATEWAY_FUNCTION,
+            function = functionInfo,
         )
         verify {
             sendAndWaitForSnapshot(message)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt
@@ -13,7 +13,6 @@
 
 package me.ahoo.wow.command
 
-import me.ahoo.wow.api.Wow
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.messaging.function.FunctionInfoData
 import me.ahoo.wow.api.messaging.function.FunctionKind
@@ -22,14 +21,14 @@ import me.ahoo.wow.command.wait.stage.WaitingForStage
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
-const val COMMAND_GATEWAY_PROCESSOR_NAME = "CommandGateway"
-
-val COMMAND_GATEWAY_FUNCTION = FunctionInfoData(
-    functionKind = FunctionKind.COMMAND,
-    contextName = Wow.WOW,
-    processorName = COMMAND_GATEWAY_PROCESSOR_NAME,
-    name = "Send",
-)
+fun CommandMessage<*>.commandGatewayFunction(): FunctionInfoData {
+    return FunctionInfoData(
+        functionKind = FunctionKind.COMMAND,
+        contextName = contextName,
+        processorName = aggregateName,
+        name = name,
+    )
+}
 
 /**
  * Command Gateway .

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
@@ -130,7 +130,14 @@ class DefaultCommandGateway(
     }
 
     private fun Throwable.toCommandResultException(command: CommandMessage<*>): CommandResultException {
-        return CommandResultException(this.toResult(command, processorName = COMMAND_GATEWAY_PROCESSOR_NAME), this)
+        return CommandResultException(
+            this.toResult(
+                commandMessage = command,
+                contextName = command.contextName,
+                processorName = command.aggregateName
+            ),
+            this
+        )
     }
 
     private fun Mono<Void>.thenEmitSentSignal(command: CommandMessage<*>, waitStrategy: WaitStrategy): Mono<Void> {
@@ -148,7 +155,7 @@ class DefaultCommandGateway(
     }
 
     private fun safeEmitSentSignal(command: CommandMessage<*>, waitStrategy: WaitStrategy) {
-        val waitSignal = COMMAND_GATEWAY_FUNCTION.toWaitSignal(
+        val waitSignal = command.commandGatewayFunction().toWaitSignal(
             id = generateGlobalId(),
             commandId = command.commandId,
             stage = CommandStage.SENT,

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/LocalCommandWaitNotifierTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/LocalCommandWaitNotifierTest.kt
@@ -13,12 +13,20 @@
 
 package me.ahoo.wow.command.wait
 
-import me.ahoo.wow.command.COMMAND_GATEWAY_FUNCTION
+import me.ahoo.wow.api.messaging.function.FunctionInfoData
+import me.ahoo.wow.api.messaging.function.FunctionKind
 import me.ahoo.wow.id.generateGlobalId
 import org.junit.jupiter.api.Test
 import reactor.kotlin.test.test
 
 internal class LocalCommandWaitNotifierTest {
+    private val functionInfo = FunctionInfoData(
+        functionKind = FunctionKind.COMMAND,
+        contextName = "wow",
+        processorName = "LocalCommandWaitNotifierTest",
+        name = "Send"
+    )
+
     @Test
     fun notifyLocal() {
         val commandWaitNotifier = LocalCommandWaitNotifier(SimpleWaitStrategyRegistrar)
@@ -28,7 +36,7 @@ internal class LocalCommandWaitNotifierTest {
                 id = generateGlobalId(),
                 commandId = generateGlobalId(),
                 stage = CommandStage.SENT,
-                function = COMMAND_GATEWAY_FUNCTION
+                function = functionInfo
             ),
         )
             .test()
@@ -44,7 +52,7 @@ internal class LocalCommandWaitNotifierTest {
                 id = generateGlobalId(),
                 commandId = generateGlobalId(),
                 stage = CommandStage.SENT,
-                function = COMMAND_GATEWAY_FUNCTION
+                function = functionInfo
             ),
         )
     }
@@ -58,7 +66,7 @@ internal class LocalCommandWaitNotifierTest {
                 id = generateGlobalId(),
                 commandId = "0THbs0sW0066001",
                 stage = CommandStage.SENT,
-                function = COMMAND_GATEWAY_FUNCTION
+                function = functionInfo
             )
         )
             .test()

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/SimpleWaitStrategyRegistrarTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/SimpleWaitStrategyRegistrarTest.kt
@@ -14,7 +14,8 @@
 package me.ahoo.wow.command.wait
 
 import me.ahoo.test.asserts.assert
-import me.ahoo.wow.command.COMMAND_GATEWAY_FUNCTION
+import me.ahoo.wow.api.messaging.function.FunctionInfoData
+import me.ahoo.wow.api.messaging.function.FunctionKind
 import me.ahoo.wow.command.wait.stage.WaitingForStage
 import me.ahoo.wow.id.GlobalIdGenerator
 import me.ahoo.wow.id.generateGlobalId
@@ -67,7 +68,12 @@ internal class SimpleWaitStrategyRegistrarTest {
             id = generateGlobalId(),
             commandId = commandId,
             stage = CommandStage.PROCESSED,
-            function = COMMAND_GATEWAY_FUNCTION
+            function = FunctionInfoData(
+                functionKind = FunctionKind.COMMAND,
+                contextName = "wow",
+                processorName = "SimpleWaitStrategyRegistrarTest",
+                name = "Send"
+            )
         )
         var nextResult = registrar.next(waitSignal)
         nextResult.assert().isFalse()

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForStageTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForStageTest.kt
@@ -14,7 +14,8 @@
 package me.ahoo.wow.command.wait
 
 import me.ahoo.test.asserts.assert
-import me.ahoo.wow.command.COMMAND_GATEWAY_FUNCTION
+import me.ahoo.wow.api.messaging.function.FunctionInfoData
+import me.ahoo.wow.api.messaging.function.FunctionKind
 import me.ahoo.wow.command.wait.stage.WaitingForStage
 import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.extractWaitingForStage
 import me.ahoo.wow.id.generateGlobalId
@@ -26,6 +27,12 @@ import java.time.Duration
 
 internal class WaitingForStageTest {
     private val contextName = "WaitingForTest"
+    private val functionInfo = FunctionInfoData(
+        functionKind = FunctionKind.COMMAND,
+        contextName = "wow",
+        processorName = "WaitingForStageTest",
+        name = "Send"
+    )
 
     @Test
     fun processedInject() {
@@ -62,7 +69,7 @@ internal class WaitingForStageTest {
             id = generateGlobalId(),
             commandId = "commandId",
             stage = CommandStage.PROCESSED,
-            function = COMMAND_GATEWAY_FUNCTION,
+            function = functionInfo,
         )
         waitStrategy.waitingLast()
             .test()
@@ -81,7 +88,7 @@ internal class WaitingForStageTest {
             id = generateGlobalId(),
             commandId = "commandId",
             stage = CommandStage.SNAPSHOT,
-            function = COMMAND_GATEWAY_FUNCTION,
+            function = functionInfo,
         )
         waitStrategy.waitingLast()
             .test()
@@ -100,13 +107,13 @@ internal class WaitingForStageTest {
             id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROCESSED,
-            function = COMMAND_GATEWAY_FUNCTION,
+            function = functionInfo,
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.SNAPSHOT,
-            function = COMMAND_GATEWAY_FUNCTION,
+            function = functionInfo,
         )
         waitStrategy.waitingLast()
             .test()
@@ -127,7 +134,7 @@ internal class WaitingForStageTest {
             id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROCESSED,
-            function = COMMAND_GATEWAY_FUNCTION,
+            function = functionInfo,
             errorCode = "ERROR_CODE"
         )
         waitStrategy.waitingLast()
@@ -146,13 +153,13 @@ internal class WaitingForStageTest {
             id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROCESSED,
-            function = COMMAND_GATEWAY_FUNCTION,
+            function = functionInfo,
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROJECTED,
-            function = COMMAND_GATEWAY_FUNCTION.copy(contextName = contextName),
+            function = functionInfo.copy(contextName = contextName),
             isLastProjection = true
         )
         waitStrategy.waitingLast()
@@ -172,13 +179,13 @@ internal class WaitingForStageTest {
             id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROCESSED,
-            function = COMMAND_GATEWAY_FUNCTION,
+            function = functionInfo,
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROJECTED,
-            function = COMMAND_GATEWAY_FUNCTION.copy(contextName = contextName, processorName = "processor"),
+            function = functionInfo.copy(contextName = contextName, processorName = "processor"),
             isLastProjection = true
         )
         waitStrategy.waitingLast()
@@ -198,13 +205,13 @@ internal class WaitingForStageTest {
             id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROCESSED,
-            function = COMMAND_GATEWAY_FUNCTION,
+            function = functionInfo,
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROJECTED,
-            function = COMMAND_GATEWAY_FUNCTION.copy(contextName = contextName, processorName = "hi"),
+            function = functionInfo.copy(contextName = contextName, processorName = "hi"),
             isLastProjection = true
         )
         waitStrategy.waitingLast()
@@ -223,13 +230,13 @@ internal class WaitingForStageTest {
             id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROCESSED,
-            function = COMMAND_GATEWAY_FUNCTION,
+            function = functionInfo,
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROJECTED,
-            function = COMMAND_GATEWAY_FUNCTION.copy(
+            function = functionInfo.copy(
                 contextName = contextName,
                 processorName = "processor",
                 name = "function"
@@ -253,13 +260,13 @@ internal class WaitingForStageTest {
             id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROCESSED,
-            function = COMMAND_GATEWAY_FUNCTION,
+            function = functionInfo,
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROJECTED,
-            function = COMMAND_GATEWAY_FUNCTION.copy(contextName = contextName),
+            function = functionInfo.copy(contextName = contextName),
             isLastProjection = false
         )
         waitStrategy.waitingLast()
@@ -280,13 +287,13 @@ internal class WaitingForStageTest {
             id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROCESSED,
-            function = COMMAND_GATEWAY_FUNCTION,
+            function = functionInfo,
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.EVENT_HANDLED,
-            function = COMMAND_GATEWAY_FUNCTION.copy(contextName = contextName),
+            function = functionInfo.copy(contextName = contextName),
             isLastProjection = false
         )
         waitStrategy.waitingLast()
@@ -306,13 +313,13 @@ internal class WaitingForStageTest {
             id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.PROCESSED,
-            function = COMMAND_GATEWAY_FUNCTION,
+            function = functionInfo,
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
             stage = CommandStage.SAGA_HANDLED,
-            function = COMMAND_GATEWAY_FUNCTION.copy(contextName = contextName)
+            function = functionInfo.copy(contextName = contextName)
         )
         waitStrategy.waitingLast()
             .test()
@@ -335,7 +342,7 @@ internal class WaitingForStageTest {
                         id = generateGlobalId(),
                         commandId = generateGlobalId(),
                         stage = CommandStage.PROJECTED,
-                        function = COMMAND_GATEWAY_FUNCTION,
+                        function = functionInfo,
                     )
                 )
             }


### PR DESCRIPTION
- Remove constant COMMAND_GATEWAY_FUNCTION and COMMAND_GATEWAY_PROCESSOR_NAME
- Create functionInfo dynamically based on command context
- Update related tests to use dynamic functionInfo
- Refactor DefaultCommandGateway to use dynamic functionInfo
