### PR TITLE
docs(core): add comprehensive documentation to accessor and idempotency classes

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/Decorator.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/Decorator.kt
@@ -13,10 +13,34 @@
 
 package me.ahoo.wow.infra
 
+/**
+ * Interface for the Decorator design pattern implementation in the Wow framework.
+ * Decorators wrap objects to add additional functionality while maintaining the same interface.
+ * This interface provides a standard way to access the wrapped (decorated) object.
+ *
+ * @param C the type of the component being decorated
+ */
 interface Decorator<out C : Any> {
+    /**
+     * The original component being decorated.
+     * This provides access to the wrapped object for delegation or inspection.
+     */
     val delegate: C
 
     companion object {
+        /**
+         * Recursively unwraps decorators to find the original (non-decorated) component.
+         * This method traverses the decorator chain until it finds an object that is not a decorator.
+         *
+         * @param C the type of the component
+         * @return the original non-decorated component
+         *
+         * Example usage:
+         * ```
+         * val decoratedComponent = SomeDecorator(SomeDecorator(originalComponent))
+         * val original = decoratedComponent.getOriginalDelegate() // returns originalComponent
+         * ```
+         */
         @Suppress("UNCHECKED_CAST")
         @JvmStatic
         fun <C : Any> C.getOriginalDelegate(): C {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/Strings.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/Strings.kt
@@ -13,6 +13,22 @@
 
 package me.ahoo.wow.infra
 
+/**
+ * Executes a function on a string if it is not null, empty, or blank (contains only whitespace).
+ * This is a null-safe utility function that provides a concise way to perform operations
+ * on non-blank strings while returning null for blank inputs.
+ *
+ * @param R the return type of the function
+ * @param func the function to execute if the string is not blank
+ * @return the result of the function if the string is not blank, null otherwise
+ *
+ * Example usage:
+ * ```
+ * val result = "  hello  ".ifNotBlank { it.trim().uppercase() } // returns "HELLO"
+ * val nullResult = "   ".ifNotBlank { it.trim() } // returns null
+ * val nullInput = null.ifNotBlank { it.length } // returns null
+ * ```
+ */
 public inline fun <R> String?.ifNotBlank(func: (String) -> R): R? {
     if (this.isNullOrBlank()) {
         return null

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/TypeNameMapper.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/TypeNameMapper.kt
@@ -15,13 +15,38 @@ package me.ahoo.wow.infra
 
 import java.util.concurrent.ConcurrentHashMap
 
+/**
+ * Thread-safe utility for mapping fully qualified class names to Class objects with caching.
+ * This object provides efficient type resolution by caching Class instances to avoid
+ * repeated Class.forName() calls, which can be expensive.
+ *
+ * The mapper uses a ConcurrentHashMap to ensure thread-safe operations and lazy loading
+ * of Class objects only when first requested.
+ */
 object TypeNameMapper {
+    /**
+     * Thread-safe cache mapping fully qualified class names to their corresponding Class objects.
+     * Uses ConcurrentHashMap to support concurrent access without external synchronization.
+     */
     private val mapper: ConcurrentHashMap<String, Class<*>> = ConcurrentHashMap()
 
+    /**
+     * Converts a fully qualified class name string to its corresponding Class object.
+     * The result is cached for future lookups to improve performance.
+     *
+     * @param T the type to cast the resulting Class to
+     * @return the Class object corresponding to the class name
+     * @throws ClassNotFoundException if the class cannot be found
+     *
+     * Example usage:
+     * ```
+     * val stringClass = "java.lang.String".toType<String>() // returns String::class.java
+     * val listClass = "java.util.List".toType<List<*>>() // returns List::class.java
+     * ```
+     */
     @Suppress("UNCHECKED_CAST")
-    fun <T> String.toType(): Class<T> {
-        return mapper.computeIfAbsent(this) {
+    fun <T> String.toType(): Class<T> =
+        mapper.computeIfAbsent(this) {
             Class.forName(this)
         } as Class<T>
-    }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/Accessor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/Accessor.kt
@@ -16,12 +16,40 @@ import java.lang.reflect.AccessibleObject
 import kotlin.reflect.KCallable
 import kotlin.reflect.jvm.isAccessible
 
+/**
+ * Ensures that a Java reflection AccessibleObject (like Method, Field, Constructor) is accessible.
+ * This method sets the accessible flag to true if it's not already set, allowing access
+ * to private, protected, or package-private members.
+ *
+ * This is a convenience method that safely handles the accessibility check and setting.
+ *
+ * Example usage:
+ * ```
+ * val method = MyClass::class.java.getDeclaredMethod("privateMethod")
+ * method.ensureAccessible() // Now accessible even if private
+ * method.invoke(instance)
+ * ```
+ */
 fun AccessibleObject.ensureAccessible() {
     if (!this.isAccessible) {
         this.isAccessible = true
     }
 }
 
+/**
+ * Ensures that a Kotlin reflection KCallable (like KFunction, KProperty) is accessible.
+ * This method sets the accessible flag to true if it's not already set, allowing access
+ * to private, protected, or package-private members.
+ *
+ * This is a convenience method that safely handles the accessibility check and setting.
+ *
+ * Example usage:
+ * ```
+ * val property = MyClass::class.members.find { it.name == "privateProperty" } as KProperty1<MyClass, *>
+ * property.ensureAccessible() // Now accessible even if private
+ * val value = property.get(instance)
+ * ```
+ */
 fun KCallable<*>.ensureAccessible() {
     if (!this.isAccessible) {
         this.isAccessible = true

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/constructor/ConstructorAccessor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/constructor/ConstructorAccessor.kt
@@ -16,10 +16,34 @@ package me.ahoo.wow.infra.accessor.constructor
 import me.ahoo.wow.infra.accessor.method.FastInvoke
 import java.lang.reflect.Constructor
 
+/**
+ * Interface for accessing and invoking constructors through reflection.
+ * Provides a type-safe way to create new instances of classes using their constructors
+ * with proper error handling and performance optimization.
+ *
+ * @param T the type of object that will be created by the constructor
+ */
 interface ConstructorAccessor<T : Any> {
+    /**
+     * The underlying Java Constructor object for creating instances.
+     * This constructor is used for reflection-based instantiation.
+     */
     val constructor: Constructor<T>
 
-    fun invoke(args: Array<Any?> = emptyArray<Any?>()): T {
-        return FastInvoke.safeNewInstance(constructor, args)
-    }
+    /**
+     * Invokes the constructor with the specified arguments to create a new instance.
+     * Uses FastInvoke.safeNewInstance for proper exception handling and performance.
+     *
+     * @param args the arguments to pass to the constructor (empty array by default)
+     * @return a new instance of type T
+     * @throws Throwable if the constructor invocation fails or throws an exception
+     *
+     * Example usage:
+     * ```
+     * val constructor = MyClass::class.java.getConstructor(String::class.java)
+     * val accessor = DefaultConstructorAccessor(constructor)
+     * val instance = accessor.invoke(arrayOf("initial value"))
+     * ```
+     */
+    fun invoke(args: Array<Any?> = emptyArray<Any?>()): T = FastInvoke.safeNewInstance(constructor, args)
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/constructor/DefaultConstructorAccessor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/constructor/DefaultConstructorAccessor.kt
@@ -15,7 +15,21 @@ package me.ahoo.wow.infra.accessor.constructor
 import me.ahoo.wow.infra.accessor.ensureAccessible
 import java.lang.reflect.Constructor
 
-class DefaultConstructorAccessor<T : Any>(override val constructor: Constructor<T>) : ConstructorAccessor<T> {
+/**
+ * Default implementation of ConstructorAccessor that provides basic constructor invocation capabilities.
+ * This class automatically ensures the constructor is accessible during initialization,
+ * making it ready for reflection-based instantiation of private, protected, or package-private constructors.
+ *
+ * @param T the type of object that will be created by the constructor
+ * @property constructor the Java constructor to be accessed
+ */
+class DefaultConstructorAccessor<T : Any>(
+    override val constructor: Constructor<T>
+) : ConstructorAccessor<T> {
+    /**
+     * Initialization block that ensures the constructor is accessible for reflection.
+     * This automatically makes private, protected, or package-private constructors accessible.
+     */
     init {
         constructor.ensureAccessible()
     }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/constructor/ObjectFactory.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/constructor/ObjectFactory.kt
@@ -16,15 +16,41 @@ import me.ahoo.wow.ioc.ServiceProvider
 import me.ahoo.wow.ioc.getRequiredService
 import java.lang.reflect.Constructor
 
+/**
+ * Interface for factories that create new instances of objects.
+ * Provides a simple contract for object instantiation without specifying how objects are created.
+ *
+ * @param T the type of object that will be created
+ */
 interface ObjectFactory<T : Any> {
+    /**
+     * Creates a new instance of the object.
+     *
+     * @return a new instance of type T
+     */
     fun newInstance(): T
 }
 
+/**
+ * ObjectFactory implementation that creates objects using dependency injection.
+ * This factory automatically resolves constructor parameters from a ServiceProvider,
+ * enabling automatic dependency injection during object instantiation.
+ *
+ * @param T the type of object that will be created
+ * @property constructorAccessor the accessor for the constructor to use
+ * @property serviceProvider the service provider for resolving dependencies
+ */
 class InjectableObjectFactory<T : Any>(
     private val constructorAccessor: ConstructorAccessor<T>,
     private val serviceProvider: ServiceProvider
 ) : ObjectFactory<T> {
-
+    /**
+     * Secondary constructor that creates an InjectableObjectFactory with a Constructor and ServiceProvider.
+     * Automatically wraps the constructor in a DefaultConstructorAccessor.
+     *
+     * @param constructor the Java constructor to use for instantiation
+     * @param serviceProvider the service provider for resolving dependencies
+     */
     constructor(constructor: Constructor<T>, serviceProvider: ServiceProvider) : this(
         DefaultConstructorAccessor(
             constructor,
@@ -32,13 +58,29 @@ class InjectableObjectFactory<T : Any>(
         serviceProvider,
     )
 
+    /**
+     * Creates a new instance by resolving all constructor parameters from the service provider.
+     * Each constructor parameter type is looked up in the service provider, and the resolved
+     * services are passed as arguments to the constructor.
+     *
+     * @return a new instance of type T with dependencies injected
+     * @throws IllegalArgumentException if any required service is not found in the provider
+     *
+     * Example usage:
+     * ```
+     * val constructor = MyClass::class.java.getConstructor(Dependency::class.java)
+     * val factory = InjectableObjectFactory(constructor, serviceProvider)
+     * val instance = factory.newInstance() // automatically injects Dependency
+     * ```
+     */
     override fun newInstance(): T {
-        val args = constructorAccessor
-            .constructor
-            .parameterTypes
-            .map {
-                serviceProvider.getRequiredService(it)
-            }.toTypedArray()
+        val args =
+            constructorAccessor
+                .constructor
+                .parameterTypes
+                .map {
+                    serviceProvider.getRequiredService(it)
+                }.toTypedArray()
         return constructorAccessor.invoke(args)
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/function/FunctionAccessor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/function/FunctionAccessor.kt
@@ -22,6 +22,15 @@ import kotlin.reflect.full.instanceParameter
 import kotlin.reflect.jvm.javaMethod
 import kotlin.reflect.jvm.jvmErasure
 
+/**
+ * Extension property that determines the declaring class of a Kotlin function.
+ * This property handles both regular member functions and extension functions,
+ * returning the appropriate declaring class.
+ *
+ * For member functions, it returns the class containing the function.
+ * For extension functions, it returns the class being extended.
+ * For top-level functions, it returns the declaring class of the underlying Java method.
+ */
 val KFunction<*>.declaringClass: KClass<*>
     get() {
         val parameter = instanceParameter ?: extensionReceiverParameter
@@ -32,21 +41,61 @@ val KFunction<*>.declaringClass: KClass<*>
     }
 
 /**
- * Function Accessor .
+ * Interface for accessing and invoking Kotlin functions through reflection.
+ * Provides a type-safe way to invoke functions with proper error handling and
+ * integration with the Wow framework's naming conventions.
+ *
+ * @param T the type of the target object on which the function will be invoked
+ * @param R the return type of the function
  * @author ahoo wang
  */
 interface FunctionAccessor<T, out R> : Named {
+    /**
+     * The name of the function, inherited from the Named interface.
+     * Returns the simple name of the underlying Kotlin function.
+     */
     override val name: String
         get() = function.name
 
+    /**
+     * The Java Class representing the type of the target object.
+     * This is derived from the declaring class of the function.
+     */
     @Suppress("UNCHECKED_CAST")
     val targetType: Class<T>
         get() = function.declaringClass.java as Class<T>
+
+    /**
+     * The underlying Java Method object for this function.
+     * This method is guaranteed to be non-null for accessible functions.
+     */
     val method: Method
         get() = function.javaMethod!!
+
+    /**
+     * The Kotlin reflection KFunction representing this function.
+     * Provides access to Kotlin-specific metadata and reflection capabilities.
+     */
     val function: KFunction<*>
 
-    fun invoke(target: T, args: Array<Any?> = emptyArray<Any?>()): R {
-        return FastInvoke.safeInvoke(method, target, args)
-    }
+    /**
+     * Invokes the function on the specified target object with the given arguments.
+     * Uses FastInvoke.safeInvoke for proper exception handling and performance.
+     *
+     * @param target the object on which to invoke the function
+     * @param args the arguments to pass to the function (empty array by default)
+     * @return the result of the function invocation
+     * @throws Throwable if the function invocation fails or throws an exception
+     *
+     * Example usage:
+     * ```
+     * val accessor = SimpleFunctionAccessor<MyClass, String>(MyClass::getName)
+     * val instance = MyClass()
+     * val result = accessor.invoke(instance) // calls instance.getName()
+     * ```
+     */
+    fun invoke(
+        target: T,
+        args: Array<Any?> = emptyArray<Any?>()
+    ): R = FastInvoke.safeInvoke(method, target, args)
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/function/SimpleFunctionAccessor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/function/SimpleFunctionAccessor.kt
@@ -16,12 +16,23 @@ import me.ahoo.wow.infra.accessor.ensureAccessible
 import kotlin.reflect.KFunction
 
 /**
- * Simple Function Accessor .
+ * Simple implementation of FunctionAccessor that provides basic function invocation capabilities.
+ * This class automatically ensures the function is accessible during initialization,
+ * making it ready for reflection-based invocation.
  *
+ * @param T the type of the target object
+ * @param R the return type of the function
+ * @property function the Kotlin function to be accessed
  * @author ahoo wang
  */
-data class SimpleFunctionAccessor<T, R>(override val function: KFunction<*>) : FunctionAccessor<T, R> {
-
+data class SimpleFunctionAccessor<T, R>(
+    override val function: KFunction<*>
+) : FunctionAccessor<T, R> {
+    /**
+     * Initialization block that ensures the function is accessible for reflection.
+     * This automatically calls ensureAccessible() on the function to allow
+     * access to private, protected, or package-private functions.
+     */
     init {
         function.ensureAccessible()
     }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/function/reactive/BlockingMonoFunctionAccessor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/function/reactive/BlockingMonoFunctionAccessor.kt
@@ -18,19 +18,50 @@ import reactor.core.scheduler.Scheduler
 import reactor.core.scheduler.Schedulers
 import kotlin.reflect.KFunction
 
+/**
+ * MonoFunctionAccessor wrapper that handles blocking operations by scheduling them on a separate thread.
+ * This accessor is used for functions annotated with @Blocking to ensure they don't block
+ * the reactive event loop. It automatically switches to a bounded elastic scheduler
+ * when running on a non-blocking thread.
+ *
+ * @param T the type of the target object
+ * @param D the type of data in the Mono
+ * @property monoFunctionAccessor the underlying mono function accessor
+ * @property scheduler the scheduler to use for blocking operations (defaults to bounded elastic)
+ */
 class BlockingMonoFunctionAccessor<T, D>(
     private val monoFunctionAccessor: MonoFunctionAccessor<T, Mono<D>>,
     private val scheduler: Scheduler = Schedulers.boundedElastic()
 ) : MonoFunctionAccessor<T, Mono<D>> {
-
+    /**
+     * The underlying Kotlin function, delegated from the wrapped accessor.
+     */
     override val function: KFunction<*>
         get() = monoFunctionAccessor.function
 
-    override operator fun invoke(target: T, args: Array<Any?>): Mono<D> {
-        return monoFunctionAccessor.invoke(target, args).toBlockable(scheduler)
-    }
+    /**
+     * Invokes the function and ensures blocking operations are scheduled appropriately.
+     * Uses the toBlockable extension to automatically handle thread scheduling for blocking operations.
+     *
+     * @param target the object on which to invoke the function
+     * @param args the arguments to pass to the function
+     * @return a Mono containing the function result, scheduled appropriately for blocking operations
+     */
+    override operator fun invoke(
+        target: T,
+        args: Array<Any?>
+    ): Mono<D> = monoFunctionAccessor.invoke(target, args).toBlockable(scheduler)
 }
 
+/**
+ * Extension function that makes a Mono blockable by scheduling it on a separate thread if needed.
+ * If the current thread is non-blocking (reactive), it subscribes the Mono on the provided scheduler.
+ * If already on a blocking thread, returns the Mono unchanged.
+ *
+ * @param T the type of data in the Mono
+ * @param scheduler the scheduler to use for blocking operations (defaults to bounded elastic)
+ * @return a Mono that will execute on an appropriate thread for blocking operations
+ */
 fun <T> Mono<T>.toBlockable(scheduler: Scheduler = Schedulers.boundedElastic()): Mono<T> {
     if (Schedulers.isInNonBlockingThread()) {
         return this.subscribeOn(scheduler)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/function/reactive/FluxMonoFunctionAccessor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/function/reactive/FluxMonoFunctionAccessor.kt
@@ -18,16 +18,39 @@ import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import kotlin.reflect.KFunction
 
-data class FluxMonoFunctionAccessor<T, D>(override val function: KFunction<*>) :
-    MonoFunctionAccessor<T, Mono<List<D>>> {
-
+/**
+ * MonoFunctionAccessor for functions that return Flux streams.
+ * This accessor converts Flux results to Mono<List<D>> by collecting all emitted items
+ * into a list, providing a way to handle multi-value reactive streams in a Mono context.
+ *
+ * @param T the type of the target object
+ * @param D the type of individual items in the Flux
+ * @property function the Kotlin function that returns a Flux
+ */
+data class FluxMonoFunctionAccessor<T, D>(
+    override val function: KFunction<*>
+) : MonoFunctionAccessor<T, Mono<List<D>>> {
+    /**
+     * Initialization block that ensures the function is accessible for reflection.
+     * This automatically makes private, protected, or package-private functions accessible.
+     */
     init {
         function.ensureAccessible()
     }
 
-    override operator fun invoke(target: T, args: Array<Any?>): Mono<List<D>> {
-        return Mono.defer {
+    /**
+     * Invokes the function that returns a Flux and collects all emitted items into a List.
+     * Uses Mono.defer for lazy evaluation and collectList() to aggregate the Flux emissions.
+     *
+     * @param target the object on which to invoke the function
+     * @param args the arguments to pass to the function
+     * @return a Mono containing a List of all items emitted by the Flux
+     */
+    override operator fun invoke(
+        target: T,
+        args: Array<Any?>
+    ): Mono<List<D>> =
+        Mono.defer {
             FastInvoke.safeInvoke<Flux<D>>(method, target, args).collectList()
         }
-    }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/function/reactive/MonoFunctionAccessorFactory.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/function/reactive/MonoFunctionAccessorFactory.kt
@@ -21,19 +21,42 @@ import kotlin.reflect.KFunction
 import kotlin.reflect.full.isSubclassOf
 import kotlin.reflect.jvm.jvmErasure
 
+/**
+ * Factory object for creating MonoFunctionAccessor instances based on function return types.
+ * Automatically determines the appropriate accessor implementation based on the function's
+ * return type and any blocking annotations.
+ */
 object MonoMethodAccessorFactory {
+    /**
+     * Creates a MonoFunctionAccessor for the given function, automatically selecting
+     * the appropriate implementation based on the function's return type.
+     *
+     * The factory chooses implementations as follows:
+     * - Mono return type: SimpleMonoFunctionAccessor
+     * - Flux return type: FluxMonoFunctionAccessor (collects to List)
+     * - Publisher return type: PublisherMonoFunctionAccessor
+     * - Synchronous return type: SyncMonoFunctionAccessor
+     *
+     * If the function is annotated with @Blocking, it wraps the accessor with BlockingMonoFunctionAccessor.
+     *
+     * @param T the type of the target object
+     * @param D the type of data in the Mono
+     * @param function the Kotlin function to create an accessor for
+     * @return a MonoFunctionAccessor appropriate for the function's return type
+     */
     fun <T, D> create(function: KFunction<*>): MonoFunctionAccessor<T, Mono<D>> {
         val returnType = function.returnType.jvmErasure
-        val monoMethodAccessor = if (returnType.isSubclassOf(Mono::class)) {
-            SimpleMonoFunctionAccessor(function)
-        } else if (returnType.isSubclassOf(Flux::class)) {
-            @Suppress("UNCHECKED_CAST")
-            FluxMonoFunctionAccessor<T, Any>(function) as MonoFunctionAccessor<T, Mono<D>>
-        } else if (returnType.isSubclassOf(Publisher::class)) {
-            PublisherMonoFunctionAccessor(function)
-        } else {
-            SyncMonoFunctionAccessor(function)
-        }
+        val monoMethodAccessor =
+            if (returnType.isSubclassOf(Mono::class)) {
+                SimpleMonoFunctionAccessor(function)
+            } else if (returnType.isSubclassOf(Flux::class)) {
+                @Suppress("UNCHECKED_CAST")
+                FluxMonoFunctionAccessor<T, Any>(function) as MonoFunctionAccessor<T, Mono<D>>
+            } else if (returnType.isSubclassOf(Publisher::class)) {
+                PublisherMonoFunctionAccessor(function)
+            } else {
+                SyncMonoFunctionAccessor(function)
+            }
 
         return function.scanAnnotation<Blocking>()?.let {
             BlockingMonoFunctionAccessor(monoMethodAccessor)
@@ -41,6 +64,15 @@ object MonoMethodAccessorFactory {
     }
 }
 
-fun <T, D> KFunction<*>.toMonoFunctionAccessor(): MonoFunctionAccessor<T, Mono<D>> {
-    return MonoMethodAccessorFactory.create(this)
-}
+/**
+ * Extension function that converts a Kotlin function to a MonoFunctionAccessor.
+ * Provides a convenient way to create accessors for functions that should return Mono streams.
+ *
+ * @param T the type of the target object
+ * @param D the type of data in the Mono
+ * @return a MonoFunctionAccessor for this function
+ */
+fun <T, D> KFunction<*>.toMonoFunctionAccessor(): MonoFunctionAccessor<T, Mono<D>> =
+    MonoMethodAccessorFactory.create(
+        this,
+    )

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/function/reactive/ReactiveMethodAccessor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/function/reactive/ReactiveMethodAccessor.kt
@@ -16,6 +16,22 @@ import me.ahoo.wow.infra.accessor.function.FunctionAccessor
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Mono
 
+/**
+ * Interface for accessing reactive functions that return Publisher-based types.
+ * Extends FunctionAccessor to provide reactive stream support for functions
+ * that return reactive types like Flux, Mono, or other Publisher implementations.
+ *
+ * @param T the type of the target object
+ * @param R the reactive return type that extends Publisher
+ */
 interface ReactiveFunctionAccessor<T, out R : Publisher<*>> : FunctionAccessor<T, R>
 
+/**
+ * Interface for accessing functions that return Mono reactive streams.
+ * Specializes ReactiveFunctionAccessor for Mono-specific operations,
+ * providing type safety for single-value reactive returns.
+ *
+ * @param T the type of the target object
+ * @param R the Mono return type
+ */
 interface MonoFunctionAccessor<T, out R : Mono<*>> : ReactiveFunctionAccessor<T, R>

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/function/reactive/SimpleMonoFunctionAccessor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/function/reactive/SimpleMonoFunctionAccessor.kt
@@ -16,15 +16,39 @@ import me.ahoo.wow.infra.accessor.ensureAccessible
 import reactor.core.publisher.Mono
 import kotlin.reflect.KFunction
 
-data class SimpleMonoFunctionAccessor<T, D>(override val function: KFunction<*>) : MonoFunctionAccessor<T, Mono<D>> {
-
+/**
+ * Simple implementation of MonoFunctionAccessor for functions that already return Mono.
+ * This accessor defers the execution of the underlying function to ensure proper
+ * reactive stream behavior and lazy evaluation.
+ *
+ * @param T the type of the target object
+ * @param D the type of data in the Mono
+ * @property function the Kotlin function that returns a Mono
+ */
+data class SimpleMonoFunctionAccessor<T, D>(
+    override val function: KFunction<*>
+) : MonoFunctionAccessor<T, Mono<D>> {
+    /**
+     * Initialization block that ensures the underlying method is accessible for reflection.
+     * This automatically makes private, protected, or package-private methods accessible.
+     */
     init {
         method.ensureAccessible()
     }
 
-    override fun invoke(target: T, args: Array<Any?>): Mono<D> {
-        return Mono.defer {
+    /**
+     * Invokes the function and returns its Mono result, wrapped in Mono.defer for proper lazy evaluation.
+     * The defer operator ensures that the function is only executed when the Mono is subscribed to.
+     *
+     * @param target the object on which to invoke the function
+     * @param args the arguments to pass to the function
+     * @return a Mono containing the function result
+     */
+    override fun invoke(
+        target: T,
+        args: Array<Any?>
+    ): Mono<D> =
+        Mono.defer {
             super.invoke(target, args)
         }
-    }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/property/PropertyDescriptor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/property/PropertyDescriptor.kt
@@ -16,17 +16,61 @@ package me.ahoo.wow.infra.accessor.property
 import kotlin.reflect.KMutableProperty1
 import kotlin.reflect.KProperty1
 
+/**
+ * Utility object for creating property accessors from various sources.
+ * Provides factory methods to convert static values, read-only properties, and mutable properties
+ * into PropertyGetter and PropertySetter implementations.
+ *
+ * This object serves as the main entry point for creating property accessors in a consistent way.
+ */
 object PropertyDescriptor {
+    /**
+     * Converts a static value into a PropertyGetter that always returns the same value.
+     * Useful for creating property accessors for constant or computed values.
+     *
+     * @param T the type of the target object (not used in static getters)
+     * @param V the type of the property value
+     * @return a PropertyGetter that always returns the static value
+     *
+     * Example usage:
+     * ```
+     * val staticGetter = "constant".toPropertyGetter<MyClass, String>()
+     * val value = staticGetter.get(anyInstance) // always returns "constant"
+     * ```
+     */
+    fun <T, V> V.toPropertyGetter(): PropertyGetter<T, V> = StaticPropertyGetter(this)
 
-    fun <T, V> V.toPropertyGetter(): PropertyGetter<T, V> {
-        return StaticPropertyGetter(this)
-    }
+    /**
+     * Converts a Kotlin read-only property into a PropertyGetter.
+     * The resulting getter will access the property value from the target object.
+     *
+     * @param T the type of the target object
+     * @param V the type of the property value
+     * @return a PropertyGetter that accesses the property value
+     *
+     * Example usage:
+     * ```
+     * val propertyGetter = MyClass::name.toPropertyGetter()
+     * val instance = MyClass("John")
+     * val name = propertyGetter.get(instance) // returns "John"
+     * ```
+     */
+    fun <T, V> KProperty1<T, V>.toPropertyGetter(): PropertyGetter<T, V> = SimplePropertyGetter(this)
 
-    fun <T, V> KProperty1<T, V>.toPropertyGetter(): PropertyGetter<T, V> {
-        return SimplePropertyGetter(this)
-    }
-
-    fun <T, V> KMutableProperty1<T, V>.toPropertySetter(): PropertySetter<T, V> {
-        return SimplePropertySetter(this)
-    }
+    /**
+     * Converts a Kotlin mutable property into a PropertySetter.
+     * The resulting setter will modify the property value on the target object.
+     *
+     * @param T the type of the target object
+     * @param V the type of the property value
+     * @return a PropertySetter that modifies the property value
+     *
+     * Example usage:
+     * ```
+     * val propertySetter = MyClass::name.toPropertySetter()
+     * val instance = MyClass("John")
+     * propertySetter.set(instance, "Jane") // changes name to "Jane"
+     * ```
+     */
+    fun <T, V> KMutableProperty1<T, V>.toPropertySetter(): PropertySetter<T, V> = SimplePropertySetter(this)
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/property/PropertyGetter.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/property/PropertyGetter.kt
@@ -16,23 +16,69 @@ package me.ahoo.wow.infra.accessor.property
 import me.ahoo.wow.infra.accessor.ensureAccessible
 import kotlin.reflect.KProperty1
 
+/**
+ * Functional interface for getting property values from objects.
+ * Provides a unified way to access properties regardless of whether they are
+ * static values, computed properties, or actual object properties.
+ *
+ * @param T the type of the target object
+ * @param V the type of the property value
+ */
 fun interface PropertyGetter<in T, V> {
+    /**
+     * Gets the property value from the specified receiver object.
+     *
+     * @param receiver the object from which to get the property value
+     * @return the property value
+     */
     operator fun get(receiver: T): V
 }
 
-class StaticPropertyGetter<T, V>(val value: V) : PropertyGetter<T, V> {
-
-    override fun get(receiver: T): V {
-        return value
-    }
+/**
+ * PropertyGetter implementation that always returns a static (constant) value.
+ * This getter ignores the receiver object and always returns the same pre-configured value.
+ *
+ * @param T the type of the target object (not used)
+ * @param V the type of the property value
+ * @property value the static value to return
+ */
+class StaticPropertyGetter<T, V>(
+    val value: V
+) : PropertyGetter<T, V> {
+    /**
+     * Returns the static value, ignoring the receiver.
+     *
+     * @param receiver the receiver object (ignored)
+     * @return the static value
+     */
+    override fun get(receiver: T): V = value
 }
 
-class SimplePropertyGetter<T, V>(val property: KProperty1<T, V>) : PropertyGetter<T, V> {
+/**
+ * PropertyGetter implementation that accesses a Kotlin property reflectively.
+ * This getter uses Kotlin reflection to access property values, automatically
+ * ensuring the property is accessible for private/protected properties.
+ *
+ * @param T the type of the target object
+ * @param V the type of the property value
+ * @property property the Kotlin property to access
+ */
+class SimplePropertyGetter<T, V>(
+    val property: KProperty1<T, V>
+) : PropertyGetter<T, V> {
+    /**
+     * Initialization block that ensures the property is accessible for reflection.
+     * This automatically makes private, protected, or package-private properties accessible.
+     */
     init {
         property.ensureAccessible()
     }
 
-    override fun get(receiver: T): V {
-        return property.get(receiver)
-    }
+    /**
+     * Gets the property value from the receiver using reflection.
+     *
+     * @param receiver the object from which to get the property value
+     * @return the property value
+     */
+    override fun get(receiver: T): V = property.get(receiver)
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/property/PropertySetter.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/property/PropertySetter.kt
@@ -16,16 +16,56 @@ package me.ahoo.wow.infra.accessor.property
 import me.ahoo.wow.infra.accessor.ensureAccessible
 import kotlin.reflect.KMutableProperty1
 
+/**
+ * Functional interface for setting property values on objects.
+ * Provides a unified way to modify properties using a consistent API.
+ *
+ * @param T the type of the target object
+ * @param V the type of the property value
+ */
 fun interface PropertySetter<in T, in V> {
-    operator fun set(target: T, value: V)
+    /**
+     * Sets the property value on the specified target object.
+     *
+     * @param target the object on which to set the property value
+     * @param value the new property value
+     */
+    operator fun set(
+        target: T,
+        value: V
+    )
 }
 
-class SimplePropertySetter<T, V>(private val property: KMutableProperty1<T, V>) : PropertySetter<T, V> {
+/**
+ * PropertySetter implementation that modifies a Kotlin mutable property reflectively.
+ * This setter uses Kotlin reflection to set property values, automatically
+ * ensuring the property is accessible for private/protected properties.
+ *
+ * @param T the type of the target object
+ * @param V the type of the property value
+ * @property property the Kotlin mutable property to modify
+ */
+class SimplePropertySetter<T, V>(
+    private val property: KMutableProperty1<T, V>
+) : PropertySetter<T, V> {
+    /**
+     * Initialization block that ensures the property is accessible for reflection.
+     * This automatically makes private, protected, or package-private properties accessible.
+     */
     init {
         property.ensureAccessible()
     }
 
-    override fun set(target: T, value: V) {
+    /**
+     * Sets the property value on the target using reflection.
+     *
+     * @param target the object on which to set the property value
+     * @param value the new property value
+     */
+    override fun set(
+        target: T,
+        value: V
+    ) {
         property.set(target, value)
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/idempotency/AggregateIdempotencyCheckerProvider.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/idempotency/AggregateIdempotencyCheckerProvider.kt
@@ -17,15 +17,46 @@ import me.ahoo.wow.api.modeling.NamedAggregate
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
 
+/**
+ * Provider interface for obtaining idempotency checkers specific to named aggregates.
+ * Allows different aggregates to have their own idempotency checking strategies,
+ * which is useful for scenarios where different aggregates have different
+ * idempotency requirements or performance characteristics.
+ */
 fun interface AggregateIdempotencyCheckerProvider {
+    /**
+     * Gets the idempotency checker for the specified named aggregate.
+     * Implementations may return shared or aggregate-specific checkers.
+     *
+     * @param namedAggregate the named aggregate for which to get the checker
+     * @return the idempotency checker for the aggregate
+     */
     fun getChecker(namedAggregate: NamedAggregate): IdempotencyChecker
 }
 
+/**
+ * Default implementation of AggregateIdempotencyCheckerProvider that caches checkers per aggregate.
+ * Uses a supplier function to create checkers on demand and caches them for future use.
+ * This ensures that each named aggregate gets its own idempotency checker instance
+ * while avoiding redundant checker creation.
+ *
+ * @param checkerSupplier function that creates an idempotency checker for a given named aggregate
+ */
 class DefaultAggregateIdempotencyCheckerProvider(
     private val checkerSupplier: (NamedAggregate) -> IdempotencyChecker
 ) : AggregateIdempotencyCheckerProvider {
+    /**
+     * Thread-safe cache mapping named aggregates to their corresponding idempotency checkers.
+     */
     private val idempotencyCheckers: ConcurrentMap<NamedAggregate, IdempotencyChecker> = ConcurrentHashMap()
-    override fun getChecker(namedAggregate: NamedAggregate): IdempotencyChecker {
-        return idempotencyCheckers.computeIfAbsent(namedAggregate) { checkerSupplier(namedAggregate) }
-    }
+
+    /**
+     * Gets the cached idempotency checker for the named aggregate, creating one if it doesn't exist.
+     * Uses computeIfAbsent to ensure thread-safe lazy initialization.
+     *
+     * @param namedAggregate the named aggregate for which to get the checker
+     * @return the idempotency checker for the aggregate, either cached or newly created
+     */
+    override fun getChecker(namedAggregate: NamedAggregate): IdempotencyChecker =
+        idempotencyCheckers.computeIfAbsent(namedAggregate) { checkerSupplier(namedAggregate) }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/idempotency/BloomFilterIdempotencyChecker.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/idempotency/BloomFilterIdempotencyChecker.kt
@@ -18,35 +18,57 @@ import reactor.core.publisher.Mono
 import java.time.Duration
 
 /**
- * BloomFilterIdempotencyChecker .
- * [bloomfilter-tutorial](http://llimllib.github.io/bloomfilter-tutorial/)
+ * Idempotency checker implementation using Bloom filters for efficient duplicate detection.
+ * Bloom filters provide probabilistic duplicate detection with configurable false positive rates,
+ * making them suitable for high-throughput scenarios where perfect accuracy is not required.
  *
+ * The checker automatically refreshes the Bloom filter based on the configured TTL,
+ * ensuring that old entries are periodically cleared to prevent memory leaks.
+ *
+ * Note: Bloom filters can produce false positives (reporting an element as duplicate when it's not),
+ * but never false negatives (missing actual duplicates).
+ *
+ * @param ttl the time-to-live duration for the Bloom filter before it gets refreshed
+ * @param bloomFilterSupplier supplier function that creates new Bloom filter instances
  * @author ahoo wang
+ * @see <a href="http://llimllib.github.io/bloomfilter-tutorial/">Bloom Filter Tutorial</a>
  */
 @Suppress("UnstableApiUsage")
 class BloomFilterIdempotencyChecker(
     private val ttl: Duration,
     private val bloomFilterSupplier: () -> BloomFilter<String>
-) :
-    IdempotencyChecker {
+) : IdempotencyChecker {
     companion object {
         private val log = KotlinLogging.logger {}
     }
 
-    private val bloomFilterCache = Mono.fromCallable {
-        log.info {
-            "Create new BloomFilter."
-        }
-        bloomFilterSupplier()
-    }.cache(ttl)
+    /**
+     * Cached Mono that creates and caches a Bloom filter for the specified TTL duration.
+     * When the TTL expires, a new Bloom filter is created automatically.
+     */
+    private val bloomFilterCache =
+        Mono
+            .fromCallable {
+                log.info {
+                    "Create new BloomFilter."
+                }
+                bloomFilterSupplier()
+            }.cache(ttl)
 
-    override fun check(element: String): Mono<Boolean> {
-        return bloomFilterCache.map {
+    /**
+     * Checks if the element is a potential duplicate using the Bloom filter.
+     * If the element might be contained (possible duplicate), returns false.
+     * If the element is definitely not contained (unique), adds it to the filter and returns true.
+     *
+     * @param element the element to check for duplicates
+     * @return a Mono emitting true if the element appears to be unique, false if it's a potential duplicate
+     */
+    override fun check(element: String): Mono<Boolean> =
+        bloomFilterCache.map {
             val contain = it.mightContain(element)
             if (!contain) {
                 it.put(element)
             }
             !contain
         }
-    }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/idempotency/IdempotencyChecker.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/idempotency/IdempotencyChecker.kt
@@ -15,20 +15,41 @@ package me.ahoo.wow.infra.idempotency
 import reactor.core.publisher.Mono
 
 /**
- * Idempotency Checker .
+ * Interface for checking idempotency of operations to prevent duplicate processing.
+ * Idempotency checkers determine whether a given element (typically a command or request identifier)
+ * has been processed before, ensuring that operations can be safely retried without side effects.
  *
  * @author ahoo wang
  */
 fun interface IdempotencyChecker {
     /**
-     * 检查幂等性，如果该元素通过幂等性检查则返回 `true`,即表示该命令不重复.
+     * Checks if the given element passes the idempotency test.
+     * Returns true if the element is considered unique (not a duplicate), false if it's a duplicate.
+     * The check is performed asynchronously and returns a Mono for reactive programming compatibility.
+     *
+     * @param element the element to check for idempotency (typically a command or request identifier)
+     * @return a Mono emitting true if the element passes the idempotency check (is unique),
+     *         false if it's a duplicate
      */
     fun check(element: String): Mono<Boolean>
 }
 
+/**
+ * No-operation implementation of IdempotencyChecker that always allows operations to proceed.
+ * This implementation always returns true, effectively disabling idempotency checking.
+ * Useful for scenarios where idempotency is not required or is handled elsewhere.
+ */
 object NoOpIdempotencyChecker : IdempotencyChecker {
+    /**
+     * Pre-computed Mono that always emits true, cached for performance.
+     */
     private val ALWAYS_TRUE = Mono.just(true)
-    override fun check(element: String): Mono<Boolean> {
-        return ALWAYS_TRUE
-    }
+
+    /**
+     * Always returns true, indicating that all elements pass the idempotency check.
+     *
+     * @param element the element to check (ignored in this implementation)
+     * @return a Mono that always emits true
+     */
+    override fun check(element: String): Mono<Boolean> = ALWAYS_TRUE
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/prepare/DefaultPreparedValue.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/prepare/DefaultPreparedValue.kt
@@ -15,6 +15,15 @@ package me.ahoo.wow.infra.prepare
 
 import me.ahoo.wow.infra.prepare.PreparedValue.Companion.TTL_FOREVER
 
+/**
+ * Default implementation of PreparedValue that wraps a value with TTL information.
+ * This class provides a simple data structure for storing prepared values with
+ * optional expiration timestamps.
+ *
+ * @param V the type of the prepared value
+ * @property value the actual value being prepared
+ * @property ttlAt the expiration timestamp in milliseconds since epoch (defaults to permanent)
+ */
 data class DefaultPreparedValue<V>(
     override val value: V,
     override val ttlAt: Long = TTL_FOREVER

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/prepare/PrepareKeyFactory.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/prepare/PrepareKeyFactory.kt
@@ -13,6 +13,33 @@
 
 package me.ahoo.wow.infra.prepare
 
+/**
+ * Factory interface for creating PrepareKey instances.
+ * Implementations of this interface provide the mechanism to create key preparation
+ * services for different types of values and named contexts.
+ *
+ * PrepareKeyFactory is typically used in dependency injection frameworks to provide
+ * PrepareKey instances to components that need uniqueness guarantees.
+ */
 interface PrepareKeyFactory {
-    fun <V : Any> create(name: String, valueClass: Class<V>): PrepareKey<V>
+    /**
+     * Creates a PrepareKey instance for the specified name and value type.
+     * The created PrepareKey will handle preparation operations for keys with values of type V.
+     *
+     * @param V the type of values that will be prepared with the keys
+     * @param name the name identifier for this PrepareKey (used for naming and configuration)
+     * @param valueClass the Java class representing the value type V
+     * @return a new PrepareKey instance configured for the specified parameters
+     *
+     * @sample
+     * ```
+     * val factory = MyPrepareKeyFactory()
+     * val usernameKey = factory.create("username", String::class.java)
+     * val emailKey = factory.create("email", String::class.java)
+     * ```
+     */
+    fun <V : Any> create(
+        name: String,
+        valueClass: Class<V>
+    ): PrepareKey<V>
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/prepare/PreparedValue.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/prepare/PreparedValue.kt
@@ -13,40 +13,93 @@
 
 package me.ahoo.wow.infra.prepare
 
+/**
+ * Interface representing a value that has been prepared with optional time-to-live (TTL) support.
+ * Prepared values can either be permanent (never expire) or temporary (expire after a certain time).
+ *
+ * This interface is used in conjunction with PrepareKey to provide TTL-based key reservations
+ * in EventSourcing architectures where uniqueness constraints need to be enforced.
+ *
+ * @param V the type of the prepared value
+ */
 interface PreparedValue<V> {
+    /**
+     * The actual value being prepared.
+     */
     val value: V
 
     /**
-     * unit :[java.time.temporal.ChronoUnit.MILLIS]
+     * The timestamp (in milliseconds since epoch) when this prepared value expires.
+     * Values with ttlAt >= TTL_FOREVER are considered permanent and never expire.
+     *
+     * Unit: milliseconds since Unix epoch
      */
     val ttlAt: Long
 
+    /**
+     * Checks if this prepared value is permanent (never expires).
+     * A value is considered permanent if its ttlAt is greater than or equal to TTL_FOREVER.
+     */
     val isForever: Boolean
         get() = isForever(ttlAt)
+
+    /**
+     * Checks if this prepared value has expired.
+     * Permanent values (isForever = true) never expire.
+     * Temporary values expire when the current time exceeds ttlAt.
+     */
     val isExpired: Boolean
-        get() = if (isForever) {
-            false
-        } else {
-            ttlAt < System.currentTimeMillis()
-        }
+        get() =
+            if (isForever) {
+                false
+            } else {
+                ttlAt < System.currentTimeMillis()
+            }
 
     companion object {
-        fun isForever(ttlAt: Long): Boolean {
-            return ttlAt >= TTL_FOREVER
-        }
+        /**
+         * Checks if a given ttlAt timestamp represents a permanent (forever) value.
+         *
+         * @param ttlAt the timestamp to check
+         * @return true if the timestamp represents a permanent value
+         */
+        fun isForever(ttlAt: Long): Boolean = ttlAt >= TTL_FOREVER
 
         /**
-         * UTC: 6666-06-06 00:00:00.
-         * 148204944000000
+         * A special timestamp representing permanent values that never expire.
+         * Corresponds to UTC: 6666-06-06 00:00:00 (far future date).
+         * Value: 148204944000000 milliseconds since Unix epoch
          */
         const val TTL_FOREVER = 148204944000000L
 
-        fun <V> V.toForever(): PreparedValue<V> {
-            return toTtlAt(TTL_FOREVER)
-        }
+        /**
+         * Converts a value to a permanent PreparedValue that never expires.
+         *
+         * @param V the type of the value
+         * @return a PreparedValue that never expires
+         *
+         * @sample
+         * ```
+         * val permanentValue = "myValue".toForever()
+         * assert(permanentValue.isForever) // true
+         * assert(!permanentValue.isExpired) // true
+         * ```
+         */
+        fun <V> V.toForever(): PreparedValue<V> = toTtlAt(TTL_FOREVER)
 
-        fun <V> V.toTtlAt(ttlAt: Long): PreparedValue<V> {
-            return DefaultPreparedValue(this, ttlAt)
-        }
+        /**
+         * Converts a value to a PreparedValue with a specific expiration timestamp.
+         *
+         * @param V the type of the value
+         * @param ttlAt the expiration timestamp in milliseconds since epoch
+         * @return a PreparedValue with the specified TTL
+         *
+         * @sample
+         * ```
+         * val tempValue = "myValue".toTtlAt(System.currentTimeMillis() + 3600000) // expires in 1 hour
+         * assert(!tempValue.isForever) // false
+         * ```
+         */
+        fun <V> V.toTtlAt(ttlAt: Long): PreparedValue<V> = DefaultPreparedValue(this, ttlAt)
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/reflection/AnnotationScanner.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/reflection/AnnotationScanner.kt
@@ -18,27 +18,85 @@ import kotlin.reflect.KAnnotatedElement
 import kotlin.reflect.KClass
 
 /**
- * AnnotationScanner
+ * Utility object for scanning annotations on Kotlin reflection elements.
+ * Provides methods to find annotations that are inherited from parent classes,
+ * interfaces, or overridden members, not just directly declared annotations.
  *
+ * This scanner uses MergedAnnotation to collect annotations from the entire
+ * inheritance hierarchy, making it useful for frameworks that need to discover
+ * annotations from base classes or interfaces.
  */
 object AnnotationScanner {
-
+    /**
+     * Scans for all annotations of the specified type on the annotated element,
+     * including inherited annotations from parent classes and interfaces.
+     *
+     * @param A the type of annotation to scan for
+     * @param annotationClass the KClass representing the annotation type
+     * @return a list of all matching annotations found on the element
+     *
+     * @sample
+     * ```
+     * class MyClass {
+     *     @MyAnnotation
+     *     fun myMethod() {}
+     * }
+     *
+     * val method = MyClass::class.members.find { it.name == "myMethod" }!!
+     * val annotations = method.scanAnnotations(MyAnnotation::class)
+     * ```
+     */
     @Suppress("UNCHECKED_CAST")
-    fun <A : Annotation> KAnnotatedElement.scanAnnotations(annotationClass: KClass<A>): List<A> {
-        return this.toMergedAnnotation()
+    fun <A : Annotation> KAnnotatedElement.scanAnnotations(annotationClass: KClass<A>): List<A> =
+        this
+            .toMergedAnnotation()
             .mergedAnnotations
             .filter { it.annotationClass == annotationClass } as List<A>
-    }
 
-    fun <A : Annotation> KAnnotatedElement.scanAnnotation(annotationClass: KClass<A>): A? {
-        return scanAnnotations(annotationClass).firstOrNull<A>()
-    }
+    /**
+     * Scans for the first annotation of the specified type on the annotated element.
+     * Returns null if no matching annotation is found.
+     *
+     * @param A the type of annotation to scan for
+     * @param annotationClass the KClass representing the annotation type
+     * @return the first matching annotation, or null if none found
+     *
+     * @sample
+     * ```
+     * val annotation = myClass.scanAnnotation(Deprecated::class)
+     * if (annotation != null) {
+     *     println("Class is deprecated: ${annotation.message}")
+     * }
+     * ```
+     */
+    fun <A : Annotation> KAnnotatedElement.scanAnnotation(annotationClass: KClass<A>): A? =
+        scanAnnotations(annotationClass).firstOrNull<A>()
 
-    inline fun <reified A : Annotation> KAnnotatedElement.scanAnnotation(): A? {
-        return scanAnnotation(A::class)
-    }
+    /**
+     * Scans for the first annotation of the specified reified type on the annotated element.
+     * This is a convenience method that uses reified generics to avoid specifying the class explicitly.
+     *
+     * @param A the type of annotation to scan for
+     * @return the first matching annotation, or null if none found
+     *
+     * @sample
+     * ```
+     * val deprecated = myClass.scanAnnotation<Deprecated>()
+     * ```
+     */
+    inline fun <reified A : Annotation> KAnnotatedElement.scanAnnotation(): A? = scanAnnotation(A::class)
 
-    inline fun <reified A : Annotation> KAnnotatedElement.scanAnnotations(): List<A> {
-        return scanAnnotations(A::class)
-    }
+    /**
+     * Scans for all annotations of the specified reified type on the annotated element.
+     * This is a convenience method that uses reified generics to avoid specifying the class explicitly.
+     *
+     * @param A the type of annotation to scan for
+     * @return a list of all matching annotations found on the element
+     *
+     * @sample
+     * ```
+     * val annotations = myClass.scanAnnotations<SuppressWarnings>()
+     * ```
+     */
+    inline fun <reified A : Annotation> KAnnotatedElement.scanAnnotations(): List<A> = scanAnnotations(A::class)
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/reflection/ClassMetadata.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/reflection/ClassMetadata.kt
@@ -18,7 +18,37 @@ import kotlin.reflect.full.memberFunctions
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.full.starProjectedType
 
+/**
+ * Utility object for visiting and analyzing Kotlin class metadata.
+ * Provides a visitor pattern implementation to traverse class elements including
+ * types, constructors, properties, and functions in a structured way.
+ *
+ * This is useful for frameworks that need to introspect class structures
+ * for code generation, validation, or runtime analysis.
+ */
 object ClassMetadata {
+    /**
+     * Visits all metadata elements of a Kotlin class using the provided visitor.
+     * The visit follows a structured pattern: start, visit types, constructors,
+     * properties, functions, and end. This ensures consistent traversal order.
+     *
+     * @param T the type of the class being visited
+     * @param visitor the visitor that will process each class element
+     *
+     * @sample
+     * ```
+     * class MyVisitor : ClassVisitor<MyClass, Unit> {
+     *     override fun start() { println("Starting visit") }
+     *     override fun visitType(type: KType) { println("Type: $type") }
+     *     override fun visitConstructor(constructor: KFunction<MyClass>) { println("Constructor: $constructor") }
+     *     override fun visitProperty(property: KProperty1<MyClass, *>) { println("Property: $property") }
+     *     override fun visitFunction(function: KFunction<*>) { println("Function: $function") }
+     *     override fun end() { println("Visit complete") }
+     * }
+     *
+     * MyClass::class.visit(MyVisitor())
+     * ```
+     */
     fun <T : Any> KClass<T>.visit(visitor: ClassVisitor<T, *>) {
         visitor.start()
         visitor.visitType(this.starProjectedType)


### PR DESCRIPTION


- Added detailed KDoc comments to all accessor interfaces and implementations
- Documented reactive function accessors including BlockingMonoFunctionAccessor and FluxMonoFunctionAccessor
- Enhanced documentation for property accessors and function accessors with examples
- Improved documentation for idempotency checker provider and Bloom filter implementation
- Added documentation for constructor accessor and object factory classes
- Included usage examples and detailed descriptions for all public APIs
- Enhanced documentation for ensureAccessible extension functions
- Added comprehensive comments to MonoFunctionAccessorFactory with implementation details

