### PR TITLE
refactor(command): rename inject to propagate in WaitStrategy

### DIFF
--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
@@ -292,7 +292,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
             waitStrategyRegistrar.unregister(message.commandId)
         }
         waitStrategyRegistrar.register(message.commandId, waitStrategy)
-        waitStrategy.inject(SimpleCommandWaitEndpoint(""), message.header)
+        waitStrategy.propagate(SimpleCommandWaitEndpoint(""), message.header)
         waitStrategy.waitingLast().subscribe()
         verify {
             send(message)
@@ -312,7 +312,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
             waitStrategyRegistrar.unregister(message.commandId)
         }
         waitStrategyRegistrar.register(message.commandId, waitStrategy)
-        waitStrategy.inject(SimpleCommandWaitEndpoint(""), message.header)
+        waitStrategy.propagate(SimpleCommandWaitEndpoint(""), message.header)
         waitStrategy.waitingLast().subscribe()
         verify {
             send(message)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
@@ -117,7 +117,7 @@ class DefaultCommandGateway(
         }
         val commandExchange: ClientCommandExchange<C> = SimpleClientCommandExchange(command, waitStrategy)
         return check(command).thenDefer {
-            waitStrategy.inject(commandWaitEndpoint, command.header)
+            waitStrategy.propagate(commandWaitEndpoint, command.header)
             commandBus.send(command)
                 .doOnSubscribe {
                     waitStrategyRegistrar.register(command.commandId, waitStrategy)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategy.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategy.kt
@@ -20,11 +20,15 @@ import reactor.core.publisher.Mono
 import reactor.core.publisher.SignalType
 import java.util.function.Consumer
 
+interface WaitStrategyPropagator {
+    fun propagate(commandWaitEndpoint: CommandWaitEndpoint, header: Header)
+}
+
 /**
  * Command Wait Strategy
  * @see me.ahoo.wow.command.wait.stage.WaitingForStage
  */
-interface WaitStrategy {
+interface WaitStrategy : WaitStrategyPropagator {
     val cancelled: Boolean
     val terminated: Boolean
     val completed: Boolean
@@ -49,8 +53,6 @@ interface WaitStrategy {
     fun complete()
 
     fun onFinally(doFinally: Consumer<SignalType>)
-
-    fun inject(commandWaitEndpoint: CommandWaitEndpoint, header: Header)
 
     interface Info :
         CommandWaitEndpoint,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForStage.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForStage.kt
@@ -38,7 +38,7 @@ abstract class WaitingForStage : WaitingFor(), CommandStageCapable {
         }
     }
 
-    override fun inject(commandWaitEndpoint: CommandWaitEndpoint, header: Header) {
+    override fun propagate(commandWaitEndpoint: CommandWaitEndpoint, header: Header) {
         val waitingFor = this
         header.with(COMMAND_WAIT_ENDPOINT, commandWaitEndpoint.endpoint)
             .with(COMMAND_WAIT_STAGE, waitingFor.stage.name)

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifierTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifierTest.kt
@@ -43,7 +43,7 @@ internal class MonoCommandWaitNotifierTest {
     @Test
     fun notifyAndForgetWrap() {
         val command = MockCreateCommand("").toCommandMessage()
-        WaitingForStage.processed().inject(SimpleCommandWaitEndpoint(""), command.header)
+        WaitingForStage.processed().propagate(SimpleCommandWaitEndpoint(""), command.header)
 
         val commandWaitNotifier = LocalCommandWaitNotifier(SimpleWaitStrategyRegistrar)
         Mono.empty<Void>()
@@ -64,7 +64,7 @@ internal class MonoCommandWaitNotifierTest {
     @Test
     fun notifyAndForgetWrapError() {
         val command = MockCreateCommand("").toCommandMessage()
-        WaitingForStage.processed().inject(SimpleCommandWaitEndpoint(""), command.header)
+        WaitingForStage.processed().propagate(SimpleCommandWaitEndpoint(""), command.header)
         val commandWaitNotifier = LocalCommandWaitNotifier(SimpleWaitStrategyRegistrar)
         RuntimeException("error")
             .toMono<Void>()
@@ -80,7 +80,7 @@ internal class MonoCommandWaitNotifierTest {
     @Test
     fun notifyAndForgetWrapAndStageIsEarly() {
         val command = MockCreateCommand("").toCommandMessage()
-        WaitingForStage.processed().inject(SimpleCommandWaitEndpoint(""), command.header)
+        WaitingForStage.processed().propagate(SimpleCommandWaitEndpoint(""), command.header)
         val commandWaitNotifier = LocalCommandWaitNotifier(SimpleWaitStrategyRegistrar)
         Mono.empty<Void>()
             .thenNotifyAndForget(commandWaitNotifier, CommandStage.PROCESSED, SimpleServerCommandExchange(command))

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForStageTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForStageTest.kt
@@ -38,7 +38,7 @@ internal class WaitingForStageTest {
     fun processedInject() {
         val waitStrategy = WaitingForStage.projected("content", "processor", "function")
         val header = DefaultHeader()
-        waitStrategy.inject(SimpleCommandWaitEndpoint("endpoint"), header)
+        waitStrategy.propagate(SimpleCommandWaitEndpoint("endpoint"), header)
         val waitStrategyInfo = header.extractWaitingForStage()
         waitStrategyInfo.assert().isNotNull()
         waitStrategyInfo!!.stage.assert().isEqualTo(CommandStage.PROJECTED)

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/propagation/WaitStrategyMessagePropagatorTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/propagation/WaitStrategyMessagePropagatorTest.kt
@@ -23,7 +23,7 @@ class WaitStrategyMessagePropagatorTest {
             MockCreateAggregate(generateGlobalId(), generateGlobalId())
                 .toCommandMessage()
         WaitingForStage.projected("context", "processor", "function")
-            .inject(SimpleCommandWaitEndpoint("wait-endpoint"), upstreamMessage.header)
+            .propagate(SimpleCommandWaitEndpoint("wait-endpoint"), upstreamMessage.header)
         WaitStrategyMessagePropagator().inject(header, upstreamMessage)
         header[COMMAND_WAIT_ENDPOINT].assert().isEqualTo("wait-endpoint")
         header[COMMAND_WAIT_STAGE].assert().isEqualTo("PROJECTED")
@@ -38,7 +38,7 @@ class WaitStrategyMessagePropagatorTest {
         val upstreamMessage =
             MockCreateAggregate(generateGlobalId(), generateGlobalId())
                 .toCommandMessage()
-        WaitingForStage.sent().inject(SimpleCommandWaitEndpoint("wait-endpoint"), upstreamMessage.header)
+        WaitingForStage.sent().propagate(SimpleCommandWaitEndpoint("wait-endpoint"), upstreamMessage.header)
         WaitStrategyMessagePropagator().inject(header, upstreamMessage)
         header[COMMAND_WAIT_ENDPOINT].assert().isEqualTo(upstreamMessage.header[COMMAND_WAIT_ENDPOINT])
         header[COMMAND_WAIT_STAGE].assert().isEqualTo(upstreamMessage.header[COMMAND_WAIT_STAGE])


### PR DESCRIPTION
- Replace `inject` method with `propagate` in WaitStrategy interface
- Update method calls in relevant classes and tests
