### PR TITLE
refactor(wow-core): rename snapshot function to PascalCase

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotDispatcher.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotDispatcher.kt
@@ -37,7 +37,7 @@ fun NamedAggregate.snapshotFunction(): FunctionInfoData {
         functionKind = FunctionKind.STATE_EVENT,
         contextName = contextName,
         processorName = aggregateName,
-        name = "SaveSnapshot"
+        name = "saveSnapshot"
     )
 }
 


### PR DESCRIPTION
- Changed the function name 'SaveSnapshot' to 'saveSnapshot' in SnapshotDispatcher
- This change aligns with Kotlin naming conventions for functions

