### PR TITLE
refactor(wow): rename commandWaitId to waitCommandId

### DIFF
--- a/example/example-server/src/main/kotlin/me/ahoo/wow/example/server/cart/CartController.kt
+++ b/example/example-server/src/main/kotlin/me/ahoo/wow/example/server/cart/CartController.kt
@@ -69,9 +69,10 @@ class CartController(
             productId = "productId",
             quantity = 1
         )
+        val command = addCartItem.toCommandMessage(ownerId = userId)
         return commandGateway.sendAndWaitStream(
-            addCartItem.toCommandMessage(ownerId = userId),
-            waitStrategy = WaitingForStage.snapshot()
+            command,
+            waitStrategy = WaitingForStage.snapshot(command.commandId)
         )
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt
@@ -37,11 +37,11 @@ val COMMAND_GATEWAY_FUNCTION = FunctionInfoData(
     name = "send",
 )
 
-fun CommandMessage<*>.commandSentSignal(commandWaitId: String, error: Throwable? = null): WaitSignal {
+fun CommandMessage<*>.commandSentSignal(waitCommandId: String, error: Throwable? = null): WaitSignal {
     val errorInfo = error?.toErrorInfo() ?: ErrorInfo.OK
     return SimpleWaitSignal(
         id = generateGlobalId(),
-        commandWaitId = commandWaitId,
+        waitCommandId = waitCommandId,
         commandId = commandId,
         aggregateId = aggregateId,
         stage = CommandStage.SENT,
@@ -83,20 +83,17 @@ interface CommandGateway : CommandBus {
     ): Mono<CommandResult>
 
     fun <C : Any> sendAndWaitForSent(
-        command: CommandMessage<C>,
-        commandWaitId: String = command.commandId,
+        command: CommandMessage<C>
     ): Mono<CommandResult> =
-        sendAndWait(command, WaitingForStage.sent(commandWaitId))
+        sendAndWait(command, WaitingForStage.sent(command.commandId))
 
     fun <C : Any> sendAndWaitForProcessed(
-        command: CommandMessage<C>,
-        commandWaitId: String = command.commandId,
+        command: CommandMessage<C>
     ): Mono<CommandResult> =
-        sendAndWait(command, WaitingForStage.processed(commandWaitId))
+        sendAndWait(command, WaitingForStage.processed(command.commandId))
 
     fun <C : Any> sendAndWaitForSnapshot(
-        command: CommandMessage<C>,
-        commandWaitId: String = command.commandId,
+        command: CommandMessage<C>
     ): Mono<CommandResult> =
-        sendAndWait(command, WaitingForStage.snapshot(commandWaitId))
+        sendAndWait(command, WaitingForStage.snapshot(command.commandId))
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandResult.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandResult.kt
@@ -27,9 +27,9 @@ import me.ahoo.wow.api.naming.Materialized
 import me.ahoo.wow.api.naming.NamedBoundedContext
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.CommandStageCapable
-import me.ahoo.wow.command.wait.CommandWaitIdCapable
 import me.ahoo.wow.command.wait.NullableAggregateVersionCapable
 import me.ahoo.wow.command.wait.SignalTimeCapable
+import me.ahoo.wow.command.wait.WaitCommandIdCapable
 import me.ahoo.wow.command.wait.WaitSignal
 import me.ahoo.wow.exception.ErrorCodes
 import me.ahoo.wow.exception.toErrorInfo
@@ -37,7 +37,7 @@ import me.ahoo.wow.id.generateGlobalId
 
 data class CommandResult(
     override val id: String,
-    override val commandWaitId: String,
+    override val waitCommandId: String,
     override val stage: CommandStage,
     override val contextName: String,
     override val aggregateName: String,
@@ -53,7 +53,7 @@ data class CommandResult(
     override val result: Map<String, Any> = emptyMap(),
     override val signalTime: Long = System.currentTimeMillis()
 ) : Identifier,
-    CommandWaitIdCapable,
+    WaitCommandIdCapable,
     CommandStageCapable,
     NamedBoundedContext,
     AggregateNameCapable,
@@ -70,7 +70,7 @@ data class CommandResult(
 fun WaitSignal.toResult(commandMessage: CommandMessage<*>): CommandResult {
     return CommandResult(
         id = this.id,
-        commandWaitId = commandWaitId,
+        waitCommandId = waitCommandId,
         stage = this.stage,
         contextName = aggregateId.contextName,
         aggregateName = aggregateId.aggregateName,
@@ -89,7 +89,7 @@ fun WaitSignal.toResult(commandMessage: CommandMessage<*>): CommandResult {
 }
 
 fun Throwable.toResult(
-    commandWaitId: String,
+    waitCommandId: String,
     commandMessage: CommandMessage<*>,
     function: FunctionInfoData = COMMAND_GATEWAY_FUNCTION,
     id: String = generateGlobalId(),
@@ -100,7 +100,7 @@ fun Throwable.toResult(
     val errorInfo = toErrorInfo()
     return CommandResult(
         id = id,
-        commandWaitId = commandWaitId,
+        waitCommandId = waitCommandId,
         stage = stage,
         contextName = commandMessage.contextName,
         aggregateName = commandMessage.aggregateName,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
@@ -69,11 +69,11 @@ class DefaultCommandGateway(
     override fun send(message: CommandMessage<*>): Mono<Void> {
         return check(message).then(commandBus.send(message)).doOnSuccess {
             val waitStrategy = message.header.extractWaitStrategy() ?: return@doOnSuccess
-            val waitSignal = message.commandSentSignal(waitStrategy.waitStrategy.id)
+            val waitSignal = message.commandSentSignal(waitStrategy.waitStrategy.waitCommandId)
             commandWaitNotifier.notifyAndForget(waitStrategy, waitSignal)
         }.doOnError {
             val waitStrategy = message.header.extractWaitStrategy() ?: return@doOnError
-            val waitSignal = message.commandSentSignal(waitStrategy.waitStrategy.id, it)
+            val waitSignal = message.commandSentSignal(waitStrategy.waitStrategy.waitCommandId, it)
             commandWaitNotifier.notifyAndForget(waitStrategy, waitSignal)
         }
     }
@@ -122,25 +122,25 @@ class DefaultCommandGateway(
                 .doOnSubscribe {
                     waitStrategyRegistrar.register(waitStrategy)
                     waitStrategy.onFinally {
-                        waitStrategyRegistrar.unregister(waitStrategy.id)
+                        waitStrategyRegistrar.unregister(waitStrategy.waitCommandId)
                     }
                 }
                 .doOnError {
-                    waitStrategyRegistrar.unregister(waitStrategy.id)
+                    waitStrategyRegistrar.unregister(waitStrategy.waitCommandId)
                 }
                 .doOnCancel {
-                    waitStrategyRegistrar.unregister(waitStrategy.id)
+                    waitStrategyRegistrar.unregister(waitStrategy.waitCommandId)
                 }
         }.doOnSuccess {
-            val waitSignal = command.commandSentSignal(waitStrategy.id)
+            val waitSignal = command.commandSentSignal(waitStrategy.waitCommandId)
             waitStrategy.next(waitSignal)
         }.doOnError {
-            val waitSignal = command.commandSentSignal(waitStrategy.id, it)
+            val waitSignal = command.commandSentSignal(waitStrategy.waitCommandId, it)
             waitStrategy.next(waitSignal)
         }.onErrorMap {
             CommandResultException(
                 it.toResult(
-                    commandWaitId = waitStrategy.id,
+                    waitCommandId = waitStrategy.waitCommandId,
                     commandMessage = command
                 ),
                 it

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWaitNotifier.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWaitNotifier.kt
@@ -21,7 +21,7 @@ import reactor.core.publisher.Mono
 import reactor.core.scheduler.Schedulers
 
 const val COMMAND_WAIT_PREFIX = "command_wait_"
-const val COMMAND_WAIT_ID = "${COMMAND_WAIT_PREFIX}id"
+const val WAIT_COMMAND_ID = "${COMMAND_WAIT_PREFIX}id"
 const val COMMAND_WAIT_ENDPOINT = "${COMMAND_WAIT_PREFIX}endpoint"
 
 interface CommandWaitEndpoint {
@@ -30,21 +30,24 @@ interface CommandWaitEndpoint {
 
 data class SimpleCommandWaitEndpoint(override val endpoint: String) : CommandWaitEndpoint
 
-data class EndpointWaitStrategy(override val endpoint: String, val waitStrategy: WaitStrategy.Materialized) :
-    CommandWaitEndpoint
+data class ExtractedWaitStrategy(
+    override val endpoint: String,
+    override val waitCommandId: String,
+    val waitStrategy: WaitStrategy.Materialized
+) : CommandWaitEndpoint, WaitCommandIdCapable
 
 fun Header.extractCommandWaitId(): String? {
-    return this[COMMAND_WAIT_ID]
+    return this[WAIT_COMMAND_ID]
 }
 
-fun Header.requireExtractCommandWaitId(): String {
+fun Header.requireExtractWaitCommandId(): String {
     return requireNotNull(extractCommandWaitId()) {
-        "$COMMAND_WAIT_ID is required!"
+        "$WAIT_COMMAND_ID is required!"
     }
 }
 
-fun Header.propagateCommandWaitId(id: String): Header {
-    return with(COMMAND_WAIT_ID, id)
+fun Header.propagateWaitCommandId(commandId: String): Header {
+    return with(WAIT_COMMAND_ID, commandId)
 }
 
 fun Header.extractCommandWaitEndpoint(): String? {
@@ -55,10 +58,11 @@ fun Header.propagateCommandWaitEndpoint(endpoint: String): Header {
     return with(COMMAND_WAIT_ENDPOINT, endpoint)
 }
 
-fun Header.extractWaitStrategy(): EndpointWaitStrategy? {
+fun Header.extractWaitStrategy(): ExtractedWaitStrategy? {
+    val waitCommandId = this.extractCommandWaitId() ?: return null
     val endpoint = this.extractCommandWaitEndpoint() ?: return null
     val waitStrategy = this.extractWaitingForStage() ?: return null
-    return EndpointWaitStrategy(endpoint, waitStrategy)
+    return ExtractedWaitStrategy(endpoint, waitCommandId, waitStrategy)
 }
 
 /**
@@ -99,7 +103,7 @@ class LocalCommandWaitNotifier(
 }
 
 fun CommandWaitNotifier.notifyAndForget(
-    waiteStrategy: EndpointWaitStrategy,
+    waiteStrategy: ExtractedWaitStrategy,
     waitSignal: WaitSignal
 ) {
     if (!waiteStrategy.waitStrategy.shouldNotify(waitSignal)) {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifier.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifier.kt
@@ -61,7 +61,7 @@ class MonoCommandWaitNotifier<E, M>(
 class CommandWaitNotifierSubscriber<E, M>(
     private val commandWaitNotifier: CommandWaitNotifier,
     private val processingStage: CommandStage,
-    private val waitStrategy: EndpointWaitStrategy,
+    private val waitStrategy: ExtractedWaitStrategy,
     private val messageExchange: E,
     private val actual: CoreSubscriber<in Void>
 ) : BaseSubscriber<Void>() where E : MessageExchange<*, M>, M : Message<*, *>, M : CommandId, M : NamedBoundedContext, M : AggregateIdCapable {
@@ -114,7 +114,7 @@ class CommandWaitNotifierSubscriber<E, M>(
 
         val waitSignal = functionInfo.toWaitSignal(
             id = messageExchange.message.id,
-            commandWaitId = waitStrategy.waitStrategy.id,
+            waitCommandId = waitStrategy.waitStrategy.waitCommandId,
             commandId = messageExchange.message.commandId,
             aggregateId = messageExchange.message.aggregateId,
             stage = processingStage,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitCommandIdCapable.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitCommandIdCapable.kt
@@ -13,6 +13,6 @@
 
 package me.ahoo.wow.command.wait
 
-interface CommandWaitIdCapable {
-    val commandWaitId: String
+interface WaitCommandIdCapable {
+    val waitCommandId: String
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitSignal.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitSignal.kt
@@ -36,7 +36,7 @@ interface NullableAggregateVersionCapable {
 
 interface WaitSignal :
     Identifier,
-    CommandWaitIdCapable,
+    WaitCommandIdCapable,
     CommandId,
     AggregateIdCapable,
     NullableAggregateVersionCapable,
@@ -57,7 +57,7 @@ interface WaitSignal :
 
 data class SimpleWaitSignal(
     override val id: String,
-    override val commandWaitId: String,
+    override val waitCommandId: String,
     override val commandId: String,
     override val aggregateId: AggregateId,
     override val stage: CommandStage,
@@ -74,7 +74,7 @@ data class SimpleWaitSignal(
     companion object {
         fun FunctionInfo.toWaitSignal(
             id: String,
-            commandWaitId: String,
+            waitCommandId: String,
             commandId: String,
             aggregateId: AggregateId,
             stage: CommandStage,
@@ -89,7 +89,7 @@ data class SimpleWaitSignal(
         ): WaitSignal {
             return SimpleWaitSignal(
                 id = id,
-                commandWaitId = commandWaitId,
+                waitCommandId = waitCommandId,
                 commandId = commandId,
                 aggregateId = aggregateId,
                 stage = stage,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategy.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategy.kt
@@ -13,7 +13,6 @@
 
 package me.ahoo.wow.command.wait
 
-import me.ahoo.wow.api.Identifier
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.messaging.Header
 import me.ahoo.wow.api.messaging.Message
@@ -29,7 +28,7 @@ import java.util.function.Consumer
  *
  * 定义了命令等待策略中关于传播行为的抽象方法，用于控制命令处理结果的传播逻辑。
  */
-interface WaitStrategyPropagator : Identifier, MessagePropagator {
+interface WaitStrategyPropagator : WaitCommandIdCapable, MessagePropagator {
 
     /**
      * 执行传播操作
@@ -60,7 +59,6 @@ interface WaitStrategy : WaitStrategyPropagator, CompletedCapable {
     override val completed: Boolean
         get() = terminated || cancelled
     val materialized: Materialized
-    override val id: String
 
     /**
      * 是否支持虚空命令
@@ -91,7 +89,6 @@ interface WaitStrategy : WaitStrategyPropagator, CompletedCapable {
     }
 
     interface Materialized :
-        Identifier,
         WaitStrategyPropagator,
         ProcessingStageShouldNotifyPredicate,
         WaitSignalShouldNotifyPredicate,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategyRegistrar.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategyRegistrar.kt
@@ -32,14 +32,14 @@ interface WaitStrategyRegistrar {
      *
      * @see java.util.Map.remove
      */
-    fun unregister(commandWaitId: String): WaitStrategy?
+    fun unregister(waitCommandId: String): WaitStrategy?
 
-    fun get(commandWaitId: String): WaitStrategy?
+    fun get(waitCommandId: String): WaitStrategy?
 
-    operator fun contains(commandWaitId: String): Boolean
+    operator fun contains(waitCommandId: String): Boolean
 
     fun next(signal: WaitSignal): Boolean {
-        val waitStrategy = get(signal.commandWaitId) ?: return false
+        val waitStrategy = get(signal.waitCommandId) ?: return false
         waitStrategy.next(signal)
         return true
     }
@@ -51,24 +51,24 @@ object SimpleWaitStrategyRegistrar : WaitStrategyRegistrar {
 
     override fun register(waitStrategy: WaitStrategy): WaitStrategy? {
         log.debug {
-            "Register - commandWaitId[${waitStrategy.id}] WaitStrategy."
+            "Register - waitCommandId[${waitStrategy.waitCommandId}] WaitStrategy."
         }
-        return waitStrategies.putIfAbsent(waitStrategy.id, waitStrategy)
+        return waitStrategies.putIfAbsent(waitStrategy.waitCommandId, waitStrategy)
     }
 
-    override fun unregister(commandWaitId: String): WaitStrategy? {
-        val value = waitStrategies.remove(commandWaitId)
+    override fun unregister(waitCommandId: String): WaitStrategy? {
+        val value = waitStrategies.remove(waitCommandId)
         log.debug {
-            "Unregister - remove commandWaitId[$commandWaitId] WaitStrategy - [${value != null}]."
+            "Unregister - remove waitCommandId[$waitCommandId] WaitStrategy - [${value != null}]."
         }
         return value
     }
 
-    override fun get(commandWaitId: String): WaitStrategy? {
-        return waitStrategies[commandWaitId]
+    override fun get(waitCommandId: String): WaitStrategy? {
+        return waitStrategies[waitCommandId]
     }
 
-    override fun contains(commandWaitId: String): Boolean {
-        return waitStrategies.containsKey(commandWaitId)
+    override fun contains(waitCommandId: String): Boolean {
+        return waitStrategies.containsKey(waitCommandId)
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForEventHandled.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForEventHandled.kt
@@ -17,7 +17,7 @@ import me.ahoo.wow.api.messaging.function.NamedFunctionInfoData
 import me.ahoo.wow.command.wait.CommandStage
 
 class WaitingForEventHandled(
-    override val id: String,
+    override val waitCommandId: String,
     override val function: NamedFunctionInfoData? = null
 ) : WaitingForFunction() {
     override val stage: CommandStage

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForFunction.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForFunction.kt
@@ -22,7 +22,7 @@ import me.ahoo.wow.command.wait.isWaitingForFunction
 abstract class WaitingForFunction : WaitingForAfterProcessed(), NullableFunctionInfoCapable<NamedFunctionInfoData> {
     override val materialized: WaitStrategy.Materialized by lazy {
         Materialized(
-            id = id,
+            waitCommandId = waitCommandId,
             stage = stage,
             function = function
         )

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForProcessed.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForProcessed.kt
@@ -15,7 +15,7 @@ package me.ahoo.wow.command.wait.stage
 
 import me.ahoo.wow.command.wait.CommandStage
 
-class WaitingForProcessed(override val id: String) : WaitingForStage() {
+class WaitingForProcessed(override val waitCommandId: String) : WaitingForStage() {
     override val stage: CommandStage
         get() = CommandStage.PROCESSED
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForProjected.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForProjected.kt
@@ -18,7 +18,7 @@ import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.WaitSignal
 
 class WaitingForProjected(
-    override val id: String,
+    override val waitCommandId: String,
     override val function: NamedFunctionInfoData? = null
 ) : WaitingForFunction() {
     override val stage: CommandStage

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForSagaHandled.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForSagaHandled.kt
@@ -17,7 +17,7 @@ import me.ahoo.wow.api.messaging.function.NamedFunctionInfoData
 import me.ahoo.wow.command.wait.CommandStage
 
 class WaitingForSagaHandled(
-    override val id: String,
+    override val waitCommandId: String,
     override val function: NamedFunctionInfoData? = null
 ) : WaitingForFunction() {
     override val stage: CommandStage

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForSent.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForSent.kt
@@ -15,7 +15,7 @@ package me.ahoo.wow.command.wait.stage
 
 import me.ahoo.wow.command.wait.CommandStage
 
-class WaitingForSent(override val id: String) : WaitingForStage() {
+class WaitingForSent(override val waitCommandId: String) : WaitingForStage() {
     override val stage: CommandStage
         get() = CommandStage.SENT
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForSnapshot.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForSnapshot.kt
@@ -15,7 +15,7 @@ package me.ahoo.wow.command.wait.stage
 
 import me.ahoo.wow.command.wait.CommandStage
 
-class WaitingForSnapshot(override val id: String) : WaitingForAfterProcessed() {
+class WaitingForSnapshot(override val waitCommandId: String) : WaitingForAfterProcessed() {
     override val stage: CommandStage
         get() = CommandStage.SNAPSHOT
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/CommandResultTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/CommandResultTest.kt
@@ -11,7 +11,7 @@ class CommandResultTest {
     fun throwableAsResult() {
         val command = MockCreateCommand(generateGlobalId()).toCommandMessage()
         val actual = IllegalStateException("test").toResult(
-            commandWaitId = generateGlobalId(),
+            waitCommandId = generateGlobalId(),
             commandMessage = command,
             function = COMMAND_GATEWAY_FUNCTION
         )

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTest.kt
@@ -43,7 +43,7 @@ internal class DefaultCommandGatewayTest : CommandGatewaySpec() {
         val messageGateway = createMessageBus()
         val message = MockVoidCommand(generateGlobalId()).toCommandMessage()
         Assertions.assertThrows(IllegalArgumentException::class.java) {
-            messageGateway.send(message, WaitingForStage.stage(CommandStage.PROCESSED, "", ""))
+            messageGateway.send(message, WaitingForStage.stage(message.commandId, CommandStage.PROCESSED, "", ""))
         }
     }
 

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/SimpleClientCommandExchangeTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/SimpleClientCommandExchangeTest.kt
@@ -22,8 +22,8 @@ class SimpleClientCommandExchangeTest {
 
     @Test
     fun main() {
-        val waitingFor = WaitingForStage.sent()
         val command = MockCreateCommand(generateGlobalId()).toCommandMessage()
+        val waitingFor = WaitingForStage.sent(command.commandId)
         val commandExchange = SimpleClientCommandExchange(command, waitingFor)
         commandExchange.message.assert().isEqualTo(command)
         commandExchange.waitStrategy.assert().isEqualTo(waitingFor)

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/LocalCommandWaitNotifierTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/LocalCommandWaitNotifierTest.kt
@@ -36,7 +36,7 @@ internal class LocalCommandWaitNotifierTest {
             "endpoint",
             SimpleWaitSignal(
                 id = generateGlobalId(),
-                commandWaitId = generateGlobalId(),
+                waitCommandId = generateGlobalId(),
                 commandId = generateGlobalId(),
                 aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
                 stage = CommandStage.SENT,
@@ -54,7 +54,7 @@ internal class LocalCommandWaitNotifierTest {
             "endpoint",
             SimpleWaitSignal(
                 id = generateGlobalId(),
-                commandWaitId = generateGlobalId(),
+                waitCommandId = generateGlobalId(),
                 commandId = generateGlobalId(),
                 aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
                 stage = CommandStage.SENT,
@@ -70,7 +70,7 @@ internal class LocalCommandWaitNotifierTest {
             "endpoint",
             SimpleWaitSignal(
                 id = generateGlobalId(),
-                commandWaitId = "0THbs0sW0066001",
+                waitCommandId = "0THbs0sW0066001",
                 commandId = "0THbs0sW0066001",
                 aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
                 stage = CommandStage.SENT,

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifierTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/MonoCommandWaitNotifierTest.kt
@@ -43,7 +43,7 @@ internal class MonoCommandWaitNotifierTest {
     @Test
     fun notifyAndForgetWrap() {
         val command = MockCreateCommand("").toCommandMessage()
-        WaitingForStage.processed().propagate("", command.header)
+        WaitingForStage.processed(command.commandId).propagate("", command.header)
 
         val commandWaitNotifier = LocalCommandWaitNotifier(SimpleWaitStrategyRegistrar)
         Mono.empty<Void>()
@@ -64,7 +64,7 @@ internal class MonoCommandWaitNotifierTest {
     @Test
     fun notifyAndForgetWrapError() {
         val command = MockCreateCommand("").toCommandMessage()
-        WaitingForStage.processed().propagate("", command.header)
+        WaitingForStage.processed(command.commandId).propagate("", command.header)
         val commandWaitNotifier = LocalCommandWaitNotifier(SimpleWaitStrategyRegistrar)
         RuntimeException("error")
             .toMono<Void>()
@@ -80,7 +80,7 @@ internal class MonoCommandWaitNotifierTest {
     @Test
     fun notifyAndForgetWrapAndStageIsEarly() {
         val command = MockCreateCommand("").toCommandMessage()
-        WaitingForStage.processed().propagate("", command.header)
+        WaitingForStage.processed(command.commandId).propagate("", command.header)
         val commandWaitNotifier = LocalCommandWaitNotifier(SimpleWaitStrategyRegistrar)
         Mono.empty<Void>()
             .thenNotifyAndForget(commandWaitNotifier, CommandStage.PROCESSED, SimpleServerCommandExchange(command))

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/SagaHandledNotifierFilterTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/SagaHandledNotifierFilterTest.kt
@@ -27,7 +27,7 @@ class SagaHandledNotifierFilterTest {
             MOCK_AGGREGATE_METADATA.aggregateId(),
             generateGlobalId()
         ) as DomainEvent<Any>
-        WaitingForStage.sagaHandled(domainEvent.contextName).propagate("", domainEvent.header)
+        WaitingForStage.sagaHandled(domainEvent.commandId, domainEvent.contextName).propagate("", domainEvent.header)
         val exchange = SimpleDomainEventExchange(domainEvent)
         val commandMessage = MockCreateAggregate(generateGlobalId(), generateGlobalId()).toCommandMessage()
         val commandStream = DefaultCommandStream(generateGlobalId(), listOf(commandMessage))

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/SimpleWaitStrategyRegistrarTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/SimpleWaitStrategyRegistrarTest.kt
@@ -27,7 +27,7 @@ internal class SimpleWaitStrategyRegistrarTest {
     @Test
     fun register() {
         val registrar = SimpleWaitStrategyRegistrar
-        val waitStrategy = WaitingForStage.processed()
+        val waitStrategy = WaitingForStage.processed(generateGlobalId())
         var registerResult = registrar.register(waitStrategy)
         registerResult.assert().isNull()
         registerResult = registrar.register(waitStrategy)
@@ -37,33 +37,33 @@ internal class SimpleWaitStrategyRegistrarTest {
     @Test
     fun unregister() {
         val registrar = SimpleWaitStrategyRegistrar
-        val waitStrategy = WaitingForStage.processed()
-        var registerResult = registrar.unregister(waitStrategy.id)
+        val waitStrategy = WaitingForStage.processed(generateGlobalId())
+        var registerResult = registrar.unregister(waitStrategy.waitCommandId)
         registerResult.assert().isNull()
         registerResult = registrar.register(waitStrategy)
         registerResult.assert().isNull()
-        val unregisterResult = registrar.unregister(waitStrategy.id)
+        val unregisterResult = registrar.unregister(waitStrategy.waitCommandId)
         unregisterResult.assert().isEqualTo(waitStrategy)
     }
 
     @Test
     fun contains() {
         val registrar = SimpleWaitStrategyRegistrar
-        val waitStrategy = WaitingForStage.processed()
-        var containsResult = registrar.contains(waitStrategy.id)
+        val waitStrategy = WaitingForStage.processed(generateGlobalId())
+        var containsResult = registrar.contains(waitStrategy.waitCommandId)
         containsResult.assert().isFalse()
         registrar.register(waitStrategy)
-        containsResult = registrar.contains(waitStrategy.id)
+        containsResult = registrar.contains(waitStrategy.waitCommandId)
         containsResult.assert().isTrue()
     }
 
     @Test
     fun next() {
         val registrar = SimpleWaitStrategyRegistrar
-        val waitStrategy = WaitingForStage.processed()
+        val waitStrategy = WaitingForStage.processed(generateGlobalId())
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
-            commandWaitId = waitStrategy.id,
+            waitCommandId = waitStrategy.waitCommandId,
             commandId = generateGlobalId(),
             aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROCESSED,
@@ -80,8 +80,8 @@ internal class SimpleWaitStrategyRegistrarTest {
         registrar.register(waitStrategy)
         nextResult = registrar.next(waitSignal)
         nextResult.assert().isTrue()
-        registrar.unregister(waitStrategy.id)
-        val containsResult = registrar.contains(waitStrategy.id)
+        registrar.unregister(waitStrategy.waitCommandId)
+        val containsResult = registrar.contains(waitStrategy.waitCommandId)
         containsResult.assert().isFalse()
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForStageTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForStageTest.kt
@@ -38,7 +38,7 @@ internal class WaitingForStageTest {
 
     @Test
     fun processedInject() {
-        val waitStrategy = WaitingForStage.projected("content", "processor", "function")
+        val waitStrategy = WaitingForStage.projected(generateGlobalId(), "content", "processor", "function")
         val header = DefaultHeader()
         waitStrategy.propagate("endpoint", header)
         val waitStrategyInfo = header.extractWaitingForStage()
@@ -64,12 +64,12 @@ internal class WaitingForStageTest {
 
     @Test
     fun processed() {
-        val waitStrategy = WaitingForStage.stage("PROCESSED", contextName)
+        val waitStrategy = WaitingForStage.stage(generateGlobalId(), "PROCESSED", contextName)
         waitStrategy.cancelled.assert().isEqualTo(false)
         waitStrategy.terminated.assert().isEqualTo(false)
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
-            commandWaitId = waitStrategy.id,
+            waitCommandId = waitStrategy.waitCommandId,
             commandId = generateGlobalId(),
             aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROCESSED,
@@ -87,10 +87,10 @@ internal class WaitingForStageTest {
 
     @Test
     fun processedIfSnapshot() {
-        val waitStrategy = WaitingForStage.stage("PROCESSED", contextName)
+        val waitStrategy = WaitingForStage.stage(generateGlobalId(), "PROCESSED", contextName)
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
-            commandWaitId = waitStrategy.id,
+            waitCommandId = waitStrategy.waitCommandId,
             commandId = generateGlobalId(),
             aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.SNAPSHOT,
@@ -108,10 +108,10 @@ internal class WaitingForStageTest {
 
     @Test
     fun snapshot() {
-        val waitStrategy = WaitingForStage.stage("SNAPSHOT", contextName)
+        val waitStrategy = WaitingForStage.stage(generateGlobalId(), "SNAPSHOT", contextName)
         val processedSignal = SimpleWaitSignal(
             id = generateGlobalId(),
-            commandWaitId = waitStrategy.id,
+            waitCommandId = waitStrategy.waitCommandId,
             commandId = generateGlobalId(),
             aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROCESSED,
@@ -119,7 +119,7 @@ internal class WaitingForStageTest {
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
-            commandWaitId = waitStrategy.id,
+            waitCommandId = waitStrategy.waitCommandId,
             commandId = generateGlobalId(),
             aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.SNAPSHOT,
@@ -139,10 +139,10 @@ internal class WaitingForStageTest {
 
     @Test
     fun snapshotFailFast() {
-        val waitStrategy = WaitingForStage.snapshot()
+        val waitStrategy = WaitingForStage.snapshot(generateGlobalId())
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
-            commandWaitId = waitStrategy.id,
+            waitCommandId = waitStrategy.waitCommandId,
             commandId = generateGlobalId(),
             aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROCESSED,
@@ -160,10 +160,10 @@ internal class WaitingForStageTest {
 
     @Test
     fun projected() {
-        val waitStrategy = WaitingForStage.stage("PROJECTED", contextName)
+        val waitStrategy = WaitingForStage.stage(generateGlobalId(), "PROJECTED", contextName)
         val processedSignal = SimpleWaitSignal(
             id = generateGlobalId(),
-            commandWaitId = waitStrategy.id,
+            waitCommandId = waitStrategy.waitCommandId,
             commandId = generateGlobalId(),
             aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROCESSED,
@@ -171,7 +171,7 @@ internal class WaitingForStageTest {
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
-            commandWaitId = waitStrategy.id,
+            waitCommandId = waitStrategy.waitCommandId,
             commandId = generateGlobalId(),
             aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROJECTED,
@@ -190,10 +190,10 @@ internal class WaitingForStageTest {
 
     @Test
     fun waitingForProjectedProcessor() {
-        val waitStrategy = WaitingForStage.projected(contextName, "processor")
+        val waitStrategy = WaitingForStage.projected(generateGlobalId(), contextName, "processor")
         val processedSignal = SimpleWaitSignal(
             id = generateGlobalId(),
-            commandWaitId = waitStrategy.id,
+            waitCommandId = waitStrategy.waitCommandId,
             commandId = generateGlobalId(),
             aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROCESSED,
@@ -201,7 +201,7 @@ internal class WaitingForStageTest {
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
-            commandWaitId = waitStrategy.id,
+            waitCommandId = waitStrategy.waitCommandId,
             commandId = generateGlobalId(),
             aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROJECTED,
@@ -220,10 +220,10 @@ internal class WaitingForStageTest {
 
     @Test
     fun waitingForProjectedProcessorNotEq() {
-        val waitStrategy = WaitingForStage.projected(contextName, "processor")
+        val waitStrategy = WaitingForStage.projected(generateGlobalId(), "processor")
         val processedSignal = SimpleWaitSignal(
             id = generateGlobalId(),
-            commandWaitId = waitStrategy.id,
+            waitCommandId = waitStrategy.waitCommandId,
             commandId = generateGlobalId(),
             aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROCESSED,
@@ -231,7 +231,7 @@ internal class WaitingForStageTest {
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
-            commandWaitId = waitStrategy.id,
+            waitCommandId = waitStrategy.waitCommandId,
             commandId = generateGlobalId(),
             aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROJECTED,
@@ -249,10 +249,10 @@ internal class WaitingForStageTest {
 
     @Test
     fun waitingForProjectedFunction() {
-        val waitStrategy = WaitingForStage.projected(contextName, "processor", "function")
+        val waitStrategy = WaitingForStage.projected(generateGlobalId(), contextName, "processor", "function")
         val processedSignal = SimpleWaitSignal(
             id = generateGlobalId(),
-            commandWaitId = waitStrategy.id,
+            waitCommandId = waitStrategy.waitCommandId,
             commandId = generateGlobalId(),
             aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROCESSED,
@@ -260,7 +260,7 @@ internal class WaitingForStageTest {
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
-            commandWaitId = waitStrategy.id,
+            waitCommandId = waitStrategy.waitCommandId,
             commandId = generateGlobalId(),
             aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROJECTED,
@@ -283,10 +283,10 @@ internal class WaitingForStageTest {
 
     @Test
     fun waitingForProjectedWhenNotLast() {
-        val waitStrategy = WaitingForStage.projected(contextName)
+        val waitStrategy = WaitingForStage.projected(generateGlobalId(), contextName)
         val processedSignal = SimpleWaitSignal(
             id = generateGlobalId(),
-            commandWaitId = waitStrategy.id,
+            waitCommandId = waitStrategy.waitCommandId,
             commandId = generateGlobalId(),
             aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROCESSED,
@@ -294,7 +294,7 @@ internal class WaitingForStageTest {
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
-            commandWaitId = waitStrategy.id,
+            waitCommandId = waitStrategy.waitCommandId,
             commandId = generateGlobalId(),
             aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROJECTED,
@@ -314,10 +314,10 @@ internal class WaitingForStageTest {
 
     @Test
     fun waitingForEventHandled() {
-        val waitStrategy = WaitingForStage.stage("EVENT_HANDLED", contextName)
+        val waitStrategy = WaitingForStage.stage(generateGlobalId(), "EVENT_HANDLED", contextName)
         val processedSignal = SimpleWaitSignal(
             id = generateGlobalId(),
-            commandWaitId = waitStrategy.id,
+            waitCommandId = waitStrategy.waitCommandId,
             commandId = generateGlobalId(),
             aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROCESSED,
@@ -325,7 +325,7 @@ internal class WaitingForStageTest {
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
-            commandWaitId = waitStrategy.id,
+            waitCommandId = waitStrategy.waitCommandId,
             commandId = generateGlobalId(),
             aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.EVENT_HANDLED,
@@ -344,10 +344,10 @@ internal class WaitingForStageTest {
 
     @Test
     fun waitingForSagaHandled() {
-        val waitStrategy = WaitingForStage.stage("SAGA_HANDLED", contextName)
+        val waitStrategy = WaitingForStage.stage(generateGlobalId(), "SAGA_HANDLED", contextName)
         val processedSignal = SimpleWaitSignal(
             id = generateGlobalId(),
-            commandWaitId = waitStrategy.id,
+            waitCommandId = waitStrategy.waitCommandId,
             commandId = generateGlobalId(),
             aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.PROCESSED,
@@ -355,7 +355,7 @@ internal class WaitingForStageTest {
         )
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
-            commandWaitId = waitStrategy.id,
+            waitCommandId = waitStrategy.waitCommandId,
             commandId = generateGlobalId(),
             aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.SAGA_HANDLED,
@@ -373,14 +373,14 @@ internal class WaitingForStageTest {
 
     @Test
     fun waitingWhenNoMatchedContext() {
-        val waitStrategy = WaitingForStage.projected(contextName)
+        val waitStrategy = WaitingForStage.projected(generateGlobalId(), contextName)
         waitStrategy.waitingLast()
             .test()
             .consumeSubscriptionWith {
                 waitStrategy.next(
                     SimpleWaitSignal(
                         id = generateGlobalId(),
-                        commandWaitId = waitStrategy.id,
+                        waitCommandId = waitStrategy.waitCommandId,
                         commandId = generateGlobalId(),
                         aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
                         stage = CommandStage.PROJECTED,
@@ -395,7 +395,7 @@ internal class WaitingForStageTest {
 
     @Test
     fun waitingWhenError() {
-        val waitStrategy = WaitingForStage.projected(contextName)
+        val waitStrategy = WaitingForStage.projected(generateGlobalId(), contextName)
         waitStrategy.error(IllegalArgumentException())
         waitStrategy.waitingLast()
             .test()
@@ -405,7 +405,7 @@ internal class WaitingForStageTest {
 
     @Test
     fun waitingForSent() {
-        val waitStrategy = WaitingForStage.stage("SENT", contextName)
+        val waitStrategy = WaitingForStage.stage(generateGlobalId(), "SENT", contextName)
         waitStrategy.error(IllegalArgumentException())
         waitStrategy.waitingLast()
             .test()
@@ -415,7 +415,7 @@ internal class WaitingForStageTest {
 
     @Test
     fun doFinallyError() {
-        val waitStrategy = WaitingForStage.projected(contextName)
+        val waitStrategy = WaitingForStage.projected(generateGlobalId(), contextName)
         waitStrategy.onFinally {
             throw IllegalArgumentException()
         }
@@ -428,7 +428,7 @@ internal class WaitingForStageTest {
 
     @Test
     fun doFinallySetTwice() {
-        val waitStrategy = WaitingForStage.projected(contextName)
+        val waitStrategy = WaitingForStage.projected(generateGlobalId(), contextName)
         waitStrategy.onFinally {
         }
         Assertions.assertThrows(IllegalStateException::class.java) {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/exception/ErrorConverterRegistrarTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/exception/ErrorConverterRegistrarTest.kt
@@ -26,7 +26,7 @@ class ErrorInfoConverterRegistrarTest {
     fun commandResultExceptionToErrorInfo() {
         val commandResult = CommandResult(
             id = generateGlobalId(),
-            commandWaitId = generateGlobalId(),
+            waitCommandId = generateGlobalId(),
             stage = CommandStage.SENT,
             aggregateId = generateGlobalId(),
             tenantId = generateGlobalId(),

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/propagation/WaitStrategyMessagePropagatorTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/propagation/WaitStrategyMessagePropagatorTest.kt
@@ -3,6 +3,7 @@ package me.ahoo.wow.messaging.propagation
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.command.toCommandMessage
 import me.ahoo.wow.command.wait.COMMAND_WAIT_ENDPOINT
+import me.ahoo.wow.command.wait.requireExtractWaitCommandId
 import me.ahoo.wow.command.wait.stage.WaitingForStage
 import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_CONTEXT
 import me.ahoo.wow.command.wait.stage.WaitingForStage.Companion.COMMAND_WAIT_FUNCTION
@@ -23,9 +24,10 @@ class WaitStrategyMessagePropagatorTest {
         val upstreamMessage =
             MockCreateAggregate(generateGlobalId(), generateGlobalId())
                 .toCommandMessage()
-        WaitingForStage.projected("context", "processor", "function")
+        WaitingForStage.projected(upstreamMessage.commandId, "context", "processor", "function")
             .propagate("wait-endpoint", upstreamMessage.header)
         WaitStrategyMessagePropagator().propagate(header, upstreamMessage)
+        header.requireExtractWaitCommandId().assert().isEqualTo(upstreamMessage.commandId)
         header[COMMAND_WAIT_ENDPOINT].assert().isEqualTo("wait-endpoint")
         header[COMMAND_WAIT_STAGE].assert().isEqualTo("PROJECTED")
         header[COMMAND_WAIT_CONTEXT].assert().isEqualTo("context")
@@ -39,7 +41,7 @@ class WaitStrategyMessagePropagatorTest {
         val upstreamMessage =
             MockCreateAggregate(generateGlobalId(), generateGlobalId())
                 .toCommandMessage()
-        WaitingForStage.sent().propagate("wait-endpoint", upstreamMessage.header)
+        WaitingForStage.sent(upstreamMessage.commandId).propagate("wait-endpoint", upstreamMessage.header)
         WaitStrategyMessagePropagator().propagate(header, upstreamMessage)
         header[COMMAND_WAIT_ENDPOINT].assert().isEqualTo(upstreamMessage.header[COMMAND_WAIT_ENDPOINT])
         header[COMMAND_WAIT_STAGE].assert().isEqualTo(upstreamMessage.header[COMMAND_WAIT_STAGE])
@@ -54,7 +56,7 @@ class WaitStrategyMessagePropagatorTest {
         val upstreamMessage =
             MockAggregateCreated(generateGlobalId())
                 .toDomainEvent(generateGlobalId(), generateGlobalId(), generateGlobalId())
-        WaitingForStage.sent().propagate("wait-endpoint", upstreamMessage.header)
+        WaitingForStage.sent(upstreamMessage.commandId).propagate("wait-endpoint", upstreamMessage.header)
         WaitStrategyMessagePropagator().propagate(header, upstreamMessage)
         header[COMMAND_WAIT_ENDPOINT].assert().isNull()
     }

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt
@@ -52,6 +52,7 @@ class CommandHandler(
         }
         val commandWaitTimeout = request.getWaitTimeout(timeout)
         val waitStrategy = WaitingForStage.stage(
+            waitCommandId = commandMessage.commandId,
             stage = stage,
             contextName = waitContext,
             processorName = request.getWaitProcessor(),

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/ResponsesKtTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/ResponsesKtTest.kt
@@ -68,7 +68,7 @@ class ResponsesKtTest {
     fun commandResultToServerResponse() {
         CommandResult(
             id = generateGlobalId(),
-            commandWaitId = generateGlobalId(),
+            waitCommandId = generateGlobalId(),
             stage = CommandStage.SENT,
             aggregateId = generateGlobalId(),
             tenantId = generateGlobalId(),

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandResponsesTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandResponsesTest.kt
@@ -44,7 +44,7 @@ class CommandResponsesTest {
         val serverRequest = MockServerRequest.builder().build()
         CommandResult(
             id = generateGlobalId(),
-            commandWaitId = generateGlobalId(),
+            waitCommandId = generateGlobalId(),
             stage = CommandStage.SENT,
             aggregateId = generateGlobalId(),
             tenantId = generateGlobalId(),
@@ -84,7 +84,7 @@ class CommandResponsesTest {
         }
         CommandResult(
             id = generateGlobalId(),
-            commandWaitId = generateGlobalId(),
+            waitCommandId = generateGlobalId(),
             stage = CommandStage.SENT,
             aggregateId = generateGlobalId(),
             tenantId = generateGlobalId(),
@@ -122,7 +122,7 @@ class CommandResponsesTest {
         }
         CommandResult(
             id = generateGlobalId(),
-            commandWaitId = generateGlobalId(),
+            waitCommandId = generateGlobalId(),
             stage = CommandStage.SENT,
             aggregateId = generateGlobalId(),
             tenantId = generateGlobalId(),
@@ -163,7 +163,7 @@ class CommandResponsesTest {
         }
         CommandResult(
             id = generateGlobalId(),
-            commandWaitId = generateGlobalId(),
+            waitCommandId = generateGlobalId(),
             stage = CommandStage.SENT,
             aggregateId = generateGlobalId(),
             tenantId = generateGlobalId(),

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/wait/CommandWaitHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/wait/CommandWaitHandlerFunctionTest.kt
@@ -24,7 +24,7 @@ class CommandWaitHandlerFunctionTest {
         val request = mockk<ServerRequest> {
             every { bodyToMono(SimpleWaitSignal::class.java) } returns SimpleWaitSignal(
                 id = generateGlobalId(),
-                commandWaitId = generateGlobalId(),
+                waitCommandId = generateGlobalId(),
                 commandId = "commandId",
                 aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
                 stage = CommandStage.SENT,

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/wait/WebClientCommandWaitNotifierTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/wait/WebClientCommandWaitNotifierTest.kt
@@ -25,7 +25,7 @@ class WebClientCommandWaitNotifierTest {
         val commandWaitEndpoint = "http://localhost:8080/command/wait"
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
-            commandWaitId = generateGlobalId(),
+            waitCommandId = generateGlobalId(),
             commandId = GlobalIdGenerator.generateAsString(),
             aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.SENT,
@@ -59,7 +59,7 @@ class WebClientCommandWaitNotifierTest {
 
         val waitSignal = SimpleWaitSignal(
             id = generateGlobalId(),
-            commandWaitId = "0ToC0Bez003X00Z",
+            waitCommandId = "0ToC0Bez003X00Z",
             commandId = "0ToC0Bez003X00Z",
             aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
             stage = CommandStage.SENT,


### PR DESCRIPTION
- Rename commandWaitId to waitCommandId in various classes and methods
- Update related tests to use new waitCommandId naming
- Modify command sent signal method to use waitCommandId instead of commandWaitId
- Update wait strategy registration and propagation to use waitCommandId


