### PR TITLE
chore(deps): update fetcher dependencies to version 3.1.2

### DIFF
--- a/compensation/dashboard/package.json
+++ b/compensation/dashboard/package.json
@@ -14,15 +14,15 @@
     "generate": "fetcher-generator generate -i http://compensation-service.dev.svc.cluster.local/v3/api-docs -o src/generated"
   },
   "dependencies": {
-    "@ahoo-wang/fetcher": "^3.1.0",
-    "@ahoo-wang/fetcher-cosec": "^3.1.0",
-    "@ahoo-wang/fetcher-decorator": "^3.1.0",
-    "@ahoo-wang/fetcher-eventbus": "^3.1.0",
-    "@ahoo-wang/fetcher-eventstream": "^3.1.0",
-    "@ahoo-wang/fetcher-react": "^3.1.0",
-    "@ahoo-wang/fetcher-storage": "^3.1.0",
-    "@ahoo-wang/fetcher-viewer": "^3.1.0",
-    "@ahoo-wang/fetcher-wow": "^3.1.0",
+    "@ahoo-wang/fetcher": "^3.1.2",
+    "@ahoo-wang/fetcher-cosec": "^3.1.2",
+    "@ahoo-wang/fetcher-decorator": "^3.1.2",
+    "@ahoo-wang/fetcher-eventbus": "^3.1.2",
+    "@ahoo-wang/fetcher-eventstream": "^3.1.2",
+    "@ahoo-wang/fetcher-react": "^3.1.2",
+    "@ahoo-wang/fetcher-storage": "^3.1.2",
+    "@ahoo-wang/fetcher-viewer": "^3.1.2",
+    "@ahoo-wang/fetcher-wow": "^3.1.2",
     "@ant-design/icons": "^5.6.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@monaco-editor/react": "4.7.0",
@@ -33,7 +33,7 @@
     "react-router": "^7.9.5"
   },
   "devDependencies": {
-    "@ahoo-wang/fetcher-generator": "^3.1.0",
+    "@ahoo-wang/fetcher-generator": "^3.1.2",
     "@eslint/js": "^9.39.1",
     "@tailwindcss/vite": "^4.1.16",
     "@testing-library/jest-dom": "^6.9.1",

--- a/compensation/dashboard/pnpm-lock.yaml
+++ b/compensation/dashboard/pnpm-lock.yaml
@@ -9,32 +9,32 @@ importers:
   .:
     dependencies:
       '@ahoo-wang/fetcher':
-        specifier: ^3.1.0
-        version: 3.1.0
+        specifier: ^3.1.2
+        version: 3.1.2
       '@ahoo-wang/fetcher-cosec':
-        specifier: ^3.1.0
-        version: 3.1.0(@ahoo-wang/fetcher-eventbus@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher-storage@3.1.0(@ahoo-wang/fetcher-eventbus@3.1.0(@ahoo-wang/fetcher@3.1.0)))(@ahoo-wang/fetcher@3.1.0)
+        specifier: ^3.1.2
+        version: 3.1.2(@ahoo-wang/fetcher-eventbus@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher-storage@3.1.2(@ahoo-wang/fetcher-eventbus@3.1.2(@ahoo-wang/fetcher@3.1.2)))(@ahoo-wang/fetcher@3.1.2)
       '@ahoo-wang/fetcher-decorator':
-        specifier: ^3.1.0
-        version: 3.1.0(@ahoo-wang/fetcher@3.1.0)
+        specifier: ^3.1.2
+        version: 3.1.2(@ahoo-wang/fetcher@3.1.2)
       '@ahoo-wang/fetcher-eventbus':
-        specifier: ^3.1.0
-        version: 3.1.0(@ahoo-wang/fetcher@3.1.0)
+        specifier: ^3.1.2
+        version: 3.1.2(@ahoo-wang/fetcher@3.1.2)
       '@ahoo-wang/fetcher-eventstream':
-        specifier: ^3.1.0
-        version: 3.1.0(@ahoo-wang/fetcher@3.1.0)
+        specifier: ^3.1.2
+        version: 3.1.2(@ahoo-wang/fetcher@3.1.2)
       '@ahoo-wang/fetcher-react':
-        specifier: ^3.1.0
-        version: 3.1.0(@ahoo-wang/fetcher-eventbus@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher-eventstream@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher-storage@3.1.0(@ahoo-wang/fetcher-eventbus@3.1.0(@ahoo-wang/fetcher@3.1.0)))(@ahoo-wang/fetcher-wow@3.1.0(@ahoo-wang/fetcher-decorator@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher-eventstream@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher@3.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^3.1.2
+        version: 3.1.2(@ahoo-wang/fetcher-eventbus@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher-eventstream@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher-storage@3.1.2(@ahoo-wang/fetcher-eventbus@3.1.2(@ahoo-wang/fetcher@3.1.2)))(@ahoo-wang/fetcher-wow@3.1.2(@ahoo-wang/fetcher-decorator@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher-eventstream@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher@3.1.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@ahoo-wang/fetcher-storage':
-        specifier: ^3.1.0
-        version: 3.1.0(@ahoo-wang/fetcher-eventbus@3.1.0(@ahoo-wang/fetcher@3.1.0))
+        specifier: ^3.1.2
+        version: 3.1.2(@ahoo-wang/fetcher-eventbus@3.1.2(@ahoo-wang/fetcher@3.1.2))
       '@ahoo-wang/fetcher-viewer':
-        specifier: ^3.1.0
-        version: 3.1.0(efced36117647742e762ba4270c2b835)
+        specifier: ^3.1.2
+        version: 3.1.2(ed0a5aa8f95054d78c6d28bc19c44476)
       '@ahoo-wang/fetcher-wow':
-        specifier: ^3.1.0
-        version: 3.1.0(@ahoo-wang/fetcher-decorator@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher-eventstream@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher@3.1.0)
+        specifier: ^3.1.2
+        version: 3.1.2(@ahoo-wang/fetcher-decorator@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher-eventstream@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher@3.1.2)
       '@ant-design/icons':
         specifier: ^5.6.1
         version: 5.6.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -61,8 +61,8 @@ importers:
         version: 7.9.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     devDependencies:
       '@ahoo-wang/fetcher-generator':
-        specifier: ^3.1.0
-        version: 3.1.0(@ahoo-wang/fetcher-decorator@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher-eventstream@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@3.1.0(@ahoo-wang/fetcher-decorator@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher-eventstream@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher@3.1.0)
+        specifier: ^3.1.2
+        version: 3.1.2(@ahoo-wang/fetcher-decorator@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher-eventstream@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@3.1.2(@ahoo-wang/fetcher-decorator@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher-eventstream@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher@3.1.2)
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.1
@@ -141,30 +141,30 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@ahoo-wang/fetcher-cosec@3.1.0':
-    resolution: {integrity: sha512-5646m/oOSJyq4nhe4o85MRTu+nsam8pAmxaVk+nM01SM0lc1utFhGSnzMG6vW4Rao/30jQtaLXO/uUDAeSlUkQ==}
+  '@ahoo-wang/fetcher-cosec@3.1.2':
+    resolution: {integrity: sha512-CprKHoR/PI983udbt5+M7Od/NLDUHDZG4wTAQQLySp72gKDz7KAAAQ3WefAYJgwE4buOu+JyWWHWcwDqDPa7SA==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
       '@ahoo-wang/fetcher-eventbus': ^3.0.0
       '@ahoo-wang/fetcher-storage': ^3.0.0
 
-  '@ahoo-wang/fetcher-decorator@3.1.0':
-    resolution: {integrity: sha512-o3QQggV2X9bRrdHN12wbNNE59E8M8dJyJZQhVVzK6GiZw1dip6bnxh60sUu0ugOKeNPDCd8W9rhGpy3fc0xKlA==}
+  '@ahoo-wang/fetcher-decorator@3.1.2':
+    resolution: {integrity: sha512-KpqZexUnngRFFOE0qC9kOSnJlNfedQxVtSjo9Xaz25CRyWJ7tac2XeMVWNtFO6PSSmpJ88EiLiU8uh4TtU/b8Q==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
 
-  '@ahoo-wang/fetcher-eventbus@3.1.0':
-    resolution: {integrity: sha512-XgDPvoPepWRi74vKOYN5M5MLRHuXmvYMfyvUek7nmwVGQfh8Omk+mCvuqFT6CL3ofvpTwgysYOP6mo3ut36tFw==}
+  '@ahoo-wang/fetcher-eventbus@3.1.2':
+    resolution: {integrity: sha512-XzKsrKFLEJTdELEqt6IQzchpoGeFy2O1q2C7Mg5b1DEnX3GxXiX/4x7ULDua0gBoJ26J98i47F2kHQAo3SKowA==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
 
-  '@ahoo-wang/fetcher-eventstream@3.1.0':
-    resolution: {integrity: sha512-SrythnMXS31FF30StcsupAyarG2r7TZGncMHXQbfu5xqH4IzFrAzsS458IYfU8VFXFcejfX8s9UTZUvwVEPOtQ==}
+  '@ahoo-wang/fetcher-eventstream@3.1.2':
+    resolution: {integrity: sha512-4trIQlhv8BTshOaga/KkrztNdYe8EuKku3ia4SDR1B1eyUVDSBk7ibxyyw9UFQHn6LjVkCT3TA6vhQxp/H8mpA==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
 
-  '@ahoo-wang/fetcher-generator@3.1.0':
-    resolution: {integrity: sha512-AGGhwrWiezYNoKawbMwW0M+Ylv7lipnMOUlVU2Havhp1ilNS/dV+Sa3y/gwDms50nf4MAQmGDFPzd3rzaKIoeQ==}
+  '@ahoo-wang/fetcher-generator@3.1.2':
+    resolution: {integrity: sha512-AhlPayno2f+b+be8/E+tRaeVV+w8tq3SDITGprmL/DxUnP37T6MA56PG+a0tmahEZKqxWJsNeuqDPY4nzpt45A==}
     hasBin: true
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
@@ -176,8 +176,8 @@ packages:
   '@ahoo-wang/fetcher-openapi@2.3.0':
     resolution: {integrity: sha512-He3I/VovQzLNajxL2hoUZKlAnt0ZpehpMpbjgxvdPEoWfeAA3qZc0+C8Mhrk3HQQAC69lZOSt3JtAvzYDxpn/Q==}
 
-  '@ahoo-wang/fetcher-react@3.1.0':
-    resolution: {integrity: sha512-5hL1lkRcwjTjncwYbvEiMm5dVLKk1mtqcmzPuUFi4XYUBWSg0lTcwy81fZl+wwfShlB+2l2upETnYrVPy5gvRQ==}
+  '@ahoo-wang/fetcher-react@3.1.2':
+    resolution: {integrity: sha512-gFeKf++gAqs8AZuTBbMp/Xs+9BbBVG7OFU1/JBqrbglcXh8LE2uffyryamtsUGO5tu5D2qd9wMfgmVtOtRgQ6Q==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
       '@ahoo-wang/fetcher-eventbus': ^3.0.0
@@ -187,13 +187,13 @@ packages:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
 
-  '@ahoo-wang/fetcher-storage@3.1.0':
-    resolution: {integrity: sha512-3LCOjcGYRFVvG1u0Pv8Oj/Kt4zwZhliyRbnOO5xAxhfL3VWs4sAlJLvL5/x8b3EsiB+Y2PcBVjnWIYfcvf2klQ==}
+  '@ahoo-wang/fetcher-storage@3.1.2':
+    resolution: {integrity: sha512-eSr5Z4Z6XZt+I9c/xIXiUkMUfkNow97aiFDV0fk+11FbPEzFLV5UzxlMTdSaGfNI9eB+Vxu5dvmQWOuDIzZQJQ==}
     peerDependencies:
       '@ahoo-wang/fetcher-eventbus': ^3.0.0
 
-  '@ahoo-wang/fetcher-viewer@3.1.0':
-    resolution: {integrity: sha512-GjnGFmOWrZivb/dnGJs6wTi/TjsaBK/nHniiExhveQ7bMemsJ2F0IQASD5MHndAc4eQoLezbyoitu6iOMW8uBA==}
+  '@ahoo-wang/fetcher-viewer@3.1.2':
+    resolution: {integrity: sha512-6TwRvY2sDUrXJQuZoYe2/D5tVy+U6oLZJZ+xRD+zuEap/MLhHGmdzvjcnTnPWqT+fdJfISKxd76XVzf0pvaoUQ==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
       '@ahoo-wang/fetcher-openapi': ^3.0.0
@@ -205,15 +205,15 @@ packages:
       react: '>=19.0.0'
       react-dom: '>=19.0.0'
 
-  '@ahoo-wang/fetcher-wow@3.1.0':
-    resolution: {integrity: sha512-9Z3GqM5pzw4eg6uonI26AKtz7xaHtaKbjC60TeJNjePqhErkfIy1uhTM6MlpH4CCBezFU/YrHg8r8ey/Ss2nCA==}
+  '@ahoo-wang/fetcher-wow@3.1.2':
+    resolution: {integrity: sha512-q8Ts7FhsqvkGKGxPrIkcVzIBqLorm3A9yhGGXreTtxEgOrsxRHHndDaGelsIwSVBMI3PlA9mH9Zftc3xEOmCAw==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
       '@ahoo-wang/fetcher-decorator': ^3.0.0
       '@ahoo-wang/fetcher-eventstream': ^3.0.0
 
-  '@ahoo-wang/fetcher@3.1.0':
-    resolution: {integrity: sha512-83kCGIotJHH84HaoK6vylCuhnwvYacU5OAgWejn389GGvEJu8Qd9PTWSsrMy7X8KncqqZeqw1hp5Wi+/6oXfuQ==}
+  '@ahoo-wang/fetcher@3.1.2':
+    resolution: {integrity: sha512-hGraG2cZdWEy6OaZISt+sP/gemgpR1K5NxUh0oGwiR4t6GJNHtQagvK7W7TmJwC8y2G/aW/UK+R0eyv7SHtypg==}
 
   '@ant-design/colors@7.2.1':
     resolution: {integrity: sha512-lCHDcEzieu4GA3n8ELeZ5VQ8pKQAWcGGLRTQ50aQM2iqPpq2evTxER84jfdPvsPAtEcZ7m44NI45edFMo8oOYQ==}
@@ -2462,72 +2462,72 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ahoo-wang/fetcher-cosec@3.1.0(@ahoo-wang/fetcher-eventbus@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher-storage@3.1.0(@ahoo-wang/fetcher-eventbus@3.1.0(@ahoo-wang/fetcher@3.1.0)))(@ahoo-wang/fetcher@3.1.0)':
+  '@ahoo-wang/fetcher-cosec@3.1.2(@ahoo-wang/fetcher-eventbus@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher-storage@3.1.2(@ahoo-wang/fetcher-eventbus@3.1.2(@ahoo-wang/fetcher@3.1.2)))(@ahoo-wang/fetcher@3.1.2)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.1.0
-      '@ahoo-wang/fetcher-eventbus': 3.1.0(@ahoo-wang/fetcher@3.1.0)
-      '@ahoo-wang/fetcher-storage': 3.1.0(@ahoo-wang/fetcher-eventbus@3.1.0(@ahoo-wang/fetcher@3.1.0))
+      '@ahoo-wang/fetcher': 3.1.2
+      '@ahoo-wang/fetcher-eventbus': 3.1.2(@ahoo-wang/fetcher@3.1.2)
+      '@ahoo-wang/fetcher-storage': 3.1.2(@ahoo-wang/fetcher-eventbus@3.1.2(@ahoo-wang/fetcher@3.1.2))
       nanoid: 5.1.6
 
-  '@ahoo-wang/fetcher-decorator@3.1.0(@ahoo-wang/fetcher@3.1.0)':
+  '@ahoo-wang/fetcher-decorator@3.1.2(@ahoo-wang/fetcher@3.1.2)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.1.0
+      '@ahoo-wang/fetcher': 3.1.2
       reflect-metadata: 0.2.2
 
-  '@ahoo-wang/fetcher-eventbus@3.1.0(@ahoo-wang/fetcher@3.1.0)':
+  '@ahoo-wang/fetcher-eventbus@3.1.2(@ahoo-wang/fetcher@3.1.2)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.1.0
+      '@ahoo-wang/fetcher': 3.1.2
 
-  '@ahoo-wang/fetcher-eventstream@3.1.0(@ahoo-wang/fetcher@3.1.0)':
+  '@ahoo-wang/fetcher-eventstream@3.1.2(@ahoo-wang/fetcher@3.1.2)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.1.0
+      '@ahoo-wang/fetcher': 3.1.2
 
-  '@ahoo-wang/fetcher-generator@3.1.0(@ahoo-wang/fetcher-decorator@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher-eventstream@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@3.1.0(@ahoo-wang/fetcher-decorator@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher-eventstream@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher@3.1.0)':
+  '@ahoo-wang/fetcher-generator@3.1.2(@ahoo-wang/fetcher-decorator@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher-eventstream@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@3.1.2(@ahoo-wang/fetcher-decorator@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher-eventstream@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher@3.1.2)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.1.0
-      '@ahoo-wang/fetcher-decorator': 3.1.0(@ahoo-wang/fetcher@3.1.0)
-      '@ahoo-wang/fetcher-eventstream': 3.1.0(@ahoo-wang/fetcher@3.1.0)
+      '@ahoo-wang/fetcher': 3.1.2
+      '@ahoo-wang/fetcher-decorator': 3.1.2(@ahoo-wang/fetcher@3.1.2)
+      '@ahoo-wang/fetcher-eventstream': 3.1.2(@ahoo-wang/fetcher@3.1.2)
       '@ahoo-wang/fetcher-openapi': 2.3.0
-      '@ahoo-wang/fetcher-wow': 3.1.0(@ahoo-wang/fetcher-decorator@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher-eventstream@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher@3.1.0)
+      '@ahoo-wang/fetcher-wow': 3.1.2(@ahoo-wang/fetcher-decorator@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher-eventstream@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher@3.1.2)
       commander: 14.0.2
       ts-morph: 27.0.2
       yaml: 2.8.1
 
   '@ahoo-wang/fetcher-openapi@2.3.0': {}
 
-  '@ahoo-wang/fetcher-react@3.1.0(@ahoo-wang/fetcher-eventbus@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher-eventstream@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher-storage@3.1.0(@ahoo-wang/fetcher-eventbus@3.1.0(@ahoo-wang/fetcher@3.1.0)))(@ahoo-wang/fetcher-wow@3.1.0(@ahoo-wang/fetcher-decorator@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher-eventstream@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher@3.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@ahoo-wang/fetcher-react@3.1.2(@ahoo-wang/fetcher-eventbus@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher-eventstream@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher-storage@3.1.2(@ahoo-wang/fetcher-eventbus@3.1.2(@ahoo-wang/fetcher@3.1.2)))(@ahoo-wang/fetcher-wow@3.1.2(@ahoo-wang/fetcher-decorator@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher-eventstream@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher@3.1.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.1.0
-      '@ahoo-wang/fetcher-eventbus': 3.1.0(@ahoo-wang/fetcher@3.1.0)
-      '@ahoo-wang/fetcher-eventstream': 3.1.0(@ahoo-wang/fetcher@3.1.0)
-      '@ahoo-wang/fetcher-storage': 3.1.0(@ahoo-wang/fetcher-eventbus@3.1.0(@ahoo-wang/fetcher@3.1.0))
-      '@ahoo-wang/fetcher-wow': 3.1.0(@ahoo-wang/fetcher-decorator@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher-eventstream@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher@3.1.0)
+      '@ahoo-wang/fetcher': 3.1.2
+      '@ahoo-wang/fetcher-eventbus': 3.1.2(@ahoo-wang/fetcher@3.1.2)
+      '@ahoo-wang/fetcher-eventstream': 3.1.2(@ahoo-wang/fetcher@3.1.2)
+      '@ahoo-wang/fetcher-storage': 3.1.2(@ahoo-wang/fetcher-eventbus@3.1.2(@ahoo-wang/fetcher@3.1.2))
+      '@ahoo-wang/fetcher-wow': 3.1.2(@ahoo-wang/fetcher-decorator@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher-eventstream@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher@3.1.2)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@ahoo-wang/fetcher-storage@3.1.0(@ahoo-wang/fetcher-eventbus@3.1.0(@ahoo-wang/fetcher@3.1.0))':
+  '@ahoo-wang/fetcher-storage@3.1.2(@ahoo-wang/fetcher-eventbus@3.1.2(@ahoo-wang/fetcher@3.1.2))':
     dependencies:
-      '@ahoo-wang/fetcher-eventbus': 3.1.0(@ahoo-wang/fetcher@3.1.0)
+      '@ahoo-wang/fetcher-eventbus': 3.1.2(@ahoo-wang/fetcher@3.1.2)
 
-  '@ahoo-wang/fetcher-viewer@3.1.0(efced36117647742e762ba4270c2b835)':
+  '@ahoo-wang/fetcher-viewer@3.1.2(ed0a5aa8f95054d78c6d28bc19c44476)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.1.0
+      '@ahoo-wang/fetcher': 3.1.2
       '@ahoo-wang/fetcher-openapi': 2.3.0
-      '@ahoo-wang/fetcher-react': 3.1.0(@ahoo-wang/fetcher-eventbus@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher-eventstream@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher-storage@3.1.0(@ahoo-wang/fetcher-eventbus@3.1.0(@ahoo-wang/fetcher@3.1.0)))(@ahoo-wang/fetcher-wow@3.1.0(@ahoo-wang/fetcher-decorator@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher-eventstream@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher@3.1.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@ahoo-wang/fetcher-storage': 3.1.0(@ahoo-wang/fetcher-eventbus@3.1.0(@ahoo-wang/fetcher@3.1.0))
-      '@ahoo-wang/fetcher-wow': 3.1.0(@ahoo-wang/fetcher-decorator@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher-eventstream@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher@3.1.0)
+      '@ahoo-wang/fetcher-react': 3.1.2(@ahoo-wang/fetcher-eventbus@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher-eventstream@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher-storage@3.1.2(@ahoo-wang/fetcher-eventbus@3.1.2(@ahoo-wang/fetcher@3.1.2)))(@ahoo-wang/fetcher-wow@3.1.2(@ahoo-wang/fetcher-decorator@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher-eventstream@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher@3.1.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@ahoo-wang/fetcher-storage': 3.1.2(@ahoo-wang/fetcher-eventbus@3.1.2(@ahoo-wang/fetcher@3.1.2))
+      '@ahoo-wang/fetcher-wow': 3.1.2(@ahoo-wang/fetcher-decorator@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher-eventstream@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher@3.1.2)
       '@ant-design/icons': 5.6.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       antd: 5.28.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@ahoo-wang/fetcher-wow@3.1.0(@ahoo-wang/fetcher-decorator@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher-eventstream@3.1.0(@ahoo-wang/fetcher@3.1.0))(@ahoo-wang/fetcher@3.1.0)':
+  '@ahoo-wang/fetcher-wow@3.1.2(@ahoo-wang/fetcher-decorator@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher-eventstream@3.1.2(@ahoo-wang/fetcher@3.1.2))(@ahoo-wang/fetcher@3.1.2)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.1.0
-      '@ahoo-wang/fetcher-decorator': 3.1.0(@ahoo-wang/fetcher@3.1.0)
-      '@ahoo-wang/fetcher-eventstream': 3.1.0(@ahoo-wang/fetcher@3.1.0)
+      '@ahoo-wang/fetcher': 3.1.2
+      '@ahoo-wang/fetcher-decorator': 3.1.2(@ahoo-wang/fetcher@3.1.2)
+      '@ahoo-wang/fetcher-eventstream': 3.1.2(@ahoo-wang/fetcher@3.1.2)
 
-  '@ahoo-wang/fetcher@3.1.0': {}
+  '@ahoo-wang/fetcher@3.1.2': {}
 
   '@ant-design/colors@7.2.1':
     dependencies:

--- a/compensation/dashboard/src/generated/compensation/execution_failed/types.ts
+++ b/compensation/dashboard/src/generated/compensation/execution_failed/types.ts
@@ -3,6 +3,30 @@ import { AggregateId, BindingError, FunctionInfo, FunctionKind, RecoverableType 
 /**
  * apply_execution_failed
  * - key: compensation.execution_failed.ApplyExecutionFailed
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object",
+ *   "properties": {
+ *     "error": {
+ *       "$ref": "#/components/schemas/compensation.execution_failed.ErrorDetails"
+ *     },
+ *     "executeAt": {
+ *       "type": "integer",
+ *       "format": "int64"
+ *     },
+ *     "recoverable": {
+ *       "$ref": "#/components/schemas/wow.api.RecoverableType"
+ *     }
+ *   },
+ *   "required": [
+ *     "error",
+ *     "executeAt"
+ *   ],
+ *   "title": "apply_execution_failed",
+ *   "description": ""
+ * }
+ * ```
  */
 export interface ApplyExecutionFailed {
     error: ErrorDetails;
@@ -14,6 +38,23 @@ export interface ApplyExecutionFailed {
 /**
  * apply_execution_success
  * - key: compensation.execution_failed.ApplyExecutionSuccess
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object",
+ *   "properties": {
+ *     "executeAt": {
+ *       "type": "integer",
+ *       "format": "int64"
+ *     }
+ *   },
+ *   "required": [
+ *     "executeAt"
+ *   ],
+ *   "title": "apply_execution_success",
+ *   "description": ""
+ * }
+ * ```
  */
 export interface ApplyExecutionSuccess {
     /** - format: int64 */
@@ -23,6 +64,33 @@ export interface ApplyExecutionSuccess {
 /**
  * apply_retry_spec
  * - key: compensation.execution_failed.ApplyRetrySpec
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object",
+ *   "properties": {
+ *     "executionTimeout": {
+ *       "type": "integer",
+ *       "format": "int32"
+ *     },
+ *     "maxRetries": {
+ *       "type": "integer",
+ *       "format": "int32"
+ *     },
+ *     "minBackoff": {
+ *       "type": "integer",
+ *       "format": "int32"
+ *     }
+ *   },
+ *   "required": [
+ *     "executionTimeout",
+ *     "maxRetries",
+ *     "minBackoff"
+ *   ],
+ *   "title": "apply_retry_spec",
+ *   "description": ""
+ * }
+ * ```
  */
 export interface ApplyRetrySpec {
     /** - format: int32 */
@@ -36,6 +104,34 @@ export interface ApplyRetrySpec {
 /**
  * change_function
  * - key: compensation.execution_failed.ChangeFunction
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object",
+ *   "properties": {
+ *     "contextName": {
+ *       "type": "string"
+ *     },
+ *     "functionKind": {
+ *       "$ref": "#/components/schemas/wow.api.messaging.FunctionKind"
+ *     },
+ *     "name": {
+ *       "type": "string"
+ *     },
+ *     "processorName": {
+ *       "type": "string"
+ *     }
+ *   },
+ *   "required": [
+ *     "contextName",
+ *     "functionKind",
+ *     "name",
+ *     "processorName"
+ *   ],
+ *   "title": "change_function",
+ *   "description": ""
+ * }
+ * ```
  */
 export interface ChangeFunction {
     contextName: string;
@@ -47,6 +143,29 @@ export interface ChangeFunction {
 /**
  * compensation_prepared
  * - key: compensation.execution_failed.CompensationPrepared
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object",
+ *   "properties": {
+ *     "eventId": {
+ *       "$ref": "#/components/schemas/compensation.execution_failed.EventId"
+ *     },
+ *     "function": {
+ *       "$ref": "#/components/schemas/wow.api.messaging.FunctionInfoData"
+ *     },
+ *     "retryState": {
+ *       "$ref": "#/components/schemas/compensation.execution_failed.RetryState"
+ *     }
+ *   },
+ *   "required": [
+ *     "eventId",
+ *     "function",
+ *     "retryState"
+ *   ],
+ *   "title": "compensation_prepared"
+ * }
+ * ```
  */
 export interface CompensationPrepared {
     eventId: EventId;
@@ -57,6 +176,48 @@ export interface CompensationPrepared {
 /**
  * create_execution_failed
  * - key: compensation.execution_failed.CreateExecutionFailed
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object",
+ *   "properties": {
+ *     "error": {
+ *       "$ref": "#/components/schemas/compensation.execution_failed.ErrorDetails"
+ *     },
+ *     "eventId": {
+ *       "$ref": "#/components/schemas/compensation.execution_failed.EventId"
+ *     },
+ *     "executeAt": {
+ *       "type": "integer",
+ *       "format": "int64"
+ *     },
+ *     "function": {
+ *       "$ref": "#/components/schemas/wow.api.messaging.FunctionInfoData"
+ *     },
+ *     "recoverable": {
+ *       "$ref": "#/components/schemas/wow.api.RecoverableType"
+ *     },
+ *     "retrySpec": {
+ *       "anyOf": [
+ *         {
+ *           "type": "null"
+ *         },
+ *         {
+ *           "$ref": "#/components/schemas/compensation.execution_failed.RetrySpec"
+ *         }
+ *       ]
+ *     }
+ *   },
+ *   "required": [
+ *     "error",
+ *     "eventId",
+ *     "executeAt",
+ *     "function"
+ *   ],
+ *   "title": "create_execution_failed",
+ *   "description": ""
+ * }
+ * ```
  */
 export interface CreateExecutionFailed {
     error: ErrorDetails;
@@ -68,7 +229,41 @@ export interface CreateExecutionFailed {
     retrySpec: (null | RetrySpec);
 }
 
-/** - key: compensation.execution_failed.ErrorDetails */
+/**
+ * - key: compensation.execution_failed.ErrorDetails
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object",
+ *   "properties": {
+ *     "bindingErrors": {
+ *       "type": "array",
+ *       "items": {
+ *         "$ref": "#/components/schemas/wow.api.BindingError"
+ *       }
+ *     },
+ *     "errorCode": {
+ *       "type": "string"
+ *     },
+ *     "errorMsg": {
+ *       "type": "string"
+ *     },
+ *     "stackTrace": {
+ *       "type": "string"
+ *     },
+ *     "succeeded": {
+ *       "type": "boolean",
+ *       "readOnly": true
+ *     }
+ *   },
+ *   "required": [
+ *     "errorCode",
+ *     "errorMsg",
+ *     "stackTrace"
+ *   ]
+ * }
+ * ```
+ */
 export interface ErrorDetails {
     bindingErrors: BindingError[];
     errorCode: string;
@@ -77,7 +272,32 @@ export interface ErrorDetails {
     readonly succeeded: boolean;
 }
 
-/** - key: compensation.execution_failed.EventId */
+/**
+ * - key: compensation.execution_failed.EventId
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object",
+ *   "properties": {
+ *     "aggregateId": {
+ *       "$ref": "#/components/schemas/wow.api.modeling.AggregateId"
+ *     },
+ *     "id": {
+ *       "type": "string"
+ *     },
+ *     "version": {
+ *       "type": "integer",
+ *       "format": "int32"
+ *     }
+ *   },
+ *   "required": [
+ *     "aggregateId",
+ *     "id",
+ *     "version"
+ *   ]
+ * }
+ * ```
+ */
 export interface EventId {
     aggregateId: AggregateId;
     id: string;
@@ -85,7 +305,66 @@ export interface EventId {
     version: number;
 }
 
-/** - key: compensation.execution_failed.ExecutionFailedAggregatedFields */
+/**
+ * - key: compensation.execution_failed.ExecutionFailedAggregatedFields
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "string",
+ *   "enum": [
+ *     "",
+ *     "aggregateId",
+ *     "tenantId",
+ *     "ownerId",
+ *     "version",
+ *     "eventId",
+ *     "firstOperator",
+ *     "operator",
+ *     "firstEventTime",
+ *     "eventTime",
+ *     "deleted",
+ *     "state",
+ *     "state.error",
+ *     "state.error.bindingErrors",
+ *     "state.error.bindingErrors.msg",
+ *     "state.error.bindingErrors.name",
+ *     "state.error.errorCode",
+ *     "state.error.errorMsg",
+ *     "state.error.stackTrace",
+ *     "state.error.succeeded",
+ *     "state.eventId",
+ *     "state.eventId.aggregateId",
+ *     "state.eventId.aggregateId.namedAggregate",
+ *     "state.eventId.aggregateId.namedAggregate.aggregateName",
+ *     "state.eventId.aggregateId.namedAggregate.contextName",
+ *     "state.eventId.aggregateId.id",
+ *     "state.eventId.aggregateId.tenantId",
+ *     "state.eventId.id",
+ *     "state.eventId.version",
+ *     "state.executeAt",
+ *     "state.function",
+ *     "state.function.contextName",
+ *     "state.function.functionKind",
+ *     "state.function.name",
+ *     "state.function.processorName",
+ *     "state.id",
+ *     "state.recoverable",
+ *     "state.retrySpec",
+ *     "state.retrySpec.executionTimeout",
+ *     "state.retrySpec.maxRetries",
+ *     "state.retrySpec.minBackoff",
+ *     "state.retryState",
+ *     "state.retryState.nextRetryAt",
+ *     "state.retryState.retries",
+ *     "state.retryState.retryAt",
+ *     "state.retryState.timeoutAt",
+ *     "state.status",
+ *     "state.isBelowRetryThreshold",
+ *     "state.isRetryable"
+ *   ]
+ * }
+ * ```
+ */
 export enum ExecutionFailedAggregatedFields {
     AGGREGATE_ID = 'aggregateId',
     TENANT_ID = 'tenantId',
@@ -140,6 +419,29 @@ export enum ExecutionFailedAggregatedFields {
 /**
  * execution_failed_applied
  * - key: compensation.execution_failed.ExecutionFailedApplied
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object",
+ *   "properties": {
+ *     "error": {
+ *       "$ref": "#/components/schemas/compensation.execution_failed.ErrorDetails"
+ *     },
+ *     "executeAt": {
+ *       "type": "integer",
+ *       "format": "int64"
+ *     },
+ *     "recoverable": {
+ *       "$ref": "#/components/schemas/wow.api.RecoverableType"
+ *     }
+ *   },
+ *   "required": [
+ *     "error",
+ *     "executeAt"
+ *   ],
+ *   "title": "execution_failed_applied"
+ * }
+ * ```
  */
 export interface ExecutionFailedApplied {
     error: ErrorDetails;
@@ -151,6 +453,45 @@ export interface ExecutionFailedApplied {
 /**
  * execution_failed_created
  * - key: compensation.execution_failed.ExecutionFailedCreated
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object",
+ *   "properties": {
+ *     "error": {
+ *       "$ref": "#/components/schemas/compensation.execution_failed.ErrorDetails"
+ *     },
+ *     "eventId": {
+ *       "$ref": "#/components/schemas/compensation.execution_failed.EventId"
+ *     },
+ *     "executeAt": {
+ *       "type": "integer",
+ *       "format": "int64"
+ *     },
+ *     "function": {
+ *       "$ref": "#/components/schemas/wow.api.messaging.FunctionInfoData"
+ *     },
+ *     "recoverable": {
+ *       "$ref": "#/components/schemas/wow.api.RecoverableType"
+ *     },
+ *     "retrySpec": {
+ *       "$ref": "#/components/schemas/compensation.execution_failed.RetrySpec"
+ *     },
+ *     "retryState": {
+ *       "$ref": "#/components/schemas/compensation.execution_failed.RetryState"
+ *     }
+ *   },
+ *   "required": [
+ *     "error",
+ *     "eventId",
+ *     "executeAt",
+ *     "function",
+ *     "retrySpec",
+ *     "retryState"
+ *   ],
+ *   "title": "execution_failed_created"
+ * }
+ * ```
  */
 export interface ExecutionFailedCreated {
     error: ErrorDetails;
@@ -163,7 +504,61 @@ export interface ExecutionFailedCreated {
     retryState: RetryState;
 }
 
-/** - key: compensation.execution_failed.ExecutionFailedState */
+/**
+ * - key: compensation.execution_failed.ExecutionFailedState
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object",
+ *   "properties": {
+ *     "error": {
+ *       "$ref": "#/components/schemas/compensation.execution_failed.ErrorDetails",
+ *       "readOnly": true
+ *     },
+ *     "eventId": {
+ *       "$ref": "#/components/schemas/compensation.execution_failed.EventId",
+ *       "readOnly": true
+ *     },
+ *     "executeAt": {
+ *       "type": "integer",
+ *       "format": "int64"
+ *     },
+ *     "function": {
+ *       "$ref": "#/components/schemas/wow.api.messaging.FunctionInfoData",
+ *       "readOnly": true
+ *     },
+ *     "id": {
+ *       "type": "string"
+ *     },
+ *     "recoverable": {
+ *       "$ref": "#/components/schemas/wow.api.RecoverableType"
+ *     },
+ *     "retrySpec": {
+ *       "$ref": "#/components/schemas/compensation.execution_failed.RetrySpec",
+ *       "readOnly": true
+ *     },
+ *     "retryState": {
+ *       "$ref": "#/components/schemas/compensation.execution_failed.RetryState",
+ *       "readOnly": true
+ *     },
+ *     "status": {
+ *       "$ref": "#/components/schemas/compensation.execution_failed.ExecutionFailedStatus"
+ *     },
+ *     "isBelowRetryThreshold": {
+ *       "type": "boolean",
+ *       "readOnly": true
+ *     },
+ *     "isRetryable": {
+ *       "type": "boolean",
+ *       "readOnly": true
+ *     }
+ *   },
+ *   "required": [
+ *     "id"
+ *   ]
+ * }
+ * ```
+ */
 export interface ExecutionFailedState {
     readonly error: ErrorDetails;
     readonly eventId: EventId;
@@ -179,7 +574,20 @@ export interface ExecutionFailedState {
     readonly isRetryable: boolean;
 }
 
-/** - key: compensation.execution_failed.ExecutionFailedStatus */
+/**
+ * - key: compensation.execution_failed.ExecutionFailedStatus
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "string",
+ *   "enum": [
+ *     "FAILED",
+ *     "PREPARED",
+ *     "SUCCEEDED"
+ *   ]
+ * }
+ * ```
+ */
 export enum ExecutionFailedStatus {
     FAILED = 'FAILED',
     PREPARED = 'PREPARED',
@@ -189,6 +597,22 @@ export enum ExecutionFailedStatus {
 /**
  * execution_success_applied
  * - key: compensation.execution_failed.ExecutionSuccessApplied
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object",
+ *   "properties": {
+ *     "executeAt": {
+ *       "type": "integer",
+ *       "format": "int64"
+ *     }
+ *   },
+ *   "required": [
+ *     "executeAt"
+ *   ],
+ *   "title": "execution_success_applied"
+ * }
+ * ```
  */
 export interface ExecutionSuccessApplied {
     /** - format: int64 */
@@ -198,12 +622,47 @@ export interface ExecutionSuccessApplied {
 /**
  * force_prepare_compensation
  * - key: compensation.execution_failed.ForcePrepareCompensation
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object",
+ *   "title": "force_prepare_compensation",
+ *   "description": ""
+ * }
+ * ```
  */
 export type ForcePrepareCompensation = Record<string, any>;
 
 /**
  * function_changed
  * - key: compensation.execution_failed.FunctionChanged
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object",
+ *   "properties": {
+ *     "contextName": {
+ *       "type": "string"
+ *     },
+ *     "functionKind": {
+ *       "$ref": "#/components/schemas/wow.api.messaging.FunctionKind"
+ *     },
+ *     "name": {
+ *       "type": "string"
+ *     },
+ *     "processorName": {
+ *       "type": "string"
+ *     }
+ *   },
+ *   "required": [
+ *     "contextName",
+ *     "functionKind",
+ *     "name",
+ *     "processorName"
+ *   ],
+ *   "title": "function_changed"
+ * }
+ * ```
  */
 export interface FunctionChanged {
     contextName: string;
@@ -215,6 +674,22 @@ export interface FunctionChanged {
 /**
  * mark_recoverable
  * - key: compensation.execution_failed.MarkRecoverable
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object",
+ *   "properties": {
+ *     "recoverable": {
+ *       "$ref": "#/components/schemas/wow.api.RecoverableType"
+ *     }
+ *   },
+ *   "required": [
+ *     "recoverable"
+ *   ],
+ *   "title": "mark_recoverable",
+ *   "description": ""
+ * }
+ * ```
  */
 export interface MarkRecoverable {
     recoverable: RecoverableType;
@@ -223,18 +698,68 @@ export interface MarkRecoverable {
 /**
  * prepare_compensation
  * - key: compensation.execution_failed.PrepareCompensation
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object",
+ *   "title": "prepare_compensation",
+ *   "description": ""
+ * }
+ * ```
  */
 export type PrepareCompensation = Record<string, any>;
 
 /**
  * recoverable_marked
  * - key: compensation.execution_failed.RecoverableMarked
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object",
+ *   "properties": {
+ *     "recoverable": {
+ *       "$ref": "#/components/schemas/wow.api.RecoverableType"
+ *     }
+ *   },
+ *   "required": [
+ *     "recoverable"
+ *   ],
+ *   "title": "recoverable_marked"
+ * }
+ * ```
  */
 export interface RecoverableMarked {
     recoverable: RecoverableType;
 }
 
-/** - key: compensation.execution_failed.RetrySpec */
+/**
+ * - key: compensation.execution_failed.RetrySpec
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object",
+ *   "properties": {
+ *     "executionTimeout": {
+ *       "type": "integer",
+ *       "format": "int32"
+ *     },
+ *     "maxRetries": {
+ *       "type": "integer",
+ *       "format": "int32"
+ *     },
+ *     "minBackoff": {
+ *       "type": "integer",
+ *       "format": "int32"
+ *     }
+ *   },
+ *   "required": [
+ *     "executionTimeout",
+ *     "maxRetries",
+ *     "minBackoff"
+ *   ]
+ * }
+ * ```
+ */
 export interface RetrySpec {
     /** - format: int32 */
     executionTimeout: number;
@@ -247,6 +772,32 @@ export interface RetrySpec {
 /**
  * retry_spec_applied
  * - key: compensation.execution_failed.RetrySpecApplied
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object",
+ *   "properties": {
+ *     "executionTimeout": {
+ *       "type": "integer",
+ *       "format": "int32"
+ *     },
+ *     "maxRetries": {
+ *       "type": "integer",
+ *       "format": "int32"
+ *     },
+ *     "minBackoff": {
+ *       "type": "integer",
+ *       "format": "int32"
+ *     }
+ *   },
+ *   "required": [
+ *     "executionTimeout",
+ *     "maxRetries",
+ *     "minBackoff"
+ *   ],
+ *   "title": "retry_spec_applied"
+ * }
+ * ```
  */
 export interface RetrySpecApplied {
     /** - format: int32 */
@@ -257,7 +808,39 @@ export interface RetrySpecApplied {
     minBackoff: number;
 }
 
-/** - key: compensation.execution_failed.RetryState */
+/**
+ * - key: compensation.execution_failed.RetryState
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object",
+ *   "properties": {
+ *     "nextRetryAt": {
+ *       "type": "integer",
+ *       "format": "int64"
+ *     },
+ *     "retries": {
+ *       "type": "integer",
+ *       "format": "int32"
+ *     },
+ *     "retryAt": {
+ *       "type": "integer",
+ *       "format": "int64"
+ *     },
+ *     "timeoutAt": {
+ *       "type": "integer",
+ *       "format": "int64"
+ *     }
+ *   },
+ *   "required": [
+ *     "nextRetryAt",
+ *     "retries",
+ *     "retryAt",
+ *     "timeoutAt"
+ *   ]
+ * }
+ * ```
+ */
 export interface RetryState {
     /** - format: int64 */
     nextRetryAt: number;

--- a/compensation/dashboard/src/generated/compensation/types.ts
+++ b/compensation/dashboard/src/generated/compensation/types.ts
@@ -1,23 +1,91 @@
-/** - key: compensation.ApiVersion */
+/**
+ * - key: compensation.ApiVersion
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "string",
+ *   "enum": [
+ *     "V2",
+ *     "V3"
+ *   ]
+ * }
+ * ```
+ */
 export enum ApiVersion {
     V2 = 'V2',
     V3 = 'V3'
 }
 
-/** - key: compensation.Link */
+/**
+ * - key: compensation.Link
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object",
+ *   "properties": {
+ *     "href": {
+ *       "type": "string"
+ *     },
+ *     "templated": {
+ *       "type": "boolean"
+ *     }
+ *   }
+ * }
+ * ```
+ */
 export interface Link {
     href: string;
     templated: boolean;
 }
 
-/** - key: compensation.SecurityContext */
+/**
+ * - key: compensation.SecurityContext
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object"
+ * }
+ * ```
+ */
 export type SecurityContext = Record<string, any>;
-/** - key: compensation.StringLinkMap */
+/**
+ * - key: compensation.StringLinkMap
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object",
+ *   "additionalProperties": {
+ *     "$ref": "#/components/schemas/compensation.Link"
+ *   }
+ * }
+ * ```
+ */
 export type StringLinkMap = Record<string, Link>;
-/** - key: compensation.StringObjectMap */
+/**
+ * - key: compensation.StringObjectMap
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object"
+ * }
+ * ```
+ */
 export type StringObjectMap = Record<string, any>;
 
-/** - key: compensation.WebServerNamespace */
+/**
+ * - key: compensation.WebServerNamespace
+ * - schema: 
+ * ```json
+ * {
+ *   "type": "object",
+ *   "properties": {
+ *     "value": {
+ *       "type": "string"
+ *     }
+ *   }
+ * }
+ * ```
+ */
 export interface WebServerNamespace {
     value: string;
 }


### PR DESCRIPTION
- Updated @ahoo-wang/fetcher from 3.1.0 to3.1.2
- Updated @ahoo-wang/fetcher-cosec from 3.1.0 to3.1.2
- Updated @ahoo-wang/fetcher-decorator from3.1.0 to3.1.2
- Updated @ahoo-wang/fetcher-eventbus from 3.1.0 to3.1.2
- Updated @ahoo-wang/fetcher-eventstream from 3.1.0 to3.1.2
- Updated @ahoo-wang/fetcher-react from 3.1.0 to3.1.2
- Updated @ahoo-wang/fetcher-storage from 3.1.0 to3.1.2
- Updated @ahoo-wang/fetcher-viewer from 3.1.0 to3.1.2
- Updated @ahoo-wang/fetcher-wow from 3.1.0 to3.1.2
- Updated @ahoo-wang/fetcher-generator from 3.1.0 to3.1.2 in devDependencies
- Updated pnpm-lock.yaml with new dependency versions
- Regenerated TypeScript types with updated schemas including JSON schema definitions
- Added detailed schema documentation for all compensation execution failed types
- Enhanced type definitions with comprehensive property descriptions and constraints
