### PR TITLE
ci(renovate): unblock dependency PR creation

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,9 +7,9 @@
   "commitMessagePrefix": "fix(deps)",
   "commitMessageTopic": "{{depName}}",
   "rangeStrategy": "bump",
-  "minimumReleaseAge": "3 days",
-  "prHourlyLimit": 2,
-  "prConcurrentLimit": 5,
+  "minimumReleaseAge": "12 hours",
+  "prHourlyLimit": 10,
+  "prConcurrentLimit": 20,
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 3pm on monday"],


### PR DESCRIPTION
## Problem
Self-hosted Renovate runs daily and reports `success`, but **no dependency-update PRs have been auto-created since 2026-06-18** (#2713, #2714 were the last). All recent `fix(deps)` PRs (#2726–#2735, including cosid 3.2.0 / cocache 4.2.0) were opened manually.

Debug logs of run [#28910302944](https://github.com/Ahoo-Wang/Wow/actions/runs/28910302944) confirm **18 branches were processed but `Open PR Count: 0`**, blocked by two config settings:

### 1. `minimumReleaseAge: 3 days` + `timestamp-required`
```
Marking 1 release(s) as pending, as they do not have a releaseTimestamp
and we're running with minimumReleaseAgeBehaviour=timestamp-required
check: minimumReleaseAge
```
New releases younger than 3 days are held pending. cosid 3.2.0 (published 7/7 12:03) and cocache 4.2.0 (published 7/7 13:34) were both < 3 days old during that day's runs, so they were suppressed.

### 2. `prHourlyLimit: 2` / `prConcurrentLimit: 5`
Even age-eligible updates pile up in the Dashboard's **Rate-Limited** section (currently 11 entries: spring, opentelemetry, react-router, actions/checkout, dragonwell, pnpm, redis, babel, etc.).

## Changes
| Setting | Before | After | Why |
|---|---|---|---|
| `minimumReleaseAge` | `3 days` | `12 hours` | Filters recalled/yanked releases while letting routine deps through on the next daily run. For self-published `me.ahoo.*` artifacts the 3-day wait added no value. |
| `prHourlyLimit` | `2` | `10` | Clear the backlog without choking CI. |
| `prConcurrentLimit` | `5` | `20` | Match. |

## Out of scope (needs manual action)
Dashboard #2715 also warns: `⚠️ Cannot access vulnerability alerts` and the run logs `Cannot read user/emails endpoint ... to retrieve gitAuthor`. These are `RENOVATE_TOKEN` PAT scope issues (`security_events`, `user:email`) and must be fixed in **GitHub → Settings → Developer settings → Personal access tokens**, not in this repo.

## Verification
- `renovate.json` validated as well-formed JSON.
- Effect will be visible on the next scheduled run (`cron: '17 2 * * *'`) or a manual `workflow_dispatch`.

## Follow-up
After merge, expect a burst of rate-limited PRs to open on the next run. The `major` updates will still require Dashboard approval (unchanged).