### PR TITLE
refactor(command): enrich CommandResult with FunctionInfo and AggregateId

### DIFF
--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
@@ -126,6 +126,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
         val processedSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = message.commandId,
+            aggregateId = message.aggregateId,
             stage = CommandStage.PROCESSED,
             function = functionInfo,
         )
@@ -149,6 +150,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
         val processedSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = message.commandId,
+            aggregateId = message.aggregateId,
             stage = CommandStage.PROCESSED,
             function = functionInfo,
         )
@@ -171,12 +173,14 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
         val processedSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = message.commandId,
+            aggregateId = message.aggregateId,
             stage = CommandStage.PROCESSED,
             function = functionInfo,
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = message.commandId,
+            aggregateId = message.aggregateId,
             stage = CommandStage.SNAPSHOT,
             function = functionInfo,
         )
@@ -201,12 +205,14 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
         val processedSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = message.commandId,
+            aggregateId = message.aggregateId,
             stage = CommandStage.PROCESSED,
             function = functionInfo,
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = message.commandId,
+            aggregateId = message.aggregateId,
             stage = CommandStage.SNAPSHOT,
             function = functionInfo,
         )
@@ -251,6 +257,7 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
         val errorSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = message.commandId,
+            aggregateId = message.aggregateId,
             stage = CommandStage.PROCESSED,
             function = FunctionInfoData(FunctionKind.COMMAND, message.contextName, "", ""),
             errorCode = "ERROR"

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/NamedAggregate.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/NamedAggregate.kt
@@ -13,7 +13,16 @@
 
 package me.ahoo.wow.api.modeling
 
+import com.fasterxml.jackson.annotation.JsonIgnore
+import io.swagger.v3.oas.annotations.media.Schema
 import me.ahoo.wow.api.naming.NamedBoundedContext
+
+interface AggregateNameCapable {
+    /**
+     * 聚合根的名称
+     */
+    val aggregateName: String
+}
 
 /**
  * 一个在特定上下文中具有唯一名称的聚合根。
@@ -21,9 +30,7 @@ import me.ahoo.wow.api.naming.NamedBoundedContext
  * @see me.ahoo.wow.command.CommandBus
  * @see me.ahoo.wow.eventsourcing.EventStore
  */
-interface NamedAggregate : NamedBoundedContext {
-    // 聚合根的名称。
-    val aggregateName: String
+interface NamedAggregate : NamedBoundedContext, AggregateNameCapable {
 
     /**
      * 检查两个聚合根是否属于同一个上下文并具有相同的聚合根名称。
@@ -47,9 +54,13 @@ interface NamedAggregateDecorator : NamedAggregate {
      */
     val namedAggregate: NamedAggregate
 
+    @get:Schema(accessMode = Schema.AccessMode.READ_ONLY)
+    @get:JsonIgnore
     override val contextName: String
         get() = namedAggregate.contextName
 
+    @get:Schema(accessMode = Schema.AccessMode.READ_ONLY)
+    @get:JsonIgnore
     override val aggregateName: String
         get() = namedAggregate.aggregateName
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt
@@ -42,6 +42,7 @@ fun CommandMessage<*>.commandSentSignal(error: Throwable? = null): WaitSignal {
     return SimpleWaitSignal(
         id = generateGlobalId(),
         commandId = commandId,
+        aggregateId = aggregateId,
         stage = CommandStage.SENT,
         function = function,
         aggregateVersion = aggregateVersion,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandResult.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandResult.kt
@@ -19,9 +19,12 @@ import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.command.RequestId
 import me.ahoo.wow.api.exception.BindingError
 import me.ahoo.wow.api.exception.ErrorInfo
-import me.ahoo.wow.api.messaging.processor.ProcessorInfo
+import me.ahoo.wow.api.messaging.function.FunctionInfoCapable
+import me.ahoo.wow.api.messaging.function.FunctionInfoData
+import me.ahoo.wow.api.modeling.AggregateNameCapable
 import me.ahoo.wow.api.modeling.TenantId
 import me.ahoo.wow.api.naming.Materialized
+import me.ahoo.wow.api.naming.NamedBoundedContext
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.CommandStageCapable
 import me.ahoo.wow.command.wait.NullableAggregateVersionCapable
@@ -32,43 +35,47 @@ import me.ahoo.wow.exception.toErrorInfo
 import me.ahoo.wow.id.generateGlobalId
 
 data class CommandResult(
+    override val id: String,
     override val stage: CommandStage,
+    override val contextName: String,
+    override val aggregateName: String,
+    override val tenantId: String,
     val aggregateId: String,
     override val aggregateVersion: Int? = null,
-    override val id: String,
-    override val contextName: String,
-    override val processorName: String,
-    override val tenantId: String,
     override val requestId: String,
     override val commandId: String,
+    override val function: FunctionInfoData,
     override val errorCode: String = ErrorCodes.SUCCEEDED,
     override val errorMsg: String = ErrorCodes.SUCCEEDED_MESSAGE,
     override val bindingErrors: List<BindingError> = emptyList(),
     override val result: Map<String, Any> = emptyMap(),
     override val signalTime: Long = System.currentTimeMillis()
-) : CommandStageCapable,
-    Identifier,
-    CommandId,
+) : Identifier,
+    CommandStageCapable,
+    NamedBoundedContext,
+    AggregateNameCapable,
     TenantId,
+    NullableAggregateVersionCapable,
+    CommandId,
     RequestId,
     ErrorInfo,
-    ProcessorInfo,
+    FunctionInfoCapable<FunctionInfoData>,
     CommandResultCapable,
     SignalTimeCapable,
-    NullableAggregateVersionCapable,
     Materialized
 
 fun WaitSignal.toResult(commandMessage: CommandMessage<*>): CommandResult {
     return CommandResult(
         id = this.id,
         stage = this.stage,
-        aggregateId = commandMessage.aggregateId.id,
+        contextName = aggregateId.contextName,
+        aggregateName = aggregateId.aggregateName,
+        tenantId = aggregateId.tenantId,
+        aggregateId = aggregateId.id,
         aggregateVersion = aggregateVersion,
-        contextName = function.contextName,
-        processorName = function.processorName,
-        tenantId = commandMessage.aggregateId.tenantId,
+        function = function,
         requestId = commandMessage.requestId,
-        commandId = commandMessage.commandId,
+        commandId = commandId,
         errorCode = this.errorCode,
         errorMsg = this.errorMsg,
         bindingErrors = bindingErrors,
@@ -79,8 +86,7 @@ fun WaitSignal.toResult(commandMessage: CommandMessage<*>): CommandResult {
 
 fun Throwable.toResult(
     commandMessage: CommandMessage<*>,
-    contextName: String = commandMessage.contextName,
-    processorName: String,
+    function: FunctionInfoData,
     id: String = generateGlobalId(),
     stage: CommandStage = CommandStage.SENT,
     result: Map<String, Any> = emptyMap(),
@@ -90,12 +96,13 @@ fun Throwable.toResult(
     return CommandResult(
         id = id,
         stage = stage,
-        aggregateId = commandMessage.aggregateId.id,
-        contextName = contextName,
-        processorName = processorName,
+        contextName = commandMessage.contextName,
+        aggregateName = commandMessage.aggregateName,
         tenantId = commandMessage.aggregateId.tenantId,
+        aggregateId = commandMessage.aggregateId.id,
         requestId = commandMessage.requestId,
         commandId = commandMessage.commandId,
+        function = function,
         errorCode = errorInfo.errorCode,
         errorMsg = errorInfo.errorMsg,
         bindingErrors = errorInfo.bindingErrors,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
@@ -141,8 +141,7 @@ class DefaultCommandGateway(
             CommandResultException(
                 it.toResult(
                     commandMessage = command,
-                    contextName = command.contextName,
-                    processorName = command.aggregateName
+                    function = command.commandGatewayFunction()
                 ),
                 it
             )

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/NotifierFilters.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/NotifierFilters.kt
@@ -19,6 +19,7 @@ import me.ahoo.wow.api.command.CommandId
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.event.DomainEvent
 import me.ahoo.wow.api.messaging.Message
+import me.ahoo.wow.api.modeling.AggregateIdCapable
 import me.ahoo.wow.api.naming.NamedBoundedContext
 import me.ahoo.wow.command.ServerCommandExchange
 import me.ahoo.wow.event.DomainEventDispatcher
@@ -38,7 +39,7 @@ import reactor.core.publisher.Mono
 abstract class AbstractNotifierFilter<T : MessageExchange<*, M>, M>(
     private val processingStage: CommandStage,
     private val commandWaitNotifier: CommandWaitNotifier
-) : ExchangeFilter<T> where M : Message<*, *>, M : CommandId, M : NamedBoundedContext {
+) : ExchangeFilter<T> where M : Message<*, *>, M : CommandId, M : NamedBoundedContext, M : AggregateIdCapable {
     override fun filter(
         exchange: T,
         next: FilterChain<T>

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitSignal.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitSignal.kt
@@ -21,6 +21,8 @@ import me.ahoo.wow.api.messaging.function.FunctionInfo
 import me.ahoo.wow.api.messaging.function.FunctionInfoCapable
 import me.ahoo.wow.api.messaging.function.FunctionInfoData
 import me.ahoo.wow.api.messaging.function.materialize
+import me.ahoo.wow.api.modeling.AggregateId
+import me.ahoo.wow.api.modeling.AggregateIdCapable
 import me.ahoo.wow.command.CommandResultCapable
 import me.ahoo.wow.exception.ErrorCodes
 
@@ -35,6 +37,7 @@ interface NullableAggregateVersionCapable {
 interface WaitSignal :
     Identifier,
     CommandId,
+    AggregateIdCapable,
     NullableAggregateVersionCapable,
     ErrorInfo,
     SignalTimeCapable,
@@ -48,6 +51,7 @@ interface WaitSignal :
 data class SimpleWaitSignal(
     override val id: String,
     override val commandId: String,
+    override val aggregateId: AggregateId,
     override val stage: CommandStage,
     override val function: FunctionInfoData,
     override val aggregateVersion: Int? = null,
@@ -62,6 +66,7 @@ data class SimpleWaitSignal(
         fun FunctionInfo.toWaitSignal(
             id: String,
             commandId: String,
+            aggregateId: AggregateId,
             stage: CommandStage,
             isLastProjection: Boolean = false,
             aggregateVersion: Int? = null,
@@ -74,6 +79,7 @@ data class SimpleWaitSignal(
             return SimpleWaitSignal(
                 id = id,
                 commandId = commandId,
+                aggregateId = aggregateId,
                 stage = stage,
                 function = this.materialize(),
                 aggregateVersion = aggregateVersion,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/DefaultAggregateId.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/DefaultAggregateId.kt
@@ -26,6 +26,7 @@ data class DefaultAggregateId(
     override val id: String,
     override val tenantId: String = TenantId.DEFAULT_TENANT_ID
 ) : AggregateId {
+
     @Transient
     private val hashCode: Int = hash()
     override fun equals(other: Any?): Boolean = equalTo(other)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/MaterializedNamedAggregate.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/MaterializedNamedAggregate.kt
@@ -24,6 +24,7 @@ data class MaterializedNamedAggregate(
     override val contextName: String,
     override val aggregateName: String
 ) : NamedAggregate, Materialized {
+
     @Transient
     private val hashCode = Objects.hash(contextName, aggregateName)
     override fun hashCode(): Int = hashCode

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/CommandResultTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/CommandResultTest.kt
@@ -12,7 +12,7 @@ class CommandResultTest {
         val command = MockCreateCommand(generateGlobalId()).toCommandMessage()
         val actual = IllegalStateException("test").toResult(
             command,
-            processorName = "processorName"
+            command.commandGatewayFunction(),
         )
         actual.id.assert().isNotBlank()
         actual.stage.assert().isEqualTo(CommandStage.SENT)

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/LocalCommandWaitNotifierTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/LocalCommandWaitNotifierTest.kt
@@ -16,6 +16,8 @@ package me.ahoo.wow.command.wait
 import me.ahoo.wow.api.messaging.function.FunctionInfoData
 import me.ahoo.wow.api.messaging.function.FunctionKind
 import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import org.junit.jupiter.api.Test
 import reactor.kotlin.test.test
 
@@ -35,6 +37,7 @@ internal class LocalCommandWaitNotifierTest {
             SimpleWaitSignal(
                 id = generateGlobalId(),
                 commandId = generateGlobalId(),
+                aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
                 stage = CommandStage.SENT,
                 function = functionInfo
             ),
@@ -51,6 +54,7 @@ internal class LocalCommandWaitNotifierTest {
             SimpleWaitSignal(
                 id = generateGlobalId(),
                 commandId = generateGlobalId(),
+                aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
                 stage = CommandStage.SENT,
                 function = functionInfo
             ),
@@ -65,6 +69,7 @@ internal class LocalCommandWaitNotifierTest {
             SimpleWaitSignal(
                 id = generateGlobalId(),
                 commandId = "0THbs0sW0066001",
+                aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
                 stage = CommandStage.SENT,
                 function = functionInfo
             )

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/SimpleWaitStrategyRegistrarTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/SimpleWaitStrategyRegistrarTest.kt
@@ -19,6 +19,8 @@ import me.ahoo.wow.api.messaging.function.FunctionKind
 import me.ahoo.wow.command.wait.stage.WaitingForStage
 import me.ahoo.wow.id.GlobalIdGenerator
 import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import org.junit.jupiter.api.Test
 
 internal class SimpleWaitStrategyRegistrarTest {
@@ -67,6 +69,7 @@ internal class SimpleWaitStrategyRegistrarTest {
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = commandId,
+            aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROCESSED,
             function = FunctionInfoData(
                 functionKind = FunctionKind.COMMAND,

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForStageTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForStageTest.kt
@@ -20,6 +20,8 @@ import me.ahoo.wow.command.wait.stage.WaitingForStage
 import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.extractWaitingForStage
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.messaging.DefaultHeader
+import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import reactor.kotlin.test.test
@@ -68,6 +70,7 @@ internal class WaitingForStageTest {
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = "commandId",
+            aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROCESSED,
             function = functionInfo,
         )
@@ -87,6 +90,7 @@ internal class WaitingForStageTest {
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = "commandId",
+            aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.SNAPSHOT,
             function = functionInfo,
         )
@@ -106,12 +110,14 @@ internal class WaitingForStageTest {
         val processedSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
+            aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROCESSED,
             function = functionInfo,
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
+            aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.SNAPSHOT,
             function = functionInfo,
         )
@@ -133,6 +139,7 @@ internal class WaitingForStageTest {
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
+            aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROCESSED,
             function = functionInfo,
             errorCode = "ERROR_CODE"
@@ -152,12 +159,14 @@ internal class WaitingForStageTest {
         val processedSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
+            aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROCESSED,
             function = functionInfo,
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
+            aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROJECTED,
             function = functionInfo.copy(contextName = contextName),
             isLastProjection = true
@@ -178,12 +187,14 @@ internal class WaitingForStageTest {
         val processedSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
+            aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROCESSED,
             function = functionInfo,
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
+            aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROJECTED,
             function = functionInfo.copy(contextName = contextName, processorName = "processor"),
             isLastProjection = true
@@ -204,12 +215,14 @@ internal class WaitingForStageTest {
         val processedSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
+            aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROCESSED,
             function = functionInfo,
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
+            aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROJECTED,
             function = functionInfo.copy(contextName = contextName, processorName = "hi"),
             isLastProjection = true
@@ -229,12 +242,14 @@ internal class WaitingForStageTest {
         val processedSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
+            aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROCESSED,
             function = functionInfo,
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
+            aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROJECTED,
             function = functionInfo.copy(
                 contextName = contextName,
@@ -259,12 +274,14 @@ internal class WaitingForStageTest {
         val processedSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
+            aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROCESSED,
             function = functionInfo,
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
+            aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROJECTED,
             function = functionInfo.copy(contextName = contextName),
             isLastProjection = false
@@ -286,12 +303,14 @@ internal class WaitingForStageTest {
         val processedSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
+            aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROCESSED,
             function = functionInfo,
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
+            aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.EVENT_HANDLED,
             function = functionInfo.copy(contextName = contextName),
             isLastProjection = false
@@ -312,12 +331,14 @@ internal class WaitingForStageTest {
         val processedSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
+            aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROCESSED,
             function = functionInfo,
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = generateGlobalId(),
+            aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.SAGA_HANDLED,
             function = functionInfo.copy(contextName = contextName)
         )
@@ -341,6 +362,7 @@ internal class WaitingForStageTest {
                     SimpleWaitSignal(
                         id = generateGlobalId(),
                         commandId = generateGlobalId(),
+                        aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
                         stage = CommandStage.PROJECTED,
                         function = functionInfo,
                     )

--- a/wow-core/src/test/kotlin/me/ahoo/wow/exception/ErrorConverterRegistrarTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/exception/ErrorConverterRegistrarTest.kt
@@ -2,6 +2,8 @@ package me.ahoo.wow.exception
 
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.exception.ErrorInfo
+import me.ahoo.wow.api.messaging.function.FunctionInfoData
+import me.ahoo.wow.api.messaging.function.FunctionKind
 import me.ahoo.wow.command.CommandResult
 import me.ahoo.wow.command.CommandResultException
 import me.ahoo.wow.command.wait.CommandStage
@@ -30,7 +32,13 @@ class ErrorInfoConverterRegistrarTest {
             requestId = generateGlobalId(),
             commandId = generateGlobalId(),
             contextName = "contextName",
-            processorName = "processorName",
+            aggregateName = "aggregateName",
+            function = FunctionInfoData(
+                functionKind = FunctionKind.COMMAND,
+                contextName = "contextName",
+                processorName = "processorName",
+                name = "name"
+            ),
             errorCode = ErrorCodes.NOT_FOUND
         )
         CommandResultException(commandResult).toErrorInfo().assert().isEqualTo(commandResult)

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/ResponsesKtTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/ResponsesKtTest.kt
@@ -17,6 +17,8 @@ import io.mockk.every
 import io.mockk.mockk
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.exception.ErrorInfo
+import me.ahoo.wow.api.messaging.function.FunctionInfoData
+import me.ahoo.wow.api.messaging.function.FunctionKind
 import me.ahoo.wow.command.CommandResult
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.exception.ErrorCodes
@@ -72,7 +74,14 @@ class ResponsesKtTest {
             requestId = generateGlobalId(),
             commandId = generateGlobalId(),
             contextName = "contextName",
-            processorName = "processorName",
+            aggregateName = "aggregateName",
+            function = FunctionInfoData(
+                functionKind = FunctionKind.COMMAND,
+                contextName = "contextName",
+                processorName = "processorName",
+                name = "functionName"
+
+            )
         ).toMono()
             .toServerResponse(MockServerRequest.builder().build(), DefaultRequestExceptionHandler)
             .test()

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandResponsesTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandResponsesTest.kt
@@ -17,6 +17,8 @@ import io.mockk.every
 import io.mockk.mockk
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.exception.ErrorInfo
+import me.ahoo.wow.api.messaging.function.FunctionInfoData
+import me.ahoo.wow.api.messaging.function.FunctionKind
 import me.ahoo.wow.command.CommandResult
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.id.generateGlobalId
@@ -48,7 +50,13 @@ class CommandResponsesTest {
             requestId = generateGlobalId(),
             commandId = generateGlobalId(),
             contextName = "contextName",
-            processorName = "processorName",
+            aggregateName = "aggregateName",
+            function = FunctionInfoData(
+                functionKind = FunctionKind.COMMAND,
+                contextName = "contextName",
+                processorName = "processorName",
+                name = "name"
+            ),
         ).toMono()
             .toFlux()
             .toCommandResponse(serverRequest, DefaultRequestExceptionHandler)
@@ -81,7 +89,13 @@ class CommandResponsesTest {
             requestId = generateGlobalId(),
             commandId = generateGlobalId(),
             contextName = "contextName",
-            processorName = "processorName",
+            aggregateName = "aggregateName",
+            function = FunctionInfoData(
+                functionKind = FunctionKind.COMMAND,
+                contextName = "contextName",
+                processorName = "processorName",
+                name = "name"
+            ),
         ).toMono()
             .toFlux()
             .toCommandResponse(serverRequest, DefaultRequestExceptionHandler)
@@ -112,7 +126,13 @@ class CommandResponsesTest {
             requestId = generateGlobalId(),
             commandId = generateGlobalId(),
             contextName = "contextName",
-            processorName = "processorName",
+            aggregateName = "aggregateName",
+            function = FunctionInfoData(
+                functionKind = FunctionKind.COMMAND,
+                contextName = "contextName",
+                processorName = "processorName",
+                name = "name"
+            ),
         ).toMono()
             .toFlux()
             .doOnNext {
@@ -146,7 +166,13 @@ class CommandResponsesTest {
             requestId = generateGlobalId(),
             commandId = generateGlobalId(),
             contextName = "contextName",
-            processorName = "processorName",
+            aggregateName = "aggregateName",
+            function = FunctionInfoData(
+                functionKind = FunctionKind.COMMAND,
+                contextName = "contextName",
+                processorName = "processorName",
+                name = "name"
+            ),
         ).toMono()
             .toFlux()
             .toCommandResponse(mockRequest, DefaultRequestExceptionHandler)

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/wait/CommandWaitHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/wait/CommandWaitHandlerFunctionTest.kt
@@ -9,6 +9,8 @@ import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.SimpleWaitSignal
 import me.ahoo.wow.command.wait.SimpleWaitStrategyRegistrar
 import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import org.junit.jupiter.api.Test
 import org.springframework.web.reactive.function.server.ServerRequest
 import reactor.kotlin.core.publisher.toMono
@@ -23,6 +25,7 @@ class CommandWaitHandlerFunctionTest {
             every { bodyToMono(SimpleWaitSignal::class.java) } returns SimpleWaitSignal(
                 id = generateGlobalId(),
                 commandId = "commandId",
+                aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
                 stage = CommandStage.SENT,
                 function = FunctionInfoData(
                     functionKind = FunctionKind.COMMAND,

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/wait/WebClientCommandWaitNotifierTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/wait/WebClientCommandWaitNotifierTest.kt
@@ -9,6 +9,8 @@ import me.ahoo.wow.command.wait.SimpleWaitSignal
 import me.ahoo.wow.command.wait.SimpleWaitStrategyRegistrar
 import me.ahoo.wow.id.GlobalIdGenerator
 import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import org.junit.jupiter.api.Test
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
@@ -24,6 +26,7 @@ class WebClientCommandWaitNotifierTest {
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = GlobalIdGenerator.generateAsString(),
+            aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.SENT,
             function = FunctionInfoData(
                 functionKind = FunctionKind.COMMAND,
@@ -56,6 +59,7 @@ class WebClientCommandWaitNotifierTest {
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
             commandId = "0ToC0Bez003X00Z",
+            aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.SENT,
             function = FunctionInfoData(
                 functionKind = FunctionKind.COMMAND,


### PR DESCRIPTION


- Add FunctionInfoData and AggregateId to CommandResult
- Update related tests and components to accommodate new fields
- Adjust WaitSignal to include AggregateId
- Refactor CommandGateway to use new CommandResult structure

