### PR TITLE
style(openapi): fix detekt formatting violations

### DIFF
--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/OpenAPIExtensionsTest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/OpenAPIExtensionsTest.kt
@@ -16,11 +16,11 @@ package me.ahoo.wow.openapi
 import io.swagger.v3.oas.models.info.Info
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.Wow
+import me.ahoo.wow.naming.MaterializedNamedBoundedContext
 import me.ahoo.wow.openapi.OpenAPIExtensions.WOW_CONTEXT_ALIAS
 import me.ahoo.wow.openapi.OpenAPIExtensions.WOW_CONTEXT_NAME
 import me.ahoo.wow.openapi.OpenAPIExtensions.WOW_VERSION
 import me.ahoo.wow.openapi.OpenAPIExtensions.withExtensions
-import me.ahoo.wow.naming.MaterializedNamedBoundedContext
 import org.junit.jupiter.api.Test
 
 internal class OpenAPIExtensionsTest {

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/aggregate/event/CountEventStreamRouteSpecTest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/aggregate/event/CountEventStreamRouteSpecTest.kt
@@ -29,13 +29,27 @@ internal class CountEventStreamRouteSpecTest {
 
     @Test
     fun `should have get method`() {
-        val spec = CountEventStreamRouteSpec(namedContext, aggregateRouteMetadata, appendTenantPath = false, appendOwnerPath = false, context)
+        val spec =
+            CountEventStreamRouteSpec(
+                namedContext,
+                aggregateRouteMetadata,
+                appendTenantPath = false,
+                appendOwnerPath = false,
+                context
+            )
         spec.method.assert().isEqualTo(Https.Method.POST)
     }
 
     @Test
     fun `should have event path suffix`() {
-        val spec = CountEventStreamRouteSpec(namedContext, aggregateRouteMetadata, appendTenantPath = false, appendOwnerPath = false, context)
+        val spec =
+            CountEventStreamRouteSpec(
+                namedContext,
+                aggregateRouteMetadata,
+                appendTenantPath = false,
+                appendOwnerPath = false,
+                context
+            )
         spec.path.assert().contains("event")
     }
 }

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/aggregate/snapshot/CountSnapshotRouteSpecTest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/aggregate/snapshot/CountSnapshotRouteSpecTest.kt
@@ -29,13 +29,27 @@ internal class CountSnapshotRouteSpecTest {
 
     @Test
     fun `should have get method`() {
-        val spec = CountSnapshotRouteSpec(namedContext, aggregateRouteMetadata, appendTenantPath = false, appendOwnerPath = false, context)
+        val spec =
+            CountSnapshotRouteSpec(
+                namedContext,
+                aggregateRouteMetadata,
+                appendTenantPath = false,
+                appendOwnerPath = false,
+                context
+            )
         spec.method.assert().isEqualTo(Https.Method.POST)
     }
 
     @Test
     fun `should have snapshot count path`() {
-        val spec = CountSnapshotRouteSpec(namedContext, aggregateRouteMetadata, appendTenantPath = false, appendOwnerPath = false, context)
+        val spec =
+            CountSnapshotRouteSpec(
+                namedContext,
+                aggregateRouteMetadata,
+                appendTenantPath = false,
+                appendOwnerPath = false,
+                context
+            )
         spec.path.assert().contains("snapshot")
     }
 }

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/metadata/CommandRouteMetadataParserTest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/metadata/CommandRouteMetadataParserTest.kt
@@ -138,7 +138,6 @@ internal class CommandRouteMetadataParserTest {
         namePathVariable.fieldPath.assert().contains("name")
         namePathVariable.variableType.assert().isNull()
     }
-
 }
 
 @CommandRoute("{id}/{name}", method = CommandRoute.Method.PATCH)


### PR DESCRIPTION
## Summary
- Fix detekt formatting violations in `wow-openapi` test sources.
- Reorder an OpenAPI extension test import and wrap route spec constructor arguments to match detekt rules.

## Changes
- `wow-openapi` tests: update import ordering, constructor argument wrapping, and remove an extra blank line before a closing brace.
- No production code, API, schema, or generated output changes.

## Testing
- `git diff --check -- wow-openapi`
- `./gradlew :wow-openapi:detekt --stacktrace`
- `./gradlew :wow-openapi:test --stacktrace`

## Risk & Compatibility
- Low risk; test-only formatting changes with no runtime behavior or API compatibility impact.

## Review Notes
- No special review notes.