### PR TITLE
docs(guide): update project template download link

### DIFF
--- a/documentation/docs/guide/getting-started.md
+++ b/documentation/docs/guide/getting-started.md
@@ -13,7 +13,7 @@
     - _Mac OS_:`~/Library/Application\ Support/JetBrains/<PRODUCT><VERSION/projectTemplates/`
     - _Linux_: `~/.config/JetBrains/<PRODUCT><VERSION>/projectTemplates/`
 - 将模板压缩包放到 _IDEA_ 项目模板目录下
-    - 模板压缩包: [wow-project-template.zip](https://gitee.com/AhooWang/wow-project-template/releases/download/v6.2.0/wow-project-template.zip)
+    - 模板压缩包: [wow-project-template.zip](https://gitee.com/AhooWang/wow-project-template/releases/download/v6.2.1/wow-project-template.zip)
 
 ## 创建项目
 


### PR DESCRIPTION
- Updated wow-project-template.zip download URL from v6.2.0 to v6.2.1
- Maintained all other documentation content and structure unchanged