### PR TITLE
chore(deps): update fetcher dependencies to v3.0.3

### DIFF
--- a/compensation/dashboard/package.json
+++ b/compensation/dashboard/package.json
@@ -14,15 +14,15 @@
     "generate": "fetcher-generator generate -i http://compensation-service.dev.svc.cluster.local/v3/api-docs -o src/generated"
   },
   "dependencies": {
-    "@ahoo-wang/fetcher": "^3.0.0",
-    "@ahoo-wang/fetcher-cosec": "^3.0.0",
-    "@ahoo-wang/fetcher-decorator": "^3.0.0",
-    "@ahoo-wang/fetcher-eventbus": "^3.0.0",
-    "@ahoo-wang/fetcher-eventstream": "^3.0.0",
-    "@ahoo-wang/fetcher-react": "^3.0.0",
-    "@ahoo-wang/fetcher-storage": "^3.0.0",
-    "@ahoo-wang/fetcher-viewer": "^3.0.0",
-    "@ahoo-wang/fetcher-wow": "^3.0.0",
+    "@ahoo-wang/fetcher": "^3.0.3",
+    "@ahoo-wang/fetcher-cosec": "^3.0.3",
+    "@ahoo-wang/fetcher-decorator": "^3.0.3",
+    "@ahoo-wang/fetcher-eventbus": "^3.0.3",
+    "@ahoo-wang/fetcher-eventstream": "^3.0.3",
+    "@ahoo-wang/fetcher-react": "^3.0.3",
+    "@ahoo-wang/fetcher-storage": "^3.0.3",
+    "@ahoo-wang/fetcher-viewer": "^3.0.3",
+    "@ahoo-wang/fetcher-wow": "^3.0.3",
     "@ant-design/icons": "^5.6.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@monaco-editor/react": "4.7.0",
@@ -33,7 +33,7 @@
     "react-router": "^7.9.5"
   },
   "devDependencies": {
-    "@ahoo-wang/fetcher-generator": "^3.0.0",
+    "@ahoo-wang/fetcher-generator": "^3.0.3",
     "@eslint/js": "^9.39.1",
     "@tailwindcss/vite": "^4.1.16",
     "@testing-library/jest-dom": "^6.9.1",
@@ -47,15 +47,15 @@
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
-    "globals": "^16.4.0",
-    "jsdom": "^27.0.1",
+    "globals": "^16.5.0",
+    "jsdom": "^27.1.0",
     "prettier": "3.6.2",
     "tailwindcss": "^4.1.16",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.3",
     "vite": "^7.1.12",
     "vite-bundle-analyzer": "^1.2.3",
-    "vitest": "^4.0.0",
+    "vitest": "^4.0.6",
     "vitest-browser-react": "^1.0.1"
   }
 }

--- a/compensation/dashboard/pnpm-lock.yaml
+++ b/compensation/dashboard/pnpm-lock.yaml
@@ -9,32 +9,32 @@ importers:
   .:
     dependencies:
       '@ahoo-wang/fetcher':
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.0.3
+        version: 3.0.3
       '@ahoo-wang/fetcher-cosec':
-        specifier: ^3.0.0
-        version: 3.0.0(@ahoo-wang/fetcher-eventbus@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher-storage@3.0.0(@ahoo-wang/fetcher-eventbus@3.0.0(@ahoo-wang/fetcher@3.0.0)))(@ahoo-wang/fetcher@3.0.0)
+        specifier: ^3.0.3
+        version: 3.0.3(@ahoo-wang/fetcher-eventbus@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher-storage@3.0.3(@ahoo-wang/fetcher-eventbus@3.0.3(@ahoo-wang/fetcher@3.0.3)))(@ahoo-wang/fetcher@3.0.3)
       '@ahoo-wang/fetcher-decorator':
-        specifier: ^3.0.0
-        version: 3.0.0(@ahoo-wang/fetcher@3.0.0)
+        specifier: ^3.0.3
+        version: 3.0.3(@ahoo-wang/fetcher@3.0.3)
       '@ahoo-wang/fetcher-eventbus':
-        specifier: ^3.0.0
-        version: 3.0.0(@ahoo-wang/fetcher@3.0.0)
+        specifier: ^3.0.3
+        version: 3.0.3(@ahoo-wang/fetcher@3.0.3)
       '@ahoo-wang/fetcher-eventstream':
-        specifier: ^3.0.0
-        version: 3.0.0(@ahoo-wang/fetcher@3.0.0)
+        specifier: ^3.0.3
+        version: 3.0.3(@ahoo-wang/fetcher@3.0.3)
       '@ahoo-wang/fetcher-react':
-        specifier: ^3.0.0
-        version: 3.0.0(@ahoo-wang/fetcher-eventbus@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher-eventstream@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher-storage@3.0.0(@ahoo-wang/fetcher-eventbus@3.0.0(@ahoo-wang/fetcher@3.0.0)))(@ahoo-wang/fetcher-wow@3.0.0(@ahoo-wang/fetcher-decorator@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher-eventstream@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher@3.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^3.0.3
+        version: 3.0.3(@ahoo-wang/fetcher-eventbus@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher-eventstream@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher-storage@3.0.3(@ahoo-wang/fetcher-eventbus@3.0.3(@ahoo-wang/fetcher@3.0.3)))(@ahoo-wang/fetcher-wow@3.0.3(@ahoo-wang/fetcher-decorator@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher-eventstream@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher@3.0.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@ahoo-wang/fetcher-storage':
-        specifier: ^3.0.0
-        version: 3.0.0(@ahoo-wang/fetcher-eventbus@3.0.0(@ahoo-wang/fetcher@3.0.0))
+        specifier: ^3.0.3
+        version: 3.0.3(@ahoo-wang/fetcher-eventbus@3.0.3(@ahoo-wang/fetcher@3.0.3))
       '@ahoo-wang/fetcher-viewer':
-        specifier: ^3.0.0
-        version: 3.0.0(447c3c504e2a71ce6ba98fbf7153b696)
+        specifier: ^3.0.3
+        version: 3.0.3(e1e1f58b194e8ae3762ba8c5960dff3b)
       '@ahoo-wang/fetcher-wow':
-        specifier: ^3.0.0
-        version: 3.0.0(@ahoo-wang/fetcher-decorator@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher-eventstream@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher@3.0.0)
+        specifier: ^3.0.3
+        version: 3.0.3(@ahoo-wang/fetcher-decorator@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher-eventstream@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher@3.0.3)
       '@ant-design/icons':
         specifier: ^5.6.1
         version: 5.6.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -61,8 +61,8 @@ importers:
         version: 7.9.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     devDependencies:
       '@ahoo-wang/fetcher-generator':
-        specifier: ^3.0.0
-        version: 3.0.0(@ahoo-wang/fetcher-decorator@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher-eventstream@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@3.0.0(@ahoo-wang/fetcher-decorator@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher-eventstream@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher@3.0.0)
+        specifier: ^3.0.3
+        version: 3.0.3(@ahoo-wang/fetcher-decorator@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher-eventstream@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@3.0.3(@ahoo-wang/fetcher-decorator@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher-eventstream@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher@3.0.3)
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.1
@@ -103,11 +103,11 @@ importers:
         specifier: ^0.4.24
         version: 0.4.24(eslint@9.39.1(jiti@2.6.1))
       globals:
-        specifier: ^16.4.0
-        version: 16.4.0
+        specifier: ^16.5.0
+        version: 16.5.0
       jsdom:
-        specifier: ^27.0.1
-        version: 27.0.1
+        specifier: ^27.1.0
+        version: 27.1.0
       prettier:
         specifier: 3.6.2
         version: 3.6.2
@@ -127,90 +127,93 @@ importers:
         specifier: ^1.2.3
         version: 1.2.3
       vitest:
-        specifier: ^4.0.0
-        version: 4.0.6(@vitest/ui@4.0.6)(jiti@2.6.1)(jsdom@27.0.1)(lightningcss@1.30.2)(yaml@2.8.1)
+        specifier: ^4.0.6
+        version: 4.0.6(@vitest/ui@4.0.6)(jiti@2.6.1)(jsdom@27.1.0)(lightningcss@1.30.2)(yaml@2.8.1)
       vitest-browser-react:
         specifier: ^1.0.1
         version: 1.0.1(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(@vitest/browser@3.2.4(vite@7.1.12(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1))(vitest@4.0.6))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@4.0.6)
 
 packages:
 
+  '@acemir/cssom@0.9.19':
+    resolution: {integrity: sha512-Pp2gAQXPZ2o7lt4j0IMwNRXqQ3pagxtDj5wctL5U2Lz4oV0ocDNlkgx4DpxfyKav4S/bePuI+SMqcBSUHLy9kg==}
+
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@ahoo-wang/fetcher-cosec@3.0.0':
-    resolution: {integrity: sha512-92zi0GSJSZQhUoI+LrV15A0MlvzXTlLqWbjyQcCqS5V1JAzFFRt4R8A1oIENEUZZSmzgjSgjDIclneW8E+g/TA==}
+  '@ahoo-wang/fetcher-cosec@3.0.3':
+    resolution: {integrity: sha512-bRz7oUeoanQJLe1U5z6qBa94d/Oy/rBbG5L3h0M3EpUSozFaw7EdqIzFdleF1EOhdXW51eu/hegCLNOAgJxgXw==}
     peerDependencies:
-      '@ahoo-wang/fetcher': ^2.3.4
-      '@ahoo-wang/fetcher-eventbus': ^2.8.5
-      '@ahoo-wang/fetcher-storage': ^2.3.4
+      '@ahoo-wang/fetcher': ^3.0.0
+      '@ahoo-wang/fetcher-eventbus': ^3.0.0
+      '@ahoo-wang/fetcher-storage': ^3.0.0
 
-  '@ahoo-wang/fetcher-decorator@3.0.0':
-    resolution: {integrity: sha512-X6DPwcIS/gSp6TvgjomaSG21U5doS2KJKlfWz0ZaDvzg/FX/U2i+RP0mJlb7MoShdIlizROzGqPza+ZCpA8GPA==}
+  '@ahoo-wang/fetcher-decorator@3.0.3':
+    resolution: {integrity: sha512-ceSvabSbQX4WhWzWbsUo08q25hSb6kgt8q1yUqlTPkWXKeou3BQSF9zUOxIS3/wFQWJS9f6VB7RzuGwLu8xw2Q==}
     peerDependencies:
-      '@ahoo-wang/fetcher': ^2.9.3
+      '@ahoo-wang/fetcher': ^3.0.0
 
-  '@ahoo-wang/fetcher-eventbus@3.0.0':
-    resolution: {integrity: sha512-0ZR9MXapLe7FjtbjtTSLIybr8dPPfV8q9c6QG7TIZMZ3zYMt6vBiS47tSjl3PD84v/sBHq1jP9pPJPPZwbuKIg==}
+  '@ahoo-wang/fetcher-eventbus@3.0.3':
+    resolution: {integrity: sha512-QtS1OXouMm8ejb3rlGKQK0TLu3G7IEx44O6ct0xatDzy6prJtsqlqM/yeeL/PsbcEt7HFY/Mjwej8Okmls20RQ==}
     peerDependencies:
-      '@ahoo-wang/fetcher': ^2.3.4
+      '@ahoo-wang/fetcher': ^3.0.0
 
-  '@ahoo-wang/fetcher-eventstream@3.0.0':
-    resolution: {integrity: sha512-tONOGIv47LAN95dLze+H5qBt4l7wpASZAEstIxj5OF+3+CKes4/1IqJ3SCvPZyVZFJPAlPiEbCJZ1AoSCYeMow==}
+  '@ahoo-wang/fetcher-eventstream@3.0.3':
+    resolution: {integrity: sha512-DYiywzn4Ao7FP9wwBrPPi0LZhlQHD+m+opZ81WbSKQbt2hjvObGbXH8y4Kbwm4DhA7wmA/UMBqeEIIaH8StLTw==}
     peerDependencies:
-      '@ahoo-wang/fetcher': ^2.3.4
+      '@ahoo-wang/fetcher': ^3.0.0
 
-  '@ahoo-wang/fetcher-generator@3.0.0':
-    resolution: {integrity: sha512-6GWV2Fy+wEf34yIFTha/S6vJHSRF8J7FEapffP1M9iXfCSb49QAAcFQZeazp8aFO0UUVyefSgeV9gUBi/nftSg==}
+  '@ahoo-wang/fetcher-generator@3.0.3':
+    resolution: {integrity: sha512-maSmW7d+Og+sjW9GUoUY34jIqY5WCVnBhMn/svVMe6XfN2CRX4ifBjuRpNlTdZooALu2UUhQ1uIspjgZylS9jQ==}
     hasBin: true
     peerDependencies:
-      '@ahoo-wang/fetcher': ^2.3.4
-      '@ahoo-wang/fetcher-decorator': ^2.3.4
-      '@ahoo-wang/fetcher-eventstream': ^2.3.4
-      '@ahoo-wang/fetcher-openapi': ^2.3.4
-      '@ahoo-wang/fetcher-wow': ^2.3.4
+      '@ahoo-wang/fetcher': ^3.0.0
+      '@ahoo-wang/fetcher-decorator': ^3.0.0
+      '@ahoo-wang/fetcher-eventstream': ^3.0.0
+      '@ahoo-wang/fetcher-openapi': ^3.0.0
+      '@ahoo-wang/fetcher-wow': ^3.0.0
 
   '@ahoo-wang/fetcher-openapi@2.3.0':
     resolution: {integrity: sha512-He3I/VovQzLNajxL2hoUZKlAnt0ZpehpMpbjgxvdPEoWfeAA3qZc0+C8Mhrk3HQQAC69lZOSt3JtAvzYDxpn/Q==}
 
-  '@ahoo-wang/fetcher-react@3.0.0':
-    resolution: {integrity: sha512-b0GCFhx5HZJethErwj/bCsLbwAsbWyhQ1ciX8Q3KU0pdZUp0bt1vyEHQ+rRzpati0GLMTWTm1LglmiWU6OAf2Q==}
+  '@ahoo-wang/fetcher-react@3.0.3':
+    resolution: {integrity: sha512-FURRXv3HzTlQBapYVHrESoTTuBY0UFC21LzH2d780ac00V3EZP8L6hI0LC1DZK/ibsWAN3v5qto3ydS2RrAyZg==}
     peerDependencies:
-      '@ahoo-wang/fetcher': ^2.3.4
-      '@ahoo-wang/fetcher-eventbus': ^2.8.8
-      '@ahoo-wang/fetcher-eventstream': ^2.3.4
-      '@ahoo-wang/fetcher-storage': ^2.3.4
-      '@ahoo-wang/fetcher-wow': ^2.3.4
+      '@ahoo-wang/fetcher': ^3.0.0
+      '@ahoo-wang/fetcher-eventbus': ^3.0.0
+      '@ahoo-wang/fetcher-eventstream': ^3.0.0
+      '@ahoo-wang/fetcher-storage': ^3.0.0
+      '@ahoo-wang/fetcher-wow': ^3.0.0
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
 
-  '@ahoo-wang/fetcher-storage@3.0.0':
-    resolution: {integrity: sha512-ZCVe2nlUi1NnPW4uB0gqAUagdoFLgdcom/unPuAuAU5vmfXnAEPSbDoDVoTOFX+BtWIQdMggLYqZz9Lb29cKKQ==}
+  '@ahoo-wang/fetcher-storage@3.0.3':
+    resolution: {integrity: sha512-pehi9zW7JWseokDXbi1T5amNH2/mlH6gvUH0VjsrWc0N6EXWzM5vWoRvVnC2yGldF4GzBpf5uNskrp2+tSYXSA==}
     peerDependencies:
-      '@ahoo-wang/fetcher-eventbus': ^2.8.5
+      '@ahoo-wang/fetcher-eventbus': ^3.0.0
 
-  '@ahoo-wang/fetcher-viewer@3.0.0':
-    resolution: {integrity: sha512-/BdoKjwF1GbmYP8X4Aez62iKO5J6QnvjkKASp+nnclK382KVd9iEke29vExbrjrfulf6R4xR95KlXhuV5nNP8w==}
+  '@ahoo-wang/fetcher-viewer@3.0.3':
+    resolution: {integrity: sha512-lxvZxaEhXdYKIKaCgn1tpgcNkQv753cVATpzGA5pySNI++UNcRnAUAscNaKD5G/OyBb0JxP4XeL73gu2aFD03A==}
     peerDependencies:
-      '@ahoo-wang/fetcher': ^2.3.4
-      '@ahoo-wang/fetcher-openapi': ^2.3.4
-      '@ahoo-wang/fetcher-react': ^2.8.0
-      '@ahoo-wang/fetcher-storage': ^2.3.4
-      '@ahoo-wang/fetcher-wow': ^2.3.4
+      '@ahoo-wang/fetcher': ^3.0.0
+      '@ahoo-wang/fetcher-openapi': ^3.0.0
+      '@ahoo-wang/fetcher-react': ^3.0.0
+      '@ahoo-wang/fetcher-storage': ^3.0.0
+      '@ahoo-wang/fetcher-wow': ^3.0.0
       '@ant-design/icons': ^5.6.1
-      antd: ^5.27.6
+      antd: ^5.28.0
       react: '>=19.0.0'
       react-dom: '>=19.0.0'
 
-  '@ahoo-wang/fetcher-wow@3.0.0':
-    resolution: {integrity: sha512-X5kxXd8sRacBGyQ5hpCgAzyju60F0BA1lXUL9xv5/aLhOOxhslZtC5GnOgulP5QlDxtfZrIFW5l08Tm8FpSylw==}
+  '@ahoo-wang/fetcher-wow@3.0.3':
+    resolution: {integrity: sha512-B4acJTJGhdidR5qTAQvpgJmJ5QEBBPM4d8XxTkAuLH02850D6kmx+IvXf+4z86BYyJnpFsz0kg+yZonHoSqt3w==}
     peerDependencies:
-      '@ahoo-wang/fetcher': ^2.3.4
-      '@ahoo-wang/fetcher-decorator': ^2.3.4
-      '@ahoo-wang/fetcher-eventstream': ^2.3.4
+      '@ahoo-wang/fetcher': ^3.0.0
+      '@ahoo-wang/fetcher-decorator': ^3.0.0
+      '@ahoo-wang/fetcher-eventstream': ^3.0.0
 
-  '@ahoo-wang/fetcher@3.0.0':
-    resolution: {integrity: sha512-R0HfPIcNcb6Mm3Wv9zjiUHRZjWRQIaNNs5M5BH+Kk1auiVL5qttPR36jfsyEQ7X3mzdKh7FCda42OHuDC9H9Jw==}
+  '@ahoo-wang/fetcher@3.0.3':
+    resolution: {integrity: sha512-7P9Q8z7sC6FJ2waFOUbs8MuJZPbFKebuUyioWMcnscP4f30cXvvsIxKgMaDApOltGAZfmzKUOzJD9+Aak6sKIQ==}
 
   '@ant-design/colors@7.2.1':
     resolution: {integrity: sha512-lCHDcEzieu4GA3n8ELeZ5VQ8pKQAWcGGLRTQ50aQM2iqPpq2evTxER84jfdPvsPAtEcZ7m44NI45edFMo8oOYQ==}
@@ -257,8 +260,8 @@ packages:
   '@asamuzakjp/css-color@4.0.5':
     resolution: {integrity: sha512-lMrXidNhPGsDjytDy11Vwlb6OIGrT3CmLg3VWNFyWkLWtijKl7xjvForlh8vuj0SHGjgl4qZEQzUmYTeQA2JFQ==}
 
-  '@asamuzakjp/dom-selector@6.7.3':
-    resolution: {integrity: sha512-kiGFeY+Hxf5KbPpjRLf+ffWbkos1aGo8MBfd91oxS3O57RgU3XhZrt/6UzoVF9VMpWbC3v87SRc9jxGrc9qHtQ==}
+  '@asamuzakjp/dom-selector@6.7.4':
+    resolution: {integrity: sha512-buQDjkm+wDPXd6c13534URWZqbz0RP5PAhXZ+LIoa5LgwInT9HVJvGIJivg75vi8I13CxDGdTnz+aY5YUJlIAA==}
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
@@ -392,158 +395,158 @@ packages:
   '@emotion/unitless@0.7.5':
     resolution: {integrity: sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==}
 
-  '@esbuild/aix-ppc64@0.25.11':
-    resolution: {integrity: sha512-Xt1dOL13m8u0WE8iplx9Ibbm+hFAO0GsU2P34UNoDGvZYkY8ifSiy6Zuc1lYxfG7svWE2fzqCUmFp5HCn51gJg==}
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.25.11':
-    resolution: {integrity: sha512-9slpyFBc4FPPz48+f6jyiXOx/Y4v34TUeDDXJpZqAWQn/08lKGeD8aDp9TMn9jDz2CiEuHwfhRmGBvpnd/PWIQ==}
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.25.11':
-    resolution: {integrity: sha512-uoa7dU+Dt3HYsethkJ1k6Z9YdcHjTrSb5NUy66ZfZaSV8hEYGD5ZHbEMXnqLFlbBflLsl89Zke7CAdDJ4JI+Gg==}
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.25.11':
-    resolution: {integrity: sha512-Sgiab4xBjPU1QoPEIqS3Xx+R2lezu0LKIEcYe6pftr56PqPygbB7+szVnzoShbx64MUupqoE0KyRlN7gezbl8g==}
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.25.11':
-    resolution: {integrity: sha512-VekY0PBCukppoQrycFxUqkCojnTQhdec0vevUL/EDOCnXd9LKWqD/bHwMPzigIJXPhC59Vd1WFIL57SKs2mg4w==}
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.25.11':
-    resolution: {integrity: sha512-+hfp3yfBalNEpTGp9loYgbknjR695HkqtY3d3/JjSRUyPg/xd6q+mQqIb5qdywnDxRZykIHs3axEqU6l1+oWEQ==}
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.25.11':
-    resolution: {integrity: sha512-CmKjrnayyTJF2eVuO//uSjl/K3KsMIeYeyN7FyDBjsR3lnSJHaXlVoAK8DZa7lXWChbuOk7NjAc7ygAwrnPBhA==}
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.25.11':
-    resolution: {integrity: sha512-Dyq+5oscTJvMaYPvW3x3FLpi2+gSZTCE/1ffdwuM6G1ARang/mb3jvjxs0mw6n3Lsw84ocfo9CrNMqc5lTfGOw==}
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.25.11':
-    resolution: {integrity: sha512-Qr8AzcplUhGvdyUF08A1kHU3Vr2O88xxP0Tm8GcdVOUm25XYcMPp2YqSVHbLuXzYQMf9Bh/iKx7YPqECs6ffLA==}
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.25.11':
-    resolution: {integrity: sha512-TBMv6B4kCfrGJ8cUPo7vd6NECZH/8hPpBHHlYI3qzoYFvWu2AdTvZNuU/7hsbKWqu/COU7NIK12dHAAqBLLXgw==}
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.11':
-    resolution: {integrity: sha512-TmnJg8BMGPehs5JKrCLqyWTVAvielc615jbkOirATQvWWB1NMXY77oLMzsUjRLa0+ngecEmDGqt5jiDC6bfvOw==}
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.25.11':
-    resolution: {integrity: sha512-DIGXL2+gvDaXlaq8xruNXUJdT5tF+SBbJQKbWy/0J7OhU8gOHOzKmGIlfTTl6nHaCOoipxQbuJi7O++ldrxgMw==}
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.11':
-    resolution: {integrity: sha512-Osx1nALUJu4pU43o9OyjSCXokFkFbyzjXb6VhGIJZQ5JZi8ylCQ9/LFagolPsHtgw6himDSyb5ETSfmp4rpiKQ==}
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.25.11':
-    resolution: {integrity: sha512-nbLFgsQQEsBa8XSgSTSlrnBSrpoWh7ioFDUmwo158gIm5NNP+17IYmNWzaIzWmgCxq56vfr34xGkOcZ7jX6CPw==}
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.11':
-    resolution: {integrity: sha512-HfyAmqZi9uBAbgKYP1yGuI7tSREXwIb438q0nqvlpxAOs3XnZ8RsisRfmVsgV486NdjD7Mw2UrFSw51lzUk1ww==}
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.25.11':
-    resolution: {integrity: sha512-HjLqVgSSYnVXRisyfmzsH6mXqyvj0SA7pG5g+9W7ESgwA70AXYNpfKBqh1KbTxmQVaYxpzA/SvlB9oclGPbApw==}
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.11':
-    resolution: {integrity: sha512-HSFAT4+WYjIhrHxKBwGmOOSpphjYkcswF449j6EjsjbinTZbp8PJtjsVK1XFJStdzXdy/jaddAep2FGY+wyFAQ==}
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.11':
-    resolution: {integrity: sha512-hr9Oxj1Fa4r04dNpWr3P8QKVVsjQhqrMSUzZzf+LZcYjZNqhA3IAfPQdEh1FLVUJSiu6sgAwp3OmwBfbFgG2Xg==}
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.25.11':
-    resolution: {integrity: sha512-u7tKA+qbzBydyj0vgpu+5h5AeudxOAGncb8N6C9Kh1N4n7wU1Xw1JDApsRjpShRpXRQlJLb9wY28ELpwdPcZ7A==}
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.11':
-    resolution: {integrity: sha512-Qq6YHhayieor3DxFOoYM1q0q1uMFYb7cSpLD2qzDSvK1NAvqFi8Xgivv0cFC6J+hWVw2teCYltyy9/m/14ryHg==}
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.25.11':
-    resolution: {integrity: sha512-CN+7c++kkbrckTOz5hrehxWN7uIhFFlmS/hqziSFVWpAzpWrQoAG4chH+nN3Be+Kzv/uuo7zhX716x3Sn2Jduw==}
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.25.11':
-    resolution: {integrity: sha512-rOREuNIQgaiR+9QuNkbkxubbp8MSO9rONmwP5nKncnWJ9v5jQ4JxFnLu4zDSRPf3x4u+2VN4pM4RdyIzDty/wQ==}
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.25.11':
-    resolution: {integrity: sha512-nq2xdYaWxyg9DcIyXkZhcYulC6pQ2FuCgem3LI92IwMgIZ69KHeY8T4Y88pcwoLIjbed8n36CyKoYRDygNSGhA==}
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.25.11':
-    resolution: {integrity: sha512-3XxECOWJq1qMZ3MN8srCJ/QfoLpL+VaxD/WfNRm1O3B4+AZ/BnLVgFbUV3eiRYDMXetciH16dwPbbHqwe1uU0Q==}
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.11':
-    resolution: {integrity: sha512-3ukss6gb9XZ8TlRyJlgLn17ecsK4NSQTmdIXRASVsiS2sQ6zPPZklNJT5GR5tE/MUarymmy8kCEf5xPCNCqVOA==}
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.25.11':
-    resolution: {integrity: sha512-D7Hpz6A2L4hzsRpPaCYkQnGOotdUpDzSGRIv9I+1ITdHROSFUWW95ZPZWQmGka1Fg7W3zFJowyn9WGwMJ0+KPA==}
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1180,8 +1183,8 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  baseline-browser-mapping@2.8.21:
-    resolution: {integrity: sha512-JU0h5APyQNsHOlAM7HnQnPToSDQoEBZqzu/YBlqDnEeymPnZDREeXJA3KBMQee+dKteAxZ2AtvQEvVYdZf241Q==}
+  baseline-browser-mapping@2.8.23:
+    resolution: {integrity: sha512-616V5YX4bepJFzNyOfce5Fa8fDJMfoxzOIzDCZwaGL8MKVpFrXqfNUoIpRn9YMI5pXf/VKgzjB4htFMsFKKdiQ==}
     hasBin: true
 
   bidi-js@1.0.3:
@@ -1206,8 +1209,8 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  caniuse-lite@1.0.30001752:
-    resolution: {integrity: sha512-vKUk7beoukxE47P5gcVNKkDRzXdVofotshHwfR9vmpeFKxmI5PBpgOMC18LUJUA/DvJ70Y7RveasIBraqsyO/g==}
+  caniuse-lite@1.0.30001753:
+    resolution: {integrity: sha512-Bj5H35MD/ebaOV4iDLqPEtiliTN29qkGtEHCwawWn4cYm+bPJM2NsaP30vtZcnERClMzp52J4+aw2UNbK4o+zw==}
 
   chai@6.2.0:
     resolution: {integrity: sha512-aUTnJc/JipRzJrNADXVvpVqi6CO0dn3nx4EVPxijri+fj3LUUDyZQOgVeW54Ob3Y1Xh9Iz8f+CgaCl8v0mn9bA==}
@@ -1318,8 +1321,8 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
-  esbuild@0.25.11:
-    resolution: {integrity: sha512-KohQwyzrKTQmhXDW1PjCv3Tyspn9n5GcY2RTDqeORIdIJY8yKIF7sTSopFmn/wpMPW4rdPXI0UE5LJLuq3bx0Q==}
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1459,8 +1462,8 @@ packages:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
-  globals@16.4.0:
-    resolution: {integrity: sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==}
+  globals@16.5.0:
+    resolution: {integrity: sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==}
     engines: {node: '>=18'}
 
   graceful-fs@4.2.11:
@@ -1566,9 +1569,9 @@ packages:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
 
-  jsdom@27.0.1:
-    resolution: {integrity: sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==}
-    engines: {node: '>=20'}
+  jsdom@27.1.0:
+    resolution: {integrity: sha512-Pcfm3eZ+eO4JdZCXthW9tCDT3nF4K+9dmeZ+5X39n+Kqz0DDIABRP5CAEOHRFZk8RGuC2efksTJxrjp8EXCunQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
     peerDependencies:
       canvas: ^3.0.0
     peerDependenciesMeta:
@@ -2109,9 +2112,6 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  rrweb-cssom@0.8.0:
-    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
-
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -2452,74 +2452,76 @@ packages:
 
 snapshots:
 
+  '@acemir/cssom@0.9.19': {}
+
   '@adobe/css-tools@4.4.4': {}
 
-  '@ahoo-wang/fetcher-cosec@3.0.0(@ahoo-wang/fetcher-eventbus@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher-storage@3.0.0(@ahoo-wang/fetcher-eventbus@3.0.0(@ahoo-wang/fetcher@3.0.0)))(@ahoo-wang/fetcher@3.0.0)':
+  '@ahoo-wang/fetcher-cosec@3.0.3(@ahoo-wang/fetcher-eventbus@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher-storage@3.0.3(@ahoo-wang/fetcher-eventbus@3.0.3(@ahoo-wang/fetcher@3.0.3)))(@ahoo-wang/fetcher@3.0.3)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.0.0
-      '@ahoo-wang/fetcher-eventbus': 3.0.0(@ahoo-wang/fetcher@3.0.0)
-      '@ahoo-wang/fetcher-storage': 3.0.0(@ahoo-wang/fetcher-eventbus@3.0.0(@ahoo-wang/fetcher@3.0.0))
+      '@ahoo-wang/fetcher': 3.0.3
+      '@ahoo-wang/fetcher-eventbus': 3.0.3(@ahoo-wang/fetcher@3.0.3)
+      '@ahoo-wang/fetcher-storage': 3.0.3(@ahoo-wang/fetcher-eventbus@3.0.3(@ahoo-wang/fetcher@3.0.3))
       nanoid: 5.1.6
 
-  '@ahoo-wang/fetcher-decorator@3.0.0(@ahoo-wang/fetcher@3.0.0)':
+  '@ahoo-wang/fetcher-decorator@3.0.3(@ahoo-wang/fetcher@3.0.3)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.0.0
+      '@ahoo-wang/fetcher': 3.0.3
       reflect-metadata: 0.2.2
 
-  '@ahoo-wang/fetcher-eventbus@3.0.0(@ahoo-wang/fetcher@3.0.0)':
+  '@ahoo-wang/fetcher-eventbus@3.0.3(@ahoo-wang/fetcher@3.0.3)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.0.0
+      '@ahoo-wang/fetcher': 3.0.3
 
-  '@ahoo-wang/fetcher-eventstream@3.0.0(@ahoo-wang/fetcher@3.0.0)':
+  '@ahoo-wang/fetcher-eventstream@3.0.3(@ahoo-wang/fetcher@3.0.3)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.0.0
+      '@ahoo-wang/fetcher': 3.0.3
 
-  '@ahoo-wang/fetcher-generator@3.0.0(@ahoo-wang/fetcher-decorator@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher-eventstream@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@3.0.0(@ahoo-wang/fetcher-decorator@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher-eventstream@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher@3.0.0)':
+  '@ahoo-wang/fetcher-generator@3.0.3(@ahoo-wang/fetcher-decorator@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher-eventstream@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@3.0.3(@ahoo-wang/fetcher-decorator@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher-eventstream@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher@3.0.3)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.0.0
-      '@ahoo-wang/fetcher-decorator': 3.0.0(@ahoo-wang/fetcher@3.0.0)
-      '@ahoo-wang/fetcher-eventstream': 3.0.0(@ahoo-wang/fetcher@3.0.0)
+      '@ahoo-wang/fetcher': 3.0.3
+      '@ahoo-wang/fetcher-decorator': 3.0.3(@ahoo-wang/fetcher@3.0.3)
+      '@ahoo-wang/fetcher-eventstream': 3.0.3(@ahoo-wang/fetcher@3.0.3)
       '@ahoo-wang/fetcher-openapi': 2.3.0
-      '@ahoo-wang/fetcher-wow': 3.0.0(@ahoo-wang/fetcher-decorator@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher-eventstream@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher@3.0.0)
+      '@ahoo-wang/fetcher-wow': 3.0.3(@ahoo-wang/fetcher-decorator@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher-eventstream@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher@3.0.3)
       commander: 14.0.2
       ts-morph: 27.0.2
       yaml: 2.8.1
 
   '@ahoo-wang/fetcher-openapi@2.3.0': {}
 
-  '@ahoo-wang/fetcher-react@3.0.0(@ahoo-wang/fetcher-eventbus@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher-eventstream@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher-storage@3.0.0(@ahoo-wang/fetcher-eventbus@3.0.0(@ahoo-wang/fetcher@3.0.0)))(@ahoo-wang/fetcher-wow@3.0.0(@ahoo-wang/fetcher-decorator@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher-eventstream@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher@3.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@ahoo-wang/fetcher-react@3.0.3(@ahoo-wang/fetcher-eventbus@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher-eventstream@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher-storage@3.0.3(@ahoo-wang/fetcher-eventbus@3.0.3(@ahoo-wang/fetcher@3.0.3)))(@ahoo-wang/fetcher-wow@3.0.3(@ahoo-wang/fetcher-decorator@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher-eventstream@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher@3.0.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.0.0
-      '@ahoo-wang/fetcher-eventbus': 3.0.0(@ahoo-wang/fetcher@3.0.0)
-      '@ahoo-wang/fetcher-eventstream': 3.0.0(@ahoo-wang/fetcher@3.0.0)
-      '@ahoo-wang/fetcher-storage': 3.0.0(@ahoo-wang/fetcher-eventbus@3.0.0(@ahoo-wang/fetcher@3.0.0))
-      '@ahoo-wang/fetcher-wow': 3.0.0(@ahoo-wang/fetcher-decorator@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher-eventstream@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher@3.0.0)
+      '@ahoo-wang/fetcher': 3.0.3
+      '@ahoo-wang/fetcher-eventbus': 3.0.3(@ahoo-wang/fetcher@3.0.3)
+      '@ahoo-wang/fetcher-eventstream': 3.0.3(@ahoo-wang/fetcher@3.0.3)
+      '@ahoo-wang/fetcher-storage': 3.0.3(@ahoo-wang/fetcher-eventbus@3.0.3(@ahoo-wang/fetcher@3.0.3))
+      '@ahoo-wang/fetcher-wow': 3.0.3(@ahoo-wang/fetcher-decorator@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher-eventstream@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher@3.0.3)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@ahoo-wang/fetcher-storage@3.0.0(@ahoo-wang/fetcher-eventbus@3.0.0(@ahoo-wang/fetcher@3.0.0))':
+  '@ahoo-wang/fetcher-storage@3.0.3(@ahoo-wang/fetcher-eventbus@3.0.3(@ahoo-wang/fetcher@3.0.3))':
     dependencies:
-      '@ahoo-wang/fetcher-eventbus': 3.0.0(@ahoo-wang/fetcher@3.0.0)
+      '@ahoo-wang/fetcher-eventbus': 3.0.3(@ahoo-wang/fetcher@3.0.3)
 
-  '@ahoo-wang/fetcher-viewer@3.0.0(447c3c504e2a71ce6ba98fbf7153b696)':
+  '@ahoo-wang/fetcher-viewer@3.0.3(e1e1f58b194e8ae3762ba8c5960dff3b)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.0.0
+      '@ahoo-wang/fetcher': 3.0.3
       '@ahoo-wang/fetcher-openapi': 2.3.0
-      '@ahoo-wang/fetcher-react': 3.0.0(@ahoo-wang/fetcher-eventbus@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher-eventstream@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher-storage@3.0.0(@ahoo-wang/fetcher-eventbus@3.0.0(@ahoo-wang/fetcher@3.0.0)))(@ahoo-wang/fetcher-wow@3.0.0(@ahoo-wang/fetcher-decorator@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher-eventstream@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher@3.0.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@ahoo-wang/fetcher-storage': 3.0.0(@ahoo-wang/fetcher-eventbus@3.0.0(@ahoo-wang/fetcher@3.0.0))
-      '@ahoo-wang/fetcher-wow': 3.0.0(@ahoo-wang/fetcher-decorator@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher-eventstream@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher@3.0.0)
+      '@ahoo-wang/fetcher-react': 3.0.3(@ahoo-wang/fetcher-eventbus@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher-eventstream@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher-storage@3.0.3(@ahoo-wang/fetcher-eventbus@3.0.3(@ahoo-wang/fetcher@3.0.3)))(@ahoo-wang/fetcher-wow@3.0.3(@ahoo-wang/fetcher-decorator@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher-eventstream@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher@3.0.3)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@ahoo-wang/fetcher-storage': 3.0.3(@ahoo-wang/fetcher-eventbus@3.0.3(@ahoo-wang/fetcher@3.0.3))
+      '@ahoo-wang/fetcher-wow': 3.0.3(@ahoo-wang/fetcher-decorator@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher-eventstream@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher@3.0.3)
       '@ant-design/icons': 5.6.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       antd: 5.28.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@ahoo-wang/fetcher-wow@3.0.0(@ahoo-wang/fetcher-decorator@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher-eventstream@3.0.0(@ahoo-wang/fetcher@3.0.0))(@ahoo-wang/fetcher@3.0.0)':
+  '@ahoo-wang/fetcher-wow@3.0.3(@ahoo-wang/fetcher-decorator@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher-eventstream@3.0.3(@ahoo-wang/fetcher@3.0.3))(@ahoo-wang/fetcher@3.0.3)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.0.0
-      '@ahoo-wang/fetcher-decorator': 3.0.0(@ahoo-wang/fetcher@3.0.0)
-      '@ahoo-wang/fetcher-eventstream': 3.0.0(@ahoo-wang/fetcher@3.0.0)
+      '@ahoo-wang/fetcher': 3.0.3
+      '@ahoo-wang/fetcher-decorator': 3.0.3(@ahoo-wang/fetcher@3.0.3)
+      '@ahoo-wang/fetcher-eventstream': 3.0.3(@ahoo-wang/fetcher@3.0.3)
 
-  '@ahoo-wang/fetcher@3.0.0': {}
+  '@ahoo-wang/fetcher@3.0.3': {}
 
   '@ant-design/colors@7.2.1':
     dependencies:
@@ -2584,7 +2586,7 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 11.2.2
 
-  '@asamuzakjp/dom-selector@6.7.3':
+  '@asamuzakjp/dom-selector@6.7.4':
     dependencies:
       '@asamuzakjp/nwsapi': 2.3.9
       bidi-js: 1.0.3
@@ -2736,82 +2738,82 @@ snapshots:
 
   '@emotion/unitless@0.7.5': {}
 
-  '@esbuild/aix-ppc64@0.25.11':
+  '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/android-arm64@0.25.11':
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
-  '@esbuild/android-arm@0.25.11':
+  '@esbuild/android-arm@0.25.12':
     optional: true
 
-  '@esbuild/android-x64@0.25.11':
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.11':
+  '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-x64@0.25.11':
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.11':
+  '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-x64@0.25.11':
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.11':
+  '@esbuild/linux-arm64@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm@0.25.11':
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.11':
+  '@esbuild/linux-ia32@0.25.12':
     optional: true
 
-  '@esbuild/linux-loong64@0.25.11':
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.11':
+  '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
-  '@esbuild/linux-ppc64@0.25.11':
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.11':
+  '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
-  '@esbuild/linux-s390x@0.25.11':
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
-  '@esbuild/linux-x64@0.25.11':
+  '@esbuild/linux-x64@0.25.12':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.25.11':
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.11':
+  '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.11':
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.11':
+  '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.25.11':
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.11':
+  '@esbuild/sunos-x64@0.25.12':
     optional: true
 
-  '@esbuild/win32-arm64@0.25.11':
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.11':
+  '@esbuild/win32-ia32@0.25.12':
     optional: true
 
-  '@esbuild/win32-x64@0.25.11':
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.0(eslint@9.39.1(jiti@2.6.1))':
@@ -3323,7 +3325,7 @@ snapshots:
       magic-string: 0.30.21
       sirv: 3.0.2
       tinyrainbow: 2.0.0
-      vitest: 4.0.6(@vitest/ui@4.0.6)(jiti@2.6.1)(jsdom@27.0.1)(lightningcss@1.30.2)(yaml@2.8.1)
+      vitest: 4.0.6(@vitest/ui@4.0.6)(jiti@2.6.1)(jsdom@27.1.0)(lightningcss@1.30.2)(yaml@2.8.1)
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -3344,7 +3346,7 @@ snapshots:
       magicast: 0.3.5
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.6(@vitest/ui@4.0.6)(jiti@2.6.1)(jsdom@27.0.1)(lightningcss@1.30.2)(yaml@2.8.1)
+      vitest: 4.0.6(@vitest/ui@4.0.6)(jiti@2.6.1)(jsdom@27.1.0)(lightningcss@1.30.2)(yaml@2.8.1)
     optionalDependencies:
       '@vitest/browser': 3.2.4(vite@7.1.12(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1))(vitest@4.0.6)
     transitivePeerDependencies:
@@ -3409,7 +3411,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.6(@vitest/ui@4.0.6)(jiti@2.6.1)(jsdom@27.0.1)(lightningcss@1.30.2)(yaml@2.8.1)
+      vitest: 4.0.6(@vitest/ui@4.0.6)(jiti@2.6.1)(jsdom@27.1.0)(lightningcss@1.30.2)(yaml@2.8.1)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -3525,7 +3527,7 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  baseline-browser-mapping@2.8.21: {}
+  baseline-browser-mapping@2.8.23: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -3546,15 +3548,15 @@ snapshots:
 
   browserslist@4.27.0:
     dependencies:
-      baseline-browser-mapping: 2.8.21
-      caniuse-lite: 1.0.30001752
+      baseline-browser-mapping: 2.8.23
+      caniuse-lite: 1.0.30001753
       electron-to-chromium: 1.5.244
       node-releases: 2.0.27
       update-browserslist-db: 1.1.4(browserslist@4.27.0)
 
   callsites@3.1.0: {}
 
-  caniuse-lite@1.0.30001752: {}
+  caniuse-lite@1.0.30001753: {}
 
   chai@6.2.0: {}
 
@@ -3642,34 +3644,34 @@ snapshots:
 
   es-module-lexer@1.7.0: {}
 
-  esbuild@0.25.11:
+  esbuild@0.25.12:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.11
-      '@esbuild/android-arm': 0.25.11
-      '@esbuild/android-arm64': 0.25.11
-      '@esbuild/android-x64': 0.25.11
-      '@esbuild/darwin-arm64': 0.25.11
-      '@esbuild/darwin-x64': 0.25.11
-      '@esbuild/freebsd-arm64': 0.25.11
-      '@esbuild/freebsd-x64': 0.25.11
-      '@esbuild/linux-arm': 0.25.11
-      '@esbuild/linux-arm64': 0.25.11
-      '@esbuild/linux-ia32': 0.25.11
-      '@esbuild/linux-loong64': 0.25.11
-      '@esbuild/linux-mips64el': 0.25.11
-      '@esbuild/linux-ppc64': 0.25.11
-      '@esbuild/linux-riscv64': 0.25.11
-      '@esbuild/linux-s390x': 0.25.11
-      '@esbuild/linux-x64': 0.25.11
-      '@esbuild/netbsd-arm64': 0.25.11
-      '@esbuild/netbsd-x64': 0.25.11
-      '@esbuild/openbsd-arm64': 0.25.11
-      '@esbuild/openbsd-x64': 0.25.11
-      '@esbuild/openharmony-arm64': 0.25.11
-      '@esbuild/sunos-x64': 0.25.11
-      '@esbuild/win32-arm64': 0.25.11
-      '@esbuild/win32-ia32': 0.25.11
-      '@esbuild/win32-x64': 0.25.11
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   escalade@3.2.0: {}
 
@@ -3823,7 +3825,7 @@ snapshots:
 
   globals@14.0.0: {}
 
-  globals@16.4.0: {}
+  globals@16.5.0: {}
 
   graceful-fs@4.2.11: {}
 
@@ -3917,9 +3919,10 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@27.0.1:
+  jsdom@27.1.0:
     dependencies:
-      '@asamuzakjp/dom-selector': 6.7.3
+      '@acemir/cssom': 0.9.19
+      '@asamuzakjp/dom-selector': 6.7.4
       cssstyle: 5.3.2
       data-urls: 6.0.0
       decimal.js: 10.6.0
@@ -3928,7 +3931,6 @@ snapshots:
       https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
       parse5: 8.0.0
-      rrweb-cssom: 0.8.0
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.0
@@ -4525,8 +4527,6 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.52.5
       fsevents: 2.3.3
 
-  rrweb-cssom@0.8.0: {}
-
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -4670,7 +4670,7 @@ snapshots:
 
   vite@7.1.12(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1):
     dependencies:
-      esbuild: 0.25.11
+      esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
@@ -4687,12 +4687,12 @@ snapshots:
       '@vitest/browser': 3.2.4(vite@7.1.12(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1))(vitest@4.0.6)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      vitest: 4.0.6(@vitest/ui@4.0.6)(jiti@2.6.1)(jsdom@27.0.1)(lightningcss@1.30.2)(yaml@2.8.1)
+      vitest: 4.0.6(@vitest/ui@4.0.6)(jiti@2.6.1)(jsdom@27.1.0)(lightningcss@1.30.2)(yaml@2.8.1)
     optionalDependencies:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.2(@types/react@19.2.2)
 
-  vitest@4.0.6(@vitest/ui@4.0.6)(jiti@2.6.1)(jsdom@27.0.1)(lightningcss@1.30.2)(yaml@2.8.1):
+  vitest@4.0.6(@vitest/ui@4.0.6)(jiti@2.6.1)(jsdom@27.1.0)(lightningcss@1.30.2)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.0.6
       '@vitest/mocker': 4.0.6(vite@7.1.12(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1))
@@ -4716,7 +4716,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@vitest/ui': 4.0.6(vitest@4.0.6)
-      jsdom: 27.0.1
+      jsdom: 27.1.0
     transitivePeerDependencies:
       - jiti
       - less

--- a/compensation/dashboard/src/generated/compensation/execution_failed/types.ts
+++ b/compensation/dashboard/src/generated/compensation/execution_failed/types.ts
@@ -74,7 +74,7 @@ export interface ErrorDetails {
     errorCode: string;
     errorMsg: string;
     stackTrace: string;
-    succeeded: boolean;
+    readonly succeeded: boolean;
 }
 
 /** - key: compensation.execution_failed.EventId */
@@ -165,18 +165,18 @@ export interface ExecutionFailedCreated {
 
 /** - key: compensation.execution_failed.ExecutionFailedState */
 export interface ExecutionFailedState {
-    error: ErrorDetails;
-    eventId: EventId;
+    readonly error: ErrorDetails;
+    readonly eventId: EventId;
     /** - format: int64 */
     executeAt: number;
-    function: FunctionInfo;
+    readonly function: FunctionInfo;
     id: string;
     recoverable: RecoverableType;
-    retrySpec: RetrySpec;
-    retryState: RetryState;
+    readonly retrySpec: RetrySpec;
+    readonly retryState: RetryState;
     status: ExecutionFailedStatus;
-    isBelowRetryThreshold: boolean;
-    isRetryable: boolean;
+    readonly isBelowRetryThreshold: boolean;
+    readonly isRetryable: boolean;
 }
 
 /** - key: compensation.execution_failed.ExecutionFailedStatus */


### PR DESCRIPTION
- Updated @ahoo-wang/fetcher and related packages from v3.0.0 to v3.0.3
- Updated dev dependencies including @ahoo-wang/fetcher-generator and jsdom
- Updated pnpm lock file to reflect new dependency versions
- Added readonly modifiers to ExecutionFailedState and ErrorDetails types
- Updated esbuild dependencies to v0.25.12
- Updated dom-selector dependency to v6.7.4
