### PR TITLE
fix(core): isolate copied event headers

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt
@@ -26,6 +26,7 @@ import me.ahoo.wow.api.modeling.AggregateIdCapable
 import me.ahoo.wow.api.modeling.SpaceId
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.messaging.DefaultHeader
+import me.ahoo.wow.serialization.event.JsonDomainEvent
 
 /**
  * Domain Event Stream interface representing a sequence of domain events.
@@ -105,7 +106,12 @@ data class SimpleDomainEventStream(
     override val commandId: String
     override val version: Int
 
-    override fun copy(): DomainEventStream = copy(header = header.copy())
+    override fun copy(): DomainEventStream = copy(
+        header = header.copy(),
+        body = body.map {
+            it.copyDomainEvent()
+        }
+    )
 
     override val size: Int
     override val createTime: Long
@@ -123,6 +129,13 @@ data class SimpleDomainEventStream(
         size = body.size
     }
 }
+
+private fun DomainEvent<*>.copyDomainEvent(): DomainEvent<*> =
+    when (this) {
+        is SimpleDomainEvent<*> -> copy(header = header.copy())
+        is JsonDomainEvent -> copy(header = header.copy())
+        else -> this
+    }
 
 /**
  * Determines if this event stream should be ignored during event sourcing.

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/InMemoryEventStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/InMemoryEventStore.kt
@@ -121,7 +121,7 @@ class InMemoryEventStore : AbstractEventStore() {
     override fun last(aggregateId: AggregateId): Mono<DomainEventStream> {
         return Mono.fromSupplier {
             val eventsOfAgg = events[aggregateId] ?: return@fromSupplier null
-            eventsOfAgg.lastOrNull()
+            eventsOfAgg.lastOrNull()?.copy()
         }
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/DefaultHeader.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/DefaultHeader.kt
@@ -170,8 +170,5 @@ fun Map<String, String>?.toHeader(): Header {
     if (this is Header) {
         return this
     }
-    if (this is MutableMap<*, *>) {
-        return DefaultHeader(this as MutableMap<String, String>)
-    }
     return DefaultHeader(this.toMutableMap())
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/serialization/event/AbstractEventStreamJsonSerializer.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/serialization/event/AbstractEventStreamJsonSerializer.kt
@@ -41,7 +41,12 @@ abstract class AbstractEventStreamJsonSerializer<M : DomainEventStream>(messageT
             generator.writeStringProperty(MessageRecords.ID, it.id)
             generator.writeStringProperty(MessageRecords.NAME, it.name)
             generator.writeStringProperty(DomainEventRecords.REVISION, it.revision)
-            generator.writeStringProperty(MessageRecords.BODY_TYPE, it.body.javaClass.name)
+            val bodyType = if (it is JsonDomainEvent) {
+                it.bodyType
+            } else {
+                it.body.javaClass.name
+            }
+            generator.writeStringProperty(MessageRecords.BODY_TYPE, bodyType)
             generator.writePOJOProperty(MessageRecords.BODY, it.body)
             generator.writeEndObject()
         }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/event/DomainEventStreamTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/event/DomainEventStreamTest.kt
@@ -2,7 +2,11 @@ package me.ahoo.wow.event
 
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.messaging.DefaultHeader
+import me.ahoo.wow.serialization.event.JsonDomainEvent
+import me.ahoo.wow.serialization.toJsonNode
 import org.junit.jupiter.api.Test
+import tools.jackson.databind.node.ObjectNode
 
 class DomainEventStreamTest {
 
@@ -50,5 +54,40 @@ class DomainEventStreamTest {
         }
         val ignoreSourcing = eventStream.ignoreSourcing()
         ignoreSourcing.assert().isTrue()
+    }
+
+    @Test
+    fun `should copy json domain event header`() {
+        val sourceEvent = MockNamedEvent().toDomainEvent(
+            aggregateId = generateGlobalId(),
+            tenantId = generateGlobalId(),
+            commandId = generateGlobalId(),
+            version = 1
+        )
+        val jsonDomainEvent = JsonDomainEvent(
+            id = sourceEvent.id,
+            header = DefaultHeader.empty().with("source", "original"),
+            bodyType = "UnknownEvent",
+            body = """{"data":"value"}""".toJsonNode<ObjectNode>(),
+            aggregateId = sourceEvent.aggregateId,
+            ownerId = sourceEvent.ownerId,
+            spaceId = sourceEvent.spaceId,
+            version = sourceEvent.version,
+            sequence = sourceEvent.sequence,
+            revision = sourceEvent.revision,
+            commandId = sourceEvent.commandId,
+            name = sourceEvent.name,
+            isLast = sourceEvent.isLast,
+            createTime = sourceEvent.createTime
+        )
+        val eventStream = SimpleDomainEventStream(
+            requestId = generateGlobalId(),
+            body = listOf(jsonDomainEvent)
+        )
+
+        val copiedEvent = eventStream.copy().first() as JsonDomainEvent
+        copiedEvent.header["source"] = "copied"
+
+        jsonDomainEvent.header["source"].assert().isEqualTo("original")
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/InMemoryEventStoreTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/InMemoryEventStoreTest.kt
@@ -12,8 +12,10 @@
  */
 package me.ahoo.wow.eventsourcing
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.metrics.MetricEventStore
 import me.ahoo.wow.tck.eventsourcing.EventStoreSpec
+import org.junit.jupiter.api.Test
 
 /**
  * InMemoryEventStoreTest .
@@ -23,5 +25,27 @@ import me.ahoo.wow.tck.eventsourcing.EventStoreSpec
 internal class InMemoryEventStoreTest : EventStoreSpec() {
     override fun createEventStore(): EventStore {
         return MetricEventStore(InMemoryEventStore())
+    }
+
+    @Test
+    fun `last should return copied event stream`() {
+        val eventStore = createEventStore()
+        val eventStream = generateEventStream()
+        eventStore.append(eventStream).block()
+
+        eventStore.last(eventStream.aggregateId).block()!!.header["polluted"] = "true"
+
+        eventStore.last(eventStream.aggregateId).block()!!.header["polluted"].assert().isNull()
+    }
+
+    @Test
+    fun `load should return copied domain event headers`() {
+        val eventStore = createEventStore()
+        val eventStream = generateEventStream()
+        eventStore.append(eventStream).block()
+
+        eventStore.load(eventStream.aggregateId).blockFirst()!!.first().header["polluted"] = "true"
+
+        eventStore.load(eventStream.aggregateId).blockFirst()!!.first().header["polluted"].assert().isNull()
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/DefaultHeaderTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/DefaultHeaderTest.kt
@@ -26,6 +26,17 @@ internal class DefaultHeaderTest {
     }
 
     @Test
+    fun `should copy mutable map when converting to header`() {
+        val values = HashMap<String, String>()
+        values[KEY] = VALUE
+
+        val header = values.toHeader()
+        values[KEY] = "changed"
+
+        header[KEY].assert().isEqualTo(VALUE)
+    }
+
+    @Test
     fun `should be empty when header has no entries`() {
         val values = HashMap<String, String>()
         val header = values.toHeader()

--- a/wow-core/src/test/kotlin/me/ahoo/wow/serialization/JsonSerializerTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/serialization/JsonSerializerTest.kt
@@ -148,6 +148,27 @@ internal class JsonSerializerTest {
     }
 
     @Test
+    fun `should preserve json domain event body type in event stream`() {
+        val namedAggregate = requiredNamedAggregate<MockAggregateCreated>()
+        val eventStream = MockDomainEventStreams.generateEventStream(
+            aggregateId = namedAggregate.aggregateId(tenantId = generateGlobalId()),
+            eventCount = 1,
+            createdEventSupplier = { MockAggregateCreated(generateGlobalId()) },
+        )
+        val unknownBodyType = "NotFoundEventStreamBody"
+        val eventStreamRecord = eventStream.toJsonString().toObjectNode()
+        val eventRecord = eventStreamRecord[MessageRecords.BODY][0] as ObjectNode
+        eventRecord.put(MessageRecords.BODY_TYPE, unknownBodyType)
+
+        val jsonEventStream = eventStreamRecord.toJsonString().toObject<DomainEventStream>()
+
+        jsonEventStream.first().assert().isInstanceOf(JsonDomainEvent::class.java)
+        val reserializedRecord = jsonEventStream.toJsonString().toObjectNode()
+        val reserializedEventRecord = reserializedRecord[MessageRecords.BODY][0] as ObjectNode
+        reserializedEventRecord[MessageRecords.BODY_TYPE].asText().assert().isEqualTo(unknownBodyType)
+    }
+
+    @Test
     fun `should serialize and deserialize snapshot`() {
         val aggregateMetadata = MOCK_AGGREGATE_METADATA
         val aggregateId = aggregateMetadata.aggregateId(


### PR DESCRIPTION
Split from #2645.

This PR tightens copy/isolation behavior for event streams, event headers, default headers, and JSON-domain-event serialization.

Verification:
- ./gradlew :wow-core:test --tests "me.ahoo.wow.event.DomainEventStreamTest" --tests "me.ahoo.wow.eventsourcing.InMemoryEventStoreTest" --tests "me.ahoo.wow.messaging.DefaultHeaderTest" --tests "me.ahoo.wow.serialization.JsonSerializerTest"