### PR TITLE
refactor(models): move CompletedCapable to api-naming module

### DIFF
--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/naming/CompletedCapable.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/naming/CompletedCapable.kt
@@ -11,6 +11,8 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.models.common
+package me.ahoo.wow.api.naming
 
-interface CompletedCapable : me.ahoo.wow.api.naming.CompletedCapable
+interface CompletedCapable {
+    val completed: Boolean
+}


### PR DESCRIPTION
- Move CompletedCapable interface from wow-models to wow-api-naming module
- Update import in wow-models to use the new location of CompletedCapable

