### PR TITLE
test: add wow-api contract coverage

### DIFF
--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/abac/AbacTagsMergerTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/abac/AbacTagsMergerTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.api.abac
+
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+
+class AbacTagsMergerTest {
+
+    @Test
+    fun `should return this when other is empty`() {
+        val tags: AbacTags = mapOf("dept" to listOf("eng"), "role" to listOf("admin"))
+        val result = tags.merge(emptyMap())
+        result.assert().isSameAs(tags)
+    }
+
+    @Test
+    fun `should return other when this is empty`() {
+        val other: AbacTags = mapOf("dept" to listOf("eng"), "role" to listOf("admin"))
+        val result = emptyMap<String, List<String>>().merge(other)
+        result.assert().isSameAs(other)
+    }
+
+    @Test
+    fun `should merge overlapping keys and deduplicate values`() {
+        val tags1: AbacTags = mapOf("dept" to listOf("eng", "qa"), "role" to listOf("admin"))
+        val tags2: AbacTags = mapOf("dept" to listOf("eng", "pm"), "role" to listOf("user"))
+        val result = tags1.merge(tags2)
+
+        result.assert().hasSize(2)
+        result["dept"].assert().containsExactlyInAnyOrder("eng", "qa", "pm")
+        result["role"].assert().containsExactlyInAnyOrder("admin", "user")
+    }
+
+    @Test
+    fun `should merge non-overlapping keys`() {
+        val tags1: AbacTags = mapOf("dept" to listOf("eng"))
+        val tags2: AbacTags = mapOf("team" to listOf("backend"))
+        val result = tags1.merge(tags2)
+
+        result.assert().hasSize(2)
+        result["dept"].assert().containsExactly("eng")
+        result["team"].assert().containsExactly("backend")
+    }
+
+    @Test
+    fun `should handle both empty maps`() {
+        val result = emptyMap<String, List<String>>().merge(emptyMap())
+        result.assert().isEmpty()
+    }
+}

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/event/DefaultAggregateDeletedTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/event/DefaultAggregateDeletedTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.api.event
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.annotation.Event
+import org.junit.jupiter.api.Test
+
+class DefaultAggregateDeletedTest {
+
+    @Test
+    fun `should DefaultAggregateDeleted be instance of AggregateDeleted`() {
+        AggregateDeleted::class.java.isAssignableFrom(DefaultAggregateDeleted::class.java).assert().isTrue()
+    }
+
+    @Test
+    fun `should DefaultAggregateDeleted have Event annotation`() {
+        AggregateDeleted::class.java.isAnnotationPresent(Event::class.java).assert().isTrue()
+    }
+}

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/event/DefaultAggregateRecoveredTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/event/DefaultAggregateRecoveredTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.api.event
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.annotation.Event
+import org.junit.jupiter.api.Test
+
+class DefaultAggregateRecoveredTest {
+
+    @Test
+    fun `should DefaultAggregateRecovered be instance of AggregateRecovered`() {
+        AggregateRecovered::class.java.isAssignableFrom(DefaultAggregateRecovered::class.java).assert().isTrue()
+    }
+
+    @Test
+    fun `should AggregateRecovered have Event annotation`() {
+        AggregateRecovered::class.java.isAnnotationPresent(Event::class.java).assert().isTrue()
+    }
+}

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/event/RevisionTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/event/RevisionTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.api.event
+
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+
+class RevisionTest {
+
+    @Test
+    fun `should DEFAULT_REVISION be 0 dot 0 dot 1`() {
+        DEFAULT_REVISION.assert().isEqualTo("0.0.1")
+    }
+
+    @Test
+    fun `should default revision property return DEFAULT_REVISION`() {
+        val revision = object : Revision {}
+        revision.revision.assert().isEqualTo(DEFAULT_REVISION)
+    }
+
+    @Test
+    fun `should custom revision property work`() {
+        val revision = object : Revision {
+            override val revision = "2.0.0"
+        }
+        revision.revision.assert().isEqualTo("2.0.0")
+    }
+}

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/exception/ErrorInfoTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/exception/ErrorInfoTest.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.api.exception
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.exception.ErrorInfo.Companion.isFailed
+import me.ahoo.wow.api.exception.ErrorInfo.Companion.materialize
+import me.ahoo.wow.api.exception.ErrorInfo.Companion.toDefault
+import org.junit.jupiter.api.Test
+
+class ErrorInfoTest {
+
+    @Test
+    fun `should OK have succeeded as true`() {
+        ErrorInfo.OK.succeeded.assert().isTrue()
+    }
+
+    @Test
+    fun `should OK have errorCode as Ok`() {
+        ErrorInfo.OK.errorCode.assert().isEqualTo("Ok")
+    }
+
+    @Test
+    fun `should of with errorCode create error with code and empty message`() {
+        val error = ErrorInfo.of("ERROR")
+        error.errorCode.assert().isEqualTo("ERROR")
+        error.errorMsg.assert().isEmpty()
+        error.bindingErrors.assert().isEmpty()
+    }
+
+    @Test
+    fun `should of with errorCode and message create error with code and message`() {
+        val error = ErrorInfo.of("ERROR", "msg")
+        error.errorCode.assert().isEqualTo("ERROR")
+        error.errorMsg.assert().isEqualTo("msg")
+        error.bindingErrors.assert().isEmpty()
+    }
+
+    @Test
+    fun `should of with bindingErrors create error with binding errors`() {
+        val bindingErrors = listOf(BindingError("field", "invalid"))
+        val error = ErrorInfo.of("ERROR", "msg", bindingErrors)
+        error.errorCode.assert().isEqualTo("ERROR")
+        error.errorMsg.assert().isEqualTo("msg")
+        error.bindingErrors.assert().hasSize(1)
+        error.bindingErrors[0].name.assert().isEqualTo("field")
+        error.bindingErrors[0].msg.assert().isEqualTo("invalid")
+    }
+
+    @Test
+    fun `should succeeded return false for non-Ok error codes`() {
+        val error = ErrorInfo.of("VALIDATION_ERROR", "validation failed")
+        error.succeeded.assert().isFalse()
+    }
+
+    @Test
+    fun `should materialize return same instance if already Materialized`() {
+        val error = ErrorInfo.OK // DefaultErrorInfo implements Materialized
+        val materialized = error.materialize()
+        materialized.assert().isSameAs(error)
+    }
+
+    @Test
+    fun `should materialize create DefaultErrorInfo for non-Materialized`() {
+        val nonMaterialized = object : ErrorInfo {
+            override val errorCode = "CUSTOM_ERROR"
+            override val errorMsg = "custom message"
+        }
+        val materialized = nonMaterialized.materialize()
+        materialized.assert().isInstanceOf(DefaultErrorInfo::class.java)
+        materialized.errorCode.assert().isEqualTo("CUSTOM_ERROR")
+        materialized.errorMsg.assert().isEqualTo("custom message")
+    }
+
+    @Test
+    fun `should toDefault return same instance if already DefaultErrorInfo`() {
+        val error = ErrorInfo.OK
+        val default = error.toDefault()
+        default.assert().isSameAs(error)
+    }
+
+    @Test
+    fun `should isFailed return true for failed ErrorInfo`() {
+        val error = ErrorInfo.of("ERROR", "something went wrong")
+        error.isFailed().assert().isTrue()
+    }
+
+    @Test
+    fun `should isFailed return false for null`() {
+        val result: Any? = null
+        result.isFailed().assert().isFalse()
+    }
+
+    @Test
+    fun `should isFailed return false for non-ErrorInfo`() {
+        val result: Any? = "not an error info"
+        result.isFailed().assert().isFalse()
+    }
+
+    @Test
+    fun `should isFailed return false for OK ErrorInfo`() {
+        ErrorInfo.OK.isFailed().assert().isFalse()
+    }
+}

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/modeling/OwnerIdTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/modeling/OwnerIdTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.api.modeling
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.modeling.OwnerId.Companion.orDefaultOwnerId
+import org.junit.jupiter.api.Test
+
+class OwnerIdTest {
+
+    @Test
+    fun `should DEFAULT_OWNER_ID be empty string`() {
+        OwnerId.DEFAULT_OWNER_ID.assert().isEmpty()
+    }
+
+    @Test
+    fun `should orDefaultOwnerId return string when not null`() {
+        val value: String? = "owner-123"
+        value.orDefaultOwnerId().assert().isEqualTo("owner-123")
+    }
+
+    @Test
+    fun `should orDefaultOwnerId return DEFAULT_OWNER_ID when null`() {
+        val value: String? = null
+        value.orDefaultOwnerId().assert().isEqualTo(OwnerId.DEFAULT_OWNER_ID)
+    }
+}

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/modeling/TenantIdTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/modeling/TenantIdTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.api.modeling
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.modeling.TenantId.Companion.orDefaultTenantId
+import org.junit.jupiter.api.Test
+
+class TenantIdTest {
+
+    @Test
+    fun `should DEFAULT_TENANT_ID be open-paren-zero-close-paren`() {
+        TenantId.DEFAULT_TENANT_ID.assert().isEqualTo("(0)")
+    }
+
+    @Test
+    fun `should orDefaultTenantId return string when not null`() {
+        val value: String? = "tenant-123"
+        value.orDefaultTenantId().assert().isEqualTo("tenant-123")
+    }
+
+    @Test
+    fun `should orDefaultTenantId return DEFAULT_TENANT_ID when null`() {
+        val value: String? = null
+        value.orDefaultTenantId().assert().isEqualTo(TenantId.DEFAULT_TENANT_ID)
+    }
+}

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/naming/NamedBoundedContextTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/naming/NamedBoundedContextTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.api.naming
+
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+
+class NamedBoundedContextTest {
+
+    private data class TestContext(override val contextName: String) : NamedBoundedContext
+
+    @Test
+    fun `should isSameBoundedContext return true for same contextName`() {
+        val context1 = TestContext("order")
+        val context2 = TestContext("order")
+        context1.isSameBoundedContext(context2).assert().isTrue()
+    }
+
+    @Test
+    fun `should isSameBoundedContext return false for different contextName`() {
+        val context1 = TestContext("order")
+        val context2 = TestContext("cart")
+        context1.isSameBoundedContext(context2).assert().isFalse()
+    }
+}


### PR DESCRIPTION
## Summary
- Add focused tests for `wow-api` ABAC tag merging and event contract metadata.
- Cover revision defaults, error materialization helpers, tenant/owner ID defaults, and bounded-context comparison.

## Validation
- `git diff --cached --check`
- `./gradlew :wow-api:test --rerun-tasks`

## Notes
- Only the 8 new `wow-api/src/test/kotlin` files are included. `CODEBASE_DEEP_DIVE_REPORT.md` remains local and untracked.