### PR TITLE
test(wow-tck): remove unnecessary await in CommandGatewaySpec

### DIFF
--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/command/CommandGatewaySpec.kt
@@ -309,7 +309,6 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
             send(message)
                 .test()
                 .expectNextCount(0)
-                .thenAwait(Duration.ofMillis(10))
                 .verifyComplete()
         }
         countDownLatch.await()
@@ -332,7 +331,6 @@ abstract class CommandGatewaySpec : MessageBusSpec<CommandMessage<*>, ServerComm
             send(message)
                 .subscribeOn(Schedulers.parallel())
                 .test()
-                .thenAwait(Duration.ofMillis(10))
                 .expectError()
                 .verify()
         }


### PR DESCRIPTION
- Remove thenAwait(Duration.ofMillis(10)) from two test cases
- This change simplifies the tests by removing unnecessary delays
