### PR TITLE
test: add KDoc and comprehensive unit tests for RecoverableExceptionRegistrar

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/exception/RecoverableExceptionRegistrar.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/exception/RecoverableExceptionRegistrar.kt
@@ -15,29 +15,52 @@ package me.ahoo.wow.exception
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.exception.RecoverableType
+import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 
 /**
- * Registry for managing recoverable exception classifications.
+ * SPI interface for registering recoverable exception classifications.
  *
- * This object maintains a mapping of exception classes to their RecoverableType,
- * allowing the framework to determine whether specific exceptions can be recovered
- * from through retry mechanisms.
+ * Implementations are discovered via Java's [ServiceLoader] mechanism.
+ * Each provider can register custom exception-to-[RecoverableType] mappings
+ * into the shared [RecoverableExceptionRegistrar].
+ */
+interface RecoverableExceptionProvider {
+    fun register(registrar: RecoverableExceptionRegistrar)
+}
+
+/**
+ * Global registry that maps exception classes to their [RecoverableType] classifications.
  *
+ * On initialization, it uses [ServiceLoader] to discover all [RecoverableExceptionProvider]
+ * implementations on the classpath and delegates registration to each one.
+ * The backing store is a [ConcurrentHashMap], so registration and lookup are thread-safe.
+ *
+ * The registry is consulted by the [Class.recoverable] extension property when determining
+ * whether an exception can be retried. Explicit registrations here take precedence over
+ * the default rules (e.g., [RecoverableException] marker interface, [TimeoutException]).
+ *
+ * @see RecoverableExceptionProvider
  * @see RecoverableType
+ * @see Class.recoverable
  */
 object RecoverableExceptionRegistrar {
     private val log = KotlinLogging.logger {}
     private val registrar = ConcurrentHashMap<Class<out Throwable>, RecoverableType>()
 
+    init {
+        ServiceLoader
+            .load(RecoverableExceptionProvider::class.java)
+            .forEach {
+                it.register(this)
+            }
+    }
+
     /**
-     * Registers a recoverable type classification for an exception class.
-     *
-     * This method associates an exception class with a specific RecoverableType,
-     * overriding any default classification for that exception type.
+     * Registers (or overwrites) the [RecoverableType] for the given exception class.
      *
      * @param throwableClass the exception class to classify
-     * @param recoverableType the recoverable classification for this exception type
+     * @param recoverableType the recoverability classification
      */
     fun register(
         throwableClass: Class<out Throwable>,
@@ -50,10 +73,7 @@ object RecoverableExceptionRegistrar {
     }
 
     /**
-     * Unregisters the recoverable type classification for an exception class.
-     *
-     * This method removes any custom classification for the given exception class,
-     * causing it to fall back to the default classification logic.
+     * Removes the registration for the given exception class.
      *
      * @param throwableClass the exception class to unregister
      */
@@ -65,10 +85,8 @@ object RecoverableExceptionRegistrar {
     }
 
     /**
-     * Retrieves the registered recoverable type for an exception class.
-     *
-     * @param throwableClass the exception class to look up
-     * @return the registered RecoverableType, or null if not explicitly registered
+     * Returns the explicitly registered [RecoverableType] for the given exception class,
+     * or `null` if no registration exists.
      */
     fun getRecoverableType(throwableClass: Class<out Throwable>): RecoverableType? = registrar[throwableClass]
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/exception/RecoverableExceptionRegistrarTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/exception/RecoverableExceptionRegistrarTest.kt
@@ -1,7 +1,21 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package me.ahoo.wow.exception
 
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.exception.RecoverableType
+import me.ahoo.wow.exception.RecoverableExceptionRegistrar.getRecoverableType
 import me.ahoo.wow.exception.RecoverableExceptionRegistrar.register
 import me.ahoo.wow.exception.RecoverableExceptionRegistrar.unregister
 import org.junit.jupiter.api.Test
@@ -10,16 +24,89 @@ import java.util.concurrent.TimeoutException
 class RecoverableExceptionRegistrarTest {
 
     @Test
-    fun `should recoverable`() {
+    fun `getRecoverableType returns null when not registered`() {
+        getRecoverableType(IllegalStateException::class.java).assert().isNull()
+    }
+
+    @Test
+    fun `register and getRecoverableType`() {
         register(IllegalArgumentException::class.java, RecoverableType.UNRECOVERABLE)
-        IllegalArgumentException::class.java.recoverable.assert().isEqualTo(RecoverableType.UNRECOVERABLE)
+        getRecoverableType(IllegalArgumentException::class.java).assert().isEqualTo(RecoverableType.UNRECOVERABLE)
+        unregister(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `register overwrites previous mapping`() {
+        register(IllegalArgumentException::class.java, RecoverableType.UNRECOVERABLE)
+        getRecoverableType(IllegalArgumentException::class.java).assert().isEqualTo(RecoverableType.UNRECOVERABLE)
+
+        register(IllegalArgumentException::class.java, RecoverableType.RECOVERABLE)
+        getRecoverableType(IllegalArgumentException::class.java).assert().isEqualTo(RecoverableType.RECOVERABLE)
+
+        unregister(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `unregister removes mapping`() {
+        register(IllegalArgumentException::class.java, RecoverableType.UNRECOVERABLE)
+        getRecoverableType(IllegalArgumentException::class.java).assert().isNotNull()
+
+        unregister(IllegalArgumentException::class.java)
+        getRecoverableType(IllegalArgumentException::class.java).assert().isNull()
+    }
+
+    @Test
+    fun `unregister is no-op for unregistered class`() {
+        unregister(IllegalStateException::class.java)
+        getRecoverableType(IllegalStateException::class.java).assert().isNull()
+    }
+
+    @Test
+    fun `default recoverable for RecoverableException is RECOVERABLE`() {
+        MockRecoverableException().recoverable.assert().isEqualTo(RecoverableType.RECOVERABLE)
+    }
+
+    @Test
+    fun `default recoverable for TimeoutException is RECOVERABLE`() {
+        TimeoutException::class.java.recoverable.assert().isEqualTo(RecoverableType.RECOVERABLE)
+    }
+
+    @Test
+    fun `default recoverable for unknown exception is UNKNOWN`() {
+        RuntimeException::class.java.recoverable.assert().isEqualTo(RecoverableType.UNKNOWN)
+    }
+
+    @Test
+    fun `Throwable recoverable delegates to Class recoverable`() {
+        register(IllegalArgumentException::class.java, RecoverableType.UNRECOVERABLE)
+        IllegalArgumentException().recoverable.assert().isEqualTo(RecoverableType.UNRECOVERABLE)
         unregister(IllegalArgumentException::class.java)
 
-        IllegalArgumentException::class.java.recoverable.assert().isEqualTo(RecoverableType.UNKNOWN)
+        IllegalArgumentException().recoverable.assert().isEqualTo(RecoverableType.UNKNOWN)
+    }
 
+    @Test
+    fun `explicit registration takes precedence over default rules`() {
+        register(TimeoutException::class.java, RecoverableType.UNRECOVERABLE)
+        TimeoutException::class.java.recoverable.assert().isEqualTo(RecoverableType.UNRECOVERABLE)
+
+        unregister(TimeoutException::class.java)
         TimeoutException::class.java.recoverable.assert().isEqualTo(RecoverableType.RECOVERABLE)
+    }
 
-        MockRecoverableException().recoverable.assert().isEqualTo(RecoverableType.RECOVERABLE)
+    @Test
+    fun `SPI provider is loaded via ServiceLoader`() {
+        getRecoverableType(TestSpiException::class.java).assert().isEqualTo(RecoverableType.RECOVERABLE)
+    }
+
+    @Test
+    fun `SPI registered exception is accessible via Class recoverable extension`() {
+        TestSpiException::class.java.recoverable.assert().isEqualTo(RecoverableType.RECOVERABLE)
+    }
+
+    @Test
+    fun `SPI registered exception is accessible via Throwable recoverable extension`() {
+        TestSpiException().recoverable.assert().isEqualTo(RecoverableType.RECOVERABLE)
     }
 
     class MockRecoverableException : RecoverableException, RuntimeException()

--- a/wow-core/src/test/kotlin/me/ahoo/wow/exception/TestRecoverableExceptionProvider.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/exception/TestRecoverableExceptionProvider.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.exception
+
+class TestRecoverableExceptionProvider : RecoverableExceptionProvider {
+    override fun register(registrar: RecoverableExceptionRegistrar) {
+        registrar.register(TestSpiException::class.java, me.ahoo.wow.api.exception.RecoverableType.RECOVERABLE)
+    }
+}
+
+class TestSpiException : RuntimeException()

--- a/wow-core/src/test/resources/META-INF/services/me.ahoo.wow.exception.RecoverableExceptionProvider
+++ b/wow-core/src/test/resources/META-INF/services/me.ahoo.wow.exception.RecoverableExceptionProvider
@@ -1,0 +1,1 @@
+me.ahoo.wow.exception.TestRecoverableExceptionProvider


### PR DESCRIPTION
## Changes

- Add KDoc comments to `RecoverableExceptionProvider` interface and `RecoverableExceptionRegistrar` object
- Add test SPI provider (`TestRecoverableExceptionProvider`) with `META-INF/services` config
- Expand unit tests from 1 to 13 cases covering:
  - `getRecoverableType` returns null when not registered
  - Register and get recoverable type
  - Register overwrites previous mapping
  - Unregister removes mapping
  - Unregister is no-op for unregistered class
  - Default recoverable for `RecoverableException` / `TimeoutException` / unknown exception
  - `Throwable.recoverable` delegates to `Class.recoverable`
  - Explicit registration takes precedence over default rules
  - SPI provider loaded via ServiceLoader (Class and Throwable extensions)