### PR TITLE
refactor(wow-core): abstract previous signal logic in WaitingFor

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingFor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingFor.kt
@@ -64,9 +64,23 @@ abstract class WaitingFor : WaitStrategy {
         emit()
     }
 
+    /**
+     * 判断给定的等待信号是否为前置信号
+     *
+     * @param signal 等待信号
+     * @return 如果是前置信号则返回 true，否则返回 false
+     */
+    abstract fun isPreviousSignal(signal: WaitSignal): Boolean
+
     protected open fun nextSignal(signal: WaitSignal) {
         tryEmit {
             waitSignalSink.emitNext(signal, busyLooping())
+            /**
+             * fail fast
+             */
+            if (signal.succeeded.not() && isPreviousSignal(signal)) {
+                complete()
+            }
         }
     }
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForStage.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForStage.kt
@@ -27,14 +27,8 @@ import me.ahoo.wow.command.wait.WaitingFor
 import java.util.*
 
 abstract class WaitingForStage : WaitingFor(), CommandStageCapable {
-    override fun nextSignal(signal: WaitSignal) {
-        super.nextSignal(signal)
-        /**
-         * fail fast
-         */
-        if (signal.succeeded.not() && stage.isPrevious(signal.stage)) {
-            complete()
-        }
+    override fun isPreviousSignal(signal: WaitSignal): Boolean {
+        return stage.isPrevious(signal.stage)
     }
 
     override fun next(signal: WaitSignal) {


### PR DESCRIPTION
- Introduce `isPreviousSignal` abstract method in WaitingFor interface
- Implement `isPreviousSignal` in WaitingForStage class
- Update `nextSignal` method to use `isPreviousSignal` for failure detection


