### PR TITLE
chore(deps): update spring-boot and fluent-assert dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # libraries
-spring-boot = "4.0.5"
+spring-boot = "4.0.6"
 cosid = "3.0.5"
 simba = "3.0.1"
 coapi = "2.0.1"
@@ -19,7 +19,7 @@ kotlinx-coroutines = "1.10.2"
 reactor-kafka = "1.3.25"
 # testing
 junit = "6.0.3"
-fluent-assert = "0.2.6"
+fluent-assert = "0.2.8"
 mockk = "1.14.9"
 kotlin-compile-testing = "0.12.1"
 jmh = "1.37"


### PR DESCRIPTION
- Updated spring-boot from version 4.0.5 to 4.0.6
- Updated fluent-assert from version 0.2.6 to 0.2.8


