### PR TITLE
feat(test): replace DynamicTest with captureDynamicTest for better error stack trace

### DIFF
--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/OrchestrationError.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/OrchestrationError.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.test
+
+import org.junit.jupiter.api.DynamicTest
+
+class OrchestrationError(orchestrationStacks: Array<StackTraceElement>, cause: Throwable) :
+    AssertionError(cause) {
+    companion object {
+        private fun mergeStacks(
+            orchestrationStacks: Array<StackTraceElement>,
+            executionStacks: Array<StackTraceElement>
+        ): Array<StackTraceElement> {
+            val skipOrchestrationStacks = orchestrationStacks.asSequence().dropWhile {
+                it.methodName !== "captureDynamicTest"
+            }.drop(1).take(8)
+            val mergedStacks = skipOrchestrationStacks + StackTraceElement(
+                "---",
+                "Test Execution Stack",
+                null,
+                -1
+            ) + executionStacks
+            return mergedStacks.toList().toTypedArray()
+        }
+    }
+
+    init {
+        this.stackTrace = mergeStacks(orchestrationStacks, cause.stackTrace)
+    }
+}
+
+fun <R> captureDynamicTest(displayName: String, block: () -> R): DynamicTest {
+    val orchestrationStacks = Thread.currentThread().stackTrace
+    return DynamicTest.dynamicTest(displayName) {
+        try {
+            block()
+        } catch (e: AssertionError) {
+            val orchestrationError = OrchestrationError(orchestrationStacks, e)
+            throw orchestrationError
+        }
+    }
+}

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/DefaultExpectDsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/DefaultExpectDsl.kt
@@ -20,9 +20,9 @@ import me.ahoo.wow.modeling.state.StateAggregate
 import me.ahoo.wow.test.aggregate.EventIterator
 import me.ahoo.wow.test.aggregate.ExpectStage
 import me.ahoo.wow.test.aggregate.ExpectedResult
+import me.ahoo.wow.test.captureDynamicTest
 import me.ahoo.wow.test.dsl.AbstractDynamicTestBuilder
 import me.ahoo.wow.test.dsl.NameSpecCapable.Companion.appendName
-import org.junit.jupiter.api.DynamicTest
 import java.util.function.Consumer
 import kotlin.reflect.KClass
 
@@ -80,7 +80,7 @@ class DefaultExpectDsl<S : Any>(
      * @return this ExpectDsl instance for method chaining
      */
     override fun expect(expected: ExpectedResult<S>.() -> Unit): ExpectDsl<S> {
-        val dynamicTest = DynamicTest.dynamicTest("Expect") {
+        val dynamicTest = captureDynamicTest("Expect") {
             delegate.verify(false).expect(expected)
         }
         dynamicNodes.add(dynamicTest)
@@ -97,7 +97,7 @@ class DefaultExpectDsl<S : Any>(
      * @return this ExpectDsl instance for method chaining
      */
     override fun expectStateAggregate(expected: StateAggregate<S>.() -> Unit): ExpectDsl<S> {
-        val dynamicTest = DynamicTest.dynamicTest("ExpectStateAggregate") {
+        val dynamicTest = captureDynamicTest("ExpectStateAggregate") {
             delegate.verify(false).expectStateAggregate(expected)
         }
         dynamicNodes.add(dynamicTest)
@@ -114,7 +114,7 @@ class DefaultExpectDsl<S : Any>(
      * @return this ExpectDsl instance for method chaining
      */
     override fun expectState(expected: S.() -> Unit): ExpectDsl<S> {
-        val dynamicTest = DynamicTest.dynamicTest("ExpectState") {
+        val dynamicTest = captureDynamicTest("ExpectState") {
             delegate.verify(false).expectState(expected)
         }
         dynamicNodes.add(dynamicTest)
@@ -144,7 +144,7 @@ class DefaultExpectDsl<S : Any>(
      * @return this ExpectDsl instance for method chaining
      */
     override fun expectEventStream(expected: DomainEventStream.() -> Unit): ExpectDsl<S> {
-        val dynamicTest = DynamicTest.dynamicTest("ExpectEventStream") {
+        val dynamicTest = captureDynamicTest("ExpectEventStream") {
             delegate.verify(false).expectEventStream(expected)
         }
         dynamicNodes.add(dynamicTest)
@@ -161,7 +161,7 @@ class DefaultExpectDsl<S : Any>(
      * @return this ExpectDsl instance for method chaining
      */
     override fun expectEventIterator(expected: EventIterator.() -> Unit): ExpectDsl<S> {
-        val dynamicTest = DynamicTest.dynamicTest("ExpectEventIterator") {
+        val dynamicTest = captureDynamicTest("ExpectEventIterator") {
             delegate.verify(false).expectEventIterator(expected)
         }
         dynamicNodes.add(dynamicTest)
@@ -179,7 +179,7 @@ class DefaultExpectDsl<S : Any>(
      * @return this ExpectDsl instance for method chaining
      */
     override fun <E : Any> expectEvent(expected: DomainEvent<E>.() -> Unit): ExpectDsl<S> {
-        val dynamicTest = DynamicTest.dynamicTest("ExpectEvent") {
+        val dynamicTest = captureDynamicTest("ExpectEvent") {
             delegate.verify(false).expectEvent(expected)
         }
         dynamicNodes.add(dynamicTest)
@@ -197,7 +197,7 @@ class DefaultExpectDsl<S : Any>(
      * @return this ExpectDsl instance for method chaining
      */
     override fun <E : Any> expectEventBody(expected: E.() -> Unit): ExpectDsl<S> {
-        val dynamicTest = DynamicTest.dynamicTest("ExpectEventBody") {
+        val dynamicTest = captureDynamicTest("ExpectEventBody") {
             delegate.verify(false).expectEventBody(expected)
         }
         dynamicNodes.add(dynamicTest)
@@ -214,7 +214,7 @@ class DefaultExpectDsl<S : Any>(
      * @return this ExpectDsl instance for method chaining
      */
     override fun expectEventCount(expected: Int): ExpectDsl<S> {
-        val dynamicTest = DynamicTest.dynamicTest("ExpectEventCount[$expected]") {
+        val dynamicTest = captureDynamicTest("ExpectEventCount[$expected]") {
             delegate.verify(false).expectEventCount(expected)
         }
         dynamicNodes.add(dynamicTest)
@@ -231,7 +231,7 @@ class DefaultExpectDsl<S : Any>(
      * @return this ExpectDsl instance for method chaining
      */
     override fun expectEventType(vararg expected: KClass<*>): ExpectDsl<S> {
-        val dynamicTest = DynamicTest.dynamicTest(
+        val dynamicTest = captureDynamicTest(
             "ExpectEventType[${
                 expected.joinToString(",") {
                     it.simpleName!!
@@ -253,7 +253,7 @@ class DefaultExpectDsl<S : Any>(
      * @return this ExpectDsl instance for method chaining
      */
     override fun expectNoError(): ExpectDsl<S> {
-        val dynamicTest = DynamicTest.dynamicTest("ExpectNoError") {
+        val dynamicTest = captureDynamicTest("ExpectNoError") {
             delegate.verify(false).expectNoError()
         }
         dynamicNodes.add(dynamicTest)
@@ -268,7 +268,7 @@ class DefaultExpectDsl<S : Any>(
      * @return this ExpectDsl instance for method chaining
      */
     override fun expectError(): ExpectDsl<S> {
-        val dynamicTest = DynamicTest.dynamicTest("ExpectError") {
+        val dynamicTest = captureDynamicTest("ExpectError") {
             delegate.verify(false).expectError()
         }
         dynamicNodes.add(dynamicTest)
@@ -286,7 +286,7 @@ class DefaultExpectDsl<S : Any>(
      * @return this ExpectDsl instance for method chaining
      */
     override fun <E : Throwable> expectError(expected: E.() -> Unit): ExpectDsl<S> {
-        val dynamicTest = DynamicTest.dynamicTest("ExpectError") {
+        val dynamicTest = captureDynamicTest("ExpectError") {
             delegate.verify(false).expectError(expected)
         }
         dynamicNodes.add(dynamicTest)
@@ -304,7 +304,7 @@ class DefaultExpectDsl<S : Any>(
      * @return this ExpectDsl instance for method chaining
      */
     override fun <E : Throwable> expectErrorType(expected: KClass<E>): ExpectDsl<S> {
-        val dynamicTest = DynamicTest.dynamicTest("ExpectErrorType[${expected.simpleName}]") {
+        val dynamicTest = captureDynamicTest("ExpectErrorType[${expected.simpleName}]") {
             delegate.verify(false).expectErrorType(expected)
         }
         dynamicNodes.add(dynamicTest)

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/DefaultExpectDsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/DefaultExpectDsl.kt
@@ -16,6 +16,7 @@ package me.ahoo.wow.test.saga.stateless.dsl
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.infra.Decorator
 import me.ahoo.wow.saga.stateless.CommandStream
+import me.ahoo.wow.test.captureDynamicTest
 import me.ahoo.wow.test.dsl.AbstractDynamicTestBuilder
 import me.ahoo.wow.test.saga.stateless.CommandIterator
 import me.ahoo.wow.test.saga.stateless.ExpectStage
@@ -46,7 +47,7 @@ class DefaultExpectDsl<T : Any>(
      * @return This DSL instance for method chaining.
      */
     override fun expect(expected: ExpectedResult<T>.() -> Unit): ExpectDsl<T> {
-        val dynamicTest = DynamicTest.dynamicTest("Expect") {
+        val dynamicTest = captureDynamicTest("Expect") {
             delegate.verify(false).expect(expected)
         }
         dynamicNodes.add(dynamicTest)
@@ -60,7 +61,7 @@ class DefaultExpectDsl<T : Any>(
      * @return This DSL instance for method chaining.
      */
     override fun expectCommandStream(expected: CommandStream.() -> Unit): ExpectDsl<T> {
-        val dynamicTest = DynamicTest.dynamicTest("ExpectCommandStream") {
+        val dynamicTest = captureDynamicTest("ExpectCommandStream") {
             delegate.verify(false).expectCommandStream(expected)
         }
         dynamicNodes.add(dynamicTest)
@@ -74,7 +75,7 @@ class DefaultExpectDsl<T : Any>(
      * @return This DSL instance for method chaining.
      */
     override fun expectCommandIterator(expected: CommandIterator.() -> Unit): ExpectDsl<T> {
-        val dynamicTest = DynamicTest.dynamicTest("ExpectCommandIterator") {
+        val dynamicTest = captureDynamicTest("ExpectCommandIterator") {
             delegate.verify(false).expectCommandIterator(expected)
         }
         dynamicNodes.add(dynamicTest)
@@ -87,7 +88,7 @@ class DefaultExpectDsl<T : Any>(
      * @return This DSL instance for method chaining.
      */
     override fun expectNoCommand(): ExpectDsl<T> {
-        val dynamicTest = DynamicTest.dynamicTest("ExpectNoCommand") {
+        val dynamicTest = captureDynamicTest("ExpectNoCommand") {
             delegate.verify(false).expectNoCommand()
         }
         dynamicNodes.add(dynamicTest)
@@ -102,7 +103,7 @@ class DefaultExpectDsl<T : Any>(
      * @return This DSL instance for method chaining.
      */
     override fun <C : Any> expectCommand(expected: CommandMessage<C>.() -> Unit): ExpectDsl<T> {
-        val dynamicTest = DynamicTest.dynamicTest("ExpectCommand") {
+        val dynamicTest = captureDynamicTest("ExpectCommand") {
             delegate.verify(false).expectCommand(expected)
         }
         dynamicNodes.add(dynamicTest)
@@ -117,7 +118,7 @@ class DefaultExpectDsl<T : Any>(
      * @return This DSL instance for method chaining.
      */
     override fun <C : Any> expectCommandBody(expected: C.() -> Unit): ExpectDsl<T> {
-        val dynamicTest = DynamicTest.dynamicTest("ExpectCommandBody") {
+        val dynamicTest = captureDynamicTest("ExpectCommandBody") {
             delegate.verify(false).expectCommandBody(expected)
         }
         dynamicNodes.add(dynamicTest)
@@ -131,7 +132,7 @@ class DefaultExpectDsl<T : Any>(
      * @return This DSL instance for method chaining.
      */
     override fun expectCommandCount(expected: Int): ExpectDsl<T> {
-        val dynamicTest = DynamicTest.dynamicTest("ExpectCommandCount[$expected]") {
+        val dynamicTest = captureDynamicTest("ExpectCommandCount[$expected]") {
             delegate.verify(false).expectCommandCount(expected)
         }
         dynamicNodes.add(dynamicTest)
@@ -146,7 +147,7 @@ class DefaultExpectDsl<T : Any>(
      */
     override fun expectCommandType(vararg expected: KClass<*>): ExpectDsl<T> {
         val dynamicTest =
-            DynamicTest.dynamicTest("ExpectCommandType[${expected.joinToString(",") { it.simpleName!! }}]") {
+            captureDynamicTest("ExpectCommandType[${expected.joinToString(",") { it.simpleName!! }}]") {
                 delegate.verify(false).expectCommandType(*expected)
             }
         dynamicNodes.add(dynamicTest)
@@ -159,7 +160,7 @@ class DefaultExpectDsl<T : Any>(
      * @return This DSL instance for method chaining.
      */
     override fun expectNoError(): ExpectDsl<T> {
-        val dynamicTest = DynamicTest.dynamicTest("ExpectNoError") {
+        val dynamicTest = captureDynamicTest("ExpectNoError") {
             delegate.verify(false).expectNoError()
         }
         dynamicNodes.add(dynamicTest)
@@ -172,7 +173,7 @@ class DefaultExpectDsl<T : Any>(
      * @return This DSL instance for method chaining.
      */
     override fun expectError(): ExpectDsl<T> {
-        val dynamicTest = DynamicTest.dynamicTest("ExpectError") {
+        val dynamicTest = captureDynamicTest("ExpectError") {
             delegate.verify(false).expectError()
         }
         dynamicNodes.add(dynamicTest)
@@ -187,7 +188,7 @@ class DefaultExpectDsl<T : Any>(
      * @return This DSL instance for method chaining.
      */
     override fun <E : Throwable> expectError(expected: E.() -> Unit): ExpectDsl<T> {
-        val dynamicTest = DynamicTest.dynamicTest("ExpectError") {
+        val dynamicTest = captureDynamicTest("ExpectError") {
             delegate.verify(false).expectError(expected)
         }
         dynamicNodes.add(dynamicTest)
@@ -202,7 +203,7 @@ class DefaultExpectDsl<T : Any>(
      * @return This DSL instance for method chaining.
      */
     override fun <E : Throwable> expectErrorType(expected: KClass<E>): ExpectDsl<T> {
-        val dynamicTest = DynamicTest.dynamicTest("ExpectErrorType[${expected.simpleName}]") {
+        val dynamicTest = captureDynamicTest("ExpectErrorType[${expected.simpleName}]") {
             delegate.verify(false).expectErrorType(expected)
         }
         dynamicNodes.add(dynamicTest)


### PR DESCRIPTION


- Replaced DynamicTest.dynamicTest with captureDynamicTest in aggregate expect DSL
- Replaced DynamicTest.dynamicTest with captureDynamicTest in saga stateless expect DSL
- Added OrchestrationError class to merge orchestration and execution stack traces
- Implemented captureDynamicTest function to wrap test execution and enhance error reporting
- Improved error stack trace readability by filtering out orchestration framework internals
- Added license header to new OrchestrationError.kt file
- Removed unused DynamicTest import statements
- Updated test utility functions to use captureDynamicTest instead of DynamicTest directly


