### PR TITLE
chore(deps): update fetcher dependencies to v2.0.1

### DIFF
--- a/compensation/dashboard/package.json
+++ b/compensation/dashboard/package.json
@@ -13,11 +13,11 @@
     "analyze": "npx vite-bundle-analyzer -p auto"
   },
   "dependencies": {
-    "@ahoo-wang/fetcher": "^2.0.0",
-    "@ahoo-wang/fetcher-cosec": "^2.0.0",
-    "@ahoo-wang/fetcher-decorator": "^2.0.0",
-    "@ahoo-wang/fetcher-eventstream": "^2.0.0",
-    "@ahoo-wang/fetcher-wow": "^2.0.0",
+    "@ahoo-wang/fetcher": "^2.0.1",
+    "@ahoo-wang/fetcher-cosec": "^2.0.1",
+    "@ahoo-wang/fetcher-decorator": "^2.0.1",
+    "@ahoo-wang/fetcher-eventstream": "^2.0.1",
+    "@ahoo-wang/fetcher-wow": "^2.0.1",
     "@ant-design/icons": "^6.0.2",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@monaco-editor/react": "4.7.0",

--- a/compensation/dashboard/pnpm-lock.yaml
+++ b/compensation/dashboard/pnpm-lock.yaml
@@ -9,20 +9,20 @@ importers:
   .:
     dependencies:
       '@ahoo-wang/fetcher':
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^2.0.1
+        version: 2.0.1
       '@ahoo-wang/fetcher-cosec':
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^2.0.1
+        version: 2.0.1
       '@ahoo-wang/fetcher-decorator':
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^2.0.1
+        version: 2.0.1
       '@ahoo-wang/fetcher-eventstream':
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^2.0.1
+        version: 2.0.1
       '@ahoo-wang/fetcher-wow':
-        specifier: ^2.0.0
-        version: 2.0.0
+        specifier: ^2.0.1
+        version: 2.0.1
       '@ant-design/icons':
         specifier: ^6.0.2
         version: 6.0.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -123,23 +123,23 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@ahoo-wang/fetcher-cosec@2.0.0':
-    resolution: {integrity: sha512-4yBRmeqhVpwmfFoxgT9JavJKW4BfSvATXJk0jziTYxiQzdJDDHDkUfR63e26TRrBNrDHbwFFnb6fBXoRf0A7Tw==}
+  '@ahoo-wang/fetcher-cosec@2.0.1':
+    resolution: {integrity: sha512-8wgn7SZ+k7XZRNan7X0tb01XkdvBeTKLQQwdN0AyooD1KiSOdSppmnhQ0nJqFR98YFD0lX4+F1knT9vYKCQkzw==}
 
-  '@ahoo-wang/fetcher-decorator@2.0.0':
-    resolution: {integrity: sha512-TNqKymlsAo0WaB5ulkn9dzRyohyQiS7KI+NJIywx1FInd1G+9zDE22mrxyTbIOcgWu2AcBg88yPtGLgNg7eNAw==}
+  '@ahoo-wang/fetcher-decorator@2.0.1':
+    resolution: {integrity: sha512-BFKNmzpHMZ/LqYqnilqq0GSWMNRw5IAE80yAxyGMeKzdgugKVVGxRgQKCxMDF/k1znCSBdiL0DB3bgBqbcg/fw==}
 
-  '@ahoo-wang/fetcher-eventstream@2.0.0':
-    resolution: {integrity: sha512-Pw12cGLVQH7GAyuFnY2x8oAIA+BAxf7F3g6YvsaTb0QaFF/p4JZVQqOE/icdCaiu7X0T9DHEdChxPVn/nk4IMQ==}
+  '@ahoo-wang/fetcher-eventstream@2.0.1':
+    resolution: {integrity: sha512-mvvCEm0AXvqgHLJGLpTxFd560rG70BVFbmWTrqFUAwBTP01aB6OtEX/wRDvehFt8xkbiyPgLGspT3Htt/3ZKiQ==}
 
-  '@ahoo-wang/fetcher-storage@2.0.0':
-    resolution: {integrity: sha512-F7IEpj13EZijiLPekRP8w+a9vGopB/YqzVw5RJFKLc1AGrU+w2L2ZXTQwd+USySqoX0IELxeguJKuGW2qJuLew==}
+  '@ahoo-wang/fetcher-storage@2.0.1':
+    resolution: {integrity: sha512-kBZM9Fy3iuqbQ13nV4SMe88U6XrqhElYNN4FyDvbYzu1AiCGpUPzN+hAk0Qmy3Fr4CVwrHfYzMZ5LuT1SphDLQ==}
 
-  '@ahoo-wang/fetcher-wow@2.0.0':
-    resolution: {integrity: sha512-RcBnyk5hotHj83Lh2oNBqdbHg+RHLNpLEEJsU8HEGUTUrtpcOekNHVol7kNxktMq/3UlrOjVnibhn3hrzA7mnQ==}
+  '@ahoo-wang/fetcher-wow@2.0.1':
+    resolution: {integrity: sha512-7Iw/6zufxAumQusvxOwwPnAj8k8QgyoPDsPahUQEJn3swyHWAGb99VjWaFH4Xan7bB+WJUq07FYJG85Gi4KjFQ==}
 
-  '@ahoo-wang/fetcher@2.0.0':
-    resolution: {integrity: sha512-L7hqVZdUVsIiP34cYFbjkk4LbCfoQ8qT5/u2q0kgDmSIOPC6JUYcD3bGXZW+az8/3s1vyU/xtIkI2cEZTQg/kg==}
+  '@ahoo-wang/fetcher@2.0.1':
+    resolution: {integrity: sha512-kFZHoj2YowVJ+oLWtIcy5J5YKRerTiiyynqliwYTmzJgS3CiPdV8f0jZPpmG/Z2KgSb3C+Ovz+sF0JTVQOQ0lg==}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -2470,30 +2470,30 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ahoo-wang/fetcher-cosec@2.0.0':
+  '@ahoo-wang/fetcher-cosec@2.0.1':
     dependencies:
-      '@ahoo-wang/fetcher': 2.0.0
-      '@ahoo-wang/fetcher-storage': 2.0.0
+      '@ahoo-wang/fetcher': 2.0.1
+      '@ahoo-wang/fetcher-storage': 2.0.1
       nanoid: 5.1.6
 
-  '@ahoo-wang/fetcher-decorator@2.0.0':
+  '@ahoo-wang/fetcher-decorator@2.0.1':
     dependencies:
-      '@ahoo-wang/fetcher': 2.0.0
+      '@ahoo-wang/fetcher': 2.0.1
       reflect-metadata: 0.2.2
 
-  '@ahoo-wang/fetcher-eventstream@2.0.0':
+  '@ahoo-wang/fetcher-eventstream@2.0.1':
     dependencies:
-      '@ahoo-wang/fetcher': 2.0.0
+      '@ahoo-wang/fetcher': 2.0.1
 
-  '@ahoo-wang/fetcher-storage@2.0.0': {}
+  '@ahoo-wang/fetcher-storage@2.0.1': {}
 
-  '@ahoo-wang/fetcher-wow@2.0.0':
+  '@ahoo-wang/fetcher-wow@2.0.1':
     dependencies:
-      '@ahoo-wang/fetcher': 2.0.0
-      '@ahoo-wang/fetcher-decorator': 2.0.0
-      '@ahoo-wang/fetcher-eventstream': 2.0.0
+      '@ahoo-wang/fetcher': 2.0.1
+      '@ahoo-wang/fetcher-decorator': 2.0.1
+      '@ahoo-wang/fetcher-eventstream': 2.0.1
 
-  '@ahoo-wang/fetcher@2.0.0': {}
+  '@ahoo-wang/fetcher@2.0.1': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:

--- a/compensation/dashboard/src/services/executionFailedCommandClient.ts
+++ b/compensation/dashboard/src/services/executionFailedCommandClient.ts
@@ -50,8 +50,7 @@ export class ExecutionFailedCommandClient extends CommandClient {
       method: HttpMethod.PUT,
       urlParams: {
         path: { id },
-      },
-      body: {},
+      }
     };
     return this.send(commandRequest);
   }
@@ -63,7 +62,6 @@ export class ExecutionFailedCommandClient extends CommandClient {
       urlParams: {
         path: { id },
       },
-      body: {},
     };
     return this.send(commandRequest);
   }


### PR DESCRIPTION
- Updated @ahoo-wang/fetcher from 2.0.0 to 2.0.1
- Updated @ahoo-wang/fetcher-cosec from 2.0.0 to2.0.1
- Updated @ahoo-wang/fetcher-decorator from2.0.0 to2.0.1
- Updated @ahoo-wang/fetcher-eventstream from 2.0 to2.0.1
- Updated @ahoo-wang/fetcher-wow from 2.0.0 to2.0.1
- Removed unnecessary empty body objects in executionFailedCommandClient.ts
- Updated pnpm-lock.yaml to reflect new dependency versions


