### PR TITLE
refactor(compensation): refactor GlobalDrawer component and update related components

### DIFF
--- a/compensation/dashboard/src/components/GlobalDrawer/GlobalDrawer.tsx
+++ b/compensation/dashboard/src/components/GlobalDrawer/GlobalDrawer.tsx
@@ -11,37 +11,23 @@
  * limitations under the License.
  */
 
-import type { DrawerProps } from "antd/es/drawer";
 import { Drawer } from "antd";
-import { createContext, useContext, useState, type ReactNode } from "react";
-
-interface GlobalDrawerContextProps {
-  openDrawer: (config: DrawerConfig) => void;
-  closeDrawer: () => void;
-  updateDrawer: (config: Partial<DrawerConfig>) => void;
-}
-
-interface DrawerConfig extends DrawerProps {
-  content?: ReactNode;
-}
-
-const GlobalDrawerContext = createContext<GlobalDrawerContextProps | null>(
-  null,
-);
+import { useState, type ReactNode } from "react";
+import { GlobalDrawerContext } from "./useGlobalDrawer";
+import type { DrawerProps } from "antd/es/drawer";
 
 interface GlobalDrawerProviderProps {
   children: ReactNode;
 }
 
 export function GlobalDrawerProvider({ children }: GlobalDrawerProviderProps) {
-  const [drawerConfig, setDrawerConfig] = useState<DrawerConfig>({
+  const [drawerProps, setDrawerProps] = useState<DrawerProps>({
     open: false,
     width: "80vw",
-    content: null,
   });
 
-  const openDrawer = (config: DrawerConfig) => {
-    setDrawerConfig({
+  const openDrawer = (config: DrawerProps) => {
+    setDrawerProps({
       width: "80vw",
       ...config,
       open: true,
@@ -49,14 +35,14 @@ export function GlobalDrawerProvider({ children }: GlobalDrawerProviderProps) {
   };
 
   const closeDrawer = () => {
-    setDrawerConfig((prev) => ({
+    setDrawerProps((prev) => ({
       ...prev,
       open: false,
     }));
   };
 
-  const updateDrawer = (config: Partial<DrawerConfig>) => {
-    setDrawerConfig((prev) => ({
+  const updateDrawer = (config: Partial<DrawerProps>) => {
+    setDrawerProps((prev) => ({
       ...prev,
       ...config,
     }));
@@ -71,19 +57,9 @@ export function GlobalDrawerProvider({ children }: GlobalDrawerProviderProps) {
       }}
     >
       {children}
-      <Drawer {...drawerConfig} onClose={closeDrawer}>
-        {drawerConfig.content}
+      <Drawer {...drawerProps} onClose={closeDrawer}>
+
       </Drawer>
     </GlobalDrawerContext.Provider>
   );
-}
-
-export function useGlobalDrawer() {
-  const context = useContext(GlobalDrawerContext);
-  if (!context) {
-    throw new Error(
-      "useGlobalDrawer must be used within a GlobalDrawerProvider",
-    );
-  }
-  return context;
 }

--- a/compensation/dashboard/src/components/GlobalDrawer/index.ts
+++ b/compensation/dashboard/src/components/GlobalDrawer/index.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export * from "./GlobalDrawer";
+export * from "./useGlobalDrawer";

--- a/compensation/dashboard/src/components/GlobalDrawer/useGlobalDrawer.ts
+++ b/compensation/dashboard/src/components/GlobalDrawer/useGlobalDrawer.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { createContext, useContext } from "react";
+import type { DrawerProps } from "antd/es/drawer";
+
+interface GlobalDrawerContextProps {
+  openDrawer: (config: DrawerProps) => void;
+  closeDrawer: () => void;
+  updateDrawer: (config: Partial<DrawerProps>) => void;
+}
+
+
+export const GlobalDrawerContext = createContext<GlobalDrawerContextProps | null>(
+  null,
+);
+
+export function useGlobalDrawer() {
+  const context = useContext(GlobalDrawerContext);
+  if (!context) {
+    throw new Error(
+      "useGlobalDrawer must be used within a GlobalDrawerProvider",
+    );
+  }
+  return context;
+}

--- a/compensation/dashboard/src/features/Failed/Actions.tsx
+++ b/compensation/dashboard/src/features/Failed/Actions.tsx
@@ -15,7 +15,7 @@ import type { StateCapable } from "@ahoo-wang/fetcher-wow";
 import type { ExecutionFailedState } from "../../services";
 import { App, Dropdown } from "antd";
 import { FailedDetails } from "./details/FailedDetails.tsx";
-import { useGlobalDrawer } from "../../components/GlobalDrawer/GlobalDrawer.tsx";
+import { useGlobalDrawer } from "../../components/GlobalDrawer";
 import type { ItemType } from "antd/es/menu/interface";
 import { executionFailedCommandService } from "../../services/executionFailedCommandClient.ts";
 
@@ -77,7 +77,7 @@ export function Actions({ state, onChanged }: ActionsProps) {
         onClick={() =>
           openDrawer({
             title: "Execution Failed Details",
-            content: <FailedDetails state={state} />,
+            children: <FailedDetails state={state} />,
           })
         }
         menu={{

--- a/compensation/dashboard/src/features/Failed/ApplyRetrySpec.tsx
+++ b/compensation/dashboard/src/features/Failed/ApplyRetrySpec.tsx
@@ -14,7 +14,7 @@
 import { Button, Form, InputNumber, App, Input } from "antd";
 import type { RetrySpec } from "../../services";
 import { executionFailedCommandService } from "../../services/executionFailedCommandClient.ts";
-import { useGlobalDrawer } from "../../components/GlobalDrawer/GlobalDrawer.tsx";
+import { useGlobalDrawer } from "../../components/GlobalDrawer";
 import type { OnChangedCapable } from "./Actions.tsx";
 
 export interface ApplyRetrySpecProps extends OnChangedCapable {

--- a/compensation/dashboard/src/features/Failed/ChangeFunction.tsx
+++ b/compensation/dashboard/src/features/Failed/ChangeFunction.tsx
@@ -15,7 +15,7 @@ import { App, Button, Form, Input, Select } from "antd";
 import { type FunctionInfo, type Identifier } from "@ahoo-wang/fetcher-wow";
 import { executionFailedCommandService } from "../../services/executionFailedCommandClient.ts";
 import type { OnChangedCapable } from "./Actions.tsx";
-import { useGlobalDrawer } from "../../components/GlobalDrawer/GlobalDrawer.tsx";
+import { useGlobalDrawer } from "../../components/GlobalDrawer";
 
 export interface ChangeFunctionProps extends OnChangedCapable {
   id: string;

--- a/compensation/dashboard/src/features/Failed/FailedTable.tsx
+++ b/compensation/dashboard/src/features/Failed/FailedTable.tsx
@@ -15,7 +15,7 @@ import { Table, Tag, Typography, Statistic, Button } from "antd";
 import type { TableColumnsType } from "antd";
 import { type PagedList } from "@ahoo-wang/fetcher-wow";
 import type { EventId, ExecutionFailedState } from "../../services";
-import { useGlobalDrawer } from "../../components/GlobalDrawer/GlobalDrawer.tsx";
+import { useGlobalDrawer } from "../../components/GlobalDrawer";
 import { EditTwoTone } from "@ant-design/icons";
 import { ApplyRetrySpec } from "./ApplyRetrySpec.tsx";
 import { useMemo } from "react";
@@ -99,7 +99,7 @@ export function FailedTable({
                       openDrawer({
                         title: "Change Function",
                         width: "500px",
-                        content: (
+                        children: (
                           <ChangeFunction
                             id={state.id}
                             functionInfo={state.function}
@@ -207,7 +207,7 @@ export function FailedTable({
                       openDrawer({
                         title: "Apply Retry Spec",
                         width: "300px",
-                        content: (
+                        children: (
                           <ApplyRetrySpec
                             id={state.id}
                             retrySpec={state.retrySpec}

--- a/compensation/dashboard/src/features/Failed/FailedView.tsx
+++ b/compensation/dashboard/src/features/Failed/FailedView.tsx
@@ -32,7 +32,7 @@ import {
 import { useEffect, useState } from "react";
 import type { Pagination } from "@ahoo-wang/fetcher-wow";
 import { useQueryParams } from "../../utils/useQuery.ts";
-import { useGlobalDrawer } from "../../components/GlobalDrawer/GlobalDrawer.tsx";
+import { useGlobalDrawer } from "../../components/GlobalDrawer";
 import { FetchingFailedDetails } from "./details/FetchingFailedDetails.tsx";
 
 interface FailedViewProps {
@@ -49,7 +49,7 @@ export default function FailedView({ category }: FailedViewProps) {
     }
     openDrawer({
       title: "Execution Failed Details",
-      content: <FetchingFailedDetails id={queryIdParams as string} />,
+      children: <FetchingFailedDetails id={queryIdParams as string} />,
     });
   }, [queryIdParams]);
   const [searchCondition, setSearchCondition] = useState<Condition>(all());

--- a/compensation/dashboard/src/main.tsx
+++ b/compensation/dashboard/src/main.tsx
@@ -6,7 +6,7 @@ import "./index.css";
 import { RouterProvider } from "react-router";
 import { AppRouter } from "./routes/Routes.tsx";
 import { App } from "antd";
-import { GlobalDrawerProvider } from "./components/GlobalDrawer/GlobalDrawer.tsx";
+import { GlobalDrawerProvider } from "./components/GlobalDrawer";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>


### PR DESCRIPTION


- Update import path for GlobalDrawer and useGlobalDrawer
- Replace 'content' prop with 'children' in Drawer components
- Refactor GlobalDrawer component to use DrawerProps directly
- Create separate file for useGlobalDrawer hook
- Update components that use GlobalDrawer to match new API

