### PR TITLE
fix(modeling): correct function context name for simple command aggregate

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt
@@ -13,6 +13,7 @@
 package me.ahoo.wow.modeling.command
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import me.ahoo.wow.api.Wow
 import me.ahoo.wow.api.command.RecoverAggregate
 import me.ahoo.wow.api.messaging.function.FunctionInfoData
 import me.ahoo.wow.api.messaging.function.FunctionKind
@@ -39,8 +40,8 @@ class SimpleCommandAggregate<C : Any, S : Any>(
     override val processorName: String = SimpleCommandAggregate::class.simpleName!!
     private val processorFunction = FunctionInfoData(
         functionKind = FunctionKind.COMMAND,
-        contextName = metadata.contextName,
-        processorName = metadata.processorName,
+        contextName = Wow.WOW,
+        processorName = processorName,
         name = SimpleCommandAggregate<*, *>::process.name
     )
     private val commandFunctionRegistry = metadata.toCommandFunctionRegistry(this)


### PR DESCRIPTION

- Update function context name to use Wow.WOW instead of metadata contextName
- This change ensures consistent naming for function context across the system


