### PR TITLE
fix(core): require scope prefix boundary

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/configuration/ScopeSearcher.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/configuration/ScopeSearcher.kt
@@ -71,7 +71,7 @@ interface ScopeSearcher<V : Any> : SortedMap<String, V> {
         }
 
         forEach {
-            if (scope.startsWith(it.key)) {
+            if (scope.startsWith("${it.key}.")) {
                 return it.value
             }
         }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/configuration/MetadataSearcherTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/configuration/MetadataSearcherTest.kt
@@ -68,4 +68,20 @@ internal class MetadataSearcherTest {
             )
         }
     }
+
+    @Test
+    fun `should not match sibling package prefix as scope`() {
+        val metadata = WowMetadata(
+            mapOf(
+                "context" to BoundedContext(
+                    aggregates = mapOf(
+                        "foo" to Aggregate(scopes = setOf("me.ahoo.foo")),
+                    ),
+                ),
+            ),
+        )
+        val searcher = metadata.toScopeNamedAggregateSearcher()
+
+        searcher.search("me.ahoo.foobar.Command").assert().isNull()
+    }
 }


### PR DESCRIPTION
Split from #2645.

This PR prevents scope lookup from matching sibling package prefixes.

Verification:
- ./gradlew :wow-core:test --tests "me.ahoo.wow.configuration.MetadataSearcherTest"