### PR TITLE
docs(wow): add comprehensive framework skills and evals

### DIFF
--- a/skills/wow/SKILL.md
+++ b/skills/wow/SKILL.md
@@ -1,0 +1,527 @@
+---
+name: wow
+description: |
+  Wow framework assistant for building DDD + Event Sourcing + CQRS microservices. Use this skill whenever the user mentions:
+  - DDD, Domain-Driven Design, aggregate roots, entities, value objects
+  - CQRS, Command Query Responsibility Segregation, read models, write models
+  - Event Sourcing, events, event store, snapshots
+  - Distributed transactions, saga, orchestration, compensation
+  - Projection processors, read model updates, query services
+  - Command gateway, wait strategies, command bus
+  - Wow framework, wow-project-template
+  - Unit testing with Given-When-Expect pattern, AggregateSpec, SagaSpec
+
+  This skill helps create, modify, and test Wow framework components including aggregates, sagas, projections, and command handlers.
+compatibility: Kotlin, Spring Boot, Gradle, MongoDB, Kafka
+---
+
+# Wow Framework Skill
+
+Wow is a modern reactive CQRS microservice framework based on DDD and Event Sourcing. This skill helps you build Wow-based applications.
+
+## Architecture Overview
+
+```
+Write Path: Command → Aggregate → Event → EventStore → EventBus
+                                       ↓
+Read Path:                     Projection → ReadModel
+```
+
+## Module Structure
+
+| Module | Purpose |
+|--------|---------|
+| `wow-api` | Public annotations and interfaces |
+| `wow-core` | Core runtime (commands, events, sagas, projections) |
+| `wow-mongo` | MongoDB event store and snapshot support |
+| `wow-kafka` | Kafka message bus support |
+| `wow-query` | Query DSL and query services |
+| `wow-test` | AggregateSpec, SagaSpec, ProjectionSpec |
+
+## Aggregate Root Modeling
+
+Wow uses the **Simple Aggregation Pattern** with separate Command Aggregate and State Aggregate classes.
+
+### Complete Example (Cart Aggregate)
+
+**CartState.kt** - Holds state and handles event sourcing:
+```kotlin
+class CartState(val id: String) : ICartInfo {
+    override var items: List<CartItem> = listOf()
+        private set
+
+    fun onCartItemAdded(cartItemAdded: CartItemAdded) {
+        items = items + cartItemAdded.added
+    }
+
+    fun onCartItemRemoved(cartItemRemoved: CartItemRemoved) {
+        items = items.filter { !cartItemRemoved.productIds.contains(it.productId) }
+    }
+
+    fun onCartQuantityChanged(cartQuantityChanged: CartQuantityChanged) {
+        items = items.map {
+            if (it.productId == cartQuantityChanged.changed.productId) {
+                cartQuantityChanged.changed
+            } else {
+                it
+            }
+        }
+    }
+}
+```
+
+**Cart.kt** - Handles commands and returns events:
+```kotlin
+@AggregateRoot(commands = [AddCartItem::class, RemoveCartItem::class])
+class Cart(private val state: CartState) {
+
+    fun onCommand(command: AddCartItem): Any {
+        require(state.items.size < MAX_CART_ITEM_SIZE) {
+            "Shopping cart can only add up to [$MAX_CART_ITEM_SIZE] items."
+        }
+        state.items.firstOrNull {
+            it.productId == command.productId
+        }?.let {
+            return CartQuantityChanged(changed = it.copy(quantity = it.quantity + command.quantity))
+        }
+        return CartItemAdded(added = CartItem(productId = command.productId, quantity = command.quantity))
+    }
+
+    fun onCommand(command: RemoveCartItem): CartItemRemoved {
+        return CartItemRemoved(productIds = command.productIds)
+    }
+}
+```
+
+### Key Conventions
+
+1. **Annotations are optional** if naming convention is followed:
+   - `@OnCommand` optional if method is named `onCommand`
+   - `@OnSourcing` optional if method is named `onSourcing`
+   - `@OnEvent` optional if method is named `onEvent`
+
+2. **@AggregateRoot annotation** specifies which commands this aggregate handles:
+   ```kotlin
+   @AggregateRoot(commands = [CreateOrder::class, UpdateOrder::class])
+   ```
+
+3. **Command handler return types**:
+   - Single event: return the event directly
+   - Multiple events: return `Any` (list of events or single event)
+   - Error: throw an exception
+
+4. **Sourcing handler parameters**:
+   - Specific event: `onCartItemAdded(event: CartItemAdded)`
+   - Generic domain event: `onSourcing(event: DomainEvent<CartItemAdded>)`
+
+### Aggregate Root Annotation Specifying Route
+
+```kotlin
+@StaticTenantId
+@AggregateRoot(commands = [MountedCommand::class])
+@AggregateRoute(owner = AggregateRoute.Owner.AGGREGATE_ID)
+class Cart(private val state: CartState) {
+    // ...
+}
+```
+
+## Command Gateway
+
+Send commands and wait for results using wait strategies.
+
+### Basic Usage
+
+```kotlin
+val command = CreateAccount(balance = 1000, name = "John").toCommandMessage()
+
+// Wait for command to be processed by aggregate
+commandGateway.sendAndWaitForProcessed(command)
+    .doOnSuccess { result ->
+        if (result.succeeded) {
+            println("Command processed! Version: ${result.aggregateVersion}")
+        }
+    }
+```
+
+### Wait Strategy Methods
+
+| Method | Description |
+|--------|-------------|
+| `sendAndWaitForSent(command)` | Wait until command is published to bus |
+| `sendAndWaitForProcessed(command)` | Wait until aggregate processes command |
+| `sendAndWaitForSnapshot(command)` | Wait until snapshot is created |
+
+### WaitStrategy API
+
+```kotlin
+WaitingForStage.sent(commandId)
+WaitingForStage.processed(commandId)
+WaitingForStage.snapshot(commandId)
+WaitingForStage.projected(waitCommandId, contextName, processorName, functionName)
+WaitingForStage.eventHandled(...)
+WaitingForStage.sagaHandled(...)
+```
+
+### Error Handling
+
+```kotlin
+commandGateway.sendAndWaitForProcessed(command)
+    .doOnError { error ->
+        when (error) {
+            is CommandResultException -> {
+                val result = error.commandResult
+                println("Error: ${result.errorCode} - ${result.errorMsg}")
+                result.bindingErrors.forEach {
+                    println("Field ${it.name}: ${it.msg}")
+                }
+            }
+            is CommandValidationException -> { ... }
+            is DuplicateRequestIdException -> { ... }
+        }
+    }
+```
+
+## Saga Pattern
+
+Use stateless saga for distributed transaction orchestration.
+
+### Complete Saga Example
+
+```kotlin
+@StatelessSaga
+class CartSaga {
+
+    @Retry(maxRetries = 5, minBackoff = 60, executionTimeout = 10)
+    fun onEvent(event: DomainEvent<OrderCreated>): CommandBuilder? {
+        val orderCreated = event.body
+        if (!orderCreated.fromCart) {
+            return null
+        }
+        return RemoveCartItem(
+            productIds = orderCreated.items.map { it.productId }.toSet(),
+        ).commandBuilder().aggregateId(event.ownerId)
+    }
+}
+```
+
+### Saga Return Types
+
+```kotlin
+// Return null - no command sent
+fun onEvent(event: NoOpEvent): Nothing? = null
+
+// Single command
+fun onEvent(event: Event1): Command1 { ... }
+
+// Return CommandBuilder for aggregateId-aware commands
+fun onEvent(event: Event): CommandBuilder {
+    return SomeCommand(...).commandBuilder().aggregateId(event.aggregateId)
+}
+
+// Multiple commands
+fun onEvent(event: Event): List<Command> { ... }
+```
+
+### @Retry Annotation (for Sagas)
+
+```kotlin
+@Retry(maxRetries = 5, minBackoff = 60, executionTimeout = 10)
+fun onEvent(event: DomainEvent<OrderCreated>): CommandBuilder? {
+    // ...
+}
+```
+
+### State Event Handler
+
+Sagas can access aggregate state with `onStateEvent`:
+
+```kotlin
+fun onStateEvent(orderCreated: OrderCreated, state: OrderState): Mono<Void> {
+    // Access both event and current state
+    return Mono.empty()
+}
+```
+
+## Projection Processor
+
+Maintain read models for CQRS.
+
+### Basic Projection
+
+```kotlin
+@ProjectionProcessor
+class OrderProjector {
+
+    @Blocking
+    fun onEvent(orderCreated: OrderCreated) {
+        // Synchronous handling
+    }
+
+    fun onStateEvent(orderCreated: OrderCreated, state: OrderState): Mono<Void> {
+        // Access full aggregate state
+        return Mono.empty()
+    }
+
+    fun onEvent(orderPaid: OrderPaid): Mono<Void> {
+        return Mono.empty()
+    }
+}
+```
+
+### Key Projection Patterns
+
+1. **@Blocking** - marks synchronous blocking operations
+2. **onStateEvent(event, state)** - access both event and full aggregate state
+3. **Return Mono<Void>** - reactive handling for async operations
+
+## Query Service DSL
+
+Query read models using the Query DSL.
+
+### Query Functions
+
+```kotlin
+// Single result
+singleQuery {
+    where { "status" eq "active" }
+    projection { "id", "name" }
+    orderBy { "createdAt" desc }
+    limit(10)
+}.query(queryService)
+
+// List of results
+listQuery {
+    where { "age" gt 18 }
+    orderBy { "name" asc }
+    offset(0)
+    limit(20)
+}.query(queryService)
+
+// Paged query
+pagedQuery {
+    where { "tenantId" eq tenantId }
+    page(1)
+    pageSize(20)
+}.query(queryService)
+```
+
+### Condition DSL
+
+```kotlin
+condition {
+    deleted(DeletionState.ALL)
+    tenantId(tenantId)
+    and {
+        "status" eq "ACTIVE"
+        "amount" gt 100
+    }
+    or {
+        "type" eq "VIP"
+        "type" eq "PREMIUM"
+    }
+}
+```
+
+### Operators
+
+| Operator | Description |
+|----------|-------------|
+| `eq` / `ne` | Equals / Not equals |
+| `gt` / `lt` / `gte` / `lte` | Comparison |
+| `contains` | String contains |
+| `isIn` / `notIn` | In list / not in list |
+| `between` | Range |
+| `startsWith` / `endsWith` | String prefix/suffix |
+| `isNull()` / `notNull()` | Null check |
+| `isTrue()` / `isFalse()` | Boolean check |
+| `today()` / `thisWeek()` / `thisMonth()` / `lastMonth()` | Date ranges |
+| `recentDays(n)` / `earlierDays(n)` | Relative date ranges |
+
+## Testing
+
+Wow provides `AggregateSpec` and `SagaSpec` for Given-When-Expect testing.
+
+### AggregateSpec Example
+
+```kotlin
+class CartSpec : AggregateSpec<Cart, CartState>(
+    {
+        on {
+            val ownerId = generateGlobalId()
+            val addCartItem = AddCartItem(productId = "productId", quantity = 1)
+            givenOwnerId(ownerId)
+            whenCommand(addCartItem) {
+                expectNoError()
+                expectEventType(CartItemAdded::class)
+                expectState { items.assert().hasSize(1) }
+                expectStateAggregate { ownerId.assert().isEqualTo(ownerId) }
+
+                fork(name = "Remove CartItem") {
+                    val removeCartItem = RemoveCartItem(productIds = setOf(addCartItem.productId))
+                    whenCommand(removeCartItem) {
+                        expectEventType(CartItemRemoved::class)
+                        expectState { items.assert().isEmpty() }
+                    }
+                }
+            }
+        }
+    }
+)
+```
+
+### SagaSpec Example
+
+```kotlin
+class CartSagaSpec : SagaSpec<CartSaga>({
+    on {
+        val ownerId = generateGlobalId()
+        val orderItem = OrderItem(
+            id = generateGlobalId(),
+            productId = generateGlobalId(),
+            price = BigDecimal(10),
+            quantity = 10,
+        )
+        whenEvent(
+            event = mockk<OrderCreated> {
+                every { items } returns listOf(orderItem)
+                every { fromCart } returns true
+            },
+            ownerId = ownerId
+        ) {
+            expectCommandType(RemoveCartItem::class)
+            expectCommand<RemoveCartItem> {
+                aggregateId.id.assert().isEqualTo(ownerId)
+                body.productIds.assert().hasSize(1)
+            }
+        }
+    }
+})
+```
+
+### Testing DSL Reference
+
+**AggregateSpec DSL:**
+
+| Method | Description |
+|--------|-------------|
+| `givenOwnerId(id)` | Set aggregate ID |
+| `givenEvent(event)` | Initialize with domain events |
+| `givenState(state, version)` | Initialize with direct state |
+| `inject { register(...) }` | Inject mock services |
+| `whenCommand(cmd)` | Execute command |
+| `expectNoError()` | Assert no error |
+| `expectErrorType<T>()` | Assert error type |
+| `expectEventType<T>()` | Assert event type |
+| `expectEventBody<T> { }` | Assert event body content |
+| `expectState { }` | Assert aggregate state |
+| `expectStateAggregate { }` | Assert aggregate metadata |
+| `expectEventCount(n)` | Assert number of events |
+| `fork(name) { }` | Branch test scenario |
+| `ref("name")` | Mark verification point |
+
+**SagaSpec DSL:**
+
+| Method | Description |
+|--------|-------------|
+| `whenEvent(event, ownerId)` | Trigger saga with event |
+| `expectCommandType<T>()` | Assert command type sent |
+| `expectCommand<T> { }` | Assert command content |
+| `expectNoCommand()` | Assert no command sent |
+
+## Event Modeling
+
+### Event Naming Convention
+
+```kotlin
+// Good - past tense + specific behavior
+@Event
+data class OrderCreated(
+    val orderId: String,
+    val customerId: String,
+    val items: List<OrderItem>,
+    val totalAmount: BigDecimal
+)
+
+@Event
+data class OrderPaid(
+    val orderId: String,
+    val paidAmount: BigDecimal,
+    val paymentId: String
+)
+
+// Avoid - vague naming
+data class OrderUpdated(val orderId: String)  // What changed?
+```
+
+### Event Revision
+
+```kotlin
+@Event(revision = "2.0")
+data class OrderShipped(
+    val orderId: String,
+    val trackingNumber: String,
+    val shippedAt: Instant
+)
+```
+
+## Project Structure
+
+```
+src/main/kotlin/
+├── domain/
+│   ├── cart/
+│   │   ├── Cart.kt              # Command aggregate
+│   │   ├── CartState.kt         # State aggregate
+│   │   ├── CartItem.kt         # Value object
+│   │   └── CartSaga.kt         # Saga (optional)
+│   ├── order/
+│   │   ├── Order.kt
+│   │   └── OrderState.kt
+│   └── projection/
+│       └── OrderProjector.kt    # Projection processor
+└── api/
+    ├── command/
+    │   └── AddCartItem.kt      # Command
+    └── event/
+        └── CartItemAdded.kt     # Event
+```
+
+## Dependencies
+
+```kotlin
+// build.gradle.kts
+dependencies {
+    implementation("me.ahoo.wow:wow-api")
+    implementation("me.ahoo.wow:wow-core")
+    implementation("me.ahoo.wow:wow-mongo")    // MongoDB support
+    implementation("me.ahoo.wow:wow-kafka")     // Kafka support
+    implementation("me.ahoo.wow:wow-query")     // Query DSL
+
+    testImplementation("me.ahoo.wow:wow-test")  // Test utilities
+}
+```
+
+## Best Practices
+
+1. **Simple Aggregation Pattern**: Use separate Command Aggregate and State Aggregate classes
+2. **Keep Aggregates Small**: One aggregate per transaction boundary
+3. **Saga for Cross-Aggregate Workflows**: Use stateless saga for distributed transactions
+4. **Event Naming**: Past tense + specific business action (OrderCreated, not OrderUpdate)
+5. **Use Projections for Read Models**: Separate read/write concerns with projection processors
+6. **@Blocking for Sync Operations**: Mark blocking projection handlers
+7. **@Retry for Resilient Sagas**: Handle transient failures in saga event handlers
+
+## References
+
+### Internal References
+
+| Reference | When to Use |
+|-----------|-------------|
+| `references/annotations.md` | Annotation parameters, @Retry, @Event revision, naming conventions, all aggregate patterns |
+| `references/dsl.md` | Complete Query DSL operators (100+), pagination, nested queries, date operators, query rewriting |
+| `references/testing.md` | AggregateSpec/SagaSpec DSL, fork/ref patterns, FluentAssert, mockk usage, default commands |
+| `references/modeling.md` | Aggregate patterns: Simple/Complex aggregation, single class pattern, inheritance pattern |
+| `references/command-gateway.md` | Wait strategies, idempotency, validation, LocalFirst mode, CommandRewriter |
+| `references/prepare-key.md` | Uniqueness constraints for EventSourcing, TTL support, user registration scenarios |
+
+These references are loaded as needed - you don't need to read them proactively.

--- a/skills/wow/evals/evals.json
+++ b/skills/wow/evals/evals.json
@@ -1,0 +1,30 @@
+{
+  "skill_name": "wow",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Create a Cart aggregate using Simple Aggregation Pattern for an e-commerce shopping cart. The cart should:\n1. Have a maximum capacity of 10 items\n2. Handle AddCartItem command that emits CartItemAdded or CartQuantityChanged events\n3. Handle RemoveCartItem command that emits CartItemRemoved event\n4. CartItem has productId and quantity fields\n\nWrite CartState.kt and Cart.kt files following Wow conventions.",
+      "expected_output": "Two Kotlin files:\n- CartState.kt: State aggregate with onCartItemAdded, onCartItemRemoved, onCartQuantityChanged sourcing handlers\n- Cart.kt: Command aggregate with @AggregateRoot annotation and onCommand handlers returning appropriate events"
+    },
+    {
+      "id": 2,
+      "prompt": "Write a TransferSaga for a bank transfer scenario. The saga should:\n1. When it receives a Prepared event, return an Entry command to deposit to target account\n2. When it receives AmountEntered event, return a Confirm command to confirm the transfer\n3. When it receives EntryFailed event, return an UnlockAmount command to unlock the source account\n\nUse @StatelessSaga annotation and onEvent handlers.",
+      "expected_output": "TransferSaga.kt with @StatelessSaga annotation and three onEvent handlers returning Entry, Confirm, and UnlockAmount commands respectively."
+    },
+    {
+      "id": 3,
+      "prompt": "Write unit tests for a Cart aggregate using AggregateSpec. Test the following scenarios:\n1. Adding an item to empty cart - should emit CartItemAdded\n2. Adding same product twice - should emit CartQuantityChanged\n3. Removing an item - should emit CartItemRemoved\n4. Adding more than 10 items - should throw error\n\nUse fork() for branching test scenarios, and verify state changes with expectState {}.",
+      "expected_output": "CartSpec.kt extending AggregateSpec<Cart, CartState> with Given-When-Expect tests using fork() for branching scenarios, expectState {} for state verification, and expectEventType {} for event assertions."
+    },
+    {
+      "id": 4,
+      "prompt": "Create an Order projection processor using @ProjectionProcessor. It should:\n1. Handle OrderCreated event to create initial order summary\n2. Handle OrderPaid event to update order status to PAID\n3. Use @Blocking annotation for the email notification handler\n\nThe projection updates an OrderSummaryRepository.",
+      "expected_output": "OrderProjector.kt with @ProjectionProcessor annotation, @OnEvent handlers for OrderCreated and OrderPaid, and a @Blocking handler for notifications."
+    },
+    {
+      "id": 5,
+      "prompt": "Write a query using Wow Query DSL to find all active orders for a specific tenant. The query should:\n1. Use pagedQuery with pagination\n2. Filter by tenantId and status=ACTIVE\n3. Sort by createdAt descending\n4. Project only id, status, and totalAmount fields",
+      "expected_output": "Kotlin code using pagedQuery { where { ... } page(...) projection { ... } } DSL to query orders by tenant and status."
+    }
+  ]
+}

--- a/skills/wow/references/annotations.md
+++ b/skills/wow/references/annotations.md
@@ -1,0 +1,252 @@
+# Wow Framework Annotations Reference
+
+## Core Annotations
+
+### @AggregateRoot
+
+Marks a class as an aggregate root. The compiler generates metadata for command handling.
+
+```kotlin
+@AggregateRoot(commands = [CreateOrder::class, UpdateOrder::class])
+class Order(private val state: OrderState) {
+    // Command handlers...
+}
+```
+
+**Parameters:**
+- `commands`: Array of command classes this aggregate handles
+- `route`: Optional aggregate route configuration
+
+### @OnCommand
+
+Marks a method as a command handler. Optional if method is named `onCommand`.
+
+```kotlin
+@OnCommand(returns = [OrderCreated::class, OrderUpdated::class])
+fun onCommand(cmd: CreateOrder): OrderCreated { ... }
+```
+
+**Parameters:**
+- `returns`: Array of event types this handler can return
+
+**Handler parameter types:**
+- Specific command: `AddCartItem`
+- Command message: `CommandMessage<AddCartItem>`
+- Command exchange: `CommandExchange<AddCartItem>`
+- Other parameters are resolved from IOC container
+
+### @OnSourcing
+
+Marks a method as an event sourcing handler. Used in State Aggregates to rebuild state from events. Optional if method is named `onSourcing`.
+
+```kotlin
+@OnSourcing
+fun onOrderCreated(event: OrderCreated) {
+    items = event.items
+    status = OrderStatus.CREATED
+}
+
+@OnSourcing
+fun onSourcing(event: DomainEvent<OrderPaid>) {  // Generic form
+    // ...
+}
+```
+
+**Handler parameter types:**
+- Specific event: `CartItemAdded`
+- Domain event: `DomainEvent<CartItemAdded>`
+
+### @StatelessSaga
+
+Marks a class as a stateless saga for distributed transaction orchestration.
+
+```kotlin
+@StatelessSaga
+class TransferSaga {
+    @OnEvent
+    fun onPrepared(event: Prepared): Entry { ... }
+}
+```
+
+### @OnEvent
+
+Marks a method as an event handler in Sagas and Projections. Optional if method is named `onEvent`.
+
+```kotlin
+@OnEvent
+fun onOrderCreated(event: OrderCreated) { ... }
+
+// Listen to specific aggregate
+@OnEvent("cart")
+fun onCartEvent(event: Any) { ... }
+```
+
+**Return types:**
+- `null` or `Nothing?` - no command sent
+- Single command - `Command`
+- `CommandBuilder` - for aggregateId-aware commands
+- `List<Command>` - multiple commands
+- `Mono<Void>` - async handling in projections
+
+### @ProjectionProcessor
+
+Marks a class as a projection processor for maintaining read models.
+
+```kotlin
+@ProjectionProcessor
+class OrderProjector {
+    fun onEvent(event: OrderCreated) { ... }
+    
+    fun onStateEvent(event: OrderPaid, state: OrderState) { ... }
+}
+```
+
+### @Blocking
+
+Marks a method as a blocking operation in projections.
+
+```kotlin
+@Blocking
+fun onEvent(event: OrderPaid) {
+    emailService.sendNotification(...)
+}
+```
+
+### @Retry
+
+Used in sagas for retry configuration on event handlers.
+
+```kotlin
+@Retry(maxRetries = 5, minBackoff = 60, executionTimeout = 10)
+fun onEvent(event: DomainEvent<OrderCreated>): CommandBuilder? { ... }
+```
+
+**Parameters:**
+- `maxRetries`: Maximum number of retry attempts
+- `minBackoff`: Minimum backoff time in seconds  
+- `executionTimeout`: Timeout for each execution in seconds
+
+## Annotation Naming Convention
+
+Most annotations are **optional** if you follow the naming convention:
+
+| Annotation | Optional if method named |
+|------------|-------------------------|
+| `@OnCommand` | `onCommand` |
+| `@OnEvent` | `onEvent` |
+| `@OnSourcing` | `onSourcing` |
+
+## Event Annotations
+
+### @Event
+
+Marks a data class as a domain event.
+
+```kotlin
+@Event
+data class OrderCreated(
+    val orderId: String,
+    val items: List<OrderItem>
+)
+
+@Event(revision = "2.0")
+data class OrderShipped(
+    val orderId: String,
+    val trackingNumber: String
+)
+```
+
+**Parameters:**
+- `revision`: Version string for event evolution
+
+## Aggregate Patterns
+
+### Simple Aggregation Pattern (Recommended)
+
+Separate Command Aggregate and State Aggregate classes:
+
+```kotlin
+// State Aggregate - holds state and handles sourcing
+class CartState(val id: String) {
+    var items: List<CartItem> = listOf()
+        private set
+    
+    fun onCartItemAdded(event: CartItemAdded) {
+        items = items + event.added
+    }
+}
+
+// Command Aggregate - handles commands
+@AggregateRoot
+class Cart(private val state: CartState) {
+    fun onCommand(cmd: AddCartItem): Any { ... }
+}
+```
+
+### Complex Aggregation Pattern
+
+Multiple related aggregates sharing a base state:
+
+```kotlin
+class OrderState(val id: String) { ... }
+class OrderStateA : OrderState(id) { ... }
+class OrderStateB : OrderState(id) { ... }
+
+@AggregateRoot
+class OrderA(private val state: OrderStateA) { ... }
+
+@AggregateRoot  
+class OrderB(private val state: OrderStateB) { ... }
+```
+
+### Inheritance Pattern
+
+Command Aggregate inherits from State Aggregate:
+
+```kotlin
+abstract class OrderState(val id: String) {
+    var items: List<OrderItem> = listOf()
+    fun onOrderCreated(e: OrderCreated) { ... }
+}
+
+@AggregateRoot
+class Order(state: OrderState) : OrderState(state.id) {
+    fun onCommand(cmd: CreateOrder): OrderCreated { ... }
+}
+```
+
+## Command Gateway Annotations
+
+### @StaticTenantId
+
+Marks an aggregate as having a static (non-changeable) tenant ID.
+
+### @AggregateRoute
+
+Configures aggregate routing.
+
+```kotlin
+@AggregateRoot(commands = [...])
+@AggregateRoute(owner = AggregateRoute.Owner.AGGREGATE_ID)
+class Cart(private val state: CartState) { ... }
+```
+
+**Owner values:**
+
+| Owner | Description |
+|-------|-------------|
+| `AGGREGATE_ID` | Route by the aggregate ID (default) |
+| `TENANT_ID` | Route by the tenant ID |
+| `GROUP` | Route by a named group |
+
+## Configuration Annotations
+
+### @Enabled
+
+Enable/disable components:
+
+```kotlin
+@Configuration
+@Enabled(properties = ["wow.command.enabled=true"])
+class CommandConfiguration { ... }
+```

--- a/skills/wow/references/command-gateway.md
+++ b/skills/wow/references/command-gateway.md
@@ -1,0 +1,645 @@
+# Command Gateway
+
+The command gateway is the core component in the system for receiving and sending commands, serving as an entry point for commands.
+It is an extension of the command bus, not only responsible for command transmission, but also adds a series of important responsibilities, including command idempotency, waiting strategies, and command validation.
+
+## API Usage
+
+The `CommandGateway` interface provides several methods for sending commands and waiting for their results. Below are the main methods and their usage patterns.
+
+### Basic Methods
+
+:::tip
+The `toCommandMessage()` extension function converts a command body into a `CommandMessage`. This is provided by the Wow framework and handles setting up the command ID, aggregate ID, and other metadata.
+:::
+
+#### send(command, waitStrategy)
+
+The base method that sends a command with a specified wait strategy and returns a `ClientCommandExchange`.
+
+```kotlin
+val command = CreateAccount(balance = 1000, name = "John").toCommandMessage()
+val waitStrategy = WaitingForStage.processed(command.commandId)
+
+commandGateway.send(command, waitStrategy)
+    .flatMap { exchange ->
+        // Access the ClientCommandExchange
+        // Use the waitStrategy to get the command result
+        exchange.waitStrategy.waiting()
+    }
+    .subscribe { signal ->
+        println("Stage: ${signal.stage} - Succeeded: ${signal.succeeded}")
+    }
+```
+
+#### sendAndWait(command, waitStrategy)
+
+Sends a command and waits for the final result. If the command fails, it throws a `CommandResultException`.
+
+```kotlin
+val command = CreateAccount(balance = 1000, name = "John").toCommandMessage()
+val waitStrategy = WaitingForStage.processed(command.commandId)
+
+commandGateway.sendAndWait(command, waitStrategy)
+    .doOnSuccess { result ->
+        println("Command processed: ${result.commandId}")
+        println("Aggregate Version: ${result.aggregateVersion}")
+    }
+    .subscribe()
+```
+
+#### sendAndWaitStream(command, waitStrategy)
+
+Returns a `Flux<CommandResult>` for real-time streaming updates as the command progresses through different stages.
+
+```kotlin
+val command = CreateAccount(balance = 1000, name = "John").toCommandMessage()
+val waitStrategy = WaitingForStage.snapshot(command.commandId)
+
+commandGateway.sendAndWaitStream(command, waitStrategy)
+    .doOnNext { result ->
+        println("Stage: ${result.stage} - Succeeded: ${result.succeeded}")
+        println("Aggregate Version: ${result.aggregateVersion}")
+    }
+    .subscribe()
+```
+
+### Convenience Methods
+
+The `CommandGateway` provides convenience methods that pre-configure common wait strategies:
+
+```kotlin
+val command = CreateAccount(balance = 1000, name = "John").toCommandMessage()
+
+// Wait until command is sent to the bus
+commandGateway.sendAndWaitForSent(command)
+    .doOnSuccess { result ->
+        println("Command sent: ${result.commandId}")
+    }
+    .subscribe()
+
+// Wait until command is processed by the aggregate
+commandGateway.sendAndWaitForProcessed(command)
+    .doOnSuccess { result ->
+        if (result.succeeded) {
+            println("Command processed successfully: ${result.commandId}")
+            println("New aggregate version: ${result.aggregateVersion}")
+        }
+    }
+    .subscribe()
+
+// Wait until aggregate snapshot is created
+commandGateway.sendAndWaitForSnapshot(command)
+    .doOnSuccess { result ->
+        println("Snapshot created for aggregate: ${result.aggregateId}")
+    }
+    .subscribe()
+```
+
+## Core Concepts
+
+### ClientCommandExchange
+
+`ClientCommandExchange` is the client-side exchange context returned when sending commands via `CommandGateway.send()`. It provides access to:
+
+* **message**: The original `CommandMessage` that was sent
+* **waitStrategy**: The `WaitStrategy` used to wait for command processing results
+* **attributes**: A mutable map for storing additional exchange-related data
+
+```kotlin
+interface ClientCommandExchange<C : Any> {
+    val message: CommandMessage<C>
+    val waitStrategy: WaitStrategy
+    val attributes: MutableMap<String, Any>
+}
+```
+
+Use `ClientCommandExchange` when you need low-level access to the wait strategy or want to implement custom waiting logic:
+
+```kotlin
+commandGateway.send(command, waitStrategy)
+    .flatMap { exchange ->
+        // Access the command message
+        val commandId = exchange.message.commandId
+        
+        // Use the wait strategy directly
+        exchange.waitStrategy.waiting()
+            .filter { signal -> signal.stage == CommandStage.PROCESSED }
+            .next()
+    }
+    .subscribe()
+```
+
+### CommandResult
+
+`CommandResult` represents the result of a command execution at a specific processing stage. It contains comprehensive information about the command processing outcome.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `String` | Unique identifier for this result |
+| `waitCommandId` | `String` | The command ID being waited on |
+| `stage` | `CommandStage` | Current processing stage (SENT, PROCESSED, SNAPSHOT, etc.) |
+| `contextName` | `String` | Bounded context name |
+| `aggregateName` | `String` | Aggregate name |
+| `tenantId` | `String` | Tenant identifier |
+| `aggregateId` | `String` | Aggregate instance identifier |
+| `aggregateVersion` | `Int?` | Aggregate version after processing (null on gateway validation failure or before processing) |
+| `requestId` | `String` | Request identifier for idempotency |
+| `commandId` | `String` | Command identifier |
+| `function` | `FunctionInfoData` | Information about the processing function |
+| `errorCode` | `String` | Error code ("Ok" on success) |
+| `errorMsg` | `String` | Error message (empty on success) |
+| `bindingErrors` | `List<BindingError>` | List of validation errors |
+| `result` | `Map<String, Any>` | Additional result data |
+| `signalTime` | `Long` | Timestamp when this result was generated |
+| `succeeded` | `Boolean` | Whether the command processing succeeded |
+
+### WaitSignal vs CommandResult
+
+* **WaitSignal**: Internal interface used within the wait strategy infrastructure. Contains processing stage information and is used for signaling between components.
+* **CommandResult**: Public API for command results. Created from `WaitSignal` and includes additional context like `requestId` and formatted aggregate information.
+
+### CommandGateway vs CommandBus
+
+`CommandGateway` extends `CommandBus` with additional high-level features:
+
+| Feature | CommandBus | CommandGateway |
+|---------|------------|----------------|
+| Send commands | ✓ | ✓ |
+| Wait strategies | ✗ | ✓ |
+| Command validation | ✗ | ✓ |
+| Idempotency checking | ✗ | ✓ |
+| Real-time result streaming | ✗ | ✓ |
+| Convenience methods | ✗ | ✓ |
+
+Use `CommandBus` when you only need basic command routing. Use `CommandGateway` for full-featured command handling with wait strategies and validation.
+
+```kotlin
+// CommandBus - basic routing only
+interface CommandBus : MessageBus<CommandMessage<*>, ServerCommandExchange<*>>
+
+// CommandGateway - extends CommandBus with additional features
+interface CommandGateway : CommandBus {
+    fun <C : Any> send(command: CommandMessage<C>, waitStrategy: WaitStrategy): Mono<out ClientCommandExchange<C>>
+    fun <C : Any> sendAndWait(command: CommandMessage<C>, waitStrategy: WaitStrategy): Mono<CommandResult>
+    fun <C : Any> sendAndWaitStream(command: CommandMessage<C>, waitStrategy: WaitStrategy): Flux<CommandResult>
+    // ... convenience methods
+}
+```
+
+## Error Handling
+
+### CommandResultException
+
+When command processing fails, `sendAndWait` throws a `CommandResultException` containing the full `CommandResult` with error details.
+
+```kotlin
+commandGateway.sendAndWait(command, waitStrategy)
+    .doOnError { error ->
+        if (error is CommandResultException) {
+            val result = error.commandResult
+            println("Command failed at stage: ${result.stage}")
+            println("Error code: ${result.errorCode}")
+            println("Error message: ${result.errorMsg}")
+            
+            // Check for validation errors
+            if (result.bindingErrors.isNotEmpty()) {
+                result.bindingErrors.forEach { bindingError ->
+                    println("Field '${bindingError.name}': ${bindingError.msg}")
+                }
+            }
+        }
+    }
+    .onErrorResume { error ->
+        // Handle the error gracefully
+        when (error) {
+            is CommandResultException -> {
+                // Log and return a fallback value
+                Mono.empty()
+            }
+            else -> Mono.error(error)
+        }
+    }
+    .subscribe()
+```
+
+### CommandValidationException
+
+Thrown when command validation fails before sending. Contains validation constraint violations.
+
+```kotlin
+// Command with validation annotations
+data class CreateAccount(
+    @field:NotBlank(message = "Name is required")
+    val name: String,
+    @field:Min(value = 0, message = "Balance must be non-negative")
+    val balance: Int
+)
+
+commandGateway.sendAndWaitForProcessed(command)
+    .doOnError { error ->
+        if (error is CommandValidationException) {
+            println("Validation failed for command: ${error.command}")
+            error.bindingErrors.forEach { bindingError ->
+                println("Field '${bindingError.name}': ${bindingError.msg}")
+            }
+        }
+    }
+    .subscribe()
+```
+
+### DuplicateRequestIdException
+
+Thrown when attempting to process a command with a request ID that has already been processed.
+
+```kotlin
+commandGateway.sendAndWaitForProcessed(command)
+    .doOnError { error ->
+        if (error is DuplicateRequestIdException) {
+            println("Duplicate request: ${error.requestId}")
+            println("Aggregate: ${error.aggregateId}")
+        }
+    }
+    .onErrorResume(DuplicateRequestIdException::class.java) { error ->
+        // Return cached result or ignore duplicate
+        Mono.empty()
+    }
+    .subscribe()
+```
+
+### Error Handling Best Practices
+
+1. **Use specific exception handlers**: Handle `CommandResultException`, `CommandValidationException`, and `DuplicateRequestIdException` separately for appropriate responses.
+
+2. **Log error details**: Always log the `errorCode`, `errorMsg`, and `bindingErrors` for debugging.
+
+3. **Implement retry logic for transient failures**:
+
+```kotlin
+commandGateway.sendAndWaitForProcessed(command)
+    .retryWhen(Retry.backoff(3, Duration.ofSeconds(1))
+        .filter { error -> isTransientError(error) })
+    .subscribe()
+
+// Transient errors are typically network or temporary infrastructure issues
+// Do NOT retry validation errors or duplicate request errors
+fun isTransientError(error: Throwable): Boolean {
+    return when (error) {
+        is CommandValidationException -> false  // Validation errors won't succeed on retry
+        is DuplicateRequestIdException -> false // Duplicate requests should not be retried
+        is CommandResultException -> false      // Business logic errors from aggregate
+        else -> true                            // Network/infrastructure errors may be transient
+    }
+}
+```
+
+4. **Handle timeout scenarios**: Configure appropriate timeouts for wait strategies.
+
+```kotlin
+commandGateway.sendAndWaitForProcessed(command)
+    .timeout(Duration.ofSeconds(30))
+    .doOnError(TimeoutException::class.java) { error ->
+        println("Command processing timed out")
+    }
+    .subscribe()
+```
+
+## Idempotency
+
+Command idempotency is the principle of ensuring that the same command is executed at most once in the system.
+
+The command gateway uses `IdempotencyChecker` to check the `RequestId` of the command for idempotency.
+If the command has already been executed, it will throw a `DuplicateRequestIdException` exception to prevent duplicate execution of the same command.
+
+The following is an example HTTP request showing how to use `Command-Request-Id` in the request to ensure command idempotency:
+
+:::tip
+Developers can also customize the `RequestId` through the `requestId` property of `CommandMessage`.
+:::
+
+::: code-group
+
+```shell {6} [Http Request]
+curl -X 'POST' \
+  'http://localhost:8080/account/create_account' \
+  -H 'accept: application/json' \
+  -H 'Command-Wait-Stage: SNAPSHOT' \
+  -H 'Command-Aggregate-Id: sourceId' \
+  -H 'Command-Request-Id: {{$uuid}}' \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "balance": 1000,
+  "name": "source"
+}'
+```
+
+```json [Response]
+{
+  "id": "0V3oAWI60001003",
+  "waitCommandId": "0V3oAWGt0001001",
+  "stage": "SNAPSHOT",
+  "contextName": "transfer-service",
+  "aggregateName": "account",
+  "tenantId": "(0)",
+  "aggregateId": "sourceId",
+  "aggregateVersion": 1,
+  "requestId": "0V3oAWGt0001001",
+  "commandId": "0V3oAWGt0001001",
+  "function": {
+    "functionKind": "STATE_EVENT",
+    "contextName": "wow",
+    "processorName": "SnapshotDispatcher",
+    "name": "save"
+  },
+  "errorCode": "Ok",
+  "errorMsg": "",
+  "result": {},
+  "signalTime": 1764297025846,
+  "succeeded": true
+}
+```
+
+:::
+
+### Configuration
+
+```yaml {5-10}
+wow:
+  command:
+    bus:
+      type: kafka
+    idempotency:
+      enabled: true
+      bloom-filter:
+        expected-insertions: 1000000
+        ttl: PT60S
+        fpp: 0.00001
+```
+
+## Waiting Strategies
+
+*Command waiting strategy* refers to a strategy where the command gateway waits for the command execution result after sending the command.
+
+*Command waiting strategy* is an important feature in the *Wow* framework, aiming to solve the data synchronization delay problem in *CQRS* and read-write separation modes.
+
+Currently supported command waiting strategies include:
+
+### WaitingForStage
+
+The waiting signals supported by `WaitingForStage` are as follows:
+
+* `SENT`: Generates a completion signal when the command is published to the command bus/queue
+* `PROCESSED`: Generates a completion signal when the command is processed by the aggregate root
+* `SNAPSHOT`: Generates a completion signal when the snapshot is generated
+* `PROJECTED`: Generates a completion signal when the *projection* of the event produced by the command is completed
+* `EVENT_HANDLED`: Generates a completion signal when the event produced by the command is processed by the *event processor*
+* `SAGA_HANDLED`: Generates a completion signal when the event produced by the command is processed by *Saga*
+
+::: code-group
+
+```shell {4} [Http Request]
+curl -X 'POST' \
+  'http://localhost:8080/account/create_account' \
+  -H 'accept: application/json' \
+  -H 'Command-Wait-Stage: SNAPSHOT' \
+  -H 'Command-Aggregate-Id: targetId' \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "balance": 1000,
+  "name": "target"
+}'
+```
+
+```json [Response]
+{
+  "id": "0V3oAdHd0001007",
+  "waitCommandId": "0V3oAdHV0001005",
+  "stage": "SNAPSHOT",
+  "contextName": "transfer-service",
+  "aggregateName": "account",
+  "tenantId": "(0)",
+  "aggregateId": "targetId",
+  "aggregateVersion": 1,
+  "requestId": "0V3oAdHV0001005",
+  "commandId": "0V3oAdHV0001005",
+  "function": {
+    "functionKind": "STATE_EVENT",
+    "contextName": "wow",
+    "processorName": "SnapshotDispatcher",
+    "name": "save"
+  },
+  "errorCode": "Ok",
+  "errorMsg": "",
+  "result": {},
+  "signalTime": 1764297052692,
+  "succeeded": true
+}
+```
+
+```text [SSE Response]
+id:0V3oCwcv0001002
+event:SENT
+data:{"id":"0V3oCwcv0001002","waitCommandId":"0V3oCwbn0001001","stage":"SENT","contextName":"transfer-service","aggregateName":"account","tenantId":"(0)","aggregateId":"targetId","aggregateVersion":0,"requestId":"0V3oCwbn0001001","commandId":"0V3oCwbn0001001","function":{"functionKind":"COMMAND","contextName":"wow","processorName":"CommandGateway","name":"send"},"errorCode":"Ok","errorMsg":"","result":{},"signalTime":1764297603701,"succeeded":true}
+
+id:0V3oCwbn0001001
+event:PROCESSED
+data:{"id":"0V3oCwbn0001001","waitCommandId":"0V3oCwbn0001001","stage":"PROCESSED","contextName":"transfer-service","aggregateName":"account","tenantId":"(0)","aggregateId":"targetId","aggregateVersion":1,"requestId":"0V3oCwbn0001001","commandId":"0V3oCwbn0001001","function":{"functionKind":"COMMAND","contextName":"transfer-service","processorName":"Account","name":"onCommand"},"errorCode":"Ok","errorMsg":"","result":{},"signalTime":1764297603737,"succeeded":true}
+
+id:0V3oCwdB0001003
+event:SNAPSHOT
+data:{"id":"0V3oCwdB0001003","waitCommandId":"0V3oCwbn0001001","stage":"SNAPSHOT","contextName":"transfer-service","aggregateName":"account","tenantId":"(0)","aggregateId":"targetId","aggregateVersion":1,"requestId":"0V3oCwbn0001001","commandId":"0V3oCwbn0001001","function":{"functionKind":"STATE_EVENT","contextName":"wow","processorName":"SnapshotDispatcher","name":"save"},"errorCode":"Ok","errorMsg":"","result":{},"signalTime":1764297603754,"succeeded":true}
+```
+
+```kotlin {1}
+commandGateway.sendAndWaitForProcessed(message)
+```
+
+:::
+
+### WaitingForChain
+
+::: code-group
+
+```shell {4-6} [Http Request]
+curl -X 'POST' \
+  'http://localhost:8080/account/sourceId/prepare' \
+  -H 'accept: application/json' \
+  -H 'Command-Wait-Stage: SAGA_HANDLED' \
+  -H 'Command-Wait-Tail-Stage: SNAPSHOT' \
+  -H 'Command-Wait-Tail-Processor: TransferSaga' \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "amount": 100,
+  "to": "targetId"
+}'
+```
+
+```json [Response]
+{
+  "id": "0V3oAkw6000100G",
+  "waitCommandId": "0V3oAkvW0001009",
+  "stage": "SNAPSHOT",
+  "contextName": "transfer-service",
+  "aggregateName": "account",
+  "tenantId": "(0)",
+  "aggregateId": "targetId",
+  "aggregateVersion": 2,
+  "requestId": "0V3oAkvW0001009",
+  "commandId": "0V3oAkw2000100E",
+  "function": {
+    "functionKind": "STATE_EVENT",
+    "contextName": "wow",
+    "processorName": "SnapshotDispatcher",
+    "name": "save"
+  },
+  "errorCode": "Ok",
+  "errorMsg": "",
+  "result": {},
+  "signalTime": 1764297082107,
+  "succeeded": true
+}
+```
+
+```text [SSE Response]
+id:0V3oCVz9000100M
+event:SENT
+data:{"id":"0V3oCVz9000100M","waitCommandId":"0V3oCVyv000100L","stage":"SENT","contextName":"transfer-service","aggregateName":"account","tenantId":"(0)","aggregateId":"sourceId","aggregateVersion":null,"requestId":"0V3oCVyv000100L","commandId":"0V3oCVyv000100L","function":{"functionKind":"COMMAND","contextName":"wow","processorName":"CommandGateway","name":"send"},"errorCode":"Ok","errorMsg":"","result":{},"signalTime":1764297501291,"succeeded":true}
+
+id:0V3oCVyv000100L
+event:PROCESSED
+data:{"id":"0V3oCVyv000100L","waitCommandId":"0V3oCVyv000100L","stage":"PROCESSED","contextName":"transfer-service","aggregateName":"account","tenantId":"(0)","aggregateId":"sourceId","aggregateVersion":4,"requestId":"0V3oCVyv000100L","commandId":"0V3oCVyv000100L","function":{"functionKind":"COMMAND","contextName":"transfer-service","processorName":"Account","name":"onCommand"},"errorCode":"Ok","errorMsg":"","result":{},"signalTime":1764297501299,"succeeded":true}
+
+id:0V3oCVzW000100R
+event:SENT
+data:{"id":"0V3oCVzW000100R","waitCommandId":"0V3oCVyv000100L","stage":"SENT","contextName":"transfer-service","aggregateName":"account","tenantId":"(0)","aggregateId":"targetId","aggregateVersion":null,"requestId":"0V3oCVyv000100L","commandId":"0V3oCVzI000100Q","function":{"functionKind":"COMMAND","contextName":"wow","processorName":"CommandGateway","name":"send"},"errorCode":"Ok","errorMsg":"","result":{},"signalTime":1764297501314,"succeeded":true}
+
+id:0V3oCVzG000100P
+event:SAGA_HANDLED
+data:{"id":"0V3oCVzG000100P","waitCommandId":"0V3oCVyv000100L","stage":"SAGA_HANDLED","contextName":"transfer-service","aggregateName":"account","tenantId":"(0)","aggregateId":"sourceId","aggregateVersion":4,"requestId":"0V3oCVyv000100L","commandId":"0V3oCVyv000100L","function":{"functionKind":"EVENT","contextName":"transfer-service","processorName":"TransferSaga","name":"onEvent"},"errorCode":"Ok","errorMsg":"","result":{},"signalTime":1764297501314,"succeeded":true}
+
+id:0V3oCVzI000100Q
+event:PROCESSED
+data:{"id":"0V3oCVzI000100Q","waitCommandId":"0V3oCVyv000100L","stage":"PROCESSED","contextName":"transfer-service","aggregateName":"account","tenantId":"(0)","aggregateId":"targetId","aggregateVersion":3,"requestId":"0V3oCVyv000100L","commandId":"0V3oCVzI000100Q","function":{"functionKind":"COMMAND","contextName":"transfer-service","processorName":"Account","name":"onCommand"},"errorCode":"Ok","errorMsg":"","result":{},"signalTime":1764297501316,"succeeded":true}
+
+id:0V3oCVzX000100S
+event:SNAPSHOT
+data:{"id":"0V3oCVzX000100S","waitCommandId":"0V3oCVyv000100L","stage":"SNAPSHOT","contextName":"transfer-service","aggregateName":"account","tenantId":"(0)","aggregateId":"targetId","aggregateVersion":3,"requestId":"0V3oCVyv000100L","commandId":"0V3oCVzI000100Q","function":{"functionKind":"STATE_EVENT","contextName":"wow","processorName":"SnapshotDispatcher","name":"save"},"errorCode":"Ok","errorMsg":"","result":{},"signalTime":1764297501317,"succeeded":true}
+
+```
+
+```kotlin {1}
+val waitStrategy = SimpleWaitingForChain.chain(
+    tailStage = CommandStage.SNAPSHOT,
+    //...
+)
+commandGateway.sendAndWait(message,waitStrategy)
+```
+
+:::
+
+## Validation
+
+The command gateway uses `jakarta.validation.Validator` to validate the command before sending it. If validation fails, it will throw a CommandValidationException exception.
+
+By utilizing `jakarta.validation.Validator`, developers can use various validation annotations provided by `jakarta.validation` to ensure that commands meet the specified specifications and conditions.
+
+## LocalFirst Mode: Reducing the Impact of Network IO
+
+Normally, the process from sending a command to the aggregate root completing command processing is as follows:
+
+1. The aggregate root processor subscribes to distributed command bus messages.
+2. The client sends the command to the distributed command bus through the command gateway.
+3. The aggregate root processor receives and processes the command.
+4. The aggregate root processor sends a completion signal to the client.
+
+In the above process, steps 2 and 3 involve network IO. The goal of LocalFirst mode is to minimize the impact of this network IO. The specific process is as follows:
+
+1. The aggregate root processor subscribes to local command bus and distributed command bus messages.
+2. The client sends the command through the command gateway.
+   1. If the command gateway determines that the command cannot be processed on the local service instance, it sends the command to the distributed command bus.
+   2. If it can be processed locally, it sends the command to both the local command bus and the distributed command bus.
+3. The aggregate root processor receives the command and processes it.
+4. The aggregate root processor sends a completion signal to the client.
+
+Through *LocalFirst mode*, sending commands to the local bus and completion signal notifications do not require network IO.
+
+### Configuration
+
+```yaml {5-6}
+wow:
+  command:
+    bus:
+      type: kafka
+      local-first:
+        enabled: true # Enabled by default
+```
+
+## Command Rewriter
+
+The command rewriter (`CommandBuilderRewriter`) is used to rewrite the command's message metadata (`aggregateId`/`tenantId`, etc.) and command body (`body`).
+
+The following is an example of a password reset command rewriter:
+
+::: tip
+Before a user resets their password (recovers password), they cannot obtain the aggregate root ID, so this rewriter is needed to obtain the `User` aggregate root ID
+:::
+
+```kotlin
+/**
+ * Password recovery (`ResetPwd`) command rewriter.
+ *
+ * This command needs to query the user aggregate root ID based on the phone number in the command body to meet the requirement that the command message aggregate root ID is mandatory.
+ *
+ */
+@Service
+class ResetPwdCommandBuilderRewriter(private val queryService: SnapshotQueryService<UserState>) :
+   CommandBuilderRewriter {
+   override val supportedCommandType: Class<ResetPwd>
+      get() = ResetPwd::class.java
+
+   override fun rewrite(commandBuilder: CommandBuilder): Mono<CommandBuilder> {
+      return singleQuery {
+         projection { include(Documents.ID_FIELD) }
+         condition {
+            nestedState()
+            PHONE_VERIFIED eq true
+            PHONE eq commandBuilder.bodyAs<ResetPwd>().phone
+         }
+      }.dynamicQuery(queryService)
+         .switchIfEmpty {
+            IllegalArgumentException("Phone number not bound.").toMono()
+         }.map {
+            commandBuilder.aggregateId(it.getValue(MessageRecords.AGGREGATE_ID))
+         }
+   }
+}
+```
+
+Developers can register the rewriter by using Spring's `@Service` annotation to register it in the Spring container.
+
+## Troubleshooting
+
+### Common Issues
+
+**Command times out**
+- Check if the aggregate is in a dead-letter state
+- Verify the wait strategy matches the operation (e.g., `SNAPSHOT` for long-running operations)
+- Increase timeout: `.timeout(Duration.ofSeconds(30))`
+
+**DuplicateRequestIdException**
+- Ensure each command has a unique `requestId` in `CommandMessage`
+- The idempotency checker caches recent request IDs - wait for TTL expiration or use a new ID
+
+**Aggregate state not rebuilding**
+- Verify `@OnSourcing` handlers exist in the State Aggregate
+- Check that event revision numbers are compatible
+- Ensure the EventStore contains the aggregate's events
+
+**CommandValidationException on valid command**
+- Verify JSR-303 annotations are on the command body (not the aggregate)
+- Check `jakarta.validation` dependency is included
+
+**Saga not firing**
+- Verify the saga's `@OnEvent` handler subscribes to the correct aggregate's events
+- Check that the event bus topic is configured correctly
+- Ensure the saga is registered as a Spring bean

--- a/skills/wow/references/dsl.md
+++ b/skills/wow/references/dsl.md
@@ -1,0 +1,240 @@
+# Wow Query DSL Reference
+
+## Query Functions
+
+### singleQuery
+
+Query a single result.
+
+```kotlin
+singleQuery {
+    where { "status" eq "active" }
+    projection { "id", "name", "email" }
+    orderBy { "createdAt" desc }
+    limit(10)
+}.query(queryService)
+```
+
+### listQuery
+
+Query a list of results.
+
+```kotlin
+listQuery {
+    where { "age" gt 18 }
+    orderBy { "name" asc }
+    offset(0)
+    limit(20)
+}.query(queryService)
+```
+
+### pagedQuery
+
+Query with pagination.
+
+```kotlin
+pagedQuery {
+    where {
+        tenantId(tenantId)
+        "status" eq "ACTIVE"
+    }
+    page(1)
+    pageSize(20)
+    orderBy { "createdAt" desc }
+    projection { "id", "status", "totalAmount" }
+}.query(queryService)
+```
+
+## Condition Operators
+
+### Field Queries
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `eq` / `ne` | Equals / Not equals | `"status" eq "ACTIVE"` |
+| `gt` / `lt` | Greater / Less than | `"age" gt 18` |
+| `gte` / `lte` | Greater/Less than or equal | `"age" gte 18` |
+| `contains` | String contains | `"name" contains "John"` |
+| `isIn` / `notIn` | In list / Not in list | `"status" isIn listOf("A", "B")` |
+| `between` | In range (inclusive) | `"age" between 18 to 65` |
+| `all` | Array contains all | `"tags" all listOf("a", "b")` |
+| `startsWith` | String prefix | `"email" startsWith "admin"` |
+| `endsWith` | String suffix | `"email" endsWith "@company.com"` |
+| `elemMatch` | Array element matches | `"items" elemMatch { "price" gt 100 }` |
+| `isNull()` | Is null | `"phone".isNull()` |
+| `notNull()` | Is not null | `"email".notNull()` |
+| `isTrue()` | Is true | `"active".isTrue()` |
+| `isFalse()` | Is false | `"deleted".isFalse()` |
+| `exists` | Field exists | `"optionalField".exists()` |
+| `raw()` | Raw query | `raw("1=1")` |
+
+### ID Queries
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `id()` | By document ID | `id("order-123")` |
+| `ids()` | By multiple IDs | `ids("id1", "id2", "id3")` |
+| `aggregateId()` | By aggregate ID | `aggregateId("cart-456")` |
+| `aggregateIds()` | By multiple aggregate IDs | `aggregateIds("id1", "id2")` |
+| `tenantId()` | By tenant ID | `tenantId("tenant-1")` |
+| `ownerId()` | By owner ID | `ownerId("user-1")` |
+| `deleted()` | By deletion state | `deleted(DeletionState.ALL)` |
+
+### Date/Time Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `today()` | Within today | `"createdAt".today()` |
+| `tomorrow()` | Within tomorrow | `"scheduledAt".tomorrow()` |
+| `beforeToday()` | Before today | `"createdAt".beforeToday()` |
+| `thisWeek()` | Within this week | `"createdAt".thisWeek()` |
+| `nextWeek()` | Within next week | `"startDate".nextWeek()` |
+| `lastWeek()` | Within last week | `"createdAt".lastWeek()` |
+| `thisMonth()` | Within this month | `"createdAt".thisMonth()` |
+| `lastMonth()` | Within last month | `"createdAt".lastMonth()` |
+| `recentDays(n)` | Within n recent days | `"updatedAt".recentDays(7)` |
+| `earlierDays(n)` | More than n days ago | `"createdAt".earlierDays(30)` |
+
+### Logical Combinations
+
+```kotlin
+condition {
+    deleted(DeletionState.ALL)
+    tenantId(tenantId)
+    and {
+        "status" eq "ACTIVE"
+        "amount" gt 100
+    }
+    or {
+        "type" eq "VIP"
+        "type" eq "PREMIUM"
+    }
+    nor {
+        "status" eq "SUSPENDED"
+    }
+    all()  // Match all documents
+}
+```
+
+### Nested Field Queries
+
+```kotlin
+condition {
+    "state" nested {
+        "status" eq "ACTIVE"
+        "recoverable" ne "UNRECOVERABLE"
+        "child" nested {
+            "field" eq "value"
+        }
+    }
+    nestedState()  // Query on nested state field
+}
+```
+
+## Projection
+
+Select specific fields to return.
+
+```kotlin
+projection {
+    include("id", "name", "email")
+    exclude("password", "secret")
+}
+```
+
+Or inline:
+
+```kotlin
+projection { "id", "status", "totalAmount" }
+```
+
+## Sorting
+
+```kotlin
+sort {
+    "createdAt".asc()
+    "name".desc()
+}
+
+orderBy {  // Shorthand
+    "createdAt".desc()
+}
+```
+
+## Pagination
+
+### Page-based (1-indexed)
+
+```kotlin
+pagedQuery {
+    page(1)      // 1-indexed page number
+    pageSize(20) // items per page
+}
+
+// Or using pagination {}
+pagination {
+    index(1)
+    size(10)
+}
+```
+
+### Offset-based
+
+```kotlin
+listQuery {
+    offset(0)
+    limit(20)
+}
+```
+
+## Query Rewriting
+
+For security/tenant filtering, you can rewrite queries:
+
+```kotlin
+@Component
+@Order(ORDER_FIRST)
+@FilterType(SnapshotQueryHandler::class)
+class DataFilterSnapshotQueryFilter : SnapshotQueryFilter {
+    override fun filter(
+        context: QueryContext<*, *>,
+        next: FilterChain<QueryContext<*, *>>,
+    ): Mono<Void> {
+        return Mono.deferContextual {
+            context.asRewritableQuery().rewriteQuery { query ->
+                val condition = condition {
+                    nestedState()
+                    WarehouseIdCapable::warehouseId.name eq warehouseId
+                }
+                query.appendCondition(condition)
+            }
+            next.filter(context)
+        }
+    }
+}
+```
+
+## OpenAPI Auto-generation
+
+Wow automatically generates OpenAPI endpoints for queries:
+
+- `POST /{aggregate}/snapshot/paged` - Paged query
+- `POST /{aggregate}/snapshot/list` - List query
+- `POST /{aggregate}/snapshot/count` - Count query
+- `POST /{aggregate}/snapshot/single` - Single result
+
+## Query Service Injection
+
+```kotlin
+class OrderService(
+    private val queryService: SnapshotQueryService<OrderState>
+) {
+    fun getById(id: String): Mono<OrderState> {
+        return singleQuery {
+            condition { id(id) }
+        }.query(queryService).toState().throwNotFoundIfEmpty()
+    }
+}
+```
+
+Bean name convention: `AggregateName.SnapshotQueryService` (e.g., `example.order.SnapshotQueryService`)

--- a/skills/wow/references/modeling.md
+++ b/skills/wow/references/modeling.md
@@ -1,0 +1,201 @@
+# Aggregate Root Modeling
+
+## Patterns
+
+### Aggregate Pattern (Recommended)
+
+The aggregate pattern places command functions and sourcing functions (containing aggregate state data) in separate classes. This approach avoids the problem of command functions directly modifying aggregate state data (by setting the `setter` accessor to `private`).
+At the same time, separation of responsibilities allows the aggregate root's command functions to focus more on command processing, while sourcing functions focus on aggregate state data changes.
+
+#### Simple Aggregation Pattern
+
+```mermaid
+---
+title: Aggregate Modeling Using Simple Aggregation Pattern
+---
+classDiagram
+    class StateAggregate {
+        +StateAggregate(id)
+        //... state fields
+        -onSourcing(domainEvent)
+    }
+    class CommandAggregate~S: StateAggregate~ {
+        <<AggregateRoot>>
+        +CommandAggregate(state)
+        -onCommand(command)
+    }
+
+StateAggregate "1" o-- "state" CommandAggregate
+```
+
+#### Complex Aggregation Pattern
+
+```mermaid
+---
+title: Aggregate Modeling Using Complex Aggregation Pattern
+---
+classDiagram
+    class StateAggregate {
+        +StateAggregate(id)
+        //... state fields
+        -onSourcing(domainEvent)
+    }
+
+    class CommandAggregate~S: StateAggregate~ {
+        +CommandAggregate(state)
+        state: S
+        -onCommand(command)
+    }
+
+    class StateAggregateA {
+        +StateAggregateA(id)
+        //... state fields
+        -onSourcing(domainEvent)
+    }
+
+    class StateAggregateB {
+        +StateAggregateB(id)
+        //... state fields
+        -onSourcing(domainEvent)
+    }
+
+    class CommandAggregateA~StateAggregateA~ {
+        <<AggregateRoot>>
+        +CommandAggregate(state)
+        state: StateAggregateA
+        -onCommand(command)
+    }
+
+    class CommandAggregateB~StateAggregateB~ {
+        <<AggregateRoot>>
+        +CommandAggregate(state)
+        state: StateAggregateB
+        -onCommand(command)
+    }
+
+StateAggregate "1" o-- "state" CommandAggregate
+StateAggregate <|-- StateAggregateA
+StateAggregate <|-- StateAggregateB
+CommandAggregate <|-- CommandAggregateA
+CommandAggregate <|-- CommandAggregateB
+StateAggregateA "1" o-- "state" CommandAggregateA
+StateAggregateB "1" o-- "state" CommandAggregateB
+```
+
+### Single Class Pattern
+
+The single class pattern places command functions, sourcing functions, and aggregate state data together in one class. The advantage is simplicity and directness.
+
+::: danger Violation of Event Sourcing Principles
+In the single class pattern, command functions can directly modify aggregate state data, which leads to:
+
+* State changes cannot be traced via events
+* Destroys the core value of Event Sourcing
+* May result in inconsistent state changes
+
+**Strongly Recommended**: Use this pattern only for simple scenarios or prototype development.
+:::
+
+```mermaid
+---
+title: Aggregate Modeling Using Single Class
+---
+classDiagram
+    class Aggregate {
+        <<AggregateRoot>>
+        +Aggregate(id)
+        //... state fields
+        -onSourcing(domainEvent)
+        -onCommand(command)
+    }
+```
+
+### Inheritance Pattern
+
+The inheritance pattern uses the state aggregate root as the base class and sets the `setter` accessor to `private` to prevent command aggregate roots from modifying aggregate state data in command functions.
+
+```mermaid
+---
+title: Aggregate Modeling Using Inheritance Pattern
+---
+classDiagram
+    class StateAggregate {
+        +StateAggregate(id)
+        //... state fields
+        -onSourcing(domainEvent)
+    }
+
+    class CommandAggregate {
+        <<AggregateRoot>>
+        -onCommand(command)
+    }
+
+    StateAggregate <|-- CommandAggregate
+```
+
+## Conventions
+
+### Command Aggregate Root
+
+The command aggregate root is responsible for defining command handler functions, processing commands to execute corresponding business logic, and finally returning domain events.
+
+* The command aggregate root needs to add the `@AggregateRoot` annotation so that the `wow-compiler` module can generate corresponding metadata definitions.
+* The `@OnCommand` annotation for command handler functions is not required. By default, naming a command handler function `onCommand` indicates it is a command handler function.
+* The first parameter of command handler functions can be defined as: specific command (`AddCartItem`), command message (`CommandMessage<AddCartItem>`), command message exchange (`CommandExchange<AddCartItem>`).
+* The remaining parameters of command handler functions will be obtained from the `IOC` container. If you have injected an instance in the `Spring IOC` container, you can obtain it directly through parameters.
+* The return value of command handler functions is one or more domain events. These domain events will first have their state changed to the latest state by the state aggregate root through sourcing functions, then be persisted to the `EventStore`.
+  * `@OnCommand(returns = [...])` is **required** when:
+    * The return type is `Any` or `Object` (polymorphic returns)
+    * A single command can produce multiple different event types
+    * The compiler cannot infer the event type from the return statement
+  * If omitted when required, `wow-compiler` will fail to identify the returned domain event type.
+* After persistence is complete, they will be published to the event bus through the `DomainEventBus`.
+
+```kotlin
+@AggregateRoot
+class Cart(private val state: CartState) {
+
+    @OnCommand(returns = [CartItemAdded::class, CartQuantityChanged::class])
+    fun onCommand(command: AddCartItem): Any {
+        require(state.items.size < MAX_CART_ITEM_SIZE) {
+            "Shopping cart can only add up to [$MAX_CART_ITEM_SIZE] items."
+        }
+        state.items.firstOrNull {
+            it.productId == command.productId
+        }?.let {
+            return CartQuantityChanged(
+                changed = it.copy(quantity = it.quantity + command.quantity),
+            )
+        }
+        val added = CartItem(
+            productId = command.productId,
+            quantity = command.quantity,
+        )
+        return CartItemAdded(
+            added = added,
+        )
+    }
+}
+```
+
+### State Aggregate Root
+
+The state aggregate root defines aggregate state data and sourcing functions.
+
+* The state aggregate root must define the aggregate root ID field in the constructor.
+* The role of sourcing functions is to apply domain events to aggregate state data, thereby changing aggregate state data.
+* Sourcing functions are marked with the `@OnSourcing` annotation. However, this annotation is optional. By default, when the function name is `onSourcing`, it indicates that the function is a sourcing function.
+* Sourcing functions accept parameters of: specific domain events (`CartItemAdded`), domain events (`DomainEvent<CartItemAdded>`).
+* No return value needs to be defined for sourcing functions.
+
+```kotlin
+class CartState(val id: String) {
+    var items: List<CartItem> = listOf()
+        private set
+
+    @OnSourcing
+    fun onCartItemAdded(cartItemAdded: CartItemAdded) {
+        items = items + cartItemAdded.added
+    }
+}
+```

--- a/skills/wow/references/prepare-key.md
+++ b/skills/wow/references/prepare-key.md
@@ -1,0 +1,129 @@
+# Prepare Key
+
+Compared to traditional databases, developers can add uniqueness constraints by setting `UNIQUE KEY` for fields.
+But in the *EventSourcing* architecture, we need to ensure `Key` uniqueness at the application level, and the `PrepareKey` specification was born for this purpose.
+
+## Define PrepareKey
+
+To use `PrepareKey`, you need to define an interface annotated with `@PreparableKey`, which must extend `PrepareKey<T>`, where `T` is the type of the key.
+
+```kotlin
+import me.ahoo.wow.api.annotation.PreparableKey
+import me.ahoo.wow.infra.prepare.PrepareKey
+
+@PreparableKey(name = "username_idx")
+interface UsernamePrepare : PrepareKey<String>
+```
+
+* `@PreparableKey(name = "username_idx")`: Specifies the name of the prepared key, used to identify the key's index in storage.
+* `PrepareKey<String>`: The generic parameter `String` indicates the key type is string.
+
+The framework automatically scans interfaces annotated with `@PreparableKey`, creates proxy instances through `PrepareKeyProxyFactory`, and registers them as Spring Beans with the interface's simple name as the bean name. This allows dependency injection to obtain `PrepareKey` instances in aggregates.
+
+## PrepareKey Interface Methods
+
+The `PrepareKey<V>` interface provides the following core methods:
+
+### Prepare Key
+
+* `prepare(key: String, value: V)`: Permanently prepares a key, ensuring other operations cannot use the same key until explicitly rolled back.
+* `prepare(key: String, value: PreparedValue<V>)`: Prepares a key with TTL (Time-To-Live) support, automatically expiring after the specified time.
+
+### Get Prepared Value
+
+* `get(key: String)`: Retrieves a non-expired prepared value.
+* `getValue(key: String)`: Retrieves complete prepared value information, including expiration status.
+
+### Rollback Key
+
+* `rollback(key: String)`: Unconditionally rolls back the specified key.
+* `rollback(key: String, value: V)`: Conditionally rolls back only if the value matches, ensuring atomicity.
+
+### Reprepare Key
+
+* `reprepare(key: String, oldValue: V, newValue: V)`: Updates the value of an existing key, using the old value for concurrency control.
+* `reprepare(oldKey: String, oldValue: V, newKey: String, newValue: V)`: Atomically releases the old key and prepares the new key, commonly used for scenarios like username changes.
+
+### Execute Operation in Prepare Context
+
+* `usingPrepare(key: String, value: V, then: (Boolean) -> Mono<R>)`: Executes an operation within a prepare context, automatically rolling back preparation if the operation fails, providing transaction-like semantics.
+
+## PreparedValue and TTL Support
+
+`PreparedValue<V>` encapsulates the value and optional TTL configuration:
+
+* Permanent preparation: `value.toForever()`
+* TTL preparation: `PreparedValue(value, Duration.ofMinutes(5))`
+
+TTL support allows temporary key reservations that automatically clean up after expiration, suitable for temporary operations requiring cleanup.
+
+## Value Type
+
+The `V` type parameter in `PrepareKey<V>` is a user-defined data class that stores the data associated with the prepared key. For example, for username uniqueness:
+
+```kotlin
+data class UsernameIndexValue(
+    val userId: String,
+    val password: String
+)
+```
+
+This value is stored alongside the key and can be retrieved to verify ownership or perform operations.
+
+## User Registration Scenario
+
+For example, when a user registers, the uniqueness of the username needs to be guaranteed:
+
+```kotlin
+@AggregateRoot
+class User(private val state: UserState) {
+    @OnCommand
+    private fun onRegister(
+        register: Register,
+        passwordEncoder: PasswordEncoder,
+        usernamePrepare: UsernamePrepare,
+    ): Mono<Registered> {
+        val encodedPassword = passwordEncoder.encode(register.password)
+        return usernamePrepare.usingPrepare(
+            key = register.username,
+            value = UsernameIndexValue(
+                userId = state.id,
+                password = encodedPassword,
+            ),
+        ) {
+            require(it) {
+                "username[${register.username}] is already registered."
+            }
+            Registered(username = register.username, password = encodedPassword).toMono()
+        }
+    }
+}
+```
+
+## User Change Username Scenario
+
+For example, when a user changes their username, the uniqueness of the new username needs to be guaranteed, and the old username needs to be rolled back:
+
+```kotlin
+    @OnCommand
+    private fun onChangeUsername(
+        changeUsername: ChangeUsername,
+        usernamePrepare: UsernamePrepare
+    ): Mono<UsernameChanged> {
+        val usernameIndexValue = UsernameIndexValue(
+            userId = state.id,
+            password = state.password,
+        )
+        return usernamePrepare.reprepare(
+            oldKey = state.username,
+            oldValue = usernameIndexValue,
+            newKey = changeUsername.newUsername,
+            newValue = usernameIndexValue
+        ).map {
+            require(it) {
+                "username[${changeUsername.newUsername}] is already registered."
+            }
+            UsernameChanged(username = changeUsername.newUsername)
+        }
+    }
+```

--- a/skills/wow/references/testing.md
+++ b/skills/wow/references/testing.md
@@ -1,0 +1,400 @@
+# Wow Testing Patterns Reference
+
+## Test Suite Overview
+
+Wow provides a Given→When→Expect test pattern:
+- **Given**: Previous domain events to initialize aggregate state
+- **When**: Current command to trigger state changes
+- **Expect**: Verify state changes meet expectations
+
+## AggregateSpec
+
+Testing aggregates using Given-When-Expect pattern.
+
+### Basic Structure
+
+```kotlin
+class CartSpec : AggregateSpec<Cart, CartState>(
+    {
+        on {
+            // Given
+            val ownerId = generateGlobalId()
+            givenOwnerId(ownerId)
+
+            // When
+            val addCartItem = AddCartItem(productId = "product-1", quantity = 1)
+            whenCommand(addCartItem) {
+                // Then
+                expectNoError()
+                expectEventType(CartItemAdded::class)
+                expectState {
+                    items.assert().hasSize(1)
+                }
+            }
+        }
+    }
+)
+```
+
+### GivenDsl Methods
+
+| Method | Description |
+|--------|-------------|
+| `givenOwnerId(id)` | Set the aggregate ID |
+| `givenEvent(event)` | Initialize with a domain event |
+| `givenEvent(events)` | Initialize with multiple events |
+| `givenState(state, version)` | Initialize with direct state |
+| `inject { register(...) }` | Inject mock services |
+| `name("description")` | Name this test scenario |
+
+### WhenDsl Methods
+
+| Method | Description |
+|--------|-------------|
+| `whenCommand(cmd)` | Execute a command |
+| `whenCommand(cmd) { }` | Execute with expectations |
+
+### ExpectDsl Methods
+
+| Method | Description |
+|--------|-------------|
+| `expectNoError()` | Assert no error occurred |
+| `expectError()` | Assert an error occurred |
+| `expectErrorType<T>()` | Assert specific error type |
+| `expectError(expected: E.() -> Unit)` | Assert error content |
+| `expectEventType<T>()` | Assert specific event type was emitted |
+| `expectEventBody<T> { }` | Assert event body content |
+| `expectEventCount(n)` | Assert number of events |
+| `expectEventStream { }` | Assert complete event stream |
+| `expectState { }` | Assert aggregate state |
+| `expectStateAggregate { }` | Assert aggregate metadata |
+| `expect(expected: ExpectedResult<S>.() -> Unit)` | Complete result expectations |
+
+### Branching with fork()
+
+| Method | Description |
+|--------|-------------|
+| `fork(name) { }` | Create a branch test scenario |
+| `fork(ref, name) { }` | Branch from a reference point |
+| `fork(ref, name, verifyError) { }` | Branch with error verification |
+| `ref("name")` | Mark a verification point |
+
+### Fork Use Cases
+
+- **Sequential Operations**: Order → Payment → Shipping
+- **Error Scenarios**: Invalid operations in different states
+- **Alternative Paths**: Different command sequences from same point
+- **Aggregate Lifecycle**: Deletion, recovery, behavior after deletion
+- **Business Rules**: Constraints across state transitions
+
+### Reference Points
+
+Mark points for cross-scenario branching:
+
+```kotlin
+whenCommand(CreateOrder(...)) {
+    expectEventType(OrderCreated::class)
+    ref("order-created")  // Mark this point
+    expectState { status.assert().isEqualTo(OrderStatus.CREATED) }
+}
+
+// Later, branch from marked point
+fork("order-created", "Pay Order") {
+    whenCommand(PayOrder(...)) {
+        expectEventType(OrderPaid::class)
+    }
+}
+```
+
+### Complete Example with Forks
+
+```kotlin
+class OrderSpec : AggregateSpec<Order, OrderState>({
+    on {
+        val ownerId = generateGlobalId()
+        givenOwnerId(ownerId)
+
+        val createOrder = CreateOrder(items, address, false)
+        whenCommand(createOrder) {
+            expectNoError()
+            expectEventType(OrderCreated::class)
+
+            fork("Pay Order") {
+                val payOrder = PayOrder(totalAmount)
+                whenCommand(payOrder) {
+                    expectEventType(OrderPaid::class)
+                    expectState { status.assert().isEqualTo(OrderStatus.PAID) }
+
+                    fork("Ship Order") {
+                        val shipOrder = ShipOrder(aggregateId.id)
+                        whenCommand(shipOrder) {
+                            expectEventType(OrderShipped::class)
+                        }
+                    }
+                }
+            }
+
+            fork("Ship Before Payment") {
+                val shipOrder = ShipOrder(aggregateId.id)
+                whenCommand(shipOrder) {
+                    expectErrorType(IllegalStateException::class)
+                }
+            }
+        }
+    }
+})
+```
+
+### Injecting Mock Services
+
+```kotlin
+on {
+    val inventoryService = object : InventoryService {
+        override fun getInventory(productId: String) = quantity.toMono()
+    }
+    val pricingService = object : PricingService {
+        override fun getProductPrice(productId: String) = price.toMono()
+    }
+
+    inject {
+        register(DefaultCreateOrderSpec(inventoryService, pricingService))
+    }
+
+    whenCommand(CreateOrder(items, address, false)) {
+        expectNoError()
+    }
+}
+```
+
+## SagaSpec
+
+Testing stateless sagas.
+
+### Basic Structure
+
+```kotlin
+class TransferSagaSpec : SagaSpec<TransferSaga>({
+    on {
+        val prepared = Prepared("to", 1)
+        whenEvent(prepared) {
+            expectNoError()
+            expectCommandType(Entry::class)
+            expectCommandBody<Entry> {
+                id.assert().isEqualTo(prepared.to)
+                amount.assert().isEqualTo(prepared.amount)
+            }
+        }
+    }
+})
+```
+
+### Saga WhenDsl Methods
+
+| Method | Description |
+|--------|-------------|
+| `whenEvent(event, ownerId)` | Trigger saga with event |
+| `name("description")` | Name this test scenario |
+| `functionFilter { }` | Filter message functions |
+| `functionName("name")` | Filter by function name |
+
+### Saga ExpectDsl Methods
+
+| Method | Description |
+|--------|-------------|
+| `expectNoError()` | Assert no error occurred |
+| `expectNoCommand()` | Assert no command was sent |
+| `expectCommandType<T>()` | Assert specific command type was sent |
+| `expectCommand<T> { }` | Assert command content |
+
+### Full Saga Example
+
+```kotlin
+class CartSagaSpec : SagaSpec<CartSaga>({
+    on {
+        name("From cart - should remove items")
+        val orderItem = OrderItem(...)
+        whenEvent(
+            event = mockk<OrderCreated> {
+                every { items } returns listOf(orderItem)
+                every { fromCart } returns true
+            },
+            ownerId = ownerId
+        ) {
+            expectCommandType(RemoveCartItem::class)
+            expectCommand<RemoveCartItem> {
+                body.productIds.assert().contains(orderItem.productId)
+            }
+        }
+    }
+
+    on {
+        name("Not from cart - should do nothing")
+        whenEvent(
+            event = mockk<OrderCreated> {
+                every { items } returns listOf(orderItem)
+                every { fromCart } returns false
+            },
+            ownerId = ownerId
+        ) {
+            expectNoCommand()
+        }
+    }
+})
+```
+
+## ProjectionSpec
+
+Testing projection processors for maintaining read models.
+
+### Basic Structure
+
+```kotlin
+class OrderProjectorSpec : ProjectionSpec<OrderProjector, OrderState>({
+    on {
+        val event = OrderCreated(orderId = "order-1", items = listOf)
+        whenEvent(event) {
+            expectNoError()
+            expectState {
+                id.assert().isEqualTo("order-1")
+            }
+        }
+    }
+})
+```
+
+### Projection WhenDsl Methods
+
+| Method | Description |
+|--------|-------------|
+| `whenEvent(event)` | Trigger projection with event |
+| `name("description")` | Name this test scenario |
+
+### Projection ExpectDsl Methods
+
+| Method | Description |
+|--------|-------------|
+| `expectNoError()` | Assert no error occurred |
+| `expectError()` | Assert an error occurred |
+| `expectState { }` | Assert projected state |
+
+### Complete Projection Example
+
+```kotlin
+class OrderProjectorSpec : ProjectionSpec<OrderProjector, OrderState>({
+    on {
+        name("OrderCreated - should project state")
+        val created = OrderCreated(
+            orderId = "order-1",
+            items = listOf(OrderItem("product-1", 2))
+        )
+        whenEvent(created) {
+            expectNoError()
+            expectState {
+                id.assert().isEqualTo("order-1")
+                items.assert().hasSize(1)
+            }
+        }
+    }
+
+    on {
+        name("OrderPaid - should update status")
+        givenEvent(OrderCreated(...))
+        val paid = OrderPaid(orderId = "order-1")
+        whenEvent(paid) {
+            expectNoError()
+            expectState {
+                status.assert().isEqualTo(OrderStatus.PAID)
+            }
+        }
+    }
+})
+```
+
+## FluentAssert Assertions
+
+Use `me.ahoo.test.asserts.assert` for assertions:
+
+```kotlin
+import me.ahoo.test.asserts.assert
+
+// Primitives
+42.assert().isGreaterThan(0)
+"hello".assert().startsWith("hel")
+
+// Collections
+listOf(1, 2, 3).assert().hasSize(3).contains(2)
+
+// Nested assertions
+expectState {
+    items.assert().hasSize(1)
+    items.first().productId.assert().isEqualTo("product-1")
+}
+```
+
+## Test Fixtures
+
+### generateGlobalId
+
+Generate a unique aggregate ID for testing:
+
+```kotlin
+val ownerId = generateGlobalId()
+```
+
+### mockk
+
+Use mockk for mocking events:
+
+```kotlin
+import io.mockk.mockk
+import io.mockk.every
+
+val mockOrderCreated = mockk<OrderCreated> {
+    every { items } returns listOf(orderItem)
+    every { fromCart } returns true
+}
+```
+
+## Default Test Commands/Events
+
+Wow provides built-in commands for testing:
+
+```kotlin
+// Delete aggregate
+whenCommand(DefaultDeleteAggregate) {
+    expectEventType(DefaultAggregateDeleted::class)
+}
+
+// Recover deleted aggregate
+whenCommand(DefaultRecoverAggregate) { ... }
+```
+
+Built-in exceptions:
+
+```kotlin
+expectErrorType(IllegalAccessDeletedAggregateException::class)
+expectErrorType(IllegalStateException::class)
+expectErrorType(DomainEventException::class)
+```
+
+## Running Tests
+
+```bash
+# Run specific test class
+./gradlew test --tests "me.ahoo.wow.example.domain.cart.CartSpec"
+
+# Run with coverage
+./gradlew domain:jacocoTestReport
+
+# Verify coverage
+./gradlew domain:jacocoTestCoverageVerification
+```
+
+## Best Practices
+
+1. **Test Coverage Target**: ≥85% for domain models
+2. **Use fork() for related operations** within same scenario
+3. **Use separate on {} blocks** for unrelated scenarios
+4. **Avoid deep nesting** (>3 levels) - use `ref()` and `fork(ref, ...)`
+5. **Use descriptive names** for fork scenarios
+6. **Test error cases** - verify behavior in invalid states


### PR DESCRIPTION
- Add evals.json with 5 evaluation prompts covering Cart aggregate, TransferSaga, unit tests, Order projection, and query DSL scenarios
- Create annotations.md reference with detailed documentation on all Wow framework annotations including @AggregateRoot, @OnCommand, @OnSourcing, @StatelessSaga, @OnEvent, @ProjectionProcessor, @Blocking, and @Retry
- Add command-gateway.md with complete API documentation covering send methods, ClientCommandExchange, CommandResult, error handling, idempotency, and waiting strategies including WaitingForStage and WaitingForChain
- Include DSL reference for query functions (singleQuery, listQuery, pagedQuery) with comprehensive operator tables for field queries, ID queries, date/time operations, and logical combinations


