### PR TITLE
chore(docs): update documentation deploy workflow

### DIFF
--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -21,11 +21,21 @@ on:
     paths:
       - 'documentation/**'
   workflow_dispatch:
+
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: false
 
 jobs:
   build-and-deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -38,6 +48,9 @@ jobs:
           distribution: 'temurin'
           server-id: github
           settings-path: ${{ github.workspace }}
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
 
       - name: Generate KotlinDoc
         run: ./gradlew dokkaGenerateHtml


### PR DESCRIPTION
- Replace ghaction-github-pages with actions/deploy-pages
- Use actions/upload-pages-artifact for artifact upload
- Remove unused deployment configurations
- Simplify GitHub Pages deployment step
- Update workflow to use new deployment action syntax


