### PR TITLE
refactor(benchmarks): make e2e results primary

### DIFF
--- a/wow-benchmarks/README.md
+++ b/wow-benchmarks/README.md
@@ -3,12 +3,23 @@
   Do not manually edit benchmark results.
 -->
 
-# Benchmark Report
+# Framework E2E Benchmark Report
 
-> Run `./gradlew :wow-benchmarks:benchmarkLocal :wow-benchmarks:generateBenchmarkReport` to generate the latest local runtime report.
->
-> Run grouped Local Runtime and Infrastructure I/O benchmarks: `./gradlew :wow-benchmarks:benchmarkLocal :wow-benchmarks:benchmarkInfrastructure :wow-benchmarks:generateGroupedBenchmarkReport`
->
-> Compare against baseline: `./gradlew :wow-benchmarks:benchmarkCompare`
->
-> Update baseline: `./gradlew :wow-benchmarks:updateBaseline`
+Framework performance conclusions must use this primary E2E report. Component benchmarks are diagnostic only.
+
+## Environment
+- **Version**: 8.4.0
+- **JVM**: OpenJDK 64-Bit Server VM 17.0.7+7-LTS
+- **OS**: Mac OS X aarch64
+- **Date**: 2026-06-08
+- **JMH Config**: threads=1, warmup=2×5s, measurement=3×10s, fork=2
+
+## Results
+
+| Benchmark | Score | Error | Unit | gc.alloc.rate.norm |
+|-----------|-------|-------|------|-------------------|
+| CommandPipelineE2EBenchmark.sendCommandAndWaitForProcessed | 73392.10 | ±14104.72 | ops/s | 14547.6 B/op |
+| InMemoryCommandDispatcherBenchmark.sendAndWaitForProcessedForNewAggregate | 62088.94 | ±6883.35 | ops/s | 6679.4 B/op |
+| InMemoryCommandDispatcherGrowthBenchmark.sendAndWaitForProcessedWithGrowingStream | 879.55 | ±43.18 | ops/s | 9682.9 B/op |
+| NoopCommandDispatcherBenchmark.sendAndWaitForProcessed | 77128.16 | ±30423.47 | ops/s | 14442.7 B/op |
+| NoopEventStoreCommandDispatcherBenchmark.sendAndWaitForProcessed | 74299.24 | ±8755.39 | ops/s | 15118.8 B/op |

--- a/wow-benchmarks/build.gradle.kts
+++ b/wow-benchmarks/build.gradle.kts
@@ -31,9 +31,68 @@ val benchmarkSmokeIncludes = listOf(
     "me.ahoo.wow.commandpath.CommandMessageBenchmark",
     "me.ahoo.wow.commandpath.CommandAggregateIdBenchmark",
     "me.ahoo.wow.commandpath.CommandPayloadSerializationBenchmark",
+    "me.ahoo.wow.commandpath.CommandPipelineE2EBenchmark",
 )
 
 val benchmarkSmokeReport = layout.buildDirectory.file("reports/jmh/benchmark-smoke.json")
+
+val frameworkE2EBenchmarkIncludes = listOf(
+    "me.ahoo.wow.commandpath.CommandPipelineE2EBenchmark",
+    "me.ahoo.wow.modeling.NoopCommandDispatcherBenchmark",
+    "me.ahoo.wow.modeling.NoopEventStoreCommandDispatcherBenchmark",
+    "me.ahoo.wow.modeling.InMemoryCommandDispatcherBenchmark",
+    "me.ahoo.wow.modeling.InMemoryCommandDispatcherGrowthBenchmark",
+)
+
+val infrastructureE2EBenchmarkIncludes = listOf(
+    "me.ahoo.wow.infrastructure.redis.RedisCommandDispatcherBenchmark",
+    "me.ahoo.wow.infrastructure.mongo.MongoCommandDispatcherBenchmark",
+)
+
+val diagnosticBenchmarkIncludes = listOf(
+    "me.ahoo.wow.command.BloomFilterIdempotencyCheckerBenchmark",
+    "me.ahoo.wow.command.CommandFactoryBenchmark",
+    "me.ahoo.wow.command.CommandGatewayBenchmark",
+    "me.ahoo.wow.command.GlobalIdBenchmark",
+    "me.ahoo.wow.command.InMemoryCommandBusBenchmark",
+    "me.ahoo.wow.commandpath.CommandAggregateHandlingBenchmark",
+    "me.ahoo.wow.commandpath.CommandAggregateIdBenchmark",
+    "me.ahoo.wow.commandpath.CommandAggregateLoadBenchmark",
+    "me.ahoo.wow.commandpath.CommandEventPublishBenchmark",
+    "me.ahoo.wow.commandpath.CommandHeaderBenchmark",
+    "me.ahoo.wow.commandpath.CommandIdempotencyBenchmark",
+    "me.ahoo.wow.commandpath.CommandMessageBenchmark",
+    "me.ahoo.wow.commandpath.CommandPayloadSerializationBenchmark",
+    "me.ahoo.wow.commandpath.CommandPipelineDiagnosticBenchmark",
+    "me.ahoo.wow.commandpath.CommandSnapshotSaveBenchmark",
+    "me.ahoo.wow.commandpath.CommandValidationBenchmark",
+    "me.ahoo.wow.event.EventDispatcherBenchmark",
+    "me.ahoo.wow.event.EventUpgraderBenchmark",
+    "me.ahoo.wow.eventsourcing.AggregateStateRecoveryBenchmark",
+    "me.ahoo.wow.eventsourcing.EventStreamFactoryBenchmark",
+    "me.ahoo.wow.eventsourcing.InMemoryEventStoreBenchmark",
+    "me.ahoo.wow.eventsourcing.NoopEventStoreBenchmark",
+    "me.ahoo.wow.eventsourcing.SnapshotBenchmark",
+    "me.ahoo.wow.messaging.FilterChainBenchmark",
+    "me.ahoo.wow.messaging.function.MessageFunctionRegistrarBenchmark",
+    "me.ahoo.wow.projection.ProjectionBenchmark",
+    "me.ahoo.wow.runtime.EventStreamCopyBenchmark",
+    "me.ahoo.wow.runtime.ReactorSinkBenchmark",
+    "me.ahoo.wow.saga.StatelessSagaBenchmark",
+    "me.ahoo.wow.serialization.SerializationBenchmark",
+)
+
+val infrastructureDiagnosticBenchmarkIncludes = listOf(
+    "me.ahoo.wow.infrastructure.redis.RedisCommandProcessingPipelineBenchmark",
+    "me.ahoo.wow.infrastructure.redis.RedisEventStoreBenchmark",
+    "me.ahoo.wow.infrastructure.redis.RedisEventStoreReadBenchmark",
+    "me.ahoo.wow.infrastructure.mongo.MongoEventStoreBenchmark",
+)
+
+fun benchmarkIncludePattern(includes: List<String>): String {
+    return includes.joinToString("|") { Regex.escape(it) + ".*" }
+}
+
 tasks.register<JavaExec>("benchmarkSmoke") {
     description = "Runs a PR-safe JMH smoke benchmark set."
     group = "verification"
@@ -41,7 +100,7 @@ tasks.register<JavaExec>("benchmarkSmoke") {
     classpath(tasks.named<Jar>("jmhJar").flatMap { it.archiveFile })
     mainClass.set("org.openjdk.jmh.Main")
     args(
-        benchmarkSmokeIncludes.joinToString("|") { Regex.escape(it) + ".*" },
+        benchmarkIncludePattern(benchmarkSmokeIncludes),
         "-wi",
         "0",
         "-i",
@@ -63,10 +122,15 @@ tasks.register<JavaExec>("benchmarkSmoke") {
     }
 }
 
-val benchmarkLocalReport = layout.buildDirectory.file("results/jmh/local.json")
-val benchmarkInfrastructureReport = layout.buildDirectory.file("results/jmh/infrastructure.json")
-val benchmarkLocalHumanReport = layout.buildDirectory.file("reports/jmh/local-human.txt")
-val benchmarkInfrastructureHumanReport = layout.buildDirectory.file("reports/jmh/infrastructure-human.txt")
+val benchmarkFrameworkE2EReport = layout.buildDirectory.file("results/jmh/framework-e2e.json")
+val benchmarkInfrastructureE2EReport = layout.buildDirectory.file("results/jmh/infrastructure-e2e.json")
+val benchmarkDiagnosticsReport = layout.buildDirectory.file("results/jmh/diagnostics.json")
+val benchmarkInfrastructureDiagnosticsReport = layout.buildDirectory.file("results/jmh/infrastructure-diagnostics.json")
+val benchmarkFrameworkE2EHumanReport = layout.buildDirectory.file("reports/jmh/framework-e2e-human.txt")
+val benchmarkInfrastructureE2EHumanReport = layout.buildDirectory.file("reports/jmh/infrastructure-e2e-human.txt")
+val benchmarkDiagnosticsHumanReport = layout.buildDirectory.file("reports/jmh/diagnostics-human.txt")
+val benchmarkInfrastructureDiagnosticsHumanReport =
+    layout.buildDirectory.file("reports/jmh/infrastructure-diagnostics-human.txt")
 
 val benchmarkJvmArgs = listOf(
     "-Xmx4g",
@@ -99,7 +163,7 @@ fun requireBenchmarkService(service: String, port: Int) {
     }.isSuccess
     require(available) {
         "$service is required for Infrastructure I/O benchmarks at localhost:$port. " +
-            "Start $service and rerun `./gradlew :wow-benchmarks:benchmarkInfrastructure`."
+            "Start $service and rerun the selected infrastructure benchmark task."
     }
 }
 
@@ -146,23 +210,47 @@ fun JavaExec.configureJmhBenchmarkRun(
     }
 }
 
-tasks.register<JavaExec>("benchmarkLocal") {
-    description = "Runs local JVM, Noop, and InMemory JMH benchmarks without Redis or Mongo."
+tasks.register<JavaExec>("benchmarkFrameworkE2E") {
+    description = "Runs primary framework E2E JMH benchmarks. Use these results for framework performance conclusions."
     group = "benchmark"
     configureJmhBenchmarkRun(
-        includePattern = """me\.ahoo\.wow\.(?!infrastructure\.).*Benchmark.*""",
-        resultsFile = benchmarkLocalReport,
-        humanOutputFile = benchmarkLocalHumanReport,
+        includePattern = benchmarkIncludePattern(frameworkE2EBenchmarkIncludes),
+        resultsFile = benchmarkFrameworkE2EReport,
+        humanOutputFile = benchmarkFrameworkE2EHumanReport,
     )
 }
 
-tasks.register<JavaExec>("benchmarkInfrastructure") {
-    description = "Runs Redis and Mongo infrastructure I/O JMH benchmarks."
+tasks.register<JavaExec>("benchmarkInfrastructureE2E") {
+    description = "Runs secondary Redis and Mongo E2E JMH benchmarks with infrastructure I/O."
     group = "benchmark"
     configureJmhBenchmarkRun(
-        includePattern = """me\.ahoo\.wow\.infrastructure\..*Benchmark.*""",
-        resultsFile = benchmarkInfrastructureReport,
-        humanOutputFile = benchmarkInfrastructureHumanReport,
+        includePattern = benchmarkIncludePattern(infrastructureE2EBenchmarkIncludes),
+        resultsFile = benchmarkInfrastructureE2EReport,
+        humanOutputFile = benchmarkInfrastructureE2EHumanReport,
+    )
+    doFirst {
+        requireBenchmarkService("Redis", 6379)
+        requireBenchmarkService("MongoDB", 27017)
+    }
+}
+
+tasks.register<JavaExec>("benchmarkDiagnostics") {
+    description = "Runs local diagnostic JMH benchmarks. Do not use these results as framework performance conclusions."
+    group = "benchmark"
+    configureJmhBenchmarkRun(
+        includePattern = benchmarkIncludePattern(diagnosticBenchmarkIncludes),
+        resultsFile = benchmarkDiagnosticsReport,
+        humanOutputFile = benchmarkDiagnosticsHumanReport,
+    )
+}
+
+tasks.register<JavaExec>("benchmarkInfrastructureDiagnostics") {
+    description = "Runs Redis and Mongo diagnostic JMH benchmarks for infrastructure bottleneck analysis."
+    group = "benchmark"
+    configureJmhBenchmarkRun(
+        includePattern = benchmarkIncludePattern(infrastructureDiagnosticBenchmarkIncludes),
+        resultsFile = benchmarkInfrastructureDiagnosticsReport,
+        humanOutputFile = benchmarkInfrastructureDiagnosticsHumanReport,
     )
     doFirst {
         requireBenchmarkService("Redis", 6379)
@@ -172,7 +260,7 @@ tasks.register<JavaExec>("benchmarkInfrastructure") {
 
 jmh {
     zip64.set(true)
-    includes.set(listOf("""me\.ahoo\.wow\.(?!infrastructure\.).*Benchmark.*"""))
+    includes.set(listOf(benchmarkIncludePattern(frameworkE2EBenchmarkIncludes)))
     threads.set(1)
     warmupIterations.set(2)
     warmup.set("5s")
@@ -180,8 +268,8 @@ jmh {
     timeOnIteration.set("10s")
     fork.set(2)
     resultFormat.set("json")
-    humanOutputFile.set(layout.buildDirectory.file("reports/jmh/human.txt"))
-    resultsFile.set(layout.buildDirectory.file("results/jmh/local.json"))
+    humanOutputFile.set(layout.buildDirectory.file("reports/jmh/framework-e2e-human.txt"))
+    resultsFile.set(layout.buildDirectory.file("results/jmh/framework-e2e.json"))
     jvmArgs.set(
         listOf(
             "-Xmx4g",

--- a/wow-benchmarks/gradle/benchmark-reporting.gradle.kts
+++ b/wow-benchmarks/gradle/benchmark-reporting.gradle.kts
@@ -6,18 +6,21 @@ import java.time.LocalDate
 import java.util.Locale
 
 val resultsDir = layout.projectDirectory.dir("results")
-val baselineJson = resultsDir.file("baseline.json")
-val localJson = layout.buildDirectory.file("results/jmh/local.json")
+val frameworkE2EBaselineJson = resultsDir.file("framework-e2e-baseline.json")
+val frameworkE2EJson = layout.buildDirectory.file("results/jmh/framework-e2e.json")
 val readmeFile = layout.projectDirectory.file("README.md")
 
-val benchmarkLocalReport = layout.buildDirectory.file("results/jmh/local.json")
-val benchmarkInfrastructureReport = layout.buildDirectory.file("results/jmh/infrastructure.json")
+val benchmarkFrameworkE2EReport = layout.buildDirectory.file("results/jmh/framework-e2e.json")
+val benchmarkInfrastructureE2EReport = layout.buildDirectory.file("results/jmh/infrastructure-e2e.json")
+val benchmarkDiagnosticsReport = layout.buildDirectory.file("results/jmh/diagnostics.json")
+val benchmarkInfrastructureDiagnosticsReport = layout.buildDirectory.file("results/jmh/infrastructure-diagnostics.json")
 
 data class BenchmarkResultGroup(
     val name: String,
     val command: String,
     val resultFile: Provider<RegularFile>,
     val required: Boolean = true,
+    val performanceConclusionSource: Boolean = false,
 )
 
 data class BenchmarkGroupReport(
@@ -89,7 +92,7 @@ fun parseBenchmarkGroup(
             return BenchmarkGroupReport(
                 group = group,
                 rows = emptyList(),
-                unavailableReason = "Status: unavailable. Result file was not present. Run ${group.command} when the required service is available.",
+                unavailableReason = "Status: unavailable. Result file was not present. Run ${group.command} to include this optional group.",
             )
         }
         throw GradleException(
@@ -210,11 +213,22 @@ fun renderGroupedBenchmarkReport(
     val parser = JsonSlurper()
     val parsedGroups = groups.map { parseBenchmarkGroup(parser, it) }
     val allRows = parsedGroups.flatMap { it.rows }
+    val conclusionRows = parsedGroups
+        .filter { it.group.performanceConclusionSource }
+        .flatMap { it.rows }
+    val diagnosticRows = parsedGroups
+        .filterNot { it.group.performanceConclusionSource }
+        .flatMap { it.rows }
     if (allRows.isEmpty()) {
         throw GradleException("No benchmark rows were available for grouped report generation.")
     }
     val sb = StringBuilder()
-    sb.appendLine("# Grouped Benchmark Report")
+    sb.appendLine("# E2E Benchmark Report")
+    sb.appendLine()
+    sb.appendLine("## Policy")
+    sb.appendLine("- Framework performance conclusions must use Primary Framework E2E results only.")
+    sb.appendLine("- Infrastructure E2E results are secondary because they include Redis or Mongo I/O.")
+    sb.appendLine("- Diagnostic results explain bottlenecks, but they are not performance success criteria.")
     sb.appendLine()
     sb.appendLine("## Environment")
     sb.appendLine("- **Version**: $version")
@@ -223,15 +237,31 @@ fun renderGroupedBenchmarkReport(
     sb.appendLine("- **Date**: ${LocalDate.now()}")
     sb.appendLine("- **JMH Config**: threads=1, warmup=2x5s, measurement=3x10s, fork=2")
     sb.appendLine()
-    sb.appendLine("## Bottlenecks")
-    sb.appendLine()
-    sb.appendLine("### Lowest Throughput")
-    sb.appendLine()
-    sb.appendThroughputBottlenecks(allRows)
-    sb.appendLine()
-    sb.appendLine("### Highest Allocation")
-    sb.appendLine()
-    sb.appendAllocationBottlenecks(allRows)
+    if (conclusionRows.isNotEmpty()) {
+        sb.appendLine("## Primary E2E Bottlenecks")
+        sb.appendLine()
+        sb.appendLine("### Lowest Throughput")
+        sb.appendLine()
+        sb.appendThroughputBottlenecks(conclusionRows)
+        sb.appendLine()
+        sb.appendLine("### Highest Allocation")
+        sb.appendLine()
+        sb.appendAllocationBottlenecks(conclusionRows)
+        sb.appendLine()
+    }
+    if (diagnosticRows.isNotEmpty()) {
+        sb.appendLine("## Diagnostic Bottlenecks")
+        sb.appendLine()
+        sb.appendLine("### Lowest Throughput")
+        sb.appendLine()
+        sb.appendThroughputBottlenecks(diagnosticRows)
+        sb.appendLine()
+        sb.appendLine("### Highest Allocation")
+        sb.appendLine()
+        sb.appendAllocationBottlenecks(diagnosticRows)
+        sb.appendLine()
+    }
+    sb.appendLine("## Group Details")
     sb.appendLine()
     parsedGroups.filter { it.rows.isNotEmpty() }.forEach { groupReport ->
         sb.appendLine("### ${groupReport.group.name} Lowest Throughput")
@@ -251,6 +281,7 @@ fun renderGroupedBenchmarkReport(
         sb.appendLine()
         sb.appendLine("- **Command**: `${group.command}`")
         sb.appendLine("- **Result File**: `${resultFile.absolutePath}`")
+        sb.appendLine("- **Performance Conclusion Source**: ${if (group.performanceConclusionSource) "yes" else "no"}")
         if (resultFile.exists()) {
             sb.appendLine("- **Last Modified**: ${Instant.ofEpochMilli(resultFile.lastModified())}")
         }
@@ -268,14 +299,15 @@ fun renderGroupedBenchmarkReport(
 }
 
 tasks.register("generateBenchmarkReport") {
-    description = "Generate benchmark README.md from JMH JSON results."
+    description = "Generate benchmark README.md from primary framework E2E JMH JSON results."
     group = "benchmark"
 
     doLast {
-        val resultsFile = localJson.get().asFile
+        val resultsFile = frameworkE2EJson.get().asFile
         if (!resultsFile.exists()) {
             throw GradleException(
-                "Local JMH results not found: ${resultsFile.absolutePath}. Run :wow-benchmarks:benchmarkLocal first."
+                "Framework E2E JMH results not found: ${resultsFile.absolutePath}. " +
+                    "Run :wow-benchmarks:benchmarkFrameworkE2E first."
             )
         }
 
@@ -290,7 +322,15 @@ tasks.register("generateBenchmarkReport") {
         val os = System.getProperty("os.name") + " " + System.getProperty("os.arch")
 
         val sb = StringBuilder()
-        sb.appendLine("# Benchmark Report")
+        sb.appendLine("<!--")
+        sb.appendLine("  This file is auto-generated by `./gradlew :wow-benchmarks:generateBenchmarkReport`.")
+        sb.appendLine("  Do not manually edit benchmark results.")
+        sb.appendLine("-->")
+        sb.appendLine()
+        sb.appendLine("# Framework E2E Benchmark Report")
+        sb.appendLine()
+        sb.appendLine("Framework performance conclusions must use this primary E2E report. " +
+            "Component benchmarks are diagnostic only.")
         sb.appendLine()
         sb.appendLine("## Environment")
         sb.appendLine("- **Version**: $version")
@@ -336,7 +376,7 @@ tasks.register("generateBenchmarkReport") {
 val groupedBenchmarkReport = layout.buildDirectory.file("reports/jmh/grouped.md")
 
 tasks.register("generateGroupedBenchmarkReport") {
-    description = "Generate a grouped benchmark report from local and infrastructure JMH JSON results."
+    description = "Generate grouped E2E and diagnostic benchmark reports from JMH JSON results."
     group = "benchmark"
     outputs.file(groupedBenchmarkReport)
     outputs.upToDateWhen { false }
@@ -346,14 +386,27 @@ tasks.register("generateGroupedBenchmarkReport") {
         val report = renderGroupedBenchmarkReport(
             groups = listOf(
                 BenchmarkResultGroup(
-                    name = "Local Runtime",
-                    command = "./gradlew :wow-benchmarks:benchmarkLocal",
-                    resultFile = benchmarkLocalReport,
+                    name = "Primary Framework E2E",
+                    command = "./gradlew :wow-benchmarks:benchmarkFrameworkE2E",
+                    resultFile = benchmarkFrameworkE2EReport,
+                    performanceConclusionSource = true,
                 ),
                 BenchmarkResultGroup(
-                    name = "Infrastructure I/O",
-                    command = "./gradlew :wow-benchmarks:benchmarkInfrastructure",
-                    resultFile = benchmarkInfrastructureReport,
+                    name = "Secondary Infrastructure E2E",
+                    command = "./gradlew :wow-benchmarks:benchmarkInfrastructureE2E",
+                    resultFile = benchmarkInfrastructureE2EReport,
+                    required = false,
+                ),
+                BenchmarkResultGroup(
+                    name = "Diagnostic Local Components",
+                    command = "./gradlew :wow-benchmarks:benchmarkDiagnostics",
+                    resultFile = benchmarkDiagnosticsReport,
+                    required = false,
+                ),
+                BenchmarkResultGroup(
+                    name = "Diagnostic Infrastructure Components",
+                    command = "./gradlew :wow-benchmarks:benchmarkInfrastructureDiagnostics",
+                    resultFile = benchmarkInfrastructureDiagnosticsReport,
                     required = false,
                 ),
             ),
@@ -366,19 +419,20 @@ tasks.register("generateGroupedBenchmarkReport") {
 }
 
 tasks.register("benchmarkCompare") {
-    description = "Compare local benchmark results against baseline."
+    description = "Compare primary framework E2E benchmark results against baseline."
     group = "benchmark"
 
     doLast {
-        val localFile = localJson.get().asFile
-        val baselineFile = baselineJson.asFile
+        val localFile = frameworkE2EJson.get().asFile
+        val baselineFile = frameworkE2EBaselineJson.asFile
 
         if (!baselineFile.exists()) {
             throw GradleException("Baseline not found: ${baselineFile.absolutePath}. Run :wow-benchmarks:updateBaseline first.")
         }
         if (!localFile.exists()) {
             throw GradleException(
-                "Local benchmark results not found: ${localFile.absolutePath}. Run :wow-benchmarks:benchmarkLocal first."
+                "Framework E2E benchmark results not found: ${localFile.absolutePath}. " +
+                    "Run :wow-benchmarks:benchmarkFrameworkE2E first."
             )
         }
 
@@ -466,16 +520,17 @@ tasks.register("benchmarkCompare") {
 }
 
 tasks.register("updateBaseline") {
-    description = "Copy local benchmark results as the new baseline."
+    description = "Copy primary framework E2E benchmark results as the new baseline."
     group = "benchmark"
 
     doLast {
-        val localFile = localJson.get().asFile
-        val baselineFile = baselineJson.asFile
+        val localFile = frameworkE2EJson.get().asFile
+        val baselineFile = frameworkE2EBaselineJson.asFile
 
         if (!localFile.exists()) {
             throw GradleException(
-                "Local benchmark results not found: ${localFile.absolutePath}. Run :wow-benchmarks:benchmarkLocal first."
+                "Framework E2E benchmark results not found: ${localFile.absolutePath}. " +
+                    "Run :wow-benchmarks:benchmarkFrameworkE2E first."
             )
         }
 

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandPipelineDiagnosticBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandPipelineDiagnosticBenchmark.kt
@@ -38,7 +38,7 @@ import org.openjdk.jmh.annotations.TearDown
 import org.openjdk.jmh.infra.Blackhole
 
 @State(Scope.Benchmark)
-open class CommandPipelineBenchmark {
+open class CommandPipelineDiagnosticBenchmark {
     private lateinit var commandDispatcherScenario: CommandDispatcherScenario
     private lateinit var commandPipelineScenario: CommandPipelineScenario
 
@@ -76,15 +76,6 @@ open class CommandPipelineBenchmark {
     @TearDown
     fun tearDown() {
         commandDispatcherScenario.close()
-    }
-
-    @Benchmark
-    fun sendCommandAndWaitForProcessed(blackhole: Blackhole) {
-        blackhole.consumeWowResult {
-            commandDispatcherScenario.commandGateway
-                .sendAndWaitForProcessed(BenchmarkCommands.commandPathAddCartItem())
-                .block()
-        }
     }
 
     @Benchmark

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandPipelineE2EBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/commandpath/CommandPipelineE2EBenchmark.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.commandpath
+
+import me.ahoo.wow.benchmark.fixture.BenchmarkAggregates
+import me.ahoo.wow.benchmark.fixture.BenchmarkCommands
+import me.ahoo.wow.benchmark.fixture.BenchmarkIds
+import me.ahoo.wow.benchmark.fixture.BenchmarkIdempotency
+import me.ahoo.wow.benchmark.scenario.CommandDispatcherScenario
+import me.ahoo.wow.benchmark.scenario.consumeWowResult
+import me.ahoo.wow.command.validation.NoOpValidator
+import me.ahoo.wow.command.wait.LocalCommandWaitNotifier
+import me.ahoo.wow.command.wait.SimpleWaitStrategyRegistrar
+import me.ahoo.wow.event.InMemoryDomainEventBus
+import me.ahoo.wow.eventsourcing.NoopEventStore
+import me.ahoo.wow.eventsourcing.snapshot.InMemorySnapshotRepository
+import me.ahoo.wow.eventsourcing.state.InMemoryStateEventBus
+import me.ahoo.wow.infra.idempotency.DefaultAggregateIdempotencyCheckerProvider
+import me.ahoo.wow.modeling.materialize
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.infra.Blackhole
+
+@State(Scope.Benchmark)
+open class CommandPipelineE2EBenchmark {
+    private lateinit var commandDispatcherScenario: CommandDispatcherScenario
+
+    @Setup
+    fun setup() {
+        BenchmarkIds.installDeterministicGlobalIdGenerator()
+        val aggregateMetadata = BenchmarkAggregates.cartMetadata
+        val eventStore = NoopEventStore
+        val snapshotRepository = InMemorySnapshotRepository()
+        val domainEventBus = InMemoryDomainEventBus()
+        val stateEventBus = InMemoryStateEventBus()
+        val commandWaitNotifier = LocalCommandWaitNotifier(SimpleWaitStrategyRegistrar)
+        commandDispatcherScenario = CommandDispatcherScenario.create(
+            eventStore = eventStore,
+            snapshotRepository = snapshotRepository,
+            domainEventBus = domainEventBus,
+            stateEventBus = stateEventBus,
+            validator = NoOpValidator,
+            commandWaitNotifier = commandWaitNotifier,
+            idempotencyCheckerProvider = DefaultAggregateIdempotencyCheckerProvider {
+                BenchmarkIdempotency.bloomFilterChecker()
+            },
+            namedAggregate = aggregateMetadata.namedAggregate.materialize(),
+        )
+    }
+
+    @TearDown
+    fun tearDown() {
+        commandDispatcherScenario.close()
+    }
+
+    @Benchmark
+    fun sendCommandAndWaitForProcessed(blackhole: Blackhole) {
+        blackhole.consumeWowResult {
+            commandDispatcherScenario.commandGateway
+                .sendAndWaitForProcessed(BenchmarkCommands.commandPathAddCartItem())
+                .block()
+        }
+    }
+}

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/infrastructure/InfrastructureAvailability.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/infrastructure/InfrastructureAvailability.kt
@@ -33,7 +33,7 @@ object InfrastructureAvailability {
         }.isSuccess
         require(available) {
             "$service is required for Infrastructure I/O benchmarks at $host:$port. " +
-                "Start $service and rerun `./gradlew :wow-benchmarks:benchmarkInfrastructure`."
+                "Start $service and rerun the selected infrastructure benchmark task."
         }
     }
 }


### PR DESCRIPTION
## Summary
- Make Framework E2E benchmarks the primary source for framework performance conclusions.
- Split the command pipeline benchmark into E2E and diagnostic classes so complete-path and component-path measurements no longer share one JMH ID group.
- Replace local/infrastructure benchmark tasks with explicit E2E and diagnostic tasks, and update reports/baselines to use Framework E2E by default.

## Changes
- Added `benchmarkFrameworkE2E`, `benchmarkInfrastructureE2E`, `benchmarkDiagnostics`, and `benchmarkInfrastructureDiagnostics` task groups.
- Updated the default `jmh` task, `generateBenchmarkReport`, `benchmarkCompare`, and `updateBaseline` to use `framework-e2e.json`.
- Updated grouped reports with a policy section and `Performance Conclusion Source` markers.
- Regenerated `wow-benchmarks/README.md` from the Framework E2E report.

## Testing
- `./gradlew :wow-benchmarks:compileJmhKotlin`
- `./gradlew :wow-benchmarks:benchmarkSmoke`
- `./gradlew :wow-benchmarks:benchmarkFrameworkE2E`
- `./gradlew :wow-benchmarks:generateBenchmarkReport :wow-benchmarks:generateGroupedBenchmarkReport`
- `./gradlew :wow-benchmarks:tasks --group benchmark`
- `git diff --check`

## Risk & Compatibility
- Benchmark task names and result files changed: use Framework E2E tasks/results for performance conclusions and diagnostics tasks/results for bottleneck analysis.
- Benchmark IDs changed for the command pipeline split.
- Runtime behavior is unchanged; this affects benchmark taxonomy, reports, and generated benchmark README output.

## Review Notes
- Reviewers should check that only `Primary Framework E2E` is marked as a performance conclusion source.