### PR TITLE
refactor(wow-core): update command wait notifier to use command list

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifier.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifier.kt
@@ -96,12 +96,12 @@ class CommandWaitNotifierSubscriber<E, M>(
         actual.onError(exception)
     }
 
-    private fun getCommandSize(): Int {
+    private fun getCommands(): List<String> {
         if (processingStage != CommandStage.SAGA_HANDLED) {
-            return 0
+            return emptyList()
         }
         val domainEventExchange = messageExchange as DomainEventExchange<*>
-        return domainEventExchange.getCommandStream()?.size ?: 0
+        return domainEventExchange.getCommandStream()?.map { it.commandId }.orEmpty()
     }
 
     private fun notifySignal(errorInfo: ErrorInfo? = null) {
@@ -123,7 +123,7 @@ class CommandWaitNotifierSubscriber<E, M>(
             errorMsg = error.errorMsg,
             bindingErrors = error.bindingErrors,
             result = messageExchange.getCommandResult(),
-            commandSize = getCommandSize()
+            commands = getCommands()
         )
         commandWaitNotifier.notifyAndForget(waitStrategy, waitSignal)
     }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitSignal.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitSignal.kt
@@ -47,9 +47,9 @@ interface WaitSignal :
     val isLastProjection: Boolean
 
     /**
-     * Number of commands emit by Saga
+     * List of command IDs sent by Saga
      */
-    val commandSize: Int
+    val commands: List<String>
 
     fun copyResult(result: Map<String, Any>): WaitSignal
 }
@@ -66,7 +66,7 @@ data class SimpleWaitSignal(
     override val errorMsg: String = ErrorCodes.SUCCEEDED_MESSAGE,
     override val bindingErrors: List<BindingError> = emptyList(),
     override val result: Map<String, Any> = emptyMap(),
-    override val commandSize: Int = 0,
+    override val commands: List<String> = listOf(),
     override val signalTime: Long = System.currentTimeMillis()
 ) : WaitSignal {
     companion object {
@@ -81,7 +81,7 @@ data class SimpleWaitSignal(
             errorMsg: String = ErrorCodes.SUCCEEDED_MESSAGE,
             bindingErrors: List<BindingError> = emptyList(),
             result: Map<String, Any> = emptyMap(),
-            commandSize: Int = 0,
+            commands: List<String> = listOf(),
             signalTime: Long = System.currentTimeMillis()
         ): WaitSignal {
             return SimpleWaitSignal(
@@ -96,7 +96,7 @@ data class SimpleWaitSignal(
                 errorMsg = errorMsg,
                 bindingErrors = bindingErrors,
                 result = result,
-                commandSize = commandSize,
+                commands = commands,
                 signalTime = signalTime
             )
         }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/SagaHandledNotifierFilterTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/SagaHandledNotifierFilterTest.kt
@@ -1,8 +1,7 @@
 package me.ahoo.wow.command.wait
 
-import io.mockk.every
-import io.mockk.mockk
 import me.ahoo.wow.api.event.DomainEvent
+import me.ahoo.wow.command.toCommandMessage
 import me.ahoo.wow.command.wait.stage.WaitingForStage
 import me.ahoo.wow.event.DomainEventExchange
 import me.ahoo.wow.event.SimpleDomainEventExchange
@@ -10,10 +9,11 @@ import me.ahoo.wow.event.toDomainEvent
 import me.ahoo.wow.filter.FilterChainBuilder
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.modeling.aggregateId
-import me.ahoo.wow.saga.stateless.CommandStream
+import me.ahoo.wow.saga.stateless.DefaultCommandStream
 import me.ahoo.wow.saga.stateless.setCommandStream
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import me.ahoo.wow.tck.mock.MockAggregateCreated
+import me.ahoo.wow.tck.mock.MockCreateAggregate
 import org.junit.jupiter.api.Test
 import reactor.kotlin.test.test
 
@@ -29,11 +29,8 @@ class SagaHandledNotifierFilterTest {
         ) as DomainEvent<Any>
         WaitingForStage.sagaHandled(domainEvent.contextName).propagate("", domainEvent.header)
         val exchange = SimpleDomainEventExchange(domainEvent)
-        val commandStream = mockk<CommandStream> {
-            every {
-                size
-            } returns 1
-        }
+        val commandMessage = MockCreateAggregate(generateGlobalId(), generateGlobalId()).toCommandMessage()
+        val commandStream = DefaultCommandStream(generateGlobalId(), listOf(commandMessage))
         exchange.setCommandStream(commandStream)
         val chain = FilterChainBuilder<DomainEventExchange<Any>>().build()
         notifierFilter.filter(exchange, chain)


### PR DESCRIPTION
- Change getCommandSize() to return List<String> instead of Int
- Update WaitSignal to use commands instead of commandSize
- Modify tests to use actual command messages instead of mocked CommandStream

