### PR TITLE
refactor(wow-core): improve error handling and signaling in WaitingFor classes

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForAfterProcessed.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForAfterProcessed.kt
@@ -50,10 +50,6 @@ abstract class WaitingForAfterProcessed : WaitingForStage(), WaitSignalShouldNot
         nextSignal(signal)
         if (signal.stage == CommandStage.PROCESSED) {
             processedSignal = signal
-            if (!signal.succeeded) {
-                super.complete()
-                return
-            }
         }
         if (shouldNotify(signal)) {
             waitingForSignal = signal

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForSnapshot.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForSnapshot.kt
@@ -14,13 +14,8 @@
 package me.ahoo.wow.command.wait.stage
 
 import me.ahoo.wow.command.wait.CommandStage
-import me.ahoo.wow.command.wait.WaitSignal
 
 class WaitingForSnapshot : WaitingForAfterProcessed() {
     override val stage: CommandStage
         get() = CommandStage.SNAPSHOT
-
-    override fun shouldNotify(signal: WaitSignal): Boolean {
-        return signal.stage == stage
-    }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForStage.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForStage.kt
@@ -24,9 +24,19 @@ import me.ahoo.wow.command.wait.CommandWaitEndpoint
 import me.ahoo.wow.command.wait.WaitSignal
 import me.ahoo.wow.command.wait.WaitStrategy
 import me.ahoo.wow.command.wait.WaitingFor
-import java.util.Locale
+import java.util.*
 
 abstract class WaitingForStage : WaitingFor(), CommandStageCapable {
+    override fun nextSignal(signal: WaitSignal) {
+        super.nextSignal(signal)
+        /**
+         * fail fast
+         */
+        if (signal.succeeded.not() && stage.isPrevious(signal.stage)) {
+            complete()
+        }
+    }
+
     override fun next(signal: WaitSignal) {
         nextSignal(signal)
         if (signal.stage == stage) {


### PR DESCRIPTION


- Add tryEmit function to handle emit operations with termination checks
- Implement fail-fast logic in WaitingForStage for unsuccessful signals
- Remove redundant success check in WaitingForAfterProcessed
- Update error and completion handling in WaitingFor class

