### PR TITLE
perf(core): specialize server command exchange attributes

### DIFF
--- a/wow-core/src/contractTest/kotlin/me/ahoo/wow/command/SimpleServerCommandExchangeContractTest.kt
+++ b/wow-core/src/contractTest/kotlin/me/ahoo/wow/command/SimpleServerCommandExchangeContractTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.command
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.messaging.handler.COMMAND_RESULT_KEY
+import me.ahoo.wow.messaging.handler.ERROR_KEY
+import me.ahoo.wow.messaging.handler.FUNCTION_KEY
+import me.ahoo.wow.messaging.handler.SERVICE_PROVIDER_KEY
+import me.ahoo.wow.modeling.command.COMMAND_AGGREGATE_KEY
+import me.ahoo.wow.tck.mock.MockVoidCommand
+import org.junit.jupiter.api.Test
+
+class SimpleServerCommandExchangeContractTest {
+
+    @Test
+    fun `known attributes are stored outside the attributes map`() {
+        val exchange = SimpleServerCommandExchange(message())
+        val knownAttributes = knownAttributes()
+
+        knownAttributes.forEach { (key, value) ->
+            exchange.setAttribute(key, value).assert().isSameAs(exchange)
+            exchange.getAttribute<AttributeValue>(key).assert().isSameAs(value)
+        }
+
+        exchange.attributes.assert().isEmpty()
+    }
+
+    @Test
+    fun `known attributes are removed from dedicated fields`() {
+        val exchange = SimpleServerCommandExchange(message())
+        val knownAttributes = knownAttributes()
+        knownAttributes.forEach { (key, value) ->
+            exchange.setAttribute(key, value)
+        }
+
+        knownAttributes.keys.forEach { key ->
+            exchange.removeAttribute(key).assert().isSameAs(exchange)
+            exchange.getAttribute<AttributeValue>(key).assert().isNull()
+        }
+
+        exchange.attributes.assert().isEmpty()
+    }
+
+    @Test
+    fun `unknown attributes still use the attributes map`() {
+        val exchange = SimpleServerCommandExchange(message())
+        val value = AttributeValue("custom")
+
+        exchange.setAttribute(UNKNOWN_KEY, value).assert().isSameAs(exchange)
+        exchange.getAttribute<AttributeValue>(UNKNOWN_KEY).assert().isSameAs(value)
+        exchange.attributes[UNKNOWN_KEY].assert().isSameAs(value)
+
+        exchange.removeAttribute(UNKNOWN_KEY).assert().isSameAs(exchange)
+        exchange.getAttribute<AttributeValue>(UNKNOWN_KEY).assert().isNull()
+        exchange.attributes.containsKey(UNKNOWN_KEY).assert().isFalse()
+    }
+
+    @Test
+    fun `constructor migrates known attributes and keeps unknown attributes`() {
+        val knownValue = AttributeValue("event-stream")
+        val customValue = AttributeValue("custom")
+        val attributes = linkedMapOf<String, Any>(
+            EVENT_STREAM_KEY to knownValue,
+            UNKNOWN_KEY to customValue,
+        )
+
+        val exchange = SimpleServerCommandExchange(message(), attributes)
+
+        exchange.getAttribute<AttributeValue>(EVENT_STREAM_KEY).assert().isSameAs(knownValue)
+        attributes.containsKey(EVENT_STREAM_KEY).assert().isFalse()
+        exchange.getAttribute<AttributeValue>(UNKNOWN_KEY).assert().isSameAs(customValue)
+        attributes[UNKNOWN_KEY].assert().isSameAs(customValue)
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    fun `constructor keeps null known attributes in the attributes map`() {
+        val customValue = AttributeValue("custom")
+        val attributes = linkedMapOf<String, Any?>(
+            EVENT_STREAM_KEY to null,
+            UNKNOWN_KEY to customValue,
+        ) as MutableMap<String, Any>
+
+        val exchange = SimpleServerCommandExchange(message(), attributes)
+
+        exchange.getAttribute<AttributeValue>(EVENT_STREAM_KEY).assert().isNull()
+        attributes.containsKey(EVENT_STREAM_KEY).assert().isTrue()
+        exchange.getAttribute<AttributeValue>(UNKNOWN_KEY).assert().isSameAs(customValue)
+    }
+
+    private fun knownAttributes(): Map<String, AttributeValue> =
+        linkedMapOf(
+            AGGREGATE_METADATA_KEY to AttributeValue("aggregate-metadata"),
+            AGGREGATE_PROCESSOR_KEY to AttributeValue("aggregate-processor"),
+            COMMAND_INVOKE_RESULT_KEY to AttributeValue("command-invoke-result"),
+            EVENT_STREAM_KEY to AttributeValue("event-stream"),
+            AGGREGATE_VERSION_KEY to AttributeValue("aggregate-version"),
+            COMMAND_AGGREGATE_KEY to AttributeValue("command-aggregate"),
+            FUNCTION_KEY to AttributeValue("function"),
+            SERVICE_PROVIDER_KEY to AttributeValue("service-provider"),
+            ERROR_KEY to AttributeValue("error"),
+            COMMAND_RESULT_KEY to AttributeValue("command-result"),
+        )
+
+    private fun message() = MockVoidCommand(generateGlobalId()).toCommandMessage()
+
+    private data class AttributeValue(val name: String)
+
+    private companion object {
+        const val UNKNOWN_KEY = "custom-key"
+    }
+}

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandExchange.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandExchange.kt
@@ -18,8 +18,13 @@ import me.ahoo.wow.api.exception.ErrorInfo
 import me.ahoo.wow.api.exception.ErrorInfo.Companion.isFailed
 import me.ahoo.wow.event.DomainEventException.Companion.toException
 import me.ahoo.wow.event.DomainEventStream
+import me.ahoo.wow.messaging.handler.COMMAND_RESULT_KEY
+import me.ahoo.wow.messaging.handler.ERROR_KEY
+import me.ahoo.wow.messaging.handler.FUNCTION_KEY
 import me.ahoo.wow.messaging.handler.MessageExchange
+import me.ahoo.wow.messaging.handler.SERVICE_PROVIDER_KEY
 import me.ahoo.wow.modeling.command.AggregateProcessor
+import me.ahoo.wow.modeling.command.COMMAND_AGGREGATE_KEY
 import me.ahoo.wow.modeling.command.getCommandAggregate
 import me.ahoo.wow.modeling.metadata.AggregateMetadata
 import java.util.concurrent.ConcurrentHashMap
@@ -199,12 +204,137 @@ interface ServerCommandExchange<C : Any> : CommandExchange<ServerCommandExchange
  * This class provides a basic implementation of the server command exchange,
  * storing the command message and any additional attributes for command processing.
  *
+ * The well-known per-command attributes are stored in dedicated volatile fields instead of the
+ * [attributes] map, so the command processing hot path avoids per-put map node allocations.
+ * Only unknown attribute keys fall back to the [attributes] map; well-known keys present in a
+ * caller-provided map are migrated into fields on construction.
+ *
  * @param C the type of the command
  * @param message the command message being processed
  * @param attributes mutable map for storing additional exchange data
  * @see ServerCommandExchange
  */
+@Suppress("TooManyFunctions")
 class SimpleServerCommandExchange<C : Any>(
     override val message: CommandMessage<C>,
     override val attributes: MutableMap<String, Any> = ConcurrentHashMap()
-) : ServerCommandExchange<C>
+) : ServerCommandExchange<C> {
+    companion object {
+        private val UNKNOWN = Any()
+    }
+
+    @Volatile
+    private var aggregateMetadata: Any? = null
+
+    @Volatile
+    private var aggregateProcessor: Any? = null
+
+    @Volatile
+    private var commandInvokeResult: Any? = null
+
+    @Volatile
+    private var eventStream: Any? = null
+
+    @Volatile
+    private var aggregateVersion: Any? = null
+
+    @Volatile
+    private var commandAggregate: Any? = null
+
+    @Volatile
+    private var function: Any? = null
+
+    @Volatile
+    private var serviceProvider: Any? = null
+
+    @Volatile
+    private var error: Any? = null
+
+    @Volatile
+    private var commandResult: Any? = null
+
+    init {
+        if (attributes.isNotEmpty()) {
+            attributes.keys.toList().forEach { key ->
+                val value = attributes[key] ?: return@forEach
+                if (storeKnownAttribute(key, value)) {
+                    attributes.remove(key)
+                }
+            }
+        }
+    }
+
+    private fun storeKnownAttribute(key: String, value: Any): Boolean {
+        when (key) {
+            AGGREGATE_METADATA_KEY -> aggregateMetadata = value
+            AGGREGATE_PROCESSOR_KEY -> aggregateProcessor = value
+            COMMAND_INVOKE_RESULT_KEY -> commandInvokeResult = value
+            EVENT_STREAM_KEY -> eventStream = value
+            AGGREGATE_VERSION_KEY -> aggregateVersion = value
+            COMMAND_AGGREGATE_KEY -> commandAggregate = value
+            FUNCTION_KEY -> function = value
+            SERVICE_PROVIDER_KEY -> serviceProvider = value
+            ERROR_KEY -> error = value
+            COMMAND_RESULT_KEY -> commandResult = value
+            else -> return false
+        }
+        return true
+    }
+
+    private fun knownAttribute(key: String): Any? {
+        return when (key) {
+            AGGREGATE_METADATA_KEY -> aggregateMetadata
+            AGGREGATE_PROCESSOR_KEY -> aggregateProcessor
+            COMMAND_INVOKE_RESULT_KEY -> commandInvokeResult
+            EVENT_STREAM_KEY -> eventStream
+            AGGREGATE_VERSION_KEY -> aggregateVersion
+            COMMAND_AGGREGATE_KEY -> commandAggregate
+            FUNCTION_KEY -> function
+            SERVICE_PROVIDER_KEY -> serviceProvider
+            ERROR_KEY -> error
+            COMMAND_RESULT_KEY -> commandResult
+            else -> UNKNOWN
+        }
+    }
+
+    private fun removeKnownAttribute(key: String): Boolean {
+        when (key) {
+            AGGREGATE_METADATA_KEY -> aggregateMetadata = null
+            AGGREGATE_PROCESSOR_KEY -> aggregateProcessor = null
+            COMMAND_INVOKE_RESULT_KEY -> commandInvokeResult = null
+            EVENT_STREAM_KEY -> eventStream = null
+            AGGREGATE_VERSION_KEY -> aggregateVersion = null
+            COMMAND_AGGREGATE_KEY -> commandAggregate = null
+            FUNCTION_KEY -> function = null
+            SERVICE_PROVIDER_KEY -> serviceProvider = null
+            ERROR_KEY -> error = null
+            COMMAND_RESULT_KEY -> commandResult = null
+            else -> return false
+        }
+        return true
+    }
+
+    override fun setAttribute(key: String, value: Any): ServerCommandExchange<C> {
+        if (!storeKnownAttribute(key, value)) {
+            attributes[key] = value
+        }
+        return this
+    }
+
+    override fun <T> getAttribute(key: String): T? {
+        val known = knownAttribute(key)
+        @Suppress("UNCHECKED_CAST")
+        return if (known !== UNKNOWN) {
+            known as T?
+        } else {
+            attributes[key] as T?
+        }
+    }
+
+    override fun removeAttribute(key: String): ServerCommandExchange<C> {
+        if (!removeKnownAttribute(key)) {
+            attributes.remove(key)
+        }
+        return this
+    }
+}

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/SimpleServerCommandExchangeTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/SimpleServerCommandExchangeTest.kt
@@ -20,9 +20,18 @@ import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.event.DomainEvent
 import me.ahoo.wow.api.exception.DefaultErrorInfo
 import me.ahoo.wow.api.exception.ErrorInfo
+import me.ahoo.wow.api.messaging.function.FunctionInfo
 import me.ahoo.wow.event.DomainEventException
 import me.ahoo.wow.event.DomainEventStream
+import me.ahoo.wow.ioc.ServiceProvider
+import me.ahoo.wow.messaging.handler.COMMAND_RESULT_KEY
+import me.ahoo.wow.messaging.handler.FUNCTION_KEY
+import me.ahoo.wow.messaging.handler.SERVICE_PROVIDER_KEY
 import me.ahoo.wow.modeling.command.AggregateProcessor
+import me.ahoo.wow.modeling.command.COMMAND_AGGREGATE_KEY
+import me.ahoo.wow.modeling.command.CommandAggregate
+import me.ahoo.wow.modeling.command.getCommandAggregate
+import me.ahoo.wow.modeling.command.setCommandAggregate
 import me.ahoo.wow.modeling.metadata.AggregateMetadata
 import org.junit.jupiter.api.Test
 
@@ -47,6 +56,122 @@ class SimpleServerCommandExchangeTest {
         exchange.getCommandInvokeResult<String>().assert().isEqualTo("handled")
         exchange.getEventStream().assert().isSameAs(eventStream)
         exchange.getAggregateVersion().assert().isEqualTo(7)
+    }
+
+    @Test
+    fun `should store message exchange attributes in dedicated fields`() {
+        val message = AccountCommand(id = "account-1").toCommandMessage()
+        val exchange = SimpleServerCommandExchange(message)
+        val commandAggregate = mockk<CommandAggregate<Any, Any>>()
+        val function = mockk<FunctionInfo>()
+        val serviceProvider = mockk<ServiceProvider>()
+        val error = IllegalStateException("failed")
+
+        exchange.setCommandAggregate(commandAggregate).assert().isSameAs(exchange)
+        exchange.setFunction(function).assert().isSameAs(exchange)
+        exchange.setServiceProvider(serviceProvider).assert().isSameAs(exchange)
+        exchange.setError(error)
+        exchange.setCommandResult("answer", 42)
+
+        exchange.getCommandAggregate<Any, Any>().assert().isSameAs(commandAggregate)
+        exchange.getFunction().assert().isSameAs(function)
+        exchange.getServiceProvider().assert().isSameAs(serviceProvider)
+        exchange.getError().assert().isSameAs(error)
+        exchange.getCommandResult<Int>("answer").assert().isEqualTo(42)
+        exchange.attributes.assert().isEmpty()
+    }
+
+    @Test
+    fun `should store and remove unknown attribute keys in attributes map`() {
+        val message = AccountCommand(id = "account-1").toCommandMessage()
+        val exchange = SimpleServerCommandExchange(message)
+
+        exchange.setAttribute("custom-key", "custom-value")
+        exchange.getAttribute<String>("custom-key").assert().isEqualTo("custom-value")
+        exchange.attributes["custom-key"].assert().isEqualTo("custom-value")
+
+        exchange.removeAttribute("custom-key")
+        exchange.getAttribute<String>("custom-key").assert().isNull()
+        exchange.attributes.containsKey("custom-key").assert().isFalse()
+    }
+
+    @Test
+    fun `should remove well-known attribute keys`() {
+        val message = AccountCommand(id = "account-1").toCommandMessage()
+        val exchange = SimpleServerCommandExchange(message)
+        val error = IllegalArgumentException("failed")
+        val aggregateMetadata = mockk<AggregateMetadata<*, *>>()
+        val aggregateProcessor = mockk<AggregateProcessor<*>>()
+        val eventStream = mockk<DomainEventStream>()
+        every { eventStream.iterator() } returns emptyList<DomainEvent<*>>().iterator()
+        val commandAggregate = mockk<CommandAggregate<Any, Any>>()
+        val function = mockk<FunctionInfo>()
+        val serviceProvider = mockk<ServiceProvider>()
+
+        exchange.setAggregateMetadata(aggregateMetadata)
+        exchange.setAggregateProcessor(aggregateProcessor)
+        exchange.setCommandInvokeResult("handled")
+        exchange.setEventStream(eventStream)
+        exchange.setError(error)
+        exchange.setCommandAggregate(commandAggregate)
+        exchange.setFunction(function)
+        exchange.setServiceProvider(serviceProvider)
+        exchange.setCommandResult("answer", 42)
+        exchange.getError().assert().isSameAs(error)
+        exchange.clearError()
+        exchange.getError().assert().isNull()
+
+        exchange.setAggregateVersion(7)
+        exchange.getAggregateVersion().assert().isEqualTo(7)
+        exchange.removeAttribute(AGGREGATE_VERSION_KEY)
+        exchange.getAggregateVersion().assert().isNull()
+
+        exchange.removeAttribute(AGGREGATE_METADATA_KEY)
+        exchange.removeAttribute(AGGREGATE_PROCESSOR_KEY)
+        exchange.removeAttribute(COMMAND_INVOKE_RESULT_KEY)
+        exchange.removeAttribute(EVENT_STREAM_KEY)
+        exchange.removeAttribute(COMMAND_AGGREGATE_KEY)
+        exchange.removeAttribute(FUNCTION_KEY)
+        exchange.removeAttribute(SERVICE_PROVIDER_KEY)
+        exchange.removeAttribute(COMMAND_RESULT_KEY)
+        exchange.getAggregateMetadata().assert().isNull()
+        exchange.getAggregateProcessor().assert().isNull()
+        exchange.getCommandInvokeResult<Any>().assert().isNull()
+        exchange.getEventStream().assert().isNull()
+        exchange.getCommandAggregate<Any, Any>().assert().isNull()
+        exchange.getFunction().assert().isNull()
+        exchange.getServiceProvider().assert().isNull()
+        exchange.getCommandResult().assert().isEmpty()
+    }
+
+    @Test
+    fun `should migrate well-known keys from caller-provided attributes map`() {
+        val message = AccountCommand(id = "account-1").toCommandMessage()
+        val eventStream = mockk<DomainEventStream>()
+        val attributes = mutableMapOf<String, Any>(
+            EVENT_STREAM_KEY to eventStream,
+            "custom-key" to "custom-value",
+        )
+        val exchange = SimpleServerCommandExchange(message, attributes)
+
+        exchange.getEventStream().assert().isSameAs(eventStream)
+        attributes.containsKey(EVENT_STREAM_KEY).assert().isFalse()
+        exchange.getAttribute<String>("custom-key").assert().isEqualTo("custom-value")
+    }
+
+    @Test
+    @Suppress("UNCHECKED_CAST")
+    fun `should leave null caller-provided known key in attributes map`() {
+        val message = AccountCommand(id = "account-1").toCommandMessage()
+        val attributes = linkedMapOf<String, Any?>(
+            EVENT_STREAM_KEY to null,
+            "custom-key" to "custom-value",
+        ) as MutableMap<String, Any>
+        val exchange = SimpleServerCommandExchange(message, attributes)
+
+        exchange.getEventStream().assert().isNull()
+        attributes.containsKey(EVENT_STREAM_KEY).assert().isTrue()
+        exchange.getAttribute<String>("custom-key").assert().isEqualTo("custom-value")
     }
 
     @Test


### PR DESCRIPTION
## Summary
- store well-known ServerCommandExchange attributes in dedicated fields
- migrate known caller-provided attributes out of the generic map
- cover set/get/remove behavior for known and unknown keys
- add contract coverage for the dedicated attribute branches

## Test plan
- ./gradlew :wow-core:test --tests "me.ahoo.wow.command.SimpleServerCommandExchangeTest" --stacktrace
- ./gradlew :wow-core:contractTest --tests "me.ahoo.wow.command.SimpleServerCommandExchangeContractTest" --stacktrace
- ./gradlew :wow-core:check --stacktrace