### PR TITLE
fix(wow-core): handle waiting for signal logic

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForAfterProcessed.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForAfterProcessed.kt
@@ -44,7 +44,8 @@ abstract class WaitingForAfterProcessed : WaitingForStage() {
             signals.forEach { signal ->
                 result.putAll(signal.result)
             }
-            signals.last().copyResult(result)
+            val waitingForSignal = waitingForSignal ?: return@map signals.last().copyResult(result)
+            waitingForSignal.copyResult(result)
         }
     }
 


### PR DESCRIPTION
- Update copyResult logic to properly handle waitingForSignal case
- Improve null safety by using elvis operator to return last signal's result

