### PR TITLE
docs(skill): fix factual errors in Wow skill — DSL API, annotations, testing, config

### DIFF
--- a/skills/wow/SKILL.md
+++ b/skills/wow/SKILL.md
@@ -1,18 +1,24 @@
 ---
 name: wow
 description: |
-  Wow framework assistant for building DDD + Event Sourcing + CQRS microservices. Use this skill whenever the user mentions:
-  - DDD, Domain-Driven Design, aggregate roots, entities, value objects
-  - CQRS, Command Query Responsibility Segregation, read models, write models
-  - Event Sourcing, events, event store, snapshots
-  - Distributed transactions, saga, orchestration, compensation
-  - Projection processors, read model updates, query services
-  - Command gateway, wait strategies, command bus
-  - Wow framework, wow-project-template
-  - Unit testing with Given-When-Expect pattern, AggregateSpec, SagaSpec
+  Wow framework assistant for building reactive DDD + Event Sourcing + CQRS microservices in Kotlin/Java on JVM 17+ with Spring Boot.
 
-  This skill helps create, modify, and test Wow framework components including aggregates, sagas, projections, and command handlers.
-compatibility: Kotlin, Spring Boot, Gradle, MongoDB, Kafka
+  Use this skill whenever the user mentions:
+  - DDD, Domain-Driven Design, aggregate roots, entities, value objects, bounded context
+  - CQRS, Command Query Responsibility Segregation, read models, write models
+  - Event Sourcing, events, event store, snapshots, domain events
+  - Distributed transactions, saga, orchestration, compensation, stateless saga
+  - Projection processors, read model updates, query services, event processors
+  - Command gateway, wait strategies, command bus, wait chains
+  - Wow framework, wow-project-template, wow-compiler, wow-test, wow-tck
+  - AggregateSpec, SagaSpec, AggregateVerifier, SagaVerifier, Given-When-Expect testing pattern
+  - Annotations: @AggregateRoot, @OnCommand, @OnSourcing, @OnEvent, @StatelessSaga, @ProjectionProcessor, @EventProcessor, @AfterCommand, @OnError, @OnStateEvent, @Retry, @BoundedContext, @CreateAggregate, @CommandRoute
+  - PrepareKey, uniqueness constraints, event compensation, execution failed
+  - Multi-tenancy, optimistic concurrency, aggregate lifecycle, soft delete/recover
+  - Kotlin microservice, reactive programming, Project Reactor, WebFlux
+
+  Also trigger when the user asks about designing a domain model, building an event-sourced aggregate, implementing a saga, creating a projection, writing Wow tests, configuring a Wow application, or any task that involves creating/modifying Kotlin files in a Wow-based project. Use this skill even if the user doesn't explicitly say "Wow" but is working in a project with Wow dependencies or Wow-style code patterns (aggregates with state classes, @AggregateRoot, command/event data classes).
+compatibility: Kotlin 2.3, JVM 17+, Spring Boot 4.x, Gradle, MongoDB, Kafka, Reactor
 ---
 
 # Wow Framework Skill
@@ -25,52 +31,39 @@ Wow is a modern reactive CQRS microservice framework based on DDD and Event Sour
 Write Path: Command → Aggregate → Event → EventStore → EventBus
                                        ↓
 Read Path:                     Projection → ReadModel
+Saga Path:                     EventBus → Saga → CommandBus
 ```
 
 ## Module Structure
 
 | Module | Purpose |
 |--------|---------|
-| `wow-api` | Public annotations and interfaces |
-| `wow-core` | Core runtime (commands, events, sagas, projections) |
+| `wow-api` | Public annotations and interfaces (`@AggregateRoot`, `@OnCommand`, `@Event`, etc.) |
+| `wow-core` | Core runtime (aggregates, command bus, event sourcing, projections, sagas) |
+| `wow-compiler` | KSP processor — generates command routing, event handling metadata, OpenAPI specs |
+| `wow-test` | `AggregateSpec`, `SagaSpec`, `AggregateVerifier`, `SagaVerifier` — Given-When-Expect testing |
 | `wow-mongo` | MongoDB event store and snapshot support |
-| `wow-kafka` | Kafka message bus support |
+| `wow-kafka` | Kafka command/event bus |
 | `wow-query` | Query DSL and query services |
-| `wow-test` | AggregateSpec, SagaSpec, ProjectionSpec |
+| `wow-spring-boot-starter` | Auto-configuration with feature capabilities |
 
 ## Aggregate Root Modeling
 
-Wow uses the **Simple Aggregation Pattern** with separate Command Aggregate and State Aggregate classes.
+Wow uses the **Aggregate Pattern** with separate Command Aggregate and State Aggregate classes.
 
-### Complete Example (Cart Aggregate)
-
-**CartState.kt** - Holds state and handles event sourcing:
+**State Aggregate** — holds state and handles event sourcing:
 ```kotlin
-class CartState(val id: String) : ICartInfo {
-    override var items: List<CartItem> = listOf()
+class CartState(val id: String) {
+    var items: List<CartItem> = listOf()
         private set
 
-    fun onCartItemAdded(cartItemAdded: CartItemAdded) {
-        items = items + cartItemAdded.added
-    }
-
-    fun onCartItemRemoved(cartItemRemoved: CartItemRemoved) {
-        items = items.filter { !cartItemRemoved.productIds.contains(it.productId) }
-    }
-
-    fun onCartQuantityChanged(cartQuantityChanged: CartQuantityChanged) {
-        items = items.map {
-            if (it.productId == cartQuantityChanged.changed.productId) {
-                cartQuantityChanged.changed
-            } else {
-                it
-            }
-        }
+    fun onCartItemAdded(event: CartItemAdded) {
+        items = items + event.added
     }
 }
 ```
 
-**Cart.kt** - Handles commands and returns events:
+**Command Aggregate** — handles commands and returns events:
 ```kotlin
 @AggregateRoot(commands = [AddCartItem::class, RemoveCartItem::class])
 class Cart(private val state: CartState) {
@@ -79,124 +72,49 @@ class Cart(private val state: CartState) {
         require(state.items.size < MAX_CART_ITEM_SIZE) {
             "Shopping cart can only add up to [$MAX_CART_ITEM_SIZE] items."
         }
-        state.items.firstOrNull {
-            it.productId == command.productId
-        }?.let {
+        state.items.firstOrNull { it.productId == command.productId }?.let {
             return CartQuantityChanged(changed = it.copy(quantity = it.quantity + command.quantity))
         }
         return CartItemAdded(added = CartItem(productId = command.productId, quantity = command.quantity))
-    }
-
-    fun onCommand(command: RemoveCartItem): CartItemRemoved {
-        return CartItemRemoved(productIds = command.productIds)
     }
 }
 ```
 
 ### Key Conventions
 
-1. **Annotations are optional** if naming convention is followed:
-   - `@OnCommand` optional if method is named `onCommand`
-   - `@OnSourcing` optional if method is named `onSourcing`
-   - `@OnEvent` optional if method is named `onEvent`
+1. **Annotations are optional** if naming convention is followed: `onCommand`, `onSourcing`, `onEvent`
+2. **@AggregateRoot(commands = [...])** specifies which commands this aggregate handles
+3. **Command handler return types**: single event, `Any` (polymorphic), or `Iterable` (multiple events)
+4. **@OnCommand(returns = [...])** is required when return type is `Any` or `Iterable`
+5. **Setter accessors on state** must be `private set` — state is only mutated through sourcing
 
-2. **@AggregateRoot annotation** specifies which commands this aggregate handles:
-   ```kotlin
-   @AggregateRoot(commands = [CreateOrder::class, UpdateOrder::class])
-   ```
-
-3. **Command handler return types**:
-   - Single event: return the event directly
-   - Multiple events: return `Any` (list of events or single event)
-   - Error: throw an exception
-
-4. **Sourcing handler parameters**:
-   - Specific event: `onCartItemAdded(event: CartItemAdded)`
-   - Generic domain event: `onSourcing(event: DomainEvent<CartItemAdded>)`
-
-### Aggregate Root Annotation Specifying Route
+### Lifecycle Hooks
 
 ```kotlin
-@StaticTenantId
-@AggregateRoot(commands = [MountedCommand::class])
-@AggregateRoute(owner = AggregateRoute.Owner.AGGREGATE_ID)
-class Cart(private val state: CartState) {
-    // ...
-}
+@AfterCommand(include = [CreateOrder::class])
+fun afterCreateOrder(exchange: ServerCommandExchange<*>): AdditionalEvent? { ... }
+
+@OnError
+fun onError(command: CreateOrder, error: Throwable) { ... }
 ```
 
-## Command Gateway
+### Other Aggregate Patterns
 
-Send commands and wait for results using wait strategies.
-
-### Basic Usage
-
-```kotlin
-val command = CreateAccount(balance = 1000, name = "John").toCommandMessage()
-
-// Wait for command to be processed by aggregate
-commandGateway.sendAndWaitForProcessed(command)
-    .doOnSuccess { result ->
-        if (result.succeeded) {
-            println("Command processed! Version: ${result.aggregateVersion}")
-        }
-    }
-```
-
-### Wait Strategy Methods
-
-| Method | Description |
-|--------|-------------|
-| `sendAndWaitForSent(command)` | Wait until command is published to bus |
-| `sendAndWaitForProcessed(command)` | Wait until aggregate processes command |
-| `sendAndWaitForSnapshot(command)` | Wait until snapshot is created |
-
-### WaitStrategy API
-
-```kotlin
-WaitingForStage.sent(commandId)
-WaitingForStage.processed(commandId)
-WaitingForStage.snapshot(commandId)
-WaitingForStage.projected(waitCommandId, contextName, processorName, functionName)
-WaitingForStage.eventHandled(...)
-WaitingForStage.sagaHandled(...)
-```
-
-### Error Handling
-
-```kotlin
-commandGateway.sendAndWaitForProcessed(command)
-    .doOnError { error ->
-        when (error) {
-            is CommandResultException -> {
-                val result = error.commandResult
-                println("Error: ${result.errorCode} - ${result.errorMsg}")
-                result.bindingErrors.forEach {
-                    println("Field ${it.name}: ${it.msg}")
-                }
-            }
-            is CommandValidationException -> { ... }
-            is DuplicateRequestIdException -> { ... }
-        }
-    }
-```
+- **Complex Aggregation**: Multiple command aggregates sharing a base state class
+- **Single Class**: Command + state in one class (avoid — violates event sourcing principles)
+- **Inheritance**: Command aggregate inherits from state aggregate
 
 ## Saga Pattern
 
-Use stateless saga for distributed transaction orchestration.
-
-### Complete Saga Example
+Stateless saga for distributed transaction orchestration.
 
 ```kotlin
 @StatelessSaga
 class CartSaga {
-
     @Retry(maxRetries = 5, minBackoff = 60, executionTimeout = 10)
     fun onEvent(event: DomainEvent<OrderCreated>): CommandBuilder? {
         val orderCreated = event.body
-        if (!orderCreated.fromCart) {
-            return null
-        }
+        if (!orderCreated.fromCart) return null
         return RemoveCartItem(
             productIds = orderCreated.items.map { it.productId }.toSet(),
         ).commandBuilder().aggregateId(event.ownerId)
@@ -206,263 +124,216 @@ class CartSaga {
 
 ### Saga Return Types
 
-```kotlin
-// Return null - no command sent
-fun onEvent(event: NoOpEvent): Nothing? = null
+| Return Type | Behavior |
+|---|---|
+| `null` | No command sent |
+| Command body | Wrapped into `CommandMessage` and sent |
+| `CommandBuilder` | Fine-grained control over aggregateId, tenantId |
+| `CommandMessage<*>` | Sent directly |
+| `Iterable` of above | Multiple commands per event |
+| `Mono<Void>` / `Mono.empty()` | Reactive no-op |
 
-// Single command
-fun onEvent(event: Event1): Command1 { ... }
+## Event & Projection Processors
 
-// Return CommandBuilder for aggregateId-aware commands
-fun onEvent(event: Event): CommandBuilder {
-    return SomeCommand(...).commandBuilder().aggregateId(event.aggregateId)
-}
+### Event Processor
 
-// Multiple commands
-fun onEvent(event: Event): List<Command> { ... }
-```
-
-### @Retry Annotation (for Sagas)
+Handles domain events for cross-aggregate operations (notifications, external integrations):
 
 ```kotlin
-@Retry(maxRetries = 5, minBackoff = 60, executionTimeout = 10)
-fun onEvent(event: DomainEvent<OrderCreated>): CommandBuilder? {
-    // ...
-}
-```
-
-### State Event Handler
-
-Sagas can access aggregate state with `onStateEvent`:
-
-```kotlin
-fun onStateEvent(orderCreated: OrderCreated, state: OrderState): Mono<Void> {
-    // Access both event and current state
-    return Mono.empty()
+@EventProcessor
+class OrderEventProcessor(private val notificationService: NotificationService) {
+    @OnEvent
+    fun onOrderCreated(event: OrderCreated): Mono<Void> {
+        return notificationService.sendOrderConfirmation(event.orderId)
+    }
 }
 ```
 
-## Projection Processor
+### Projection Processor
 
-Maintain read models for CQRS.
-
-### Basic Projection
+Maintains read models for CQRS:
 
 ```kotlin
 @ProjectionProcessor
-class OrderProjector {
+class OrderProjector(private val repository: OrderSummaryRepository) {
+    fun onEvent(orderCreated: OrderCreated): Mono<Void> {
+        return repository.save(OrderSummary.from(orderCreated))
+    }
+
+    fun onStateEvent(event: OrderPaid, state: OrderState): Mono<Void> {
+        // Access both event and full aggregate state
+    }
 
     @Blocking
-    fun onEvent(orderCreated: OrderCreated) {
-        // Synchronous handling
-    }
-
-    fun onStateEvent(orderCreated: OrderCreated, state: OrderState): Mono<Void> {
-        // Access full aggregate state
-        return Mono.empty()
-    }
-
-    fun onEvent(orderPaid: OrderPaid): Mono<Void> {
-        return Mono.empty()
+    fun onEvent(orderShipped: OrderShipped) {
+        emailService.sendNotification(...)
     }
 }
 ```
 
-### Key Projection Patterns
-
-1. **@Blocking** - marks synchronous blocking operations
-2. **onStateEvent(event, state)** - access both event and full aggregate state
-3. **Return Mono<Void>** - reactive handling for async operations
-
-## Query Service DSL
-
-Query read models using the Query DSL.
-
-### Query Functions
+## Command Gateway
 
 ```kotlin
-// Single result
+val command = CreateAccount(balance = 1000, name = "John").toCommandMessage()
+
+// Convenience methods
+commandGateway.sendAndWaitForSent(command)
+commandGateway.sendAndWaitForProcessed(command)
+commandGateway.sendAndWaitForSnapshot(command)
+
+// Wait strategies
+WaitingForStage.sent(commandId)
+WaitingForStage.processed(commandId)
+WaitingForStage.snapshot(commandId)
+WaitingForStage.projected(waitCommandId, contextName, processorName, functionName)
+WaitingForStage.sagaHandled(...)
+
+// Chain strategy — wait for saga + downstream processing
+val waitStrategy = SimpleWaitingForChain.chain(tailStage = CommandStage.SNAPSHOT, ...)
+commandGateway.sendAndWait(message, waitStrategy)
+```
+
+## Query DSL
+
+```kotlin
 singleQuery {
-    where { "status" eq "active" }
-    projection { "id", "name" }
-    orderBy { "createdAt" desc }
-    limit(10)
+    condition { "status" eq "active" }
+    projection { include("id", "name") }
+    sort { "createdAt".desc() }
 }.query(queryService)
 
-// List of results
-listQuery {
-    where { "age" gt 18 }
-    orderBy { "name" asc }
-    offset(0)
-    limit(20)
-}.query(queryService)
-
-// Paged query
 pagedQuery {
-    where { "tenantId" eq tenantId }
-    page(1)
-    pageSize(20)
+    condition { tenantId(tenantId); "status" eq "ACTIVE" }
+    pagination { index(1); size(20) }
 }.query(queryService)
 ```
-
-### Condition DSL
-
-```kotlin
-condition {
-    deleted(DeletionState.ALL)
-    tenantId(tenantId)
-    and {
-        "status" eq "ACTIVE"
-        "amount" gt 100
-    }
-    or {
-        "type" eq "VIP"
-        "type" eq "PREMIUM"
-    }
-}
-```
-
-### Operators
-
-| Operator | Description |
-|----------|-------------|
-| `eq` / `ne` | Equals / Not equals |
-| `gt` / `lt` / `gte` / `lte` | Comparison |
-| `contains` | String contains |
-| `isIn` / `notIn` | In list / not in list |
-| `between` | Range |
-| `startsWith` / `endsWith` | String prefix/suffix |
-| `isNull()` / `notNull()` | Null check |
-| `isTrue()` / `isFalse()` | Boolean check |
-| `today()` / `thisWeek()` / `thisMonth()` / `lastMonth()` | Date ranges |
-| `recentDays(n)` / `earlierDays(n)` | Relative date ranges |
 
 ## Testing
 
-Wow provides `AggregateSpec` and `SagaSpec` for Given-When-Expect testing.
-
-### AggregateSpec Example
+### AggregateSpec
 
 ```kotlin
-class CartSpec : AggregateSpec<Cart, CartState>(
-    {
-        on {
-            val ownerId = generateGlobalId()
-            val addCartItem = AddCartItem(productId = "productId", quantity = 1)
-            givenOwnerId(ownerId)
-            whenCommand(addCartItem) {
-                expectNoError()
-                expectEventType(CartItemAdded::class)
-                expectState { items.assert().hasSize(1) }
-                expectStateAggregate { ownerId.assert().isEqualTo(ownerId) }
-
-                fork(name = "Remove CartItem") {
-                    val removeCartItem = RemoveCartItem(productIds = setOf(addCartItem.productId))
-                    whenCommand(removeCartItem) {
-                        expectEventType(CartItemRemoved::class)
-                        expectState { items.assert().isEmpty() }
-                    }
-                }
-            }
-        }
-    }
-)
-```
-
-### SagaSpec Example
-
-```kotlin
-class CartSagaSpec : SagaSpec<CartSaga>({
+class CartSpec : AggregateSpec<Cart, CartState>({
     on {
         val ownerId = generateGlobalId()
-        val orderItem = OrderItem(
-            id = generateGlobalId(),
-            productId = generateGlobalId(),
-            price = BigDecimal(10),
-            quantity = 10,
-        )
-        whenEvent(
-            event = mockk<OrderCreated> {
-                every { items } returns listOf(orderItem)
-                every { fromCart } returns true
-            },
-            ownerId = ownerId
-        ) {
-            expectCommandType(RemoveCartItem::class)
-            expectCommand<RemoveCartItem> {
-                aggregateId.id.assert().isEqualTo(ownerId)
-                body.productIds.assert().hasSize(1)
+        givenOwnerId(ownerId)
+        whenCommand(AddCartItem(productId = "p1", quantity = 1)) {
+            expectNoError()
+            expectEventType(CartItemAdded::class)
+            expectState { items.assert().hasSize(1) }
+
+            fork("Remove item") {
+                whenCommand(RemoveCartItem(productIds = setOf("p1"))) {
+                    expectEventType(CartItemRemoved::class)
+                    expectState { items.assert().isEmpty() }
+                }
             }
         }
     }
 })
 ```
 
-### Testing DSL Reference
-
-**AggregateSpec DSL:**
-
-| Method | Description |
-|--------|-------------|
-| `givenOwnerId(id)` | Set aggregate ID |
-| `givenEvent(event)` | Initialize with domain events |
-| `givenState(state, version)` | Initialize with direct state |
-| `inject { register(...) }` | Inject mock services |
-| `whenCommand(cmd)` | Execute command |
-| `expectNoError()` | Assert no error |
-| `expectErrorType<T>()` | Assert error type |
-| `expectEventType<T>()` | Assert event type |
-| `expectEventBody<T> { }` | Assert event body content |
-| `expectState { }` | Assert aggregate state |
-| `expectStateAggregate { }` | Assert aggregate metadata |
-| `expectEventCount(n)` | Assert number of events |
-| `fork(name) { }` | Branch test scenario |
-| `ref("name")` | Mark verification point |
-
-**SagaSpec DSL:**
-
-| Method | Description |
-|--------|-------------|
-| `whenEvent(event, ownerId)` | Trigger saga with event |
-| `expectCommandType<T>()` | Assert command type sent |
-| `expectCommand<T> { }` | Assert command content |
-| `expectNoCommand()` | Assert no command sent |
-
-## Event Modeling
-
-### Event Naming Convention
+### SagaSpec
 
 ```kotlin
-// Good - past tense + specific behavior
-@Event
-data class OrderCreated(
-    val orderId: String,
-    val customerId: String,
-    val items: List<OrderItem>,
-    val totalAmount: BigDecimal
-)
-
-@Event
-data class OrderPaid(
-    val orderId: String,
-    val paidAmount: BigDecimal,
-    val paymentId: String
-)
-
-// Avoid - vague naming
-data class OrderUpdated(val orderId: String)  // What changed?
+class CartSagaSpec : SagaSpec<CartSaga>({
+    on {
+        whenEvent(
+            event = mockk<OrderCreated> { every { fromCart } returns true },
+            ownerId = ownerId
+        ) {
+            expectCommandType(RemoveCartItem::class)
+            expectCommand<RemoveCartItem> {
+                aggregateId.id.assert().isEqualTo(ownerId)
+            }
+        }
+    }
+})
 ```
 
-### Event Revision
+### AggregateVerifier (Fluent API)
 
 ```kotlin
-@Event(revision = "2.0")
-data class OrderShipped(
-    val orderId: String,
-    val trackingNumber: String,
-    val shippedAt: Instant
-)
+Cart::class.java.aggregateVerifier<Cart, CartState>()
+    .given()
+    .whenCommand(AddCartItem(productId = "p1", quantity = 1))
+    .expectEventType(CartItemAdded::class)
+    .expectState { items.assert().hasSize(1) }
+    .verify()
+
+// Or using reified generics:
+aggregateVerifier<Cart, CartState>()
+    .given()
+    .whenCommand(addCartItem)
+    .expectNoError()
+    .verify()
 ```
+
+### SagaVerifier (Fluent API)
+
+```kotlin
+sagaVerifier<CartSaga>()
+    .whenEvent(mockOrderCreatedEvent)
+    .expectNoCommand()
+    .verify()
+```
+
+## Aggregate Lifecycle
+
+- **Creation**: `@CreateAggregate` command, version starts at 0
+- **Command Processing**: Validate → Execute → Source → Persist
+- **Deletion**: `DefaultDeleteAggregate` → soft delete (`deleted = true`)
+- **Recovery**: `DefaultRecoverAggregate` → restore active state
+- **Serial Processing**: Only one command per aggregate at a time (CommandState: STORED → SOURCED → STORED)
+- **Optimistic Concurrency**: `aggregateVersion` on commands for conflict detection
+
+## Bounded Context
+
+```kotlin
+@BoundedContext(
+    name = "example",
+    alias = "ex",
+    aggregates = [
+        BoundedContext.Aggregate(name = "order"),
+        BoundedContext.Aggregate(name = "cart")
+    ]
+)
+object ExampleBoundedContext
+```
+
+## Multi-Tenancy
+
+Every `AggregateId` includes `tenantId`:
+- `@StaticTenantId` — fixed tenant on aggregate
+- `@TenantId` on command parameter — extract from command body
+- `@AggregateRoute(owner = ...)` — ownership validation (NEVER, ALWAYS, AGGREGATE_ID)
+
+## PrepareKey (Uniqueness Constraints)
+
+For application-level uniqueness in EventSourcing:
+
+```kotlin
+@PreparableKey(name = "username_idx")
+interface UsernamePrepare : PrepareKey<String>
+
+@AggregateRoot
+class User(private val state: UserState) {
+    fun onRegister(register: Register, usernamePrepare: UsernamePrepare): Mono<Registered> {
+        return usernamePrepare.usingPrepare(key = register.username, value = ...) {
+            require(it) { "username already registered." }
+            Registered(...).toMono()
+        }
+    }
+}
+```
+
+## Event Compensation
+
+Failed event handlers are tracked as `ExecutionFailed` aggregates with automatic retry:
+- `@Retry` annotation configures maxRetries, minBackoff, executionTimeout
+- `@Retry(enabled = false)` to disable for specific handlers
+- Exponential backoff: `nextRetryAt = now + minBackoff * 2^retries`
+- Compensation dashboard for monitoring and manual intervention
 
 ## Project Structure
 
@@ -472,56 +343,39 @@ src/main/kotlin/
 │   ├── cart/
 │   │   ├── Cart.kt              # Command aggregate
 │   │   ├── CartState.kt         # State aggregate
-│   │   ├── CartItem.kt         # Value object
-│   │   └── CartSaga.kt         # Saga (optional)
-│   ├── order/
-│   │   ├── Order.kt
-│   │   └── OrderState.kt
-│   └── projection/
-│       └── OrderProjector.kt    # Projection processor
+│   │   ├── CartSaga.kt          # Saga (optional)
+│   │   └── CartProjector.kt     # Projection (optional)
+│   └── order/
+│       ├── Order.kt
+│       └── OrderState.kt
 └── api/
     ├── command/
-    │   └── AddCartItem.kt      # Command
+    │   └── AddCartItem.kt
     └── event/
-        └── CartItemAdded.kt     # Event
+        └── CartItemAdded.kt
 ```
 
 ## Dependencies
 
 ```kotlin
-// build.gradle.kts
 dependencies {
     implementation("me.ahoo.wow:wow-api")
     implementation("me.ahoo.wow:wow-core")
-    implementation("me.ahoo.wow:wow-mongo")    // MongoDB support
-    implementation("me.ahoo.wow:wow-kafka")     // Kafka support
-    implementation("me.ahoo.wow:wow-query")     // Query DSL
-
-    testImplementation("me.ahoo.wow:wow-test")  // Test utilities
+    implementation("me.ahoo.wow:wow-mongo")
+    implementation("me.ahoo.wow:wow-kafka")
+    implementation("me.ahoo.wow:wow-query")
+    testImplementation("me.ahoo.wow:wow-test")
 }
 ```
 
-## Best Practices
-
-1. **Simple Aggregation Pattern**: Use separate Command Aggregate and State Aggregate classes
-2. **Keep Aggregates Small**: One aggregate per transaction boundary
-3. **Saga for Cross-Aggregate Workflows**: Use stateless saga for distributed transactions
-4. **Event Naming**: Past tense + specific business action (OrderCreated, not OrderUpdate)
-5. **Use Projections for Read Models**: Separate read/write concerns with projection processors
-6. **@Blocking for Sync Operations**: Mark blocking projection handlers
-7. **@Retry for Resilient Sagas**: Handle transient failures in saga event handlers
-
 ## References
-
-### Internal References
 
 | Reference | When to Use |
 |-----------|-------------|
-| `references/annotations.md` | Annotation parameters, @Retry, @Event revision, naming conventions, all aggregate patterns |
-| `references/dsl.md` | Complete Query DSL operators (100+), pagination, nested queries, date operators, query rewriting |
-| `references/testing.md` | AggregateSpec/SagaSpec DSL, fork/ref patterns, FluentAssert, mockk usage, default commands |
-| `references/modeling.md` | Aggregate patterns: Simple/Complex aggregation, single class pattern, inheritance pattern |
-| `references/command-gateway.md` | Wait strategies, idempotency, validation, LocalFirst mode, CommandRewriter |
+| `references/annotations.md` | All annotation parameters, aggregate patterns, command/sourcing/event handler details |
+| `references/dsl.md` | Complete Query DSL operators (100+), pagination, nested queries, date operators |
+| `references/testing.md` | AggregateSpec/SagaSpec DSL, AggregateVerifier/SagaVerifier fluent API, fork/ref patterns, FluentAssert, mockk |
+| `references/modeling.md` | Aggregate patterns: Simple/Complex/Single/Inheritance, bounded context, lifecycle hooks |
+| `references/command-gateway.md` | Wait strategies, idempotency, validation, LocalFirst mode, CommandRewriter, WaitingForChain |
 | `references/prepare-key.md` | Uniqueness constraints for EventSourcing, TTL support, user registration scenarios |
-
-These references are loaded as needed - you don't need to read them proactively.
+| `references/configuration.md` | Complete YAML configuration reference for all Wow modules |

--- a/skills/wow/references/annotations.md
+++ b/skills/wow/references/annotations.md
@@ -15,7 +15,6 @@ class Order(private val state: OrderState) {
 
 **Parameters:**
 - `commands`: Array of command classes this aggregate handles
-- `route`: Optional aggregate route configuration
 
 ### @OnCommand
 
@@ -27,13 +26,16 @@ fun onCommand(cmd: CreateOrder): OrderCreated { ... }
 ```
 
 **Parameters:**
-- `returns`: Array of event types this handler can return
+- `returns`: Array of event types this handler can return. **Required** when:
+  - Return type is `Any` or `Object` (polymorphic returns)
+  - A single command can produce multiple different event types
+  - The compiler cannot infer the event type from the return statement
 
 **Handler parameter types:**
 - Specific command: `AddCartItem`
 - Command message: `CommandMessage<AddCartItem>`
 - Command exchange: `CommandExchange<AddCartItem>`
-- Other parameters are resolved from IOC container
+- Other parameters are resolved from IOC container (use `@Name` for qualified injection)
 
 ### @OnSourcing
 
@@ -56,6 +58,49 @@ fun onSourcing(event: DomainEvent<OrderPaid>) {  // Generic form
 - Specific event: `CartItemAdded`
 - Domain event: `DomainEvent<CartItemAdded>`
 
+**Rules:**
+- Must be deterministic — same events always produce same state
+- Must have no side effects (no external service calls, no writes)
+- Applied sequentially in event order
+
+### @AfterCommand
+
+Post-processing hook that executes after the main command handler completes. If the method returns a non-null value, it is appended as an additional domain event.
+
+```kotlin
+@AfterCommand
+fun afterCreateOrder(exchange: ServerCommandExchange<*>): OrderConfirmed? {
+    val result = exchange.getCommandInvokeResult<OrderCreated>()
+    return null
+}
+```
+
+**Filter parameters:**
+- `include`: Array of command classes to trigger this hook
+- `exclude`: Array of command classes to skip
+
+```kotlin
+@AfterCommand(include = [CreateOrder::class], exclude = [CancelOrder::class])
+fun onAfterCommand(exchange: ServerCommandExchange<*>): AdditionalEvent? { ... }
+```
+
+Multiple `@AfterCommand` functions are supported, with execution order controlled by `@Order`.
+
+### @OnError
+
+Error handler that executes when command processing fails:
+
+```kotlin
+@OnError
+fun onError(command: CreateOrder, error: Throwable) {
+    // Log or publish error event
+}
+```
+
+Can also accept `eventStream: DomainEventStream?` as a third parameter.
+
+## Event Handler Annotations
+
 ### @StatelessSaga
 
 Marks a class as a stateless saga for distributed transaction orchestration.
@@ -70,7 +115,7 @@ class TransferSaga {
 
 ### @OnEvent
 
-Marks a method as an event handler in Sagas and Projections. Optional if method is named `onEvent`.
+Marks a method as an event handler in Sagas, Projections, and Event Processors. Optional if method is named `onEvent`.
 
 ```kotlin
 @OnEvent
@@ -82,11 +127,28 @@ fun onCartEvent(event: Any) { ... }
 ```
 
 **Return types:**
-- `null` or `Nothing?` - no command sent
-- Single command - `Command`
-- `CommandBuilder` - for aggregateId-aware commands
-- `List<Command>` - multiple commands
-- `Mono<Void>` - async handling in projections
+| Return Type | Behavior |
+|---|---|
+| `null` / `Nothing?` | No command sent |
+| Command body | Wrapped into `CommandMessage` and sent |
+| `CommandBuilder` | Fine-grained control over aggregateId, tenantId |
+| `CommandMessage<*>` | Sent directly |
+| `Iterable` of above | Multiple commands per event |
+| `Mono<Void>` / `Mono.empty()` | Reactive no-op |
+
+### @OnStateEvent
+
+Marks a method as a state-aware event handler. Provides access to both the event and the aggregate state.
+
+```kotlin
+@ProjectionProcessor
+class OrderProjection {
+    fun onStateEvent(event: OrderPaid, state: OrderState) { ... }
+    fun onStateEvent(event: OrderPaid, state: ReadOnlyStateAggregate<OrderState>) { ... }
+}
+```
+
+Optional if method is named `onStateEvent`.
 
 ### @ProjectionProcessor
 
@@ -96,14 +158,29 @@ Marks a class as a projection processor for maintaining read models.
 @ProjectionProcessor
 class OrderProjector {
     fun onEvent(event: OrderCreated) { ... }
-    
     fun onStateEvent(event: OrderPaid, state: OrderState) { ... }
+}
+```
+
+### @EventProcessor
+
+Marks a class as a general-purpose event processor for cross-aggregate operations (notifications, external integrations).
+
+```kotlin
+@EventProcessor
+class OrderEventProcessor(
+    private val notificationService: NotificationService
+) {
+    @OnEvent
+    fun onOrderCreated(event: OrderCreated): Mono<Void> {
+        return notificationService.sendOrderConfirmation(event.orderId)
+    }
 }
 ```
 
 ### @Blocking
 
-Marks a method as a blocking operation in projections.
+Marks a method as a blocking operation in projections/event processors.
 
 ```kotlin
 @Blocking
@@ -114,7 +191,7 @@ fun onEvent(event: OrderPaid) {
 
 ### @Retry
 
-Used in sagas for retry configuration on event handlers.
+Configures retry and compensation behavior for event handlers.
 
 ```kotlin
 @Retry(maxRetries = 5, minBackoff = 60, executionTimeout = 10)
@@ -122,19 +199,78 @@ fun onEvent(event: DomainEvent<OrderCreated>): CommandBuilder? { ... }
 ```
 
 **Parameters:**
-- `maxRetries`: Maximum number of retry attempts
-- `minBackoff`: Minimum backoff time in seconds  
-- `executionTimeout`: Timeout for each execution in seconds
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | Boolean | `true` | Set `false` to disable compensation |
+| `maxRetries` | Int | `10` | Maximum retry attempts |
+| `minBackoff` | Int | `180` | Initial backoff in seconds (grows exponentially: `minBackoff * 2^retries`) |
+| `executionTimeout` | Int | `120` | Max time per execution in seconds |
+| `recoverable` | Array | `[]` | Exception types that trigger retries |
+| `unrecoverable` | Array | `[]` | Exception types that fail immediately |
 
-## Annotation Naming Convention
+## Command Annotations
 
-Most annotations are **optional** if you follow the naming convention:
+### @CreateAggregate
 
-| Annotation | Optional if method named |
-|------------|-------------------------|
-| `@OnCommand` | `onCommand` |
-| `@OnEvent` | `onEvent` |
-| `@OnSourcing` | `onSourcing` |
+Marks a command as an aggregate initializer.
+
+```kotlin
+@CreateAggregate
+data class CreateUserCommand(
+    @AggregateId
+    val userId: String,
+    val email: String
+)
+```
+
+### @AllowCreate
+
+Permits a command to create an aggregate if it does not already exist.
+
+### @VoidCommand
+
+Marks a command as fire-and-forget (no response expected).
+
+### @CommandRoute
+
+Configures REST route for a command. Used by `wow-compiler` to generate API endpoints.
+
+```kotlin
+@CommandRoute(action = "", method = CommandRoute.Method.DELETE, appendIdPath = CommandRoute.AppendPath.ALWAYS)
+object DefaultDeleteAggregate : DeleteAggregate
+```
+
+## Aggregate Route & Routing
+
+### @AggregateRoute
+
+Configures aggregate REST API routing and ownership.
+
+```kotlin
+@AggregateRoot(commands = [...])
+@AggregateRoute(
+    resourceName = "sales-order",
+    spaced = true,
+    owner = AggregateRoute.Owner.ALWAYS
+)
+class Order(private val state: OrderState) { ... }
+```
+
+**Parameters:**
+| Attribute | Default | Description |
+|---|---|---|
+| `resourceName` | lowercased class name | Custom API path segment |
+| `enabled` | `true` | Set `false` to disable automatic route generation |
+| `spaced` | `false` | Space-separate the resource name in URL paths |
+| `owner` | `NEVER` | Ownership policy: `NEVER`, `ALWAYS`, or `AGGREGATE_ID` |
+
+Disable route generation entirely:
+
+```kotlin
+@AggregateRoot
+@AggregateRoute(enabled = false)
+class InternalAggregate(val id: String) { ... }
+```
 
 ## Event Annotations
 
@@ -157,7 +293,44 @@ data class OrderShipped(
 ```
 
 **Parameters:**
-- `revision`: Version string for event evolution
+- `revision`: Version string for event evolution/backward compatibility
+
+## Bounded Context
+
+### @BoundedContext
+
+Declares a bounded context boundary.
+
+```kotlin
+@BoundedContext(
+    name = "example",
+    alias = "ex",
+    aggregates = [
+        BoundedContext.Aggregate(name = "order"),
+        BoundedContext.Aggregate(name = "cart")
+    ]
+)
+object ExampleBoundedContext
+```
+
+**Parameters:**
+| Parameter | Description |
+|---|---|
+| `name` | Unique context identifier used for routing |
+| `alias` | Shorter reference name |
+| `description` | Human-readable purpose |
+| `scopes` | Boundary scope identifiers |
+| `aggregates` | Array of `@Aggregate` definitions within the context |
+
+## Multi-Tenancy Annotations
+
+### @StaticTenantId
+
+Marks an aggregate as having a static (non-changeable) tenant ID.
+
+### @TenantId
+
+Used on a command parameter to extract tenant from the command body.
 
 ## Aggregate Patterns
 
@@ -166,17 +339,14 @@ data class OrderShipped(
 Separate Command Aggregate and State Aggregate classes:
 
 ```kotlin
-// State Aggregate - holds state and handles sourcing
 class CartState(val id: String) {
     var items: List<CartItem> = listOf()
         private set
-    
     fun onCartItemAdded(event: CartItemAdded) {
         items = items + event.added
     }
 }
 
-// Command Aggregate - handles commands
 @AggregateRoot
 class Cart(private val state: CartState) {
     fun onCommand(cmd: AddCartItem): Any { ... }
@@ -190,54 +360,40 @@ Multiple related aggregates sharing a base state:
 ```kotlin
 class OrderState(val id: String) { ... }
 class OrderStateA : OrderState(id) { ... }
-class OrderStateB : OrderState(id) { ... }
 
 @AggregateRoot
 class OrderA(private val state: OrderStateA) { ... }
-
-@AggregateRoot  
-class OrderB(private val state: OrderStateB) { ... }
 ```
+
+### Single Class Pattern
+
+Command + state in one class. **Avoid** — violates event sourcing principles by allowing direct state mutation in command handlers.
 
 ### Inheritance Pattern
 
-Command Aggregate inherits from State Aggregate:
+Command aggregate inherits from state aggregate with `private set` on setters.
 
-```kotlin
-abstract class OrderState(val id: String) {
-    var items: List<OrderItem> = listOf()
-    fun onOrderCreated(e: OrderCreated) { ... }
-}
+## Annotation Naming Convention
 
-@AggregateRoot
-class Order(state: OrderState) : OrderState(state.id) {
-    fun onCommand(cmd: CreateOrder): OrderCreated { ... }
-}
-```
+| Annotation | Optional if method named |
+|------------|-------------------------|
+| `@OnCommand` | `onCommand` |
+| `@OnEvent` | `onEvent` |
+| `@OnSourcing` | `onSourcing` |
+| `@OnStateEvent` | `onStateEvent` |
+| `@OnError` | `onError` |
 
-## Command Gateway Annotations
+## Special Built-in Events
 
-### @StaticTenantId
+The framework automatically handles these events without explicit `@OnSourcing` methods:
 
-Marks an aggregate as having a static (non-changeable) tenant ID.
-
-### @AggregateRoute
-
-Configures aggregate routing.
-
-```kotlin
-@AggregateRoot(commands = [...])
-@AggregateRoute(owner = AggregateRoute.Owner.AGGREGATE_ID)
-class Cart(private val state: CartState) { ... }
-```
-
-**Owner values:**
-
-| Owner | Description |
-|-------|-------------|
-| `AGGREGATE_ID` | Route by the aggregate ID (default) |
-| `TENANT_ID` | Route by the tenant ID |
-| `GROUP` | Route by a named group |
+| Event | Effect |
+|---|---|
+| `AggregateDeleted` | Sets `deleted = true` |
+| `AggregateRecovered` | Sets `deleted = false` |
+| `OwnerTransferred` | Updates `ownerId` |
+| `SpaceTransferred` | Updates `spaceId` |
+| `ResourceTagsApplied` | Updates `tags` (ABAC) |
 
 ## Configuration Annotations
 

--- a/skills/wow/references/command-gateway.md
+++ b/skills/wow/references/command-gateway.md
@@ -1,167 +1,103 @@
 # Command Gateway
 
-The command gateway is the core component in the system for receiving and sending commands, serving as an entry point for commands.
-It is an extension of the command bus, not only responsible for command transmission, but also adds a series of important responsibilities, including command idempotency, waiting strategies, and command validation.
+The command gateway is the core component for receiving and sending commands. It extends the command bus with idempotency, wait strategies, and command validation.
 
 ## API Usage
 
-The `CommandGateway` interface provides several methods for sending commands and waiting for their results. Below are the main methods and their usage patterns.
-
-### Basic Methods
-
-:::tip
-The `toCommandMessage()` extension function converts a command body into a `CommandMessage`. This is provided by the Wow framework and handles setting up the command ID, aggregate ID, and other metadata.
-:::
-
-#### send(command, waitStrategy)
-
-The base method that sends a command with a specified wait strategy and returns a `ClientCommandExchange`.
-
-```kotlin
-val command = CreateAccount(balance = 1000, name = "John").toCommandMessage()
-val waitStrategy = WaitingForStage.processed(command.commandId)
-
-commandGateway.send(command, waitStrategy)
-    .flatMap { exchange ->
-        // Access the ClientCommandExchange
-        // Use the waitStrategy to get the command result
-        exchange.waitStrategy.waiting()
-    }
-    .subscribe { signal ->
-        println("Stage: ${signal.stage} - Succeeded: ${signal.succeeded}")
-    }
-```
-
-#### sendAndWait(command, waitStrategy)
-
-Sends a command and waits for the final result. If the command fails, it throws a `CommandResultException`.
-
-```kotlin
-val command = CreateAccount(balance = 1000, name = "John").toCommandMessage()
-val waitStrategy = WaitingForStage.processed(command.commandId)
-
-commandGateway.sendAndWait(command, waitStrategy)
-    .doOnSuccess { result ->
-        println("Command processed: ${result.commandId}")
-        println("Aggregate Version: ${result.aggregateVersion}")
-    }
-    .subscribe()
-```
-
-#### sendAndWaitStream(command, waitStrategy)
-
-Returns a `Flux<CommandResult>` for real-time streaming updates as the command progresses through different stages.
-
-```kotlin
-val command = CreateAccount(balance = 1000, name = "John").toCommandMessage()
-val waitStrategy = WaitingForStage.snapshot(command.commandId)
-
-commandGateway.sendAndWaitStream(command, waitStrategy)
-    .doOnNext { result ->
-        println("Stage: ${result.stage} - Succeeded: ${result.succeeded}")
-        println("Aggregate Version: ${result.aggregateVersion}")
-    }
-    .subscribe()
-```
-
 ### Convenience Methods
 
-The `CommandGateway` provides convenience methods that pre-configure common wait strategies:
-
 ```kotlin
 val command = CreateAccount(balance = 1000, name = "John").toCommandMessage()
 
-// Wait until command is sent to the bus
+// Wait until command is sent to bus
 commandGateway.sendAndWaitForSent(command)
     .doOnSuccess { result ->
         println("Command sent: ${result.commandId}")
     }
-    .subscribe()
 
-// Wait until command is processed by the aggregate
+// Wait until command is processed by aggregate
 commandGateway.sendAndWaitForProcessed(command)
     .doOnSuccess { result ->
         if (result.succeeded) {
-            println("Command processed successfully: ${result.commandId}")
-            println("New aggregate version: ${result.aggregateVersion}")
+            println("Command processed! Version: ${result.aggregateVersion}")
         }
     }
-    .subscribe()
 
 // Wait until aggregate snapshot is created
 commandGateway.sendAndWaitForSnapshot(command)
     .doOnSuccess { result ->
         println("Snapshot created for aggregate: ${result.aggregateId}")
     }
-    .subscribe()
 ```
 
-## Core Concepts
-
-### ClientCommandExchange
-
-`ClientCommandExchange` is the client-side exchange context returned when sending commands via `CommandGateway.send()`. It provides access to:
-
-* **message**: The original `CommandMessage` that was sent
-* **waitStrategy**: The `WaitStrategy` used to wait for command processing results
-* **attributes**: A mutable map for storing additional exchange-related data
+### Base Methods
 
 ```kotlin
-interface ClientCommandExchange<C : Any> {
-    val message: CommandMessage<C>
-    val waitStrategy: WaitStrategy
-    val attributes: MutableMap<String, Any>
-}
-```
-
-Use `ClientCommandExchange` when you need low-level access to the wait strategy or want to implement custom waiting logic:
-
-```kotlin
+// Send with specific wait strategy
 commandGateway.send(command, waitStrategy)
     .flatMap { exchange ->
-        // Access the command message
-        val commandId = exchange.message.commandId
-        
-        // Use the wait strategy directly
         exchange.waitStrategy.waiting()
-            .filter { signal -> signal.stage == CommandStage.PROCESSED }
-            .next()
     }
-    .subscribe()
+
+// Send and wait for final result
+commandGateway.sendAndWait(command, waitStrategy)
+    .doOnSuccess { result -> ... }
+
+// Streaming updates as command progresses through stages
+commandGateway.sendAndWaitStream(command, waitStrategy)
+    .doOnNext { result ->
+        println("Stage: ${result.stage} - Succeeded: ${result.succeeded}")
+    }
 ```
 
-### CommandResult
+## Wait Strategies
 
-`CommandResult` represents the result of a command execution at a specific processing stage. It contains comprehensive information about the command processing outcome.
+### WaitingForStage
 
-| Property | Type | Description |
-|----------|------|-------------|
-| `id` | `String` | Unique identifier for this result |
-| `waitCommandId` | `String` | The command ID being waited on |
-| `stage` | `CommandStage` | Current processing stage (SENT, PROCESSED, SNAPSHOT, etc.) |
-| `contextName` | `String` | Bounded context name |
-| `aggregateName` | `String` | Aggregate name |
-| `tenantId` | `String` | Tenant identifier |
-| `aggregateId` | `String` | Aggregate instance identifier |
-| `aggregateVersion` | `Int?` | Aggregate version after processing (null on gateway validation failure or before processing) |
-| `requestId` | `String` | Request identifier for idempotency |
-| `commandId` | `String` | Command identifier |
-| `function` | `FunctionInfoData` | Information about the processing function |
-| `errorCode` | `String` | Error code ("Ok" on success) |
-| `errorMsg` | `String` | Error message (empty on success) |
-| `bindingErrors` | `List<BindingError>` | List of validation errors |
-| `result` | `Map<String, Any>` | Additional result data |
-| `signalTime` | `Long` | Timestamp when this result was generated |
-| `succeeded` | `Boolean` | Whether the command processing succeeded |
+| Stage | Signal Generated When |
+|-------|----------------------|
+| `SENT` | Command published to bus/queue |
+| `PROCESSED` | Command processed by aggregate root |
+| `SNAPSHOT` | Snapshot generated |
+| `PROJECTED` | Projection of event completed |
+| `EVENT_HANDLED` | Event processed by event processor |
+| `SAGA_HANDLED` | Event processed by Saga |
 
-### WaitSignal vs CommandResult
+```kotlin
+WaitingForStage.sent(commandId)
+WaitingForStage.processed(commandId)
+WaitingForStage.snapshot(commandId)
+WaitingForStage.projected(waitCommandId, contextName, processorName, functionName)
+WaitingForStage.eventHandled(...)
+WaitingForStage.sagaHandled(...)
+```
 
-* **WaitSignal**: Internal interface used within the wait strategy infrastructure. Contains processing stage information and is used for signaling between components.
-* **CommandResult**: Public API for command results. Created from `WaitSignal` and includes additional context like `requestId` and formatted aggregate information.
+### WaitingForChain
 
-### CommandGateway vs CommandBus
+Wait for the **entire saga chain** to complete. Used for end-to-end request-reply semantics in distributed operations.
 
-`CommandGateway` extends `CommandBus` with additional high-level features:
+For example, a client initiating a bank transfer can wait until both the saga has processed the event and the resulting downstream command has been fully processed.
+
+```http
+POST /account/sourceId/prepare
+Command-Wait-Stage: SAGA_HANDLED
+Command-Wait-Tail-Stage: SNAPSHOT
+Command-Wait-Tail-Processor: TransferSaga
+```
+
+Programmatic usage:
+
+```kotlin
+val waitStrategy = SimpleWaitingForChain.chain(
+    tailStage = CommandStage.SNAPSHOT,
+    // optional: tailProcessor, tailContextName
+)
+commandGateway.sendAndWait(message, waitStrategy)
+```
+
+This guarantees the entire distributed workflow has completed when the response returns.
+
+## CommandGateway vs CommandBus
 
 | Feature | CommandBus | CommandGateway |
 |---------|------------|----------------|
@@ -172,108 +108,49 @@ commandGateway.send(command, waitStrategy)
 | Real-time result streaming | ✗ | ✓ |
 | Convenience methods | ✗ | ✓ |
 
-Use `CommandBus` when you only need basic command routing. Use `CommandGateway` for full-featured command handling with wait strategies and validation.
+## CommandResult Properties
 
-```kotlin
-// CommandBus - basic routing only
-interface CommandBus : MessageBus<CommandMessage<*>, ServerCommandExchange<*>>
-
-// CommandGateway - extends CommandBus with additional features
-interface CommandGateway : CommandBus {
-    fun <C : Any> send(command: CommandMessage<C>, waitStrategy: WaitStrategy): Mono<out ClientCommandExchange<C>>
-    fun <C : Any> sendAndWait(command: CommandMessage<C>, waitStrategy: WaitStrategy): Mono<CommandResult>
-    fun <C : Any> sendAndWaitStream(command: CommandMessage<C>, waitStrategy: WaitStrategy): Flux<CommandResult>
-    // ... convenience methods
-}
-```
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `String` | Unique result identifier |
+| `waitCommandId` | `String` | Command ID being waited on |
+| `stage` | `CommandStage` | Current processing stage |
+| `contextName` | `String` | Bounded context name |
+| `aggregateName` | `String` | Aggregate name |
+| `tenantId` | `String` | Tenant identifier |
+| `aggregateId` | `String` | Aggregate instance ID |
+| `aggregateVersion` | `Int?` | Version after processing |
+| `requestId` | `String` | Request identifier for idempotency |
+| `commandId` | `String` | Command identifier |
+| `errorCode` | `String` | Error code ("Ok" on success) |
+| `errorMsg` | `String` | Error message |
+| `bindingErrors` | `List<BindingError>` | Validation errors |
+| `succeeded` | `Boolean` | Whether processing succeeded |
 
 ## Error Handling
 
 ### CommandResultException
 
-When command processing fails, `sendAndWait` throws a `CommandResultException` containing the full `CommandResult` with error details.
+When command processing fails, `sendAndWait` throws `CommandResultException`:
 
 ```kotlin
-commandGateway.sendAndWait(command, waitStrategy)
+commandGateway.sendAndWaitForProcessed(command)
     .doOnError { error ->
-        if (error is CommandResultException) {
-            val result = error.commandResult
-            println("Command failed at stage: ${result.stage}")
-            println("Error code: ${result.errorCode}")
-            println("Error message: ${result.errorMsg}")
-            
-            // Check for validation errors
-            if (result.bindingErrors.isNotEmpty()) {
-                result.bindingErrors.forEach { bindingError ->
-                    println("Field '${bindingError.name}': ${bindingError.msg}")
-                }
-            }
-        }
-    }
-    .onErrorResume { error ->
-        // Handle the error gracefully
         when (error) {
             is CommandResultException -> {
-                // Log and return a fallback value
-                Mono.empty()
+                val result = error.commandResult
+                println("Error: ${result.errorCode} - ${result.errorMsg}")
+                result.bindingErrors.forEach {
+                    println("Field ${it.name}: ${it.msg}")
+                }
             }
-            else -> Mono.error(error)
+            is CommandValidationException -> { /* validation failed */ }
+            is DuplicateRequestIdException -> { /* duplicate request */ }
         }
     }
-    .subscribe()
 ```
 
-### CommandValidationException
-
-Thrown when command validation fails before sending. Contains validation constraint violations.
-
-```kotlin
-// Command with validation annotations
-data class CreateAccount(
-    @field:NotBlank(message = "Name is required")
-    val name: String,
-    @field:Min(value = 0, message = "Balance must be non-negative")
-    val balance: Int
-)
-
-commandGateway.sendAndWaitForProcessed(command)
-    .doOnError { error ->
-        if (error is CommandValidationException) {
-            println("Validation failed for command: ${error.command}")
-            error.bindingErrors.forEach { bindingError ->
-                println("Field '${bindingError.name}': ${bindingError.msg}")
-            }
-        }
-    }
-    .subscribe()
-```
-
-### DuplicateRequestIdException
-
-Thrown when attempting to process a command with a request ID that has already been processed.
-
-```kotlin
-commandGateway.sendAndWaitForProcessed(command)
-    .doOnError { error ->
-        if (error is DuplicateRequestIdException) {
-            println("Duplicate request: ${error.requestId}")
-            println("Aggregate: ${error.aggregateId}")
-        }
-    }
-    .onErrorResume(DuplicateRequestIdException::class.java) { error ->
-        // Return cached result or ignore duplicate
-        Mono.empty()
-    }
-    .subscribe()
-```
-
-### Error Handling Best Practices
-
-1. **Use specific exception handlers**: Handle `CommandResultException`, `CommandValidationException`, and `DuplicateRequestIdException` separately for appropriate responses.
-
-2. **Log error details**: Always log the `errorCode`, `errorMsg`, and `bindingErrors` for debugging.
-
-3. **Implement retry logic for transient failures**:
+### Retry Logic
 
 ```kotlin
 commandGateway.sendAndWaitForProcessed(command)
@@ -281,93 +158,30 @@ commandGateway.sendAndWaitForProcessed(command)
         .filter { error -> isTransientError(error) })
     .subscribe()
 
-// Transient errors are typically network or temporary infrastructure issues
-// Do NOT retry validation errors or duplicate request errors
 fun isTransientError(error: Throwable): Boolean {
     return when (error) {
-        is CommandValidationException -> false  // Validation errors won't succeed on retry
-        is DuplicateRequestIdException -> false // Duplicate requests should not be retried
-        is CommandResultException -> false      // Business logic errors from aggregate
-        else -> true                            // Network/infrastructure errors may be transient
+        is CommandValidationException -> false
+        is DuplicateRequestIdException -> false
+        is CommandResultException -> false
+        else -> true  // Network/infrastructure errors
     }
 }
-```
-
-4. **Handle timeout scenarios**: Configure appropriate timeouts for wait strategies.
-
-```kotlin
-commandGateway.sendAndWaitForProcessed(command)
-    .timeout(Duration.ofSeconds(30))
-    .doOnError(TimeoutException::class.java) { error ->
-        println("Command processing timed out")
-    }
-    .subscribe()
 ```
 
 ## Idempotency
 
-Command idempotency is the principle of ensuring that the same command is executed at most once in the system.
+Commands are deduplicated by `RequestId`:
 
-The command gateway uses `IdempotencyChecker` to check the `RequestId` of the command for idempotency.
-If the command has already been executed, it will throw a `DuplicateRequestIdException` exception to prevent duplicate execution of the same command.
-
-The following is an example HTTP request showing how to use `Command-Request-Id` in the request to ensure command idempotency:
-
-:::tip
-Developers can also customize the `RequestId` through the `requestId` property of `CommandMessage`.
-:::
-
-::: code-group
-
-```shell {6} [Http Request]
-curl -X 'POST' \
-  'http://localhost:8080/account/create_account' \
-  -H 'accept: application/json' \
-  -H 'Command-Wait-Stage: SNAPSHOT' \
-  -H 'Command-Aggregate-Id: sourceId' \
-  -H 'Command-Request-Id: {{$uuid}}' \
-  -H 'Content-Type: application/json' \
-  -d '{
-  "balance": 1000,
-  "name": "source"
-}'
+```http
+POST /account/create_account
+Command-Request-Id: {{$uuid}}
 ```
 
-```json [Response]
-{
-  "id": "0V3oAWI60001003",
-  "waitCommandId": "0V3oAWGt0001001",
-  "stage": "SNAPSHOT",
-  "contextName": "transfer-service",
-  "aggregateName": "account",
-  "tenantId": "(0)",
-  "aggregateId": "sourceId",
-  "aggregateVersion": 1,
-  "requestId": "0V3oAWGt0001001",
-  "commandId": "0V3oAWGt0001001",
-  "function": {
-    "functionKind": "STATE_EVENT",
-    "contextName": "wow",
-    "processorName": "SnapshotDispatcher",
-    "name": "save"
-  },
-  "errorCode": "Ok",
-  "errorMsg": "",
-  "result": {},
-  "signalTime": 1764297025846,
-  "succeeded": true
-}
-```
+Configure idempotency checking:
 
-:::
-
-### Configuration
-
-```yaml {5-10}
+```yaml
 wow:
   command:
-    bus:
-      type: kafka
     idempotency:
       enabled: true
       bloom-filter:
@@ -376,270 +190,69 @@ wow:
         fpp: 0.00001
 ```
 
-## Waiting Strategies
+## LocalFirst Mode
 
-*Command waiting strategy* refers to a strategy where the command gateway waits for the command execution result after sending the command.
+Reduces network IO by processing commands locally when possible:
 
-*Command waiting strategy* is an important feature in the *Wow* framework, aiming to solve the data synchronization delay problem in *CQRS* and read-write separation modes.
-
-Currently supported command waiting strategies include:
-
-### WaitingForStage
-
-The waiting signals supported by `WaitingForStage` are as follows:
-
-* `SENT`: Generates a completion signal when the command is published to the command bus/queue
-* `PROCESSED`: Generates a completion signal when the command is processed by the aggregate root
-* `SNAPSHOT`: Generates a completion signal when the snapshot is generated
-* `PROJECTED`: Generates a completion signal when the *projection* of the event produced by the command is completed
-* `EVENT_HANDLED`: Generates a completion signal when the event produced by the command is processed by the *event processor*
-* `SAGA_HANDLED`: Generates a completion signal when the event produced by the command is processed by *Saga*
-
-::: code-group
-
-```shell {4} [Http Request]
-curl -X 'POST' \
-  'http://localhost:8080/account/create_account' \
-  -H 'accept: application/json' \
-  -H 'Command-Wait-Stage: SNAPSHOT' \
-  -H 'Command-Aggregate-Id: targetId' \
-  -H 'Content-Type: application/json' \
-  -d '{
-  "balance": 1000,
-  "name": "target"
-}'
-```
-
-```json [Response]
-{
-  "id": "0V3oAdHd0001007",
-  "waitCommandId": "0V3oAdHV0001005",
-  "stage": "SNAPSHOT",
-  "contextName": "transfer-service",
-  "aggregateName": "account",
-  "tenantId": "(0)",
-  "aggregateId": "targetId",
-  "aggregateVersion": 1,
-  "requestId": "0V3oAdHV0001005",
-  "commandId": "0V3oAdHV0001005",
-  "function": {
-    "functionKind": "STATE_EVENT",
-    "contextName": "wow",
-    "processorName": "SnapshotDispatcher",
-    "name": "save"
-  },
-  "errorCode": "Ok",
-  "errorMsg": "",
-  "result": {},
-  "signalTime": 1764297052692,
-  "succeeded": true
-}
-```
-
-```text [SSE Response]
-id:0V3oCwcv0001002
-event:SENT
-data:{"id":"0V3oCwcv0001002","waitCommandId":"0V3oCwbn0001001","stage":"SENT","contextName":"transfer-service","aggregateName":"account","tenantId":"(0)","aggregateId":"targetId","aggregateVersion":0,"requestId":"0V3oCwbn0001001","commandId":"0V3oCwbn0001001","function":{"functionKind":"COMMAND","contextName":"wow","processorName":"CommandGateway","name":"send"},"errorCode":"Ok","errorMsg":"","result":{},"signalTime":1764297603701,"succeeded":true}
-
-id:0V3oCwbn0001001
-event:PROCESSED
-data:{"id":"0V3oCwbn0001001","waitCommandId":"0V3oCwbn0001001","stage":"PROCESSED","contextName":"transfer-service","aggregateName":"account","tenantId":"(0)","aggregateId":"targetId","aggregateVersion":1,"requestId":"0V3oCwbn0001001","commandId":"0V3oCwbn0001001","function":{"functionKind":"COMMAND","contextName":"transfer-service","processorName":"Account","name":"onCommand"},"errorCode":"Ok","errorMsg":"","result":{},"signalTime":1764297603737,"succeeded":true}
-
-id:0V3oCwdB0001003
-event:SNAPSHOT
-data:{"id":"0V3oCwdB0001003","waitCommandId":"0V3oCwbn0001001","stage":"SNAPSHOT","contextName":"transfer-service","aggregateName":"account","tenantId":"(0)","aggregateId":"targetId","aggregateVersion":1,"requestId":"0V3oCwbn0001001","commandId":"0V3oCwbn0001001","function":{"functionKind":"STATE_EVENT","contextName":"wow","processorName":"SnapshotDispatcher","name":"save"},"errorCode":"Ok","errorMsg":"","result":{},"signalTime":1764297603754,"succeeded":true}
-```
-
-```kotlin {1}
-commandGateway.sendAndWaitForProcessed(message)
-```
-
-:::
-
-### WaitingForChain
-
-::: code-group
-
-```shell {4-6} [Http Request]
-curl -X 'POST' \
-  'http://localhost:8080/account/sourceId/prepare' \
-  -H 'accept: application/json' \
-  -H 'Command-Wait-Stage: SAGA_HANDLED' \
-  -H 'Command-Wait-Tail-Stage: SNAPSHOT' \
-  -H 'Command-Wait-Tail-Processor: TransferSaga' \
-  -H 'Content-Type: application/json' \
-  -d '{
-  "amount": 100,
-  "to": "targetId"
-}'
-```
-
-```json [Response]
-{
-  "id": "0V3oAkw6000100G",
-  "waitCommandId": "0V3oAkvW0001009",
-  "stage": "SNAPSHOT",
-  "contextName": "transfer-service",
-  "aggregateName": "account",
-  "tenantId": "(0)",
-  "aggregateId": "targetId",
-  "aggregateVersion": 2,
-  "requestId": "0V3oAkvW0001009",
-  "commandId": "0V3oAkw2000100E",
-  "function": {
-    "functionKind": "STATE_EVENT",
-    "contextName": "wow",
-    "processorName": "SnapshotDispatcher",
-    "name": "save"
-  },
-  "errorCode": "Ok",
-  "errorMsg": "",
-  "result": {},
-  "signalTime": 1764297082107,
-  "succeeded": true
-}
-```
-
-```text [SSE Response]
-id:0V3oCVz9000100M
-event:SENT
-data:{"id":"0V3oCVz9000100M","waitCommandId":"0V3oCVyv000100L","stage":"SENT","contextName":"transfer-service","aggregateName":"account","tenantId":"(0)","aggregateId":"sourceId","aggregateVersion":null,"requestId":"0V3oCVyv000100L","commandId":"0V3oCVyv000100L","function":{"functionKind":"COMMAND","contextName":"wow","processorName":"CommandGateway","name":"send"},"errorCode":"Ok","errorMsg":"","result":{},"signalTime":1764297501291,"succeeded":true}
-
-id:0V3oCVyv000100L
-event:PROCESSED
-data:{"id":"0V3oCVyv000100L","waitCommandId":"0V3oCVyv000100L","stage":"PROCESSED","contextName":"transfer-service","aggregateName":"account","tenantId":"(0)","aggregateId":"sourceId","aggregateVersion":4,"requestId":"0V3oCVyv000100L","commandId":"0V3oCVyv000100L","function":{"functionKind":"COMMAND","contextName":"transfer-service","processorName":"Account","name":"onCommand"},"errorCode":"Ok","errorMsg":"","result":{},"signalTime":1764297501299,"succeeded":true}
-
-id:0V3oCVzW000100R
-event:SENT
-data:{"id":"0V3oCVzW000100R","waitCommandId":"0V3oCVyv000100L","stage":"SENT","contextName":"transfer-service","aggregateName":"account","tenantId":"(0)","aggregateId":"targetId","aggregateVersion":null,"requestId":"0V3oCVyv000100L","commandId":"0V3oCVzI000100Q","function":{"functionKind":"COMMAND","contextName":"wow","processorName":"CommandGateway","name":"send"},"errorCode":"Ok","errorMsg":"","result":{},"signalTime":1764297501314,"succeeded":true}
-
-id:0V3oCVzG000100P
-event:SAGA_HANDLED
-data:{"id":"0V3oCVzG000100P","waitCommandId":"0V3oCVyv000100L","stage":"SAGA_HANDLED","contextName":"transfer-service","aggregateName":"account","tenantId":"(0)","aggregateId":"sourceId","aggregateVersion":4,"requestId":"0V3oCVyv000100L","commandId":"0V3oCVyv000100L","function":{"functionKind":"EVENT","contextName":"transfer-service","processorName":"TransferSaga","name":"onEvent"},"errorCode":"Ok","errorMsg":"","result":{},"signalTime":1764297501314,"succeeded":true}
-
-id:0V3oCVzI000100Q
-event:PROCESSED
-data:{"id":"0V3oCVzI000100Q","waitCommandId":"0V3oCVyv000100L","stage":"PROCESSED","contextName":"transfer-service","aggregateName":"account","tenantId":"(0)","aggregateId":"targetId","aggregateVersion":3,"requestId":"0V3oCVyv000100L","commandId":"0V3oCVzI000100Q","function":{"functionKind":"COMMAND","contextName":"transfer-service","processorName":"Account","name":"onCommand"},"errorCode":"Ok","errorMsg":"","result":{},"signalTime":1764297501316,"succeeded":true}
-
-id:0V3oCVzX000100S
-event:SNAPSHOT
-data:{"id":"0V3oCVzX000100S","waitCommandId":"0V3oCVyv000100L","stage":"SNAPSHOT","contextName":"transfer-service","aggregateName":"account","tenantId":"(0)","aggregateId":"targetId","aggregateVersion":3,"requestId":"0V3oCVyv000100L","commandId":"0V3oCVzI000100Q","function":{"functionKind":"STATE_EVENT","contextName":"wow","processorName":"SnapshotDispatcher","name":"save"},"errorCode":"Ok","errorMsg":"","result":{},"signalTime":1764297501317,"succeeded":true}
-
-```
-
-```kotlin {1}
-val waitStrategy = SimpleWaitingForChain.chain(
-    tailStage = CommandStage.SNAPSHOT,
-    //...
-)
-commandGateway.sendAndWait(message,waitStrategy)
-```
-
-:::
-
-## Validation
-
-The command gateway uses `jakarta.validation.Validator` to validate the command before sending it. If validation fails, it will throw a CommandValidationException exception.
-
-By utilizing `jakarta.validation.Validator`, developers can use various validation annotations provided by `jakarta.validation` to ensure that commands meet the specified specifications and conditions.
-
-## LocalFirst Mode: Reducing the Impact of Network IO
-
-Normally, the process from sending a command to the aggregate root completing command processing is as follows:
-
-1. The aggregate root processor subscribes to distributed command bus messages.
-2. The client sends the command to the distributed command bus through the command gateway.
-3. The aggregate root processor receives and processes the command.
-4. The aggregate root processor sends a completion signal to the client.
-
-In the above process, steps 2 and 3 involve network IO. The goal of LocalFirst mode is to minimize the impact of this network IO. The specific process is as follows:
-
-1. The aggregate root processor subscribes to local command bus and distributed command bus messages.
-2. The client sends the command through the command gateway.
-   1. If the command gateway determines that the command cannot be processed on the local service instance, it sends the command to the distributed command bus.
-   2. If it can be processed locally, it sends the command to both the local command bus and the distributed command bus.
-3. The aggregate root processor receives the command and processes it.
-4. The aggregate root processor sends a completion signal to the client.
-
-Through *LocalFirst mode*, sending commands to the local bus and completion signal notifications do not require network IO.
-
-### Configuration
-
-```yaml {5-6}
+```yaml
 wow:
   command:
     bus:
       type: kafka
       local-first:
-        enabled: true # Enabled by default
+        enabled: true  # Default
 ```
+
+When enabled, if the command gateway determines the command can be processed locally, it sends to both the local and distributed command bus, eliminating network IO for local operations.
 
 ## Command Rewriter
 
-The command rewriter (`CommandBuilderRewriter`) is used to rewrite the command's message metadata (`aggregateId`/`tenantId`, etc.) and command body (`body`).
-
-The following is an example of a password reset command rewriter:
-
-::: tip
-Before a user resets their password (recovers password), they cannot obtain the aggregate root ID, so this rewriter is needed to obtain the `User` aggregate root ID
-:::
+Rewrite command metadata (`aggregateId`/`tenantId`) and body before processing:
 
 ```kotlin
-/**
- * Password recovery (`ResetPwd`) command rewriter.
- *
- * This command needs to query the user aggregate root ID based on the phone number in the command body to meet the requirement that the command message aggregate root ID is mandatory.
- *
- */
 @Service
-class ResetPwdCommandBuilderRewriter(private val queryService: SnapshotQueryService<UserState>) :
-   CommandBuilderRewriter {
-   override val supportedCommandType: Class<ResetPwd>
-      get() = ResetPwd::class.java
+class ResetPwdCommandBuilderRewriter(
+    private val queryService: SnapshotQueryService<UserState>
+) : CommandBuilderRewriter {
 
-   override fun rewrite(commandBuilder: CommandBuilder): Mono<CommandBuilder> {
-      return singleQuery {
-         projection { include(Documents.ID_FIELD) }
-         condition {
-            nestedState()
-            PHONE_VERIFIED eq true
-            PHONE eq commandBuilder.bodyAs<ResetPwd>().phone
-         }
-      }.dynamicQuery(queryService)
-         .switchIfEmpty {
-            IllegalArgumentException("Phone number not bound.").toMono()
-         }.map {
-            commandBuilder.aggregateId(it.getValue(MessageRecords.AGGREGATE_ID))
-         }
-   }
+    override val supportedCommandType: Class<ResetPwd>
+        get() = ResetPwd::class.java
+
+    override fun rewrite(commandBuilder: CommandBuilder): Mono<CommandBuilder> {
+        return singleQuery {
+            projection { include(Documents.ID_FIELD) }
+            condition {
+                nestedState()
+                PHONE_VERIFIED eq true
+                PHONE eq commandBuilder.bodyAs<ResetPwd>().phone
+            }
+        }.dynamicQuery(queryService)
+            .switchIfEmpty { IllegalArgumentException("Phone not bound.").toMono() }
+            .map {
+                commandBuilder.aggregateId(it.getValue(MessageRecords.AGGREGATE_ID))
+            }
+    }
 }
 ```
 
-Developers can register the rewriter by using Spring's `@Service` annotation to register it in the Spring container.
+Register via Spring's `@Service` annotation.
+
+## HTTP Headers
+
+| Header | Description |
+|--------|-------------|
+| `Command-Wait-Stage` | Wait stage: SENT, PROCESSED, SNAPSHOT, PROJECTED, EVENT_HANDLED, SAGA_HANDLED |
+| `Command-Aggregate-Id` | Target aggregate ID |
+| `Command-Request-Id` | Idempotency key |
+| `Command-Wait-Tail-Stage` | Tail wait stage for chain strategy |
+| `Command-Wait-Tail-Processor` | Tail processor name for chain strategy |
 
 ## Troubleshooting
 
-### Common Issues
+**Command times out**: Check aggregate dead-letter state, verify wait strategy, increase timeout.
 
-**Command times out**
-- Check if the aggregate is in a dead-letter state
-- Verify the wait strategy matches the operation (e.g., `SNAPSHOT` for long-running operations)
-- Increase timeout: `.timeout(Duration.ofSeconds(30))`
+**DuplicateRequestIdException**: Use unique `requestId` per command, wait for TTL expiration.
 
-**DuplicateRequestIdException**
-- Ensure each command has a unique `requestId` in `CommandMessage`
-- The idempotency checker caches recent request IDs - wait for TTL expiration or use a new ID
+**Aggregate state not rebuilding**: Verify `@OnSourcing` handlers, check event revision compatibility.
 
-**Aggregate state not rebuilding**
-- Verify `@OnSourcing` handlers exist in the State Aggregate
-- Check that event revision numbers are compatible
-- Ensure the EventStore contains the aggregate's events
-
-**CommandValidationException on valid command**
-- Verify JSR-303 annotations are on the command body (not the aggregate)
-- Check `jakarta.validation` dependency is included
-
-**Saga not firing**
-- Verify the saga's `@OnEvent` handler subscribes to the correct aggregate's events
-- Check that the event bus topic is configured correctly
-- Ensure the saga is registered as a Spring bean
+**CommandValidationException**: Verify JSR-303 annotations on command body, check `jakarta.validation` dependency.

--- a/skills/wow/references/configuration.md
+++ b/skills/wow/references/configuration.md
@@ -1,0 +1,277 @@
+# Wow Configuration Reference
+
+All configuration is under the `wow` prefix in `application.yaml`.
+
+## Core Configuration
+
+```yaml
+wow:
+  enabled: true                    # Enable/disable Wow framework
+  context-name: my-service         # Bounded context name (default: spring.application.name)
+  shutdown-timeout: 60s            # Graceful shutdown timeout
+```
+
+## Complete Configuration Template
+
+```yaml
+wow:
+  enabled: true
+  context-name: order-service
+  shutdown-timeout: 120s
+
+  # Command Bus
+  command:
+    bus:
+      type: kafka                  # kafka, redis, in_memory, no_op
+      local-first:
+        enabled: true              # Process local messages first
+    idempotency:
+      enabled: true
+      bloom-filter:
+        expected-insertions: 1000000
+        ttl: PT60S
+        fpp: 0.00001
+
+  # Event Bus
+  event:
+    bus:
+      type: kafka
+      local-first:
+        enabled: true
+
+  # State Event Bus
+  eventsourcing:
+    state:
+      bus:
+        type: kafka
+        local-first:
+          enabled: true
+    store:
+      storage: mongo               # mongo, r2dbc, redis, elasticsearch, in_memory, delay
+    snapshot:
+      enabled: true
+      strategy: all                # all, version_offset
+      storage: mongo
+      version-offset: 10
+
+  # Infrastructure
+  kafka:
+    bootstrap-servers:
+      - localhost:9092
+    topic-prefix: 'wow.'
+
+  mongo:
+    enabled: true
+    auto-init-schema: true
+    event-stream-database: wow_event_db
+    snapshot-database: wow_snapshot_db
+    prepare-database: wow_prepare_db
+
+  redis:
+    enabled: true
+
+  r2dbc:
+    enabled: true
+    datasource:
+      type: simple                 # simple or sharding
+
+  elasticsearch:
+    enabled: true
+
+  # Features
+  compensation:
+    enabled: true
+    host: https://your-dashboard.example.com
+    webhook:
+      weixin:
+        url: <webhook-url>
+        events:
+          - execution_failed_created
+          - execution_failed_applied
+          - execution_success_applied
+
+  openapi:
+    enabled: true
+
+  webflux:
+    enabled: true
+    global-error:
+      enabled: true
+```
+
+## Command Bus
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `wow.command.bus.type` | BusType | `kafka` | Command bus implementation |
+| `wow.command.bus.local-first.enabled` | Boolean | `true` | Enable LocalFirst mode |
+| `wow.command.idempotency.enabled` | Boolean | `true` | Enable idempotency checking |
+| `wow.command.idempotency.bloom-filter.expected-insertions` | Int | `1000000` | Bloom filter capacity |
+| `wow.command.idempotency.bloom-filter.ttl` | Duration | `PT60S` | Bloom filter TTL |
+| `wow.command.idempotency.bloom-filter.fpp` | Double | `0.00001` | False positive probability |
+
+## Event Bus
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `wow.event.bus.type` | BusType | `kafka` | Event bus implementation |
+| `wow.event.bus.local-first.enabled` | Boolean | `true` | Enable LocalFirst mode |
+
+## State Event Bus
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `wow.eventsourcing.state.bus.type` | BusType | `kafka` | State event bus type |
+| `wow.eventsourcing.state.bus.local-first.enabled` | Boolean | `true` | Enable LocalFirst mode |
+
+## Event Sourcing
+
+### Event Store
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `wow.eventsourcing.store.storage` | StorageType | `mongo` | Event store backend |
+
+### Snapshot
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `wow.eventsourcing.snapshot.enabled` | Boolean | `true` | Enable snapshot functionality |
+| `wow.eventsourcing.snapshot.strategy` | Strategy | `all` | Snapshot strategy: `all` or `version_offset` |
+| `wow.eventsourcing.snapshot.version-offset` | Int | `10` | Version offset for VERSION_OFFSET strategy |
+| `wow.eventsourcing.snapshot.storage` | StorageType | `mongo` | Snapshot storage backend |
+
+## Infrastructure
+
+### Kafka
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `wow.kafka.enabled` | Boolean | `true` | Enable Kafka support |
+| `wow.kafka.bootstrap-servers` | List\<String\> | | Kafka broker addresses |
+| `wow.kafka.topic-prefix` | String | `wow.` | Topic name prefix |
+
+### MongoDB
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `wow.mongo.enabled` | Boolean | `true` | Enable MongoDB support |
+| `wow.mongo.auto-init-schema` | Boolean | `true` | Auto-create collections |
+| `wow.mongo.event-stream-database` | String | Spring MongoDB database | Event stream database |
+| `wow.mongo.snapshot-database` | String | Spring MongoDB database | Snapshot database |
+| `wow.mongo.prepare-database` | String | Spring MongoDB database | Prepare key database |
+
+### Redis
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `wow.redis.enabled` | Boolean | `true` | Enable Redis support |
+
+### R2DBC
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `wow.r2dbc.enabled` | Boolean | `true` | Enable R2DBC support |
+| `wow.r2dbc.datasource.type` | Type | `simple` | `simple` or `sharding` |
+
+### Elasticsearch
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `wow.elasticsearch.enabled` | Boolean | `true` | Enable Elasticsearch support |
+
+## Features
+
+### Event Compensation
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `wow.compensation.enabled` | Boolean | `true` | Enable event compensation |
+| `wow.compensation.host` | String | | Dashboard URL for notification links |
+| `wow.compensation.webhook.weixin.url` | String | | WeChat Work webhook URL |
+| `wow.compensation.webhook.weixin.events` | List\<String\> | all events | Notification event types |
+
+### OpenAPI
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `wow.openapi.enabled` | Boolean | `true` | Enable OpenAPI support |
+
+### WebFlux
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `wow.webflux.enabled` | Boolean | `true` | Enable WebFlux support |
+| `wow.webflux.global-error.enabled` | Boolean | `true` | Enable global error handling |
+
+## Bus Types
+
+| Type | Description |
+|------|-------------|
+| `kafka` | Apache Kafka (recommended for production) |
+| `redis` | Redis Streams |
+| `in_memory` | In-memory (for testing) |
+| `no_op` | No-op (for special cases) |
+
+## Storage Types
+
+| Type | Description |
+|------|-------------|
+| `mongo` | MongoDB (recommended for event store) |
+| `r2dbc` | R2DBC-compatible databases |
+| `redis` | Redis for high-performance scenarios |
+| `elasticsearch` | Elasticsearch for full-text search |
+| `in_memory` | In-memory (for testing) |
+| `delay` | Delay (for testing) |
+
+## Environment-Specific Configurations
+
+### Development
+
+```yaml
+wow:
+  command:
+    bus:
+      type: in_memory
+  event:
+    bus:
+      type: in_memory
+  eventsourcing:
+    store:
+      storage: in_memory
+    snapshot:
+      storage: in_memory
+      strategy: all
+```
+
+### Production
+
+```yaml
+wow:
+  command:
+    bus:
+      type: kafka
+      local-first:
+        enabled: true
+  event:
+    bus:
+      type: kafka
+      local-first:
+        enabled: true
+  eventsourcing:
+    store:
+      storage: mongo
+    snapshot:
+      enabled: true
+      strategy: version_offset
+      version-offset: 10
+      storage: mongo
+  kafka:
+    bootstrap-servers:
+      - kafka-0:9092
+      - kafka-1:9092
+      - kafka-2:9092
+  mongo:
+    enabled: true
+    auto-init-schema: true
+```

--- a/skills/wow/references/dsl.md
+++ b/skills/wow/references/dsl.md
@@ -1,92 +1,142 @@
 # Wow Query DSL Reference
 
+All DSL functions are in package `me.ahoo.wow.query.dsl`.
+
 ## Query Functions
 
 ### singleQuery
 
-Query a single result.
+Query a single result:
 
 ```kotlin
 singleQuery {
-    where { "status" eq "active" }
-    projection { "id", "name", "email" }
-    orderBy { "createdAt" desc }
-    limit(10)
-}.query(queryService)
+    condition {
+        "status" eq "active"
+    }
+    projection {
+        include("id", "name", "email")
+    }
+    sort {
+        "createdAt".desc()
+    }
+}
 ```
 
 ### listQuery
 
-Query a list of results.
+Query a list of results. Has a `limit` method:
 
 ```kotlin
 listQuery {
-    where { "age" gt 18 }
-    orderBy { "name" asc }
-    offset(0)
+    condition {
+        "age" gt 18
+    }
+    sort {
+        "name".asc()
+    }
     limit(20)
-}.query(queryService)
+}
 ```
 
 ### pagedQuery
 
-Query with pagination.
+Query with pagination:
 
 ```kotlin
 pagedQuery {
-    where {
+    condition {
         tenantId(tenantId)
         "status" eq "ACTIVE"
     }
-    page(1)
-    pageSize(20)
-    orderBy { "createdAt" desc }
-    projection { "id", "status", "totalAmount" }
-}.query(queryService)
+    pagination {
+        index(1)
+        size(20)
+    }
+    sort {
+        "createdAt".desc()
+    }
+    projection {
+        include("id", "status", "totalAmount")
+    }
+}
 ```
 
-## Condition Operators
+### countQuery
 
-### Field Queries
+Count documents matching a condition:
+
+```kotlin
+condition {
+    "status" eq "active"
+}.count(queryService)
+```
+
+## Condition DSL
+
+### Top-Level Functions
 
 | Operator | Description | Example |
 |----------|-------------|---------|
-| `eq` / `ne` | Equals / Not equals | `"status" eq "ACTIVE"` |
-| `gt` / `lt` | Greater / Less than | `"age" gt 18` |
-| `gte` / `lte` | Greater/Less than or equal | `"age" gte 18` |
+| `id` | By document ID | `id("order-123")` |
+| `ids` | By multiple IDs | `ids("id1", "id2")` |
+| `aggregateId` | By aggregate ID | `aggregateId("cart-456")` |
+| `aggregateIds` | By multiple aggregate IDs | `aggregateIds("id1", "id2")` |
+| `tenantId` | By tenant ID | `tenantId("tenant-1")` |
+| `ownerId` | By owner ID | `ownerId("user-1")` |
+| `spaceId` | By space ID | `spaceId("space-1")` |
+| `deleted` | By deletion state | `deleted(DeletionState.ALL)` |
+| `all` | Match all documents | `all()` |
+| `raw` | Raw query value | `raw("1=1")` |
+
+### Field Comparison Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `eq` | Equals | `"status" eq "ACTIVE"` |
+| `ne` | Not equals | `"status" ne "DELETED"` |
+| `gt` | Greater than | `"age" gt 18` |
+| `lt` | Less than | `"age" lt 65` |
+| `gte` | Greater than or equal | `"age" gte 18` |
+| `lte` | Less than or equal | `"age" lte 65` |
+
+### String Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
 | `contains` | String contains | `"name" contains "John"` |
-| `isIn` / `notIn` | In list / Not in list | `"status" isIn listOf("A", "B")` |
-| `between` | In range (inclusive) | `"age" between 18 to 65` |
-| `all` | Array contains all | `"tags" all listOf("a", "b")` |
 | `startsWith` | String prefix | `"email" startsWith "admin"` |
 | `endsWith` | String suffix | `"email" endsWith "@company.com"` |
-| `elemMatch` | Array element matches | `"items" elemMatch { "price" gt 100 }` |
+| `match` | String match | `"name" match "John"` |
+
+### Collection Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `isIn` | In list | `"status" isIn listOf("A", "B")` |
+| `notIn` | Not in list | `"status" notIn listOf("C", "D")` |
+| `between` | In range (Pair) | `"age" between (18 to 65)` |
+| `between` / `to` | In range (infix) | `"age" between 18 to 65` |
+| `all` | Array contains all | `"tags" all listOf("a", "b")` |
+| `elemMatch` | Array element match | `"items" elemMatch { "price" gt 100 }` |
+
+### Null / Boolean Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
 | `isNull()` | Is null | `"phone".isNull()` |
 | `notNull()` | Is not null | `"email".notNull()` |
 | `isTrue()` | Is true | `"active".isTrue()` |
 | `isFalse()` | Is false | `"deleted".isFalse()` |
 | `exists` | Field exists | `"optionalField".exists()` |
-| `raw()` | Raw query | `raw("1=1")` |
-
-### ID Queries
-
-| Operator | Description | Example |
-|----------|-------------|---------|
-| `id()` | By document ID | `id("order-123")` |
-| `ids()` | By multiple IDs | `ids("id1", "id2", "id3")` |
-| `aggregateId()` | By aggregate ID | `aggregateId("cart-456")` |
-| `aggregateIds()` | By multiple aggregate IDs | `aggregateIds("id1", "id2")` |
-| `tenantId()` | By tenant ID | `tenantId("tenant-1")` |
-| `ownerId()` | By owner ID | `ownerId("user-1")` |
-| `deleted()` | By deletion state | `deleted(DeletionState.ALL)` |
+| `exists(false)` | Field does not exist | `"optionalField".exists(false)` |
 
 ### Date/Time Operators
 
 | Operator | Description | Example |
 |----------|-------------|---------|
 | `today()` | Within today | `"createdAt".today()` |
+| `beforeToday` | Before today at given time | `"createdAt" beforeToday time` |
 | `tomorrow()` | Within tomorrow | `"scheduledAt".tomorrow()` |
-| `beforeToday()` | Before today | `"createdAt".beforeToday()` |
 | `thisWeek()` | Within this week | `"createdAt".thisWeek()` |
 | `nextWeek()` | Within next week | `"startDate".nextWeek()` |
 | `lastWeek()` | Within last week | `"createdAt".lastWeek()` |
@@ -94,6 +144,8 @@ pagedQuery {
 | `lastMonth()` | Within last month | `"createdAt".lastMonth()` |
 | `recentDays(n)` | Within n recent days | `"updatedAt".recentDays(7)` |
 | `earlierDays(n)` | More than n days ago | `"createdAt".earlierDays(30)` |
+
+All date operators accept an optional `datePattern` parameter.
 
 ### Logical Combinations
 
@@ -112,7 +164,7 @@ condition {
     nor {
         "status" eq "SUSPENDED"
     }
-    all()  // Match all documents
+    all()
 }
 ```
 
@@ -127,13 +179,23 @@ condition {
             "field" eq "value"
         }
     }
-    nestedState()  // Query on nested state field
+    nestedState()  // extension in package me.ahoo.wow.query.snapshot
 }
 ```
 
-## Projection
+### Using KCallable (Property References)
 
-Select specific fields to return.
+All field operators also accept `KCallable<*>` for type-safe field access:
+
+```kotlin
+condition {
+    WarehouseIdCapable::warehouseId eq warehouseId
+}
+```
+
+## Projection DSL
+
+Select specific fields to return:
 
 ```kotlin
 projection {
@@ -142,54 +204,101 @@ projection {
 }
 ```
 
-Or inline:
+Or use directly inside query blocks:
 
 ```kotlin
-projection { "id", "status", "totalAmount" }
+singleQuery {
+    projection {
+        include("id", "status", "totalAmount")
+    }
+}
 ```
 
-## Sorting
+## Sort DSL
 
 ```kotlin
 sort {
-    "createdAt".asc()
-    "name".desc()
-}
-
-orderBy {  // Shorthand
+    "name".asc()
     "createdAt".desc()
 }
 ```
 
-## Pagination
-
-### Page-based (1-indexed)
+Used inside query blocks:
 
 ```kotlin
-pagedQuery {
-    page(1)      // 1-indexed page number
-    pageSize(20) // items per page
+listQuery {
+    sort {
+        "field1".asc()
+        "field2".desc()
+    }
 }
+```
 
-// Or using pagination {}
+## Pagination DSL
+
+1-indexed pagination:
+
+```kotlin
 pagination {
     index(1)
     size(10)
 }
 ```
 
-### Offset-based
+Used directly or inside `pagedQuery`:
 
 ```kotlin
-listQuery {
-    offset(0)
-    limit(20)
+pagedQuery {
+    pagination {
+        index(1)
+        size(20)
+    }
 }
+```
+
+## Executing Queries
+
+Use the `.query(queryService)` extension function (from `me.ahoo.wow.query.snapshot`):
+
+```kotlin
+// Single result - returns Mono<MaterializedSnapshot<S>>
+singleQuery {
+    condition { id(id) }
+}.query(queryService)
+
+// List result - returns Flux<MaterializedSnapshot<S>>
+listQuery {
+    limit(10)
+    sort { "field1".asc() }
+    condition { "field1" eq "value1" }
+}.query(queryService)
+
+// Paged result - returns Mono<PagedList<MaterializedSnapshot<S>>>
+pagedQuery {
+    pagination { index(1); size(10) }
+    sort { "field1".asc() }
+    condition {
+        and {
+            "field3" eq "value3"
+            "field4" startsWith "value4"
+        }
+    }
+}.query(queryService)
+
+// Count - returns Mono<Long>
+condition {
+    "field1" eq "value1"
+}.count(queryService)
+
+// Dynamic queries (runtime document type)
+singleQuery { ... }.dynamicQuery(queryService)
+listQuery { ... }.dynamicQuery(queryService)
+pagedQuery { ... }.dynamicQuery(queryService)
 ```
 
 ## Query Rewriting
 
-For security/tenant filtering, you can rewrite queries:
+For security/tenant filtering:
 
 ```kotlin
 @Component
@@ -202,26 +311,17 @@ class DataFilterSnapshotQueryFilter : SnapshotQueryFilter {
     ): Mono<Void> {
         return Mono.deferContextual {
             context.asRewritableQuery().rewriteQuery { query ->
-                val condition = condition {
+                val warehouseCondition = condition {
                     nestedState()
-                    WarehouseIdCapable::warehouseId.name eq warehouseId
+                    WarehouseIdCapable::warehouseId eq warehouseId
                 }
-                query.appendCondition(condition)
+                query.appendCondition(warehouseCondition)
             }
             next.filter(context)
         }
     }
 }
 ```
-
-## OpenAPI Auto-generation
-
-Wow automatically generates OpenAPI endpoints for queries:
-
-- `POST /{aggregate}/snapshot/paged` - Paged query
-- `POST /{aggregate}/snapshot/list` - List query
-- `POST /{aggregate}/snapshot/count` - Count query
-- `POST /{aggregate}/snapshot/single` - Single result
 
 ## Query Service Injection
 
@@ -237,4 +337,13 @@ class OrderService(
 }
 ```
 
-Bean name convention: `AggregateName.SnapshotQueryService` (e.g., `example.order.SnapshotQueryService`)
+Bean name convention: `{AggregateName}.SnapshotQueryService` (e.g., `example.order.SnapshotQueryService`).
+
+## OpenAPI Auto-generation
+
+Wow automatically generates OpenAPI query endpoints:
+
+- `POST /{aggregate}/snapshot/paged` — Paged query
+- `POST /{aggregate}/snapshot/list` — List query
+- `POST /{aggregate}/snapshot/count` — Count query
+- `POST /{aggregate}/snapshot/single` — Single result

--- a/skills/wow/references/modeling.md
+++ b/skills/wow/references/modeling.md
@@ -9,151 +9,39 @@ At the same time, separation of responsibilities allows the aggregate root's com
 
 #### Simple Aggregation Pattern
 
-```mermaid
----
-title: Aggregate Modeling Using Simple Aggregation Pattern
----
-classDiagram
-    class StateAggregate {
-        +StateAggregate(id)
-        //... state fields
-        -onSourcing(domainEvent)
-    }
-    class CommandAggregate~S: StateAggregate~ {
-        <<AggregateRoot>>
-        +CommandAggregate(state)
-        -onCommand(command)
-    }
-
-StateAggregate "1" o-- "state" CommandAggregate
-
+```
+StateAggregate ←--state-- CommandAggregate(@AggregateRoot)
 ```
 
 #### Complex Aggregation Pattern
 
-```mermaid
----
-title: Aggregate Modeling Using Complex Aggregation Pattern
----
-classDiagram
-    class StateAggregate {
-        +StateAggregate(id)
-        //... state fields
-        -onSourcing(domainEvent)
-    }
-
-    class CommandAggregate~S: StateAggregate~ {
-        +CommandAggregate(state)
-        state: S
-        -onCommand(command)
-    }
-
-    class StateAggregateA {
-        +StateAggregateA(id)
-        //... state fields
-        -onSourcing(domainEvent)
-    }
-
-    class StateAggregateB {
-        +StateAggregateB(id)
-        //... state fields
-        -onSourcing(domainEvent)
-    }
-
-    class CommandAggregateA~StateAggregateA~ {
-        <<AggregateRoot>>
-        +CommandAggregate(state)
-        state: StateAggregateA
-        -onCommand(command)
-    }
-
-    class CommandAggregateB~StateAggregateB~ {
-        <<AggregateRoot>>
-        +CommandAggregate(state)
-        state: StateAggregateB
-        -onCommand(command)
-    }
-
-StateAggregate "1" o-- "state" CommandAggregate
-StateAggregate <|-- StateAggregateA
-StateAggregate <|-- StateAggregateB
-CommandAggregate <|-- CommandAggregateA
-CommandAggregate <|-- CommandAggregateB
-StateAggregateA "1" o-- "state" CommandAggregateA
-StateAggregateB "1" o-- "state" CommandAggregateB
-
+```
+StateAggregate ←--state-- CommandAggregate
+  ├── StateAggregateA ←--state-- CommandAggregateA(@AggregateRoot)
+  └── StateAggregateB ←--state-- CommandAggregateB(@AggregateRoot)
 ```
 
 ### Single Class Pattern
 
-The single class pattern places command functions, sourcing functions, and aggregate state data together in one class. The advantage is simplicity and directness.
-
-::: danger Violation of Event Sourcing Principles
-In the single class pattern, command functions can directly modify aggregate state data, which leads to:
-
-* State changes cannot be traced via events
-* Destroys the core value of Event Sourcing
-* May result in inconsistent state changes
-
-**Strongly Recommended**: Use this pattern only for simple scenarios or prototype development.
-:::
-
-```mermaid
----
-title: Aggregate Modeling Using Single Class
----
-classDiagram
-    class Aggregate {
-        <<AggregateRoot>>
-        +Aggregate(id)
-        //... state fields
-        -onSourcing(domainEvent)
-        -onCommand(command)
-    }
-
-```
+Command + sourcing + state in one class. **Avoid** — violates event sourcing principles:
+- Command functions can directly modify state
+- State changes cannot be traced via events
+- Use only for simple prototypes
 
 ### Inheritance Pattern
 
-The inheritance pattern uses the state aggregate root as the base class and sets the `setter` accessor to `private` to prevent command aggregate roots from modifying aggregate state data in command functions.
-
-```mermaid
----
-title: Aggregate Modeling Using Inheritance Pattern
----
-classDiagram
-    class StateAggregate {
-        +StateAggregate(id)
-        //... state fields
-        -onSourcing(domainEvent)
-    }
-
-    class CommandAggregate {
-        <<AggregateRoot>>
-        -onCommand(command)
-    }
-
-    StateAggregate <|-- CommandAggregate
-
-```
+Command aggregate inherits from state aggregate with `private set` on setters.
 
 ## Conventions
 
 ### Command Aggregate Root
 
-The command aggregate root is responsible for defining command handler functions, processing commands to execute corresponding business logic, and finally returning domain events.
-
-* The command aggregate root needs to add the `@AggregateRoot` annotation so that the `wow-compiler` module can generate corresponding metadata definitions.
-* The `@OnCommand` annotation for command handler functions is not required. By default, naming a command handler function `onCommand` indicates it is a command handler function.
-* The first parameter of command handler functions can be defined as: specific command (`AddCartItem`), command message (`CommandMessage<AddCartItem>`), command message exchange (`CommandExchange<AddCartItem>`).
-* The remaining parameters of command handler functions will be obtained from the `IOC` container. If you have injected an instance in the `Spring IOC` container, you can obtain it directly through parameters.
-* The return value of command handler functions is one or more domain events. These domain events will first have their state changed to the latest state by the state aggregate root through sourcing functions, then be persisted to the `EventStore`.
-  * `@OnCommand(returns = [...])` is **required** when:
-    * The return type is `Any` or `Object` (polymorphic returns)
-    * A single command can produce multiple different event types
-    * The compiler cannot infer the event type from the return statement
-  * If omitted when required, `wow-compiler` will fail to identify the returned domain event type.
-* After persistence is complete, they will be published to the event bus through the `DomainEventBus`.
+- Add `@AggregateRoot` annotation for `wow-compiler` metadata generation
+- `@OnCommand` is optional if method is named `onCommand`
+- First parameter: specific command, `CommandMessage<C>`, or `CommandExchange<C>`
+- Other parameters resolved from IOC container (use `@Name` for qualified injection)
+- Return value: one or more domain events
+- `@OnCommand(returns = [...])` is required when return type is `Any` or polymorphic
 
 ```kotlin
 @AggregateRoot
@@ -182,15 +70,37 @@ class Cart(private val state: CartState) {
 }
 ```
 
+### AfterCommand Hook
+
+Post-processing hook that executes after command handler completes. Non-null return values are appended as additional events.
+
+```kotlin
+@AfterCommand(include = [CreateOrder::class])
+fun afterCreateOrder(exchange: ServerCommandExchange<*>): OrderConfirmed? {
+    val result = exchange.getCommandInvokeResult<OrderCreated>()
+    return null
+}
+```
+
+### Error Handling with OnError
+
+```kotlin
+@OnError
+fun onError(command: CreateOrder, error: Throwable) {
+    // Handle error, log or publish error event
+}
+```
+
+Can also accept `eventStream: DomainEventStream?` as a third parameter.
+
 ### State Aggregate Root
 
-The state aggregate root defines aggregate state data and sourcing functions.
-
-* The state aggregate root must define the aggregate root ID field in the constructor.
-* The role of sourcing functions is to apply domain events to aggregate state data, thereby changing aggregate state data.
-* Sourcing functions are marked with the `@OnSourcing` annotation. However, this annotation is optional. By default, when the function name is `onSourcing`, it indicates that the function is a sourcing function.
-* Sourcing functions accept parameters of: specific domain events (`CartItemAdded`), domain events (`DomainEvent<CartItemAdded>`).
-* No return value needs to be defined for sourcing functions.
+- Must define aggregate root ID field in constructor
+- Sourcing functions apply domain events to state
+- `@OnSourcing` optional if method named `onSourcing`
+- Sourcing parameters: specific event or `DomainEvent<T>`
+- No return value — state is mutated in place
+- **Must be deterministic and side-effect-free**
 
 ```kotlin
 class CartState(val id: String) {
@@ -202,4 +112,155 @@ class CartState(val id: String) {
         items = items + cartItemAdded.added
     }
 }
+```
+
+## Bounded Context
+
+A bounded context defines a coherent area of the domain with its own ubiquitous language and rules.
+
+```kotlin
+@BoundedContext(
+    name = "example",
+    alias = "ex",
+    aggregates = [
+        BoundedContext.Aggregate(name = "order"),
+        BoundedContext.Aggregate(name = "cart")
+    ]
+)
+object ExampleBoundedContext
+```
+
+Every `AggregateId` includes a `contextName`, ensuring commands and events are routed within the correct bounded context.
+
+## Aggregate Lifecycle
+
+### State Machine
+
+```
+NEW (version=0) → STORED → SOURCED → STORED (cycle per command)
+                             ↓
+                         EXPIRED (unrecoverable error)
+
+STORED → DELETED (DefaultDeleteAggregate)
+DELETED → STORED (DefaultRecoverAggregate)
+```
+
+### Command Processing Phases
+
+1. **Validation Gates** (6 sequential checks):
+   - Version check (optimistic concurrency)
+   - Initialization check (`initialized || isCreate || allowCreate`)
+   - Owner check (multi-tenancy)
+   - Space check (multi-tenancy)
+   - CommandState check (`STORED` — serial processing)
+   - Delete check (reject unless `RecoverAggregate`)
+
+2. **Command Execution**: `@OnCommand` handler produces events
+
+3. **Event Sourcing**: `@OnSourcing` methods apply events to state deterministically
+
+4. **Event Persistence**: Atomic append to EventStore with version conflict check
+
+5. **Event Publication**: Events published to DomainEventBus
+
+### Version Lifecycle
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `UNINITIALIZED_VERSION` | `0` | Just created, no events |
+| `INITIAL_VERSION` | `1` | First event applied |
+| `initialized` | `version > 0` | Has any events |
+| `expectedNextVersion` | `version + 1` | Next expected version |
+
+### Special Built-in Events
+
+Handled automatically without explicit `@OnSourcing`:
+
+| Event | Effect |
+|---|---|
+| `AggregateDeleted` | `deleted = true` |
+| `AggregateRecovered` | `deleted = false` |
+| `OwnerTransferred` | `ownerId = toOwnerId` |
+| `SpaceTransferred` | `spaceId = toSpaceId` |
+| `ResourceTagsApplied` | `tags = event.tags` |
+
+### Missing @OnSourcing
+
+If no matching `@OnSourcing` handler exists for an event, the framework:
+- Does NOT throw an error
+- Logs a debug message
+- Still updates the aggregate version
+
+This allows forward-compatible state evolution.
+
+### State Rebuild Strategy
+
+When loading an existing aggregate:
+- **Snapshot-based**: Load snapshot, replay only incremental events after snapshot version
+- **Full replay**: No snapshot → replay all events from version 1
+
+Point-in-time reconstruction is supported via `tailEventTime` parameter.
+
+## Multi-Tenancy
+
+Every `AggregateId` includes `tenantId`:
+
+- `@StaticTenantId` on aggregate class — fixed tenant
+- `@TenantId` on command parameter — extract from command body
+- `BoundedContext.Aggregate(tenantId = "...")` — static tenant assignment
+
+## Aggregate Routing
+
+```kotlin
+@AggregateRoute(
+    resourceName = "sales-order",
+    spaced = true,
+    owner = AggregateRoute.Owner.ALWAYS
+)
+class Order(private val state: OrderState) { ... }
+```
+
+| Attribute | Description |
+|---|---|
+| `resourceName` | Custom API path segment |
+| `enabled` | Set `false` to disable route generation |
+| `owner` | Ownership: `NEVER`, `ALWAYS`, `AGGREGATE_ID` |
+
+## Aggregate Scheduler
+
+Each aggregate gets a dedicated Reactor Scheduler to control concurrent execution:
+
+```kotlin
+fun interface AggregateSchedulerSupplier {
+    fun getOrInitialize(namedAggregate: NamedAggregate): Scheduler
+}
+```
+
+Default implementation creates a parallel scheduler per aggregate: `Schedulers.newParallel("$name-${namedAggregate.aggregateName}")`.
+
+## Event Naming Convention
+
+```kotlin
+// Good - past tense + specific behavior
+@Event
+data class OrderCreated(
+    val orderId: String,
+    val customerId: String,
+    val items: List<OrderItem>,
+    val totalAmount: BigDecimal
+)
+
+// Avoid - vague naming
+data class OrderUpdated(val orderId: String)  // What changed?
+```
+
+### Event Revision
+
+```kotlin
+@Event(revision = "2.0")
+data class OrderShipped(
+    val orderId: String,
+    val trackingNumber: String,
+    val shippedAt: Instant
+)
 ```

--- a/skills/wow/references/testing.md
+++ b/skills/wow/references/testing.md
@@ -4,8 +4,14 @@
 
 Wow provides a Given→When→Expect test pattern:
 - **Given**: Previous domain events to initialize aggregate state
-- **When**: Current command to trigger state changes
-- **Expect**: Verify state changes meet expectations
+- **When**: Current command or event to trigger changes
+- **Expect**: Verify results meet expectations
+
+Use `me.ahoo.test.asserts.assert` for assertions — NOT AssertJ's `assertThat()`.
+
+```kotlin
+import me.ahoo.test.asserts.assert
+```
 
 ## AggregateSpec
 
@@ -17,14 +23,11 @@ Testing aggregates using Given-When-Expect pattern.
 class CartSpec : AggregateSpec<Cart, CartState>(
     {
         on {
-            // Given
             val ownerId = generateGlobalId()
             givenOwnerId(ownerId)
 
-            // When
             val addCartItem = AddCartItem(productId = "product-1", quantity = 1)
             whenCommand(addCartItem) {
-                // Then
                 expectNoError()
                 expectEventType(CartItemAdded::class)
                 expectState {
@@ -79,17 +82,13 @@ class CartSpec : AggregateSpec<Cart, CartState>(
 | `fork(ref, name, verifyError) { }` | Branch with error verification |
 | `ref("name")` | Mark a verification point |
 
-### Fork Use Cases
-
-- **Sequential Operations**: Order → Payment → Shipping
-- **Error Scenarios**: Invalid operations in different states
-- **Alternative Paths**: Different command sequences from same point
-- **Aggregate Lifecycle**: Deletion, recovery, behavior after deletion
-- **Business Rules**: Constraints across state transitions
+**Fork Use Cases:**
+- Sequential Operations: Order → Payment → Shipping
+- Error Scenarios: Invalid operations in different states
+- Alternative Paths: Different command sequences from same point
+- Aggregate Lifecycle: Deletion, recovery, behavior after deletion
 
 ### Reference Points
-
-Mark points for cross-scenario branching:
 
 ```kotlin
 whenCommand(CreateOrder(...)) {
@@ -98,7 +97,7 @@ whenCommand(CreateOrder(...)) {
     expectState { status.assert().isEqualTo(OrderStatus.CREATED) }
 }
 
-// Later, branch from marked point
+// Branch from marked point
 fork("order-created", "Pay Order") {
     whenCommand(PayOrder(...)) {
         expectEventType(OrderPaid::class)
@@ -120,14 +119,12 @@ class OrderSpec : AggregateSpec<Order, OrderState>({
             expectEventType(OrderCreated::class)
 
             fork("Pay Order") {
-                val payOrder = PayOrder(totalAmount)
-                whenCommand(payOrder) {
+                whenCommand(PayOrder(totalAmount)) {
                     expectEventType(OrderPaid::class)
                     expectState { status.assert().isEqualTo(OrderStatus.PAID) }
 
                     fork("Ship Order") {
-                        val shipOrder = ShipOrder(aggregateId.id)
-                        whenCommand(shipOrder) {
+                        whenCommand(ShipOrder(aggregateId.id)) {
                             expectEventType(OrderShipped::class)
                         }
                     }
@@ -135,8 +132,7 @@ class OrderSpec : AggregateSpec<Order, OrderState>({
             }
 
             fork("Ship Before Payment") {
-                val shipOrder = ShipOrder(aggregateId.id)
-                whenCommand(shipOrder) {
+                whenCommand(ShipOrder(aggregateId.id)) {
                     expectErrorType(IllegalStateException::class)
                 }
             }
@@ -152,9 +148,6 @@ on {
     val inventoryService = object : InventoryService {
         override fun getInventory(productId: String) = quantity.toMono()
     }
-    val pricingService = object : PricingService {
-        override fun getProductPrice(productId: String) = price.toMono()
-    }
 
     inject {
         register(DefaultCreateOrderSpec(inventoryService, pricingService))
@@ -166,9 +159,32 @@ on {
 }
 ```
 
+### Testing Delete/Recover
+
+```kotlin
+// Delete aggregate
+whenCommand(DefaultDeleteAggregate) {
+    expectEventType(DefaultAggregateDeleted::class)
+}
+
+// Verify deleted state
+fork("Cannot operate after delete") {
+    whenCommand(SomeCommand(...)) {
+        expectErrorType(IllegalAccessDeletedAggregateException::class)
+    }
+}
+
+// Recover
+fork("Recover aggregate") {
+    whenCommand(DefaultRecoverAggregate) {
+        expectEventType(DefaultAggregateRecovered::class)
+    }
+}
+```
+
 ## SagaSpec
 
-Testing stateless sagas.
+Testing stateless sagas with Given-When-Expect pattern.
 
 ### Basic Structure
 
@@ -204,15 +220,15 @@ class TransferSagaSpec : SagaSpec<TransferSaga>({
 | `expectNoError()` | Assert no error occurred |
 | `expectNoCommand()` | Assert no command was sent |
 | `expectCommandType<T>()` | Assert specific command type was sent |
-| `expectCommand<T> { }` | Assert command content |
+| `expectCommand<T> { }` | Assert full `CommandMessage<T>` (includes `aggregateId`, headers) |
+| `expectCommandBody<T> { }` | Assert command body content (`T.() -> Unit`) |
 
-### Full Saga Example
+### Conditional Saga Testing
 
 ```kotlin
 class CartSagaSpec : SagaSpec<CartSaga>({
     on {
         name("From cart - should remove items")
-        val orderItem = OrderItem(...)
         whenEvent(
             event = mockk<OrderCreated> {
                 every { items } returns listOf(orderItem)
@@ -222,7 +238,8 @@ class CartSagaSpec : SagaSpec<CartSaga>({
         ) {
             expectCommandType(RemoveCartItem::class)
             expectCommand<RemoveCartItem> {
-                body.productIds.assert().contains(orderItem.productId)
+                aggregateId.id.assert().isEqualTo(ownerId)
+                body.productIds.assert().hasSize(1)
             }
         }
     }
@@ -242,72 +259,102 @@ class CartSagaSpec : SagaSpec<CartSaga>({
 })
 ```
 
-## ProjectionSpec
-
-Testing projection processors for maintaining read models.
-
-### Basic Structure
+### Multiple Event Handlers
 
 ```kotlin
-class OrderProjectorSpec : ProjectionSpec<OrderProjector, OrderState>({
+class TransferSagaSpec : SagaSpec<TransferSaga>({
     on {
-        val event = OrderCreated(orderId = "order-1", items = listOf)
-        whenEvent(event) {
-            expectNoError()
-            expectState {
-                id.assert().isEqualTo("order-1")
+        whenEvent(Prepared("to", 1)) {
+            expectCommandType(Entry::class)
+            expectCommandBody<Entry> {
+                id.assert().isEqualTo("to")
+                amount.assert().isEqualTo(1)
             }
+        }
+    }
+    on {
+        whenEvent(AmountEntered("sourceId", 1)) {
+            expectCommandType(Confirm::class)
+        }
+    }
+    on {
+        whenEvent(EntryFailed("sourceId", 1)) {
+            expectCommandType(UnlockAmount::class)
         }
     }
 })
 ```
 
-### Projection WhenDsl Methods
+## SagaVerifier (Fluent API)
 
-| Method | Description |
-|--------|-------------|
-| `whenEvent(event)` | Trigger projection with event |
-| `name("description")` | Name this test scenario |
-
-### Projection ExpectDsl Methods
-
-| Method | Description |
-|--------|-------------|
-| `expectNoError()` | Assert no error occurred |
-| `expectError()` | Assert an error occurred |
-| `expectState { }` | Assert projected state |
-
-### Complete Projection Example
+For programmatic saga testing:
 
 ```kotlin
-class OrderProjectorSpec : ProjectionSpec<OrderProjector, OrderState>({
-    on {
-        name("OrderCreated - should project state")
-        val created = OrderCreated(
-            orderId = "order-1",
-            items = listOf(OrderItem("product-1", 2))
-        )
-        whenEvent(created) {
-            expectNoError()
-            expectState {
-                id.assert().isEqualTo("order-1")
-                items.assert().hasSize(1)
-            }
-        }
-    }
+// Standalone with reified generics
+sagaVerifier<CartSaga>()
+    .whenEvent(mockOrderCreatedEvent)
+    .expectNoCommand()
+    .verify()
 
-    on {
-        name("OrderPaid - should update status")
-        givenEvent(OrderCreated(...))
-        val paid = OrderPaid(orderId = "order-1")
-        whenEvent(paid) {
-            expectNoError()
-            expectState {
-                status.assert().isEqualTo(OrderStatus.PAID)
-            }
-        }
+// Extension function on Class
+CartSaga::class.java.sagaVerifier()
+    .whenEvent(mockOrderCreatedEvent)
+    .expectCommandType(RemoveCartItem::class)
+    .verify()
+```
+
+The verifier pre-configures an in-memory command bus, test validator, and no-op idempotency checker for isolated testing.
+
+## Projection Testing
+
+Projection processors are tested using standard unit testing with MockK, since they are regular Spring components:
+
+```kotlin
+class OrderProjectorTest {
+    private val repository = mockk<OrderSummaryRepository>()
+    private val projector = OrderProjector(repository)
+
+    @Test
+    fun `on OrderCreated should create order summary`() {
+        val event = OrderCreated(
+            orderId = "order-001",
+            customerId = "customer-001",
+            items = listOf(OrderItem(productId = "prod-001", quantity = 2))
+        )
+        every { repository.save(any()) } returns Mono.empty()
+
+        val result = projector.onEvent(event).block()
+
+        verify(exactly = 1) { repository.save(any()) }
     }
-})
+}
+```
+
+## AggregateVerifier (Fluent API)
+
+For programmatic aggregate testing, use extension function on `Class<C>` or standalone function with reified generics:
+
+```kotlin
+// Extension function on Class
+Cart::class.java.aggregateVerifier<Cart, CartState>()
+    .given()
+    .whenCommand(addCartItem)
+    .expectEventType(CartItemAdded::class)
+    .expectState { items.assert().hasSize(1) }
+    .verify()
+
+// Standalone with reified generics
+aggregateVerifier<Cart, CartState>()
+    .given()
+    .whenCommand(addCartItem)
+    .expectNoError()
+    .verify()
+
+// With custom aggregate ID
+aggregateVerifier<Cart, CartState>(aggregateId = "cart-123")
+    .given()
+    .whenCommand(addCartItem)
+    .verify()
 ```
 
 ## FluentAssert Assertions
@@ -357,7 +404,7 @@ val mockOrderCreated = mockk<OrderCreated> {
 
 ## Default Test Commands/Events
 
-Wow provides built-in commands for testing:
+Wow provides built-in commands for testing aggregate lifecycle:
 
 ```kotlin
 // Delete aggregate
@@ -366,13 +413,16 @@ whenCommand(DefaultDeleteAggregate) {
 }
 
 // Recover deleted aggregate
-whenCommand(DefaultRecoverAggregate) { ... }
+whenCommand(DefaultRecoverAggregate) {
+    expectEventType(DefaultAggregateRecovered::class)
+}
 ```
 
-Built-in exceptions:
+Built-in exceptions for error assertions:
 
 ```kotlin
 expectErrorType(IllegalAccessDeletedAggregateException::class)
+expectErrorType(CommandExpectVersionConflictException::class)
 expectErrorType(IllegalStateException::class)
 expectErrorType(DomainEventException::class)
 ```
@@ -386,7 +436,7 @@ expectErrorType(DomainEventException::class)
 # Run with coverage
 ./gradlew domain:jacocoTestReport
 
-# Verify coverage
+# Verify coverage (80% minimum on domain modules)
 ./gradlew domain:jacocoTestCoverageVerification
 ```
 
@@ -395,6 +445,8 @@ expectErrorType(DomainEventException::class)
 1. **Test Coverage Target**: ≥85% for domain models
 2. **Use fork() for related operations** within same scenario
 3. **Use separate on {} blocks** for unrelated scenarios
-4. **Avoid deep nesting** (>3 levels) - use `ref()` and `fork(ref, ...)`
-5. **Use descriptive names** for fork scenarios
-6. **Test error cases** - verify behavior in invalid states
+4. **Avoid deep nesting** (>3 levels) — use `ref()` and `fork(ref, ...)`
+5. **Use descriptive names** for fork scenarios: `fork("Pay Order")`
+6. **Test error cases** — verify behavior in invalid states
+7. **Test deletion/recovery** — verify aggregate lifecycle behavior
+8. **Use FluentAssert** — `me.ahoo.test.asserts.assert`, not AssertJ's `assertThat()`


### PR DESCRIPTION
## Summary
- **Fix factual errors in `dsl.md`**: Replace non-existent `where`→`condition`, `orderBy`→`sort`, `page`/`pageSize`→`pagination{}`, `offset`, `limit` in `singleQuery`, bare-string `projection{}` shorthand — all verified against `wow-query` source.
- **Remove non-existent test APIs**: `ProjectionSpec` and `expectSaved` don't exist in `wow-test`.
- **Fix `AggregateVerifier`/`SagaVerifier` API** — correct extension-function signature (`Class<T>.aggregateVerifier<S>()`, `sagaVerifier<T>()`).
- **Fix `@AggregateRoute` owner default** from `AGGREGATE_ID` → `NEVER` (matches source).
- **Add missing annotations**: `@EventProcessor`, `@AfterCommand`, `@OnError`, `@OnStateEvent`, `@CreateAggregate`, `@CommandRoute`, `@BoundedContext`, multi-tenancy.
- **Add missing lifecycle coverage**: `@AfterCommand` / `@OnError` hooks, bounded context, aggregate lifecycle state machine, special built-in events to modeling refs.
- **Add `WaitingForChain`** strategy, HTTP headers table, `CommandResult` properties, idempotency config to command-gateway refs.
- **New `configuration.md` reference** — complete YAML config covering all modules.
- **Condensed SKILL.md** from 527→383 lines; broader trigger description.
- All changes verified against actual source in `wow-api`, `wow-core`, `wow-query`, `wow-test`, and `wow-compiler`.

## Test plan
- [x] All DSL functions verified against `wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/`
- [x] Test APIs verified against `test/wow-test/src/main/kotlin/me/ahoo/wow/test/`
- [x] Annotation defaults verified against `wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/`
- [x] Removed references contain no remaining stale patterns