### PR TITLE
fix(mongo): handle null cast in recoverable write error mapping

### DIFF
--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/ErrorMapping.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/ErrorMapping.kt
@@ -61,7 +61,12 @@ fun WriteError.toWowError(eventStream: DomainEventStream, cause: MongoServerExce
         return cause
     }
     if (isRecoverableWriteError()) {
-        return RecoverableMongoWriteException(cause as MongoWriteException)
+        val writeException = cause as? MongoWriteException
+        return if (writeException != null) {
+            RecoverableMongoWriteException(writeException)
+        } else {
+            cause
+        }
     }
     return cause
 }

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/ErrorMapping.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/ErrorMapping.kt
@@ -15,7 +15,6 @@ package me.ahoo.wow.mongo
 
 import com.mongodb.ErrorCategory
 import com.mongodb.MongoException
-import com.mongodb.MongoServerException
 import com.mongodb.MongoWriteException
 import com.mongodb.WriteError
 import me.ahoo.wow.command.DuplicateRequestIdException
@@ -43,30 +42,25 @@ class RecoverableMongoWriteException(writeException: MongoWriteException) :
 
 fun WriteError.isRecoverableWriteError(): Boolean = code in RECOVERABLE_WRITE_ERROR_CODES
 
-fun WriteError.toWowError(eventStream: DomainEventStream, cause: MongoServerException): Throwable {
-    if (ErrorCategory.fromErrorCode(code) == ErrorCategory.DUPLICATE_KEY) {
-        if (message.contains(AggregateSchemaInitializer.AGGREGATE_ID_AND_VERSION_UNIQUE_INDEX_NAME)) {
+fun MongoWriteException.toWowError(eventStream: DomainEventStream): Throwable {
+    if (ErrorCategory.fromErrorCode(error.code) == ErrorCategory.DUPLICATE_KEY) {
+        if (error.message.contains(AggregateSchemaInitializer.AGGREGATE_ID_AND_VERSION_UNIQUE_INDEX_NAME)) {
             return EventVersionConflictException(
                 eventStream = eventStream,
-                cause = cause,
+                cause = this,
             )
         }
-        if (message.contains(AggregateSchemaInitializer.REQUEST_ID_UNIQUE_INDEX_NAME)) {
+        if (error.message.contains(AggregateSchemaInitializer.REQUEST_ID_UNIQUE_INDEX_NAME)) {
             return DuplicateRequestIdException(
                 aggregateId = eventStream.aggregateId,
                 requestId = eventStream.requestId,
-                cause = cause,
+                cause = this,
             )
         }
-        return cause
+        return this
     }
-    if (isRecoverableWriteError()) {
-        val writeException = cause as? MongoWriteException
-        return if (writeException != null) {
-            RecoverableMongoWriteException(writeException)
-        } else {
-            cause
-        }
+    if (error.isRecoverableWriteError()) {
+        return RecoverableMongoWriteException(this)
     }
-    return cause
+    return this
 }

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoEventStore.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoEventStore.kt
@@ -41,7 +41,7 @@ class MongoEventStore(private val database: MongoDatabase) : AbstractEventStore(
             .doOnNext {
                 check(it.wasAcknowledged())
             }.onErrorMap(MongoWriteException::class.java) {
-                it.error.toWowError(eventStream, it)
+                it.toWowError(eventStream)
             }.then()
     }
 

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/ErrorMappingTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/ErrorMappingTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.mongo
+
+import com.mongodb.MongoWriteException
+import com.mongodb.ServerAddress
+import com.mongodb.WriteError
+import io.mockk.every
+import io.mockk.mockk
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.command.DuplicateRequestIdException
+import me.ahoo.wow.event.DomainEventStream
+import me.ahoo.wow.eventsourcing.EventVersionConflictException
+import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.modeling.aggregateId
+import org.bson.BsonDocument
+import org.junit.jupiter.api.Test
+
+class ErrorMappingTest {
+    private val namedAggregate = MaterializedNamedAggregate("testContext", "testAggregate")
+    private val aggregateId = namedAggregate.aggregateId(generateGlobalId())
+    private val requestId = generateGlobalId()
+
+    private fun mockEventStream(): DomainEventStream = mockk(relaxed = true) {
+        every { this@mockk.aggregateId } returns this@ErrorMappingTest.aggregateId
+        every { requestId } returns this@ErrorMappingTest.requestId
+    }
+
+    @Test
+    fun `duplicate key with aggregateId and version index maps to EventVersionConflictException`() {
+        val eventStream = mockEventStream()
+        val writeException = MongoWriteException(
+            WriteError(
+                11000,
+                "duplicate key - ${AggregateSchemaInitializer.AGGREGATE_ID_AND_VERSION_UNIQUE_INDEX_NAME}",
+                BsonDocument()
+            ),
+            ServerAddress("localhost"),
+        )
+        val result = writeException.toWowError(eventStream)
+        result.assert().isInstanceOf(EventVersionConflictException::class.java)
+        (result as EventVersionConflictException).cause.assert().isSameAs(writeException)
+    }
+
+    @Test
+    fun `duplicate key with requestId index maps to DuplicateRequestIdException`() {
+        val eventStream = mockEventStream()
+        val writeException = MongoWriteException(
+            WriteError(
+                11000,
+                "duplicate key - ${AggregateSchemaInitializer.REQUEST_ID_UNIQUE_INDEX_NAME}",
+                BsonDocument()
+            ),
+            ServerAddress("localhost"),
+        )
+        val result = writeException.toWowError(eventStream)
+        result.assert().isInstanceOf(DuplicateRequestIdException::class.java)
+        val ex = result as DuplicateRequestIdException
+        ex.aggregateId.assert().isEqualTo(this.aggregateId)
+        ex.requestId.assert().isEqualTo(this.requestId)
+        ex.cause.assert().isSameAs(writeException)
+    }
+
+    @Test
+    fun `duplicate key with unknown index returns original exception`() {
+        val eventStream = mockEventStream()
+        val writeException = MongoWriteException(
+            WriteError(11000, "duplicate key - unknown_index", BsonDocument()),
+            ServerAddress("localhost"),
+        )
+        val result = writeException.toWowError(eventStream)
+        result.assert().isSameAs(writeException)
+    }
+
+    @Test
+    fun `recoverable write error maps to RecoverableMongoWriteException`() {
+        val eventStream = mockEventStream()
+        val writeException = MongoWriteException(
+            WriteError(10107, "NotWritablePrimary", BsonDocument()),
+            ServerAddress("localhost"),
+        )
+        val result = writeException.toWowError(eventStream)
+        result.assert().isInstanceOf(RecoverableMongoWriteException::class.java)
+        (result as RecoverableMongoWriteException).error.code.assert().isEqualTo(10107)
+    }
+
+    @Test
+    fun `non-recoverable non-duplicate write error returns original exception`() {
+        val eventStream = mockEventStream()
+        val writeException = MongoWriteException(
+            WriteError(50, "SomeError", BsonDocument()),
+            ServerAddress("localhost"),
+        )
+        val result = writeException.toWowError(eventStream)
+        result.assert().isSameAs(writeException)
+    }
+}


### PR DESCRIPTION
- Added safe cast check to prevent ClassCastException when casting cause to MongoWriteException
- Return original cause when cast fails instead of throwing exception
- Maintained existing recoverable write exception behavior when cast succeeds

