### PR TITLE
refactor(wow-spring): deprecate Spring-specific annotations in favor of API ones

### DIFF
--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/stereotype/EventProcessor.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/stereotype/EventProcessor.kt
@@ -15,15 +15,15 @@ package me.ahoo.wow.spring.stereotype
 
 import org.springframework.stereotype.Component
 
-@Component
-@me.ahoo.wow.api.annotation.EventProcessor
 @Deprecated(
-    message = "Use EventProcessorComponent instead.",
+    message = "Use EventProcessor instead.",
     replaceWith = ReplaceWith(
-        expression = "EventProcessorComponent",
-        imports = ["me.ahoo.wow.spring.stereotype.EventProcessorComponent"]
+        expression = "EventProcessor",
+        imports = ["me.ahoo.wow.api.annotation.EventProcessor"]
     )
 )
+@Component
+@me.ahoo.wow.api.annotation.EventProcessor
 annotation class EventProcessor
 
 @Deprecated(

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/stereotype/ProjectionProcessor.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/stereotype/ProjectionProcessor.kt
@@ -15,18 +15,15 @@ package me.ahoo.wow.spring.stereotype
 
 import org.springframework.stereotype.Component
 
-/**
- * @see org.springframework.core.annotation.MergedAnnotations
- */
-@Component
-@me.ahoo.wow.api.annotation.ProjectionProcessor
 @Deprecated(
-    message = "Use ProjectionProcessorComponent instead.",
-    ReplaceWith(
-        expression = "ProjectionProcessorComponent",
-        imports = ["me.ahoo.wow.spring.stereotype.ProjectionProcessorComponent"]
+    message = "Use ProjectionProcessor instead.",
+    replaceWith = ReplaceWith(
+        expression = "ProjectionProcessor",
+        imports = ["me.ahoo.wow.api.annotation.ProjectionProcessor"]
     )
 )
+@Component
+@me.ahoo.wow.api.annotation.ProjectionProcessor
 annotation class ProjectionProcessor
 
 @Deprecated(

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/stereotype/StatelessSaga.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/stereotype/StatelessSaga.kt
@@ -15,15 +15,15 @@ package me.ahoo.wow.spring.stereotype
 
 import org.springframework.stereotype.Component
 
-@Component
-@me.ahoo.wow.api.annotation.StatelessSaga
 @Deprecated(
-    message = "Use StatelessSagaComponent instead.",
-    ReplaceWith(
-        expression = "StatelessSagaComponent",
-        imports = ["me.ahoo.wow.spring.stereotype.StatelessSagaComponent"]
+    message = "Use StatelessSaga instead.",
+    replaceWith = ReplaceWith(
+        expression = "StatelessSaga",
+        imports = ["me.ahoo.wow.api.annotation.StatelessSaga"]
     )
 )
+@Component
+@me.ahoo.wow.api.annotation.StatelessSaga
 annotation class StatelessSaga
 
 @Deprecated(


### PR DESCRIPTION


- Deprecate EventProcessor, ProjectionProcessor, and StatelessSaga annotations
- Update deprecated annotations to use API versions instead
- Adjust import statements and update documentation

