### PR TITLE
perf(core): dispatch local wait notifications directly

### DIFF
--- a/wow-benchmarks/results/reports/quick-framework-e2e.md
+++ b/wow-benchmarks/results/reports/quick-framework-e2e.md
@@ -11,7 +11,7 @@ Quick Framework E2E results are directional local feedback. Use Full E2E runs fo
 - **Version**: 8.5.0
 - **JVM**: OpenJDK 64-Bit Server VM 17.0.7+7-LTS
 - **OS**: Mac OS X 26.5.1 aarch64
-- **DateTime**: 2026-06-11T20:24:26+08:00
+- **DateTime**: 2026-06-12T09:15:09+08:00
 - **CPU Cores**: 14
 - **Physical Memory**: 24.0 GiB
 - **Benchmark JVM Args**: `-Xmx4g -Xms4g -XX:+UseG1GC -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints -XX:+AlwaysPreTouch`
@@ -21,27 +21,27 @@ Quick Framework E2E results are directional local feedback. Use Full E2E runs fo
 
 | Suite | Benchmark | Threads | Mode | Score | Error | Unit | gc.alloc.rate.norm |
 |-------|-----------|---------|------|-------|-------|------|-------------------|
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling) | 1 | avgt | 10.48 | - | us/op | 5081.3 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling) | 1 | thrpt | 94512.71 | - | ops/s | 5077.9 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling) | 4 | avgt | 23.89 | - | us/op | 5062.4 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling) | 4 | thrpt | 169466.18 | - | ops/s | 5062.6 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate) | 1 | avgt | 12.09 | - | us/op | 6486.0 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate) | 1 | thrpt | 85645.21 | - | ops/s | 6489.0 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate) | 4 | avgt | 25.78 | - | us/op | 6620.7 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate) | 4 | thrpt | 151894.85 | - | ops/s | 6509.7 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store) | 1 | avgt | 11.04 | - | us/op | 6700.6 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store) | 1 | thrpt | 90861.86 | - | ops/s | 6724.3 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store) | 4 | avgt | 24.96 | - | us/op | 6724.4 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store) | 4 | thrpt | 165572.46 | - | ops/s | 6746.5 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=ceiling) | 1 | avgt | 623.22 | - | ns/op | 2252.2 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=ceiling) | 1 | thrpt | 1608693.61 | - | ops/s | 2252.2 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=ceiling) | 4 | avgt | 3.30 | - | us/op | 2253.3 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=ceiling) | 4 | thrpt | 1206521.10 | - | ops/s | 2253.2 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=in-memory-new-aggregate) | 1 | avgt | 664.85 | - | ns/op | 2988.2 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=in-memory-new-aggregate) | 1 | thrpt | 1393671.79 | - | ops/s | 3020.2 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=in-memory-new-aggregate) | 4 | avgt | 2.30 | - | us/op | 3022.4 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=in-memory-new-aggregate) | 4 | thrpt | 1656405.43 | - | ops/s | 3070.2 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=noop-store) | 1 | avgt | 798.56 | - | ns/op | 3260.2 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=noop-store) | 1 | thrpt | 1285836.07 | - | ops/s | 3260.2 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=noop-store) | 4 | avgt | 3.28 | - | us/op | 3262.0 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=noop-store) | 4 | thrpt | 1427656.04 | - | ops/s | 3262.2 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling) | 1 | avgt | 10.76 | - | us/op | 5078.5 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling) | 1 | thrpt | 85129.18 | - | ops/s | 5083.5 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling) | 4 | avgt | 24.41 | - | us/op | 5087.1 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling) | 4 | thrpt | 165411.49 | - | ops/s | 5063.0 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate) | 1 | avgt | 12.48 | - | us/op | 6470.9 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate) | 1 | thrpt | 81208.02 | - | ops/s | 6517.7 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate) | 4 | avgt | 26.74 | - | us/op | 6534.7 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate) | 4 | thrpt | 145590.62 | - | ops/s | 6536.8 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store) | 1 | avgt | 12.15 | - | us/op | 6748.4 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store) | 1 | thrpt | 88260.41 | - | ops/s | 6725.6 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store) | 4 | avgt | 24.83 | - | us/op | 6724.1 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store) | 4 | thrpt | 162271.89 | - | ops/s | 6730.2 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=ceiling) | 1 | avgt | 607.42 | - | ns/op | 2252.2 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=ceiling) | 1 | thrpt | 1581641.70 | - | ops/s | 2252.2 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=ceiling) | 4 | avgt | 3.19 | - | us/op | 2277.5 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=ceiling) | 4 | thrpt | 1228290.90 | - | ops/s | 2253.4 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=in-memory-new-aggregate) | 1 | avgt | 738.38 | - | ns/op | 3020.2 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=in-memory-new-aggregate) | 1 | thrpt | 1353578.88 | - | ops/s | 3020.2 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=in-memory-new-aggregate) | 4 | avgt | 2.40 | - | us/op | 3022.6 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=in-memory-new-aggregate) | 4 | thrpt | 1618040.93 | - | ops/s | 3022.4 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=noop-store) | 1 | avgt | 793.28 | - | ns/op | 3260.2 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=noop-store) | 1 | thrpt | 1281580.83 | - | ops/s | 3260.2 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=noop-store) | 4 | avgt | 3.43 | - | us/op | 3261.7 B/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitSent (scenario=noop-store) | 4 | thrpt | 1230932.16 | - | ops/s | 3261.9 B/op |

--- a/wow-core/src/contractTest/kotlin/me/ahoo/wow/command/wait/LocalCommandWaitNotifierContractTest.kt
+++ b/wow-core/src/contractTest/kotlin/me/ahoo/wow/command/wait/LocalCommandWaitNotifierContractTest.kt
@@ -20,7 +20,7 @@ import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.modeling.DefaultAggregateId
 import org.junit.jupiter.api.Test
-import reactor.test.StepVerifier
+import reactor.kotlin.test.test
 
 class LocalCommandWaitNotifierContractTest {
 
@@ -30,7 +30,8 @@ class LocalCommandWaitNotifierContractTest {
         val notifier = LocalCommandWaitNotifier(registrar)
         val signal = signal()
 
-        StepVerifier.create(notifier.notify(TEST_ENDPOINT, signal))
+        notifier.notify(TEST_ENDPOINT, signal)
+            .test()
             .verifyComplete()
 
         registrar.signals.assert().containsExactly(signal)
@@ -41,7 +42,8 @@ class LocalCommandWaitNotifierContractTest {
         val registrar = RecordingWaitStrategyRegistrar()
         val notifier = LocalCommandWaitNotifier(registrar)
 
-        StepVerifier.create(notifier.notify(TEST_ENDPOINT, signal(waitCommandId = "")))
+        notifier.notify(TEST_ENDPOINT, signal(waitCommandId = ""))
+            .test()
             .verifyComplete()
 
         registrar.signals.assert().isEmpty()

--- a/wow-core/src/contractTest/kotlin/me/ahoo/wow/command/wait/LocalCommandWaitNotifierContractTest.kt
+++ b/wow-core/src/contractTest/kotlin/me/ahoo/wow/command/wait/LocalCommandWaitNotifierContractTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.command.wait
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.messaging.function.FunctionInfoData
+import me.ahoo.wow.api.messaging.function.FunctionKind
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.modeling.DefaultAggregateId
+import org.junit.jupiter.api.Test
+import reactor.test.StepVerifier
+
+class LocalCommandWaitNotifierContractTest {
+
+    @Test
+    fun `notify forwards local signal`() {
+        val registrar = RecordingWaitStrategyRegistrar()
+        val notifier = LocalCommandWaitNotifier(registrar)
+        val signal = signal()
+
+        StepVerifier.create(notifier.notify(TEST_ENDPOINT, signal))
+            .verifyComplete()
+
+        registrar.signals.assert().containsExactly(signal)
+    }
+
+    @Test
+    fun `notify ignores non local signal`() {
+        val registrar = RecordingWaitStrategyRegistrar()
+        val notifier = LocalCommandWaitNotifier(registrar)
+
+        StepVerifier.create(notifier.notify(TEST_ENDPOINT, signal(waitCommandId = "")))
+            .verifyComplete()
+
+        registrar.signals.assert().isEmpty()
+    }
+
+    @Test
+    fun `notifyAndForget forwards local signal synchronously`() {
+        val registrar = RecordingWaitStrategyRegistrar()
+        val notifier = LocalCommandWaitNotifier(registrar)
+        val signal = signal()
+
+        notifier.notifyAndForget(TEST_ENDPOINT, signal)
+
+        registrar.signals.assert().containsExactly(signal)
+    }
+
+    @Test
+    fun `notifyAndForget ignores non local signal`() {
+        val registrar = RecordingWaitStrategyRegistrar()
+        val notifier = LocalCommandWaitNotifier(registrar)
+
+        notifier.notifyAndForget(TEST_ENDPOINT, signal(waitCommandId = ""))
+
+        registrar.signals.assert().isEmpty()
+    }
+
+    @Test
+    fun `notifyAndForget swallows registrar failures`() {
+        val notifier = LocalCommandWaitNotifier(ThrowingWaitStrategyRegistrar())
+
+        notifier.notifyAndForget(TEST_ENDPOINT, signal())
+    }
+
+    private fun signal(waitCommandId: String = generateGlobalId()): WaitSignal =
+        SimpleWaitSignal(
+            id = generateGlobalId(),
+            waitCommandId = waitCommandId,
+            commandId = waitCommandId,
+            aggregateId = DefaultAggregateId(TestNamedAggregate, "aggregate-id"),
+            stage = CommandStage.PROCESSED,
+            function = FunctionInfoData(
+                functionKind = FunctionKind.EVENT,
+                contextName = TestNamedAggregate.contextName,
+                processorName = "processor",
+                name = "function",
+            ),
+        )
+
+    private object TestNamedAggregate : NamedAggregate {
+        override val contextName: String = "context"
+        override val aggregateName: String = "aggregate"
+    }
+
+    private class RecordingWaitStrategyRegistrar : WaitStrategyRegistrar {
+        val signals: MutableList<WaitSignal> = mutableListOf()
+
+        override fun register(waitStrategy: WaitStrategy): WaitStrategy? = null
+
+        override fun unregister(waitCommandId: String): WaitStrategy? = null
+
+        override fun get(waitCommandId: String): WaitStrategy? = null
+
+        override fun contains(waitCommandId: String): Boolean = false
+
+        override fun next(signal: WaitSignal): Boolean {
+            signals += signal
+            return true
+        }
+    }
+
+    private class ThrowingWaitStrategyRegistrar : WaitStrategyRegistrar {
+        override fun register(waitStrategy: WaitStrategy): WaitStrategy? = null
+
+        override fun unregister(waitCommandId: String): WaitStrategy? = null
+
+        override fun get(waitCommandId: String): WaitStrategy? = null
+
+        override fun contains(waitCommandId: String): Boolean = false
+
+        override fun next(signal: WaitSignal): Boolean {
+            error("boom")
+        }
+    }
+
+    private companion object {
+        const val TEST_ENDPOINT = "test-endpoint"
+    }
+}

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWaitNotifier.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWaitNotifier.kt
@@ -78,17 +78,41 @@ class LocalCommandWaitNotifier(
         waitSignal: WaitSignal
     ): Mono<Void> =
         Mono.fromRunnable {
-            if (isLocalWaitStrategy(waitSignal.waitCommandId)) {
-                log.debug {
-                    "Notify Local - waitSignal: $waitSignal"
-                }
-                waitStrategyRegistrar.next(waitSignal)
-            } else {
-                log.warn {
-                    "Ignore Notify - waitSignal: $waitSignal"
-                }
+            notifyLocal(waitSignal)
+        }
+
+    /**
+     * Local notification completes synchronously, so the fire-and-forget path skips the
+     * per-signal `Mono.fromRunnable` and subscriber allocations of the default implementation.
+     * Notification failures are logged instead of propagating to the notifying pipeline,
+     * matching the dropped-error semantics of `notify(...).subscribe()`.
+     */
+    @Suppress("TooGenericExceptionCaught")
+    override fun notifyAndForget(
+        commandWaitEndpoint: String,
+        waitSignal: WaitSignal
+    ) {
+        try {
+            notifyLocal(waitSignal)
+        } catch (error: Throwable) {
+            log.error(error) {
+                "NotifyAndForget failed - waitSignal: $waitSignal"
             }
         }
+    }
+
+    private fun notifyLocal(waitSignal: WaitSignal) {
+        if (isLocalWaitStrategy(waitSignal.waitCommandId)) {
+            log.debug {
+                "Notify Local - waitSignal: $waitSignal"
+            }
+            waitStrategyRegistrar.next(waitSignal)
+        } else {
+            log.warn {
+                "Ignore Notify - waitSignal: $waitSignal"
+            }
+        }
+    }
 }
 
 /**

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/LocalCommandWaitNotifierTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/LocalCommandWaitNotifierTest.kt
@@ -45,6 +45,25 @@ class LocalCommandWaitNotifierTest {
     }
 
     @Test
+    fun `notifyAndForget forwards local signal synchronously`() {
+        val registrar = RecordingWaitStrategyRegistrar()
+        val notifier = LocalCommandWaitNotifier(registrar)
+        val signal = testSignal(CommandStage.PROCESSED, waitCommandId = generateGlobalId())
+
+        notifier.notifyAndForget(TEST_ENDPOINT, signal)
+
+        registrar.signals.assert().containsExactly(signal)
+    }
+
+    @Test
+    fun `notifyAndForget swallows registrar failures`() {
+        val notifier = LocalCommandWaitNotifier(ThrowingWaitStrategyRegistrar())
+        val signal = testSignal(CommandStage.PROCESSED, waitCommandId = generateGlobalId())
+
+        notifier.notifyAndForget(TEST_ENDPOINT, signal)
+    }
+
+    @Test
     fun `cancelling notify before request does not forward signal`() {
         val registrar = RecordingWaitStrategyRegistrar()
         val notifier = LocalCommandWaitNotifier(registrar)
@@ -55,5 +74,19 @@ class LocalCommandWaitNotifierTest {
             .verify()
 
         registrar.signals.assert().isEmpty()
+    }
+
+    private class ThrowingWaitStrategyRegistrar : WaitStrategyRegistrar {
+        override fun register(waitStrategy: WaitStrategy): WaitStrategy? = null
+
+        override fun unregister(waitCommandId: String): WaitStrategy? = null
+
+        override fun get(waitCommandId: String): WaitStrategy? = null
+
+        override fun contains(waitCommandId: String): Boolean = false
+
+        override fun next(signal: WaitSignal): Boolean {
+            error("boom")
+        }
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/LocalCommandWaitNotifierTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/LocalCommandWaitNotifierTest.kt
@@ -16,6 +16,7 @@ package me.ahoo.wow.command.wait
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.id.generateGlobalId
 import org.junit.jupiter.api.Test
+import reactor.kotlin.test.test
 import reactor.test.StepVerifier
 
 class LocalCommandWaitNotifierTest {
@@ -26,7 +27,8 @@ class LocalCommandWaitNotifierTest {
         val notifier = LocalCommandWaitNotifier(registrar)
         val signal = testSignal(CommandStage.PROCESSED, waitCommandId = generateGlobalId())
 
-        StepVerifier.create(notifier.notify(TEST_ENDPOINT, signal))
+        notifier.notify(TEST_ENDPOINT, signal)
+            .test()
             .verifyComplete()
 
         registrar.signals.assert().containsExactly(signal)
@@ -38,7 +40,8 @@ class LocalCommandWaitNotifierTest {
         val notifier = LocalCommandWaitNotifier(registrar)
         val signal = testSignal(CommandStage.PROCESSED, waitCommandId = "")
 
-        StepVerifier.create(notifier.notify(TEST_ENDPOINT, signal))
+        notifier.notify(TEST_ENDPOINT, signal)
+            .test()
             .verifyComplete()
 
         registrar.signals.assert().isEmpty()


### PR DESCRIPTION
## Summary
- dispatch local wait notifications directly in notifyAndForget
- avoid per-signal Mono/subscriber allocation for the local fire-and-forget path
- keep dropped-error semantics by logging registrar failures
- add contract coverage for the new direct dispatch branches
- record the Quick Framework E2E report generated for this notifier-only PR

## Test plan
- ./gradlew :wow-core:test --tests "me.ahoo.wow.command.wait.LocalCommandWaitNotifierTest" --stacktrace
- ./gradlew :wow-core:contractTest --tests "me.ahoo.wow.command.wait.LocalCommandWaitNotifierContractTest" --stacktrace
- ./gradlew :wow-core:check --stacktrace
- ./gradlew :wow-benchmarks:benchmarkQuickE2E :wow-benchmarks:generateBenchmarkReport