### PR TITLE
refactor(exception): enhance recoverable exception lookup with class hierarchy traversal

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/exception/RecoverableExceptionRegistrar.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/exception/RecoverableExceptionRegistrar.kt
@@ -85,8 +85,21 @@ object RecoverableExceptionRegistrar {
     }
 
     /**
-     * Returns the explicitly registered [RecoverableType] for the given exception class,
+     * Returns the registered [RecoverableType] for the given exception class,
      * or `null` if no registration exists.
+     *
+     * Lookup walks the class hierarchy: if the exact class is not registered,
+     * each superclass is checked in order. This ensures that subclasses of a
+     * registered exception (e.g., MongoDB socket exception subclasses) are
+     * correctly classified without requiring individual registration.
      */
-    fun getRecoverableType(throwableClass: Class<out Throwable>): RecoverableType? = registrar[throwableClass]
+    fun getRecoverableType(throwableClass: Class<out Throwable>): RecoverableType? {
+        registrar[throwableClass]?.let { return it }
+        var superclass = throwableClass.superclass
+        while (superclass != null && Throwable::class.java.isAssignableFrom(superclass)) {
+            registrar[superclass]?.let { return it }
+            superclass = superclass.superclass
+        }
+        return null
+    }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/lifecycle/GracefullyStoppable.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/lifecycle/GracefullyStoppable.kt
@@ -20,44 +20,22 @@ import java.time.Duration
  * Interface for components that support graceful shutdown.
  *
  * Implementations of this interface provide both synchronous and asynchronous
- * graceful stop operations. The synchronous `close()` method blocks until
- * all ongoing operations complete, while `stopGracefully()` returns a reactive
- * stream that completes when shutdown is finished.
+ * graceful stop operations. The synchronous [stop] method has a default timeout
+ * of 30 seconds; if shutdown does not complete within that window, the call returns
+ * without guaranteeing all in-flight operations have finished. Use [stop] with a
+ * custom [Duration] to adjust the timeout, or call [stopGracefully] directly for
+ * fully asynchronous shutdown.
  *
  * This is particularly useful for message dispatchers, connection pools, and
  * other resources that need to complete in-flight operations before terminating.
- *
- * Example usage:
- * ```kotlin
- * class MyDispatcher : GracefullyStoppable {
- *     private val activeOperations = mutableListOf<Mono<Void>>()
- *
- *     override fun stopGracefully(): Mono<Void> {
- *         // Cancel new operations and wait for active ones
- *         stopAcceptingNewOperations()
- *         return if (activeOperations.isNotEmpty()) {
- *             Flux.merge(activeOperations).then()
- *         } else {
- *             Mono.empty()
- *         }
- *     }
- * }
- *
- * // Usage
- * val dispatcher = MyDispatcher()
- * // ... use dispatcher ...
- * dispatcher.close() // Blocks until graceful shutdown completes
- * ```
  *
  * @see AutoCloseable for the standard close contract
  */
 interface GracefullyStoppable : AutoCloseable {
     /**
-     * Closes this resource by performing a graceful shutdown.
+     * Closes this resource by performing a graceful shutdown with a 30-second timeout.
      *
-     * This method implements the [AutoCloseable] contract and delegates
-     * to the [stop] method to ensure all ongoing operations complete
-     * before the resource is closed.
+     * This method implements the [AutoCloseable] contract and delegates to [stop].
      *
      * @throws Exception if an error occurs during shutdown
      * @see AutoCloseable.close
@@ -68,14 +46,11 @@ interface GracefullyStoppable : AutoCloseable {
     }
 
     /**
-     * Synchronously closes this resource with graceful shutdown.
+     * Synchronously stops this resource with a 30-second timeout.
      *
-     * This method blocks the calling thread until all ongoing operations
-     * complete and the resource is fully shut down. It delegates to the
-     * asynchronous `closeGracefully()` method and waits for its completion.
-     *
-     * This implementation ensures that `close()` adheres to the `AutoCloseable`
-     * contract while providing graceful shutdown behavior.
+     * Blocks the calling thread until all ongoing operations complete or the
+     * 30-second timeout expires — whichever comes first. If the timeout expires,
+     * this method returns without guaranteeing that all operations have finished.
      *
      * @throws IllegalStateException if the underlying reactive stream fails
      * @see stopGracefully for the asynchronous version
@@ -85,21 +60,16 @@ interface GracefullyStoppable : AutoCloseable {
     }
 
     /**
-     * Synchronously closes this resource with graceful shutdown within a specified timeout.
+     * Synchronously stops this resource within the specified [timeout].
      *
-     * This method blocks the calling thread until either all ongoing operations complete
-     * and the resource is fully shut down, or the specified timeout expires. It delegates
-     * to the asynchronous `closeGracefully()` method and waits for its completion with
-     * a time limit.
-     *
-     * If the timeout expires before shutdown completes, the method returns without
-     * guaranteeing that all operations have finished. Implementations should handle
-     * any necessary cleanup in such cases.
+     * Blocks the calling thread until all ongoing operations complete or the
+     * timeout expires. If the timeout expires, this method returns without
+     * guaranteeing that all operations have finished.
      *
      * @param timeout The maximum duration to wait for graceful shutdown to complete
      * @throws IllegalStateException if the underlying reactive stream fails
      * @see stopGracefully for the asynchronous version
-     * @see stop for the version without timeout
+     * @see stop for the version with the default 30-second timeout
      */
     fun stop(timeout: Duration) {
         stopGracefully().block(timeout)

--- a/wow-core/src/test/kotlin/me/ahoo/wow/exception/RecoverableExceptionRegistrarTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/exception/RecoverableExceptionRegistrarTest.kt
@@ -109,5 +109,36 @@ class RecoverableExceptionRegistrarTest {
         TestSpiException().recoverable.assert().isEqualTo(RecoverableType.RECOVERABLE)
     }
 
+    @Test
+    fun `getRecoverableType resolves superclass registration for subclass`() {
+        register(RuntimeException::class.java, RecoverableType.UNRECOVERABLE)
+        getRecoverableType(IllegalStateException::class.java).assert()
+            .isEqualTo(RecoverableType.UNRECOVERABLE)
+        unregister(RuntimeException::class.java)
+    }
+
+    @Test
+    fun `getRecoverableType prefers exact match over superclass`() {
+        register(RuntimeException::class.java, RecoverableType.UNRECOVERABLE)
+        register(IllegalStateException::class.java, RecoverableType.RECOVERABLE)
+        getRecoverableType(IllegalStateException::class.java).assert()
+            .isEqualTo(RecoverableType.RECOVERABLE)
+        unregister(RuntimeException::class.java)
+        unregister(IllegalStateException::class.java)
+    }
+
+    @Test
+    fun `getRecoverableType returns null when no superclass registered`() {
+        getRecoverableType(IllegalStateException::class.java).assert().isNull()
+    }
+
+    @Test
+    fun `Class recoverable extension resolves superclass registration`() {
+        register(RuntimeException::class.java, RecoverableType.UNRECOVERABLE)
+        IllegalStateException::class.java.recoverable.assert()
+            .isEqualTo(RecoverableType.UNRECOVERABLE)
+        unregister(RuntimeException::class.java)
+    }
+
     class MockRecoverableException : RecoverableException, RuntimeException()
 }


### PR DESCRIPTION


- Modified getRecoverableType to walk class hierarchy when exact match not found
- Added support for subclass exception classification without individual registration
- Improved exception handling for inherited recoverable types

refactor(lifecycle): update GracefullyStoppable interface documentation and behavior

- Clarified synchronous stop methods now have 30-second default timeout
- Updated close method to delegate to stop with default timeout
- Refined documentation to explain timeout behavior and operation guarantees
- Simplified interface documentation by removing verbose examples


