### PR TITLE
docs(navbar): add event compensation example link

### DIFF
--- a/documentation/docs/.vitepress/configs/navbar.en.ts
+++ b/documentation/docs/.vitepress/configs/navbar.en.ts
@@ -24,6 +24,7 @@ export const navbarEn: DefaultTheme.NavItem[] = [
                 items: [
                     {text: 'Bank Transfer (JAVA)', link: '/reference/example/transfer'},
                     {text: 'Order System', link: '/reference/example/order'},
+                    {text: 'Event Compensation', link: '/reference/example/compensation'},
                 ],
             },
             {

--- a/documentation/docs/.vitepress/configs/navbar.zh.ts
+++ b/documentation/docs/.vitepress/configs/navbar.zh.ts
@@ -24,6 +24,7 @@ export const navbarZh: DefaultTheme.NavItem[] = [
                 items: [
                     {text: '银行转账(JAVA)', link: '/zh/reference/example/transfer'},
                     {text: '订单系统', link: '/zh/reference/example/order'},
+                    {text: '事件补偿', link: '/zh/reference/example/compensation'},
                 ],
             },
             {

--- a/documentation/docs/en/reference/example/compensation.md
+++ b/documentation/docs/en/reference/example/compensation.md
@@ -25,4 +25,4 @@ _[Event Compensation](https://github.com/Ahoo-Wang/Wow/tree/main/compensation)_ 
 
 ## Detailed Documentation
 
-For detailed usage instructions on event compensation, please refer to the [Event Compensation Guide](/guide/event-compensation).
+For detailed usage instructions on event compensation, please refer to the [Event Compensation Guide](../../guide/event-compensation).

--- a/documentation/docs/zh/reference/example/compensation.md
+++ b/documentation/docs/zh/reference/example/compensation.md
@@ -25,4 +25,4 @@ _[事件补偿](https://github.com/Ahoo-Wang/Wow/tree/main/compensation)_ 是一
 
 ## 详细文档
 
-关于事件补偿的详细使用说明，请参阅 [事件补偿指南](/zh/guide/event-compensation)。
+关于事件补偿的详细使用说明，请参阅 [事件补偿指南](../../guide/event-compensation)。


### PR DESCRIPTION
- Added "Event Compensation" item to English navbar examples
- Added "事件补偿" item to Chinese navbar examples
- Updated documentation links to use relative paths
- Fixed broken links in compensation example docs for both languages

