### PR TITLE
perf(messaging): optimize WaitStrategyMessagePropagator for non-CommandMessages

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/WaitStrategyMessagePropagator.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/WaitStrategyMessagePropagator.kt
@@ -17,14 +17,15 @@ import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.messaging.Header
 import me.ahoo.wow.api.messaging.Message
 import me.ahoo.wow.command.wait.extractWaitStrategy
+import me.ahoo.wow.command.wait.stage.WaitingForStage
 
 class WaitStrategyMessagePropagator : MessagePropagator {
     override fun propagate(header: Header, upstream: Message<*, *>) {
-        if (upstream !is CommandMessage<*>) {
-            return
-        }
         val upstreamHeader = upstream.header
         val waitStrategy = upstreamHeader.extractWaitStrategy() ?: return
+        if (waitStrategy.waitStrategy is WaitingForStage.Materialized && upstream !is CommandMessage<*>) {
+            return
+        }
         waitStrategy.waitStrategy.propagate(waitStrategy.endpoint, header)
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/propagation/WaitStrategyMessagePropagatorTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/propagation/WaitStrategyMessagePropagatorTest.kt
@@ -8,8 +8,10 @@ import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_CON
 import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_FUNCTION
 import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_PROCESSOR
 import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_STAGE
+import me.ahoo.wow.event.toDomainEvent
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.messaging.DefaultHeader
+import me.ahoo.wow.tck.mock.MockAggregateCreated
 import me.ahoo.wow.tck.mock.MockCreateAggregate
 import org.junit.jupiter.api.Test
 
@@ -44,5 +46,16 @@ class WaitStrategyMessagePropagatorTest {
         header[COMMAND_WAIT_CONTEXT].assert().isNull()
         header[COMMAND_WAIT_PROCESSOR].assert().isNull()
         header[COMMAND_WAIT_FUNCTION].assert().isNull()
+    }
+
+    @Test
+    fun propagateIfDomainEvent() {
+        val header = DefaultHeader.empty()
+        val upstreamMessage =
+            MockAggregateCreated(generateGlobalId())
+                .toDomainEvent(generateGlobalId(), generateGlobalId(), generateGlobalId())
+        WaitingForStage.sent().propagate("wait-endpoint", upstreamMessage.header)
+        WaitStrategyMessagePropagator().propagate(header, upstreamMessage)
+        header[COMMAND_WAIT_ENDPOINT].assert().isNull()
     }
 }


### PR DESCRIPTION
- Early exit for non-CommandMessages when WaitingForStage is not used
- This change improves performance by reducing unnecessary processing

