### PR TITLE
chore(deps): update fetcher dependencies to v2.12.9

### DIFF
--- a/compensation/dashboard/package.json
+++ b/compensation/dashboard/package.json
@@ -14,14 +14,14 @@
     "generate": "fetcher-generator generate -i http://compensation-service.dev.svc.cluster.local/v3/api-docs -o src/generated"
   },
   "dependencies": {
-    "@ahoo-wang/fetcher": "^2.12.6",
-    "@ahoo-wang/fetcher-cosec": "^2.12.6",
-    "@ahoo-wang/fetcher-decorator": "^2.12.6",
-    "@ahoo-wang/fetcher-eventbus": "^2.12.6",
-    "@ahoo-wang/fetcher-eventstream": "^2.12.6",
-    "@ahoo-wang/fetcher-react": "^2.12.6",
-    "@ahoo-wang/fetcher-storage": "^2.12.6",
-    "@ahoo-wang/fetcher-wow": "^2.12.6",
+    "@ahoo-wang/fetcher": "^2.12.9",
+    "@ahoo-wang/fetcher-cosec": "^2.12.9",
+    "@ahoo-wang/fetcher-decorator": "^2.12.9",
+    "@ahoo-wang/fetcher-eventbus": "^2.12.9",
+    "@ahoo-wang/fetcher-eventstream": "^2.12.9",
+    "@ahoo-wang/fetcher-react": "^2.12.9",
+    "@ahoo-wang/fetcher-storage": "^2.12.9",
+    "@ahoo-wang/fetcher-wow": "^2.12.9",
     "@ant-design/icons": "^6.1.0",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@monaco-editor/react": "4.7.0",
@@ -33,7 +33,7 @@
     "tailwindcss": "^4.1.15"
   },
   "devDependencies": {
-    "@ahoo-wang/fetcher-generator": "^2.12.6",
+    "@ahoo-wang/fetcher-generator": "^2.12.9",
     "@eslint/js": "^9.38.0",
     "@tailwindcss/vite": "^4.1.15",
     "@testing-library/jest-dom": "^6.9.1",

--- a/compensation/dashboard/pnpm-lock.yaml
+++ b/compensation/dashboard/pnpm-lock.yaml
@@ -9,29 +9,29 @@ importers:
   .:
     dependencies:
       '@ahoo-wang/fetcher':
-        specifier: ^2.12.6
-        version: 2.12.6
+        specifier: ^2.12.9
+        version: 2.12.9
       '@ahoo-wang/fetcher-cosec':
-        specifier: ^2.12.6
-        version: 2.12.6(@ahoo-wang/fetcher-eventbus@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher-storage@2.12.6(@ahoo-wang/fetcher-eventbus@2.12.6(@ahoo-wang/fetcher@2.12.6)))(@ahoo-wang/fetcher@2.12.6)
+        specifier: ^2.12.9
+        version: 2.12.9(@ahoo-wang/fetcher-eventbus@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher-storage@2.12.9(@ahoo-wang/fetcher-eventbus@2.12.9(@ahoo-wang/fetcher@2.12.9)))(@ahoo-wang/fetcher@2.12.9)
       '@ahoo-wang/fetcher-decorator':
-        specifier: ^2.12.6
-        version: 2.12.6(@ahoo-wang/fetcher@2.12.6)
+        specifier: ^2.12.9
+        version: 2.12.9(@ahoo-wang/fetcher@2.12.9)
       '@ahoo-wang/fetcher-eventbus':
-        specifier: ^2.12.6
-        version: 2.12.6(@ahoo-wang/fetcher@2.12.6)
+        specifier: ^2.12.9
+        version: 2.12.9(@ahoo-wang/fetcher@2.12.9)
       '@ahoo-wang/fetcher-eventstream':
-        specifier: ^2.12.6
-        version: 2.12.6(@ahoo-wang/fetcher@2.12.6)
+        specifier: ^2.12.9
+        version: 2.12.9(@ahoo-wang/fetcher@2.12.9)
       '@ahoo-wang/fetcher-react':
-        specifier: ^2.12.6
-        version: 2.12.6(@ahoo-wang/fetcher-eventbus@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher-eventstream@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher-storage@2.12.6(@ahoo-wang/fetcher-eventbus@2.12.6(@ahoo-wang/fetcher@2.12.6)))(@ahoo-wang/fetcher-wow@2.12.6(@ahoo-wang/fetcher-decorator@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher-eventstream@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher@2.12.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^2.12.9
+        version: 2.12.9(@ahoo-wang/fetcher-eventbus@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher-eventstream@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher-storage@2.12.9(@ahoo-wang/fetcher-eventbus@2.12.9(@ahoo-wang/fetcher@2.12.9)))(@ahoo-wang/fetcher-wow@2.12.9(@ahoo-wang/fetcher-decorator@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher-eventstream@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher@2.12.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@ahoo-wang/fetcher-storage':
-        specifier: ^2.12.6
-        version: 2.12.6(@ahoo-wang/fetcher-eventbus@2.12.6(@ahoo-wang/fetcher@2.12.6))
+        specifier: ^2.12.9
+        version: 2.12.9(@ahoo-wang/fetcher-eventbus@2.12.9(@ahoo-wang/fetcher@2.12.9))
       '@ahoo-wang/fetcher-wow':
-        specifier: ^2.12.6
-        version: 2.12.6(@ahoo-wang/fetcher-decorator@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher-eventstream@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher@2.12.6)
+        specifier: ^2.12.9
+        version: 2.12.9(@ahoo-wang/fetcher-decorator@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher-eventstream@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher@2.12.9)
       '@ant-design/icons':
         specifier: ^6.1.0
         version: 6.1.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -61,8 +61,8 @@ importers:
         version: 4.1.15
     devDependencies:
       '@ahoo-wang/fetcher-generator':
-        specifier: ^2.12.6
-        version: 2.12.6(@ahoo-wang/fetcher-decorator@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher-eventstream@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@2.12.6(@ahoo-wang/fetcher-decorator@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher-eventstream@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher@2.12.6)
+        specifier: ^2.12.9
+        version: 2.12.9(@ahoo-wang/fetcher-decorator@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher-eventstream@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@2.12.9(@ahoo-wang/fetcher-decorator@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher-eventstream@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher@2.12.9)
       '@eslint/js':
         specifier: ^9.38.0
         version: 9.38.0
@@ -132,30 +132,30 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@ahoo-wang/fetcher-cosec@2.12.6':
-    resolution: {integrity: sha512-2fvYQMqB6YDw0c+SG8zErRO+Gdmh6e8lDFpLbh3l8SeTDFh2wrPOwihj44PLq9DhBbr+a6jXK9Yq2EB5STp/zQ==}
+  '@ahoo-wang/fetcher-cosec@2.12.9':
+    resolution: {integrity: sha512-qME55kxcnK/yPHRB9IKlsYWFm8SpjCNvfMEPyL8WtmxtfDlw6UwABci0A4BlFvqh17JV+NCFfgUZxQnE2Up4jg==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^2.3.4
       '@ahoo-wang/fetcher-eventbus': ^2.8.5
       '@ahoo-wang/fetcher-storage': ^2.3.4
 
-  '@ahoo-wang/fetcher-decorator@2.12.6':
-    resolution: {integrity: sha512-DGxlPc+ThloDoGW4AFiugvC6/hajDB8rDAhld6uBeO+iO5FRiBj3w45IQBn3K+fxIN1rG+l/k3MLfqkk7sFAxw==}
+  '@ahoo-wang/fetcher-decorator@2.12.9':
+    resolution: {integrity: sha512-B04543BIrQ2uYlMwK4kryOv+zYCNtjSpQjDp4gMuIUns1Em986ejWd+lZj2AK7EmDNCfdYi4y5cZ/H6RNYGl8A==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^2.9.3
 
-  '@ahoo-wang/fetcher-eventbus@2.12.6':
-    resolution: {integrity: sha512-3tU2paF99N8VQPR+EY5qg53cR3WHEMX0CWBzjKcmJSB9qH117b5LrIm6t0oo9B99ZnSjixSC+EDyyJ2aKNntsg==}
+  '@ahoo-wang/fetcher-eventbus@2.12.9':
+    resolution: {integrity: sha512-Rs6BwjBNapygyxPxb9AwsBcUnIU7QKTDyDX4veftLJ85vW0YWkDi1QtTE+nV83xDQriGYkNIXPRngD1aY53f6Q==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^2.3.4
 
-  '@ahoo-wang/fetcher-eventstream@2.12.6':
-    resolution: {integrity: sha512-NGF+dqpg4rBSAhZkkB1JyJdZxQJoHNzpR7GIrnsetQCoTJhdjJanNehBlZ1fEyKhsZCQXUTPiPXi1VRCiGJ3Bg==}
+  '@ahoo-wang/fetcher-eventstream@2.12.9':
+    resolution: {integrity: sha512-XqbhmVaGHWP5K/+jLEhNdQG73rbHWCzZ+yUziNfzsfQ0aCfZplOhdy7d7toNBY4fgdRZvFbPlaPAtIQYxTSoWw==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^2.3.4
 
-  '@ahoo-wang/fetcher-generator@2.12.6':
-    resolution: {integrity: sha512-ldbRU0qChWHWoX4BTChTMtcq8H1ExrrpZzgVQ3bba1XyTBS+6CvIFZw/UALfppDjVaGrGqKbW5Bp412zGOk8zQ==}
+  '@ahoo-wang/fetcher-generator@2.12.9':
+    resolution: {integrity: sha512-qnQ5tqpFNZKkUNgv7haEsctQNDm9tVTE3aZMZ3iuON9MGNSLT25MxYf0+PWBud/8fDBy/w9CRCU+Kg58uQP0cg==}
     hasBin: true
     peerDependencies:
       '@ahoo-wang/fetcher': ^2.3.4
@@ -167,8 +167,8 @@ packages:
   '@ahoo-wang/fetcher-openapi@2.3.0':
     resolution: {integrity: sha512-He3I/VovQzLNajxL2hoUZKlAnt0ZpehpMpbjgxvdPEoWfeAA3qZc0+C8Mhrk3HQQAC69lZOSt3JtAvzYDxpn/Q==}
 
-  '@ahoo-wang/fetcher-react@2.12.6':
-    resolution: {integrity: sha512-FjrB29AYKDDQLMLcL9imXE+tqkwXcf1gUBFpkmNN1iL1pqiFsepzryo2b/f7YhgQeTFWNnUS+THu+Btn0qUQSw==}
+  '@ahoo-wang/fetcher-react@2.12.9':
+    resolution: {integrity: sha512-eHvRxUacAiQl8nblhNpZQWhsux6UA69qWngHt2LPu9dNWUrq6zdYuLoJYJyHibzoTojcpBIT1qGH3we7r6i7zg==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^2.3.4
       '@ahoo-wang/fetcher-eventbus': ^2.8.8
@@ -178,20 +178,20 @@ packages:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
 
-  '@ahoo-wang/fetcher-storage@2.12.6':
-    resolution: {integrity: sha512-2aOFRwpCTMDkqIXfQkObl3SfvmVJRtHQTife77yB9eoNHPqekFztayIBjs9/bhdU+B7R2Y3K9Ikfb/jgLxLzgA==}
+  '@ahoo-wang/fetcher-storage@2.12.9':
+    resolution: {integrity: sha512-XfLr9mW9byw42YHlHCHNIK8TAD9dUCD/ReNrmyrZ+S/VVMk9u500OjlpRcVR4hq9Wy8kBZJ4fXBoBpisxjxmhg==}
     peerDependencies:
       '@ahoo-wang/fetcher-eventbus': ^2.8.5
 
-  '@ahoo-wang/fetcher-wow@2.12.6':
-    resolution: {integrity: sha512-cWO3TX9zml6IvFa+N4cHWAcDJovdNNOVs5Tj1v7kqiN2HQjFkxv9viwJmQDNPWpMwHiKq+0ubQNkYnNpvHwhzQ==}
+  '@ahoo-wang/fetcher-wow@2.12.9':
+    resolution: {integrity: sha512-6roQyeiMg3nZ5Y6pGFVitYpAaQTcFw26AzuOyr1NqLJHLvz7jvpT9SzuRbo81mDt95bb8RHWVo7yXhuN4Gy81A==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^2.3.4
       '@ahoo-wang/fetcher-decorator': ^2.3.4
       '@ahoo-wang/fetcher-eventstream': ^2.3.4
 
-  '@ahoo-wang/fetcher@2.12.6':
-    resolution: {integrity: sha512-X+uHMTDCGb2ZX32X83u/gfAnK3166UZrsVE0Rk2pmMG/VJ/GScuOi3qDVpihoGaN/SvUeF0To9sMNoPbS7A7wQ==}
+  '@ahoo-wang/fetcher@2.12.9':
+    resolution: {integrity: sha512-qFaBukXe33+H9e2L4NzV44ymwuVuCBy+gq9rrMdDtDnvD8D1E8usvyUQdwiTzuc5VtXOUxcco3RYLjpwZ/Ycxg==}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -555,8 +555,8 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
-  '@eslint-community/regexpp@4.12.1':
-    resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
   '@eslint/config-array@0.21.1':
@@ -1198,8 +1198,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.26.3:
-    resolution: {integrity: sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==}
+  browserslist@4.27.0:
+    resolution: {integrity: sha512-AXVQwdhot1eqLihwasPElhX2tAZiBjWdJ9i/Zcj2S6QYIjkx62OKSfnobkriB81C3l4w0rVy3Nt4jaTBltYEpw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -1324,8 +1324,8 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  electron-to-chromium@1.5.238:
-    resolution: {integrity: sha512-khBdc+w/Gv+cS8e/Pbnaw/FXcBUeKrRVik9IxfXtgREOWyJhR4tj43n3amkVogJ/yeQUqzkrZcFhtIxIdqmmcQ==}
+  electron-to-chromium@1.5.239:
+    resolution: {integrity: sha512-1y5w0Zsq39MSPmEjHjbizvhYoTaulVtivpxkp5q5kaPmQtsK6/2nvAzGRxNMS9DoYySp9PkW0MAQDwU1m764mg==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -2362,8 +2362,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  update-browserslist-db@1.1.3:
-    resolution: {integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==}
+  update-browserslist-db@1.1.4:
+    resolution: {integrity: sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
@@ -2550,60 +2550,60 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ahoo-wang/fetcher-cosec@2.12.6(@ahoo-wang/fetcher-eventbus@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher-storage@2.12.6(@ahoo-wang/fetcher-eventbus@2.12.6(@ahoo-wang/fetcher@2.12.6)))(@ahoo-wang/fetcher@2.12.6)':
+  '@ahoo-wang/fetcher-cosec@2.12.9(@ahoo-wang/fetcher-eventbus@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher-storage@2.12.9(@ahoo-wang/fetcher-eventbus@2.12.9(@ahoo-wang/fetcher@2.12.9)))(@ahoo-wang/fetcher@2.12.9)':
     dependencies:
-      '@ahoo-wang/fetcher': 2.12.6
-      '@ahoo-wang/fetcher-eventbus': 2.12.6(@ahoo-wang/fetcher@2.12.6)
-      '@ahoo-wang/fetcher-storage': 2.12.6(@ahoo-wang/fetcher-eventbus@2.12.6(@ahoo-wang/fetcher@2.12.6))
+      '@ahoo-wang/fetcher': 2.12.9
+      '@ahoo-wang/fetcher-eventbus': 2.12.9(@ahoo-wang/fetcher@2.12.9)
+      '@ahoo-wang/fetcher-storage': 2.12.9(@ahoo-wang/fetcher-eventbus@2.12.9(@ahoo-wang/fetcher@2.12.9))
       nanoid: 5.1.6
 
-  '@ahoo-wang/fetcher-decorator@2.12.6(@ahoo-wang/fetcher@2.12.6)':
+  '@ahoo-wang/fetcher-decorator@2.12.9(@ahoo-wang/fetcher@2.12.9)':
     dependencies:
-      '@ahoo-wang/fetcher': 2.12.6
+      '@ahoo-wang/fetcher': 2.12.9
       reflect-metadata: 0.2.2
 
-  '@ahoo-wang/fetcher-eventbus@2.12.6(@ahoo-wang/fetcher@2.12.6)':
+  '@ahoo-wang/fetcher-eventbus@2.12.9(@ahoo-wang/fetcher@2.12.9)':
     dependencies:
-      '@ahoo-wang/fetcher': 2.12.6
+      '@ahoo-wang/fetcher': 2.12.9
 
-  '@ahoo-wang/fetcher-eventstream@2.12.6(@ahoo-wang/fetcher@2.12.6)':
+  '@ahoo-wang/fetcher-eventstream@2.12.9(@ahoo-wang/fetcher@2.12.9)':
     dependencies:
-      '@ahoo-wang/fetcher': 2.12.6
+      '@ahoo-wang/fetcher': 2.12.9
 
-  '@ahoo-wang/fetcher-generator@2.12.6(@ahoo-wang/fetcher-decorator@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher-eventstream@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@2.12.6(@ahoo-wang/fetcher-decorator@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher-eventstream@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher@2.12.6)':
+  '@ahoo-wang/fetcher-generator@2.12.9(@ahoo-wang/fetcher-decorator@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher-eventstream@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@2.12.9(@ahoo-wang/fetcher-decorator@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher-eventstream@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher@2.12.9)':
     dependencies:
-      '@ahoo-wang/fetcher': 2.12.6
-      '@ahoo-wang/fetcher-decorator': 2.12.6(@ahoo-wang/fetcher@2.12.6)
-      '@ahoo-wang/fetcher-eventstream': 2.12.6(@ahoo-wang/fetcher@2.12.6)
+      '@ahoo-wang/fetcher': 2.12.9
+      '@ahoo-wang/fetcher-decorator': 2.12.9(@ahoo-wang/fetcher@2.12.9)
+      '@ahoo-wang/fetcher-eventstream': 2.12.9(@ahoo-wang/fetcher@2.12.9)
       '@ahoo-wang/fetcher-openapi': 2.3.0
-      '@ahoo-wang/fetcher-wow': 2.12.6(@ahoo-wang/fetcher-decorator@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher-eventstream@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher@2.12.6)
+      '@ahoo-wang/fetcher-wow': 2.12.9(@ahoo-wang/fetcher-decorator@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher-eventstream@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher@2.12.9)
       commander: 14.0.1
       ts-morph: 27.0.2
       yaml: 2.8.1
 
   '@ahoo-wang/fetcher-openapi@2.3.0': {}
 
-  '@ahoo-wang/fetcher-react@2.12.6(@ahoo-wang/fetcher-eventbus@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher-eventstream@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher-storage@2.12.6(@ahoo-wang/fetcher-eventbus@2.12.6(@ahoo-wang/fetcher@2.12.6)))(@ahoo-wang/fetcher-wow@2.12.6(@ahoo-wang/fetcher-decorator@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher-eventstream@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher@2.12.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@ahoo-wang/fetcher-react@2.12.9(@ahoo-wang/fetcher-eventbus@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher-eventstream@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher-storage@2.12.9(@ahoo-wang/fetcher-eventbus@2.12.9(@ahoo-wang/fetcher@2.12.9)))(@ahoo-wang/fetcher-wow@2.12.9(@ahoo-wang/fetcher-decorator@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher-eventstream@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher@2.12.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@ahoo-wang/fetcher': 2.12.6
-      '@ahoo-wang/fetcher-eventbus': 2.12.6(@ahoo-wang/fetcher@2.12.6)
-      '@ahoo-wang/fetcher-eventstream': 2.12.6(@ahoo-wang/fetcher@2.12.6)
-      '@ahoo-wang/fetcher-storage': 2.12.6(@ahoo-wang/fetcher-eventbus@2.12.6(@ahoo-wang/fetcher@2.12.6))
-      '@ahoo-wang/fetcher-wow': 2.12.6(@ahoo-wang/fetcher-decorator@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher-eventstream@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher@2.12.6)
+      '@ahoo-wang/fetcher': 2.12.9
+      '@ahoo-wang/fetcher-eventbus': 2.12.9(@ahoo-wang/fetcher@2.12.9)
+      '@ahoo-wang/fetcher-eventstream': 2.12.9(@ahoo-wang/fetcher@2.12.9)
+      '@ahoo-wang/fetcher-storage': 2.12.9(@ahoo-wang/fetcher-eventbus@2.12.9(@ahoo-wang/fetcher@2.12.9))
+      '@ahoo-wang/fetcher-wow': 2.12.9(@ahoo-wang/fetcher-decorator@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher-eventstream@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher@2.12.9)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@ahoo-wang/fetcher-storage@2.12.6(@ahoo-wang/fetcher-eventbus@2.12.6(@ahoo-wang/fetcher@2.12.6))':
+  '@ahoo-wang/fetcher-storage@2.12.9(@ahoo-wang/fetcher-eventbus@2.12.9(@ahoo-wang/fetcher@2.12.9))':
     dependencies:
-      '@ahoo-wang/fetcher-eventbus': 2.12.6(@ahoo-wang/fetcher@2.12.6)
+      '@ahoo-wang/fetcher-eventbus': 2.12.9(@ahoo-wang/fetcher@2.12.9)
 
-  '@ahoo-wang/fetcher-wow@2.12.6(@ahoo-wang/fetcher-decorator@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher-eventstream@2.12.6(@ahoo-wang/fetcher@2.12.6))(@ahoo-wang/fetcher@2.12.6)':
+  '@ahoo-wang/fetcher-wow@2.12.9(@ahoo-wang/fetcher-decorator@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher-eventstream@2.12.9(@ahoo-wang/fetcher@2.12.9))(@ahoo-wang/fetcher@2.12.9)':
     dependencies:
-      '@ahoo-wang/fetcher': 2.12.6
-      '@ahoo-wang/fetcher-decorator': 2.12.6(@ahoo-wang/fetcher@2.12.6)
-      '@ahoo-wang/fetcher-eventstream': 2.12.6(@ahoo-wang/fetcher@2.12.6)
+      '@ahoo-wang/fetcher': 2.12.9
+      '@ahoo-wang/fetcher-decorator': 2.12.9(@ahoo-wang/fetcher@2.12.9)
+      '@ahoo-wang/fetcher-eventstream': 2.12.9(@ahoo-wang/fetcher@2.12.9)
 
-  '@ahoo-wang/fetcher@2.12.6': {}
+  '@ahoo-wang/fetcher@2.12.9': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -2738,7 +2738,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.28.4
       '@babel/helper-validator-option': 7.27.1
-      browserslist: 4.26.3
+      browserslist: 4.27.0
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -2925,7 +2925,7 @@ snapshots:
       eslint: 9.38.0(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/regexpp@4.12.1': {}
+  '@eslint-community/regexpp@4.12.2': {}
 
   '@eslint/config-array@0.21.1':
     dependencies:
@@ -3336,7 +3336,7 @@ snapshots:
 
   '@typescript-eslint/eslint-plugin@8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/regexpp': 4.12.1
+      '@eslint-community/regexpp': 4.12.2
       '@typescript-eslint/parser': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.46.2
       '@typescript-eslint/type-utils': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
@@ -3652,13 +3652,13 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.26.3:
+  browserslist@4.27.0:
     dependencies:
       baseline-browser-mapping: 2.8.19
       caniuse-lite: 1.0.30001751
-      electron-to-chromium: 1.5.238
+      electron-to-chromium: 1.5.239
       node-releases: 2.0.26
-      update-browserslist-db: 1.1.3(browserslist@4.26.3)
+      update-browserslist-db: 1.1.4(browserslist@4.27.0)
 
   cac@6.7.14: {}
 
@@ -3757,7 +3757,7 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  electron-to-chromium@1.5.238: {}
+  electron-to-chromium@1.5.239: {}
 
   emoji-regex@8.0.0: {}
 
@@ -3832,7 +3832,7 @@ snapshots:
   eslint@9.38.0(jiti@2.6.1):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(jiti@2.6.1))
-      '@eslint-community/regexpp': 4.12.1
+      '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.21.1
       '@eslint/config-helpers': 0.4.1
       '@eslint/core': 0.16.0
@@ -4856,9 +4856,9 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  update-browserslist-db@1.1.3(browserslist@4.26.3):
+  update-browserslist-db@1.1.4(browserslist@4.27.0):
     dependencies:
-      browserslist: 4.26.3
+      browserslist: 4.27.0
       escalade: 3.2.0
       picocolors: 1.1.1
 


### PR DESCRIPTION
- Updated all @ahoo-wang/fetcher related dependencies from 2.12.6 to 2.12.9
- Updated @ahoo-wang/fetcher-generator from2.12.6 to 2.12.9
- Updated browserslist from4.26.3 to 4.27.0
- Updated electron-to-chromium from 1.5.238 to1.5.239
- Updated update-browserslist-db from 1.1.3 to1.1.4
- Updated @eslint-community/regexpp from 4.12.1 to 4.12.2

