### PR TITLE
feat(compensation): add execution failed details functionality

### DIFF
--- a/compensation/dashboard/src/components/Failed/FailedView.tsx
+++ b/compensation/dashboard/src/components/Failed/FailedView.tsx
@@ -31,12 +31,27 @@ import {
 } from "../../services";
 import { useEffect, useState } from "react";
 import type { Pagination } from "@ahoo-wang/fetcher-wow";
+import { useQueryParams } from "../../utils/useQuery.ts";
+import { useGlobalDrawer } from "../GlobalDrawer/GlobalDrawer.tsx";
+import { FetchingFailedDetails } from "./details/FetchingFailedDetails.tsx";
 
 interface FailedViewProps {
   category: FindCategory;
 }
 
 export default function FailedView({ category }: FailedViewProps) {
+  const { openDrawer } = useGlobalDrawer();
+  const queryIdParams = useQueryParams("id");
+
+  useEffect(() => {
+    if (!queryIdParams) {
+      return;
+    }
+    openDrawer({
+      title: "Execution Failed Details",
+      content: <FetchingFailedDetails id={queryIdParams as string} />,
+    });
+  }, [queryIdParams]);
   const [searchCondition, setSearchCondition] = useState<Condition>(all());
   const [searchPagination, setSearchPagination] = useState<Pagination>(() => {
     return pagination();

--- a/compensation/dashboard/src/components/Failed/details/FetchingFailedDetails.tsx
+++ b/compensation/dashboard/src/components/Failed/details/FetchingFailedDetails.tsx
@@ -16,14 +16,16 @@ import {
   executionFailedSnapshotQueryClient,
   type ExecutionFailedState,
 } from "../../../services";
-import { aggregateId, singleQuery } from "@ahoo-wang/fetcher-wow";
+import {
+  aggregateId,
+  type Identifier,
+  singleQuery,
+} from "@ahoo-wang/fetcher-wow";
 import { Flex, Skeleton, Typography } from "antd";
 const { Text } = Typography;
 import { FailedDetails } from "./FailedDetails.tsx";
 
-export interface FetchingFailedDetailsProps {
-  id: string;
-}
+export interface FetchingFailedDetailsProps extends Identifier {}
 
 export function FetchingFailedDetails({ id }: FetchingFailedDetailsProps) {
   const { data, error, isLoading } = useSWR(id, () =>


### PR DESCRIPTION
- Add useQueryParams and useGlobalDrawer hooks to FailedView
- Implement logic to open GlobalDrawer with FetchingFailedDetails component when id query param is present
- Update FetchingFailedDetails to use Identifier type for id prop

