### PR TITLE
feat(core): add flattened function invoker entrypoint

### DIFF
--- a/wow-core/src/contractTest/java/me/ahoo/wow/infra/invoker/FunctionInvokerContractTest.java
+++ b/wow-core/src/contractTest/java/me/ahoo/wow/infra/invoker/FunctionInvokerContractTest.java
@@ -233,6 +233,11 @@ class FunctionInvokerContractTest {
         }
 
         @Override
+        public Object invoke(Object[] args) throws Throwable {
+            return FunctionInvocationSupport.invoke(this, args);
+        }
+
+        @Override
         public Object invoke(Object receiver, Object[] args) {
             lastReceiver = receiver;
             lastArgs = args;

--- a/wow-core/src/contractTest/java/me/ahoo/wow/infra/invoker/FunctionInvokerContractTest.java
+++ b/wow-core/src/contractTest/java/me/ahoo/wow/infra/invoker/FunctionInvokerContractTest.java
@@ -48,6 +48,30 @@ class FunctionInvokerContractTest {
     }
 
     @Test
+    void functionInvokerSupportsFlattenedInvocationArguments() throws Throwable {
+        ArityTarget target = new ArityTarget();
+        Method instanceMethod = ArityTarget.class.getDeclaredMethod("arity1", String.class);
+        instanceMethod.trySetAccessible();
+        FunctionInvoker instanceInvoker = FunctionInvokerFactory.create(instanceMethod);
+        assertThat(instanceInvoker.invoke(new Object[]{target, "arg"})).isEqualTo(1);
+        assertThatThrownBy(() -> instanceInvoker.invoke(new Object[0]))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("receiver");
+
+        Method staticMethod = ArityTarget.class.getDeclaredMethod("staticArity1", String.class);
+        staticMethod.trySetAccessible();
+        FunctionInvoker staticInvoker = FunctionInvokerFactory.create(staticMethod);
+        assertThat(staticInvoker.invoke(new Object[]{"arg"})).isEqualTo(1);
+
+        Constructor<ArityConstructedTarget> constructor = ArityConstructedTarget.class.getDeclaredConstructor(
+            String.class
+        );
+        constructor.trySetAccessible();
+        FunctionInvoker constructorInvoker = FunctionInvokerFactory.create(constructor);
+        assertThat(((ArityConstructedTarget) constructorInvoker.invoke(new Object[]{"arg"})).arity).isEqualTo(1);
+    }
+
+    @Test
     void defaultArityMethodsDelegateToArrayInvocation() throws Throwable {
         RecordingInstanceInvoker instanceInvoker = new RecordingInstanceInvoker();
         RecordingReceiverlessInvoker receiverlessInvoker = new RecordingReceiverlessInvoker();

--- a/wow-core/src/contractTest/kotlin/me/ahoo/wow/infra/accessor/function/FunctionInvokerAccessorSupportContractTest.kt
+++ b/wow-core/src/contractTest/kotlin/me/ahoo/wow/infra/accessor/function/FunctionInvokerAccessorSupportContractTest.kt
@@ -55,6 +55,10 @@ class FunctionInvokerAccessorSupportContractTest {
     fun `unsupported invoker should fail fast`() {
         val invoker = object : FunctionInvoker {
             override fun parameterCount(): Int = 0
+
+            override fun invoke(args: Array<Any?>): Any? {
+                error("unsupported")
+            }
         }
 
         assertThrows<IllegalStateException> {

--- a/wow-core/src/main/java/me/ahoo/wow/infra/invoker/AbstractMethodHandleReceiverlessFunctionInvoker.java
+++ b/wow-core/src/main/java/me/ahoo/wow/infra/invoker/AbstractMethodHandleReceiverlessFunctionInvoker.java
@@ -34,7 +34,7 @@ abstract class AbstractMethodHandleReceiverlessFunctionInvoker implements Receiv
         Object[] actualArgs = FunctionInvocationSupport.actualArgs(args);
         try {
             if (actualArgs.length <= 9) {
-                return FunctionInvocationSupport.invokeByArgumentArray(this, actualArgs);
+                return FunctionInvocationSupport.invoke(this, actualArgs);
             }
             return handle.invokeWithArguments(actualArgs);
         } catch (Throwable error) {

--- a/wow-core/src/main/java/me/ahoo/wow/infra/invoker/FunctionInvocationSupport.java
+++ b/wow-core/src/main/java/me/ahoo/wow/infra/invoker/FunctionInvocationSupport.java
@@ -16,6 +16,7 @@ package me.ahoo.wow.infra.invoker;
 import java.lang.invoke.WrongMethodTypeException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 
 final class FunctionInvocationSupport {
     static final Object[] EMPTY_ARGS = new Object[0];
@@ -27,26 +28,40 @@ final class FunctionInvocationSupport {
         return args == null ? EMPTY_ARGS : args;
     }
 
+    static Object receiver(Object[] actualArgs) {
+        if (actualArgs.length == 0) {
+            throw new IllegalArgumentException("Instance function invocation requires receiver as the first argument.");
+        }
+        return actualArgs[0];
+    }
+
+    static Object[] argumentsWithoutReceiver(Object[] actualArgs) {
+        return actualArgs.length == 1
+            ? EMPTY_ARGS
+            : Arrays.copyOfRange(actualArgs, 1, actualArgs.length);
+    }
+
     static Object invoke(InstanceFunctionInvoker invoker, Object[] args)
             throws Throwable {
         Object[] actualArgs = actualArgs(args);
+        Object receiver = receiver(actualArgs);
         return switch (actualArgs.length) {
-            case 1 -> invoker.invoke0(actualArgs[0]);
-            case 2 -> invoker.invoke1(actualArgs[0], actualArgs[1]);
-            case 3 -> invoker.invoke2(actualArgs[0], actualArgs[1], actualArgs[2]);
-            case 4 -> invoker.invoke3(actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3]);
-            case 5 -> invoker.invoke4(actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3], actualArgs[4]);
-            case 6 ->
-                    invoker.invoke5(actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3], actualArgs[4], actualArgs[5]);
-            case 7 ->
-                    invoker.invoke6(actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3], actualArgs[4], actualArgs[5], actualArgs[6]);
-            case 8 ->
-                    invoker.invoke7(actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3], actualArgs[4], actualArgs[5], actualArgs[6], actualArgs[7]);
-            case 9 ->
-                    invoker.invoke8(actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3], actualArgs[4], actualArgs[5], actualArgs[6], actualArgs[7], actualArgs[8]);
-            case 10 ->
-                    invoker.invoke9(actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3], actualArgs[4], actualArgs[5], actualArgs[6], actualArgs[7], actualArgs[8], actualArgs[9]);
-            default -> invoker.invoke(actualArgs);
+            case 1 -> invoker.invoke0(receiver);
+            case 2 -> invoker.invoke1(receiver, actualArgs[1]);
+            case 3 -> invoker.invoke2(receiver, actualArgs[1], actualArgs[2]);
+            case 4 -> invoker.invoke3(receiver, actualArgs[1], actualArgs[2], actualArgs[3]);
+            case 5 -> invoker.invoke4(receiver, actualArgs[1], actualArgs[2], actualArgs[3], actualArgs[4]);
+            case 6 -> invoker.invoke5(receiver, actualArgs[1], actualArgs[2], actualArgs[3], actualArgs[4],
+                actualArgs[5]);
+            case 7 -> invoker.invoke6(receiver, actualArgs[1], actualArgs[2], actualArgs[3], actualArgs[4],
+                actualArgs[5], actualArgs[6]);
+            case 8 -> invoker.invoke7(receiver, actualArgs[1], actualArgs[2], actualArgs[3], actualArgs[4],
+                actualArgs[5], actualArgs[6], actualArgs[7]);
+            case 9 -> invoker.invoke8(receiver, actualArgs[1], actualArgs[2], actualArgs[3], actualArgs[4],
+                actualArgs[5], actualArgs[6], actualArgs[7], actualArgs[8]);
+            case 10 -> invoker.invoke9(receiver, actualArgs[1], actualArgs[2], actualArgs[3], actualArgs[4],
+                actualArgs[5], actualArgs[6], actualArgs[7], actualArgs[8], actualArgs[9]);
+            default -> invoker.invoke(receiver, argumentsWithoutReceiver(actualArgs));
         };
     }
 

--- a/wow-core/src/main/java/me/ahoo/wow/infra/invoker/FunctionInvocationSupport.java
+++ b/wow-core/src/main/java/me/ahoo/wow/infra/invoker/FunctionInvocationSupport.java
@@ -27,7 +27,30 @@ final class FunctionInvocationSupport {
         return args == null ? EMPTY_ARGS : args;
     }
 
-    static Object invokeByArgumentArray(InstanceFunctionInvoker invoker, Object receiver, Object[] args)
+    static Object invoke(InstanceFunctionInvoker invoker, Object[] args)
+            throws Throwable {
+        Object[] actualArgs = actualArgs(args);
+        return switch (actualArgs.length) {
+            case 1 -> invoker.invoke0(actualArgs[0]);
+            case 2 -> invoker.invoke1(actualArgs[0], actualArgs[1]);
+            case 3 -> invoker.invoke2(actualArgs[0], actualArgs[1], actualArgs[2]);
+            case 4 -> invoker.invoke3(actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3]);
+            case 5 -> invoker.invoke4(actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3], actualArgs[4]);
+            case 6 ->
+                    invoker.invoke5(actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3], actualArgs[4], actualArgs[5]);
+            case 7 ->
+                    invoker.invoke6(actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3], actualArgs[4], actualArgs[5], actualArgs[6]);
+            case 8 ->
+                    invoker.invoke7(actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3], actualArgs[4], actualArgs[5], actualArgs[6], actualArgs[7]);
+            case 9 ->
+                    invoker.invoke8(actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3], actualArgs[4], actualArgs[5], actualArgs[6], actualArgs[7], actualArgs[8]);
+            case 10 ->
+                    invoker.invoke9(actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3], actualArgs[4], actualArgs[5], actualArgs[6], actualArgs[7], actualArgs[8], actualArgs[9]);
+            default -> invoker.invoke(actualArgs);
+        };
+    }
+
+    static Object invoke(InstanceFunctionInvoker invoker, Object receiver, Object[] args)
             throws Throwable {
         Object[] actualArgs = actualArgs(args);
         return switch (actualArgs.length) {
@@ -37,20 +60,20 @@ final class FunctionInvocationSupport {
             case 3 -> invoker.invoke3(receiver, actualArgs[0], actualArgs[1], actualArgs[2]);
             case 4 -> invoker.invoke4(receiver, actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3]);
             case 5 -> invoker.invoke5(receiver, actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3],
-                actualArgs[4]);
+                    actualArgs[4]);
             case 6 -> invoker.invoke6(receiver, actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3],
-                actualArgs[4], actualArgs[5]);
+                    actualArgs[4], actualArgs[5]);
             case 7 -> invoker.invoke7(receiver, actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3],
-                actualArgs[4], actualArgs[5], actualArgs[6]);
+                    actualArgs[4], actualArgs[5], actualArgs[6]);
             case 8 -> invoker.invoke8(receiver, actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3],
-                actualArgs[4], actualArgs[5], actualArgs[6], actualArgs[7]);
+                    actualArgs[4], actualArgs[5], actualArgs[6], actualArgs[7]);
             case 9 -> invoker.invoke9(receiver, actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3],
-                actualArgs[4], actualArgs[5], actualArgs[6], actualArgs[7], actualArgs[8]);
+                    actualArgs[4], actualArgs[5], actualArgs[6], actualArgs[7], actualArgs[8]);
             default -> invoker.invoke(receiver, actualArgs);
         };
     }
 
-    static Object invokeByArgumentArray(ReceiverlessFunctionInvoker invoker, Object[] args) throws Throwable {
+    static Object invoke(ReceiverlessFunctionInvoker invoker, Object[] args) throws Throwable {
         Object[] actualArgs = actualArgs(args);
         return switch (actualArgs.length) {
             case 0 -> invoker.invoke0();
@@ -60,13 +83,13 @@ final class FunctionInvocationSupport {
             case 4 -> invoker.invoke4(actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3]);
             case 5 -> invoker.invoke5(actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3], actualArgs[4]);
             case 6 -> invoker.invoke6(actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3], actualArgs[4],
-                actualArgs[5]);
+                    actualArgs[5]);
             case 7 -> invoker.invoke7(actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3], actualArgs[4],
-                actualArgs[5], actualArgs[6]);
+                    actualArgs[5], actualArgs[6]);
             case 8 -> invoker.invoke8(actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3], actualArgs[4],
-                actualArgs[5], actualArgs[6], actualArgs[7]);
+                    actualArgs[5], actualArgs[6], actualArgs[7]);
             case 9 -> invoker.invoke9(actualArgs[0], actualArgs[1], actualArgs[2], actualArgs[3], actualArgs[4],
-                actualArgs[5], actualArgs[6], actualArgs[7], actualArgs[8]);
+                    actualArgs[5], actualArgs[6], actualArgs[7], actualArgs[8]);
             default -> invoker.invoke(actualArgs);
         };
     }
@@ -88,8 +111,8 @@ final class FunctionInvocationSupport {
 
     private static boolean shouldNormalize(Throwable error) {
         return error instanceof WrongMethodTypeException
-            || error instanceof ClassCastException
-            || error instanceof NullPointerException;
+                || error instanceof ClassCastException
+                || error instanceof NullPointerException;
     }
 
     private static boolean isValidInvocation(Method method, boolean staticMethod, Object receiver, Object[] args) {
@@ -137,20 +160,20 @@ final class FunctionInvocationSupport {
         }
         if (parameterType == int.class) {
             return argType == Integer.class || argType == Short.class || argType == Byte.class
-                || argType == Character.class;
+                    || argType == Character.class;
         }
         if (parameterType == long.class) {
             return argType == Long.class || argType == Integer.class || argType == Short.class
-                || argType == Byte.class || argType == Character.class;
+                    || argType == Byte.class || argType == Character.class;
         }
         if (parameterType == float.class) {
             return argType == Float.class || argType == Long.class || argType == Integer.class
-                || argType == Short.class || argType == Byte.class || argType == Character.class;
+                    || argType == Short.class || argType == Byte.class || argType == Character.class;
         }
         if (parameterType == double.class) {
             return argType == Double.class || argType == Float.class || argType == Long.class
-                || argType == Integer.class || argType == Short.class || argType == Byte.class
-                || argType == Character.class;
+                    || argType == Integer.class || argType == Short.class || argType == Byte.class
+                    || argType == Character.class;
         }
         return false;
     }

--- a/wow-core/src/main/java/me/ahoo/wow/infra/invoker/FunctionInvoker.java
+++ b/wow-core/src/main/java/me/ahoo/wow/infra/invoker/FunctionInvoker.java
@@ -15,4 +15,19 @@ package me.ahoo.wow.infra.invoker;
 
 public interface FunctionInvoker {
     int parameterCount();
+
+    /**
+     * Invokes the function with flattened invocation arguments.
+     *
+     * <p>For receiver-based instance functions, {@code args[0]} must be the receiver, followed by the
+     * function parameters.</p>
+     *
+     * <p>For static functions and constructors, {@code args} contains only the function or constructor
+     * parameters and does not include a receiver.</p>
+     *
+     * @param args flattened invocation arguments
+     * @return invocation result
+     * @throws Throwable if the invocation fails
+     */
+    Object invoke(Object[] args) throws Throwable;
 }

--- a/wow-core/src/main/java/me/ahoo/wow/infra/invoker/InstanceFunctionInvoker.java
+++ b/wow-core/src/main/java/me/ahoo/wow/infra/invoker/InstanceFunctionInvoker.java
@@ -13,7 +13,22 @@
 
 package me.ahoo.wow.infra.invoker;
 
+import java.util.Arrays;
+
 public interface InstanceFunctionInvoker extends FunctionInvoker {
+    @Override
+    default Object invoke(Object[] args) throws Throwable {
+        Object[] actualArgs = FunctionInvocationSupport.actualArgs(args);
+        if (actualArgs.length == 0) {
+            throw new IllegalArgumentException("Instance function invocation requires receiver as the first argument.");
+        }
+        Object receiver = actualArgs[0];
+        Object[] arguments = actualArgs.length == 1
+            ? FunctionInvocationSupport.EMPTY_ARGS
+            : Arrays.copyOfRange(actualArgs, 1, actualArgs.length);
+        return invoke(receiver, arguments);
+    }
+
     Object invoke(Object receiver, Object[] args) throws Throwable;
 
     default Object invoke0(Object receiver) throws Throwable {

--- a/wow-core/src/main/java/me/ahoo/wow/infra/invoker/InstanceFunctionInvoker.java
+++ b/wow-core/src/main/java/me/ahoo/wow/infra/invoker/InstanceFunctionInvoker.java
@@ -13,21 +13,8 @@
 
 package me.ahoo.wow.infra.invoker;
 
-import java.util.Arrays;
 
 public interface InstanceFunctionInvoker extends FunctionInvoker {
-    @Override
-    default Object invoke(Object[] args) throws Throwable {
-        Object[] actualArgs = FunctionInvocationSupport.actualArgs(args);
-        if (actualArgs.length == 0) {
-            throw new IllegalArgumentException("Instance function invocation requires receiver as the first argument.");
-        }
-        Object receiver = actualArgs[0];
-        Object[] arguments = actualArgs.length == 1
-            ? FunctionInvocationSupport.EMPTY_ARGS
-            : Arrays.copyOfRange(actualArgs, 1, actualArgs.length);
-        return invoke(receiver, arguments);
-    }
 
     Object invoke(Object receiver, Object[] args) throws Throwable;
 

--- a/wow-core/src/main/java/me/ahoo/wow/infra/invoker/MethodHandleInstanceFunctionInvoker.java
+++ b/wow-core/src/main/java/me/ahoo/wow/infra/invoker/MethodHandleInstanceFunctionInvoker.java
@@ -33,11 +33,23 @@ final class MethodHandleInstanceFunctionInvoker implements InstanceFunctionInvok
     }
 
     @Override
+    public Object invoke(Object[] args) throws Throwable {
+        try {
+            if (args.length <= 10) {
+                return FunctionInvocationSupport.invoke(this, args);
+            }
+            return handle.invokeWithArguments(args);
+        } catch (Throwable error) {
+            throw normalize(error, args[0], args);
+        }
+    }
+
+    @Override
     public Object invoke(Object receiver, Object[] args) throws Throwable {
         Object[] actualArgs = FunctionInvocationSupport.actualArgs(args);
         try {
             if (actualArgs.length <= 9) {
-                return FunctionInvocationSupport.invokeByArgumentArray(this, receiver, actualArgs);
+                return FunctionInvocationSupport.invoke(this, receiver, actualArgs);
             }
             Object[] arguments = new Object[actualArgs.length + 1];
             arguments[0] = receiver;

--- a/wow-core/src/main/java/me/ahoo/wow/infra/invoker/MethodHandleInstanceFunctionInvoker.java
+++ b/wow-core/src/main/java/me/ahoo/wow/infra/invoker/MethodHandleInstanceFunctionInvoker.java
@@ -34,13 +34,15 @@ final class MethodHandleInstanceFunctionInvoker implements InstanceFunctionInvok
 
     @Override
     public Object invoke(Object[] args) throws Throwable {
+        Object[] actualArgs = FunctionInvocationSupport.actualArgs(args);
+        Object receiver = FunctionInvocationSupport.receiver(actualArgs);
         try {
-            if (args.length <= 10) {
-                return FunctionInvocationSupport.invoke(this, args);
+            if (actualArgs.length <= 10) {
+                return FunctionInvocationSupport.invoke(this, actualArgs);
             }
-            return handle.invokeWithArguments(args);
+            return handle.invokeWithArguments(actualArgs);
         } catch (Throwable error) {
-            throw normalize(error, args[0], args);
+            throw normalize(error, receiver, FunctionInvocationSupport.argumentsWithoutReceiver(actualArgs));
         }
     }
 

--- a/wow-core/src/main/java/me/ahoo/wow/infra/invoker/ReceiverlessFunctionInvoker.java
+++ b/wow-core/src/main/java/me/ahoo/wow/infra/invoker/ReceiverlessFunctionInvoker.java
@@ -14,6 +14,7 @@
 package me.ahoo.wow.infra.invoker;
 
 public interface ReceiverlessFunctionInvoker extends FunctionInvoker {
+    @Override
     Object invoke(Object[] args) throws Throwable;
 
     default Object invoke0() throws Throwable {

--- a/wow-core/src/main/java/me/ahoo/wow/infra/invoker/ReflectionInstanceFunctionInvoker.java
+++ b/wow-core/src/main/java/me/ahoo/wow/infra/invoker/ReflectionInstanceFunctionInvoker.java
@@ -15,7 +15,6 @@ package me.ahoo.wow.infra.invoker;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Arrays;
 
 final class ReflectionInstanceFunctionInvoker implements InstanceFunctionInvoker {
     private final Method method;
@@ -34,14 +33,8 @@ final class ReflectionInstanceFunctionInvoker implements InstanceFunctionInvoker
     @Override
     public Object invoke(Object[] args) throws Throwable {
         Object[] actualArgs = FunctionInvocationSupport.actualArgs(args);
-        if (actualArgs.length == 0) {
-            throw new IllegalArgumentException("Instance function invocation requires receiver as the first argument.");
-        }
-        Object receiver = actualArgs[0];
-        Object[] arguments = actualArgs.length == 1
-                ? FunctionInvocationSupport.EMPTY_ARGS
-                : Arrays.copyOfRange(actualArgs, 1, actualArgs.length);
-        return invoke(receiver, arguments);
+        Object receiver = FunctionInvocationSupport.receiver(actualArgs);
+        return invoke(receiver, FunctionInvocationSupport.argumentsWithoutReceiver(actualArgs));
     }
 
     @Override

--- a/wow-core/src/main/java/me/ahoo/wow/infra/invoker/ReflectionInstanceFunctionInvoker.java
+++ b/wow-core/src/main/java/me/ahoo/wow/infra/invoker/ReflectionInstanceFunctionInvoker.java
@@ -15,6 +15,7 @@ package me.ahoo.wow.infra.invoker;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
 
 final class ReflectionInstanceFunctionInvoker implements InstanceFunctionInvoker {
     private final Method method;
@@ -28,6 +29,19 @@ final class ReflectionInstanceFunctionInvoker implements InstanceFunctionInvoker
     @Override
     public int parameterCount() {
         return parameterCount;
+    }
+
+    @Override
+    public Object invoke(Object[] args) throws Throwable {
+        Object[] actualArgs = FunctionInvocationSupport.actualArgs(args);
+        if (actualArgs.length == 0) {
+            throw new IllegalArgumentException("Instance function invocation requires receiver as the first argument.");
+        }
+        Object receiver = actualArgs[0];
+        Object[] arguments = actualArgs.length == 1
+                ? FunctionInvocationSupport.EMPTY_ARGS
+                : Arrays.copyOfRange(actualArgs, 1, actualArgs.length);
+        return invoke(receiver, arguments);
     }
 
     @Override

--- a/wow-core/src/test/java/me/ahoo/wow/infra/invoker/FunctionInvokerFactoryTest.java
+++ b/wow-core/src/test/java/me/ahoo/wow/infra/invoker/FunctionInvokerFactoryTest.java
@@ -73,6 +73,29 @@ class FunctionInvokerFactoryTest {
     }
 
     @Test
+    void invokeFlattenedArgumentsForInstanceMethodRequiresReceiverAsFirstArgument() throws Throwable {
+        Method method = Target.class.getDeclaredMethod("hidden", String.class);
+        method.trySetAccessible();
+        FunctionInvoker invoker = FunctionInvokerFactory.create(method);
+        Target target = new Target();
+
+        Object result = invoker.invoke(new Object[]{target, "wow"});
+
+        assertThat(result).isEqualTo("hello wow");
+    }
+
+    @Test
+    void invokeFlattenedArgumentsForInstanceMethodRequiresReceiver() throws NoSuchMethodException {
+        Method method = Target.class.getDeclaredMethod("hidden", String.class);
+        method.trySetAccessible();
+        FunctionInvoker invoker = FunctionInvokerFactory.create(method);
+
+        assertThatThrownBy(() -> invoker.invoke(new Object[0]))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessageContaining("receiver");
+    }
+
+    @Test
     void invoke1StaticMethodWithoutTarget() throws Throwable {
         Method method = Target.class.getDeclaredMethod("staticHello", String.class);
         method.trySetAccessible();
@@ -84,12 +107,35 @@ class FunctionInvokerFactoryTest {
     }
 
     @Test
+    void invokeFlattenedArgumentsForStaticMethodDoesNotRequireReceiver() throws Throwable {
+        Method method = Target.class.getDeclaredMethod("staticHello", String.class);
+        method.trySetAccessible();
+        FunctionInvoker invoker = FunctionInvokerFactory.create(method);
+
+        Object result = invoker.invoke(new Object[]{"wow"});
+
+        assertThat(result).isEqualTo("static wow");
+    }
+
+    @Test
     void invoke1PrivateConstructorWithoutTarget() throws Throwable {
         Constructor<OneArgTarget> constructor = OneArgTarget.class.getDeclaredConstructor(String.class);
         constructor.trySetAccessible();
         ConstructorFunctionInvoker invoker = FunctionInvokerFactory.create(constructor);
 
         Object result = invoker.invoke1("created");
+
+        assertThat(result).isInstanceOf(OneArgTarget.class);
+        assertThat(((OneArgTarget) result).value).isEqualTo("created");
+    }
+
+    @Test
+    void invokeFlattenedArgumentsForConstructorDoesNotRequireReceiver() throws Throwable {
+        Constructor<OneArgTarget> constructor = OneArgTarget.class.getDeclaredConstructor(String.class);
+        constructor.trySetAccessible();
+        FunctionInvoker invoker = FunctionInvokerFactory.create(constructor);
+
+        Object result = invoker.invoke(new Object[]{"created"});
 
         assertThat(result).isInstanceOf(OneArgTarget.class);
         assertThat(((OneArgTarget) result).value).isEqualTo("created");

--- a/wow-core/src/test/java/me/ahoo/wow/infra/invoker/FunctionInvokerFactoryTest.java
+++ b/wow-core/src/test/java/me/ahoo/wow/infra/invoker/FunctionInvokerFactoryTest.java
@@ -96,6 +96,21 @@ class FunctionInvokerFactoryTest {
     }
 
     @Test
+    void invokeFlattenedArgumentsForInstanceMethodPreservesTenArgBusinessException() throws NoSuchMethodException {
+        Method method = Target.class.getDeclaredMethod("tenArgBusinessNpe", String.class, String.class, String.class,
+            String.class, String.class, String.class, String.class, String.class, String.class, String.class);
+        method.trySetAccessible();
+        FunctionInvoker invoker = FunctionInvokerFactory.create(method);
+        Target target = new Target();
+
+        assertThatThrownBy(() -> invoker.invoke(new Object[]{
+            target, "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"
+        })).isInstanceOf(NullPointerException.class)
+            .isNotInstanceOf(IllegalArgumentException.class)
+            .hasMessage("business");
+    }
+
+    @Test
     void invoke1StaticMethodWithoutTarget() throws Throwable {
         Method method = Target.class.getDeclaredMethod("staticHello", String.class);
         method.trySetAccessible();
@@ -182,6 +197,12 @@ class FunctionInvokerFactoryTest {
 
         private static String staticHello(String value) {
             return "static " + value;
+        }
+
+        @SuppressWarnings("unused")
+        private void tenArgBusinessNpe(String arg1, String arg2, String arg3, String arg4, String arg5,
+                                       String arg6, String arg7, String arg8, String arg9, String arg10) {
+            throw new NullPointerException("business");
         }
     }
 


### PR DESCRIPTION
## Summary
- Add a flattened `FunctionInvoker.invoke(Object[] args)` entrypoint shared by method and constructor invocation.
- Document receiver semantics: instance calls put the receiver at `args[0]`, while static functions and constructors pass only invocation parameters.
- Route receiverless and instance invokers through centralized arity dispatch so 0-9 argument fast paths stay consistent.
- Extend unit and contract coverage for flattened method, static method, constructor, receiver validation, and high-arity exception behavior.

## Changes
- `wow-core` invoker API now exposes a unified flattened invocation method on `FunctionInvoker`.
- `ReceiverlessFunctionInvoker` delegates arity-specific methods to the flattened array entrypoint for static methods and constructors.
- Instance invocation support extracts receiver and argument arrays centrally before dispatching to `invoke0` through `invoke9` or the generic receiver path.
- Method-handle and reflection instance implementations now normalize flattened instance calls consistently, including empty receiver validation and 10+ argument fallback behavior.
- Contract tests and factory tests cover the new entrypoint for instance methods, static methods, constructors, accessor support, null args, missing receiver, and preservation of business exceptions.

## Testing
- `./gradlew :wow-core:test --tests "me.ahoo.wow.infra.invoker.FunctionInvokerFactoryTest" :wow-core:contractTest --tests "me.ahoo.wow.infra.invoker.FunctionInvokerContractTest" --rerun-tasks --stacktrace`
- `./gradlew :wow-core:check --stacktrace`
- `git diff --check`
- `git diff --cached --check`

## Risk & Compatibility
- BREAKING CHANGE: custom implementations of `FunctionInvoker` must now implement `Object invoke(Object[] args) throws Throwable`.
- Instance flattened invocation requires the receiver as the first array element; static and constructor invocations do not include a receiver.
- Main runtime risk is incorrect receiver/argument splitting or exception normalization for high-arity instance methods; tests were added around those paths.

## Review Notes
- Please pay special attention to flattened instance invocation semantics and the fallback path for methods with 10+ flattened arguments.