### PR TITLE
docs(guide): update PrepareKey documentation with detailed usage

### DIFF
--- a/documentation/docs/.vitepress/configs/sidebar.en.ts
+++ b/documentation/docs/.vitepress/configs/sidebar.en.ts
@@ -59,7 +59,7 @@ export const sidebarEn: DefaultTheme.Sidebar = {
                 // {text: 'Architecture', link: 'architecture'},
                 {text: 'ID Generator', link: 'id-generator'},
                 {text: 'Compiler', link: 'compiler'},
-                {text: 'Pre-allocated Key', link: 'prepare-key'},
+                {text: 'Prepare Key', link: 'prepare-key'},
                 // {text: 'Metrics', link: 'metrics'},
                 // {text: 'Observability', link: 'observability'},
                 // {text: 'Aggregate Scheduler', link: 'aggregate-scheduler'},

--- a/documentation/docs/en/guide/advanced/prepare-key.md
+++ b/documentation/docs/en/guide/advanced/prepare-key.md
@@ -3,6 +3,60 @@
 Compared to traditional databases, developers can add uniqueness constraints by setting `UNIQUE KEY` for fields.
 But in the _EventSourcing_ architecture, we need to ensure `Key` uniqueness at the application level, and the `PrepareKey` specification was born for this purpose.
 
+## Define PrepareKey
+
+To use `PrepareKey`, you need to define an interface annotated with `@PreparableKey`, which must extend `PrepareKey<T>`, where `T` is the type of the key.
+
+```kotlin
+import me.ahoo.wow.api.annotation.PreparableKey
+import me.ahoo.wow.infra.prepare.PrepareKey
+
+@PreparableKey(name = "username_idx")
+interface UsernamePrepare : PrepareKey<String>
+```
+
+- `@PreparableKey(name = "username_idx")`: Specifies the name of the prepared key, used to identify the key's index in storage.
+- `PrepareKey<String>`: The generic parameter `String` indicates the key type is string.
+
+The framework automatically scans interfaces annotated with `@PreparableKey`, creates proxy instances through `PrepareKeyProxyFactory`, and registers them as Spring Beans with the interface's simple name as the bean name. This allows dependency injection to obtain `PrepareKey` instances in aggregates.
+
+## PrepareKey Interface Methods
+
+The `PrepareKey<V>` interface provides the following core methods:
+
+### Prepare Key
+
+- `prepare(key: String, value: V)`: Permanently prepares a key, ensuring other operations cannot use the same key until explicitly rolled back.
+- `prepare(key: String, value: PreparedValue<V>)`: Prepares a key with TTL (Time-To-Live) support, automatically expiring after the specified time.
+
+### Get Prepared Value
+
+- `get(key: String)`: Retrieves a non-expired prepared value.
+- `getValue(key: String)`: Retrieves complete prepared value information, including expiration status.
+
+### Rollback Key
+
+- `rollback(key: String)`: Unconditionally rolls back the specified key.
+- `rollback(key: String, value: V)`: Conditionally rolls back only if the value matches, ensuring atomicity.
+
+### Reprepare Key
+
+- `reprepare(key: String, oldValue: V, newValue: V)`: Updates the value of an existing key, using the old value for concurrency control.
+- `reprepare(oldKey: String, oldValue: V, newKey: String, newValue: V)`: Atomically releases the old key and prepares the new key, commonly used for scenarios like username changes.
+
+### Execute Operation in Prepare Context
+
+- `usingPrepare(key: String, value: V, then: (Boolean) -> Mono<R>)`: Executes an operation within a prepare context, automatically rolling back preparation if the operation fails, providing transaction-like semantics.
+
+## PreparedValue and TTL Support
+
+`PreparedValue<V>` encapsulates the value and optional TTL configuration:
+
+- Permanent preparation: `value.toForever()`
+- TTL preparation: `PreparedValue(value, Duration.ofMinutes(5))`
+
+TTL support allows temporary key reservations that automatically clean up after expiration, suitable for temporary operations requiring cleanup.
+
 ## User Registration Scenario
 
 For example, when a user registers, the uniqueness of the username needs to be guaranteed:

--- a/documentation/docs/zh/guide/advanced/prepare-key.md
+++ b/documentation/docs/zh/guide/advanced/prepare-key.md
@@ -3,6 +3,60 @@
 相比传统数据库，开发者可以通过为字段设置 `UNIQUE KEY` 来增加唯一性约束。
 但在 _EventSourcing_ 架构中，我们需要在应用层面保证 `Key` 的唯一性，`PrepareKey` 规范就是为此而生。
 
+## 定义 PrepareKey
+
+要使用 `PrepareKey`，需要定义一个接口，并使用 `@PreparableKey` 注解标注，该接口需要继承 `PrepareKey<T>`，其中 `T` 为 Key 的类型。
+
+```kotlin
+import me.ahoo.wow.api.annotation.PreparableKey
+import me.ahoo.wow.infra.prepare.PrepareKey
+
+@PreparableKey(name = "username_idx")
+interface UsernamePrepare : PrepareKey<String>
+```
+
+- `@PreparableKey(name = "username_idx")`：指定预分配 Key 的名称，用于标识该 Key 在存储中的索引。
+- `PrepareKey<String>`：泛型参数 `String` 表示 Key 的类型为字符串。
+
+框架会自动扫描标注了 `@PreparableKey` 注解的接口，并通过 `PrepareKeyProxyFactory` 创建代理实例，将其注册为 Spring Bean，Bean 名称为接口的简单名称。这样就可以在聚合中使用依赖注入的方式获取 `PrepareKey` 实例。
+
+## PrepareKey 接口方法
+
+`PrepareKey<V>` 接口提供了以下核心方法：
+
+### 准备 Key
+
+- `prepare(key: String, value: V)`：永久准备一个 Key，确保其他操作无法使用相同的 Key 直到显式回滚。
+- `prepare(key: String, value: PreparedValue<V>)`：准备一个 Key，支持 TTL（生存时间），过期后自动失效。
+
+### 获取准备的值
+
+- `get(key: String)`：获取已准备的非过期值。
+- `getValue(key: String)`：获取完整的准备值信息，包括过期状态。
+
+### 回滚 Key
+
+- `rollback(key: String)`：无条件回滚指定的 Key。
+- `rollback(key: String, value: V)`：条件回滚，只有当值匹配时才回滚，确保原子性。
+
+### 重新准备 Key
+
+- `reprepare(key: String, oldValue: V, newValue: V)`：更新现有 Key 的值，使用旧值进行并发控制。
+- `reprepare(oldKey: String, oldValue: V, newKey: String, newValue: V)`：原子性地释放旧 Key 并准备新 Key，常用于用户名变更等场景。
+
+### 使用准备上下文执行操作
+
+- `usingPrepare(key: String, value: V, then: (Boolean) -> Mono<R>)`：在准备上下文中执行操作，如果操作失败自动回滚准备，提供事务-like 语义。
+
+## PreparedValue 与 TTL 支持
+
+`PreparedValue<V>` 封装了值和可选的 TTL 配置：
+
+- 永久准备：`value.toForever()`
+- 带 TTL 准备：`PreparedValue(value, Duration.ofMinutes(5))`
+
+TTL 支持允许临时预留 Key，过期后自动清理，适用于需要清理的临时操作。
+
 ## 用户注册场景
 
 例如当用户注册时，需要保证用户名的唯一性：


### PR DESCRIPTION
- Renamed sidebar entry from 'Pre-allocated Key' to 'Prepare Key'
- Added comprehensive documentation for PrepareKey definition and usage
- Documented core PrepareKey interface methods including prepare, get, rollback, and reprepare
- Added sections for PreparedValue and TTL support with examples
- Included detailed Kotlin code examples for UsernamePrepare interface
- Explained automatic proxy creation and Spring Bean registration
- Added transaction-like semantics documentation for usingPrepare method
- Updated both English and Chinese documentation files

