### PR TITLE
build(example-server): remove bootstrap location property

### DIFF
--- a/example/example-server/build.gradle.kts
+++ b/example/example-server/build.gradle.kts
@@ -49,7 +49,6 @@ application {
         "-Dcom.sun.management.jmxremote.ssl=false",
         "-Dcom.sun.management.jmxremote.port=5555",
         "-Dspring.cloud.bootstrap.enabled=true",
-        "-Dspring.cloud.bootstrap.location=config/bootstrap.yaml",
         "-Dspring.config.location=file:./config/",
     )
 }


### PR DESCRIPTION
Removed the spring.cloud.bootstrap.location property from the JVM arguments in the build.gradle.kts file. This change simplifies the configuration and relies on the default bootstrap file location.

