### PR TITLE
chore(config): add threaddump to springdoc actuator endpoints

### DIFF
--- a/example/example-server/src/main/resources/application.yaml
+++ b/example/example-server/src/main/resources/application.yaml
@@ -12,6 +12,7 @@ management:
           - cosid
           - cosidGenerator
           - cosidStringGenerator
+          - threaddump
 
 springdoc:
   show-actuator: true


### PR DESCRIPTION
- Added 'threaddump' to the list of exposed actuator endpoints
- Updated application.yaml configuration to include threaddump
- Enabled thread dump functionality for monitoring and debugging
- Configured springdoc to display actuator endpoints including threaddump
- Ensured proper indentation and formatting in YAML configuration file


