### PR TITLE
feat(wow-core): add command size information to WaitSignal

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifier.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifier.kt
@@ -76,9 +76,10 @@ class CommandWaitNotifierSubscriber<E, M>(
         return actual.currentContext()
     }
 
-    override fun hookOnNext(value: Void) {
-        // Mono<Void> will not call this method.
-    }
+    /**
+     * Mono<Void> will not call this method.
+     */
+    override fun hookOnNext(value: Void) = Unit
 
     override fun hookOnSubscribe(subscription: Subscription) {
         actual.onSubscribe(this)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitSignal.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitSignal.kt
@@ -45,6 +45,12 @@ interface WaitSignal :
     FunctionInfoCapable<FunctionInfoData> {
     val stage: CommandStage
     val isLastProjection: Boolean
+
+    /**
+     * Number of commands emit by Saga
+     */
+    val commandSize: Int
+
     fun copyResult(result: Map<String, Any>): WaitSignal
 }
 
@@ -60,6 +66,7 @@ data class SimpleWaitSignal(
     override val errorMsg: String = ErrorCodes.SUCCEEDED_MESSAGE,
     override val bindingErrors: List<BindingError> = emptyList(),
     override val result: Map<String, Any> = emptyMap(),
+    override val commandSize: Int = 0,
     override val signalTime: Long = System.currentTimeMillis()
 ) : WaitSignal {
     companion object {
@@ -74,6 +81,7 @@ data class SimpleWaitSignal(
             errorMsg: String = ErrorCodes.SUCCEEDED_MESSAGE,
             bindingErrors: List<BindingError> = emptyList(),
             result: Map<String, Any> = emptyMap(),
+            commandSize: Int = 0,
             signalTime: Long = System.currentTimeMillis()
         ): WaitSignal {
             return SimpleWaitSignal(
@@ -88,6 +96,7 @@ data class SimpleWaitSignal(
                 errorMsg = errorMsg,
                 bindingErrors = bindingErrors,
                 result = result,
+                commandSize = commandSize,
                 signalTime = signalTime
             )
         }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/SagaHandledNotifierFilterTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/SagaHandledNotifierFilterTest.kt
@@ -3,24 +3,38 @@ package me.ahoo.wow.command.wait
 import io.mockk.every
 import io.mockk.mockk
 import me.ahoo.wow.api.event.DomainEvent
+import me.ahoo.wow.command.wait.stage.WaitingForStage
 import me.ahoo.wow.event.DomainEventExchange
 import me.ahoo.wow.event.SimpleDomainEventExchange
+import me.ahoo.wow.event.toDomainEvent
 import me.ahoo.wow.filter.FilterChainBuilder
-import me.ahoo.wow.id.GlobalIdGenerator
-import me.ahoo.wow.messaging.DefaultHeader
+import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.saga.stateless.CommandStream
+import me.ahoo.wow.saga.stateless.setCommandStream
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
+import me.ahoo.wow.tck.mock.MockAggregateCreated
 import org.junit.jupiter.api.Test
 import reactor.kotlin.test.test
 
 class SagaHandledNotifierFilterTest {
 
+    @Suppress("UNCHECKED_CAST")
     @Test
     fun filter() {
         val notifierFilter = SagaHandledNotifierFilter(LocalCommandWaitNotifier(SimpleWaitStrategyRegistrar))
-        val domainEvent = mockk<DomainEvent<Any>>()
-        every { domainEvent.header } returns DefaultHeader.empty()
-        every { domainEvent.commandId } returns GlobalIdGenerator.generateAsString()
-        every { domainEvent.isLast } returns true
-        val exchange = SimpleDomainEventExchange(domainEvent, mockk())
+        val domainEvent = MockAggregateCreated(generateGlobalId()).toDomainEvent(
+            MOCK_AGGREGATE_METADATA.aggregateId(),
+            generateGlobalId()
+        ) as DomainEvent<Any>
+        WaitingForStage.sagaHandled(domainEvent.contextName).propagate("", domainEvent.header)
+        val exchange = SimpleDomainEventExchange(domainEvent)
+        val commandStream = mockk<CommandStream> {
+            every {
+                size
+            } returns 1
+        }
+        exchange.setCommandStream(commandStream)
         val chain = FilterChainBuilder<DomainEventExchange<Any>>().build()
         notifierFilter.filter(exchange, chain)
             .test()


### PR DESCRIPTION
- Add getCommandSize() method to MonoCommandWaitNotifier
- Update WaitSignal interface and SimpleWaitSignal class to include commandSize
- This enhancement allows tracking the number of commands emitted by Saga

