### PR TITLE
chore(deps): update fetcher dependencies to v3.1.9

### DIFF
--- a/compensation/dashboard/package.json
+++ b/compensation/dashboard/package.json
@@ -14,15 +14,15 @@
     "generate": "fetcher-generator generate -i http://compensation-service.dev.svc.cluster.local/v3/api-docs -o src/generated"
   },
   "dependencies": {
-    "@ahoo-wang/fetcher": "^3.1.8",
-    "@ahoo-wang/fetcher-cosec": "^3.1.8",
-    "@ahoo-wang/fetcher-decorator": "^3.1.8",
-    "@ahoo-wang/fetcher-eventbus": "^3.1.8",
-    "@ahoo-wang/fetcher-eventstream": "^3.1.8",
-    "@ahoo-wang/fetcher-react": "^3.1.8",
-    "@ahoo-wang/fetcher-storage": "^3.1.8",
-    "@ahoo-wang/fetcher-viewer": "^3.1.8",
-    "@ahoo-wang/fetcher-wow": "^3.1.8",
+    "@ahoo-wang/fetcher": "^3.1.9",
+    "@ahoo-wang/fetcher-cosec": "^3.1.9",
+    "@ahoo-wang/fetcher-decorator": "^3.1.9",
+    "@ahoo-wang/fetcher-eventbus": "^3.1.9",
+    "@ahoo-wang/fetcher-eventstream": "^3.1.9",
+    "@ahoo-wang/fetcher-react": "^3.1.9",
+    "@ahoo-wang/fetcher-storage": "^3.1.9",
+    "@ahoo-wang/fetcher-viewer": "^3.1.9",
+    "@ahoo-wang/fetcher-wow": "^3.1.9",
     "@ant-design/icons": "^5.6.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "@monaco-editor/react": "4.7.0",
@@ -30,17 +30,17 @@
     "dayjs": "^1.11.19",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-router": "^7.9.5"
+    "react-router": "^7.9.6"
   },
   "devDependencies": {
-    "@ahoo-wang/fetcher-generator": "^3.1.8",
+    "@ahoo-wang/fetcher-generator": "^3.1.9",
     "@eslint/js": "^9.39.1",
     "@tailwindcss/vite": "^4.1.17",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
-    "@types/react": "^19.2.2",
-    "@types/react-dom": "^19.2.2",
-    "@vitejs/plugin-react": "^5.1.0",
+    "@types/react": "^19.2.4",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.1",
     "@vitest/coverage-v8": "4.0.8",
     "@vitest/ui": "4.0.8",
     "babel-plugin-react-compiler": "^1.0.0",
@@ -48,7 +48,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
-    "jsdom": "^27.1.0",
+    "jsdom": "^27.2.0",
     "prettier": "3.6.2",
     "tailwindcss": "^4.1.17",
     "typescript": "~5.9.3",
@@ -56,6 +56,6 @@
     "vite": "^7.2.2",
     "vite-bundle-analyzer": "^1.2.3",
     "vitest": "^4.0.8",
-    "vitest-browser-react": "^2.0.0"
+    "vitest-browser-react": "^2.0.2"
   }
 }

--- a/compensation/dashboard/pnpm-lock.yaml
+++ b/compensation/dashboard/pnpm-lock.yaml
@@ -9,32 +9,32 @@ importers:
   .:
     dependencies:
       '@ahoo-wang/fetcher':
-        specifier: ^3.1.8
-        version: 3.1.8
+        specifier: ^3.1.9
+        version: 3.1.9
       '@ahoo-wang/fetcher-cosec':
-        specifier: ^3.1.8
-        version: 3.1.8(@ahoo-wang/fetcher-eventbus@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher-storage@3.1.8(@ahoo-wang/fetcher-eventbus@3.1.8(@ahoo-wang/fetcher@3.1.8)))(@ahoo-wang/fetcher@3.1.8)
+        specifier: ^3.1.9
+        version: 3.1.9(@ahoo-wang/fetcher-eventbus@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher-storage@3.1.9(@ahoo-wang/fetcher-eventbus@3.1.9(@ahoo-wang/fetcher@3.1.9)))(@ahoo-wang/fetcher@3.1.9)
       '@ahoo-wang/fetcher-decorator':
-        specifier: ^3.1.8
-        version: 3.1.8(@ahoo-wang/fetcher@3.1.8)
+        specifier: ^3.1.9
+        version: 3.1.9(@ahoo-wang/fetcher@3.1.9)
       '@ahoo-wang/fetcher-eventbus':
-        specifier: ^3.1.8
-        version: 3.1.8(@ahoo-wang/fetcher@3.1.8)
+        specifier: ^3.1.9
+        version: 3.1.9(@ahoo-wang/fetcher@3.1.9)
       '@ahoo-wang/fetcher-eventstream':
-        specifier: ^3.1.8
-        version: 3.1.8(@ahoo-wang/fetcher@3.1.8)
+        specifier: ^3.1.9
+        version: 3.1.9(@ahoo-wang/fetcher@3.1.9)
       '@ahoo-wang/fetcher-react':
-        specifier: ^3.1.8
-        version: 3.1.8(@ahoo-wang/fetcher-eventbus@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher-eventstream@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher-storage@3.1.8(@ahoo-wang/fetcher-eventbus@3.1.8(@ahoo-wang/fetcher@3.1.8)))(@ahoo-wang/fetcher-wow@3.1.8(@ahoo-wang/fetcher-decorator@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher-eventstream@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher@3.1.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^3.1.9
+        version: 3.1.9(@ahoo-wang/fetcher-eventbus@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher-eventstream@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher-storage@3.1.9(@ahoo-wang/fetcher-eventbus@3.1.9(@ahoo-wang/fetcher@3.1.9)))(@ahoo-wang/fetcher-wow@3.1.9(@ahoo-wang/fetcher-decorator@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher-eventstream@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher@3.1.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@ahoo-wang/fetcher-storage':
-        specifier: ^3.1.8
-        version: 3.1.8(@ahoo-wang/fetcher-eventbus@3.1.8(@ahoo-wang/fetcher@3.1.8))
+        specifier: ^3.1.9
+        version: 3.1.9(@ahoo-wang/fetcher-eventbus@3.1.9(@ahoo-wang/fetcher@3.1.9))
       '@ahoo-wang/fetcher-viewer':
-        specifier: ^3.1.8
-        version: 3.1.8(7259fca7242172d90b290bd88e1efa81)
+        specifier: ^3.1.9
+        version: 3.1.9(43bf63ff7e2b28654baf43997f922d74)
       '@ahoo-wang/fetcher-wow':
-        specifier: ^3.1.8
-        version: 3.1.8(@ahoo-wang/fetcher-decorator@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher-eventstream@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher@3.1.8)
+        specifier: ^3.1.9
+        version: 3.1.9(@ahoo-wang/fetcher-decorator@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher-eventstream@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher@3.1.9)
       '@ant-design/icons':
         specifier: ^5.6.1
         version: 5.6.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -57,12 +57,12 @@ importers:
         specifier: ^19.2.0
         version: 19.2.0(react@19.2.0)
       react-router:
-        specifier: ^7.9.5
-        version: 7.9.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        specifier: ^7.9.6
+        version: 7.9.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
     devDependencies:
       '@ahoo-wang/fetcher-generator':
-        specifier: ^3.1.8
-        version: 3.1.8(@ahoo-wang/fetcher-decorator@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher-eventstream@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@3.1.8(@ahoo-wang/fetcher-decorator@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher-eventstream@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher@3.1.8)
+        specifier: ^3.1.9
+        version: 3.1.9(@ahoo-wang/fetcher-decorator@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher-eventstream@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@3.1.9(@ahoo-wang/fetcher-decorator@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher-eventstream@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher@3.1.9)
       '@eslint/js':
         specifier: ^9.39.1
         version: 9.39.1
@@ -74,16 +74,16 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@types/react':
-        specifier: ^19.2.2
-        version: 19.2.2
+        specifier: ^19.2.4
+        version: 19.2.4
       '@types/react-dom':
-        specifier: ^19.2.2
-        version: 19.2.2(@types/react@19.2.2)
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.4)
       '@vitejs/plugin-react':
-        specifier: ^5.1.0
-        version: 5.1.0(vite@7.2.2(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1))
+        specifier: ^5.1.1
+        version: 5.1.1(vite@7.2.2(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1))
       '@vitest/coverage-v8':
         specifier: 4.0.8
         version: 4.0.8(vitest@4.0.8)
@@ -106,8 +106,8 @@ importers:
         specifier: ^16.5.0
         version: 16.5.0
       jsdom:
-        specifier: ^27.1.0
-        version: 27.1.0
+        specifier: ^27.2.0
+        version: 27.2.0
       prettier:
         specifier: 3.6.2
         version: 3.6.2
@@ -128,10 +128,10 @@ importers:
         version: 1.2.3
       vitest:
         specifier: ^4.0.8
-        version: 4.0.8(@vitest/ui@4.0.8)(jiti@2.6.1)(jsdom@27.1.0)(lightningcss@1.30.2)(yaml@2.8.1)
+        version: 4.0.8(@vitest/ui@4.0.8)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(yaml@2.8.1)
       vitest-browser-react:
-        specifier: ^2.0.0
-        version: 2.0.2(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@4.0.8)
+        specifier: ^2.0.2
+        version: 2.0.2(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@4.0.8)
 
 packages:
 
@@ -141,30 +141,30 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@ahoo-wang/fetcher-cosec@3.1.8':
-    resolution: {integrity: sha512-iahIb5pE8iXO4Y+YWNmzMipqh85N2B17XH4coH33LDdp8AX4tLYb8gSirZRW/UfOhULkA2uFftekgb36qkASkQ==}
+  '@ahoo-wang/fetcher-cosec@3.1.9':
+    resolution: {integrity: sha512-tbWKQFAXcJCDkIxY44U6cbS+B7y0jfNyc/a7qNGaZvqhzYyhVjv9fUjWiSwdv7SQos9/LNS/dMDb6GgutvV21A==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
       '@ahoo-wang/fetcher-eventbus': ^3.0.0
       '@ahoo-wang/fetcher-storage': ^3.0.0
 
-  '@ahoo-wang/fetcher-decorator@3.1.8':
-    resolution: {integrity: sha512-X+9dYc6I8fUV5t6Hmdy/ICRFBqL042+OKZ42i/Fezz22wSqJipEPcDJTbhQCpRyJjCSnZFFNqitKkxN1zmRB9g==}
+  '@ahoo-wang/fetcher-decorator@3.1.9':
+    resolution: {integrity: sha512-a8DcPC3X4JCtNvdzzmuYka2VN1mGiI+L80HBj5svSc0xvI2ZXKYQCDzgylULlHA+fY1KqnKkcKvKX2rD0B4Fuw==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
 
-  '@ahoo-wang/fetcher-eventbus@3.1.8':
-    resolution: {integrity: sha512-/yJjLoEQc/mLLdglX5TPd2RILmVeGxr6ZoBTA1WqJ80xcLaAH0heiapNiaKZ1myqUH5mpJHFgBtqnEO3mdjqGg==}
+  '@ahoo-wang/fetcher-eventbus@3.1.9':
+    resolution: {integrity: sha512-aRej1VRd7KvKiOBbXA1/LQQJDrNFIzW2E+YlSotS0TJTRmiAtySJoT4CX9WX987Ini0Mew+/ALvo+LLFdUqWlA==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
 
-  '@ahoo-wang/fetcher-eventstream@3.1.8':
-    resolution: {integrity: sha512-01nNNVuGeRI+uIZyKGUoho8Q55VMJSfAtHDm4X5qJHMJow1qAxVkM7yl34k4yzZ2audqIn5+Z1exkxSgIIntJg==}
+  '@ahoo-wang/fetcher-eventstream@3.1.9':
+    resolution: {integrity: sha512-w+ZvwTQlWkD2sm8K4+PhVwI7YecsWO+n+Mpc9WwYrdUiSFAD0loHX/Wzh/uQuJIoeDxHPrMcdxrto8pSnhTU7w==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
 
-  '@ahoo-wang/fetcher-generator@3.1.8':
-    resolution: {integrity: sha512-dZQNsM4q4/nxGS6sQNQOIP5S10dZcUEijpFFMwe6E1Z5+aPny5Hhjzdy/0NLlTQ1l0DLuSfkrTrfzujnQgX56A==}
+  '@ahoo-wang/fetcher-generator@3.1.9':
+    resolution: {integrity: sha512-lytvfm9if2SzlRUosH9RcviiLmGrhlZ6e+GtaDzJQ2vOzMEjlkgd0m0pzI65nw91ZVbSiJzko5LWh6fM15b53g==}
     hasBin: true
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
@@ -176,8 +176,8 @@ packages:
   '@ahoo-wang/fetcher-openapi@2.3.0':
     resolution: {integrity: sha512-He3I/VovQzLNajxL2hoUZKlAnt0ZpehpMpbjgxvdPEoWfeAA3qZc0+C8Mhrk3HQQAC69lZOSt3JtAvzYDxpn/Q==}
 
-  '@ahoo-wang/fetcher-react@3.1.8':
-    resolution: {integrity: sha512-J7XZIHhtm7duFZTHsMunCUvOHzL1di+xkiQvTFj9nvWEse33Eldeh6E1Jzlen4Doj3eW2KzN6MPklPyaHkZ/lw==}
+  '@ahoo-wang/fetcher-react@3.1.9':
+    resolution: {integrity: sha512-WfBPQWMjxRIXEaOVKfyZzhV8kUtIh3+aRJt4V03QCtjKPpfxDk6Rhs1LOFvGwuv0oax5JS2rRXMaVchYVV5QLw==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
       '@ahoo-wang/fetcher-eventbus': ^3.0.0
@@ -187,13 +187,13 @@ packages:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
 
-  '@ahoo-wang/fetcher-storage@3.1.8':
-    resolution: {integrity: sha512-9KSooO67nRI0DgSKe2BEo0Kiukrm4adtPpiUfRkXfk4sd0cwJQDNw6ixYpkHcoVXYN417gEWCFaszZUPmbubXQ==}
+  '@ahoo-wang/fetcher-storage@3.1.9':
+    resolution: {integrity: sha512-0o8+H/WLKsyAgutYepaUNrJdpZO667Ax49NLAjB8t8jpfwhOpDSXNFUWMSeeP1AlpU4khY8wgkhExiXpNthjVw==}
     peerDependencies:
       '@ahoo-wang/fetcher-eventbus': ^3.0.0
 
-  '@ahoo-wang/fetcher-viewer@3.1.8':
-    resolution: {integrity: sha512-8vQ/1+TWlT4buiJ3LnBYpsWG1jwq6oVM/YN86/b+RBEPPBbFJE9+YGfq18eQ/c7aZyGirnitTfw4TGdLQM7lNg==}
+  '@ahoo-wang/fetcher-viewer@3.1.9':
+    resolution: {integrity: sha512-8C+RRQHU1MGAxSFIWqeFpVW7OmDI4FMfWrSfgb8cLwLtbL6aMBgx1Kh5nBpXl+GrJ+fOIq9ao/C0Dxl++Q4vzg==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
       '@ahoo-wang/fetcher-openapi': ^3.0.0
@@ -206,15 +206,15 @@ packages:
       react: '>=19.0.0'
       react-dom: '>=19.0.0'
 
-  '@ahoo-wang/fetcher-wow@3.1.8':
-    resolution: {integrity: sha512-lYRHKOWJG0Od+uA6Agc3U5oKn+kLVCR5KdaJkUqJ+1ghckbIx4FDR+QRWJiNOrUCqiXFxDmZdjXYYO+J9ZsoHg==}
+  '@ahoo-wang/fetcher-wow@3.1.9':
+    resolution: {integrity: sha512-c4ND1v0zzm3hb5NDWSaN375JLkdyHuTgngdlVEvtYyVqlO49A7cH/ERsLcsUx7WmEBmLn3/3Vu3H7LWAHGO8NA==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
       '@ahoo-wang/fetcher-decorator': ^3.0.0
       '@ahoo-wang/fetcher-eventstream': ^3.0.0
 
-  '@ahoo-wang/fetcher@3.1.8':
-    resolution: {integrity: sha512-+EAhUF0RQtLWTPlV7i7hwvSxBUHZt+PGQnKQzsmI9/5Jecymy+VDd3W6TSepYu32uywOHzNr/pJ1cbF0gSKj2Q==}
+  '@ahoo-wang/fetcher@3.1.9':
+    resolution: {integrity: sha512-KTwMxq6hacNMY6FLlVXEhuWR8Y5VD+zBz7hbWiO0XpovHKE9PfHGyGV3SHt9+/GTh78Im3qJzPBrrareBaTqcQ==}
 
   '@ant-design/colors@7.2.1':
     resolution: {integrity: sha512-lCHDcEzieu4GA3n8ELeZ5VQ8pKQAWcGGLRTQ50aQM2iqPpq2evTxER84jfdPvsPAtEcZ7m44NI45edFMo8oOYQ==}
@@ -382,8 +382,8 @@ packages:
     peerDependencies:
       '@csstools/css-tokenizer': ^3.0.4
 
-  '@csstools/css-syntax-patches-for-csstree@1.0.15':
-    resolution: {integrity: sha512-q0p6zkVq2lJnmzZVPR33doA51G7YOja+FBvRdp5ISIthL0MtFCgYHHhR563z9WFGxcOn0WfjSkPDJ5Qig3H3Sw==}
+  '@csstools/css-syntax-patches-for-csstree@1.0.16':
+    resolution: {integrity: sha512-2SpS4/UaWQaGpBINyG5ZuCHnUDeVByOhvbkARwfmnfxDvTaj80yOI1cD8Tw93ICV5Fx4fnyDKWQZI1CDtcWyUg==}
     engines: {node: '>=18'}
 
   '@csstools/css-tokenizer@3.0.4':
@@ -710,8 +710,8 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
-  '@rolldown/pluginutils@1.0.0-beta.43':
-    resolution: {integrity: sha512-5Uxg7fQUCmfhax7FJke2+8B6cqgeUJUD9o2uXIKXhD+mG0mL6NObmVoi9wXEU1tY89mZKgAYA6fTbftx3q2ZPQ==}
+  '@rolldown/pluginutils@1.0.0-beta.47':
+    resolution: {integrity: sha512-8QagwMH3kNCuzD8EWL8R2YPW5e4OrHNSAHRFDdmFqEwEaD/KcNKjVoumo+gP2vW5eKB2UPbM6vTYiGZX0ixLnw==}
 
   '@rollup/rollup-android-arm-eabi@4.53.2':
     resolution: {integrity: sha512-yDPzwsgiFO26RJA4nZo8I+xqzh7sJTZIWQOxn+/XOdPE31lAvLIYCKqjV+lNH/vxE2L2iH3plKxDCRK6i+CwhA==}
@@ -969,13 +969,13 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/react-dom@19.2.2':
-    resolution: {integrity: sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==}
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
       '@types/react': ^19.2.0
 
-  '@types/react@19.2.2':
-    resolution: {integrity: sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==}
+  '@types/react@19.2.4':
+    resolution: {integrity: sha512-tBFxBp9Nfyy5rsmefN+WXc1JeW/j2BpBHFdLZbEVfs9wn3E3NRFxwV0pJg8M1qQAexFpvz73hJXFofV0ZAu92A==}
 
   '@typescript-eslint/eslint-plugin@8.46.4':
     resolution: {integrity: sha512-R48VhmTJqplNyDxCyqqVkFSZIx1qX6PzwqgcXn1olLrzxcSBDlOsbtcnQuQhNtnNiJ4Xe5gREI1foajYaYU2Vg==}
@@ -1036,8 +1036,8 @@ packages:
     resolution: {integrity: sha512-/++5CYLQqsO9HFGLI7APrxBJYo+5OCMpViuhV8q5/Qa3o5mMrF//eQHks+PXcsAVaLdn817fMuS7zqoXNNZGaw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@vitejs/plugin-react@5.1.0':
-    resolution: {integrity: sha512-4LuWrg7EKWgQaMJfnN+wcmbAW+VSsCmqGohftWjuct47bv8uE4n/nPpq4XjJPsxgq00GGG5J8dvBczp8uxScew==}
+  '@vitejs/plugin-react@5.1.1':
+    resolution: {integrity: sha512-WQfkSw0QbQ5aJ2CHYw23ZGkqnRwqKHD/KYsMeTkZzPT4Jcf0DcBxBtwMJxnu6E7oxw5+JC6ZAiePgh28uJ1HBA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -1143,8 +1143,8 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
-  baseline-browser-mapping@2.8.25:
-    resolution: {integrity: sha512-2NovHVesVF5TXefsGX1yzx1xgr7+m9JQenvz6FQY3qd+YXkKkYiv+vTCc7OriP9mcDZpTC5mAOYN4ocd29+erA==}
+  baseline-browser-mapping@2.8.28:
+    resolution: {integrity: sha512-gYjt7OIqdM0PcttNYP2aVrr2G0bMALkBaoehD4BuRGjAOtipg0b6wHg1yNL+s5zSnLZZrGHOw4IrND8CD+3oIQ==}
     hasBin: true
 
   bidi-js@1.0.3:
@@ -1172,8 +1172,8 @@ packages:
   caniuse-lite@1.0.30001754:
     resolution: {integrity: sha512-x6OeBXueoAceOmotzx3PO4Zpt4rzpeIFsSr6AAePTZxSkXiYDUmpypEl7e2+8NCd9bD7bXjqyef8CJYPC1jfxg==}
 
-  chai@6.2.0:
-    resolution: {integrity: sha512-aUTnJc/JipRzJrNADXVvpVqi6CO0dn3nx4EVPxijri+fj3LUUDyZQOgVeW54Ob3Y1Xh9Iz8f+CgaCl8v0mn9bA==}
+  chai@6.2.1:
+    resolution: {integrity: sha512-p4Z49OGG5W/WBCPSS/dH3jQ73kD6tiMmUM+bckNK6Jr5JHMG3k9bg/BvKR8lKmtVBKmOiuVaV2ws8s9oSbwysg==}
     engines: {node: '>=18'}
 
   chalk@4.1.2:
@@ -1267,8 +1267,8 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
-  electron-to-chromium@1.5.250:
-    resolution: {integrity: sha512-/5UMj9IiGDMOFBnN4i7/Ry5onJrAGSbOGo3s9FEKmwobGq6xw832ccET0CE3CkkMBZ8GJSlUIesZofpyurqDXw==}
+  electron-to-chromium@1.5.251:
+    resolution: {integrity: sha512-lmyEOp4G0XT3qrYswNB4np1kx90k6QCXpnSHYv2xEsUuEu8JCobpDVYO6vMseirQyyCC6GCIGGxd5szMBa0tRA==}
 
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
@@ -1525,12 +1525,12 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
-  jsdom@27.1.0:
-    resolution: {integrity: sha512-Pcfm3eZ+eO4JdZCXthW9tCDT3nF4K+9dmeZ+5X39n+Kqz0DDIABRP5CAEOHRFZk8RGuC2efksTJxrjp8EXCunQ==}
+  jsdom@27.2.0:
+    resolution: {integrity: sha512-454TI39PeRDW1LgpyLPyURtB4Zx1tklSr6+OFOipsxGUH1WMTvk6C65JQdrj455+DP2uJ1+veBEHTGFKWVLFoA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
     peerDependencies:
       canvas: ^3.0.0
@@ -2028,8 +2028,8 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
-  react-router@7.9.5:
-    resolution: {integrity: sha512-JmxqrnBZ6E9hWmf02jzNn9Jm3UqyeimyiwzD69NjxGySG6lIz/1LVPsoTCwN7NBX2XjCEa1LIX5EMz1j2b6u6A==}
+  react-router@7.9.6:
+    resolution: {integrity: sha512-Y1tUp8clYRXpfPITyuifmSoE2vncSME18uVLgaqyxh9H35JWpIfzHo+9y3Fzh5odk/jxPW29IgLgzcdwxGqyNA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
@@ -2403,73 +2403,73 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ahoo-wang/fetcher-cosec@3.1.8(@ahoo-wang/fetcher-eventbus@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher-storage@3.1.8(@ahoo-wang/fetcher-eventbus@3.1.8(@ahoo-wang/fetcher@3.1.8)))(@ahoo-wang/fetcher@3.1.8)':
+  '@ahoo-wang/fetcher-cosec@3.1.9(@ahoo-wang/fetcher-eventbus@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher-storage@3.1.9(@ahoo-wang/fetcher-eventbus@3.1.9(@ahoo-wang/fetcher@3.1.9)))(@ahoo-wang/fetcher@3.1.9)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.1.8
-      '@ahoo-wang/fetcher-eventbus': 3.1.8(@ahoo-wang/fetcher@3.1.8)
-      '@ahoo-wang/fetcher-storage': 3.1.8(@ahoo-wang/fetcher-eventbus@3.1.8(@ahoo-wang/fetcher@3.1.8))
+      '@ahoo-wang/fetcher': 3.1.9
+      '@ahoo-wang/fetcher-eventbus': 3.1.9(@ahoo-wang/fetcher@3.1.9)
+      '@ahoo-wang/fetcher-storage': 3.1.9(@ahoo-wang/fetcher-eventbus@3.1.9(@ahoo-wang/fetcher@3.1.9))
       nanoid: 5.1.6
 
-  '@ahoo-wang/fetcher-decorator@3.1.8(@ahoo-wang/fetcher@3.1.8)':
+  '@ahoo-wang/fetcher-decorator@3.1.9(@ahoo-wang/fetcher@3.1.9)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.1.8
+      '@ahoo-wang/fetcher': 3.1.9
       reflect-metadata: 0.2.2
 
-  '@ahoo-wang/fetcher-eventbus@3.1.8(@ahoo-wang/fetcher@3.1.8)':
+  '@ahoo-wang/fetcher-eventbus@3.1.9(@ahoo-wang/fetcher@3.1.9)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.1.8
+      '@ahoo-wang/fetcher': 3.1.9
 
-  '@ahoo-wang/fetcher-eventstream@3.1.8(@ahoo-wang/fetcher@3.1.8)':
+  '@ahoo-wang/fetcher-eventstream@3.1.9(@ahoo-wang/fetcher@3.1.9)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.1.8
+      '@ahoo-wang/fetcher': 3.1.9
 
-  '@ahoo-wang/fetcher-generator@3.1.8(@ahoo-wang/fetcher-decorator@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher-eventstream@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@3.1.8(@ahoo-wang/fetcher-decorator@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher-eventstream@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher@3.1.8)':
+  '@ahoo-wang/fetcher-generator@3.1.9(@ahoo-wang/fetcher-decorator@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher-eventstream@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@3.1.9(@ahoo-wang/fetcher-decorator@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher-eventstream@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher@3.1.9)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.1.8
-      '@ahoo-wang/fetcher-decorator': 3.1.8(@ahoo-wang/fetcher@3.1.8)
-      '@ahoo-wang/fetcher-eventstream': 3.1.8(@ahoo-wang/fetcher@3.1.8)
+      '@ahoo-wang/fetcher': 3.1.9
+      '@ahoo-wang/fetcher-decorator': 3.1.9(@ahoo-wang/fetcher@3.1.9)
+      '@ahoo-wang/fetcher-eventstream': 3.1.9(@ahoo-wang/fetcher@3.1.9)
       '@ahoo-wang/fetcher-openapi': 2.3.0
-      '@ahoo-wang/fetcher-wow': 3.1.8(@ahoo-wang/fetcher-decorator@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher-eventstream@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher@3.1.8)
+      '@ahoo-wang/fetcher-wow': 3.1.9(@ahoo-wang/fetcher-decorator@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher-eventstream@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher@3.1.9)
       commander: 14.0.2
       ts-morph: 27.0.2
       yaml: 2.8.1
 
   '@ahoo-wang/fetcher-openapi@2.3.0': {}
 
-  '@ahoo-wang/fetcher-react@3.1.8(@ahoo-wang/fetcher-eventbus@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher-eventstream@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher-storage@3.1.8(@ahoo-wang/fetcher-eventbus@3.1.8(@ahoo-wang/fetcher@3.1.8)))(@ahoo-wang/fetcher-wow@3.1.8(@ahoo-wang/fetcher-decorator@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher-eventstream@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher@3.1.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@ahoo-wang/fetcher-react@3.1.9(@ahoo-wang/fetcher-eventbus@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher-eventstream@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher-storage@3.1.9(@ahoo-wang/fetcher-eventbus@3.1.9(@ahoo-wang/fetcher@3.1.9)))(@ahoo-wang/fetcher-wow@3.1.9(@ahoo-wang/fetcher-decorator@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher-eventstream@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher@3.1.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.1.8
-      '@ahoo-wang/fetcher-eventbus': 3.1.8(@ahoo-wang/fetcher@3.1.8)
-      '@ahoo-wang/fetcher-eventstream': 3.1.8(@ahoo-wang/fetcher@3.1.8)
-      '@ahoo-wang/fetcher-storage': 3.1.8(@ahoo-wang/fetcher-eventbus@3.1.8(@ahoo-wang/fetcher@3.1.8))
-      '@ahoo-wang/fetcher-wow': 3.1.8(@ahoo-wang/fetcher-decorator@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher-eventstream@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher@3.1.8)
+      '@ahoo-wang/fetcher': 3.1.9
+      '@ahoo-wang/fetcher-eventbus': 3.1.9(@ahoo-wang/fetcher@3.1.9)
+      '@ahoo-wang/fetcher-eventstream': 3.1.9(@ahoo-wang/fetcher@3.1.9)
+      '@ahoo-wang/fetcher-storage': 3.1.9(@ahoo-wang/fetcher-eventbus@3.1.9(@ahoo-wang/fetcher@3.1.9))
+      '@ahoo-wang/fetcher-wow': 3.1.9(@ahoo-wang/fetcher-decorator@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher-eventstream@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher@3.1.9)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@ahoo-wang/fetcher-storage@3.1.8(@ahoo-wang/fetcher-eventbus@3.1.8(@ahoo-wang/fetcher@3.1.8))':
+  '@ahoo-wang/fetcher-storage@3.1.9(@ahoo-wang/fetcher-eventbus@3.1.9(@ahoo-wang/fetcher@3.1.9))':
     dependencies:
-      '@ahoo-wang/fetcher-eventbus': 3.1.8(@ahoo-wang/fetcher@3.1.8)
+      '@ahoo-wang/fetcher-eventbus': 3.1.9(@ahoo-wang/fetcher@3.1.9)
 
-  '@ahoo-wang/fetcher-viewer@3.1.8(7259fca7242172d90b290bd88e1efa81)':
+  '@ahoo-wang/fetcher-viewer@3.1.9(43bf63ff7e2b28654baf43997f922d74)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.1.8
+      '@ahoo-wang/fetcher': 3.1.9
       '@ahoo-wang/fetcher-openapi': 2.3.0
-      '@ahoo-wang/fetcher-react': 3.1.8(@ahoo-wang/fetcher-eventbus@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher-eventstream@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher-storage@3.1.8(@ahoo-wang/fetcher-eventbus@3.1.8(@ahoo-wang/fetcher@3.1.8)))(@ahoo-wang/fetcher-wow@3.1.8(@ahoo-wang/fetcher-decorator@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher-eventstream@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher@3.1.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@ahoo-wang/fetcher-storage': 3.1.8(@ahoo-wang/fetcher-eventbus@3.1.8(@ahoo-wang/fetcher@3.1.8))
-      '@ahoo-wang/fetcher-wow': 3.1.8(@ahoo-wang/fetcher-decorator@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher-eventstream@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher@3.1.8)
+      '@ahoo-wang/fetcher-react': 3.1.9(@ahoo-wang/fetcher-eventbus@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher-eventstream@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher-storage@3.1.9(@ahoo-wang/fetcher-eventbus@3.1.9(@ahoo-wang/fetcher@3.1.9)))(@ahoo-wang/fetcher-wow@3.1.9(@ahoo-wang/fetcher-decorator@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher-eventstream@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher@3.1.9)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@ahoo-wang/fetcher-storage': 3.1.9(@ahoo-wang/fetcher-eventbus@3.1.9(@ahoo-wang/fetcher@3.1.9))
+      '@ahoo-wang/fetcher-wow': 3.1.9(@ahoo-wang/fetcher-decorator@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher-eventstream@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher@3.1.9)
       '@ant-design/icons': 5.6.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       antd: 5.28.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       dayjs: 1.11.19
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@ahoo-wang/fetcher-wow@3.1.8(@ahoo-wang/fetcher-decorator@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher-eventstream@3.1.8(@ahoo-wang/fetcher@3.1.8))(@ahoo-wang/fetcher@3.1.8)':
+  '@ahoo-wang/fetcher-wow@3.1.9(@ahoo-wang/fetcher-decorator@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher-eventstream@3.1.9(@ahoo-wang/fetcher@3.1.9))(@ahoo-wang/fetcher@3.1.9)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.1.8
-      '@ahoo-wang/fetcher-decorator': 3.1.8(@ahoo-wang/fetcher@3.1.8)
-      '@ahoo-wang/fetcher-eventstream': 3.1.8(@ahoo-wang/fetcher@3.1.8)
+      '@ahoo-wang/fetcher': 3.1.9
+      '@ahoo-wang/fetcher-decorator': 3.1.9(@ahoo-wang/fetcher@3.1.9)
+      '@ahoo-wang/fetcher-eventstream': 3.1.9(@ahoo-wang/fetcher@3.1.9)
 
-  '@ahoo-wang/fetcher@3.1.8': {}
+  '@ahoo-wang/fetcher@3.1.9': {}
 
   '@ant-design/colors@7.2.1':
     dependencies:
@@ -2678,7 +2678,7 @@ snapshots:
     dependencies:
       '@csstools/css-tokenizer': 3.0.4
 
-  '@csstools/css-syntax-patches-for-csstree@1.0.15': {}
+  '@csstools/css-syntax-patches-for-csstree@1.0.16': {}
 
   '@csstools/css-tokenizer@3.0.4': {}
 
@@ -2795,7 +2795,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       minimatch: 3.1.2
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -2939,7 +2939,7 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@rolldown/pluginutils@1.0.0-beta.43': {}
+  '@rolldown/pluginutils@1.0.0-beta.47': {}
 
   '@rollup/rollup-android-arm-eabi@4.53.2':
     optional: true
@@ -3097,15 +3097,15 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.28.4
       '@testing-library/dom': 10.4.1
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:
-      '@types/react': 19.2.2
-      '@types/react-dom': 19.2.2(@types/react@19.2.2)
+      '@types/react': 19.2.4
+      '@types/react-dom': 19.2.3(@types/react@19.2.4)
 
   '@ts-morph/common@0.28.1':
     dependencies:
@@ -3147,11 +3147,11 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/react-dom@19.2.2(@types/react@19.2.2)':
+  '@types/react-dom@19.2.3(@types/react@19.2.4)':
     dependencies:
-      '@types/react': 19.2.2
+      '@types/react': 19.2.4
 
-  '@types/react@19.2.2':
+  '@types/react@19.2.4':
     dependencies:
       csstype: 3.1.3
 
@@ -3248,12 +3248,12 @@ snapshots:
       '@typescript-eslint/types': 8.46.4
       eslint-visitor-keys: 4.2.1
 
-  '@vitejs/plugin-react@5.1.0(vite@7.2.2(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1))':
+  '@vitejs/plugin-react@5.1.1(vite@7.2.2(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
-      '@rolldown/pluginutils': 1.0.0-beta.43
+      '@rolldown/pluginutils': 1.0.0-beta.47
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
       vite: 7.2.2(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1)
@@ -3273,7 +3273,7 @@ snapshots:
       magicast: 0.5.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.8(@vitest/ui@4.0.8)(jiti@2.6.1)(jsdom@27.1.0)(lightningcss@1.30.2)(yaml@2.8.1)
+      vitest: 4.0.8(@vitest/ui@4.0.8)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -3283,7 +3283,7 @@ snapshots:
       '@types/chai': 5.2.3
       '@vitest/spy': 4.0.8
       '@vitest/utils': 4.0.8
-      chai: 6.2.0
+      chai: 6.2.1
       tinyrainbow: 3.0.3
 
   '@vitest/mocker@4.0.8(vite@7.2.2(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1))':
@@ -3320,7 +3320,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.8(@vitest/ui@4.0.8)(jiti@2.6.1)(jsdom@27.1.0)(lightningcss@1.30.2)(yaml@2.8.1)
+      vitest: 4.0.8(@vitest/ui@4.0.8)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(yaml@2.8.1)
 
   '@vitest/utils@4.0.8':
     dependencies:
@@ -3430,7 +3430,7 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
-  baseline-browser-mapping@2.8.25: {}
+  baseline-browser-mapping@2.8.28: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -3451,9 +3451,9 @@ snapshots:
 
   browserslist@4.28.0:
     dependencies:
-      baseline-browser-mapping: 2.8.25
+      baseline-browser-mapping: 2.8.28
       caniuse-lite: 1.0.30001754
-      electron-to-chromium: 1.5.250
+      electron-to-chromium: 1.5.251
       node-releases: 2.0.27
       update-browserslist-db: 1.1.4(browserslist@4.28.0)
 
@@ -3461,7 +3461,7 @@ snapshots:
 
   caniuse-lite@1.0.30001754: {}
 
-  chai@6.2.0: {}
+  chai@6.2.1: {}
 
   chalk@4.1.2:
     dependencies:
@@ -3508,7 +3508,7 @@ snapshots:
   cssstyle@5.3.3:
     dependencies:
       '@asamuzakjp/css-color': 4.0.5
-      '@csstools/css-syntax-patches-for-csstree': 1.0.15
+      '@csstools/css-syntax-patches-for-csstree': 1.0.16
       css-tree: 3.1.0
 
   csstype@3.1.3: {}
@@ -3536,7 +3536,7 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  electron-to-chromium@1.5.250: {}
+  electron-to-chromium@1.5.251: {}
 
   enhanced-resolve@5.18.3:
     dependencies:
@@ -3818,11 +3818,11 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.1.0:
+  js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
 
-  jsdom@27.1.0:
+  jsdom@27.2.0:
     dependencies:
       '@acemir/cssom': 0.9.23
       '@asamuzakjp/dom-selector': 6.7.4
@@ -4375,7 +4375,7 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
-  react-router@7.9.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+  react-router@7.9.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
       cookie: 1.0.2
       react: 19.2.0
@@ -4579,16 +4579,16 @@ snapshots:
       lightningcss: 1.30.2
       yaml: 2.8.1
 
-  vitest-browser-react@2.0.2(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@4.0.8):
+  vitest-browser-react@2.0.2(@types/react-dom@19.2.3(@types/react@19.2.4))(@types/react@19.2.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vitest@4.0.8):
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      vitest: 4.0.8(@vitest/ui@4.0.8)(jiti@2.6.1)(jsdom@27.1.0)(lightningcss@1.30.2)(yaml@2.8.1)
+      vitest: 4.0.8(@vitest/ui@4.0.8)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(yaml@2.8.1)
     optionalDependencies:
-      '@types/react': 19.2.2
-      '@types/react-dom': 19.2.2(@types/react@19.2.2)
+      '@types/react': 19.2.4
+      '@types/react-dom': 19.2.3(@types/react@19.2.4)
 
-  vitest@4.0.8(@vitest/ui@4.0.8)(jiti@2.6.1)(jsdom@27.1.0)(lightningcss@1.30.2)(yaml@2.8.1):
+  vitest@4.0.8(@vitest/ui@4.0.8)(jiti@2.6.1)(jsdom@27.2.0)(lightningcss@1.30.2)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.0.8
       '@vitest/mocker': 4.0.8(vite@7.2.2(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1))
@@ -4612,7 +4612,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@vitest/ui': 4.0.8(vitest@4.0.8)
-      jsdom: 27.1.0
+      jsdom: 27.2.0
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
- Updated @ahoo-wang/fetcher from3.1.8 to3.1.9
- Updated @ahoo-wang/fetcher-cosec from3.1.8 to3.1.9
- Updated @ahoo-wang/fetcher-decorator from 3.1.8 to3.1.9
- Updated @ahoo-wang/fetcher-eventbus from 3.1.8 to3.1.9
- Updated @ahoo-wang/fetcher-eventstream from 3.1.8 to 3.1.9
- Updated @ahoo-wang/fetcher-react from 3.1.8 to3.1.9
- Updated @ahoo-wang/fetcher-storage from 3.1.8 to3.1.9
- Updated @ahoo-wang/fetcher-viewer from 3.1.8 to3.1.9
- Updated @ahoo-wang/fetcher-wow from3.1.8 to3.1.9
- Updated @ahoo-wang/fetcher-generator from3.1.8 to3.1.9
- Updated react-router from7.9.5 to 7.9.6
- Updated @types/react from19.2.2 to 19.2.4
- Updated @types/react-dom from 19.2 to19.2.3
- Updated @vitejs/plugin-react from 5.1.0 to 5.1.1
- Updated jsdom from27.1.0 to27.2.0
- Updated vitest-browser-react from 2.0.0 to 2.0.2
