### PR TITLE
fix(core): preserve async command event ordering

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/AbstractCommandFunction.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/AbstractCommandFunction.kt
@@ -73,7 +73,7 @@ abstract class AbstractCommandFunction<C : Any>(
             return invokeCommandThenSetCommandInvokeResult(exchange)
         }
         val afterFunctionResult = Flux.fromIterable(afterCommandFunctions)
-            .flatMap {
+            .concatMap {
                 it.invoke(exchange)
             }.flatMapIterable { event ->
                 event.flatEvent()

--- a/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt
@@ -78,8 +78,8 @@ class StatelessSagaFunction(
         return Flux
             .fromIterable(handleResult as Iterable<Any>)
             .index()
-            .flatMap {
-                toCommand(domainEvent = domainEvent, singleResult = it.t2!!, index = it.t1.toInt())
+            .concatMap {
+                toCommand(domainEvent = domainEvent, singleResult = it.t2, index = it.t1.toInt())
             }
     }
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/scheduler/AggregateSchedulerSupplier.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/scheduler/AggregateSchedulerSupplier.kt
@@ -128,10 +128,12 @@ class DefaultAggregateSchedulerSupplier(
      * Stops all schedulers gracefully.
      */
     override fun stopGracefully(): Mono<Void> {
-        return Flux.fromIterable(schedulers.values).flatMap {
-            it.disposeGracefully()
-        }.then().doFinally {
+        return Flux.defer {
+            val cachedSchedulers = schedulers.values.toList()
             schedulers.clear()
-        }
+            Flux.fromIterable(cachedSchedulers)
+        }.flatMap {
+            it.disposeGracefully()
+        }.then()
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/modeling/annotation/MockAggregates.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/modeling/annotation/MockAggregates.kt
@@ -21,6 +21,8 @@ import me.ahoo.wow.api.annotation.ORDER_LAST
 import me.ahoo.wow.api.annotation.OnCommand
 import me.ahoo.wow.api.annotation.Order
 import me.ahoo.wow.command.ServerCommandExchange
+import reactor.core.publisher.Mono
+import java.time.Duration
 
 class MockAggregate(val id: String)
 
@@ -73,12 +75,35 @@ class MockAfterCommandAggregate(val id: String) {
     }
 }
 
+@Suppress("UNUSED_PARAMETER")
+class MockAsyncAfterCommandAggregate(val id: String) {
+
+    @OnCommand
+    fun onCommand(command: CreateCmd): CmdCreated {
+        return CmdCreated
+    }
+
+    @Order(ORDER_FIRST)
+    @AfterCommand
+    fun firstAfterCommand(exchange: ServerCommandExchange<Any>): Mono<FirstAfter> {
+        return Mono.just(FirstAfter).delayElement(Duration.ofMillis(50))
+    }
+
+    @Order(ORDER_LAST)
+    @AfterCommand
+    fun lastAfterCommand(exchange: ServerCommandExchange<Any>): Mono<LastAfter> {
+        return Mono.just(LastAfter)
+    }
+}
+
 @CreateAggregate
 object CreateCmd
 object CmdCreated
 object UpdateCmd
 object CmdUpdated
 object CmdAfter
+object FirstAfter
+object LastAfter
 
 @Suppress("UNUSED_PARAMETER")
 class MockDefaultAfterCommandAggregate(val id: String) {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregateTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregateTest.kt
@@ -32,7 +32,10 @@ import me.ahoo.wow.modeling.annotation.CmdAfter
 import me.ahoo.wow.modeling.annotation.CmdCreated
 import me.ahoo.wow.modeling.annotation.CmdUpdated
 import me.ahoo.wow.modeling.annotation.CreateCmd
+import me.ahoo.wow.modeling.annotation.FirstAfter
+import me.ahoo.wow.modeling.annotation.LastAfter
 import me.ahoo.wow.modeling.annotation.MockAfterCommandAggregate
+import me.ahoo.wow.modeling.annotation.MockAsyncAfterCommandAggregate
 import me.ahoo.wow.modeling.annotation.UpdateCmd
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory.toStateAggregate
@@ -195,6 +198,14 @@ internal class SimpleCommandAggregateTest {
             .then()
             .whenCommand(UpdateCmd)
             .expectEventType(CmdUpdated::class.java, CmdAfter::class.java, CmdAfter::class.java)
+            .verify()
+    }
+
+    @Test
+    fun `should preserve ordered async after command events`() {
+        aggregateVerifier<MockAsyncAfterCommandAggregate, MockAsyncAfterCommandAggregate>()
+            .whenCommand(CreateCmd)
+            .expectEventType(CmdCreated::class.java, FirstAfter::class.java, LastAfter::class.java)
             .verify()
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunctionTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunctionTest.kt
@@ -7,10 +7,15 @@ import me.ahoo.wow.api.annotation.OnEvent
 import me.ahoo.wow.api.annotation.Retry
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.messaging.function.FunctionKind
+import me.ahoo.wow.command.CommandGateway
 import me.ahoo.wow.command.factory.CommandBuilder
 import me.ahoo.wow.command.factory.CommandBuilder.Companion.commandBuilder
+import me.ahoo.wow.command.factory.CommandMessageFactory
 import me.ahoo.wow.command.toCommandMessage
 import me.ahoo.wow.event.DomainEventExchange
+import me.ahoo.wow.event.SimpleDomainEventExchange
+import me.ahoo.wow.event.toDomainEventStream
+import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.messaging.function.MessageFunction
 import me.ahoo.wow.tck.mock.MockAggregateCreated
 import me.ahoo.wow.tck.mock.MockChangeAggregate
@@ -19,6 +24,7 @@ import me.ahoo.wow.test.SagaVerifier.sagaVerifier
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import java.time.Duration
 
 class StatelessSagaFunctionTest {
 
@@ -77,6 +83,50 @@ class StatelessSagaFunctionTest {
                 requestId.assert().isNotEqualTo(id)
             }
             .verify()
+    }
+
+    @Test
+    fun `should preserve iterable command order when command creation is asynchronous`() {
+        val sentBodyTypes = mutableListOf<Class<*>>()
+        val commandGateway = mockk<CommandGateway> {
+            every { send(any<CommandMessage<*>>()) } answers {
+                sentBodyTypes.add(firstArg<CommandMessage<*>>().body.javaClass)
+                Mono.empty()
+            }
+        }
+        val commandMessageFactory = object : CommandMessageFactory {
+            override fun <TARGET : Any> create(commandBuilder: CommandBuilder): Mono<CommandMessage<TARGET>> {
+                val commandMessage = commandBuilder.toCommandMessage<TARGET>()
+                val delay = if (commandMessage.body is MockCreateAggregate) {
+                    Duration.ofMillis(50)
+                } else {
+                    Duration.ZERO
+                }
+                return Mono.delay(delay).thenReturn(commandMessage)
+            }
+        }
+        val delegate = object : MessageFunction<Any, DomainEventExchange<*>, Mono<*>> {
+            override val contextName: String = "context"
+            override val name: String = "onEvent"
+            override val processor: Any = "processor"
+            override val supportedType: Class<*> = MockAggregateCreated::class.java
+            override val supportedTopics = emptySet<me.ahoo.wow.api.modeling.NamedAggregate>()
+            override val functionKind: FunctionKind = FunctionKind.EVENT
+            override fun <A : Annotation> getAnnotation(annotationClass: Class<A>): A? = null
+            override fun invoke(exchange: DomainEventExchange<*>): Mono<*> = Mono.just<Any>(
+                listOf(MockCreateAggregate("", ""), MockChangeAggregate("", ""))
+            )
+        }
+        val statelessSagaFunction = StatelessSagaFunction(delegate, commandGateway, commandMessageFactory)
+        val upstream = MockCreateAggregate(generateGlobalId(), "data").toCommandMessage()
+        val event = MockAggregateCreated("data").toDomainEventStream(
+            upstream = upstream,
+            aggregateVersion = 1,
+        ).body.first()
+
+        statelessSagaFunction.invoke(SimpleDomainEventExchange(event)).block()
+
+        sentBodyTypes.assert().containsSequence(MockCreateAggregate::class.java, MockChangeAggregate::class.java)
     }
 
     class MockSaga {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunctionTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunctionTest.kt
@@ -124,7 +124,7 @@ class StatelessSagaFunctionTest {
             aggregateVersion = 1,
         ).body.first()
 
-        statelessSagaFunction.invoke(SimpleDomainEventExchange(event)).block()
+        statelessSagaFunction.invoke(SimpleDomainEventExchange(event)).block(Duration.ofSeconds(5))
 
         sentBodyTypes.assert().containsSequence(MockCreateAggregate::class.java, MockChangeAggregate::class.java)
     }

--- a/wow-core/src/test/resources/META-INF/wow-metadata.json
+++ b/wow-core/src/test/resources/META-INF/wow-metadata.json
@@ -49,6 +49,9 @@
         "modeling_annotation_mock_after_command_aggregate": {
           "type": "me.ahoo.wow.modeling.annotation.MockAfterCommandAggregate"
         },
+        "modeling_annotation_mock_async_after_command_aggregate": {
+          "type": "me.ahoo.wow.modeling.annotation.MockAsyncAfterCommandAggregate"
+        },
         "modeling_annotation_mock_default_after_command_aggregate": {
           "type": "me.ahoo.wow.modeling.annotation.MockDefaultAfterCommandAggregate"
         },


### PR DESCRIPTION
Split from #2645.

This PR preserves deterministic ordering for async after-command events and stateless saga command creation.

It also includes a CI fix for `DefaultAggregateSchedulerSupplier.stopGracefully()`: the scheduler cache is cleared before the graceful-disposal sequence completes, so callers that request a scheduler immediately after `stopGracefully().block()` do not receive a disposed scheduler. This keeps the existing scheduler lifecycle tests deterministic on CI.

Verification:
- ./gradlew :wow-core:test --tests "me.ahoo.wow.modeling.command.SimpleCommandAggregateTest" --tests "me.ahoo.wow.saga.stateless.StatelessSagaFunctionTest"
- ./gradlew wow-core:check --stacktrace