### PR TITLE
fix(core): normalize aggregate id generator keys

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/id/AggregateIdGenerator.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/id/AggregateIdGenerator.kt
@@ -58,6 +58,14 @@ object AggregateIdGeneratorRegistrar :
             .sortedByOrder()
     }
 
+    override fun containsKey(key: NamedAggregate): Boolean {
+        return AGGREGATE_ID_GENERATORS.containsKey(key.materialize())
+    }
+
+    override fun get(key: NamedAggregate): IdGenerator? {
+        return AGGREGATE_ID_GENERATORS[key.materialize()]
+    }
+
     /**
      * Retrieves or initializes an [IdGenerator] for the given [NamedAggregate].
      *
@@ -69,25 +77,30 @@ object AggregateIdGeneratorRegistrar :
      * @return the [IdGenerator] associated with the [key]
      * @throws IllegalStateException if no [AggregateIdGeneratorFactory] can create an [IdGenerator] for the [key]
      */
-    fun getOrInitialize(key: NamedAggregate): IdGenerator =
-        AGGREGATE_ID_GENERATORS.computeIfAbsent(key) { _ ->
+    fun getOrInitialize(key: NamedAggregate): IdGenerator {
+        val materializedKey = key.materialize()
+        return AGGREGATE_ID_GENERATORS.computeIfAbsent(materializedKey) { _ ->
             factories.firstNotNullOfOrNull {
                 log.info {
-                    "Load $it to create [$key]'s AggregateIdGenerator."
+                    "Load $it to create [$materializedKey]'s AggregateIdGenerator."
                 }
-                val idGenerator = it.create(key)
+                val idGenerator = it.create(materializedKey)
                 if (idGenerator == null) {
                     log.info {
-                        "Ignore: $it create [$key]'s AggregateIdGenerator is null."
+                        "Ignore: $it create [$materializedKey]'s AggregateIdGenerator is null."
                     }
                 } else {
                     log.info {
-                        "Setup $idGenerator to [$key]'s AggregateIdGenerator."
+                        "Setup $idGenerator to [$materializedKey]'s AggregateIdGenerator."
                     }
                 }
                 idGenerator
-            } ?: throw IllegalStateException("No AggregateIdGeneratorFactory found for [$key]'s AggregateIdGenerator.")
+            }
+                ?: throw IllegalStateException(
+                    "No AggregateIdGeneratorFactory found for [$materializedKey]'s AggregateIdGenerator."
+                )
         }
+    }
 
     /**
      * Generates a unique ID string for the given [key].

--- a/wow-core/src/test/kotlin/me/ahoo/wow/id/AggregateIdGeneratorRegistrarTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/id/AggregateIdGeneratorRegistrarTest.kt
@@ -26,4 +26,34 @@ internal class AggregateIdGeneratorRegistrarTest {
         id.assert().isNotNull()
         AggregateIdGeneratorRegistrar[namedAggregate].assert().isNotNull
     }
+
+    @Test
+    fun `should materialize key when initialize generator`() {
+        val contextName = generateGlobalId()
+        val aggregateName = generateGlobalId()
+        val namedAggregate = object : me.ahoo.wow.api.modeling.NamedAggregate {
+            override val contextName: String = contextName
+            override val aggregateName: String = aggregateName
+        }
+        val materialized = MaterializedNamedAggregate(contextName, aggregateName)
+
+        val idGenerator = AggregateIdGeneratorRegistrar.getOrInitialize(namedAggregate)
+
+        AggregateIdGeneratorRegistrar[materialized].assert().isSameAs(idGenerator)
+    }
+
+    @Test
+    fun `should materialize key when query generator`() {
+        val contextName = generateGlobalId()
+        val aggregateName = generateGlobalId()
+        val namedAggregate = object : me.ahoo.wow.api.modeling.NamedAggregate {
+            override val contextName: String = contextName
+            override val aggregateName: String = aggregateName
+        }
+
+        val idGenerator = AggregateIdGeneratorRegistrar.getOrInitialize(namedAggregate)
+
+        AggregateIdGeneratorRegistrar[namedAggregate].assert().isSameAs(idGenerator)
+        AggregateIdGeneratorRegistrar.containsKey(namedAggregate).assert().isTrue()
+    }
 }


### PR DESCRIPTION
Split from #2645.

This PR materializes aggregate-id-generator cache keys consistently for initialization and map-style lookups.

Verification:
- ./gradlew :wow-core:test --tests "me.ahoo.wow.id.AggregateIdGeneratorRegistrarTest"