### PR TITLE
docs: optimize README and getting-started guide with Use this template button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,271 +1,127 @@
 <p align="center" style="text-align:center;">
-  <img width="150" src="document/design/assets/logo.svg" alt="Wow:A Modern Reactive CQRS Architecture Microservice development framework based on DDD and EventSourcing"/>
+  <img width="150" src="documentation/docs/public/images/logo.svg" alt="Wow"/>
 </p>
 
-# Wow : Modern Reactive CQRS Architecture Microservice development framework based on DDD and EventSourcing
+<h1 align="center">Wow</h1>
 
-[![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg)](https://github.com/Ahoo-Wang/Wow/blob/main/LICENSE)
-[![GitHub release](https://img.shields.io/github/release/Ahoo-Wang/Wow.svg)](https://github.com/Ahoo-Wang/Wow/releases)
-[![Maven Central Version](https://img.shields.io/maven-central/v/me.ahoo.wow/wow-core)](https://central.sonatype.com/artifact/me.ahoo.wow/wow-core)
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/cfc724df22db4f9387525258c8a59609)](https://app.codacy.com/gh/Ahoo-Wang/Wow/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
-[![codecov](https://codecov.io/gh/Ahoo-Wang/Wow/branch/main/graph/badge.svg?token=uloJrLoQir)](https://codecov.io/gh/Ahoo-Wang/Wow)
-[![Integration Test Status](https://github.com/Ahoo-Wang/Wow/actions/workflows/integration-test.yml/badge.svg)](https://github.com/Ahoo-Wang/Wow)
-[![Awesome Kotlin Badge](https://kotlin.link/awesome-kotlin.svg)](https://github.com/KotlinBy/awesome-kotlin)
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Ahoo-Wang/Wow)
+<p align="center"><strong>Domain Model as a Service</strong></p>
 
-**Domain-Driven** | **Event-Driven** | **Test-Driven** | **Declarative-Design** | **Reactive Programming** | **Command Query Responsibility Segregation** | **Event Sourcing**
+<p align="center">Modern Reactive CQRS Architecture Microservice Development Framework<br>Based on DDD & Event Sourcing</p>
 
-> [中文文档](https://wow.ahoo.me/zh/) | [English Document](https://wow.ahoo.me/)
+<p align="center">
+  <a href="https://github.com/Ahoo-Wang/Wow/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202-4EB1BA.svg" alt="License"/></a>
+  <a href="https://github.com/Ahoo-Wang/Wow/releases"><img src="https://img.shields.io/github/release/Ahoo-Wang/Wow.svg" alt="GitHub release"/></a>
+  <a href="https://central.sonatype.com/artifact/me.ahoo.wow/wow-core"><img src="https://img.shields.io/maven-central/v/me.ahoo.wow/wow-core" alt="Maven Central"/></a>
+  <a href="https://app.codacy.com/gh/Ahoo-Wang/Wow/dashboard"><img src="https://app.codacy.com/project/badge/Grade/cfc724df22db4f9387525258c8a59609" alt="Codacy"/></a>
+  <a href="https://codecov.io/gh/Ahoo-Wang/Wow"><img src="https://codecov.io/gh/Ahoo-Wang/Wow/branch/main/graph/badge.svg?token=uloJrLoQir" alt="Codecov"/></a>
+  <a href="https://github.com/Ahoo-Wang/Wow/actions/workflows/integration-test.yml"><img src="https://github.com/Ahoo-Wang/Wow/actions/workflows/integration-test.yml/badge.svg" alt="CI"/></a>
+  <a href="https://kotlin.link/"><img src="https://kotlin.link/awesome-kotlin.svg" alt="Awesome Kotlin"/></a>
+  <a href="https://deepwiki.com/Ahoo-Wang/Wow"><img src="https://deepwiki.com/badge.svg" alt="DeepWiki"/></a>
+</p>
 
-## Spring Boot Version Compatibility
+<p align="center">
+  <strong>Domain-Driven</strong> &middot; <strong>Event-Driven</strong> &middot; <strong>Test-Driven</strong> &middot; <strong>Declarative Design</strong> &middot; <strong>Reactive</strong> &middot; <strong>CQRS</strong> &middot; <strong>Event Sourcing</strong>
+</p>
 
-> **Wow 6.x** supports Spring Boot 3.x , base Java 17
->
-> **Wow 8.x** supports Spring Boot 4.x , base Java 17
+<p align="center">
+  <a href="https://wow.ahoo.me/">English</a> &middot; <a href="https://wow.ahoo.me/zh/">中文</a>
+</p>
+
+---
 
 ## Quick Start
 
-Use [Wow Project Template](https://github.com/Ahoo-Wang/wow-project-template) to quickly create a DDD project based on the Wow framework.
+[![Use this template](https://img.shields.io/badge/Use%20this%20template-2ea44f?style=for-the-badge&logo=github)](https://github.com/new?template_name=wow-project-template&template_owner=Ahoo-Wang)
 
-## Features Overview
+Click the button above to create a new repository from [Wow Project Template](https://github.com/Ahoo-Wang/wow-project-template), then clone it and start writing your domain model.
 
-<p align="center" style="text-align:center">
-  <img src="documentation/docs/public/images/Features.png" alt="Wow-Features"/>
-</p>
+> **Wow 8.x** supports Spring Boot 4.x, Java 17+
+> 
+> **Wow 6.x** supports Spring Boot 3.x, Java 17+
+
+## Features
+
+<p align="center"><img src="documentation/docs/public/images/Features.png" alt="Wow Features" width="95%"/></p>
+
+| Feature | Description |
+|---------|-------------|
+| **Domain Model as a Service** | Just write the domain model, Wow auto-generates OpenAPI interfaces |
+| **Test Suite** | Given→When→Expect pattern, 80%+ coverage made easy |
+| **High Performance** | AppendOnly writes, query-oriented search engines for reads |
+| **Horizontal Scalability** | No sharding rules needed, code unchanged when scaling out |
+| **Distributed Transactions** | Saga orchestration pattern for complex multi-service transactions |
+| **Event Compensation** | Visual dashboard + automatic retry for eventual consistency |
+| **Observability** | End-to-end OpenTelemetry integration for monitoring and debugging |
+| **Reactive** | Non-blocking async messaging with Project Reactor |
+| **Business Intelligence** | Rich event-sourced data with minimal ETL cost |
 
 ## Architecture
 
-<p align="center" style="text-align:center">
-  <img width="95%" src="documentation/docs/public/images/Architecture.svg" alt="Wow-Architecture"/>
-</p>
+<p align="center"><img src="documentation/docs/public/images/Architecture.svg" alt="Architecture" width="95%"/></p>
 
 ### Command Processing Propagation Chain
 
-<p align="center" style="text-align:center;">
-  <img  width="95%" src="documentation/docs/public/images/wait/WaitingForChain.svg" alt="Wow-WaitingForChain"/>
-</p>
+<p align="center"><img src="documentation/docs/public/images/wait/WaitingForChain.svg" alt="Command Processing Chain" width="95%"/></p>
 
-## Performance Test (Example)
+## Performance
+
+Stress test of the example application (2 min):
+
+| Operation | Wait Strategy | Avg TPS | Peak TPS | Avg Latency |
+|-----------|--------------|---------|----------|-------------|
+| Add To Cart | `SENT` | 59,625 | 82,312 | 29 ms |
+| Add To Cart | `PROCESSED` | 18,696 | 24,141 | 239 ms |
+| Create Order | `SENT` | 47,838 | 86,200 | 217 ms |
+| Create Order | `PROCESSED` | 18,230 | 25,506 | 268 ms |
+
+<details>
+<summary>Performance Details & Deployment</summary>
 
 - Test Code: [Example](./example)
-- Test Case: Add To Shopping Cart / Create Order
-- Command `WaitStrategy`: `SENT`、`PROCESSED`
+- Deployment: [Redis](deploy/example/perf/redis.yaml) / [MongoDB](deploy/example/perf/mongo.yaml) / [Kafka](deploy/example/perf/kafka.yaml)
 
-### Deployment
-
-- [Redis](deploy/example/perf/redis.yaml)
-- [MongoDB](deploy/example/perf/mongo.yaml)
-- [Kafka](deploy/example/perf/kafka.yaml)
-- [Application-Config](deploy/example/perf/config/mongo_kafka_redis.yaml)
-- [Application-Deployment](deploy/example/perf/deployment.yaml)
-
-### Test Report
-
-#### Add To Shopping Cart
-
-- [Request](deploy/example/request/AddCartItem.http)
-- [Detailed Report(PDF)-SENT](./document/example/perf/Example.Cart.Add@SENT.pdf)
-- [Detailed Report(PDF)-PROCESSED](./document/example/perf/Example.Cart.Add@PROCESSED.pdf)
-
-> `WaitStrategy`:`SENT` Mode, The `AddCartItem` command write request API After 2 minutes of stress testing, the average TPS was *59625*, the peak was *82312*, and the average response time was *29* ms.
-
-<p align="center" style="text-align:center">
+<p align="center">
   <img src="./document/example/perf/Example.Cart.Add@SENT.png" alt="AddCartItem-SENT"/>
 </p>
 
-> `WaitStrategy`:`PROCESSED` Mode, The `AddCartItem` command write request API After 2 minutes of stress testing, the average TPS was *18696*, the peak was *24141*, and the average response time was *239* ms.
-
-<p align="center" style="text-align:center">
-  <img src="./document/example/perf/Example.Cart.Add@PROCESSED.png" alt="AddCartItem-PROCESSED"/>
-</p>
-
-#### Create Order
-
-- [Request](deploy/example/request/CreateOrder.http)
-- [Detailed Report(PDF)-SENT](./document/example/perf/Example.Order.Create@SENT.pdf)
-- [Detailed Report(PDF)-PROCESSED](./document/example/perf/Example.Order.Create@PROCESSED.pdf)
-
-> `WaitStrategy`:`SENT` Mode, The `CreateOrder` command write request API After 2 minutes of stress testing, the average TPS was *47838*, the peak was *86200*, and the average response time was *217* ms.
-
-<p align="center" style="text-align:center">
+<p align="center">
   <img src="./document/example/perf/Example.Order.Create@SENT.png" alt="CreateOrder-SENT"/>
 </p>
 
-> `WaitStrategy`:`PROCESSED` Mode, The `CreateOrder` command write request API After 2 minutes of stress testing, the average TPS was *18230*, the peak was *25506*, and the average response time was *268* ms.
+</details>
 
-<p align="center" style="text-align:center">
-  <img src="./document/example/perf/Example.Order.Create@PROCESSED.png" alt="CreateOrder-PROCESSED"/>
-</p>
+## Test Suite
 
-## Event Sourcing
+> Given → When → Expect
 
-<p align="center" style="text-align:center">
-  <img src="./document/design/assets/EventSourcing.svg" alt="Wow-EventSourcing"/>
-</p>
+<p align="center"><img src="document/design/assets/CI-Flow.png" alt="CI Flow" width="80%"/></p>
 
-## Observability
-
-<p align="center" style="text-align:center">
-  <img src="./document/design/assets/OpenTelemetry.png" alt="Wow-Observability"/>
-</p>
-
-## OpenAPI (Spring WebFlux Integration)
-
-> Automatically register the `Command` routing processing function (`HandlerFunction`), and developers only need to
-> write the domain model to complete the service development.
-
-<p align="center" style="text-align:center">
-  <img src="document/design/assets/OpenAPI-Swagger.png" alt="Wow-Spring-WebFlux-Integration"/>
-</p>
-
-## Test suite: 80%+ test coverage is very easy
-
-> Given -> When -> Expect .
-
-<p align="center" style="text-align:center">
-  <img src="./document/design/assets/CI-Flow.png" alt="Wow-CI-Flow"/>
-</p>
-
-## Preconditions
-
-- Understanding **Domain Driven Design**：《Implementing Domain-Driven Design》,《Domain-Driven Design: Tackling Complexity
-  in the Heart of Software》
-- Understanding **Command Query Responsibility Segregation**(CQRS)
-- Understanding **EventSourcing**
-- Understanding **Reactive Programming**
-
-### Order Service（Kotlin）
-
-[Example-Order](./example)
-
-### Transfer（JAVA）
-
-[Example-Transfer](./example/transfer)
-
-## Unit Test Suite
-
-### 80%+ test coverage is very easy.
-
-![Test Coverage](./document/example/example-domain-jococo.png)
-
-> Given -> When -> Expect .
-
-### Aggregate Unit Test (`AggregateVerifier`)
-
-[Aggregate Test](./example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/order/OrderTest.kt)
+### Aggregate Test (`AggregateVerifier`)
 
 ```kotlin
 class CartSpec : AggregateSpec<Cart, CartState>({
   on {
-    val ownerId = generateGlobalId()
-    val addCartItem = AddCartItem(
-      productId = "productId",
-      quantity = 1,
-    )
-    givenOwnerId(ownerId)
-    whenCommand(addCartItem) {
+    whenCommand(AddCartItem(productId = "productId", quantity = 1)) {
       expectNoError()
       expectEventType(CartItemAdded::class)
       expectState {
         items.assert().hasSize(1)
       }
-      expectStateAggregate {
-        ownerId.assert().isEqualTo(ownerId)
-      }
-      fork {
-        val removeCartItem = RemoveCartItem(
-          productIds = setOf(addCartItem.productId),
-        )
-        whenCommand(removeCartItem) {
-          expectEventType(CartItemRemoved::class)
-        }
-      }
-      fork {
-        whenCommand(DefaultDeleteAggregate) {
-          expectEventType(DefaultAggregateDeleted::class)
-          expectStateAggregate {
-            deleted.assert().isTrue()
-          }
-
-          fork {
-            whenCommand(DefaultDeleteAggregate) {
-              expectErrorType(IllegalAccessDeletedAggregateException::class)
-            }
-          }
-          fork {
-            whenCommand(DefaultRecoverAggregate) {
-              expectNoError()
-              expectStateAggregate {
-                deleted.assert().isFalse()
-              }
-              fork {
-                whenCommand(DefaultRecoverAggregate) {
-                  expectErrorType(IllegalStateException::class)
-                }
-              }
-            }
-          }
-        }
-      }
     }
   }
-}
-)
+})
 ```
 
-### Saga Unit Test (`SagaVerifier`)
-
-[Saga Test](./example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSagaTest.kt)
+### Saga Test (`SagaVerifier`)
 
 ```kotlin
 class CartSagaSpec : SagaSpec<CartSaga>({
   on {
-    val ownerId = generateGlobalId()
-    val orderItem = OrderItem(
-      id = generateGlobalId(),
-      productId = generateGlobalId(),
-      price = BigDecimal.valueOf(10),
-      quantity = 10,
-    )
-    whenEvent(
-      event = mockk<OrderCreated> {
-        every {
-          items
-        } returns listOf(orderItem)
-        every {
-          fromCart
-        } returns true
-      },
-      ownerId = ownerId
-    ) {
+    whenEvent(event = mockk<OrderCreated> {
+      every { items } returns listOf(orderItem)
+      every { fromCart } returns true
+    }, ownerId = ownerId) {
       expectCommandType(RemoveCartItem::class)
-      expectCommand<RemoveCartItem> {
-        aggregateId.id.assert().isEqualTo(ownerId)
-        body.productIds.assert().hasSize(1)
-        body.productIds.assert().first().isEqualTo(orderItem.productId)
-      }
-    }
-  }
-  on {
-    name("NotFromCart")
-    val orderItem = OrderItem(
-      id = generateGlobalId(),
-      productId = generateGlobalId(),
-      price = BigDecimal.valueOf(10),
-      quantity = 10,
-    )
-    whenEvent(
-      event = mockk<OrderCreated> {
-        every {
-          items
-        } returns listOf(orderItem)
-        every {
-          fromCart
-        } returns false
-      },
-      ownerId = generateGlobalId()
-    ) {
-      expectNoCommand()
     }
   }
 })
@@ -273,65 +129,75 @@ class CartSagaSpec : SagaSpec<CartSaga>({
 
 ## Design
 
-### Modeling
+### Modeling Patterns
 
-| **Single Class**                                                                       | **Inheritance Pattern**                                                                     | **Aggregation Pattern**                                                                     |
-|----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|:--------------------------------------------------------------------------------------------|
-| ![Single Class - Modeling](./document/design/assets/Modeling-Single-Class-Pattern.svg) | ![Inheritance Pattern- Modeling](./document/design/assets/Modeling-Inheritance-Pattern.svg) | ![Aggregation Pattern- Modeling](./document/design/assets/Modeling-Aggregation-Pattern.svg) |
+| Single Class | Inheritance | Aggregation |
+|:---:|:---:|:---:|
+| ![Single Class](./document/design/assets/Modeling-Single-Class-Pattern.svg) | ![Inheritance](./document/design/assets/Modeling-Inheritance-Pattern.svg) | ![Aggregation](./document/design/assets/Modeling-Aggregation-Pattern.svg) |
 
-### Load Aggregate
+### Core Flows
 
-<p align="center" style="text-align:center">
-  <img src="./document/design/assets/Load-Aggregate.svg" alt="Load Aggregate"/>
-</p>
+<p align="center"><img src="./document/design/assets/Command-Event-Flow.svg" alt="Command And Event Flow" width="95%"/></p>
 
-### Aggregate State Flow
+<p align="center"><img src="./document/design/assets/EventSourcing.svg" alt="Event Sourcing" width="80%"/></p>
 
-<p align="center" style="text-align:center">
-  <img src="./document/design/assets/Aggregate-State-Flow.svg" alt="Aggregate State Flow"/>
-</p>
+<details>
+<summary>More Design Diagrams</summary>
 
-### Send Command
+**Load Aggregate**
 
-<p align="center" style="text-align:center">
-  <img src="./document/design/assets/Send-Command.svg" alt="Send Command"/>
-</p>
+<p align="center"><img src="./document/design/assets/Load-Aggregate.svg" alt="Load Aggregate" width="95%"/></p>
 
-### Command And Event Flow
+**Aggregate State Flow**
 
-<p align="center" style="text-align:center">
-  <img src="./document/design/assets/Command-Event-Flow.svg" alt="Command And Event Flow"/>
-</p>
+<p align="center"><img src="./document/design/assets/Aggregate-State-Flow.svg" alt="Aggregate State Flow" width="95%"/></p>
+
+**Send Command**
+
+<p align="center"><img src="./document/design/assets/Send-Command.svg" alt="Send Command" width="95%"/></p>
+
+**Observability**
+
+<p align="center"><img src="./document/design/assets/OpenTelemetry.png" alt="Observability" width="80%"/></p>
+
+</details>
 
 ## Event Compensation
 
-### Use Case
+<p align="center"><img src="documentation/docs/public/images/compensation/dashboard.png" alt="Compensation Dashboard" width="80%"/></p>
 
-<p align="center" style="text-align:center">
-  <img src="documentation/docs/public/images/compensation/usercase.svg" alt="Event-Compensation-UserCase"/>
-</p>
+<details>
+<summary>Compensation Details</summary>
 
-### Execution Sequence Diagram
+<p align="center"><img src="documentation/docs/public/images/compensation/usercase.svg" alt="Compensation Use Case" width="80%"/></p>
 
-<p align="center" style="text-align:center">
-  <img src="documentation/docs/public/images/compensation/process-sequence-diagram.svg" alt="Event-Compensation"/>
-</p>
+<p align="center"><img src="documentation/docs/public/images/compensation/process-sequence-diagram.svg" alt="Compensation Sequence" width="80%"/></p>
 
-### Dashboard
+<p align="center"><img src="documentation/docs/public/images/compensation/dashboard-apply-retry-spec.png" alt="Apply Retry Spec" width="80%"/></p>
 
-<p align="center" style="text-align:center">
-  <img src="documentation/docs/public/images/compensation/dashboard.png" alt="Compensation-Dashboard"/>
-</p>
+<p align="center"><img src="documentation/docs/public/images/compensation/dashboard-succeeded.png" alt="Compensation Succeeded" width="80%"/></p>
 
-<p align="center" style="text-align:center">
-  <img src="documentation/docs/public/images/compensation/dashboard-apply-retry-spec.png" alt="Compensation-Dashboard"/>
-</p>
+</details>
 
-<p align="center" style="text-align:center">
-  <img src="documentation/docs/public/images/compensation/dashboard-succeeded.png" alt="Compensation-Dashboard"/>
-</p>
+## Ecosystem
 
-<p align="center" style="text-align:center">
-  <img src="documentation/docs/public/images/compensation/dashboard-error.png" alt="Compensation-Dashboard-Error"/>
-</p>
+| Project | Description |
+|---------|-------------|
+| [CosId](https://github.com/Ahoo-Wang/CosId) | Universal, flexible, high-performance distributed ID generator |
+| [CoSec](https://github.com/Ahoo-Wang/CoSec) | Multi-tenant reactive security framework based on RBAC and policies |
+| [CoCache](https://github.com/Ahoo-Wang/CoCache) | Distributed consistent secondary cache framework |
+| [Simba](https://github.com/Ahoo-Wang/Simba) | Easy-to-use, flexible distributed lock service |
+| [CoSky](https://github.com/Ahoo-Wang/CoSky) | High-performance, low-cost microservice governance platform |
+| [CoApi](https://github.com/Ahoo-Wang/CoApi) | Zero-boilerplate HTTP client auto-configuration for Spring 6 |
+| [FluentAssert](https://github.com/Ahoo-Wang/FluentAssert) | Kotlin fluent assertion library for readable and expressive tests |
 
+## Examples
+
+| Example | Language | Description |
+|---------|----------|-------------|
+| [Order Service](./example) | Kotlin | Aggregates, sagas, projections — full DDD demo |
+| [Bank Transfer](./example/transfer) | Java | Simple event sourcing demo |
+
+## License
+
+Wow is released under the [Apache 2.0 License](LICENSE).

--- a/documentation/docs/en/guide/getting-started.md
+++ b/documentation/docs/en/guide/getting-started.md
@@ -7,36 +7,15 @@ description: Get started with the Wow framework using the project template to qu
 
 > Use the [Wow Project Template](https://github.com/Ahoo-Wang/wow-project-template) to quickly create a DDD project based on the _Wow_ framework.
 
-## Install Template
-
-[IntelliJ IDEA Project Template Guide](https://www.jetbrains.com/help/idea/saving-project-as-template.html)
-
-[IntelliJ IDEA Configuration Directory Guide](https://www.jetbrains.com/help/idea/directories-used-by-the-ide-to-store-settings-caches-plugins-and-logs.html#config-directory)
-
-- _IDEA_ project template directory: `<IDE config home>/projectTemplates`
-    - _Windows_: `C:\Users\<USERNAME>\AppData\Roaming\JetBrains\<PRODUCT><VERSION>\projectTemplates\`
-    - _Mac OS_:`~/Library/Application\ Support/JetBrains/<PRODUCT><VERSION/projectTemplates/`
-    - _Linux_: `~/.config/JetBrains/<PRODUCT><VERSION>/projectTemplates/`
-- Place the template zip package in the _IDEA_ project template directory
-    - Template zip package: [wow-project-template.zip](https://github.com/Ahoo-Wang/wow-project-template/releases/download/v8.3.6/wow-project-template.zip)
-
 ## Create Project
 
-> [Create project from template](https://www.jetbrains.com/help/idea/saving-project-as-template.html#create-project-from-template)
+[![Use this template](https://img.shields.io/badge/Use%20this%20template-2ea44f?style=for-the-badge&logo=github)](https://github.com/new?template_name=wow-project-template&template_owner=Ahoo-Wang)
 
-![Create Project](../../public/images/getting-started/new-project.png)
+Click the button above to create a new repository from [Wow Project Template](https://github.com/Ahoo-Wang/wow-project-template), then clone it locally.
 
 - Modify the `settings.gradle.kts` file, change `rootProject.name` to the project name
 - Modify `api/{package}/DemoService`
 - Modify `domain/{package}/DemoBoundedContext`
-
-::: tip
-When IDEA creates a project based on a template, the `gradlew` script may be commented out, you need to copy it again from the template project.
-> Enable executable permissions:
-```shell
-chmod +x ./gradlew
-```
-:::
 
 
 ## Project Modules

--- a/documentation/docs/zh/guide/getting-started.md
+++ b/documentation/docs/zh/guide/getting-started.md
@@ -7,36 +7,15 @@ description: 使用 Wow 项目模板快速创建基于 DDD 的微服务项目。
 
 > 使用 [Wow 项目模板](https://github.com/Ahoo-Wang/wow-project-template) 快速创建基于 _Wow_ 框架的 _DDD_ 项目。
 
-## 安装模板
-
-[IDEA 项目模板指南](https://www.jetbrains.com/help/idea/saving-project-as-template.html)
-
-[IDEA 配置目录指南](https://www.jetbrains.com/help/idea/directories-used-by-the-ide-to-store-settings-caches-plugins-and-logs.html#config-directory)
-
-- _IDEA_ 项目模板目录：`<IDE config home>/projectTemplates`
-    - _Windows_: `C:\Users\<USERNAME>\AppData\Roaming\JetBrains\<PRODUCT><VERSION>\projectTemplates\`
-    - _Mac OS_:`~/Library/Application\ Support/JetBrains/<PRODUCT><VERSION/projectTemplates/`
-    - _Linux_: `~/.config/JetBrains/<PRODUCT><VERSION>/projectTemplates/`
-- 将模板压缩包放到 _IDEA_ 项目模板目录下
-    - 模板压缩包: [wow-project-template.zip](https://gitee.com/AhooWang/wow-project-template/releases/download/v8.3.6/wow-project-template.zip)
-
 ## 创建项目
 
-> [使用模板创建项目](https://www.jetbrains.com/help/idea/saving-project-as-template.html#create-project-from-template)
+[![Use this template](https://img.shields.io/badge/Use%20this%20template-2ea44f?style=for-the-badge&logo=github)](https://github.com/new?template_name=wow-project-template&template_owner=Ahoo-Wang)
 
-![创建项目](../../public/images/getting-started/new-project.png)
+点击上方按钮即可从 [Wow 项目模板](https://github.com/Ahoo-Wang/wow-project-template) 创建你自己的项目仓库，然后克隆到本地。
 
 - 修改 `settings.gradle.kts` 文件，将 `rootProject.name` 修改为项目名称
 - 修改 `api/{package}/DemoService`
 - 修改 `domain/{package}/DemoBoundedContext`
-
-::: tip
-IDEA 基于模版创建项目会将 `gradlew` 脚本被注释，需要重新从模板项目中Copy过来。
-> 开启可执行权限：
-```shell
-chmod +x ./gradlew
-```
-:::
 
 
 ## 项目模块


### PR DESCRIPTION
## Changes

### README.md
- Restructured header: centered logo, title, tagline with cleaner hierarchy
- Adopted **"Domain Model as a Service"** as primary tagline (aligned with documentation)
- Added features table with concise descriptions
- Replaced verbose performance screenshots with summary table, moved details into collapsible section
- Trimmed test code examples to essential patterns
- Grouped secondary design diagrams into collapsible section
- Added **Ecosystem** table and **Examples** table
- Added **License** section
- Replaced IDEA template download approach with **"Use this template"** badge button

### getting-started.md (en/zh)
- Removed "Install Template" section (IDEA template directory setup)
- Removed "Create Project" section (IDEA project template workflow)
- Added **"Use this template"** badge button matching README style
- Simplified project creation to GitHub one-click flow