### PR TITLE
refactor(services): rename service to client and update dependencies

### DIFF
--- a/compensation/dashboard/package.json
+++ b/compensation/dashboard/package.json
@@ -13,11 +13,11 @@
     "analyze": "npx vite-bundle-analyzer -p auto"
   },
   "dependencies": {
-    "@ahoo-wang/fetcher": "^1.9.8",
-    "@ahoo-wang/fetcher-cosec": "^1.9.8",
-    "@ahoo-wang/fetcher-decorator": "^1.9.8",
-    "@ahoo-wang/fetcher-eventstream": "^1.9.8",
-    "@ahoo-wang/fetcher-wow": "^1.9.8",
+    "@ahoo-wang/fetcher": "^2.0.0",
+    "@ahoo-wang/fetcher-cosec": "^2.0.0",
+    "@ahoo-wang/fetcher-decorator": "^2.0.0",
+    "@ahoo-wang/fetcher-eventstream": "^2.0.0",
+    "@ahoo-wang/fetcher-wow": "^2.0.0",
     "@ant-design/icons": "^6.0.2",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@monaco-editor/react": "4.7.0",

--- a/compensation/dashboard/pnpm-lock.yaml
+++ b/compensation/dashboard/pnpm-lock.yaml
@@ -9,20 +9,20 @@ importers:
   .:
     dependencies:
       '@ahoo-wang/fetcher':
-        specifier: ^1.9.8
-        version: 1.9.8
+        specifier: ^2.0.0
+        version: 2.0.0
       '@ahoo-wang/fetcher-cosec':
-        specifier: ^1.9.8
-        version: 1.9.8
+        specifier: ^2.0.0
+        version: 2.0.0
       '@ahoo-wang/fetcher-decorator':
-        specifier: ^1.9.8
-        version: 1.9.8
+        specifier: ^2.0.0
+        version: 2.0.0
       '@ahoo-wang/fetcher-eventstream':
-        specifier: ^1.9.8
-        version: 1.9.8
+        specifier: ^2.0.0
+        version: 2.0.0
       '@ahoo-wang/fetcher-wow':
-        specifier: ^1.9.8
-        version: 1.9.8
+        specifier: ^2.0.0
+        version: 2.0.0
       '@ant-design/icons':
         specifier: ^6.0.2
         version: 6.0.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -123,23 +123,23 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@ahoo-wang/fetcher-cosec@1.9.8':
-    resolution: {integrity: sha512-wUBOZlbdflTO9k7amIMYQtwTiMjmFh9ZiM89trRswJBEBkJYoX6gbnRezN0ZqFbVxpDel6RDjOu0enP0GWZo6w==}
+  '@ahoo-wang/fetcher-cosec@2.0.0':
+    resolution: {integrity: sha512-4yBRmeqhVpwmfFoxgT9JavJKW4BfSvATXJk0jziTYxiQzdJDDHDkUfR63e26TRrBNrDHbwFFnb6fBXoRf0A7Tw==}
 
-  '@ahoo-wang/fetcher-decorator@1.9.8':
-    resolution: {integrity: sha512-JFd9HSMBZhQS9guDGP7uV8R0Twyq2dogUqGGrjiCoYlO+8WDe5ocG9Bh2VKASY2pAFtwYv00YU07zpPuQPl55A==}
+  '@ahoo-wang/fetcher-decorator@2.0.0':
+    resolution: {integrity: sha512-TNqKymlsAo0WaB5ulkn9dzRyohyQiS7KI+NJIywx1FInd1G+9zDE22mrxyTbIOcgWu2AcBg88yPtGLgNg7eNAw==}
 
-  '@ahoo-wang/fetcher-eventstream@1.9.8':
-    resolution: {integrity: sha512-kALmLEqWDS9hlsRG/CZEIVTEw7rORZotLscZ6WA4BCip3wFwQz2XsygxRlSFgUo7FMETmVjyJuMBYMf3Z3KJzg==}
+  '@ahoo-wang/fetcher-eventstream@2.0.0':
+    resolution: {integrity: sha512-Pw12cGLVQH7GAyuFnY2x8oAIA+BAxf7F3g6YvsaTb0QaFF/p4JZVQqOE/icdCaiu7X0T9DHEdChxPVn/nk4IMQ==}
 
-  '@ahoo-wang/fetcher-storage@1.9.8':
-    resolution: {integrity: sha512-2sDlsVorSo/ovM3pZmAHt4grsSGES/pVYWduwyLEk/RGud+qBWv//dNIWUz5/savIQjfNXdJLHRUn3hQjvSCPA==}
+  '@ahoo-wang/fetcher-storage@2.0.0':
+    resolution: {integrity: sha512-F7IEpj13EZijiLPekRP8w+a9vGopB/YqzVw5RJFKLc1AGrU+w2L2ZXTQwd+USySqoX0IELxeguJKuGW2qJuLew==}
 
-  '@ahoo-wang/fetcher-wow@1.9.8':
-    resolution: {integrity: sha512-QiA/oYsWpUCJf6WA2ggBoEHSDcEMiyUZgGyJQXqLtXeCWIfuLkaN4rvgZtcjJoQ+dO0fvhw+auGTyN5ICJ4Ohw==}
+  '@ahoo-wang/fetcher-wow@2.0.0':
+    resolution: {integrity: sha512-RcBnyk5hotHj83Lh2oNBqdbHg+RHLNpLEEJsU8HEGUTUrtpcOekNHVol7kNxktMq/3UlrOjVnibhn3hrzA7mnQ==}
 
-  '@ahoo-wang/fetcher@1.9.8':
-    resolution: {integrity: sha512-+T/gXbcRU94+Ju2lvB1VBjdsk3itTSbux03MAGXjwPEbIPPwomeuU2voeNHZE8uLLGGowMqrmpUwYJHyCcYXxA==}
+  '@ahoo-wang/fetcher@2.0.0':
+    resolution: {integrity: sha512-L7hqVZdUVsIiP34cYFbjkk4LbCfoQ8qT5/u2q0kgDmSIOPC6JUYcD3bGXZW+az8/3s1vyU/xtIkI2cEZTQg/kg==}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -2470,30 +2470,30 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ahoo-wang/fetcher-cosec@1.9.8':
+  '@ahoo-wang/fetcher-cosec@2.0.0':
     dependencies:
-      '@ahoo-wang/fetcher': 1.9.8
-      '@ahoo-wang/fetcher-storage': 1.9.8
+      '@ahoo-wang/fetcher': 2.0.0
+      '@ahoo-wang/fetcher-storage': 2.0.0
       nanoid: 5.1.6
 
-  '@ahoo-wang/fetcher-decorator@1.9.8':
+  '@ahoo-wang/fetcher-decorator@2.0.0':
     dependencies:
-      '@ahoo-wang/fetcher': 1.9.8
-      '@ahoo-wang/fetcher-eventstream': 1.9.8
+      '@ahoo-wang/fetcher': 2.0.0
       reflect-metadata: 0.2.2
 
-  '@ahoo-wang/fetcher-eventstream@1.9.8':
+  '@ahoo-wang/fetcher-eventstream@2.0.0':
     dependencies:
-      '@ahoo-wang/fetcher': 1.9.8
+      '@ahoo-wang/fetcher': 2.0.0
 
-  '@ahoo-wang/fetcher-storage@1.9.8': {}
+  '@ahoo-wang/fetcher-storage@2.0.0': {}
 
-  '@ahoo-wang/fetcher-wow@1.9.8':
+  '@ahoo-wang/fetcher-wow@2.0.0':
     dependencies:
-      '@ahoo-wang/fetcher': 1.9.8
-      '@ahoo-wang/fetcher-eventstream': 1.9.8
+      '@ahoo-wang/fetcher': 2.0.0
+      '@ahoo-wang/fetcher-decorator': 2.0.0
+      '@ahoo-wang/fetcher-eventstream': 2.0.0
 
-  '@ahoo-wang/fetcher@1.9.8': {}
+  '@ahoo-wang/fetcher@2.0.0': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:

--- a/compensation/dashboard/src/features/Failed/Actions.tsx
+++ b/compensation/dashboard/src/features/Failed/Actions.tsx
@@ -17,7 +17,7 @@ import { App, Dropdown } from "antd";
 import { FailedDetails } from "./details/FailedDetails.tsx";
 import { useGlobalDrawer } from "../../components/GlobalDrawer";
 import type { ItemType } from "antd/es/menu/interface";
-import { executionFailedCommandService } from "../../services/executionFailedCommandClient.ts";
+import { executionFailedCommandClient } from "../../services/executionFailedCommandClient.ts";
 
 export interface OnChangedCapable {
   onChanged?: () => void;
@@ -36,7 +36,7 @@ export function Actions({ state, onChanged }: ActionsProps) {
       key: "prepare",
       label: "Prepare",
       onClick: () => {
-        executionFailedCommandService
+        executionFailedCommandClient
           .prepare(state.id)
           .then(() => {
             notification.success({ message: "Prepare Success" });
@@ -54,7 +54,7 @@ export function Actions({ state, onChanged }: ActionsProps) {
       key: "forcePrepare",
       label: "Force Prepare",
       onClick: () => {
-        executionFailedCommandService
+        executionFailedCommandClient
           .forcePrepare(state.id)
           .then(() => {
             notification.success({ message: "Force Prepare Success" });

--- a/compensation/dashboard/src/features/Failed/ApplyRetrySpec.tsx
+++ b/compensation/dashboard/src/features/Failed/ApplyRetrySpec.tsx
@@ -13,7 +13,7 @@
 
 import { Button, Form, InputNumber, App, Input } from "antd";
 import type { RetrySpec } from "../../services";
-import { executionFailedCommandService } from "../../services/executionFailedCommandClient.ts";
+import { executionFailedCommandClient } from "../../services/executionFailedCommandClient.ts";
 import { useGlobalDrawer } from "../../components/GlobalDrawer";
 import type { OnChangedCapable } from "./Actions.tsx";
 
@@ -40,7 +40,7 @@ export function ApplyRetrySpec({
 
   const handleOk = () => {
     form.validateFields().then((values) => {
-      executionFailedCommandService
+      executionFailedCommandClient
         .applyRetrySpec(id, values)
         .then(() => {
           notification.info({ message: "Apply Retry Spec Successfully" });

--- a/compensation/dashboard/src/features/Failed/ChangeFunction.tsx
+++ b/compensation/dashboard/src/features/Failed/ChangeFunction.tsx
@@ -13,7 +13,7 @@
 
 import { App, Button, Form, Input, Select } from "antd";
 import { type FunctionInfo, type Identifier } from "@ahoo-wang/fetcher-wow";
-import { executionFailedCommandService } from "../../services/executionFailedCommandClient.ts";
+import { executionFailedCommandClient } from "../../services/executionFailedCommandClient.ts";
 import type { OnChangedCapable } from "./Actions.tsx";
 import { useGlobalDrawer } from "../../components/GlobalDrawer";
 
@@ -39,7 +39,7 @@ export function ChangeFunction({
   });
   const handleOk = () => {
     form.validateFields().then((values) => {
-      executionFailedCommandService
+      executionFailedCommandClient
         .changeFunction(id, values)
         .then(() => {
           onChanged?.();

--- a/compensation/dashboard/src/features/Failed/FailedView.tsx
+++ b/compensation/dashboard/src/features/Failed/FailedView.tsx
@@ -77,6 +77,7 @@ export default function FailedView({ category }: FailedViewProps) {
         condition: and(
           RetryConditions.categoryToCondition(category),
           searchCondition,
+
         ),
         pagination: searchPagination,
         sort: [desc(SnapshotMetadataFields.FIRST_EVENT_TIME)],

--- a/compensation/dashboard/src/features/Failed/MarkRecoverable.tsx
+++ b/compensation/dashboard/src/features/Failed/MarkRecoverable.tsx
@@ -14,7 +14,7 @@
 import { App, Select } from "antd";
 import { type Identifier, RecoverableType } from "@ahoo-wang/fetcher-wow";
 import {
-  executionFailedCommandService,
+  executionFailedCommandClient,
   type MarkRecoverable,
 } from "../../services/executionFailedCommandClient.ts";
 import type { OnChangedCapable } from "./Actions.tsx";
@@ -35,7 +35,7 @@ export function MarkRecoverable({
   );
   const change = async (recoverable: RecoverableType) => {
     try {
-      await executionFailedCommandService.markRecoverable(id, {
+      await executionFailedCommandClient.markRecoverable(id, {
         recoverable,
       });
       notification.success({

--- a/compensation/dashboard/src/services/compensationFetcher.ts
+++ b/compensation/dashboard/src/services/compensationFetcher.ts
@@ -12,7 +12,7 @@
  */
 
 import { NamedFetcher } from "@ahoo-wang/fetcher";
-import type { ClientOptions } from "@ahoo-wang/fetcher-wow";
+import { type ApiMetadata } from "@ahoo-wang/fetcher-decorator";
 import { cosecRequestInterceptor } from "./cosec.ts";
 
 export const COMPENSATION_FETCHER_NAME = "compensation";
@@ -20,7 +20,7 @@ export const compensationFetcher = new NamedFetcher(COMPENSATION_FETCHER_NAME, {
   baseURL: import.meta.env.VITE_API_BASE_URL,
 });
 compensationFetcher.interceptors.request.use(cosecRequestInterceptor);
-export const executionFailedClientOptions: ClientOptions = {
+export const executionFailedClientOptions: ApiMetadata = {
   fetcher: compensationFetcher,
   basePath: "execution_failed",
 };

--- a/compensation/dashboard/src/services/executionFailedCommandClient.ts
+++ b/compensation/dashboard/src/services/executionFailedCommandClient.ts
@@ -12,25 +12,20 @@
  */
 
 import {
-  type ClientOptions,
   CommandClient,
   type CommandRequest,
   type CommandResult,
   type FunctionInfo,
   type RecoverableType,
 } from "@ahoo-wang/fetcher-wow";
-import {
-  compensationFetcher,
-} from "./compensationFetcher";
+import { compensationFetcher } from "./compensationFetcher";
+import type { ApiMetadata } from "@ahoo-wang/fetcher-decorator";
 import { HttpMethod } from "@ahoo-wang/fetcher";
 
-export const executionFailedCommandClientOptions: ClientOptions = {
+export const executionFailedCommandClientOptions: ApiMetadata = {
   fetcher: compensationFetcher,
   basePath: "execution_failed/{id}",
 };
-export const executionFailedCommandClient = new CommandClient(
-  executionFailedCommandClientOptions,
-);
 
 export interface ApplyRetrySpec {
   maxRetries: number;
@@ -44,51 +39,81 @@ export interface MarkRecoverable {
 
 export interface ChangeFunction extends FunctionInfo {}
 
-export class ExecutionFailedCommandService {
-  private sendCommand(
-    path: string,
-    id: string,
-    commandBody: any = {},
-    method: HttpMethod = HttpMethod.PUT,
-  ): Promise<CommandResult> {
+export class ExecutionFailedCommandClient extends CommandClient {
+  constructor(apiMetadata?: ApiMetadata) {
+    super(apiMetadata);
+  }
+
+  prepare(id: string): Promise<CommandResult> {
     const commandRequest: CommandRequest = {
-      method: method,
+      path: "prepare_compensation",
+      method: HttpMethod.PUT,
       urlParams: {
         path: { id },
       },
-      body: commandBody,
+      body: {},
     };
-    return executionFailedCommandClient.send(path, commandRequest);
-  }
-  prepare(id: string): Promise<CommandResult> {
-    return this.sendCommand("prepare_compensation", id);
+    return this.send(commandRequest);
   }
 
   forcePrepare(id: string): Promise<CommandResult> {
-    return this.sendCommand("force_prepare_compensation", id);
+    const commandRequest: CommandRequest = {
+      path: "force_prepare_compensation",
+      method: HttpMethod.PUT,
+      urlParams: {
+        path: { id },
+      },
+      body: {},
+    };
+    return this.send(commandRequest);
   }
 
   applyRetrySpec(
     id: string,
     appRetrySpec: ApplyRetrySpec,
   ): Promise<CommandResult> {
-    return this.sendCommand("apply_retry_spec", id, appRetrySpec);
+    const commandRequest: CommandRequest<ApplyRetrySpec> = {
+      path: "apply_retry_spec",
+      method: HttpMethod.PUT,
+      urlParams: {
+        path: { id },
+      },
+      body: appRetrySpec,
+    };
+    return this.send(commandRequest);
   }
 
   markRecoverable(
     id: string,
     markRecoverable: MarkRecoverable,
   ): Promise<CommandResult> {
-    return this.sendCommand("mark_recoverable", id, markRecoverable);
+    const commandRequest: CommandRequest<MarkRecoverable> = {
+      path: "mark_recoverable",
+      method: HttpMethod.PUT,
+      urlParams: {
+        path: { id },
+      },
+      body: markRecoverable,
+    };
+    return this.send(commandRequest);
   }
 
   changeFunction(
     id: string,
     changeFunction: ChangeFunction,
   ): Promise<CommandResult> {
-    return this.sendCommand("change_function", id, changeFunction);
+    const commandRequest: CommandRequest<ChangeFunction> = {
+      path: "change_function",
+      method: HttpMethod.PUT,
+      urlParams: {
+        path: { id },
+      },
+      body: changeFunction,
+    };
+    return this.send(commandRequest);
   }
 }
 
-export const executionFailedCommandService =
-  new ExecutionFailedCommandService();
+export const executionFailedCommandClient = new ExecutionFailedCommandClient(
+  executionFailedCommandClientOptions,
+);

--- a/compensation/dashboard/src/services/executionFailedQueryClient.ts
+++ b/compensation/dashboard/src/services/executionFailedQueryClient.ts
@@ -11,17 +11,18 @@
  * limitations under the License.
  */
 
-
-
 import {
   EventStreamQueryClient,
   SnapshotQueryClient,
 } from "@ahoo-wang/fetcher-wow";
-import type { ExecutionFailedState } from "./executionFailedState";
+import {
+  type ExecutionFailedState,
+} from "./executionFailedState";
 import { executionFailedClientOptions } from "./compensationFetcher";
 
-export const executionFailedSnapshotQueryClient =
-  new SnapshotQueryClient<ExecutionFailedState>(executionFailedClientOptions);
+export const executionFailedSnapshotQueryClient = new SnapshotQueryClient<
+  ExecutionFailedState
+>(executionFailedClientOptions);
 
 export const executionFailedEventQueryClient = new EventStreamQueryClient(
   executionFailedClientOptions,

--- a/compensation/dashboard/src/services/executionFailedState.ts
+++ b/compensation/dashboard/src/services/executionFailedState.ts
@@ -11,15 +11,14 @@
  * limitations under the License.
  */
 
-import {
-  type AggregateId,
-  type BindingError,
-  type ErrorInfo,
-  type FunctionInfo,
-  type Identifier,
-  type RecoverableType,
-  SnapshotMetadataFields,
-  type Version,
+import type {
+  AggregateId,
+  BindingError,
+  ErrorInfo,
+  FunctionInfo,
+  Identifier,
+  RecoverableType,
+  Version,
 } from "@ahoo-wang/fetcher-wow";
 
 /**
@@ -69,13 +68,13 @@ export interface RetryState {
   timeoutAt: number;
 }
 
-export class ExecutionFailedFields {
-  static readonly STATUS = `${SnapshotMetadataFields.STATE}.status`;
-  static readonly RECOVERABLE = `${SnapshotMetadataFields.STATE}.recoverable`;
-  static readonly IS_RETRYABLE = `${SnapshotMetadataFields.STATE}.isRetryable`;
-  static readonly IS_BELOW_RETRY_THRESHOLD = `${SnapshotMetadataFields.STATE}.isBelowRetryThreshold`;
-  static readonly NEXT_RETRY_AT = `${SnapshotMetadataFields.STATE}.retryState.nextRetryAt`;
-  static readonly TIMEOUT_AT = `${SnapshotMetadataFields.STATE}.retryState.timeoutAt`;
+export enum ExecutionFailedFields {
+  STATUS = `state.status`,
+  RECOVERABLE = `state.recoverable`,
+  IS_RETRYABLE = `state.isRetryable`,
+  IS_BELOW_RETRY_THRESHOLD = `state.isBelowRetryThreshold`,
+  NEXT_RETRY_AT = `state.retryState.nextRetryAt`,
+  TIMEOUT_AT = `state.retryState.timeoutAt`,
 }
 
 /**


### PR DESCRIPTION
- Renamed ExecutionFailedCommandService to ExecutionFailedCommandClient
- Updated import statements to use executionFailedCommandClient
- Changed ClientOptions to ApiMetadata in compensationFetcher.ts
- Upgraded @ahoo-wang/fetcher dependencies from 1.9.8 to 2.0.0
- Modified ExecutionFailedFields from class to enum
- Adjusted command client instantiation and method calls
- Fixed import formatting in executionFailedState.ts
- Added missing comma in FailedView.tsx condition block

