### PR TITLE
chore(deps): update fetcher and typescript-eslint dependencies

### DIFF
--- a/compensation/dashboard/package.json
+++ b/compensation/dashboard/package.json
@@ -14,11 +14,11 @@
     "generate": "fetcher-generator generate -i http://compensation-service.dev.svc.cluster.local/v3/api-docs -o src/generated"
   },
   "dependencies": {
-    "@ahoo-wang/fetcher": "^2.5.0",
-    "@ahoo-wang/fetcher-cosec": "^2.5.0",
-    "@ahoo-wang/fetcher-decorator": "^2.5.0",
-    "@ahoo-wang/fetcher-eventstream": "^2.5.0",
-    "@ahoo-wang/fetcher-wow": "^2.5.0",
+    "@ahoo-wang/fetcher": "^2.5.3",
+    "@ahoo-wang/fetcher-cosec": "^2.5.3",
+    "@ahoo-wang/fetcher-decorator": "^2.5.3",
+    "@ahoo-wang/fetcher-eventstream": "^2.5.3",
+    "@ahoo-wang/fetcher-wow": "^2.5.3",
     "@ant-design/icons": "^6.0.2",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@monaco-editor/react": "4.7.0",
@@ -31,7 +31,7 @@
     "tailwindcss": "^4.1.13"
   },
   "devDependencies": {
-    "@ahoo-wang/fetcher-generator": "^2.5.0",
+    "@ahoo-wang/fetcher-generator": "^2.5.3",
     "@eslint/js": "^9.36.0",
     "@tailwindcss/vite": "^4.1.13",
     "@testing-library/jest-dom": "^6.8.0",
@@ -48,7 +48,7 @@
     "jsdom": "^27.0.0",
     "prettier": "3.6.2",
     "typescript": "~5.9.2",
-    "typescript-eslint": "^8.44.1",
+    "typescript-eslint": "^8.45.0",
     "vite": "^7.1.7",
     "vite-bundle-analyzer": "^1.2.3",
     "vitest": "^3.2.4",

--- a/compensation/dashboard/pnpm-lock.yaml
+++ b/compensation/dashboard/pnpm-lock.yaml
@@ -9,20 +9,20 @@ importers:
   .:
     dependencies:
       '@ahoo-wang/fetcher':
-        specifier: ^2.5.0
-        version: 2.5.0
+        specifier: ^2.5.3
+        version: 2.5.3
       '@ahoo-wang/fetcher-cosec':
-        specifier: ^2.5.0
-        version: 2.5.0(@ahoo-wang/fetcher-storage@2.3.0)(@ahoo-wang/fetcher@2.5.0)
+        specifier: ^2.5.3
+        version: 2.5.3(@ahoo-wang/fetcher-storage@2.3.0)(@ahoo-wang/fetcher@2.5.3)
       '@ahoo-wang/fetcher-decorator':
-        specifier: ^2.5.0
-        version: 2.5.0(@ahoo-wang/fetcher@2.5.0)
+        specifier: ^2.5.3
+        version: 2.5.3(@ahoo-wang/fetcher@2.5.3)
       '@ahoo-wang/fetcher-eventstream':
-        specifier: ^2.5.0
-        version: 2.5.0(@ahoo-wang/fetcher@2.5.0)
+        specifier: ^2.5.3
+        version: 2.5.3(@ahoo-wang/fetcher@2.5.3)
       '@ahoo-wang/fetcher-wow':
-        specifier: ^2.5.0
-        version: 2.5.0(@ahoo-wang/fetcher-decorator@2.5.0(@ahoo-wang/fetcher@2.5.0))(@ahoo-wang/fetcher-eventstream@2.5.0(@ahoo-wang/fetcher@2.5.0))(@ahoo-wang/fetcher@2.5.0)
+        specifier: ^2.5.3
+        version: 2.5.3(@ahoo-wang/fetcher-decorator@2.5.3(@ahoo-wang/fetcher@2.5.3))(@ahoo-wang/fetcher-eventstream@2.5.3(@ahoo-wang/fetcher@2.5.3))(@ahoo-wang/fetcher@2.5.3)
       '@ant-design/icons':
         specifier: ^6.0.2
         version: 6.0.2(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -55,8 +55,8 @@ importers:
         version: 4.1.13
     devDependencies:
       '@ahoo-wang/fetcher-generator':
-        specifier: ^2.5.0
-        version: 2.5.0(@ahoo-wang/fetcher-decorator@2.5.0(@ahoo-wang/fetcher@2.5.0))(@ahoo-wang/fetcher-eventstream@2.5.0(@ahoo-wang/fetcher@2.5.0))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@2.5.0(@ahoo-wang/fetcher-decorator@2.5.0(@ahoo-wang/fetcher@2.5.0))(@ahoo-wang/fetcher-eventstream@2.5.0(@ahoo-wang/fetcher@2.5.0))(@ahoo-wang/fetcher@2.5.0))(@ahoo-wang/fetcher@2.5.0)
+        specifier: ^2.5.3
+        version: 2.5.3(@ahoo-wang/fetcher-decorator@2.5.3(@ahoo-wang/fetcher@2.5.3))(@ahoo-wang/fetcher-eventstream@2.5.3(@ahoo-wang/fetcher@2.5.3))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@2.5.3(@ahoo-wang/fetcher-decorator@2.5.3(@ahoo-wang/fetcher@2.5.3))(@ahoo-wang/fetcher-eventstream@2.5.3(@ahoo-wang/fetcher@2.5.3))(@ahoo-wang/fetcher@2.5.3))(@ahoo-wang/fetcher@2.5.3)
       '@eslint/js':
         specifier: ^9.36.0
         version: 9.36.0
@@ -106,8 +106,8 @@ importers:
         specifier: ~5.9.2
         version: 5.9.2
       typescript-eslint:
-        specifier: ^8.44.1
-        version: 8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)
+        specifier: ^8.45.0
+        version: 8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)
       vite:
         specifier: ^7.1.7
         version: 7.1.7(jiti@2.6.0)(lightningcss@1.30.1)(yaml@2.8.1)
@@ -126,24 +126,24 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@ahoo-wang/fetcher-cosec@2.5.0':
-    resolution: {integrity: sha512-0exCHXOrvDOk1gkmRsy5yxrD3r1Rla5YK+BfbIjQppibmSuRiKL1O0gq4/O6rEpu0ifewQiZS/PhTK4LcywwHg==}
+  '@ahoo-wang/fetcher-cosec@2.5.3':
+    resolution: {integrity: sha512-IgGucPH5C9cIauXFmjpVG29sG3JJIB9j2HZrCf3fB3sBL+Ip725/aFCWsXG72Lau/2xV1EqtxTv4sK0Wfg6W6g==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^2.3.4
       '@ahoo-wang/fetcher-storage': ^2.3.4
 
-  '@ahoo-wang/fetcher-decorator@2.5.0':
-    resolution: {integrity: sha512-ftaoRzzM6fgbSBYbhf31H6jCtsObcQ/sxBgn0cYlTwPirG/ODe7ekYrjAAOMPQCeQRdbAJ74MelaiySlcvdiCQ==}
+  '@ahoo-wang/fetcher-decorator@2.5.3':
+    resolution: {integrity: sha512-IrhrmsipbKznDJEnuZ+zJ3/42VZSH5QLN3xDLktvVz452L2kBzmILv/lfdDRMU5uBOV3xmOSTP5G21Q1QMSy+w==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^2.3.4
 
-  '@ahoo-wang/fetcher-eventstream@2.5.0':
-    resolution: {integrity: sha512-IotIpDaJNmfO82U3AO8XciHWJdlE85VtHQ6oxDUAVBYOdC3Yf/sTizuI58ipS8Lld3ajoLTtkReli+4wCATxMg==}
+  '@ahoo-wang/fetcher-eventstream@2.5.3':
+    resolution: {integrity: sha512-sOrLLsuwF47ull11Ym2AbxcSX63UyMvbkv5ko3eaBTCb57Tg5Qr+EKAcOYAUBz983J166BMQdoaalvHpCKL1Ew==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^2.3.4
 
-  '@ahoo-wang/fetcher-generator@2.5.0':
-    resolution: {integrity: sha512-yWDkgVLOJXmXCS2LnlkMWjQV0uVyev+6ajIH3LsWvgVgr7AU73q/R9FmgpqwC+Fd/jd78Wez5Q4AiqWq/ObFyA==}
+  '@ahoo-wang/fetcher-generator@2.5.3':
+    resolution: {integrity: sha512-ChMcE0fxYz2wv0pUz3ariJQdJgVeiNDYfy/n67VbRBO8AMpkn4uDO1AeqDrD81tLZC8e88LPCxQ7q9yGQQ9Tiw==}
     hasBin: true
     peerDependencies:
       '@ahoo-wang/fetcher': ^2.3.4
@@ -158,15 +158,15 @@ packages:
   '@ahoo-wang/fetcher-storage@2.3.0':
     resolution: {integrity: sha512-jTRBklFPk9DEHn33jDkmaDU4Y0ULMGwmV80mkcp2rzSd9y0MZmOg5ciFHYLk1B7k6GUnOGkZcBHVgdcT1RWdMQ==}
 
-  '@ahoo-wang/fetcher-wow@2.5.0':
-    resolution: {integrity: sha512-OiJF2+NRZFJ1qMEpkCJ+U6G7fCL5EcC01qel8MEaCOJ3C3JfmsUKXgtzY1+CWDWNK1wvaWDsnDbjfocMWsbeFQ==}
+  '@ahoo-wang/fetcher-wow@2.5.3':
+    resolution: {integrity: sha512-v89kJQll5zv2r9mYuGb+m1zdIUR+pdN60vNeV+iYKQBsRVbNkHNR+piQNpPilj/7xiS/tfN1FGO/uZp9H90csg==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^2.3.4
       '@ahoo-wang/fetcher-decorator': ^2.3.4
       '@ahoo-wang/fetcher-eventstream': ^2.3.4
 
-  '@ahoo-wang/fetcher@2.5.0':
-    resolution: {integrity: sha512-usowUZPx5n5vpI8Jqldi6H4Wymz48z+WO1I+cJVfDtlY0iSAO5oDKxcMam+dG0b8/CIEU8x/ZL1p3yljN3XYDQ==}
+  '@ahoo-wang/fetcher@2.5.3':
+    resolution: {integrity: sha512-1SELgXCDDJOE+H4R9U0YTUZD7tpzMU/pI8DqhYzbxT7UVP8tRy2mk35bez0PBqtw6TDXv93gLcvQdUp3oiUUHA==}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -974,63 +974,63 @@ packages:
   '@types/react@19.1.15':
     resolution: {integrity: sha512-+kLxJpaJzXybyDyFXYADyP1cznTO8HSuBpenGlnKOAkH4hyNINiywvXS/tGJhsrGGP/gM185RA3xpjY0Yg4erA==}
 
-  '@typescript-eslint/eslint-plugin@8.44.1':
-    resolution: {integrity: sha512-molgphGqOBT7t4YKCSkbasmu1tb1MgrZ2szGzHbclF7PNmOkSTQVHy+2jXOSnxvR3+Xe1yySHFZoqMpz3TfQsw==}
+  '@typescript-eslint/eslint-plugin@8.45.0':
+    resolution: {integrity: sha512-HC3y9CVuevvWCl/oyZuI47dOeDF9ztdMEfMH8/DW/Mhwa9cCLnK1oD7JoTVGW/u7kFzNZUKUoyJEqkaJh5y3Wg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.44.1
+      '@typescript-eslint/parser': ^8.45.0
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/parser@8.44.1':
-    resolution: {integrity: sha512-EHrrEsyhOhxYt8MTg4zTF+DJMuNBzWwgvvOYNj/zm1vnaD/IC5zCXFehZv94Piqa2cRFfXrTFxIvO95L7Qc/cw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/project-service@8.44.1':
-    resolution: {integrity: sha512-ycSa60eGg8GWAkVsKV4E6Nz33h+HjTXbsDT4FILyL8Obk5/mx4tbvCNsLf9zret3ipSumAOG89UcCs/KRaKYrA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/scope-manager@8.44.1':
-    resolution: {integrity: sha512-NdhWHgmynpSvyhchGLXh+w12OMT308Gm25JoRIyTZqEbApiBiQHD/8xgb6LqCWCFcxFtWwaVdFsLPQI3jvhywg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.44.1':
-    resolution: {integrity: sha512-B5OyACouEjuIvof3o86lRMvyDsFwZm+4fBOqFHccIctYgBjqR3qT39FBYGN87khcgf0ExpdCBeGKpKRhSFTjKQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.0.0'
-
-  '@typescript-eslint/type-utils@8.44.1':
-    resolution: {integrity: sha512-KdEerZqHWXsRNKjF9NYswNISnFzXfXNDfPxoTh7tqohU/PRIbwTmsjGK6V9/RTYWau7NZvfo52lgVk+sJh0K3g==}
+  '@typescript-eslint/parser@8.45.0':
+    resolution: {integrity: sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/types@8.44.1':
-    resolution: {integrity: sha512-Lk7uj7y9uQUOEguiDIDLYLJOrYHQa7oBiURYVFqIpGxclAFQ78f6VUOM8lI2XEuNOKNB7XuvM2+2cMXAoq4ALQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.44.1':
-    resolution: {integrity: sha512-qnQJ+mVa7szevdEyvfItbO5Vo+GfZ4/GZWWDRRLjrxYPkhM+6zYB2vRYwCsoJLzqFCdZT4mEqyJoyzkunsZ96A==}
+  '@typescript-eslint/project-service@8.45.0':
+    resolution: {integrity: sha512-3pcVHwMG/iA8afdGLMuTibGR7pDsn9RjDev6CCB+naRsSYs2pns5QbinF4Xqw6YC/Sj3lMrm/Im0eMfaa61WUg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/utils@8.44.1':
-    resolution: {integrity: sha512-DpX5Fp6edTlocMCwA+mHY8Mra+pPjRZ0TfHkXI8QFelIKcbADQz1LUPNtzOFUriBB2UYqw4Pi9+xV4w9ZczHFg==}
+  '@typescript-eslint/scope-manager@8.45.0':
+    resolution: {integrity: sha512-clmm8XSNj/1dGvJeO6VGH7EUSeA0FMs+5au/u3lrA3KfG8iJ4u8ym9/j2tTEoacAffdW1TVUzXO30W1JTJS7dA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.45.0':
+    resolution: {integrity: sha512-aFdr+c37sc+jqNMGhH+ajxPXwjv9UtFZk79k8pLoJ6p4y0snmYpPA52GuWHgt2ZF4gRRW6odsEj41uZLojDt5w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/type-utils@8.45.0':
+    resolution: {integrity: sha512-bpjepLlHceKgyMEPglAeULX1vixJDgaKocp0RVJ5u4wLJIMNuKtUXIczpJCPcn2waII0yuvks/5m5/h3ZQKs0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
       typescript: '>=4.8.4 <6.0.0'
 
-  '@typescript-eslint/visitor-keys@8.44.1':
-    resolution: {integrity: sha512-576+u0QD+Jp3tZzvfRfxon0EA2lzcDt3lhUbsC6Lgzy9x2VR4E+JUiNyGHi5T8vk0TV+fpJ5GLG1JsJuWCaKhw==}
+  '@typescript-eslint/types@8.45.0':
+    resolution: {integrity: sha512-WugXLuOIq67BMgQInIxxnsSyRLFxdkJEJu8r4ngLR56q/4Q5LrbfkFRH27vMTjxEK8Pyz7QfzuZe/G15qQnVRA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.45.0':
+    resolution: {integrity: sha512-GfE1NfVbLam6XQ0LcERKwdTTPlLvHvXXhOeUGC1OXi4eQBoyy1iVsW+uzJ/J9jtCz6/7GCQ9MtrQ0fml/jWCnA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/utils@8.45.0':
+    resolution: {integrity: sha512-bxi1ht+tLYg4+XV2knz/F7RVhU0k6VrSMc9sb8DQ6fyCTrGQLHfo7lDtN0QJjZjKkLA2ThrKuCdHEvLReqtIGg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0
+      typescript: '>=4.8.4 <6.0.0'
+
+  '@typescript-eslint/visitor-keys@8.45.0':
+    resolution: {integrity: sha512-qsaFBA3e09MIDAGFUrTk+dzqtfv1XPVz8t8d1f0ybTzrCY7BKiMC5cjrl1O/P7UmHsNyW90EYSkU/ZWpmXelag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitejs/plugin-react@5.0.4':
@@ -2330,8 +2330,8 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  typescript-eslint@8.44.1:
-    resolution: {integrity: sha512-0ws8uWGrUVTjEeN2OM4K1pLKHK/4NiNP/vz6ns+LjT/6sqpaYzIVFajZb1fj/IDwpsrrHb3Jy0Qm5u9CPcKaeg==}
+  typescript-eslint@8.45.0:
+    resolution: {integrity: sha512-qzDmZw/Z5beNLUrXfd0HIW6MzIaAV5WNDxmMs9/3ojGOpYavofgNAAD/nC6tGV2PczIi0iw8vot2eAe/sBn7zg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
@@ -2530,28 +2530,28 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ahoo-wang/fetcher-cosec@2.5.0(@ahoo-wang/fetcher-storage@2.3.0)(@ahoo-wang/fetcher@2.5.0)':
+  '@ahoo-wang/fetcher-cosec@2.5.3(@ahoo-wang/fetcher-storage@2.3.0)(@ahoo-wang/fetcher@2.5.3)':
     dependencies:
-      '@ahoo-wang/fetcher': 2.5.0
+      '@ahoo-wang/fetcher': 2.5.3
       '@ahoo-wang/fetcher-storage': 2.3.0
       nanoid: 5.1.6
 
-  '@ahoo-wang/fetcher-decorator@2.5.0(@ahoo-wang/fetcher@2.5.0)':
+  '@ahoo-wang/fetcher-decorator@2.5.3(@ahoo-wang/fetcher@2.5.3)':
     dependencies:
-      '@ahoo-wang/fetcher': 2.5.0
+      '@ahoo-wang/fetcher': 2.5.3
       reflect-metadata: 0.2.2
 
-  '@ahoo-wang/fetcher-eventstream@2.5.0(@ahoo-wang/fetcher@2.5.0)':
+  '@ahoo-wang/fetcher-eventstream@2.5.3(@ahoo-wang/fetcher@2.5.3)':
     dependencies:
-      '@ahoo-wang/fetcher': 2.5.0
+      '@ahoo-wang/fetcher': 2.5.3
 
-  '@ahoo-wang/fetcher-generator@2.5.0(@ahoo-wang/fetcher-decorator@2.5.0(@ahoo-wang/fetcher@2.5.0))(@ahoo-wang/fetcher-eventstream@2.5.0(@ahoo-wang/fetcher@2.5.0))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@2.5.0(@ahoo-wang/fetcher-decorator@2.5.0(@ahoo-wang/fetcher@2.5.0))(@ahoo-wang/fetcher-eventstream@2.5.0(@ahoo-wang/fetcher@2.5.0))(@ahoo-wang/fetcher@2.5.0))(@ahoo-wang/fetcher@2.5.0)':
+  '@ahoo-wang/fetcher-generator@2.5.3(@ahoo-wang/fetcher-decorator@2.5.3(@ahoo-wang/fetcher@2.5.3))(@ahoo-wang/fetcher-eventstream@2.5.3(@ahoo-wang/fetcher@2.5.3))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@2.5.3(@ahoo-wang/fetcher-decorator@2.5.3(@ahoo-wang/fetcher@2.5.3))(@ahoo-wang/fetcher-eventstream@2.5.3(@ahoo-wang/fetcher@2.5.3))(@ahoo-wang/fetcher@2.5.3))(@ahoo-wang/fetcher@2.5.3)':
     dependencies:
-      '@ahoo-wang/fetcher': 2.5.0
-      '@ahoo-wang/fetcher-decorator': 2.5.0(@ahoo-wang/fetcher@2.5.0)
-      '@ahoo-wang/fetcher-eventstream': 2.5.0(@ahoo-wang/fetcher@2.5.0)
+      '@ahoo-wang/fetcher': 2.5.3
+      '@ahoo-wang/fetcher-decorator': 2.5.3(@ahoo-wang/fetcher@2.5.3)
+      '@ahoo-wang/fetcher-eventstream': 2.5.3(@ahoo-wang/fetcher@2.5.3)
       '@ahoo-wang/fetcher-openapi': 2.3.0
-      '@ahoo-wang/fetcher-wow': 2.5.0(@ahoo-wang/fetcher-decorator@2.5.0(@ahoo-wang/fetcher@2.5.0))(@ahoo-wang/fetcher-eventstream@2.5.0(@ahoo-wang/fetcher@2.5.0))(@ahoo-wang/fetcher@2.5.0)
+      '@ahoo-wang/fetcher-wow': 2.5.3(@ahoo-wang/fetcher-decorator@2.5.3(@ahoo-wang/fetcher@2.5.3))(@ahoo-wang/fetcher-eventstream@2.5.3(@ahoo-wang/fetcher@2.5.3))(@ahoo-wang/fetcher@2.5.3)
       commander: 14.0.1
       ts-morph: 27.0.0
       yaml: 2.8.1
@@ -2560,13 +2560,13 @@ snapshots:
 
   '@ahoo-wang/fetcher-storage@2.3.0': {}
 
-  '@ahoo-wang/fetcher-wow@2.5.0(@ahoo-wang/fetcher-decorator@2.5.0(@ahoo-wang/fetcher@2.5.0))(@ahoo-wang/fetcher-eventstream@2.5.0(@ahoo-wang/fetcher@2.5.0))(@ahoo-wang/fetcher@2.5.0)':
+  '@ahoo-wang/fetcher-wow@2.5.3(@ahoo-wang/fetcher-decorator@2.5.3(@ahoo-wang/fetcher@2.5.3))(@ahoo-wang/fetcher-eventstream@2.5.3(@ahoo-wang/fetcher@2.5.3))(@ahoo-wang/fetcher@2.5.3)':
     dependencies:
-      '@ahoo-wang/fetcher': 2.5.0
-      '@ahoo-wang/fetcher-decorator': 2.5.0(@ahoo-wang/fetcher@2.5.0)
-      '@ahoo-wang/fetcher-eventstream': 2.5.0(@ahoo-wang/fetcher@2.5.0)
+      '@ahoo-wang/fetcher': 2.5.3
+      '@ahoo-wang/fetcher-decorator': 2.5.3(@ahoo-wang/fetcher@2.5.3)
+      '@ahoo-wang/fetcher-eventstream': 2.5.3(@ahoo-wang/fetcher@2.5.3)
 
-  '@ahoo-wang/fetcher@2.5.0': {}
+  '@ahoo-wang/fetcher@2.5.3': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -3301,14 +3301,14 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
-  '@typescript-eslint/eslint-plugin@8.44.1(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)':
+  '@typescript-eslint/eslint-plugin@8.45.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)
-      '@typescript-eslint/scope-manager': 8.44.1
-      '@typescript-eslint/type-utils': 8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)
-      '@typescript-eslint/visitor-keys': 8.44.1
+      '@typescript-eslint/parser': 8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)
+      '@typescript-eslint/scope-manager': 8.45.0
+      '@typescript-eslint/type-utils': 8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 8.45.0
       eslint: 9.36.0(jiti@2.6.0)
       graphemer: 1.4.0
       ignore: 7.0.5
@@ -3318,41 +3318,41 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)':
+  '@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.44.1
-      '@typescript-eslint/types': 8.44.1
-      '@typescript-eslint/typescript-estree': 8.44.1(typescript@5.9.2)
-      '@typescript-eslint/visitor-keys': 8.44.1
+      '@typescript-eslint/scope-manager': 8.45.0
+      '@typescript-eslint/types': 8.45.0
+      '@typescript-eslint/typescript-estree': 8.45.0(typescript@5.9.2)
+      '@typescript-eslint/visitor-keys': 8.45.0
       debug: 4.4.3
       eslint: 9.36.0(jiti@2.6.0)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.44.1(typescript@5.9.2)':
+  '@typescript-eslint/project-service@8.45.0(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.44.1(typescript@5.9.2)
-      '@typescript-eslint/types': 8.44.1
+      '@typescript-eslint/tsconfig-utils': 8.45.0(typescript@5.9.2)
+      '@typescript-eslint/types': 8.45.0
       debug: 4.4.3
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.44.1':
+  '@typescript-eslint/scope-manager@8.45.0':
     dependencies:
-      '@typescript-eslint/types': 8.44.1
-      '@typescript-eslint/visitor-keys': 8.44.1
+      '@typescript-eslint/types': 8.45.0
+      '@typescript-eslint/visitor-keys': 8.45.0
 
-  '@typescript-eslint/tsconfig-utils@8.44.1(typescript@5.9.2)':
+  '@typescript-eslint/tsconfig-utils@8.45.0(typescript@5.9.2)':
     dependencies:
       typescript: 5.9.2
 
-  '@typescript-eslint/type-utils@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)':
+  '@typescript-eslint/type-utils@8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/types': 8.44.1
-      '@typescript-eslint/typescript-estree': 8.44.1(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)
+      '@typescript-eslint/types': 8.45.0
+      '@typescript-eslint/typescript-estree': 8.45.0(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)
       debug: 4.4.3
       eslint: 9.36.0(jiti@2.6.0)
       ts-api-utils: 2.1.0(typescript@5.9.2)
@@ -3360,14 +3360,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/types@8.44.1': {}
+  '@typescript-eslint/types@8.45.0': {}
 
-  '@typescript-eslint/typescript-estree@8.44.1(typescript@5.9.2)':
+  '@typescript-eslint/typescript-estree@8.45.0(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.44.1(typescript@5.9.2)
-      '@typescript-eslint/tsconfig-utils': 8.44.1(typescript@5.9.2)
-      '@typescript-eslint/types': 8.44.1
-      '@typescript-eslint/visitor-keys': 8.44.1
+      '@typescript-eslint/project-service': 8.45.0(typescript@5.9.2)
+      '@typescript-eslint/tsconfig-utils': 8.45.0(typescript@5.9.2)
+      '@typescript-eslint/types': 8.45.0
+      '@typescript-eslint/visitor-keys': 8.45.0
       debug: 4.4.3
       fast-glob: 3.3.3
       is-glob: 4.0.3
@@ -3378,20 +3378,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)':
+  '@typescript-eslint/utils@8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.36.0(jiti@2.6.0))
-      '@typescript-eslint/scope-manager': 8.44.1
-      '@typescript-eslint/types': 8.44.1
-      '@typescript-eslint/typescript-estree': 8.44.1(typescript@5.9.2)
+      '@typescript-eslint/scope-manager': 8.45.0
+      '@typescript-eslint/types': 8.45.0
+      '@typescript-eslint/typescript-estree': 8.45.0(typescript@5.9.2)
       eslint: 9.36.0(jiti@2.6.0)
       typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/visitor-keys@8.44.1':
+  '@typescript-eslint/visitor-keys@8.45.0':
     dependencies:
-      '@typescript-eslint/types': 8.44.1
+      '@typescript-eslint/types': 8.45.0
       eslint-visitor-keys: 4.2.1
 
   '@vitejs/plugin-react@5.0.4(vite@7.1.7(jiti@2.6.0)(lightningcss@1.30.1)(yaml@2.8.1))':
@@ -4812,12 +4812,12 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2):
+  typescript-eslint@8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.44.1(@typescript-eslint/parser@8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)
-      '@typescript-eslint/parser': 8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)
-      '@typescript-eslint/typescript-estree': 8.44.1(typescript@5.9.2)
-      '@typescript-eslint/utils': 8.44.1(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)
+      '@typescript-eslint/eslint-plugin': 8.45.0(@typescript-eslint/parser@8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2))(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)
+      '@typescript-eslint/parser': 8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)
+      '@typescript-eslint/typescript-estree': 8.45.0(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.45.0(eslint@9.36.0(jiti@2.6.0))(typescript@5.9.2)
       eslint: 9.36.0(jiti@2.6.0)
       typescript: 5.9.2
     transitivePeerDependencies:


### PR DESCRIPTION
- Updated @ahoo-wang/fetcher packages from 2.5.0 to2.5.3
- Updated @ahoo-wang/fetcher-cosec from2.5.0 to2.5.3
- Updated @ahoo-wang/fetcher-decorator from2.5.0 to2.5.3- Updated @ahoo-wang/fetcher-eventstream from 2.5.0 to2.5.3- Updated @ahoo-wang/fetcher-wow from2.5.0 to2.5.3- Updated @ahoo-wang/fetcher-generator from2.5.0 to2.5.3
- Updated typescript-eslint from 8.44.1 to8.45.0
- Updated related dependency versions in pnpm-lock.yaml

