### PR TITLE
refactor(demo): rename enum path variable to mockEnum

### DIFF
--- a/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/MockVariableCommand.kt
+++ b/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/MockVariableCommand.kt
@@ -22,7 +22,7 @@ import me.ahoo.wow.api.annotation.Order
     appendIdPath = CommandRoute.AppendPath.ALWAYS,
     appendTenantPath = CommandRoute.AppendPath.ALWAYS,
     appendOwnerPath = CommandRoute.AppendPath.ALWAYS,
-    action = "{id}/{customerId}/{enum}"
+    action = "{id}/{customerId}/{mockEnum}"
 )
 data class MockVariableCommand(
     @field:CommandRoute.PathVariable
@@ -34,7 +34,7 @@ data class MockVariableCommand(
     @field:CommandRoute.PathVariable
     val customerId: Int,
     @field:CommandRoute.PathVariable
-    val enum: MockEnum,
+    val mockEnum: MockEnum,
     @field:CommandRoute.HeaderVariable
     val headerParameter: String,
     @field:CommandRoute.HeaderVariable


### PR DESCRIPTION
- Updated command route action placeholder from {enum} to {mockEnum}
- Renamed enum parameter to mockEnum in MockVariableCommand data class
- Maintained all existing command route configurations and mappings

