### PR TITLE
chore: add OpenAI agent metadata for Wow skills

### DIFF
--- a/skills/wow-code-review/agents/openai.yaml
+++ b/skills/wow-code-review/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Wow Code Review"
+  short_description: "Review Wow DDD and event-sourcing code"
+  default_prompt: "Use $wow-code-review to review this Wow diff for aggregate, saga, and test issues."

--- a/skills/wow-debugging/agents/openai.yaml
+++ b/skills/wow-debugging/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Wow Debugging"
+  short_description: "Debug Wow command and event pipelines"
+  default_prompt: "Use $wow-debugging to find the failing stage in a Wow command, event, saga, or wait flow."

--- a/skills/wow-development-workflow/agents/openai.yaml
+++ b/skills/wow-development-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Wow Development Workflow"
+  short_description: "End-to-end aggregate and saga workflow"
+  default_prompt: "Use $wow-development-workflow to design and verify a Wow aggregate or saga change."

--- a/skills/wow/agents/openai.yaml
+++ b/skills/wow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Wow Framework"
+  short_description: "DDD, CQRS, and Event Sourcing guidance"
+  default_prompt: "Use $wow to help me model, test, or debug a Wow framework service."


### PR DESCRIPTION
## Summary
- Add OpenAI agent interface metadata for the Wow framework skill.
- Add OpenAI agent interface metadata for Wow code review, debugging, and development workflow skills.

## Validation
- `ruby -e 'require "yaml"; ...' skills/wow/agents/openai.yaml skills/wow-code-review/agents/openai.yaml skills/wow-debugging/agents/openai.yaml skills/wow-development-workflow/agents/openai.yaml`\n\n## Notes\n- Only the four `skills/*/agents/openai.yaml` files are included. Other local untracked files are intentionally left out.