### PR TITLE
perf(core): index message functions by topic

### DIFF
--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/messaging/function/MessageFunctionRegistrarBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/messaging/function/MessageFunctionRegistrarBenchmark.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.messaging.function
+
+import me.ahoo.wow.api.messaging.Message
+import me.ahoo.wow.api.messaging.function.FunctionKind
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.naming.NamedBoundedContext
+import me.ahoo.wow.event.DomainEventExchange
+import me.ahoo.wow.event.SimpleDomainEvent
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.modeling.aggregateId
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.infra.Blackhole
+import java.util.concurrent.CopyOnWriteArraySet
+
+@State(Scope.Benchmark)
+open class MessageFunctionRegistrarBenchmark {
+    @Param("1024")
+    var functionCount: Int = 0
+
+    private lateinit var message: SimpleDomainEvent<BenchmarkEventBody>
+    private lateinit var indexedRegistrar: MessageFunctionRegistrar<MessageFunction<*, *, *>>
+    private lateinit var linearRegistrar: MessageFunctionRegistrar<MessageFunction<*, *, *>>
+
+    @Setup
+    fun setup() {
+        val targetTopic = MaterializedNamedAggregate("benchmark", "target")
+        message = SimpleDomainEvent(
+            id = "event-id",
+            body = BenchmarkEventBody,
+            aggregateId = targetTopic.aggregateId("target-id"),
+            version = 1,
+            commandId = "command-id",
+        )
+        indexedRegistrar = SimpleMessageFunctionRegistrar()
+        linearRegistrar = LinearMessageFunctionRegistrar()
+        repeat(functionCount - 1) {
+            val function = BenchmarkMessageFunction(
+                topic = MaterializedNamedAggregate("benchmark", "aggregate-$it")
+            )
+            indexedRegistrar.register(function)
+            linearRegistrar.register(function)
+        }
+        BenchmarkMessageFunction(topic = targetTopic).let {
+            indexedRegistrar.register(it)
+            linearRegistrar.register(it)
+        }
+    }
+
+    @Benchmark
+    fun indexedLookup(blackhole: Blackhole) {
+        blackhole.consume(indexedRegistrar.supportedFunctions(message).count())
+    }
+
+    @Benchmark
+    fun linearLookup(blackhole: Blackhole) {
+        blackhole.consume(linearRegistrar.supportedFunctions(message).count())
+    }
+}
+
+private object BenchmarkEventBody
+
+private class BenchmarkMessageFunction(
+    private val topic: NamedAggregate,
+) : MessageFunction<Any, DomainEventExchange<*>, Any> {
+    override val supportedType: Class<*> = BenchmarkEventBody::class.java
+    override val supportedTopics: Set<NamedAggregate> = setOf(topic)
+    override val processor: Any = this
+    override val functionKind: FunctionKind = FunctionKind.EVENT
+    override val contextName: String = topic.contextName
+    override val name: String = "benchmark-${topic.aggregateName}"
+
+    override fun <A : Annotation> getAnnotation(annotationClass: Class<A>): A? = null
+
+    override fun invoke(exchange: DomainEventExchange<*>): Any = Unit
+}
+
+private class LinearMessageFunctionRegistrar<F : MessageFunction<*, *, *>> : MessageFunctionRegistrar<F> {
+    private val registrar: CopyOnWriteArraySet<F> = CopyOnWriteArraySet()
+
+    override val functions: Set<F>
+        get() = registrar
+
+    override fun register(function: F) {
+        registrar.add(function)
+    }
+
+    override fun unregister(function: F) {
+        registrar.remove(function)
+    }
+
+    override fun filter(predicate: (F) -> Boolean): MessageFunctionRegistrar<F> {
+        val filteredRegistrar = LinearMessageFunctionRegistrar<F>()
+        filteredRegistrar.registrar.addAll(registrar.filter(predicate))
+        return filteredRegistrar
+    }
+
+    override fun <M> supportedFunctions(message: M): Sequence<F>
+        where M : Message<*, Any>,
+              M : NamedBoundedContext,
+              M : NamedAggregate =
+        functions.asSequence()
+            .filter {
+                it.supportMessage(message)
+            }
+}

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/function/SimpleMessageFunctionRegistrar.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/function/SimpleMessageFunctionRegistrar.kt
@@ -17,6 +17,9 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.messaging.Message
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.api.naming.NamedBoundedContext
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.modeling.materialize
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArraySet
 
 /**
@@ -36,6 +39,40 @@ class SimpleMessageFunctionRegistrar<F : MessageFunction<*, *, *>> : MessageFunc
      * Thread-safe set for storing registered functions.
      */
     private val registrar: CopyOnWriteArraySet<F> = CopyOnWriteArraySet()
+    private val topicIndex: ConcurrentHashMap<MaterializedNamedAggregate, CopyOnWriteArraySet<F>> = ConcurrentHashMap()
+    private val unindexedRegistrar: CopyOnWriteArraySet<F> = CopyOnWriteArraySet()
+
+    private fun index(function: F) {
+        if (function.supportedTopics.isEmpty()) {
+            unindexedRegistrar.add(function)
+            return
+        }
+        function.supportedTopics.forEach { topic ->
+            topicIndex.compute(topic.materialize()) { _, functions ->
+                (functions ?: CopyOnWriteArraySet()).also {
+                    it.add(function)
+                }
+            }
+        }
+    }
+
+    private fun deindex(function: F) {
+        if (function.supportedTopics.isEmpty()) {
+            unindexedRegistrar.remove(function)
+            return
+        }
+        function.supportedTopics.forEach { topic ->
+            val materializedTopic = topic.materialize()
+            topicIndex.computeIfPresent(materializedTopic) { _, functions ->
+                functions.remove(function)
+                if (functions.isEmpty()) {
+                    null
+                } else {
+                    functions
+                }
+            }
+        }
+    }
 
     /**
      * Registers a function and logs the registration.
@@ -46,7 +83,9 @@ class SimpleMessageFunctionRegistrar<F : MessageFunction<*, *, *>> : MessageFunc
         log.info {
             "Register $function."
         }
-        registrar.add(function)
+        if (registrar.add(function)) {
+            index(function)
+        }
     }
 
     /**
@@ -58,13 +97,18 @@ class SimpleMessageFunctionRegistrar<F : MessageFunction<*, *, *>> : MessageFunc
         log.info {
             "Unregister $function."
         }
-        registrar.remove(function)
+        if (registrar.remove(function)) {
+            deindex(function)
+        }
     }
 
     override fun filter(predicate: (F) -> Boolean): MessageFunctionRegistrar<F> {
         val filteredRegistrar = SimpleMessageFunctionRegistrar<F>()
         val filteredFunctions = registrar.filter(predicate)
-        filteredRegistrar.registrar.addAll(filteredFunctions)
+        filteredFunctions.forEach {
+            filteredRegistrar.registrar.add(it)
+            filteredRegistrar.index(it)
+        }
         return filteredRegistrar
     }
 
@@ -86,9 +130,23 @@ class SimpleMessageFunctionRegistrar<F : MessageFunction<*, *, *>> : MessageFunc
     override fun <M> supportedFunctions(
         message: M
     ): Sequence<F>
-        where M : Message<*, Any>, M : NamedBoundedContext, M : NamedAggregate =
-        functions.asSequence()
+        where M : Message<*, Any>, M : NamedBoundedContext, M : NamedAggregate {
+        val topicFunctions = topicIndex[message.materialize()]
+        if (topicFunctions.isNullOrEmpty()) {
+            return unindexedRegistrar.asSequence()
+                .filter {
+                    it.supportMessage(message)
+                }
+        }
+        if (unindexedRegistrar.isEmpty()) {
+            return topicFunctions.asSequence()
+                .filter {
+                    it.supportMessage(message)
+                }
+        }
+        return (topicFunctions.asSequence() + unindexedRegistrar.asSequence())
             .filter {
                 it.supportMessage(message)
             }
+    }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/function/SimpleMessageFunctionRegistrarTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/function/SimpleMessageFunctionRegistrarTest.kt
@@ -16,10 +16,16 @@ import io.mockk.every
 import io.mockk.mockk
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.event.DomainEvent
+import me.ahoo.wow.api.messaging.Message
+import me.ahoo.wow.api.messaging.function.FunctionKind
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.naming.NamedBoundedContext
 import me.ahoo.wow.configuration.requiredNamedAggregate
 import me.ahoo.wow.event.DomainEventExchange
 import me.ahoo.wow.messaging.function.FunctionMetadataParser.toFunctionMetadata
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
 import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicInteger
 
 internal class SimpleMessageFunctionRegistrarTest {
     private val message = mockk<DomainEvent<MockEventBody>> {
@@ -69,4 +75,60 @@ internal class SimpleMessageFunctionRegistrarTest {
         val actual = registrar.supportedFunctions(message).toSet()
         actual.assert().isEmpty()
     }
+
+    @Test
+    fun `should lookup functions by aggregate topic before evaluating support`() {
+        val targetTopic = requiredNamedAggregate<MockEventBody>()
+        val unrelatedSupportCount = AtomicInteger()
+        val matchingSupportCount = AtomicInteger()
+        val registrar = SimpleMessageFunctionRegistrar<MessageFunction<*, *, *>>()
+        (1..128).forEach {
+            registrar.register(
+                CountingMessageFunction(
+                    topic = MaterializedNamedAggregate(targetTopic.contextName, "unrelated-$it"),
+                    supportCount = unrelatedSupportCount,
+                )
+            )
+        }
+        val matchingFunctions = (1..2).map {
+            CountingMessageFunction(
+                topic = targetTopic,
+                supportCount = matchingSupportCount,
+            ).also { function ->
+                registrar.register(function)
+            }
+        }
+
+        val actual = registrar.supportedFunctions(message).toSet()
+
+        actual.assert().containsAll(matchingFunctions)
+        actual.assert().hasSize(matchingFunctions.size)
+        matchingSupportCount.get().assert().isEqualTo(matchingFunctions.size)
+        unrelatedSupportCount.get().assert().isEqualTo(0)
+    }
+}
+
+private class CountingMessageFunction(
+    private val topic: NamedAggregate,
+    private val supportCount: AtomicInteger,
+) : MessageFunction<Any, DomainEventExchange<*>, Any> {
+    override val supportedType: Class<*> = MockEventBody::class.java
+    override val supportedTopics: Set<NamedAggregate> = setOf(topic)
+    override val processor: Any = this
+    override val functionKind: FunctionKind = FunctionKind.EVENT
+    override val contextName: String = topic.contextName
+    override val name: String = "counting-${topic.aggregateName}"
+
+    override fun <A : Annotation> getAnnotation(annotationClass: Class<A>): A? = null
+
+    override fun <M> supportMessage(message: M): Boolean
+        where M : Message<*, Any>, M : NamedBoundedContext, M : NamedAggregate {
+        supportCount.incrementAndGet()
+        return supportedType.isInstance(message.body) &&
+            supportedTopics.any {
+                it.isSameAggregateName(message)
+            }
+    }
+
+    override fun invoke(exchange: DomainEventExchange<*>): Any = Unit
 }


### PR DESCRIPTION
Split from #2645.

This PR optimizes SimpleMessageFunctionRegistrar lookup by indexing functions by materialized aggregate topic and keeping unindexed handlers in a separate bucket.

Verification:
- ./gradlew :wow-core:test --tests "me.ahoo.wow.messaging.function.SimpleMessageFunctionRegistrarTest"
- ./gradlew :wow-benchmarks:compileJmhKotlin