### PR TITLE
ci: speed up PR feedback

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,18 +1,17 @@
 name: Codecov
 on:
   push:
-    paths-ignore:
-      - 'document/**'
-      - 'documentation/**'
-      - 'schema/**'
-      - 'wow-example/**'
-  pull_request:
+    branches:
+      - main
     paths-ignore:
       - 'document/**'
       - 'documentation/**'
       - 'schema/**'
       - 'wow-example/**'
   workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions:
   contents: read
   issues: read
@@ -90,4 +89,3 @@ jobs:
           verbose: true # optional (default = false)
 #          directory: ./build/reports/jacoco/codeCoverageReport/
           files: ./test/code-coverage-report/build/reports/jacoco/codeCoverageReport/codeCoverageReport.xml
-          path_to_write_report: ./coverage/codecov_report.txt

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,9 +14,7 @@ concurrency:
   cancel-in-progress: true
 permissions:
   contents: read
-  issues: read
   checks: write
-  pull-requests: write
 env:
   CI: GITHUB_ACTIONS
 jobs:
@@ -53,6 +51,7 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v2.23.0
         if: always()
         with:
+          comment_mode: off
           ignore_runs: true
           large_files: true
           files: |

--- a/.github/workflows/compensation-deploy.yml
+++ b/.github/workflows/compensation-deploy.yml
@@ -112,7 +112,6 @@ jobs:
             registry.cn-shanghai.aliyuncs.com/ahoo/wow-compensation-server
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 

--- a/.github/workflows/compensation-deploy.yml
+++ b/.github/workflows/compensation-deploy.yml
@@ -21,17 +21,13 @@ on:
       - 'documentation/**'
       - 'schema/**'
     branches:
-      - '**'
+      - main
     tags:
       - 'v*.*.*'
-  pull_request:
-    paths-ignore:
-      - 'document/**'
-      - 'documentation/**'
-      - 'schema/**'
-    branches:
-      - 'main'
   workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   compensation-docker-deploy:
     name: Push Docker image

--- a/.github/workflows/compensation-test.yml
+++ b/.github/workflows/compensation-test.yml
@@ -19,6 +19,9 @@ on:
       - 'documentation/**'
       - 'schema/**'
       - 'wow-example/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   CI: GITHUB_ACTIONS
@@ -41,7 +44,7 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test Compensation-Core
-        run: ./gradlew wow-compensation-core:clean wow-compensation-core:check --stacktrace
+        run: ./gradlew wow-compensation-core:check --stacktrace
   compensation-domain-test:
     name: Compensation Domain Test
     runs-on: ubuntu-latest
@@ -59,4 +62,4 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test Compensation-Domain
-        run: ./gradlew wow-compensation-domain:clean wow-compensation-domain:check --stacktrace
+        run: ./gradlew wow-compensation-domain:check --stacktrace

--- a/.github/workflows/example-deploy.yml
+++ b/.github/workflows/example-deploy.yml
@@ -21,16 +21,13 @@ on:
       - 'documentation/**'
       - 'schema/**'
     branches:
-      - '**'
+      - main
     tags:
       - 'v*.*.*'
-  pull_request:
-    paths-ignore:
-      - 'document/**'
-      - 'documentation/**'
-      - 'schema/**'
-    branches:
-      - 'main'
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   example-docker-deploy:

--- a/.github/workflows/example-deploy.yml
+++ b/.github/workflows/example-deploy.yml
@@ -88,7 +88,6 @@ jobs:
             registry.cn-shanghai.aliyuncs.com/ahoo/wow-example-server
           tags: |
             type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 

--- a/.github/workflows/example-java-test.yml
+++ b/.github/workflows/example-java-test.yml
@@ -18,6 +18,9 @@ on:
       - 'document/**'
       - 'documentation/**'
       - 'schema/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 env:
   CI: GITHUB_ACTIONS
 
@@ -42,10 +45,10 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test example-transfer-api
-        run: ./gradlew example-transfer-api:clean example-transfer-api:build --stacktrace
+        run: ./gradlew example-transfer-api:build --stacktrace
 
       - name: Test example-transfer-domain
-        run: ./gradlew example-transfer-domain:clean example-transfer-domain:build --stacktrace
+        run: ./gradlew example-transfer-domain:build --stacktrace
 
       - name: Test example-transfer-server
-        run: ./gradlew example-transfer-server:clean example-transfer-server:build --stacktrace
+        run: ./gradlew example-transfer-server:build --stacktrace

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -19,6 +19,9 @@ on:
       - 'documentation/**'
       - 'schema/**'
       - 'wow-example/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 env:
   CI: GITHUB_ACTIONS
 
@@ -40,7 +43,7 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test Wow-Api
-        run: ./gradlew wow-api:clean wow-api:check --stacktrace
+        run: ./gradlew wow-api:check --stacktrace
 
   wow-core-test:
     name: Wow Core Test
@@ -60,7 +63,7 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test Wow-Core
-        run: ./gradlew wow-core:clean wow-core:check --stacktrace
+        run: ./gradlew wow-core:check --stacktrace
   wow-schema-test:
     name: Wow Schema Test
     runs-on: ubuntu-latest
@@ -79,7 +82,7 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test Wow-Schema
-        run: ./gradlew wow-schema:clean wow-schema:check --stacktrace
+        run: ./gradlew wow-schema:check --stacktrace
   wow-openapi-test:
     name: Wow OpenAPI Test
     runs-on: ubuntu-latest
@@ -98,7 +101,7 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test Wow-OpenAPI
-        run: ./gradlew wow-openapi:clean wow-openapi:check --stacktrace
+        run: ./gradlew wow-openapi:check --stacktrace
 
   wow-compiler-test:
     name: Wow Compiler Test
@@ -118,7 +121,7 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test Wow-Compiler
-        run: ./gradlew wow-compiler:clean wow-compiler:check --stacktrace
+        run: ./gradlew wow-compiler:check --stacktrace
 
   wow-bi-test:
     name: Wow BI Test
@@ -138,7 +141,7 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test Wow-BI
-        run: ./gradlew wow-bi:clean wow-bi:check --stacktrace
+        run: ./gradlew wow-bi:check --stacktrace
 
   wow-query-test:
     name: Wow Query Test
@@ -158,7 +161,7 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test Wow-Query
-        run: ./gradlew wow-query:clean wow-query:check --stacktrace
+        run: ./gradlew wow-query:check --stacktrace
 
   wow-cocache-test:
     name: Wow CoCache Test
@@ -178,7 +181,7 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test Wow-CoCache
-        run: ./gradlew wow-cocache:clean wow-cocache:check --stacktrace
+        run: ./gradlew wow-cocache:check --stacktrace
 
   wow-models-test:
     name: Wow Models Test
@@ -198,7 +201,7 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test Wow-Models
-        run: ./gradlew wow-models:clean wow-models:check --stacktrace
+        run: ./gradlew wow-models:check --stacktrace
 
   wow-kafka-test:
     name: Wow Kafka Test
@@ -218,7 +221,7 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test Wow-Kafka
-        run: ./gradlew wow-kafka:clean wow-kafka:check --stacktrace
+        run: ./gradlew wow-kafka:check --stacktrace
 
   wow-mongo-test:
     name: Wow Mongo Test
@@ -238,7 +241,7 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test Wow-Mongo
-        run: ./gradlew wow-mongo:clean wow-mongo:check --stacktrace
+        run: ./gradlew wow-mongo:check --stacktrace
 
   wow-redis-test:
     name: Wow Redis Test
@@ -268,7 +271,7 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test Wow-Redis
-        run: ./gradlew wow-redis:clean wow-redis:check --stacktrace
+        run: ./gradlew wow-redis:check --stacktrace
 
   wow-it-test:
     name: Wow IT Test
@@ -288,7 +291,7 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test Wow-IT
-        run: ./gradlew wow-it:clean wow-it:check --stacktrace
+        run: ./gradlew wow-it:check --stacktrace
 
   wow-r2dbc-test:
     name: Wow R2DBC Test
@@ -308,7 +311,7 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test Wow-R2DBC
-        run: ./gradlew wow-r2dbc:clean wow-r2dbc:check --stacktrace
+        run: ./gradlew wow-r2dbc:check --stacktrace
 
   wow-elasticsearch-test:
     name: Wow ElasticSearch Test
@@ -328,7 +331,7 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test Wow-ElasticSearch
-        run: ./gradlew wow-elasticsearch:clean wow-elasticsearch:check --stacktrace
+        run: ./gradlew wow-elasticsearch:check --stacktrace
 
   wow-spring-test:
     name: Wow Spring Test
@@ -348,7 +351,7 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test Wow-Spring
-        run: ./gradlew wow-spring:clean wow-spring:check --stacktrace
+        run: ./gradlew wow-spring:check --stacktrace
 
   wow-webflux-test:
     name: Wow Webflux Test
@@ -368,7 +371,7 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test Wow-Webflux
-        run: ./gradlew wow-webflux:clean wow-webflux:check --stacktrace
+        run: ./gradlew wow-webflux:check --stacktrace
 
   wow-cosec-test:
     name: Wow CoSec Test
@@ -388,7 +391,7 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test Wow-CoSec
-        run: ./gradlew wow-cosec:clean wow-cosec:check --stacktrace
+        run: ./gradlew wow-cosec:check --stacktrace
 
   wow-spring-boot-starter-test:
     name: Wow Spring-Boot-Starter Test
@@ -408,7 +411,7 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test Wow-Spring-Boot-Starter
-        run: ./gradlew wow-spring-boot-starter:clean wow-spring-boot-starter:check --stacktrace
+        run: ./gradlew wow-spring-boot-starter:check --stacktrace
 
   wow-opentelemetry-test:
     name: Wow Opentelemetry Test
@@ -428,4 +431,4 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test Wow-opentelemetry
-        run: ./gradlew wow-opentelemetry:clean wow-opentelemetry:check --stacktrace
+        run: ./gradlew wow-opentelemetry:check --stacktrace


### PR DESCRIPTION
## Summary
- Move Codecov out of the PR blocking path by limiting it to main pushes and manual runs.
- Stop Docker deploy workflows from running on PRs or feature branch pushes; keep main, tags, scheduled runs, and manual dispatch.
- Add PR concurrency cancellation and remove clean from PR Gradle checks to improve cache reuse.

## Validation
- go run github.com/rhysd/actionlint/cmd/actionlint@latest
- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f); puts "parsed #{f}" }'
- git diff --check
- ./gradlew wow-api:check wow-compensation-core:check example-transfer-api:build --dry-run

## Notes
- This PR only changes GitHub Actions workflow configuration.
- Full Gradle test execution was not run because the change is workflow-only; representative task resolution was verified with Gradle dry-run.