### PR TITLE
perf(core): lazily materialize command wait sinks

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingFor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitingFor.kt
@@ -14,42 +14,68 @@
 package me.ahoo.wow.command.wait
 
 import io.github.oshai.kotlinlogging.KotlinLogging
-import me.ahoo.wow.infra.sink.cancelled
-import me.ahoo.wow.infra.sink.concurrent
-import me.ahoo.wow.infra.sink.terminated
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.core.publisher.SignalType
 import reactor.core.publisher.Sinks
-import reactor.core.publisher.Sinks.EmitFailureHandler
-import java.util.concurrent.atomic.AtomicReference
+import reactor.util.concurrent.Queues
+import java.util.concurrent.locks.ReentrantLock
 import java.util.function.Consumer
+import kotlin.concurrent.withLock
 
 /**
  * Abstract base class for wait strategies that wait for specific command processing stages.
  * Provides common functionality for managing wait signals, completion, and error handling.
  * Subclasses must implement the logic for determining which signals are relevant.
+ *
+ * Signals are buffered in a small list until a subscriber materializes, so the dominant
+ * `waitingLast()` path never allocates a Flux sink: the final signal is computed directly
+ * from the buffered signals when the strategy completes. A Flux sink is materialized lazily
+ * only when `waiting()` is subscribed, replaying any buffered signals.
+ * At most one subscriber is supported across `waiting()` and `waitingLast()`.
  */
 abstract class WaitingFor : WaitStrategy {
     companion object {
         private val log = KotlinLogging.logger {}
+        private const val FLUX_BUFFER_LINK_SIZE = 8
+        private const val SIGNAL_BUFFER_CAPACITY = 4
     }
 
-    protected val waitSignalSink: Sinks.Many<WaitSignal> =
-        Sinks.unsafe().many().unicast().onBackpressureBuffer<WaitSignal>().concurrent()
+    private val lock = ReentrantLock()
+
+    /**
+     * Signals received before a subscriber materializes, and the source for the final merged
+     * signal of `waitingLast()`. Guarded by [lock].
+     */
+    private var bufferedSignals: MutableList<WaitSignal>? = null
+    private var fluxSink: Sinks.Many<WaitSignal>? = null
+    private var monoSink: Sinks.One<WaitSignal>? = null
+    private var subscribed: Boolean = false
+    private var terminalError: Throwable? = null
+
+    @Volatile
+    private var terminatedFlag = false
+
+    @Volatile
+    private var cancelledFlag = false
+
+    @Volatile
+    private var onFinallyHook: Consumer<SignalType> = EmptyOnFinally
+
     override val cancelled: Boolean
-        get() = waitSignalSink.cancelled
+        get() = cancelledFlag
 
     override val terminated: Boolean
-        get() = waitSignalSink.terminated
+        get() = terminatedFlag
 
     override val supportVoidCommand: Boolean = false
 
-    protected var onFinallyHook: AtomicReference<Consumer<SignalType>> = AtomicReference(EmptyOnFinally)
-
     @Suppress("TooGenericExceptionCaught")
     protected fun safeDoFinally(signalType: SignalType) {
-        val currentHook = onFinallyHook.get()
+        if (signalType == SignalType.CANCEL) {
+            cancelledFlag = true
+        }
+        val currentHook = onFinallyHook
         try {
             currentHook.accept(signalType)
         } catch (error: Throwable) {
@@ -59,31 +85,104 @@ abstract class WaitingFor : WaitStrategy {
         }
     }
 
-    override fun waiting(): Flux<WaitSignal> = waitSignalSink.asFlux().doFinally(this::safeDoFinally)
+    override fun waiting(): Flux<WaitSignal> {
+        return Flux.defer {
+            materializeFlux()
+        }.doFinally(this::safeDoFinally)
+    }
 
     override fun waitingLast(): Mono<WaitSignal> {
-        return waiting().collectList().mapNotNull { signals ->
-            if (signals.isEmpty()) {
-                return@mapNotNull null
+        return Mono.defer {
+            materializeMono()
+        }.doFinally(this::safeDoFinally)
+    }
+
+    private fun materializeFlux(): Flux<WaitSignal> {
+        lock.withLock {
+            if (subscribed) {
+                return Flux.error(IllegalStateException("WaitingFor allows only a single Subscriber"))
             }
-            signals.sortBy { it.signalTime }
-            val result: MutableMap<String, Any> = mutableMapOf()
-            signals.forEach { signal ->
-                result.putAll(signal.result)
+            subscribed = true
+            val sink = Sinks.unsafe().many().unicast()
+                .onBackpressureBuffer(Queues.unbounded<WaitSignal>(FLUX_BUFFER_LINK_SIZE).get())
+            bufferedSignals?.forEach {
+                sink.tryEmitNext(it)
             }
-            signals.last().copyResult(result)
+            bufferedSignals = null
+            val error = terminalError
+            if (error != null) {
+                sink.tryEmitError(error)
+            } else if (terminatedFlag) {
+                sink.tryEmitComplete()
+            } else {
+                fluxSink = sink
+            }
+            return sink.asFlux()
         }
     }
 
-    protected fun tryEmit(emit: () -> Unit): Boolean {
-        if (completed) {
-            log.warn {
-                "WaitingFor is terminated or cancelled, ignore emit."
+    private fun materializeMono(): Mono<WaitSignal> {
+        lock.withLock {
+            if (subscribed) {
+                return Mono.error(IllegalStateException("WaitingFor allows only a single Subscriber"))
             }
-            return false
+            subscribed = true
+            val error = terminalError
+            if (error != null) {
+                return Mono.error(error)
+            }
+            if (terminatedFlag) {
+                val finalSignal = finalSignal()
+                bufferedSignals = null
+                return Mono.justOrEmpty(finalSignal)
+            }
+            val sink = Sinks.unsafe().one<WaitSignal>()
+            monoSink = sink
+            return sink.asMono()
         }
-        emit()
-        return true
+    }
+
+    /**
+     * Computes the final signal emitted by `waitingLast()`: the signal resolved by
+     * [resolveLastSignal] carrying the result entries merged from every buffered signal
+     * in arrival order. Caller must hold [lock].
+     */
+    private fun finalSignal(): WaitSignal? {
+        val signals = bufferedSignals
+        if (signals.isNullOrEmpty()) {
+            return null
+        }
+        if (signals.size == 1) {
+            return signals[0]
+        }
+        var merged: MutableMap<String, Any>? = null
+        signals.forEach { signal ->
+            if (signal.result.isNotEmpty()) {
+                val target = merged ?: LinkedHashMap<String, Any>().also { merged = it }
+                target.putAll(signal.result)
+            }
+        }
+        val last = resolveLastSignal(signals)
+        val mergedResult = merged ?: return last
+        return last.copyResult(mergedResult)
+    }
+
+    /**
+     * Resolves which buffered signal `waitingLast()` should emit. Defaults to the signal with
+     * the greatest [WaitSignal.signalTime], preferring the later arrival on ties.
+     *
+     * @param signals The non-empty list of buffered signals in arrival order.
+     * @return The signal whose fields (besides the merged result) back the final signal.
+     */
+    protected open fun resolveLastSignal(signals: List<WaitSignal>): WaitSignal {
+        var last = signals[0]
+        for (index in 1 until signals.size) {
+            val signal = signals[index]
+            if (signal.signalTime >= last.signalTime) {
+                last = signal
+            }
+        }
+        return last
     }
 
     /**
@@ -97,32 +196,94 @@ abstract class WaitingFor : WaitStrategy {
     abstract fun isPreviousSignal(signal: WaitSignal): Boolean
 
     protected open fun nextSignal(signal: WaitSignal) {
-        tryEmit {
-            waitSignalSink.emitNext(signal, EmitFailureHandler.FAIL_FAST)
+        lock.withLock {
+            if (completed) {
+                logIgnoreEmit()
+                return
+            }
+            val sink = fluxSink
+            if (sink != null) {
+                sink.tryEmitNext(signal)
+            } else {
+                val buffer = bufferedSignals ?: ArrayList<WaitSignal>(SIGNAL_BUFFER_CAPACITY).also {
+                    bufferedSignals = it
+                }
+                buffer.add(signal)
+            }
             /**
              * fail fast
              */
             if (signal.succeeded.not() && isPreviousSignal(signal)) {
-                complete()
+                doComplete()
             }
         }
     }
 
     override fun error(throwable: Throwable) {
-        tryEmit {
-            waitSignalSink.emitError(throwable, EmitFailureHandler.FAIL_FAST)
+        lock.withLock {
+            if (completed) {
+                logIgnoreEmit()
+                return
+            }
+            terminatedFlag = true
+            terminalError = throwable
+            fluxSink?.let {
+                it.tryEmitError(throwable)
+                fluxSink = null
+                return
+            }
+            monoSink?.let {
+                it.tryEmitError(throwable)
+                monoSink = null
+            }
         }
     }
 
     override fun complete() {
-        tryEmit {
-            waitSignalSink.emitComplete(EmitFailureHandler.FAIL_FAST)
+        lock.withLock {
+            if (completed) {
+                logIgnoreEmit()
+                return
+            }
+            doComplete()
+        }
+    }
+
+    /**
+     * Terminates the strategy and delivers the terminal signal to the materialized sink,
+     * if any. Caller must hold [lock] and have verified the strategy is not completed.
+     */
+    private fun doComplete() {
+        terminatedFlag = true
+        fluxSink?.let {
+            it.tryEmitComplete()
+            fluxSink = null
+            return
+        }
+        monoSink?.let {
+            val finalSignal = finalSignal()
+            bufferedSignals = null
+            if (finalSignal == null) {
+                it.tryEmitEmpty()
+            } else {
+                it.tryEmitValue(finalSignal)
+            }
+            monoSink = null
+        }
+    }
+
+    private fun logIgnoreEmit() {
+        log.warn {
+            "WaitingFor is terminated or cancelled, ignore emit."
         }
     }
 
     override fun onFinally(doFinally: Consumer<SignalType>) {
-        check(this.onFinallyHook.compareAndSet(EmptyOnFinally, doFinally)) {
-            "Finally hook already set [${this.onFinallyHook.get()}]"
+        lock.withLock {
+            check(onFinallyHook === EmptyOnFinally) {
+                "Finally hook already set [$onFinallyHook]"
+            }
+            onFinallyHook = doFinally
         }
     }
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForAfterProcessed.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/stage/WaitingForAfterProcessed.kt
@@ -15,7 +15,6 @@ package me.ahoo.wow.command.wait.stage
 
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.WaitSignal
-import reactor.core.publisher.Mono
 
 /**
  * Abstract base class for wait strategies that wait for a specific stage after command processing is complete.
@@ -42,18 +41,12 @@ abstract class WaitingForAfterProcessed : WaitingForStage() {
 
     open fun isWaitingFor(signal: WaitSignal): Boolean = signal.stage == stage
 
-    override fun waitingLast(): Mono<WaitSignal> {
-        return waiting().collectList().mapNotNull { signals ->
-            if (signals.isEmpty()) {
-                return@mapNotNull null
-            }
-            val result: MutableMap<String, Any> = mutableMapOf()
-            signals.forEach { signal ->
-                result.putAll(signal.result)
-            }
-            val waitingForSignal = waitingForSignal ?: return@mapNotNull signals.last().copyResult(result)
-            waitingForSignal.copyResult(result)
-        }
+    /**
+     * The final signal is the target-stage signal, not the chronologically last one: the
+     * target stage (e.g. PROJECTED) may be notified before PROCESSED arrives.
+     */
+    override fun resolveLastSignal(signals: List<WaitSignal>): WaitSignal {
+        return waitingForSignal ?: signals.last()
     }
 
     override fun next(signal: WaitSignal) {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForLazySinkTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitingForLazySinkTest.kt
@@ -1,0 +1,322 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.command.wait
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.command.wait.stage.WaitingForStage
+import org.junit.jupiter.api.Test
+import reactor.test.StepVerifier
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class WaitingForLazySinkTest {
+
+    @Test
+    fun `waitingLast emits target stage signal merged from buffered signals`() {
+        val strategy = WaitingForStage.processed("wait-id")
+        val sentSignal = testSignal(
+            stage = CommandStage.SENT,
+            waitCommandId = "wait-id",
+            result = mapOf("sent" to 1),
+            signalTime = 1
+        )
+        val processedSignal = testSignal(
+            stage = CommandStage.PROCESSED,
+            waitCommandId = "wait-id",
+            result = mapOf("processed" to 2),
+            signalTime = 2
+        )
+
+        StepVerifier.create(strategy.waitingLast())
+            .then {
+                strategy.next(sentSignal)
+                strategy.next(processedSignal)
+            }
+            .consumeNextWith {
+                it.stage.assert().isEqualTo(CommandStage.PROCESSED)
+                it.result.assert().isEqualTo(mapOf("sent" to 1, "processed" to 2))
+            }
+            .verifyComplete()
+        strategy.terminated.assert().isTrue()
+    }
+
+    @Test
+    fun `waitingLast subscribed after completion emits final signal immediately`() {
+        val strategy = WaitingForStage.processed("wait-id")
+        val processedSignal = testSignal(stage = CommandStage.PROCESSED, waitCommandId = "wait-id")
+        strategy.next(processedSignal)
+        strategy.terminated.assert().isTrue()
+
+        StepVerifier.create(strategy.waitingLast())
+            .consumeNextWith {
+                it.stage.assert().isEqualTo(CommandStage.PROCESSED)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `waitingLast completes empty when completed without signals`() {
+        val strategy = WaitingForStage.processed("wait-id")
+        strategy.complete()
+
+        StepVerifier.create(strategy.waitingLast())
+            .verifyComplete()
+    }
+
+    @Test
+    fun `waitingLast emits empty when subscriber materializes before empty completion`() {
+        val strategy = WaitingForStage.processed("wait-id")
+
+        StepVerifier.create(strategy.waitingLast())
+            .then {
+                strategy.complete()
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `waitingLast swallows finally hook failure`() {
+        val strategy = WaitingForStage.processed("wait-id")
+        strategy.onFinally {
+            error("boom")
+        }
+
+        StepVerifier.create(strategy.waitingLast())
+            .then {
+                strategy.complete()
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `cancelled waitingLast marks strategy cancelled`() {
+        val strategy = WaitingForStage.processed("wait-id")
+
+        StepVerifier.create(strategy.waitingLast())
+            .thenCancel()
+            .verify()
+        strategy.cancelled.assert().isTrue()
+    }
+
+    @Test
+    fun `waitingLast returns single signal without copying`() {
+        val strategy = WaitingForStage.processed("wait-id")
+        val processedSignal = testSignal(
+            stage = CommandStage.PROCESSED,
+            waitCommandId = "wait-id",
+            result = mapOf("key" to "value")
+        )
+
+        StepVerifier.create(strategy.waitingLast())
+            .then {
+                strategy.next(processedSignal)
+            }
+            .consumeNextWith {
+                it.assert().isSameAs(processedSignal)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `after processed wait falls back to last signal when manually completed before target stage`() {
+        val strategy = WaitingForStage.projected("wait-id", TEST_CONTEXT)
+        val sentSignal = testSignal(
+            stage = CommandStage.SENT,
+            waitCommandId = "wait-id",
+            signalTime = 1
+        )
+        val processedSignal = testSignal(
+            stage = CommandStage.PROCESSED,
+            waitCommandId = "wait-id",
+            signalTime = 2
+        )
+
+        StepVerifier.create(strategy.waitingLast())
+            .then {
+                strategy.next(sentSignal)
+                strategy.next(processedSignal)
+                strategy.complete()
+            }
+            .expectNext(processedSignal)
+            .verifyComplete()
+    }
+
+    @Test
+    fun `waiting replays signals buffered before subscription`() {
+        val strategy = WaitingForStage.processed("wait-id")
+        val sentSignal = testSignal(stage = CommandStage.SENT, waitCommandId = "wait-id")
+        strategy.next(sentSignal)
+
+        StepVerifier.create(strategy.waiting())
+            .expectNext(sentSignal)
+            .then {
+                strategy.next(testSignal(stage = CommandStage.PROCESSED, waitCommandId = "wait-id"))
+            }
+            .expectNextCount(1)
+            .verifyComplete()
+    }
+
+    @Test
+    fun `waiting subscribed after completion replays all signals and completes`() {
+        val strategy = WaitingForStage.processed("wait-id")
+        val sentSignal = testSignal(stage = CommandStage.SENT, waitCommandId = "wait-id")
+        val processedSignal = testSignal(stage = CommandStage.PROCESSED, waitCommandId = "wait-id")
+        strategy.next(sentSignal)
+        strategy.next(processedSignal)
+
+        StepVerifier.create(strategy.waiting())
+            .expectNext(sentSignal, processedSignal)
+            .verifyComplete()
+    }
+
+    @Test
+    fun `error before subscription propagates to waitingLast subscriber`() {
+        val strategy = WaitingForStage.processed("wait-id")
+        val error = IllegalStateException("boom")
+        strategy.error(error)
+        strategy.terminated.assert().isTrue()
+
+        StepVerifier.create(strategy.waitingLast())
+            .verifyErrorMatches { it === error }
+    }
+
+    @Test
+    fun `error before subscription propagates to waiting subscriber after replay`() {
+        val strategy = WaitingForStage.processed("wait-id")
+        val sentSignal = testSignal(stage = CommandStage.SENT, waitCommandId = "wait-id")
+        val error = IllegalStateException("boom")
+        strategy.next(sentSignal)
+        strategy.error(error)
+
+        StepVerifier.create(strategy.waiting())
+            .expectNext(sentSignal)
+            .verifyErrorMatches { it === error }
+    }
+
+    @Test
+    fun `error after subscription propagates to waitingLast subscriber`() {
+        val strategy = WaitingForStage.processed("wait-id")
+        val error = IllegalStateException("boom")
+
+        StepVerifier.create(strategy.waitingLast())
+            .then {
+                strategy.error(error)
+            }
+            .verifyErrorMatches { it === error }
+    }
+
+    @Test
+    fun `error after waiting subscription propagates to waiting subscriber`() {
+        val strategy = WaitingForStage.processed("wait-id")
+        val error = IllegalStateException("boom")
+
+        StepVerifier.create(strategy.waiting())
+            .then {
+                strategy.error(error)
+            }
+            .verifyErrorMatches { it === error }
+    }
+
+    @Test
+    fun `second subscriber is rejected`() {
+        val strategy = WaitingForStage.processed("wait-id")
+        strategy.waiting().subscribe()
+
+        StepVerifier.create(strategy.waitingLast())
+            .verifyError(IllegalStateException::class.java)
+
+        StepVerifier.create(strategy.waiting())
+            .verifyError(IllegalStateException::class.java)
+    }
+
+    @Test
+    fun `failed prerequisite signal fail-fast completes strategy`() {
+        val strategy = WaitingForStage.processed("wait-id")
+        val failedSentSignal = testSignal(stage = CommandStage.SENT, waitCommandId = "wait-id", errorCode = "ERROR")
+
+        StepVerifier.create(strategy.waitingLast())
+            .then {
+                strategy.next(failedSentSignal)
+            }
+            .consumeNextWith {
+                it.errorCode.assert().isEqualTo("ERROR")
+            }
+            .verifyComplete()
+        strategy.terminated.assert().isTrue()
+    }
+
+    @Test
+    fun `signals after completion are ignored`() {
+        val strategy = WaitingForStage.processed("wait-id")
+        strategy.complete()
+        strategy.next(testSignal(stage = CommandStage.PROCESSED, waitCommandId = "wait-id"))
+        strategy.complete()
+        strategy.error(IllegalStateException("ignored"))
+
+        StepVerifier.create(strategy.waitingLast())
+            .verifyComplete()
+    }
+
+    @Test
+    fun `resolveLastSignal prefers greatest signal time`() {
+        val strategy = WaitingForStage.processed("wait-id")
+        val lateSignal = testSignal(stage = CommandStage.SENT, waitCommandId = "wait-id", signalTime = 10)
+        val processedSignal = testSignal(stage = CommandStage.PROCESSED, waitCommandId = "wait-id", signalTime = 5)
+
+        StepVerifier.create(strategy.waitingLast())
+            .then {
+                strategy.next(lateSignal)
+                strategy.next(processedSignal)
+            }
+            .consumeNextWith {
+                it.stage.assert().isEqualTo(CommandStage.SENT)
+                it.signalTime.assert().isEqualTo(10)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `concurrent next signals are serialized without loss`() {
+        val strategy = WaitingForStage.processed("wait-id")
+        val received = CopyOnWriteArrayList<WaitSignal>()
+        strategy.waiting().subscribe { received.add(it) }
+        val threadCount = 8
+        val signalsPerThread = 100
+        val startLatch = CountDownLatch(1)
+        val doneLatch = CountDownLatch(threadCount)
+        val failures = AtomicInteger()
+        repeat(threadCount) {
+            Thread {
+                try {
+                    startLatch.await()
+                    repeat(signalsPerThread) {
+                        strategy.next(testSignal(stage = CommandStage.SENT, waitCommandId = "wait-id"))
+                    }
+                } catch (ignored: Throwable) {
+                    failures.incrementAndGet()
+                } finally {
+                    doneLatch.countDown()
+                }
+            }.start()
+        }
+        startLatch.countDown()
+        doneLatch.await(10, TimeUnit.SECONDS).assert().isTrue()
+        failures.get().assert().isZero()
+        received.size.assert().isEqualTo(threadCount * signalsPerThread)
+        strategy.complete()
+        strategy.terminated.assert().isTrue()
+    }
+}


### PR DESCRIPTION
## Summary
- lazily materialize the WaitingFor Flux sink only when waiting() is subscribed
- let waitingLast() compute the final signal directly from buffered wait signals
- preserve target-stage final-signal behavior for after-processed wait strategies

## Split notes
- LocalCommandWaitNotifier direct dispatch moved to #2695
- SimpleServerCommandExchange dedicated attributes moved to #2696
- benchmark report/design notes are intentionally left out of this code PR

## Test plan
- ./gradlew :wow-core:test --tests "me.ahoo.wow.command.wait.WaitingForLazySinkTest" --stacktrace
- ./gradlew :wow-core:check --stacktrace