### PR TITLE
refactor(wow-core): restructure WaitStrategyPropagator interface

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategy.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitStrategy.kt
@@ -28,7 +28,7 @@ import java.util.function.Consumer
  *
  * 定义了命令等待策略中关于传播行为的抽象方法，用于控制命令处理结果的传播逻辑。
  */
-interface WaitStrategyPropagator : MessagePropagator {
+interface WaitStrategyPropagator {
 
     /**
      * 执行传播操作
@@ -39,21 +39,6 @@ interface WaitStrategyPropagator : MessagePropagator {
      * @param header 消息头信息，包含元数据和上下文信息
      */
     fun propagate(commandWaitEndpoint: String, header: Header)
-
-    /**
-     * 判断是否应该传播指定的消息
-     *
-     * @param upstream 上游消息对象，包含命令或事件的相关信息
-     * @return 如果应该传播该消息则返回 true，否则返回 false
-     */
-    fun shouldPropagate(upstream: Message<*, *>): Boolean {
-        return upstream is CommandMessage<*>
-    }
-
-    override fun propagate(header: Header, upstream: Message<*, *>) {
-        val commandWaitEndpoint = upstream.header.requireExtractCommandWaitEndpoint()
-        propagate(commandWaitEndpoint, header)
-    }
 }
 
 /**
@@ -87,18 +72,39 @@ interface WaitStrategy : WaitCommandIdCapable, WaitStrategyPropagator, Completed
 
     fun onFinally(doFinally: Consumer<SignalType>)
 
+    /**
+     * 执行传播操作
+     *
+     * 将命令处理结果传播到指定的等待端点
+     *
+     * @param commandWaitEndpoint 命令等待端点地址
+     * @param header 消息头信息，包含元数据和上下文信息
+     */
     override fun propagate(commandWaitEndpoint: String, header: Header) {
         header.propagateWaitCommandId(waitCommandId)
         materialized.propagate(commandWaitEndpoint, header)
     }
 
-    override fun propagate(header: Header, upstream: Message<*, *>) {
-        materialized.propagate(header, upstream)
-    }
-
     interface Materialized :
-        WaitStrategyPropagator,
         ProcessingStageShouldNotifyPredicate,
         WaitSignalShouldNotifyPredicate,
-        me.ahoo.wow.api.naming.Materialized
+        me.ahoo.wow.api.naming.Materialized,
+        WaitStrategyPropagator,
+        MessagePropagator {
+
+        /**
+         * 判断是否应该传播指定的消息
+         *
+         * @param upstream 上游消息对象，包含命令或事件的相关信息
+         * @return 如果应该传播该消息则返回 true，否则返回 false
+         */
+        fun shouldPropagate(upstream: Message<*, *>): Boolean {
+            return upstream is CommandMessage<*>
+        }
+
+        override fun propagate(header: Header, upstream: Message<*, *>) {
+            val commandWaitEndpoint = upstream.header.requireExtractCommandWaitEndpoint()
+            propagate(commandWaitEndpoint, header)
+        }
+    }
 }


### PR DESCRIPTION
- Remove shouldPropagate and propagate overloaded methods from WaitStrategyPropagator
- Add these methods to a new Materialized interface
- Update WaitStrategy to use the new Materialized interface
- Simplify the overall structure and improve code organization
