### PR TITLE
refactor(redis): centralize redis lua script loading

### DIFF
--- a/wow-redis/src/main/kotlin/me/ahoo/wow/redis/RedisScripts.kt
+++ b/wow-redis/src/main/kotlin/me/ahoo/wow/redis/RedisScripts.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.redis
+
+import org.springframework.core.io.ClassPathResource
+import org.springframework.data.redis.core.script.RedisScript
+
+internal object RedisScripts {
+    fun <T : Any> load(resourceName: String, resultType: Class<T>): RedisScript<T> {
+        val script = ClassPathResource(resourceName).inputStream.bufferedReader(Charsets.UTF_8).use {
+            it.readText()
+        }
+        return RedisScript.of(script, resultType)
+    }
+}

--- a/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStore.kt
+++ b/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStore.kt
@@ -20,11 +20,10 @@ import me.ahoo.wow.eventsourcing.AbstractEventStore
 import me.ahoo.wow.eventsourcing.EventVersionConflictException
 import me.ahoo.wow.exception.ErrorCodes
 import me.ahoo.wow.naming.getContextAlias
+import me.ahoo.wow.redis.RedisScripts
 import me.ahoo.wow.redis.eventsourcing.EventStreamKeyConverter.toKey
 import me.ahoo.wow.serialization.toJsonString
 import me.ahoo.wow.serialization.toObject
-import org.springframework.core.io.ClassPathResource
-import org.springframework.core.io.Resource
 import org.springframework.data.domain.Range
 import org.springframework.data.redis.connection.Limit
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate
@@ -36,9 +35,8 @@ class RedisEventStore(
     private val redisTemplate: ReactiveStringRedisTemplate
 ) : AbstractEventStore() {
     companion object {
-        private val RESOURCE_EVENT_STEAM_APPEND: Resource = ClassPathResource("event_steam_append.lua")
         val SCRIPT_EVENT_STEAM_APPEND: RedisScript<String> =
-            RedisScript.of(RESOURCE_EVENT_STEAM_APPEND, String::class.java)
+            RedisScripts.load("event_steam_append.lua", String::class.java)
     }
 
     override fun appendStream(eventStream: DomainEventStream): Mono<Void> {

--- a/wow-redis/src/main/kotlin/me/ahoo/wow/redis/prepare/RedisPrepareKey.kt
+++ b/wow-redis/src/main/kotlin/me/ahoo/wow/redis/prepare/RedisPrepareKey.kt
@@ -16,12 +16,11 @@ package me.ahoo.wow.redis.prepare
 import me.ahoo.wow.infra.prepare.PrepareKey
 import me.ahoo.wow.infra.prepare.PreparedValue
 import me.ahoo.wow.infra.prepare.PreparedValue.Companion.toTtlAt
+import me.ahoo.wow.redis.RedisScripts
 import me.ahoo.wow.redis.eventsourcing.RedisWrappedKey.wrap
 import me.ahoo.wow.redis.prepare.PrepareKeyConverter.toKey
 import me.ahoo.wow.serialization.toJsonString
 import me.ahoo.wow.serialization.toObject
-import org.springframework.core.io.ClassPathResource
-import org.springframework.core.io.Resource
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate
 import org.springframework.data.redis.core.script.RedisScript
 import reactor.core.publisher.Mono
@@ -35,27 +34,20 @@ class RedisPrepareKey<V : Any>(
     private val redisTemplate: ReactiveStringRedisTemplate
 ) : PrepareKey<V> {
     companion object {
-        private val RESOURCE_PREPARE_PREPARE: Resource = ClassPathResource("prepare_prepare.lua")
         val SCRIPT_PREPARE_PREPARE: RedisScript<Boolean> =
-            RedisScript.of(RESOURCE_PREPARE_PREPARE, Boolean::class.java)
+            RedisScripts.load("prepare_prepare.lua", Boolean::class.java)
 
-        private val RESOURCE_PREPARE_REPREPARE: Resource = ClassPathResource("prepare_reprepare.lua")
         val SCRIPT_PREPARE_REPREPARE: RedisScript<Boolean> =
-            RedisScript.of(RESOURCE_PREPARE_REPREPARE, Boolean::class.java)
+            RedisScripts.load("prepare_reprepare.lua", Boolean::class.java)
 
-        private val RESOURCE_PREPARE_REPREPARE_WITH_OLD_VALUE: Resource =
-            ClassPathResource("prepare_reprepare_with_old_value.lua")
         val SCRIPT_PREPARE_REPREPARE_WITH_OLD_VALUE: RedisScript<Boolean> =
-            RedisScript.of(RESOURCE_PREPARE_REPREPARE_WITH_OLD_VALUE, Boolean::class.java)
+            RedisScripts.load("prepare_reprepare_with_old_value.lua", Boolean::class.java)
 
-        private val RESOURCE_PREPARE_ROLLBACK: Resource = ClassPathResource("prepare_rollback.lua")
         val SCRIPT_PREPARE_ROLLBACK: RedisScript<Boolean> =
-            RedisScript.of(RESOURCE_PREPARE_ROLLBACK, Boolean::class.java)
+            RedisScripts.load("prepare_rollback.lua", Boolean::class.java)
 
-        private val RESOURCE_PREPARE_ROLLBACK_WITH_OLD_VALUE: Resource =
-            ClassPathResource("prepare_rollback_with_old_value.lua")
         val SCRIPT_PREPARE_ROLLBACK_WITH_OLD_VALUE: RedisScript<Boolean> =
-            RedisScript.of(RESOURCE_PREPARE_ROLLBACK_WITH_OLD_VALUE, Boolean::class.java)
+            RedisScripts.load("prepare_rollback_with_old_value.lua", Boolean::class.java)
     }
 
     private fun Map<String, String>.decode(): PreparedValue<V>? {


### PR DESCRIPTION
## Summary
- Add a shared Redis Lua script loader in wow-redis for consistent loading of Lua resources.
- Update RedisEventStore to use the shared loader for event_steam_append.lua.
- Update RedisPrepareKey to use the shared loader for prepare-related Lua scripts.

## Changes
- New helper: `me.ahoo.wow.redis.RedisScripts`.
- Replaced multiple inline `ClassPathResource`/`Resource` script declarations with `RedisScripts.load(...)` calls.

## Testing
- Not run (not requested).

## Risk & Compatibility
- Low risk; behavior of script lookup remains the same (same script files and signatures) with refactored loading path.
