### PR TITLE
fix(webflux): accept documented wait timeout header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ gradle-app.setting
 # Kotlin daemon
 .kotlin/
 
+# Python cache
+__pycache__/
+**/__pycache__/
+
 # 忽略 .DS_Store 文件
 .DS_Store
 **/.DS_Store
@@ -23,6 +27,9 @@ gradle-app.setting
 # IDE
 /.idea/
 /.vscode/
+
+# Local agent configuration
+/.claude/
 
 # Superpowers
 docs/superpowers/

--- a/compensation/dashboard/.gitignore
+++ b/compensation/dashboard/.gitignore
@@ -10,6 +10,8 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+coverage
+playwright-report
 *.local
 
 # Editor directories and files

--- a/scripts/skill_lint.py
+++ b/scripts/skill_lint.py
@@ -18,6 +18,8 @@ class Finding:
 
 ASSERT_THAT_PATTERN = re.compile(r"\bassertThat\s*\(")
 NEGATIVE_ASSERT_THAT_GUIDANCE = re.compile(r"\b(?:not|NOT|never|avoid)\b|不要|不使用")
+LEGACY_WAIT_TIMEOUT_PATTERN = re.compile(r"\bCommand-Wait-Timout\b")
+LEGACY_WAIT_TIMEOUT_GUIDANCE = re.compile(r"\blegacy\b.*\bcompatibility\b|\bcompatibility\b.*\blegacy\b")
 
 PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
     (
@@ -25,7 +27,7 @@ PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
         "Use rg or rg --files instead of Claude-style Grep/Glob wording.",
     ),
     (
-        re.compile(r"(?:^|[\s`./])(?:domain|api):(?:compileKotlin|test|check|jacocoTestReport|jacocoTestCoverageVerification)\b"),
+        re.compile(r"(?:^|[\s`./:])(?:domain|api):(?:compileKotlin|test|check|jacocoTestReport|jacocoTestCoverageVerification)\b"),
         "Use resolved Gradle module placeholders instead of hard-coded domain/api modules.",
     ),
     (
@@ -37,8 +39,8 @@ PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
         "Use `Condition.count(queryService)` wording; Wow does not expose a countQuery DSL function.",
     ),
     (
-        re.compile(r"\bCommand-Wait-Timeout\b"),
-        "Use the current source header spelling `Command-Wait-Timout`, and note the docs/source mismatch when relevant.",
+        LEGACY_WAIT_TIMEOUT_PATTERN,
+        "Use the documented `Command-Wait-Timeout` header; the misspelled form is legacy compatibility only.",
     ),
     (
         re.compile(r"\bPreparedValue\s*\("),
@@ -104,6 +106,12 @@ def lint(root: Path) -> list[Finding]:
                     pattern is ASSERT_THAT_PATTERN
                     and ASSERT_THAT_PATTERN.search(line)
                     and NEGATIVE_ASSERT_THAT_GUIDANCE.search(line)
+                ):
+                    continue
+                if (
+                    pattern is LEGACY_WAIT_TIMEOUT_PATTERN
+                    and LEGACY_WAIT_TIMEOUT_PATTERN.search(line)
+                    and LEGACY_WAIT_TIMEOUT_GUIDANCE.search(line)
                 ):
                     continue
                 if pattern.search(line):

--- a/scripts/test_skill_lint.py
+++ b/scripts/test_skill_lint.py
@@ -21,6 +21,38 @@ class SkillLintTest(unittest.TestCase):
             self.assertIn("Use resolved Gradle module placeholders instead of hard-coded domain/api modules.", messages)
             self.assertIn("Use Wow Query DSL condition/pagination APIs instead of where/page wording.", messages)
 
+    def test_reports_colon_prefixed_gradle_module_placeholders(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            skill = root / "skills" / "wow" / "SKILL.md"
+            skill.parent.mkdir(parents=True)
+            skill.write_text("Run ./gradlew :api:test\nRun ./gradlew :domain:check", encoding="utf-8")
+
+            findings = skill_lint.lint(root)
+
+            self.assertEqual(2, len(findings))
+            self.assertEqual(
+                [
+                    "Use resolved Gradle module placeholders instead of hard-coded domain/api modules.",
+                    "Use resolved Gradle module placeholders instead of hard-coded domain/api modules.",
+                ],
+                [finding.message for finding in findings],
+            )
+
+    def test_allows_legacy_wait_timeout_compatibility_guidance(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            skill = root / "skills" / "wow" / "references" / "command-gateway.md"
+            skill.parent.mkdir(parents=True)
+            skill.write_text(
+                "The legacy misspelled `Command-Wait-Timout` header remains accepted for compatibility.",
+                encoding="utf-8",
+            )
+
+            findings = skill_lint.lint(root)
+
+            self.assertEqual([], findings)
+
     def test_reports_missing_reference_links(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -74,7 +106,7 @@ class SkillLintTest(unittest.TestCase):
             skill = root / "skills" / "wow" / "references" / "prepare-key.md"
             skill.parent.mkdir(parents=True)
             skill.write_text(
-                "Use countQuery, Command-Wait-Timeout, PreparedValue(value, duration), @Enabled(properties = []), @get:Summary, wow.compensation.host, and **/settings.gradle.kts.",
+                "Use countQuery, Command-Wait-Timout, PreparedValue(value, duration), @Enabled(properties = []), @get:Summary, wow.compensation.host, and **/settings.gradle.kts.",
                 encoding="utf-8",
             )
 
@@ -87,7 +119,7 @@ class SkillLintTest(unittest.TestCase):
                 messages,
             )
             self.assertIn(
-                "Use the current source header spelling `Command-Wait-Timout`, and note the docs/source mismatch when relevant.",
+                "Use the documented `Command-Wait-Timeout` header; the misspelled form is legacy compatibility only.",
                 messages,
             )
             self.assertIn(

--- a/skills/wow/references/command-gateway.md
+++ b/skills/wow/references/command-gateway.md
@@ -263,7 +263,7 @@ Register via Spring's `@Service` annotation.
 | `Command-Wait-Context` | Bounded context for function-level waiting; defaults to the command context when blank |
 | `Command-Wait-Processor` | Processor name for function-level waiting |
 | `Command-Wait-Function` | Function name for function-level waiting |
-| `Command-Wait-Timout` | Current source spelling for wait timeout in milliseconds |
+| `Command-Wait-Timeout` | Wait timeout in milliseconds |
 | `Command-Aggregate-Id` | Target aggregate ID |
 | `Command-Aggregate-Version` | Expected aggregate version for conflict control |
 | `Command-Request-Id` | Idempotency key |
@@ -279,7 +279,7 @@ Register via Spring's `@Service` annotation.
 | `Command-Type` | Fully qualified command body type for generic command routes |
 | `Command-Header-*` | Prefix for custom command headers |
 
-Note: public documentation may spell the timeout header with `Timeout`, but the current source constant is `Command-Wait-Timout`. Use the source spelling when validating the current checkout.
+The legacy misspelled `Command-Wait-Timout` header remains accepted for compatibility, but new clients and documentation should use `Command-Wait-Timeout`.
 
 ## Troubleshooting
 

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/command/CommandComponent.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/aggregate/command/CommandComponent.kt
@@ -57,7 +57,8 @@ object CommandComponent {
         const val AGGREGATE_VERSION = "${COMMAND_HEADERS_PREFIX}Aggregate-Version"
 
         const val WAIT_PREFIX = "${COMMAND_HEADERS_PREFIX}Wait-"
-        const val WAIT_TIME_OUT = "${WAIT_PREFIX}Timout"
+        const val WAIT_TIME_OUT = "${WAIT_PREFIX}Timeout"
+        const val LEGACY_WAIT_TIME_OUT = "${WAIT_PREFIX}Timout"
 
         //region Wait Stage
         const val WAIT_STAGE = "${WAIT_PREFIX}Stage"

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/AggregateRequest.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/AggregateRequest.kt
@@ -102,7 +102,9 @@ fun ServerRequest.isSse(): Boolean {
 }
 
 fun ServerRequest.getWaitTimeout(default: Duration = DEFAULT_TIME_OUT): Duration {
-    return headers().firstHeader(CommandComponent.Header.WAIT_TIME_OUT)?.toLongOrNull()?.let {
+    val waitTimeout = headers().firstHeader(CommandComponent.Header.WAIT_TIME_OUT)
+        ?: headers().firstHeader(CommandComponent.Header.LEGACY_WAIT_TIME_OUT)
+    return waitTimeout?.toLongOrNull()?.let {
         Duration.ofMillis(it)
     } ?: default
 }

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/AggregateRequestTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/AggregateRequestTest.kt
@@ -189,6 +189,27 @@ class AggregateRequestTest {
     }
 
     @Test
+    fun `should expose documented wait timeout header`() {
+        CommandComponent.Header.WAIT_TIME_OUT.assert().isEqualTo("Command-Wait-Timeout")
+    }
+
+    @Test
+    fun `should get wait timeout from documented header`() {
+        val request = MockServerRequest.builder()
+            .header("Command-Wait-Timeout", "5000")
+            .build()
+        request.getWaitTimeout().assert().isEqualTo(Duration.ofMillis(5000))
+    }
+
+    @Test
+    fun `should get wait timeout from legacy misspelled header`() {
+        val request = MockServerRequest.builder()
+            .header("Command-Wait-Timout", "5000")
+            .build()
+        request.getWaitTimeout().assert().isEqualTo(Duration.ofMillis(5000))
+    }
+
+    @Test
     fun `should use default wait timeout when header is missing`() {
         val request = MockServerRequest.builder().build()
         request.getWaitTimeout(Duration.ofSeconds(10)).assert().isEqualTo(Duration.ofSeconds(10))


### PR DESCRIPTION
## Summary
- expose `Command-Wait-Timeout` as the public wait timeout header while keeping the legacy misspelled `Command-Wait-Timout` header accepted for compatibility
- update Wow skill guidance and lint rules to prefer the documented header spelling
- ignore local agent config, Python cache, and dashboard test/report output directories

## Root Cause
`CommandComponent.Header.WAIT_TIME_OUT` used the misspelled `Command-Wait-Timout` value, while public documentation already told clients to send `Command-Wait-Timeout`. Runtime request parsing only read the misspelled constant, so documented clients silently fell back to the default timeout.

## Verification
- `python3 scripts/test_skill_lint.py`
- `python3 scripts/skill_lint.py`
- `jq empty skills/wow/evals/evals.json`
- `git diff --check`
- `./gradlew wow-webflux:check`