### PR TITLE
fix(core): resolve exception handlers by type hierarchy

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/exception/ErrorInfoConverterRegistrar.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/exception/ErrorInfoConverterRegistrar.kt
@@ -97,10 +97,23 @@ object ErrorInfoConverterRegistrar {
     /**
      * Retrieves the error converter for a specific exception type.
      *
+     * Lookup walks the class hierarchy: if the exact class is not registered,
+     * each superclass is checked in order. This allows a converter registered
+     * for a framework/base exception to handle its subclasses.
+     *
      * @param throwableClass the exception class to look up
      * @return the registered converter for this exception type, or null if none is registered
      */
-    fun get(throwableClass: Class<out Throwable>): ErrorInfoConverter<Throwable>? = registrar[throwableClass]
+    @Suppress("UNCHECKED_CAST")
+    fun get(throwableClass: Class<out Throwable>): ErrorInfoConverter<Throwable>? {
+        registrar[throwableClass]?.let { return it }
+        var superclass = throwableClass.superclass
+        while (superclass != null && Throwable::class.java.isAssignableFrom(superclass)) {
+            registrar[superclass as Class<out Throwable>]?.let { return it }
+            superclass = superclass.superclass
+        }
+        return null
+    }
 }
 
 /**

--- a/wow-core/src/main/kotlin/me/ahoo/wow/exception/WowException.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/exception/WowException.kt
@@ -140,11 +140,38 @@ fun Retry?.recoverable(throwableClass: Class<out Throwable>): RecoverableType {
         return throwableClass.recoverable
     }
 
-    if (recoverable.any { it.java == throwableClass }) {
+    val recoverableDistance = recoverable.closestAssignableDistance(throwableClass)
+    val unrecoverableDistance = unrecoverable.closestAssignableDistance(throwableClass)
+    if (recoverableDistance != null || unrecoverableDistance != null) {
+        if (unrecoverableDistance != null &&
+            (recoverableDistance == null || unrecoverableDistance < recoverableDistance)
+        ) {
+            return RecoverableType.UNRECOVERABLE
+        }
         return RecoverableType.RECOVERABLE
     }
-    if (unrecoverable.any { it.java == throwableClass }) {
-        return RecoverableType.UNRECOVERABLE
-    }
     return throwableClass.recoverable
+}
+
+private fun Array<out kotlin.reflect.KClass<out Throwable>>.closestAssignableDistance(
+    throwableClass: Class<out Throwable>
+): Int? =
+    asSequence()
+        .mapNotNull { it.java.assignableDistanceTo(throwableClass) }
+        .minOrNull()
+
+private fun Class<out Throwable>.assignableDistanceTo(throwableClass: Class<out Throwable>): Int? {
+    if (!isAssignableFrom(throwableClass)) {
+        return null
+    }
+    var distance = 0
+    var current: Class<*>? = throwableClass
+    while (current != null) {
+        if (current == this) {
+            return distance
+        }
+        distance++
+        current = current.superclass
+    }
+    return null
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/exception/WowException.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/exception/WowException.kt
@@ -122,13 +122,14 @@ val Class<out Throwable>.recoverable: RecoverableType
  * Determines recoverable type considering Retry annotation configuration.
  *
  * This function evaluates the recoverable type of an exception class in the context
- * of a Retry annotation. The Retry annotation can explicitly mark certain exceptions
- * as recoverable or unrecoverable, overriding the default classifications.
+ * of a Retry annotation. The Retry annotation can mark exceptions, including
+ * assignable superclasses, as recoverable or unrecoverable, overriding the default
+ * classifications.
  *
  * Priority order:
- * 1. Explicitly listed in retry.recoverable → RECOVERABLE
- * 2. Explicitly listed in retry.unrecoverable → UNRECOVERABLE
- * 3. Default classification for the exception class
+ * 1. Nearest assignable type in retry.recoverable or retry.unrecoverable
+ * 2. Recoverable match when both lists match at the same distance
+ * 3. Default classification for the exception class when neither list matches
  *
  * @param throwableClass the exception class to evaluate
  * @return the recoverable type considering retry configuration

--- a/wow-core/src/test/kotlin/me/ahoo/wow/exception/ErrorInfoConverterRegistrarTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/exception/ErrorInfoConverterRegistrarTest.kt
@@ -44,9 +44,16 @@ class ErrorInfoConverterRegistrarTest {
         )
         CommandResultException(commandResult).toErrorInfo().assert().isEqualTo(commandResult)
     }
+
+    @Test
+    fun `should resolve superclass converter for subclass`() {
+        CustomSubclassException().toErrorInfo().errorCode.assert().isEqualTo("CUSTOM_EXCEPTION")
+    }
 }
 
-class CustomException : RuntimeException()
+open class CustomException : RuntimeException()
+
+class CustomSubclassException : CustomException()
 
 object CustomExceptionErrorInfoConverter : ErrorInfoConverter<CustomException> {
     override fun convert(error: CustomException): ErrorInfo {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/exception/WowExceptionTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/exception/WowExceptionTest.kt
@@ -43,6 +43,15 @@ class WowExceptionTest {
             unrecoverable = arrayOf(IllegalArgumentException::class)
         ).recoverable(IllegalArgumentException::class.java)
             .assert().isEqualTo(RecoverableType.UNRECOVERABLE)
+        Retry(recoverable = arrayOf(RuntimeException::class)).recoverable(IllegalStateException::class.java)
+            .assert().isEqualTo(RecoverableType.RECOVERABLE)
+        Retry(unrecoverable = arrayOf(RuntimeException::class)).recoverable(IllegalStateException::class.java)
+            .assert().isEqualTo(RecoverableType.UNRECOVERABLE)
+        Retry(
+            recoverable = arrayOf(RuntimeException::class),
+            unrecoverable = arrayOf(IllegalArgumentException::class)
+        ).recoverable(IllegalArgumentException::class.java)
+            .assert().isEqualTo(RecoverableType.UNRECOVERABLE)
     }
 
     companion object {


### PR DESCRIPTION
Split from #2645.

This PR makes retry classification and error-info converter lookup handle assignable superclass relationships deterministically.

Verification:
- ./gradlew :wow-core:test --tests "me.ahoo.wow.exception.ErrorInfoConverterRegistrarTest" --tests "me.ahoo.wow.exception.WowExceptionTest"