### PR TITLE
fix(core): make metrics decoration idempotent

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/AbstractMetricDecorator.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/AbstractMetricDecorator.kt
@@ -28,7 +28,8 @@ import reactor.core.publisher.Mono
  */
 abstract class AbstractMetricDecorator<T : Any>(
     final override val delegate: T
-) : Decorator<T> {
+) : Decorator<T>,
+    Metrizable {
     /**
      * The source identifier derived from the original delegate's class name.
      * This is used for metrics tagging to identify the component type.

--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricCommandHandler.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricCommandHandler.kt
@@ -29,7 +29,8 @@ import reactor.core.publisher.Mono
 class MetricCommandHandler(
     override val delegate: CommandHandler
 ) : CommandHandler,
-    Decorator<CommandHandler> {
+    Decorator<CommandHandler>,
+    Metrizable {
     /**
      * Handles a server command exchange and collects metrics on the operation.
      * Metrics collected include timing, success/failure rates, and tags for aggregate and command identification.

--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricDomainEventHandler.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricDomainEventHandler.kt
@@ -29,7 +29,8 @@ import reactor.core.publisher.Mono
 class MetricDomainEventHandler(
     override val delegate: DomainEventHandler
 ) : DomainEventHandler,
-    Decorator<DomainEventHandler> {
+    Decorator<DomainEventHandler>,
+    Metrizable {
     /**
      * Handles a domain event exchange and collects metrics on the operation.
      * Metrics collected include timing, success/failure rates, and tags for aggregate, event,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricProjectionHandler.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricProjectionHandler.kt
@@ -29,7 +29,8 @@ import reactor.core.publisher.Mono
 class MetricProjectionHandler(
     override val delegate: ProjectionHandler
 ) : ProjectionHandler,
-    Decorator<ProjectionHandler> {
+    Decorator<ProjectionHandler>,
+    Metrizable {
     /**
      * Handles a domain event exchange for projection and collects metrics on the operation.
      * Metrics collected include timing, success/failure rates, and tags for aggregate, event,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricSnapshotHandler.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricSnapshotHandler.kt
@@ -29,7 +29,8 @@ import reactor.core.publisher.Mono
 class MetricSnapshotHandler(
     override val delegate: SnapshotHandler
 ) : SnapshotHandler,
-    Decorator<SnapshotHandler> {
+    Decorator<SnapshotHandler>,
+    Metrizable {
     /**
      * Handles a state event exchange for snapshot creation and collects metrics on the operation.
      * Metrics collected include timing, success/failure rates, and tags for aggregate identification.

--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricSnapshotStrategy.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricSnapshotStrategy.kt
@@ -29,7 +29,8 @@ import reactor.core.publisher.Mono
 class MetricSnapshotStrategy(
     override val delegate: SnapshotStrategy
 ) : SnapshotStrategy,
-    Decorator<SnapshotStrategy> {
+    Decorator<SnapshotStrategy>,
+    Metrizable {
     /**
      * Processes a state event exchange for snapshot strategy evaluation and collects metrics on the operation.
      * Metrics collected include timing, success/failure rates, and tags for aggregate identification.

--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricStatelessSagaHandler.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricStatelessSagaHandler.kt
@@ -29,7 +29,8 @@ import reactor.core.publisher.Mono
 class MetricStatelessSagaHandler(
     override val delegate: StatelessSagaHandler
 ) : StatelessSagaHandler,
-    Decorator<StatelessSagaHandler> {
+    Decorator<StatelessSagaHandler>,
+    Metrizable {
     /**
      * Handles a domain event exchange for saga processing and collects metrics on the operation.
      * Metrics collected include timing, success/failure rates, and tags for aggregate, event,

--- a/wow-core/src/test/kotlin/me/ahoo/wow/metrics/MetricsTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/metrics/MetricsTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.metrics
+
+import io.mockk.mockk
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.event.dispatcher.DomainEventHandler
+import me.ahoo.wow.eventsourcing.snapshot.SnapshotRepository
+import me.ahoo.wow.eventsourcing.snapshot.SnapshotStrategy
+import me.ahoo.wow.eventsourcing.snapshot.dispatcher.SnapshotHandler
+import me.ahoo.wow.metrics.Metrics.metrizable
+import me.ahoo.wow.modeling.command.dispatcher.CommandHandler
+import me.ahoo.wow.projection.ProjectionHandler
+import me.ahoo.wow.saga.stateless.StatelessSagaHandler
+import org.junit.jupiter.api.Test
+
+class MetricsTest {
+    @Test
+    fun `should not wrap handlers repeatedly`() {
+        assertNotWrappedRepeatedly(mockk<CommandHandler>())
+        assertNotWrappedRepeatedly(mockk<DomainEventHandler>())
+        assertNotWrappedRepeatedly(mockk<ProjectionHandler>())
+        assertNotWrappedRepeatedly(mockk<StatelessSagaHandler>())
+        assertNotWrappedRepeatedly(mockk<SnapshotHandler>())
+    }
+
+    @Test
+    fun `should not wrap snapshot components repeatedly`() {
+        assertNotWrappedRepeatedly(mockk<SnapshotRepository>())
+        assertNotWrappedRepeatedly(mockk<SnapshotStrategy>())
+    }
+
+    private inline fun <reified T : Any> assertNotWrappedRepeatedly(component: T) {
+        val once = component.metrizable()
+        val twice = once.metrizable()
+
+        twice.assert().isSameAs(once)
+    }
+}


### PR DESCRIPTION
Split from #2645.

This PR marks metric decorators as metrizable to prevent double wrapping.

Verification:
- ./gradlew :wow-core:test --tests "me.ahoo.wow.metrics.MetricsTest"