### PR TITLE
refactor(messaging): rename inject to propagate in MessagePropagator

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandFactory.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandFactory.kt
@@ -25,7 +25,7 @@ import me.ahoo.wow.command.factory.CommandBuilder
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.id.generateId
 import me.ahoo.wow.messaging.DefaultHeader
-import me.ahoo.wow.messaging.propagation.MessagePropagatorProvider.inject
+import me.ahoo.wow.messaging.propagation.MessagePropagatorProvider.propagate
 import me.ahoo.wow.messaging.propagation.TraceMessagePropagator.Companion.ensureTraceId
 import me.ahoo.wow.modeling.aggregateId
 
@@ -43,7 +43,7 @@ fun <C : Any> C.toCommandMessage(
     upstream: DomainEvent<*>? = null,
 ): CommandMessage<C> {
     upstream?.let {
-        header.inject(it)
+        header.propagate(it)
     }
     val metadata = javaClass.commandMetadata()
     val commandNamedAggregate = namedAggregate ?: metadata.namedAggregateGetter?.getNamedAggregate(this)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStreamFactory.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStreamFactory.kt
@@ -21,7 +21,7 @@ import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.api.modeling.OwnerId
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.messaging.DefaultHeader
-import me.ahoo.wow.messaging.propagation.MessagePropagatorProvider.inject
+import me.ahoo.wow.messaging.propagation.MessagePropagatorProvider.propagate
 
 @Suppress("UNCHECKED_CAST")
 fun Any.flatEvent(): Iterable<Any> {
@@ -47,7 +47,7 @@ fun Any.toDomainEventStream(
     header: Header = DefaultHeader.empty(),
     createTime: Long = System.currentTimeMillis()
 ): DomainEventStream {
-    header.inject(upstream)
+    header.propagate(upstream)
     val eventStreamId = generateGlobalId()
     val aggregateId = upstream.aggregateId
     val streamVersion = aggregateVersion + 1

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/CommandOperatorMessagePropagator.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/CommandOperatorMessagePropagator.kt
@@ -19,7 +19,7 @@ import me.ahoo.wow.command.CommandOperator.operator
 import me.ahoo.wow.command.CommandOperator.withOperator
 
 class CommandOperatorMessagePropagator : MessagePropagator {
-    override fun inject(header: Header, upstream: Message<*, *>) {
+    override fun propagate(header: Header, upstream: Message<*, *>) {
         upstream.header.operator?.let {
             header.withOperator(it)
         }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/CommandRequestHeaderPropagator.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/CommandRequestHeaderPropagator.kt
@@ -42,7 +42,7 @@ class CommandRequestHeaderPropagator : MessagePropagator {
 
     private val enabled: Boolean = System.getProperty(ENABLED_KEY)?.toBoolean() != false
 
-    override fun inject(header: Header, upstream: Message<*, *>) {
+    override fun propagate(header: Header, upstream: Message<*, *>) {
         if (!enabled) {
             return
         }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/MessagePropagator.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/MessagePropagator.kt
@@ -16,6 +16,15 @@ package me.ahoo.wow.messaging.propagation
 import me.ahoo.wow.api.messaging.Header
 import me.ahoo.wow.api.messaging.Message
 
+/**
+ * 消息传播器接口，用于将上游消息的上下文信息传播到指定的头部信息中
+ */
 interface MessagePropagator {
-    fun inject(header: Header, upstream: Message<*, *>)
+    /**
+     * 将上游消息的上下文信息传播到目标头部
+     *
+     * @param header 目标消息的头部信息，用于接收传播的上下文数据
+     * @param upstream 上游消息，提供需要传播的上下文信息
+     */
+    fun propagate(header: Header, upstream: Message<*, *>)
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/MessagePropagatorProvider.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/MessagePropagatorProvider.kt
@@ -33,12 +33,12 @@ object MessagePropagatorProvider : MessagePropagator {
             }
     }
 
-    override fun inject(header: Header, upstream: Message<*, *>) {
-        messagePropagators.forEach { it.inject(header, upstream) }
+    override fun propagate(header: Header, upstream: Message<*, *>) {
+        messagePropagators.forEach { it.propagate(header, upstream) }
     }
 
-    fun Header.inject(upstream: Message<*, *>): Header {
-        inject(this, upstream)
+    fun Header.propagate(upstream: Message<*, *>): Header {
+        propagate(this, upstream)
         return this
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/TraceMessagePropagator.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/TraceMessagePropagator.kt
@@ -59,7 +59,7 @@ class TraceMessagePropagator : MessagePropagator {
         }
     }
 
-    override fun inject(header: Header, upstream: Message<*, *>) {
+    override fun propagate(header: Header, upstream: Message<*, *>) {
         upstream.header.traceId?.let {
             header.withTraceId(it)
         }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/WaitStrategyMessagePropagator.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/WaitStrategyMessagePropagator.kt
@@ -23,7 +23,7 @@ import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_PRO
 import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_STAGE
 
 class WaitStrategyMessagePropagator : MessagePropagator {
-    override fun inject(header: Header, upstream: Message<*, *>) {
+    override fun propagate(header: Header, upstream: Message<*, *>) {
         if (upstream !is CommandMessage<*>) {
             return
         }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt
@@ -24,7 +24,7 @@ import me.ahoo.wow.command.factory.CommandMessageFactory
 import me.ahoo.wow.event.DomainEventExchange
 import me.ahoo.wow.infra.Decorator
 import me.ahoo.wow.messaging.function.MessageFunction
-import me.ahoo.wow.messaging.propagation.MessagePropagatorProvider.inject
+import me.ahoo.wow.messaging.propagation.MessagePropagatorProvider.propagate
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -75,7 +75,7 @@ class StatelessSagaFunction(
 
     private fun toCommand(domainEvent: DomainEvent<*>, singleResult: Any, index: Int = 0): Mono<CommandMessage<*>> {
         if (singleResult is CommandMessage<*>) {
-            singleResult.header.inject(domainEvent)
+            singleResult.header.propagate(domainEvent)
             return singleResult.toMono()
         }
         val commandBuilder = singleResult as? CommandBuilder ?: singleResult.commandBuilder()

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/propagation/CommandOperatorMessagePropagatorTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/propagation/CommandOperatorMessagePropagatorTest.kt
@@ -12,23 +12,23 @@ import org.junit.jupiter.api.Test
 class CommandOperatorMessagePropagatorTest {
 
     @Test
-    fun inject() {
+    fun propagate() {
         val header = DefaultHeader.empty()
         val upstreamMessage =
             MockCreateAggregate(GlobalIdGenerator.generateAsString(), GlobalIdGenerator.generateAsString())
                 .toCommandMessage()
         upstreamMessage.header.withOperator("operator")
-        CommandOperatorMessagePropagator().inject(header, upstreamMessage)
+        CommandOperatorMessagePropagator().propagate(header, upstreamMessage)
         header.operator.assert().isEqualTo("operator")
     }
 
     @Test
-    fun injectIfNull() {
+    fun propagateIfNull() {
         val header = DefaultHeader.empty()
         val upstreamMessage =
             MockCreateAggregate(GlobalIdGenerator.generateAsString(), GlobalIdGenerator.generateAsString())
                 .toCommandMessage()
-        CommandOperatorMessagePropagator().inject(header, upstreamMessage)
+        CommandOperatorMessagePropagator().propagate(header, upstreamMessage)
         header.operator.assert().isNull()
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/propagation/CommandRequestHeaderPropagatorTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/propagation/CommandRequestHeaderPropagatorTest.kt
@@ -26,51 +26,51 @@ import org.junit.jupiter.api.Test
 
 class CommandRequestHeaderPropagatorTest {
     @Test
-    fun inject() {
+    fun propagate() {
         val injectedHeader = DefaultHeader.empty()
         val upstreamMessage =
             MockCreateAggregate(generateGlobalId(), generateGlobalId())
                 .toCommandMessage()
         upstreamMessage.header.withUserAgent("userAgent").withRemoteIp("remoteIp")
-        CommandRequestHeaderPropagator().inject(injectedHeader, upstreamMessage)
+        CommandRequestHeaderPropagator().propagate(injectedHeader, upstreamMessage)
         injectedHeader.userAgent.assert().isEqualTo(upstreamMessage.header.userAgent)
         injectedHeader.remoteIp.assert().isEqualTo(upstreamMessage.header.remoteIp)
     }
 
     @Test
-    fun injectIfNull() {
+    fun propagateIfNull() {
         val injectedHeader = DefaultHeader.empty()
         val upstreamMessage =
             MockCreateAggregate(generateGlobalId(), generateGlobalId())
                 .toCommandMessage()
-        CommandRequestHeaderPropagator().inject(injectedHeader, upstreamMessage)
+        CommandRequestHeaderPropagator().propagate(injectedHeader, upstreamMessage)
         injectedHeader.userAgent.assert().isNull()
         injectedHeader.remoteIp.assert().isNull()
     }
 
     @Test
-    fun injectDisabled() {
+    fun propagateDisabled() {
         System.setProperty(CommandRequestHeaderPropagator.ENABLED_KEY, "false")
         val injectedHeader = DefaultHeader.empty()
         val upstreamMessage =
             MockCreateAggregate(generateGlobalId(), generateGlobalId())
                 .toCommandMessage()
         upstreamMessage.header.withUserAgent("userAgent").withRemoteIp("remoteIp")
-        CommandRequestHeaderPropagator().inject(injectedHeader, upstreamMessage)
+        CommandRequestHeaderPropagator().propagate(injectedHeader, upstreamMessage)
         injectedHeader.userAgent.assert().isNull()
         injectedHeader.remoteIp.assert().isNull()
         System.clearProperty(CommandRequestHeaderPropagator.ENABLED_KEY)
     }
 
     @Test
-    fun injectEnabled() {
+    fun propagateEnabled() {
         System.setProperty(CommandRequestHeaderPropagator.ENABLED_KEY, "true")
         val injectedHeader = DefaultHeader.empty()
         val upstreamMessage =
             MockCreateAggregate(generateGlobalId(), generateGlobalId())
                 .toCommandMessage()
         upstreamMessage.header.withUserAgent("userAgent").withRemoteIp("remoteIp")
-        CommandRequestHeaderPropagator().inject(injectedHeader, upstreamMessage)
+        CommandRequestHeaderPropagator().propagate(injectedHeader, upstreamMessage)
         injectedHeader.userAgent.assert().isEqualTo(upstreamMessage.header.userAgent)
         injectedHeader.remoteIp.assert().isEqualTo(upstreamMessage.header.remoteIp)
         System.clearProperty(CommandRequestHeaderPropagator.ENABLED_KEY)

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/propagation/MessagePropagatorProviderTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/propagation/MessagePropagatorProviderTest.kt
@@ -3,18 +3,18 @@ package me.ahoo.wow.messaging.propagation
 import me.ahoo.wow.command.toCommandMessage
 import me.ahoo.wow.id.GlobalIdGenerator
 import me.ahoo.wow.messaging.DefaultHeader
-import me.ahoo.wow.messaging.propagation.MessagePropagatorProvider.inject
+import me.ahoo.wow.messaging.propagation.MessagePropagatorProvider.propagate
 import me.ahoo.wow.tck.mock.MockCreateAggregate
 import org.junit.jupiter.api.Test
 
 class MessagePropagatorProviderTest {
 
     @Test
-    fun inject() {
+    fun propagate() {
         val header = DefaultHeader.empty()
         val upstreamMessage =
             MockCreateAggregate(GlobalIdGenerator.generateAsString(), GlobalIdGenerator.generateAsString())
                 .toCommandMessage()
-        header.inject(upstreamMessage)
+        header.propagate(upstreamMessage)
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/propagation/TraceMessagePropagatorTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/propagation/TraceMessagePropagatorTest.kt
@@ -17,12 +17,12 @@ import org.junit.jupiter.api.Test
 class TraceMessagePropagatorTest {
 
     @Test
-    fun inject() {
+    fun propagate() {
         val injectedHeader = DefaultHeader.empty()
         val upstreamMessage =
             MockCreateAggregate(GlobalIdGenerator.generateAsString(), GlobalIdGenerator.generateAsString())
                 .toCommandMessage()
-        TraceMessagePropagator().inject(injectedHeader, upstreamMessage)
+        TraceMessagePropagator().propagate(injectedHeader, upstreamMessage)
         upstreamMessage.header.traceId.assert().isEqualTo(upstreamMessage.id)
         injectedHeader.traceId.assert().isEqualTo(upstreamMessage.header.traceId)
         injectedHeader.upstreamId.assert().isEqualTo(upstreamMessage.id)
@@ -30,13 +30,13 @@ class TraceMessagePropagatorTest {
     }
 
     @Test
-    fun injectIfNotNamed() {
+    fun propagateIfNotNamed() {
         val injectedHeader = DefaultHeader.empty()
         val upstreamMessage = mockk<Message<*, *>> {
             every { id } returns generateGlobalId()
             every { header } returns DefaultHeader.empty()
         }
-        TraceMessagePropagator().inject(injectedHeader, upstreamMessage)
+        TraceMessagePropagator().propagate(injectedHeader, upstreamMessage)
         injectedHeader.upstreamName.assert().isNull()
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/propagation/WaitStrategyMessagePropagatorTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/propagation/WaitStrategyMessagePropagatorTest.kt
@@ -17,14 +17,14 @@ import org.junit.jupiter.api.Test
 class WaitStrategyMessagePropagatorTest {
 
     @Test
-    fun inject() {
+    fun propagate() {
         val header = DefaultHeader.empty()
         val upstreamMessage =
             MockCreateAggregate(generateGlobalId(), generateGlobalId())
                 .toCommandMessage()
         WaitingForStage.projected("context", "processor", "function")
             .propagate(SimpleCommandWaitEndpoint("wait-endpoint"), upstreamMessage.header)
-        WaitStrategyMessagePropagator().inject(header, upstreamMessage)
+        WaitStrategyMessagePropagator().propagate(header, upstreamMessage)
         header[COMMAND_WAIT_ENDPOINT].assert().isEqualTo("wait-endpoint")
         header[COMMAND_WAIT_STAGE].assert().isEqualTo("PROJECTED")
         header[COMMAND_WAIT_CONTEXT].assert().isEqualTo("context")
@@ -33,13 +33,13 @@ class WaitStrategyMessagePropagatorTest {
     }
 
     @Test
-    fun injectIfBlank() {
+    fun propagateIfBlank() {
         val header = DefaultHeader.empty()
         val upstreamMessage =
             MockCreateAggregate(generateGlobalId(), generateGlobalId())
                 .toCommandMessage()
         WaitingForStage.sent().propagate(SimpleCommandWaitEndpoint("wait-endpoint"), upstreamMessage.header)
-        WaitStrategyMessagePropagator().inject(header, upstreamMessage)
+        WaitStrategyMessagePropagator().propagate(header, upstreamMessage)
         header[COMMAND_WAIT_ENDPOINT].assert().isEqualTo(upstreamMessage.header[COMMAND_WAIT_ENDPOINT])
         header[COMMAND_WAIT_STAGE].assert().isEqualTo(upstreamMessage.header[COMMAND_WAIT_STAGE])
         header[COMMAND_WAIT_CONTEXT].assert().isNull()

--- a/wow-cosec/src/main/kotlin/me/ahoo/wow/cosec/propagation/CoSecMessagePropagator.kt
+++ b/wow-cosec/src/main/kotlin/me/ahoo/wow/cosec/propagation/CoSecMessagePropagator.kt
@@ -36,7 +36,7 @@ class CoSecMessagePropagator : MessagePropagator {
         }
     }
 
-    override fun inject(header: Header, upstream: Message<*, *>) {
+    override fun propagate(header: Header, upstream: Message<*, *>) {
         upstream.header.appId?.let {
             header.withAppId(it)
         }

--- a/wow-cosec/src/test/kotlin/me/ahoo/wow/cosec/propagation/CoSecMessagePropagatorTest.kt
+++ b/wow-cosec/src/test/kotlin/me/ahoo/wow/cosec/propagation/CoSecMessagePropagatorTest.kt
@@ -28,23 +28,23 @@ class CoSecMessagePropagatorTest {
     val coSecMessagePropagator = CoSecMessagePropagator()
 
     @Test
-    fun inject() {
+    fun propagate() {
         val injectedHeader = DefaultHeader.empty()
         val upstreamMessage = MockCreateAggregate(generateGlobalId(), generateGlobalId())
             .toCommandMessage()
         upstreamMessage.header.withAppId("appId").withDeviceId("deviceId")
-        coSecMessagePropagator.inject(injectedHeader, upstreamMessage)
+        coSecMessagePropagator.propagate(injectedHeader, upstreamMessage)
         injectedHeader.appId.assert().isEqualTo(upstreamMessage.header.appId)
         injectedHeader.deviceId.assert().isEqualTo(upstreamMessage.header.deviceId)
     }
 
     @Test
-    fun injectIfNull() {
+    fun propagateIfNull() {
         val injectedHeader = DefaultHeader.empty()
         val upstreamMessage =
             MockCreateAggregate(generateGlobalId(), generateGlobalId())
                 .toCommandMessage()
-        coSecMessagePropagator.inject(injectedHeader, upstreamMessage)
+        coSecMessagePropagator.propagate(injectedHeader, upstreamMessage)
         injectedHeader.appId.assert().isNull()
         injectedHeader.deviceId.assert().isNull()
     }


### PR DESCRIPTION
- Rename inject() method to propagate() in MessagePropagator interface
- Update related classes and tests to use new propagate() method
- Improve method naming consistency across the codebase

