### PR TITLE
docs(api): reorder and enhance annotation documentation

### DIFF
--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/Order.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/Order.kt
@@ -34,17 +34,6 @@ const val ORDER_LAST = Int.MAX_VALUE
  * - Managing dependencies between processors
  * - Implementing complex business workflows
  *
- * @param value The priority value. Lower numbers execute first. Common values:
- *             ORDER_FIRST (-2^31), ORDER_DEFAULT (0), ORDER_LAST (2^31-1)
- * @param before Array of classes that this element should execute before.
- *              Useful for relative ordering without hard-coded values.
- * @param after Array of classes that this element should execute after.
- *             Useful for relative ordering without hard-coded values.
- *
- * @see ORDER_FIRST for the highest priority
- * @see ORDER_DEFAULT for normal priority
- * @see ORDER_LAST for the lowest priority
- *
  * Example usage:
  * ```kotlin
  * @EventProcessor
@@ -69,6 +58,17 @@ const val ORDER_LAST = Int.MAX_VALUE
  *     }
  * }
  * ```
+ *
+ * @param value The priority value. Lower numbers execute first. Common values:
+ *             ORDER_FIRST (-2^31), ORDER_DEFAULT (0), ORDER_LAST (2^31-1)
+ * @param before Array of classes that this element should execute before.
+ *              Useful for relative ordering without hard-coded values.
+ * @param after Array of classes that this element should execute after.
+ *             Useful for relative ordering without hard-coded values.
+ *
+ * @see ORDER_FIRST for the highest priority
+ * @see ORDER_DEFAULT for normal priority
+ * @see ORDER_LAST for the lowest priority
  */
 @Target(AnnotationTarget.CLASS, AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.FUNCTION)
 @Inherited

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/OwnerId.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/OwnerId.kt
@@ -28,9 +28,6 @@ import java.lang.annotation.Inherited
  * The annotated field/property should contain a unique identifier for the owner/tenant,
  * such as a user ID, organization ID, or tenant key.
  *
- * @see TenantId for tenant-specific identification
- * @see AggregateRoute.Owner for ownership routing policies
- *
  * Example usage:
  * ```kotlin
  * @AggregateRoot
@@ -54,6 +51,9 @@ import java.lang.annotation.Inherited
  *     val newName: String
  * )
  * ```
+ *
+ * @see TenantId for tenant-specific identification
+ * @see AggregateRoute.Owner for ownership routing policies
  */
 @Target(
     AnnotationTarget.FIELD,

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/PreparableKey.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/PreparableKey.kt
@@ -15,6 +15,109 @@ package me.ahoo.wow.api.annotation
 
 import org.springframework.stereotype.Component
 
+/**
+ * Marks an interface as a PrepareKey for optimistic concurrency control and resource reservation.
+ *
+ * PrepareKey interfaces define operations for preparing, committing, and rolling back
+ * changes to shared resources in a transactional manner. This annotation enables the framework
+ * to automatically generate proxy implementations that handle the complete prepare-commit-rollback
+ * lifecycle with built-in error handling and transaction management.
+ *
+ * The annotated interface must extend `PrepareKey<T>` where `T` is the value type being prepared.
+ * The framework creates dynamic proxy instances that delegate to underlying PrepareKey implementations
+ * while providing additional capabilities such as:
+ * - Automatic transaction management
+ * - Error handling and rollback on failures
+ * - Resource cleanup on exceptions
+ * - Lifecycle management for prepared values
+ *
+ * ## Prepare-Commit-Rollback Lifecycle
+ *
+ * 1. **Prepare**: Reserve or validate the resource before making changes
+ * 2. **Execute**: Perform the business logic within the prepared context
+ * 3. **Commit**: Confirm the changes if execution succeeds
+ * 4. **Rollback**: Release/cancel the preparation if execution fails
+ *
+ * ## Thread Safety
+ *
+ * PrepareKey implementations should be thread-safe as they may be used concurrently
+ * across multiple requests. The framework handles synchronization through the proxy layer.
+ *
+ * ## Error Handling
+ *
+ * If an exception occurs during the `usingPrepare` block, the framework automatically:
+ * - Calls `rollback()` to release prepared resources
+ * - Propagates the original exception to the caller
+ * - Ensures cleanup happens even if rollback fails
+ *
+ * @param name Optional custom name for the prepare key. If empty, the framework will
+ *             derive the name from the interface's simple class name. The name is used
+ *             to identify and configure the underlying PrepareKey implementation.
+ *             Type: String
+ *             Default: "" (empty string)
+ *
+ * @throws IllegalArgumentException if the annotated class does not extend PrepareKey<T>
+ * @throws IllegalStateException if proxy creation fails due to configuration issues
+ *
+ * Example usage:
+ * ```kotlin
+ * @PreparableKey("user-username")
+ * interface UserUsernamePrepareKey : PrepareKey<String> {
+ *     // Interface can declare additional prepare-related methods
+ *     fun validateUsername(username: String): Boolean
+ * }
+ *
+ * // Usage in service with automatic lifecycle management
+ * @Service
+ * class UserService(
+ *     private val usernameKey: UserUsernamePrepareKey
+ * ) {
+ *
+ *     fun changeUsername(userId: String, newUsername: String) {
+ *         // Framework automatically handles prepare/commit/rollback
+ *         usernameKey.usingPrepare(newUsername) {
+ *             // This block executes within prepared context
+ *             require(usernameKey.validateUsername(newUsername)) {
+ *                 "Username already taken"
+ *             }
+ *
+ *             // Perform the actual username change
+ *             userRepository.updateUsername(userId, newUsername)
+ *
+ *             // If successful, framework calls commit()
+ *             // If exception thrown, framework calls rollback()
+ *         }
+ *     }
+ *
+ *     fun registerUser(email: String, username: String): UserId {
+ *         return usernameKey.usingPrepare(username) {
+ *             val userId = userRepository.createUser(email)
+ *             userRepository.setUsername(userId, username)
+ *             userId  // Return value from prepared block
+ *         }
+ *     }
+ * }
+ *
+ * // Manual lifecycle management (less common)
+ * fun manualUsernameChange(usernameKey: UserUsernamePrepareKey, newUsername: String) {
+ *     val preparedValue = usernameKey.prepare(newUsername)
+ *     try {
+ *         // Perform operations with prepared value
+ *         usernameKey.commit(preparedValue)
+ *     } catch (e: Exception) {
+ *         usernameKey.rollback(preparedValue)
+ *         throw e
+ *     }
+ * }
+ * ```
+ *
+ * @see PrepareKey for the base interface defining prepare operations
+ * @see me.ahoo.wow.infra.prepare.proxy.PrepareKeyProxyFactory for proxy creation details
+ * @see me.ahoo.wow.infra.prepare.PreparedValue for the prepared value container
+ * @since 1.0.0
+ */
 @Target(AnnotationTarget.CLASS)
 @Component
-annotation class PreparableKey(val name: String = "")
+annotation class PreparableKey(
+    val name: String = ""
+)

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/Summary.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/Summary.kt
@@ -28,10 +28,6 @@ import java.lang.annotation.Inherited
  * The summary should be brief (1-2 sentences) and focus on the most important
  * aspect of the annotated element. For more detailed descriptions, use @Description.
  *
- * @param value The summary text. Should be concise and descriptive.
- *
- * @see Description for longer, more detailed descriptions
- *
  * Example usage:
  * ```kotlin
  * @Summary("Manages customer orders and fulfillment")
@@ -46,6 +42,10 @@ import java.lang.annotation.Inherited
  *     val status: OrderStatus
  * }
  * ```
+ *
+ * @param value The summary text. Should be concise and descriptive.
+ *
+ * @see Description for longer, more detailed descriptions
  */
 @Target(
     AnnotationTarget.CLASS,


### PR DESCRIPTION
- Reordered documentation sections in Order annotation for better readability
- Moved related @see references to follow example usage in OwnerId annotation
- Added comprehensive documentation for PreparableKey including lifecycle and error handling
- Repositioned parameter documentation in Summary annotation to maintain consistency
- Enhanced documentation structure across multiple annotations for clarity
- Maintained all existing functionality while improving documentation flow
