### PR TITLE
refactor(prepare): introduce ApplicationBasePackageScanner for base package resolution

### DIFF
--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/prepare/ApplicationBasePackageScanner.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/prepare/ApplicationBasePackageScanner.kt
@@ -1,0 +1,108 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.spring.boot.starter.prepare
+
+import org.springframework.beans.factory.BeanFactory
+import org.springframework.beans.factory.BeanFactoryAware
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition
+import org.springframework.boot.autoconfigure.AutoConfigurationPackages
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.context.EnvironmentAware
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
+import org.springframework.core.env.Environment
+import org.springframework.core.type.filter.AnnotationTypeFilter
+import org.springframework.util.ClassUtils
+
+class ApplicationBasePackageScanner : EnvironmentAware, BeanFactoryAware {
+    private lateinit var env: Environment
+    private lateinit var beanFactory: BeanFactory
+    override fun setEnvironment(environment: Environment) {
+        this.env = environment
+    }
+
+    override fun setBeanFactory(beanFactory: BeanFactory) {
+        this.beanFactory = beanFactory
+    }
+
+    /**
+     * 从Environment中获取指定key对应的字符串集合
+     *
+     * 该方法支持两种配置方式：
+     * 1. 逗号分隔的单个属性值（如 "package1,package2,package3"）
+     * 2. 数组形式的属性值（如 "key[0]=value1", "key[1]=value2"）
+     *
+     * @param key 配置项的键名
+     * @return 解析后的字符串集合，如果未找到配置则返回空集合
+     */
+    fun getStringSet(key: String): Set<String> {
+        val basePackages = env.getProperty(key)
+        if (basePackages?.isNotBlank() == true) {
+            // 处理逗号分隔的配置值
+            return basePackages.split(",").map { it.trim() }.filter { it.isNotEmpty() }.toSet()
+        }
+        var currentIndex = 0
+        // 处理数组形式的配置值
+        return buildSet {
+            while (true) {
+                val basePackage = env.getProperty("$key[$currentIndex]")
+                if (basePackage.isNullOrBlank()) {
+                    return@buildSet
+                }
+                add(basePackage.trim())
+                currentIndex++
+            }
+        }
+    }
+
+    /**
+     * 获取应用的基础包路径集合
+     *
+     * @return 应用配置的扫描基础包路径集合，如果没有配置则返回空集合
+     */
+    fun getApplicationBasePackages(): Set<String> {
+        // 检查是否存在自动配置包，如果不存在则返回空集合
+        if (!AutoConfigurationPackages.has(beanFactory)) {
+            return setOf()
+        }
+        val autoBasePackages = AutoConfigurationPackages.get(beanFactory)
+        val appBasePackages = mutableSetOf<String>()
+        appBasePackages.addAll(autoBasePackages)
+        for (autoBasePackage in autoBasePackages) {
+            val scanner = SpringBootApplicationScanner(false, env)
+            val candidates = scanner.findCandidateComponents(autoBasePackage)
+            // 遍历所有候选组件，提取@SpringBootApplication注解中配置的扫描包路径
+            for (candidate in candidates) {
+                val appBeanClass = Class.forName(candidate.beanClassName)
+                val appAnnotation = appBeanClass.getAnnotation(SpringBootApplication::class.java)
+                appBasePackages.addAll(appAnnotation.scanBasePackages)
+                val typedBasePackages = appAnnotation.scanBasePackageClasses.map {
+                    ClassUtils.getPackageName(it.java)
+                }
+                appBasePackages.addAll(typedBasePackages)
+            }
+        }
+        return appBasePackages
+    }
+
+    internal class SpringBootApplicationScanner(useDefaultFilters: Boolean, environment: Environment) :
+        ClassPathScanningCandidateComponentProvider(useDefaultFilters, environment) {
+        init {
+            addIncludeFilter(AnnotationTypeFilter(SpringBootApplication::class.java))
+        }
+
+        override fun isCandidateComponent(beanDefinition: AnnotatedBeanDefinition): Boolean {
+            return beanDefinition.metadata.isConcrete
+        }
+    }
+}

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareAutoConfiguration.kt
@@ -28,6 +28,12 @@ import org.springframework.context.annotation.Import
 @EnableConfigurationProperties(PrepareProperties::class)
 @Import(PrepareKeyAutoRegistrar::class)
 class PrepareAutoConfiguration {
+
+    @Bean
+    fun applicationBasePackageScanner(): ApplicationBasePackageScanner {
+        return ApplicationBasePackageScanner()
+    }
+
     @Bean
     @ConditionalOnBean(PrepareKeyFactory::class)
     fun prepareKeyProxyFactory(prepareKeyFactory: PrepareKeyFactory): PrepareKeyProxyFactory {

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareKeyAutoRegistrar.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareKeyAutoRegistrar.kt
@@ -22,7 +22,6 @@ import org.springframework.beans.factory.BeanFactoryAware
 import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition
 import org.springframework.beans.factory.support.BeanDefinitionBuilder
 import org.springframework.beans.factory.support.BeanDefinitionRegistry
-import org.springframework.boot.autoconfigure.AutoConfigurationPackages
 import org.springframework.context.EnvironmentAware
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar
@@ -33,24 +32,6 @@ import org.springframework.core.type.filter.AnnotationTypeFilter
 class PrepareKeyAutoRegistrar : ImportBeanDefinitionRegistrar, EnvironmentAware, BeanFactoryAware {
     companion object {
         private val logger = KotlinLogging.logger { }
-    }
-
-    private fun getPropertyBasePackages(): Set<String> {
-        val basePackages = env.getProperty(PrepareProperties.BASE_PACKAGES)
-        if (basePackages?.isNotBlank() == true) {
-            return basePackages.split(",").toSet()
-        }
-        var currentIndex = 0
-        buildSet {
-            while (true) {
-                val basePackage = env.getProperty("${PrepareProperties.BASE_PACKAGES}[$currentIndex]")
-                if (basePackage.isNullOrBlank()) {
-                    return this
-                }
-                add(basePackage)
-                currentIndex++
-            }
-        }
     }
 
     private lateinit var env: Environment
@@ -64,12 +45,8 @@ class PrepareKeyAutoRegistrar : ImportBeanDefinitionRegistrar, EnvironmentAware,
     }
 
     private fun getBasePackages(): Set<String> {
-        val configBasePackages = getPropertyBasePackages()
-        if (!AutoConfigurationPackages.has(beanFactory)) {
-            return configBasePackages.toSet()
-        }
-        val autoBasePackages = AutoConfigurationPackages.get(this.beanFactory)
-        return configBasePackages + autoBasePackages
+        val applicationBasePackageScanner = beanFactory.getBean(ApplicationBasePackageScanner::class.java)
+        return applicationBasePackageScanner.getStringSet(PrepareProperties.BASE_PACKAGES) + applicationBasePackageScanner.getApplicationBasePackages()
     }
 
     override fun registerBeanDefinitions(importingClassMetadata: AnnotationMetadata, registry: BeanDefinitionRegistry) {
@@ -78,7 +55,7 @@ class PrepareKeyAutoRegistrar : ImportBeanDefinitionRegistrar, EnvironmentAware,
             logger.warn { "No auto-configuration base packages found" }
             return
         }
-        val scanner = Scanner(false, env)
+        val scanner = PreparableKeyScanner(false, env)
         for (basePackage in basePackages) {
             val candidates = scanner.findCandidateComponents(basePackage)
             for (candidate in candidates) {
@@ -97,7 +74,7 @@ class PrepareKeyAutoRegistrar : ImportBeanDefinitionRegistrar, EnvironmentAware,
         }
     }
 
-    class Scanner(useDefaultFilters: Boolean, environment: Environment) :
+    class PreparableKeyScanner(useDefaultFilters: Boolean, environment: Environment) :
         ClassPathScanningCandidateComponentProvider(useDefaultFilters, environment) {
         init {
             addIncludeFilter(AnnotationTypeFilter(PreparableKey::class.java))

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareAutoConfigurationTest.kt
@@ -16,6 +16,7 @@ package me.ahoo.wow.spring.boot.starter.prepare
 import io.mockk.mockk
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.annotation.PreparableKey
+import me.ahoo.wow.example.domain.ExampleBoundedContext
 import me.ahoo.wow.infra.prepare.PrepareKey
 import me.ahoo.wow.infra.prepare.PrepareKeyFactory
 import me.ahoo.wow.infra.prepare.proxy.PrepareKeyProxyFactory
@@ -157,7 +158,8 @@ class PrepareAutoConfigurationTest {
         WowWebClientAutoConfiguration::class,
         CompensationAutoConfiguration::class,
         QueryAutoConfiguration::class,
-    ]
+    ],
+    scanBasePackageClasses = [ExampleBoundedContext::class]
 )
 class EnablePrepareConfiguration
 


### PR DESCRIPTION


- Add ApplicationBasePackageScanner class to handle base package scanning
- Update PrepareAutoConfiguration to include ApplicationBasePackageScanner bean
- Modify PrepareKeyAutoRegistrar to use ApplicationBasePackageScanner for base package resolution
- Update tests to reflect new base package scanning approach

