### PR TITLE
refactor(benchmarks): clarify benchmark ids

### DIFF
--- a/wow-benchmarks/build.gradle.kts
+++ b/wow-benchmarks/build.gradle.kts
@@ -27,10 +27,10 @@ val benchmarkSmokeIncludes = listOf(
     "me.ahoo.wow.command.CommandFactoryBenchmark",
     "me.ahoo.wow.command.GlobalIdBenchmark",
     "me.ahoo.wow.messaging.function.MessageFunctionRegistrarBenchmark",
-    "me.ahoo.wow.hotpath.HeaderCreationBenchmark",
-    "me.ahoo.wow.hotpath.MessageWrappingBenchmark",
-    "me.ahoo.wow.hotpath.AggregateIdGenerationBenchmark",
-    "me.ahoo.wow.hotpath.ObjectMapperLookupBenchmark",
+    "me.ahoo.wow.commandpath.CommandHeaderBenchmark",
+    "me.ahoo.wow.commandpath.CommandMessageBenchmark",
+    "me.ahoo.wow.commandpath.CommandAggregateIdBenchmark",
+    "me.ahoo.wow.commandpath.CommandPayloadSerializationBenchmark",
 )
 
 val benchmarkSmokeReport = layout.buildDirectory.file("reports/jmh/benchmark-smoke.json")

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/fixture/BenchmarkCommands.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/fixture/BenchmarkCommands.kt
@@ -39,7 +39,7 @@ object BenchmarkCommands {
         )
     }
 
-    fun hotPathAddCartItem(): CommandMessage<AddCartItem> {
+    fun commandPathAddCartItem(): CommandMessage<AddCartItem> {
         return addCartItem(
             id = BenchmarkIds.nextGlobalId(),
             requestId = BenchmarkIds.nextGlobalId(),

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/scenario/CommandPipelineScenario.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/scenario/CommandPipelineScenario.kt
@@ -85,7 +85,7 @@ class CommandPipelineScenario private constructor(
             stateEventBus: StateEventBus = InMemoryStateEventBus(),
             commandWaitNotifier: CommandWaitNotifier = LocalCommandWaitNotifier(SimpleWaitStrategyRegistrar),
             aggregateMetadata: AggregateMetadata<*, *> = BenchmarkAggregates.cartMetadata,
-            newAggregateCommandFactory: () -> CommandMessage<*> = BenchmarkCommands::hotPathAddCartItem,
+            newAggregateCommandFactory: () -> CommandMessage<*> = BenchmarkCommands::commandPathAddCartItem,
         ): CommandPipelineScenario {
             val stateAggregateRepository: StateAggregateRepository =
                 EventSourcingStateAggregateRepository(

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandAggregateHandlingBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandAggregateHandlingBenchmark.kt
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.hotpath
+package me.ahoo.wow.commandpath
 
 import me.ahoo.wow.benchmark.fixture.BenchmarkAggregates
 import me.ahoo.wow.benchmark.fixture.BenchmarkCommands
@@ -26,11 +26,11 @@ import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.infra.Blackhole
 
 @State(Scope.Benchmark)
-open class CommandHandlingBenchmark {
+open class CommandAggregateHandlingBenchmark {
     private val commandAggregateFactory = SimpleCommandAggregateFactory(NoopEventStore)
 
     @Benchmark
-    fun createAggregateAndHandle(blackhole: Blackhole) {
+    fun createStateAggregateAndApplyEventStream(blackhole: Blackhole) {
         val aggregateId = BenchmarkAggregates.aggregateId()
         val aggregate = ConstructorStateAggregateFactory.create(
             BenchmarkAggregates.cartMetadata.state,
@@ -41,7 +41,7 @@ open class CommandHandlingBenchmark {
     }
 
     @Benchmark
-    fun createAggregateFromEmpty(blackhole: Blackhole) {
+    fun createEmptyStateAggregate(blackhole: Blackhole) {
         val aggregate = ConstructorStateAggregateFactory.create(
             BenchmarkAggregates.cartMetadata.state,
             BenchmarkAggregates.aggregateId(),
@@ -51,7 +51,7 @@ open class CommandHandlingBenchmark {
 
     @Benchmark
     fun createCommandAggregate(blackhole: Blackhole) {
-        val commandMessage = BenchmarkCommands.hotPathAddCartItem()
+        val commandMessage = BenchmarkCommands.commandPathAddCartItem()
         val stateAggregate = ConstructorStateAggregateFactory.create(
             BenchmarkAggregates.cartMetadata.state,
             commandMessage.aggregateId,
@@ -65,7 +65,7 @@ open class CommandHandlingBenchmark {
 
     @Benchmark
     fun processCommandAggregate(blackhole: Blackhole) {
-        val commandMessage = BenchmarkCommands.hotPathAddCartItem()
+        val commandMessage = BenchmarkCommands.commandPathAddCartItem()
         val stateAggregate = ConstructorStateAggregateFactory.create(
             BenchmarkAggregates.cartMetadata.state,
             commandMessage.aggregateId,

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandAggregateIdBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandAggregateIdBenchmark.kt
@@ -11,37 +11,46 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.hotpath
+package me.ahoo.wow.commandpath
 
 import me.ahoo.wow.benchmark.fixture.BenchmarkAggregates
-import me.ahoo.wow.benchmark.fixture.BenchmarkEvents
-import me.ahoo.wow.event.InMemoryDomainEventBus
+import me.ahoo.wow.benchmark.fixture.BenchmarkIds
+import me.ahoo.wow.modeling.DefaultAggregateId
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.Setup
 import org.openjdk.jmh.annotations.State
-import org.openjdk.jmh.annotations.TearDown
 import org.openjdk.jmh.infra.Blackhole
 
 @State(Scope.Benchmark)
-open class EventPublishBenchmark {
-    private lateinit var eventBus: InMemoryDomainEventBus
-    private val eventStream = BenchmarkEvents.singleEventStream()
-
+open class CommandAggregateIdBenchmark {
     @Setup
     fun setup() {
-        eventBus = InMemoryDomainEventBus()
-        eventBus.receive(setOf(BenchmarkAggregates.namedAggregate)).subscribe()
-    }
-
-    @TearDown
-    fun tearDown() {
-        eventBus.close()
+        BenchmarkIds.installDeterministicGlobalIdGenerator()
     }
 
     @Benchmark
-    fun publishEvent(blackhole: Blackhole) {
-        val result = eventBus.send(eventStream).block()
-        blackhole.consume(result)
+    fun generateGlobalId(blackhole: Blackhole) {
+        val id = BenchmarkIds.nextGlobalId()
+        blackhole.consume(id)
+    }
+
+    @Benchmark
+    fun createAggregateId(blackhole: Blackhole) {
+        val aggregateId = DefaultAggregateId(
+            namedAggregate = BenchmarkAggregates.namedAggregate,
+            id = "test-id",
+        )
+        blackhole.consume(aggregateId)
+    }
+
+    @Benchmark
+    fun generateGlobalIdAndCreateAggregateId(blackhole: Blackhole) {
+        val id = BenchmarkIds.nextGlobalId()
+        val aggregateId = DefaultAggregateId(
+            namedAggregate = BenchmarkAggregates.namedAggregate,
+            id = id,
+        )
+        blackhole.consume(aggregateId)
     }
 }

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandAggregateLoadBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandAggregateLoadBenchmark.kt
@@ -11,39 +11,49 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.hotpath
+package me.ahoo.wow.commandpath
 
+import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.benchmark.fixture.BenchmarkAggregates
-import me.ahoo.wow.benchmark.fixture.BenchmarkEvents
+import me.ahoo.wow.eventsourcing.EventSourcingStateAggregateRepository
+import me.ahoo.wow.eventsourcing.InMemoryEventStore
 import me.ahoo.wow.eventsourcing.snapshot.InMemorySnapshotRepository
-import me.ahoo.wow.eventsourcing.snapshot.SimpleSnapshot
-import me.ahoo.wow.eventsourcing.state.StateEvent.Companion.toStateEvent
 import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.Setup
 import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
 import org.openjdk.jmh.infra.Blackhole
 
 @State(Scope.Benchmark)
-open class SnapshotSaveBenchmark {
-    private lateinit var snapshotRepository: InMemorySnapshotRepository
-    private lateinit var snapshot: SimpleSnapshot<*>
+open class CommandAggregateLoadBenchmark {
+    private lateinit var repository: EventSourcingStateAggregateRepository
+    private lateinit var aggregateId: AggregateId
 
     @Setup
     fun setup() {
-        snapshotRepository = InMemorySnapshotRepository()
-        val aggregateId = BenchmarkAggregates.aggregateId()
-        val aggregate = ConstructorStateAggregateFactory.create(
-            BenchmarkAggregates.cartMetadata.state,
-            aggregateId,
+        val eventStore = InMemoryEventStore()
+        repository = EventSourcingStateAggregateRepository(
+            ConstructorStateAggregateFactory,
+            InMemorySnapshotRepository(),
+            eventStore,
         )
-        snapshot = SimpleSnapshot(BenchmarkEvents.singleEventStream(aggregateId).toStateEvent(aggregate))
+        aggregateId = BenchmarkAggregates.aggregateId()
+    }
+
+    @TearDown
+    fun tearDown() {
+        setup()
     }
 
     @Benchmark
-    fun saveSnapshot(blackhole: Blackhole) {
-        val result = snapshotRepository.save(snapshot).block()
-        blackhole.consume(result)
+    fun loadEmptyStateAggregate(blackhole: Blackhole) {
+        val aggregate = repository.load(
+            aggregateId,
+            BenchmarkAggregates.cartMetadata.state,
+            Int.MAX_VALUE,
+        ).block()
+        blackhole.consume(aggregate)
     }
 }

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandEventPublishBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandEventPublishBenchmark.kt
@@ -11,46 +11,37 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.hotpath
+package me.ahoo.wow.commandpath
 
 import me.ahoo.wow.benchmark.fixture.BenchmarkAggregates
-import me.ahoo.wow.benchmark.fixture.BenchmarkIds
-import me.ahoo.wow.modeling.DefaultAggregateId
+import me.ahoo.wow.benchmark.fixture.BenchmarkEvents
+import me.ahoo.wow.event.InMemoryDomainEventBus
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.Setup
 import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
 import org.openjdk.jmh.infra.Blackhole
 
 @State(Scope.Benchmark)
-open class AggregateIdGenerationBenchmark {
+open class CommandEventPublishBenchmark {
+    private lateinit var eventBus: InMemoryDomainEventBus
+    private val eventStream = BenchmarkEvents.singleEventStream()
+
     @Setup
     fun setup() {
-        BenchmarkIds.installDeterministicGlobalIdGenerator()
+        eventBus = InMemoryDomainEventBus()
+        eventBus.receive(setOf(BenchmarkAggregates.namedAggregate)).subscribe()
+    }
+
+    @TearDown
+    fun tearDown() {
+        eventBus.close()
     }
 
     @Benchmark
-    fun generateGlobalId(blackhole: Blackhole) {
-        val id = BenchmarkIds.nextGlobalId()
-        blackhole.consume(id)
-    }
-
-    @Benchmark
-    fun createAggregateId(blackhole: Blackhole) {
-        val aggregateId = DefaultAggregateId(
-            namedAggregate = BenchmarkAggregates.namedAggregate,
-            id = "test-id",
-        )
-        blackhole.consume(aggregateId)
-    }
-
-    @Benchmark
-    fun generateIdAndCreateAggregateId(blackhole: Blackhole) {
-        val id = BenchmarkIds.nextGlobalId()
-        val aggregateId = DefaultAggregateId(
-            namedAggregate = BenchmarkAggregates.namedAggregate,
-            id = id,
-        )
-        blackhole.consume(aggregateId)
+    fun publishDomainEventStream(blackhole: Blackhole) {
+        val result = eventBus.send(eventStream).block()
+        blackhole.consume(result)
     }
 }

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandHeaderBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandHeaderBenchmark.kt
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.hotpath
+package me.ahoo.wow.commandpath
 
 import me.ahoo.wow.benchmark.fixture.BenchmarkHeaders
 import org.openjdk.jmh.annotations.Benchmark
@@ -20,15 +20,15 @@ import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.infra.Blackhole
 
 @State(Scope.Benchmark)
-open class HeaderCreationBenchmark {
+open class CommandHeaderBenchmark {
     @Benchmark
-    fun createEmptyHeader(blackhole: Blackhole) {
+    fun createEmptyCommandHeader(blackhole: Blackhole) {
         val header = BenchmarkHeaders.emptyHeader()
         blackhole.consume(header)
     }
 
     @Benchmark
-    fun createAndMutateHeader(blackhole: Blackhole) {
+    fun createAndMutateCommandHeader(blackhole: Blackhole) {
         val header = BenchmarkHeaders.emptyHeader()
         header["key1"] = "value1"
         header["key2"] = "value2"
@@ -36,7 +36,7 @@ open class HeaderCreationBenchmark {
     }
 
     @Benchmark
-    fun headerReadAfterWrite(blackhole: Blackhole) {
+    fun readCommandHeaderAfterWrite(blackhole: Blackhole) {
         val header = BenchmarkHeaders.emptyHeader()
         header["key"] = "value"
         val value = header["key"]

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandIdempotencyBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandIdempotencyBenchmark.kt
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.hotpath
+package me.ahoo.wow.commandpath
 
 import me.ahoo.wow.benchmark.fixture.BenchmarkIdempotency
 import me.ahoo.wow.id.generateGlobalId
@@ -23,7 +23,7 @@ import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.infra.Blackhole
 
 @State(Scope.Benchmark)
-open class IdempotencyBenchmark {
+open class CommandIdempotencyBenchmark {
     private lateinit var idempotencyChecker: BloomFilterIdempotencyChecker
 
     @Setup
@@ -32,13 +32,13 @@ open class IdempotencyBenchmark {
     }
 
     @Benchmark
-    fun checkNewId(blackhole: Blackhole) {
+    fun checkNewRequestId(blackhole: Blackhole) {
         val result = idempotencyChecker.check(generateGlobalId()).block()
         blackhole.consume(result)
     }
 
     @Benchmark
-    fun checkFixedId(blackhole: Blackhole) {
+    fun checkKnownRequestId(blackhole: Blackhole) {
         val result = idempotencyChecker.check("known-request-id").block()
         blackhole.consume(result)
     }

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandMessageBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandMessageBenchmark.kt
@@ -11,25 +11,35 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.hotpath
+package me.ahoo.wow.commandpath
 
 import me.ahoo.wow.benchmark.fixture.BenchmarkCommands
-import me.ahoo.wow.command.ServerCommandExchange
-import me.ahoo.wow.command.SimpleServerCommandExchange
-import me.ahoo.wow.test.validation.TestValidator
+import me.ahoo.wow.benchmark.fixture.BenchmarkIds
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.infra.Blackhole
 
 @State(Scope.Benchmark)
-open class CommandValidationBenchmark {
-    private val commandMessage = BenchmarkCommands.hotPathAddCartItem()
+open class CommandMessageBenchmark {
+    @Setup
+    fun setup() {
+        BenchmarkIds.installDeterministicGlobalIdGenerator()
+    }
 
     @Benchmark
-    fun validateCommand(blackhole: Blackhole) {
-        val exchange: ServerCommandExchange<*> = SimpleServerCommandExchange(commandMessage)
-        TestValidator.validate(commandMessage.body)
-        blackhole.consume(exchange)
+    fun createCommandMessage(blackhole: Blackhole) {
+        val msg = BenchmarkCommands.newAggregateAddCartItem()
+        blackhole.consume(msg)
+    }
+
+    @Benchmark
+    fun readCommandMessageProperties(blackhole: Blackhole) {
+        val msg = BenchmarkCommands.newAggregateAddCartItem()
+        blackhole.consume(msg.id)
+        blackhole.consume(msg.aggregateId)
+        blackhole.consume(msg.requestId)
+        blackhole.consume(msg.body)
     }
 }

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandPayloadSerializationBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandPayloadSerializationBenchmark.kt
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.hotpath
+package me.ahoo.wow.commandpath
 
 import me.ahoo.wow.serialization.JsonSerializer
 import me.ahoo.wow.serialization.toJsonString
@@ -24,31 +24,31 @@ import org.openjdk.jmh.infra.Blackhole
 data class SmallPayload(val name: String = "test", val value: Int = 42)
 
 @State(Scope.Benchmark)
-open class ObjectMapperLookupBenchmark {
+open class CommandPayloadSerializationBenchmark {
     private val payload = SmallPayload()
     private val preSerialized = payload.toJsonString()
 
     @Benchmark
-    fun serialize(blackhole: Blackhole) {
+    fun serializePayload(blackhole: Blackhole) {
         val json = payload.toJsonString()
         blackhole.consume(json)
     }
 
     @Benchmark
-    fun deserialize(blackhole: Blackhole) {
+    fun deserializePayload(blackhole: Blackhole) {
         val obj = preSerialized.toObject<SmallPayload>()
         blackhole.consume(obj)
     }
 
     @Benchmark
-    fun roundTrip(blackhole: Blackhole) {
+    fun roundTripPayload(blackhole: Blackhole) {
         val json = payload.toJsonString()
         val obj = json.toObject<SmallPayload>()
         blackhole.consume(obj)
     }
 
     @Benchmark
-    fun serializeWithSharedMapper(blackhole: Blackhole) {
+    fun serializePayloadWithSharedMapper(blackhole: Blackhole) {
         val json = JsonSerializer.writeValueAsString(payload)
         blackhole.consume(json)
     }

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandPipelineBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandPipelineBenchmark.kt
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.hotpath
+package me.ahoo.wow.commandpath
 
 import me.ahoo.wow.benchmark.fixture.BenchmarkAggregates
 import me.ahoo.wow.benchmark.fixture.BenchmarkCommands
@@ -38,7 +38,7 @@ import org.openjdk.jmh.annotations.TearDown
 import org.openjdk.jmh.infra.Blackhole
 
 @State(Scope.Benchmark)
-open class CommandProcessingPipelineBenchmark {
+open class CommandPipelineBenchmark {
     private lateinit var commandDispatcherScenario: CommandDispatcherScenario
     private lateinit var commandPipelineScenario: CommandPipelineScenario
 
@@ -79,10 +79,10 @@ open class CommandProcessingPipelineBenchmark {
     }
 
     @Benchmark
-    fun sendAndWaitForProcessed(blackhole: Blackhole) {
+    fun sendCommandAndWaitForProcessed(blackhole: Blackhole) {
         blackhole.consumeWowResult {
             commandDispatcherScenario.commandGateway
-                .sendAndWaitForProcessed(BenchmarkCommands.hotPathAddCartItem())
+                .sendAndWaitForProcessed(BenchmarkCommands.commandPathAddCartItem())
                 .block()
         }
     }
@@ -97,7 +97,7 @@ open class CommandProcessingPipelineBenchmark {
     }
 
     @Benchmark
-    fun handleAggregateOnlyWithoutRetry(blackhole: Blackhole) {
+    fun handleAggregateWithoutRetry(blackhole: Blackhole) {
         blackhole.consumeWowResult {
             commandPipelineScenario.aggregateOnlyWithoutRetryHandler
                 .handle(commandPipelineScenario.createServerExchange())
@@ -106,7 +106,7 @@ open class CommandProcessingPipelineBenchmark {
     }
 
     @Benchmark
-    fun handleAggregateAndDomainEvent(blackhole: Blackhole) {
+    fun handleAggregateAndSendDomainEvent(blackhole: Blackhole) {
         blackhole.consumeWowResult {
             commandPipelineScenario.aggregateAndDomainEventHandler
                 .handle(commandPipelineScenario.createServerExchange())
@@ -115,7 +115,7 @@ open class CommandProcessingPipelineBenchmark {
     }
 
     @Benchmark
-    fun handleAggregateDomainAndStateEvent(blackhole: Blackhole) {
+    fun handleAggregateAndSendDomainStateEvents(blackhole: Blackhole) {
         blackhole.consumeWowResult {
             commandPipelineScenario.aggregateDomainAndStateEventHandler
                 .handle(commandPipelineScenario.createServerExchange())
@@ -124,7 +124,7 @@ open class CommandProcessingPipelineBenchmark {
     }
 
     @Benchmark
-    fun handleAggregateDomainStateAndProcessedNotifierWithoutWait(blackhole: Blackhole) {
+    fun handleAggregateAndNotifyProcessedWithoutWait(blackhole: Blackhole) {
         blackhole.consumeWowResult {
             commandPipelineScenario.aggregateDomainStateAndProcessedNotifierHandler
                 .handle(commandPipelineScenario.createServerExchange())
@@ -133,9 +133,9 @@ open class CommandProcessingPipelineBenchmark {
     }
 
     @Benchmark
-    fun handleAggregateDomainStateAndProcessedNotifierWithLocalWait(blackhole: Blackhole) {
+    fun handleAggregateAndNotifyProcessedWithLocalWait(blackhole: Blackhole) {
         blackhole.consumeWowResult {
-            val commandMessage = BenchmarkCommands.hotPathAddCartItem()
+            val commandMessage = BenchmarkCommands.commandPathAddCartItem()
             val waitStrategy = WaitingForStage.processed(commandMessage.commandId)
             waitStrategy.propagate("", commandMessage.header)
             SimpleWaitStrategyRegistrar.register(waitStrategy)
@@ -151,10 +151,10 @@ open class CommandProcessingPipelineBenchmark {
     }
 
     @Benchmark
-    fun sendFireAndForget(blackhole: Blackhole) {
+    fun sendCommandFireAndForget(blackhole: Blackhole) {
         blackhole.consumeWowResult {
             commandDispatcherScenario.commandGateway
-                .send(BenchmarkCommands.hotPathAddCartItem())
+                .send(BenchmarkCommands.commandPathAddCartItem())
                 .block()
         }
     }

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandSnapshotSaveBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandSnapshotSaveBenchmark.kt
@@ -11,49 +11,39 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.hotpath
+package me.ahoo.wow.commandpath
 
-import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.benchmark.fixture.BenchmarkAggregates
-import me.ahoo.wow.eventsourcing.EventSourcingStateAggregateRepository
-import me.ahoo.wow.eventsourcing.InMemoryEventStore
+import me.ahoo.wow.benchmark.fixture.BenchmarkEvents
 import me.ahoo.wow.eventsourcing.snapshot.InMemorySnapshotRepository
+import me.ahoo.wow.eventsourcing.snapshot.SimpleSnapshot
+import me.ahoo.wow.eventsourcing.state.StateEvent.Companion.toStateEvent
 import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.Setup
 import org.openjdk.jmh.annotations.State
-import org.openjdk.jmh.annotations.TearDown
 import org.openjdk.jmh.infra.Blackhole
 
 @State(Scope.Benchmark)
-open class AggregateLoadingBenchmark {
-    private lateinit var repository: EventSourcingStateAggregateRepository
-    private lateinit var aggregateId: AggregateId
+open class CommandSnapshotSaveBenchmark {
+    private lateinit var snapshotRepository: InMemorySnapshotRepository
+    private lateinit var snapshot: SimpleSnapshot<*>
 
     @Setup
     fun setup() {
-        val eventStore = InMemoryEventStore()
-        repository = EventSourcingStateAggregateRepository(
-            ConstructorStateAggregateFactory,
-            InMemorySnapshotRepository(),
-            eventStore,
+        snapshotRepository = InMemorySnapshotRepository()
+        val aggregateId = BenchmarkAggregates.aggregateId()
+        val aggregate = ConstructorStateAggregateFactory.create(
+            BenchmarkAggregates.cartMetadata.state,
+            aggregateId,
         )
-        aggregateId = BenchmarkAggregates.aggregateId()
-    }
-
-    @TearDown
-    fun tearDown() {
-        setup()
+        snapshot = SimpleSnapshot(BenchmarkEvents.singleEventStream(aggregateId).toStateEvent(aggregate))
     }
 
     @Benchmark
-    fun loadEmptyAggregate(blackhole: Blackhole) {
-        val aggregate = repository.load(
-            aggregateId,
-            BenchmarkAggregates.cartMetadata.state,
-            Int.MAX_VALUE,
-        ).block()
-        blackhole.consume(aggregate)
+    fun saveCommandSnapshot(blackhole: Blackhole) {
+        val result = snapshotRepository.save(snapshot).block()
+        blackhole.consume(result)
     }
 }

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandValidationBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandValidationBenchmark.kt
@@ -11,35 +11,25 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.hotpath
+package me.ahoo.wow.commandpath
 
 import me.ahoo.wow.benchmark.fixture.BenchmarkCommands
-import me.ahoo.wow.benchmark.fixture.BenchmarkIds
+import me.ahoo.wow.command.ServerCommandExchange
+import me.ahoo.wow.command.SimpleServerCommandExchange
+import me.ahoo.wow.test.validation.TestValidator
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.Scope
-import org.openjdk.jmh.annotations.Setup
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.infra.Blackhole
 
 @State(Scope.Benchmark)
-open class MessageWrappingBenchmark {
-    @Setup
-    fun setup() {
-        BenchmarkIds.installDeterministicGlobalIdGenerator()
-    }
+open class CommandValidationBenchmark {
+    private val commandMessage = BenchmarkCommands.commandPathAddCartItem()
 
     @Benchmark
-    fun createCommandMessage(blackhole: Blackhole) {
-        val msg = BenchmarkCommands.newAggregateAddCartItem()
-        blackhole.consume(msg)
-    }
-
-    @Benchmark
-    fun readCommandMessageProperties(blackhole: Blackhole) {
-        val msg = BenchmarkCommands.newAggregateAddCartItem()
-        blackhole.consume(msg.id)
-        blackhole.consume(msg.aggregateId)
-        blackhole.consume(msg.requestId)
-        blackhole.consume(msg.body)
+    fun validateCommand(blackhole: Blackhole) {
+        val exchange: ServerCommandExchange<*> = SimpleServerCommandExchange(commandMessage)
+        TestValidator.validate(commandMessage.body)
+        blackhole.consume(exchange)
     }
 }

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/infrastructure/redis/RedisCommandProcessingPipelineBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/infrastructure/redis/RedisCommandProcessingPipelineBenchmark.kt
@@ -67,7 +67,7 @@ open class RedisCommandProcessingPipelineBenchmark {
     }
 
     @Benchmark
-    fun handleAggregateDomainAndStateEvent(blackHole: Blackhole) {
+    fun handleAggregateAndSendDomainStateEvents(blackHole: Blackhole) {
         blackHole.consumeWowResult {
             commandPipelineScenario.aggregateDomainAndStateEventHandler
                 .handle(commandPipelineScenario.createServerExchange())
@@ -76,7 +76,7 @@ open class RedisCommandProcessingPipelineBenchmark {
     }
 
     @Benchmark
-    fun handleAggregateDomainStateAndProcessedNotifierWithoutWait(blackHole: Blackhole) {
+    fun handleAggregateAndNotifyProcessedWithoutWait(blackHole: Blackhole) {
         blackHole.consumeWowResult {
             commandPipelineScenario.aggregateDomainStateAndProcessedNotifierHandler
                 .handle(commandPipelineScenario.createServerExchange())
@@ -85,7 +85,7 @@ open class RedisCommandProcessingPipelineBenchmark {
     }
 
     @Benchmark
-    fun handleAggregateDomainStateAndProcessedNotifierWithLocalWait(blackHole: Blackhole) {
+    fun handleAggregateAndNotifyProcessedWithLocalWait(blackHole: Blackhole) {
         blackHole.consumeWowResult {
             val commandMessage = BenchmarkCommands.newAggregateAddCartItem()
             val waitStrategy = WaitingForStage.processed(commandMessage.commandId)

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/runtime/EventStreamCopyBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/runtime/EventStreamCopyBenchmark.kt
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.infra
+package me.ahoo.wow.runtime
 
 import me.ahoo.wow.benchmark.fixture.BenchmarkEvents
 import me.ahoo.wow.event.DomainEventStream
@@ -23,22 +23,22 @@ import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.State
 
 @State(Scope.Benchmark)
-open class DeepCopyBenchmark {
+open class EventStreamCopyBenchmark {
 
     private val eventStream: DomainEventStream = BenchmarkEvents.singleEventStream()
 
     @Benchmark
-    fun jsonRoundTrip(): DomainEventStream {
+    fun copyEventStreamByJsonRoundTrip(): DomainEventStream {
         return eventStream.toJsonString().toObject<DomainEventStream>()
     }
 
     @Benchmark
-    fun domainCopy(): DomainEventStream {
+    fun copyEventStreamWithDomainCopy(): DomainEventStream {
         return eventStream.copy()
     }
 
     @Benchmark
-    fun convertValueToMap(): Map<String, Any> {
+    fun convertEventStreamToMap(): Map<String, Any> {
         return eventStream.toLinkedHashMap()
     }
 

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/runtime/ReactorSinkBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/runtime/ReactorSinkBenchmark.kt
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.infra
+package me.ahoo.wow.runtime
 
 import me.ahoo.wow.infra.sink.ConcurrentManySink
 import me.ahoo.wow.infra.sink.concurrent
@@ -27,7 +27,7 @@ import reactor.core.scheduler.Scheduler
 import reactor.core.scheduler.Schedulers
 
 @State(Scope.Benchmark)
-open class SinkBenchmark {
+open class ReactorSinkBenchmark {
     private lateinit var sink: Sinks.Many<String>
     private lateinit var concurrentManySink: ConcurrentManySink<String>
     private lateinit var emitScheduler: Scheduler
@@ -53,31 +53,31 @@ open class SinkBenchmark {
     }
 
     @Benchmark
-    fun directSinkEmit() {
+    fun emitDirectlyToReactorSink() {
         sink.tryEmitNext("test").orThrow()
     }
 
     @Benchmark
-    fun monoFromRunnableSend() {
+    fun emitWithMonoFromRunnable() {
         Mono.fromRunnable<Void> {
             sink.tryEmitNext("test").orThrow()
         }.block()
     }
 
     @Benchmark
-    fun withConcurrentManySink() {
+    fun emitWithConcurrentManySink() {
         concurrentManySink.tryEmitNext("test").orThrow()
     }
 
     @Benchmark
-    fun withConcurrentManySinkFromRunnableSend() {
+    fun emitConcurrentManySinkWithMonoFromRunnable() {
         Mono.fromRunnable<Void> {
             concurrentManySink.tryEmitNext("test").orThrow()
         }.block()
     }
 
     @Benchmark
-    fun monoFromRunnableSendWithSubscribeOnSingleScheduler() {
+    fun emitWithMonoFromRunnableOnSingleScheduler() {
         Mono.fromRunnable<Void> {
             sink.tryEmitNext("test").orThrow()
         }.subscribeOn(emitScheduler).block()


### PR DESCRIPTION
## Summary
- Rename command write-path JMH classes from the old `hotpath` package into `commandpath` with clearer class and method names.
- Rename local runtime primitive benchmarks from `infra` into `runtime` so they are not confused with Redis/Mongo Infrastructure I/O benchmarks.
- Update benchmark smoke includes and shared command fixture naming to match the new benchmark taxonomy.

## Changes
- `wow-benchmarks` command-path benchmarks now use names such as `CommandPipelineBenchmark`, `CommandHeaderBenchmark`, and `CommandPayloadSerializationBenchmark`.
- Local runtime primitive benchmarks now use `EventStreamCopyBenchmark` and `ReactorSinkBenchmark` under `me.ahoo.wow.runtime`.
- Redis command pipeline benchmark method names now match the local command pipeline naming style.

## Testing
- `./gradlew :wow-benchmarks:compileJmhKotlin`
- `./gradlew :wow-benchmarks:benchmarkSmoke`
- `git diff --check`
- Residual old benchmark ID scan for `hotpath`, `hotPath`, and previous benchmark class names.

## Risk & Compatibility
- Benchmark IDs change because JMH class and method names changed. Historical benchmark result comparison should account for renamed IDs.
- Runtime behavior is unchanged; this is a benchmark taxonomy and naming cleanup.

## Review Notes
- Pay special attention to the renamed JMH IDs in `benchmarkSmokeIncludes` and command-path benchmark method names.