### PR TITLE
fix: support tenant aggregate constructors in compiler

### DIFF
--- a/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/AggregateRootResolver.kt
+++ b/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/AggregateRootResolver.kt
@@ -40,8 +40,10 @@ object AggregateRootResolver {
             "AggregateRoot[${qualifiedName!!.asString()}] must have a primary constructor with one parameter,like ctor(id) / ctor(id,tenantId) or ctor(state)."
         }
 
-        val ctorParameterDeclaration = aggregateRootCtor.parameters.single().type.resolve().declaration
-        val aggregationPattern = ctorParameterDeclaration.qualifiedName!!.asString() != String::class.qualifiedName!!
+        val ctorParameterDeclaration = aggregateRootCtor.parameters.first().type.resolve().declaration
+        val aggregationPattern =
+            aggregateRootCtor.parameters.size == 1 &&
+                ctorParameterDeclaration.qualifiedName!!.asString() != String::class.qualifiedName!!
 
         val stateAggregateDeclaration = if (aggregationPattern) {
             (ctorParameterDeclaration as KSClassDeclaration)

--- a/wow-compiler/src/test/kotlin/me/ahoo/wow/compiler/MockTenantCompilerAggregate.kt
+++ b/wow-compiler/src/test/kotlin/me/ahoo/wow/compiler/MockTenantCompilerAggregate.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.compiler
+
+import me.ahoo.wow.api.annotation.AggregateRoot
+
+@AggregateRoot
+class MockTenantCompilerAggregate(
+    val id: String,
+    val tenantId: String
+)

--- a/wow-compiler/src/test/kotlin/me/ahoo/wow/compiler/query/QuerySymbolProcessorTest.kt
+++ b/wow-compiler/src/test/kotlin/me/ahoo/wow/compiler/query/QuerySymbolProcessorTest.kt
@@ -57,6 +57,41 @@ class QuerySymbolProcessorTest {
 
     @OptIn(ExperimentalCompilerApi::class)
     @Test
+    fun `should process aggregate with id and tenantId constructor`() {
+        val mockTenantCompilerAggregateFile =
+            File("src/test/kotlin/me/ahoo/wow/compiler/MockTenantCompilerAggregate.kt")
+        compileTestQuerySymbolProcessor(
+            listOf(mockTenantCompilerAggregateFile),
+        ) { compilation, _ ->
+            val navFile = Path(
+                compilation.kspSourcesDir.path,
+                "kotlin/me/ahoo/wow/compiler",
+                "MockTenantCompilerAggregateProperties.kt"
+            )
+            val navFileContent = navFile.toFile().readText()
+            val navFileContentLines = navFileContent.lines()
+            val navFileContentLinesWithoutGenerated = navFileContentLines.subList(0, 4) + navFileContentLines.subList(
+                5,
+                navFileContentLines.size
+            )
+            val navFileContentWithoutGenerated = navFileContentLinesWithoutGenerated.joinToString("\n").trimIndent()
+            navFileContentWithoutGenerated.assert().isEqualTo(
+                """
+                |package me.ahoo.wow.compiler
+                |
+                |import me.ahoo.wow.api.annotation.Generated
+                |
+                |object MockTenantCompilerAggregateProperties {
+                |    const val ID = "id"
+                |    const val TENANT_ID = "tenantId"
+                |}
+                """.trimMargin()
+            )
+        }
+    }
+
+    @OptIn(ExperimentalCompilerApi::class)
+    @Test
     fun `should process example project`() {
         val exampleApiDir = File("../example/example-api/src/main/kotlin/me/ahoo/wow/example/api")
         val exampleApiFiles = exampleApiDir.walkTopDown().filter { it.isFile }.toList()


### PR DESCRIPTION
## Summary
- Fix KSP aggregate root metadata resolution for `ctor(id, tenantId)` aggregates.
- Add a compiler query processor regression fixture and test for two-String constructor aggregates.

## Root cause
`AggregateRootResolver` allowed constructors with one or two parameters, but then called `parameters.single()`, so valid two-parameter aggregate constructors failed during KSP processing with `List has more than one element`.

## Validation
- `./gradlew :wow-compiler:test --tests "me.ahoo.wow.compiler.query.QuerySymbolProcessorTest.should process aggregate with id and tenantId constructor" --rerun-tasks --stacktrace`
- `./gradlew :wow-compiler:check --stacktrace`