### PR TITLE
refactor(api): rename targetOwnerId to toOwnerId in OwnerTransferred

### DIFF
--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/event/OwnerTransferred.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/event/OwnerTransferred.kt
@@ -19,9 +19,9 @@ package me.ahoo.wow.api.event
  * This interface is typically implemented by domain events that signal a change in ownership,
  * such as transferring responsibility or control of an entity to another party.
  *
- * @property targetOwnerId The unique identifier of the new owner to whom ownership is being transferred.
+ * @property toOwnerId The unique identifier of the new owner to whom ownership is being transferred.
  *                         This should be a non-empty string representing the owner's ID.
  */
 interface OwnerTransferred {
-    val targetOwnerId: String
+    val toOwnerId: String
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/state/SimpleStateAggregate.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/state/SimpleStateAggregate.kt
@@ -138,7 +138,7 @@ class SimpleStateAggregate<S : Any>(
             deleted = false
         }
         if (domainEventBody is OwnerTransferred) {
-            ownerId = domainEventBody.targetOwnerId
+            ownerId = domainEventBody.toOwnerId
         }
         val sourcingFunction = sourcingRegistry[domainEvent.body.javaClass]
         if (sourcingFunction != null) {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/modeling/state/SimpleStateAggregateTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/modeling/state/SimpleStateAggregateTest.kt
@@ -403,7 +403,7 @@ internal class SimpleStateAggregateTest {
     class TestAggregateRecovered : AggregateRecovered
 
     data class TestOwnerTransferred(
-        override val targetOwnerId: String
+        override val toOwnerId: String
     ) : OwnerTransferred
 
     data class TestNormalEvent(


### PR DESCRIPTION
- Renamed property targetOwnerId to toOwnerId in OwnerTransferred interface
- Updated implementation in SimpleStateAggregate to use toOwnerId
- Adjusted test cases to reflect the property name change
