### PR TITLE
refactor(wow-core): optimize wait strategy notification logic

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWaitNotifier.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWaitNotifier.kt
@@ -70,6 +70,13 @@ class LocalCommandWaitNotifier(
     }
 }
 
+fun CommandWaitNotifier.notifyAndForget(waiteStrategy: WaitStrategy.Info, waitSignal: WaitSignal) {
+    if (!waiteStrategy.shouldNotify(waitSignal.stage)) {
+        return
+    }
+    notifyAndForget(waiteStrategy.endpoint, waitSignal)
+}
+
 fun isLocalCommand(commandId: String): Boolean {
     if (commandId.isBlank()) {
         return false

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifier.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifier.kt
@@ -111,10 +111,7 @@ class CommandWaitNotifierSubscriber<E, M>(
             bindingErrors = error.bindingErrors,
             result = messageExchange.getCommandResult()
         )
-        if (!waitStrategy.shouldNotify(waitSignal)) {
-            return
-        }
-        commandWaitNotifier.notifyAndForget(waitStrategy.endpoint, waitSignal)
+        commandWaitNotifier.notifyAndForget(waitStrategy, waitSignal)
     }
 
     override fun hookOnComplete() {


### PR DESCRIPTION
- Add notifyAndForget extension function to CommandWaitNotifier
- Update MonoCommandWaitNotifier to use the new extension function
- Simplify notification logic by moving shouldNotify check into the new function
