### PR TITLE
ci(deps): add dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,74 @@
+#
+# Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      gradle-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/documentation"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      documentation-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/compensation/dashboard"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      dashboard-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- Add GitHub Dependabot configuration for automated dependency update PRs.
- Cover GitHub Actions, the Gradle root project, the documentation pnpm workspace, and the compensation dashboard pnpm workspace.
- Group dependency updates by ecosystem or workspace and schedule weekly checks in the Asia/Shanghai timezone.

## Changes
- Add `.github/dependabot.yml` using Dependabot v2 configuration.
- Configure weekly update checks for `github-actions`, `gradle`, and two `npm` entries that cover pnpm lockfiles.
- Limit each update entry to 5 open PRs and use `chore(deps)` commit prefixes.

## Testing
- `ruby` YAML validation for `.github/dependabot.yml`, including version, update entries, schedules, groups, PR limits, and commit prefix.

## Risk & Compatibility
- Low risk; this only adds dependency update automation.
- No runtime, build, publishing, or existing workflow behavior changes are introduced by the diff.
- Dependabot will only start opening update PRs after the configuration is merged into the default branch.

## Review Notes
- Check whether the weekly schedule and grouping granularity match the desired maintenance cadence.