### PR TITLE
refactor(wow-core): replace contextName, processorName, functionName with function object

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingFors.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingFors.kt
@@ -14,11 +14,13 @@
 package me.ahoo.wow.command.wait
 
 import me.ahoo.wow.api.messaging.function.FunctionInfo
-import me.ahoo.wow.api.messaging.function.FunctionNameCapable
-import me.ahoo.wow.api.messaging.processor.ProcessorInfo
+import me.ahoo.wow.api.messaging.function.NamedFunctionInfo
 import me.ahoo.wow.infra.ifNotBlank
 
-fun <T> T.isWaitingForFunction(function: FunctionInfo): Boolean where T : ProcessorInfo, T : FunctionNameCapable {
+fun NamedFunctionInfo?.isWaitingForFunction(function: FunctionInfo): Boolean {
+    if (this == null) {
+        return true
+    }
     contextName.ifNotBlank {
         if (!isSameBoundedContext(function)) {
             return false
@@ -30,8 +32,8 @@ fun <T> T.isWaitingForFunction(function: FunctionInfo): Boolean where T : Proces
         }
     }
 
-    functionName.ifNotBlank {
-        return functionName == function.name
+    name.ifNotBlank {
+        return name == function.name
     }
     return true
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForEventHandled.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForEventHandled.kt
@@ -13,12 +13,11 @@
 
 package me.ahoo.wow.command.wait.stage
 
+import me.ahoo.wow.api.messaging.function.NamedFunctionInfoData
 import me.ahoo.wow.command.wait.CommandStage
 
 class WaitingForEventHandled(
-    override val contextName: String,
-    override val processorName: String = "",
-    override val functionName: String = ""
+    override val function: NamedFunctionInfoData? = null
 ) : WaitingForFunction() {
     override val stage: CommandStage
         get() = CommandStage.EVENT_HANDLED

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForFunction.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForFunction.kt
@@ -13,19 +13,17 @@
 
 package me.ahoo.wow.command.wait.stage
 
-import me.ahoo.wow.api.messaging.function.FunctionNameCapable
-import me.ahoo.wow.api.messaging.processor.ProcessorInfo
+import me.ahoo.wow.api.messaging.function.NamedFunctionInfoData
+import me.ahoo.wow.api.messaging.function.NullableFunctionInfoCapable
 import me.ahoo.wow.command.wait.WaitSignal
 import me.ahoo.wow.command.wait.WaitStrategy
 import me.ahoo.wow.command.wait.isWaitingForFunction
 
-abstract class WaitingForFunction : WaitingForAfterProcessed(), ProcessorInfo, FunctionNameCapable {
+abstract class WaitingForFunction : WaitingForAfterProcessed(), NullableFunctionInfoCapable<NamedFunctionInfoData> {
     override val materialized: WaitStrategy.Materialized by lazy {
         Materialized(
             stage = stage,
-            contextName = contextName,
-            processorName = processorName,
-            functionName = functionName
+            function = function
         )
     }
 
@@ -33,6 +31,6 @@ abstract class WaitingForFunction : WaitingForAfterProcessed(), ProcessorInfo, F
         if (!super.isWaitingFor(signal)) {
             return false
         }
-        return this.isWaitingForFunction(signal.function)
+        return this.function.isWaitingForFunction(signal.function)
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForProjected.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForProjected.kt
@@ -13,13 +13,12 @@
 
 package me.ahoo.wow.command.wait.stage
 
+import me.ahoo.wow.api.messaging.function.NamedFunctionInfoData
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.WaitSignal
 
 class WaitingForProjected(
-    override val contextName: String,
-    override val processorName: String = "",
-    override val functionName: String = ""
+    override val function: NamedFunctionInfoData? = null
 ) : WaitingForFunction() {
     override val stage: CommandStage
         get() = CommandStage.PROJECTED

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForSagaHandled.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForSagaHandled.kt
@@ -13,12 +13,11 @@
 
 package me.ahoo.wow.command.wait.stage
 
+import me.ahoo.wow.api.messaging.function.NamedFunctionInfoData
 import me.ahoo.wow.command.wait.CommandStage
 
 class WaitingForSagaHandled(
-    override val contextName: String,
-    override val processorName: String = "",
-    override val functionName: String = ""
+    override val function: NamedFunctionInfoData? = null
 ) : WaitingForFunction() {
     override val stage: CommandStage
         get() = CommandStage.SAGA_HANDLED

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForStageTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForStageTest.kt
@@ -44,9 +44,9 @@ internal class WaitingForStageTest {
         val waitStrategyInfo = header.extractWaitingForStage()
         waitStrategyInfo.assert().isNotNull()
         waitStrategyInfo!!.stage.assert().isEqualTo(CommandStage.PROJECTED)
-        waitStrategyInfo.contextName.assert().isEqualTo("content")
-        waitStrategyInfo.processorName.assert().isEqualTo("processor")
-        waitStrategyInfo.functionName.assert().isEqualTo("function")
+        waitStrategyInfo.function?.contextName.assert().isEqualTo("content")
+        waitStrategyInfo.function?.processorName.assert().isEqualTo("processor")
+        waitStrategyInfo.function?.name.assert().isEqualTo("function")
     }
 
     @Test

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForsTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForsTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.command.wait
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.messaging.function.FunctionInfo
+import me.ahoo.wow.api.messaging.function.FunctionKind
+import me.ahoo.wow.api.messaging.function.NamedFunctionInfo
+import me.ahoo.wow.api.messaging.function.NamedFunctionInfoData
+import org.junit.jupiter.api.Test
+
+class WaitingForsTest {
+
+    private val testFunctionInfo = object : FunctionInfo {
+        override val functionKind: FunctionKind = FunctionKind.COMMAND
+        override val contextName: String = "test-context"
+        override val processorName: String = "test-processor"
+        override val name: String = "test-function"
+    }
+
+    @Test
+    fun isWaitingForFunctionWhenNull() {
+        val waitingFor: NamedFunctionInfo? = null
+        waitingFor.isWaitingForFunction(testFunctionInfo).assert().isTrue()
+    }
+
+    @Test
+    fun isWaitingForFunctionWithAllEmpty() {
+        val waitingFor = NamedFunctionInfoData(
+            contextName = "",
+            processorName = "",
+            name = ""
+        )
+        waitingFor.isWaitingForFunction(testFunctionInfo).assert().isTrue()
+    }
+
+    @Test
+    fun isWaitingForFunctionWithOnlyContext() {
+        val waitingFor = NamedFunctionInfoData(
+            contextName = "test-context",
+            processorName = "",
+            name = ""
+        )
+        waitingFor.isWaitingForFunction(testFunctionInfo).assert().isTrue()
+
+        val waitingForDifferentContext = NamedFunctionInfoData(
+            contextName = "different-context",
+            processorName = "",
+            name = ""
+        )
+        waitingForDifferentContext.isWaitingForFunction(testFunctionInfo).assert().isFalse()
+    }
+
+    @Test
+    fun isWaitingForFunctionWithOnlyProcessor() {
+        val waitingFor = NamedFunctionInfoData(
+            contextName = "",
+            processorName = "test-processor",
+            name = ""
+        )
+        waitingFor.isWaitingForFunction(testFunctionInfo).assert().isTrue()
+
+        val waitingForDifferentProcessor = NamedFunctionInfoData(
+            contextName = "",
+            processorName = "different-processor",
+            name = ""
+        )
+        waitingForDifferentProcessor.isWaitingForFunction(testFunctionInfo).assert().isFalse()
+    }
+
+    @Test
+    fun isWaitingForFunctionWithOnlyName() {
+        val waitingFor = NamedFunctionInfoData(
+            contextName = "",
+            processorName = "",
+            name = "test-function"
+        )
+        waitingFor.isWaitingForFunction(testFunctionInfo).assert().isTrue()
+
+        val waitingForDifferentName = NamedFunctionInfoData(
+            contextName = "",
+            processorName = "",
+            name = "different-function"
+        )
+        waitingForDifferentName.isWaitingForFunction(testFunctionInfo).assert().isFalse()
+    }
+
+    @Test
+    fun isWaitingForFunctionWithAllFields() {
+        val waitingFor = NamedFunctionInfoData(
+            contextName = "test-context",
+            processorName = "test-processor",
+            name = "test-function"
+        )
+        waitingFor.isWaitingForFunction(testFunctionInfo).assert().isTrue()
+
+        val waitingForDifferentAll = NamedFunctionInfoData(
+            contextName = "different-context",
+            processorName = "different-processor",
+            name = "different-function"
+        )
+        waitingForDifferentAll.isWaitingForFunction(testFunctionInfo).assert().isFalse()
+    }
+
+    @Test
+    fun isWaitingForFunctionWithPartialMatch() {
+        val waitingFor = NamedFunctionInfoData(
+            contextName = "test-context",
+            processorName = "test-processor",
+            name = ""
+        )
+        waitingFor.isWaitingForFunction(testFunctionInfo).assert().isTrue()
+
+        val waitingForContextAndDifferentProcessor = NamedFunctionInfoData(
+            contextName = "test-context",
+            processorName = "different-processor",
+            name = ""
+        )
+        waitingForContextAndDifferentProcessor.isWaitingForFunction(testFunctionInfo).assert().isFalse()
+    }
+}


### PR DESCRIPTION


- Introduce NamedFunctionInfoData to encapsulate function information
- Update WaitingForFunction and related classes to use NamedFunctionInfoData
- Modify isWaitingForFunction to use NamedFunctionInfoData
- Adjust WaitingForStage.Materialized to handle function information
- Update related tests to accommodate the new structure

