### PR TITLE
refactor(test): rename TestDsl to TestDslMarker

### DIFF
--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/Dsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/aggregate/dsl/Dsl.kt
@@ -28,7 +28,7 @@ import me.ahoo.wow.modeling.state.StateAggregateFactory
 import me.ahoo.wow.test.aggregate.AggregateExpecter
 import me.ahoo.wow.test.aggregate.ExpectedResult
 import me.ahoo.wow.test.dsl.NameSpecCapable
-import me.ahoo.wow.test.dsl.TestDsl
+import me.ahoo.wow.test.dsl.TestDslMarker
 import me.ahoo.wow.test.saga.stateless.dsl.InjectPublicServiceCapable
 
 /**
@@ -40,7 +40,7 @@ import me.ahoo.wow.test.saga.stateless.dsl.InjectPublicServiceCapable
  *
  * @param S the type of the aggregate state
  */
-@TestDsl
+@TestDslMarker
 interface AggregateDsl<S : Any> :
     InjectPublicServiceCapable,
     AggregateDslContextCapable<S> {
@@ -122,7 +122,7 @@ interface AggregateDsl<S : Any> :
  *
  * @param S the type of the aggregate state
  */
-@TestDsl
+@TestDslMarker
 interface GivenDsl<S : Any> :
     WhenDsl<S>,
     NameSpecCapable,
@@ -200,7 +200,7 @@ interface GivenDsl<S : Any> :
  *
  * @param S the type of the aggregate state
  */
-@TestDsl
+@TestDslMarker
 interface WhenDsl<S : Any> :
     NameSpecCapable,
     AggregateDslContextCapable<S> {
@@ -232,7 +232,7 @@ interface WhenDsl<S : Any> :
  *
  * @param S the type of the aggregate state
  */
-@TestDsl
+@TestDslMarker
 interface ExpectDsl<S : Any> :
     AggregateExpecter<S, ExpectDsl<S>>,
     AggregateDslContextCapable<S> {
@@ -308,7 +308,7 @@ interface ExpectDsl<S : Any> :
  *
  * @param S the type of the aggregate state
  */
-@TestDsl
+@TestDslMarker
 interface ForkedVerifiedStageDsl<S : Any> : GivenDsl<S> {
     /** The verified result from the previous command execution that this fork starts from. */
     val verifiedResult: ExpectedResult<S>

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/dsl/TestDslMarker.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/dsl/TestDslMarker.kt
@@ -23,7 +23,7 @@ package me.ahoo.wow.test.dsl
  *
  * ## Purpose
  *
- * The `@TestDsl` marker ensures that:
+ * The `@TestDslMarker` marker ensures that:
  * - Test DSLs maintain clear hierarchical boundaries
  * - Child DSL contexts cannot accidentally call parent DSL methods
  * - IDE provides accurate code completion and error highlighting
@@ -34,17 +34,17 @@ package me.ahoo.wow.test.dsl
  * Apply this annotation to all DSL interfaces in the testing framework:
  *
  * ```kotlin
- * @TestDsl
+ * @TestDslMarker
  * interface AggregateDsl<S : Any> {
  *     fun on(block: GivenDsl<S>.() -> Unit)
  * }
  *
- * @TestDsl
+ * @TestDslMarker
  * interface GivenDsl<S : Any> {
  *     fun whenCommand(command: Any, block: ExpectDsl<S>.() -> Unit)
  * }
  *
- * @TestDsl
+ * @TestDslMarker
  * interface ExpectDsl<S : Any> {
  *     fun expectEvent(type: KClass<*>)
  * }
@@ -59,7 +59,7 @@ package me.ahoo.wow.test.dsl
  *
  * @see DslMarker for the underlying Kotlin compiler support
  * @see me.ahoo.wow.test.aggregate.dsl.AggregateDsl for aggregate testing DSL
- * @see me.ahoo.wow.test.saga.dsl.StatelessSagaDsl for saga testing DSL
+ * @see me.ahoo.wow.test.saga.stateless.dsl.StatelessSagaDsl for saga testing DSL
  */
 @DslMarker
-annotation class TestDsl
+annotation class TestDslMarker

--- a/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/Dsl.kt
+++ b/test/wow-test/src/main/kotlin/me/ahoo/wow/test/saga/stateless/dsl/Dsl.kt
@@ -24,7 +24,7 @@ import me.ahoo.wow.messaging.function.MessageFunction
 import me.ahoo.wow.test.SagaVerifier.defaultCommandGateway
 import me.ahoo.wow.test.dsl.InjectServiceCapable
 import me.ahoo.wow.test.dsl.NameSpecCapable
-import me.ahoo.wow.test.dsl.TestDsl
+import me.ahoo.wow.test.dsl.TestDslMarker
 import me.ahoo.wow.test.saga.stateless.StatelessSagaExpecter
 import me.ahoo.wow.test.validation.TestValidator
 
@@ -37,7 +37,7 @@ import me.ahoo.wow.test.validation.TestValidator
  *
  * @param T The type of the saga being tested.
  */
-@TestDsl
+@TestDslMarker
 interface StatelessSagaDsl<T : Any> : InjectPublicServiceCapable {
     /**
      * Defines a test scenario with optional custom components.
@@ -70,7 +70,7 @@ interface StatelessSagaDsl<T : Any> : InjectPublicServiceCapable {
  *
  * @param T The type of the saga being tested.
  */
-@TestDsl
+@TestDslMarker
 interface WhenDsl<T : Any> :
     NameSpecCapable,
     InjectServiceCapable<Unit> {
@@ -119,5 +119,5 @@ interface WhenDsl<T : Any> :
  *
  * @param T The type of the saga being tested.
  */
-@TestDsl
+@TestDslMarker
 interface ExpectDsl<T : Any> : StatelessSagaExpecter<T, ExpectDsl<T>>


### PR DESCRIPTION
- Renamed TestDsl annotation to TestDslMarker for clarity
- Updated all usages across aggregate and saga DSLs
- Adjusted documentation to reflect the new name
- Ensured consistent naming in import statements
- Updated references in comments and examples
- Maintained backward compatibility through refactoring

