### PR TITLE
refactor(benchmarks): exclude growing stream from default e2e

### DIFF
--- a/wow-benchmarks/gradle/benchmarking.gradle.kts
+++ b/wow-benchmarks/gradle/benchmarking.gradle.kts
@@ -681,7 +681,14 @@ fun renderGroupedBenchmarkReport(
                 "or claiming framework performance conclusions."
         )
     }
+    sb.appendLine(
+        "- Framework E2E results isolate command pipeline overhead with in-memory or noop stores; " +
+            "they are not production persistence capacity."
+    )
     sb.appendLine("- Infrastructure E2E results reflect real Redis or Mongo persistence paths when services are available.")
+    sb.appendLine(
+        "- No-snapshot growing-stream scenarios are diagnostics for replay pressure, not default E2E goals."
+    )
     sb.appendLine("- Component results explain bottlenecks and are not standalone performance goals.")
     sb.appendLine("- Smoke results are excluded from performance reports.")
     sb.appendLine()
@@ -788,6 +795,9 @@ tasks.register("generateBenchmarkReport") {
         sb.appendLine()
         sb.appendLine(
             "Framework performance conclusions use Full E2E results. " +
+                "Framework E2E isolates command pipeline overhead with in-memory or noop stores; " +
+                "Redis and Mongo Infrastructure E2E results reflect real persistence paths. " +
+                "No-snapshot growing-stream scenarios are diagnostics for replay pressure, not default E2E goals. " +
                 "Component benchmarks explain bottlenecks and Smoke only verifies benchmark entry health."
         )
         sb.appendLine()

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/e2e/CommandWriteE2EBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/e2e/CommandWriteE2EBenchmark.kt
@@ -58,7 +58,6 @@ open class CommandWriteE2EBenchmark {
         "ceiling",
         "noop-store",
         "in-memory-new-aggregate",
-        "in-memory-growing-stream",
     )
     lateinit var scenario: String
 


### PR DESCRIPTION
## Summary
- Exclude `in-memory-growing-stream` from the default framework E2E benchmark matrix.
- Keep the growing-stream scenario implementation available for explicit diagnostic runs.
- Clarify that Framework E2E isolates command pipeline overhead with in-memory/noop stores, while Redis/Mongo Infrastructure E2E represents real persistence paths.
- Document no-snapshot growing-stream scenarios as replay-pressure diagnostics rather than default E2E goals.

## Changes
- Updated `CommandWriteE2EBenchmark` default `@Param` scenarios to include only `ceiling`, `noop-store`, and `in-memory-new-aggregate`.
- Left `in-memory-growing-stream` setup and command creation branches intact so it can still be selected manually with JMH parameters.
- Updated generated benchmark report wording so future README/grouped reports describe framework, infrastructure, component, smoke, and diagnostic benchmark scope precisely.

## Testing
- `./gradlew :wow-benchmarks:jmhJar --stacktrace --console=plain`
- `./gradlew :wow-benchmarks:benchmarkQuickE2E --stacktrace --console=plain`
- `./gradlew :wow-benchmarks:help --console=plain`

## Risk & Compatibility
Low risk; no public API changes. This only changes the default benchmark parameter matrix and report wording. Manual JMH runs can still select `in-memory-growing-stream` explicitly.

## Review Notes
Please verify that excluding the no-snapshot growing-stream case from default E2E and documenting it as a diagnostic case matches the intended benchmark interpretation.
