### PR TITLE
refactor(command): simplify ObjectNode creation in CommandBodyExtractor

### DIFF
--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandBodyExtractor.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandBodyExtractor.kt
@@ -45,6 +45,6 @@ class CommandBodyExtractor<C : Any>(private val commandRouteMetadata: CommandRou
 
 internal fun Mono<ObjectNode>.switchEmptyObjectNodeIfEmpty(): Mono<ObjectNode> {
     return switchIfEmpty {
-        ObjectNode(JsonSerializer.nodeFactory, mutableMapOf()).toMono()
+        ObjectNode(JsonSerializer.nodeFactory).toMono()
     }
 }


### PR DESCRIPTION
- Remove unnecessary mutableMapOf() parameter
- Use default constructor for ObjectNode
- Maintain same functionality with cleaner code


