### PR TITLE
perf(core): reduce noop wait signal overhead

### DIFF
--- a/docs/superpowers/specs/2026-06-09-noop-benchmark-performance-design.md
+++ b/docs/superpowers/specs/2026-06-09-noop-benchmark-performance-design.md
@@ -1,0 +1,161 @@
+# Noop Benchmark Performance Design
+
+## Context
+
+The current checkout is at `origin/main` with recent command hotpath work already merged. The active noop performance evidence is in `wow-benchmarks`:
+
+- `CommandWriteE2EBenchmark` covers Framework E2E command write scenarios: `ceiling`, `noop-store`, and `in-memory-new-aggregate`.
+- The checked-in quick Framework E2E report shows `noop-store` as the highest allocation framework scenario.
+- Component benchmark output is currently absent from `quick-grouped.md`, so existing reports identify the E2E symptom but do not isolate the next fixed-cost source.
+
+The current `noop-store` quick E2E rows show:
+
+- `sendAndWaitProcessed`, 1 thread: about `86.5k ops/s`, about `6.9 KB/op`.
+- `sendAndWaitSent`, 1 thread: about `756.6k ops/s`, about `6.2 KB/op`.
+
+This means the next optimization should not start by changing persistence. The sent path already allocates heavily before aggregate processing, and the processed path adds aggregate/filter costs on top of that baseline.
+
+## Goal
+
+Improve noop command-write benchmark performance by reducing fixed allocation and latency in the command wait/sent path, while preserving public API behavior and reactive semantics.
+
+Success is measured by:
+
+- A focused component benchmark that explains the fixed overhead in the wait/sent path.
+- Lower `gc.alloc.rate.norm` and equal or higher throughput in the focused benchmark after optimization.
+- No regression in `CommandWriteE2EBenchmark` `noop-store` rows for `sendAndWaitSent` and `sendAndWaitProcessed`.
+- Passing `wow-core` tests and checks.
+
+## Non-Goals
+
+This design does not change:
+
+- Gradle module structure.
+- Redis, Mongo, R2DBC, Kafka, WebFlux, OpenAPI, or generated dashboard clients.
+- Event store, snapshot repository, or infrastructure persistence behavior.
+- The public `WaitStrategy`, `CommandGateway`, or `CommandBus` API contracts.
+- Command result wire format or error result semantics.
+
+## Recommended Approach
+
+Use a diagnostic-first workflow:
+
+1. Add a narrow `wow-benchmarks` component benchmark for the wait/sent path.
+2. Use it to isolate whether fixed allocation comes mainly from `waitingLast()`, wait signal creation/completion, header propagation, or in-memory bus send/receive.
+3. Optimize only the proven hotspot in `wow-core`.
+4. Validate with unit tests, smoke benchmark, focused before/after JMH, and Framework E2E noop rows.
+
+This is preferred over direct code changes because the current reports rank the E2E symptom but do not contain component rows for cause analysis.
+
+## Architecture
+
+The work is bounded to two modules:
+
+- `wow-benchmarks` gains a focused component benchmark for diagnosis.
+- `wow-core` receives a small wait/sent hotpath optimization only after benchmark evidence identifies the target.
+
+No storage modules or transport modules are changed. The optimization remains local to command wait handling and command send path fixed overhead.
+
+## Components
+
+### Focused Component Benchmark
+
+Add a component benchmark that can independently measure:
+
+- `WaitingForStage.waitingLast()` on a single-stage wait.
+- Wait signal creation and completion.
+- Header propagation for wait metadata.
+- Optional in-memory command bus send/receive overhead if the first rows show the wait strategy alone is not enough to explain E2E allocation.
+
+The benchmark is diagnostic evidence, not a standalone framework capacity claim.
+
+### Wait Path Optimization
+
+If `waitingLast()` is confirmed as a hotspot, optimize the single-stage path away from:
+
+- collecting all signals into a list,
+- sorting by signal time,
+- merging result maps,
+- copying the last signal unconditionally.
+
+The optimization must preserve the current behavior for:
+
+- multiple signals,
+- previous-stage failure signals,
+- result map merging,
+- chain waits,
+- final cleanup through `onFinally`.
+
+The public `WaitStrategy.waitingLast()` method remains unchanged.
+
+### E2E Regression Anchor
+
+Use `CommandWriteE2EBenchmark` `noop-store` as the final benchmark anchor:
+
+- `sendAndWaitSent` should reflect wait/sent fixed-cost reduction.
+- `sendAndWaitProcessed` should improve only if the removed fixed cost was shared by the processed path.
+
+The focused component benchmark explains the cause; the E2E benchmark confirms user-visible framework path impact.
+
+## Data Flow
+
+The relevant noop command path is:
+
+`CommandGateway.sendAndWait*` -> `WaitingForStage` propagates wait metadata into the command header -> `InMemoryCommandBus` sends the command -> the dispatcher or processed filter emits a `WaitSignal` -> `waitingLast()` turns the final signal into a `CommandResult`.
+
+The design reduces fixed allocation inside this flow. It does not change command processing order, event stream publishing, state event publishing, idempotency checks, or validation behavior.
+
+## Error Handling
+
+Existing error semantics must be preserved:
+
+- Send failures still map through `CommandResultException`.
+- Wait signal error fields remain intact.
+- Previous-stage failures still terminate waits correctly.
+- `WaitStrategy.onFinally` still unregisters wait strategies.
+- Result maps from multiple signals are still merged in the same effective order for paths that need merging.
+
+Any fast path must be guarded so it only applies when it is semantically equivalent to the existing general path.
+
+## Testing
+
+Add or update `wow-core` tests for:
+
+- single-signal `waitingLast()` success,
+- multiple-signal result merge behavior,
+- previous-stage failure handling,
+- completion and unregister behavior,
+- unchanged command wait result conversion.
+
+Add or update `wow-benchmarks` smoke coverage if the focused benchmark should remain part of the PR safety gate.
+
+## Verification
+
+Use this validation ladder:
+
+1. Run a focused before benchmark for the new diagnostic component rows.
+2. Implement the smallest proven optimization.
+3. Run `./gradlew :wow-core:test`.
+4. Run `./gradlew :wow-core:check`.
+5. Run `./gradlew :wow-benchmarks:benchmarkSmoke --stacktrace`.
+6. Run the same focused JMH after benchmark and compare throughput plus `gc.alloc.rate.norm`.
+7. If the focused rows improve, run `./gradlew :wow-benchmarks:benchmarkQuickE2E :wow-benchmarks:generateBenchmarkReport` to validate the `noop-store` E2E rows.
+
+Only benchmark output from commands actually run in this worktree should be used as final evidence.
+
+## Risks
+
+- `waitingLast()` supports more than the simple sent/processed path; a fast path can break multi-signal waits if applied too broadly.
+- Header mutation must respect read-only boundaries after messages are sent.
+- E2E benchmark variance can hide small wins, so component rows should explain the expected mechanism.
+- Benchmarks are local-machine directional feedback unless full E2E runs are performed.
+
+## Acceptance Criteria
+
+- The focused benchmark exists and can isolate wait/sent fixed overhead.
+- The optimized code preserves existing public API behavior.
+- All relevant `wow-core` tests pass.
+- `:wow-core:check` passes.
+- `:wow-benchmarks:benchmarkSmoke --stacktrace` passes.
+- Focused before/after JMH shows reduced allocation for the chosen hotspot.
+- `noop-store` E2E rows do not regress and preferably improve in allocation and throughput.

--- a/docs/superpowers/specs/2026-06-10-send-wait-sent-fast-path-design.md
+++ b/docs/superpowers/specs/2026-06-10-send-wait-sent-fast-path-design.md
@@ -1,0 +1,58 @@
+# sendAndWaitForSent Fast Path Design
+
+## Context
+
+The current noop benchmark branch already reduced `WaitingFor.waitingLast()` overhead for the single empty-result signal case and added `WaitNotifyComponentBenchmark` coverage. The remaining quick E2E data still shows `CommandWriteE2EBenchmark.sendAndWaitSent (scenario=noop-store)` allocating about `6060 B/op`, while the component data shows the local wait-notify path still spends allocations in wait strategy registration, propagation, sink subscription, and result conversion.
+
+`sendAndWaitForSent(command)` is a narrower contract than the generic wait APIs. It only waits until the command has been accepted by the `CommandBus`; it does not need downstream wait propagation because no later processing stage is involved. The generic APIs must keep their existing behavior because callers may pass custom wait strategies and rely on header propagation.
+
+## Decision
+
+Implement a dedicated `DefaultCommandGateway.sendAndWaitForSent(command)` override. The override will:
+
+- run the same validation and idempotency checks as `send(command)`;
+- call `commandBus.send(command)`;
+- on success, build a `SENT` `CommandResult` directly from `command.commandSentSignal(command.commandId).toResult(command)`;
+- on failure, keep the existing error surface by throwing `CommandResultException` with a `SENT` failure result;
+- skip wait header propagation, wait strategy registration, sink notification, and `waitingLast()` for this convenience API.
+
+The implementation will not change:
+
+- `CommandGateway.sendAndWait(command, waitStrategy)`;
+- `CommandGateway.send(command, waitStrategy)`;
+- `CommandGateway.sendAndWaitStream(command, waitStrategy)`;
+- extracted wait strategy propagation from headers;
+- processed, snapshot, projected, event-handled, saga-handled, or waiting-chain behavior.
+
+## Compatibility Boundary
+
+The only intentional behavior change is internal side effects for `sendAndWaitForSent(command)`: it will no longer write `command_wait_*` headers or register a `WaitingForSent` strategy. This is acceptable because the convenience API completes at the gateway `SENT` stage and does not require downstream notification.
+
+The generic `sendAndWait(command, WaitingForStage.sent(...))` path remains available for callers that explicitly want the full wait strategy machinery and header propagation.
+
+## Tests
+
+Add focused tests in `DefaultCommandGatewayTest`:
+
+- `sendAndWaitForSent` returns a successful `SENT` result and sends the command;
+- it does not propagate command wait headers, register wait strategies, or notify wait notifiers;
+- command bus failure is mapped to `CommandResultException` with a `SENT` result;
+- void commands are accepted on this path.
+
+Run the targeted gateway tests, full `:wow-core:test`, and `:wow-core:check`.
+
+## Benchmark Proof
+
+Use quick E2E as the proof loop:
+
+```bash
+./gradlew :wow-benchmarks:benchmarkQuickE2E :wow-benchmarks:generateBenchmarkReport --stacktrace
+```
+
+Compare before/after `CommandWriteE2EBenchmark.sendAndWaitSent (scenario=noop-store)` for:
+
+- `gc.alloc.rate.norm`;
+- throughput;
+- average time.
+
+The expected result is lower `B/op` on the noop sent path. Throughput may vary in quick JMH runs, so the final conclusion must distinguish allocation reduction from directional throughput movement.

--- a/wow-benchmarks/gradle/benchmarking.gradle.kts
+++ b/wow-benchmarks/gradle/benchmarking.gradle.kts
@@ -115,6 +115,7 @@ val smokeSuite = BenchmarkSuite(
         "me.ahoo.wow.benchmark.component.CommandMessageComponentBenchmark",
         "me.ahoo.wow.benchmark.component.AccessorComponentBenchmark",
         "me.ahoo.wow.benchmark.component.SerializationComponentBenchmark",
+        "me.ahoo.wow.benchmark.component.WaitNotifyComponentBenchmark",
         "me.ahoo.wow.benchmark.e2e.CommandWriteE2EBenchmark",
     ),
     resultFileName = "benchmark-smoke.json",

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/component/WaitNotifyComponentBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/component/WaitNotifyComponentBenchmark.kt
@@ -23,6 +23,7 @@ import me.ahoo.wow.command.wait.SimpleWaitSignal
 import me.ahoo.wow.command.wait.SimpleWaitStrategyRegistrar
 import me.ahoo.wow.command.wait.WaitSignal
 import me.ahoo.wow.command.wait.stage.WaitingForStage
+import me.ahoo.wow.messaging.DefaultHeader
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.Setup
@@ -73,6 +74,28 @@ open class WaitNotifyComponentBenchmark {
         blackhole.consume(result)
     }
 
+    @Benchmark
+    fun propagateSentWaitHeaders(blackhole: Blackhole) {
+        val waitStrategy = WaitingForStage.sent(BenchmarkIds.nextGlobalId())
+        val header = DefaultHeader.empty()
+        waitStrategy.propagate("", header)
+        blackhole.consume(header)
+    }
+
+    @Benchmark
+    fun waitForSent(blackhole: Blackhole) {
+        val waitStrategy = WaitingForStage.sent(BenchmarkIds.nextGlobalId())
+        SimpleWaitStrategyRegistrar.register(waitStrategy)
+        waitStrategy.onFinally {
+            SimpleWaitStrategyRegistrar.unregister(waitStrategy.waitCommandId)
+        }
+        val signal = sentSignal(waitStrategy.waitCommandId)
+        val result = notifier.notify("", signal)
+            .then(waitStrategy.waitingLast())
+            .block()
+        blackhole.consume(result)
+    }
+
     private fun waitSignal(waitCommandId: String): WaitSignal {
         return SimpleWaitSignal(
             id = BenchmarkIds.nextGlobalId(),
@@ -87,6 +110,24 @@ open class WaitNotifyComponentBenchmark {
                 name = "process",
             ),
             aggregateVersion = 1,
+            isLastProjection = true,
+        )
+    }
+
+    private fun sentSignal(waitCommandId: String): WaitSignal {
+        return SimpleWaitSignal(
+            id = BenchmarkIds.nextGlobalId(),
+            waitCommandId = waitCommandId,
+            commandId = waitCommandId,
+            aggregateId = BenchmarkAggregates.aggregateId(),
+            stage = CommandStage.SENT,
+            function = FunctionInfoData(
+                functionKind = FunctionKind.COMMAND,
+                contextName = BenchmarkAggregates.namedAggregate.contextName,
+                processorName = "BenchmarkCommandGateway",
+                name = "send",
+            ),
+            aggregateVersion = null,
             isLastProjection = true,
         )
     }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
@@ -152,6 +152,26 @@ class DefaultCommandGateway(
                     }
             }
 
+    private fun CommandMessage<*>.toSentCommandResult(): CommandResult =
+        commandSentSignal(commandId).toResult(this)
+
+    override fun <C : Any> sendAndWaitForSent(command: CommandMessage<C>): Mono<CommandResult> {
+        return check(command)
+            .thenDefer {
+                commandBus.send(command)
+            }.thenDefer {
+                Mono.just(command.toSentCommandResult())
+            }.onErrorMap {
+                CommandResultException(
+                    it.toResult(
+                        waitCommandId = command.commandId,
+                        commandMessage = command,
+                    ),
+                    it,
+                )
+            }
+    }
+
     /**
      * Sends a command and waits for the final result.
      * Throws CommandResultException if the command execution fails.

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingFor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingFor.kt
@@ -25,6 +25,29 @@ import reactor.core.publisher.Sinks.EmitFailureHandler
 import java.util.concurrent.atomic.AtomicReference
 import java.util.function.Consumer
 
+internal fun MutableList<WaitSignal>.lastSignalWithMergedResult(): WaitSignal? {
+    if (isEmpty()) {
+        return null
+    }
+    if (size == 1) {
+        val signal = first()
+        if (signal.result.isEmpty()) {
+            return signal
+        }
+        return signal.copyResult(signal.result.toMap())
+    }
+    sortBy { it.signalTime }
+    return last().copyResult(mergedResult())
+}
+
+internal fun Iterable<WaitSignal>.mergedResult(): Map<String, Any> {
+    val result: MutableMap<String, Any> = mutableMapOf()
+    forEach { signal ->
+        result.putAll(signal.result)
+    }
+    return result
+}
+
 /**
  * Abstract base class for wait strategies that wait for specific command processing stages.
  * Provides common functionality for managing wait signals, completion, and error handling.
@@ -63,15 +86,7 @@ abstract class WaitingFor : WaitStrategy {
 
     override fun waitingLast(): Mono<WaitSignal> {
         return waiting().collectList().mapNotNull { signals ->
-            if (signals.isEmpty()) {
-                return@mapNotNull null
-            }
-            signals.sortBy { it.signalTime }
-            val result: MutableMap<String, Any> = mutableMapOf()
-            signals.forEach { signal ->
-                result.putAll(signal.result)
-            }
-            signals.last().copyResult(result)
+            signals.lastSignalWithMergedResult()
         }
     }
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForAfterProcessed.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForAfterProcessed.kt
@@ -15,6 +15,8 @@ package me.ahoo.wow.command.wait.stage
 
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.WaitSignal
+import me.ahoo.wow.command.wait.lastSignalWithMergedResult
+import me.ahoo.wow.command.wait.mergedResult
 import reactor.core.publisher.Mono
 
 /**
@@ -47,12 +49,11 @@ abstract class WaitingForAfterProcessed : WaitingForStage() {
             if (signals.isEmpty()) {
                 return@mapNotNull null
             }
-            val result: MutableMap<String, Any> = mutableMapOf()
-            signals.forEach { signal ->
-                result.putAll(signal.result)
+            val waitingForSignal = waitingForSignal
+            if (waitingForSignal == null) {
+                return@mapNotNull signals.lastSignalWithMergedResult()
             }
-            val waitingForSignal = waitingForSignal ?: return@mapNotNull signals.last().copyResult(result)
-            waitingForSignal.copyResult(result)
+            waitingForSignal.copyResult(signals.mergedResult())
         }
     }
 

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTest.kt
@@ -96,6 +96,66 @@ class DefaultCommandGatewayTest {
     }
 
     @Test
+    fun `sendAndWaitForSent returns sent result without wait strategy side effects`() {
+        val commandBus = RecordingCommandBus()
+        val registrar = RecordingWaitStrategyRegistrar()
+        val notifier = RecordingCommandWaitNotifier()
+        val gateway = commandGateway(
+            commandBus = commandBus,
+            registrar = registrar,
+            notifier = notifier,
+        )
+        val command = TestCommandMessage(id = "command-id")
+
+        StepVerifier.create(gateway.sendAndWaitForSent(command))
+            .assertNext { result ->
+                result.stage.assert().isEqualTo(CommandStage.SENT)
+                result.waitCommandId.assert().isEqualTo("command-id")
+                result.commandId.assert().isEqualTo("command-id")
+                result.requestId.assert().isEqualTo(command.requestId)
+                result.errorCode.assert().isEqualTo("Ok")
+            }
+            .verifyComplete()
+
+        commandBus.sent.single().assert().isSameAs(command)
+        command.header["command_wait_id"].assert().isNull()
+        command.header["command_wait_endpoint"].assert().isNull()
+        command.header["command_wait_stage"].assert().isNull()
+        registrar.contains("command-id").assert().isFalse()
+        notifier.notifications.assert().isEmpty()
+    }
+
+    @Test
+    fun `sendAndWaitForSent maps command bus errors to command result exception`() {
+        val commandBus = RecordingCommandBus().apply {
+            sendResult = { Mono.error(IllegalStateException("bus failed")) }
+        }
+        val gateway = commandGateway(commandBus = commandBus)
+
+        StepVerifier.create(gateway.sendAndWaitForSent(TestCommandMessage(id = "command-id")))
+            .expectErrorSatisfies { error ->
+                error.assert().isInstanceOf(CommandResultException::class.java)
+                val exception = error as CommandResultException
+                exception.commandResult.stage.assert().isEqualTo(CommandStage.SENT)
+                exception.commandResult.waitCommandId.assert().isEqualTo("command-id")
+                exception.commandResult.commandId.assert().isEqualTo("command-id")
+            }
+            .verify()
+    }
+
+    @Test
+    fun `sendAndWaitForSent supports void commands`() {
+        val gateway = commandGateway()
+
+        StepVerifier.create(gateway.sendAndWaitForSent(TestCommandMessage(id = "void-command", isVoid = true)))
+            .assertNext { result ->
+                result.stage.assert().isEqualTo(CommandStage.SENT)
+                result.commandId.assert().isEqualTo("void-command")
+            }
+            .verifyComplete()
+    }
+
+    @Test
     fun `send with wait strategy maps command bus errors to command result exception and unregisters`() {
         val commandBus = RecordingCommandBus().apply {
             sendResult = { Mono.error(IllegalStateException("bus failed")) }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/chain/SimpleWaitingForChainNotifyTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/chain/SimpleWaitingForChainNotifyTest.kt
@@ -74,4 +74,37 @@ class SimpleWaitingForChainNotifyTest {
             }
             .verifyComplete()
     }
+
+    @Test
+    fun `chain waitingLast merges results from previous and final signals`() {
+        val chain = SimpleWaitingForChain.chain(
+            waitCommandId = "main-command",
+            function = testNamedFunction(),
+            tailStage = CommandStage.PROCESSED,
+            tailFunction = testNamedFunction(),
+        )
+        val processed = testSignal(
+            CommandStage.PROCESSED,
+            commandId = "main-command",
+            result = mapOf("processed" to 1),
+            signalTime = 1,
+        )
+        val saga = testSignal(
+            CommandStage.SAGA_HANDLED,
+            commandId = "main-command",
+            result = mapOf("saga" to 2),
+            signalTime = 2,
+        )
+
+        StepVerifier.create(chain.waitingLast())
+            .then {
+                chain.next(processed)
+                chain.next(saga)
+            }
+            .assertNext { signal ->
+                signal.stage.assert().isEqualTo(CommandStage.SAGA_HANDLED)
+                signal.result.assert().isEqualTo(mapOf("processed" to 1, "saga" to 2))
+            }
+            .verifyComplete()
+    }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/stage/WaitingForStageNotificationTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/stage/WaitingForStageNotificationTest.kt
@@ -35,6 +35,19 @@ class WaitingForStageNotificationTest {
     }
 
     @Test
+    fun `processed waitingLast returns single empty result signal without copying`() {
+        val strategy = WaitingForStage.processed("wait-id")
+        val processed = testSignal(CommandStage.PROCESSED)
+
+        StepVerifier.create(strategy.waitingLast())
+            .then { strategy.next(processed) }
+            .assertNext { signal ->
+                signal.assert().isSameAs(processed)
+            }
+            .verifyComplete()
+    }
+
+    @Test
     fun `snapshot strategy completes after processed and snapshot and returns merged result`() {
         val strategy = WaitingForStage.snapshot("wait-id")
         val processed = testSignal(CommandStage.PROCESSED, result = mapOf("processed" to 1), signalTime = 1)
@@ -48,6 +61,25 @@ class WaitingForStageNotificationTest {
             .assertNext { signal ->
                 signal.stage.assert().isEqualTo(CommandStage.SNAPSHOT)
                 signal.result.assert().isEqualTo(mapOf("processed" to 1, "snapshot" to 2))
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `snapshot waitingLast returns failed processed signal when previous stage fails`() {
+        val strategy = WaitingForStage.snapshot("wait-id")
+        val failedProcessed = testSignal(
+            CommandStage.PROCESSED,
+            errorCode = "failed",
+            errorMsg = "processed failed",
+        )
+
+        StepVerifier.create(strategy.waitingLast())
+            .then { strategy.next(failedProcessed) }
+            .assertNext { signal ->
+                signal.stage.assert().isEqualTo(CommandStage.PROCESSED)
+                signal.errorCode.assert().isEqualTo("failed")
+                signal.errorMsg.assert().isEqualTo("processed failed")
             }
             .verifyComplete()
     }


### PR DESCRIPTION
## Summary
- Add noop wait-notify benchmark diagnostics for sent waits so the send-and-wait-sent path can be measured independently.
- Optimize `waitingLast()` for the common single empty-result signal case by returning the original signal instead of copying and merging maps.
- Add a dedicated `DefaultCommandGateway.sendAndWaitForSent` fast path that bypasses generic wait strategy registration, wait headers, sink subscription, and `waitingLast()` for the sent convenience API.
- Add regression tests for sent fast-path side effects, error mapping, void command support, single-signal identity, failed prior-stage fallback, and merged wait results.

## Changes
- `wow-benchmarks`: includes `WaitNotifyComponentBenchmark` in the smoke suite and adds sent wait propagation/notification benchmarks.
- `wow-core`: extracts wait signal result merging helpers and uses a single-signal fast path in `WaitingFor.waitingLast()`.
- `wow-core`: updates `WaitingForAfterProcessed.waitingLast()` to share merge logic while preserving target-stage metadata.
- `wow-core`: overrides `sendAndWaitForSent` in `DefaultCommandGateway` to return a direct `SENT` result after command bus send succeeds.
- `docs/superpowers`: records the noop benchmark performance designs used for the implementation.

## Benchmark Result
Quick E2E directional result for `CommandWriteE2EBenchmark.sendAndWaitSent (scenario=noop-store)`:

| Threads | Before | After | Change |
| --- | ---: | ---: | ---: |
| 1 throughput | 770,645.11 ops/s | 1,249,238.49 ops/s | +62.10% |
| 1 allocation | 6060.2 B/op | 3348.3 B/op | -44.75% |
| 4 throughput | 1,190,882.30 ops/s | 1,392,839.05 ops/s | +16.96% |
| 4 allocation | 6063.1 B/op | 3350.2 B/op | -44.74% |

Processed noop remained in the same allocation range and is not claimed as optimized by the sent fast path:

| Benchmark | Threads | Throughput | Allocation |
| --- | ---: | ---: | ---: |
| `sendAndWaitProcessed(noop-store)` | 1 | 83,973.97 ops/s | 6946.8 B/op |
| `sendAndWaitProcessed(noop-store)` | 4 | 152,762.87 ops/s | 6942.4 B/op |

## Testing
- `./gradlew :wow-core:test --tests "me.ahoo.wow.command.DefaultCommandGatewayTest"`
- `./gradlew :wow-core:test --tests "me.ahoo.wow.command.wait.stage.WaitingForStageNotificationTest" --tests "me.ahoo.wow.command.wait.chain.SimpleWaitingForChainNotifyTest"`
- `./gradlew :wow-core:test --tests "me.ahoo.wow.command.wait.*"`
- `./gradlew :wow-core:test`
- `./gradlew :wow-core:check`
- `./gradlew :wow-benchmarks:benchmarkSmoke --stacktrace`
- `./gradlew :wow-benchmarks:benchmarkQuickComponentThread1 --stacktrace`
- `./gradlew :wow-benchmarks:benchmarkQuickE2E :wow-benchmarks:generateBenchmarkReport --stacktrace`

## Risk & Compatibility
- No public API signature or dependency changes.
- `sendAndWaitForSent(command)` no longer writes `command_wait_*` headers or registers a wait strategy; this is intentional for the sent convenience API because it completes at gateway send success.
- Generic `send(command, waitStrategy)`, `sendAndWait(command, waitStrategy)`, streaming waits, and downstream stage propagation keep the existing wait strategy behavior.
- The `waitingLast()` single empty-result fast path returns the original emitted `WaitSignal`, relying on emitted signals not being mutated after emission.

## Review Notes
- Review the `DefaultCommandGateway.sendAndWaitForSent` override as the main behavior change.
- Review `WaitingForAfterProcessed.waitingLast()` fallback path; it preserves failed previous-stage signals when the target stage never arrives.
- Local benchmark report output was generated for validation but is not included in this PR.
