### PR TITLE
perf(core): fast-path sendAndWaitForSent

### DIFF
--- a/wow-benchmarks/results/reports/quick-framework-e2e.md
+++ b/wow-benchmarks/results/reports/quick-framework-e2e.md
@@ -11,7 +11,7 @@ Quick Framework E2E results are directional local feedback. Use Full E2E runs fo
 - **Version**: 8.5.0
 - **JVM**: OpenJDK 64-Bit Server VM 17.0.7+7-LTS
 - **OS**: Mac OS X 26.5.1 aarch64
-- **DateTime**: 2026-06-11T10:49:12+08:00
+- **DateTime**: 2026-06-11T20:24:26+08:00
 - **CPU Cores**: 14
 - **Physical Memory**: 24.0 GiB
 - **Benchmark JVM Args**: `-Xmx4g -Xms4g -XX:+UseG1GC -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints -XX:+AlwaysPreTouch`
@@ -21,27 +21,27 @@ Quick Framework E2E results are directional local feedback. Use Full E2E runs fo
 
 | Suite | Benchmark | Threads | Mode | Score | Error | Unit | gc.alloc.rate.norm |
 |-------|-----------|---------|------|-------|-------|------|-------------------|
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling) | 1 | avgt | 11.01 | - | us/op | 5082.5 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling) | 1 | thrpt | 91062.39 | - | ops/s | 5082.5 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling) | 4 | avgt | 24.57 | - | us/op | 5063.6 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling) | 4 | thrpt | 163735.92 | - | ops/s | 5063.3 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate) | 1 | avgt | 13.02 | - | us/op | 6498.8 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate) | 1 | thrpt | 78576.99 | - | ops/s | 6496.6 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate) | 4 | avgt | 27.16 | - | us/op | 6505.7 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate) | 4 | thrpt | 145819.27 | - | ops/s | 6560.0 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store) | 1 | avgt | 12.15 | - | us/op | 6880.6 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store) | 1 | thrpt | 84108.09 | - | ops/s | 6706.8 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store) | 4 | avgt | 25.12 | - | us/op | 6724.7 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store) | 4 | thrpt | 164328.42 | - | ops/s | 6771.5 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=ceiling) | 1 | avgt | 997.88 | - | ns/op | 4964.3 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=ceiling) | 1 | thrpt | 1031902.33 | - | ops/s | 4964.2 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=ceiling) | 4 | avgt | 3.09 | - | us/op | 4966.2 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=ceiling) | 4 | thrpt | 1285165.02 | - | ops/s | 4966.1 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=in-memory-new-aggregate) | 1 | avgt | 1.19 | - | us/op | 5732.3 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=in-memory-new-aggregate) | 1 | thrpt | 842459.58 | - | ops/s | 5732.3 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=in-memory-new-aggregate) | 4 | avgt | 3.17 | - | us/op | 5735.5 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=in-memory-new-aggregate) | 4 | thrpt | 1279705.32 | - | ops/s | 5735.9 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=noop-store) | 1 | avgt | 1.25 | - | us/op | 5972.2 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=noop-store) | 1 | thrpt | 801609.21 | - | ops/s | 5988.3 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=noop-store) | 4 | avgt | 3.31 | - | us/op | 5974.3 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=noop-store) | 4 | thrpt | 1144025.90 | - | ops/s | 5974.4 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling) | 1 | avgt | 10.48 | - | us/op | 5081.3 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling) | 1 | thrpt | 94512.71 | - | ops/s | 5077.9 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling) | 4 | avgt | 23.89 | - | us/op | 5062.4 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling) | 4 | thrpt | 169466.18 | - | ops/s | 5062.6 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate) | 1 | avgt | 12.09 | - | us/op | 6486.0 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate) | 1 | thrpt | 85645.21 | - | ops/s | 6489.0 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate) | 4 | avgt | 25.78 | - | us/op | 6620.7 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate) | 4 | thrpt | 151894.85 | - | ops/s | 6509.7 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store) | 1 | avgt | 11.04 | - | us/op | 6700.6 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store) | 1 | thrpt | 90861.86 | - | ops/s | 6724.3 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store) | 4 | avgt | 24.96 | - | us/op | 6724.4 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store) | 4 | thrpt | 165572.46 | - | ops/s | 6746.5 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=ceiling) | 1 | avgt | 623.22 | - | ns/op | 2252.2 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=ceiling) | 1 | thrpt | 1608693.61 | - | ops/s | 2252.2 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=ceiling) | 4 | avgt | 3.30 | - | us/op | 2253.3 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=ceiling) | 4 | thrpt | 1206521.10 | - | ops/s | 2253.2 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=in-memory-new-aggregate) | 1 | avgt | 664.85 | - | ns/op | 2988.2 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=in-memory-new-aggregate) | 1 | thrpt | 1393671.79 | - | ops/s | 3020.2 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=in-memory-new-aggregate) | 4 | avgt | 2.30 | - | us/op | 3022.4 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=in-memory-new-aggregate) | 4 | thrpt | 1656405.43 | - | ops/s | 3070.2 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=noop-store) | 1 | avgt | 798.56 | - | ns/op | 3260.2 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=noop-store) | 1 | thrpt | 1285836.07 | - | ops/s | 3260.2 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=noop-store) | 4 | avgt | 3.28 | - | us/op | 3262.0 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=noop-store) | 4 | thrpt | 1427656.04 | - | ops/s | 3262.2 B/op |

--- a/wow-core/src/contractTest/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTest.kt
+++ b/wow-core/src/contractTest/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTest.kt
@@ -51,6 +51,66 @@ internal class DefaultCommandGatewayTest : CommandGatewaySpec() {
     }
 
     @Test
+    fun `should return sent stage result when sendAndWaitForSent succeeds`() {
+        val message = createMessage()
+        verify {
+            sendAndWaitForSent(message)
+                .test()
+                .consumeNextWith {
+                    it.succeeded.assert().isTrue()
+                    it.stage.assert().isEqualTo(CommandStage.SENT)
+                    it.waitCommandId.assert().isEqualTo(message.commandId)
+                    it.commandId.assert().isEqualTo(message.commandId)
+                    it.requestId.assert().isEqualTo(message.requestId)
+                    it.aggregateId.assert().isEqualTo(message.aggregateId.id)
+                    it.function.assert().isEqualTo(COMMAND_GATEWAY_FUNCTION)
+                }
+                .verifyComplete()
+        }
+        waitStrategyRegistrar.contains(message.commandId).assert().isFalse()
+    }
+
+    @Test
+    fun `should support void command when sendAndWaitForSent`() {
+        val messageGateway = createMessageBus()
+        val message = MockVoidCommand(generateGlobalId()).toCommandMessage()
+        messageGateway.sendAndWaitForSent(message)
+            .test()
+            .consumeNextWith {
+                it.succeeded.assert().isTrue()
+                it.stage.assert().isEqualTo(CommandStage.SENT)
+            }
+            .verifyComplete()
+        waitStrategyRegistrar.contains(message.commandId).assert().isFalse()
+    }
+
+    @Test
+    fun `should wrap command bus error when sendAndWaitForSent`() {
+        val commandBus = mockk<CommandBus> {
+            every { send(any()) } returns IllegalArgumentException().toMono()
+        }
+        val commandGateway = DefaultCommandGateway(
+            commandWaitEndpoint = SimpleCommandWaitEndpoint(""),
+            commandBus = commandBus,
+            validator = TestValidator,
+            idempotencyCheckerProvider = DefaultAggregateIdempotencyCheckerProvider { idempotencyChecker },
+            waitStrategyRegistrar = waitStrategyRegistrar,
+            commandWaitNotifier = LocalCommandWaitNotifier(SimpleWaitStrategyRegistrar)
+        )
+        val message = createMessage()
+        commandGateway.sendAndWaitForSent(message)
+            .test()
+            .consumeErrorWith {
+                it.assert().isInstanceOf(CommandResultException::class.java)
+                val commandResult = (it as CommandResultException).commandResult
+                commandResult.stage.assert().isEqualTo(CommandStage.SENT)
+                commandResult.succeeded.assert().isFalse()
+            }
+            .verify()
+        waitStrategyRegistrar.contains(message.commandId).assert().isFalse()
+    }
+
+    @Test
     fun `should validate command body`() {
         val message = MockCommandBody().toCommandMessage()
         verify {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
@@ -17,12 +17,14 @@ import jakarta.validation.Validator
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.command.validation.CommandValidator
 import me.ahoo.wow.command.validation.validateCommand
+import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.CommandWaitEndpoint
 import me.ahoo.wow.command.wait.CommandWaitNotifier
 import me.ahoo.wow.command.wait.WaitStrategy
 import me.ahoo.wow.command.wait.WaitStrategyRegistrar
 import me.ahoo.wow.command.wait.extractWaitStrategy
 import me.ahoo.wow.command.wait.notifyAndForget
+import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.infra.idempotency.AggregateIdempotencyCheckerProvider
 import me.ahoo.wow.modeling.materialize
 import me.ahoo.wow.reactor.thenDefer
@@ -126,6 +128,49 @@ class DefaultCommandGateway(
                 commandWaitNotifier.notifyAndForget(waitStrategy, waitSignal)
             }
     }
+
+    /**
+     * Sends a command and completes with the SENT stage result as soon as the command bus accepts it.
+     *
+     * The SENT signal is synthesized by this gateway itself once [CommandBus.send] completes, so this
+     * fast path skips the wait-strategy registration, sink allocation, and wait-header propagation that
+     * [sendAndWait] requires. Downstream stage notifiers see no wait headers and therefore stay no-op,
+     * which matches the SENT-only contract: no stage after SENT is ever waited on.
+     *
+     * @param C The type of the command body.
+     * @param command The command message to send.
+     * @return A Mono emitting the SENT stage CommandResult.
+     * @throws CommandResultException if the pre-send checks fail or the command bus rejects the command.
+     */
+    override fun <C : Any> sendAndWaitForSent(command: CommandMessage<C>): Mono<CommandResult> =
+        check(command)
+            .thenDefer {
+                commandBus.send(command)
+            }.then(
+                Mono.fromCallable {
+                    CommandResult(
+                        id = generateGlobalId(),
+                        waitCommandId = command.commandId,
+                        stage = CommandStage.SENT,
+                        contextName = command.aggregateId.contextName,
+                        aggregateName = command.aggregateId.aggregateName,
+                        tenantId = command.aggregateId.tenantId,
+                        aggregateId = command.aggregateId.id,
+                        aggregateVersion = command.aggregateVersion,
+                        requestId = command.requestId,
+                        commandId = command.commandId,
+                        function = COMMAND_GATEWAY_FUNCTION,
+                    )
+                },
+            ).onErrorMap {
+                CommandResultException(
+                    it.toResult(
+                        waitCommandId = command.commandId,
+                        commandMessage = command,
+                    ),
+                    it,
+                )
+            }
 
     /**
      * Sends a command and returns a stream of command results as they become available.


### PR DESCRIPTION
## Summary
- add a dedicated DefaultCommandGateway.sendAndWaitForSent fast path that synthesizes the SENT result after command bus acceptance
- skip wait-strategy registration, wait-header propagation, sink allocation, and downstream notifier work for SENT-only waits
- add contract coverage for success, void command support, and command bus error wrapping
- refresh the focused Quick Framework E2E report on macOS for this fast-path branch

## Validation
- ./gradlew :wow-core:check --stacktrace
- ./gradlew :wow-benchmarks:benchmarkQuickE2E :wow-benchmarks:generateBenchmarkReport --no-parallel
- git diff --check origin/main...HEAD

## Benchmark Notes
- Quick Framework E2E only; directional local feedback, not a Full E2E baseline
- Environment: macOS aarch64, JDK 17.0.7, 14 cores, 24 GiB memory