### PR TITLE
refactor(eventsourcing): standardize snapshot function information

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/AggregateSnapshotDispatcher.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/AggregateSnapshotDispatcher.kt
@@ -32,14 +32,13 @@ class AggregateSnapshotDispatcher(
     override val scheduler: Scheduler,
     override val messageFlux: Flux<StateEventExchange<*>>
 ) : AggregateMessageDispatcher<StateEventExchange<*>>(), ProcessorInfo {
-    private val snapshotFunction = namedAggregate.snapshotFunction()
     override val contextName: String
-        get() = snapshotFunction.contextName
+        get() = namedAggregate.contextName
     override val processorName: String
-        get() = snapshotFunction.processorName
+        get() = SNAPSHOT_PROCESSOR_NAME
 
     override fun handleExchange(exchange: StateEventExchange<*>): Mono<Void> {
-        exchange.setFunction(snapshotFunction)
+        exchange.setFunction(SNAPSHOT_FUNCTION)
         return snapshotHandler.handle(exchange)
     }
 

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/compensation/EventCompensateHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/compensation/EventCompensateHandlerFunctionTest.kt
@@ -18,7 +18,7 @@ import me.ahoo.wow.event.InMemoryDomainEventBus
 import me.ahoo.wow.event.compensation.DomainEventCompensator
 import me.ahoo.wow.event.compensation.StateEventCompensator
 import me.ahoo.wow.eventsourcing.InMemoryEventStore
-import me.ahoo.wow.eventsourcing.snapshot.snapshotFunction
+import me.ahoo.wow.eventsourcing.snapshot.SNAPSHOT_FUNCTION
 import me.ahoo.wow.eventsourcing.state.InMemoryStateEventBus
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.messaging.compensation.CompensationTarget
@@ -69,7 +69,7 @@ class EventCompensateHandlerFunctionTest {
             .pathVariable(MessageRecords.TENANT_ID, generateGlobalId())
             .body(
                 CompensationTarget(
-                    function = MOCK_AGGREGATE_METADATA.snapshotFunction()
+                    function = SNAPSHOT_FUNCTION
                 ).toMono()
             )
         handlerFunction.handle(request)


### PR DESCRIPTION
- Extract SNAPSHOT_FUNCTION as a constant
- Update contextName and processorName in AggregateSnapshotDispatcher
- Modify EventCompensateHandlerFunctionTest to use SNAPSHOT_FUNCTION constant
- Remove snapshotFunction() from NamedAggregate


