### PR TITLE
chore(deps): update fetcher dependencies to v2.15.3

### DIFF
--- a/compensation/dashboard/package.json
+++ b/compensation/dashboard/package.json
@@ -14,15 +14,15 @@
     "generate": "fetcher-generator generate -i http://compensation-service.dev.svc.cluster.local/v3/api-docs -o src/generated"
   },
   "dependencies": {
-    "@ahoo-wang/fetcher": "^2.13.11",
-    "@ahoo-wang/fetcher-cosec": "^2.13.11",
-    "@ahoo-wang/fetcher-decorator": "^2.13.11",
-    "@ahoo-wang/fetcher-eventbus": "^2.13.11",
-    "@ahoo-wang/fetcher-eventstream": "^2.13.11",
-    "@ahoo-wang/fetcher-react": "^2.13.11",
-    "@ahoo-wang/fetcher-storage": "^2.13.11",
-    "@ahoo-wang/fetcher-viewer": "^2.13.11",
-    "@ahoo-wang/fetcher-wow": "^2.13.10",
+    "@ahoo-wang/fetcher": "^2.15.3",
+    "@ahoo-wang/fetcher-cosec": "^2.15.3",
+    "@ahoo-wang/fetcher-decorator": "^2.15.3",
+    "@ahoo-wang/fetcher-eventbus": "^2.15.3",
+    "@ahoo-wang/fetcher-eventstream": "^2.15.3",
+    "@ahoo-wang/fetcher-react": "^2.15.3",
+    "@ahoo-wang/fetcher-storage": "^2.15.3",
+    "@ahoo-wang/fetcher-viewer": "^2.15.3",
+    "@ahoo-wang/fetcher-wow": "^2.15.3",
     "@ant-design/icons": "^6.1.0",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@monaco-editor/react": "4.7.0",
@@ -30,11 +30,10 @@
     "dayjs": "^1.11.18",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-router": "^7.9.4",
-    "tailwindcss": "^4.1.16"
+    "react-router": "^7.9.5"
   },
   "devDependencies": {
-    "@ahoo-wang/fetcher-generator": "^2.13.11",
+    "@ahoo-wang/fetcher-generator": "^2.15.3",
     "@eslint/js": "^9.38.0",
     "@tailwindcss/vite": "^4.1.16",
     "@testing-library/jest-dom": "^6.9.1",
@@ -56,6 +55,7 @@
     "vite": "^7.1.12",
     "vite-bundle-analyzer": "^1.2.3",
     "vitest": "^3.2.4",
-    "vitest-browser-react": "^1.0.1"
+    "vitest-browser-react": "^1.0.1",
+    "tailwindcss": "^4.1.16"
   }
 }

--- a/compensation/dashboard/pnpm-lock.yaml
+++ b/compensation/dashboard/pnpm-lock.yaml
@@ -9,32 +9,32 @@ importers:
   .:
     dependencies:
       '@ahoo-wang/fetcher':
-        specifier: ^2.13.11
-        version: 2.13.11
+        specifier: ^2.15.3
+        version: 2.15.3
       '@ahoo-wang/fetcher-cosec':
-        specifier: ^2.13.11
-        version: 2.13.11(@ahoo-wang/fetcher-eventbus@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher-storage@2.13.11(@ahoo-wang/fetcher-eventbus@2.13.11(@ahoo-wang/fetcher@2.13.11)))(@ahoo-wang/fetcher@2.13.11)
+        specifier: ^2.15.3
+        version: 2.15.3(@ahoo-wang/fetcher-eventbus@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher-storage@2.15.3(@ahoo-wang/fetcher-eventbus@2.15.3(@ahoo-wang/fetcher@2.15.3)))(@ahoo-wang/fetcher@2.15.3)
       '@ahoo-wang/fetcher-decorator':
-        specifier: ^2.13.11
-        version: 2.13.11(@ahoo-wang/fetcher@2.13.11)
+        specifier: ^2.15.3
+        version: 2.15.3(@ahoo-wang/fetcher@2.15.3)
       '@ahoo-wang/fetcher-eventbus':
-        specifier: ^2.13.11
-        version: 2.13.11(@ahoo-wang/fetcher@2.13.11)
+        specifier: ^2.15.3
+        version: 2.15.3(@ahoo-wang/fetcher@2.15.3)
       '@ahoo-wang/fetcher-eventstream':
-        specifier: ^2.13.11
-        version: 2.13.11(@ahoo-wang/fetcher@2.13.11)
+        specifier: ^2.15.3
+        version: 2.15.3(@ahoo-wang/fetcher@2.15.3)
       '@ahoo-wang/fetcher-react':
-        specifier: ^2.13.11
-        version: 2.13.11(@ahoo-wang/fetcher-eventbus@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher-eventstream@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher-storage@2.13.11(@ahoo-wang/fetcher-eventbus@2.13.11(@ahoo-wang/fetcher@2.13.11)))(@ahoo-wang/fetcher-wow@2.13.10(@ahoo-wang/fetcher-decorator@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher-eventstream@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher@2.13.11)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^2.15.3
+        version: 2.15.3(@ahoo-wang/fetcher-eventbus@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher-eventstream@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher-storage@2.15.3(@ahoo-wang/fetcher-eventbus@2.15.3(@ahoo-wang/fetcher@2.15.3)))(@ahoo-wang/fetcher-wow@2.15.3(@ahoo-wang/fetcher-decorator@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher-eventstream@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher@2.15.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@ahoo-wang/fetcher-storage':
-        specifier: ^2.13.11
-        version: 2.13.11(@ahoo-wang/fetcher-eventbus@2.13.11(@ahoo-wang/fetcher@2.13.11))
+        specifier: ^2.15.3
+        version: 2.15.3(@ahoo-wang/fetcher-eventbus@2.15.3(@ahoo-wang/fetcher@2.15.3))
       '@ahoo-wang/fetcher-viewer':
-        specifier: ^2.13.11
-        version: 2.13.11(d3179586a5c572437ec10cba69449b37)
+        specifier: ^2.15.3
+        version: 2.15.3(12fe5b959a21fe295a120947e1541885)
       '@ahoo-wang/fetcher-wow':
-        specifier: ^2.13.10
-        version: 2.13.10(@ahoo-wang/fetcher-decorator@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher-eventstream@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher@2.13.11)
+        specifier: ^2.15.3
+        version: 2.15.3(@ahoo-wang/fetcher-decorator@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher-eventstream@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher@2.15.3)
       '@ant-design/icons':
         specifier: ^6.1.0
         version: 6.1.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -57,15 +57,12 @@ importers:
         specifier: ^19.2.0
         version: 19.2.0(react@19.2.0)
       react-router:
-        specifier: ^7.9.4
-        version: 7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      tailwindcss:
-        specifier: ^4.1.16
-        version: 4.1.16
+        specifier: ^7.9.5
+        version: 7.9.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     devDependencies:
       '@ahoo-wang/fetcher-generator':
-        specifier: ^2.13.11
-        version: 2.13.11(@ahoo-wang/fetcher-decorator@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher-eventstream@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@2.13.10(@ahoo-wang/fetcher-decorator@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher-eventstream@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher@2.13.11)
+        specifier: ^2.15.3
+        version: 2.15.3(@ahoo-wang/fetcher-decorator@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher-eventstream@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@2.15.3(@ahoo-wang/fetcher-decorator@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher-eventstream@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher@2.15.3)
       '@eslint/js':
         specifier: ^9.38.0
         version: 9.38.0
@@ -114,6 +111,9 @@ importers:
       prettier:
         specifier: 3.6.2
         version: 3.6.2
+      tailwindcss:
+        specifier: ^4.1.16
+        version: 4.1.16
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -138,30 +138,30 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@ahoo-wang/fetcher-cosec@2.13.11':
-    resolution: {integrity: sha512-48FdRiK9u5Rs6ZyZjg7hmASUCqW3olGB22D1yexp56Sd26Tn0ZKVqiwM86hTZ7sqtaVG+RUGDkp38a1wBcEnDg==}
+  '@ahoo-wang/fetcher-cosec@2.15.3':
+    resolution: {integrity: sha512-zwu12jwfY2x/Qjn/wO3lQfOvr9YK7yPy+t0Depaxew4hL2P6lvaGIoW6LkkYYZxKySIzXqb0kFO1NaTH5LkfNw==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^2.3.4
       '@ahoo-wang/fetcher-eventbus': ^2.8.5
       '@ahoo-wang/fetcher-storage': ^2.3.4
 
-  '@ahoo-wang/fetcher-decorator@2.13.11':
-    resolution: {integrity: sha512-QSI+Mfx1d9TSZotkjZyMU2DyOAM5u+WpD6DcLrkjA6ZQh++oipnSREIwKh04LAL5r11YM3EPR30gHNfHrineDA==}
+  '@ahoo-wang/fetcher-decorator@2.15.3':
+    resolution: {integrity: sha512-IrqOMddZxOv2cAHwIAtDK/5jfBX1Ud27iQ4uesHhT6BPwF3APxlkXyfzRw1i/v1DD1XHLqRrsTN2QbvRzXeHcg==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^2.9.3
 
-  '@ahoo-wang/fetcher-eventbus@2.13.11':
-    resolution: {integrity: sha512-he5lJtadJhSLyNM4MU8qhnkRJL3oAKXyR9prJXorNfzg+lYjN+8wuKLKMlfVxaJAyHxUZofZYR2vDaqCkAbpkg==}
+  '@ahoo-wang/fetcher-eventbus@2.15.3':
+    resolution: {integrity: sha512-NYM+eIUm8k75B26OVkgEBYd1LxCQuHo5jKB7F9Q8HyFYarsSnL3dHXyWqT7SRK+TBX/QrXOvwzucchP5hijPCg==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^2.3.4
 
-  '@ahoo-wang/fetcher-eventstream@2.13.11':
-    resolution: {integrity: sha512-ltXboQZcWV7h5lLcza5RX3KrXcie9l4SePgBSxDANREbA44ZugIQYKswmItqVhU1lVVxO970rxw/197mmHHrQg==}
+  '@ahoo-wang/fetcher-eventstream@2.15.3':
+    resolution: {integrity: sha512-HOxzF1aW7fMeU6Am8AghavyCgoQs/owPy24JsfVNwPuvyBVdlaEhAZcl4whrDN6CrlFul/XZ6zB3MET39F7g/Q==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^2.3.4
 
-  '@ahoo-wang/fetcher-generator@2.13.11':
-    resolution: {integrity: sha512-beemf7u42TDQ+Offtz6Z2mWxRbE+3USP8QjV1inneVEZg/An3hBMSLOQLsPFIAfY0kxFuygpzjsPZvutUW8TTw==}
+  '@ahoo-wang/fetcher-generator@2.15.3':
+    resolution: {integrity: sha512-8EiP6Amgn6eTtToArZ6vhJFU5J1gPfrfDIWZyXJZ/aLo8J+mGP7l38BSsmkSwcLWq6FzEuuFJP6U1OSv/9dUXQ==}
     hasBin: true
     peerDependencies:
       '@ahoo-wang/fetcher': ^2.3.4
@@ -173,8 +173,8 @@ packages:
   '@ahoo-wang/fetcher-openapi@2.3.0':
     resolution: {integrity: sha512-He3I/VovQzLNajxL2hoUZKlAnt0ZpehpMpbjgxvdPEoWfeAA3qZc0+C8Mhrk3HQQAC69lZOSt3JtAvzYDxpn/Q==}
 
-  '@ahoo-wang/fetcher-react@2.13.11':
-    resolution: {integrity: sha512-pa1rq0rT5KzL+WOlwsrY1+lYNxgK4BhH/tuV1OGgSj+c7S8Xh6oENGUegCCDOIDoFuxnT++dlicKovC2ooKf+g==}
+  '@ahoo-wang/fetcher-react@2.15.3':
+    resolution: {integrity: sha512-Yedd81W+YhC/nYYj/8VaE95HbOXNMfB6PQxeTHZPsjnyUVgvonD8Sj82953BGjNPNKdyHZCJnQJSqQjZIUZxHA==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^2.3.4
       '@ahoo-wang/fetcher-eventbus': ^2.8.8
@@ -184,13 +184,13 @@ packages:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
 
-  '@ahoo-wang/fetcher-storage@2.13.11':
-    resolution: {integrity: sha512-h+m02evVos0FNxR3jtmB3LptziuLe2rGoipLiMrFcRuXopuyZKCPOOFJDi3kJeUA+swttizUu5v4jLuH8OgY/Q==}
+  '@ahoo-wang/fetcher-storage@2.15.3':
+    resolution: {integrity: sha512-fuyGxAEQdOf+h2udPPsticrTYXJHlvgl0AMXpeg1Phz1zLHFRFeCDg3YAFqVoHEIr2QoezOjio6+TMVcSsDRQQ==}
     peerDependencies:
       '@ahoo-wang/fetcher-eventbus': ^2.8.5
 
-  '@ahoo-wang/fetcher-viewer@2.13.11':
-    resolution: {integrity: sha512-+tZLfeA9oDmVsxEpVt/beEigi7xn5PVyhtO4kg+KdZ6HpZTU3vi0pGJh7SC/p65IDuCeZ9vlnBdtLvKmyqobTA==}
+  '@ahoo-wang/fetcher-viewer@2.15.3':
+    resolution: {integrity: sha512-+YoKDVQmGZbTIDLci2/50ENsnSSgMRwWm7tk+gqcvrOErqBiT66/Cd62agr9Eab4uDI8ubjNFsEs03RJQJFk1Q==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^2.3.4
       '@ahoo-wang/fetcher-openapi': ^2.3.4
@@ -202,15 +202,15 @@ packages:
       react: '>=19.0.0'
       react-dom: '>=19.0.0'
 
-  '@ahoo-wang/fetcher-wow@2.13.10':
-    resolution: {integrity: sha512-sO+qmNTM+m0HYk0VL5UE5929FfFqadgSS3MMBeWiCTbdhcbHROfKiVjRfQhe1qH+iaI8H3sW3DoLpBaZt0PFlA==}
+  '@ahoo-wang/fetcher-wow@2.15.3':
+    resolution: {integrity: sha512-iVmS7urOOrsHDe7cpPtgTQ2PiiB1CE7FLk/NacoXhIENkrCIENC2IkhW/Zc4gVR8N/KWD5ROYBdVFKBDnIBEIA==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^2.3.4
       '@ahoo-wang/fetcher-decorator': ^2.3.4
       '@ahoo-wang/fetcher-eventstream': ^2.3.4
 
-  '@ahoo-wang/fetcher@2.13.11':
-    resolution: {integrity: sha512-dQkpIazv2gZ+D2DroX5pT05tySD2GpWv6Kxs/2aVCRAIOTTcK26HZSmAcu2ARfKf74pLrsOCB8fQ4iapnk1lNw==}
+  '@ahoo-wang/fetcher@2.15.3':
+    resolution: {integrity: sha512-w4VbsJ4jvmvWZikUFzOS3CgU8WMqn152DICnwePVePAt9K2x+B5EVoY6Wi1exziUAvTfQFv8OvtSnAL9dLNfKw==}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -582,12 +582,16 @@ packages:
     resolution: {integrity: sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/config-helpers@0.4.1':
-    resolution: {integrity: sha512-csZAzkNhsgwb0I/UAV6/RGFTbiakPCf0ZrGmrIxQpYvGZ00PhTkSnyKNolphgIvmnJeGw6rcGVEXfTzUnFuEvw==}
+  '@eslint/config-helpers@0.4.2':
+    resolution: {integrity: sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/core@0.16.0':
     resolution: {integrity: sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@eslint/core@0.17.0':
+    resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/eslintrc@3.3.1':
@@ -602,8 +606,8 @@ packages:
     resolution: {integrity: sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/plugin-kit@0.4.0':
-    resolution: {integrity: sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==}
+  '@eslint/plugin-kit@0.4.1':
+    resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@humanfs/core@0.19.1':
@@ -1003,9 +1007,6 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/js-cookie@2.2.7':
-    resolution: {integrity: sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==}
-
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -1140,9 +1141,6 @@ packages:
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
-  '@xobotyi/scrollbar-width@1.9.5':
-    resolution: {integrity: sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==}
-
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1209,8 +1207,8 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  baseline-browser-mapping@2.8.20:
-    resolution: {integrity: sha512-JMWsdF+O8Orq3EMukbUN1QfbLK9mX2CkUmQBcW2T0s8OmdAUL5LLM/6wFwSrqXzlXB13yhyK9gTKS1rIizOduQ==}
+  baseline-browser-mapping@2.8.21:
+    resolution: {integrity: sha512-JU0h5APyQNsHOlAM7HnQnPToSDQoEBZqzu/YBlqDnEeymPnZDREeXJA3KBMQee+dKteAxZ2AtvQEvVYdZf241Q==}
     hasBin: true
 
   bidi-js@1.0.3:
@@ -1295,13 +1293,6 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  css-in-js-utils@3.1.0:
-    resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
-
-  css-tree@1.1.3:
-    resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
-    engines: {node: '>=8.0.0'}
-
   css-tree@3.1.0:
     resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
@@ -1359,8 +1350,8 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  electron-to-chromium@1.5.241:
-    resolution: {integrity: sha512-ILMvKX/ZV5WIJzzdtuHg8xquk2y0BOGlFOxBVwTpbiXqWIH0hamG45ddU4R3PQ0gYu+xgo0vdHXHli9sHIGb4w==}
+  electron-to-chromium@1.5.243:
+    resolution: {integrity: sha512-ZCphxFW3Q1TVhcgS9blfut1PX8lusVi2SvXQgmEEnK4TCmE1JhH2JkjJN+DNt0pJJwfBri5AROBnz2b/C+YU9g==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -1375,9 +1366,6 @@ packages:
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
-
-  error-stack-parser@2.1.4:
-    resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -1467,12 +1455,6 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
-
-  fast-shallow-equal@1.0.0:
-    resolution: {integrity: sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==}
-
-  fastest-stable-stringify@2.0.2:
-    resolution: {integrity: sha512-bijHueCGd0LqqNK9b5oCMHc0MluJAx0cwqASgbWMvkO01lCYgIhacVRLcaDz3QnyYIRNJRDwMb41VuT6pHJ91Q==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -1572,9 +1554,6 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
-  hyphenate-style-name@1.1.0:
-    resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
-
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
@@ -1598,9 +1577,6 @@ packages:
   indent-string@4.0.0:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
-
-  inline-style-prefixer@7.0.1:
-    resolution: {integrity: sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1649,9 +1625,6 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
-
-  js-cookie@2.2.1:
-    resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1805,9 +1778,6 @@ packages:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
 
-  mdn-data@2.0.14:
-    resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
-
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
@@ -1823,8 +1793,8 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
-  minimatch@10.0.3:
-    resolution: {integrity: sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==}
+  minimatch@10.1.1:
+    resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
 
   minimatch@3.1.2:
@@ -1848,12 +1818,6 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  nano-css@5.6.2:
-    resolution: {integrity: sha512-+6bHaC8dSDGALM1HJjOHVXpuastdu2xFoZlC77Jh4cg+33Zcgm+Gxd+1xsnpZK14eyHObSp82+ll5y3SX75liw==}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
-
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -1867,8 +1831,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  node-releases@2.0.26:
-    resolution: {integrity: sha512-S2M9YimhSjBSvYnlr5/+umAnPHE++ODwt5e2Ij6FoX45HA/s4vHdkDx1eax2pAPeAOqu4s9b7ppahsyEFdVqQA==}
+  node-releases@2.0.27:
+    resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1985,8 +1949,8 @@ packages:
       react: '>=16.11.0'
       react-dom: '>=16.11.0'
 
-  rc-field-form@2.7.0:
-    resolution: {integrity: sha512-hgKsCay2taxzVnBPZl+1n4ZondsV78G++XVsMIJCAoioMjlMQR9YwAp7JZDIECzIu2Z66R+f4SFIRrO2DjDNAA==}
+  rc-field-form@2.7.1:
+    resolution: {integrity: sha512-vKeSifSJ6HoLaAB+B8aq/Qgm8a3dyxROzCtKNCsBQgiverpc4kWDQihoUwzUj+zNWJOykwSY4dNX3QrGwtVb9A==}
     engines: {node: '>=8.x'}
     peerDependencies:
       react: '>=16.9.0'
@@ -2192,8 +2156,8 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
-  react-router@7.9.4:
-    resolution: {integrity: sha512-SD3G8HKviFHg9xj7dNODUKDFgpG4xqD5nhyd0mYoB5iISepuZAvzSr8ywxgxKJ52yRzf/HWtVHc9AWwoTbljvA==}
+  react-router@7.9.5:
+    resolution: {integrity: sha512-JmxqrnBZ6E9hWmf02jzNn9Jm3UqyeimyiwzD69NjxGySG6lIz/1LVPsoTCwN7NBX2XjCEa1LIX5EMz1j2b6u6A==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -2201,18 +2165,6 @@ packages:
     peerDependenciesMeta:
       react-dom:
         optional: true
-
-  react-universal-interface@0.6.2:
-    resolution: {integrity: sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==}
-    peerDependencies:
-      react: '*'
-      tslib: '*'
-
-  react-use@17.6.0:
-    resolution: {integrity: sha512-OmedEScUMKFfzn1Ir8dBxiLLSOzhKe/dPZwVxcujweSj45aNM7BEGPb9BEVIgVEqEXx6f3/TsXzwIktNgUR02g==}
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
 
   react@19.2.0:
     resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
@@ -2248,9 +2200,6 @@ packages:
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
-  rtl-css-js@1.16.1:
-    resolution: {integrity: sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==}
-
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -2263,10 +2212,6 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
-
-  screenfull@5.2.0:
-    resolution: {integrity: sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==}
-    engines: {node: '>=0.10.0'}
 
   scroll-into-view-if-needed@3.1.0:
     resolution: {integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==}
@@ -2282,10 +2227,6 @@ packages:
 
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
-
-  set-harmonic-interval@1.0.1:
-    resolution: {integrity: sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g==}
-    engines: {node: '>=6.9'}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -2310,28 +2251,8 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
-  source-map@0.5.6:
-    resolution: {integrity: sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==}
-    engines: {node: '>=0.10.0'}
-
-  source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
-    engines: {node: '>=0.10.0'}
-
-  stack-generator@2.0.10:
-    resolution: {integrity: sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==}
-
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
-
-  stackframe@1.3.4:
-    resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
-
-  stacktrace-gps@3.1.2:
-    resolution: {integrity: sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==}
-
-  stacktrace-js@2.0.2:
-    resolution: {integrity: sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==}
 
   state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
@@ -2389,10 +2310,6 @@ packages:
   test-exclude@7.0.1:
     resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
     engines: {node: '>=18'}
-
-  throttle-debounce@3.0.1:
-    resolution: {integrity: sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==}
-    engines: {node: '>=10'}
 
   throttle-debounce@5.0.2:
     resolution: {integrity: sha512-B71/4oyj61iNH0KeCamLuE2rmKuTO5byTOSVwECM5FA7TiAiAW+UqTKZ9ERueC4qvgSttUhdmq1mXC3kJqGX7A==}
@@ -2452,14 +2369,8 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
-  ts-easing@0.2.0:
-    resolution: {integrity: sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==}
-
   ts-morph@27.0.2:
     resolution: {integrity: sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==}
-
-  tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2665,73 +2576,72 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ahoo-wang/fetcher-cosec@2.13.11(@ahoo-wang/fetcher-eventbus@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher-storage@2.13.11(@ahoo-wang/fetcher-eventbus@2.13.11(@ahoo-wang/fetcher@2.13.11)))(@ahoo-wang/fetcher@2.13.11)':
+  '@ahoo-wang/fetcher-cosec@2.15.3(@ahoo-wang/fetcher-eventbus@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher-storage@2.15.3(@ahoo-wang/fetcher-eventbus@2.15.3(@ahoo-wang/fetcher@2.15.3)))(@ahoo-wang/fetcher@2.15.3)':
     dependencies:
-      '@ahoo-wang/fetcher': 2.13.11
-      '@ahoo-wang/fetcher-eventbus': 2.13.11(@ahoo-wang/fetcher@2.13.11)
-      '@ahoo-wang/fetcher-storage': 2.13.11(@ahoo-wang/fetcher-eventbus@2.13.11(@ahoo-wang/fetcher@2.13.11))
+      '@ahoo-wang/fetcher': 2.15.3
+      '@ahoo-wang/fetcher-eventbus': 2.15.3(@ahoo-wang/fetcher@2.15.3)
+      '@ahoo-wang/fetcher-storage': 2.15.3(@ahoo-wang/fetcher-eventbus@2.15.3(@ahoo-wang/fetcher@2.15.3))
       nanoid: 5.1.6
 
-  '@ahoo-wang/fetcher-decorator@2.13.11(@ahoo-wang/fetcher@2.13.11)':
+  '@ahoo-wang/fetcher-decorator@2.15.3(@ahoo-wang/fetcher@2.15.3)':
     dependencies:
-      '@ahoo-wang/fetcher': 2.13.11
+      '@ahoo-wang/fetcher': 2.15.3
       reflect-metadata: 0.2.2
 
-  '@ahoo-wang/fetcher-eventbus@2.13.11(@ahoo-wang/fetcher@2.13.11)':
+  '@ahoo-wang/fetcher-eventbus@2.15.3(@ahoo-wang/fetcher@2.15.3)':
     dependencies:
-      '@ahoo-wang/fetcher': 2.13.11
+      '@ahoo-wang/fetcher': 2.15.3
 
-  '@ahoo-wang/fetcher-eventstream@2.13.11(@ahoo-wang/fetcher@2.13.11)':
+  '@ahoo-wang/fetcher-eventstream@2.15.3(@ahoo-wang/fetcher@2.15.3)':
     dependencies:
-      '@ahoo-wang/fetcher': 2.13.11
+      '@ahoo-wang/fetcher': 2.15.3
 
-  '@ahoo-wang/fetcher-generator@2.13.11(@ahoo-wang/fetcher-decorator@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher-eventstream@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@2.13.10(@ahoo-wang/fetcher-decorator@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher-eventstream@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher@2.13.11)':
+  '@ahoo-wang/fetcher-generator@2.15.3(@ahoo-wang/fetcher-decorator@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher-eventstream@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@2.15.3(@ahoo-wang/fetcher-decorator@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher-eventstream@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher@2.15.3)':
     dependencies:
-      '@ahoo-wang/fetcher': 2.13.11
-      '@ahoo-wang/fetcher-decorator': 2.13.11(@ahoo-wang/fetcher@2.13.11)
-      '@ahoo-wang/fetcher-eventstream': 2.13.11(@ahoo-wang/fetcher@2.13.11)
+      '@ahoo-wang/fetcher': 2.15.3
+      '@ahoo-wang/fetcher-decorator': 2.15.3(@ahoo-wang/fetcher@2.15.3)
+      '@ahoo-wang/fetcher-eventstream': 2.15.3(@ahoo-wang/fetcher@2.15.3)
       '@ahoo-wang/fetcher-openapi': 2.3.0
-      '@ahoo-wang/fetcher-wow': 2.13.10(@ahoo-wang/fetcher-decorator@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher-eventstream@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher@2.13.11)
+      '@ahoo-wang/fetcher-wow': 2.15.3(@ahoo-wang/fetcher-decorator@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher-eventstream@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher@2.15.3)
       commander: 14.0.2
       ts-morph: 27.0.2
       yaml: 2.8.1
 
   '@ahoo-wang/fetcher-openapi@2.3.0': {}
 
-  '@ahoo-wang/fetcher-react@2.13.11(@ahoo-wang/fetcher-eventbus@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher-eventstream@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher-storage@2.13.11(@ahoo-wang/fetcher-eventbus@2.13.11(@ahoo-wang/fetcher@2.13.11)))(@ahoo-wang/fetcher-wow@2.13.10(@ahoo-wang/fetcher-decorator@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher-eventstream@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher@2.13.11)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@ahoo-wang/fetcher-react@2.15.3(@ahoo-wang/fetcher-eventbus@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher-eventstream@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher-storage@2.15.3(@ahoo-wang/fetcher-eventbus@2.15.3(@ahoo-wang/fetcher@2.15.3)))(@ahoo-wang/fetcher-wow@2.15.3(@ahoo-wang/fetcher-decorator@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher-eventstream@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher@2.15.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@ahoo-wang/fetcher': 2.13.11
-      '@ahoo-wang/fetcher-eventbus': 2.13.11(@ahoo-wang/fetcher@2.13.11)
-      '@ahoo-wang/fetcher-eventstream': 2.13.11(@ahoo-wang/fetcher@2.13.11)
-      '@ahoo-wang/fetcher-storage': 2.13.11(@ahoo-wang/fetcher-eventbus@2.13.11(@ahoo-wang/fetcher@2.13.11))
-      '@ahoo-wang/fetcher-wow': 2.13.10(@ahoo-wang/fetcher-decorator@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher-eventstream@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher@2.13.11)
+      '@ahoo-wang/fetcher': 2.15.3
+      '@ahoo-wang/fetcher-eventbus': 2.15.3(@ahoo-wang/fetcher@2.15.3)
+      '@ahoo-wang/fetcher-eventstream': 2.15.3(@ahoo-wang/fetcher@2.15.3)
+      '@ahoo-wang/fetcher-storage': 2.15.3(@ahoo-wang/fetcher-eventbus@2.15.3(@ahoo-wang/fetcher@2.15.3))
+      '@ahoo-wang/fetcher-wow': 2.15.3(@ahoo-wang/fetcher-decorator@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher-eventstream@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher@2.15.3)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@ahoo-wang/fetcher-storage@2.13.11(@ahoo-wang/fetcher-eventbus@2.13.11(@ahoo-wang/fetcher@2.13.11))':
+  '@ahoo-wang/fetcher-storage@2.15.3(@ahoo-wang/fetcher-eventbus@2.15.3(@ahoo-wang/fetcher@2.15.3))':
     dependencies:
-      '@ahoo-wang/fetcher-eventbus': 2.13.11(@ahoo-wang/fetcher@2.13.11)
+      '@ahoo-wang/fetcher-eventbus': 2.15.3(@ahoo-wang/fetcher@2.15.3)
 
-  '@ahoo-wang/fetcher-viewer@2.13.11(d3179586a5c572437ec10cba69449b37)':
+  '@ahoo-wang/fetcher-viewer@2.15.3(12fe5b959a21fe295a120947e1541885)':
     dependencies:
-      '@ahoo-wang/fetcher': 2.13.11
+      '@ahoo-wang/fetcher': 2.15.3
       '@ahoo-wang/fetcher-openapi': 2.3.0
-      '@ahoo-wang/fetcher-react': 2.13.11(@ahoo-wang/fetcher-eventbus@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher-eventstream@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher-storage@2.13.11(@ahoo-wang/fetcher-eventbus@2.13.11(@ahoo-wang/fetcher@2.13.11)))(@ahoo-wang/fetcher-wow@2.13.10(@ahoo-wang/fetcher-decorator@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher-eventstream@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher@2.13.11)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@ahoo-wang/fetcher-storage': 2.13.11(@ahoo-wang/fetcher-eventbus@2.13.11(@ahoo-wang/fetcher@2.13.11))
-      '@ahoo-wang/fetcher-wow': 2.13.10(@ahoo-wang/fetcher-decorator@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher-eventstream@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher@2.13.11)
+      '@ahoo-wang/fetcher-react': 2.15.3(@ahoo-wang/fetcher-eventbus@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher-eventstream@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher-storage@2.15.3(@ahoo-wang/fetcher-eventbus@2.15.3(@ahoo-wang/fetcher@2.15.3)))(@ahoo-wang/fetcher-wow@2.15.3(@ahoo-wang/fetcher-decorator@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher-eventstream@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher@2.15.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@ahoo-wang/fetcher-storage': 2.15.3(@ahoo-wang/fetcher-eventbus@2.15.3(@ahoo-wang/fetcher@2.15.3))
+      '@ahoo-wang/fetcher-wow': 2.15.3(@ahoo-wang/fetcher-decorator@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher-eventstream@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher@2.15.3)
       '@ant-design/icons': 6.1.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       antd: 5.27.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      react-use: 17.6.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
 
-  '@ahoo-wang/fetcher-wow@2.13.10(@ahoo-wang/fetcher-decorator@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher-eventstream@2.13.11(@ahoo-wang/fetcher@2.13.11))(@ahoo-wang/fetcher@2.13.11)':
+  '@ahoo-wang/fetcher-wow@2.15.3(@ahoo-wang/fetcher-decorator@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher-eventstream@2.15.3(@ahoo-wang/fetcher@2.15.3))(@ahoo-wang/fetcher@2.15.3)':
     dependencies:
-      '@ahoo-wang/fetcher': 2.13.11
-      '@ahoo-wang/fetcher-decorator': 2.13.11(@ahoo-wang/fetcher@2.13.11)
-      '@ahoo-wang/fetcher-eventstream': 2.13.11(@ahoo-wang/fetcher@2.13.11)
+      '@ahoo-wang/fetcher': 2.15.3
+      '@ahoo-wang/fetcher-decorator': 2.15.3(@ahoo-wang/fetcher@2.15.3)
+      '@ahoo-wang/fetcher-eventstream': 2.15.3(@ahoo-wang/fetcher@2.15.3)
 
-  '@ahoo-wang/fetcher@2.13.11': {}
+  '@ahoo-wang/fetcher@2.15.3': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -3063,11 +2973,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@eslint/config-helpers@0.4.1':
+  '@eslint/config-helpers@0.4.2':
     dependencies:
-      '@eslint/core': 0.16.0
+      '@eslint/core': 0.17.0
 
   '@eslint/core@0.16.0':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/core@0.17.0':
     dependencies:
       '@types/json-schema': 7.0.15
 
@@ -3089,9 +3003,9 @@ snapshots:
 
   '@eslint/object-schema@2.1.7': {}
 
-  '@eslint/plugin-kit@0.4.0':
+  '@eslint/plugin-kit@0.4.1':
     dependencies:
-      '@eslint/core': 0.16.0
+      '@eslint/core': 0.17.0
       levn: 0.4.1
 
   '@humanfs/core@0.19.1': {}
@@ -3416,7 +3330,7 @@ snapshots:
 
   '@ts-morph/common@0.28.1':
     dependencies:
-      minimatch: 10.0.3
+      minimatch: 10.1.1
       path-browserify: 1.0.1
       tinyglobby: 0.2.15
 
@@ -3451,8 +3365,6 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
-
-  '@types/js-cookie@2.2.7': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -3660,8 +3572,6 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
-  '@xobotyi/scrollbar-width@1.9.5': {}
-
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -3712,7 +3622,7 @@ snapshots:
       rc-dialog: 9.6.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       rc-drawer: 7.3.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       rc-dropdown: 4.2.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      rc-field-form: 2.7.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      rc-field-form: 2.7.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       rc-image: 7.12.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       rc-input: 1.8.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       rc-input-number: 9.5.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -3769,7 +3679,7 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  baseline-browser-mapping@2.8.20: {}
+  baseline-browser-mapping@2.8.21: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -3790,10 +3700,10 @@ snapshots:
 
   browserslist@4.27.0:
     dependencies:
-      baseline-browser-mapping: 2.8.20
+      baseline-browser-mapping: 2.8.21
       caniuse-lite: 1.0.30001751
-      electron-to-chromium: 1.5.241
-      node-releases: 2.0.26
+      electron-to-chromium: 1.5.243
+      node-releases: 2.0.27
       update-browserslist-db: 1.1.4(browserslist@4.27.0)
 
   cac@6.7.14: {}
@@ -3849,15 +3759,6 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  css-in-js-utils@3.1.0:
-    dependencies:
-      hyphenate-style-name: 1.1.0
-
-  css-tree@1.1.3:
-    dependencies:
-      mdn-data: 2.0.14
-      source-map: 0.6.1
-
   css-tree@3.1.0:
     dependencies:
       mdn-data: 2.12.2
@@ -3902,7 +3803,7 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  electron-to-chromium@1.5.241: {}
+  electron-to-chromium@1.5.243: {}
 
   emoji-regex@8.0.0: {}
 
@@ -3914,10 +3815,6 @@ snapshots:
       tapable: 2.3.0
 
   entities@6.0.1: {}
-
-  error-stack-parser@2.1.4:
-    dependencies:
-      stackframe: 1.3.4
 
   es-module-lexer@1.7.0: {}
 
@@ -3983,11 +3880,11 @@ snapshots:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.38.0(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.21.1
-      '@eslint/config-helpers': 0.4.1
+      '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.16.0
       '@eslint/eslintrc': 3.3.1
       '@eslint/js': 9.38.0
-      '@eslint/plugin-kit': 0.4.0
+      '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.7
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
@@ -4056,10 +3953,6 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
-
-  fast-shallow-equal@1.0.0: {}
-
-  fastest-stable-stringify@2.0.2: {}
 
   fastq@1.19.1:
     dependencies:
@@ -4154,8 +4047,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  hyphenate-style-name@1.1.0: {}
-
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
@@ -4172,10 +4063,6 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   indent-string@4.0.0: {}
-
-  inline-style-prefixer@7.0.1:
-    dependencies:
-      css-in-js-utils: 3.1.0
 
   is-extglob@2.1.1: {}
 
@@ -4221,8 +4108,6 @@ snapshots:
       '@pkgjs/parseargs': 0.11.0
 
   jiti@2.6.1: {}
-
-  js-cookie@2.2.1: {}
 
   js-tokens@4.0.0: {}
 
@@ -4364,8 +4249,6 @@ snapshots:
     dependencies:
       semver: 7.7.3
 
-  mdn-data@2.0.14: {}
-
   mdn-data@2.12.2: {}
 
   merge2@1.4.1: {}
@@ -4377,7 +4260,7 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  minimatch@10.0.3:
+  minimatch@10.1.1:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
 
@@ -4397,26 +4280,13 @@ snapshots:
 
   ms@2.1.3: {}
 
-  nano-css@5.6.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-      css-tree: 1.1.3
-      csstype: 3.1.3
-      fastest-stable-stringify: 2.0.2
-      inline-style-prefixer: 7.0.1
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      rtl-css-js: 1.16.1
-      stacktrace-js: 2.0.2
-      stylis: 4.3.6
-
   nanoid@3.3.11: {}
 
   nanoid@5.1.6: {}
 
   natural-compare@1.4.0: {}
 
-  node-releases@2.0.26: {}
+  node-releases@2.0.27: {}
 
   optionator@0.9.4:
     dependencies:
@@ -4542,7 +4412,7 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  rc-field-form@2.7.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  rc-field-form@2.7.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       '@babel/runtime': 7.28.4
       '@rc-component/async-validator': 5.0.4
@@ -4816,37 +4686,13 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
-  react-router@7.9.4(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-router@7.9.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       cookie: 1.0.2
       react: 19.2.0
       set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.0(react@19.2.0)
-
-  react-universal-interface@0.6.2(react@19.2.0)(tslib@2.8.1):
-    dependencies:
-      react: 19.2.0
-      tslib: 2.8.1
-
-  react-use@17.6.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
-    dependencies:
-      '@types/js-cookie': 2.2.7
-      '@xobotyi/scrollbar-width': 1.9.5
-      copy-to-clipboard: 3.3.3
-      fast-deep-equal: 3.1.3
-      fast-shallow-equal: 1.0.0
-      js-cookie: 2.2.1
-      nano-css: 5.6.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      react: 19.2.0
-      react-dom: 19.2.0(react@19.2.0)
-      react-universal-interface: 0.6.2(react@19.2.0)(tslib@2.8.1)
-      resize-observer-polyfill: 1.5.1
-      screenfull: 5.2.0
-      set-harmonic-interval: 1.0.1
-      throttle-debounce: 3.0.1
-      ts-easing: 0.2.0
-      tslib: 2.8.1
 
   react@19.2.0: {}
 
@@ -4895,10 +4741,6 @@ snapshots:
 
   rrweb-cssom@0.8.0: {}
 
-  rtl-css-js@1.16.1:
-    dependencies:
-      '@babel/runtime': 7.28.4
-
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -4911,8 +4753,6 @@ snapshots:
 
   scheduler@0.27.0: {}
 
-  screenfull@5.2.0: {}
-
   scroll-into-view-if-needed@3.1.0:
     dependencies:
       compute-scroll-into-view: 3.1.1
@@ -4922,8 +4762,6 @@ snapshots:
   semver@7.7.3: {}
 
   set-cookie-parser@2.7.2: {}
-
-  set-harmonic-interval@1.0.1: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -4943,28 +4781,7 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  source-map@0.5.6: {}
-
-  source-map@0.6.1: {}
-
-  stack-generator@2.0.10:
-    dependencies:
-      stackframe: 1.3.4
-
   stackback@0.0.2: {}
-
-  stackframe@1.3.4: {}
-
-  stacktrace-gps@3.1.2:
-    dependencies:
-      source-map: 0.5.6
-      stackframe: 1.3.4
-
-  stacktrace-js@2.0.2:
-    dependencies:
-      error-stack-parser: 2.1.4
-      stack-generator: 2.0.10
-      stacktrace-gps: 3.1.2
 
   state-local@1.0.7: {}
 
@@ -5020,8 +4837,6 @@ snapshots:
       glob: 10.4.5
       minimatch: 9.0.5
 
-  throttle-debounce@3.0.1: {}
-
   throttle-debounce@5.0.2: {}
 
   tinybench@2.9.0: {}
@@ -5065,14 +4880,10 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-easing@0.2.0: {}
-
   ts-morph@27.0.2:
     dependencies:
       '@ts-morph/common': 0.28.1
       code-block-writer: 13.0.3
-
-  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
- Updated @ahoo-wang/fetcher and related packages from v2.13.11 to v2.15.3
- Updated react-router from v7.9.4 to v7.9.5
- Updated @ahoo-wang/fetcher-generator from v2.13.11 to v2.15.3
- Moved tailwindcss dependency from dependencies to devDependencies
- Updated various sub-dependencies including electron-to-chromium and minimatch

