### PR TITLE
refactor(wow-core): improve wait strategy notification logic

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWaitNotifier.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWaitNotifier.kt
@@ -87,7 +87,7 @@ fun CommandWaitNotifier.notifyAndForget(
     waiteStrategy: EndpointWaitStrategy,
     waitSignal: WaitSignal
 ) {
-    if (!waiteStrategy.waitStrategy.shouldNotify(waitSignal.stage)) {
+    if (!waiteStrategy.waitStrategy.shouldNotify(waitSignal)) {
         return
     }
     notifyAndForget(waiteStrategy.endpoint, waitSignal)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingFors.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingFors.kt
@@ -11,28 +11,27 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.command.wait.stage
+package me.ahoo.wow.command.wait
 
+import me.ahoo.wow.api.messaging.function.FunctionInfo
 import me.ahoo.wow.api.messaging.function.FunctionNameCapable
 import me.ahoo.wow.api.messaging.processor.ProcessorInfo
-import me.ahoo.wow.command.wait.WaitSignal
-import me.ahoo.wow.command.wait.WaitStrategy
-import me.ahoo.wow.command.wait.isWaitingForFunction
+import me.ahoo.wow.infra.ifNotBlank
 
-abstract class WaitingForFunction : WaitingForAfterProcessed(), ProcessorInfo, FunctionNameCapable {
-    override val materialized: WaitStrategy.Materialized by lazy {
-        Materialized(
-            stage = stage,
-            contextName = contextName,
-            processorName = processorName,
-            functionName = functionName
-        )
-    }
-
-    override fun isWaitingFor(signal: WaitSignal): Boolean {
-        if (!super.isWaitingFor(signal)) {
+fun <T> T.isWaitingForFunction(function: FunctionInfo): Boolean where T : ProcessorInfo, T : FunctionNameCapable {
+    contextName.ifNotBlank {
+        if (!isSameBoundedContext(function)) {
             return false
         }
-        return this.isWaitingForFunction(signal.function)
     }
+    processorName.ifNotBlank {
+        if (processorName != function.processorName) {
+            return false
+        }
+    }
+
+    functionName.ifNotBlank {
+        return functionName == function.name
+    }
+    return true
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForAfterProcessed.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForAfterProcessed.kt
@@ -15,10 +15,9 @@ package me.ahoo.wow.command.wait.stage
 
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.WaitSignal
-import me.ahoo.wow.command.wait.WaitSignalShouldNotifyPredicate
 import reactor.core.publisher.Mono
 
-abstract class WaitingForAfterProcessed : WaitingForStage(), WaitSignalShouldNotifyPredicate {
+abstract class WaitingForAfterProcessed : WaitingForStage() {
     @Volatile
     private var processedSignal: WaitSignal? = null
 
@@ -35,7 +34,7 @@ abstract class WaitingForAfterProcessed : WaitingForStage(), WaitSignalShouldNot
         super.complete()
     }
 
-    override fun shouldNotify(signal: WaitSignal): Boolean {
+    open fun isWaitingFor(signal: WaitSignal): Boolean {
         return signal.stage == stage
     }
 
@@ -54,7 +53,7 @@ abstract class WaitingForAfterProcessed : WaitingForStage(), WaitSignalShouldNot
         if (signal.stage == CommandStage.PROCESSED) {
             processedSignal = signal
         }
-        if (shouldNotify(signal)) {
+        if (isWaitingFor(signal)) {
             waitingForSignal = signal
         }
         tryComplete()

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForProjected.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForProjected.kt
@@ -24,7 +24,7 @@ class WaitingForProjected(
     override val stage: CommandStage
         get() = CommandStage.PROJECTED
 
-    override fun shouldNotify(signal: WaitSignal): Boolean {
-        return super.shouldNotify(signal) && signal.isLastProjection
+    override fun isWaitingFor(signal: WaitSignal): Boolean {
+        return super.isWaitingFor(signal) && signal.isLastProjection
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForStage.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForStage.kt
@@ -22,6 +22,7 @@ import me.ahoo.wow.command.wait.CommandStageCapable
 import me.ahoo.wow.command.wait.WaitSignal
 import me.ahoo.wow.command.wait.WaitStrategy
 import me.ahoo.wow.command.wait.WaitingFor
+import me.ahoo.wow.command.wait.isWaitingForFunction
 import me.ahoo.wow.command.wait.propagateCommandWaitEndpoint
 import me.ahoo.wow.infra.ifNotBlank
 import java.util.*
@@ -55,7 +56,13 @@ abstract class WaitingForStage : WaitingFor(), CommandStageCapable {
         }
 
         override fun shouldNotify(signal: WaitSignal): Boolean {
-            return true
+            if (stage.isPrevious(signal.stage)) {
+                return true
+            }
+            if (stage != signal.stage) {
+                return false
+            }
+            return this.isWaitingForFunction(signal.function)
         }
 
         override fun propagate(commandWaitEndpoint: String, header: Header) {


### PR DESCRIPTION
- Update CommandWaitNotifier to use new notification logic
- Refactor WaitingForAfterProcessed to use isWaitingFor method
- Modify WaitingForFunction to use isWaitingForFunction extension function
- Update WaitingForProjected to use isWaitingFor method
- Add new WaitingFors file with isWaitingForFunction extension function
- Update WaitingForStage to use new waiting logic

