### PR TITLE
fix(core): enforce header mutation contracts

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStreamFactory.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStreamFactory.kt
@@ -142,8 +142,12 @@ private fun Iterable<*>.toDomainEvents(
     eventStreamHeader: Header,
     createTime: Long
 ): List<DomainEvent<Any>> {
-    val eventCount = count()
-    return mapIndexed { index, event ->
+    val events = when (this) {
+        is Collection<*> -> this
+        else -> toList()
+    }
+    val eventCount = events.size
+    return events.mapIndexed { index, event ->
         val sequence = (index + DEFAULT_EVENT_SEQUENCE)
         event!!.toDomainEvent(
             id = generateGlobalId(),
@@ -154,8 +158,8 @@ private fun Iterable<*>.toDomainEvents(
             ownerId = ownerId,
             spaceId = spaceId,
             commandId = command.commandId,
-            header = eventStreamHeader.copy(),
+            header = eventStreamHeader,
             createTime = createTime,
         )
-    }.toList()
+    }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/DefaultHeader.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/DefaultHeader.kt
@@ -39,6 +39,19 @@ class DefaultHeader(
         fun empty(): Header = DefaultHeader()
     }
 
+    private val guardedEntries = GuardedMutableEntrySet(delegate.entries, ::checkWritable)
+    private val guardedKeys = GuardedMutableSet(delegate.keys, ::checkWritable)
+    private val guardedValues = GuardedMutableCollection(delegate.values, ::checkWritable)
+
+    override val entries: MutableSet<MutableMap.MutableEntry<String, String>>
+        get() = guardedEntries
+
+    override val keys: MutableSet<String>
+        get() = guardedKeys
+
+    override val values: MutableCollection<String>
+        get() = guardedValues
+
     /**
      * Makes this header read-only and returns it.
      *
@@ -68,10 +81,14 @@ class DefaultHeader(
      * @return The result of the block execution
      * @throws UnsupportedOperationException if the header is read-only
      */
-    private inline fun <T> write(block: () -> T): T {
+    private fun checkWritable() {
         if (isReadOnly) {
             throw UnsupportedOperationException("Header is read only.")
         }
+    }
+
+    private inline fun <T> write(block: () -> T): T {
+        checkWritable()
         return block()
     }
 
@@ -144,13 +161,157 @@ class DefaultHeader(
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (other !is DefaultHeader) return false
-        return delegate == other.delegate
+        if (other !is Map<*, *>) return false
+        return delegate == other
     }
 
     override fun hashCode(): Int = delegate.hashCode()
 
     override fun toString(): String = "DefaultHeader(delegate=$delegate)"
+
+    private open class GuardedMutableCollection<T>(
+        private val delegate: MutableCollection<T>,
+        private val checkWritable: () -> Unit
+    ) : MutableCollection<T> {
+        override val size: Int
+            get() = delegate.size
+
+        override fun add(element: T): Boolean {
+            checkWritable()
+            return delegate.add(element)
+        }
+
+        override fun addAll(elements: Collection<T>): Boolean {
+            checkWritable()
+            return delegate.addAll(elements)
+        }
+
+        override fun clear() {
+            checkWritable()
+            delegate.clear()
+        }
+
+        override fun contains(element: T): Boolean = delegate.contains(element)
+
+        override fun containsAll(elements: Collection<T>): Boolean = delegate.containsAll(elements)
+
+        override fun isEmpty(): Boolean = delegate.isEmpty()
+
+        override fun iterator(): MutableIterator<T> =
+            GuardedMutableIterator(delegate.iterator(), checkWritable) { it }
+
+        override fun remove(element: T): Boolean {
+            checkWritable()
+            return delegate.remove(element)
+        }
+
+        override fun removeAll(elements: Collection<T>): Boolean {
+            checkWritable()
+            return delegate.removeAll(elements)
+        }
+
+        override fun retainAll(elements: Collection<T>): Boolean {
+            checkWritable()
+            return delegate.retainAll(elements)
+        }
+    }
+
+    private class GuardedMutableSet<T>(
+        delegate: MutableSet<T>,
+        checkWritable: () -> Unit
+    ) : GuardedMutableCollection<T>(delegate, checkWritable),
+        MutableSet<T>
+
+    private class GuardedMutableEntrySet(
+        private val delegate: MutableSet<MutableMap.MutableEntry<String, String>>,
+        private val checkWritable: () -> Unit
+    ) : MutableSet<MutableMap.MutableEntry<String, String>> {
+        override val size: Int
+            get() = delegate.size
+
+        override fun add(element: MutableMap.MutableEntry<String, String>): Boolean {
+            checkWritable()
+            return delegate.add(element)
+        }
+
+        override fun addAll(elements: Collection<MutableMap.MutableEntry<String, String>>): Boolean {
+            checkWritable()
+            return delegate.addAll(elements)
+        }
+
+        override fun clear() {
+            checkWritable()
+            delegate.clear()
+        }
+
+        override fun contains(element: MutableMap.MutableEntry<String, String>): Boolean = delegate.contains(element)
+
+        override fun containsAll(elements: Collection<MutableMap.MutableEntry<String, String>>): Boolean =
+            delegate.containsAll(elements)
+
+        override fun isEmpty(): Boolean = delegate.isEmpty()
+
+        override fun iterator(): MutableIterator<MutableMap.MutableEntry<String, String>> =
+            GuardedMutableIterator(delegate.iterator(), checkWritable) {
+                GuardedMutableEntry(it, checkWritable)
+            }
+
+        override fun remove(element: MutableMap.MutableEntry<String, String>): Boolean {
+            checkWritable()
+            return delegate.remove(element)
+        }
+
+        override fun removeAll(elements: Collection<MutableMap.MutableEntry<String, String>>): Boolean {
+            checkWritable()
+            return delegate.removeAll(elements)
+        }
+
+        override fun retainAll(elements: Collection<MutableMap.MutableEntry<String, String>>): Boolean {
+            checkWritable()
+            return delegate.retainAll(elements)
+        }
+    }
+
+    private class GuardedMutableIterator<T>(
+        private val delegate: MutableIterator<T>,
+        private val checkWritable: () -> Unit,
+        private val wrap: (T) -> T
+    ) : MutableIterator<T> {
+        override fun hasNext(): Boolean = delegate.hasNext()
+
+        override fun next(): T = wrap(delegate.next())
+
+        override fun remove() {
+            checkWritable()
+            delegate.remove()
+        }
+    }
+
+    private class GuardedMutableEntry(
+        private val delegate: MutableMap.MutableEntry<String, String>,
+        private val checkWritable: () -> Unit
+    ) : MutableMap.MutableEntry<String, String> {
+        override val key: String
+            get() = delegate.key
+        override val value: String
+            get() = delegate.value
+
+        override fun setValue(newValue: String): String {
+            checkWritable()
+            return delegate.setValue(newValue)
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (other !is Map.Entry<*, *>) {
+                return false
+            }
+            return key == other.key && value == other.value
+        }
+
+        override fun hashCode(): Int = key.hashCode() xor value.hashCode()
+
+        override fun toString(): String = "$key=$value"
+    }
 }
 
 /**

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/SimpleCommandMessageTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/SimpleCommandMessageTest.kt
@@ -18,4 +18,30 @@ class SimpleCommandMessageTest {
         command.isReadOnly.assert().isEqualTo(true)
         command.ownerId.assert().isEqualTo(ownerId)
     }
+
+    @Test
+    fun `should create command message with supplied header`() {
+        val header = DefaultHeader.empty().with("source", "original")
+
+        val command = MockCreateCommand(GlobalIdGenerator.generateAsString()).toCommandMessage(header = header)
+        header["source"] = "mutated"
+
+        command.header.assert().isSameAs(header)
+        command.header["source"].assert().isEqualTo("mutated")
+        command.withReadOnly()
+        header.isReadOnly.assert().isTrue()
+    }
+
+    @Test
+    fun `should copy command message with independent header`() {
+        val command = MockCreateCommand(GlobalIdGenerator.generateAsString()).toCommandMessage(
+            header = DefaultHeader.empty().with("source", "original")
+        )
+        val copied = command.copy()
+        copied.header["source"] = "mutated"
+        command.withReadOnly()
+
+        command.header["source"].assert().isEqualTo("original")
+        copied.header["source"].assert().isEqualTo("mutated")
+    }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/event/DomainEventFactoryTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/event/DomainEventFactoryTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.event
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.messaging.DefaultHeader
+import org.junit.jupiter.api.Test
+
+internal class DomainEventFactoryTest {
+    @Test
+    fun `should create domain event with supplied header`() {
+        val header = DefaultHeader.empty().with("source", "original")
+
+        val event = MockNamedEvent().toDomainEvent(
+            aggregateId = "id",
+            tenantId = "tenant",
+            commandId = "command",
+            header = header,
+        )
+        header["source"] = "mutated"
+
+        event.header.assert().isSameAs(header)
+        event.header["source"].assert().isEqualTo("mutated")
+    }
+}

--- a/wow-core/src/test/kotlin/me/ahoo/wow/event/DomainEventStreamFactoryKtTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/event/DomainEventStreamFactoryKtTest.kt
@@ -1,6 +1,9 @@
 package me.ahoo.wow.event
 
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.command.MockCreateCommand
+import me.ahoo.wow.command.toCommandMessage
+import me.ahoo.wow.messaging.DefaultHeader
 import org.junit.jupiter.api.Test
 
 class DomainEventStreamFactoryKtTest {
@@ -21,5 +24,44 @@ class DomainEventStreamFactoryKtTest {
     fun `should flat event other`() {
         val flat = Any().flatEvent().toList()
         flat.size.assert().isEqualTo(1)
+    }
+
+    @Test
+    fun `should create event stream from one shot iterable`() {
+        val events = OneShotEvents(listOf(MockNamedEvent(), MockNamedEvent()))
+
+        val eventStream = events.toDomainEventStream(MockCreateCommand("id").toCommandMessage())
+
+        eventStream.body.assert().hasSize(2)
+    }
+
+    @Test
+    fun `should create event stream with supplied header`() {
+        val header = DefaultHeader.empty().with("source", "original")
+
+        val eventStream = MockNamedEvent().toDomainEventStream(
+            upstream = MockCreateCommand("id").toCommandMessage(),
+            header = header,
+        )
+        header["source"] = "mutated"
+
+        eventStream.header.assert().isSameAs(header)
+        eventStream.first().header.assert().isSameAs(header)
+        eventStream.header["source"].assert().isEqualTo("mutated")
+        eventStream.first().header["source"].assert().isEqualTo("mutated")
+    }
+
+    private class OneShotEvents(
+        private val events: List<Any>
+    ) : Iterable<Any> {
+        private var consumed = false
+
+        override fun iterator(): Iterator<Any> {
+            if (consumed) {
+                return emptyList<Any>().iterator()
+            }
+            consumed = true
+            return events.iterator()
+        }
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/DefaultHeaderTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/DefaultHeaderTest.kt
@@ -37,6 +37,16 @@ internal class DefaultHeaderTest {
     }
 
     @Test
+    fun `should use supplied mutable map when constructing header`() {
+        val values = mutableMapOf(KEY to VALUE)
+
+        val header = DefaultHeader(values)
+        values[KEY] = "changed"
+
+        header[KEY].assert().isEqualTo("changed")
+    }
+
+    @Test
     fun `should be empty when header has no entries`() {
         val values = HashMap<String, String>()
         val header = values.toHeader()
@@ -115,6 +125,13 @@ internal class DefaultHeaderTest {
     }
 
     @Test
+    fun `should implement map equals contract`() {
+        val header = DefaultHeader(mutableMapOf(KEY to VALUE))
+
+        header.assert().isEqualTo(mapOf(KEY to VALUE))
+    }
+
+    @Test
     fun `should return zero hashCode for empty header`() {
         DefaultHeader.empty().hashCode().assert().isEqualTo(0)
     }
@@ -176,6 +193,50 @@ internal class DefaultHeaderTest {
         assertThrownBy<UnsupportedOperationException> {
             header.putAll(mapOf(KEY to VALUE))
         }
+    }
+
+    @Test
+    fun `should throw UnsupportedOperationException on readonly header view operations`() {
+        val header = DefaultHeader(mutableMapOf(KEY to VALUE)).withReadOnly()
+
+        assertThrownBy<UnsupportedOperationException> {
+            header.keys.remove(KEY)
+        }
+        assertThrownBy<UnsupportedOperationException> {
+            header.values.remove(VALUE)
+        }
+        assertThrownBy<UnsupportedOperationException> {
+            header.entries.clear()
+        }
+        assertThrownBy<UnsupportedOperationException> {
+            header.entries.first().setValue("changed")
+        }
+        header[KEY].assert().isEqualTo(VALUE)
+    }
+
+    @Test
+    fun `should throw UnsupportedOperationException on captured header view operations after readonly`() {
+        val header = DefaultHeader(mutableMapOf(KEY to VALUE))
+        val keys = header.keys
+        val values = header.values
+        val entries = header.entries
+        val entry = entries.first()
+
+        header.withReadOnly()
+
+        assertThrownBy<UnsupportedOperationException> {
+            keys.remove(KEY)
+        }
+        assertThrownBy<UnsupportedOperationException> {
+            values.remove(VALUE)
+        }
+        assertThrownBy<UnsupportedOperationException> {
+            entries.clear()
+        }
+        assertThrownBy<UnsupportedOperationException> {
+            entry.setValue("changed")
+        }
+        header[KEY].assert().isEqualTo(VALUE)
     }
 
     companion object {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunctionTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunctionTest.kt
@@ -129,6 +129,42 @@ class StatelessSagaFunctionTest {
         sentBodyTypes.assert().containsSequence(MockCreateAggregate::class.java, MockChangeAggregate::class.java)
     }
 
+    @Test
+    fun `should send returned command message when saga returns command message`() {
+        val returnedCommand = MockCreateAggregate("", "").toCommandMessage()
+        val sentCommands = mutableListOf<CommandMessage<*>>()
+        val commandGateway = mockk<CommandGateway> {
+            every { send(any<CommandMessage<*>>()) } answers {
+                val sentCommand = firstArg<CommandMessage<*>>()
+                sentCommand.withReadOnly()
+                sentCommands.add(sentCommand)
+                Mono.empty()
+            }
+        }
+        val delegate = object : MessageFunction<Any, DomainEventExchange<*>, Mono<*>> {
+            override val contextName: String = "context"
+            override val name: String = "onEvent"
+            override val processor: Any = "processor"
+            override val supportedType: Class<*> = MockAggregateCreated::class.java
+            override val supportedTopics = emptySet<me.ahoo.wow.api.modeling.NamedAggregate>()
+            override val functionKind: FunctionKind = FunctionKind.EVENT
+            override fun <A : Annotation> getAnnotation(annotationClass: Class<A>): A? = null
+            override fun invoke(exchange: DomainEventExchange<*>): Mono<*> = Mono.just(returnedCommand)
+        }
+        val statelessSagaFunction = StatelessSagaFunction(delegate, commandGateway, mockk())
+        val upstream = MockCreateAggregate(generateGlobalId(), "data").toCommandMessage()
+        val event = MockAggregateCreated("data").toDomainEventStream(
+            upstream = upstream,
+            aggregateVersion = 1,
+        ).body.first()
+
+        statelessSagaFunction.invoke(SimpleDomainEventExchange(event)).block(Duration.ofSeconds(5))
+
+        sentCommands.assert().hasSize(1)
+        sentCommands.first().assert().isSameAs(returnedCommand)
+        returnedCommand.isReadOnly.assert().isTrue()
+    }
+
     class MockSaga {
         @Suppress("UNUSED_PARAMETER")
         @OnEvent

--- a/wow-core/src/test/kotlin/me/ahoo/wow/serialization/JsonSerializerTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/serialization/JsonSerializerTest.kt
@@ -85,6 +85,20 @@ internal class JsonSerializerTest {
     }
 
     @Test
+    fun `should deserialize event stream with shared stream header`() {
+        val namedAggregate = requiredNamedAggregate<MockCreateAggregate>()
+        val eventStream = MockDomainEventStreams.generateEventStream(
+            aggregateId = namedAggregate.aggregateId(tenantId = generateGlobalId()),
+            eventCount = 1,
+        )
+
+        val input = eventStream.toJsonString().toObject<DomainEventStream>()
+        input.first().header["polluted"] = "true"
+
+        input.header["polluted"].assert().isEqualTo("true")
+    }
+
+    @Test
     fun `should deep copy event stream`() {
         val namedAggregate = requiredNamedAggregate<MockCreateAggregate>()
         val eventStream = MockDomainEventStreams.generateEventStream(


### PR DESCRIPTION
## Summary
- Enforce `Header` read-only behavior through `keys`, `values`, and `entries` views, including views captured before `withReadOnly()` is called.
- Preserve existing factory ownership contracts by using supplied headers instead of adding defensive copies at command/event/event-stream creation boundaries.
- Keep the documented `toHeader()` copy for ordinary maps while avoiding an extra constructor-level map copy.
- Preserve one-shot iterable support in event stream creation without forcing extra copies for existing collections.

## Changes
- **Messaging headers**
  - `DefaultHeader` now exposes guarded mutable views that check read-only state on write operations.
  - `DefaultHeader` construction uses the supplied mutable delegate; `Map.toHeader()` remains the copy boundary for ordinary maps.
  - Map equality behavior remains aligned with the `Map` contract.
- **Command/event creation**
  - Command, domain event, event stream, saga-returned command, and serialized event stream paths now follow the existing supplied-header contract instead of creating additional defensive header copies.
- **Tests**
  - Adds regression coverage for read-only header view mutation, captured views after `withReadOnly()`, supplied-header ownership, `copy()` header independence, and one-shot event iterables.

## Testing
- `git diff --check`
- `./gradlew :wow-core:test --tests "me.ahoo.wow.command.SimpleCommandMessageTest" --tests "me.ahoo.wow.event.DomainEventFactoryTest" --tests "me.ahoo.wow.event.DomainEventStreamFactoryKtTest" --tests "me.ahoo.wow.messaging.DefaultHeaderTest" --tests "me.ahoo.wow.saga.stateless.StatelessSagaFunctionTest" --tests "me.ahoo.wow.serialization.JsonSerializerTest"`
- `./gradlew :wow-core:check`

## Risk & Compatibility
- Low risk; this preserves the target branch's factory behavior of using supplied headers while strengthening read-only enforcement.
- Code that mutates a header after passing it into a factory will continue to mutate the resulting message header until the message/header is marked read-only.
- No configuration changes or migration requirements identified from the diff.

## Review Notes
- Review the guarded `DefaultHeader` view implementations and the supplied-header ownership tests closely.
