### PR TITLE
fix(core): filter snapshot scans by aggregate

### DIFF
--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/eventsourcing/snapshot/SnapshotRepositorySpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/eventsourcing/snapshot/SnapshotRepositorySpec.kt
@@ -21,6 +21,7 @@ import me.ahoo.wow.eventsourcing.snapshot.SnapshotRepository
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.metrics.Metrics.metrizable
 import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.modeling.toNamedAggregate
 import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory
 import me.ahoo.wow.modeling.state.StateAggregateFactory
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
@@ -180,6 +181,33 @@ abstract class SnapshotRepositorySpec {
         snapshotRepository.scanAggregateId(snapshot.aggregateId, afterId = snapshot.aggregateId.id, limit = 1)
             .test()
             .expectNextCount(0)
+            .verifyComplete()
+    }
+
+    @Test
+    open fun scanAggregateIdShouldFilterNamedAggregate() {
+        val snapshotRepository = createSnapshotRepository().metrizable()
+        val cursorId = generateGlobalId()
+        val targetAggregateId = aggregateMetadata.aggregateId(generateGlobalId())
+        val otherAggregateId = "other_aggregate"
+            .toNamedAggregate(aggregateMetadata.contextName)
+            .aggregateId(generateGlobalId())
+        val targetStateAggregate = stateAggregateFactory.create(aggregateMetadata.state, targetAggregateId)
+        val otherStateAggregate = stateAggregateFactory.create(aggregateMetadata.state, otherAggregateId)
+
+        snapshotRepository.save(SimpleSnapshot(targetStateAggregate, Clock.systemUTC().millis()))
+            .test()
+            .verifyComplete()
+        snapshotRepository.save(SimpleSnapshot(otherStateAggregate, Clock.systemUTC().millis()))
+            .test()
+            .verifyComplete()
+
+        snapshotRepository.scanAggregateId(aggregateMetadata, afterId = cursorId, limit = 10)
+            .collectList()
+            .test()
+            .consumeNextWith {
+                it.assert().containsExactly(targetAggregateId)
+            }
             .verifyComplete()
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/InMemorySnapshotRepository.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/InMemorySnapshotRepository.kt
@@ -69,7 +69,8 @@ class InMemorySnapshotRepository : SnapshotRepository {
         }
 
     /**
-     * Scans aggregate IDs from the in-memory map, sorted and filtered by afterId and limit.
+     * Scans aggregate IDs from the in-memory map, filtered by named aggregate and afterId,
+     * then sorted and limited.
      *
      * @param namedAggregate the named aggregate to scan
      * @param afterId the ID to start scanning after

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/InMemorySnapshotRepository.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/InMemorySnapshotRepository.kt
@@ -71,7 +71,7 @@ class InMemorySnapshotRepository : SnapshotRepository {
     /**
      * Scans aggregate IDs from the in-memory map, sorted and filtered by afterId and limit.
      *
-     * @param namedAggregate the named aggregate (not used in this implementation)
+     * @param namedAggregate the named aggregate to scan
      * @param afterId the ID to start scanning after
      * @param limit the maximum number of IDs to return
      * @return a Flux of aggregate IDs
@@ -84,6 +84,9 @@ class InMemorySnapshotRepository : SnapshotRepository {
         aggregateIdMapSnapshot.keys
             .sortedBy { it.id }
             .toFlux()
+            .filter {
+                it.isSameAggregateName(namedAggregate)
+            }
             .filter {
                 it.id > afterId
             }.take(limit.toLong())

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/InMemorySnapshotRepository.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/InMemorySnapshotRepository.kt
@@ -82,12 +82,16 @@ class InMemorySnapshotRepository : SnapshotRepository {
         limit: Int
     ): Flux<AggregateId> =
         aggregateIdMapSnapshot.keys
-            .sortedBy { it.id }
-            .toFlux()
+            .asSequence()
             .filter {
                 it.isSameAggregateName(namedAggregate)
             }
             .filter {
                 it.id > afterId
-            }.take(limit.toLong())
+            }
+            .sortedBy {
+                it.id
+            }
+            .take(limit)
+            .toFlux()
 }

--- a/wow-r2dbc/src/test/resources/init-schema-mysql.sql
+++ b/wow-r2dbc/src/test/resources/init-schema-mysql.sql
@@ -114,6 +114,8 @@ create table if not exists mock_aggregate_snapshot
 )
     collate = utf8mb4_bin;
 
+create table if not exists other_aggregate_snapshot like mock_aggregate_snapshot;
+
 create table if not exists eventsourcing_mock_aggregate_event_stream_0
 (
     id           char(15)        not null comment 'event stream id' primary key,


### PR DESCRIPTION
Split from #2645.

This PR filters in-memory snapshot scan results by named aggregate and adds TCK/fixture coverage for aggregate isolation.

Verification:
- ./gradlew :wow-core:compileKotlin :wow-tck:compileKotlin