### PR TITLE
refactor(command): Refactor the command waiting policy propagation mechanism

### DIFF
--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
@@ -292,7 +292,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
             waitStrategyRegistrar.unregister(message.commandId)
         }
         waitStrategyRegistrar.register(message.commandId, waitStrategy)
-        waitStrategy.propagate(SimpleCommandWaitEndpoint(""), message.header)
+        waitStrategy.propagate("", message.header)
         waitStrategy.waitingLast().subscribe()
         verify {
             send(message)
@@ -312,7 +312,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
             waitStrategyRegistrar.unregister(message.commandId)
         }
         waitStrategyRegistrar.register(message.commandId, waitStrategy)
-        waitStrategy.propagate(SimpleCommandWaitEndpoint(""), message.header)
+        waitStrategy.propagate("", message.header)
         waitStrategy.waitingLast().subscribe()
         verify {
             send(message)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWaitNotifier.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWaitNotifier.kt
@@ -29,7 +29,7 @@ interface CommandWaitEndpoint {
 
 data class SimpleCommandWaitEndpoint(override val endpoint: String) : CommandWaitEndpoint
 
-data class EndpointWaitWaitStrategy(override val endpoint: String, val waitStrategy: WaitStrategy.Materialized) :
+data class EndpointWaitStrategy(override val endpoint: String, val waitStrategy: WaitStrategy.Materialized) :
     CommandWaitEndpoint
 
 fun Header.extractCommandWaitEndpoint(): String? {
@@ -40,10 +40,10 @@ fun Header.propagateCommandWaitEndpoint(endpoint: String): Header {
     return with(COMMAND_WAIT_ENDPOINT, endpoint)
 }
 
-fun Header.extractWaitStrategy(): EndpointWaitWaitStrategy? {
+fun Header.extractWaitStrategy(): EndpointWaitStrategy? {
     val endpoint = this.extractCommandWaitEndpoint() ?: return null
     val waitStrategy = this.extractWaitingForStage() ?: return null
-    return EndpointWaitWaitStrategy(endpoint, waitStrategy)
+    return EndpointWaitStrategy(endpoint, waitStrategy)
 }
 
 /**
@@ -84,7 +84,7 @@ class LocalCommandWaitNotifier(
 }
 
 fun CommandWaitNotifier.notifyAndForget(
-    waiteStrategy: EndpointWaitWaitStrategy,
+    waiteStrategy: EndpointWaitStrategy,
     waitSignal: WaitSignal
 ) {
     if (!waiteStrategy.waitStrategy.shouldNotify(waitSignal.stage)) {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWaitNotifier.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWaitNotifier.kt
@@ -29,6 +29,9 @@ interface CommandWaitEndpoint {
 
 data class SimpleCommandWaitEndpoint(override val endpoint: String) : CommandWaitEndpoint
 
+data class EndpointWaitWaitStrategy(override val endpoint: String, val waitStrategy: WaitStrategy.Materialized) :
+    CommandWaitEndpoint
+
 fun Header.extractCommandWaitEndpoint(): String? {
     return this[COMMAND_WAIT_ENDPOINT]
 }
@@ -37,8 +40,10 @@ fun Header.propagateCommandWaitEndpoint(endpoint: String): Header {
     return with(COMMAND_WAIT_ENDPOINT, endpoint)
 }
 
-fun Header.extractWaitStrategyInfo(): WaitStrategy.Info? {
-    return extractWaitingForStage()
+fun Header.extractWaitStrategy(): EndpointWaitWaitStrategy? {
+    val endpoint = this.extractCommandWaitEndpoint() ?: return null
+    val waitStrategy = this.extractWaitingForStage() ?: return null
+    return EndpointWaitWaitStrategy(endpoint, waitStrategy)
 }
 
 /**
@@ -78,8 +83,11 @@ class LocalCommandWaitNotifier(
     }
 }
 
-fun CommandWaitNotifier.notifyAndForget(waiteStrategy: WaitStrategy.Info, waitSignal: WaitSignal) {
-    if (!waiteStrategy.shouldNotify(waitSignal.stage)) {
+fun CommandWaitNotifier.notifyAndForget(
+    waiteStrategy: EndpointWaitWaitStrategy,
+    waitSignal: WaitSignal
+) {
+    if (!waiteStrategy.waitStrategy.shouldNotify(waitSignal.stage)) {
         return
     }
     notifyAndForget(waiteStrategy.endpoint, waitSignal)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifier.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifier.kt
@@ -38,8 +38,8 @@ class MonoCommandWaitNotifier<E, M>(
 ) : Mono<Void>() where E : MessageExchange<*, M>, M : Message<*, *>, M : CommandId, M : NamedBoundedContext {
     override fun subscribe(actual: CoreSubscriber<in Void>) {
         val message = messageExchange.message
-        val waitStrategy = message.header.extractWaitStrategyInfo() ?: return source.subscribe(actual)
-        if (!waitStrategy.shouldNotify(processingStage)) {
+        val waitStrategy = message.header.extractWaitStrategy() ?: return source.subscribe(actual)
+        if (!waitStrategy.waitStrategy.shouldNotify(processingStage)) {
             return source.subscribe(actual)
         }
 
@@ -58,7 +58,7 @@ class MonoCommandWaitNotifier<E, M>(
 class CommandWaitNotifierSubscriber<E, M>(
     private val commandWaitNotifier: CommandWaitNotifier,
     private val processingStage: CommandStage,
-    private val waitStrategy: WaitStrategy.Info,
+    private val waitStrategy: EndpointWaitWaitStrategy,
     private val messageExchange: E,
     private val actual: CoreSubscriber<in Void>
 ) : BaseSubscriber<Void>() where E : MessageExchange<*, M>, M : Message<*, *>, M : CommandId, M : NamedBoundedContext {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifier.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifier.kt
@@ -58,7 +58,7 @@ class MonoCommandWaitNotifier<E, M>(
 class CommandWaitNotifierSubscriber<E, M>(
     private val commandWaitNotifier: CommandWaitNotifier,
     private val processingStage: CommandStage,
-    private val waitStrategy: EndpointWaitWaitStrategy,
+    private val waitStrategy: EndpointWaitStrategy,
     private val messageExchange: E,
     private val actual: CoreSubscriber<in Void>
 ) : BaseSubscriber<Void>() where E : MessageExchange<*, M>, M : Message<*, *>, M : CommandId, M : NamedBoundedContext {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategy.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategy.kt
@@ -14,14 +14,13 @@
 package me.ahoo.wow.command.wait
 
 import me.ahoo.wow.api.messaging.Header
-import me.ahoo.wow.api.naming.Materialized
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.core.publisher.SignalType
 import java.util.function.Consumer
 
 interface WaitStrategyPropagator {
-    fun propagate(commandWaitEndpoint: CommandWaitEndpoint, header: Header)
+    fun propagate(commandWaitEndpoint: String, header: Header)
 }
 
 /**
@@ -33,6 +32,7 @@ interface WaitStrategy : WaitStrategyPropagator {
     val terminated: Boolean
     val completed: Boolean
         get() = terminated || cancelled
+    val materialized: Materialized
 
     /**
      * 是否支持虚空命令
@@ -53,10 +53,13 @@ interface WaitStrategy : WaitStrategyPropagator {
     fun complete()
 
     fun onFinally(doFinally: Consumer<SignalType>)
+    override fun propagate(commandWaitEndpoint: String, header: Header) {
+        materialized.propagate(commandWaitEndpoint, header)
+    }
 
-    interface Info :
-        CommandWaitEndpoint,
+    interface Materialized :
+        WaitStrategyPropagator,
         ProcessingStageShouldNotifyPredicate,
         WaitSignalShouldNotifyPredicate,
-        Materialized
+        me.ahoo.wow.api.naming.Materialized
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForFunction.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForFunction.kt
@@ -16,8 +16,18 @@ package me.ahoo.wow.command.wait.stage
 import me.ahoo.wow.api.messaging.function.FunctionNameCapable
 import me.ahoo.wow.api.messaging.processor.ProcessorInfo
 import me.ahoo.wow.command.wait.WaitSignal
+import me.ahoo.wow.command.wait.WaitStrategy
 
 abstract class WaitingForFunction : WaitingForAfterProcessed(), ProcessorInfo, FunctionNameCapable {
+    override val materialized: WaitStrategy.Materialized by lazy {
+        Materialized(
+            stage = stage,
+            contextName = contextName,
+            processorName = processorName,
+            functionName = functionName
+        )
+    }
+
     override fun shouldNotify(signal: WaitSignal): Boolean {
         if (!super.shouldNotify(signal) || !isSameBoundedContext(signal.function)) {
             return false

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/WaitStrategyMessagePropagator.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/WaitStrategyMessagePropagator.kt
@@ -16,12 +16,7 @@ package me.ahoo.wow.messaging.propagation
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.messaging.Header
 import me.ahoo.wow.api.messaging.Message
-import me.ahoo.wow.command.wait.COMMAND_WAIT_ENDPOINT
-import me.ahoo.wow.command.wait.extractCommandWaitEndpoint
-import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_CONTEXT
-import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_FUNCTION
-import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_PROCESSOR
-import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_STAGE
+import me.ahoo.wow.command.wait.extractWaitStrategy
 
 class WaitStrategyMessagePropagator : MessagePropagator {
     override fun propagate(header: Header, upstream: Message<*, *>) {
@@ -29,21 +24,7 @@ class WaitStrategyMessagePropagator : MessagePropagator {
             return
         }
         val upstreamHeader = upstream.header
-        val commandWaitEndpoint = upstreamHeader.extractCommandWaitEndpoint() ?: return
-        header.with(COMMAND_WAIT_ENDPOINT, commandWaitEndpoint)
-        val commandWaitStage = upstreamHeader[COMMAND_WAIT_STAGE].orEmpty()
-        header.with(COMMAND_WAIT_STAGE, commandWaitStage)
-        val commandWaitContext = upstreamHeader[COMMAND_WAIT_CONTEXT]
-        if (!commandWaitContext.isNullOrBlank()) {
-            header.with(COMMAND_WAIT_CONTEXT, commandWaitContext)
-        }
-        val commandWaitProcessor = upstreamHeader[COMMAND_WAIT_PROCESSOR]
-        if (!commandWaitProcessor.isNullOrBlank()) {
-            header.with(COMMAND_WAIT_PROCESSOR, commandWaitProcessor)
-        }
-        val commandWaitFunction = upstreamHeader[COMMAND_WAIT_FUNCTION]
-        if (!commandWaitFunction.isNullOrBlank()) {
-            header.with(COMMAND_WAIT_FUNCTION, commandWaitFunction)
-        }
+        val waitStrategy = upstreamHeader.extractWaitStrategy() ?: return
+        waitStrategy.waitStrategy.propagate(waitStrategy.endpoint, header)
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifierTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifierTest.kt
@@ -43,7 +43,7 @@ internal class MonoCommandWaitNotifierTest {
     @Test
     fun notifyAndForgetWrap() {
         val command = MockCreateCommand("").toCommandMessage()
-        WaitingForStage.processed().propagate(SimpleCommandWaitEndpoint(""), command.header)
+        WaitingForStage.processed().propagate("", command.header)
 
         val commandWaitNotifier = LocalCommandWaitNotifier(SimpleWaitStrategyRegistrar)
         Mono.empty<Void>()
@@ -64,7 +64,7 @@ internal class MonoCommandWaitNotifierTest {
     @Test
     fun notifyAndForgetWrapError() {
         val command = MockCreateCommand("").toCommandMessage()
-        WaitingForStage.processed().propagate(SimpleCommandWaitEndpoint(""), command.header)
+        WaitingForStage.processed().propagate("", command.header)
         val commandWaitNotifier = LocalCommandWaitNotifier(SimpleWaitStrategyRegistrar)
         RuntimeException("error")
             .toMono<Void>()
@@ -80,7 +80,7 @@ internal class MonoCommandWaitNotifierTest {
     @Test
     fun notifyAndForgetWrapAndStageIsEarly() {
         val command = MockCreateCommand("").toCommandMessage()
-        WaitingForStage.processed().propagate(SimpleCommandWaitEndpoint(""), command.header)
+        WaitingForStage.processed().propagate("", command.header)
         val commandWaitNotifier = LocalCommandWaitNotifier(SimpleWaitStrategyRegistrar)
         Mono.empty<Void>()
             .thenNotifyAndForget(commandWaitNotifier, CommandStage.PROCESSED, SimpleServerCommandExchange(command))

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForStageTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForStageTest.kt
@@ -38,7 +38,7 @@ internal class WaitingForStageTest {
     fun processedInject() {
         val waitStrategy = WaitingForStage.projected("content", "processor", "function")
         val header = DefaultHeader()
-        waitStrategy.propagate(SimpleCommandWaitEndpoint("endpoint"), header)
+        waitStrategy.propagate("endpoint", header)
         val waitStrategyInfo = header.extractWaitingForStage()
         waitStrategyInfo.assert().isNotNull()
         waitStrategyInfo!!.stage.assert().isEqualTo(CommandStage.PROJECTED)

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/propagation/WaitStrategyMessagePropagatorTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/propagation/WaitStrategyMessagePropagatorTest.kt
@@ -3,7 +3,6 @@ package me.ahoo.wow.messaging.propagation
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.command.toCommandMessage
 import me.ahoo.wow.command.wait.COMMAND_WAIT_ENDPOINT
-import me.ahoo.wow.command.wait.SimpleCommandWaitEndpoint
 import me.ahoo.wow.command.wait.stage.WaitingForStage
 import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_CONTEXT
 import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_FUNCTION
@@ -23,7 +22,7 @@ class WaitStrategyMessagePropagatorTest {
             MockCreateAggregate(generateGlobalId(), generateGlobalId())
                 .toCommandMessage()
         WaitingForStage.projected("context", "processor", "function")
-            .propagate(SimpleCommandWaitEndpoint("wait-endpoint"), upstreamMessage.header)
+            .propagate("wait-endpoint", upstreamMessage.header)
         WaitStrategyMessagePropagator().propagate(header, upstreamMessage)
         header[COMMAND_WAIT_ENDPOINT].assert().isEqualTo("wait-endpoint")
         header[COMMAND_WAIT_STAGE].assert().isEqualTo("PROJECTED")
@@ -38,7 +37,7 @@ class WaitStrategyMessagePropagatorTest {
         val upstreamMessage =
             MockCreateAggregate(generateGlobalId(), generateGlobalId())
                 .toCommandMessage()
-        WaitingForStage.sent().propagate(SimpleCommandWaitEndpoint("wait-endpoint"), upstreamMessage.header)
+        WaitingForStage.sent().propagate("wait-endpoint", upstreamMessage.header)
         WaitStrategyMessagePropagator().propagate(header, upstreamMessage)
         header[COMMAND_WAIT_ENDPOINT].assert().isEqualTo(upstreamMessage.header[COMMAND_WAIT_ENDPOINT])
         header[COMMAND_WAIT_STAGE].assert().isEqualTo(upstreamMessage.header[COMMAND_WAIT_STAGE])


### PR DESCRIPTION
- remove the SimpleCommandWaitEndpoint class
- add a EndpointWaitWaitStrategy class to encapsulate the waiting policy and endpoint information
- modify the extractWaitStrategy method in Header to return a new EndpointWaitWaitStrategy object
- update the logic in CommandWaitNotifier and DefaultCommandGateway, use the new waiting policy object
- refactor the WaitingForStage class, use the Materialized class to encapsulate serialized information
- update the WaitStrategyMessagePropagator to support the new waiting policy propagation mechanism
