### PR TITLE
ci: add targeted workflow path filters

### DIFF
--- a/.github/workflows/compensation-deploy.yml
+++ b/.github/workflows/compensation-deploy.yml
@@ -16,14 +16,23 @@ on:
   schedule:
     - cron: '0 10 * * *'
   push:
-    paths-ignore:
-      - 'examples/**'
-      - 'documentation/**'
-      - 'schema/**'
     branches:
       - main
     tags:
       - 'v*.*.*'
+    paths:
+      - '.github/workflows/compensation-deploy.yml'
+      - 'build.gradle.kts'
+      - 'settings.gradle.kts'
+      - 'gradle.properties'
+      - 'gradle/**'
+      - 'config/**'
+      - 'wow-*/**'
+      - 'compensation/dashboard/**'
+      - 'compensation/wow-compensation-api/**'
+      - 'compensation/wow-compensation-core/**'
+      - 'compensation/wow-compensation-domain/**'
+      - 'compensation/wow-compensation-server/**'
   workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/compensation-test.yml
+++ b/.github/workflows/compensation-test.yml
@@ -14,11 +14,22 @@
 name: Compensation Test
 on:
   pull_request:
-    paths-ignore:
-      - 'document/**'
-      - 'documentation/**'
-      - 'schema/**'
-      - 'wow-example/**'
+    paths:
+      - '.github/workflows/compensation-test.yml'
+      - 'build.gradle.kts'
+      - 'settings.gradle.kts'
+      - 'gradle.properties'
+      - 'gradle/**'
+      - 'config/**'
+      - 'wow-api/**'
+      - 'wow-core/**'
+      - 'wow-spring/**'
+      - 'wow-compiler/**'
+      - 'wow-dependencies/**'
+      - 'test/wow-test/**'
+      - 'compensation/wow-compensation-api/**'
+      - 'compensation/wow-compensation-core/**'
+      - 'compensation/wow-compensation-domain/**'
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/example-deploy.yml
+++ b/.github/workflows/example-deploy.yml
@@ -16,14 +16,22 @@ on:
   schedule:
     - cron: '0 10 * * *'
   push:
-    paths-ignore:
-      - 'document/**'
-      - 'documentation/**'
-      - 'schema/**'
     branches:
       - main
     tags:
       - 'v*.*.*'
+    paths:
+      - '.github/workflows/example-deploy.yml'
+      - 'build.gradle.kts'
+      - 'settings.gradle.kts'
+      - 'gradle.properties'
+      - 'gradle/**'
+      - 'config/**'
+      - 'wow-*/**'
+      - 'test/wow-mock/**'
+      - 'example/example-api/**'
+      - 'example/example-domain/**'
+      - 'example/example-server/**'
   workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/example-java-test.yml
+++ b/.github/workflows/example-java-test.yml
@@ -21,16 +21,10 @@ on:
       - 'gradle.properties'
       - 'gradle/**'
       - 'config/**'
-      - 'wow-api/**'
-      - 'wow-core/**'
-      - 'wow-spring/**'
-      - 'wow-compiler/**'
-      - 'wow-webflux/**'
-      - 'wow-opentelemetry/**'
-      - 'wow-spring-boot-starter/**'
-      - 'wow-dependencies/**'
-      - 'test/wow-test/**'
-      - 'example/transfer/**'
+      - 'wow-*/**'
+      - 'test/**'
+      - 'example/**'
+      - 'compensation/wow-compensation-*/**'
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/example-java-test.yml
+++ b/.github/workflows/example-java-test.yml
@@ -14,10 +14,23 @@
 name: Java compatibility Test
 on:
   pull_request:
-    paths-ignore:
-      - 'document/**'
-      - 'documentation/**'
-      - 'schema/**'
+    paths:
+      - '.github/workflows/example-java-test.yml'
+      - 'build.gradle.kts'
+      - 'settings.gradle.kts'
+      - 'gradle.properties'
+      - 'gradle/**'
+      - 'config/**'
+      - 'wow-api/**'
+      - 'wow-core/**'
+      - 'wow-spring/**'
+      - 'wow-compiler/**'
+      - 'wow-webflux/**'
+      - 'wow-opentelemetry/**'
+      - 'wow-spring-boot-starter/**'
+      - 'wow-dependencies/**'
+      - 'test/wow-test/**'
+      - 'example/transfer/**'
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -14,11 +14,15 @@
 name: Integration Test
 on:
   pull_request:
-    paths-ignore:
-      - 'document/**'
-      - 'documentation/**'
-      - 'schema/**'
-      - 'wow-example/**'
+    paths:
+      - '.github/workflows/integration-test.yml'
+      - 'build.gradle.kts'
+      - 'settings.gradle.kts'
+      - 'gradle.properties'
+      - 'gradle/**'
+      - 'config/**'
+      - 'wow-*/**'
+      - 'test/**'
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Add path-based PR triggers so Integration, Compensation, and Java compatibility checks run only for relevant module or Gradle/config changes.
- Add path filters to main-branch Docker deploy workflows so example and compensation images rebuild only when their inputs change.
- Preserve tag-triggered Docker releases; GitHub Actions does not evaluate path filters for tag pushes.

## Validation
- go run github.com/rhysd/actionlint/cmd/actionlint@latest
- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f); puts "parsed #{f}" }'\n- git diff --check\n- local Ruby path-filter simulation for docs-only, shared core, compensation, dashboard, Java transfer, example server, and Gradle catalog changes\n\n## Notes\n- This PR only changes GitHub Actions workflow trigger configuration.\n- Path filters use conservative shared-module coverage so Gradle config and core runtime changes still run broad checks.