### PR TITLE
feat(schema): support type-level summary and description annotations

### DIFF
--- a/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/AddCartItem.kt
+++ b/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/AddCartItem.kt
@@ -11,9 +11,8 @@ import me.ahoo.wow.api.annotation.Summary
 @AllowCreate
 @CommandRoute(
     method = CommandRoute.Method.POST,
-    summary = "加入购物车",
-    description = "加入购物车"
 )
+@Summary("加入购物车")
 data class AddCartItem(
     @field:NotBlank
     val productId: String,

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/DescriptionResolver.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/DescriptionResolver.kt
@@ -15,13 +15,20 @@ package me.ahoo.wow.schema
 
 import com.github.victools.jsonschema.generator.ConfigFunction
 import com.github.victools.jsonschema.generator.FieldScope
+import com.github.victools.jsonschema.generator.TypeScope
 import me.ahoo.wow.api.annotation.Description
 import me.ahoo.wow.infra.reflection.AnnotationScanner.scanAnnotation
 import kotlin.reflect.jvm.kotlinProperty
 
-object DescriptionResolver : ConfigFunction<FieldScope, String> {
+object DescriptionFieldResolver : ConfigFunction<FieldScope, String> {
     override fun apply(fieldScope: FieldScope): String? {
         val property = fieldScope.rawMember.kotlinProperty ?: return null
         return property.scanAnnotation<Description>()?.value
+    }
+}
+
+object DescriptionTypeResolver : ConfigFunction<TypeScope, String> {
+    override fun apply(typeScope: TypeScope): String? {
+        return typeScope.type.erasedType.kotlin.scanAnnotation<Description>()?.value
     }
 }

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/SummaryTitleResolver.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/SummaryTitleResolver.kt
@@ -15,13 +15,20 @@ package me.ahoo.wow.schema
 
 import com.github.victools.jsonschema.generator.ConfigFunction
 import com.github.victools.jsonschema.generator.FieldScope
+import com.github.victools.jsonschema.generator.TypeScope
 import me.ahoo.wow.api.annotation.Summary
 import me.ahoo.wow.infra.reflection.AnnotationScanner.scanAnnotation
 import kotlin.reflect.jvm.kotlinProperty
 
-object SummaryTitleResolver : ConfigFunction<FieldScope, String> {
+object SummaryTitleFieldResolver : ConfigFunction<FieldScope, String> {
     override fun apply(fieldScope: FieldScope): String? {
         val property = fieldScope.rawMember.kotlinProperty ?: return null
         return property.scanAnnotation<Summary>()?.value
+    }
+}
+
+object SummaryTitleTypeResolver : ConfigFunction<TypeScope, String> {
+    override fun apply(typeScope: TypeScope): String? {
+        return typeScope.type.erasedType.kotlin.scanAnnotation<Summary>()?.value
     }
 }

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowModule.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowModule.kt
@@ -38,10 +38,12 @@ class WowModule(
     Module {
     override fun applyToConfigBuilder(builder: SchemaGeneratorConfigBuilder) {
         val fieldConfigPart = builder.forFields()
-        fieldConfigPart.withTitleResolver(SummaryTitleResolver)
-        fieldConfigPart.withDescriptionResolver(DescriptionResolver)
+        fieldConfigPart.withTitleResolver(SummaryTitleFieldResolver)
+        fieldConfigPart.withDescriptionResolver(DescriptionFieldResolver)
         ignoreCommandRouteVariable(fieldConfigPart)
         val generalConfigPart = builder.forTypesInGeneral()
+        generalConfigPart.withTitleResolver(SummaryTitleTypeResolver)
+        generalConfigPart.withDescriptionResolver(DescriptionTypeResolver)
         generalConfigPart.withCustomDefinitionProvider(AggregateIdDefinitionProvider)
         generalConfigPart.withCustomDefinitionProvider(CommandDefinitionProvider)
         generalConfigPart.withCustomDefinitionProvider(DomainEventDefinitionProvider)

--- a/wow-schema/src/test/resources/META-INF/wow-schema/CartAggregatedDomainEventStream.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/CartAggregatedDomainEventStream.json
@@ -133,7 +133,8 @@
                   "$ref" : "#/$defs/example.cart.CartItem"
                 }
               },
-              "required" : [ "added" ]
+              "required" : [ "added" ],
+              "title" : "商品已加入购物车"
             }
           },
           "description" : "The body of the domain event",

--- a/wow-schema/src/test/resources/META-INF/wow-schema/CreateOrderCommandMessage.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/CreateOrderCommandMessage.json
@@ -154,6 +154,7 @@
         }
       },
       "required" : [ "address", "fromCart", "items" ],
+      "title" : "下单",
       "description" : "Command message body"
     },
     "createTime" : {


### PR DESCRIPTION
- Add DescriptionTypeResolver to resolve @Description on types
- Add SummaryTitleTypeResolver to resolve @Summary on types
- Rename DescriptionResolver to DescriptionFieldResolver
- Rename SummaryTitleResolver to SummaryTitleFieldResolver
- Update WowModule to apply type resolvers for title and description
- Update schema generation to include type-level titles in JSON output
- Adjust command route annotation usage in AddCartItem example

