### PR TITLE
test(benchmarks): add infrastructure Docker profiles

### DIFF
--- a/wow-benchmarks/README.md
+++ b/wow-benchmarks/README.md
@@ -133,6 +133,27 @@ Infrastructure E2E benchmarks require local services:
 | Redis | `localhost:6379` |
 | MongoDB | `localhost:27017` |
 
+For Redis, use the benchmark Docker profile:
+
+```bash
+docker compose -f wow-benchmarks/docker/compose.redis.yml up -d
+```
+
+The Redis profile pins `redis:7.4.9-alpine`, uses tmpfs-backed data, disables
+RDB/AOF persistence, and sets `io-threads=2` with threaded reads. This keeps
+local Docker CPU contention lower during the `threads=1,4` infrastructure runs.
+
+For MongoDB, use the benchmark Docker profile:
+
+```bash
+docker compose -f wow-benchmarks/docker/compose.mongo.yml up -d
+```
+
+The MongoDB profile pins `mongo:8.3.4`, uses tmpfs-backed data, keeps the
+WiredTiger cache at 2 GiB, disables diagnostic and TTL background work, and
+disables WiredTiger collection and journal compression to reduce local CPU
+overhead in write-heavy infrastructure benchmarks.
+
 If these services are not running, use Framework E2E and Component benchmarks instead.
 
 ## Baseline Utilities

--- a/wow-benchmarks/docker/compose.mongo.yml
+++ b/wow-benchmarks/docker/compose.mongo.yml
@@ -1,0 +1,39 @@
+name: wow-benchmarks-mongo
+
+services:
+  mongo:
+    image: mongo:8.3.4
+    container_name: wow-benchmark-mongo
+    restart: unless-stopped
+    ports:
+      - "27017:27017"
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: root
+    tmpfs:
+      - /data/db:rw,noexec,nosuid,size=4096m
+      - /data/configdb:rw,noexec,nosuid,size=512m
+    command:
+      - mongod
+      - --auth
+      - --bind_ip_all
+      - --wiredTigerCacheSizeGB
+      - "2"
+      - --wiredTigerCollectionBlockCompressor
+      - none
+      - --wiredTigerJournalCompressor
+      - none
+      - --setParameter
+      - diagnosticDataCollectionEnabled=false
+      - --setParameter
+      - ttlMonitorEnabled=false
+    healthcheck:
+      test:
+        - CMD-SHELL
+        - >
+          mongosh --quiet -u root -p root --authenticationDatabase admin
+          --eval 'db.adminCommand({ ping: 1 }).ok' | grep -q 1
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 10s

--- a/wow-benchmarks/docker/compose.redis.yml
+++ b/wow-benchmarks/docker/compose.redis.yml
@@ -1,0 +1,27 @@
+name: wow-benchmarks-redis
+
+services:
+  redis:
+    image: redis:7.4.9-alpine
+    container_name: wow-benchmark-redis
+    restart: unless-stopped
+    ports:
+      - "6379:6379"
+    volumes:
+      - ./redis.conf:/usr/local/etc/redis/redis.conf:ro
+    tmpfs:
+      - /data:rw,noexec,nosuid,size=1024m
+    sysctls:
+      net.core.somaxconn: "1024"
+    command:
+      - redis-server
+      - /usr/local/etc/redis/redis.conf
+    healthcheck:
+      test:
+        - CMD
+        - redis-cli
+        - ping
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 5s

--- a/wow-benchmarks/docker/redis.conf
+++ b/wow-benchmarks/docker/redis.conf
@@ -1,0 +1,8 @@
+appendonly no
+save ""
+protected-mode no
+tcp-backlog 1024
+# Keep Redis below the Docker CPU cap to leave headroom for the JMH JVM and
+# other infrastructure containers during local benchmark runs.
+io-threads 2
+io-threads-do-reads yes

--- a/wow-benchmarks/results/reports/quick-infrastructure-e2e.md
+++ b/wow-benchmarks/results/reports/quick-infrastructure-e2e.md
@@ -11,7 +11,7 @@ Quick Infrastructure E2E results are directional local feedback for real Redis a
 - **Version**: 8.5.0
 - **JVM**: OpenJDK 64-Bit Server VM 17.0.7+7-LTS
 - **OS**: Mac OS X 26.5.1 aarch64
-- **DateTime**: 2026-06-16T02:10:59+08:00
+- **DateTime**: 2026-06-16T16:13:52+08:00
 - **CPU Cores**: 14
 - **Physical Memory**: 24.0 GiB
 - **Benchmark JVM Args**: `-Xmx4g -Xms4g -XX:+UseG1GC -XX:+UnlockDiagnosticVMOptions -XX:+DebugNonSafepoints -XX:+AlwaysPreTouch`
@@ -21,11 +21,11 @@ Quick Infrastructure E2E results are directional local feedback for real Redis a
 
 | Suite | Benchmark | Threads | Mode | Score | Error | Unit | gc.alloc.rate.norm |
 |-------|-----------|---------|------|-------|-------|------|-------------------|
-| Infrastructure E2E | MongoCommandWriteE2EBenchmark.sendAndWaitProcessed | 1 | avgt | 194.36 | - | us/op | 14387.3 B/op |
-| Infrastructure E2E | MongoCommandWriteE2EBenchmark.sendAndWaitProcessed | 1 | thrpt | 5142.71 | - | ops/s | 14330.4 B/op |
-| Infrastructure E2E | MongoCommandWriteE2EBenchmark.sendAndWaitProcessed | 4 | avgt | 274.62 | - | us/op | 13514.1 B/op |
-| Infrastructure E2E | MongoCommandWriteE2EBenchmark.sendAndWaitProcessed | 4 | thrpt | 14504.56 | - | ops/s | 13563.6 B/op |
-| Infrastructure E2E | RedisCommandWriteE2EBenchmark.sendAndWaitProcessed | 1 | avgt | 153.05 | - | us/op | 6397.4 B/op |
-| Infrastructure E2E | RedisCommandWriteE2EBenchmark.sendAndWaitProcessed | 1 | thrpt | 6564.18 | - | ops/s | 6345.6 B/op |
-| Infrastructure E2E | RedisCommandWriteE2EBenchmark.sendAndWaitProcessed | 4 | avgt | 190.32 | - | us/op | 5527.7 B/op |
-| Infrastructure E2E | RedisCommandWriteE2EBenchmark.sendAndWaitProcessed | 4 | thrpt | 21059.85 | - | ops/s | 5630.6 B/op |
+| Infrastructure E2E | MongoCommandWriteE2EBenchmark.sendAndWaitProcessed | 1 | avgt | 198.96 | - | us/op | 13801.7 B/op |
+| Infrastructure E2E | MongoCommandWriteE2EBenchmark.sendAndWaitProcessed | 1 | thrpt | 4709.30 | - | ops/s | 13979.0 B/op |
+| Infrastructure E2E | MongoCommandWriteE2EBenchmark.sendAndWaitProcessed | 4 | avgt | 287.10 | - | us/op | 12907.8 B/op |
+| Infrastructure E2E | MongoCommandWriteE2EBenchmark.sendAndWaitProcessed | 4 | thrpt | 13848.26 | - | ops/s | 12990.6 B/op |
+| Infrastructure E2E | RedisCommandWriteE2EBenchmark.sendAndWaitProcessed | 1 | avgt | 151.25 | - | us/op | 5797.0 B/op |
+| Infrastructure E2E | RedisCommandWriteE2EBenchmark.sendAndWaitProcessed | 1 | thrpt | 6678.75 | - | ops/s | 5732.2 B/op |
+| Infrastructure E2E | RedisCommandWriteE2EBenchmark.sendAndWaitProcessed | 4 | avgt | 197.67 | - | us/op | 4989.3 B/op |
+| Infrastructure E2E | RedisCommandWriteE2EBenchmark.sendAndWaitProcessed | 4 | thrpt | 20159.10 | - | ops/s | 4991.0 B/op |


### PR DESCRIPTION
## Summary
- Add Docker Compose profiles for local Redis and MongoDB services used by infrastructure benchmarks.
- Pin Redis and MongoDB versions and tune their local benchmark settings to reduce Docker-related noise.
- Document the benchmark service startup commands in the benchmarks README.
- Refresh the quick Infrastructure E2E report from a new local run using the Docker profiles.

## Changes
- `wow-benchmarks/docker`: adds Redis and MongoDB Compose profiles with fixed container names, ports, tmpfs-backed data, health checks, and benchmark-oriented service settings.
- Redis profile: pins `redis:7.4.9-alpine`, disables RDB/AOF persistence, and uses `io-threads=2` with threaded reads.
- MongoDB profile: pins `mongo:8.3.4`, keeps WiredTiger cache at 2 GiB, disables diagnostic/TTL background work, and disables WiredTiger collection and journal compression for local write-heavy benchmark runs.
- `wow-benchmarks/README.md`: documents how to start Redis and MongoDB benchmark profiles.
- `quick-infrastructure-e2e.md`: updates the generated quick Infrastructure E2E report.

## Testing
- `docker compose -f wow-benchmarks/docker/compose.redis.yml config`
- `docker compose -f wow-benchmarks/docker/compose.mongo.yml config`
- Verified Redis and MongoDB benchmark containers were `healthy` after starting from the Compose profiles.
- Verified runtime versions: Redis `7.4.9`, MongoDB `8.3.4`.
- `./gradlew :wow-benchmarks:benchmarkQuickInfrastructureE2E :wow-benchmarks:generateInfrastructureBenchmarkReport` passed in 2m 4s.
- `git diff --check`

## Risk & Compatibility
- Low runtime risk; changes are scoped to local benchmark Docker profiles, benchmark documentation, and generated benchmark report output.
- The profiles bind `localhost:6379` and `localhost:27017`, so developers with existing local Redis or MongoDB services must stop those services or use their own setup.
- MongoDB compression settings are benchmark-profile settings only and are not production deployment guidance.

## Review Notes
- Please review the Redis and MongoDB service settings in `wow-benchmarks/docker/` and the generated report update.
