### PR TITLE
refactor(wow-core): optimize command wait propagation logic

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategy.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategy.kt
@@ -17,6 +17,7 @@ import me.ahoo.wow.api.Identifier
 import me.ahoo.wow.api.messaging.Header
 import me.ahoo.wow.api.messaging.Message
 import me.ahoo.wow.api.naming.CompletedCapable
+import me.ahoo.wow.messaging.propagation.MessagePropagator
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.core.publisher.SignalType
@@ -27,15 +28,7 @@ import java.util.function.Consumer
  *
  * 定义了命令等待策略中关于传播行为的抽象方法，用于控制命令处理结果的传播逻辑。
  */
-interface WaitStrategyPropagator : Identifier {
-
-    /**
-     * 判断是否应该传播指定的消息
-     *
-     * @param upstream 上游消息对象，包含命令或事件的相关信息
-     * @return 如果应该传播该消息则返回 true，否则返回 false
-     */
-    fun shouldPropagate(upstream: Message<*, *>): Boolean
+interface WaitStrategyPropagator : Identifier, MessagePropagator {
 
     /**
      * 执行传播操作
@@ -79,12 +72,13 @@ interface WaitStrategy : WaitStrategyPropagator, CompletedCapable {
     fun complete()
 
     fun onFinally(doFinally: Consumer<SignalType>)
-    override fun shouldPropagate(upstream: Message<*, *>): Boolean {
-        return materialized.shouldPropagate(upstream)
-    }
 
     override fun propagate(commandWaitEndpoint: String, header: Header) {
         materialized.propagate(commandWaitEndpoint, header)
+    }
+
+    override fun propagate(header: Header, upstream: Message<*, *>) {
+        materialized.propagate(header, upstream)
     }
 
     interface Materialized :

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForStage.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForStage.kt
@@ -24,6 +24,7 @@ import me.ahoo.wow.command.wait.CommandStageCapable
 import me.ahoo.wow.command.wait.WaitSignal
 import me.ahoo.wow.command.wait.WaitStrategy
 import me.ahoo.wow.command.wait.WaitingFor
+import me.ahoo.wow.command.wait.extractCommandWaitEndpoint
 import me.ahoo.wow.command.wait.isWaitingForFunction
 import me.ahoo.wow.command.wait.propagateCommandWaitEndpoint
 import me.ahoo.wow.command.wait.propagateCommandWaitId
@@ -73,8 +74,12 @@ abstract class WaitingForStage : WaitingFor(), CommandStageCapable {
             return this.function.isWaitingForFunction(signal.function)
         }
 
-        override fun shouldPropagate(upstream: Message<*, *>): Boolean {
-            return upstream is CommandMessage<*>
+        override fun propagate(header: Header, upstream: Message<*, *>) {
+            if (upstream !is CommandMessage<*>) {
+                return
+            }
+            val commandWaitEndpoint = upstream.header.extractCommandWaitEndpoint() ?: return
+            propagate(commandWaitEndpoint, header)
         }
 
         override fun propagate(commandWaitEndpoint: String, header: Header) {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/WaitStrategyMessagePropagator.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/WaitStrategyMessagePropagator.kt
@@ -21,9 +21,6 @@ class WaitStrategyMessagePropagator : MessagePropagator {
     override fun propagate(header: Header, upstream: Message<*, *>) {
         val upstreamHeader = upstream.header
         val waitStrategy = upstreamHeader.extractWaitStrategy() ?: return
-        if (!waitStrategy.waitStrategy.shouldPropagate(upstream)) {
-            return
-        }
-        waitStrategy.waitStrategy.propagate(waitStrategy.endpoint, header)
+        waitStrategy.waitStrategy.propagate(header, upstream)
     }
 }


### PR DESCRIPTION
- Remove unnecessary shouldPropagate method from WaitStrategyPropagator
- Simplify propagation logic in WaitingForStage and WaitStrategy
- Update WaitStrategyMessagePropagator to use new propagation method
