### PR TITLE
build(example-transfer-api): opt-in for KSP experimental and configure KSP options

### DIFF
--- a/example/transfer/example-transfer-api/build.gradle.kts
+++ b/example/transfer/example-transfer-api/build.gradle.kts
@@ -1,3 +1,7 @@
+@file:OptIn(KspExperimental::class)
+
+import com.google.devtools.ksp.KspExperimental
+
 plugins {
     alias(libs.plugins.ksp)
 }
@@ -8,4 +12,12 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-annotations")
     api("jakarta.validation:jakarta.validation-api")
     ksp(project(":wow-compiler"))
+}
+
+ksp {
+//    TODO
+//    fix: [ksp] java.lang.ClassCastException: class ksp.com.intellij.psi.impl.source.PsiRecordComponentImpl
+//    cannot be cast to class ksp.com.intellij.psi.PsiJvmModifiersOwner (ksp.com.intellij.psi.impl.source.PsiRecordComponentImpl
+//    and ksp.com.intellij.psi.PsiJvmModifiersOwner are in unnamed module of loader java.net.URLClassLoader @6e1a421c)
+    useKsp2.set(false)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,7 @@ org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 #org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 #org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 kotlin.code.style=official
+ksp.useKSP2=true
 ksp.incremental=true
 ksp.incremental.log=true
 group=me.ahoo.wow


### PR DESCRIPTION


- Add KSP experimental opt-in annotation
- Import KSP experimental package
- Set up KSP configuration in build.gradle.kts
- Disable KSP2 due to a known issue with PsiRecordComponentImpl
- Enable KSP2 in gradle.properties for other modules


