### PR TITLE
chore(deps): update fetcher libraries and vitest dependencies

### DIFF
--- a/compensation/dashboard/package.json
+++ b/compensation/dashboard/package.json
@@ -14,15 +14,15 @@
     "generate": "fetcher-generator generate -i http://compensation-service.dev.svc.cluster.local/v3/api-docs -o src/generated"
   },
   "dependencies": {
-    "@ahoo-wang/fetcher": "^3.15.0",
-    "@ahoo-wang/fetcher-cosec": "^3.15.0",
-    "@ahoo-wang/fetcher-decorator": "^3.15.0",
-    "@ahoo-wang/fetcher-eventbus": "^3.15.0",
-    "@ahoo-wang/fetcher-eventstream": "^3.15.0",
-    "@ahoo-wang/fetcher-react": "^3.15.0",
-    "@ahoo-wang/fetcher-storage": "^3.15.0",
-    "@ahoo-wang/fetcher-viewer": "^3.15.0",
-    "@ahoo-wang/fetcher-wow": "^3.15.0",
+    "@ahoo-wang/fetcher": "^3.15.1",
+    "@ahoo-wang/fetcher-cosec": "^3.15.1",
+    "@ahoo-wang/fetcher-decorator": "^3.15.1",
+    "@ahoo-wang/fetcher-eventbus": "^3.15.1",
+    "@ahoo-wang/fetcher-eventstream": "^3.15.1",
+    "@ahoo-wang/fetcher-react": "^3.15.1",
+    "@ahoo-wang/fetcher-storage": "^3.15.1",
+    "@ahoo-wang/fetcher-viewer": "^3.15.1",
+    "@ahoo-wang/fetcher-wow": "^3.15.1",
     "@ant-design/icons": "^6.1.1",
     "@monaco-editor/react": "4.7.0",
     "antd": "^6.3.5",
@@ -33,7 +33,7 @@
     "react-router": "^7.14.0"
   },
   "devDependencies": {
-    "@ahoo-wang/fetcher-generator": "^3.15.0",
+    "@ahoo-wang/fetcher-generator": "^3.15.1",
     "@babel/plugin-proposal-decorators": "7.29.0",
     "@eslint/js": "^10.0.1",
     "@rolldown/plugin-babel": "^0.2.2",
@@ -57,7 +57,7 @@
     "typescript-eslint": "^8.58.1",
     "vite": "8.0.8",
     "vite-bundle-analyzer": "^1.3.7",
-    "vitest": "^4.1.3",
+    "vitest": "^4.1.4",
     "vitest-browser-react": "^2.2.0"
   }
 }

--- a/compensation/dashboard/pnpm-lock.yaml
+++ b/compensation/dashboard/pnpm-lock.yaml
@@ -9,32 +9,32 @@ importers:
   .:
     dependencies:
       '@ahoo-wang/fetcher':
-        specifier: ^3.15.0
-        version: 3.15.0
+        specifier: ^3.15.1
+        version: 3.15.1
       '@ahoo-wang/fetcher-cosec':
-        specifier: ^3.15.0
-        version: 3.15.0(@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-storage@3.15.0(@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0)))(@ahoo-wang/fetcher@3.15.0)
+        specifier: ^3.15.1
+        version: 3.15.1(@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-storage@3.15.1(@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1)))(@ahoo-wang/fetcher@3.15.1)
       '@ahoo-wang/fetcher-decorator':
-        specifier: ^3.15.0
-        version: 3.15.0(@ahoo-wang/fetcher@3.15.0)
+        specifier: ^3.15.1
+        version: 3.15.1(@ahoo-wang/fetcher@3.15.1)
       '@ahoo-wang/fetcher-eventbus':
-        specifier: ^3.15.0
-        version: 3.15.0(@ahoo-wang/fetcher@3.15.0)
+        specifier: ^3.15.1
+        version: 3.15.1(@ahoo-wang/fetcher@3.15.1)
       '@ahoo-wang/fetcher-eventstream':
-        specifier: ^3.15.0
-        version: 3.15.0(@ahoo-wang/fetcher@3.15.0)
+        specifier: ^3.15.1
+        version: 3.15.1(@ahoo-wang/fetcher@3.15.1)
       '@ahoo-wang/fetcher-react':
-        specifier: ^3.15.0
-        version: 3.15.0(@ahoo-wang/fetcher-cosec@3.15.0(@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-storage@3.15.0(@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0)))(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-eventstream@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-storage@3.15.0(@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0)))(@ahoo-wang/fetcher-wow@3.15.0(@ahoo-wang/fetcher-decorator@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-eventstream@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher@3.15.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: ^3.15.1
+        version: 3.15.1(@ahoo-wang/fetcher-cosec@3.15.1(@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-storage@3.15.1(@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1)))(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-eventstream@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-storage@3.15.1(@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1)))(@ahoo-wang/fetcher-wow@3.15.1(@ahoo-wang/fetcher-decorator@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-eventstream@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher@3.15.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@ahoo-wang/fetcher-storage':
-        specifier: ^3.15.0
-        version: 3.15.0(@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0))
+        specifier: ^3.15.1
+        version: 3.15.1(@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1))
       '@ahoo-wang/fetcher-viewer':
-        specifier: ^3.15.0
-        version: 3.15.0(ce3c903e9000edd5bfe7f7efc285f140)
+        specifier: ^3.15.1
+        version: 3.15.1(4c3007d464c0293fdfc150b0f2727513)
       '@ahoo-wang/fetcher-wow':
-        specifier: ^3.15.0
-        version: 3.15.0(@ahoo-wang/fetcher-decorator@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-eventstream@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher@3.15.0)
+        specifier: ^3.15.1
+        version: 3.15.1(@ahoo-wang/fetcher-decorator@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-eventstream@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher@3.15.1)
       '@ant-design/icons':
         specifier: ^6.1.1
         version: 6.1.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -61,8 +61,8 @@ importers:
         version: 7.14.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
     devDependencies:
       '@ahoo-wang/fetcher-generator':
-        specifier: ^3.15.0
-        version: 3.15.0(@ahoo-wang/fetcher-decorator@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-eventstream@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@3.15.0(@ahoo-wang/fetcher-decorator@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-eventstream@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher@3.15.0)
+        specifier: ^3.15.1
+        version: 3.15.1(@ahoo-wang/fetcher-decorator@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-eventstream@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@3.15.1(@ahoo-wang/fetcher-decorator@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-eventstream@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher@3.15.1)
       '@babel/plugin-proposal-decorators':
         specifier: 7.29.0
         version: 7.29.0(@babel/core@7.29.0)
@@ -133,7 +133,7 @@ importers:
         specifier: ^1.3.7
         version: 1.3.7
       vitest:
-        specifier: ^4.1.3
+        specifier: ^4.1.4
         version: 4.1.4(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2)(vite@8.0.8(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
       vitest-browser-react:
         specifier: ^2.2.0
@@ -144,30 +144,30 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@ahoo-wang/fetcher-cosec@3.15.0':
-    resolution: {integrity: sha512-6rwuUxifcMcUeaXfZFiIEmaVaXfiM8gCIDB8tPA5NLIso3ZRqctt66kRRwqrJO3USOcS93rwTtJu2ARPYx5Isg==}
+  '@ahoo-wang/fetcher-cosec@3.15.1':
+    resolution: {integrity: sha512-73xOkzTCnOBevtYu7iWfynLkssEpxKZniYwIeVnVhSAp4XsmbqKLpc/xZfCGElvUY7AI1yqmw6C9s1xRLhFaOQ==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
       '@ahoo-wang/fetcher-eventbus': ^3.0.0
       '@ahoo-wang/fetcher-storage': ^3.0.0
 
-  '@ahoo-wang/fetcher-decorator@3.15.0':
-    resolution: {integrity: sha512-9lrNl1UhtkXCS1ahBUo6QM2tIfO7gpO94p3NXIOAFuLLs3OMGVl+b/ctnyh2oz0u0BG39kGPVPVdX3vUv2LNlQ==}
+  '@ahoo-wang/fetcher-decorator@3.15.1':
+    resolution: {integrity: sha512-5XUQHszpzxnyfGqkLQj6k/0H3nl/qBrbYBEVn/rIlvS0H2/87VCBy452qrarEda8u5w5LNHYp13X6vitPRHEhg==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
 
-  '@ahoo-wang/fetcher-eventbus@3.15.0':
-    resolution: {integrity: sha512-wMVJSYMxQwRtl6wdcMR5d1QE68SfHFV8MDz0g+6FEZ0C5rtnrVJK74dM0rUvfPKyK6LDroGo4CcuxKxCgFp1IQ==}
+  '@ahoo-wang/fetcher-eventbus@3.15.1':
+    resolution: {integrity: sha512-wGfMqED10hyp7ZkQ3hxcN1JAjSVeSjO84sZv8vqzfkKDNUgK5VkWELn6UqCiPAFHAttEw11qq+JEhgEoOcbNug==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
 
-  '@ahoo-wang/fetcher-eventstream@3.15.0':
-    resolution: {integrity: sha512-nqJfS6Uf916vDedB+wlRwu9yNWFi4a+qlgcoyigo3gYqZaGNkXfQgNvceJToSMKf3ZimrZ9ox86jmdVAQe0eQA==}
+  '@ahoo-wang/fetcher-eventstream@3.15.1':
+    resolution: {integrity: sha512-5ByOdJSH2v8hamqXafyKjP3mcQ8QaOhn729GsWrVDlf/hbRVSa4CDgQ6j9b6OXrbAwY7eAi21gYLw5ddaPdhlg==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
 
-  '@ahoo-wang/fetcher-generator@3.15.0':
-    resolution: {integrity: sha512-uKaRLr3qyel47Nl0drJDbZHrBUs7FXHXw5vaX5lcYcwnXcOeVRdt7RwM8E28s1DwXUgO1u0PmevRREieH9p/Ug==}
+  '@ahoo-wang/fetcher-generator@3.15.1':
+    resolution: {integrity: sha512-H5zfjiq8xfTQdojHoUsYAenzzRQzjGacByGmNuzfTBK/LuLYySwilFAG+yIqXl9iThd3DKM6WRH9EA9/GdoxbQ==}
     hasBin: true
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
@@ -179,8 +179,8 @@ packages:
   '@ahoo-wang/fetcher-openapi@2.3.0':
     resolution: {integrity: sha512-He3I/VovQzLNajxL2hoUZKlAnt0ZpehpMpbjgxvdPEoWfeAA3qZc0+C8Mhrk3HQQAC69lZOSt3JtAvzYDxpn/Q==}
 
-  '@ahoo-wang/fetcher-react@3.15.0':
-    resolution: {integrity: sha512-2Qa7nZM61KE1YIX7bo5SrA8mPJBQXzeeBTPa4kEUyNpd72qgCzOoFr5nxSMG+2g/M/oDKt3rRnbaXcKp7RRAVw==}
+  '@ahoo-wang/fetcher-react@3.15.1':
+    resolution: {integrity: sha512-5SAHd0I33aIDhY3BtGHhzPO6JDd7yl6S0Tf15Q6jUv2tjZpwD9b4TxNEYcqVjdExC9WZlWZGvZVXJI0IuR4rLQ==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
       '@ahoo-wang/fetcher-cosec': ^3.5.1
@@ -188,16 +188,16 @@ packages:
       '@ahoo-wang/fetcher-eventstream': ^3.0.0
       '@ahoo-wang/fetcher-storage': ^3.0.0
       '@ahoo-wang/fetcher-wow': ^3.0.0
-      react: ^19.2.4
-      react-dom: ^19.2.4
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
-  '@ahoo-wang/fetcher-storage@3.15.0':
-    resolution: {integrity: sha512-mUMKWCeECSbTIFnb7b+yPfykQUFIa2xzMXZkAHB3whYt7/Oo6Ag27B3ZJpKzQI6J/kD4cPAtlRPQvork/ZwqSA==}
+  '@ahoo-wang/fetcher-storage@3.15.1':
+    resolution: {integrity: sha512-aL8e4OIVATSNzRHspxyWZY1MeGaqAU8DBHXM8CLm3HKJ6rTFJ+zCvvUR6oQCU+tyOHqiyTk0AzLSrMRHl5Mbew==}
     peerDependencies:
       '@ahoo-wang/fetcher-eventbus': ^3.0.0
 
-  '@ahoo-wang/fetcher-viewer@3.15.0':
-    resolution: {integrity: sha512-TID1UunwSDtF9Rr7LuMQpkVnmQsQXxg/adjKIJTa3TMppo8m8k5H2OPKljpG3SVvOM+tzChycSmcf5HMipyDZw==}
+  '@ahoo-wang/fetcher-viewer@3.15.1':
+    resolution: {integrity: sha512-HwS0XIl6phuNVBtsmzM9m0fBmWbqAgytDFDPQyY1bfiuex5U+TWszE4VonPZl2P5TKjEE4gXudfWRyFvadaC4w==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
       '@ahoo-wang/fetcher-decorator': ^3.0.0
@@ -210,18 +210,18 @@ packages:
       '@ant-design/icons': ^6.0.0
       antd: ^6.3.5
       dayjs: ^1.11.19
-      react: ^19.2.4
-      react-dom: ^19.2.4
+      react: ^19.2.5
+      react-dom: ^19.2.5
 
-  '@ahoo-wang/fetcher-wow@3.15.0':
-    resolution: {integrity: sha512-YvjCG4835GOgbhiyMak4P3LwQYrQYK3TxoY0d0hlUbR1/1J8MvHAdVZq1fSjxyL1BiEjIEx4u7CEW+K6ZpnOjA==}
+  '@ahoo-wang/fetcher-wow@3.15.1':
+    resolution: {integrity: sha512-i1Vz1SmAjF9F8M6VjMiXDrZgjBlZ4oPY61NUvEueNMcMf9UX+WbRDg0sb82ELfTvHjGW6diuZqNNjy+gIgXLSQ==}
     peerDependencies:
       '@ahoo-wang/fetcher': ^3.0.0
       '@ahoo-wang/fetcher-decorator': ^3.0.0
       '@ahoo-wang/fetcher-eventstream': ^3.0.0
 
-  '@ahoo-wang/fetcher@3.15.0':
-    resolution: {integrity: sha512-93V96pkC6lFgn05gyu/h+4SMLBhVqXjZJKSs0RwzFtEux6zbxUBd9lWyIfNIA2IynmPYHwWifByZauSbAMdUfA==}
+  '@ahoo-wang/fetcher@3.15.1':
+    resolution: {integrity: sha512-QzfU0b3vGSUBJeKHHbfI0fk0mH8sTbFMZ4ofYjPaVQDeMcRYsxQmMsP6/fpj4oYA2UxBX6pTiBkUe9fofY9sbw==}
 
   '@ant-design/colors@8.0.1':
     resolution: {integrity: sha512-foPVl0+SWIslGUtD/xBr1p9U4AKzPhNYEseXYRRo5QSzGACYZrQbe11AYJbYfAWnWSpGBx6JjBmSeugUsD9vqQ==}
@@ -258,12 +258,12 @@ packages:
       react: ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@asamuzakjp/css-color@5.1.8':
-    resolution: {integrity: sha512-OISPR9c2uPo23rUdvfEQiLPjoMLOpEeLNnP5iGkxr6tDDxJd3NjD+6fxY0mdaMbIPUjFGL4HFOJqLvow5q4aqQ==}
+  '@asamuzakjp/css-color@5.1.9':
+    resolution: {integrity: sha512-zd9c/Wdso6v1U7v6w3i/hbAr4K7NaSHImdpvmLt+Y9ea5BhilnIGNkfhOJ7FEIuPipAnE9tZeDOll05WDT0kgg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
-  '@asamuzakjp/dom-selector@7.0.8':
-    resolution: {integrity: sha512-erMO6FgtM02dC24NGm0xufMzWz5OF0wXKR7BpvGD973bq/GbmR8/DbxNZbj0YevQ5hlToJaWSVK/G9/NDgGEVw==}
+  '@asamuzakjp/dom-selector@7.0.9':
+    resolution: {integrity: sha512-r3ElRr7y8ucyN2KdICwGsmj19RoN13CLCa/pvGydghWK6ZzeKQ+TcDjVdtEZz2ElpndM5jXw//B9CEee0mWnVg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   '@asamuzakjp/nwsapi@2.3.9':
@@ -1427,8 +1427,8 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.10.16:
-    resolution: {integrity: sha512-Lyf3aK28zpsD1yQMiiHD4RvVb6UdMoo8xzG2XzFIfR9luPzOpcBlAsT/qfB1XWS1bxWT+UtE4WmQgsp297FYOA==}
+  baseline-browser-mapping@2.10.17:
+    resolution: {integrity: sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -2355,78 +2355,78 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ahoo-wang/fetcher-cosec@3.15.0(@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-storage@3.15.0(@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0)))(@ahoo-wang/fetcher@3.15.0)':
+  '@ahoo-wang/fetcher-cosec@3.15.1(@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-storage@3.15.1(@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1)))(@ahoo-wang/fetcher@3.15.1)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.15.0
-      '@ahoo-wang/fetcher-eventbus': 3.15.0(@ahoo-wang/fetcher@3.15.0)
-      '@ahoo-wang/fetcher-storage': 3.15.0(@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0))
+      '@ahoo-wang/fetcher': 3.15.1
+      '@ahoo-wang/fetcher-eventbus': 3.15.1(@ahoo-wang/fetcher@3.15.1)
+      '@ahoo-wang/fetcher-storage': 3.15.1(@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1))
       nanoid: 5.1.7
 
-  '@ahoo-wang/fetcher-decorator@3.15.0(@ahoo-wang/fetcher@3.15.0)':
+  '@ahoo-wang/fetcher-decorator@3.15.1(@ahoo-wang/fetcher@3.15.1)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.15.0
+      '@ahoo-wang/fetcher': 3.15.1
       reflect-metadata: 0.2.2
 
-  '@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0)':
+  '@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.15.0
+      '@ahoo-wang/fetcher': 3.15.1
 
-  '@ahoo-wang/fetcher-eventstream@3.15.0(@ahoo-wang/fetcher@3.15.0)':
+  '@ahoo-wang/fetcher-eventstream@3.15.1(@ahoo-wang/fetcher@3.15.1)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.15.0
+      '@ahoo-wang/fetcher': 3.15.1
 
-  '@ahoo-wang/fetcher-generator@3.15.0(@ahoo-wang/fetcher-decorator@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-eventstream@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@3.15.0(@ahoo-wang/fetcher-decorator@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-eventstream@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher@3.15.0)':
+  '@ahoo-wang/fetcher-generator@3.15.1(@ahoo-wang/fetcher-decorator@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-eventstream@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-openapi@2.3.0)(@ahoo-wang/fetcher-wow@3.15.1(@ahoo-wang/fetcher-decorator@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-eventstream@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher@3.15.1)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.15.0
-      '@ahoo-wang/fetcher-decorator': 3.15.0(@ahoo-wang/fetcher@3.15.0)
-      '@ahoo-wang/fetcher-eventstream': 3.15.0(@ahoo-wang/fetcher@3.15.0)
+      '@ahoo-wang/fetcher': 3.15.1
+      '@ahoo-wang/fetcher-decorator': 3.15.1(@ahoo-wang/fetcher@3.15.1)
+      '@ahoo-wang/fetcher-eventstream': 3.15.1(@ahoo-wang/fetcher@3.15.1)
       '@ahoo-wang/fetcher-openapi': 2.3.0
-      '@ahoo-wang/fetcher-wow': 3.15.0(@ahoo-wang/fetcher-decorator@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-eventstream@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher@3.15.0)
+      '@ahoo-wang/fetcher-wow': 3.15.1(@ahoo-wang/fetcher-decorator@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-eventstream@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher@3.15.1)
       commander: 14.0.3
       ts-morph: 27.0.2
       yaml: 2.8.3
 
   '@ahoo-wang/fetcher-openapi@2.3.0': {}
 
-  '@ahoo-wang/fetcher-react@3.15.0(@ahoo-wang/fetcher-cosec@3.15.0(@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-storage@3.15.0(@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0)))(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-eventstream@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-storage@3.15.0(@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0)))(@ahoo-wang/fetcher-wow@3.15.0(@ahoo-wang/fetcher-decorator@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-eventstream@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher@3.15.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@ahoo-wang/fetcher-react@3.15.1(@ahoo-wang/fetcher-cosec@3.15.1(@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-storage@3.15.1(@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1)))(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-eventstream@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-storage@3.15.1(@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1)))(@ahoo-wang/fetcher-wow@3.15.1(@ahoo-wang/fetcher-decorator@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-eventstream@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher@3.15.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.15.0
-      '@ahoo-wang/fetcher-cosec': 3.15.0(@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-storage@3.15.0(@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0)))(@ahoo-wang/fetcher@3.15.0)
-      '@ahoo-wang/fetcher-eventbus': 3.15.0(@ahoo-wang/fetcher@3.15.0)
-      '@ahoo-wang/fetcher-eventstream': 3.15.0(@ahoo-wang/fetcher@3.15.0)
-      '@ahoo-wang/fetcher-storage': 3.15.0(@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0))
-      '@ahoo-wang/fetcher-wow': 3.15.0(@ahoo-wang/fetcher-decorator@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-eventstream@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher@3.15.0)
+      '@ahoo-wang/fetcher': 3.15.1
+      '@ahoo-wang/fetcher-cosec': 3.15.1(@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-storage@3.15.1(@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1)))(@ahoo-wang/fetcher@3.15.1)
+      '@ahoo-wang/fetcher-eventbus': 3.15.1(@ahoo-wang/fetcher@3.15.1)
+      '@ahoo-wang/fetcher-eventstream': 3.15.1(@ahoo-wang/fetcher@3.15.1)
+      '@ahoo-wang/fetcher-storage': 3.15.1(@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1))
+      '@ahoo-wang/fetcher-wow': 3.15.1(@ahoo-wang/fetcher-decorator@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-eventstream@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher@3.15.1)
       immer: 11.1.4
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@ahoo-wang/fetcher-storage@3.15.0(@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0))':
+  '@ahoo-wang/fetcher-storage@3.15.1(@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1))':
     dependencies:
-      '@ahoo-wang/fetcher-eventbus': 3.15.0(@ahoo-wang/fetcher@3.15.0)
+      '@ahoo-wang/fetcher-eventbus': 3.15.1(@ahoo-wang/fetcher@3.15.1)
 
-  '@ahoo-wang/fetcher-viewer@3.15.0(ce3c903e9000edd5bfe7f7efc285f140)':
+  '@ahoo-wang/fetcher-viewer@3.15.1(4c3007d464c0293fdfc150b0f2727513)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.15.0
-      '@ahoo-wang/fetcher-decorator': 3.15.0(@ahoo-wang/fetcher@3.15.0)
-      '@ahoo-wang/fetcher-eventbus': 3.15.0(@ahoo-wang/fetcher@3.15.0)
-      '@ahoo-wang/fetcher-eventstream': 3.15.0(@ahoo-wang/fetcher@3.15.0)
+      '@ahoo-wang/fetcher': 3.15.1
+      '@ahoo-wang/fetcher-decorator': 3.15.1(@ahoo-wang/fetcher@3.15.1)
+      '@ahoo-wang/fetcher-eventbus': 3.15.1(@ahoo-wang/fetcher@3.15.1)
+      '@ahoo-wang/fetcher-eventstream': 3.15.1(@ahoo-wang/fetcher@3.15.1)
       '@ahoo-wang/fetcher-openapi': 2.3.0
-      '@ahoo-wang/fetcher-react': 3.15.0(@ahoo-wang/fetcher-cosec@3.15.0(@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-storage@3.15.0(@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0)))(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-eventstream@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-storage@3.15.0(@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0)))(@ahoo-wang/fetcher-wow@3.15.0(@ahoo-wang/fetcher-decorator@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-eventstream@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher@3.15.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@ahoo-wang/fetcher-storage': 3.15.0(@ahoo-wang/fetcher-eventbus@3.15.0(@ahoo-wang/fetcher@3.15.0))
-      '@ahoo-wang/fetcher-wow': 3.15.0(@ahoo-wang/fetcher-decorator@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-eventstream@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher@3.15.0)
+      '@ahoo-wang/fetcher-react': 3.15.1(@ahoo-wang/fetcher-cosec@3.15.1(@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-storage@3.15.1(@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1)))(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-eventstream@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-storage@3.15.1(@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1)))(@ahoo-wang/fetcher-wow@3.15.1(@ahoo-wang/fetcher-decorator@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-eventstream@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher@3.15.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@ahoo-wang/fetcher-storage': 3.15.1(@ahoo-wang/fetcher-eventbus@3.15.1(@ahoo-wang/fetcher@3.15.1))
+      '@ahoo-wang/fetcher-wow': 3.15.1(@ahoo-wang/fetcher-decorator@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-eventstream@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher@3.15.1)
       '@ant-design/icons': 6.1.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       antd: 6.3.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       dayjs: 1.11.20
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@ahoo-wang/fetcher-wow@3.15.0(@ahoo-wang/fetcher-decorator@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher-eventstream@3.15.0(@ahoo-wang/fetcher@3.15.0))(@ahoo-wang/fetcher@3.15.0)':
+  '@ahoo-wang/fetcher-wow@3.15.1(@ahoo-wang/fetcher-decorator@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher-eventstream@3.15.1(@ahoo-wang/fetcher@3.15.1))(@ahoo-wang/fetcher@3.15.1)':
     dependencies:
-      '@ahoo-wang/fetcher': 3.15.0
-      '@ahoo-wang/fetcher-decorator': 3.15.0(@ahoo-wang/fetcher@3.15.0)
-      '@ahoo-wang/fetcher-eventstream': 3.15.0(@ahoo-wang/fetcher@3.15.0)
+      '@ahoo-wang/fetcher': 3.15.1
+      '@ahoo-wang/fetcher-decorator': 3.15.1(@ahoo-wang/fetcher@3.15.1)
+      '@ahoo-wang/fetcher-eventstream': 3.15.1(@ahoo-wang/fetcher@3.15.1)
 
-  '@ahoo-wang/fetcher@3.15.0': {}
+  '@ahoo-wang/fetcher@3.15.1': {}
 
   '@ant-design/colors@8.0.1':
     dependencies:
@@ -2474,14 +2474,14 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       throttle-debounce: 5.0.2
 
-  '@asamuzakjp/css-color@5.1.8':
+  '@asamuzakjp/css-color@5.1.9':
     dependencies:
       '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-color-parser': 4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
-  '@asamuzakjp/dom-selector@7.0.8':
+  '@asamuzakjp/dom-selector@7.0.9':
     dependencies:
       '@asamuzakjp/nwsapi': 2.3.9
       bidi-js: 1.0.3
@@ -3681,7 +3681,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.10.16: {}
+  baseline-browser-mapping@2.10.17: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -3693,7 +3693,7 @@ snapshots:
 
   browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.16
+      baseline-browser-mapping: 2.10.17
       caniuse-lite: 1.0.30001787
       electron-to-chromium: 1.5.334
       node-releases: 2.0.37
@@ -4003,8 +4003,8 @@ snapshots:
 
   jsdom@29.0.2:
     dependencies:
-      '@asamuzakjp/css-color': 5.1.8
-      '@asamuzakjp/dom-selector': 7.0.8
+      '@asamuzakjp/css-color': 5.1.9
+      '@asamuzakjp/dom-selector': 7.0.9
       '@bramus/specificity': 2.4.2
       '@csstools/css-syntax-patches-for-csstree': 1.1.2(css-tree@3.2.1)
       '@exodus/bytes': 1.15.0


### PR DESCRIPTION
- Updated @ahoo-wang/fetcher packages from 3.15.0 to 3.15.1
- Updated @ahoo-wang/fetcher-generator from 3.15.0 to 3.15.1
- Updated vitest from 4.1.3 to 4.1.4
- All fetcher-related dependencies updated to same minor version
- Development dependencies aligned with latest versions

