### PR TITLE
fix(wow-core): correct contextName and processorName in SimpleCommandAggregate

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt
@@ -39,8 +39,8 @@ class SimpleCommandAggregate<C : Any, S : Any>(
     override val processorName: String = metadata.processorName
     private val processorFunction = FunctionInfoData(
         functionKind = FunctionKind.COMMAND,
-        contextName = metadata.processorName,
-        processorName = metadata.contextName,
+        contextName = metadata.contextName,
+        processorName = metadata.processorName,
         name = "process"
     )
     private val commandFunctionRegistry = metadata.toCommandFunctionRegistry(this)


### PR DESCRIPTION


- Swap contextName and processorName in FunctionInfoData initialization
- This change ensures that the correct names are used for command processing


