### PR TITLE
test(webflux): add real-scenario tests with example-domain

### DIFF
--- a/wow-webflux/build.gradle.kts
+++ b/wow-webflux/build.gradle.kts
@@ -6,4 +6,5 @@ dependencies {
     api("org.springframework:spring-webflux")
     testImplementation("org.springframework:spring-test")
     testImplementation(project(":wow-tck"))
+    testImplementation(project(":example-domain"))
 }

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/RouterFunctionBuilderTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/RouterFunctionBuilderTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.route
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.eventsourcing.EventSourcingStateAggregateRepository
+import me.ahoo.wow.eventsourcing.InMemoryEventStore
+import me.ahoo.wow.eventsourcing.snapshot.NoOpSnapshotRepository
+import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory
+import me.ahoo.wow.openapi.aggregate.state.LoadAggregateRouteSpec
+import me.ahoo.wow.openapi.context.OpenAPIComponentContext
+import me.ahoo.wow.openapi.metadata.aggregateRouteMetadata
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
+import me.ahoo.wow.webflux.exception.DefaultRequestExceptionHandler
+import me.ahoo.wow.webflux.route.state.LoadAggregateHandlerFunctionFactory
+import org.junit.jupiter.api.Test
+
+class RouteHandlerFunctionRegistrarTest {
+
+    @Test
+    fun `should register factory and retrieve by spec type`() {
+        val registrar = RouteHandlerFunctionRegistrar()
+        val stateRepository = EventSourcingStateAggregateRepository(
+            stateAggregateFactory = ConstructorStateAggregateFactory,
+            snapshotRepository = NoOpSnapshotRepository,
+            eventStore = InMemoryEventStore(),
+        )
+        val factory = LoadAggregateHandlerFunctionFactory(
+            stateAggregateRepository = stateRepository,
+            exceptionHandler = DefaultRequestExceptionHandler,
+        )
+        registrar.register(factory)
+
+        val loadAggregateSpec = LoadAggregateRouteSpec(
+            MOCK_AGGREGATE_METADATA,
+            aggregateRouteMetadata = MOCK_AGGREGATE_METADATA.command.aggregateType.aggregateRouteMetadata(),
+            componentContext = OpenAPIComponentContext.default()
+        )
+
+        val found = registrar.getFactory(loadAggregateSpec)
+        found.assert().isNotNull()
+        found.assert().isSameAs(factory)
+        @Suppress("UNCHECKED_CAST")
+        val handlerFunction = (found as RouteHandlerFunctionFactory<LoadAggregateRouteSpec>).create(loadAggregateSpec)
+        handlerFunction.assert().isNotNull()
+    }
+
+    @Test
+    fun `should return null for unregistered spec type`() {
+        val registrar = RouteHandlerFunctionRegistrar()
+        val loadAggregateSpec = LoadAggregateRouteSpec(
+            MOCK_AGGREGATE_METADATA,
+            aggregateRouteMetadata = MOCK_AGGREGATE_METADATA.command.aggregateType.aggregateRouteMetadata(),
+            componentContext = OpenAPIComponentContext.default()
+        )
+        registrar.getFactory(loadAggregateSpec).assert().isNull()
+    }
+
+    @Test
+    fun `should overwrite factory when registering same spec type`() {
+        val registrar = RouteHandlerFunctionRegistrar()
+        val stateRepository = EventSourcingStateAggregateRepository(
+            stateAggregateFactory = ConstructorStateAggregateFactory,
+            snapshotRepository = NoOpSnapshotRepository,
+            eventStore = InMemoryEventStore(),
+        )
+        val factory1 = LoadAggregateHandlerFunctionFactory(
+            stateAggregateRepository = stateRepository,
+            exceptionHandler = DefaultRequestExceptionHandler,
+        )
+        val factory2 = LoadAggregateHandlerFunctionFactory(
+            stateAggregateRepository = stateRepository,
+            exceptionHandler = DefaultRequestExceptionHandler,
+        )
+        registrar.register(factory1)
+        registrar.register(factory2)
+
+        val loadAggregateSpec = LoadAggregateRouteSpec(
+            MOCK_AGGREGATE_METADATA,
+            aggregateRouteMetadata = MOCK_AGGREGATE_METADATA.command.aggregateType.aggregateRouteMetadata(),
+            componentContext = OpenAPIComponentContext.default()
+        )
+
+        val found = registrar.getFactory(loadAggregateSpec)
+        found.assert().isSameAs(factory2)
+    }
+}
+
+class RouterFunctionBuilderTest {
+
+    @Test
+    fun `should build router function with manually provided specs`() {
+        val registrar = RouteHandlerFunctionRegistrar()
+        val stateRepository = EventSourcingStateAggregateRepository(
+            stateAggregateFactory = ConstructorStateAggregateFactory,
+            snapshotRepository = NoOpSnapshotRepository,
+            eventStore = InMemoryEventStore(),
+        )
+        registrar.register(
+            LoadAggregateHandlerFunctionFactory(
+                stateAggregateRepository = stateRepository,
+                exceptionHandler = DefaultRequestExceptionHandler,
+            )
+        )
+
+        val aggregateRouteMetadata = MOCK_AGGREGATE_METADATA.command.aggregateType.aggregateRouteMetadata()
+        val loadAggregateSpec = LoadAggregateRouteSpec(
+            MOCK_AGGREGATE_METADATA,
+            aggregateRouteMetadata = aggregateRouteMetadata,
+            componentContext = OpenAPIComponentContext.default()
+        )
+
+        // Use RouterSpecs with manual route addition via iterable constructor
+        val routerSpecs = me.ahoo.wow.openapi.RouterSpecs(
+            MOCK_AGGREGATE_METADATA,
+            routes = mutableListOf(loadAggregateSpec),
+        )
+        val builder = RouterFunctionBuilder(routerSpecs, registrar)
+        val routerFunction = builder.build()
+        routerFunction.assert().isNotNull()
+    }
+}

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CartCommandFacadeHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CartCommandFacadeHandlerFunctionTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.route.command
+
+import com.sun.security.auth.UserPrincipal
+import io.mockk.spyk
+import io.mockk.verify
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.command.CommandGateway
+import me.ahoo.wow.command.factory.SimpleCommandBuilderRewriterRegistry
+import me.ahoo.wow.command.factory.SimpleCommandMessageFactory
+import me.ahoo.wow.command.validation.NoOpValidator
+import me.ahoo.wow.command.wait.CommandStage
+import me.ahoo.wow.example.api.cart.AddCartItem
+import me.ahoo.wow.example.domain.cart.Cart
+import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.openapi.aggregate.command.CommandComponent
+import me.ahoo.wow.openapi.aggregate.command.CommandFacadeRouteSpec
+import me.ahoo.wow.openapi.context.OpenAPIComponentContext
+import me.ahoo.wow.openapi.metadata.aggregateRouteMetadata
+import me.ahoo.wow.serialization.MessageRecords
+import me.ahoo.wow.test.SagaVerifier
+import me.ahoo.wow.webflux.exception.DefaultRequestExceptionHandler
+import me.ahoo.wow.webflux.route.command.extractor.DefaultCommandBuilderExtractor
+import me.ahoo.wow.webflux.route.command.extractor.DefaultCommandMessageExtractor
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.mock.web.reactive.function.server.MockServerRequest
+import reactor.kotlin.core.publisher.toMono
+import reactor.kotlin.test.test
+import reactor.util.function.Tuples
+
+class CartCommandFacadeHandlerFunctionTest {
+
+    @Test
+    fun `should dispatch AddCartItem via facade using command type header`() {
+        val commandGateway = spyk<CommandGateway>(SagaVerifier.defaultCommandGateway())
+        val cartRouteMetadata = Cart::class.java.aggregateRouteMetadata()
+
+        val handlerFunction = CommandFacadeHandlerFunctionFactory(
+            commandGateway = commandGateway,
+            commandMessageExtractor = DefaultCommandMessageExtractor(
+                SimpleCommandMessageFactory(NoOpValidator, SimpleCommandBuilderRewriterRegistry()),
+                DefaultCommandBuilderExtractor
+            ),
+            exceptionHandler = DefaultRequestExceptionHandler
+        ).create(CommandFacadeRouteSpec(OpenAPIComponentContext.default()))
+
+        val aggregateId = generateGlobalId()
+        val request = MockServerRequest.builder()
+            .method(HttpMethod.POST)
+            .pathVariable(MessageRecords.TENANT_ID, generateGlobalId())
+            .pathVariable(MessageRecords.OWNER_ID, aggregateId)
+            .principal(UserPrincipal(generateGlobalId()))
+            .header(CommandComponent.Header.WAIT_STAGE, CommandStage.SENT.name)
+            .header(CommandComponent.Header.COMMAND_TYPE, AddCartItem::class.java.name)
+            .body(
+                Tuples.of(
+                    AddCartItem(
+                        productId = "product-1",
+                        quantity = 3,
+                    ) as Any,
+                    cartRouteMetadata
+                ).toMono()
+            )
+        handlerFunction.handle(request)
+            .test()
+            .consumeNextWith {
+                it.statusCode().assert().isEqualTo(HttpStatus.OK)
+            }.verifyComplete()
+
+        verify {
+            commandGateway.sendAndWait<Any>(any(), any())
+        }
+    }
+}

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CartCommandHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CartCommandHandlerFunctionTest.kt
@@ -1,0 +1,179 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.route.command
+
+import com.sun.security.auth.UserPrincipal
+import io.mockk.spyk
+import io.mockk.verify
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.command.CommandGateway
+import me.ahoo.wow.command.factory.SimpleCommandBuilderRewriterRegistry
+import me.ahoo.wow.command.factory.SimpleCommandMessageFactory
+import me.ahoo.wow.command.validation.NoOpValidator
+import me.ahoo.wow.command.wait.CommandStage
+import me.ahoo.wow.example.api.cart.AddCartItem
+import me.ahoo.wow.example.api.cart.ChangeQuantity
+import me.ahoo.wow.example.api.cart.RemoveCartItem
+import me.ahoo.wow.example.domain.cart.Cart
+import me.ahoo.wow.example.domain.cart.CartState
+import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.modeling.annotation.aggregateMetadata
+import me.ahoo.wow.openapi.aggregate.command.CommandComponent
+import me.ahoo.wow.openapi.metadata.aggregateRouteMetadata
+import me.ahoo.wow.openapi.metadata.commandRouteMetadata
+import me.ahoo.wow.serialization.MessageRecords
+import me.ahoo.wow.test.SagaVerifier
+import me.ahoo.wow.webflux.exception.DefaultRequestExceptionHandler
+import me.ahoo.wow.webflux.route.command.extractor.DefaultCommandBuilderExtractor
+import me.ahoo.wow.webflux.route.command.extractor.DefaultCommandMessageExtractor
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.mock.web.reactive.function.server.MockServerRequest
+import reactor.kotlin.core.publisher.toMono
+import reactor.kotlin.test.test
+
+class CartCommandHandlerFunctionTest {
+
+    companion object {
+        val CART_AGGREGATE_METADATA = aggregateMetadata<Cart, CartState>()
+        val CART_AGGREGATE_ROUTE_METADATA = Cart::class.java.aggregateRouteMetadata()
+    }
+
+    @Test
+    fun `should send AddCartItem command and return sent stage`() {
+        val commandGateway = spyk<CommandGateway>(SagaVerifier.defaultCommandGateway())
+        val commandRouteMetadata = commandRouteMetadata<AddCartItem>()
+        val handlerFunction = CommandHandlerFunction(
+            CART_AGGREGATE_ROUTE_METADATA,
+            commandRouteMetadata,
+            commandGateway,
+            DefaultCommandMessageExtractor(
+                SimpleCommandMessageFactory(NoOpValidator, SimpleCommandBuilderRewriterRegistry()),
+                DefaultCommandBuilderExtractor
+            ),
+            DefaultRequestExceptionHandler,
+        )
+
+        val aggregateId = generateGlobalId()
+        val request = MockServerRequest.builder()
+            .method(HttpMethod.POST)
+            .pathVariable(MessageRecords.TENANT_ID, generateGlobalId())
+            .pathVariable(MessageRecords.OWNER_ID, aggregateId)
+            .principal(UserPrincipal(generateGlobalId()))
+            .header(CommandComponent.Header.WAIT_STAGE, CommandStage.SENT.name)
+            .body(
+                AddCartItem(
+                    productId = "product-1",
+                    quantity = 2,
+                ).toMono()
+            )
+        handlerFunction.handle(request)
+            .test()
+            .consumeNextWith {
+                it.statusCode().assert().isEqualTo(HttpStatus.OK)
+            }.verifyComplete()
+
+        verify {
+            commandGateway.sendAndWait<Any>(any(), any())
+        }
+    }
+
+    @Test
+    fun `should send ChangeQuantity command through handler`() {
+        val commandGateway = spyk<CommandGateway>(SagaVerifier.defaultCommandGateway())
+        val commandRouteMetadata = commandRouteMetadata<ChangeQuantity>()
+        val handlerFunction = CommandHandlerFunction(
+            CART_AGGREGATE_ROUTE_METADATA,
+            commandRouteMetadata,
+            commandGateway,
+            DefaultCommandMessageExtractor(
+                SimpleCommandMessageFactory(NoOpValidator, SimpleCommandBuilderRewriterRegistry()),
+                DefaultCommandBuilderExtractor
+            ),
+            DefaultRequestExceptionHandler,
+        )
+
+        val aggregateId = generateGlobalId()
+        val request = MockServerRequest.builder()
+            .method(HttpMethod.PUT)
+            .pathVariable(MessageRecords.ID, aggregateId)
+            .pathVariable(MessageRecords.TENANT_ID, generateGlobalId())
+            .pathVariable(MessageRecords.OWNER_ID, aggregateId)
+            .principal(UserPrincipal(generateGlobalId()))
+            .header(CommandComponent.Header.WAIT_STAGE, CommandStage.SENT.name)
+            .body(
+                ChangeQuantity(
+                    productId = "product-1",
+                    quantity = 5,
+                ).toMono()
+            )
+        handlerFunction.handle(request)
+            .test()
+            .consumeNextWith {
+                it.statusCode().assert().isEqualTo(HttpStatus.OK)
+            }.verifyComplete()
+
+        verify {
+            commandGateway.sendAndWait<Any>(any(), any())
+        }
+    }
+
+    @Test
+    fun `should send RemoveCartItem command through handler`() {
+        val commandGateway = spyk<CommandGateway>(SagaVerifier.defaultCommandGateway())
+        val commandRouteMetadata = commandRouteMetadata<RemoveCartItem>()
+        val handlerFunction = CommandHandlerFunction(
+            CART_AGGREGATE_ROUTE_METADATA,
+            commandRouteMetadata,
+            commandGateway,
+            DefaultCommandMessageExtractor(
+                SimpleCommandMessageFactory(NoOpValidator, SimpleCommandBuilderRewriterRegistry()),
+                DefaultCommandBuilderExtractor
+            ),
+            DefaultRequestExceptionHandler,
+        )
+
+        val aggregateId = generateGlobalId()
+        val request = MockServerRequest.builder()
+            .method(HttpMethod.DELETE)
+            .pathVariable(MessageRecords.TENANT_ID, generateGlobalId())
+            .pathVariable(MessageRecords.OWNER_ID, aggregateId)
+            .principal(UserPrincipal(generateGlobalId()))
+            .header(CommandComponent.Header.WAIT_STAGE, CommandStage.SENT.name)
+            .body(
+                RemoveCartItem(
+                    productIds = setOf("product-1"),
+                ).toMono()
+            )
+        handlerFunction.handle(request)
+            .test()
+            .consumeNextWith {
+                it.statusCode().assert().isEqualTo(HttpStatus.OK)
+            }.verifyComplete()
+
+        verify {
+            commandGateway.sendAndWait<Any>(any(), any())
+        }
+    }
+
+    @Test
+    fun `should use AGGREGATE_ID owner to resolve aggregate id from owner id`() {
+        val aggregateRouteMetadata = CART_AGGREGATE_ROUTE_METADATA
+        // Cart uses @AggregateRoute(owner = AGGREGATE_ID), so owner == aggregate ID
+        aggregateRouteMetadata.owner.assert().isEqualTo(
+            me.ahoo.wow.api.annotation.AggregateRoute.Owner.AGGREGATE_ID
+        )
+    }
+}

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/DefaultRewriteRequestConditionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/DefaultRewriteRequestConditionTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.route.query
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.ListQuery
+import me.ahoo.wow.openapi.CommonComponent
+import me.ahoo.wow.openapi.aggregate.command.CommandComponent
+import me.ahoo.wow.serialization.MessageRecords
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.reactive.function.server.MockServerRequest
+
+class DefaultRewriteRequestConditionTest {
+
+    @Test
+    fun `should not rewrite condition when no tenant or owner headers`() {
+        val request = MockServerRequest.builder().build()
+        val originalCondition = Condition("id")
+        val result = DefaultRewriteRequestCondition.rewrite(
+            MOCK_AGGREGATE_METADATA,
+            request,
+            originalCondition
+        )
+        result.assert().isSameAs(originalCondition)
+    }
+
+    @Test
+    fun `should append tenant condition from header`() {
+        val tenantId = "tenant-123"
+        val request = MockServerRequest.builder()
+            .header(CommandComponent.Header.TENANT_ID, tenantId)
+            .build()
+        val originalCondition = Condition("id")
+        val result = DefaultRewriteRequestCondition.rewrite(
+            MOCK_AGGREGATE_METADATA,
+            request,
+            ListQuery(condition = originalCondition)
+        )
+        result.condition.assert().isNotSameAs(originalCondition)
+    }
+
+    @Test
+    fun `should append owner condition from path variable`() {
+        val ownerId = "owner-123"
+        val request = MockServerRequest.builder()
+            .pathVariable(MessageRecords.OWNER_ID, ownerId)
+            .build()
+        val originalCondition = Condition("id")
+        val result = DefaultRewriteRequestCondition.rewrite(
+            MOCK_AGGREGATE_METADATA,
+            request,
+            ListQuery(condition = originalCondition)
+        )
+        result.condition.assert().isNotSameAs(originalCondition)
+    }
+
+    @Test
+    fun `should append space condition from header`() {
+        val spaceId = "space-123"
+        val request = MockServerRequest.builder()
+            .header(CommonComponent.Header.SPACE_ID, spaceId)
+            .build()
+        val originalCondition = Condition("id")
+        val result = DefaultRewriteRequestCondition.rewrite(
+            MOCK_AGGREGATE_METADATA,
+            request,
+            ListQuery(condition = originalCondition)
+        )
+        result.condition.assert().isNotSameAs(originalCondition)
+    }
+}

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractorTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractorTest.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.route.query
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.ListQuery
+import me.ahoo.wow.api.query.PagedQuery
+import me.ahoo.wow.api.query.SingleQuery
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
+import me.ahoo.wow.webflux.exception.DefaultRequestExceptionHandler
+import me.ahoo.wow.webflux.route.RouteTestFixtures
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.reactive.function.server.MockServerRequest
+import reactor.kotlin.core.publisher.toMono
+import reactor.kotlin.test.test
+
+class QueryBodyExtractorTest {
+
+    @Test
+    fun `should extract condition via count handler`() {
+        // Test condition extraction through CountQueryHandlerFunction end-to-end
+        val handlerFunction = CountQueryHandlerFunctionFactory(
+            me.ahoo.wow.openapi.aggregate.snapshot.CountSnapshotRouteSpec::class.java,
+            RouteTestFixtures.snapshotQueryHandler,
+            DefaultRewriteRequestCondition,
+            DefaultRequestExceptionHandler
+        ).create(
+            me.ahoo.wow.openapi.aggregate.snapshot.CountSnapshotRouteSpec(
+                MOCK_AGGREGATE_METADATA,
+                aggregateRouteMetadata = RouteTestFixtures.MOCK_AGGREGATE_ROUTE_METADATA,
+                appendTenantPath = true,
+                appendOwnerPath = false,
+                componentContext = me.ahoo.wow.openapi.context.OpenAPIComponentContext.default()
+            )
+        )
+
+        val request = MockServerRequest.builder()
+            .body(Condition.ALL.toMono())
+
+        handlerFunction.handle(request)
+            .test()
+            .consumeNextWith {
+                it.statusCode().assert().isEqualTo(org.springframework.http.HttpStatus.OK)
+            }.verifyComplete()
+    }
+
+    @Test
+    fun `should extract list query via list handler`() {
+        val handlerFunction = ListQueryHandlerFunctionFactory(
+            me.ahoo.wow.openapi.aggregate.snapshot.ListQuerySnapshotRouteSpec::class.java,
+            RouteTestFixtures.snapshotQueryHandler,
+            DefaultRewriteRequestCondition,
+            DefaultRequestExceptionHandler
+        ).create(
+            me.ahoo.wow.openapi.aggregate.snapshot.ListQuerySnapshotRouteSpec(
+                MOCK_AGGREGATE_METADATA,
+                aggregateRouteMetadata = RouteTestFixtures.MOCK_AGGREGATE_ROUTE_METADATA,
+                appendTenantPath = true,
+                appendOwnerPath = false,
+                componentContext = me.ahoo.wow.openapi.context.OpenAPIComponentContext.default()
+            )
+        )
+
+        val request = MockServerRequest.builder()
+            .body(ListQuery(condition = Condition.ALL).toMono())
+
+        handlerFunction.handle(request)
+            .test()
+            .consumeNextWith {
+                it.statusCode().assert().isEqualTo(org.springframework.http.HttpStatus.OK)
+            }.verifyComplete()
+    }
+
+    @Test
+    fun `should extract paged query via paged handler`() {
+        val handlerFunction = PagedQueryHandlerFunctionFactory(
+            me.ahoo.wow.openapi.aggregate.snapshot.PagedQuerySnapshotRouteSpec::class.java,
+            RouteTestFixtures.snapshotQueryHandler,
+            DefaultRewriteRequestCondition,
+            DefaultRequestExceptionHandler
+        ).create(
+            me.ahoo.wow.openapi.aggregate.snapshot.PagedQuerySnapshotRouteSpec(
+                MOCK_AGGREGATE_METADATA,
+                aggregateRouteMetadata = RouteTestFixtures.MOCK_AGGREGATE_ROUTE_METADATA,
+                appendTenantPath = true,
+                appendOwnerPath = false,
+                componentContext = me.ahoo.wow.openapi.context.OpenAPIComponentContext.default()
+            )
+        )
+
+        val request = MockServerRequest.builder()
+            .body(PagedQuery(condition = Condition.ALL).toMono())
+
+        handlerFunction.handle(request)
+            .test()
+            .consumeNextWith {
+                it.statusCode().assert().isEqualTo(org.springframework.http.HttpStatus.OK)
+            }.verifyComplete()
+    }
+
+    @Test
+    fun `should extract single query and return not found when no data`() {
+        // NoOpSnapshotQueryServiceFactory returns empty for single query,
+        // so throwNotFoundIfEmpty() results in 404 NOT_FOUND.
+        // This tests that the body extraction and query pipeline work correctly.
+        val handlerFunction = SingleQueryHandlerFunctionFactory(
+            me.ahoo.wow.openapi.aggregate.snapshot.SingleSnapshotRouteSpec::class.java,
+            RouteTestFixtures.snapshotQueryHandler,
+            DefaultRewriteRequestCondition,
+            DefaultRequestExceptionHandler
+        ).create(
+            me.ahoo.wow.openapi.aggregate.snapshot.SingleSnapshotRouteSpec(
+                MOCK_AGGREGATE_METADATA,
+                aggregateRouteMetadata = RouteTestFixtures.MOCK_AGGREGATE_ROUTE_METADATA,
+                appendTenantPath = true,
+                appendOwnerPath = false,
+                componentContext = me.ahoo.wow.openapi.context.OpenAPIComponentContext.default()
+            )
+        )
+
+        val request = MockServerRequest.builder()
+            .body(SingleQuery(condition = Condition.ALL).toMono())
+
+        handlerFunction.handle(request)
+            .test()
+            .consumeNextWith {
+                // NoOp returns empty, which triggers throwNotFoundIfEmpty → 404
+                it.statusCode().assert().isEqualTo(org.springframework.http.HttpStatus.NOT_FOUND)
+            }.verifyComplete()
+    }
+}

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/state/CartAggregateTracingHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/state/CartAggregateTracingHandlerFunctionTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.route.state
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.eventsourcing.InMemoryEventStore
+import me.ahoo.wow.example.api.cart.AddCartItem
+import me.ahoo.wow.example.api.cart.CartItemAdded
+import me.ahoo.wow.example.domain.cart.Cart
+import me.ahoo.wow.example.domain.cart.CartState
+import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.modeling.annotation.aggregateMetadata
+import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory
+import me.ahoo.wow.openapi.aggregate.state.AggregateTracingRouteSpec
+import me.ahoo.wow.openapi.context.OpenAPIComponentContext
+import me.ahoo.wow.openapi.metadata.aggregateRouteMetadata
+import me.ahoo.wow.serialization.MessageRecords
+import me.ahoo.wow.test.aggregate.whenCommand
+import me.ahoo.wow.test.aggregateVerifier
+import me.ahoo.wow.webflux.exception.DefaultRequestExceptionHandler
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.mock.web.reactive.function.server.MockServerRequest
+import reactor.kotlin.test.test
+
+class CartAggregateTracingHandlerFunctionTest {
+
+    companion object {
+        val CART_AGGREGATE_METADATA = aggregateMetadata<Cart, CartState>()
+        val CART_AGGREGATE_ROUTE_METADATA = Cart::class.java.aggregateRouteMetadata()
+    }
+
+    @Test
+    fun `should trace cart aggregate events after AddCartItem`() {
+        val eventStore = InMemoryEventStore()
+        val aggregateId = generateGlobalId()
+        aggregateVerifier<Cart, CartState>(aggregateId, eventStore = eventStore)
+            .givenOwnerId(aggregateId)
+            .whenCommand(AddCartItem(productId = "product-1", quantity = 3))
+            .expectNoError()
+            .expectEventType(CartItemAdded::class.java)
+            .verify()
+
+        val handlerFunction = AggregateTracingHandlerFunctionFactory(
+            ConstructorStateAggregateFactory,
+            eventStore,
+            DefaultRequestExceptionHandler
+        ).create(
+            AggregateTracingRouteSpec(
+                CART_AGGREGATE_METADATA,
+                aggregateRouteMetadata = CART_AGGREGATE_ROUTE_METADATA,
+                componentContext = OpenAPIComponentContext.default()
+            )
+        )
+
+        val request = MockServerRequest.builder()
+            .pathVariable(MessageRecords.ID, aggregateId)
+            .pathVariable(MessageRecords.TENANT_ID, me.ahoo.wow.api.modeling.TenantId.DEFAULT_TENANT_ID)
+            .build()
+        handlerFunction.handle(request)
+            .test()
+            .consumeNextWith {
+                it.statusCode().assert().isEqualTo(HttpStatus.OK)
+            }.verifyComplete()
+    }
+}

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/state/CartStateHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/state/CartStateHandlerFunctionTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.route.state
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.eventsourcing.EventSourcingStateAggregateRepository
+import me.ahoo.wow.eventsourcing.InMemoryEventStore
+import me.ahoo.wow.eventsourcing.snapshot.NoOpSnapshotRepository
+import me.ahoo.wow.example.api.cart.AddCartItem
+import me.ahoo.wow.example.api.cart.CartItemAdded
+import me.ahoo.wow.example.domain.cart.Cart
+import me.ahoo.wow.example.domain.cart.CartState
+import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.modeling.annotation.aggregateMetadata
+import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory
+import me.ahoo.wow.openapi.aggregate.state.LoadAggregateRouteSpec
+import me.ahoo.wow.openapi.context.OpenAPIComponentContext
+import me.ahoo.wow.openapi.metadata.aggregateRouteMetadata
+import me.ahoo.wow.serialization.MessageRecords
+import me.ahoo.wow.test.aggregate.whenCommand
+import me.ahoo.wow.test.aggregateVerifier
+import me.ahoo.wow.webflux.exception.DefaultRequestExceptionHandler
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.mock.web.reactive.function.server.MockServerRequest
+import reactor.kotlin.test.test
+import java.net.URI
+
+class CartStateHandlerFunctionTest {
+
+    companion object {
+        val CART_AGGREGATE_METADATA = aggregateMetadata<Cart, CartState>()
+        val CART_AGGREGATE_ROUTE_METADATA = Cart::class.java.aggregateRouteMetadata()
+    }
+
+    @Test
+    fun `should load cart state with items after AddCartItem command`() {
+        val eventStore = InMemoryEventStore()
+        val aggregateId = generateGlobalId()
+        aggregateVerifier<Cart, CartState>(aggregateId, eventStore = eventStore)
+            .givenOwnerId(aggregateId)
+            .whenCommand(AddCartItem(productId = "product-1", quantity = 3))
+            .expectNoError()
+            .expectEventType(CartItemAdded::class.java)
+            .expectState {
+                items.assert().hasSize(1)
+                items[0].productId.assert().isEqualTo("product-1")
+                items[0].quantity.assert().isEqualTo(3)
+            }
+            .verify()
+
+        val handlerFunction = LoadAggregateHandlerFunctionFactory(
+            stateAggregateRepository = EventSourcingStateAggregateRepository(
+                stateAggregateFactory = ConstructorStateAggregateFactory,
+                snapshotRepository = NoOpSnapshotRepository,
+                eventStore = eventStore,
+            ),
+            exceptionHandler = DefaultRequestExceptionHandler,
+        ).create(
+            LoadAggregateRouteSpec(
+                CART_AGGREGATE_METADATA,
+                aggregateRouteMetadata = CART_AGGREGATE_ROUTE_METADATA,
+                componentContext = OpenAPIComponentContext.default()
+            )
+        )
+
+        val request = MockServerRequest.builder()
+            .method(HttpMethod.GET)
+            .uri(URI.create("http://localhost"))
+            .pathVariable(MessageRecords.ID, aggregateId)
+            .pathVariable(MessageRecords.OWNER_ID, aggregateId)
+            .build()
+        handlerFunction.handle(request)
+            .test()
+            .consumeNextWith {
+                it.statusCode().assert().isEqualTo(HttpStatus.OK)
+            }.verifyComplete()
+    }
+
+    @Test
+    fun `should return not found when loading non-existent cart`() {
+        val handlerFunction = LoadAggregateHandlerFunctionFactory(
+            stateAggregateRepository = EventSourcingStateAggregateRepository(
+                stateAggregateFactory = ConstructorStateAggregateFactory,
+                snapshotRepository = NoOpSnapshotRepository,
+                eventStore = InMemoryEventStore(),
+            ),
+            exceptionHandler = DefaultRequestExceptionHandler,
+        ).create(
+            LoadAggregateRouteSpec(
+                CART_AGGREGATE_METADATA,
+                aggregateRouteMetadata = CART_AGGREGATE_ROUTE_METADATA,
+                componentContext = OpenAPIComponentContext.default()
+            )
+        )
+
+        val request = MockServerRequest.builder()
+            .method(HttpMethod.GET)
+            .uri(URI.create("http://localhost"))
+            .pathVariable(MessageRecords.ID, generateGlobalId())
+            .pathVariable(MessageRecords.OWNER_ID, generateGlobalId())
+            .build()
+        handlerFunction.handle(request)
+            .test()
+            .consumeNextWith {
+                it.statusCode().assert().isEqualTo(HttpStatus.NOT_FOUND)
+            }.verifyComplete()
+    }
+}


### PR DESCRIPTION
## Summary

在上一轮 PR #2666 基础上，引入 `example-domain` 依赖补充真实场景测试。

### 变更内容

- **build.gradle.kts**: 添加 `testImplementation(project(":example-domain"))`

### 新增测试文件 (7 个, 20 个测试用例)

| 文件 | 测试数 | 说明 |
|------|--------|------|
| `command/CartCommandHandlerFunctionTest` | 4 | AddCartItem/ChangeQuantity/RemoveCartItem 命令路由 + AGGREGATE_ID owner 验证 |
| `command/CartCommandFacadeHandlerFunctionTest` | 1 | Facade 路由通过 Command-Type header 识别 Cart 命令 |
| `state/CartStateHandlerFunctionTest` | 2 | 真实 CartState 加载（验证 items 列表内容）+ not found 场景 |
| `state/CartAggregateTracingHandlerFunctionTest` | 1 | Cart 聚合事件追踪 |
| `query/QueryBodyExtractorTest` | 4 | count/list/paged/single 查询端到端测试 |
| `query/DefaultRewriteRequestConditionTest` | 4 | tenant/owner/space 条件重写逻辑 |
| `route/RouterFunctionBuilderTest` | 4 | 路由注册/查找/覆盖 + RouterFunction 构建 |

### 真实场景覆盖点

- Cart 聚合使用 `@AggregateRoute(owner = AGGREGATE_ID)` 策略（MockAggregate 不具备）
- 多种命令类型（AddCartItem/ChangeQuantity/RemoveCartItem）路由验证
- 真实 CartState 的 `items` 列表状态断言（MockAggregate 只有 `data: String`）
- Query 包首次覆盖测试
- RouterFunctionBuilder 首次覆盖测试

### 验证

```
./gradlew :wow-webflux:check  # BUILD SUCCESSFUL
```