### PR TITLE
skills(wow): add plugin publish metadata

### DIFF
--- a/skills/plugins.json
+++ b/skills/plugins.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": 1,
+  "plugins": [
+    {
+      "name": "ahoo-wow-skills",
+      "description": "Agent skills for building, testing, reviewing, and debugging Wow reactive DDD, Event Sourcing, and CQRS microservices.",
+      "skills": {
+        "include": [
+          "*"
+        ],
+        "exclude": [
+          "*-workspace"
+        ]
+      },
+      "keywords": [
+        "wow",
+        "ddd",
+        "cqrs",
+        "event-sourcing",
+        "saga",
+        "aggregate",
+        "kotlin",
+        "spring-boot",
+        "reactor",
+        "microservices"
+      ],
+      "category": "development",
+      "interface": {
+        "displayName": "Ahoo Wow Skills",
+        "capabilities": [
+          "Skills"
+        ],
+        "defaultPrompt": "Help me design, test, review, and debug Wow DDD, Event Sourcing, and CQRS services."
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `skills/plugins.json` as platform-neutral plugin publish metadata for the Wow skill source repository.
- Declare one marketplace plugin, `ahoo-wow-skills`, covering the current Wow skill directories while excluding `*-workspace` skills.
- Keep generated platform manifests and distribution directories out of this upstream repository.

## Validation

- `jq empty skills/plugins.json`
- `python3 scripts/skill_lint.py`
- `python3 scripts/test_skill_lint.py`
