### PR TITLE
docs: add data access control documentation (tenant, owner, space, ABAC)

### DIFF
--- a/documentation/docs/.vitepress/configs/sidebar.en.ts
+++ b/documentation/docs/.vitepress/configs/sidebar.en.ts
@@ -60,6 +60,7 @@ export const sidebarEn: DefaultTheme.Sidebar = {
                 {text: 'Distributed Transactions (Saga)', link: 'saga'},
                 {text: 'Projection', link: 'projection'},
                 {text: 'Query Service', link: 'query'},
+                {text: 'Data Access Control', link: 'data-access'},
                 {text: 'Event Processor', link: 'event-processor'},
             ],
         },

--- a/documentation/docs/.vitepress/configs/sidebar.zh.ts
+++ b/documentation/docs/.vitepress/configs/sidebar.zh.ts
@@ -60,6 +60,7 @@ export const sidebarZh: DefaultTheme.Sidebar = {
                 {text: '分布式事务(Saga)', link: 'saga'},
                 {text: '投影', link: 'projection'},
                 {text: '查询服务', link: 'query'},
+                {text: '数据权限', link: 'data-access'},
                 {text: '事件处理器', link: 'event-processor'},
             ],
         },

--- a/documentation/docs/en/guide/data-access.md
+++ b/documentation/docs/en/guide/data-access.md
@@ -1,0 +1,324 @@
+---
+title: "Data Access Control"
+description: "Understand Wow's multi-level data isolation model: Tenant, Owner, Space, and ABAC attribute-based access control for fine-grained permissions."
+outline: deep
+---
+
+# Data Access Control
+
+Wow provides a layered data access control model that covers the most common multi-tenancy and permission scenarios:
+
+1. **Tenant** — isolates data by organization/customer
+2. **Owner** — isolates data by user identity within a tenant
+3. **Space** — provides namespace-based partitioning within a tenant
+4. **ABAC** — fine-grained attribute-based access control using tags
+
+These layers work independently and can be combined freely. You can use only tenant isolation, or combine all four for maximum security.
+
+```mermaid
+graph TB
+    subgraph Isolation_Layers["Data Isolation Layers"]
+        T["Tenant"]
+        S["Space"]
+        O["Owner"]
+        A["ABAC Tags"]
+    end
+
+    T -->|contains| S
+    S -->|contains| O
+    O -->|protected by| A
+
+    style T fill:#e8f5e9
+    style S fill:#e3f2fd
+    style O fill:#fff3e0
+    style A fill:#fce4ec
+```
+
+<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/TenantId.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/OwnerId.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/SpaceIdCapable.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/abac/Taggable.kt -->
+
+## Tenant
+
+Tenant is the top-level isolation boundary. In a SaaS application, each customer (organization) is typically a separate tenant. Wow automatically propagates tenant context through commands and events, ensuring data is isolated at the storage level.
+
+### Annotation-based Tenant ID
+
+Use the `@TenantId` annotation on a command or aggregate state property to tell the framework that this field carries the tenant identifier:
+
+```kotlin
+@AggregateRoot
+class OrderAggregate(
+    @AggregateId
+    val orderId: String,
+
+    @TenantId
+    val tenantId: String  // Which organization this order belongs to
+)
+```
+
+```kotlin
+data class CreateOrder(
+    @AggregateId
+    val orderId: String,
+
+    @TenantId
+    val tenantId: String, // Automatically populated from request context
+
+    val items: List<OrderItem>
+)
+```
+
+The framework uses this annotation to:
+- Automatically set tenant context from incoming requests
+- Isolate event store and snapshot storage by tenant
+- Enforce tenant boundaries in query operations
+
+### Static Tenant ID
+
+For aggregates that always belong to a fixed tenant (e.g., system configuration), use `@StaticTenantId`:
+
+```kotlin
+@AggregateRoot
+@StaticTenantId("system-tenant")
+class SystemConfigurationAggregate {
+    // Always belongs to system tenant
+}
+```
+
+### Default Tenant
+
+When no tenant is specified, Wow uses a default tenant ID `(0)`. This is transparent — single-tenant applications don't need to deal with tenant IDs at all.
+
+<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/TenantId.kt:57-94, wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/TenantId.kt:20-43 -->
+
+## Owner
+
+Within a tenant, the **Owner** layer isolates data by individual user identity. This ensures that users can only access their own data (e.g., "my orders", "my shopping cart").
+
+### Annotation-based Owner ID
+
+Use the `@OwnerId` annotation to mark the owner identifier:
+
+```kotlin
+data class AddToCart(
+    @AggregateId
+    val cartId: String,
+
+    @OwnerId
+    val userId: String,  // The user who owns this cart
+
+    val productId: String,
+    val quantity: Int
+)
+```
+
+### Ownership Routing Policy
+
+The `@AggregateRoute` annotation controls how ownership is enforced via the `owner` parameter:
+
+```kotlin
+@AggregateRoot
+@AggregateRoute(
+    resourceName = "orders",
+    owner = AggregateRoute.Owner.ALWAYS
+)
+class OrderAggregate(
+    @AggregateId
+    val orderId: String,
+
+    @OwnerId
+    val customerId: String
+)
+```
+
+Available policies:
+
+| Policy | Description | Use Case |
+|--------|-------------|----------|
+| `NEVER` | No ownership required | Public resources, system aggregates |
+| `ALWAYS` | Ownership always required | User-specific data (orders, profiles) |
+| `AGGREGATE_ID` | Aggregate ID doubles as owner ID | Per-user aggregates (user profile, settings) |
+
+### Ownership Transfer
+
+When ownership needs to change (e.g., transferring a task to another user), implement the `OwnerTransferred` event interface:
+
+```kotlin
+data class TaskTransferred(
+    override val toOwnerId: String
+) : OwnerTransferred
+```
+
+The framework recognizes this event and automatically updates the aggregate's owner context.
+
+<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/OwnerId.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AggregateRoute.kt:59-91, wow-api/src/main/kotlin/me/ahoo/wow/api/event/OwnerTransferred.kt -->
+
+## Space
+
+**Space** provides namespace-based data partitioning within a tenant. It adds a third isolation dimension for scenarios like:
+
+- Environment separation (dev / staging / prod)
+- Business domain partitioning (primary / archive)
+- Organizational unit boundaries
+
+```kotlin
+// Aggregates can belong to different spaces within the same tenant
+data class ArchivedOrder(
+    @AggregateId
+    val orderId: String,
+
+    @TenantId
+    val tenantId: String,
+
+    val spaceId: SpaceId  // "archive" space
+)
+```
+
+Space transfer follows the same pattern as ownership transfer — implement `SpaceTransferred`:
+
+```kotlin
+data class OrderArchived(
+    override val toSpaceId: SpaceId
+) : SpaceTransferred
+```
+
+Default space ID is an empty string `""`, meaning all aggregates without explicit space assignment live in the default space.
+
+<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/SpaceIdCapable.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/event/SpaceTransferred.kt -->
+
+## ABAC (Attribute-Based Access Control)
+
+While Tenant, Owner, and Space provide structural isolation, **ABAC** provides fine-grained, attribute-based access control. It works by attaching tags to both **principals** (users/services) and **resources** (aggregates), then matching them at query time.
+
+### Core Concepts
+
+```mermaid
+graph LR
+    P["Principal Tags"] -->|matched against| R["Resource Tags"]
+    R -->|produces| A["Access Decision"]
+
+    subgraph Principal["Principal (User/Service)"]
+        PT1["dept: [eng, pm]"]
+        PT2["role: [admin]"]
+    end
+
+    subgraph Resource["Resource (Aggregate)"]
+        RT1["dept: [eng]"]
+    end
+
+    P --> PT1
+    P --> PT2
+    R --> RT1
+```
+
+<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/abac/Taggable.kt:63-98 -->
+
+**AbacTags** — A map of key-value pairs where each key maps to a list of values:
+
+```kotlin
+// User tags: belongs to engineering and product departments, admin role
+val userTags: AbacTags = mapOf(
+    "dept" to listOf("eng", "pm"),
+    "role" to listOf("admin")
+)
+
+// Resource tags: only accessible by engineering department
+val resourceTags: AbacTags = mapOf(
+    "dept" to listOf("eng")
+)
+
+// Public resource: no tags = accessible by everyone
+val publicResource: AbacTags = emptyMap()
+```
+
+**Wildcard** — The value `["*"]` matches all values for that key:
+
+```kotlin
+// Can access resources from any department
+val adminTags: AbacTags = mapOf(
+    "dept" to listOf("*")
+)
+```
+
+### Applying Resource Tags
+
+Use the `ApplyAbacTags` command interface to set tags on an aggregate:
+
+```kotlin
+@AggregateRoot
+class DocumentAggregate(
+    @AggregateId
+    val docId: String,
+    var tags: AbacTags = emptyMap()
+) {
+    @OnCommand
+    fun onCommand(command: ApplyAbacTags): AbacTagsApplied {
+        // Validate and merge tags
+        return DefaultResourceTagsApplied(command.tags)
+    }
+}
+```
+
+Or use the built-in `DefaultApplyResourceTags` command which provides a ready-to-use tags management endpoint:
+
+```kotlin
+// The framework automatically handles DefaultApplyResourceTags
+// generating a PUT endpoint: PUT /{resourceName}/{id}/tags
+```
+
+### Tag Merging
+
+Tags can be merged using the `merge` extension function. For the same key, values from both sides are combined (union):
+
+```kotlin
+val tags1 = mapOf("dept" to listOf("eng"), "role" to listOf("admin"))
+val tags2 = mapOf("dept" to listOf("pm"), "team" to listOf("backend"))
+
+tags1.merge(tags2)
+// Result: { "dept": ["eng", "pm"], "role": ["admin"], "team": ["backend"] }
+```
+
+<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/abac/ApplyAbacTags.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/abac/ApplyResourceTags.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/abac/AbacTagsMerger.kt -->
+
+### ABAC Query Filter
+
+When querying snapshots, the `AbacQueryFilter` automatically injects permission conditions based on the principal's tags. The matching rules are:
+
+| Principal Tags | Resource Tags | Result |
+|---------------|---------------|--------|
+| `["*"]` (wildcard) | Any | ✅ Match |
+| `["a", "b"]` | `["a"]` | ✅ Match |
+| `["a", "b"]` | `["c"]` | ❌ No match |
+| Any | Key absent | ✅ Match (resource is public for this key) |
+
+The filter converts principal tags into query conditions:
+- For wildcard tags: checks that the key exists on the resource
+- For regular tags: matches resources where the key is absent, empty, or has a value in the principal's list
+
+To implement custom principal tag resolution, extend `AbacQueryFilter`:
+
+```kotlin
+@Component
+class MyAbacQueryFilter : AbacQueryFilter() {
+    override fun getPrincipalTags(
+        contextView: ContextView,
+        context: QueryContext<*, *>
+    ): Mono<AbacTags> {
+        // Resolve principal tags from security context, JWT, etc.
+        return SecurityContext.fromContext(contextView)
+            .map { it.abacTags }
+    }
+}
+```
+
+<!-- Sources: wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/AbacQueryFilter.kt -->
+
+## Layered Isolation Summary
+
+| Layer | Scope | Mechanism | Typical Use Case |
+|-------|-------|-----------|-----------------|
+| Tenant | Organization | `@TenantId` annotation + storage isolation | SaaS multi-tenancy |
+| Space | Namespace within tenant | `SpaceId` field + storage partitioning | Environment, domain separation |
+| Owner | Individual user | `@OwnerId` annotation + route policy | "My data" isolation |
+| ABAC | Attribute-based | Tags on principal + resource + query filter | Fine-grained permission (department, role, level) |
+
+These layers are **additive** — enabling more layers adds more restrictions. A query without any layer applied returns all data; enabling tenant + owner + ABAC restricts to only the data the authenticated user is allowed to see.

--- a/documentation/docs/en/guide/data-access.md
+++ b/documentation/docs/en/guide/data-access.md
@@ -1,19 +1,19 @@
 ---
 title: "Data Access Control"
-description: "Understand Wow's multi-level data isolation model: Tenant, Owner, Space, and ABAC attribute-based access control for fine-grained permissions."
+description: "Understand Wow's layered data isolation model: Tenant, Owner, Space, and ABAC attribute-based access control for fine-grained permissions."
 outline: deep
 ---
 
 # Data Access Control
 
-Wow provides a layered data access control model that covers the most common multi-tenancy and permission scenarios:
+Wow provides three optional data isolation layers and an attribute-based access control layer:
 
-1. **Tenant** — isolates data by organization/customer
-2. **Owner** — isolates data by user identity within a tenant
-3. **Space** — provides namespace-based partitioning within a tenant
+1. **Tenant** — isolates data by organization/customer (optional)
+2. **Owner** — isolates data by user identity within a tenant (optional)
+3. **Space** — provides namespace-based partitioning within a tenant (optional)
 4. **ABAC** — fine-grained attribute-based access control using tags
 
-These layers work independently and can be combined freely. You can use only tenant isolation, or combine all four for maximum security.
+All three isolation layers are **optional** and can be enabled independently or combined freely. Single-tenant applications don't need any isolation layer; SaaS applications can combine tenant, owner, space, and ABAC as needed.
 
 ```mermaid
 graph TB
@@ -34,7 +34,21 @@ graph TB
     style A fill:#fce4ec
 ```
 
-<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/TenantId.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/OwnerId.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/SpaceIdCapable.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/abac/Taggable.kt -->
+## RESTful URL Pattern
+
+The data isolation layers are reflected in the automatically generated RESTful API paths:
+
+```
+[tenant/{tenantId}]/[owner/{ownerId}]/resource/[{resourceId}]/action
+```
+
+| Layer | Path / Header | When Applied |
+|-------|---------------|--------------|
+| Tenant | `tenant/{tenantId}` path prefix | Aggregate is **not** marked with `@StaticTenantId` |
+| Owner | `owner/{ownerId}` path prefix | `@AggregateRoute(owner ≠ NEVER)` |
+| Space | `Wow-Space-Id` request header | `@AggregateRoute(spaced = true)` |
+
+The framework generates **multiple route variants** for each aggregate — a default route without prefixes, a tenant-only route, and an owner-only route — so callers can use the minimal scope they need.
 
 ## Tenant
 
@@ -71,6 +85,7 @@ The framework uses this annotation to:
 - Automatically set tenant context from incoming requests
 - Isolate event store and snapshot storage by tenant
 - Enforce tenant boundaries in query operations
+- Generate the `tenant/{tenantId}` path prefix in RESTful APIs
 
 ### Static Tenant ID
 
@@ -81,14 +96,13 @@ For aggregates that always belong to a fixed tenant (e.g., system configuration)
 @StaticTenantId("system-tenant")
 class SystemConfigurationAggregate {
     // Always belongs to system tenant
+    // No tenant/{tenantId} path prefix in generated APIs
 }
 ```
 
 ### Default Tenant
 
 When no tenant is specified, Wow uses a default tenant ID `(0)`. This is transparent — single-tenant applications don't need to deal with tenant IDs at all.
-
-<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/TenantId.kt:57-94, wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/TenantId.kt:20-43 -->
 
 ## Owner
 
@@ -132,11 +146,13 @@ class OrderAggregate(
 
 Available policies:
 
-| Policy | Description | Use Case |
-|--------|-------------|----------|
-| `NEVER` | No ownership required | Public resources, system aggregates |
-| `ALWAYS` | Ownership always required | User-specific data (orders, profiles) |
-| `AGGREGATE_ID` | Aggregate ID doubles as owner ID | Per-user aggregates (user profile, settings) |
+| Policy | `owned` | Description | API Path | Use Case |
+|--------|---------|-------------|----------|----------|
+| `NEVER` | `false` | No ownership required | `/orders/{id}` | Public resources, system aggregates |
+| `ALWAYS` | `true` | Ownership always required | `/owner/{ownerId}/orders/{id}` | User-specific data (orders, profiles) |
+| `AGGREGATE_ID` | `true` | Aggregate ID doubles as owner ID | `/owner/{ownerId}/orders` (no `{id}`) | Per-user aggregates (user profile, settings) |
+
+When `AGGREGATE_ID` is used, the `{resourceId}` path parameter is removed since the owner ID already identifies the aggregate.
 
 ### Ownership Transfer
 
@@ -150,8 +166,6 @@ data class TaskTransferred(
 
 The framework recognizes this event and automatically updates the aggregate's owner context.
 
-<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/OwnerId.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AggregateRoute.kt:59-91, wow-api/src/main/kotlin/me/ahoo/wow/api/event/OwnerTransferred.kt -->
-
 ## Space
 
 **Space** provides namespace-based data partitioning within a tenant. It adds a third isolation dimension for scenarios like:
@@ -160,18 +174,23 @@ The framework recognizes this event and automatically updates the aggregate's ow
 - Business domain partitioning (primary / archive)
 - Organizational unit boundaries
 
+### Enabling Space
+
+Set `spaced = true` on `@AggregateRoute`:
+
 ```kotlin
-// Aggregates can belong to different spaces within the same tenant
-data class ArchivedOrder(
-    @AggregateId
-    val orderId: String,
-
-    @TenantId
-    val tenantId: String,
-
-    val spaceId: SpaceId  // "archive" space
+@AggregateRoot
+@AggregateRoute(
+    resourceName = "sales-order",
+    spaced = true,
+    owner = AggregateRoute.Owner.ALWAYS
 )
+class Order(private val state: OrderState)
 ```
+
+When `spaced = true`, the generated API adds a `Wow-Space-Id` request header parameter. The default space ID is an empty string `""`, meaning all aggregates without explicit space assignment live in the default space.
+
+### Space Transfer
 
 Space transfer follows the same pattern as ownership transfer — implement `SpaceTransferred`:
 
@@ -181,9 +200,7 @@ data class OrderArchived(
 ) : SpaceTransferred
 ```
 
-Default space ID is an empty string `""`, meaning all aggregates without explicit space assignment live in the default space.
-
-<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/SpaceIdCapable.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/event/SpaceTransferred.kt -->
+The framework recognizes this event and automatically updates the aggregate's space context.
 
 ## ABAC (Attribute-Based Access Control)
 
@@ -209,8 +226,6 @@ graph LR
     P --> PT2
     R --> RT1
 ```
-
-<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/abac/Taggable.kt:63-98 -->
 
 **AbacTags** — A map of key-value pairs where each key maps to a list of values:
 
@@ -252,17 +267,16 @@ class DocumentAggregate(
 ) {
     @OnCommand
     fun onCommand(command: ApplyAbacTags): AbacTagsApplied {
-        // Validate and merge tags
         return DefaultResourceTagsApplied(command.tags)
     }
 }
 ```
 
-Or use the built-in `DefaultApplyResourceTags` command which provides a ready-to-use tags management endpoint:
+Or use the built-in `DefaultApplyResourceTags` command which generates a ready-to-use endpoint:
 
 ```kotlin
-// The framework automatically handles DefaultApplyResourceTags
-// generating a PUT endpoint: PUT /{resourceName}/{id}/tags
+// PUT /{resourceName}/{id}/tags
+// Body: { "tags": { "dept": ["eng"], "role": ["admin"] } }
 ```
 
 ### Tag Merging
@@ -277,7 +291,30 @@ tags1.merge(tags2)
 // Result: { "dept": ["eng", "pm"], "role": ["admin"], "team": ["backend"] }
 ```
 
-<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/abac/ApplyAbacTags.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/abac/ApplyResourceTags.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/abac/AbacTagsMerger.kt -->
+### Dynamic Tag Extraction with StateAggregateTagsExtractor
+
+Tags can be extracted dynamically from aggregate state at query time, rather than being stored statically. Implement `StateAggregateTagsExtractor` on the state class:
+
+```kotlin
+class OrderState(
+    val id: String
+) : StateAggregateTagsExtractor<OrderState> {
+
+    lateinit var address: ShippingAddress
+    // ... other fields ...
+
+    override fun extract(source: ReadOnlyStateAggregate<OrderState>): AbacTags {
+        val staticTags = mapOf(
+            "address-country" to listOf(address.country),
+            "address-province" to listOf(address.province),
+        )
+        // Merge with tags stored on the aggregate
+        return staticTags.merge(source.tags)
+    }
+}
+```
+
+This pattern allows ABAC rules to be based on aggregate state fields (like address) combined with explicitly assigned tags.
 
 ### ABAC Query Filter
 
@@ -290,35 +327,42 @@ When querying snapshots, the `AbacQueryFilter` automatically injects permission 
 | `["a", "b"]` | `["c"]` | ❌ No match |
 | Any | Key absent | ✅ Match (resource is public for this key) |
 
-The filter converts principal tags into query conditions:
-- For wildcard tags: checks that the key exists on the resource
-- For regular tags: matches resources where the key is absent, empty, or has a value in the principal's list
+The filter converts principal tags into query conditions using AND logic across all keys:
+- **Wildcard** tags: checks that the key exists on the resource (`EXISTS`)
+- **Regular** tags: matches resources where the key is absent, empty, or has a value in the principal's list
 
 To implement custom principal tag resolution, extend `AbacQueryFilter`:
 
 ```kotlin
 @Component
-class MyAbacQueryFilter : AbacQueryFilter() {
+class MemberAbacQueryFilter(
+    private val memberCache: MemberCache
+) : AbacQueryFilter() {
+
     override fun getPrincipalTags(
         contextView: ContextView,
         context: QueryContext<*, *>
     ): Mono<AbacTags> {
-        // Resolve principal tags from security context, JWT, etc.
-        return SecurityContext.fromContext(contextView)
-            .map { it.abacTags }
+        val securityContext = contextView.getSecurityContextOrEmpty()
+            ?: return Mono.empty()
+        val principal = securityContext.principal
+
+        // Look up member tags from cache based on user + tenant + app
+        return Mono.fromCallable {
+            val memberId = memberId(userId = principal.id, tenantId = principal.tenantId)
+            memberCache[memberId]?.tags?.get(appId)
+        }
     }
 }
 ```
 
-<!-- Sources: wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/AbacQueryFilter.kt -->
-
 ## Layered Isolation Summary
 
-| Layer | Scope | Mechanism | Typical Use Case |
-|-------|-------|-----------|-----------------|
-| Tenant | Organization | `@TenantId` annotation + storage isolation | SaaS multi-tenancy |
-| Space | Namespace within tenant | `SpaceId` field + storage partitioning | Environment, domain separation |
-| Owner | Individual user | `@OwnerId` annotation + route policy | "My data" isolation |
-| ABAC | Attribute-based | Tags on principal + resource + query filter | Fine-grained permission (department, role, level) |
+| Layer | Scope | Mechanism | API Representation | Typical Use Case |
+|-------|-------|-----------|-------------------|-----------------|
+| Tenant | Organization | `@TenantId` / `@StaticTenantId` + storage isolation | `tenant/{tenantId}` path prefix | SaaS multi-tenancy |
+| Space | Namespace within tenant | `@AggregateRoute(spaced = true)` + storage partitioning | `Wow-Space-Id` request header | Environment, domain separation |
+| Owner | Individual user | `@OwnerId` + `@AggregateRoute(owner)` | `owner/{ownerId}` path prefix | "My data" isolation |
+| ABAC | Attribute-based | Tags on principal + resource + query filter | Internal filter (no API surface) | Fine-grained permission (department, role, level) |
 
 These layers are **additive** — enabling more layers adds more restrictions. A query without any layer applied returns all data; enabling tenant + owner + ABAC restricts to only the data the authenticated user is allowed to see.

--- a/documentation/docs/zh/guide/data-access.md
+++ b/documentation/docs/zh/guide/data-access.md
@@ -1,0 +1,324 @@
+---
+title: "数据权限"
+description: "了解 Wow 的多层数据隔离模型：租户、拥有者、命名空间以及基于属性的访问控制（ABAC），实现细粒度权限管理。"
+outline: deep
+---
+
+# 数据权限
+
+Wow 提供了分层的数据权限控制模型，覆盖了最常见的多租户和权限场景：
+
+1. **租户（Tenant）** — 按组织/客户隔离数据
+2. **拥有者（Owner）** — 在租户内按用户身份隔离数据
+3. **命名空间（Space）** — 在租户内提供基于命名空间的分区
+4. **ABAC** — 基于属性的细粒度访问控制
+
+这些层级独立工作，可以自由组合。你可以仅使用租户隔离，也可以组合全部四个层级以获得最大安全性。
+
+```mermaid
+graph TB
+    subgraph Isolation_Layers["数据隔离层级"]
+        T["租户 Tenant"]
+        S["命名空间 Space"]
+        O["拥有者 Owner"]
+        A["ABAC 标签"]
+    end
+
+    T -->|包含| S
+    S -->|包含| O
+    O -->|受保护于| A
+
+    style T fill:#e8f5e9
+    style S fill:#e3f2fd
+    style O fill:#fff3e0
+    style A fill:#fce4ec
+```
+
+<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/TenantId.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/OwnerId.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/SpaceIdCapable.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/abac/Taggable.kt -->
+
+## 租户（Tenant）
+
+租户是最高层级的数据隔离边界。在 SaaS 应用中，每个客户（组织）通常是一个独立的租户。Wow 自动在命令和事件中传播租户上下文，确保数据在存储层面被隔离。
+
+### 基于注解的租户 ID
+
+使用 `@TenantId` 注解标记命令或聚合状态中的租户标识字段：
+
+```kotlin
+@AggregateRoot
+class OrderAggregate(
+    @AggregateId
+    val orderId: String,
+
+    @TenantId
+    val tenantId: String  // 该订单所属的组织
+)
+```
+
+```kotlin
+data class CreateOrder(
+    @AggregateId
+    val orderId: String,
+
+    @TenantId
+    val tenantId: String, // 自动从请求上下文填充
+
+    val items: List<OrderItem>
+)
+```
+
+框架利用此注解实现：
+- 从请求中自动设置租户上下文
+- 按租户隔离事件存储和快照存储
+- 在查询操作中强制租户边界
+
+### 静态租户 ID
+
+对于始终属于固定租户的聚合（如系统配置），使用 `@StaticTenantId`：
+
+```kotlin
+@AggregateRoot
+@StaticTenantId("system-tenant")
+class SystemConfigurationAggregate {
+    // 始终属于系统租户
+}
+```
+
+### 默认租户
+
+未指定租户时，Wow 使用默认租户 ID `(0)`。这对单租户应用是透明的 — 无需处理租户 ID。
+
+<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/TenantId.kt:57-94, wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/TenantId.kt:20-43 -->
+
+## 拥有者（Owner）
+
+在租户内部，**拥有者**层级按用户身份隔离数据，确保用户只能访问自己的数据（如"我的订单"、"我的购物车"）。
+
+### 基于注解的拥有者 ID
+
+使用 `@OwnerId` 注解标记拥有者标识：
+
+```kotlin
+data class AddToCart(
+    @AggregateId
+    val cartId: String,
+
+    @OwnerId
+    val userId: String,  // 拥有此购物车的用户
+
+    val productId: String,
+    val quantity: Int
+)
+```
+
+### 拥有者路由策略
+
+`@AggregateRoute` 注解通过 `owner` 参数控制拥有权的强制方式：
+
+```kotlin
+@AggregateRoot
+@AggregateRoute(
+    resourceName = "orders",
+    owner = AggregateRoute.Owner.ALWAYS
+)
+class OrderAggregate(
+    @AggregateId
+    val orderId: String,
+
+    @OwnerId
+    val customerId: String
+)
+```
+
+可用策略：
+
+| 策略 | 说明 | 适用场景 |
+|------|------|---------|
+| `NEVER` | 无需拥有者上下文 | 公共资源、系统聚合 |
+| `ALWAYS` | 始终需要拥有者上下文 | 用户专属数据（订单、个人资料） |
+| `AGGREGATE_ID` | 聚合 ID 即拥有者 ID | 每用户聚合（用户资料、设置） |
+
+### 拥有权转移
+
+当需要变更拥有者时（如将任务转交给其他用户），实现 `OwnerTransferred` 事件接口：
+
+```kotlin
+data class TaskTransferred(
+    override val toOwnerId: String
+) : OwnerTransferred
+```
+
+框架识别此事件并自动更新聚合的拥有者上下文。
+
+<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/OwnerId.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AggregateRoute.kt:59-91, wow-api/src/main/kotlin/me/ahoo/wow/api/event/OwnerTransferred.kt -->
+
+## 命名空间（Space）
+
+**命名空间**在租户内提供基于命名空间的数据分区，增加了第三个隔离维度，适用于：
+
+- 环境隔离（dev / staging / prod）
+- 业务域分区（primary / archive）
+- 组织单元边界
+
+```kotlin
+// 聚合可以属于同一租户内的不同命名空间
+data class ArchivedOrder(
+    @AggregateId
+    val orderId: String,
+
+    @TenantId
+    val tenantId: String,
+
+    val spaceId: SpaceId  // "archive" 命名空间
+)
+```
+
+命名空间转移遵循与拥有权转移相同的模式 — 实现 `SpaceTransferred`：
+
+```kotlin
+data class OrderArchived(
+    override val toSpaceId: SpaceId
+) : SpaceTransferred
+```
+
+默认命名空间 ID 为空字符串 `""`，即所有未显式指定命名空间的聚合都在默认空间中。
+
+<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/SpaceIdCapable.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/event/SpaceTransferred.kt -->
+
+## ABAC（基于属性的访问控制）
+
+租户、拥有者和命名空间提供结构性隔离，而 **ABAC** 提供细粒度的、基于属性的访问控制。它通过为**主体**（用户/服务）和**资源**（聚合）附加标签，然后在查询时进行匹配来实现。
+
+### 核心概念
+
+```mermaid
+graph LR
+    P["主体标签"] -->|匹配| R["资源标签"]
+    R -->|产生| A["访问决策"]
+
+    subgraph Principal["主体（用户/服务）"]
+        PT1["dept: [eng, pm]"]
+        PT2["role: [admin]"]
+    end
+
+    subgraph Resource["资源（聚合）"]
+        RT1["dept: [eng]"]
+    end
+
+    P --> PT1
+    P --> PT2
+    R --> RT1
+```
+
+<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/abac/Taggable.kt:63-98 -->
+
+**AbacTags** — 键值对映射，每个键对应一个值列表：
+
+```kotlin
+// 用户标签：属于工程部和产品部，角色为管理员
+val userTags: AbacTags = mapOf(
+    "dept" to listOf("eng", "pm"),
+    "role" to listOf("admin")
+)
+
+// 资源标签：仅允许工程部访问
+val resourceTags: AbacTags = mapOf(
+    "dept" to listOf("eng")
+)
+
+// 公开资源：无标签 = 所有人可访问
+val publicResource: AbacTags = emptyMap()
+```
+
+**通配符** — 值 `["*"]` 匹配该键下的所有值：
+
+```kotlin
+// 可以访问任何部门的资源
+val adminTags: AbacTags = mapOf(
+    "dept" to listOf("*")
+)
+```
+
+### 应用资源标签
+
+使用 `ApplyAbacTags` 命令接口为聚合设置标签：
+
+```kotlin
+@AggregateRoot
+class DocumentAggregate(
+    @AggregateId
+    val docId: String,
+    var tags: AbacTags = emptyMap()
+) {
+    @OnCommand
+    fun onCommand(command: ApplyAbacTags): AbacTagsApplied {
+        // 验证并合并标签
+        return DefaultResourceTagsApplied(command.tags)
+    }
+}
+```
+
+或者使用内置的 `DefaultApplyResourceTags` 命令，它提供了开箱即用的标签管理端点：
+
+```kotlin
+// 框架自动处理 DefaultApplyResourceTags
+// 生成 PUT 端点：PUT /{resourceName}/{id}/tags
+```
+
+### 标签合并
+
+使用 `merge` 扩展函数合并标签。对于相同的键，双方的值会合并（并集）：
+
+```kotlin
+val tags1 = mapOf("dept" to listOf("eng"), "role" to listOf("admin"))
+val tags2 = mapOf("dept" to listOf("pm"), "team" to listOf("backend"))
+
+tags1.merge(tags2)
+// 结果：{ "dept": ["eng", "pm"], "role": ["admin"], "team": ["backend"] }
+```
+
+<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/abac/ApplyAbacTags.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/abac/ApplyResourceTags.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/abac/AbacTagsMerger.kt -->
+
+### ABAC 查询过滤器
+
+查询快照时，`AbacQueryFilter` 根据主体的标签自动注入权限过滤条件。匹配规则如下：
+
+| 主体标签 | 资源标签 | 结果 |
+|---------|---------|------|
+| `["*"]`（通配符） | 任意 | ✅ 匹配 |
+| `["a", "b"]` | `["a"]` | ✅ 匹配 |
+| `["a", "b"]` | `["c"]` | ❌ 不匹配 |
+| 任意 | 键不存在 | ✅ 匹配（该键对应的资源为公开） |
+
+过滤器将主体标签转换为查询条件：
+- 通配符标签：检查资源上该键是否存在
+- 普通标签：匹配键不存在、值为空、或值在主体列表中的资源
+
+实现自定义的主体标签解析，继承 `AbacQueryFilter`：
+
+```kotlin
+@Component
+class MyAbacQueryFilter : AbacQueryFilter() {
+    override fun getPrincipalTags(
+        contextView: ContextView,
+        context: QueryContext<*, *>
+    ): Mono<AbacTags> {
+        // 从安全上下文、JWT 等解析主体标签
+        return SecurityContext.fromContext(contextView)
+            .map { it.abacTags }
+    }
+}
+```
+
+<!-- Sources: wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/AbacQueryFilter.kt -->
+
+## 隔离层级总结
+
+| 层级 | 作用范围 | 机制 | 典型场景 |
+|------|---------|------|---------|
+| 租户 | 组织 | `@TenantId` 注解 + 存储隔离 | SaaS 多租户 |
+| 命名空间 | 租户内的命名空间 | `SpaceId` 字段 + 存储分区 | 环境、业务域隔离 |
+| 拥有者 | 个人用户 | `@OwnerId` 注解 + 路由策略 | "我的数据"隔离 |
+| ABAC | 基于属性 | 主体标签 + 资源标签 + 查询过滤器 | 细粒度权限（部门、角色、级别） |
+
+这些层级是**叠加**关系 — 启用更多层级意味着更严格的限制。未启用任何层级的查询返回全部数据；同时启用租户 + 拥有者 + ABAC，则仅返回经过认证的用户被允许查看的数据。

--- a/documentation/docs/zh/guide/data-access.md
+++ b/documentation/docs/zh/guide/data-access.md
@@ -6,14 +6,14 @@ outline: deep
 
 # 数据权限
 
-Wow 提供了分层的数据权限控制模型，覆盖了最常见的多租户和权限场景：
+Wow 提供了三个可选的数据隔离层和一个基于属性的访问控制层：
 
-1. **租户（Tenant）** — 按组织/客户隔离数据
-2. **拥有者（Owner）** — 在租户内按用户身份隔离数据
-3. **命名空间（Space）** — 在租户内提供基于命名空间的分区
+1. **租户（Tenant）** — 按组织/客户隔离数据（可选）
+2. **拥有者（Owner）** — 在租户内按用户身份隔离数据（可选）
+3. **命名空间（Space）** — 在租户内提供基于命名空间的分区（可选）
 4. **ABAC** — 基于属性的细粒度访问控制
 
-这些层级独立工作，可以自由组合。你可以仅使用租户隔离，也可以组合全部四个层级以获得最大安全性。
+这三层隔离都是**可选**的，可以独立启用或自由组合。单租户应用无需启用任何隔离层；SaaS 应用可以按需组合租户、拥有者、命名空间和 ABAC。
 
 ```mermaid
 graph TB
@@ -34,7 +34,21 @@ graph TB
     style A fill:#fce4ec
 ```
 
-<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/TenantId.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/OwnerId.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/SpaceIdCapable.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/abac/Taggable.kt -->
+## RESTful URL 模式
+
+数据隔离层级直接体现在自动生成的 RESTful API 路径中：
+
+```
+[tenant/{tenantId}]/[owner/{ownerId}]/resource/[{resourceId}]/action
+```
+
+| 层级 | 路径 / 请求头 | 生效条件 |
+|------|--------------|---------|
+| 租户 | `tenant/{tenantId}` 路径前缀 | 聚合**未**标记 `@StaticTenantId` |
+| 拥有者 | `owner/{ownerId}` 路径前缀 | `@AggregateRoute(owner ≠ NEVER)` |
+| 命名空间 | `Wow-Space-Id` 请求头 | `@AggregateRoute(spaced = true)` |
+
+框架为每个聚合生成**多套路由变体** — 默认路由（无前缀）、仅租户路由、仅拥有者路由 — 调用方可以根据需要选择最小作用域。
 
 ## 租户（Tenant）
 
@@ -71,6 +85,7 @@ data class CreateOrder(
 - 从请求中自动设置租户上下文
 - 按租户隔离事件存储和快照存储
 - 在查询操作中强制租户边界
+- 在 RESTful API 中生成 `tenant/{tenantId}` 路径前缀
 
 ### 静态租户 ID
 
@@ -81,14 +96,13 @@ data class CreateOrder(
 @StaticTenantId("system-tenant")
 class SystemConfigurationAggregate {
     // 始终属于系统租户
+    // 生成的 API 不会包含 tenant/{tenantId} 路径前缀
 }
 ```
 
 ### 默认租户
 
 未指定租户时，Wow 使用默认租户 ID `(0)`。这对单租户应用是透明的 — 无需处理租户 ID。
-
-<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/TenantId.kt:57-94, wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/TenantId.kt:20-43 -->
 
 ## 拥有者（Owner）
 
@@ -132,11 +146,13 @@ class OrderAggregate(
 
 可用策略：
 
-| 策略 | 说明 | 适用场景 |
-|------|------|---------|
-| `NEVER` | 无需拥有者上下文 | 公共资源、系统聚合 |
-| `ALWAYS` | 始终需要拥有者上下文 | 用户专属数据（订单、个人资料） |
-| `AGGREGATE_ID` | 聚合 ID 即拥有者 ID | 每用户聚合（用户资料、设置） |
+| 策略 | `owned` | 说明 | API 路径 | 适用场景 |
+|------|---------|------|---------|---------|
+| `NEVER` | `false` | 无需拥有者上下文 | `/orders/{id}` | 公共资源、系统聚合 |
+| `ALWAYS` | `true` | 始终需要拥有者上下文 | `/owner/{ownerId}/orders/{id}` | 用户专属数据（订单、个人资料） |
+| `AGGREGATE_ID` | `true` | 聚合 ID 即拥有者 ID | `/owner/{ownerId}/orders`（无 `{id}`） | 每用户聚合（用户资料、设置） |
+
+当使用 `AGGREGATE_ID` 时，`{resourceId}` 路径参数会被移除，因为拥有者 ID 已经标识了聚合。
 
 ### 拥有权转移
 
@@ -150,8 +166,6 @@ data class TaskTransferred(
 
 框架识别此事件并自动更新聚合的拥有者上下文。
 
-<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/OwnerId.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AggregateRoute.kt:59-91, wow-api/src/main/kotlin/me/ahoo/wow/api/event/OwnerTransferred.kt -->
-
 ## 命名空间（Space）
 
 **命名空间**在租户内提供基于命名空间的数据分区，增加了第三个隔离维度，适用于：
@@ -160,18 +174,23 @@ data class TaskTransferred(
 - 业务域分区（primary / archive）
 - 组织单元边界
 
+### 启用命名空间
+
+在 `@AggregateRoute` 中设置 `spaced = true`：
+
 ```kotlin
-// 聚合可以属于同一租户内的不同命名空间
-data class ArchivedOrder(
-    @AggregateId
-    val orderId: String,
-
-    @TenantId
-    val tenantId: String,
-
-    val spaceId: SpaceId  // "archive" 命名空间
+@AggregateRoot
+@AggregateRoute(
+    resourceName = "sales-order",
+    spaced = true,
+    owner = AggregateRoute.Owner.ALWAYS
 )
+class Order(private val state: OrderState)
 ```
+
+当 `spaced = true` 时，生成的 API 会添加 `Wow-Space-Id` 请求头参数。默认命名空间 ID 为空字符串 `""`，即所有未显式指定命名空间的聚合都在默认空间中。
+
+### 命名空间转移
 
 命名空间转移遵循与拥有权转移相同的模式 — 实现 `SpaceTransferred`：
 
@@ -181,9 +200,7 @@ data class OrderArchived(
 ) : SpaceTransferred
 ```
 
-默认命名空间 ID 为空字符串 `""`，即所有未显式指定命名空间的聚合都在默认空间中。
-
-<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/SpaceIdCapable.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/event/SpaceTransferred.kt -->
+框架识别此事件并自动更新聚合的命名空间上下文。
 
 ## ABAC（基于属性的访问控制）
 
@@ -209,8 +226,6 @@ graph LR
     P --> PT2
     R --> RT1
 ```
-
-<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/abac/Taggable.kt:63-98 -->
 
 **AbacTags** — 键值对映射，每个键对应一个值列表：
 
@@ -261,8 +276,8 @@ class DocumentAggregate(
 或者使用内置的 `DefaultApplyResourceTags` 命令，它提供了开箱即用的标签管理端点：
 
 ```kotlin
-// 框架自动处理 DefaultApplyResourceTags
-// 生成 PUT 端点：PUT /{resourceName}/{id}/tags
+// PUT /{resourceName}/{id}/tags
+// Body: { "tags": { "dept": ["eng"], "role": ["admin"] } }
 ```
 
 ### 标签合并
@@ -277,7 +292,30 @@ tags1.merge(tags2)
 // 结果：{ "dept": ["eng", "pm"], "role": ["admin"], "team": ["backend"] }
 ```
 
-<!-- Sources: wow-api/src/main/kotlin/me/ahoo/wow/api/abac/ApplyAbacTags.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/abac/ApplyResourceTags.kt, wow-api/src/main/kotlin/me/ahoo/wow/api/abac/AbacTagsMerger.kt -->
+### 动态标签提取（StateAggregateTagsExtractor）
+
+标签可以在查询时从聚合状态中动态提取，而非仅依赖静态存储。在状态类上实现 `StateAggregateTagsExtractor`：
+
+```kotlin
+class OrderState(
+    val id: String
+) : StateAggregateTagsExtractor<OrderState> {
+
+    lateinit var address: ShippingAddress
+    // ... 其他字段 ...
+
+    override fun extract(source: ReadOnlyStateAggregate<OrderState>): AbacTags {
+        val stateTags = mapOf(
+            "address-country" to listOf(address.country),
+            "address-province" to listOf(address.province),
+        )
+        // 与聚合上显式存储的标签合并
+        return stateTags.merge(source.tags)
+    }
+}
+```
+
+这种模式允许 ABAC 规则基于聚合状态字段（如地址）与显式分配的标签组合进行匹配。
 
 ### ABAC 查询过滤器
 
@@ -290,35 +328,42 @@ tags1.merge(tags2)
 | `["a", "b"]` | `["c"]` | ❌ 不匹配 |
 | 任意 | 键不存在 | ✅ 匹配（该键对应的资源为公开） |
 
-过滤器将主体标签转换为查询条件：
-- 通配符标签：检查资源上该键是否存在
-- 普通标签：匹配键不存在、值为空、或值在主体列表中的资源
+过滤器将主体标签转换为查询条件，所有标签键之间使用 AND 逻辑：
+- **通配符**标签：检查资源上该键是否存在（`EXISTS`）
+- **普通**标签：匹配键不存在、值为空、或值在主体列表中的资源
 
 实现自定义的主体标签解析，继承 `AbacQueryFilter`：
 
 ```kotlin
 @Component
-class MyAbacQueryFilter : AbacQueryFilter() {
+class MemberAbacQueryFilter(
+    private val memberCache: MemberCache
+) : AbacQueryFilter() {
+
     override fun getPrincipalTags(
         contextView: ContextView,
         context: QueryContext<*, *>
     ): Mono<AbacTags> {
-        // 从安全上下文、JWT 等解析主体标签
-        return SecurityContext.fromContext(contextView)
-            .map { it.abacTags }
+        val securityContext = contextView.getSecurityContextOrEmpty()
+            ?: return Mono.empty()
+        val principal = securityContext.principal
+
+        // 根据用户 + 租户 + 应用从缓存查找成员标签
+        return Mono.fromCallable {
+            val memberId = memberId(userId = principal.id, tenantId = principal.tenantId)
+            memberCache[memberId]?.tags?.get(appId)
+        }
     }
 }
 ```
 
-<!-- Sources: wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/AbacQueryFilter.kt -->
-
 ## 隔离层级总结
 
-| 层级 | 作用范围 | 机制 | 典型场景 |
-|------|---------|------|---------|
-| 租户 | 组织 | `@TenantId` 注解 + 存储隔离 | SaaS 多租户 |
-| 命名空间 | 租户内的命名空间 | `SpaceId` 字段 + 存储分区 | 环境、业务域隔离 |
-| 拥有者 | 个人用户 | `@OwnerId` 注解 + 路由策略 | "我的数据"隔离 |
-| ABAC | 基于属性 | 主体标签 + 资源标签 + 查询过滤器 | 细粒度权限（部门、角色、级别） |
+| 层级 | 作用范围 | 机制 | API 表现 | 典型场景 |
+|------|---------|------|---------|---------|
+| 租户 | 组织 | `@TenantId` / `@StaticTenantId` + 存储隔离 | `tenant/{tenantId}` 路径前缀 | SaaS 多租户 |
+| 命名空间 | 租户内的命名空间 | `@AggregateRoute(spaced = true)` + 存储分区 | `Wow-Space-Id` 请求头 | 环境、业务域隔离 |
+| 拥有者 | 个人用户 | `@OwnerId` + `@AggregateRoute(owner)` | `owner/{ownerId}` 路径前缀 | "我的数据"隔离 |
+| ABAC | 基于属性 | 主体标签 + 资源标签 + 查询过滤器 | 内部过滤（无 API 表面） | 细粒度权限（部门、角色、级别） |
 
 这些层级是**叠加**关系 — 启用更多层级意味着更严格的限制。未启用任何层级的查询返回全部数据；同时启用租户 + 拥有者 + ABAC，则仅返回经过认证的用户被允许查看的数据。


### PR DESCRIPTION
## Summary

Add comprehensive documentation for Wow's multi-layer data access control model.

## Changes

### New documentation page: Data Access Control (`data-access.md`)

Covers four isolation layers with code examples and Mermaid diagrams:

1. **Tenant** — `@TenantId`, `@StaticTenantId`, default tenant
2. **Owner** — `@OwnerId`, routing policies (`NEVER`/`ALWAYS`/`AGGREGATE_ID`), ownership transfer via `OwnerTransferred`
3. **Space** — namespace partitioning within tenant, `SpaceTransferred` transfer
4. **ABAC** — `AbacTags`, wildcard matching, `ApplyAbacTags` command, tag merging, `AbacQueryFilter` with matching rules table

### Sidebar registration

- Added "Data Access Control" to Core section in English sidebar
- Added "数据权限" to 核心 section in Chinese sidebar

### Files

- `documentation/docs/en/guide/data-access.md` — English version (324 lines)
- `documentation/docs/zh/guide/data-access.md` — Chinese version (324 lines)
- `sidebar.en.ts` / `sidebar.zh.ts` — sidebar config updates

### Also includes

- Previous README optimization commit (Why Wow? section + enriched Features table)