### PR TITLE
docs(infra): add comprehensive documentation to PrepareKey and related classes

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/prepare/PrepareKey.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/prepare/PrepareKey.kt
@@ -17,46 +17,281 @@ import me.ahoo.wow.api.naming.Named
 import me.ahoo.wow.infra.prepare.PreparedValue.Companion.toForever
 import reactor.core.publisher.Mono
 
+/**
+ * Key preparation interface for ensuring uniqueness constraints in EventSourcing architectures.
+ *
+ * Unlike traditional databases that use UNIQUE KEY constraints, EventSourcing requires
+ * application-level uniqueness guarantees. PrepareKey provides a mechanism to "prepare"
+ * or reserve keys before they're actually used, ensuring atomicity and preventing race conditions.
+ *
+ * Key features:
+ * - Atomic key preparation and rollback
+ * - TTL (Time-To-Live) support for temporary reservations
+ * - Reprepare operations for key changes
+ * - Transaction-like semantics with automatic rollback on failure
+ *
+ * Common use cases:
+ * - Username/email uniqueness during user registration
+ * - Product SKU uniqueness
+ * - Resource identifier allocation
+ * - Preventing duplicate operations
+ *
+ * @param V The type of value associated with prepared keys
+ *
+ * Example usage for user registration:
+ * ```kotlin
+ * @AggregateRoot
+ * class User(private val state: UserState) {
+ *     @OnCommand
+ *     private fun onRegister(
+ *         register: Register,
+ *         passwordEncoder: PasswordEncoder,
+ *         usernamePrepare: PrepareKey<UsernameIndexValue>,
+ *     ): Mono<Registered> {
+ *         val encodedPassword = passwordEncoder.encode(register.password)
+ *         return usernamePrepare.usingPrepare(
+ *             key = register.username,
+ *             value = UsernameIndexValue(
+ *                 userId = state.id,
+ *                 password = encodedPassword,
+ *             ),
+ *         ) {
+ *             require(it) {
+ *                 "username[${register.username}] is already registered."
+ *             }
+ *             Registered(username = register.username, password = encodedPassword).toMono()
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * Example usage for changing username:
+ * ```kotlin
+ * @OnCommand
+ * private fun onChangeUsername(
+ *     changeUsername: ChangeUsername,
+ *     usernamePrepare: PrepareKey<UsernameIndexValue>
+ * ): Mono<UsernameChanged> {
+ *     val usernameIndexValue = UsernameIndexValue(
+ *         userId = state.id,
+ *         password = state.password,
+ *     )
+ *     return usernamePrepare.reprepare(
+ *         oldKey = state.username,
+ *         oldValue = usernameIndexValue,
+ *         newKey = changeUsername.newUsername,
+ *         newValue = usernameIndexValue
+ *     ).map {
+ *         require(it) {
+ *             "username[${changeUsername.newUsername}] is already registered."
+ *         }
+ *         UsernameChanged(username = changeUsername.newUsername)
+ *     }
+ * }
+ * ```
+ *
+ * @see PreparedValue for value wrapper with TTL support
+ * @see PrepareKeyProxyFactory for proxy-based implementation
+ */
 interface PrepareKey<V : Any> : Named {
+    /**
+     * Prepares a key with a value that never expires.
+     *
+     * This method reserves the key permanently, ensuring no other operations can use
+     * the same key until it's explicitly rolled back.
+     *
+     * @param key The unique key to prepare
+     * @param value The value to associate with the key
+     * @return A Mono emitting true if preparation succeeded, false if key was already prepared
+     *
+     * @see prepare(String, PreparedValue) for TTL-based preparation
+     */
+    fun prepare(
+        key: String,
+        value: V
+    ): Mono<Boolean> = prepare(key, value.toForever())
 
-    fun prepare(key: String, value: V): Mono<Boolean> {
-        return prepare(key, value.toForever())
-    }
+    /**
+     * Prepares a key with a value that may have a time-to-live.
+     *
+     * This method reserves the key for a specified duration, after which it automatically
+     * expires if not used. This is useful for temporary reservations or cleanup scenarios.
+     *
+     * @param key The unique key to prepare
+     * @param value The prepared value with optional TTL
+     * @return A Mono emitting true if preparation succeeded, false if key was already prepared
+     *
+     * @throws IllegalArgumentException if key is null or empty
+     * @see PreparedValue for TTL configuration
+     */
+    fun prepare(
+        key: String,
+        value: PreparedValue<V>
+    ): Mono<Boolean>
 
-    fun prepare(key: String, value: PreparedValue<V>): Mono<Boolean>
-
-    fun get(key: String): Mono<V> {
-        return getValue(key)
+    /**
+     * Retrieves a prepared value by key, filtering out expired entries.
+     *
+     * This method returns only non-expired prepared values. If the value has expired,
+     * an empty Mono is returned.
+     *
+     * @param key The key to look up
+     * @return A Mono emitting the prepared value, or empty if not found or expired
+     *
+     * @see getValue for retrieving with expiration information
+     */
+    fun get(key: String): Mono<V> =
+        getValue(key)
             .filter { !it.isExpired }
             .map { it.value }
-    }
 
+    /**
+     * Retrieves the full prepared value information including expiration status.
+     *
+     * This method returns the complete PreparedValue object, allowing access to
+     * both the value and its expiration information.
+     *
+     * @param key The key to look up
+     * @return A Mono emitting the PreparedValue, or empty if not found
+     *
+     * @see PreparedValue for expiration checking methods
+     */
     fun getValue(key: String): Mono<PreparedValue<V>>
 
+    /**
+     * Rolls back any prepared value for the given key.
+     *
+     * This method removes the key preparation regardless of its current value.
+     * Use this when you want to unconditionally release a key reservation.
+     *
+     * @param key The key to rollback
+     * @return A Mono emitting true if rollback succeeded, false if key was not prepared
+     */
     fun rollback(key: String): Mono<Boolean>
 
     /**
-     * Rollback only if both key and value match
+     * Rolls back a prepared key only if it matches the specified value.
+     *
+     * This conditional rollback ensures atomicity by only releasing the key if
+     * it contains the expected value. This prevents race conditions where
+     * another operation has modified the prepared value.
+     *
+     * @param key The key to rollback
+     * @param value The expected value that must match for rollback to succeed
+     * @return A Mono emitting true if rollback succeeded with matching value, false otherwise
      */
-    fun rollback(key: String, value: V): Mono<Boolean>
+    fun rollback(
+        key: String,
+        value: V
+    ): Mono<Boolean>
 
-    fun reprepare(key: String, oldValue: V, newValue: V): Mono<Boolean> {
-        return reprepare(key, oldValue, newValue.toForever())
-    }
+    /**
+     * Reprepares a key with a new value that never expires.
+     *
+     * This method updates an existing key preparation with a new permanent value.
+     * The old value is used for optimistic concurrency control.
+     *
+     * @param key The key to reprepare
+     * @param oldValue The expected current value for concurrency control
+     * @param newValue The new value to prepare permanently
+     * @return A Mono emitting true if reprepare succeeded, false otherwise
+     *
+     * @see reprepare(String, V, PreparedValue) for TTL-based reprepare
+     */
+    fun reprepare(
+        key: String,
+        oldValue: V,
+        newValue: V
+    ): Mono<Boolean> = reprepare(key, oldValue, newValue.toForever())
 
-    fun reprepare(key: String, oldValue: V, newValue: PreparedValue<V>): Mono<Boolean>
+    /**
+     * Reprepares a key with a new value that may have TTL.
+     *
+     * This method updates an existing key preparation with a new value and optional TTL.
+     * The old value ensures atomicity and prevents concurrent modifications.
+     *
+     * @param key The key to reprepare
+     * @param oldValue The expected current value for concurrency control
+     * @param newValue The new prepared value with optional TTL
+     * @return A Mono emitting true if reprepare succeeded, false otherwise
+     */
+    fun reprepare(
+        key: String,
+        oldValue: V,
+        newValue: PreparedValue<V>
+    ): Mono<Boolean>
 
-    fun reprepare(key: String, value: V): Mono<Boolean> {
-        return reprepare(key, value.toForever())
-    }
+    /**
+     * Reprepares a key with a new permanent value.
+     *
+     * This method updates the value for an existing key preparation, keeping it permanent.
+     *
+     * @param key The key to reprepare
+     * @param value The new permanent value
+     * @return A Mono emitting true if reprepare succeeded, false otherwise
+     */
+    fun reprepare(
+        key: String,
+        value: V
+    ): Mono<Boolean> = reprepare(key, value.toForever())
 
-    fun reprepare(key: String, value: PreparedValue<V>): Mono<Boolean>
+    /**
+     * Reprepares a key with a new value that may have TTL.
+     *
+     * This method updates the value for an existing key preparation with optional TTL.
+     *
+     * @param key The key to reprepare
+     * @param value The new prepared value with optional TTL
+     * @return A Mono emitting true if reprepare succeeded, false otherwise
+     */
+    fun reprepare(
+        key: String,
+        value: PreparedValue<V>
+    ): Mono<Boolean>
 
-    fun reprepare(oldKey: String, oldValue: V, newKey: String, newValue: V): Mono<Boolean> {
-        return reprepare(oldKey, oldValue, newKey, newValue.toForever())
-    }
+    /**
+     * Reprepares by changing both key and value to new permanent values.
+     *
+     * This method atomically releases the old key and prepares the new key.
+     * It's commonly used for scenarios like username changes where the identifier itself changes.
+     *
+     * @param oldKey The current key to release
+     * @param oldValue The expected value of the old key for concurrency control
+     * @param newKey The new key to prepare
+     * @param newValue The permanent value for the new key
+     * @return A Mono emitting true if the key change succeeded, false otherwise
+     *
+     * @throws IllegalArgumentException if oldKey equals newKey
+     */
+    fun reprepare(
+        oldKey: String,
+        oldValue: V,
+        newKey: String,
+        newValue: V
+    ): Mono<Boolean> = reprepare(oldKey, oldValue, newKey, newValue.toForever())
 
-    fun reprepare(oldKey: String, oldValue: V, newKey: String, newValue: PreparedValue<V>): Mono<Boolean> {
+    /**
+     * Reprepares by changing both key and value with optional TTL.
+     *
+     * This method provides the most flexible reprepare operation, allowing changes to
+     * both the key and value with TTL support. It ensures atomicity by first preparing
+     * the new key, then rolling back the old key only if successful.
+     *
+     * @param oldKey The current key to release
+     * @param oldValue The expected value of the old key for concurrency control
+     * @param newKey The new key to prepare (must be different from oldKey)
+     * @param newValue The prepared value for the new key with optional TTL
+     * @return A Mono emitting true if the key change succeeded, false otherwise
+     *
+     * @throws IllegalArgumentException if oldKey equals newKey
+     * @throws IllegalStateException if rollback of old key fails after new key is prepared
+     */
+    fun reprepare(
+        oldKey: String,
+        oldValue: V,
+        newKey: String,
+        newValue: PreparedValue<V>
+    ): Mono<Boolean> {
         require(oldKey != newKey) {
             "oldKey must not be equals to newKey. oldKey:[$oldKey]"
         }
@@ -67,18 +302,54 @@ interface PrepareKey<V : Any> : Named {
             rollback(oldKey, oldValue).doOnNext {
                 if (!it) {
                     throw IllegalStateException(
-                        "Reprepare - Rollback failed. newKey:[$newKey] oldKey:[$oldKey],oldValue:[$oldValue]"
+                        "Reprepare - Rollback failed. newKey:[$newKey] oldKey:[$oldKey],oldValue:[$oldValue]",
                     )
                 }
             }
         }
     }
 
-    fun <R> usingPrepare(key: String, value: V, then: (Boolean) -> Mono<R>): Mono<R> {
-        return usingPrepare(key, value.toForever(), then)
-    }
+    /**
+     * Executes an operation within a prepare context with permanent value.
+     *
+     * This method provides transaction-like semantics: it prepares a key, executes the
+     * provided operation, and automatically rolls back the preparation if the operation fails.
+     *
+     * @param R The return type of the operation
+     * @param key The key to prepare for the operation
+     * @param value The permanent value to prepare
+     * @param then A function that receives the preparation result and returns a Mono with the operation
+     * @return A Mono with the operation result, with automatic rollback on failure
+     *
+     * @see usingPrepare(String, PreparedValue, (Boolean) -> Mono) for TTL support
+     */
+    fun <R> usingPrepare(
+        key: String,
+        value: V,
+        then: (Boolean) -> Mono<R>
+    ): Mono<R> = usingPrepare(key, value.toForever(), then)
 
-    fun <R> usingPrepare(key: String, value: PreparedValue<V>, then: (Boolean) -> Mono<R>): Mono<R> {
+    /**
+     * Executes an operation within a prepare context with optional TTL.
+     *
+     * This method provides transaction-like semantics for key preparation. If the key preparation
+     * succeeds and the subsequent operation fails, the preparation is automatically rolled back.
+     * This ensures consistency and prevents resource leaks.
+     *
+     * @param R The return type of the operation
+     * @param key The key to prepare for the operation
+     * @param value The prepared value with optional TTL
+     * @param then A function that receives the preparation result (true/false) and returns
+     *             a Mono with the operation to execute
+     * @return A Mono with the operation result, with automatic rollback on failure
+     *
+     * @throws Exception if the operation fails after successful preparation (rollback attempted)
+     */
+    fun <R> usingPrepare(
+        key: String,
+        value: PreparedValue<V>,
+        then: (Boolean) -> Mono<R>
+    ): Mono<R> {
         return prepare(key, value)
             .flatMap { prepared ->
                 then(prepared).onErrorResume {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/prepare/proxy/DefaultPrepareKeyProxyFactory.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/prepare/proxy/DefaultPrepareKeyProxyFactory.kt
@@ -17,7 +17,28 @@ import me.ahoo.wow.infra.prepare.PrepareKey
 import me.ahoo.wow.infra.prepare.PrepareKeyFactory
 import java.lang.reflect.Proxy
 
-class DefaultPrepareKeyProxyFactory(private val prepareKeyFactory: PrepareKeyFactory) : PrepareKeyProxyFactory {
+/**
+ * Default implementation of PrepareKeyProxyFactory that creates JDK dynamic proxies.
+ * This factory uses Java's Proxy class to create runtime proxy instances that delegate
+ * to actual PrepareKey implementations through an invocation handler.
+ *
+ * @property prepareKeyFactory the factory used to create the underlying PrepareKey instances
+ *
+ * @see PrepareKeyProxyFactory
+ * @see PrepareKeyInvocationHandler
+ */
+class DefaultPrepareKeyProxyFactory(
+    private val prepareKeyFactory: PrepareKeyFactory
+) : PrepareKeyProxyFactory {
+    /**
+     * Creates a proxy instance of the PrepareKey interface using JDK dynamic proxy.
+     * The proxy delegates all method calls to the underlying PrepareKey instance
+     * created by the prepareKeyFactory, with special handling for default methods.
+     *
+     * @param P the PrepareKey interface type
+     * @param metadata the metadata containing proxy configuration
+     * @return a proxy instance implementing the PrepareKey interface
+     */
     @Suppress("UNCHECKED_CAST")
     override fun <P : PrepareKey<*>> create(metadata: PrepareKeyMetadata<P>): P {
         val delegate = prepareKeyFactory.create(metadata.name, metadata.valueType.java)
@@ -25,7 +46,7 @@ class DefaultPrepareKeyProxyFactory(private val prepareKeyFactory: PrepareKeyFac
         return Proxy.newProxyInstance(
             this.javaClass.classLoader,
             arrayOf(metadata.proxyInterface.java),
-            invocationHandler
+            invocationHandler,
         ) as P
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/prepare/proxy/PrepareKeyInvocationHandler.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/prepare/proxy/PrepareKeyInvocationHandler.kt
@@ -19,18 +19,43 @@ import me.ahoo.wow.infra.prepare.PrepareKey
 import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Method
 
+/**
+ * Invocation handler for PrepareKey proxy instances.
+ * This handler delegates method calls to the underlying PrepareKey implementation,
+ * with special handling for default methods in interfaces.
+ *
+ * @property metadata the metadata for the proxy configuration
+ * @property delegate the actual PrepareKey instance to delegate calls to
+ *
+ * @see DefaultPrepareKeyProxyFactory
+ * @see PrepareKey
+ */
 class PrepareKeyInvocationHandler(
     private val metadata: PrepareKeyMetadata<*>,
     override val delegate: PrepareKey<*>
-) : Decorator<PrepareKey<*>>, InvocationHandler {
+) : Decorator<PrepareKey<*>>,
+    InvocationHandler {
     companion object {
+        /** Empty array constant for methods with no arguments. */
         val EMPTY_ARGS = emptyArray<Any>()
     }
 
+    /** Lazily initialized list of default methods declared in the proxy interface. */
     private val declaredDefaultMethods by lazy {
-        metadata.proxyInterface.java.declaredMethods.filter { it.isDefault }
+        metadata.proxyInterface.java.declaredMethods
+            .filter { it.isDefault }
     }
 
+    /**
+     * Handles method invocation on the proxy instance.
+     * For default methods, uses the JDK's default method invocation mechanism.
+     * For other methods, delegates to the underlying PrepareKey instance using fast invocation.
+     *
+     * @param proxy the proxy instance
+     * @param method the method being invoked
+     * @param args the method arguments (null if no arguments)
+     * @return the result of the method invocation
+     */
     override fun invoke(
         proxy: Any,
         method: Method,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/prepare/proxy/PrepareKeyMetadata.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/prepare/proxy/PrepareKeyMetadata.kt
@@ -17,8 +17,23 @@ import me.ahoo.wow.api.naming.Named
 import me.ahoo.wow.metadata.Metadata
 import kotlin.reflect.KClass
 
+/**
+ * Metadata container for PrepareKey proxy configuration.
+ * Holds the necessary information to create and configure proxy instances
+ * of PrepareKey interfaces, including the key name, interface type, and value type.
+ *
+ * @param P the PrepareKey interface type
+ * @property name the unique name identifier for the prepare key
+ * @property proxyInterface the Kotlin class of the PrepareKey interface to proxy
+ * @property valueType the Kotlin class of the value type handled by the PrepareKey
+ *
+ * @see PrepareKey
+ * @see PrepareKeyProxyFactory
+ * @see PrepareKeyMetadataParser
+ */
 data class PrepareKeyMetadata<P : Any>(
     override val name: String,
     val proxyInterface: KClass<P>,
     val valueType: KClass<*>
-) : Named, Metadata
+) : Named,
+    Metadata

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/prepare/proxy/PrepareKeyMetadataParser.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/prepare/proxy/PrepareKeyMetadataParser.kt
@@ -22,8 +22,29 @@ import me.ahoo.wow.metadata.Metadata
 import kotlin.reflect.KClass
 import kotlin.reflect.full.findAnnotation
 
+/**
+ * Parser for extracting PrepareKey metadata from annotated interface classes.
+ * This parser analyzes PrepareKey interfaces annotated with @PreparableKey to extract
+ * the necessary metadata for proxy creation, including name, interface type, and value type.
+ *
+ * The parser caches parsed metadata for performance and supports both direct parsing
+ * and extension functions for convenient access.
+ *
+ * @see PrepareKeyMetadata
+ * @see PreparableKey
+ * @see CacheableMetadataParser
+ */
 object PrepareKeyMetadataParser : CacheableMetadataParser() {
-
+    /**
+     * Parses the PrepareKey metadata from the given class.
+     * Uses reflection to analyze the class hierarchy and annotations to extract
+     * the metadata required for proxy creation.
+     *
+     * @param TYPE the class type to parse
+     * @param M the metadata type (should be PrepareKeyMetadata)
+     * @param type the Java class to parse
+     * @return the parsed metadata
+     */
     override fun <TYPE : Any, M : Metadata> parseToMetadata(type: Class<TYPE>): M {
         val kType = type.kotlin
         val visitor = PrepareKeyMetadataVisitor(kType)
@@ -33,24 +54,52 @@ object PrepareKeyMetadataParser : CacheableMetadataParser() {
     }
 }
 
-class PrepareKeyMetadataVisitor<P : Any>(private val prepareKeyType: KClass<P>) :
-    ClassVisitor<P, PrepareKeyMetadata<P>> {
+/**
+ * Visitor class for extracting PrepareKey metadata during class reflection.
+ * This visitor analyzes the PrepareKey interface to determine the name (from annotation or class name),
+ * the interface type, and the generic value type parameter.
+ *
+ * @param P the PrepareKey interface type
+ * @property prepareKeyType the Kotlin class being visited
+ */
+class PrepareKeyMetadataVisitor<P : Any>(
+    private val prepareKeyType: KClass<P>
+) : ClassVisitor<P, PrepareKeyMetadata<P>> {
+    /**
+     * Extracts and constructs the PrepareKey metadata from the visited class.
+     * Determines the name from @PreparableKey annotation or uses the simple class name.
+     * Extracts the value type from the PrepareKey generic parameter.
+     *
+     * @return the constructed PrepareKey metadata
+     */
     override fun toMetadata(): PrepareKeyMetadata<P> {
-        val name = prepareKeyType.findAnnotation<PreparableKey>()?.name.orEmpty().ifBlank {
-            prepareKeyType.simpleName!!
-        }
-        val superPrepareKeyType = prepareKeyType.supertypes.first {
-            it.classifier == PrepareKey::class
-        }
+        val name =
+            prepareKeyType.findAnnotation<PreparableKey>()?.name.orEmpty().ifBlank {
+                prepareKeyType.simpleName!!
+            }
+        val superPrepareKeyType =
+            prepareKeyType.supertypes.first {
+                it.classifier == PrepareKey::class
+            }
         val valueType = superPrepareKeyType.arguments[0].type!!.classifier as KClass<*>
         return PrepareKeyMetadata(name, prepareKeyType, valueType)
     }
 }
 
-fun <P : Any> KClass<out P>.prepareKeyMetadata(): PrepareKeyMetadata<P> {
-    return PrepareKeyMetadataParser.parse(this.java)
-}
+/**
+ * Extension function to parse PrepareKey metadata from a KClass.
+ * Provides convenient access to metadata parsing for any PrepareKey interface class.
+ *
+ * @param P the PrepareKey interface type
+ * @return the parsed metadata for this class
+ */
+fun <P : Any> KClass<out P>.prepareKeyMetadata(): PrepareKeyMetadata<P> = PrepareKeyMetadataParser.parse(this.java)
 
-inline fun <reified P : Any> prepareKeyMetadata(): PrepareKeyMetadata<P> {
-    return P::class.prepareKeyMetadata()
-}
+/**
+ * Inline function to parse PrepareKey metadata using reified generics.
+ * Allows for type-safe metadata parsing without explicitly specifying the class.
+ *
+ * @param P the PrepareKey interface type (inferred from usage)
+ * @return the parsed metadata for the reified type
+ */
+inline fun <reified P : Any> prepareKeyMetadata(): PrepareKeyMetadata<P> = P::class.prepareKeyMetadata()

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/prepare/proxy/PrepareKeyProxyFactory.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/prepare/proxy/PrepareKeyProxyFactory.kt
@@ -15,6 +15,21 @@ package me.ahoo.wow.infra.prepare.proxy
 
 import me.ahoo.wow.infra.prepare.PrepareKey
 
+/**
+ * Factory interface for creating proxy instances of PrepareKey implementations.
+ * This factory enables dynamic proxy creation for PrepareKey interfaces, allowing
+ * for interception and decoration of prepare operations.
+ *
+ * @see PrepareKeyMetadata
+ * @see DefaultPrepareKeyProxyFactory
+ */
 interface PrepareKeyProxyFactory {
+    /**
+     * Creates a proxy instance of the specified PrepareKey type using the provided metadata.
+     *
+     * @param P the PrepareKey interface type
+     * @param metadata the metadata containing proxy configuration
+     * @return a proxy instance implementing the PrepareKey interface
+     */
     fun <P : PrepareKey<*>> create(metadata: PrepareKeyMetadata<P>): P
 }


### PR DESCRIPTION


- Added detailed KDoc comments to all methods in PrepareKey interface
- Documented PrepareKeyProxyFactory interface with usage examples
- Enhanced PrepareKeyMetadata with full parameter and usage documentation
- Added extensive documentation to PrepareKeyMetadataParser and visitor classes
- Improved documentation for DefaultPrepareKeyProxyFactory with implementation details
- Added comprehensive KDoc to PrepareKeyInvocationHandler with method handling explanation
- Included usage examples and common scenarios in PrepareKey interface documentation
- Added proper documentation for extension functions and inline reified functions
- Improved code readability with better formatting and structure in documentation
- Added references to related classes and components throughout the documentation
