### PR TITLE
ci: optimize Renovate configuration

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,7 +1,8 @@
 name: Renovate
 on:
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '17 10 * * *'
+      timezone: "Asia/Shanghai"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,8 +1,7 @@
 name: Renovate
 on:
   schedule:
-    - cron: '17 10 * * *'
-      timezone: "Asia/Shanghai"
+    - cron: '17 2 * * *'
   workflow_dispatch:
 
 concurrency:

--- a/renovate.json
+++ b/renovate.json
@@ -3,21 +3,124 @@
   "extends": ["config:recommended"],
   "timezone": "Asia/Shanghai",
   "labels": ["dependencies"],
+  "dependencyDashboard": true,
   "commitMessagePrefix": "fix(deps)",
   "commitMessageTopic": "{{depName}}",
   "rangeStrategy": "bump",
-  "lockFileMaintenance": { "enabled": false },
+  "minimumReleaseAge": "3 days",
+  "prHourlyLimit": 2,
   "prConcurrentLimit": 5,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 3pm on monday"],
+    "commitMessageTopic": "lock files"
+  },
   "packageRules": [
     {
-      "description": "Group Spring ecosystem updates into a single PR",
-      "matchPackagePatterns": ["^org\\.springframework"],
-      "groupName": "spring"
+      "description": "Require manual approval for major version updates.",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
     },
     {
-      "description": "Group Kotlin-related updates into a single PR",
-      "matchPackagePatterns": ["^org\\.jetbrains\\.kotlin"],
-      "groupName": "kotlin"
+      "description": "Group GitHub Actions updates.",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions",
+      "commitMessageTopic": "GitHub Actions"
+    },
+    {
+      "description": "Group Spring Boot, Spring Framework, and Springdoc updates.",
+      "matchDatasources": ["maven"],
+      "matchPackageNames": [
+        "/^org\\.springframework[.:]/",
+        "/^org\\.springdoc:/"
+      ],
+      "groupName": "spring",
+      "commitMessageTopic": "Spring ecosystem"
+    },
+    {
+      "description": "Group Kotlin compiler, Kotlin plugins, KSP, and Kotlin compile-testing updates.",
+      "matchPackageNames": [
+        "/^org\\.jetbrains\\.kotlin([.:]|$)/",
+        "/^com\\.google\\.devtools\\.ksp([.:]|$)/",
+        "dev.zacsweers.kctfork:ksp"
+      ],
+      "groupName": "kotlin",
+      "commitMessageTopic": "Kotlin toolchain"
+    },
+    {
+      "description": "Group OpenTelemetry core and instrumentation BOMs so API/SDK and instrumentation stay aligned.",
+      "matchDatasources": ["maven"],
+      "matchPackageNames": [
+        "io.opentelemetry:opentelemetry-bom",
+        "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom"
+      ],
+      "groupName": "opentelemetry",
+      "commitMessageTopic": "OpenTelemetry BOMs"
+    },
+    {
+      "description": "Keep OpenTelemetry semantic conventions visible because this artifact is alpha-versioned independently.",
+      "matchDatasources": ["maven"],
+      "matchPackageNames": ["io.opentelemetry:opentelemetry-semconv"],
+      "commitMessageTopic": "OpenTelemetry semantic conventions"
+    },
+    {
+      "description": "Group Ahoo platform BOM updates used by wow-dependencies.",
+      "matchDatasources": ["maven"],
+      "matchPackageNames": [
+        "me.ahoo.cosid:cosid-bom",
+        "me.ahoo.simba:simba-bom",
+        "me.ahoo.coapi:coapi-bom",
+        "me.ahoo.cocache:cocache-bom"
+      ],
+      "groupName": "ahoo-platform-boms",
+      "commitMessageTopic": "Ahoo platform BOMs"
+    },
+    {
+      "description": "Group Ahoo Fetcher packages because the dashboard uses the generated client stack as one version family.",
+      "matchDatasources": ["npm"],
+      "matchPackageNames": ["/^@ahoo-wang\\/fetcher/"],
+      "groupName": "fetcher",
+      "commitMessageTopic": "Fetcher packages"
+    },
+    {
+      "description": "Group React runtime packages used by the compensation dashboard.",
+      "matchDatasources": ["npm"],
+      "matchPackageNames": [
+        "react",
+        "react-dom",
+        "@types/react",
+        "@types/react-dom",
+        "react-router"
+      ],
+      "groupName": "react",
+      "commitMessageTopic": "React ecosystem"
+    },
+    {
+      "description": "Group Vite and Vitest tooling used by the compensation dashboard.",
+      "matchDatasources": ["npm"],
+      "matchPackageNames": [
+        "vite",
+        "@vitejs/plugin-react",
+        "vitest",
+        "@vitest/coverage-v8",
+        "@vitest/ui",
+        "vitest-browser-react",
+        "vite-bundle-analyzer"
+      ],
+      "groupName": "vite-vitest",
+      "commitMessageTopic": "Vite and Vitest"
+    },
+    {
+      "description": "Group VitePress documentation tooling.",
+      "matchDatasources": ["npm"],
+      "matchPackageNames": [
+        "vitepress",
+        "vitepress-plugin-llms",
+        "vitepress-plugin-mermaid",
+        "mermaid"
+      ],
+      "groupName": "vitepress",
+      "commitMessageTopic": "VitePress documentation"
     }
   ]
 }


### PR DESCRIPTION
## Goal

Improve Renovate behavior for this repository so coupled dependency families are updated together, scheduled runs avoid GitHub Actions peak timing, and risky updates are easier to review before PR creation.

## Changes

- Enable the Renovate Dependency Dashboard and require dashboard approval for major updates.
- Add a short `minimumReleaseAge` and throttle PR creation to reduce noisy or very fresh dependency updates.
- Enable weekly lockfile maintenance.
- Group coupled Gradle and npm ecosystems, including OpenTelemetry BOMs, Spring, Kotlin/KSP, Ahoo platform BOMs, Fetcher, React, Vite/Vitest, VitePress, and GitHub Actions.
- Move the Renovate scheduled workflow away from the top of the hour by encoding 10:17 Asia/Shanghai as `17 2 * * *` UTC.

## Verification

- `jq . renovate.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/renovate.yml'); puts 'JSON/YAML ok'"`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/renovate.yml`
- `npx --yes --package renovate -- renovate-config-validator --no-global --strict`
- `env GITHUB_COM_TOKEN="$(gh auth token)" npx --yes --package renovate -- renovate --platform=local --repository-cache=disabled --dry-run=lookup --require-config=required --onboarding=false`
- `git diff --check`

The Renovate dry run extracted 61 dependency files and 178 dependencies successfully.

## Risks and Notes

- Major version updates will wait for manual approval in the Dependency Dashboard.
- Normal dependency updates will wait for the configured 3-day release age.
- Weekly lockfile maintenance can create an additional PR when lockfiles drift.
