### PR TITLE
fix(core): harden accessor edge cases

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/constructor/ObjectFactory.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/constructor/ObjectFactory.kt
@@ -15,7 +15,8 @@ package me.ahoo.wow.infra.accessor.constructor
 import me.ahoo.wow.ioc.ServiceProvider
 import me.ahoo.wow.ioc.getRequiredService
 import java.lang.reflect.Constructor
-import kotlin.reflect.KParameter
+import kotlin.reflect.KType
+import kotlin.reflect.full.starProjectedType
 import kotlin.reflect.full.valueParameters
 import kotlin.reflect.jvm.kotlinFunction
 
@@ -61,7 +62,12 @@ class InjectableObjectFactory<T : Any>(
         serviceProvider,
     )
 
-    private val parameters: List<KParameter> = constructorAccessor.constructor.kotlinFunction!!.valueParameters
+    private val parameterTypes: List<KType> =
+        constructorAccessor.constructor.kotlinFunction?.valueParameters?.map {
+            it.type
+        } ?: constructorAccessor.constructor.parameterTypes.map {
+            it.kotlin.starProjectedType
+        }
 
     /**
      * Creates a new instance by resolving all constructor parameters from the service provider.
@@ -79,9 +85,9 @@ class InjectableObjectFactory<T : Any>(
      * ```
      */
     override fun newInstance(): T {
-        val args = parameters
+        val args = parameterTypes
             .map {
-                serviceProvider.getRequiredService<Any>(it.type)
+                serviceProvider.getRequiredService<Any>(it)
             }.toTypedArray()
         return constructorAccessor.invoke(args)
     }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/function/reactive/BlockingMonoFunctionAccessor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/accessor/function/reactive/BlockingMonoFunctionAccessor.kt
@@ -63,8 +63,10 @@ class BlockingMonoFunctionAccessor<T, D : Any>(
  * @return a Mono that will execute on an appropriate thread for blocking operations
  */
 fun <T : Any> Mono<T>.toBlockable(scheduler: Scheduler = Schedulers.boundedElastic()): Mono<T> {
-    if (Schedulers.isInNonBlockingThread()) {
-        return this.subscribeOn(scheduler)
+    return Mono.defer {
+        if (Schedulers.isInNonBlockingThread()) {
+            return@defer this.subscribeOn(scheduler)
+        }
+        this
     }
-    return this
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/infra/accessor/constructor/InjectableObjectFactoryTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/infra/accessor/constructor/InjectableObjectFactoryTest.kt
@@ -15,6 +15,7 @@ package me.ahoo.wow.infra.accessor.constructor
 
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.ioc.SimpleServiceProvider
+import me.ahoo.wow.ioc.register
 import org.junit.jupiter.api.Test
 
 internal class InjectableObjectFactoryTest {
@@ -40,6 +41,18 @@ internal class InjectableObjectFactoryTest {
         val mockServiceWithInject = injectableObjectFactory.newInstance()
         mockServiceWithInject.assert().isNotNull()
         mockServiceWithInject.injectService.assert().isEqualTo(injectService)
+    }
+
+    @Test
+    fun `should create java instance with inject`() {
+        val serviceProvider = SimpleServiceProvider()
+        val bytes = "java".toByteArray()
+        serviceProvider.register<ByteArray>(bytes)
+
+        val injectableObjectFactory =
+            InjectableObjectFactory(String::class.java.getConstructor(ByteArray::class.java), serviceProvider)
+
+        injectableObjectFactory.newInstance().assert().isEqualTo("java")
     }
 }
 

--- a/wow-core/src/test/kotlin/me/ahoo/wow/infra/accessor/function/reactive/BlockingMonoFunctionAccessorTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/infra/accessor/function/reactive/BlockingMonoFunctionAccessorTest.kt
@@ -39,6 +39,17 @@ class BlockingMonoFunctionAccessorTest {
                 it.assert().doesNotStartWith("boundedElastic")
             }.verifyComplete()
     }
+
+    @Test
+    fun `should switch to bounded elastic when subscribed from non blocking thread`() {
+        val blockingMonoMethodAccessor = BlockingMethod::blocking.toMonoFunctionAccessor<BlockingMethod, String>()
+        blockingMonoMethodAccessor.invoke(BlockingMethod())
+            .subscribeOn(Schedulers.parallel())
+            .test()
+            .consumeNextWith {
+                it.assert().startsWith("boundedElastic")
+            }.verifyComplete()
+    }
 }
 
 class BlockingMethod {


### PR DESCRIPTION
Split from #2645.

This PR supports Java constructor injection fallback parameter types and defers blocking Mono scheduler decisions to subscription time.

Verification:
- ./gradlew :wow-core:test --tests "me.ahoo.wow.infra.accessor.constructor.InjectableObjectFactoryTest" --tests "me.ahoo.wow.infra.accessor.function.reactive.BlockingMonoFunctionAccessorTest"