### PR TITLE
fix(core): harden reactive dispatcher lifecycle

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
@@ -113,7 +113,9 @@ class DefaultCommandGateway(
      */
     override fun send(message: CommandMessage<*>): Mono<Void> {
         return check(message)
-            .then(commandBus.send(message))
+            .thenDefer {
+                commandBus.send(message)
+            }
             .doOnSuccess {
                 val waitStrategy = message.header.extractWaitStrategy() ?: return@doOnSuccess
                 val waitSignal = message.commandSentSignal(waitStrategy.waitCommandId)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/event/dispatcher/AbstractEventDispatcher.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/event/dispatcher/AbstractEventDispatcher.kt
@@ -58,4 +58,9 @@ abstract class AbstractEventDispatcher<E : MessageExchange<*, *>, BUS : MessageB
     override fun receiveMessage(namedAggregate: NamedAggregate): Flux<E> {
         return messageBus.receive(setOf(namedAggregate))
     }
+
+    internal fun stopAggregateDispatchersGracefully(): Mono<Void> = super.stopGracefully()
+
+    override fun stopGracefully(): Mono<Void> =
+        stopAggregateDispatchersGracefully().then(schedulerSupplier.stopGracefully())
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/event/dispatcher/CompositeEventDispatcher.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/event/dispatcher/CompositeEventDispatcher.kt
@@ -133,6 +133,9 @@ open class CompositeEventDispatcher(
      * @return A [Mono] that completes when both dispatchers have stopped gracefully.
      */
     override fun stopGracefully(): Mono<Void> {
-        return Mono.`when`(eventStreamDispatcher.stopGracefully(), stateEventDispatcher.stopGracefully())
+        return Mono.`when`(
+            eventStreamDispatcher.stopAggregateDispatchersGracefully(),
+            stateEventDispatcher.stopAggregateDispatchersGracefully()
+        ).then(schedulerSupplier.stopGracefully())
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/event/dispatcher/DomainEventFunctionFilter.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/event/dispatcher/DomainEventFunctionFilter.kt
@@ -66,6 +66,6 @@ open class DomainEventFunctionFilter(
         return eventFunction
             .invoke(exchange)
             .checkpoint("Invoke ${eventFunction.qualifiedName} [DomainEventFunctionFilter]")
-            .then(next.filter(exchange))
+            .then(Mono.defer { next.filter(exchange) })
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/dispatcher/SnapshotDispatcher.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/dispatcher/SnapshotDispatcher.kt
@@ -28,6 +28,7 @@ import me.ahoo.wow.messaging.handler.ExchangeAck.filterThenAck
 import me.ahoo.wow.scheduler.AggregateSchedulerSupplier
 import me.ahoo.wow.scheduler.DefaultAggregateSchedulerSupplier
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 internal const val SNAPSHOT_PROCESSOR_NAME = "SnapshotDispatcher"
 
@@ -71,4 +72,7 @@ class SnapshotDispatcher(
             scheduler = schedulerSupplier.getOrInitialize(namedAggregate),
         )
     }
+
+    override fun stopGracefully(): Mono<Void> =
+        super.stopGracefully().then(schedulerSupplier.stopGracefully())
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/dispatcher/SnapshotFunctionFilter.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/dispatcher/SnapshotFunctionFilter.kt
@@ -30,6 +30,6 @@ class SnapshotFunctionFilter(private val snapshotStrategy: SnapshotStrategy) : E
         return snapshotStrategy.onEvent(exchange)
             .checkpoint("OnEvent Message[${exchange.message.id}] [SnapshotFunctionFilter]")
             .finallyAck(exchange)
-            .then(next.filter(exchange))
+            .then(Mono.defer { next.filter(exchange) })
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/SendStateEventFilter.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/SendStateEventFilter.kt
@@ -72,7 +72,7 @@ class SendStateEventFilter(
             stateEventBus.send(stateEvent)
                 .checkpoint("Send Message[${eventStream.id}] [SendStateEventFilter]")
                 .logErrorResume()
-                .then(next.filter(exchange))
+                .then(Mono.defer { next.filter(exchange) })
         }
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/AggregateDispatcher.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/AggregateDispatcher.kt
@@ -215,7 +215,9 @@ abstract class AggregateDispatcher<T : MessageExchange<*, *>> :
             .metrics()
             .concatMap { exchange ->
                 activeTaskCounter.incrementAndGet()
-                handleExchange(exchange).doFinally {
+                Mono.defer {
+                    handleExchange(exchange)
+                }.doFinally {
                     val remaining = activeTaskCounter.decrementAndGet()
                     if (isDisposed && remaining <= 0) {
                         log.info {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/MainDispatcher.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/MainDispatcher.kt
@@ -114,7 +114,7 @@ abstract class MainDispatcher<T : Any> : MessageDispatcher {
      * and metrics context. This property is initialized on first access to avoid
      * unnecessary resource allocation.
      */
-    protected val aggregateDispatchers by lazy {
+    private val aggregateDispatchersLazy = lazy {
         namedAggregates
             .map {
                 val messageFlux =
@@ -124,6 +124,9 @@ abstract class MainDispatcher<T : Any> : MessageDispatcher {
                 newAggregateDispatcher(it, messageFlux)
             }
     }
+
+    protected val aggregateDispatchers: List<MessageDispatcher>
+        get() = aggregateDispatchersLazy.value
 
     private fun String.withNamePrefix(): String = "[$name][${this@MainDispatcher.javaClass.simpleName}] $this"
 
@@ -162,6 +165,9 @@ abstract class MainDispatcher<T : Any> : MessageDispatcher {
     override fun stopGracefully(): Mono<Void> {
         log.info {
             "Stop Gracefully.".withNamePrefix()
+        }
+        if (!aggregateDispatchersLazy.isInitialized()) {
+            return Mono.empty()
         }
         return Flux
             .fromIterable(aggregateDispatchers)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/handler/ExchangeAck.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/handler/ExchangeAck.kt
@@ -23,6 +23,11 @@ import reactor.core.publisher.Mono
  * regardless of processing success or failure.
  */
 object ExchangeAck {
+    private fun MessageExchange<*, *>.acknowledgeDefer(): Mono<Void> =
+        Mono.defer {
+            acknowledge()
+        }
+
     /**
      * Ensures the exchange is acknowledged after Mono completion, even on error.
      *
@@ -34,9 +39,9 @@ object ExchangeAck {
      */
     fun Mono<*>.finallyAck(exchange: MessageExchange<*, *>): Mono<Void> =
         onErrorResume {
-            exchange.acknowledge()
+            exchange.acknowledgeDefer()
                 .then(Mono.error(it))
-        }.then(exchange.acknowledge())
+        }.then(exchange.acknowledgeDefer())
 
     /**
      * Ensures the exchange is acknowledged after Flux completion, even on error.
@@ -49,9 +54,9 @@ object ExchangeAck {
      */
     fun Flux<*>.finallyAck(exchange: MessageExchange<*, *>): Mono<Void> =
         onErrorResume {
-            exchange.acknowledge()
+            exchange.acknowledgeDefer()
                 .then(Mono.error(it))
-        }.then(exchange.acknowledge())
+        }.then(exchange.acknowledgeDefer())
 
     /**
      * Filters the flux and acknowledges exchanges that don't match the predicate.

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/AggregateProcessorFilter.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/AggregateProcessorFilter.kt
@@ -45,6 +45,6 @@ class AggregateProcessorFilter(
                 "[${aggregateProcessor.aggregateId}] Process Command[${exchange.message.id}] [AggregateProcessorFilter]"
             )
             .finallyAck(exchange)
-            .then(next.filter(exchange))
+            .then(Mono.defer { next.filter(exchange) })
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/CommandDispatcher.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/CommandDispatcher.kt
@@ -25,6 +25,7 @@ import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.scheduler.AggregateSchedulerSupplier
 import me.ahoo.wow.scheduler.DefaultAggregateSchedulerSupplier
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 /**
  * Command Dispatcher .
@@ -63,4 +64,7 @@ class CommandDispatcher(
             scheduler = schedulerSupplier.getOrInitialize(namedAggregate),
         )
     }
+
+    override fun stopGracefully(): Mono<Void> =
+        super.stopGracefully().then(schedulerSupplier.stopGracefully())
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt
@@ -19,7 +19,6 @@ import me.ahoo.wow.api.annotation.Order
 import me.ahoo.wow.command.ServerCommandExchange
 import me.ahoo.wow.event.DomainEventBus
 import me.ahoo.wow.filter.FilterChain
-import me.ahoo.wow.messaging.function.logErrorResume
 import reactor.core.publisher.Mono
 
 @Order(ORDER_LAST, after = [AggregateProcessorFilter::class])
@@ -42,8 +41,7 @@ class SendDomainEventStreamFilter(
             }
             domainEventBus.send(eventStream)
                 .checkpoint("Send Message[${eventStream.id}] [SendDomainEventStreamFilter]")
-                .logErrorResume()
-                .then(next.filter(exchange))
+                .then(Mono.defer { next.filter(exchange) })
         }
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTest.kt
@@ -15,6 +15,7 @@ package me.ahoo.wow.command
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import me.ahoo.test.asserts.assert
 import me.ahoo.test.asserts.assertThrownBy
 import me.ahoo.wow.api.command.validation.CommandValidator
@@ -25,10 +26,12 @@ import me.ahoo.wow.command.wait.SimpleWaitStrategyRegistrar
 import me.ahoo.wow.command.wait.stage.WaitingForStage
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.infra.idempotency.DefaultAggregateIdempotencyCheckerProvider
+import me.ahoo.wow.infra.idempotency.IdempotencyChecker
 import me.ahoo.wow.tck.command.CommandGatewaySpec
 import me.ahoo.wow.tck.mock.MockVoidCommand
 import me.ahoo.wow.test.validation.TestValidator
 import org.junit.jupiter.api.Test
+import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
 import reactor.kotlin.test.test
 import java.time.Duration
@@ -95,6 +98,32 @@ internal class DefaultCommandGatewayTest : CommandGatewaySpec() {
             .verify()
         Thread.sleep(10)
         waitStrategyRegistrar.contains(message.commandId).assert().isFalse()
+    }
+
+    @Test
+    fun `should not send command when idempotency check fails`() {
+        val commandBus = mockk<CommandBus> {
+            every { send(any()) } returns Mono.empty()
+        }
+        val commandGateway = DefaultCommandGateway(
+            commandWaitEndpoint = SimpleCommandWaitEndpoint(""),
+            commandBus = commandBus,
+            validator = TestValidator,
+            idempotencyCheckerProvider = DefaultAggregateIdempotencyCheckerProvider {
+                IdempotencyChecker { Mono.just(false) }
+            },
+            waitStrategyRegistrar = waitStrategyRegistrar,
+            commandWaitNotifier = LocalCommandWaitNotifier(SimpleWaitStrategyRegistrar)
+        )
+
+        commandGateway.send(createMessage())
+            .test()
+            .expectError(DuplicateRequestIdException::class.java)
+            .verify()
+
+        verify(exactly = 0) {
+            commandBus.send(any())
+        }
     }
 
     class MockCommandBody : CommandValidator {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/event/DomainEventDispatcherTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/event/DomainEventDispatcherTest.kt
@@ -12,6 +12,7 @@
  */
 package me.ahoo.wow.event
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.Version
 import me.ahoo.wow.api.messaging.function.FunctionKind
 import me.ahoo.wow.api.modeling.NamedAggregate
@@ -20,6 +21,7 @@ import me.ahoo.wow.event.dispatcher.DefaultDomainEventHandler
 import me.ahoo.wow.event.dispatcher.DomainEventDispatcher
 import me.ahoo.wow.event.dispatcher.DomainEventFunctionFilter
 import me.ahoo.wow.event.dispatcher.DomainEventFunctionRegistrar
+import me.ahoo.wow.event.dispatcher.DomainEventHandler
 import me.ahoo.wow.eventsourcing.state.InMemoryStateEventBus
 import me.ahoo.wow.eventsourcing.state.StateEventBus
 import me.ahoo.wow.filter.FilterChainBuilder
@@ -28,13 +30,17 @@ import me.ahoo.wow.ioc.SimpleServiceProvider
 import me.ahoo.wow.messaging.function.MessageFunction
 import me.ahoo.wow.metrics.Metrics.metrizable
 import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.scheduler.AggregateSchedulerSupplier
 import me.ahoo.wow.tck.mock.MockAggregateChanged
 import me.ahoo.wow.tck.mock.MockAggregateCreated
 import me.ahoo.wow.test.aggregate.GivenInitializationCommand
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Mono
 import reactor.core.publisher.Sinks
+import reactor.core.scheduler.Scheduler
+import reactor.core.scheduler.Schedulers
 import java.time.Duration
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.LockSupport
 
 internal class DomainEventDispatcherTest {
@@ -42,6 +48,30 @@ internal class DomainEventDispatcherTest {
     private val domainEventBus: DomainEventBus = InMemoryDomainEventBus()
     private val stateEventBus: StateEventBus = InMemoryStateEventBus()
     private val functionRegistrar = DomainEventFunctionRegistrar()
+
+    @Test
+    fun `should stop scheduler supplier gracefully`() {
+        val schedulerSupplier = RecordingAggregateSchedulerSupplier()
+        val functionRegistrar = DomainEventFunctionRegistrar()
+        functionRegistrar.registerProcessor(NoOpMessageFunction(namedAggregate))
+        val domainEventProcessor = DomainEventDispatcher(
+            name = "test.DomainEventProcessor",
+            domainEventBus = InMemoryDomainEventBus(),
+            stateEventBus = InMemoryStateEventBus(),
+            functionRegistrar = functionRegistrar,
+            eventHandler = object : DomainEventHandler {
+                override fun handle(context: DomainEventExchange<*>): Mono<Void> {
+                    return Mono.empty()
+                }
+            },
+            schedulerSupplier = schedulerSupplier,
+        )
+
+        domainEventProcessor.start()
+        domainEventProcessor.stopGracefully().block(Duration.ofSeconds(5))
+
+        schedulerSupplier.stopped.get().assert().isTrue()
+    }
 
     @Test
     fun `should run`() {
@@ -100,5 +130,43 @@ internal class DomainEventDispatcherTest {
 
         LockSupport.parkNanos(Duration.ofSeconds(1).toNanos())
         domainEventProcessor.close()
+    }
+
+    private class NoOpMessageFunction(
+        private val namedAggregate: NamedAggregate,
+    ) : MessageFunction<Any, DomainEventExchange<*>, Mono<*>> {
+        override val contextName: String
+            get() = namedAggregate.contextName
+        override val name: String
+            get() = "noop"
+        override val supportedType: Class<*>
+            get() = Any::class.java
+        override val processor: Any
+            get() = this
+        override val functionKind: FunctionKind
+            get() = FunctionKind.EVENT
+        override val supportedTopics: Set<NamedAggregate>
+            get() = setOf(namedAggregate)
+
+        override fun <A : Annotation> getAnnotation(annotationClass: Class<A>): A? {
+            return null
+        }
+
+        override fun invoke(exchange: DomainEventExchange<*>): Mono<*> {
+            return Mono.empty<Void>()
+        }
+    }
+
+    private class RecordingAggregateSchedulerSupplier : AggregateSchedulerSupplier {
+        val stopped = AtomicBoolean()
+        private val scheduler = Schedulers.newSingle("recording-domain-event-dispatcher")
+
+        override fun getOrInitialize(namedAggregate: NamedAggregate): Scheduler = scheduler
+
+        override fun stopGracefully(): Mono<Void> =
+            Mono.fromRunnable {
+                stopped.set(true)
+                scheduler.dispose()
+            }
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/event/dispatcher/EventStreamDispatcherLifecycleTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/event/dispatcher/EventStreamDispatcherLifecycleTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.event.dispatcher
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.messaging.function.FunctionKind
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.configuration.requiredNamedAggregate
+import me.ahoo.wow.event.DomainEventExchange
+import me.ahoo.wow.event.InMemoryDomainEventBus
+import me.ahoo.wow.messaging.function.MessageFunction
+import me.ahoo.wow.scheduler.AggregateSchedulerSupplier
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Scheduler
+import reactor.core.scheduler.Schedulers
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal class EventStreamDispatcherLifecycleTest {
+    private val namedAggregate = EventStreamDispatcherLifecycleTest::class.java.requiredNamedAggregate()
+
+    @org.junit.jupiter.api.Test
+    fun `should stop scheduler supplier gracefully`() {
+        val schedulerSupplier = RecordingAggregateSchedulerSupplier()
+        val functionRegistrar = DomainEventFunctionRegistrar()
+        functionRegistrar.registerProcessor(NoOpMessageFunction(namedAggregate))
+        val eventStreamDispatcher = EventStreamDispatcher(
+            name = "test.EventStreamDispatcher",
+            parallelism = 1,
+            messageBus = InMemoryDomainEventBus(),
+            functionRegistrar = functionRegistrar,
+            eventHandler = object : EventHandler {
+                override fun handle(context: DomainEventExchange<*>): Mono<Void> {
+                    return Mono.empty()
+                }
+            },
+            schedulerSupplier = schedulerSupplier,
+        )
+
+        eventStreamDispatcher.start()
+        eventStreamDispatcher.stopGracefully().block(Duration.ofSeconds(5))
+
+        schedulerSupplier.stopped.get().assert().isTrue()
+    }
+
+    private class NoOpMessageFunction(
+        private val namedAggregate: NamedAggregate,
+    ) : MessageFunction<Any, DomainEventExchange<*>, Mono<*>> {
+        override val contextName: String
+            get() = namedAggregate.contextName
+        override val name: String
+            get() = "noop"
+        override val supportedType: Class<*>
+            get() = Any::class.java
+        override val processor: Any
+            get() = this
+        override val functionKind: FunctionKind
+            get() = FunctionKind.EVENT
+        override val supportedTopics: Set<NamedAggregate>
+            get() = setOf(namedAggregate)
+
+        override fun <A : Annotation> getAnnotation(annotationClass: Class<A>): A? {
+            return null
+        }
+
+        override fun invoke(exchange: DomainEventExchange<*>): Mono<*> {
+            return Mono.empty<Void>()
+        }
+    }
+
+    private class RecordingAggregateSchedulerSupplier : AggregateSchedulerSupplier {
+        val stopped = AtomicBoolean()
+        private val scheduler = Schedulers.newSingle("recording-event-stream-dispatcher")
+
+        override fun getOrInitialize(namedAggregate: NamedAggregate): Scheduler = scheduler
+
+        override fun stopGracefully(): Mono<Void> =
+            Mono.fromRunnable {
+                stopped.set(true)
+                scheduler.dispose()
+            }
+    }
+}

--- a/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotDispatcherTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotDispatcherTest.kt
@@ -13,12 +13,14 @@
 
 package me.ahoo.wow.eventsourcing.snapshot
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.event.toDomainEventStream
 import me.ahoo.wow.eventsourcing.snapshot.dispatcher.DefaultSnapshotHandler
 import me.ahoo.wow.eventsourcing.snapshot.dispatcher.SnapshotDispatcher
 import me.ahoo.wow.eventsourcing.snapshot.dispatcher.SnapshotFunctionFilter
+import me.ahoo.wow.eventsourcing.snapshot.dispatcher.SnapshotHandler
 import me.ahoo.wow.eventsourcing.state.InMemoryStateEventBus
 import me.ahoo.wow.eventsourcing.state.StateEvent.Companion.toStateEvent
 import me.ahoo.wow.eventsourcing.state.StateEventExchange
@@ -27,6 +29,7 @@ import me.ahoo.wow.id.GlobalIdGenerator
 import me.ahoo.wow.metrics.Metrics.metrizable
 import me.ahoo.wow.modeling.aggregateId
 import me.ahoo.wow.modeling.materialize
+import me.ahoo.wow.scheduler.AggregateSchedulerSupplier
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import me.ahoo.wow.tck.mock.MockAggregateCreated
 import me.ahoo.wow.tck.mock.MockStateAggregate
@@ -35,7 +38,11 @@ import org.junit.jupiter.api.Test
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.core.publisher.Sinks
+import reactor.core.scheduler.Scheduler
+import reactor.core.scheduler.Schedulers
 import reactor.kotlin.test.test
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicBoolean
 
 internal class SnapshotDispatcherTest {
     protected val aggregateMetadata = MOCK_AGGREGATE_METADATA
@@ -103,5 +110,39 @@ internal class SnapshotDispatcherTest {
             .verifyComplete()
 
         snapshotDispatcher.close()
+    }
+
+    @Test
+    fun `should stop scheduler supplier gracefully`() {
+        val schedulerSupplier = RecordingAggregateSchedulerSupplier()
+        val snapshotDispatcher = SnapshotDispatcher(
+            name = "test",
+            namedAggregates = setOf(aggregateMetadata.materialize()),
+            snapshotHandler = object : SnapshotHandler {
+                override fun handle(context: StateEventExchange<*>): Mono<Void> {
+                    return Mono.empty()
+                }
+            },
+            stateEventBus = InMemoryStateEventBus(),
+            schedulerSupplier = schedulerSupplier,
+        )
+
+        snapshotDispatcher.start()
+        snapshotDispatcher.stopGracefully().block(Duration.ofSeconds(5))
+
+        schedulerSupplier.stopped.get().assert().isTrue()
+    }
+
+    private class RecordingAggregateSchedulerSupplier : AggregateSchedulerSupplier {
+        val stopped = AtomicBoolean()
+        private val scheduler = Schedulers.newSingle("recording-snapshot-dispatcher")
+
+        override fun getOrInitialize(namedAggregate: NamedAggregate): Scheduler = scheduler
+
+        override fun stopGracefully(): Mono<Void> =
+            Mono.fromRunnable {
+                stopped.set(true)
+                scheduler.dispose()
+            }
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/dispatcher/AggregateDispatcherTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/dispatcher/AggregateDispatcherTest.kt
@@ -12,6 +12,7 @@
  */
 package me.ahoo.wow.messaging.dispatcher
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.messaging.Header
 import me.ahoo.wow.api.messaging.Message
 import me.ahoo.wow.api.modeling.NamedAggregate
@@ -24,6 +25,8 @@ import reactor.core.publisher.Mono
 import reactor.core.scheduler.Schedulers
 import java.time.Duration
 import java.util.*
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 internal class AggregateDispatcherTest {
     @Test
@@ -38,8 +41,27 @@ internal class AggregateDispatcherTest {
         testDispatcher.stopGracefully().block(Duration.ofSeconds(5))
     }
 
+    @Test
+    fun `should stop gracefully when handle exchange throws before returning mono`() {
+        val testDispatcher = ThrowingAggregateDispatcher()
+        testDispatcher.start()
+
+        testDispatcher.invoked.await(2, TimeUnit.SECONDS).assert().isTrue()
+
+        testDispatcher.stopGracefully().block(Duration.ofSeconds(1))
+    }
+
     class TestAggregateDispatcher : TestBaseAggregateDispatcher() {
         override fun handleExchange(exchange: TestMessageExchange): Mono<Void> = Mono.empty()
+    }
+
+    class ThrowingAggregateDispatcher : TestBaseAggregateDispatcher() {
+        val invoked = CountDownLatch(1)
+
+        override fun handleExchange(exchange: TestMessageExchange): Mono<Void> {
+            invoked.countDown()
+            throw IllegalStateException("handleExchange")
+        }
     }
 
     abstract class TestBaseAggregateDispatcher : AggregateDispatcher<TestMessageExchange>() {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/dispatcher/MainDispatcherTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/dispatcher/MainDispatcherTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.messaging.dispatcher
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.modeling.materialize
+import me.ahoo.wow.modeling.toNamedAggregate
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+
+internal class MainDispatcherTest {
+    @Test
+    fun `should not initialize aggregate dispatchers when stopping before start`() {
+        val dispatcher = RecordingMainDispatcher()
+
+        dispatcher.stopGracefully().block(Duration.ofSeconds(1))
+
+        dispatcher.receiveCount.get().assert().isEqualTo(0)
+        dispatcher.createCount.get().assert().isEqualTo(0)
+        dispatcher.childStopCount.get().assert().isEqualTo(0)
+    }
+
+    private class RecordingMainDispatcher : MainDispatcher<String>() {
+        val receiveCount = AtomicInteger()
+        val createCount = AtomicInteger()
+        val childStopCount = AtomicInteger()
+
+        override val name: String = "RecordingMainDispatcher"
+        override val namedAggregates: Set<NamedAggregate> = setOf(
+            "test.test".toNamedAggregate().materialize(),
+        )
+
+        override fun receiveMessage(namedAggregate: NamedAggregate): Flux<String> {
+            receiveCount.incrementAndGet()
+            return Flux.never()
+        }
+
+        override fun newAggregateDispatcher(
+            namedAggregate: NamedAggregate,
+            messageFlux: Flux<String>
+        ): MessageDispatcher {
+            createCount.incrementAndGet()
+            return object : MessageDispatcher {
+                override val name: String = "RecordingChildDispatcher"
+
+                override fun start() = Unit
+
+                override fun stopGracefully(): Mono<Void> {
+                    childStopCount.incrementAndGet()
+                    return Mono.empty()
+                }
+            }
+        }
+    }
+}

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/handler/ExchangeAckTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/handler/ExchangeAckTest.kt
@@ -13,6 +13,20 @@ import reactor.kotlin.test.test
 class ExchangeAckTest {
 
     @Test
+    fun `should not mono ack before subscription`() {
+        val exchange = mockk<MessageExchange<*, *>> {
+            every { acknowledge() } returns Mono.empty()
+        }
+
+        val finallyAck = Mono.empty<Void>().finallyAck(exchange)
+
+        verify(exactly = 0) {
+            exchange.acknowledge()
+        }
+        finallyAck.test().verifyComplete()
+    }
+
+    @Test
     fun `should mono finally ack`() {
         val exchange = mockk<MessageExchange<*, *>> {
             every { acknowledge() } returns Mono.empty()
@@ -41,6 +55,20 @@ class ExchangeAckTest {
         verify {
             exchange.acknowledge()
         }
+    }
+
+    @Test
+    fun `should not flux ack before subscription`() {
+        val exchange = mockk<MessageExchange<*, *>> {
+            every { acknowledge() } returns Mono.empty()
+        }
+
+        val finallyAck = Flux.empty<Void>().finallyAck(exchange)
+
+        verify(exactly = 0) {
+            exchange.acknowledge()
+        }
+        finallyAck.test().verifyComplete()
     }
 
     @Test

--- a/wow-core/src/test/kotlin/me/ahoo/wow/modeling/command/dispatcher/CommandDispatcherLifecycleTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/modeling/command/dispatcher/CommandDispatcherLifecycleTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.modeling.command.dispatcher
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.command.CommandMessage
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.command.CommandBus
+import me.ahoo.wow.command.ServerCommandExchange
+import me.ahoo.wow.scheduler.AggregateSchedulerSupplier
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Scheduler
+import reactor.core.scheduler.Schedulers
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal class CommandDispatcherLifecycleTest {
+    @org.junit.jupiter.api.Test
+    fun `should stop scheduler supplier gracefully`() {
+        val schedulerSupplier = RecordingAggregateSchedulerSupplier()
+        val commandDispatcher = CommandDispatcher(
+            namedAggregates = setOf(MOCK_AGGREGATE_METADATA),
+            commandBus = NoOpCommandBus,
+            commandHandler = NoOpCommandHandler,
+            schedulerSupplier = schedulerSupplier,
+        )
+
+        commandDispatcher.start()
+        commandDispatcher.stopGracefully().block(Duration.ofSeconds(5))
+
+        schedulerSupplier.stopped.get().assert().isTrue()
+    }
+
+    private object NoOpCommandBus : CommandBus {
+        override fun send(message: CommandMessage<*>): Mono<Void> = Mono.empty()
+
+        override fun receive(namedAggregates: Set<NamedAggregate>): Flux<ServerCommandExchange<*>> = Flux.never()
+    }
+
+    private object NoOpCommandHandler : CommandHandler {
+        override fun handle(context: ServerCommandExchange<*>): Mono<Void> = Mono.empty()
+    }
+
+    private class RecordingAggregateSchedulerSupplier : AggregateSchedulerSupplier {
+        val stopped = AtomicBoolean()
+        private val scheduler = Schedulers.newSingle("recording-command-dispatcher")
+
+        override fun getOrInitialize(namedAggregate: NamedAggregate): Scheduler = scheduler
+
+        override fun stopGracefully(): Mono<Void> =
+            Mono.fromRunnable {
+                stopped.set(true)
+                scheduler.dispose()
+            }
+    }
+}

--- a/wow-core/src/test/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilterTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilterTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.modeling.command.dispatcher
+
+import io.mockk.Called
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import me.ahoo.wow.command.ServerCommandExchange
+import me.ahoo.wow.event.DomainEventBus
+import me.ahoo.wow.event.MockNamedEvent
+import me.ahoo.wow.event.SimpleDomainEventStream
+import me.ahoo.wow.event.toDomainEvent
+import me.ahoo.wow.filter.FilterChain
+import me.ahoo.wow.id.generateGlobalId
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.Mono
+import reactor.kotlin.test.test
+
+class SendDomainEventStreamFilterTest {
+
+    @Test
+    fun `should propagate domain event bus send failure`() {
+        val error = IllegalStateException("domain event bus failed")
+        val eventStream = MockNamedEvent().toDomainEvent(
+            aggregateId = generateGlobalId(),
+            tenantId = generateGlobalId(),
+            commandId = generateGlobalId(),
+            version = 1,
+        ).let {
+            SimpleDomainEventStream(requestId = generateGlobalId(), body = listOf(it))
+        }
+        val domainEventBus = mockk<DomainEventBus> {
+            every { send(eventStream) } returns Mono.error(error)
+        }
+        val filter = SendDomainEventStreamFilter(domainEventBus)
+        val exchange = mockk<ServerCommandExchange<*>> {
+            every { getEventStream() } returns eventStream
+        }
+        val next = mockk<FilterChain<ServerCommandExchange<*>>> {
+            every { filter(any()) } returns Mono.empty()
+        }
+
+        filter.filter(exchange, next)
+            .test()
+            .expectErrorMatches { it === error }
+            .verify()
+
+        verify {
+            next wasNot Called
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Harden core dispatcher/filter lifecycles so reactive subscriptions are released and terminal paths are acknowledged consistently.
- Add regression coverage for command, event, snapshot, aggregate, and main dispatcher lifecycle behavior.

## Verification
- `git diff --check`
- `./gradlew :wow-core:test --tests "me.ahoo.wow.command.DefaultCommandGatewayTest" --tests "me.ahoo.wow.messaging.handler.ExchangeAckTest" --tests "me.ahoo.wow.messaging.dispatcher.AggregateDispatcherTest" --tests "me.ahoo.wow.messaging.dispatcher.MainDispatcherTest" --tests "me.ahoo.wow.modeling.command.dispatcher.SendDomainEventStreamFilterTest" --tests "me.ahoo.wow.modeling.command.dispatcher.CommandDispatcherLifecycleTest" --tests "me.ahoo.wow.event.DomainEventDispatcherTest" --tests "me.ahoo.wow.event.dispatcher.EventStreamDispatcherLifecycleTest" --tests "me.ahoo.wow.eventsourcing.snapshot.SnapshotDispatcherTest"`
- `./gradlew :wow-core:check`
