### PR TITLE
chore(ci): add Gradle caching to documentation deploy workflow

### DIFF
--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -49,6 +49,16 @@ jobs:
           server-id: github
           settings-path: ${{ github.workspace }}
 
+      - name: Cache Gradle packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
 


### PR DESCRIPTION
- Add cache action for Gradle dependencies and wrapper
- Configure cache paths for ~/.gradle/caches and ~/.gradle/wrapper
- Set cache key using runner OS and hash of Gradle files
- Add fallback restore keys for Gradle cache
- Maintain existing Pages setup step


