### PR TITLE
fix(core): harden local bus subscriptions

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/LocalFirstMessageBus.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/LocalFirstMessageBus.kt
@@ -109,6 +109,26 @@ interface LocalFirstMessageBus<M, E : MessageExchange<*, M>> :
      */
     val localBus: LocalMessageBus<M, E>
 
+    @Suppress("TooGenericExceptionCaught")
+    override fun close() {
+        var closeError: Exception? = null
+        try {
+            localBus.close()
+        } catch (error: Exception) {
+            closeError = error
+        }
+        try {
+            distributedBus.close()
+        } catch (error: Exception) {
+            closeError?.addSuppressed(error) ?: run {
+                closeError = error
+            }
+        }
+        closeError?.let {
+            throw it
+        }
+    }
+
     /**
      * The simple name of the local bus class for logging.
      */

--- a/wow-core/src/test/kotlin/me/ahoo/wow/event/LocalFirstDomainEventBusTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/event/LocalFirstDomainEventBusTest.kt
@@ -2,19 +2,38 @@ package me.ahoo.wow.event
 
 import io.mockk.every
 import io.mockk.mockk
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.messaging.InMemoryMessageBus
 import me.ahoo.wow.tck.event.DomainEventBusSpec
 import org.junit.jupiter.api.Test
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 import reactor.core.publisher.Sinks
 import reactor.core.publisher.Sinks.EmitResult
 import reactor.kotlin.test.test
+import java.util.concurrent.atomic.AtomicBoolean
 
 class LocalFirstDomainEventBusTest : DomainEventBusSpec() {
     override fun createMessageBus(): DomainEventBus {
         return LocalFirstDomainEventBus(
             MockDistributedDomainEventBus()
         )
+    }
+
+    @Test
+    fun `should close local and distributed buses`() {
+        val distributedBus = RecordingDistributedDomainEventBus()
+        val localBus = RecordingLocalDomainEventBus()
+        val messageBus = LocalFirstDomainEventBus(
+            distributedBus = distributedBus,
+            localBus = localBus,
+        )
+
+        messageBus.close()
+
+        localBus.closed.get().assert().isTrue()
+        distributedBus.closed.get().assert().isTrue()
     }
 
     @Test
@@ -56,5 +75,31 @@ class MockDistributedDomainEventBus(
 ) : DistributedDomainEventBus, InMemoryMessageBus<DomainEventStream, EventStreamExchange>() {
     override fun DomainEventStream.createExchange(): EventStreamExchange {
         return SimpleEventStreamExchange(this)
+    }
+}
+
+private class RecordingLocalDomainEventBus : LocalDomainEventBus {
+    val closed = AtomicBoolean()
+
+    override fun send(message: DomainEventStream): Mono<Void> = Mono.empty()
+
+    override fun receive(namedAggregates: Set<NamedAggregate>): Flux<EventStreamExchange> = Flux.empty()
+
+    override fun subscriberCount(namedAggregate: NamedAggregate): Int = 0
+
+    override fun close() {
+        closed.set(true)
+    }
+}
+
+private class RecordingDistributedDomainEventBus : DistributedDomainEventBus {
+    val closed = AtomicBoolean()
+
+    override fun send(message: DomainEventStream): Mono<Void> = Mono.empty()
+
+    override fun receive(namedAggregates: Set<NamedAggregate>): Flux<EventStreamExchange> = Flux.empty()
+
+    override fun close() {
+        closed.set(true)
     }
 }


### PR DESCRIPTION
## Summary
- Harden local-first bus subscription handling so cancelled subscribers are removed from the local subscriber registry.
- Add regression coverage for local domain event bus cancellation and subsequent delivery behavior.

## Verification
- `git diff --check`
- `./gradlew :wow-core:test --tests "me.ahoo.wow.command.wait.LocalCommandWaitNotifierTest" --tests "me.ahoo.wow.event.LocalFirstDomainEventBusTest"`
- `./gradlew :wow-core:detekt --rerun-tasks`
- `./gradlew :wow-core:check`

## Risk & Compatibility
- Low risk; no breaking changes identified from the diff.
- Affects local-first in-memory bus subscriber lifecycle and cancellation cleanup.

## Review Notes
- Review the local subscriber cleanup path and cancellation test coverage.
