### PR TITLE
refactor(command): optimize CommandGateway and CommandResult

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.command
 
+import me.ahoo.wow.api.Wow
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.exception.ErrorInfo
 import me.ahoo.wow.api.messaging.function.FunctionInfoData
@@ -27,24 +28,23 @@ import me.ahoo.wow.id.generateGlobalId
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
-fun CommandMessage<*>.commandGatewayFunction(): FunctionInfoData {
-    return FunctionInfoData(
-        functionKind = FunctionKind.COMMAND,
-        contextName = contextName,
-        processorName = aggregateName,
-        name = name,
-    )
-}
+const val COMMAND_GATEWAY_PROCESSOR_NAME = "CommandGateway"
+
+val COMMAND_GATEWAY_FUNCTION = FunctionInfoData(
+    functionKind = FunctionKind.COMMAND,
+    contextName = Wow.WOW,
+    processorName = COMMAND_GATEWAY_PROCESSOR_NAME,
+    name = "send",
+)
 
 fun CommandMessage<*>.commandSentSignal(error: Throwable? = null): WaitSignal {
-    val function = commandGatewayFunction()
     val errorInfo = error?.toErrorInfo() ?: ErrorInfo.OK
     return SimpleWaitSignal(
         id = generateGlobalId(),
         commandId = commandId,
         aggregateId = aggregateId,
         stage = CommandStage.SENT,
-        function = function,
+        function = COMMAND_GATEWAY_FUNCTION,
         aggregateVersion = aggregateVersion,
         isLastProjection = true,
         errorCode = errorInfo.errorCode,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandResult.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandResult.kt
@@ -86,7 +86,7 @@ fun WaitSignal.toResult(commandMessage: CommandMessage<*>): CommandResult {
 
 fun Throwable.toResult(
     commandMessage: CommandMessage<*>,
-    function: FunctionInfoData,
+    function: FunctionInfoData = COMMAND_GATEWAY_FUNCTION,
     id: String = generateGlobalId(),
     stage: CommandStage = CommandStage.SENT,
     result: Map<String, Any> = emptyMap(),

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
@@ -140,8 +140,7 @@ class DefaultCommandGateway(
         }.onErrorMap {
             CommandResultException(
                 it.toResult(
-                    commandMessage = command,
-                    function = command.commandGatewayFunction()
+                    commandMessage = command
                 ),
                 it
             )

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/CommandResultTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/CommandResultTest.kt
@@ -12,7 +12,7 @@ class CommandResultTest {
         val command = MockCreateCommand(generateGlobalId()).toCommandMessage()
         val actual = IllegalStateException("test").toResult(
             command,
-            command.commandGatewayFunction(),
+            COMMAND_GATEWAY_FUNCTION
         )
         actual.id.assert().isNotBlank()
         actual.stage.assert().isEqualTo(CommandStage.SENT)
@@ -22,6 +22,7 @@ class CommandResultTest {
         actual.commandId.assert().isEqualTo(command.commandId)
         actual.errorCode.assert().isEqualTo(ErrorCodes.ILLEGAL_STATE)
         actual.errorMsg.assert().isEqualTo("test")
+        actual.function.assert().isEqualTo(COMMAND_GATEWAY_FUNCTION)
         actual.bindingErrors.assert().isEmpty()
         actual.result.assert().isEmpty()
         actual.signalTime.assert().isGreaterThan(0)


### PR DESCRIPTION
- Extract COMMAND_GATEWAY_FUNCTION as a constant
- Update CommandMessage to use COMMAND_GATEWAY_FUNCTION instead of commandGatewayFunction()
- Modify CommandResult to use COMMAND_GATEWAY_FUNCTION by default
- Update tests to reflect the changes

