### PR TITLE
fix(core): harden core runtime edge cases

### DIFF
--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/eventsourcing/snapshot/SnapshotRepositorySpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/eventsourcing/snapshot/SnapshotRepositorySpec.kt
@@ -21,6 +21,7 @@ import me.ahoo.wow.eventsourcing.snapshot.SnapshotRepository
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.metrics.Metrics.metrizable
 import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.modeling.toNamedAggregate
 import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory
 import me.ahoo.wow.modeling.state.StateAggregateFactory
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
@@ -180,6 +181,33 @@ abstract class SnapshotRepositorySpec {
         snapshotRepository.scanAggregateId(snapshot.aggregateId, afterId = snapshot.aggregateId.id, limit = 1)
             .test()
             .expectNextCount(0)
+            .verifyComplete()
+    }
+
+    @Test
+    open fun scanAggregateIdShouldFilterNamedAggregate() {
+        val snapshotRepository = createSnapshotRepository().metrizable()
+        val cursorId = generateGlobalId()
+        val targetAggregateId = aggregateMetadata.aggregateId(generateGlobalId())
+        val otherAggregateId = "other_aggregate"
+            .toNamedAggregate(aggregateMetadata.contextName)
+            .aggregateId(generateGlobalId())
+        val targetStateAggregate = stateAggregateFactory.create(aggregateMetadata.state, targetAggregateId)
+        val otherStateAggregate = stateAggregateFactory.create(aggregateMetadata.state, otherAggregateId)
+
+        snapshotRepository.save(SimpleSnapshot(targetStateAggregate, Clock.systemUTC().millis()))
+            .test()
+            .verifyComplete()
+        snapshotRepository.save(SimpleSnapshot(otherStateAggregate, Clock.systemUTC().millis()))
+            .test()
+            .verifyComplete()
+
+        snapshotRepository.scanAggregateId(aggregateMetadata, afterId = cursorId, limit = 10)
+            .collectList()
+            .test()
+            .consumeNextWith {
+                it.assert().containsExactly(targetAggregateId)
+            }
             .verifyComplete()
     }
 }

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/messaging/function/MessageFunctionRegistrarBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/messaging/function/MessageFunctionRegistrarBenchmark.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.messaging.function
+
+import me.ahoo.wow.api.messaging.Message
+import me.ahoo.wow.api.messaging.function.FunctionKind
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.naming.NamedBoundedContext
+import me.ahoo.wow.event.DomainEventExchange
+import me.ahoo.wow.event.SimpleDomainEvent
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.modeling.aggregateId
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.infra.Blackhole
+import java.util.concurrent.CopyOnWriteArraySet
+
+@State(Scope.Benchmark)
+open class MessageFunctionRegistrarBenchmark {
+    @Param("1024")
+    var functionCount: Int = 0
+
+    private lateinit var message: SimpleDomainEvent<BenchmarkEventBody>
+    private lateinit var indexedRegistrar: MessageFunctionRegistrar<MessageFunction<*, *, *>>
+    private lateinit var linearRegistrar: MessageFunctionRegistrar<MessageFunction<*, *, *>>
+
+    @Setup
+    fun setup() {
+        val targetTopic = MaterializedNamedAggregate("benchmark", "target")
+        message = SimpleDomainEvent(
+            id = "event-id",
+            body = BenchmarkEventBody,
+            aggregateId = targetTopic.aggregateId("target-id"),
+            version = 1,
+            commandId = "command-id",
+        )
+        indexedRegistrar = SimpleMessageFunctionRegistrar()
+        linearRegistrar = LinearMessageFunctionRegistrar()
+        repeat(functionCount - 1) {
+            val function = BenchmarkMessageFunction(
+                topic = MaterializedNamedAggregate("benchmark", "aggregate-$it")
+            )
+            indexedRegistrar.register(function)
+            linearRegistrar.register(function)
+        }
+        BenchmarkMessageFunction(topic = targetTopic).let {
+            indexedRegistrar.register(it)
+            linearRegistrar.register(it)
+        }
+    }
+
+    @Benchmark
+    fun indexedLookup(blackhole: Blackhole) {
+        blackhole.consume(indexedRegistrar.supportedFunctions(message).count())
+    }
+
+    @Benchmark
+    fun linearLookup(blackhole: Blackhole) {
+        blackhole.consume(linearRegistrar.supportedFunctions(message).count())
+    }
+}
+
+private object BenchmarkEventBody
+
+private class BenchmarkMessageFunction(
+    private val topic: NamedAggregate,
+) : MessageFunction<Any, DomainEventExchange<*>, Any> {
+    override val supportedType: Class<*> = BenchmarkEventBody::class.java
+    override val supportedTopics: Set<NamedAggregate> = setOf(topic)
+    override val processor: Any = this
+    override val functionKind: FunctionKind = FunctionKind.EVENT
+    override val contextName: String = topic.contextName
+    override val name: String = "benchmark-${topic.aggregateName}"
+
+    override fun <A : Annotation> getAnnotation(annotationClass: Class<A>): A? = null
+
+    override fun invoke(exchange: DomainEventExchange<*>): Any = Unit
+}
+
+private class LinearMessageFunctionRegistrar<F : MessageFunction<*, *, *>> : MessageFunctionRegistrar<F> {
+    private val registrar: CopyOnWriteArraySet<F> = CopyOnWriteArraySet()
+
+    override val functions: Set<F>
+        get() = registrar
+
+    override fun register(function: F) {
+        registrar.add(function)
+    }
+
+    override fun unregister(function: F) {
+        registrar.remove(function)
+    }
+
+    override fun filter(predicate: (F) -> Boolean): MessageFunctionRegistrar<F> {
+        val filteredRegistrar = LinearMessageFunctionRegistrar<F>()
+        filteredRegistrar.registrar.addAll(registrar.filter(predicate))
+        return filteredRegistrar
+    }
+
+    override fun <M> supportedFunctions(message: M): Sequence<F>
+        where M : Message<*, Any>,
+              M : NamedBoundedContext,
+              M : NamedAggregate =
+        functions.asSequence()
+            .filter {
+                it.supportMessage(message)
+            }
+}

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWaitNotifier.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWaitNotifier.kt
@@ -78,7 +78,7 @@ class LocalCommandWaitNotifier(
         waitSignal: WaitSignal
     ): Mono<Void> =
         Mono.fromRunnable {
-            if (isLocalWaitStrategy(waitSignal.id)) {
+            if (isLocalWaitStrategy(waitSignal.waitCommandId)) {
                 log.debug {
                     "Notify Local - waitSignal: $waitSignal"
                 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/configuration/ScopeSearcher.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/configuration/ScopeSearcher.kt
@@ -71,7 +71,7 @@ interface ScopeSearcher<V : Any> : SortedMap<String, V> {
         }
 
         forEach {
-            if (scope.startsWith(it.key)) {
+            if (scope.startsWith("${it.key}.")) {
                 return it.value
             }
         }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt
@@ -26,6 +26,7 @@ import me.ahoo.wow.api.modeling.AggregateIdCapable
 import me.ahoo.wow.api.modeling.SpaceId
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.messaging.DefaultHeader
+import me.ahoo.wow.serialization.event.JsonDomainEvent
 
 /**
  * Domain Event Stream interface representing a sequence of domain events.
@@ -105,7 +106,12 @@ data class SimpleDomainEventStream(
     override val commandId: String
     override val version: Int
 
-    override fun copy(): DomainEventStream = copy(header = header.copy())
+    override fun copy(): DomainEventStream = copy(
+        header = header.copy(),
+        body = body.map {
+            it.copyDomainEvent()
+        }
+    )
 
     override val size: Int
     override val createTime: Long
@@ -123,6 +129,13 @@ data class SimpleDomainEventStream(
         size = body.size
     }
 }
+
+private fun DomainEvent<*>.copyDomainEvent(): DomainEvent<*> =
+    when (this) {
+        is SimpleDomainEvent<*> -> copy(header = header.copy())
+        is JsonDomainEvent -> copy(header = header.copy())
+        else -> this
+    }
 
 /**
  * Determines if this event stream should be ignored during event sourcing.

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/InMemoryEventStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/InMemoryEventStore.kt
@@ -121,7 +121,7 @@ class InMemoryEventStore : AbstractEventStore() {
     override fun last(aggregateId: AggregateId): Mono<DomainEventStream> {
         return Mono.fromSupplier {
             val eventsOfAgg = events[aggregateId] ?: return@fromSupplier null
-            eventsOfAgg.lastOrNull()
+            eventsOfAgg.lastOrNull()?.copy()
         }
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/InMemorySnapshotRepository.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/InMemorySnapshotRepository.kt
@@ -71,7 +71,7 @@ class InMemorySnapshotRepository : SnapshotRepository {
     /**
      * Scans aggregate IDs from the in-memory map, sorted and filtered by afterId and limit.
      *
-     * @param namedAggregate the named aggregate (not used in this implementation)
+     * @param namedAggregate the named aggregate to scan
      * @param afterId the ID to start scanning after
      * @param limit the maximum number of IDs to return
      * @return a Flux of aggregate IDs
@@ -84,6 +84,9 @@ class InMemorySnapshotRepository : SnapshotRepository {
         aggregateIdMapSnapshot.keys
             .sortedBy { it.id }
             .toFlux()
+            .filter {
+                it.isSameAggregateName(namedAggregate)
+            }
             .filter {
                 it.id > afterId
             }.take(limit.toLong())

--- a/wow-core/src/main/kotlin/me/ahoo/wow/exception/ErrorInfoConverterRegistrar.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/exception/ErrorInfoConverterRegistrar.kt
@@ -97,10 +97,23 @@ object ErrorInfoConverterRegistrar {
     /**
      * Retrieves the error converter for a specific exception type.
      *
+     * Lookup walks the class hierarchy: if the exact class is not registered,
+     * each superclass is checked in order. This allows a converter registered
+     * for a framework/base exception to handle its subclasses.
+     *
      * @param throwableClass the exception class to look up
      * @return the registered converter for this exception type, or null if none is registered
      */
-    fun get(throwableClass: Class<out Throwable>): ErrorInfoConverter<Throwable>? = registrar[throwableClass]
+    @Suppress("UNCHECKED_CAST")
+    fun get(throwableClass: Class<out Throwable>): ErrorInfoConverter<Throwable>? {
+        registrar[throwableClass]?.let { return it }
+        var superclass = throwableClass.superclass
+        while (superclass != null && Throwable::class.java.isAssignableFrom(superclass)) {
+            registrar[superclass as Class<out Throwable>]?.let { return it }
+            superclass = superclass.superclass
+        }
+        return null
+    }
 }
 
 /**

--- a/wow-core/src/main/kotlin/me/ahoo/wow/exception/WowException.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/exception/WowException.kt
@@ -140,11 +140,38 @@ fun Retry?.recoverable(throwableClass: Class<out Throwable>): RecoverableType {
         return throwableClass.recoverable
     }
 
-    if (recoverable.any { it.java == throwableClass }) {
+    val recoverableDistance = recoverable.closestAssignableDistance(throwableClass)
+    val unrecoverableDistance = unrecoverable.closestAssignableDistance(throwableClass)
+    if (recoverableDistance != null || unrecoverableDistance != null) {
+        if (unrecoverableDistance != null &&
+            (recoverableDistance == null || unrecoverableDistance < recoverableDistance)
+        ) {
+            return RecoverableType.UNRECOVERABLE
+        }
         return RecoverableType.RECOVERABLE
     }
-    if (unrecoverable.any { it.java == throwableClass }) {
-        return RecoverableType.UNRECOVERABLE
-    }
     return throwableClass.recoverable
+}
+
+private fun Array<out kotlin.reflect.KClass<out Throwable>>.closestAssignableDistance(
+    throwableClass: Class<out Throwable>
+): Int? =
+    asSequence()
+        .mapNotNull { it.java.assignableDistanceTo(throwableClass) }
+        .minOrNull()
+
+private fun Class<out Throwable>.assignableDistanceTo(throwableClass: Class<out Throwable>): Int? {
+    if (!isAssignableFrom(throwableClass)) {
+        return null
+    }
+    var distance = 0
+    var current: Class<*>? = throwableClass
+    while (current != null) {
+        if (current == this) {
+            return distance
+        }
+        distance++
+        current = current.superclass
+    }
+    return null
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/id/AggregateIdGenerator.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/id/AggregateIdGenerator.kt
@@ -58,6 +58,14 @@ object AggregateIdGeneratorRegistrar :
             .sortedByOrder()
     }
 
+    override fun containsKey(key: NamedAggregate): Boolean {
+        return AGGREGATE_ID_GENERATORS.containsKey(key.materialize())
+    }
+
+    override fun get(key: NamedAggregate): IdGenerator? {
+        return AGGREGATE_ID_GENERATORS[key.materialize()]
+    }
+
     /**
      * Retrieves or initializes an [IdGenerator] for the given [NamedAggregate].
      *

--- a/wow-core/src/main/kotlin/me/ahoo/wow/id/AggregateIdGenerator.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/id/AggregateIdGenerator.kt
@@ -69,25 +69,30 @@ object AggregateIdGeneratorRegistrar :
      * @return the [IdGenerator] associated with the [key]
      * @throws IllegalStateException if no [AggregateIdGeneratorFactory] can create an [IdGenerator] for the [key]
      */
-    fun getOrInitialize(key: NamedAggregate): IdGenerator =
-        AGGREGATE_ID_GENERATORS.computeIfAbsent(key) { _ ->
+    fun getOrInitialize(key: NamedAggregate): IdGenerator {
+        val materializedKey = key.materialize()
+        return AGGREGATE_ID_GENERATORS.computeIfAbsent(materializedKey) { _ ->
             factories.firstNotNullOfOrNull {
                 log.info {
-                    "Load $it to create [$key]'s AggregateIdGenerator."
+                    "Load $it to create [$materializedKey]'s AggregateIdGenerator."
                 }
-                val idGenerator = it.create(key)
+                val idGenerator = it.create(materializedKey)
                 if (idGenerator == null) {
                     log.info {
-                        "Ignore: $it create [$key]'s AggregateIdGenerator is null."
+                        "Ignore: $it create [$materializedKey]'s AggregateIdGenerator is null."
                     }
                 } else {
                     log.info {
-                        "Setup $idGenerator to [$key]'s AggregateIdGenerator."
+                        "Setup $idGenerator to [$materializedKey]'s AggregateIdGenerator."
                     }
                 }
                 idGenerator
-            } ?: throw IllegalStateException("No AggregateIdGeneratorFactory found for [$key]'s AggregateIdGenerator.")
+            }
+                ?: throw IllegalStateException(
+                    "No AggregateIdGeneratorFactory found for [$materializedKey]'s AggregateIdGenerator."
+                )
         }
+    }
 
     /**
      * Generates a unique ID string for the given [key].

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/constructor/ObjectFactory.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/constructor/ObjectFactory.kt
@@ -15,7 +15,8 @@ package me.ahoo.wow.infra.accessor.constructor
 import me.ahoo.wow.ioc.ServiceProvider
 import me.ahoo.wow.ioc.getRequiredService
 import java.lang.reflect.Constructor
-import kotlin.reflect.KParameter
+import kotlin.reflect.KType
+import kotlin.reflect.full.starProjectedType
 import kotlin.reflect.full.valueParameters
 import kotlin.reflect.jvm.kotlinFunction
 
@@ -61,7 +62,12 @@ class InjectableObjectFactory<T : Any>(
         serviceProvider,
     )
 
-    private val parameters: List<KParameter> = constructorAccessor.constructor.kotlinFunction!!.valueParameters
+    private val parameterTypes: List<KType> =
+        constructorAccessor.constructor.kotlinFunction?.valueParameters?.map {
+            it.type
+        } ?: constructorAccessor.constructor.parameterTypes.map {
+            it.kotlin.starProjectedType
+        }
 
     /**
      * Creates a new instance by resolving all constructor parameters from the service provider.
@@ -79,9 +85,9 @@ class InjectableObjectFactory<T : Any>(
      * ```
      */
     override fun newInstance(): T {
-        val args = parameters
+        val args = parameterTypes
             .map {
-                serviceProvider.getRequiredService<Any>(it.type)
+                serviceProvider.getRequiredService<Any>(it)
             }.toTypedArray()
         return constructorAccessor.invoke(args)
     }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/function/reactive/BlockingMonoFunctionAccessor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/function/reactive/BlockingMonoFunctionAccessor.kt
@@ -63,8 +63,10 @@ class BlockingMonoFunctionAccessor<T, D : Any>(
  * @return a Mono that will execute on an appropriate thread for blocking operations
  */
 fun <T : Any> Mono<T>.toBlockable(scheduler: Scheduler = Schedulers.boundedElastic()): Mono<T> {
-    if (Schedulers.isInNonBlockingThread()) {
-        return this.subscribeOn(scheduler)
+    return Mono.defer {
+        if (Schedulers.isInNonBlockingThread()) {
+            return@defer this.subscribeOn(scheduler)
+        }
+        this
     }
-    return this
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/DefaultHeader.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/DefaultHeader.kt
@@ -170,8 +170,5 @@ fun Map<String, String>?.toHeader(): Header {
     if (this is Header) {
         return this
     }
-    if (this is MutableMap<*, *>) {
-        return DefaultHeader(this as MutableMap<String, String>)
-    }
     return DefaultHeader(this.toMutableMap())
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/function/SimpleMessageFunctionRegistrar.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/function/SimpleMessageFunctionRegistrar.kt
@@ -17,6 +17,9 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.messaging.Message
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.api.naming.NamedBoundedContext
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.modeling.materialize
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArraySet
 
 /**
@@ -36,6 +39,40 @@ class SimpleMessageFunctionRegistrar<F : MessageFunction<*, *, *>> : MessageFunc
      * Thread-safe set for storing registered functions.
      */
     private val registrar: CopyOnWriteArraySet<F> = CopyOnWriteArraySet()
+    private val topicIndex: ConcurrentHashMap<MaterializedNamedAggregate, CopyOnWriteArraySet<F>> = ConcurrentHashMap()
+    private val unindexedRegistrar: CopyOnWriteArraySet<F> = CopyOnWriteArraySet()
+
+    private fun index(function: F) {
+        if (function.supportedTopics.isEmpty()) {
+            unindexedRegistrar.add(function)
+            return
+        }
+        function.supportedTopics.forEach { topic ->
+            topicIndex.compute(topic.materialize()) { _, functions ->
+                (functions ?: CopyOnWriteArraySet()).also {
+                    it.add(function)
+                }
+            }
+        }
+    }
+
+    private fun deindex(function: F) {
+        if (function.supportedTopics.isEmpty()) {
+            unindexedRegistrar.remove(function)
+            return
+        }
+        function.supportedTopics.forEach { topic ->
+            val materializedTopic = topic.materialize()
+            topicIndex.computeIfPresent(materializedTopic) { _, functions ->
+                functions.remove(function)
+                if (functions.isEmpty()) {
+                    null
+                } else {
+                    functions
+                }
+            }
+        }
+    }
 
     /**
      * Registers a function and logs the registration.
@@ -46,7 +83,9 @@ class SimpleMessageFunctionRegistrar<F : MessageFunction<*, *, *>> : MessageFunc
         log.info {
             "Register $function."
         }
-        registrar.add(function)
+        if (registrar.add(function)) {
+            index(function)
+        }
     }
 
     /**
@@ -58,13 +97,18 @@ class SimpleMessageFunctionRegistrar<F : MessageFunction<*, *, *>> : MessageFunc
         log.info {
             "Unregister $function."
         }
-        registrar.remove(function)
+        if (registrar.remove(function)) {
+            deindex(function)
+        }
     }
 
     override fun filter(predicate: (F) -> Boolean): MessageFunctionRegistrar<F> {
         val filteredRegistrar = SimpleMessageFunctionRegistrar<F>()
         val filteredFunctions = registrar.filter(predicate)
-        filteredRegistrar.registrar.addAll(filteredFunctions)
+        filteredFunctions.forEach {
+            filteredRegistrar.registrar.add(it)
+            filteredRegistrar.index(it)
+        }
         return filteredRegistrar
     }
 
@@ -86,9 +130,23 @@ class SimpleMessageFunctionRegistrar<F : MessageFunction<*, *, *>> : MessageFunc
     override fun <M> supportedFunctions(
         message: M
     ): Sequence<F>
-        where M : Message<*, Any>, M : NamedBoundedContext, M : NamedAggregate =
-        functions.asSequence()
+        where M : Message<*, Any>, M : NamedBoundedContext, M : NamedAggregate {
+        val topicFunctions = topicIndex[message.materialize()]
+        if (topicFunctions.isNullOrEmpty()) {
+            return unindexedRegistrar.asSequence()
+                .filter {
+                    it.supportMessage(message)
+                }
+        }
+        if (unindexedRegistrar.isEmpty()) {
+            return topicFunctions.asSequence()
+                .filter {
+                    it.supportMessage(message)
+                }
+        }
+        return (topicFunctions.asSequence() + unindexedRegistrar.asSequence())
             .filter {
                 it.supportMessage(message)
             }
+    }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/AbstractMetricDecorator.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/AbstractMetricDecorator.kt
@@ -28,7 +28,8 @@ import reactor.core.publisher.Mono
  */
 abstract class AbstractMetricDecorator<T : Any>(
     final override val delegate: T
-) : Decorator<T> {
+) : Decorator<T>,
+    Metrizable {
     /**
      * The source identifier derived from the original delegate's class name.
      * This is used for metrics tagging to identify the component type.

--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricCommandHandler.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricCommandHandler.kt
@@ -29,7 +29,8 @@ import reactor.core.publisher.Mono
 class MetricCommandHandler(
     override val delegate: CommandHandler
 ) : CommandHandler,
-    Decorator<CommandHandler> {
+    Decorator<CommandHandler>,
+    Metrizable {
     /**
      * Handles a server command exchange and collects metrics on the operation.
      * Metrics collected include timing, success/failure rates, and tags for aggregate and command identification.

--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricDomainEventHandler.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricDomainEventHandler.kt
@@ -29,7 +29,8 @@ import reactor.core.publisher.Mono
 class MetricDomainEventHandler(
     override val delegate: DomainEventHandler
 ) : DomainEventHandler,
-    Decorator<DomainEventHandler> {
+    Decorator<DomainEventHandler>,
+    Metrizable {
     /**
      * Handles a domain event exchange and collects metrics on the operation.
      * Metrics collected include timing, success/failure rates, and tags for aggregate, event,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricProjectionHandler.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricProjectionHandler.kt
@@ -29,7 +29,8 @@ import reactor.core.publisher.Mono
 class MetricProjectionHandler(
     override val delegate: ProjectionHandler
 ) : ProjectionHandler,
-    Decorator<ProjectionHandler> {
+    Decorator<ProjectionHandler>,
+    Metrizable {
     /**
      * Handles a domain event exchange for projection and collects metrics on the operation.
      * Metrics collected include timing, success/failure rates, and tags for aggregate, event,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricSnapshotHandler.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricSnapshotHandler.kt
@@ -29,7 +29,8 @@ import reactor.core.publisher.Mono
 class MetricSnapshotHandler(
     override val delegate: SnapshotHandler
 ) : SnapshotHandler,
-    Decorator<SnapshotHandler> {
+    Decorator<SnapshotHandler>,
+    Metrizable {
     /**
      * Handles a state event exchange for snapshot creation and collects metrics on the operation.
      * Metrics collected include timing, success/failure rates, and tags for aggregate identification.

--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricSnapshotStrategy.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricSnapshotStrategy.kt
@@ -29,7 +29,8 @@ import reactor.core.publisher.Mono
 class MetricSnapshotStrategy(
     override val delegate: SnapshotStrategy
 ) : SnapshotStrategy,
-    Decorator<SnapshotStrategy> {
+    Decorator<SnapshotStrategy>,
+    Metrizable {
     /**
      * Processes a state event exchange for snapshot strategy evaluation and collects metrics on the operation.
      * Metrics collected include timing, success/failure rates, and tags for aggregate identification.

--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricStatelessSagaHandler.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricStatelessSagaHandler.kt
@@ -29,7 +29,8 @@ import reactor.core.publisher.Mono
 class MetricStatelessSagaHandler(
     override val delegate: StatelessSagaHandler
 ) : StatelessSagaHandler,
-    Decorator<StatelessSagaHandler> {
+    Decorator<StatelessSagaHandler>,
+    Metrizable {
     /**
      * Handles a domain event exchange for saga processing and collects metrics on the operation.
      * Metrics collected include timing, success/failure rates, and tags for aggregate, event,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/AbstractCommandFunction.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/AbstractCommandFunction.kt
@@ -73,7 +73,7 @@ abstract class AbstractCommandFunction<C : Any>(
             return invokeCommandThenSetCommandInvokeResult(exchange)
         }
         val afterFunctionResult = Flux.fromIterable(afterCommandFunctions)
-            .flatMap {
+            .concatMap {
                 it.invoke(exchange)
             }.flatMapIterable { event ->
                 event.flatEvent()

--- a/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt
@@ -78,8 +78,8 @@ class StatelessSagaFunction(
         return Flux
             .fromIterable(handleResult as Iterable<Any>)
             .index()
-            .flatMap {
-                toCommand(domainEvent = domainEvent, singleResult = it.t2!!, index = it.t1.toInt())
+            .concatMap {
+                toCommand(domainEvent = domainEvent, singleResult = it.t2, index = it.t1.toInt())
             }
     }
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/serialization/event/AbstractEventStreamJsonSerializer.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/serialization/event/AbstractEventStreamJsonSerializer.kt
@@ -41,7 +41,12 @@ abstract class AbstractEventStreamJsonSerializer<M : DomainEventStream>(messageT
             generator.writeStringProperty(MessageRecords.ID, it.id)
             generator.writeStringProperty(MessageRecords.NAME, it.name)
             generator.writeStringProperty(DomainEventRecords.REVISION, it.revision)
-            generator.writeStringProperty(MessageRecords.BODY_TYPE, it.body.javaClass.name)
+            val bodyType = if (it is JsonDomainEvent) {
+                it.bodyType
+            } else {
+                it.body.javaClass.name
+            }
+            generator.writeStringProperty(MessageRecords.BODY_TYPE, bodyType)
             generator.writePOJOProperty(MessageRecords.BODY, it.body)
             generator.writeEndObject()
         }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/LocalCommandWaitNotifierTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/LocalCommandWaitNotifierTest.kt
@@ -13,8 +13,14 @@
 
 package me.ahoo.wow.command.wait
 
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import me.ahoo.cosid.cosid.ClockSyncCosIdGenerator
+import me.ahoo.cosid.cosid.Radix62CosIdGenerator
 import me.ahoo.wow.api.messaging.function.FunctionInfoData
 import me.ahoo.wow.api.messaging.function.FunctionKind
+import me.ahoo.wow.id.GlobalIdGenerator
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.modeling.aggregateId
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
@@ -79,5 +85,42 @@ internal class LocalCommandWaitNotifierTest {
         )
             .test()
             .verifyComplete()
+    }
+
+    @Test
+    fun `should notify local wait strategy when signal id is remote`() {
+        val registrar = mockk<WaitStrategyRegistrar> {
+            every { next(any()) } returns true
+        }
+        val commandWaitNotifier = LocalCommandWaitNotifier(registrar)
+        val waitCommandId = generateGlobalId()
+        val remoteSignalId = ClockSyncCosIdGenerator(
+            Radix62CosIdGenerator(remoteMachineId())
+        ).generateAsString()
+        val waitSignal = SimpleWaitSignal(
+            id = remoteSignalId,
+            waitCommandId = waitCommandId,
+            commandId = remoteSignalId,
+            aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(),
+            stage = CommandStage.PROCESSED,
+            function = functionInfo
+        )
+
+        commandWaitNotifier.notify("endpoint", waitSignal)
+            .test()
+            .verifyComplete()
+
+        verify(exactly = 1) {
+            registrar.next(waitSignal)
+        }
+    }
+
+    private fun remoteMachineId(): Int {
+        val localMachineId = GlobalIdGenerator.machineId
+        return if (localMachineId == 1) {
+            2
+        } else {
+            1
+        }
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/configuration/MetadataSearcherTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/configuration/MetadataSearcherTest.kt
@@ -68,4 +68,20 @@ internal class MetadataSearcherTest {
             )
         }
     }
+
+    @Test
+    fun `should not match sibling package prefix as scope`() {
+        val metadata = WowMetadata(
+            mapOf(
+                "context" to BoundedContext(
+                    aggregates = mapOf(
+                        "foo" to Aggregate(scopes = setOf("me.ahoo.foo")),
+                    ),
+                ),
+            ),
+        )
+        val searcher = metadata.toScopeNamedAggregateSearcher()
+
+        searcher.search("me.ahoo.foobar.Command").assert().isNull()
+    }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/event/DomainEventStreamTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/event/DomainEventStreamTest.kt
@@ -2,7 +2,11 @@ package me.ahoo.wow.event
 
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.messaging.DefaultHeader
+import me.ahoo.wow.serialization.event.JsonDomainEvent
+import me.ahoo.wow.serialization.toJsonNode
 import org.junit.jupiter.api.Test
+import tools.jackson.databind.node.ObjectNode
 
 class DomainEventStreamTest {
 
@@ -50,5 +54,40 @@ class DomainEventStreamTest {
         }
         val ignoreSourcing = eventStream.ignoreSourcing()
         ignoreSourcing.assert().isTrue()
+    }
+
+    @Test
+    fun `should copy json domain event header`() {
+        val sourceEvent = MockNamedEvent().toDomainEvent(
+            aggregateId = generateGlobalId(),
+            tenantId = generateGlobalId(),
+            commandId = generateGlobalId(),
+            version = 1
+        )
+        val jsonDomainEvent = JsonDomainEvent(
+            id = sourceEvent.id,
+            header = DefaultHeader.empty().with("source", "original"),
+            bodyType = "UnknownEvent",
+            body = """{"data":"value"}""".toJsonNode<ObjectNode>(),
+            aggregateId = sourceEvent.aggregateId,
+            ownerId = sourceEvent.ownerId,
+            spaceId = sourceEvent.spaceId,
+            version = sourceEvent.version,
+            sequence = sourceEvent.sequence,
+            revision = sourceEvent.revision,
+            commandId = sourceEvent.commandId,
+            name = sourceEvent.name,
+            isLast = sourceEvent.isLast,
+            createTime = sourceEvent.createTime
+        )
+        val eventStream = SimpleDomainEventStream(
+            requestId = generateGlobalId(),
+            body = listOf(jsonDomainEvent)
+        )
+
+        val copiedEvent = eventStream.copy().first() as JsonDomainEvent
+        copiedEvent.header["source"] = "copied"
+
+        jsonDomainEvent.header["source"].assert().isEqualTo("original")
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/InMemoryEventStoreTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/InMemoryEventStoreTest.kt
@@ -12,8 +12,10 @@
  */
 package me.ahoo.wow.eventsourcing
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.metrics.MetricEventStore
 import me.ahoo.wow.tck.eventsourcing.EventStoreSpec
+import org.junit.jupiter.api.Test
 
 /**
  * InMemoryEventStoreTest .
@@ -23,5 +25,27 @@ import me.ahoo.wow.tck.eventsourcing.EventStoreSpec
 internal class InMemoryEventStoreTest : EventStoreSpec() {
     override fun createEventStore(): EventStore {
         return MetricEventStore(InMemoryEventStore())
+    }
+
+    @Test
+    fun `last should return copied event stream`() {
+        val eventStore = createEventStore()
+        val eventStream = generateEventStream()
+        eventStore.append(eventStream).block()
+
+        eventStore.last(eventStream.aggregateId).block()!!.header["polluted"] = "true"
+
+        eventStore.last(eventStream.aggregateId).block()!!.header["polluted"].assert().isNull()
+    }
+
+    @Test
+    fun `load should return copied domain event headers`() {
+        val eventStore = createEventStore()
+        val eventStream = generateEventStream()
+        eventStore.append(eventStream).block()
+
+        eventStore.load(eventStream.aggregateId).blockFirst()!!.first().header["polluted"] = "true"
+
+        eventStore.load(eventStream.aggregateId).blockFirst()!!.first().header["polluted"].assert().isNull()
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/exception/ErrorInfoConverterRegistrarTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/exception/ErrorInfoConverterRegistrarTest.kt
@@ -44,9 +44,16 @@ class ErrorInfoConverterRegistrarTest {
         )
         CommandResultException(commandResult).toErrorInfo().assert().isEqualTo(commandResult)
     }
+
+    @Test
+    fun `should resolve superclass converter for subclass`() {
+        CustomSubclassException().toErrorInfo().errorCode.assert().isEqualTo("CUSTOM_EXCEPTION")
+    }
 }
 
-class CustomException : RuntimeException()
+open class CustomException : RuntimeException()
+
+class CustomSubclassException : CustomException()
 
 object CustomExceptionErrorInfoConverter : ErrorInfoConverter<CustomException> {
     override fun convert(error: CustomException): ErrorInfo {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/exception/WowExceptionTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/exception/WowExceptionTest.kt
@@ -43,6 +43,15 @@ class WowExceptionTest {
             unrecoverable = arrayOf(IllegalArgumentException::class)
         ).recoverable(IllegalArgumentException::class.java)
             .assert().isEqualTo(RecoverableType.UNRECOVERABLE)
+        Retry(recoverable = arrayOf(RuntimeException::class)).recoverable(IllegalStateException::class.java)
+            .assert().isEqualTo(RecoverableType.RECOVERABLE)
+        Retry(unrecoverable = arrayOf(RuntimeException::class)).recoverable(IllegalStateException::class.java)
+            .assert().isEqualTo(RecoverableType.UNRECOVERABLE)
+        Retry(
+            recoverable = arrayOf(RuntimeException::class),
+            unrecoverable = arrayOf(IllegalArgumentException::class)
+        ).recoverable(IllegalArgumentException::class.java)
+            .assert().isEqualTo(RecoverableType.UNRECOVERABLE)
     }
 
     companion object {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/id/AggregateIdGeneratorRegistrarTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/id/AggregateIdGeneratorRegistrarTest.kt
@@ -41,4 +41,19 @@ internal class AggregateIdGeneratorRegistrarTest {
 
         AggregateIdGeneratorRegistrar[materialized].assert().isSameAs(idGenerator)
     }
+
+    @Test
+    fun `should materialize key when query generator`() {
+        val contextName = generateGlobalId()
+        val aggregateName = generateGlobalId()
+        val namedAggregate = object : me.ahoo.wow.api.modeling.NamedAggregate {
+            override val contextName: String = contextName
+            override val aggregateName: String = aggregateName
+        }
+
+        val idGenerator = AggregateIdGeneratorRegistrar.getOrInitialize(namedAggregate)
+
+        AggregateIdGeneratorRegistrar[namedAggregate].assert().isSameAs(idGenerator)
+        AggregateIdGeneratorRegistrar.containsKey(namedAggregate).assert().isTrue()
+    }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/id/AggregateIdGeneratorRegistrarTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/id/AggregateIdGeneratorRegistrarTest.kt
@@ -26,4 +26,19 @@ internal class AggregateIdGeneratorRegistrarTest {
         id.assert().isNotNull()
         AggregateIdGeneratorRegistrar[namedAggregate].assert().isNotNull
     }
+
+    @Test
+    fun `should materialize key when initialize generator`() {
+        val contextName = generateGlobalId()
+        val aggregateName = generateGlobalId()
+        val namedAggregate = object : me.ahoo.wow.api.modeling.NamedAggregate {
+            override val contextName: String = contextName
+            override val aggregateName: String = aggregateName
+        }
+        val materialized = MaterializedNamedAggregate(contextName, aggregateName)
+
+        val idGenerator = AggregateIdGeneratorRegistrar.getOrInitialize(namedAggregate)
+
+        AggregateIdGeneratorRegistrar[materialized].assert().isSameAs(idGenerator)
+    }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/infra/accessor/constructor/InjectableObjectFactoryTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/infra/accessor/constructor/InjectableObjectFactoryTest.kt
@@ -15,6 +15,7 @@ package me.ahoo.wow.infra.accessor.constructor
 
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.ioc.SimpleServiceProvider
+import me.ahoo.wow.ioc.register
 import org.junit.jupiter.api.Test
 
 internal class InjectableObjectFactoryTest {
@@ -40,6 +41,18 @@ internal class InjectableObjectFactoryTest {
         val mockServiceWithInject = injectableObjectFactory.newInstance()
         mockServiceWithInject.assert().isNotNull()
         mockServiceWithInject.injectService.assert().isEqualTo(injectService)
+    }
+
+    @Test
+    fun `should create java instance with inject`() {
+        val serviceProvider = SimpleServiceProvider()
+        val bytes = "java".toByteArray()
+        serviceProvider.register<ByteArray>(bytes)
+
+        val injectableObjectFactory =
+            InjectableObjectFactory(String::class.java.getConstructor(ByteArray::class.java), serviceProvider)
+
+        injectableObjectFactory.newInstance().assert().isEqualTo("java")
     }
 }
 

--- a/wow-core/src/test/kotlin/me/ahoo/wow/infra/accessor/function/reactive/BlockingMonoFunctionAccessorTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/infra/accessor/function/reactive/BlockingMonoFunctionAccessorTest.kt
@@ -39,6 +39,17 @@ class BlockingMonoFunctionAccessorTest {
                 it.assert().doesNotStartWith("boundedElastic")
             }.verifyComplete()
     }
+
+    @Test
+    fun `should switch to bounded elastic when subscribed from non blocking thread`() {
+        val blockingMonoMethodAccessor = BlockingMethod::blocking.toMonoFunctionAccessor<BlockingMethod, String>()
+        blockingMonoMethodAccessor.invoke(BlockingMethod())
+            .subscribeOn(Schedulers.parallel())
+            .test()
+            .consumeNextWith {
+                it.assert().startsWith("boundedElastic")
+            }.verifyComplete()
+    }
 }
 
 class BlockingMethod {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/DefaultHeaderTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/DefaultHeaderTest.kt
@@ -26,6 +26,17 @@ internal class DefaultHeaderTest {
     }
 
     @Test
+    fun `should copy mutable map when converting to header`() {
+        val values = HashMap<String, String>()
+        values[KEY] = VALUE
+
+        val header = values.toHeader()
+        values[KEY] = "changed"
+
+        header[KEY].assert().isEqualTo(VALUE)
+    }
+
+    @Test
     fun `should be empty when header has no entries`() {
         val values = HashMap<String, String>()
         val header = values.toHeader()

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/function/SimpleMessageFunctionRegistrarTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/function/SimpleMessageFunctionRegistrarTest.kt
@@ -16,10 +16,16 @@ import io.mockk.every
 import io.mockk.mockk
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.event.DomainEvent
+import me.ahoo.wow.api.messaging.Message
+import me.ahoo.wow.api.messaging.function.FunctionKind
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.naming.NamedBoundedContext
 import me.ahoo.wow.configuration.requiredNamedAggregate
 import me.ahoo.wow.event.DomainEventExchange
 import me.ahoo.wow.messaging.function.FunctionMetadataParser.toFunctionMetadata
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
 import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
 
 internal class SimpleMessageFunctionRegistrarTest {
     private val message = mockk<DomainEvent<MockEventBody>> {
@@ -69,4 +75,60 @@ internal class SimpleMessageFunctionRegistrarTest {
         val actual = registrar.supportedFunctions(message).toSet()
         actual.assert().isEmpty()
     }
+
+    @Test
+    fun `should lookup functions by aggregate topic before evaluating support`() {
+        val targetTopic = requiredNamedAggregate<MockEventBody>()
+        val unrelatedSupportCount = AtomicInteger()
+        val matchingSupportCount = AtomicInteger()
+        val registrar = SimpleMessageFunctionRegistrar<MessageFunction<*, *, *>>()
+        (1..128).forEach {
+            registrar.register(
+                CountingMessageFunction(
+                    topic = MaterializedNamedAggregate(targetTopic.contextName, "unrelated-$it"),
+                    supportCount = unrelatedSupportCount,
+                )
+            )
+        }
+        val matchingFunctions = (1..2).map {
+            CountingMessageFunction(
+                topic = targetTopic,
+                supportCount = matchingSupportCount,
+            ).also { function ->
+                registrar.register(function)
+            }
+        }
+
+        val actual = registrar.supportedFunctions(message).toSet()
+
+        actual.assert().containsAll(matchingFunctions)
+        actual.assert().hasSize(matchingFunctions.size)
+        matchingSupportCount.get().assert().isEqualTo(matchingFunctions.size)
+        unrelatedSupportCount.get().assert().isEqualTo(0)
+    }
+}
+
+private class CountingMessageFunction(
+    private val topic: NamedAggregate,
+    private val supportCount: AtomicInteger,
+) : MessageFunction<Any, DomainEventExchange<*>, Any> {
+    override val supportedType: Class<*> = MockEventBody::class.java
+    override val supportedTopics: Set<NamedAggregate> = setOf(topic)
+    override val processor: Any = this
+    override val functionKind: FunctionKind = FunctionKind.EVENT
+    override val contextName: String = topic.contextName
+    override val name: String = "counting-${topic.aggregateName}"
+
+    override fun <A : Annotation> getAnnotation(annotationClass: Class<A>): A? = null
+
+    override fun <M> supportMessage(message: M): Boolean
+        where M : Message<*, Any>, M : NamedBoundedContext, M : NamedAggregate {
+        supportCount.incrementAndGet()
+        return supportedType.isInstance(message.body) &&
+            supportedTopics.any {
+                it.isSameAggregateName(message)
+            }
+    }
+
+    override fun invoke(exchange: DomainEventExchange<*>): Any = Unit
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/metrics/MetricsTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/metrics/MetricsTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.metrics
+
+import io.mockk.mockk
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.event.dispatcher.DomainEventHandler
+import me.ahoo.wow.eventsourcing.snapshot.SnapshotRepository
+import me.ahoo.wow.eventsourcing.snapshot.SnapshotStrategy
+import me.ahoo.wow.eventsourcing.snapshot.dispatcher.SnapshotHandler
+import me.ahoo.wow.metrics.Metrics.metrizable
+import me.ahoo.wow.modeling.command.dispatcher.CommandHandler
+import me.ahoo.wow.projection.ProjectionHandler
+import me.ahoo.wow.saga.stateless.StatelessSagaHandler
+import org.junit.jupiter.api.Test
+
+class MetricsTest {
+    @Test
+    fun `should not wrap handlers repeatedly`() {
+        assertNotWrappedRepeatedly(mockk<CommandHandler>())
+        assertNotWrappedRepeatedly(mockk<DomainEventHandler>())
+        assertNotWrappedRepeatedly(mockk<ProjectionHandler>())
+        assertNotWrappedRepeatedly(mockk<StatelessSagaHandler>())
+        assertNotWrappedRepeatedly(mockk<SnapshotHandler>())
+    }
+
+    @Test
+    fun `should not wrap snapshot components repeatedly`() {
+        assertNotWrappedRepeatedly(mockk<SnapshotRepository>())
+        assertNotWrappedRepeatedly(mockk<SnapshotStrategy>())
+    }
+
+    private inline fun <reified T : Any> assertNotWrappedRepeatedly(component: T) {
+        val once = component.metrizable()
+        val twice = once.metrizable()
+
+        twice.assert().isSameAs(once)
+    }
+}

--- a/wow-core/src/test/kotlin/me/ahoo/wow/modeling/annotation/MockAggregates.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/modeling/annotation/MockAggregates.kt
@@ -21,6 +21,8 @@ import me.ahoo.wow.api.annotation.ORDER_LAST
 import me.ahoo.wow.api.annotation.OnCommand
 import me.ahoo.wow.api.annotation.Order
 import me.ahoo.wow.command.ServerCommandExchange
+import reactor.core.publisher.Mono
+import java.time.Duration
 
 class MockAggregate(val id: String)
 
@@ -73,12 +75,35 @@ class MockAfterCommandAggregate(val id: String) {
     }
 }
 
+@Suppress("UNUSED_PARAMETER")
+class MockAsyncAfterCommandAggregate(val id: String) {
+
+    @OnCommand
+    fun onCommand(command: CreateCmd): CmdCreated {
+        return CmdCreated
+    }
+
+    @Order(ORDER_FIRST)
+    @AfterCommand
+    fun firstAfterCommand(exchange: ServerCommandExchange<Any>): Mono<FirstAfter> {
+        return Mono.just(FirstAfter).delayElement(Duration.ofMillis(50))
+    }
+
+    @Order(ORDER_LAST)
+    @AfterCommand
+    fun lastAfterCommand(exchange: ServerCommandExchange<Any>): Mono<LastAfter> {
+        return Mono.just(LastAfter)
+    }
+}
+
 @CreateAggregate
 object CreateCmd
 object CmdCreated
 object UpdateCmd
 object CmdUpdated
 object CmdAfter
+object FirstAfter
+object LastAfter
 
 @Suppress("UNUSED_PARAMETER")
 class MockDefaultAfterCommandAggregate(val id: String) {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregateTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregateTest.kt
@@ -32,7 +32,10 @@ import me.ahoo.wow.modeling.annotation.CmdAfter
 import me.ahoo.wow.modeling.annotation.CmdCreated
 import me.ahoo.wow.modeling.annotation.CmdUpdated
 import me.ahoo.wow.modeling.annotation.CreateCmd
+import me.ahoo.wow.modeling.annotation.FirstAfter
+import me.ahoo.wow.modeling.annotation.LastAfter
 import me.ahoo.wow.modeling.annotation.MockAfterCommandAggregate
+import me.ahoo.wow.modeling.annotation.MockAsyncAfterCommandAggregate
 import me.ahoo.wow.modeling.annotation.UpdateCmd
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory.toStateAggregate
@@ -195,6 +198,14 @@ internal class SimpleCommandAggregateTest {
             .then()
             .whenCommand(UpdateCmd)
             .expectEventType(CmdUpdated::class.java, CmdAfter::class.java, CmdAfter::class.java)
+            .verify()
+    }
+
+    @Test
+    fun `should preserve ordered async after command events`() {
+        aggregateVerifier<MockAsyncAfterCommandAggregate, MockAsyncAfterCommandAggregate>()
+            .whenCommand(CreateCmd)
+            .expectEventType(CmdCreated::class.java, FirstAfter::class.java, LastAfter::class.java)
             .verify()
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunctionTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunctionTest.kt
@@ -7,10 +7,15 @@ import me.ahoo.wow.api.annotation.OnEvent
 import me.ahoo.wow.api.annotation.Retry
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.messaging.function.FunctionKind
+import me.ahoo.wow.command.CommandGateway
 import me.ahoo.wow.command.factory.CommandBuilder
 import me.ahoo.wow.command.factory.CommandBuilder.Companion.commandBuilder
+import me.ahoo.wow.command.factory.CommandMessageFactory
 import me.ahoo.wow.command.toCommandMessage
 import me.ahoo.wow.event.DomainEventExchange
+import me.ahoo.wow.event.SimpleDomainEventExchange
+import me.ahoo.wow.event.toDomainEventStream
+import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.messaging.function.MessageFunction
 import me.ahoo.wow.tck.mock.MockAggregateCreated
 import me.ahoo.wow.tck.mock.MockChangeAggregate
@@ -19,6 +24,7 @@ import me.ahoo.wow.test.SagaVerifier.sagaVerifier
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import java.time.Duration
 
 class StatelessSagaFunctionTest {
 
@@ -77,6 +83,50 @@ class StatelessSagaFunctionTest {
                 requestId.assert().isNotEqualTo(id)
             }
             .verify()
+    }
+
+    @Test
+    fun `should preserve iterable command order when command creation is asynchronous`() {
+        val sentBodyTypes = mutableListOf<Class<*>>()
+        val commandGateway = mockk<CommandGateway> {
+            every { send(any<CommandMessage<*>>()) } answers {
+                sentBodyTypes.add(firstArg<CommandMessage<*>>().body.javaClass)
+                Mono.empty()
+            }
+        }
+        val commandMessageFactory = object : CommandMessageFactory {
+            override fun <TARGET : Any> create(commandBuilder: CommandBuilder): Mono<CommandMessage<TARGET>> {
+                val commandMessage = commandBuilder.toCommandMessage<TARGET>()
+                val delay = if (commandMessage.body is MockCreateAggregate) {
+                    Duration.ofMillis(50)
+                } else {
+                    Duration.ZERO
+                }
+                return Mono.delay(delay).thenReturn(commandMessage)
+            }
+        }
+        val delegate = object : MessageFunction<Any, DomainEventExchange<*>, Mono<*>> {
+            override val contextName: String = "context"
+            override val name: String = "onEvent"
+            override val processor: Any = "processor"
+            override val supportedType: Class<*> = MockAggregateCreated::class.java
+            override val supportedTopics = emptySet<me.ahoo.wow.api.modeling.NamedAggregate>()
+            override val functionKind: FunctionKind = FunctionKind.EVENT
+            override fun <A : Annotation> getAnnotation(annotationClass: Class<A>): A? = null
+            override fun invoke(exchange: DomainEventExchange<*>): Mono<*> = Mono.just<Any>(
+                listOf(MockCreateAggregate("", ""), MockChangeAggregate("", ""))
+            )
+        }
+        val statelessSagaFunction = StatelessSagaFunction(delegate, commandGateway, commandMessageFactory)
+        val upstream = MockCreateAggregate(generateGlobalId(), "data").toCommandMessage()
+        val event = MockAggregateCreated("data").toDomainEventStream(
+            upstream = upstream,
+            aggregateVersion = 1,
+        ).body.first()
+
+        statelessSagaFunction.invoke(SimpleDomainEventExchange(event)).block()
+
+        sentBodyTypes.assert().containsSequence(MockCreateAggregate::class.java, MockChangeAggregate::class.java)
     }
 
     class MockSaga {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/serialization/JsonSerializerTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/serialization/JsonSerializerTest.kt
@@ -148,6 +148,27 @@ internal class JsonSerializerTest {
     }
 
     @Test
+    fun `should preserve json domain event body type in event stream`() {
+        val namedAggregate = requiredNamedAggregate<MockAggregateCreated>()
+        val eventStream = MockDomainEventStreams.generateEventStream(
+            aggregateId = namedAggregate.aggregateId(tenantId = generateGlobalId()),
+            eventCount = 1,
+            createdEventSupplier = { MockAggregateCreated(generateGlobalId()) },
+        )
+        val unknownBodyType = "NotFoundEventStreamBody"
+        val eventStreamRecord = eventStream.toJsonString().toObjectNode()
+        val eventRecord = eventStreamRecord[MessageRecords.BODY][0] as ObjectNode
+        eventRecord.put(MessageRecords.BODY_TYPE, unknownBodyType)
+
+        val jsonEventStream = eventStreamRecord.toJsonString().toObject<DomainEventStream>()
+
+        jsonEventStream.first().assert().isInstanceOf(JsonDomainEvent::class.java)
+        val reserializedRecord = jsonEventStream.toJsonString().toObjectNode()
+        val reserializedEventRecord = reserializedRecord[MessageRecords.BODY][0] as ObjectNode
+        reserializedEventRecord[MessageRecords.BODY_TYPE].asText().assert().isEqualTo(unknownBodyType)
+    }
+
+    @Test
     fun `should serialize and deserialize snapshot`() {
         val aggregateMetadata = MOCK_AGGREGATE_METADATA
         val aggregateId = aggregateMetadata.aggregateId(

--- a/wow-core/src/test/resources/META-INF/wow-metadata.json
+++ b/wow-core/src/test/resources/META-INF/wow-metadata.json
@@ -49,6 +49,9 @@
         "modeling_annotation_mock_after_command_aggregate": {
           "type": "me.ahoo.wow.modeling.annotation.MockAfterCommandAggregate"
         },
+        "modeling_annotation_mock_async_after_command_aggregate": {
+          "type": "me.ahoo.wow.modeling.annotation.MockAsyncAfterCommandAggregate"
+        },
         "modeling_annotation_mock_default_after_command_aggregate": {
           "type": "me.ahoo.wow.modeling.annotation.MockDefaultAfterCommandAggregate"
         },

--- a/wow-r2dbc/src/test/resources/init-schema-mysql.sql
+++ b/wow-r2dbc/src/test/resources/init-schema-mysql.sql
@@ -114,6 +114,8 @@ create table if not exists mock_aggregate_snapshot
 )
     collate = utf8mb4_bin;
 
+create table if not exists other_aggregate_snapshot like mock_aggregate_snapshot;
+
 create table if not exists eventsourcing_mock_aggregate_event_stream_0
 (
     id           char(15)        not null comment 'event stream id' primary key,


### PR DESCRIPTION
## Summary

- Hardened several core runtime edge cases around wait notification routing, snapshot/event-store isolation, event stream copying, retry/error matching, Java constructor injection, aggregate ID generation, metadata scope lookup, async command ordering, saga command ordering, and metrics wrapper idempotency.
- Indexed message function lookup by materialized aggregate topic to avoid scanning unrelated registered handlers.
- Added regression coverage for the fixed behaviors plus a JMH benchmark for the registrar lookup path.

## Impact

The changes reduce accidental cross-aggregate matches, protect mutable in-memory state from caller mutation, preserve serialized event body types, and make core dispatch paths more deterministic. The registrar benchmark shows indexed lookup staying in the tens of ns/op under a 1024-handler setup, compared with the previous linear scan in the low microseconds.

## Verification

- `git diff --check`
- `CI=GITHUB_ACTIONS ./gradlew :wow-r2dbc:test --tests "me.ahoo.wow.r2dbc.R2dbcSnapshotRepositoryTest.scanAggregateIdShouldFilterNamedAggregate" --stacktrace`
- `CI=GITHUB_ACTIONS ./gradlew wow-r2dbc:check --stacktrace`
- `./gradlew :wow-core:check :wow-benchmarks:jmhJar`
- `java -jar wow-benchmarks/build/libs/wow-benchmarks-8.3.9-jmh.jar 'MessageFunctionRegistrarBenchmark.*' -wi 1 -i 2 -r 1s -w 1s -f 1 -t 1 -bm avgt -tu ns -prof gc`
  - `indexedLookup`: 18.363 ns/op
  - `linearLookup`: 2908.952 ns/op

## Follow-up Candidates

- Event dispatcher intra-event parallelism, event-store version-gap policy, local-first handler fallback semantics, and BloomFilter check atomicity remain larger design questions rather than narrow fixes in this PR.
