### PR TITLE
feat(bi)!: harden deployment protocol and enable script endpoint

### DIFF
--- a/documentation/docs/en/guide/bi.md
+++ b/documentation/docs/en/guide/bi.md
@@ -64,7 +64,15 @@ The default `unsupportedTypeStrategy` is `RAW_JSON`. With `FAIL`, an unsupported
 
 ### HTTP Route
 
-The Spring WebFlux route and its Swagger/OpenAPI operation are enabled by default. Configure a deployment-unique `wow.bi.script.consumer-group-namespace` when at least one local aggregate requires Kafka consumers; otherwise generation returns `400` instead of preventing application startup. Set `wow.bi.script.enabled=false` to remove both the runtime route and its OpenAPI operation without constructing or validating BI generation options or an inspector. The route uses the same `BiScriptOptions`:
+The Spring WebFlux route and its Swagger/OpenAPI operation are enabled by default. This does not add authentication, so the application security policy must protect the management endpoint; set `wow.bi.script.enabled=false` to remove both. Configure a deployment-unique `wow.bi.script.consumer-group-namespace` whenever `DEPLOY` generates Kafka consumers and for every `RESET`, including an empty aggregate scope. Missing configuration returns `400` instead of preventing application startup. An empty `DEPLOY` without a namespace remains unanchored; supplying one gives the empty scope a durable deployment identity that later aggregate additions can reuse. While disabled, the Starter does not construct or validate BI generation options or an inspector. The route uses the same `BiScriptOptions`:
+
+```yaml
+wow:
+  bi:
+    script:
+      enabled: true
+      consumer-group-namespace: orders-production-blue
+```
 
 ```shell
 curl -X POST 'http://localhost:8080/wow/bi/script' \
@@ -103,9 +111,20 @@ The server configuration and every non-null `POST` override use the same maximum
 
 When `topology` is present, `topology.mode` is mandatory. In `CLUSTER` mode, omitted `cluster` fields inherit the current Cluster base, or the domain Cluster defaults when the server base is Standalone. `STANDALONE` rejects a `cluster` object. An invalid or empty body returns `400`; a missing or unsupported `Content-Type` returns `415`. `Accept` quality values are honored; JSON returns SQL, diagnostics, and the destructive flag, while SQL and wildcards return only `result.script`. No supported requested representation, or assigning `q=0` to all supported representations, returns `406`. Every successful response includes `Wow-BI-Diagnostic-Count`. Generation runs on the bounded-elastic scheduler.
 
-This version injects `NoOpBiDeploymentInspector` by default. It returns explicit `Unavailable`: ordinary `DEPLOY` remains available for an initial deployment or offline preview but emits `INSPECTION_UNAVAILABLE`, cannot clean up stale objects, and cannot recover a consumer identity created by `RESET`; configuration changes can therefore select a different consumer group. `RESET` is rejected. For full reconciliation, configure `wow.bi.script.inspector.type=CLICKHOUSE` together with `inspector.clickhouse.endpoints` to enable the official ClickHouse Java `client-v2` implementation. Errors from a real inspector propagate and are never degraded to NoOp; selecting `CLICKHOUSE` without the client-v2 classes fails startup. A custom `BiDeploymentInspector` bean still has the highest priority.
+By default the Starter injects `NoOpBiDeploymentInspector`. It returns explicit `Unavailable`: ordinary `DEPLOY` remains available for an initial deployment or offline preview but emits `INSPECTION_UNAVAILABLE`, cannot clean up stale objects, and cannot recover a consumer identity created by `RESET`; configuration changes can therefore select a different consumer group. `RESET` is rejected. For full reconciliation, configure `wow.bi.script.inspector.type=CLICKHOUSE` together with `inspector.clickhouse.endpoints` to enable the official ClickHouse Java `client-v2` implementation. Errors from a real inspector propagate and are never degraded to NoOp; selecting `CLICKHOUSE` without the client-v2 classes fails startup. A custom `BiDeploymentInspector` bean still has the highest priority.
 
-To intentionally rebuild all BI data, send `operation=RESET` with `replayFromEarliestConfirmed=true`. Only an available inspector can enumerate all owned catalog objects, so Reset first removes current and orphan stores and then creates a fresh consumer identity. Every generated object and a zero-row deployment anchor store version, deployment fingerprint, aggregate owner, object kind, and identity in `system.tables.comment`. Service restarts recover from that catalog state without Wow service memory or an external manifest.
+To intentionally rebuild all BI data, send `operation=RESET` with `replayFromEarliestConfirmed=true`. Reset also requires a configured `consumerGroupNamespace` so its recovery state has a durable canonical anchor. Only an available inspector can enumerate all owned catalog objects. Every generated object and a zero-row deployment anchor store protocol/layout version, deployment phase, fingerprint, aggregate owner, object kind, and identity in `system.tables.comment`. Service restarts recover from that catalog state without Wow service memory or an external manifest.
+
+Metadata protocol v2 makes Reset recoverable across process or SQL-client interruption. Generated statements must be executed in order and the executor must stop on the first error:
+
+1. Write the canonical anchor as `RESETTING` with a new consumer identity.
+2. Keep that anchor while dropping all other owned objects and rebuilding the durable table/view graph.
+3. Replace the anchor as `STABLE`.
+4. Create Kafka queue tables and Kafka consumer materialized views last.
+
+If execution stops, never replay the original SQL file blindly: inspect the catalog and regenerate from its current phase. While the anchor is `RESETTING`, generate `RESET` with the same configuration; the generator reuses the recorded identity, while `DEPLOY` is rejected. If the anchor is already `STABLE` but Kafka ingress is incomplete, generate `DEPLOY` to finish it. Replaying a completed Reset could delete rebuilt data while reusing already-committed Kafka offsets; generating another Reset after `STABLE` deliberately begins a new reset epoch and identity instead. Protocol v2 intentionally rejects v1 ownership markers; adopting v2 requires stopping the old consumers and explicitly cleaning or rebuilding the old scope. External coordination must guarantee one writer for the entire physical BI object namespace, not merely one writer per `deploymentId`; deployments that share databases and normalized object names can otherwise race after inspection. ClickHouse `ON CLUSTER` DDL is not a cross-replica transaction, so replica divergence remains a fail-closed operational recovery case.
+
+`DEPLOY` and `RESET` reconcile only the current physical ownership scope; they do not migrate `database`, `consumerDatabase`, `consumerGroupNamespace`, topology mode, cluster name, or installation. Visible topology-fingerprint drift is rejected. A scope change can make old objects undiscoverable, so stop old consumers, explicitly clean the old scope, and only then deploy the new scope.
 
 ## Generated SQL Contract
 
@@ -215,16 +234,16 @@ JSONExtract("data", 'tags', 'Map(String, Array(String))') AS "tags"
 
 WITH arrayJoin(arrayZip(arrayEnumerate("body"), "body")) AS "events"
 SELECT "events".1 AS "event_sequence",
-       JSONExtract("events".2, 'body', 'String') AS "event_body";
+       JSONExtractRaw("events".2, 'body') AS "event_body";
 ```
 
 The same header-masking lexical extraction is used for top-level `state`, preventing a nested header key named `state` from replacing the authoritative state token.
 
-The writable state store is partitioned monthly by `create_time` and ordered by `(aggregate_id, version)`. Standalone mode writes `example_order_state_store`; cluster mode writes through the distributed store into `example_order_state_store_local`. `example_order_state` is always a deduplicated read view.
+The writable state store is partitioned monthly by `create_time` and ordered by `(aggregate_id, version)`. This key relies on Wow's aggregate identity contract: within one named aggregate, `aggregate_id` is unique across all tenants; `tenant_id` is not a namespace in which an ID may be reused. Standalone mode writes `example_order_state_store`; cluster mode writes through the distributed store into `example_order_state_store_local`. `example_order_state` is always a deduplicated read view.
 
 ### Latest State
 
-The latest-state store receives all columns from the state store and is partitioned by first-event time. `example_order_state_last` is the authoritative public view and always applies `FINAL`; storage tables are intentionally separated behind the `*_store` suffix.
+The latest-state store receives all columns from the state store and is partitioned by first-event time. Its `ORDER BY aggregate_id` likewise requires aggregate IDs to remain unique across tenants within the named aggregate. `example_order_state_last` is the authoritative public view and always applies `FINAL`; storage tables are intentionally separated behind the `*_store` suffix.
 
 ```sql
 CREATE TABLE IF NOT EXISTS "bi_db"."example_order_state_last_store"
@@ -268,7 +287,7 @@ AS SELECT * FROM "bi_db"."example_order_state_store";
 The root view expands one-to-one objects into columns and inherits state-event metadata through `__*` columns. Physical input columns are qualified through the fixed `__source` table alias so domain output aliases cannot shadow metadata columns:
 
 ```sql
-CREATE VIEW IF NOT EXISTS "bi_db"."example_order_state_last_root" ON CLUSTER '{cluster}' AS
+CREATE OR REPLACE VIEW "bi_db"."example_order_state_last_root" ON CLUSTER '{cluster}' AS
 WITH JSONExtractRaw("__source"."state", 'address') AS "address"
 SELECT JSONExtract("address", 'city', 'String') AS "address__city",
        JSONExtract("__source"."state", 'id', 'String') AS "id",
@@ -286,7 +305,7 @@ FROM "bi_db"."example_order_state_last" AS "__source";
 An object collection produces a child view. `arrayJoin` expands each object element into one row while inheriting parent columns and metadata:
 
 ```sql
-CREATE VIEW IF NOT EXISTS "bi_db"."example_order_state_last_root_items" ON CLUSTER '{cluster}' AS
+CREATE OR REPLACE VIEW "bi_db"."example_order_state_last_root_items" ON CLUSTER '{cluster}' AS
 WITH arrayJoin(arrayZip(arrayEnumerate(JSONExtractArrayRaw("__source"."state", 'items')),
                         JSONExtractArrayRaw("__source"."state", 'items'))) AS "__cursor__items",
      tupleElement("__cursor__items", 2) AS "items"

--- a/documentation/docs/en/guide/configuration.md
+++ b/documentation/docs/en/guide/configuration.md
@@ -356,7 +356,7 @@ These properties establish the server-side base for the ClickHouse SQL returned 
 
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
-| `wow.bi.script.enabled` | Boolean | `true` | Exposes the BI script HTTP route and its OpenAPI operation; set to `false` to remove both |
+| `wow.bi.script.enabled` | Boolean | `true` | Enabled by default; set to `false` to remove both the BI script HTTP route and its OpenAPI operation; application security must protect the endpoint |
 | `wow.bi.script.database` | String | `bi_db` | Database for command/state `*_store` tables plus public, latest-state, and expansion views; maximum 128 characters |
 | `wow.bi.script.consumer-database` | String | `bi_db_consumer` | Database for Kafka queue tables, consumer materialized views, and the deployment anchor; maximum 128 characters |
 | `wow.bi.script.topology.mode` | Enum | `CLUSTER` | Physical DDL topology: `CLUSTER` or `STANDALONE` |
@@ -365,7 +365,7 @@ These properties establish the server-side base for the ClickHouse SQL returned 
 | `wow.bi.script.timezone` | String | `Asia/Shanghai` | ClickHouse timezone for generated date-time columns and conversions; maximum 64 characters |
 | `wow.bi.script.kafka-bootstrap-servers` | String | Inherit `wow.kafka.bootstrap-servers`; otherwise `localhost:9093` | BI Kafka broker override; multiple inherited brokers are joined with commas; maximum 4096 characters |
 | `wow.bi.script.topic-prefix` | String | Inherit `wow.kafka.topic-prefix`; otherwise `wow.` | BI topic prefix override; maximum 128 characters |
-| `wow.bi.script.consumer-group-namespace` | String | none | Required when generation includes at least one aggregate's Kafka consumers; deployment-unique namespace embedded in every consumer group |
+| `wow.bi.script.consumer-group-namespace` | String | none | Required for every `RESET`, including an empty aggregate scope, and for `DEPLOY` whenever Kafka consumers are generated; deployment-unique namespace embedded in every consumer group |
 | `wow.bi.script.kafka-offset-storage` | Enum | `BROKER` | `BROKER` uses Kafka offsets; `KEEPER` enables ClickHouse Keeper-backed offsets |
 | `wow.bi.script.kafka-keeper-path-prefix` | String | `/clickhouse/wow-bi` | Keeper path prefix used only with `KEEPER` |
 | `wow.bi.script.max-expansion-depth` | Int | `5` | Maximum complex-property expansion depth; must be at least `1` |
@@ -376,19 +376,23 @@ These properties establish the server-side base for the ClickHouse SQL returned 
 | `wow.bi.script.inspector.clickhouse.username` | String | `default` | ClickHouse Basic Auth username |
 | `wow.bi.script.inspector.clickhouse.password` | String | empty | ClickHouse Basic Auth password; redacted from property and client-option string representations |
 | `wow.bi.script.inspector.clickhouse.connection-pool-enabled` | Boolean | `true` | Maps to `Client.Builder.enableConnectionPool` |
-| `wow.bi.script.inspector.clickhouse.connection-timeout` | Duration | `3s` | Maps to `Client.Builder.setConnectTimeout`; must be positive |
-| `wow.bi.script.inspector.clickhouse.connection-request-timeout` | Duration | `10s` | Maximum wait for a pooled connection; maps to `setConnectionRequestTimeout` and must be positive |
-| `wow.bi.script.inspector.clickhouse.socket-timeout` | Duration | `10s` | Socket read/write timeout; maps to `setSocketTimeout`; zero means no driver socket deadline |
-| `wow.bi.script.inspector.clickhouse.execution-timeout` | Duration | `10s` | Deadline for one driver operation; maps to `setExecutionTimeout`; zero means no driver operation deadline |
+| `wow.bi.script.inspector.clickhouse.connection-timeout` | Duration | `3s` | Maps to `Client.Builder.setConnectTimeout`; must be at least `1ms` |
+| `wow.bi.script.inspector.clickhouse.connection-request-timeout` | Duration | `10s` | Maximum wait for a pooled connection; maps to `setConnectionRequestTimeout` and must be at least `1ms` |
+| `wow.bi.script.inspector.clickhouse.socket-timeout` | Duration | `10s` | Socket read/write timeout; maps to `setSocketTimeout`; must be at least `1ms` and no greater than `inspector.timeout` |
+| `wow.bi.script.inspector.clickhouse.execution-timeout` | Duration | `10s` | Deadline for one driver operation; the inspector enables asynchronous requests, configures `setExecutionTimeout`, and bounds the returned future with this value; zero means no driver operation deadline, otherwise the minimum is `1ms` |
 | `wow.bi.script.inspector.clickhouse.max-connections` | Int | `10` | Maximum open connections per endpoint; maps to `setMaxConnections` and must be positive |
 | `wow.bi.script.inspector.clickhouse.max-retries` | Int | `0` | Driver retry count; maps to `setMaxRetries` and must not be negative |
 
-The default `NO_OP` implementation does not contact ClickHouse. Explicitly enable catalog reconciliation with:
+`execution-timeout` bounds how long the inspector waits for the asynchronous result, but client-v2 does not turn that future timeout into an HTTP abort. Therefore `socket-timeout` is mandatory and cannot exceed the total `inspector.timeout`; cancelled-response cleanup runs off the timeout scheduler and remains bounded by that transport deadline.
+
+The default `NO_OP` implementation does not contact ClickHouse. Select the `CLICKHOUSE` inspector for catalog reconciliation:
 
 ```yaml
 wow:
   bi:
     script:
+      enabled: true
+      consumer-group-namespace: orders-production-blue
       topology:
         mode: STANDALONE
       inspector:
@@ -409,7 +413,7 @@ wow:
           max-retries: 0
 ```
 
-The built-in inspector is implemented in `wow-bi` with the official ClickHouse Java `client-v2`. Its typed Spring Boot properties map one-to-one to the corresponding `Client.Builder` concepts instead of merging unrelated driver timeouts. The inspector owns and closes the client with the Spring context; synchronous driver calls run on Reactor's bounded-elastic scheduler, avoiding a redundant driver executor. Catalog queries use typed RowBinary records and named parameters, and cluster mode verifies replica participation and owned-object definitions while ignoring unrelated replica-local catalog differences. Connection, timeout, invalid ownership-marker, and owned replica-divergence failures propagate without silently falling back to `NO_OP`. Selecting `CLICKHOUSE` without the client-v2 classes fails application startup. Use a custom `BiDeploymentInspector` bean for unsupported proxy, mTLS, or authentication requirements; a custom bean takes precedence over both built-in implementations.
+The built-in inspector is implemented in `wow-bi` with the official ClickHouse Java `client-v2`. Its typed Spring Boot properties map one-to-one to the corresponding `Client.Builder` concepts instead of merging unrelated driver timeouts. The inspector owns and closes the client with the Spring context; it starts asynchronous client-v2 queries and waits for each returned future on Reactor's bounded-elastic scheduler without creating another driver executor. Catalog queries use typed RowBinary records and named parameters, and cluster mode verifies replica participation and owned-object definitions while ignoring unrelated replica-local catalog differences. Connection, timeout, invalid ownership-marker, and owned replica-divergence failures propagate without silently falling back to `NO_OP`. Selecting `CLICKHOUSE` without the client-v2 classes fails application startup. Use a custom `BiDeploymentInspector` bean for unsupported proxy, mTLS, or authentication requirements; a custom bean takes precedence over both built-in implementations.
 
 Standalone topology:
 
@@ -429,6 +433,8 @@ Cluster topology:
 wow:
   bi:
     script:
+      enabled: true
+      consumer-group-namespace: orders-production-blue
       topology:
         mode: CLUSTER
         cluster:
@@ -438,6 +444,8 @@ wow:
 
 `STANDALONE` creates `*_store` physical tables with `ReplacingMergeTree`; `command`, `state`, and `state_last` remain read-only views that query their stores with `FINAL`. It rejects `topology.cluster`. `CLUSTER` creates replicated `*_store_local` physical tables, `*_store` `Distributed` write facades, and the same public read views; omitted cluster fields use the defaults shown above. Cluster DDL always uses ClickHouse's `{shard}` and `{replica}` server macros, including the Keeper consumer replica identity; they are intentionally not application-level overrides.
 
+`DEPLOY` and `RESET` reconcile only the current physical ownership scope; they do not migrate `database`, `consumerDatabase`, `consumerGroupNamespace`, topology mode, cluster name, or installation. Visible topology-fingerprint drift is rejected. Because a scope change can make old objects undiscoverable, stop old consumers and explicitly clean the old scope before deploying the new scope.
+
 The complete precedence, from lowest to highest, is:
 
 1. `BiScriptOptions` domain defaults;
@@ -445,11 +453,11 @@ The complete precedence, from lowest to highest, is:
 3. `wow.bi.script.*` application properties;
 4. Non-null `POST` request fields.
 
-When a real deployment inspector is configured, `database`, `consumerDatabase`, and `topology` are fixed to the server configuration and request overrides for those fields return `400`. This prevents a public request from using the server's ClickHouse credentials to inspect an arbitrary database or cluster. The default `NO_OP` inspector permits those overrides because it never contacts ClickHouse.
+When a real deployment inspector is configured, `database`, `consumerDatabase`, and `topology` are fixed to the server configuration and request overrides for those fields return `400`. This prevents a public request from using the server's ClickHouse credentials to inspect an arbitrary database or cluster. The default `NO_OP` inspector permits those overrides because it never contacts ClickHouse; such output is an offline preview, not a migration of an existing scope.
 
 Thus, explicit `wow.bi.script.kafka-bootstrap-servers` / `wow.bi.script.topic-prefix` values override the corresponding `wow.kafka.bootstrap-servers` / `wow.kafka.topic-prefix` values, even when equal to their defaults. Multiple inherited Kafka brokers are joined with commas. Every other absent application binding falls back directly to its `BiScriptOptions` domain default. The length limits in the table apply equally to the server configuration and the corresponding non-null `POST` overrides (`database`, `consumerDatabase`, `timezone`, `kafkaBootstrapServers`, `topicPrefix`, `topology.cluster.name`, and `topology.cluster.installation`). A value exactly at its 64, 128, or 4096 character limit is accepted. When BI script generation is enabled, the Starter validates the server base while constructing the domain options: a value over its limit, blank required strings, control characters, `max-expansion-depth < 1`, and cluster fields supplied in `STANDALONE` mode all fail application startup. With `enabled=false`, the Starter neither constructs nor validates BI generation options or an inspector. For HTTP overrides, the server-configured `maxExpansionDepth` is the request ceiling.
 
-The endpoint and its OpenAPI operation are present by default and are both removed when `enabled=false`. Missing `consumer-group-namespace` does not fail startup; generation returns `400` only when at least one local aggregate requires Kafka consumers. The endpoint requires `Content-Type: application/json` and a JSON body. Use `{}` to generate SQL from the server base without request overrides:
+The endpoint and its OpenAPI operation are registered by default; `enabled=false` removes both. Enablement does not provide authentication. Missing `consumer-group-namespace` does not fail startup, but generation returns `400` for every `RESET`, including an empty aggregate scope, and for `DEPLOY` whenever Kafka consumers are generated. An empty `DEPLOY` without it remains unanchored. The endpoint requires `Content-Type: application/json` and a JSON body. Use `{}` to generate SQL from the server base without request overrides:
 
 ```bash
 curl -X POST 'http://localhost:8080/wow/bi/script' \
@@ -484,7 +492,7 @@ A Cluster request may provide only selected cluster fields. Omitted cluster fiel
 }
 ```
 
-When `topology` is present, `topology.mode` is mandatory. `STANDALONE` rejects a `cluster` object. Invalid JSON, an empty body, an over-limit non-null override, another invalid option value, or an invalid topology combination returns a `400` response. A missing or unsupported request `Content-Type` returns `415`; OpenAPI declares the common `wow.UnsupportedMediaType` response, and runtime uses `Wow-Error-Code: UnsupportedMediaType`. With a real inspector, inconsistent catalog state returns `502`, an unavailable ClickHouse service returns `503`, and an inspection timeout returns `504`. `Accept` quality values are honored; JSON returns SQL, diagnostics, and the destructive flag, while SQL and wildcards return SQL. If no requested representation is supported or every supported representation is explicitly assigned `q=0`, the endpoint returns `406` with `Wow-Error-Code: NotAcceptable`. Every `200` response includes `Wow-BI-Diagnostic-Count`, including SQL responses whose body cannot carry diagnostics. Callers no longer submit manifests. The default NoOp inspector permits offline `DEPLOY` with an unreconciled diagnostic but rejects `RESET`. With an explicitly configured ClickHouse inspector, catalog ownership markers restore the identity and drive stale cleanup and confirmed Reset.
+When `topology` is present, `topology.mode` is mandatory. `STANDALONE` rejects a `cluster` object. Invalid JSON, an empty body, an over-limit non-null override, another invalid option value, or an invalid topology combination returns a `400` response. A missing or unsupported request `Content-Type` returns `415`; OpenAPI declares the common `wow.UnsupportedMediaType` response, and runtime uses `Wow-Error-Code: UnsupportedMediaType`. An unexpected generation failure returns `500`. With a real inspector, inconsistent catalog state returns `502`, an unavailable ClickHouse service returns `503`, and an inspection timeout returns `504`. `Accept` quality values are honored; JSON returns SQL, diagnostics, and the destructive flag, while SQL and wildcards return SQL. If no requested representation is supported or every supported representation is explicitly assigned `q=0`, the endpoint returns `406` with `Wow-Error-Code: NotAcceptable`. Every `200` response includes `Wow-BI-Diagnostic-Count`, including SQL responses whose body cannot carry diagnostics. Callers no longer submit manifests. The default NoOp inspector permits offline `DEPLOY` with an unreconciled diagnostic but rejects `RESET`. With an explicitly configured ClickHouse inspector, catalog ownership markers restore the identity and drive stale cleanup and confirmed Reset.
 
 See [Business Intelligence](./bi) for structured result diagnostics, current expansion semantics, and lossless mappings.
 

--- a/documentation/docs/en/guide/core-concepts.md
+++ b/documentation/docs/en/guide/core-concepts.md
@@ -395,6 +395,8 @@ This mapping (see [FunctionKind.kt:27-71](https://github.com/Ahoo-Wang/Wow/blob/
 
 Wow supports multi-tenancy at the aggregate level. Every `AggregateId` includes a `tenantId` property. Commands are scoped to a tenant, and the event store partitions events by tenant.
 
+> **Aggregate ID uniqueness:** `tenantId` does not create an independent aggregate-ID namespace. Within the same `NamedAggregate` (`contextName` + `aggregateName`), `id` must be unique across all tenants. For example, two `order` aggregate instances must not both use `order-123`, even if one belongs to tenant A and the other to tenant B. The tenant ID remains routing and isolation context, but it does not relax aggregate ID uniqueness.
+
 Tenancy can be configured at the annotation level:
 
 - `@TenantId` on a command parameter to extract tenant from the command body

--- a/documentation/docs/en/guide/open-api.md
+++ b/documentation/docs/en/guide/open-api.md
@@ -164,7 +164,7 @@ curl -X 'GET' \
 
 ### Generate BI Sync Script
 
-`POST /wow/bi/script` generates ClickHouse synchronization and expansion SQL for the current local aggregates. It requires an `application/json` request body. The OpenAPI schema lists deployment overrides plus `operation` and `replayFromEarliestConfirmed`; `previousManifest` is no longer part of the contract. Nested cluster fields are only `name` and `installation`. It also lists the enum values `DEPLOY` / `RESET`, `CLUSTER` / `STANDALONE`, and `FAIL` / `RAW_JSON`. A request may lower `maxExpansionDepth`, but cannot exceed the server-configured value, which is the endpoint's safety ceiling.
+`POST /wow/bi/script` generates ClickHouse synchronization and expansion SQL for the current local aggregates. The route and this OpenAPI operation are registered by default; set `wow.bi.script.enabled=false` to remove both. Enablement does not add authentication, so protect the management endpoint with the application's security policy. It requires an `application/json` request body. The OpenAPI schema lists deployment overrides plus `operation` and `replayFromEarliestConfirmed`; `previousManifest` is no longer part of the contract. Nested cluster fields are only `name` and `installation`. It also lists the enum values `DEPLOY` / `RESET`, `CLUSTER` / `STANDALONE`, and `FAIL` / `RAW_JSON`. A request may lower `maxExpansionDepth`, but cannot exceed the server-configured value, which is the endpoint's safety ceiling.
 
 The same maximum lengths apply to server configuration and every non-null request override: `database` 128 characters, `consumerDatabase` 128, `timezone` 64, `topicPrefix` 128, `kafkaBootstrapServers` 4096, and `topology.cluster.name` and `topology.cluster.installation` 128 each. A value exactly at its limit is accepted. A longer server value fails application startup; a longer override returns `400`.
 
@@ -175,11 +175,12 @@ The same maximum lengths apply to server configuration and every non-null reques
 | `400` | Error response | Empty or invalid JSON body, over-limit override, another invalid option value, or invalid topology combination |
 | `406` | Error response | No requested representation is supported, or every supported representation has `q=0`; runtime `Wow-Error-Code` is `NotAcceptable` |
 | `415` | Common `wow.UnsupportedMediaType` response | Missing or unsupported request `Content-Type`; runtime `Wow-Error-Code` is `UnsupportedMediaType` |
+| `500` | Error response | Unexpected BI script generation failure |
 | `502` | Error response | The owned ClickHouse catalog is inconsistent across inspected replicas |
 | `503` | Error response | ClickHouse catalog inspection is unavailable |
 | `504` | Error response | ClickHouse catalog inspection timed out |
 
-`{}` performs `DEPLOY` with the server-side options unchanged; callers do not persist deployment history. The default NoOp inspector returns an unreconciled diagnostic, while a registered ClickHouse inspector restores history from the catalog. `RESET` only carries `replayFromEarliestConfirmed=true`, but returns `400` unless inspection is available. When `topology` is present, `topology.mode` is mandatory. In `CLUSTER` mode, omitted cluster fields inherit the current Cluster server base, or the domain Cluster defaults when the server base is Standalone. `STANDALONE` rejects a `cluster` object. The legacy `GET` method has no route for this path and returns `404`.
+`{}` performs `DEPLOY` with the server-side options unchanged; callers do not persist deployment history. The default NoOp inspector returns an unreconciled diagnostic, while a registered ClickHouse inspector restores history from the catalog. `RESET` carries `replayFromEarliestConfirmed=true`, requires a configured server-side `consumerGroupNamespace` even for an empty aggregate scope, and returns `400` unless inspection is available. When `topology` is present, `topology.mode` is mandatory. In `CLUSTER` mode, omitted cluster fields inherit the current Cluster server base, or the domain Cluster defaults when the server base is Standalone. `STANDALONE` rejects a `cluster` object. `DEPLOY` and `RESET` do not migrate databases, consumer-group namespace, or ClickHouse topology; stop and clean the old physical scope before deploying a new one. The legacy `GET` method has no route for this path and returns `404`.
 
 ::: code-group
 

--- a/documentation/docs/en/onboarding/contributor-guide.md
+++ b/documentation/docs/en/onboarding/contributor-guide.md
@@ -576,7 +576,7 @@ Source: [README.md:70-99](https://github.com/Ahoo-Wang/Wow/blob/main/README.md#L
 | Interface / Class | Module | Role | Source |
 |---|---|---|---|
 | `Named` | `wow-api` | Base interface for nameable objects | [Named.kt:22](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/naming/Named.kt#L22) |
-| `AggregateId` | `wow-api` | Composite aggregate identifier: tenant + context + name + id | [AggregateId.kt:29](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt#L29) |
+| `AggregateId` | `wow-api` | Aggregate coordinates carrying tenant, context, name, and ID; the ID is unique within the named aggregate across tenants | [AggregateId.kt:29](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt#L29) |
 | `CommandMessage<C>` | `wow-api` | Command envelope with aggregate targeting, versioning, idempotency | [CommandMessage.kt:53](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L53) |
 | `DomainEvent<T>` | `wow-api` | Immutable fact about past state change, carries aggregate identity | [DomainEvent.kt:52](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/event/DomainEvent.kt#L52) |
 | `Message<SOURCE, T>` | `wow-api` | Generic message with header + body, fluent API | [Message.kt:38](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/messaging/Message.kt#L38) |
@@ -1042,7 +1042,7 @@ allEvents!!.forEach { println("Event: ${it.body}") }
 | Term | Definition | Key Source |
 |---|---|---|
 | **Aggregate** | A cluster of domain objects treated as a single transactional unit. In Wow, split into `CommandAggregate` (handles commands) and `StateAggregate` (holds state). | [CommandAggregate.kt:41-53](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/CommandAggregate.kt#L41-L53) |
-| **AggregateId** | Composite identifier: `tenantId` + `contextName` + `aggregateName` + `id`. Supports multi-tenancy, sharding, and comparison. | [AggregateId.kt:29-57](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt#L29-L57) |
+| **AggregateId** | Aggregate coordinates carrying `tenantId`, `contextName`, `aggregateName`, and `id`. Within one named aggregate, `id` is unique across tenants; `tenantId` is routing and isolation context, not an ID namespace. | [AggregateId.kt:29-57](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt#L29-L57) |
 | **Aggregate Root** | The entry point to an aggregate. Annotated with `@AggregateRoot`. All external references go through it. | [AggregateRoot.kt:66](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AggregateRoot.kt#L66) |
 | **Bounded Context** | A DDD term for a boundary within which a domain model is consistent. In Wow, defined by the `@BoundedContext` annotation and the `contextName` in `AggregateId`. | [AggregateId.kt:29](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt#L29) |
 | **Command** | A request to change the state of an aggregate. Represented by `CommandMessage<C>`. Commands are imperative: "Do this." | [CommandMessage.kt:53](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L53) |

--- a/documentation/docs/zh/guide/bi.md
+++ b/documentation/docs/zh/guide/bi.md
@@ -64,7 +64,15 @@ val diagnostics: List<BiScriptDiagnostic> = result.diagnostics
 
 ### HTTP 路由
 
-Spring WebFlux 路由及其 Swagger/OpenAPI operation 默认启用。当至少一个本地聚合需要生成 Kafka consumer 时，必须配置部署唯一的 `wow.bi.script.consumer-group-namespace`；否则请求返回 `400`，不会阻止应用启动。配置 `wow.bi.script.enabled=false` 可同时移除运行时路由及其 OpenAPI operation，并且不会构造或校验 BI 生成选项和 inspector。该路由使用同一个 `BiScriptOptions`：
+Spring WebFlux 路由及其 Swagger/OpenAPI operation 默认开启。启用本身不会增加鉴权，因此应用安全策略必须保护该管理端点；配置 `wow.bi.script.enabled=false` 会同时移除二者。`DEPLOY` 生成 Kafka consumer 时，以及所有 `RESET`（包括空聚合作用域），都必须配置部署唯一的 `wow.bi.script.consumer-group-namespace`；缺少配置时请求返回 `400`，不会阻止应用启动。未配置 namespace 的空 `DEPLOY` 不会创建 anchor；配置后，空作用域也会获得可供后续聚合复用的持久部署身份。禁用时 Starter 不构造或校验 BI 生成选项和 inspector。该路由使用同一个 `BiScriptOptions`：
+
+```yaml
+wow:
+  bi:
+    script:
+      enabled: true
+      consumer-group-namespace: orders-production-blue
+```
 
 ```shell
 curl -X POST 'http://localhost:8080/wow/bi/script' \
@@ -103,9 +111,20 @@ JSON 请求体必填。`{}` 保持服务端 `BiScriptOptions` 不变；非 `null
 
 提供 `topology` 时必须提供 `topology.mode`。在 `CLUSTER` 模式下，省略的 `cluster` 字段继承当前集群基础配置；如果服务端基础配置是独立模式，则继承领域集群默认值。`STANDALONE` 拒绝 `cluster` 对象。无效或空请求体返回 `400`；缺少或不支持的 `Content-Type` 返回 `415`。响应会遵循 `Accept` 的 quality value；JSON 返回 SQL、诊断与 destructive 标记，SQL 与通配符只返回 `result.script`。请求的表示均不受支持，或所有受支持表示均设为 `q=0` 时返回 `406`。每个成功响应都包含 `Wow-BI-Diagnostic-Count`。生成工作在线程池 `boundedElastic` 上执行。
 
-本版本默认注入 `NoOpBiDeploymentInspector`。它返回显式 `Unavailable`：普通 `DEPLOY` 仅适合首次部署或离线预览，同时会产生 `INSPECTION_UNAVAILABLE` 诊断；它无法清理旧对象，也无法恢复 `RESET` 创建的 consumer identity，配置变化还可能选择新的 consumer group。`RESET` 会被拒绝。需要完整对账时，配置 `wow.bi.script.inspector.type=CLICKHOUSE` 及 `inspector.clickhouse.endpoints`，即可启用 ClickHouse 官方 Java `client-v2` 实现。真实 inspector 查询失败会直接传播错误，不会降级为 NoOp；选择 `CLICKHOUSE` 但缺少 client-v2 类时应用启动失败。自定义 `BiDeploymentInspector` Bean 仍具有最高优先级。
+Starter 默认注入 `NoOpBiDeploymentInspector`。它返回显式 `Unavailable`：普通 `DEPLOY` 仅适合首次部署或离线预览，同时会产生 `INSPECTION_UNAVAILABLE` 诊断；它无法清理旧对象，也无法恢复 `RESET` 创建的 consumer identity，配置变化还可能选择新的 consumer group。`RESET` 会被拒绝。需要完整对账时，配置 `wow.bi.script.inspector.type=CLICKHOUSE` 及 `inspector.clickhouse.endpoints`，即可启用 ClickHouse 官方 Java `client-v2` 实现。真实 inspector 查询失败会直接传播错误，不会降级为 NoOp；选择 `CLICKHOUSE` 但缺少 client-v2 类时应用启动失败。自定义 `BiDeploymentInspector` Bean 仍具有最高优先级。
 
-如需有意重建全部 BI 数据，请发送 `operation=RESET` 与 `replayFromEarliestConfirmed=true`。只有可用 inspector 能从 ClickHouse catalog 枚举全部 owned 对象，因此 Reset 会先删除当前及 orphan store，再创建新的 consumer identity。每个生成对象和零行 deployment anchor 都把版本、deployment fingerprint、聚合 owner、对象类型和 identity 写入 `system.tables.comment`；服务重启后直接从 catalog 恢复，不依赖 Wow 服务内存或外部 manifest。
+如需有意重建全部 BI 数据，请发送 `operation=RESET` 与 `replayFromEarliestConfirmed=true`。Reset 还要求配置 `consumerGroupNamespace`，以便在 canonical anchor 中持久化恢复状态。只有可用 inspector 能从 ClickHouse catalog 枚举全部 owned 对象。每个生成对象和零行 deployment anchor 都把协议/布局版本、deployment phase、fingerprint、聚合 owner、对象类型和 identity 写入 `system.tables.comment`；服务重启后直接从 catalog 恢复，不依赖 Wow 服务内存或外部 manifest。
+
+元数据协议 v2 使 Reset 能从进程或 SQL 客户端中断中恢复。生成语句必须按顺序执行，并且执行器必须在首个错误处停止：
+
+1. 先把 canonical anchor 写为 `RESETTING`，并记录新的 consumer identity。
+2. 保留该 anchor，删除其余全部 owned 对象并重建持久表/视图图。
+3. 把 anchor 替换为 `STABLE`。
+4. 最后创建 Kafka queue 表和 Kafka consumer 物化视图。
+
+执行中断后绝不能盲目重放原 SQL 文件，必须重新 inspection，并根据 catalog 当前 phase 重新生成。如果 anchor 是 `RESETTING`，应使用相同配置重新生成 `RESET`；生成器会复用已记录的 identity，而 `DEPLOY` 会被拒绝。如果 anchor 已是 `STABLE`、但 Kafka ingress 尚未完成，应生成 `DEPLOY` 补齐。重放已完成的 Reset 可能先删除重建数据、却继续复用已经提交 offset 的 Kafka identity；进入 `STABLE` 后重新生成 Reset 则会有意开启新的 reset epoch 和 identity。协议 v2 会有意拒绝 v1 ownership marker；采用 v2 前必须停止旧 consumer，并显式清理或重建旧范围。外部协调必须保证整个 BI 物理对象命名空间只有一个写者，而不只是每个 `deploymentId` 一个写者；共享数据库和规范化对象名的 deployment 仍可能在 inspection 后发生竞争。ClickHouse `ON CLUSTER` DDL 不是跨副本事务，副本分歧仍是 fail-closed 的运维恢复场景。
+
+`DEPLOY` 与 `RESET` 只对账当前物理归属范围，不迁移 `database`、`consumerDatabase`、`consumerGroupNamespace`、拓扑模式、cluster name 或 installation。可见的 topology fingerprint 漂移会被拒绝；范围变化可能使旧对象不可发现，因此必须先停止旧 consumer、显式清理旧范围，再部署新范围。
 
 ## 生成的 SQL 契约
 
@@ -215,16 +234,16 @@ JSONExtract("data", 'tags', 'Map(String, Array(String))') AS "tags"
 
 WITH arrayJoin(arrayZip(arrayEnumerate("body"), "body")) AS "events"
 SELECT "events".1 AS "event_sequence",
-       JSONExtract("events".2, 'body', 'String') AS "event_body";
+       JSONExtractRaw("events".2, 'body') AS "event_body";
 ```
 
 顶层 `state` 使用相同的 header 屏蔽词法提取，避免 header 中名为 `state` 的嵌套字段替换权威状态 token。
 
-可写状态存储按 `create_time` 月分区，以 `(aggregate_id, version)` 排序。独立模式写入 `example_order_state_store`；集群模式通过分布式 store 写入 `example_order_state_store_local`。`example_order_state` 始终是去重读取视图。
+可写状态存储按 `create_time` 月分区，以 `(aggregate_id, version)` 排序。该排序键依赖 Wow 的聚合标识契约：在同一个命名聚合范围内，`aggregate_id` 必须跨所有租户保持唯一，`tenant_id` 不是可复用聚合 ID 的命名空间。独立模式写入 `example_order_state_store`；集群模式通过分布式 store 写入 `example_order_state_store_local`。`example_order_state` 始终是去重读取视图。
 
 ### 最新状态
 
-最新状态存储从状态 store 接收全部列，并按首次事件时间分区。`example_order_state_last` 是始终执行 `FINAL` 的权威公共视图；可写存储统一隔离在 `*_store` 后缀之后。
+最新状态存储从状态 store 接收全部列，并按首次事件时间分区。其 `ORDER BY aggregate_id` 同样要求聚合 ID 在命名聚合范围内跨租户保持唯一。`example_order_state_last` 是始终执行 `FINAL` 的权威公共视图；可写存储统一隔离在 `*_store` 后缀之后。
 
 ```sql
 CREATE TABLE IF NOT EXISTS "bi_db"."example_order_state_last_store"
@@ -268,7 +287,7 @@ AS SELECT * FROM "bi_db"."example_order_state_store";
 根视图将一对一对象展开为列，并以 `__*` 列继承状态事件元数据。物理输入列统一通过固定表别名 `__source` 限定，避免领域输出别名遮蔽元数据列：
 
 ```sql
-CREATE VIEW IF NOT EXISTS "bi_db"."example_order_state_last_root" ON CLUSTER '{cluster}' AS
+CREATE OR REPLACE VIEW "bi_db"."example_order_state_last_root" ON CLUSTER '{cluster}' AS
 WITH JSONExtractRaw("__source"."state", 'address') AS "address"
 SELECT JSONExtract("address", 'city', 'String') AS "address__city",
        JSONExtract("__source"."state", 'id', 'String') AS "id",
@@ -286,7 +305,7 @@ FROM "bi_db"."example_order_state_last" AS "__source";
 对象集合生成子视图；`arrayJoin` 将每个对象元素展开成一行，同时继承父视图列和元数据：
 
 ```sql
-CREATE VIEW IF NOT EXISTS "bi_db"."example_order_state_last_root_items" ON CLUSTER '{cluster}' AS
+CREATE OR REPLACE VIEW "bi_db"."example_order_state_last_root_items" ON CLUSTER '{cluster}' AS
 WITH arrayJoin(arrayZip(arrayEnumerate(JSONExtractArrayRaw("__source"."state", 'items')),
                         JSONExtractArrayRaw("__source"."state", 'items'))) AS "__cursor__items",
      tupleElement("__cursor__items", 2) AS "items"

--- a/documentation/docs/zh/guide/configuration.md
+++ b/documentation/docs/zh/guide/configuration.md
@@ -355,7 +355,7 @@ wow:
 
 | 属性 | 类型 | 默认值 | 描述 |
 |------|------|--------|------|
-| `wow.bi.script.enabled` | Boolean | `true` | 暴露 BI 脚本 HTTP 路由及其 OpenAPI operation；配置为 `false` 时同时移除两者 |
+| `wow.bi.script.enabled` | Boolean | `true` | 默认启用；配置为 `false` 时同时移除 BI 脚本 HTTP 路由及其 OpenAPI operation；端点仍须由应用安全策略保护 |
 | `wow.bi.script.database` | String | `bi_db` | command/state `*_store` 存储表、公共视图、最新状态视图及展开视图所在数据库；最大 128 个字符 |
 | `wow.bi.script.consumer-database` | String | `bi_db_consumer` | Kafka 队列表、消费物化视图及 deployment anchor 所在数据库；最大 128 个字符 |
 | `wow.bi.script.topology.mode` | Enum | `CLUSTER` | 物理 DDL 拓扑：`CLUSTER` 或 `STANDALONE` |
@@ -364,7 +364,7 @@ wow:
 | `wow.bi.script.timezone` | String | `Asia/Shanghai` | 生成的日期时间列和转换表达式使用的 ClickHouse 时区；最大 64 个字符 |
 | `wow.bi.script.kafka-bootstrap-servers` | String | 继承 `wow.kafka.bootstrap-servers`，否则为 `localhost:9093` | BI Kafka broker 覆盖值；继承多个 broker 时以逗号连接；最大 4096 个字符 |
 | `wow.bi.script.topic-prefix` | String | 继承 `wow.kafka.topic-prefix`，否则为 `wow.` | BI topic 前缀覆盖值；最大 128 个字符 |
-| `wow.bi.script.consumer-group-namespace` | String | 无 | 生成内容包含至少一个聚合的 Kafka consumer 时必填；写入每个 consumer group 的部署唯一命名空间 |
+| `wow.bi.script.consumer-group-namespace` | String | 无 | 所有 `RESET`（包括空聚合作用域）均必填；`DEPLOY` 生成 Kafka consumer 时也必填；写入每个 consumer group 的部署唯一命名空间 |
 | `wow.bi.script.kafka-offset-storage` | Enum | `BROKER` | `BROKER` 使用 Kafka offset；`KEEPER` 使用 ClickHouse Keeper offset |
 | `wow.bi.script.kafka-keeper-path-prefix` | String | `/clickhouse/wow-bi` | 仅 `KEEPER` 模式使用的 Keeper 路径前缀 |
 | `wow.bi.script.max-expansion-depth` | Int | `5` | 复杂属性的最大展开深度，必须大于等于 `1` |
@@ -375,19 +375,23 @@ wow:
 | `wow.bi.script.inspector.clickhouse.username` | String | `default` | ClickHouse Basic Auth 用户名 |
 | `wow.bi.script.inspector.clickhouse.password` | String | 空 | ClickHouse Basic Auth 密码；属性和客户端选项的字符串表示都会脱敏 |
 | `wow.bi.script.inspector.clickhouse.connection-pool-enabled` | Boolean | `true` | 对应 `Client.Builder.enableConnectionPool` |
-| `wow.bi.script.inspector.clickhouse.connection-timeout` | Duration | `3s` | 对应 `Client.Builder.setConnectTimeout`，必须大于零 |
-| `wow.bi.script.inspector.clickhouse.connection-request-timeout` | Duration | `10s` | 等待连接池连接的最长时间；对应 `setConnectionRequestTimeout`，必须大于零 |
-| `wow.bi.script.inspector.clickhouse.socket-timeout` | Duration | `10s` | socket 读写超时；对应 `setSocketTimeout`；零表示不设置驱动 socket deadline |
-| `wow.bi.script.inspector.clickhouse.execution-timeout` | Duration | `10s` | 单次驱动 operation deadline；对应 `setExecutionTimeout`；零表示不设置驱动 operation deadline |
+| `wow.bi.script.inspector.clickhouse.connection-timeout` | Duration | `3s` | 对应 `Client.Builder.setConnectTimeout`，最小为 `1ms` |
+| `wow.bi.script.inspector.clickhouse.connection-request-timeout` | Duration | `10s` | 等待连接池连接的最长时间；对应 `setConnectionRequestTimeout`，最小为 `1ms` |
+| `wow.bi.script.inspector.clickhouse.socket-timeout` | Duration | `10s` | socket 读写超时；对应 `setSocketTimeout`；最小为 `1ms`，且不得大于 `inspector.timeout` |
+| `wow.bi.script.inspector.clickhouse.execution-timeout` | Duration | `10s` | 单次驱动 operation deadline；检查器启用异步请求，同时配置 `setExecutionTimeout` 并使用该值限制返回 future 的等待时间；零表示不设置驱动 operation deadline，非零值最小为 `1ms` |
 | `wow.bi.script.inspector.clickhouse.max-connections` | Int | `10` | 每个 endpoint 的最大连接数；对应 `setMaxConnections`，必须大于零 |
 | `wow.bi.script.inspector.clickhouse.max-retries` | Int | `0` | 驱动重试次数；对应 `setMaxRetries`，不得为负数 |
 
-默认 `NO_OP` 不访问 ClickHouse。需要根据实际 catalog ownership marker 对账时显式启用：
+`execution-timeout` 限制检查器等待异步结果的时间，但 client-v2 不会把 future 超时转换为 HTTP abort。因此 `socket-timeout` 必须配置且不得大于总 `inspector.timeout`；取消后的响应清理会移出 timeout scheduler，并继续受该传输层 deadline 约束。
+
+默认 `NO_OP` 不访问 ClickHouse。需要根据实际 catalog ownership marker 对账时，选择 `CLICKHOUSE` inspector：
 
 ```yaml
 wow:
   bi:
     script:
+      enabled: true
+      consumer-group-namespace: orders-production-blue
       topology:
         mode: STANDALONE
       inspector:
@@ -408,7 +412,7 @@ wow:
           max-retries: 0
 ```
 
-内置 inspector 位于 `wow-bi`，直接使用 ClickHouse 官方 Java `client-v2`。Spring Boot 强类型属性与对应的 `Client.Builder` 概念一一映射，不再把不同语义的驱动超时合并成一个字段。inspector 独占 Client 并随 Spring Context 关闭；同步驱动调用运行在 Reactor `boundedElastic` 上，不再额外创建一层驱动 executor。catalog 查询使用带命名参数的强类型 RowBinary 记录；集群模式核验参与副本集合与 owned 对象定义，同时忽略无关的副本本地 catalog 差异。连接错误、超时、无效 ownership marker 或 owned 对象副本不一致都会直接失败，不会静默回退到 `NO_OP`。选择 `CLICKHOUSE` 但缺少 client-v2 类时应用启动失败。官方客户端属性尚未覆盖的代理、mTLS 或认证需求可通过自定义 `BiDeploymentInspector` Bean 实现；自定义 Bean 优先于两种内置实现。
+内置 inspector 位于 `wow-bi`，直接使用 ClickHouse 官方 Java `client-v2`。Spring Boot 强类型属性与对应的 `Client.Builder` 概念一一映射，不再把不同语义的驱动超时合并成一个字段。inspector 独占 Client 并随 Spring Context 关闭；它发起 client-v2 异步查询，并在 Reactor `boundedElastic` 上等待每个返回的 future，不额外创建驱动 executor。catalog 查询使用带命名参数的强类型 RowBinary 记录；集群模式核验参与副本集合与 owned 对象定义，同时忽略无关的副本本地 catalog 差异。连接错误、超时、无效 ownership marker 或 owned 对象副本不一致都会直接失败，不会静默回退到 `NO_OP`。选择 `CLICKHOUSE` 但缺少 client-v2 类时应用启动失败。官方客户端属性尚未覆盖的代理、mTLS 或认证需求可通过自定义 `BiDeploymentInspector` Bean 实现；自定义 Bean 优先于两种内置实现。
 
 独立拓扑：
 
@@ -428,6 +432,8 @@ wow:
 wow:
   bi:
     script:
+      enabled: true
+      consumer-group-namespace: orders-production-blue
       topology:
         mode: CLUSTER
         cluster:
@@ -437,6 +443,8 @@ wow:
 
 `STANDALONE` 创建使用 `ReplacingMergeTree` 的 `*_store` 物理存储表，`command`、`state`、`state_last` 保持为对存储表执行 `FINAL` 的只读视图，并拒绝配置 `topology.cluster`。`CLUSTER` 创建复制的 `*_store_local` 物理表、作为 `Distributed` 写入门面的 `*_store`，以及相同的公共只读视图；未配置的集群字段使用上表默认值。集群 DDL 始终使用 ClickHouse 服务端 `{shard}` 与 `{replica}` 宏，Keeper consumer 的副本标识也使用 `{replica}`；这些值有意不开放为应用级覆盖项。
 
+`DEPLOY` 与 `RESET` 只对账当前物理归属范围，不迁移 `database`、`consumerDatabase`、`consumerGroupNamespace`、拓扑模式、cluster name 或 installation。可见的 topology fingerprint 漂移会被拒绝；范围变化可能使旧对象不可发现，因此必须先停止旧 consumer、显式清理旧范围，再部署新范围。
+
 完整优先级从低到高为：
 
 1. `BiScriptOptions` 领域默认值；
@@ -444,11 +452,11 @@ wow:
 3. `wow.bi.script.*` 应用配置；
 4. 非 `null` 的 `POST` 请求字段。
 
-配置真实 deployment inspector 后，`database`、`consumerDatabase` 与 `topology` 固定使用服务端配置；请求覆盖这些字段会返回 `400`，避免外部请求借用服务端 ClickHouse 凭据查询任意数据库或集群。默认 `NO_OP` inspector 不访问 ClickHouse，因此仍允许这些覆盖。
+配置真实 deployment inspector 后，`database`、`consumerDatabase` 与 `topology` 固定使用服务端配置；请求覆盖这些字段会返回 `400`，避免外部请求借用服务端 ClickHouse 凭据查询任意数据库或集群。默认 `NO_OP` inspector 不访问 ClickHouse，因此仍允许这些覆盖；其输出仅是离线预览，不会迁移已有范围。
 
 因此，显式 `wow.bi.script.kafka-bootstrap-servers` / `wow.bi.script.topic-prefix` 会覆盖对应的 `wow.kafka.bootstrap-servers` / `wow.kafka.topic-prefix`，即使其值等于默认值；继承多个 Kafka broker 时以逗号连接。其他未配置的应用绑定属性直接回退到 `BiScriptOptions` 领域默认值。表中的长度限制同时适用于服务端配置和对应的非 `null` `POST` override（`database`、`consumerDatabase`、`timezone`、`kafkaBootstrapServers`、`topicPrefix`、`topology.cluster.name` 和 `topology.cluster.installation`）。长度恰好等于 64、128 或 4096 字符限制的值可被接受。启用 BI 脚本生成时，Starter 在构造服务端基础选项时统一执行校验：超过长度限制、必填字符串为空白或包含控制字符、`max-expansion-depth < 1`，以及在 `STANDALONE` 模式提供集群字段都会使应用启动失败。配置 `enabled=false` 时，Starter 不构造或校验 BI 生成选项和 inspector。对于 HTTP override，服务端配置的 `maxExpansionDepth` 是请求 ceiling。
 
-端点及其 OpenAPI operation 默认存在，配置 `enabled=false` 时会同时移除。未配置 `consumer-group-namespace` 不会导致启动失败；只有至少一个本地聚合需要生成 Kafka consumer 时，请求才会返回 `400`。端点要求 `Content-Type: application/json` 和 JSON 请求体。使用 `{}` 可在不提供请求覆盖值的情况下按服务端基础配置生成 SQL：
+端点及其 OpenAPI operation 默认注册；配置 `enabled=false` 会同时移除二者。启用本身不会提供鉴权。未配置 `consumer-group-namespace` 不会导致启动失败，但所有 `RESET`（包括空聚合作用域），以及会生成 Kafka consumer 的 `DEPLOY` 都会返回 `400`；未配置时的空 `DEPLOY` 不建立 anchor。端点要求 `Content-Type: application/json` 和 JSON 请求体。使用 `{}` 可在不提供请求覆盖值的情况下按服务端基础配置生成 SQL：
 
 ```bash
 curl -X POST 'http://localhost:8080/wow/bi/script' \
@@ -483,7 +491,7 @@ curl -X POST 'http://localhost:8080/wow/bi/script' \
 }
 ```
 
-提供 `topology` 时必须提供 `topology.mode`。`STANDALONE` 拒绝 `cluster` 对象。无效 JSON、空请求体、超过长度限制的非 `null` override、其他无效选项值或无效拓扑组合返回 `400`；缺少或不支持的请求 `Content-Type` 返回 `415`。OpenAPI 声明公共 `wow.UnsupportedMediaType` response，运行时使用 `Wow-Error-Code: UnsupportedMediaType`。启用真实 inspector 后，catalog 状态不一致返回 `502`，ClickHouse 不可用返回 `503`，检查超时返回 `504`。响应会遵循 `Accept` 的 quality value；JSON 返回 SQL、诊断与 destructive 标记，SQL 与通配符返回 SQL。如果请求未接受任何受支持的表示，或将其全部显式设为 `q=0`，端点返回 `406` 及 `Wow-Error-Code: NotAcceptable`。所有 `200` 响应都包含 `Wow-BI-Diagnostic-Count`，包括响应体无法携带诊断的 SQL 响应。调用方不再提交 manifest。默认 NoOp inspector 允许离线 `DEPLOY` 并返回未对账诊断，但拒绝 `RESET`；显式配置 ClickHouse inspector 后，服务从 catalog ownership marker 恢复 identity、清理旧对象，并在 `replayFromEarliestConfirmed=true` 时执行 Reset。
+提供 `topology` 时必须提供 `topology.mode`。`STANDALONE` 拒绝 `cluster` 对象。无效 JSON、空请求体、超过长度限制的非 `null` override、其他无效选项值或无效拓扑组合返回 `400`；缺少或不支持的请求 `Content-Type` 返回 `415`。OpenAPI 声明公共 `wow.UnsupportedMediaType` response，运行时使用 `Wow-Error-Code: UnsupportedMediaType`。未预期的生成失败返回 `500`。启用真实 inspector 后，catalog 状态不一致返回 `502`，ClickHouse 不可用返回 `503`，检查超时返回 `504`。响应会遵循 `Accept` 的 quality value；JSON 返回 SQL、诊断与 destructive 标记，SQL 与通配符返回 SQL。如果请求未接受任何受支持的表示，或将其全部显式设为 `q=0`，端点返回 `406` 及 `Wow-Error-Code: NotAcceptable`。所有 `200` 响应都包含 `Wow-BI-Diagnostic-Count`，包括响应体无法携带诊断的 SQL 响应。调用方不再提交 manifest。默认 NoOp inspector 允许离线 `DEPLOY` 并返回未对账诊断，但拒绝 `RESET`；显式配置 ClickHouse inspector 后，服务从 catalog ownership marker 恢复 identity、清理旧对象，并在 `replayFromEarliestConfirmed=true` 时执行 Reset。
 
 结构化结果诊断、当前展开语义与无损映射参见[商业智能](./bi)。
 

--- a/documentation/docs/zh/guide/core-concepts.md
+++ b/documentation/docs/zh/guide/core-concepts.md
@@ -408,6 +408,8 @@ classDiagram
 
 Wow 在聚合级别支持多租户。每个 `AggregateId` 都包含一个 `tenantId` 属性。命令作用域限定为租户，事件存储按租户分区事件。
 
+> **聚合 ID 唯一性约束：** `tenantId` 不会创建独立的聚合 ID 命名空间。在同一个 `NamedAggregate`（`contextName` + `aggregateName`）范围内，`id` 必须在所有租户之间保持唯一。例如，两个 `order` 聚合实例不能同时使用 `order-123`，即使它们分别属于租户 A 和租户 B。租户 ID 仍用于路由和隔离，但不会放宽聚合 ID 的唯一性。
+
 租户可以在注解级别配置：
 
 - 命令参数上的 `@TenantId` 从命令体提取租户

--- a/documentation/docs/zh/guide/open-api.md
+++ b/documentation/docs/zh/guide/open-api.md
@@ -165,7 +165,7 @@ curl -X 'GET' \
 
 ### 生成 BI 同步脚本
 
-`POST /wow/bi/script` 生成当前本地聚合的 ClickHouse 同步与展开 SQL，并要求提供 `application/json` 请求体。OpenAPI schema 除部署覆盖字段外还包含 `operation` 与 `replayFromEarliestConfirmed`，不再包含 `previousManifest`；嵌套集群字段只包含 `name` 和 `installation`。schema 同时列出枚举值 `DEPLOY` / `RESET`、`CLUSTER` / `STANDALONE` 与 `FAIL` / `RAW_JSON`。请求可以降低 `maxExpansionDepth`，但不能超过服务端配置值；该配置是端点的安全上限。
+`POST /wow/bi/script` 生成当前本地聚合的 ClickHouse 同步与展开 SQL。该路由及 OpenAPI operation 默认注册；配置 `wow.bi.script.enabled=false` 会同时移除二者。启用本身不会增加鉴权，因此必须由应用安全策略保护该管理端点。端点要求提供 `application/json` 请求体。OpenAPI schema 除部署覆盖字段外还包含 `operation` 与 `replayFromEarliestConfirmed`，不再包含 `previousManifest`；嵌套集群字段只包含 `name` 和 `installation`。schema 同时列出枚举值 `DEPLOY` / `RESET`、`CLUSTER` / `STANDALONE` 与 `FAIL` / `RAW_JSON`。请求可以降低 `maxExpansionDepth`，但不能超过服务端配置值；该配置是端点的安全上限。
 
 服务端配置和每个非 `null` 请求 override 使用相同的最大长度：`database` 128 个字符、`consumerDatabase` 128、`timezone` 64、`topicPrefix` 128、`kafkaBootstrapServers` 4096，`topology.cluster.name` 与 `topology.cluster.installation` 各 128。长度恰好等于限制的值可被接受；更长的服务端值会使应用启动失败，更长的 override 返回 `400`。
 
@@ -176,11 +176,12 @@ curl -X 'GET' \
 | `400` | 错误响应 | 空或无效 JSON 请求体、超过长度限制的 override、其他无效选项值或无效拓扑组合 |
 | `406` | 错误响应 | 请求的表示均不受支持，或所有受支持的表示均设为 `q=0`；运行时 `Wow-Error-Code` 为 `NotAcceptable` |
 | `415` | 公共 `wow.UnsupportedMediaType` response | 缺少或不支持的请求 `Content-Type`；运行时 `Wow-Error-Code` 为 `UnsupportedMediaType` |
+| `500` | 错误响应 | 未预期的 BI 脚本生成失败 |
 | `502` | 错误响应 | inspected replica 上的 owned ClickHouse catalog 不一致 |
 | `503` | 错误响应 | ClickHouse catalog inspection 不可用 |
 | `504` | 错误响应 | ClickHouse catalog inspection 超时 |
 
-`{}` 使用服务端选项执行 `DEPLOY`，调用方无需保存部署历史。默认 NoOp inspector 会返回未对账诊断；注册 ClickHouse inspector 后从 catalog 恢复历史。`RESET` 只需 `replayFromEarliestConfirmed=true`，但 inspector 必须可用，否则返回 `400`。提供 `topology` 时必须提供 `topology.mode`。在 `CLUSTER` 模式下，省略的集群字段继承当前集群服务端基础配置；如果服务端基础配置是独立模式，则继承领域集群默认值。`STANDALONE` 拒绝 `cluster` 对象。旧版 `GET` 方法在该路径上没有路由并返回 `404`。
+`{}` 使用服务端选项执行 `DEPLOY`，调用方无需保存部署历史。默认 NoOp inspector 会返回未对账诊断；注册 ClickHouse inspector 后从 catalog 恢复历史。`RESET` 需要 `replayFromEarliestConfirmed=true`，即使聚合作用域为空也要求服务端配置 `consumerGroupNamespace`，且 inspector 必须可用，否则返回 `400`。提供 `topology` 时必须提供 `topology.mode`。在 `CLUSTER` 模式下，省略的集群字段继承当前集群服务端基础配置；如果服务端基础配置是独立模式，则继承领域集群默认值。`STANDALONE` 拒绝 `cluster` 对象。`DEPLOY` 与 `RESET` 不迁移数据库、consumer-group namespace 或 ClickHouse 拓扑；部署新范围前必须先停止并清理旧物理范围。旧版 `GET` 方法在该路径上没有路由并返回 `404`。
 
 ::: code-group
 

--- a/documentation/docs/zh/onboarding/contributor-guide.md
+++ b/documentation/docs/zh/onboarding/contributor-guide.md
@@ -576,7 +576,7 @@ Source: [README.md:70-99](https://github.com/Ahoo-Wang/Wow/blob/main/README.md#L
 | 接口 / 类 | 模块 | 角色 | 源代码 |
 |---|---|---|---|
 | `Named` | `wow-api` | 可命名对象的基接口 | [Named.kt:22](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/naming/Named.kt#L22) |
-| `AggregateId` | `wow-api` | 复合聚合标识符：tenant + context + name + id | [AggregateId.kt:29](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt#L29) |
+| `AggregateId` | `wow-api` | 携带租户、上下文、名称与 ID 的聚合坐标；ID 在命名聚合范围内跨租户唯一 | [AggregateId.kt:29](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt#L29) |
 | `CommandMessage<C>` | `wow-api` | 命令信封，包含聚合定位、版本控制、幂等性 | [CommandMessage.kt:53](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L53) |
 | `DomainEvent<T>` | `wow-api` | 关于过去状态变更的不可变事实，携带聚合标识 | [DomainEvent.kt:52](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/event/DomainEvent.kt#L52) |
 | `Message<SOURCE, T>` | `wow-api` | 带 header + body 的泛型消息，流式 API | [Message.kt:38](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/messaging/Message.kt#L38) |
@@ -1042,7 +1042,7 @@ allEvents!!.forEach { println("Event: ${it.body}") }
 | 术语 | 定义 | 关键源代码 |
 |---|---|---|
 | **聚合（Aggregate）** | 一组作为单个事务单元处理的领域对象。在 Wow 中，分为 `CommandAggregate`（处理命令）和 `StateAggregate`（持有状态）。 | [CommandAggregate.kt:41-53](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/CommandAggregate.kt#L41-L53) |
-| **聚合标识（AggregateId）** | 复合标识符：`tenantId` + `contextName` + `aggregateName` + `id`。支持多租户、分片和比较。 | [AggregateId.kt:29-57](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt#L29-L57) |
+| **聚合标识（AggregateId）** | 携带 `tenantId`、`contextName`、`aggregateName` 与 `id` 的聚合坐标。在同一个命名聚合范围内，`id` 跨租户唯一；`tenantId` 是路由和隔离上下文，不是 ID 命名空间。 | [AggregateId.kt:29-57](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt#L29-L57) |
 | **聚合根（Aggregate Root）** | 聚合的入口点。使用 `@AggregateRoot` 注解。所有外部引用都通过它进行。 | [AggregateRoot.kt:66](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AggregateRoot.kt#L66) |
 | **限界上下文（Bounded Context）** | DDD 术语，指领域模型在其中保持一致的边界。在 Wow 中，由 `@BoundedContext` 注解和 `AggregateId` 中的 `contextName` 定义。 | [AggregateId.kt:29](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt#L29) |
 | **命令（Command）** | 改变聚合状态的请求。由 `CommandMessage<C>` 表示。命令是祈使式的："执行这个。" | [CommandMessage.kt:53](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L53) |

--- a/example/example-server/src/test/kotlin/me/ahoo/wow/example/server/ExampleServerBiConfigurationTest.kt
+++ b/example/example-server/src/test/kotlin/me/ahoo/wow/example/server/ExampleServerBiConfigurationTest.kt
@@ -29,7 +29,7 @@ class ExampleServerBiConfigurationTest {
             assertEquals(
                 true,
                 properties.firstNotNullOfOrNull { it.getProperty(BI_ENABLED_PROPERTY) },
-                "$configuration must explicitly enable the BI script endpoint",
+                "$configuration must keep the BI script endpoint enabled",
             )
             assertEquals(
                 CONSUMER_GROUP_NAMESPACE,
@@ -39,7 +39,7 @@ class ExampleServerBiConfigurationTest {
             assertEquals(
                 "NO_OP",
                 properties.firstNotNullOfOrNull { it.getProperty(INSPECTOR_TYPE_PROPERTY) },
-                "$configuration must keep BI deployment inspection disabled by default",
+                "$configuration must use the NO_OP BI deployment inspector",
             )
         }
     }

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AggregateId.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AggregateId.kt
@@ -19,7 +19,10 @@ const val DEFAULT_AGGREGATE_ID_NAME = "id"
 /**
  * Marks a field or property as the aggregate identifier.
  *
- * The aggregate ID uniquely identifies an instance of an aggregate within its bounded context.
+ * The aggregate ID uniquely identifies an instance within its named aggregate. This uniqueness is global across
+ * tenants: tenant ID is routing and isolation context, not a namespace that permits reusing the same aggregate ID.
+ * Two instances of the same aggregate type must therefore never share an ID, even when they belong to different
+ * tenants.
  * This annotation is used by the framework to automatically map command payloads to the correct
  * aggregate instances and to generate routing information.
  *

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt
@@ -20,6 +20,11 @@ import me.ahoo.wow.api.Identifier
  * As an identifier, it not only identifies the aggregate root but also supports naming, decorator pattern,
  * tenant identification, and value comparison.
  *
+ * The [id] must be unique within the same [namedAggregate], regardless of [tenantId]. The tenant ID provides
+ * routing and isolation context; it does not create a separate namespace in which the same aggregate ID may be
+ * reused. Consequently, two instances of the same named aggregate must never share an [id], even when they belong
+ * to different tenants.
+ *
  * @see Identifier
  * @see NamedAggregate
  * @see NamedAggregateDecorator
@@ -34,6 +39,7 @@ interface AggregateId :
     Comparable<AggregateId> {
     /**
      * The named aggregate that this ID belongs to.
+     * Within this scope, [id] is unique across all tenants.
      * @see MaterializedNamedAggregate
      */
     override val namedAggregate: NamedAggregate

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateIdCapable.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateIdCapable.kt
@@ -19,7 +19,8 @@ package me.ahoo.wow.api.modeling
  * entities and value objects treated as a single unit. In Domain-Driven Design (DDD),
  * aggregates are the basic units for maintaining data consistency.
  *
- * @property aggregateId The aggregate ID used to uniquely identify an aggregate instance.
+ * @property aggregateId The aggregate ID used to uniquely identify an aggregate instance. Its `id` value must be
+ * unique within the named aggregate across all tenants; tenant ID is not an aggregate-ID namespace.
  */
 interface AggregateIdCapable {
     val aggregateId: AggregateId

--- a/wow-bi/src/integrationTest/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspectorIntegrationTest.kt
+++ b/wow-bi/src/integrationTest/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspectorIntegrationTest.kt
@@ -13,7 +13,9 @@
 
 package me.ahoo.wow.bi
 
+import com.clickhouse.client.api.ClientException
 import me.ahoo.test.asserts.assert
+import me.ahoo.test.asserts.assertThrownBy
 import org.junit.jupiter.api.Test
 import org.testcontainers.clickhouse.ClickHouseContainer
 import org.testcontainers.utility.DockerImageName
@@ -24,6 +26,31 @@ import java.time.Duration
 
 class ClickHouseBiDeploymentInspectorIntegrationTest {
     @Test
+    fun `should apply execution timeout to a real ClickHouse request`() {
+        ClickHouseContainer(DockerImageName.parse(CLICKHOUSE_IMAGE)).use { clickHouse ->
+            clickHouse.start()
+            NativeClickHouseCatalogClient.create(
+                ClickHouseClientOptions(
+                    endpoints = listOf(URI.create(clickHouse.httpUrl)),
+                    username = clickHouse.username,
+                    password = clickHouse.password,
+                    connectionTimeout = Duration.ofSeconds(5),
+                    socketTimeout = Duration.ofSeconds(2),
+                    executionTimeout = Duration.ofMillis(100),
+                )
+            ).use { catalogClient ->
+                assertThrownBy<ClientException> {
+                    catalogClient.query(
+                        sql = "SELECT sleep(1) AS value",
+                        parameters = emptyMap(),
+                        columns = listOf("value"),
+                    )
+                }.hasMessageContaining("ClickHouse BI catalog query timed out")
+            }
+        }
+    }
+
+    @Test
     fun `should inspect the real ClickHouse system catalog through client v2`() {
         ClickHouseContainer(DockerImageName.parse(CLICKHOUSE_IMAGE)).use { clickHouse ->
             clickHouse.start()
@@ -32,21 +59,53 @@ class ClickHouseBiDeploymentInspectorIntegrationTest {
                 consumerDatabase = CONSUMER_DATABASE,
                 consumerGroupNamespace = "native-inspector-integration",
                 topology = ClickHouseTopology.Standalone,
+                kafkaBootstrapServers = KAFKA_BOOTSTRAP_SERVERS,
             )
             val descriptor = BiDeploymentDescriptor.from(options)
-            val metadata = BiObjectMetadata(
+            val identity = BiConsumerIdentity.deterministic(descriptor)
+            val storeMetadata = BiObjectMetadata(
                 deploymentId = descriptor.deploymentId,
                 configurationFingerprint = descriptor.configurationFingerprint,
+                topologyFingerprint = descriptor.topologyFingerprint,
                 aggregate = "integration.catalog",
                 kind = BiObjectKind.STORE,
             )
+            val queueMetadata = BiObjectMetadata(
+                deploymentId = descriptor.deploymentId,
+                configurationFingerprint = descriptor.configurationFingerprint,
+                topologyFingerprint = descriptor.topologyFingerprint,
+                aggregate = "integration.catalog",
+                kind = BiObjectKind.QUEUE,
+                consumerIdentity = identity.value,
+            )
+            val anchorMetadata = BiObjectMetadata(
+                deploymentId = descriptor.deploymentId,
+                configurationFingerprint = descriptor.configurationFingerprint,
+                topologyFingerprint = descriptor.topologyFingerprint,
+                kind = BiObjectKind.ANCHOR,
+                consumerIdentity = identity.value,
+            )
+            val expectedGroup = "wow-bi.${identity.value}.catalog_command_consumer"
             DriverManager.getConnection(clickHouse.jdbcUrl, clickHouse.username, clickHouse.password).use { connection ->
                 connection.createStatement().use { statement ->
                     statement.execute("CREATE DATABASE $DATABASE")
+                    statement.execute("CREATE DATABASE $CONSUMER_DATABASE")
                     statement.execute(
                         "CREATE TABLE $DATABASE.$TABLE (id UInt64) " +
-                            "ENGINE = MergeTree ORDER BY id " +
-                            "COMMENT '${BiObjectMetadataCodec.encode(metadata)}'"
+                            "ENGINE = ReplacingMergeTree ORDER BY id " +
+                            "COMMENT '${BiObjectMetadataCodec.encode(storeMetadata)}'"
+                    )
+                    statement.execute(
+                        "CREATE TABLE $CONSUMER_DATABASE.$QUEUE (data String) " +
+                            "ENGINE = Kafka('$KAFKA_BOOTSTRAP_SERVERS', '${options.topicPrefix}integration.catalog.command', " +
+                            "'$expectedGroup', 'JSONAsString') " +
+                            "SETTINGS kafka_num_consumers = 2 " +
+                            "COMMENT '${BiObjectMetadataCodec.encode(queueMetadata)}'"
+                    )
+                    statement.execute(
+                        "CREATE VIEW $CONSUMER_DATABASE.__wow_bi_deployment AS " +
+                            "SELECT 1 AS alive WHERE 0 " +
+                            "COMMENT '${BiObjectMetadataCodec.encode(anchorMetadata)}'"
                     )
                 }
             }
@@ -62,14 +121,55 @@ class ClickHouseBiDeploymentInspectorIntegrationTest {
                 inspectionTimeout = Duration.ofSeconds(10),
             ).use { inspector ->
                 val available = inspector.inspect(options).block() as BiDeploymentInspection.Available
-                val observed = available.deployment.objects.single()
+                val observed = available.deployment.objects.single { it.key == BiObjectKey(DATABASE, TABLE) }
+                val queue = available.deployment.objects.single {
+                    it.key == BiObjectKey(CONSUMER_DATABASE, QUEUE)
+                }
 
                 observed.database.assert().isEqualTo(DATABASE)
                 observed.name.assert().isEqualTo(TABLE)
-                observed.engine.assert().isEqualTo("MergeTree")
-                observed.engineFull.assert().contains("MergeTree")
+                observed.engine.assert().isEqualTo("ReplacingMergeTree")
+                observed.engineFull.assert().contains("ReplacingMergeTree")
                 observed.createTableQuery.assert().contains("CREATE TABLE", TABLE)
-                observed.metadata.assert().isEqualTo(metadata)
+                observed.metadata.assert().isEqualTo(storeMetadata)
+
+                queue.engine.assert().isEqualTo("Kafka")
+                queue.engineFull.assert()
+                    .startsWith("Kafka(")
+                    .contains("'$expectedGroup'", "SETTINGS kafka_num_consumers = 2")
+                queue.metadata.assert().isEqualTo(queueMetadata)
+
+                val changedOptions = options.copy(
+                    kafkaBootstrapServers = "changed-kafka:9092",
+                    topicPrefix = "changed.",
+                    kafkaOffsetStorage = KafkaOffsetStorage.KEEPER,
+                    kafkaKeeperPathPrefix = "/changed/wow-bi",
+                )
+                val changedDescriptor = BiDeploymentDescriptor.from(changedOptions)
+                val changedInspection = inspector.inspect(changedOptions).block()
+                    as BiDeploymentInspection.Available
+                assertThrownBy<IllegalArgumentException> {
+                    BiScriptGenerator(changedOptions).generate(
+                        emptySet(),
+                        BiScriptOperation.Deploy,
+                        changedInspection,
+                    )
+                }.hasMessageContaining("use RESET")
+
+                val resetInspection = inspector.inspect(changedOptions, BiScriptOperation.Reset(true)).block()
+                    as BiDeploymentInspection.Available
+                val reset = BiScriptGenerator(changedOptions).generate(
+                    emptySet(),
+                    BiScriptOperation.Reset(true),
+                    resetInspection,
+                )
+                reset.script.assert()
+                    .contains(
+                        "DROP TABLE IF EXISTS \"$CONSUMER_DATABASE\".\"$QUEUE\"",
+                        "\"configurationFingerprint\":\"${changedDescriptor.configurationFingerprint}\"",
+                        "\"phase\":\"RESETTING\"",
+                        "\"phase\":\"STABLE\"",
+                    )
             }
         }
     }
@@ -117,6 +217,8 @@ class ClickHouseBiDeploymentInspectorIntegrationTest {
         const val DATABASE = "wow_bi_native_inspector"
         const val CONSUMER_DATABASE = "wow_bi_native_inspector_consumer"
         const val TABLE = "catalog_store"
+        const val QUEUE = "catalog_command_queue"
+        const val KAFKA_BOOTSTRAP_SERVERS = "kafka-a:9092,kafka-b:9092"
         const val CLUSTER = "test_cluster"
         const val CLUSTER_CONFIG_RESOURCE = "clickhouse-test-cluster.xml"
         const val CLUSTER_CONFIG_PATH = "/etc/clickhouse-server/config.d/clickhouse-test-cluster.xml"

--- a/wow-bi/src/integrationTest/kotlin/me/ahoo/wow/bi/ClickHouseExpansionIntegrationTest.kt
+++ b/wow-bi/src/integrationTest/kotlin/me/ahoo/wow/bi/ClickHouseExpansionIntegrationTest.kt
@@ -24,6 +24,7 @@ import me.ahoo.wow.naming.NamingConverter
 import me.ahoo.wow.serialization.JsonSerializer
 import org.junit.jupiter.api.DynamicTest
 import org.junit.jupiter.api.TestFactory
+import org.junit.jupiter.api.assertThrows
 import org.testcontainers.clickhouse.ClickHouseContainer
 import org.testcontainers.utility.DockerImageName
 import org.testcontainers.utility.MountableFile
@@ -34,8 +35,10 @@ import tools.jackson.databind.annotation.JsonSerialize
 import tools.jackson.databind.jsonFormatVisitors.JsonFormatVisitorWrapper
 import tools.jackson.databind.ser.std.StdSerializer
 import java.math.BigDecimal
+import java.net.URI
 import java.sql.Connection
 import java.sql.DriverManager
+import java.sql.SQLException
 import java.time.Duration
 import java.time.Instant
 import java.time.Year
@@ -70,7 +73,9 @@ class ClickHouseExpansionIntegrationTest {
             consumerGroupNamespace = "integration-test",
         )
         val namedAggregate = aggregateMetadata<ClickHouseExpansionAggregate, ClickHouseExpansionState>()
-        val result = BiScriptGenerator(options).generate(setOf(namedAggregate))
+        val generator = BiScriptGenerator(options)
+        val namedAggregates = setOf(namedAggregate)
+        val result = generator.generate(namedAggregates)
         result.diagnostics
             .filter { it.path == "claimedArrayList" || it.path == "claimedMap" }
             .associate { it.path to it.code }
@@ -132,17 +137,64 @@ class ClickHouseExpansionIntegrationTest {
                 ).single().assert().isEqualTo(EXPECTED_SCALAR_ROW)
 
                 connection.assertLatestStateReadsAreDeduplicated()
-                connection.assertDeployIsIdempotent(result, case)
+                connection.assertOfflineDeployFailsClosed(result, case)
+                ClickHouseBiDeploymentInspector(
+                    ClickHouseClientOptions(
+                        endpoints = listOf(URI.create(clickHouse.httpUrl)),
+                        username = clickHouse.username,
+                        password = clickHouse.password,
+                    )
+                ).use { inspector ->
+                    repeat(2) {
+                        val authoritativeDeploy = generator.generate(
+                            namedAggregates,
+                            inspection = inspector.inspect(options).block()!!,
+                        )
+                        connection.assertAuthoritativeDeployIsIdempotent(authoritativeDeploy, case)
+                    }
+                }
             }
         }
     }
 
-    private fun Connection.assertDeployIsIdempotent(
+    private fun Connection.assertOfflineDeployFailsClosed(
         result: BiScriptResult,
         case: TopologyCase,
     ) {
         val before = listOf(COMMAND_STORE_TABLE, STATE_STORE_TABLE, STATE_LAST_STORE_TABLE)
             .associateWith { table -> queryCount("SELECT count() FROM ${qualified(DATABASE, table)}") }
+
+        val failure = assertThrows<SQLException> {
+            result.statements.forEach(::executeSql)
+        }
+        generateSequence<Throwable>(failure) { error -> error.cause }
+            .mapNotNull { error -> error.message }
+            .joinToString("\n")
+            .assert()
+            .contains("TABLE_ALREADY_EXISTS")
+
+        assertGeneratedObjects(case)
+        before.forEach { (table, expectedCount) ->
+            queryCount("SELECT count() FROM ${qualified(DATABASE, table)}")
+                .assert().isEqualTo(expectedCount)
+        }
+    }
+
+    private fun Connection.assertAuthoritativeDeployIsIdempotent(
+        result: BiScriptResult,
+        case: TopologyCase,
+    ) {
+        val before = listOf(COMMAND_STORE_TABLE, STATE_STORE_TABLE, STATE_LAST_STORE_TABLE)
+            .associateWith { table -> queryCount("SELECT count() FROM ${qualified(DATABASE, table)}") }
+        val queueUuids = queueUuids()
+        queueUuids.values.forEach { uuid -> uuid.assert().isNotEqualTo(NIL_UUID) }
+        val script = result.statements.joinToString("\n")
+        queueUuids.keys.forEach { queue ->
+            script.assert().doesNotContain(
+                "DROP TABLE IF EXISTS ${qualified(CONSUMER_DATABASE, queue)}",
+                "CREATE TABLE ${qualified(CONSUMER_DATABASE, queue)}",
+            )
+        }
 
         result.statements.forEach(::executeSql)
 
@@ -151,7 +203,17 @@ class ClickHouseExpansionIntegrationTest {
             queryCount("SELECT count() FROM ${qualified(DATABASE, table)}")
                 .assert().isEqualTo(expectedCount)
         }
+        queueUuids().assert().isEqualTo(queueUuids)
     }
+
+    private fun Connection.queueUuids(): Map<String, String> =
+        listOf("${COMMAND_TABLE}_queue", "${STATE_TABLE}_queue").associateWith { queue ->
+            queryRows(
+                "SELECT toString(uuid) AS uuid FROM system.tables " +
+                    "WHERE database = ${literal(CONSUMER_DATABASE)} AND name = ${literal(queue)}",
+                listOf("uuid"),
+            ).single().getValue("uuid")
+        }
 
     private fun Connection.assertJsonExtractionSemantics() {
         val unicodeEscape = "\\u0041"
@@ -483,6 +545,7 @@ class ClickHouseExpansionIntegrationTest {
         const val STATE_STORE_TABLE = "${STATE_TABLE}_store"
         const val STATE_LAST_TABLE = "bi_it_nullable_state_last"
         const val STATE_LAST_STORE_TABLE = "${STATE_LAST_TABLE}_store"
+        const val NIL_UUID = "00000000-0000-0000-0000-000000000000"
         const val ROOT_VIEW = "bi_it_nullable_state_last_root"
         const val CHILD_VIEW = "bi_it_nullable_state_last_root_nullable_objects"
         const val RECOVERY_CHILD_VIEW = "bi_it_nullable_state_last_root_recovery_items"

--- a/wow-bi/src/integrationTest/kotlin/me/ahoo/wow/bi/KafkaClickHouseIntegrationTest.kt
+++ b/wow-bi/src/integrationTest/kotlin/me/ahoo/wow/bi/KafkaClickHouseIntegrationTest.kt
@@ -23,11 +23,13 @@ import org.apache.kafka.clients.producer.ProducerConfig
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.common.serialization.StringSerializer
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.testcontainers.clickhouse.ClickHouseContainer
 import org.testcontainers.containers.Network
 import org.testcontainers.kafka.ConfluentKafkaContainer
 import org.testcontainers.utility.DockerImageName
 import org.testcontainers.utility.MountableFile
+import java.net.URI
 import java.sql.Connection
 import java.sql.DriverManager
 import java.time.Duration
@@ -61,16 +63,25 @@ class KafkaClickHouseIntegrationTest {
                     val generator = BiScriptGenerator(options)
                     val firstDeploy = generator.generate(setOf(aggregate))
 
-                    connection(clickHouse).use { connection ->
-                        producer(kafka).use { producer ->
-                            producer.sendJson(commandTopic, "command-1", commandMessage("command-1", 42))
-                            producer.sendJson(stateTopic, "state-1", stateMessage(version = 1, scalar = 1))
-                            producer.sendJson(stateTopic, "state-2", stateMessage(version = 2, scalar = 2))
-                        }
-                        firstDeploy.statements.forEach { statement -> connection.executeStatement(statement) }
+                    inspector(clickHouse).use { inspector ->
+                        connection(clickHouse).use { connection ->
+                            producer(kafka).use { producer ->
+                                producer.sendJson(commandTopic, "command-1", commandMessage("command-1", 42))
+                                producer.sendJson(stateTopic, "state-1", stateMessage(version = 1, scalar = 1))
+                                producer.sendJson(stateTopic, "state-2", stateMessage(version = 2, scalar = 2))
+                            }
+                            firstDeploy.statements.forEach { statement -> connection.executeStatement(statement) }
 
                         connection.awaitLong("SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "command_store")}", 1)
                         connection.awaitLong("SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "state_store")}", 2)
+                        connection.awaitLong(
+                            "SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "state_event")}",
+                            2,
+                        )
+                        connection.queryString(
+                            "SELECT event_body FROM $DATABASE.${naming.toTableName(aggregate, "state_event")} " +
+                                "WHERE version = 2",
+                        ).assert().isEqualTo("{\"value\":2}")
                         connection.awaitLong(
                             "SELECT version FROM $DATABASE.${naming.toTableName(aggregate, "state_last")} " +
                                 "WHERE aggregate_id = '$AGGREGATE_ID'",
@@ -88,16 +99,32 @@ class KafkaClickHouseIntegrationTest {
                                 "WHERE __aggregate_id = '$AGGREGATE_ID'",
                             2,
                         )
+                        val queueUuids = listOf("command", "state").associateWith { suffix ->
+                            connection.queryString(
+                                "SELECT toString(uuid) FROM system.tables " +
+                                    "WHERE database = '$CONSUMER_DATABASE' AND " +
+                                "name = '${naming.toTableName(aggregate, "${suffix}_queue")}'",
+                            )
+                        }
+                        queueUuids.values.forEach { uuid -> uuid.assert().isNotEqualTo(NIL_UUID) }
 
                         val redeploy = generator.generate(
                             setOf(aggregate),
                             BiScriptOperation.Deploy,
-                            connection.inspect(options),
+                            inspector.inspectAvailable(options),
                         )
+                        redeploy.assertDoesNotMutateQueues(naming, aggregate)
                         redeploy.statements.forEach { statement -> connection.executeStatement(statement) }
                         connection.queryLong(
                             "SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "state_store")}"
                         ).assert().isEqualTo(2)
+                        queueUuids.forEach { (suffix, uuid) ->
+                            connection.queryString(
+                                "SELECT toString(uuid) FROM system.tables " +
+                                    "WHERE database = '$CONSUMER_DATABASE' AND " +
+                                    "name = '${naming.toTableName(aggregate, "${suffix}_queue")}'",
+                            ).assert().isEqualTo(uuid)
+                        }
 
                         producer(kafka).use { producer ->
                             producer.sendJson(commandTopic, "command-2", commandMessage("command-2", 84))
@@ -109,27 +136,74 @@ class KafkaClickHouseIntegrationTest {
                         val reset = generator.generate(
                             setOf(aggregate),
                             BiScriptOperation.Reset(replayFromEarliestConfirmed = true),
-                            connection.inspect(options),
+                            inspector.inspectAvailable(options, BiScriptOperation.Reset(true)),
                         )
-                        consumerIdentity(reset.script).assert().isNotEqualTo(consumerIdentity(firstDeploy.script))
-                        reset.statements.forEach { statement -> connection.executeStatement(statement) }
+                        val resetIdentity = consumerIdentity(reset.script)
+                        resetIdentity.assert().isNotEqualTo(consumerIdentity(firstDeploy.script))
+                        val firstDurableStatement = reset.indexOfStatement(
+                            "CREATE TABLE IF NOT EXISTS \"$DATABASE\".\"${
+                                naming.toTableName(aggregate, "command_store")
+                            }\""
+                        )
+                        reset.statements.take(firstDurableStatement)
+                            .forEach { statement -> connection.executeStatement(statement) }
 
-                        connection.awaitLong("SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "command_store")}", 2)
-                        connection.awaitLong("SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "state_store")}", 3)
+                        val resettingInspection = inspector.inspectAvailable(
+                            options,
+                            BiScriptOperation.Reset(true),
+                        )
+                        resettingInspection.anchorMetadata().phase.assert().isEqualTo(BiDeploymentPhase.RESETTING)
+                        resettingInspection.consumerIdentity().assert().isEqualTo(resetIdentity)
+                        assertThrows<IllegalArgumentException> {
+                            generator.generate(setOf(aggregate), BiScriptOperation.Deploy, resettingInspection)
+                        }.message.assert().contains("RESETTING")
+
+                        val retryReset = generator.generate(
+                            setOf(aggregate),
+                            BiScriptOperation.Reset(replayFromEarliestConfirmed = true),
+                            resettingInspection,
+                        )
+                        consumerIdentity(retryReset.script).assert().isEqualTo(resetIdentity)
+                        val stableAnchorStatement = retryReset.indexOfAnchorStatement(BiDeploymentPhase.STABLE)
+                        retryReset.statements.take(stableAnchorStatement + 1)
+                            .forEach { statement -> connection.executeStatement(statement) }
+
+                        val stableInspection = inspector.inspectAvailable(options)
+                        stableInspection.anchorMetadata().phase.assert().isEqualTo(BiDeploymentPhase.STABLE)
+                        stableInspection.consumerIdentity().assert().isEqualTo(resetIdentity)
+                        listOf("command", "state").flatMap { suffix ->
+                            listOf(
+                                naming.toTableName(aggregate, "${suffix}_queue"),
+                                naming.toTableName(aggregate, "${suffix}_consumer"),
+                            )
+                        }.forEach { table ->
+                            connection.queryLong(
+                                "SELECT count() FROM system.tables WHERE database = '$CONSUMER_DATABASE' " +
+                                    "AND name = '$table'"
+                            ).assert().isZero()
+                        }
+
+                        val deployAfterReset = generator.generate(
+                            setOf(aggregate),
+                            BiScriptOperation.Deploy,
+                            stableInspection,
+                        )
+                        consumerIdentity(deployAfterReset.script).assert().isEqualTo(resetIdentity)
+                        deployAfterReset.statements.forEach { statement -> connection.executeStatement(statement) }
+                        inspector.inspectAvailable(options).consumerIdentity().assert().isEqualTo(resetIdentity)
+                        connection.awaitLong(
+                            "SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "command_store")}",
+                            2,
+                        )
+                        connection.awaitLong(
+                            "SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "state_store")}",
+                            3,
+                        )
                         connection.awaitLong(
                             "SELECT version FROM $DATABASE.${naming.toTableName(aggregate, "state_last")} " +
                                 "WHERE aggregate_id = '$AGGREGATE_ID'",
                             3,
                         )
-
-                        val deployAfterReset = generator.generate(
-                            setOf(aggregate),
-                            BiScriptOperation.Deploy,
-                            connection.inspect(options),
-                        )
-                        consumerIdentity(deployAfterReset.script).assert()
-                            .isEqualTo(consumerIdentity(reset.script))
-                        deployAfterReset.statements.forEach { statement -> connection.executeStatement(statement) }
                         producer(kafka).use { producer ->
                             producer.sendJson(stateTopic, "state-4", stateMessage(version = 4, scalar = 4))
                         }
@@ -139,6 +213,7 @@ class KafkaClickHouseIntegrationTest {
                                 "WHERE aggregate_id = '$AGGREGATE_ID'",
                             4,
                         )
+                        }
                     }
                 }
             }
@@ -164,6 +239,24 @@ class KafkaClickHouseIntegrationTest {
         container.username,
         container.password,
     )
+
+    private fun inspector(container: ClickHouseContainer): ClickHouseBiDeploymentInspector =
+        ClickHouseBiDeploymentInspector(
+            clientOptions = ClickHouseClientOptions(
+                endpoints = listOf(URI.create(container.httpUrl)),
+                username = container.username,
+                password = container.password,
+                connectionTimeout = Duration.ofSeconds(5),
+                socketTimeout = Duration.ofSeconds(10),
+            ),
+            inspectionTimeout = Duration.ofSeconds(10),
+        )
+
+    private fun ClickHouseBiDeploymentInspector.inspectAvailable(
+        options: BiScriptOptions,
+        operation: BiScriptOperation = BiScriptOperation.Deploy,
+    ): BiDeploymentInspection.Available =
+        inspect(options, operation).block() as BiDeploymentInspection.Available
 
     private fun producer(container: ConfluentKafkaContainer): KafkaProducer<String, String> = KafkaProducer(
         mapOf(
@@ -211,7 +304,15 @@ class KafkaClickHouseIntegrationTest {
         "requestId" to "request-$version",
         "version" to version,
         "state" to mapOf("id" to AGGREGATE_ID, "nullableScalar" to scalar),
-        "body" to emptyList<Any>(),
+        "body" to listOf(
+            mapOf(
+                "id" to "event-$version",
+                "name" to "TestEvent",
+                "revision" to "1.0.0",
+                "bodyType" to "TestEvent",
+                "body" to mapOf("value" to scalar),
+            )
+        ),
         "firstOperator" to "tester",
         "firstEventTime" to 1_000L * version,
         "createTime" to 1_000L * version,
@@ -219,34 +320,44 @@ class KafkaClickHouseIntegrationTest {
         "deleted" to false,
     )
 
-    private fun Connection.inspect(options: BiScriptOptions): BiDeploymentInspection.Available {
-        val objects = createStatement().use { statement ->
-            statement.executeQuery(
-                "SELECT database, name, engine, engine_full, create_table_query, comment " +
-                    "FROM system.tables WHERE database IN ('${options.database}', '${options.consumerDatabase}')"
-            ).use { result ->
-                buildList {
-                    while (result.next()) {
-                        add(
-                            ObservedBiObject(
-                                database = result.getString("database"),
-                                name = result.getString("name"),
-                                engine = result.getString("engine"),
-                                engineFull = result.getString("engine_full"),
-                                createTableQuery = result.getString("create_table_query"),
-                                metadata = BiObjectMetadataCodec.decode(result.getString("comment")),
-                            )
-                        )
-                    }
-                }
-            }
-        }
-        return BiDeploymentInspection.Available(ObservedBiDeployment(objects))
-    }
-
     private fun consumerIdentity(script: String): String = requireNotNull(
         Regex("wow-bi\\.([0-9a-f]{32})\\.").find(script)?.groupValues?.get(1)
     )
+
+    private fun BiDeploymentInspection.Available.consumerIdentity(): String =
+        requireNotNull(anchorMetadata().consumerIdentity)
+
+    private fun BiDeploymentInspection.Available.anchorMetadata(): BiObjectMetadata =
+        requireNotNull(
+            deployment.objects.single { observed -> observed.metadata?.kind == BiObjectKind.ANCHOR }.metadata
+        )
+
+    private fun BiScriptResult.indexOfStatement(fragment: String): Int =
+        statements.indexOfFirst { statement -> statement.contains(fragment) }.also { index ->
+            check(index >= 0) { "Statement containing [$fragment] was not generated." }
+        }
+
+    private fun BiScriptResult.indexOfAnchorStatement(phase: BiDeploymentPhase): Int =
+        statements.indexOfFirst { statement ->
+            statement.contains("__wow_bi_deployment") && statement.contains("\"phase\":\"$phase\"")
+        }.also { index ->
+            check(index >= 0) { "Deployment anchor in phase [$phase] was not generated." }
+        }
+
+    private fun BiScriptResult.assertDoesNotMutateQueues(
+        naming: BiTableNaming,
+        aggregate: me.ahoo.wow.api.modeling.NamedAggregate,
+    ) {
+        val script = statements.joinToString("\n")
+        listOf("command", "state").forEach { suffix ->
+            val queue = naming.toTableName(aggregate, "${suffix}_queue")
+            script.assert()
+                .doesNotContain(
+                    "DROP TABLE IF EXISTS \"$CONSUMER_DATABASE\".\"$queue\"",
+                    "CREATE TABLE \"$CONSUMER_DATABASE\".\"$queue\"",
+                )
+        }
+    }
 
     private fun Connection.executeStatement(sql: String) {
         createStatement().use { statement -> statement.execute(sql) }
@@ -256,6 +367,13 @@ class KafkaClickHouseIntegrationTest {
         statement.executeQuery(sql).use { result ->
             check(result.next()) { "Query returned no rows: $sql" }
             result.getLong(1)
+        }
+    }
+
+    private fun Connection.queryString(sql: String): String = createStatement().use { statement ->
+        statement.executeQuery(sql).use { result ->
+            check(result.next()) { "Query returned no rows: $sql" }
+            result.getString(1)
         }
     }
 
@@ -301,6 +419,7 @@ class KafkaClickHouseIntegrationTest {
         const val CONSUMER_DATABASE = "bi_kafka_it_consumer"
         const val KAFKA_NETWORK_ALIAS = "kafka"
         const val KAFKA_INTERNAL_BOOTSTRAP_SERVERS = "$KAFKA_NETWORK_ALIAS:19092"
+        const val NIL_UUID = "00000000-0000-0000-0000-000000000000"
         const val TOPIC_PREFIX = "bi-e2e."
         const val AGGREGATE_ID = "aggregate-kafka"
         val AWAIT_TIMEOUT: Duration = Duration.ofSeconds(30)

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiDeploymentInspection.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiDeploymentInspection.kt
@@ -24,13 +24,22 @@ fun interface BiDeploymentInspector {
     val allowsDynamicScope: Boolean
         get() = false
 
-    fun inspect(options: BiScriptOptions): Mono<BiDeploymentInspection>
+    fun inspect(
+        options: BiScriptOptions,
+        operation: BiScriptOperation,
+    ): Mono<BiDeploymentInspection>
+
+    fun inspect(options: BiScriptOptions): Mono<BiDeploymentInspection> =
+        inspect(options, BiScriptOperation.Deploy)
 }
 
 data object NoOpBiDeploymentInspector : BiDeploymentInspector {
     override val allowsDynamicScope: Boolean = true
 
-    override fun inspect(options: BiScriptOptions): Mono<BiDeploymentInspection> =
+    override fun inspect(
+        options: BiScriptOptions,
+        operation: BiScriptOperation,
+    ): Mono<BiDeploymentInspection> =
         Mono.just(BiDeploymentInspection.Unavailable)
 }
 
@@ -70,6 +79,18 @@ sealed class BiDeploymentInspectionException(
 }
 
 data class ObservedBiDeployment(val objects: List<ObservedBiObject>) {
+    init {
+        val duplicateKeys = objects.groupingBy(ObservedBiObject::key)
+            .eachCount()
+            .filterValues { count -> count > 1 }
+            .keys
+            .map { key -> "${key.database}.${key.name}" }
+            .sorted()
+        require(duplicateKeys.isEmpty()) {
+            "Observed BI deployment contains duplicate catalog objects: ${duplicateKeys.joinToString()}"
+        }
+    }
+
     val ownedObjects: List<ObservedBiObject>
         get() = objects.filter { it.metadata != null }
 }
@@ -95,11 +116,18 @@ enum class BiObjectKind {
     CONSUMER,
 }
 
+enum class BiDeploymentPhase {
+    STABLE,
+    RESETTING,
+}
+
 data class BiObjectMetadata(
     val protocolVersion: Int = CURRENT_PROTOCOL_VERSION,
     val layoutVersion: Int = CURRENT_LAYOUT_VERSION,
+    val phase: BiDeploymentPhase = BiDeploymentPhase.STABLE,
     val deploymentId: String,
     val configurationFingerprint: String,
+    val topologyFingerprint: String,
     val aggregate: String? = null,
     val kind: BiObjectKind,
     val consumerIdentity: String? = null,
@@ -115,14 +143,23 @@ data class BiObjectMetadata(
         require(DIGEST_PATTERN.matches(configurationFingerprint)) {
             "Invalid BI configurationFingerprint: $configurationFingerprint"
         }
+        require(DIGEST_PATTERN.matches(topologyFingerprint)) {
+            "Invalid BI topologyFingerprint: $topologyFingerprint"
+        }
         consumerIdentity?.let(::BiConsumerIdentity)
         require(kind == BiObjectKind.ANCHOR || aggregate != null) {
             "BI catalog object [$kind] requires an aggregate owner"
         }
+        require(phase != BiDeploymentPhase.RESETTING || kind == BiObjectKind.ANCHOR) {
+            "BI RESETTING phase is only valid for the deployment anchor"
+        }
+        require(phase != BiDeploymentPhase.RESETTING || consumerIdentity != null) {
+            "BI RESETTING deployment anchor requires a consumer identity"
+        }
     }
 
     companion object {
-        const val CURRENT_PROTOCOL_VERSION: Int = 1
+        const val CURRENT_PROTOCOL_VERSION: Int = 2
         const val CURRENT_LAYOUT_VERSION: Int = 6
         private val DIGEST_PATTERN = Regex("[0-9a-f]{32}")
     }
@@ -131,16 +168,61 @@ data class BiObjectMetadata(
 object BiObjectMetadataCodec {
     private const val PREFIX = "wow-bi:"
 
-    fun encode(metadata: BiObjectMetadata): String =
-        PREFIX + JsonSerializer.writeValueAsString(metadata)
+    fun encode(metadata: BiObjectMetadata): String {
+        return PREFIX + JsonSerializer.writeValueAsString(
+            BiObjectMetadataWire(
+                protocolVersion = metadata.protocolVersion,
+                layoutVersion = metadata.layoutVersion,
+                phase = metadata.phase,
+                deploymentId = metadata.deploymentId,
+                configurationFingerprint = metadata.configurationFingerprint,
+                topologyFingerprint = metadata.topologyFingerprint,
+                aggregate = metadata.aggregate,
+                kind = metadata.kind,
+                consumerIdentity = metadata.consumerIdentity,
+            )
+        )
+    }
 
     fun decode(comment: String): BiObjectMetadata? {
         if (!comment.startsWith(PREFIX)) {
             return null
         }
-        return JsonSerializer.readValue(comment.removePrefix(PREFIX), BiObjectMetadata::class.java)
+        val wire = JsonSerializer.readValue(comment.removePrefix(PREFIX), BiObjectMetadataWire::class.java)
+        require(wire.protocolVersion == BiObjectMetadata.CURRENT_PROTOCOL_VERSION) {
+            "Unsupported BI object metadata protocol version: ${wire.protocolVersion}"
+        }
+        val phase = requireNotNull(wire.phase) {
+            "BI object metadata protocol v2 requires phase"
+        }
+        val topologyFingerprint = requireNotNull(wire.topologyFingerprint) {
+            "BI object metadata protocol v2 requires topologyFingerprint"
+        }
+        return BiObjectMetadata(
+            protocolVersion = wire.protocolVersion,
+            layoutVersion = wire.layoutVersion,
+            phase = phase,
+            deploymentId = wire.deploymentId,
+            configurationFingerprint = wire.configurationFingerprint,
+            topologyFingerprint = topologyFingerprint,
+            aggregate = wire.aggregate,
+            kind = wire.kind,
+            consumerIdentity = wire.consumerIdentity,
+        )
     }
 }
+
+private data class BiObjectMetadataWire(
+    val protocolVersion: Int,
+    val layoutVersion: Int,
+    val phase: BiDeploymentPhase? = null,
+    val deploymentId: String,
+    val configurationFingerprint: String,
+    val topologyFingerprint: String? = null,
+    val aggregate: String? = null,
+    val kind: BiObjectKind,
+    val consumerIdentity: String? = null,
+)
 
 @JvmInline
 value class BiConsumerIdentity(val value: String) {
@@ -162,6 +244,7 @@ value class BiConsumerIdentity(val value: String) {
 data class BiDeploymentDescriptor(
     val deploymentId: String,
     val configurationFingerprint: String,
+    val topologyFingerprint: String,
 ) {
     companion object {
         fun from(options: BiScriptOptions): BiDeploymentDescriptor {
@@ -188,7 +271,16 @@ data class BiDeploymentDescriptor(
                     options.kafkaKeeperPathPrefix,
                 ).joinToString("\u0000")
             )
-            return BiDeploymentDescriptor(deploymentId, configurationFingerprint)
+            val topologyFingerprint = sha256(
+                listOf(
+                    options.database,
+                    options.consumerDatabase,
+                    if (cluster == null) "STANDALONE" else "CLUSTER",
+                    cluster?.name.orEmpty(),
+                    cluster?.installation.orEmpty(),
+                ).joinToString("\u0000")
+            )
+            return BiDeploymentDescriptor(deploymentId, configurationFingerprint, topologyFingerprint)
         }
     }
 }

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiScriptGenerator.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiScriptGenerator.kt
@@ -17,13 +17,14 @@ import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.bi.expansion.BiTableNaming
 import me.ahoo.wow.bi.expansion.plan.StateExpansionPlan
 import me.ahoo.wow.bi.expansion.plan.StateExpansionPlanner
+import me.ahoo.wow.bi.renderer.CatalogMutationMode
 import me.ahoo.wow.bi.renderer.ClickHouseScriptRenderer
 import me.ahoo.wow.modeling.toStringWithAlias
 import java.util.Collections
 
 class BiScriptGenerator(private val options: BiScriptOptions = BiScriptOptions()) {
 
-    @Suppress("LongMethod")
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
     fun generate(
         namedAggregates: Set<NamedAggregate>,
         operation: BiScriptOperation = BiScriptOperation.Deploy,
@@ -43,12 +44,24 @@ class BiScriptGenerator(private val options: BiScriptOptions = BiScriptOptions()
             .sortedWith(compareBy<NamedAggregate> { it.contextName }.thenBy { it.aggregateName })
             .map { namedAggregate -> PlannedAggregate(namedAggregate, planner.plan(namedAggregate)) }
         val descriptor = BiDeploymentDescriptor.from(options)
-        val desiredObjects = plannedAggregates.desiredObjects() + desiredAnchor()
+        val shouldRenderDeploymentAnchor = options.consumerGroupNamespace != null
+        require(operation !is BiScriptOperation.Reset || shouldRenderDeploymentAnchor) {
+            "consumerGroupNamespace must be configured before RESET so its recovery state can be persisted"
+        }
+        val desiredObjects = plannedAggregates.desiredObjects() +
+            if (shouldRenderDeploymentAnchor) listOf(desiredAnchor()) else emptyList()
         validateDesiredObjectNames(desiredObjects)
         val observed = (inspection as? BiDeploymentInspection.Available)?.deployment
         observed?.validate(descriptor, desiredObjects, operation)
         val consumerIdentity = resolveConsumerIdentity(operation, descriptor, observed)
-        val renderer = ClickHouseScriptRenderer(options, consumerIdentity, descriptor)
+        val retainedQueueKeys = resolveRetainedQueueKeys(operation, desiredObjects, descriptor, observed)
+        val renderer = ClickHouseScriptRenderer(
+            options,
+            consumerIdentity,
+            descriptor,
+            if (observed == null) CatalogMutationMode.CREATE_ONLY else CatalogMutationMode.RECONCILE,
+            retainedQueueKeys,
+        )
 
         val globalSection = ScriptSection("global", renderer.renderGlobalStatements())
         val lifecycleSections = renderLifecycle(
@@ -59,29 +72,54 @@ class BiScriptGenerator(private val options: BiScriptOptions = BiScriptOptions()
             observed,
             renderer,
         )
-        val aggregateSections = plannedAggregates.flatMap { planned ->
+        val durableAggregateSections = plannedAggregates.flatMap { planned ->
             val name = planned.namedAggregate.toStringWithAlias()
             listOf(
-                ScriptSection("$name.command", renderer.renderCommandStatements(planned.namedAggregate)),
+                ScriptSection("$name.commandStorage", renderer.renderCommandStorageStatements(planned.namedAggregate)),
                 ScriptSection("$name.stateStorage", renderer.renderStateStorageStatements(planned.namedAggregate)),
                 ScriptSection("$name.stateLast", renderer.renderStateLastStatements(planned.namedAggregate)),
                 ScriptSection("$name.expansion", renderer.renderExpansionStatements(planned.plan, name)),
+                ScriptSection("$name.commandPublic", renderer.renderCommandPublicStatements(planned.namedAggregate)),
                 ScriptSection("$name.statePublic", renderer.renderStatePublicStatements(planned.namedAggregate)),
+            )
+        }
+        val ingressSections = plannedAggregates.flatMap { planned ->
+            val name = planned.namedAggregate.toStringWithAlias()
+            listOf(
+                ScriptSection("$name.commandIngress", renderer.renderCommandIngressStatements(planned.namedAggregate)),
                 ScriptSection("$name.stateIngress", renderer.renderStateIngressStatements(planned.namedAggregate)),
             )
         }
-        val anchorSection = ScriptSection("deployment-anchor", listOf(renderer.renderAnchorStatement()))
-        val orderedSections = listOf(globalSection) + lifecycleSections + aggregateSections + anchorSection
+        val resetIntentSection = if (operation is BiScriptOperation.Reset) {
+            ScriptSection(
+                "deployment-reset-intent",
+                listOf(renderer.renderAnchorStatement(BiDeploymentPhase.RESETTING)),
+            )
+        } else {
+            null
+        }
+        val anchorSection = if (shouldRenderDeploymentAnchor) {
+            ScriptSection(
+                "deployment-anchor",
+                listOf(renderer.renderAnchorStatement(BiDeploymentPhase.STABLE)),
+            )
+        } else {
+            null
+        }
+        val orderedSections = listOf(globalSection) + listOfNotNull(resetIntentSection) + lifecycleSections +
+            durableAggregateSections + listOfNotNull(anchorSection) + ingressSections
         val statements = Collections.unmodifiableList(
             ArrayList(orderedSections.flatMap(ScriptSection::statements))
         )
         val script = buildString {
             appendSection(globalSection)
             appendLine("-- lifecycle --")
+            resetIntentSection?.let { section -> appendSection(section) }
             lifecycleSections.forEach { section -> appendSection(section) }
             appendLine("-- lifecycle --")
-            aggregateSections.forEach { section -> appendSection(section) }
-            appendSection(anchorSection)
+            durableAggregateSections.forEach { section -> appendSection(section) }
+            anchorSection?.let { section -> appendSection(section) }
+            ingressSections.forEach { section -> appendSection(section) }
         }
         val diagnostics = buildList {
             if (plannedAggregates.isNotEmpty()) {
@@ -102,6 +140,25 @@ class BiScriptGenerator(private val options: BiScriptOptions = BiScriptOptions()
         )
     }
 
+    private fun resolveRetainedQueueKeys(
+        operation: BiScriptOperation,
+        desiredObjects: List<DesiredBiObject>,
+        descriptor: BiDeploymentDescriptor,
+        observed: ObservedBiDeployment?,
+    ): Set<BiObjectKey> {
+        if (operation != BiScriptOperation.Deploy || observed == null) {
+            return emptySet()
+        }
+        val desiredQueueKeys = desiredObjects.asSequence()
+            .filter { it.kind == BiObjectKind.QUEUE }
+            .map(DesiredBiObject::key)
+            .toSet()
+        return observed.ownedBy(descriptor).asSequence()
+            .filter { it.metadata?.kind == BiObjectKind.QUEUE && it.key in desiredQueueKeys }
+            .map(ObservedBiObject::key)
+            .toSet()
+    }
+
     private fun renderLifecycle(
         operation: BiScriptOperation,
         plannedAggregates: List<PlannedAggregate>,
@@ -112,13 +169,15 @@ class BiScriptGenerator(private val options: BiScriptOptions = BiScriptOptions()
     ): List<ScriptSection> = buildList {
         when (operation) {
             BiScriptOperation.Deploy -> {
-                plannedAggregates.forEach { planned ->
-                    add(
-                        ScriptSection(
-                            "${planned.namedAggregate.toStringWithAlias()}.pause-ingress",
-                            renderer.renderPauseIngressStatements(planned.namedAggregate),
+                if (observed != null) {
+                    plannedAggregates.forEach { planned ->
+                        add(
+                            ScriptSection(
+                                "${planned.namedAggregate.toStringWithAlias()}.pause-ingress",
+                                renderer.renderPauseIngressStatements(planned.namedAggregate),
+                            )
                         )
-                    )
+                    }
                 }
                 val desiredKeys = desiredObjects.map(DesiredBiObject::key).toSet()
                 val staleObjects = observed?.ownedBy(descriptor).orEmpty()
@@ -131,7 +190,9 @@ class BiScriptGenerator(private val options: BiScriptOptions = BiScriptOptions()
             }
 
             is BiScriptOperation.Reset -> {
+                val anchorKey = desiredAnchor().key
                 val ownedObjects = checkNotNull(observed).ownedBy(descriptor)
+                    .filterNot { it.key == anchorKey }
                 if (ownedObjects.isNotEmpty()) {
                     add(ScriptSection("reset-observed-catalog", renderer.renderDropObservedStatements(ownedObjects)))
                 }
@@ -146,7 +207,18 @@ class BiScriptGenerator(private val options: BiScriptOptions = BiScriptOptions()
     ): BiConsumerIdentity = when (operation) {
         BiScriptOperation.Deploy ->
             observed?.consumerIdentity(descriptor) ?: BiConsumerIdentity.deterministic(descriptor)
-        is BiScriptOperation.Reset -> BiConsumerIdentity.random()
+        is BiScriptOperation.Reset ->
+            observed?.resettingAnchor(descriptor)?.metadata?.consumerIdentity
+                ?.let(::BiConsumerIdentity)
+                ?: BiConsumerIdentity.random()
+    }
+
+    private fun ObservedBiDeployment.resettingAnchor(
+        descriptor: BiDeploymentDescriptor,
+    ): ObservedBiObject? = objects.firstOrNull { observed ->
+        observed.key == desiredAnchor().key &&
+            observed.metadata?.deploymentId == descriptor.deploymentId &&
+            observed.metadata.phase == BiDeploymentPhase.RESETTING
     }
 
     private fun ObservedBiDeployment.consumerIdentity(descriptor: BiDeploymentDescriptor): BiConsumerIdentity? {
@@ -169,26 +241,125 @@ class BiScriptGenerator(private val options: BiScriptOptions = BiScriptOptions()
         operation: BiScriptOperation,
     ) {
         val desiredByKey = desiredObjects.associateBy(DesiredBiObject::key)
+        validateDeploymentTopology(descriptor)
+        validateDeploymentAnchor(descriptor, operation)
         objects.forEach { observed ->
-            val desired = desiredByKey[observed.key]
-            val metadata = observed.metadata
-            if (desired != null) {
-                require(metadata != null && metadata.deploymentId == descriptor.deploymentId) {
-                    "BI object [${observed.database}.${observed.name}] is occupied by a foreign catalog object"
-                }
-                require(metadata.kind == desired.kind && metadata.aggregate == desired.aggregate) {
-                    "BI object [${observed.database}.${observed.name}] has inconsistent ownership metadata"
-                }
-            }
-            if (metadata?.deploymentId == descriptor.deploymentId && operation == BiScriptOperation.Deploy) {
-                require(metadata.configurationFingerprint == descriptor.configurationFingerprint) {
-                    "Observed BI deployment configuration differs from the requested configuration; use RESET"
-                }
-            }
+            validateObservedObject(
+                observed = observed,
+                desired = desiredByKey[observed.key],
+                descriptor = descriptor,
+                operation = operation,
+            )
         }
         if (operation == BiScriptOperation.Deploy) {
             consumerIdentity(descriptor)
         }
+    }
+
+    private fun ObservedBiDeployment.validateDeploymentTopology(
+        descriptor: BiDeploymentDescriptor,
+    ) {
+        val currentObjects = ownedBy(descriptor)
+        if (currentObjects.isEmpty()) {
+            return
+        }
+        val observedTopologies = currentObjects.map { observed ->
+            requireNotNull(observed.metadata).topologyFingerprint
+        }.distinct()
+        require(observedTopologies.size <= 1) {
+            "Observed BI deployment contains mixed topology fingerprints: $observedTopologies"
+        }
+        require(observedTopologies.single() == descriptor.topologyFingerprint) {
+            "Observed BI deployment topology differs from the requested topology and cannot be migrated through " +
+                "DEPLOY or RESET"
+        }
+    }
+
+    private fun ObservedBiDeployment.validateDeploymentAnchor(
+        descriptor: BiDeploymentDescriptor,
+        operation: BiScriptOperation,
+    ) {
+        val deploymentAnchors = objects.filter { observed ->
+            observed.metadata?.deploymentId == descriptor.deploymentId &&
+                observed.metadata.kind == BiObjectKind.ANCHOR
+        }
+        require(deploymentAnchors.size <= 1) {
+            "Observed BI deployment contains multiple deployment anchors: " +
+                deploymentAnchors.map { anchor -> "${anchor.database}.${anchor.name}" }.sorted()
+        }
+        deploymentAnchors.singleOrNull()?.let { anchor ->
+            val canonicalAnchor = desiredAnchor().key
+            require(anchor.key == canonicalAnchor) {
+                "Observed BI deployment anchor must use canonical key " +
+                    "[${canonicalAnchor.database}.${canonicalAnchor.name}], but found " +
+                    "[${anchor.database}.${anchor.name}]"
+            }
+        }
+        resettingAnchor(descriptor)?.let { anchor ->
+            val metadata = checkNotNull(anchor.metadata)
+            when (operation) {
+                BiScriptOperation.Deploy -> throw IllegalArgumentException(
+                    "Observed BI deployment is RESETTING; retry RESET with the same configuration"
+                )
+
+                is BiScriptOperation.Reset -> require(
+                    metadata.configurationFingerprint == descriptor.configurationFingerprint
+                ) {
+                    "Observed BI deployment is RESETTING with a different configuration; " +
+                        "retry RESET with the original configuration"
+                }
+            }
+        }
+    }
+
+    private fun validateObservedObject(
+        observed: ObservedBiObject,
+        desired: DesiredBiObject?,
+        descriptor: BiDeploymentDescriptor,
+        operation: BiScriptOperation,
+    ) {
+        val metadata = observed.metadata
+        if (desired != null) {
+            require(
+                metadata != null &&
+                    metadata.deploymentId == descriptor.deploymentId
+            ) {
+                "BI object [${observed.database}.${observed.name}] is occupied by a foreign catalog object"
+            }
+            require(metadata.kind == desired.kind && metadata.aggregate == desired.aggregate) {
+                "BI object [${observed.database}.${observed.name}] has inconsistent ownership metadata"
+            }
+            if (desired.kind == BiObjectKind.ANCHOR) {
+                require(observed.engine == desired.expectedEngine) {
+                    "BI deployment anchor [${observed.database}.${observed.name}] must use the View engine"
+                }
+            } else {
+                require(observed.engine == desired.expectedEngine) {
+                    "BI object [${observed.database}.${observed.name}] has incompatible engine " +
+                        "[${observed.engine}]; expected engine [${desired.expectedEngine}]"
+                }
+            }
+        } else if (metadata?.deploymentId == descriptor.deploymentId) {
+            require(metadata.kind.acceptsEngine(observed.engine)) {
+                "BI object [${observed.database}.${observed.name}] kind [${metadata.kind}] has incompatible engine " +
+                    "[${observed.engine}]"
+            }
+        }
+        if (metadata?.deploymentId == descriptor.deploymentId && operation == BiScriptOperation.Deploy) {
+            require(metadata.configurationFingerprint == descriptor.configurationFingerprint) {
+                "Observed BI deployment configuration differs from the requested configuration; use RESET"
+            }
+        }
+    }
+
+    private fun BiObjectKind.acceptsEngine(engine: String): Boolean = when (this) {
+        BiObjectKind.ANCHOR,
+        BiObjectKind.VIEW,
+        -> engine == "View"
+
+        BiObjectKind.STORE -> engine in STORE_ENGINES
+        BiObjectKind.QUEUE -> engine == "Kafka"
+        BiObjectKind.CONSUMER -> engine == "MaterializedView"
     }
 
     private fun ObservedBiDeployment.ownedBy(descriptor: BiDeploymentDescriptor): List<ObservedBiObject> =
@@ -206,17 +377,7 @@ class BiScriptGenerator(private val options: BiScriptOptions = BiScriptOptions()
         val stateLast = naming.toTableName(namedAggregate, "state_last")
         return buildList {
             listOf(command, state, stateLast).forEach { table ->
-                val store = "${table}_store"
-                add(DesiredBiObject(BiObjectKey(options.database, store), aggregate, BiObjectKind.STORE))
-                if (options.topology is ClickHouseTopology.Cluster) {
-                    add(
-                        DesiredBiObject(
-                            BiObjectKey(options.database, "${store}_local"),
-                            aggregate,
-                            BiObjectKind.STORE,
-                        )
-                    )
-                }
+                addDesiredStores(table, aggregate)
             }
             add(DesiredBiObject(BiObjectKey(options.database, command), aggregate, BiObjectKind.VIEW))
             add(DesiredBiObject(BiObjectKey(options.database, state), aggregate, BiObjectKind.VIEW))
@@ -252,6 +413,28 @@ class BiScriptGenerator(private val options: BiScriptOptions = BiScriptOptions()
                     BiObjectKey(options.consumerDatabase, "${stateLast}_consumer"),
                     aggregate,
                     BiObjectKind.CONSUMER,
+                )
+            )
+        }
+    }
+
+    private fun MutableList<DesiredBiObject>.addDesiredStores(
+        table: String,
+        aggregate: String,
+    ) {
+        val store = "${table}_store"
+        val storeEngine = when (options.topology) {
+            is ClickHouseTopology.Cluster -> "Distributed"
+            ClickHouseTopology.Standalone -> "ReplacingMergeTree"
+        }
+        add(DesiredBiObject(BiObjectKey(options.database, store), aggregate, BiObjectKind.STORE, storeEngine))
+        if (options.topology is ClickHouseTopology.Cluster) {
+            add(
+                DesiredBiObject(
+                    BiObjectKey(options.database, "${store}_local"),
+                    aggregate,
+                    BiObjectKind.STORE,
+                    "ReplicatedReplacingMergeTree",
                 )
             )
         }
@@ -341,10 +524,30 @@ class BiScriptGenerator(private val options: BiScriptOptions = BiScriptOptions()
         val key: BiObjectKey,
         val aggregate: String?,
         val kind: BiObjectKind,
+        val expectedEngine: String = kind.defaultEngine,
     )
 
     private data class ScriptSection(
         val name: String,
         val statements: List<String>,
     )
+
+    private companion object {
+        val STORE_ENGINES: Set<String> = setOf(
+            "ReplacingMergeTree",
+            "ReplicatedReplacingMergeTree",
+            "Distributed",
+        )
+
+        val BiObjectKind.defaultEngine: String
+            get() = when (this) {
+                BiObjectKind.ANCHOR,
+                BiObjectKind.VIEW,
+                -> "View"
+
+                BiObjectKind.STORE -> "ReplacingMergeTree"
+                BiObjectKind.QUEUE -> "Kafka"
+                BiObjectKind.CONSUMER -> "MaterializedView"
+            }
+    }
 }

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiScriptGenerator.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiScriptGenerator.kt
@@ -379,16 +379,24 @@ class BiScriptGenerator(private val options: BiScriptOptions = BiScriptOptions()
             listOf(command, state, stateLast).forEach { table ->
                 addDesiredStores(table, aggregate)
             }
-            add(DesiredBiObject(BiObjectKey(options.database, command), aggregate, BiObjectKind.VIEW))
-            add(DesiredBiObject(BiObjectKey(options.database, state), aggregate, BiObjectKind.VIEW))
-            add(DesiredBiObject(BiObjectKey(options.database, "${state}_event"), aggregate, BiObjectKind.VIEW))
-            add(DesiredBiObject(BiObjectKey(options.database, stateLast), aggregate, BiObjectKind.VIEW))
+            add(DesiredBiObject(BiObjectKey(options.database, command), aggregate, BiObjectKind.VIEW, VIEW_ENGINE))
+            add(DesiredBiObject(BiObjectKey(options.database, state), aggregate, BiObjectKind.VIEW, VIEW_ENGINE))
+            add(
+                DesiredBiObject(
+                    BiObjectKey(options.database, "${state}_event"),
+                    aggregate,
+                    BiObjectKind.VIEW,
+                    VIEW_ENGINE,
+                )
+            )
+            add(DesiredBiObject(BiObjectKey(options.database, stateLast), aggregate, BiObjectKind.VIEW, VIEW_ENGINE))
             plan.views.forEach { view ->
                 add(
                     DesiredBiObject(
                         BiObjectKey(options.database, view.targetTableName),
                         aggregate,
                         BiObjectKind.VIEW,
+                        VIEW_ENGINE,
                     )
                 )
             }
@@ -398,6 +406,7 @@ class BiScriptGenerator(private val options: BiScriptOptions = BiScriptOptions()
                         BiObjectKey(options.consumerDatabase, "${table}_queue"),
                         aggregate,
                         BiObjectKind.QUEUE,
+                        QUEUE_ENGINE,
                     )
                 )
                 add(
@@ -405,6 +414,7 @@ class BiScriptGenerator(private val options: BiScriptOptions = BiScriptOptions()
                         BiObjectKey(options.consumerDatabase, "${table}_consumer"),
                         aggregate,
                         BiObjectKind.CONSUMER,
+                        CONSUMER_ENGINE,
                     )
                 )
             }
@@ -413,6 +423,7 @@ class BiScriptGenerator(private val options: BiScriptOptions = BiScriptOptions()
                     BiObjectKey(options.consumerDatabase, "${stateLast}_consumer"),
                     aggregate,
                     BiObjectKind.CONSUMER,
+                    CONSUMER_ENGINE,
                 )
             )
         }
@@ -445,6 +456,7 @@ class BiScriptGenerator(private val options: BiScriptOptions = BiScriptOptions()
             BiObjectKey(options.consumerDatabase, ClickHouseScriptRenderer.DEPLOYMENT_ANCHOR),
             null,
             BiObjectKind.ANCHOR,
+            VIEW_ENGINE,
         )
 
     private fun validateDesiredObjectNames(objects: List<DesiredBiObject>) {
@@ -524,7 +536,7 @@ class BiScriptGenerator(private val options: BiScriptOptions = BiScriptOptions()
         val key: BiObjectKey,
         val aggregate: String?,
         val kind: BiObjectKind,
-        val expectedEngine: String = kind.defaultEngine,
+        val expectedEngine: String,
     )
 
     private data class ScriptSection(
@@ -533,21 +545,14 @@ class BiScriptGenerator(private val options: BiScriptOptions = BiScriptOptions()
     )
 
     private companion object {
+        const val VIEW_ENGINE: String = "View"
+        const val QUEUE_ENGINE: String = "Kafka"
+        const val CONSUMER_ENGINE: String = "MaterializedView"
+
         val STORE_ENGINES: Set<String> = setOf(
             "ReplacingMergeTree",
             "ReplicatedReplacingMergeTree",
             "Distributed",
         )
-
-        val BiObjectKind.defaultEngine: String
-            get() = when (this) {
-                BiObjectKind.ANCHOR,
-                BiObjectKind.VIEW,
-                -> "View"
-
-                BiObjectKind.STORE -> "ReplacingMergeTree"
-                BiObjectKind.QUEUE -> "Kafka"
-                BiObjectKind.CONSUMER -> "MaterializedView"
-            }
     }
 }

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspector.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspector.kt
@@ -15,12 +15,23 @@ package me.ahoo.wow.bi
 
 import com.clickhouse.client.api.Client
 import com.clickhouse.client.api.ClientException
+import com.clickhouse.client.api.query.QueryResponse
+import com.clickhouse.client.api.query.QuerySettings
+import com.clickhouse.data.ClickHouseFormat
+import me.ahoo.wow.bi.renderer.ClickHouseSqlSyntax
 import reactor.core.publisher.Mono
+import reactor.core.scheduler.Scheduler
 import reactor.core.scheduler.Schedulers
 import tools.jackson.core.JacksonException
 import java.time.Duration
 import java.time.temporal.ChronoUnit
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Reads Wow BI ownership markers directly from the ClickHouse system catalog.
@@ -30,12 +41,13 @@ import java.util.concurrent.TimeoutException
 class ClickHouseBiDeploymentInspector internal constructor(
     private val catalogClient: ClickHouseCatalogClient,
     private val inspectionTimeout: Duration = DEFAULT_INSPECTION_TIMEOUT,
+    private val timeoutScheduler: Scheduler = Schedulers.parallel(),
 ) : BiDeploymentInspector, AutoCloseable {
     constructor(
         clientOptions: ClickHouseClientOptions,
         inspectionTimeout: Duration = DEFAULT_INSPECTION_TIMEOUT,
     ) : this(
-        catalogClient = NativeClickHouseCatalogClient.create(clientOptions),
+        catalogClient = createCatalogClient(clientOptions, inspectionTimeout),
         inspectionTimeout = inspectionTimeout,
     )
 
@@ -43,32 +55,46 @@ class ClickHouseBiDeploymentInspector internal constructor(
         inspectionTimeout.requireValidTimeout("inspectionTimeout")
     }
 
-    override fun inspect(options: BiScriptOptions): Mono<BiDeploymentInspection> =
-        Mono.fromCallable<BiDeploymentInspection> {
-            val deployment = try {
-                when (val topology = options.topology) {
-                    ClickHouseTopology.Standalone -> inspectStandalone(options)
-                    is ClickHouseTopology.Cluster -> inspectCluster(options, topology)
+    override fun inspect(
+        options: BiScriptOptions,
+        operation: BiScriptOperation,
+    ): Mono<BiDeploymentInspection> =
+        Mono.defer {
+            val cancellation = ClickHouseQueryCancellation()
+            Mono.fromCallable<BiDeploymentInspection> {
+                try {
+                    val deployment = when (val topology = options.topology) {
+                        ClickHouseTopology.Standalone -> inspectStandalone(options, operation, cancellation)
+                        is ClickHouseTopology.Cluster -> inspectCluster(options, topology, operation, cancellation)
+                    }
+                    BiDeploymentInspection.Available(deployment)
+                } catch (error: BiDeploymentInspectionException) {
+                    error.cancelledInspectionOrThrow(cancellation)
+                } catch (error: IllegalArgumentException) {
+                    BiDeploymentInspectionException.Inconsistent(
+                        error.message ?: "ClickHouse BI catalog is inconsistent",
+                        error,
+                    ).cancelledInspectionOrThrow(cancellation)
+                } catch (error: IllegalStateException) {
+                    BiDeploymentInspectionException.Inconsistent(
+                        error.message ?: "ClickHouse BI catalog is inconsistent",
+                        error,
+                    ).cancelledInspectionOrThrow(cancellation)
+                } catch (error: ClientException) {
+                    error.toInspectionException().cancelledInspectionOrThrow(cancellation)
+                } catch (error: InterruptedException) {
+                    Thread.currentThread().interrupt()
+                    error.cancelledInspectionOrThrow(cancellation)
+                } finally {
+                    if (cancellation.isCancelled) {
+                        Thread.interrupted()
+                    }
                 }
-            } catch (error: BiDeploymentInspectionException) {
-                throw error
-            } catch (error: IllegalArgumentException) {
-                throw BiDeploymentInspectionException.Inconsistent(
-                    error.message ?: "ClickHouse BI catalog is inconsistent",
-                    error,
-                )
-            } catch (error: IllegalStateException) {
-                throw BiDeploymentInspectionException.Inconsistent(
-                    error.message ?: "ClickHouse BI catalog is inconsistent",
-                    error,
-                )
-            } catch (error: ClientException) {
-                throw error.toInspectionException()
             }
-            BiDeploymentInspection.Available(deployment)
+                .subscribeOn(Schedulers.boundedElastic())
+                .doOnCancel(cancellation::cancel)
+                .timeout(inspectionTimeout, timeoutScheduler)
         }
-            .subscribeOn(Schedulers.boundedElastic())
-            .timeout(inspectionTimeout)
             .onErrorMap(TimeoutException::class.java) { error ->
                 BiDeploymentInspectionException.Timeout(
                     message = "ClickHouse BI deployment inspection timed out",
@@ -80,24 +106,32 @@ class ClickHouseBiDeploymentInspector internal constructor(
         catalogClient.close()
     }
 
-    private fun inspectStandalone(options: BiScriptOptions): ObservedBiDeployment {
+    private fun inspectStandalone(
+        options: BiScriptOptions,
+        operation: BiScriptOperation,
+        cancellation: ClickHouseQueryCancellation,
+    ): ObservedBiDeployment {
         val records = catalogClient.query(
             sql = STANDALONE_CATALOG_QUERY,
             parameters = options.catalogParameters(),
             columns = CATALOG_COLUMNS,
+            cancellation = cancellation,
         )
-        return validateObjects(records.map(ClickHouseCatalogRecord::toObservedObject))
+        return validateObjects(options, operation, records.map(ClickHouseCatalogRecord::toObservedObject))
     }
 
     private fun inspectCluster(
         options: BiScriptOptions,
         cluster: ClickHouseTopology.Cluster,
+        operation: BiScriptOperation,
+        cancellation: ClickHouseQueryCancellation,
     ): ObservedBiDeployment {
         val parameters = options.catalogParameters() + ("cluster" to cluster.name)
         val nodes = catalogClient.query(
             sql = CLUSTER_NODES_QUERY,
             parameters = mapOf("cluster" to cluster.name),
             columns = NODE_COLUMNS,
+            cancellation = cancellation,
         ).map(ClickHouseCatalogRecord::toNode).toSet()
         check(nodes.isNotEmpty()) {
             "ClickHouse BI cluster [${cluster.name}] returned no replicas"
@@ -107,9 +141,10 @@ class ClickHouseBiDeploymentInspector internal constructor(
             sql = CLUSTER_CATALOG_QUERY,
             parameters = parameters,
             columns = NODE_COLUMNS + CATALOG_COLUMNS,
+            cancellation = cancellation,
         ).map { record -> NodeObject(record.toNode(), record.toObservedObject()) }
         validateClusterCatalog(cluster.name, nodes, objects)
-        return validateObjects(objects.map(NodeObject::objectValue))
+        return validateObjects(options, operation, objects.map(NodeObject::objectValue))
     }
 
     private fun validateClusterCatalog(
@@ -136,7 +171,11 @@ class ClickHouseBiDeploymentInspector internal constructor(
         }
     }
 
-    private fun validateObjects(objects: List<ObservedBiObject>): ObservedBiDeployment {
+    private fun validateObjects(
+        options: BiScriptOptions,
+        operation: BiScriptOperation,
+        objects: List<ObservedBiObject>,
+    ): ObservedBiDeployment {
         val uniqueObjects = objects.groupBy(ObservedBiObject::key).map { (key, replicas) ->
             val definitions = replicas.map(ObservedBiObject::toCatalogDefinition).distinct()
             check(definitions.size == 1 || replicas.none { it.metadata != null }) {
@@ -144,21 +183,86 @@ class ClickHouseBiDeploymentInspector internal constructor(
             }
             replicas.first()
         }.sortedWith(compareBy<ObservedBiObject> { it.database }.thenBy { it.name })
-        uniqueObjects.filter { it.metadata?.kind == BiObjectKind.QUEUE }.forEach(::validateQueueIdentity)
+        val descriptor = BiDeploymentDescriptor.from(options)
+        val requestedDeploymentMetadata = uniqueObjects.asSequence()
+            .mapNotNull(ObservedBiObject::metadata)
+            .filter { metadata -> metadata.deploymentId == descriptor.deploymentId }
+            .toList()
+        val requestedDeploymentIsStable = requestedDeploymentMetadata.all { metadata ->
+            metadata.phase == BiDeploymentPhase.STABLE &&
+                metadata.configurationFingerprint == descriptor.configurationFingerprint
+        }
+        uniqueObjects.filter { it.metadata?.kind == BiObjectKind.QUEUE }
+            .forEach { queue ->
+                val validateRequestedConfiguration =
+                    operation == BiScriptOperation.Deploy &&
+                        requestedDeploymentIsStable &&
+                        queue.metadata?.deploymentId == descriptor.deploymentId
+                validateQueueIdentity(options, queue, validateRequestedConfiguration)
+            }
         return ObservedBiDeployment(uniqueObjects)
     }
 
-    private fun validateQueueIdentity(queue: ObservedBiObject) {
+    private fun validateQueueIdentity(
+        options: BiScriptOptions,
+        queue: ObservedBiObject,
+        validateRequestedConfiguration: Boolean,
+    ) {
         check(queue.engine == "Kafka") {
             "Owned BI queue [${queue.database}.${queue.name}] must use the Kafka engine"
         }
-        val identity = checkNotNull(queue.metadata?.consumerIdentity) {
+        val metadata = checkNotNull(queue.metadata)
+        val identity = checkNotNull(metadata.consumerIdentity) {
             "Owned BI queue [${queue.database}.${queue.name}] is missing consumerIdentity"
         }
         val consumerName = queue.name.removeSuffix("_queue") + "_consumer"
         val expectedGroup = "wow-bi.$identity.$consumerName"
-        check(queue.engineFull.contains("'$expectedGroup'")) {
+        val arguments = queue.engineFull.functionArguments("Kafka").orEmpty()
+        val actualGroup = arguments.getOrNull(KAFKA_GROUP_ARGUMENT_INDEX)
+        check(actualGroup == ClickHouseSqlSyntax.stringLiteral(expectedGroup)) {
             "Owned BI queue [${queue.database}.${queue.name}] has an unexpected Kafka consumer group"
+        }
+        val streamKind = when {
+            queue.name.endsWith("_command_queue") -> "command"
+            queue.name.endsWith("_state_queue") -> "state"
+            else -> error("Owned BI queue [${queue.database}.${queue.name}] has an unsupported queue name")
+        }
+        check(arguments.getOrNull(KAFKA_FORMAT_ARGUMENT_INDEX) == ClickHouseSqlSyntax.stringLiteral(KAFKA_FORMAT)) {
+            "Owned BI queue [${queue.database}.${queue.name}] has an unexpected Kafka format"
+        }
+        if (!validateRequestedConfiguration) {
+            return
+        }
+        check(
+            arguments.getOrNull(KAFKA_BROKERS_ARGUMENT_INDEX) ==
+                ClickHouseSqlSyntax.stringLiteral(options.kafkaBootstrapServers)
+        ) {
+            "Owned BI queue [${queue.database}.${queue.name}] has unexpected Kafka bootstrap servers"
+        }
+        val expectedTopic = "${options.topicPrefix}${checkNotNull(metadata.aggregate)}.$streamKind"
+        check(arguments.getOrNull(KAFKA_TOPIC_ARGUMENT_INDEX) == ClickHouseSqlSyntax.stringLiteral(expectedTopic)) {
+            "Owned BI queue [${queue.database}.${queue.name}] has an unexpected Kafka topic"
+        }
+        val actualKeeperPath = queue.engineFull.settingLiteral(KAFKA_KEEPER_PATH_SETTING)
+        val actualReplicaName = queue.engineFull.settingLiteral(KAFKA_REPLICA_NAME_SETTING)
+        when (options.kafkaOffsetStorage) {
+            KafkaOffsetStorage.BROKER -> check(actualKeeperPath == null && actualReplicaName == null) {
+                "Owned BI queue [${queue.database}.${queue.name}] has unexpected Keeper offset settings"
+            }
+
+            KafkaOffsetStorage.KEEPER -> {
+                val expectedKeeperPath = "${options.kafkaKeeperPathPrefix.trimEnd('/')}/$identity/${queue.name}"
+                check(actualKeeperPath == ClickHouseSqlSyntax.stringLiteral(expectedKeeperPath)) {
+                    "Owned BI queue [${queue.database}.${queue.name}] has an unexpected Kafka Keeper path"
+                }
+                val expectedReplicaName = when (options.topology) {
+                    is ClickHouseTopology.Cluster -> "{replica}"
+                    ClickHouseTopology.Standalone -> identity
+                }
+                check(actualReplicaName == ClickHouseSqlSyntax.stringLiteral(expectedReplicaName)) {
+                    "Owned BI queue [${queue.database}.${queue.name}] has an unexpected Kafka Keeper replica name"
+                }
+            }
         }
     }
 
@@ -169,6 +273,13 @@ class ClickHouseBiDeploymentInspector internal constructor(
 
     private companion object {
         val DEFAULT_INSPECTION_TIMEOUT: Duration = Duration.ofSeconds(30)
+        const val KAFKA_BROKERS_ARGUMENT_INDEX: Int = 0
+        const val KAFKA_TOPIC_ARGUMENT_INDEX: Int = 1
+        const val KAFKA_GROUP_ARGUMENT_INDEX: Int = 2
+        const val KAFKA_FORMAT_ARGUMENT_INDEX: Int = 3
+        const val KAFKA_FORMAT: String = "JSONAsString"
+        const val KAFKA_KEEPER_PATH_SETTING: String = "kafka_keeper_path"
+        const val KAFKA_REPLICA_NAME_SETTING: String = "kafka_replica_name"
 
         val NODE_COLUMNS = listOf("host_name", "tcp_port")
         val CATALOG_COLUMNS = listOf(
@@ -184,12 +295,14 @@ class ClickHouseBiDeploymentInspector internal constructor(
             SELECT database, name, engine, engine_full, create_table_query, comment
             FROM system.tables
             WHERE database IN ({database:String}, {consumerDatabase:String})
+            SETTINGS show_table_uuid_in_table_create_query_if_not_nil = 0
         """.trimIndent()
 
         val CLUSTER_NODES_QUERY: String = """
             SELECT hostName() AS host_name, tcpPort() AS tcp_port
             FROM clusterAllReplicas({cluster:String}, system.one)
-            SETTINGS skip_unavailable_shards = 0
+            SETTINGS skip_unavailable_shards = 0,
+                     show_table_uuid_in_table_create_query_if_not_nil = 0
         """.trimIndent()
 
         val CLUSTER_CATALOG_QUERY: String = """
@@ -203,8 +316,20 @@ class ClickHouseBiDeploymentInspector internal constructor(
                    comment
             FROM clusterAllReplicas({cluster:String}, system.tables)
             WHERE database IN ({database:String}, {consumerDatabase:String})
-            SETTINGS skip_unavailable_shards = 0
+            SETTINGS skip_unavailable_shards = 0,
+                     show_table_uuid_in_table_create_query_if_not_nil = 0
         """.trimIndent()
+
+        fun createCatalogClient(
+            options: ClickHouseClientOptions,
+            inspectionTimeout: Duration,
+        ): NativeClickHouseCatalogClient {
+            inspectionTimeout.requireValidTimeout("inspectionTimeout")
+            require(options.socketTimeout <= inspectionTimeout) {
+                "socketTimeout [${options.socketTimeout}] must not exceed inspectionTimeout [$inspectionTimeout]"
+            }
+            return NativeClickHouseCatalogClient.create(options)
+        }
     }
 }
 
@@ -214,6 +339,44 @@ internal interface ClickHouseCatalogClient : AutoCloseable {
         parameters: Map<String, Any>,
         columns: List<String>,
     ): List<ClickHouseCatalogRecord>
+
+    fun query(
+        sql: String,
+        parameters: Map<String, Any>,
+        columns: List<String>,
+        cancellation: ClickHouseQueryCancellation,
+    ): List<ClickHouseCatalogRecord> = query(sql, parameters, columns)
+}
+
+internal class ClickHouseQueryCancellation {
+    private val cancelled = AtomicBoolean()
+    private val callbacks = CopyOnWriteArrayList<() -> Unit>()
+
+    val isCancelled: Boolean
+        get() = cancelled.get()
+
+    fun invokeOnCancel(callback: () -> Unit): AutoCloseable {
+        if (cancelled.get()) {
+            callback()
+            return AutoCloseable { }
+        }
+        callbacks += callback
+        if (cancelled.get() && callbacks.remove(callback)) {
+            callback()
+        }
+        return AutoCloseable { callbacks.remove(callback) }
+    }
+
+    fun cancel() {
+        if (!cancelled.compareAndSet(false, true)) {
+            return
+        }
+        callbacks.forEach { callback ->
+            if (callbacks.remove(callback)) {
+                callback()
+            }
+        }
+    }
 }
 
 internal data class ClickHouseCatalogNode(
@@ -260,17 +423,197 @@ internal data class ClickHouseCatalogRecord(
     }
 }
 
-internal class NativeClickHouseCatalogClient private constructor(
+internal class NativeClickHouseCatalogClient internal constructor(
     private val client: Client,
+    private val executionTimeout: Duration = Duration.ZERO,
 ) : ClickHouseCatalogClient {
     override fun query(
         sql: String,
         parameters: Map<String, Any>,
         columns: List<String>,
+    ): List<ClickHouseCatalogRecord> = query(
+        sql = sql,
+        parameters = parameters,
+        columns = columns,
+        cancellation = ClickHouseQueryCancellation(),
+    )
+
+    override fun query(
+        sql: String,
+        parameters: Map<String, Any>,
+        columns: List<String>,
+        cancellation: ClickHouseQueryCancellation,
     ): List<ClickHouseCatalogRecord> {
-        return client.queryAll(sql, parameters).map { record ->
-            ClickHouseCatalogRecord(columns.associateWith { column -> record.getString(column) })
+        if (cancellation.isCancelled) {
+            throwCancelledQuery()
         }
+        val settings = QuerySettings()
+            .setFormat(ClickHouseFormat.RowBinaryWithNamesAndTypes)
+            .waitEndOfQuery(true)
+        val responseFuture = client.query(sql, parameters, settings)
+        val responseLifecycle = QueryResponseLifecycle(responseFuture)
+        val queryThread = Thread.currentThread()
+        val cancellationRegistration = cancellation.invokeOnCancel {
+            if (responseLifecycle.cancel()) {
+                queryThread.interrupt()
+                responseLifecycle.cleanupCancelled()
+            }
+        }
+        try {
+            val response = responseFuture.awaitResponse(responseLifecycle)
+            return responseLifecycle.use {
+                client.newBinaryFormatReader(response).use { reader ->
+                    buildList {
+                        while (reader.next() != null) {
+                            add(ClickHouseCatalogRecord(columns.associateWith(reader::getString)))
+                        }
+                    }
+                }
+            }
+        } finally {
+            cancellationRegistration.close()
+        }
+    }
+
+    private fun CompletableFuture<QueryResponse>.awaitResponse(
+        responseLifecycle: QueryResponseLifecycle,
+    ): QueryResponse {
+        val response = try {
+            if (executionTimeout.isZero) {
+                get()
+            } else {
+                get(executionTimeout.toNanos(), TimeUnit.NANOSECONDS)
+            }
+        } catch (error: InterruptedException) {
+            responseLifecycle.abandon()
+            Thread.currentThread().interrupt()
+            throwInterruptedQuery(error)
+        } catch (error: TimeoutException) {
+            responseLifecycle.abandon()
+            throwTimedOutQuery(error)
+        } catch (error: ExecutionException) {
+            responseLifecycle.abandon()
+            throwFailedQuery(error.cause)
+        }
+        if (!responseLifecycle.claim(response)) {
+            throwCancelledQuery()
+        }
+        return response
+    }
+
+    private fun throwInterruptedQuery(cause: InterruptedException): Nothing =
+        throw ClientException("ClickHouse BI catalog query was interrupted", cause)
+
+    private fun throwTimedOutQuery(cause: TimeoutException): Nothing =
+        throw ClientException("ClickHouse BI catalog query timed out", cause)
+
+    private fun throwFailedQuery(cause: Throwable?): Nothing =
+        throw ClientException("Failed to get ClickHouse BI catalog query response", cause)
+
+    private fun throwCancelledQuery(): Nothing =
+        throw ClientException("ClickHouse BI catalog query was cancelled")
+
+    private class QueryResponseLifecycle(
+        responseFuture: CompletableFuture<QueryResponse>,
+    ) : AutoCloseable {
+        private val state = AtomicReference(QueryResponseState.PENDING)
+        private val response = AtomicReference<QueryResponse?>()
+        private val responseClosed = AtomicBoolean()
+        private val cleanupScheduled = AtomicBoolean()
+
+        init {
+            responseFuture.whenComplete { completedResponse, _ ->
+                if (completedResponse != null) {
+                    response.compareAndSet(null, completedResponse)
+                    if (state.get() == QueryResponseState.CANCELLED) {
+                        cleanupCancelled()
+                    }
+                }
+            }
+        }
+
+        fun claim(completedResponse: QueryResponse): Boolean {
+            response.compareAndSet(null, completedResponse)
+            if (state.compareAndSet(QueryResponseState.PENDING, QueryResponseState.CLAIMED)) {
+                return true
+            }
+            closeResponse(propagateFailure = false)
+            return false
+        }
+
+        fun abandon() {
+            if (transitionToCancelled()) {
+                cleanupCancelled()
+            }
+        }
+
+        fun cancel(): Boolean = transitionToCancelled()
+
+        fun cleanupCancelled() {
+            if (state.get() != QueryResponseState.CANCELLED || response.get() == null) {
+                return
+            }
+            if (cleanupScheduled.compareAndSet(false, true)) {
+                Schedulers.boundedElastic().schedule {
+                    closeResponse(propagateFailure = false)
+                }
+            }
+        }
+
+        private fun transitionToCancelled(): Boolean {
+            while (true) {
+                when (val currentState = state.get()) {
+                    QueryResponseState.PENDING,
+                    QueryResponseState.CLAIMED,
+                    -> if (state.compareAndSet(currentState, QueryResponseState.CANCELLED)) {
+                        return true
+                    }
+
+                    QueryResponseState.CANCELLED,
+                    QueryResponseState.COMPLETED,
+                    -> return false
+                }
+            }
+        }
+
+        override fun close() {
+            while (true) {
+                when (val currentState = state.get()) {
+                    QueryResponseState.PENDING,
+                    QueryResponseState.CLAIMED,
+                    -> if (state.compareAndSet(currentState, QueryResponseState.COMPLETED)) {
+                        closeResponse(propagateFailure = true)
+                        return
+                    }
+
+                    QueryResponseState.CANCELLED -> {
+                        closeResponse(propagateFailure = false)
+                        return
+                    }
+
+                    QueryResponseState.COMPLETED -> return
+                }
+            }
+        }
+
+        private fun closeResponse(propagateFailure: Boolean) {
+            val claimedResponse = response.get() ?: return
+            if (!responseClosed.compareAndSet(false, true)) {
+                return
+            }
+            if (propagateFailure) {
+                claimedResponse.close()
+            } else {
+                runCatching { claimedResponse.close() }
+            }
+        }
+    }
+
+    private enum class QueryResponseState {
+        PENDING,
+        CLAIMED,
+        CANCELLED,
+        COMPLETED,
     }
 
     override fun close() {
@@ -289,11 +632,12 @@ internal class NativeClickHouseCatalogClient private constructor(
                 .setConnectionRequestTimeout(options.connectionRequestTimeout.toMillis(), ChronoUnit.MILLIS)
                 .setSocketTimeout(options.socketTimeout.toMillis())
                 .setExecutionTimeout(options.executionTimeout.toMillis(), ChronoUnit.MILLIS)
+                .useAsyncRequests(true)
                 .setMaxConnections(options.maxConnections)
                 .setMaxRetries(options.maxRetries)
                 .setClientName(CLIENT_NAME)
                 .build()
-            return NativeClickHouseCatalogClient(client)
+            return NativeClickHouseCatalogClient(client, options.executionTimeout)
         }
 
         private const val CLIENT_NAME = "wow-bi"
@@ -304,6 +648,15 @@ private fun BiScriptOptions.catalogParameters(): Map<String, Any> = mapOf(
     "database" to database,
     "consumerDatabase" to consumerDatabase,
 )
+
+private fun Throwable.cancelledInspectionOrThrow(
+    cancellation: ClickHouseQueryCancellation,
+): BiDeploymentInspection {
+    if (cancellation.isCancelled) {
+        return BiDeploymentInspection.Unavailable
+    }
+    throw this
+}
 
 private fun ObservedBiObject.toCatalogDefinition(): ClickHouseCatalogDefinition = ClickHouseCatalogDefinition(
     engine = engine,
@@ -334,3 +687,112 @@ private fun ClientException.toInspectionException(): BiDeploymentInspectionExcep
 
 private fun Throwable.isTimeout(): Boolean =
     this is TimeoutException || javaClass.simpleName.endsWith("TimeoutException")
+
+private fun String.functionArguments(functionName: String): List<String>? =
+    FunctionArgumentsParser(trim(), functionName).parse()
+
+private fun String.settingLiteral(name: String): String? =
+    Regex("""\b${Regex.escape(name)}\s*=\s*('(?:\\.|''|[^'])*')""")
+        .find(this)
+        ?.groupValues
+        ?.get(1)
+
+private class FunctionArgumentsParser(
+    private val expression: String,
+    private val functionName: String,
+) {
+    private var index: Int = 0
+    private var argumentStart: Int = 0
+    private var activeQuote: Char? = null
+    private var nestedDepth: Int = 0
+    private val arguments = mutableListOf<String>()
+
+    fun parse(): List<String>? {
+        if (!moveToArgumentsStart()) {
+            return null
+        }
+        while (index < expression.length) {
+            val action = activeQuote?.let { quote -> consumeQuoted(expression[index], quote) }
+                ?: consumeUnquoted(expression[index])
+            when (action) {
+                ParseAction.COMPLETE -> return arguments
+                ParseAction.INVALID -> return null
+                ParseAction.CONTINUE -> index++
+            }
+        }
+        return null
+    }
+
+    private fun moveToArgumentsStart(): Boolean {
+        if (!expression.startsWith(functionName)) {
+            return false
+        }
+        index = functionName.length
+        while (index < expression.length && expression[index].isWhitespace()) {
+            index++
+        }
+        if (expression.getOrNull(index) != '(') {
+            return false
+        }
+        argumentStart = ++index
+        return true
+    }
+
+    private fun consumeQuoted(character: Char, quote: Char): ParseAction {
+        when {
+            character == '\\' -> index++
+            character == quote && expression.getOrNull(index + 1) == quote -> index++
+            character == quote -> activeQuote = null
+        }
+        return ParseAction.CONTINUE
+    }
+
+    private fun consumeUnquoted(character: Char): ParseAction = when (character) {
+        '\'', '"' -> {
+            activeQuote = character
+            ParseAction.CONTINUE
+        }
+        '(', '[', '{' -> {
+            nestedDepth++
+            ParseAction.CONTINUE
+        }
+        ']', '}' -> closeNestedExpression()
+        ',' -> splitArgument()
+        ')' -> closeFunction()
+        else -> ParseAction.CONTINUE
+    }
+
+    private fun closeNestedExpression(): ParseAction {
+        if (nestedDepth == 0) {
+            return ParseAction.INVALID
+        }
+        nestedDepth--
+        return ParseAction.CONTINUE
+    }
+
+    private fun splitArgument(): ParseAction {
+        if (nestedDepth == 0) {
+            arguments += expression.substring(argumentStart, index).trim()
+            argumentStart = index + 1
+        }
+        return ParseAction.CONTINUE
+    }
+
+    private fun closeFunction(): ParseAction {
+        if (nestedDepth > 0) {
+            nestedDepth--
+            return ParseAction.CONTINUE
+        }
+        val lastArgument = expression.substring(argumentStart, index).trim()
+        if (lastArgument.isNotEmpty() || arguments.isNotEmpty()) {
+            arguments += lastArgument
+        }
+        return ParseAction.COMPLETE
+    }
+
+    private enum class ParseAction {
+        CONTINUE,
+        COMPLETE,
+        INVALID,
+    }
+}

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspector.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspector.kt
@@ -25,6 +25,7 @@ import reactor.core.scheduler.Schedulers
 import tools.jackson.core.JacksonException
 import java.time.Duration
 import java.time.temporal.ChronoUnit
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.ExecutionException
@@ -32,6 +33,16 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
+
+private const val CLICKHOUSE_CATALOG_CLEANUP_THREADS: Int = 4
+private const val CLICKHOUSE_CATALOG_CLEANUP_TTL_SECONDS: Int = 60
+private val CLICKHOUSE_CATALOG_CLEANUP_SCHEDULER: Scheduler = Schedulers.newBoundedElastic(
+    CLICKHOUSE_CATALOG_CLEANUP_THREADS,
+    Schedulers.DEFAULT_BOUNDED_ELASTIC_QUEUESIZE,
+    "wow-bi-catalog-cleanup",
+    CLICKHOUSE_CATALOG_CLEANUP_TTL_SECONDS,
+    true,
+)
 
 /**
  * Reads Wow BI ownership markers directly from the ClickHouse system catalog.
@@ -491,6 +502,9 @@ internal class NativeClickHouseCatalogClient internal constructor(
         } catch (error: TimeoutException) {
             responseLifecycle.abandon()
             throwTimedOutQuery(error)
+        } catch (error: CancellationException) {
+            responseLifecycle.abandon()
+            throwCancelledQuery(error)
         } catch (error: ExecutionException) {
             responseLifecycle.abandon()
             throwFailedQuery(error.cause)
@@ -512,6 +526,9 @@ internal class NativeClickHouseCatalogClient internal constructor(
 
     private fun throwCancelledQuery(): Nothing =
         throw ClientException("ClickHouse BI catalog query was cancelled")
+
+    private fun throwCancelledQuery(cause: CancellationException): Nothing =
+        throw ClientException("ClickHouse BI catalog query was cancelled", cause)
 
     private class QueryResponseLifecycle(
         responseFuture: CompletableFuture<QueryResponse>,
@@ -554,7 +571,7 @@ internal class NativeClickHouseCatalogClient internal constructor(
                 return
             }
             if (cleanupScheduled.compareAndSet(false, true)) {
-                Schedulers.boundedElastic().schedule {
+                CLICKHOUSE_CATALOG_CLEANUP_SCHEDULER.schedule {
                     closeResponse(propagateFailure = false)
                 }
             }

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseClientOptions.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseClientOptions.kt
@@ -38,10 +38,22 @@ data class ClickHouseClientOptions(
         endpoints.forEachIndexed { index, endpoint -> endpoint.validate(index) }
         require(endpoints.distinct().size == endpoints.size) { "endpoints must not contain duplicates" }
         require(username.isNotBlank()) { "username must not be blank" }
-        connectionTimeout.requireValidTimeout("connectionTimeout")
-        connectionRequestTimeout.requireValidTimeout("connectionRequestTimeout")
-        socketTimeout.requireValidTimeout("socketTimeout", allowZero = true, maxMillis = Int.MAX_VALUE.toLong())
-        executionTimeout.requireValidTimeout("executionTimeout", allowZero = true, maxMillis = Int.MAX_VALUE.toLong())
+        connectionTimeout.requireValidTimeout("connectionTimeout", requireAtLeastOneMillisecond = true)
+        connectionRequestTimeout.requireValidTimeout(
+            "connectionRequestTimeout",
+            requireAtLeastOneMillisecond = true,
+        )
+        socketTimeout.requireValidTimeout(
+            "socketTimeout",
+            maxMillis = Int.MAX_VALUE.toLong(),
+            requireAtLeastOneMillisecond = true,
+        )
+        executionTimeout.requireValidTimeout(
+            "executionTimeout",
+            allowZero = true,
+            maxMillis = Int.MAX_VALUE.toLong(),
+            requireAtLeastOneMillisecond = true,
+        )
         require(maxConnections > 0) { "maxConnections must be greater than zero" }
         require(maxRetries >= 0) { "maxRetries must not be negative" }
     }
@@ -78,6 +90,7 @@ internal fun Duration.requireValidTimeout(
     name: String,
     allowZero: Boolean = false,
     maxMillis: Long = Long.MAX_VALUE,
+    requireAtLeastOneMillisecond: Boolean = false,
 ): Long {
     require(!isNegative && (allowZero || !isZero)) {
         if (allowZero) "$name must not be negative" else "$name must be greater than zero"
@@ -86,6 +99,13 @@ internal fun Duration.requireValidTimeout(
         toMillis()
     } catch (error: ArithmeticException) {
         throw IllegalArgumentException("$name is too large", error)
+    }
+    require(!requireAtLeastOneMillisecond || isZero || millis >= 1) {
+        if (allowZero) {
+            "$name must be zero or at least 1 millisecond"
+        } else {
+            "$name must be at least 1 millisecond"
+        }
     }
     require(millis <= maxMillis) { "$name must not exceed $maxMillis milliseconds" }
     return millis

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseScriptRenderer.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseScriptRenderer.kt
@@ -16,6 +16,8 @@ package me.ahoo.wow.bi.renderer
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.bi.BiConsumerIdentity
 import me.ahoo.wow.bi.BiDeploymentDescriptor
+import me.ahoo.wow.bi.BiDeploymentPhase
+import me.ahoo.wow.bi.BiObjectKey
 import me.ahoo.wow.bi.BiObjectKind
 import me.ahoo.wow.bi.BiObjectMetadata
 import me.ahoo.wow.bi.BiObjectMetadataCodec
@@ -38,14 +40,24 @@ import me.ahoo.wow.bi.type.ClickHouseType
 import me.ahoo.wow.modeling.toStringWithAlias
 import java.util.Collections
 
+internal enum class CatalogMutationMode {
+    RECONCILE,
+    CREATE_ONLY,
+}
+
+// Keeping the complete ClickHouse graph here preserves shared naming, quoting, and ownership semantics.
+@Suppress("LargeClass")
 internal class ClickHouseScriptRenderer(
     private val options: BiScriptOptions = BiScriptOptions(consumerGroupNamespace = "test"),
     private val consumerIdentity: BiConsumerIdentity =
         BiConsumerIdentity.deterministic(BiDeploymentDescriptor.from(options)),
     private val deployment: BiDeploymentDescriptor = BiDeploymentDescriptor.from(options),
+    private val catalogMutationMode: CatalogMutationMode = CatalogMutationMode.RECONCILE,
+    private val retainedQueueKeys: Set<BiObjectKey> = emptySet(),
 ) {
     private val naming = BiTableNaming(options)
     private val topology = options.topology.toDdl()
+    private val metadataColumns = buildMetadataColumns(options.timezone)
 
     fun renderGlobal(): String = renderGlobalStatements().joinToString(STATEMENT_SEPARATOR)
 
@@ -100,9 +112,9 @@ internal class ClickHouseScriptRenderer(
         }
     )
 
-    fun renderAnchorStatement(): String {
-        val comment = metadataComment(BiObjectKind.ANCHOR, null)
-        return "CREATE OR REPLACE VIEW ${qualified(options.consumerDatabase, DEPLOYMENT_ANCHOR)}" +
+    fun renderAnchorStatement(phase: BiDeploymentPhase = BiDeploymentPhase.STABLE): String {
+        val comment = metadataComment(BiObjectKind.ANCHOR, null, phase)
+        return "$viewCreateClause ${qualified(options.consumerDatabase, DEPLOYMENT_ANCHOR)}" +
             "${scopeClause()} AS (SELECT 1 AS ${identifier("alive")} WHERE 0) COMMENT $comment;"
     }
 
@@ -110,8 +122,22 @@ internal class ClickHouseScriptRenderer(
     fun renderCommand(namedAggregate: NamedAggregate): String =
         renderCommandStatements(namedAggregate).joinToString(STATEMENT_SEPARATOR)
 
+    fun renderCommandStatements(namedAggregate: NamedAggregate): List<String> =
+        renderCommandGraphStatements(namedAggregate)
+
+    fun renderCommandStorageStatements(namedAggregate: NamedAggregate): List<String> =
+        renderCommandGraphStatements(namedAggregate).take(commandStorageStatementCount())
+
+    fun renderCommandPublicStatements(namedAggregate: NamedAggregate): List<String> =
+        renderCommandGraphStatements(namedAggregate).takeLast(COMMAND_PUBLIC_STATEMENT_COUNT)
+
+    fun renderCommandIngressStatements(namedAggregate: NamedAggregate): List<String> =
+        renderCommandGraphStatements(namedAggregate)
+            .drop(commandStorageStatementCount())
+            .dropLast(COMMAND_PUBLIC_STATEMENT_COUNT)
+
     @Suppress("LongMethod")
-    fun renderCommandStatements(namedAggregate: NamedAggregate): List<String> {
+    private fun renderCommandGraphStatements(namedAggregate: NamedAggregate): List<String> {
         val aggregate = namedAggregate.toStringWithAlias()
         val storeComment = metadataComment(BiObjectKind.STORE, aggregate)
         val viewComment = metadataComment(BiObjectKind.VIEW, aggregate)
@@ -128,7 +154,7 @@ internal class ClickHouseScriptRenderer(
             buildList {
                 add(
                     """
-                CREATE TABLE IF NOT EXISTS ${qualified(options.database, physicalTable)}${scopeClause()}
+                $tableCreateClause ${qualified(options.database, physicalTable)}${scopeClause()}
                 (
                     ${identifier("id")} String,
                     ${identifier("context_name")} String,
@@ -158,21 +184,25 @@ internal class ClickHouseScriptRenderer(
                     logicalTableName = storeTable,
                     physicalTableName = physicalTable,
                     shardingKey = "sipHash64(${identifier("aggregate_id")})",
+                    createIfNotExists = catalogMutationMode == CatalogMutationMode.RECONCILE,
                 )?.withTableComment(storeComment)?.let(::add)
-                add(dropView(options.consumerDatabase, consumerTable))
-                add(drop(options.consumerDatabase, queueTable))
-                add(
-                    """
-                CREATE TABLE IF NOT EXISTS ${qualified(options.consumerDatabase, queueTable)}${scopeClause()}
+                if (catalogMutationMode == CatalogMutationMode.RECONCILE) {
+                    add(dropView(options.consumerDatabase, consumerTable))
+                }
+                if (!isQueueRetained(queueTable)) {
+                    add(
+                        """
+                CREATE TABLE ${qualified(options.consumerDatabase, queueTable)}${scopeClause()}
                 (${identifier("data")} String)
                 ENGINE = Kafka(${literal(options.kafkaBootstrapServers)}, ${literal(topic)},
                                ${literal(consumerGroup(consumerTable))}, ${literal("JSONAsString")})
                 ${kafkaSettings(queueTable, queueComment)};
-                    """.trimIndent()
-                )
+                        """.trimIndent()
+                    )
+                }
                 add(
                     """
-                CREATE MATERIALIZED VIEW IF NOT EXISTS ${qualified(
+                $materializedViewCreateClause ${qualified(
                         options.consumerDatabase,
                         consumerTable
                     )}${scopeClause()}
@@ -201,7 +231,7 @@ internal class ClickHouseScriptRenderer(
                 )
                 add(
                     """
-                CREATE OR REPLACE VIEW ${qualified(options.database, table)}${scopeClause()}
+                $viewCreateClause ${qualified(options.database, table)}${scopeClause()}
                 AS (SELECT * FROM ${qualified(options.database, storeTable)} FINAL)
                 COMMENT $viewComment;
                     """.trimIndent()
@@ -236,13 +266,14 @@ internal class ClickHouseScriptRenderer(
         val stateTable = naming.toTableName(namedAggregate, STATE_SUFFIX)
         return immutableStatements(
             dropView(options.consumerDatabase, "${commandTable}_consumer"),
-            drop(options.consumerDatabase, "${commandTable}_queue"),
             dropView(options.consumerDatabase, "${stateTable}_consumer"),
-            drop(options.consumerDatabase, "${stateTable}_queue"),
         )
     }
 
     private fun stateStorageStatementCount(): Int =
+        if (options.topology is ClickHouseTopology.Cluster) 2 else 1
+
+    private fun commandStorageStatementCount(): Int =
         if (options.topology is ClickHouseTopology.Cluster) 2 else 1
 
     @Suppress("LongMethod")
@@ -263,7 +294,7 @@ internal class ClickHouseScriptRenderer(
             buildList {
                 add(
                     """
-            CREATE TABLE IF NOT EXISTS ${qualified(options.database, physicalTable)}${scopeClause()}
+            $tableCreateClause ${qualified(options.database, physicalTable)}${scopeClause()}
             (
                 ${identifier("id")} String,
                 ${identifier("context_name")} String,
@@ -294,22 +325,26 @@ internal class ClickHouseScriptRenderer(
                     logicalTableName = storeTable,
                     physicalTableName = physicalTable,
                     shardingKey = "sipHash64(${identifier("aggregate_id")})",
+                    createIfNotExists = catalogMutationMode == CatalogMutationMode.RECONCILE,
                 )?.withTableComment(storeComment)?.let(::add)
-                add(dropView(options.consumerDatabase, consumerTable))
-                add(drop(options.consumerDatabase, queueTable))
-                add(
-                    """
-            CREATE TABLE IF NOT EXISTS ${qualified(options.consumerDatabase, queueTable)}${scopeClause()}
+                if (catalogMutationMode == CatalogMutationMode.RECONCILE) {
+                    add(dropView(options.consumerDatabase, consumerTable))
+                }
+                if (!isQueueRetained(queueTable)) {
+                    add(
+                        """
+            CREATE TABLE ${qualified(options.consumerDatabase, queueTable)}${scopeClause()}
             (
                 ${identifier("data")} String
             ) ENGINE = Kafka(${literal(options.kafkaBootstrapServers)}, ${literal(topic)},
                              ${literal(consumerGroup(consumerTable))}, ${literal("JSONAsString")})
             ${kafkaSettings(queueTable, queueComment)};
-                    """.trimIndent()
-                )
+                        """.trimIndent()
+                    )
+                }
                 add(
                     """
-            CREATE MATERIALIZED VIEW IF NOT EXISTS ${qualified(options.consumerDatabase, consumerTable)}${scopeClause()}
+            $materializedViewCreateClause ${qualified(options.consumerDatabase, consumerTable)}${scopeClause()}
             TO ${qualified(options.database, storeTable)}
             AS (
             SELECT ${jsonString("data", "id")} AS ${identifier("id")},
@@ -336,14 +371,14 @@ internal class ClickHouseScriptRenderer(
                 )
                 add(
                     """
-            CREATE OR REPLACE VIEW ${qualified(options.database, table)}${scopeClause()}
+            $viewCreateClause ${qualified(options.database, table)}${scopeClause()}
             AS (SELECT * FROM ${qualified(options.database, storeTable)} FINAL)
             COMMENT $viewComment;
                     """.trimIndent()
                 )
                 add(
                     """
-            CREATE OR REPLACE VIEW ${qualified(options.database, eventTable)}${scopeClause()}
+            $viewCreateClause ${qualified(options.database, eventTable)}${scopeClause()}
             AS (
             WITH arrayJoin(arrayZip(arrayEnumerate(${identifier("body")}),
                                     ${identifier("body")})) AS ${identifier("events")}
@@ -364,7 +399,7 @@ internal class ClickHouseScriptRenderer(
                    ${jsonTupleValue("events", 2, "name", "String")} AS ${identifier("event_name")},
                    ${jsonTupleValue("events", 2, "revision", "String")} AS ${identifier("event_revision")},
                    ${jsonTupleValue("events", 2, "bodyType", "String")} AS ${identifier("event_body_type")},
-                   ${jsonTupleValue("events", 2, "body", "String")} AS ${identifier("event_body")},
+                   ${jsonTupleRaw("events", 2, "body")} AS ${identifier("event_body")},
                    ${identifier("first_operator")},
                    ${identifier("first_event_time")},
                    ${identifier("create_time")},
@@ -397,7 +432,7 @@ internal class ClickHouseScriptRenderer(
             buildList {
                 add(
                     """
-            CREATE TABLE IF NOT EXISTS ${qualified(options.database, physicalTable)}${scopeClause()}
+            $tableCreateClause ${qualified(options.database, physicalTable)}${scopeClause()}
             (
                 ${identifier("id")} String,
                 ${identifier("context_name")} String,
@@ -428,11 +463,14 @@ internal class ClickHouseScriptRenderer(
                     logicalTableName = storeTable,
                     physicalTableName = physicalTable,
                     shardingKey = "sipHash64(${identifier("aggregate_id")})",
+                    createIfNotExists = catalogMutationMode == CatalogMutationMode.RECONCILE,
                 )?.withTableComment(storeComment)?.let(::add)
-                add(dropView(options.consumerDatabase, consumerTable))
+                if (catalogMutationMode == CatalogMutationMode.RECONCILE) {
+                    add(dropView(options.consumerDatabase, consumerTable))
+                }
                 add(
                     """
-            CREATE MATERIALIZED VIEW IF NOT EXISTS ${qualified(options.consumerDatabase, consumerTable)}${scopeClause()}
+            $materializedViewCreateClause ${qualified(options.consumerDatabase, consumerTable)}${scopeClause()}
             TO ${qualified(options.database, storeTable)}
             AS (
             SELECT *
@@ -442,7 +480,7 @@ internal class ClickHouseScriptRenderer(
                 )
                 add(
                     """
-            CREATE OR REPLACE VIEW ${qualified(options.database, table)}${scopeClause()}
+            $viewCreateClause ${qualified(options.database, table)}${scopeClause()}
             AS (SELECT * FROM ${qualified(options.database, storeTable)} FINAL)
             COMMENT $viewComment;
                     """.trimIndent()
@@ -470,7 +508,7 @@ internal class ClickHouseScriptRenderer(
             .joinToString(",\n")
         return buildString {
             appendLine(
-                "CREATE OR REPLACE VIEW ${qualified(options.database, view.targetTableName)}" +
+                "$viewCreateClause ${qualified(options.database, view.targetTableName)}" +
                     "${scopeClause()} AS ("
             )
             if (withSql.isNotBlank()) {
@@ -588,11 +626,17 @@ internal class ClickHouseScriptRenderer(
 
     private fun literal(value: String): String = stringLiteral(value)
 
-    private fun metadataComment(kind: BiObjectKind, aggregate: String?): String = literal(
+    private fun metadataComment(
+        kind: BiObjectKind,
+        aggregate: String?,
+        phase: BiDeploymentPhase = BiDeploymentPhase.STABLE,
+    ): String = literal(
         BiObjectMetadataCodec.encode(
             BiObjectMetadata(
                 deploymentId = deployment.deploymentId,
                 configurationFingerprint = deployment.configurationFingerprint,
+                topologyFingerprint = deployment.topologyFingerprint,
+                phase = phase,
                 aggregate = aggregate,
                 kind = kind,
                 consumerIdentity = consumerIdentity.value,
@@ -657,39 +701,32 @@ internal class ClickHouseScriptRenderer(
     ): String =
         "JSONExtract(${identifier(source)}.$tupleIndex, ${literal(property)}, ${literal(sqlType)})"
 
+    private fun jsonTupleRaw(source: String, tupleIndex: Int, property: String): String =
+        "JSONExtractRaw(${identifier(source)}.$tupleIndex, ${literal(property)})"
+
+    private val tableCreateClause: String
+        get() = when (catalogMutationMode) {
+            CatalogMutationMode.RECONCILE -> "CREATE TABLE IF NOT EXISTS"
+            CatalogMutationMode.CREATE_ONLY -> "CREATE TABLE"
+        }
+
+    private val materializedViewCreateClause: String
+        get() = when (catalogMutationMode) {
+            CatalogMutationMode.RECONCILE -> "CREATE MATERIALIZED VIEW IF NOT EXISTS"
+            CatalogMutationMode.CREATE_ONLY -> "CREATE MATERIALIZED VIEW"
+        }
+
+    private val viewCreateClause: String
+        get() = when (catalogMutationMode) {
+            CatalogMutationMode.RECONCILE -> "CREATE OR REPLACE VIEW"
+            CatalogMutationMode.CREATE_ONLY -> "CREATE VIEW"
+        }
+
+    private fun isQueueRetained(queueTable: String): Boolean =
+        BiObjectKey(options.consumerDatabase, queueTable) in retainedQueueKeys
+
     private fun epochMillis(source: String, property: String): String =
         "toDateTime64(${jsonInt(source, property)} / 1000.0, 3, ${literal(options.timezone)})"
-
-    private val metadataColumns: List<ColumnPlan> = listOf(
-        metadataColumn("id", ClickHouseType.String),
-        metadataColumn("aggregate_id", ClickHouseType.String),
-        metadataColumn("tenant_id", ClickHouseType.String),
-        metadataColumn("owner_id", ClickHouseType.String),
-        metadataColumn("space_id", ClickHouseType.String),
-        metadataColumn("command_id", ClickHouseType.String),
-        metadataColumn("request_id", ClickHouseType.String),
-        metadataColumn("version", ClickHouseType.UInt32),
-        metadataColumn("first_operator", ClickHouseType.String),
-        metadataColumn("first_event_time", ClickHouseType.DateTime64(3, options.timezone)),
-        metadataColumn("create_time", ClickHouseType.DateTime64(3, options.timezone)),
-        metadataColumn(
-            "tags",
-            ClickHouseType.Map(
-                ClickHouseType.String,
-                ClickHouseType.Array(ClickHouseType.String),
-            ),
-        ),
-        metadataColumn("deleted", ClickHouseType.Bool),
-    )
-
-    private fun metadataColumn(name: String, type: ClickHouseType): ColumnPlan = ColumnPlan(
-        name = name,
-        path = name,
-        targetName = "__$name",
-        type = type,
-        extraction = ColumnExtraction.Reference(ColumnReference.Input(name)),
-        placement = ColumnPlacement.SELECT,
-    )
 
     companion object {
         const val DEPLOYMENT_ANCHOR = "__wow_bi_deployment"
@@ -702,6 +739,38 @@ internal class ClickHouseScriptRenderer(
         const val INDEX_TARGET = "__index"
         const val SOURCE_ALIAS = "__source"
         const val STATEMENT_SEPARATOR = "\n\n"
+        const val COMMAND_PUBLIC_STATEMENT_COUNT: Int = 1
         const val STATE_PUBLIC_STATEMENT_COUNT: Int = 2
     }
 }
+
+private fun buildMetadataColumns(timezone: String): List<ColumnPlan> = listOf(
+    metadataColumn("id", ClickHouseType.String),
+    metadataColumn("aggregate_id", ClickHouseType.String),
+    metadataColumn("tenant_id", ClickHouseType.String),
+    metadataColumn("owner_id", ClickHouseType.String),
+    metadataColumn("space_id", ClickHouseType.String),
+    metadataColumn("command_id", ClickHouseType.String),
+    metadataColumn("request_id", ClickHouseType.String),
+    metadataColumn("version", ClickHouseType.UInt32),
+    metadataColumn("first_operator", ClickHouseType.String),
+    metadataColumn("first_event_time", ClickHouseType.DateTime64(3, timezone)),
+    metadataColumn("create_time", ClickHouseType.DateTime64(3, timezone)),
+    metadataColumn(
+        "tags",
+        ClickHouseType.Map(
+            ClickHouseType.String,
+            ClickHouseType.Array(ClickHouseType.String),
+        ),
+    ),
+    metadataColumn("deleted", ClickHouseType.Bool),
+)
+
+private fun metadataColumn(name: String, type: ClickHouseType): ColumnPlan = ColumnPlan(
+    name = name,
+    path = name,
+    targetName = "__$name",
+    type = type,
+    extraction = ColumnExtraction.Reference(ColumnReference.Input(name)),
+    placement = ColumnPlacement.SELECT,
+)

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseScriptRenderer.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseScriptRenderer.kt
@@ -112,7 +112,7 @@ internal class ClickHouseScriptRenderer(
         }
     )
 
-    fun renderAnchorStatement(phase: BiDeploymentPhase = BiDeploymentPhase.STABLE): String {
+    fun renderAnchorStatement(phase: BiDeploymentPhase): String {
         val comment = metadataComment(BiObjectKind.ANCHOR, null, phase)
         return "$viewCreateClause ${qualified(options.consumerDatabase, DEPLOYMENT_ANCHOR)}" +
             "${scopeClause()} AS (SELECT 1 AS ${identifier("alive")} WHERE 0) COMMENT $comment;"

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseTopologyDdl.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseTopologyDdl.kt
@@ -31,7 +31,7 @@ internal interface ClickHouseTopologyDdl {
         logicalTableName: String,
         physicalTableName: String,
         shardingKey: String,
-        createIfNotExists: Boolean = true,
+        createIfNotExists: Boolean,
     ): String?
 
     fun dropTableNames(logicalTableName: String): List<String>

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseTopologyDdl.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseTopologyDdl.kt
@@ -31,6 +31,7 @@ internal interface ClickHouseTopologyDdl {
         logicalTableName: String,
         physicalTableName: String,
         shardingKey: String,
+        createIfNotExists: Boolean = true,
     ): String?
 
     fun dropTableNames(logicalTableName: String): List<String>
@@ -63,13 +64,16 @@ private class ClusterTopologyDdl(private val topology: ClickHouseTopology.Cluste
         logicalTableName: String,
         physicalTableName: String,
         shardingKey: String,
-    ): String =
-        """
-            CREATE TABLE IF NOT EXISTS ${qualified(database, logicalTableName)} $scopeClause
+        createIfNotExists: Boolean,
+    ): String {
+        val ifNotExistsClause = if (createIfNotExists) " IF NOT EXISTS" else ""
+        return """
+            CREATE TABLE$ifNotExistsClause ${qualified(database, logicalTableName)} $scopeClause
             AS ${qualified(database, physicalTableName)}
             ENGINE = Distributed(${stringLiteral(topology.name)}, ${quoteIdentifier(database)},
                                  ${stringLiteral(physicalTableName)}, $shardingKey);
         """.trimIndent()
+    }
 
     override fun dropTableNames(logicalTableName: String): List<String> =
         listOf(logicalTableName, physicalTableName(logicalTableName))
@@ -90,6 +94,7 @@ private data object StandaloneTopologyDdl : ClickHouseTopologyDdl {
         logicalTableName: String,
         physicalTableName: String,
         shardingKey: String,
+        createIfNotExists: Boolean,
     ): String? = null
 
     override fun dropTableNames(logicalTableName: String): List<String> = listOf(logicalTableName)

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiDeploymentInspectorTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiDeploymentInspectorTest.kt
@@ -25,10 +25,18 @@ class BiDeploymentInspectorTest {
             .isEqualTo(BiDeploymentInspection.Unavailable)
         NoOpBiDeploymentInspector.allowsDynamicScope.assert().isTrue()
 
-        val authoritative = BiDeploymentInspector {
+        val inspectedOperations = mutableListOf<BiScriptOperation>()
+        val authoritative = BiDeploymentInspector { _, operation ->
+            inspectedOperations += operation
             Mono.just(BiDeploymentInspection.Available(ObservedBiDeployment(emptyList())))
         }
         authoritative.allowsDynamicScope.assert().isFalse()
+        authoritative.inspect(BiScriptOptions()).block()
+        authoritative.inspect(BiScriptOptions(), BiScriptOperation.Reset(true)).block()
+        inspectedOperations.assert().containsExactly(
+            BiScriptOperation.Deploy,
+            BiScriptOperation.Reset(true),
+        )
     }
 
     @Test
@@ -36,6 +44,7 @@ class BiDeploymentInspectorTest {
         val metadata = BiObjectMetadata(
             deploymentId = "a".repeat(32),
             configurationFingerprint = "b".repeat(32),
+            topologyFingerprint = "c".repeat(32),
             aggregate = "example.order",
             kind = BiObjectKind.QUEUE,
         )
@@ -45,6 +54,100 @@ class BiDeploymentInspectorTest {
         encoded.assert().startsWith("wow-bi:")
         BiObjectMetadataCodec.decode(encoded).assert().isEqualTo(metadata)
         BiObjectMetadataCodec.decode("user-owned").assert().isNull()
+    }
+
+    @Test
+    fun `object metadata codec should reject protocol v1`() {
+        val legacy = """
+            wow-bi:{
+              "protocolVersion": 1,
+              "layoutVersion": 6,
+              "deploymentId": "${"a".repeat(32)}",
+              "configurationFingerprint": "${"b".repeat(32)}",
+              "aggregate": null,
+              "kind": "ANCHOR",
+              "consumerIdentity": "${"c".repeat(32)}"
+            }
+        """.trimIndent()
+
+        assertThrows<IllegalArgumentException> {
+            BiObjectMetadataCodec.decode(legacy)
+        }.message.assert().contains("Unsupported BI object metadata protocol version: 1")
+    }
+
+    @Test
+    fun `object metadata codec should fail closed when protocol v2 phase is missing`() {
+        val incomplete = """
+            wow-bi:{
+              "protocolVersion": 2,
+              "layoutVersion": 6,
+              "deploymentId": "${"a".repeat(32)}",
+              "configurationFingerprint": "${"b".repeat(32)}",
+              "aggregate": null,
+              "kind": "ANCHOR",
+              "consumerIdentity": "${"c".repeat(32)}"
+            }
+        """.trimIndent()
+
+        assertThrows<IllegalArgumentException> {
+            BiObjectMetadataCodec.decode(incomplete)
+        }.message.assert().contains("protocol v2 requires phase")
+    }
+
+    @Test
+    fun `object metadata codec should fail closed when protocol v2 topology fingerprint is missing`() {
+        val incomplete = """
+            wow-bi:{
+              "protocolVersion": 2,
+              "layoutVersion": 6,
+              "phase": "STABLE",
+              "deploymentId": "${"a".repeat(32)}",
+              "configurationFingerprint": "${"b".repeat(32)}",
+              "aggregate": null,
+              "kind": "ANCHOR",
+              "consumerIdentity": "${"c".repeat(32)}"
+            }
+        """.trimIndent()
+
+        assertThrows<IllegalArgumentException> {
+            BiObjectMetadataCodec.decode(incomplete)
+        }.message.assert().contains("protocol v2 requires topologyFingerprint")
+    }
+
+    @Test
+    fun `object metadata codec should fail closed for an unknown wire protocol`() {
+        val unknown = """
+            wow-bi:{
+              "protocolVersion": 3,
+              "layoutVersion": 6,
+              "phase": "STABLE",
+              "deploymentId": "${"a".repeat(32)}",
+              "configurationFingerprint": "${"b".repeat(32)}",
+              "aggregate": null,
+              "kind": "ANCHOR",
+              "consumerIdentity": "${"c".repeat(32)}"
+            }
+        """.trimIndent()
+
+        assertThrows<IllegalArgumentException> {
+            BiObjectMetadataCodec.decode(unknown)
+        }.message.assert().contains("Unsupported BI object metadata protocol version: 3")
+    }
+
+    @Test
+    fun `observed deployment should reject duplicate catalog keys`() {
+        val duplicate = ObservedBiObject(
+            database = "bi_db_consumer",
+            name = "__wow_bi_deployment",
+            engine = "View",
+        )
+
+        assertThrows<IllegalArgumentException> {
+            ObservedBiDeployment(listOf(duplicate, duplicate.copy(engineFull = "View")))
+        }.message.assert().contains(
+            "duplicate catalog object",
+            "bi_db_consumer.__wow_bi_deployment",
+        )
     }
 
     @Test
@@ -58,10 +161,35 @@ class BiDeploymentInspectorTest {
     }
 
     @Test
+    fun `deployment descriptor should distinguish physical ownership scopes and topology`() {
+        val options = BiScriptOptions(
+            database = "bi_db",
+            consumerDatabase = "bi_db_consumer",
+            consumerGroupNamespace = "orders-blue",
+            topology = ClickHouseTopology.Cluster(name = "cluster-a", installation = "installation-a"),
+        )
+        val descriptor = BiDeploymentDescriptor.from(options)
+
+        BiDeploymentDescriptor.from(options.copy(database = "other_db")).deploymentId.assert()
+            .isNotEqualTo(descriptor.deploymentId)
+        BiDeploymentDescriptor.from(options.copy(consumerDatabase = "other_consumer_db")).deploymentId.assert()
+            .isNotEqualTo(descriptor.deploymentId)
+        BiDeploymentDescriptor.from(options.copy(consumerGroupNamespace = "orders-green")).deploymentId.assert()
+            .isNotEqualTo(descriptor.deploymentId)
+
+        val changedTopology = BiDeploymentDescriptor.from(
+            options.copy(topology = ClickHouseTopology.Cluster(name = "cluster-b", installation = "installation-a"))
+        )
+        changedTopology.deploymentId.assert().isEqualTo(descriptor.deploymentId)
+        changedTopology.topologyFingerprint.assert().isNotEqualTo(descriptor.topologyFingerprint)
+    }
+
+    @Test
     fun `object metadata should reject every incompatible ownership marker`() {
         val valid = BiObjectMetadata(
             deploymentId = "a".repeat(32),
             configurationFingerprint = "b".repeat(32),
+            topologyFingerprint = "d".repeat(32),
             aggregate = "example.order",
             kind = BiObjectKind.QUEUE,
             consumerIdentity = "c".repeat(32),
@@ -74,8 +202,10 @@ class BiDeploymentInspectorTest {
             { valid.copy(deploymentId = "invalid") } to "Invalid BI deploymentId",
             { valid.copy(configurationFingerprint = "invalid") } to
                 "Invalid BI configurationFingerprint",
+            { valid.copy(topologyFingerprint = "invalid") } to "Invalid BI topologyFingerprint",
             { valid.copy(consumerIdentity = "invalid") } to "Invalid BI consumer identity",
             { valid.copy(aggregate = null) } to "requires an aggregate owner",
+            { valid.copy(phase = BiDeploymentPhase.RESETTING) } to "RESETTING phase is only valid for the deployment anchor",
         )
 
         invalidMetadata.forEach { (createMetadata, expectedMessage) ->
@@ -85,6 +215,14 @@ class BiDeploymentInspectorTest {
         }
 
         valid.copy(kind = BiObjectKind.ANCHOR, aggregate = null).aggregate.assert().isNull()
+        assertThrows<IllegalArgumentException> {
+            valid.copy(
+                kind = BiObjectKind.ANCHOR,
+                aggregate = null,
+                phase = BiDeploymentPhase.RESETTING,
+                consumerIdentity = null,
+            )
+        }.message.assert().contains("RESETTING deployment anchor requires a consumer identity")
     }
 
     @Test

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiPublicApiTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiPublicApiTest.kt
@@ -46,6 +46,7 @@ class BiPublicApiTest {
             BiDeploymentInspectionException.Timeout::class.qualifiedName,
             BiDeploymentInspectionException.Unavailable::class.qualifiedName,
             BiDeploymentInspector::class.qualifiedName,
+            BiDeploymentPhase::class.qualifiedName,
             BiObjectKey::class.qualifiedName,
             BiObjectKind::class.qualifiedName,
             BiObjectMetadata::class.qualifiedName,

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiScriptGeneratorTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiScriptGeneratorTest.kt
@@ -15,6 +15,7 @@ package me.ahoo.wow.bi
 
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.modeling.NamedAggregateDecorator
 import me.ahoo.wow.configuration.MetadataSearcher
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -442,6 +443,24 @@ class BiScriptGeneratorTest {
     }
 
     @Test
+    fun `should reject multiple deployment anchors before choosing a canonical anchor`() {
+        val canonicalAnchor = anchor()
+        val duplicateAnchor = canonicalAnchor.copy(name = "rogue_deployment_anchor")
+
+        assertThrows<IllegalArgumentException> {
+            generator().generate(
+                setOf(aggregate),
+                BiScriptOperation.Deploy,
+                availableInspection(canonicalAnchor, duplicateAnchor),
+            )
+        }.message.assert().contains(
+            "multiple deployment anchors",
+            "__wow_bi_deployment",
+            "rogue_deployment_anchor",
+        )
+    }
+
+    @Test
     fun `should reset an identified empty scope and require a durable anchor namespace`() {
         val staleStore = observed(
             database = "bi_db",
@@ -530,6 +549,55 @@ class BiScriptGeneratorTest {
                 )
             }.message.assert().contains("incompatible", "engine")
         }
+    }
+
+    @Test
+    fun `should validate and reconcile a stale consumer by its physical engine`() {
+        val staleConsumer = observed(
+            database = "bi_db_consumer",
+            name = "bi_removed_command_consumer",
+            kind = BiObjectKind.CONSUMER,
+            aggregate = "bi-service.removed",
+        )
+
+        generator().generate(
+            setOf(aggregate),
+            BiScriptOperation.Deploy,
+            availableInspection(anchor(), staleConsumer.copy(engine = "MaterializedView")),
+        ).script.assert().contains(
+            "DROP VIEW IF EXISTS \"bi_db_consumer\".\"bi_removed_command_consumer\""
+        )
+
+        assertThrows<IllegalArgumentException> {
+            generator().generate(
+                setOf(aggregate),
+                BiScriptOperation.Deploy,
+                availableInspection(anchor(), staleConsumer.copy(engine = "View")),
+            )
+        }.message.assert().contains("incompatible engine", "bi_removed_command_consumer")
+    }
+
+    @Test
+    fun `should reconcile an owned stale queue without touching an unowned catalog object`() {
+        val staleQueue = observed(
+            database = "bi_db_consumer",
+            name = "bi_removed_command_queue",
+            kind = BiObjectKind.QUEUE,
+            aggregate = "bi-service.removed",
+        )
+        val userTable = ObservedBiObject(
+            database = "bi_db",
+            name = "user_managed_table",
+            engine = "MergeTree",
+        )
+
+        generator().generate(
+            setOf(aggregate),
+            BiScriptOperation.Deploy,
+            availableInspection(anchor(), staleQueue, userTable),
+        ).script.assert()
+            .contains("DROP TABLE IF EXISTS \"bi_db_consumer\".\"bi_removed_command_queue\"")
+            .doesNotContain("user_managed_table")
     }
 
     @Test
@@ -769,6 +837,17 @@ class BiScriptGeneratorTest {
         forward.script.indexOf("-- bi.aggregate.commandStorage --")
             .assert()
             .isLessThan(forward.script.indexOf("-- bi.sibling.commandStorage --"))
+    }
+
+    @Test
+    fun `should reject duplicate aggregate inputs that resolve to the same BI object names`() {
+        val duplicate = object : NamedAggregateDecorator {
+            override val namedAggregate: NamedAggregate = aggregate
+        }
+
+        assertThrows<IllegalArgumentException> {
+            generator().generate(linkedSetOf(aggregate, duplicate))
+        }.message.assert().contains("BI object name collision", "bi_aggregate_command_store")
     }
 
     @Test

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiScriptGeneratorTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiScriptGeneratorTest.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.assertThrows
 import java.nio.file.Files
 import java.nio.file.Path
 
+@Suppress("LargeClass")
 class BiScriptGeneratorTest {
     private val aggregate = namedAggregate("aggregate")
     private val sibling = namedAggregate("sibling")
@@ -29,7 +30,9 @@ class BiScriptGeneratorTest {
     fun `should generate complete default sections with lossless fallbacks`() {
         val result = generator().generate(setOf(aggregate))
 
-        result.script.assert().contains("-- bi.aggregate.command --")
+        result.script.assert().contains("-- bi.aggregate.commandStorage --")
+        result.script.assert().contains("-- bi.aggregate.commandPublic --")
+        result.script.assert().contains("-- bi.aggregate.commandIngress --")
         result.script.assert().contains("-- bi.aggregate.stateStorage --")
         result.script.assert().contains("-- bi.aggregate.stateLast --")
         result.script.assert().contains("-- bi.aggregate.stateIngress --")
@@ -98,18 +101,18 @@ class BiScriptGeneratorTest {
         statements.none {
             it.startsWith("DROP TABLE") && it.contains("\"bi_db\".")
         }.assert().isTrue()
-        indexOfStatement(statements, "CREATE TABLE IF NOT EXISTS \"bi_db\".\"bi_aggregate_command_store_local\"")
+        indexOfStatement(statements, "CREATE TABLE \"bi_db\".\"bi_aggregate_command_store_local\"")
             .assert().isLessThan(
                 indexOfStatement(
                     statements,
-                    "CREATE TABLE IF NOT EXISTS \"bi_db\".\"bi_aggregate_state_store_local\"",
+                    "CREATE TABLE \"bi_db\".\"bi_aggregate_state_store_local\"",
                 )
             )
-        indexOfStatement(statements, "CREATE TABLE IF NOT EXISTS \"bi_db\".\"bi_aggregate_state_last_store_local\"")
+        indexOfStatement(statements, "CREATE TABLE \"bi_db\".\"bi_aggregate_state_last_store_local\"")
             .assert().isLessThan(
                 indexOfStatement(
                     statements,
-                    "CREATE OR REPLACE VIEW \"bi_db\".\"bi_aggregate_state_last_root\"",
+                    "CREATE VIEW \"bi_db\".\"bi_aggregate_state_last_root\"",
                 )
             )
 
@@ -132,13 +135,71 @@ class BiScriptGeneratorTest {
         deploy.destructive.assert().isFalse()
         deploy.script.assert().doesNotContain("DROP TABLE IF EXISTS \"bi_db\".")
         reset.destructive.assert().isTrue()
-        reset.script.assert().contains("DROP VIEW IF EXISTS \"bi_db_consumer\".\"__wow_bi_deployment\"")
+        reset.script.assert().doesNotContain("DROP VIEW IF EXISTS \"bi_db_consumer\".\"__wow_bi_deployment\"")
         reset.script.assert().doesNotContain("wow-bi.test.")
         assertThrows<IllegalArgumentException> {
             BiScriptOperation.Reset(replayFromEarliestConfirmed = false)
         }
         assertThrows<IllegalArgumentException> {
             generator().generate(setOf(aggregate), BiScriptOperation.Reset(true))
+        }
+    }
+
+    @Test
+    fun `should persist resetting intent before destructive work and stabilize before Kafka ingress`() {
+        val inspection = availableInspection(
+            anchor(),
+            observed("bi_db", "bi_sibling_command_store", BiObjectKind.STORE, "bi-service.sibling"),
+            observed(
+                "bi_db_consumer",
+                "bi_sibling_command_queue",
+                BiObjectKind.QUEUE,
+                "bi-service.sibling",
+            ),
+        )
+
+        val reset = generator().generate(setOf(aggregate), BiScriptOperation.Reset(true), inspection)
+        val statements = reset.statements
+        val resettingAnchor = indexOfAnchorStatement(statements, BiDeploymentPhase.RESETTING)
+        val stableAnchor = indexOfAnchorStatement(statements, BiDeploymentPhase.STABLE)
+        val firstDestructiveDrop = indexOfStatement(
+            statements,
+            "DROP TABLE IF EXISTS \"bi_db_consumer\".\"bi_sibling_command_queue\"",
+        )
+        val durableGraph = indexOfStatement(
+            statements,
+            "CREATE OR REPLACE VIEW \"bi_db\".\"bi_aggregate_state_last_root\"",
+        )
+        val commandQueue = indexOfStatement(
+            statements,
+            "CREATE TABLE \"bi_db_consumer\".\"bi_aggregate_command_queue\"",
+        )
+        val stateQueue = indexOfStatement(
+            statements,
+            "CREATE TABLE \"bi_db_consumer\".\"bi_aggregate_state_queue\"",
+        )
+
+        resettingAnchor.assert().isLessThan(firstDestructiveDrop)
+        firstDestructiveDrop.assert().isLessThan(durableGraph)
+        durableGraph.assert().isLessThan(stableAnchor)
+        stableAnchor.assert().isLessThan(commandQueue)
+        stableAnchor.assert().isLessThan(stateQueue)
+        val resetSql = statements.joinToString("\n")
+        resetSql.assert()
+            .doesNotContain("DROP VIEW IF EXISTS \"bi_db_consumer\".\"__wow_bi_deployment\"")
+            .contains(
+                "DROP TABLE IF EXISTS \"bi_db_consumer\".\"bi_sibling_command_queue\" " +
+                    "ON CLUSTER '{cluster}' SYNC",
+            )
+        statements.filter { statement -> statement.contains("__wow_bi_deployment") }.assert().hasSize(2)
+        statements.filter { statement -> statement.contains("__wow_bi_deployment") }.all { statement ->
+            statement.contains("ON CLUSTER '{cluster}'")
+        }.assert().isTrue()
+        listOf(
+            "bi_aggregate_command_consumer",
+            "bi_aggregate_state_consumer",
+        ).forEach { consumer ->
+            stableAnchor.assert().isLessThan(indexOfStatement(statements, consumer))
         }
     }
 
@@ -186,6 +247,70 @@ class BiScriptGeneratorTest {
         result.diagnostics.single { it.code == BiScriptDiagnosticCode.INSPECTION_UNAVAILABLE }
             .decision.assert().isEqualTo(BiScriptMappingDecision.RECONCILIATION_SKIPPED)
         result.script.assert().contains("__wow_bi_deployment", "wow-bi:")
+        result.statements.drop(2).joinToString("\n").assert()
+            .doesNotContain("DROP ", "CREATE OR REPLACE", "IF NOT EXISTS")
+            .contains(
+                "CREATE TABLE \"bi_db\".\"bi_aggregate_command_store_local\"",
+                "CREATE TABLE \"bi_db_consumer\".\"bi_aggregate_command_queue\"",
+                "CREATE MATERIALIZED VIEW \"bi_db_consumer\".\"bi_aggregate_command_consumer\"",
+                "CREATE VIEW \"bi_db_consumer\".\"__wow_bi_deployment\"",
+            )
+    }
+
+    @Test
+    fun `should preserve Kafka queues during an authoritative deploy`() {
+        val result = generator().generate(
+            setOf(aggregate),
+            BiScriptOperation.Deploy,
+            availableInspection(
+                anchor(),
+                observed(
+                    "bi_db_consumer",
+                    "bi_aggregate_command_queue",
+                    BiObjectKind.QUEUE,
+                    "bi.aggregate",
+                ),
+                observed(
+                    "bi_db_consumer",
+                    "bi_aggregate_state_queue",
+                    BiObjectKind.QUEUE,
+                    "bi.aggregate",
+                ),
+            ),
+        )
+
+        result.script.assert()
+            .contains(
+                "DROP VIEW IF EXISTS \"bi_db_consumer\".\"bi_aggregate_command_consumer\"",
+                "DROP VIEW IF EXISTS \"bi_db_consumer\".\"bi_aggregate_state_consumer\"",
+            )
+            .doesNotContain(
+                "DROP TABLE IF EXISTS \"bi_db_consumer\".\"bi_aggregate_command_queue\"",
+                "DROP TABLE IF EXISTS \"bi_db_consumer\".\"bi_aggregate_state_queue\"",
+                "CREATE TABLE \"bi_db_consumer\".\"bi_aggregate_command_queue\"",
+                "CREATE TABLE \"bi_db_consumer\".\"bi_aggregate_state_queue\"",
+                "CREATE TABLE IF NOT EXISTS \"bi_db_consumer\".\"bi_aggregate_command_queue\"",
+                "CREATE TABLE IF NOT EXISTS \"bi_db_consumer\".\"bi_aggregate_state_queue\"",
+            )
+    }
+
+    @Test
+    fun `should create an authoritatively missing Kafka queue without an existence guard`() {
+        val result = generator().generate(
+            setOf(aggregate),
+            BiScriptOperation.Deploy,
+            availableInspection(anchor()),
+        )
+
+        result.script.assert()
+            .contains(
+                "CREATE TABLE \"bi_db_consumer\".\"bi_aggregate_command_queue\"",
+                "CREATE TABLE \"bi_db_consumer\".\"bi_aggregate_state_queue\"",
+            )
+            .doesNotContain(
+                "CREATE TABLE IF NOT EXISTS \"bi_db_consumer\".\"bi_aggregate_command_queue\"",
+                "CREATE TABLE IF NOT EXISTS \"bi_db_consumer\".\"bi_aggregate_state_queue\"",
+            )
     }
 
     @Test
@@ -246,7 +371,7 @@ class BiScriptGeneratorTest {
     }
 
     @Test
-    fun `should reuse observed consumer identity and reset with a new identity`() {
+    fun `should reuse stable identity for deploy and create a new reset identity`() {
         val identity = BiConsumerIdentity("1".repeat(32))
         val inspection = availableInspection(anchor(identity = identity))
 
@@ -259,6 +384,181 @@ class BiScriptGeneratorTest {
 
         deploy.script.assert().contains("wow-bi.${identity.value}.bi_aggregate_command_consumer")
         reset.script.assert().doesNotContain("wow-bi.${identity.value}.bi_aggregate_command_consumer")
+    }
+
+    @Test
+    fun `should reuse resetting identity while cleaning residual objects from the prior epoch`() {
+        val oldIdentity = BiConsumerIdentity("1".repeat(32))
+        val resetIdentity = BiConsumerIdentity("2".repeat(32))
+        val inspection = availableInspection(
+            anchor(identity = resetIdentity, phase = BiDeploymentPhase.RESETTING),
+            observed(
+                database = "bi_db",
+                name = "bi_legacy_command_store",
+                kind = BiObjectKind.STORE,
+                aggregate = "bi-service.legacy",
+                identity = oldIdentity,
+            ),
+        )
+
+        val retry = generator().generate(setOf(aggregate), BiScriptOperation.Reset(true), inspection)
+
+        retry.script.assert()
+            .contains(
+                "wow-bi.${resetIdentity.value}.bi_aggregate_command_consumer",
+                "\"phase\":\"RESETTING\"",
+                "\"phase\":\"STABLE\"",
+                "DROP TABLE IF EXISTS \"bi_db\".\"bi_legacy_command_store\"",
+            )
+            .doesNotContain("wow-bi.${oldIdentity.value}.bi_aggregate_command_consumer")
+    }
+
+    @Test
+    fun `should reject deploy while reset is in progress`() {
+        assertThrows<IllegalArgumentException> {
+            generator().generate(
+                setOf(aggregate),
+                BiScriptOperation.Deploy,
+                availableInspection(anchor(phase = BiDeploymentPhase.RESETTING)),
+            )
+        }.message.assert().contains("RESETTING", "retry RESET")
+    }
+
+    @Test
+    fun `should reject a non-canonical deployment anchor`() {
+        val rogueAnchor = observed(
+            database = "bi_db_consumer",
+            name = "rogue_deployment_anchor",
+            kind = BiObjectKind.ANCHOR,
+            aggregate = null,
+            phase = BiDeploymentPhase.RESETTING,
+        )
+
+        listOf(BiScriptOperation.Deploy, BiScriptOperation.Reset(true)).forEach { operation ->
+            assertThrows<IllegalArgumentException> {
+                generator().generate(setOf(aggregate), operation, availableInspection(rogueAnchor))
+            }.message.assert().contains("anchor", "canonical", "rogue_deployment_anchor")
+        }
+    }
+
+    @Test
+    fun `should reset an identified empty scope and require a durable anchor namespace`() {
+        val staleStore = observed(
+            database = "bi_db",
+            name = "legacy_state_store",
+            kind = BiObjectKind.STORE,
+            aggregate = "legacy.aggregate",
+        )
+
+        val reset = generator().generate(
+            emptySet(),
+            BiScriptOperation.Reset(true),
+            availableInspection(anchor(), staleStore),
+        )
+
+        reset.script.assert()
+            .contains(
+                "\"phase\":\"RESETTING\"",
+                "DROP TABLE IF EXISTS \"bi_db\".\"legacy_state_store\"",
+                "\"phase\":\"STABLE\"",
+            )
+            .doesNotContain("ENGINE = Kafka", "_command_queue", "_state_queue")
+        reset.statements.filter { statement -> statement.contains("__wow_bi_deployment") }
+            .assert().hasSize(2)
+
+        assertThrows<IllegalArgumentException> {
+            BiScriptGenerator().generate(
+                emptySet(),
+                BiScriptOperation.Reset(true),
+                availableInspection(),
+            )
+        }.message.assert().contains("consumerGroupNamespace", "before RESET")
+    }
+
+    @Test
+    fun `should reject a canonical anchor with an incompatible engine`() {
+        val invalidAnchor = anchor().copy(engine = "MergeTree")
+
+        listOf(BiScriptOperation.Deploy, BiScriptOperation.Reset(true)).forEach { operation ->
+            assertThrows<IllegalArgumentException> {
+                generator().generate(setOf(aggregate), operation, availableInspection(invalidAnchor))
+            }.message.assert().contains("must use the View engine")
+        }
+    }
+
+    @Test
+    fun `should reject owned catalog objects whose kind is incompatible with the physical engine`() {
+        val incompatibleObjects = listOf(
+            observed(
+                database = "bi_db",
+                name = "bi_aggregate_command_store",
+                kind = BiObjectKind.STORE,
+                aggregate = "bi.aggregate",
+            ).copy(engine = "View"),
+            observed(
+                database = "bi_db",
+                name = "bi_aggregate_command",
+                kind = BiObjectKind.VIEW,
+                aggregate = "bi.aggregate",
+            ).copy(engine = "MergeTree"),
+            observed(
+                database = "bi_db_consumer",
+                name = "bi_aggregate_command_queue",
+                kind = BiObjectKind.QUEUE,
+                aggregate = "bi.aggregate",
+            ).copy(engine = "View"),
+            observed(
+                database = "bi_db_consumer",
+                name = "bi_aggregate_command_consumer",
+                kind = BiObjectKind.CONSUMER,
+                aggregate = "bi.aggregate",
+            ).copy(engine = "View"),
+            observed(
+                database = "bi_db",
+                name = "removed_state_store",
+                kind = BiObjectKind.STORE,
+                aggregate = "bi-service.removed",
+            ).copy(engine = "View"),
+        )
+
+        incompatibleObjects.forEach { incompatible ->
+            assertThrows<IllegalArgumentException> {
+                generator().generate(
+                    setOf(aggregate),
+                    BiScriptOperation.Deploy,
+                    availableInspection(incompatible),
+                )
+            }.message.assert().contains("incompatible", "engine")
+        }
+    }
+
+    @Test
+    fun `should reject a desired cluster store with the wrong store engine`() {
+        val distributedStoreUsingLocalEngine = observed(
+            database = "bi_db",
+            name = "bi_aggregate_command_store",
+            kind = BiObjectKind.STORE,
+            aggregate = "bi.aggregate",
+        ).copy(engine = "ReplicatedReplacingMergeTree")
+
+        assertThrows<IllegalArgumentException> {
+            generator().generate(
+                setOf(aggregate),
+                BiScriptOperation.Deploy,
+                availableInspection(distributedStoreUsingLocalEngine),
+            )
+        }.message.assert().contains("expected engine", "Distributed")
+    }
+
+    @Test
+    fun `should reject resetting retry with a different configuration`() {
+        val currentOptions = BiScriptOptions(consumerGroupNamespace = "test")
+        val changedOptions = currentOptions.copy(kafkaBootstrapServers = "changed-kafka:9092")
+        val inspection = availableInspection(anchor(currentOptions, phase = BiDeploymentPhase.RESETTING))
+
+        assertThrows<IllegalArgumentException> {
+            generator(changedOptions).generate(setOf(aggregate), BiScriptOperation.Reset(true), inspection)
+        }.message.assert().contains("RESETTING", "configuration")
     }
 
     @Test
@@ -289,6 +589,7 @@ class BiScriptGeneratorTest {
                 metadata = BiObjectMetadata(
                     deploymentId = descriptor.deploymentId,
                     configurationFingerprint = descriptor.configurationFingerprint,
+                    topologyFingerprint = descriptor.topologyFingerprint,
                     kind = BiObjectKind.ANCHOR,
                 ),
             )
@@ -364,6 +665,49 @@ class BiScriptGeneratorTest {
     }
 
     @Test
+    fun `should reject topology migration through deploy or reset`() {
+        val currentOptions = BiScriptOptions(
+            consumerGroupNamespace = "test",
+            topology = ClickHouseTopology.Cluster(name = "current-cluster", installation = "current-installation"),
+        )
+        val inspection = availableInspection(anchor(currentOptions))
+        val changedTopologies = listOf(
+            ClickHouseTopology.Standalone,
+            ClickHouseTopology.Cluster(name = "other-cluster", installation = "current-installation"),
+            ClickHouseTopology.Cluster(name = "current-cluster", installation = "other-installation"),
+        )
+
+        changedTopologies.forEach { topology ->
+            val changedOptions = currentOptions.copy(topology = topology)
+            listOf(BiScriptOperation.Deploy, BiScriptOperation.Reset(true)).forEach { operation ->
+                assertThrows<IllegalArgumentException> {
+                    generator(changedOptions).generate(setOf(aggregate), operation, inspection)
+                }.message.assert().contains("topology", "cannot be migrated")
+            }
+        }
+    }
+
+    @Test
+    fun `should reject mixed topology fingerprints in one observed deployment`() {
+        val mixedStore = observed(
+            database = "bi_db",
+            name = "example_order_state_store",
+            kind = BiObjectKind.STORE,
+            aggregate = "example.order",
+        ).let { observed ->
+            observed.copy(metadata = observed.metadata!!.copy(topologyFingerprint = "f".repeat(32)))
+        }
+
+        assertThrows<IllegalArgumentException> {
+            generator().generate(
+                setOf(aggregate),
+                BiScriptOperation.Deploy,
+                availableInspection(anchor(), mixedStore),
+            )
+        }.message.assert().contains("mixed topology fingerprints")
+    }
+
+    @Test
     fun `should never delete catalog objects owned by another deployment`() {
         val foreignOptions = BiScriptOptions(
             database = "bi_db",
@@ -422,9 +766,9 @@ class BiScriptGeneratorTest {
         val reverse = BiScriptGenerator(options).generate(linkedSetOf(sibling, aggregate))
 
         forward.assert().isEqualTo(reverse)
-        forward.script.indexOf("-- bi.aggregate.command --")
+        forward.script.indexOf("-- bi.aggregate.commandStorage --")
             .assert()
-            .isLessThan(forward.script.indexOf("-- bi.sibling.command --"))
+            .isLessThan(forward.script.indexOf("-- bi.sibling.commandStorage --"))
     }
 
     @Test
@@ -462,16 +806,55 @@ class BiScriptGeneratorTest {
     }
 
     @Test
-    fun `should generate global state and deployment anchor for an empty aggregate set`() {
+    fun `should generate global state without a deployment anchor for an unidentified empty scope`() {
         val result = BiScriptGenerator().generate(emptySet())
 
         result.script.assert().contains("-- global --")
         result.script.assert().contains("CREATE DATABASE IF NOT EXISTS")
         result.script.assert().contains("-- lifecycle --")
-        result.script.assert().contains("-- deployment-anchor --", "__wow_bi_deployment")
-        result.script.assert().doesNotContain(".command --")
+        result.script.assert().doesNotContain("-- deployment-anchor --", "__wow_bi_deployment", ".command --")
         result.diagnostics.map(BiScriptDiagnostic::code)
             .assert().containsExactly(BiScriptDiagnosticCode.INSPECTION_UNAVAILABLE)
+    }
+
+    @Test
+    fun `should preserve the deployment anchor for an identified empty scope`() {
+        generator().generate(emptySet()).script.assert()
+            .contains("-- deployment-anchor --", "__wow_bi_deployment")
+            .doesNotContain(".command --")
+    }
+
+    @Test
+    fun `should reconcile a previously owned anchor for an unidentified empty scope`() {
+        val options = BiScriptOptions()
+
+        val result = BiScriptGenerator(options).generate(
+            emptySet(),
+            inspection = availableInspection(anchor(options)),
+        )
+
+        result.script.assert()
+            .contains(
+                "-- reconcile-observed-catalog --",
+                "DROP VIEW IF EXISTS \"bi_db_consumer\".\"__wow_bi_deployment\"",
+            )
+            .doesNotContain("-- deployment-anchor --", "CREATE OR REPLACE VIEW")
+    }
+
+    @Test
+    fun `should reject an unidentified empty anchor when a different deployment starts`() {
+        val legacyOptions = BiScriptOptions()
+        val currentOptions = BiScriptOptions(consumerGroupNamespace = "test")
+
+        listOf(BiScriptOperation.Deploy, BiScriptOperation.Reset(true)).forEach { operation ->
+            assertThrows<IllegalArgumentException> {
+                generator(currentOptions).generate(
+                    setOf(aggregate),
+                    operation = operation,
+                    inspection = availableInspection(anchor(legacyOptions)),
+                )
+            }.message.assert().contains("occupied by a foreign catalog object")
+        }
     }
 
     @Test
@@ -497,6 +880,7 @@ class BiScriptGeneratorTest {
     private fun anchor(
         options: BiScriptOptions = BiScriptOptions(consumerGroupNamespace = "test"),
         identity: BiConsumerIdentity = BiConsumerIdentity.deterministic(BiDeploymentDescriptor.from(options)),
+        phase: BiDeploymentPhase = BiDeploymentPhase.STABLE,
     ): ObservedBiObject = observed(
         database = options.consumerDatabase,
         name = "__wow_bi_deployment",
@@ -504,6 +888,7 @@ class BiScriptGeneratorTest {
         aggregate = null,
         options = options,
         identity = identity,
+        phase = phase,
     )
 
     private fun observed(
@@ -513,6 +898,7 @@ class BiScriptGeneratorTest {
         aggregate: String?,
         options: BiScriptOptions = BiScriptOptions(consumerGroupNamespace = "test"),
         identity: BiConsumerIdentity = BiConsumerIdentity.deterministic(BiDeploymentDescriptor.from(options)),
+        phase: BiDeploymentPhase = BiDeploymentPhase.STABLE,
     ): ObservedBiObject {
         val descriptor = BiDeploymentDescriptor.from(options)
         return ObservedBiObject(
@@ -526,6 +912,8 @@ class BiScriptGeneratorTest {
             metadata = BiObjectMetadata(
                 deploymentId = descriptor.deploymentId,
                 configurationFingerprint = descriptor.configurationFingerprint,
+                topologyFingerprint = descriptor.topologyFingerprint,
+                phase = phase,
                 aggregate = aggregate,
                 kind = kind,
                 consumerIdentity = identity.value,
@@ -549,5 +937,12 @@ class BiScriptGeneratorTest {
     private fun indexOfStatement(statements: List<String>, fragment: String): Int =
         statements.indexOfFirst { it.contains(fragment) }.also { index ->
             check(index >= 0) { "Statement containing [$fragment] was not generated." }
+        }
+
+    private fun indexOfAnchorStatement(statements: List<String>, phase: BiDeploymentPhase): Int =
+        statements.indexOfFirst { statement ->
+            statement.contains("__wow_bi_deployment") && statement.contains("\"phase\":\"$phase\"")
+        }.also { index ->
+            check(index >= 0) { "Deployment anchor in phase [$phase] was not generated." }
         }
 }

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspectorTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspectorTest.kt
@@ -236,6 +236,21 @@ class ClickHouseBiDeploymentInspectorTest {
     }
 
     @Test
+    fun `should use a safe default message for catalog validation failures without a message`() {
+        listOf(IllegalArgumentException(), IllegalStateException()).forEach { failure ->
+            val client = StubClickHouseCatalogClient { _, _, _ -> throw failure }
+
+            ClickHouseBiDeploymentInspector(client).inspect(OPTIONS).test()
+                .expectErrorMatches {
+                    it is BiDeploymentInspectionException.Inconsistent &&
+                        it.message == "ClickHouse BI catalog is inconsistent" &&
+                        it.cause === failure
+                }
+                .verify()
+        }
+    }
+
+    @Test
     fun `should accept a catalog that is identical on every cluster replica`() {
         val client = clusterClient(
             catalogRecord(node = NODE_A),
@@ -359,6 +374,8 @@ class ClickHouseBiDeploymentInspectorTest {
         val expectedGroup = "wow-bi.${identity.value}.example_order_command_consumer"
         val malformedDefinitions = listOf(
             "NotKafka('localhost:9093', 'wow.example.order.command', '$expectedGroup', 'JSONAsString')",
+            "Kafka",
+            "Kafka()",
             "Kafka 'localhost:9093', 'wow.example.order.command', '$expectedGroup', 'JSONAsString'",
             "Kafka('localhost:9093', 'wow.example.order.command', '$expectedGroup', 'JSONAsString'",
             "Kafka('localhost:9093'], 'wow.example.order.command', '$expectedGroup', 'JSONAsString')",
@@ -396,6 +413,8 @@ class ClickHouseBiDeploymentInspectorTest {
             "Kafka(concat('localhost', ':9093'), 'wow.example.order.command', " +
                 "'$expectedGroup', 'JSONAsString')",
             "Kafka(['localhost:9093'], 'wow.example.order.command', '$expectedGroup', 'JSONAsString')",
+            "Kafka('local\\'host:9093', 'wow.example.order.command', '$expectedGroup', 'JSONAsString')",
+            "Kafka('local''host:9093', 'wow.example.order.command', '$expectedGroup', 'JSONAsString')",
         )
 
         ClickHouseBiDeploymentInspector(
@@ -770,15 +789,11 @@ class ClickHouseBiDeploymentInspectorTest {
         val response = mockk<QueryResponse>(relaxed = true)
         val responseFuture = CompletableFuture<QueryResponse>()
         val queryStarted = CountDownLatch(1)
-        val cleanupThread = AtomicReference<String>()
         every {
             client.query(any<String>(), any<Map<String, Any>>(), any<QuerySettings>())
         } answers {
             queryStarted.countDown()
             responseFuture
-        }
-        every { response.close() } answers {
-            cleanupThread.set(Thread.currentThread().name)
         }
         val timeoutScheduler = VirtualTimeScheduler.create()
 
@@ -797,10 +812,56 @@ class ClickHouseBiDeploymentInspectorTest {
 
             responseFuture.complete(response).assert().isTrue()
             verify(exactly = 1, timeout = 1_000) { response.close() }
-            cleanupThread.get().assert().startsWith("wow-bi-catalog-cleanup-")
             responseFuture.isCancelled.assert().isFalse()
         } finally {
             timeoutScheduler.dispose()
+        }
+    }
+
+    @Test
+    fun `should isolate cancelled response cleanup from the blocking query scheduler`() {
+        val client = mockk<Client>(relaxed = true)
+        val response = mockk<QueryResponse>(relaxed = true)
+        val responseFuture = CompletableFuture<QueryResponse>()
+        val queryStarted = CountDownLatch(1)
+        val cleanupThread = AtomicReference<String>()
+        val cancellation = ClickHouseQueryCancellation()
+        val executor = Executors.newSingleThreadExecutor()
+        every {
+            client.query(any<String>(), any<Map<String, Any>>(), any<QuerySettings>())
+        } answers {
+            queryStarted.countDown()
+            responseFuture
+        }
+        every { response.close() } answers {
+            cleanupThread.set(Thread.currentThread().name)
+            throw IllegalStateException("close failed")
+        }
+
+        try {
+            val queryFailure = CompletableFuture.supplyAsync(
+                {
+                    runCatching {
+                        NativeClickHouseCatalogClient(client).query(
+                            sql = "SELECT catalog",
+                            parameters = emptyMap(),
+                            columns = CATALOG_COLUMNS,
+                            cancellation = cancellation,
+                        )
+                    }.exceptionOrNull()
+                },
+                executor,
+            )
+            queryStarted.await(1, TimeUnit.SECONDS).assert().isTrue()
+
+            cancellation.cancel()
+            (queryFailure.get(1, TimeUnit.SECONDS) is ClientException).assert().isTrue()
+            responseFuture.complete(response).assert().isTrue()
+
+            verify(exactly = 1, timeout = 1_000) { response.close() }
+            cleanupThread.get().assert().startsWith("wow-bi-catalog-cleanup-")
+        } finally {
+            executor.shutdownNow()
         }
     }
 

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspectorTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspectorTest.kt
@@ -28,13 +28,16 @@ import org.junit.jupiter.api.assertTimeoutPreemptively
 import reactor.kotlin.test.test
 import reactor.test.scheduler.VirtualTimeScheduler
 import tools.jackson.core.JacksonException
+import java.net.SocketTimeoutException
 import java.net.URI
 import java.time.Duration
+import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
 @Suppress("LargeClass")
@@ -246,6 +249,21 @@ class ClickHouseBiDeploymentInspectorTest {
     }
 
     @Test
+    fun `should reject duplicate owned rows from one cluster node when another replica is missing`() {
+        val client = clusterClient(
+            catalogRecord(node = NODE_A, comment = OWNED_COMMENT),
+            catalogRecord(node = NODE_A, comment = OWNED_COMMENT),
+        )
+
+        ClickHouseBiDeploymentInspector(client).inspect(CLUSTER_OPTIONS).test()
+            .expectErrorMatches {
+                it is BiDeploymentInspectionException.Inconsistent &&
+                    it.message!!.contains("is missing from a replica")
+            }
+            .verify()
+    }
+
+    @Test
     fun `should reject incomplete catalog records`() {
         val client = StubClickHouseCatalogClient(
             records(
@@ -333,6 +351,165 @@ class ClickHouseBiDeploymentInspectorTest {
                 }
                 .verify()
         }
+    }
+
+    @Test
+    fun `should fail closed for malformed Kafka engine expressions`() {
+        val identity = BiConsumerIdentity.deterministic(DESCRIPTOR)
+        val expectedGroup = "wow-bi.${identity.value}.example_order_command_consumer"
+        val malformedDefinitions = listOf(
+            "NotKafka('localhost:9093', 'wow.example.order.command', '$expectedGroup', 'JSONAsString')",
+            "Kafka 'localhost:9093', 'wow.example.order.command', '$expectedGroup', 'JSONAsString'",
+            "Kafka('localhost:9093', 'wow.example.order.command', '$expectedGroup', 'JSONAsString'",
+            "Kafka('localhost:9093'], 'wow.example.order.command', '$expectedGroup', 'JSONAsString')",
+        )
+
+        malformedDefinitions.forEach { engineFull ->
+            val client = StubClickHouseCatalogClient(
+                records(
+                    catalogRecord(
+                        database = OPTIONS.consumerDatabase,
+                        name = "example_order_command_queue",
+                        engine = "Kafka",
+                        engineFull = engineFull,
+                        comment = queueComment(identity.value),
+                    )
+                )
+            )
+
+            ClickHouseBiDeploymentInspector(client).inspect(OPTIONS).test()
+                .expectErrorMatches {
+                    it is BiDeploymentInspectionException.Inconsistent &&
+                        it.message!!.contains("unexpected Kafka consumer group")
+                }
+                .verify()
+        }
+    }
+
+    @Test
+    fun `should parse whitespace and nested Kafka engine arguments without shifting consumer identity`() {
+        val identity = BiConsumerIdentity.deterministic(DESCRIPTOR)
+        val expectedGroup = "wow-bi.${identity.value}.example_order_command_consumer"
+        val whitespaceDefinition =
+            "Kafka   ('localhost:9093', 'wow.example.order.command', '$expectedGroup', 'JSONAsString')"
+        val nestedDefinitions = listOf(
+            "Kafka(concat('localhost', ':9093'), 'wow.example.order.command', " +
+                "'$expectedGroup', 'JSONAsString')",
+            "Kafka(['localhost:9093'], 'wow.example.order.command', '$expectedGroup', 'JSONAsString')",
+        )
+
+        ClickHouseBiDeploymentInspector(
+            StubClickHouseCatalogClient(
+                records(
+                    catalogRecord(
+                        database = OPTIONS.consumerDatabase,
+                        name = "example_order_command_queue",
+                        engine = "Kafka",
+                        engineFull = whitespaceDefinition,
+                        comment = queueComment(identity.value),
+                    )
+                )
+            )
+        ).inspect(OPTIONS).test()
+            .expectNextCount(1)
+            .verifyComplete()
+
+        nestedDefinitions.forEach { nestedDefinition ->
+            ClickHouseBiDeploymentInspector(
+                StubClickHouseCatalogClient(
+                    records(
+                        catalogRecord(
+                            database = OPTIONS.consumerDatabase,
+                            name = "example_order_command_queue",
+                            engine = "Kafka",
+                            engineFull = nestedDefinition,
+                            comment = queueComment(identity.value),
+                        )
+                    )
+                )
+            ).inspect(OPTIONS).test()
+                .expectErrorMatches {
+                    it is BiDeploymentInspectionException.Inconsistent &&
+                        it.message!!.contains("unexpected Kafka bootstrap servers")
+                }
+                .verify()
+        }
+    }
+
+    @Test
+    fun `should accept a cluster Keeper state queue with the replica placeholder`() {
+        val options = CLUSTER_OPTIONS.copy(kafkaOffsetStorage = KafkaOffsetStorage.KEEPER)
+        val descriptor = BiDeploymentDescriptor.from(options)
+        val identity = BiConsumerIdentity.deterministic(descriptor)
+        val queueName = "example_order_state_queue"
+        val expectedGroup = "wow-bi.${identity.value}.example_order_state_consumer"
+        val keeperPath = "${options.kafkaKeeperPathPrefix}/${identity.value}/$queueName"
+        val engineFull =
+            "Kafka('localhost:9093', 'wow.example.order.state', '$expectedGroup', 'JSONAsString') " +
+                "SETTINGS kafka_keeper_path = '$keeperPath', kafka_replica_name = '{replica}'"
+        val client = clusterClient(
+            catalogRecord(
+                node = NODE_A,
+                database = options.consumerDatabase,
+                name = queueName,
+                engine = "Kafka",
+                engineFull = engineFull,
+                comment = queueComment(identity.value, options),
+            ),
+            catalogRecord(
+                node = NODE_B,
+                database = options.consumerDatabase,
+                name = queueName,
+                engine = "Kafka",
+                engineFull = engineFull,
+                comment = queueComment(identity.value, options),
+            ),
+        )
+
+        ClickHouseBiDeploymentInspector(client).inspect(options).test()
+            .assertNext { inspection ->
+                val available = inspection as BiDeploymentInspection.Available
+                available.deployment.objects.single().name.assert().isEqualTo(queueName)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `should defer requested source validation while its deployment anchor is resetting`() {
+        val identity = BiConsumerIdentity.deterministic(DESCRIPTOR)
+        val expectedGroup = "wow-bi.${identity.value}.example_order_command_consumer"
+        val resettingAnchor = BiObjectMetadataCodec.encode(
+            BiObjectMetadata(
+                deploymentId = DESCRIPTOR.deploymentId,
+                configurationFingerprint = DESCRIPTOR.configurationFingerprint,
+                topologyFingerprint = DESCRIPTOR.topologyFingerprint,
+                phase = BiDeploymentPhase.RESETTING,
+                aggregate = null,
+                kind = BiObjectKind.ANCHOR,
+                consumerIdentity = identity.value,
+            )
+        )
+        val client = StubClickHouseCatalogClient(
+            records(
+                catalogRecord(
+                    database = OPTIONS.consumerDatabase,
+                    name = "__wow_bi_deployment",
+                    comment = resettingAnchor,
+                ),
+                catalogRecord(
+                    database = OPTIONS.consumerDatabase,
+                    name = "example_order_command_queue",
+                    engine = "Kafka",
+                    engineFull = "Kafka('old-kafka:9092', 'old.example.order.command', " +
+                        "'$expectedGroup', 'JSONAsString')",
+                    comment = queueComment(identity.value),
+                ),
+            )
+        )
+
+        ClickHouseBiDeploymentInspector(client).inspect(OPTIONS).test()
+            .expectNextCount(1)
+            .verifyComplete()
     }
 
     @Test
@@ -593,11 +770,15 @@ class ClickHouseBiDeploymentInspectorTest {
         val response = mockk<QueryResponse>(relaxed = true)
         val responseFuture = CompletableFuture<QueryResponse>()
         val queryStarted = CountDownLatch(1)
+        val cleanupThread = AtomicReference<String>()
         every {
             client.query(any<String>(), any<Map<String, Any>>(), any<QuerySettings>())
         } answers {
             queryStarted.countDown()
             responseFuture
+        }
+        every { response.close() } answers {
+            cleanupThread.set(Thread.currentThread().name)
         }
         val timeoutScheduler = VirtualTimeScheduler.create()
 
@@ -616,6 +797,7 @@ class ClickHouseBiDeploymentInspectorTest {
 
             responseFuture.complete(response).assert().isTrue()
             verify(exactly = 1, timeout = 1_000) { response.close() }
+            cleanupThread.get().assert().startsWith("wow-bi-catalog-cleanup-")
             responseFuture.isCancelled.assert().isFalse()
         } finally {
             timeoutScheduler.dispose()
@@ -710,6 +892,20 @@ class ClickHouseBiDeploymentInspectorTest {
         } finally {
             Thread.interrupted()
         }
+    }
+
+    @Test
+    fun `should invoke cancellation callbacks exactly once before and after cancellation`() {
+        val cancellation = ClickHouseQueryCancellation()
+        val callbackCount = AtomicInteger()
+        val registration = cancellation.invokeOnCancel(callbackCount::incrementAndGet)
+
+        cancellation.cancel()
+        cancellation.cancel()
+        cancellation.invokeOnCancel(callbackCount::incrementAndGet).close()
+        registration.close()
+
+        callbackCount.get().assert().isEqualTo(2)
     }
 
     @Test
@@ -887,6 +1083,84 @@ class ClickHouseBiDeploymentInspectorTest {
         responseFuture.complete(response).assert().isTrue()
         verify(exactly = 1, timeout = 1_000) { response.close() }
         responseFuture.isCancelled.assert().isFalse()
+    }
+
+    @Test
+    fun `should classify a cancelled native query future as unavailable`() {
+        val client = mockk<Client>(relaxed = true)
+        val cancelledFuture = CompletableFuture<QueryResponse>().apply { cancel(false) }
+        every {
+            client.query(any<String>(), any<Map<String, Any>>(), any<QuerySettings>())
+        } returns cancelledFuture
+
+        ClickHouseBiDeploymentInspector(NativeClickHouseCatalogClient(client)).inspect(OPTIONS).test()
+            .expectErrorMatches {
+                it is BiDeploymentInspectionException.Unavailable &&
+                    it.cause is ClientException &&
+                    it.cause?.cause is CancellationException
+            }
+            .verify()
+
+        verify(exactly = 0) { client.newBinaryFormatReader(any()) }
+    }
+
+    @Test
+    fun `should classify exceptionally completed native query futures`() {
+        val failures = listOf(
+            IllegalStateException("transport failed") to BiDeploymentInspectionException.Unavailable::class.java,
+            SocketTimeoutException("socket timed out") to BiDeploymentInspectionException.Timeout::class.java,
+        )
+
+        failures.forEach { (failure, expectedType) ->
+            val client = mockk<Client>(relaxed = true)
+            every {
+                client.query(any<String>(), any<Map<String, Any>>(), any<QuerySettings>())
+            } returns CompletableFuture.failedFuture(failure)
+
+            ClickHouseBiDeploymentInspector(NativeClickHouseCatalogClient(client)).inspect(OPTIONS).test()
+                .expectErrorMatches { error ->
+                    expectedType.isInstance(error) &&
+                        error.cause is ClientException &&
+                        error.cause?.cause === failure
+                }
+                .verify()
+
+            verify(exactly = 0) { client.newBinaryFormatReader(any()) }
+        }
+    }
+
+    @Test
+    fun `should suppress late inspection failures after cancellation`() {
+        val failures = listOf(
+            BiDeploymentInspectionException.Unavailable("cancelled inspection"),
+            IllegalArgumentException("cancelled argument"),
+            IllegalStateException("cancelled state"),
+        )
+
+        failures.forEach { failure ->
+            val client = object : ClickHouseCatalogClient {
+                override fun query(
+                    sql: String,
+                    parameters: Map<String, Any>,
+                    columns: List<String>,
+                ): List<ClickHouseCatalogRecord> = error("The cancellation-aware overload must be used")
+
+                override fun query(
+                    sql: String,
+                    parameters: Map<String, Any>,
+                    columns: List<String>,
+                    cancellation: ClickHouseQueryCancellation,
+                ): List<ClickHouseCatalogRecord> {
+                    cancellation.cancel()
+                    throw failure
+                }
+
+                override fun close() = Unit
+            }
+
+            ClickHouseBiDeploymentInspector(client).inspect(OPTIONS).block().assert()
+                .isEqualTo(BiDeploymentInspection.Unavailable)
+        }
     }
 
     @Test

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspectorTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspectorTest.kt
@@ -13,17 +13,31 @@
 
 package me.ahoo.wow.bi
 
+import com.clickhouse.client.api.Client
 import com.clickhouse.client.api.ClientException
+import com.clickhouse.client.api.data_formats.ClickHouseBinaryFormatReader
+import com.clickhouse.client.api.query.QueryResponse
+import com.clickhouse.client.api.query.QuerySettings
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.assertTimeoutPreemptively
 import reactor.kotlin.test.test
+import reactor.test.scheduler.VirtualTimeScheduler
 import tools.jackson.core.JacksonException
 import java.net.URI
 import java.time.Duration
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicReference
 
+@Suppress("LargeClass")
 class ClickHouseBiDeploymentInspectorTest {
     @Test
     fun `should configure and close the official client without opening a connection`() {
@@ -35,7 +49,7 @@ class ClickHouseBiDeploymentInspectorTest {
                 connectionPoolEnabled = false,
                 connectionTimeout = Duration.ofSeconds(1),
                 connectionRequestTimeout = Duration.ofSeconds(2),
-                socketTimeout = Duration.ZERO,
+                socketTimeout = Duration.ofSeconds(4),
                 executionTimeout = Duration.ZERO,
                 maxConnections = 3,
                 maxRetries = 1,
@@ -47,11 +61,31 @@ class ClickHouseBiDeploymentInspectorTest {
     }
 
     @Test
+    fun `should reject a socket timeout longer than the total inspection timeout`() {
+        val failure = assertThrows<IllegalArgumentException> {
+            ClickHouseBiDeploymentInspector(
+                ClickHouseClientOptions(
+                    endpoints = listOf(URI.create("http://clickhouse:8123")),
+                    socketTimeout = Duration.ofSeconds(5),
+                ),
+                inspectionTimeout = Duration.ofSeconds(4),
+            )
+        }
+
+        failure.message.assert().contains("socketTimeout", "inspectionTimeout")
+    }
+
+    @Test
     fun `should inspect an authoritative empty standalone catalog off the caller thread`() {
         val queryThread = AtomicReference<String>()
         val client = StubClickHouseCatalogClient { sql, parameters, columns ->
             queryThread.set(Thread.currentThread().name)
-            sql.assert().contains("FROM system.tables").doesNotContain("clusterAllReplicas")
+            sql.assert()
+                .contains(
+                    "FROM system.tables",
+                    "show_table_uuid_in_table_create_query_if_not_nil = 0",
+                )
+                .doesNotContain("clusterAllReplicas")
             parameters.assert().isEqualTo(
                 mapOf(
                     "database" to OPTIONS.database,
@@ -75,6 +109,7 @@ class ClickHouseBiDeploymentInspectorTest {
         val metadata = BiObjectMetadata(
             deploymentId = DESCRIPTOR.deploymentId,
             configurationFingerprint = DESCRIPTOR.configurationFingerprint,
+            topologyFingerprint = DESCRIPTOR.topologyFingerprint,
             aggregate = "example.order",
             kind = BiObjectKind.QUEUE,
             consumerIdentity = identity.value,
@@ -85,8 +120,9 @@ class ClickHouseBiDeploymentInspectorTest {
                     database = OPTIONS.consumerDatabase,
                     name = "example_order_command_queue",
                     engine = "Kafka",
-                    engineFull = "Kafka('kafka:9092', 'topic', " +
-                        "'wow-bi.${identity.value}.example_order_command_consumer', 'JSONAsString')",
+                    engineFull = "Kafka('localhost:9093', 'wow.example.order.command', " +
+                        "'wow-bi.${identity.value}.example_order_command_consumer', 'JSONAsString') " +
+                        "SETTINGS kafka_num_consumers = 2",
                     comment = BiObjectMetadataCodec.encode(metadata),
                 )
             )
@@ -278,12 +314,232 @@ class ClickHouseBiDeploymentInspectorTest {
                 engineFull = "Kafka('kafka:9092', 'topic', 'wrong-group', 'JSONAsString')",
                 comment = validComment,
             ) to "has an unexpected Kafka consumer group",
+            catalogRecord(
+                database = OPTIONS.consumerDatabase,
+                name = "example_order_command_queue",
+                engine = "Kafka",
+                engineFull = "Kafka('$expectedGroup', 'topic', 'wrong-group', 'JSONAsString')",
+                comment = validComment,
+            ) to "has an unexpected Kafka consumer group",
         )
 
         invalidQueues.forEach { (record, expectedMessage) ->
             ClickHouseBiDeploymentInspector(StubClickHouseCatalogClient(records(record)))
                 .inspect(OPTIONS)
                 .test()
+                .expectErrorMatches {
+                    it is BiDeploymentInspectionException.Inconsistent &&
+                        it.message!!.contains(expectedMessage)
+                }
+                .verify()
+        }
+    }
+
+    @Test
+    fun `should fail closed when an owned Kafka queue source definition drifted`() {
+        val identity = BiConsumerIdentity.deterministic(DESCRIPTOR)
+        val expectedGroup = "wow-bi.${identity.value}.example_order_command_consumer"
+        val validComment = queueComment(identity.value)
+        val invalidDefinitions = listOf(
+            "Kafka('other:9092', 'wow.example.order.command', '$expectedGroup', 'JSONAsString')" to
+                "unexpected Kafka bootstrap servers",
+            "Kafka('localhost:9093', 'other.topic', '$expectedGroup', 'JSONAsString')" to
+                "unexpected Kafka topic",
+            "Kafka('localhost:9093', 'wow.example.order.command', '$expectedGroup', 'JSONEachRow')" to
+                "unexpected Kafka format",
+            "Kafka('localhost:9093', 'wow.example.order.command', '$expectedGroup', 'JSONAsString') " +
+                "SETTINGS kafka_keeper_path = '/unexpected', kafka_replica_name = '${identity.value}'" to
+                "unexpected Keeper offset settings",
+        )
+
+        invalidDefinitions.forEach { (engineFull, expectedMessage) ->
+            val client = StubClickHouseCatalogClient(
+                records(
+                    catalogRecord(
+                        database = OPTIONS.consumerDatabase,
+                        name = "example_order_command_queue",
+                        engine = "Kafka",
+                        engineFull = engineFull,
+                        comment = validComment,
+                    )
+                )
+            )
+
+            ClickHouseBiDeploymentInspector(client).inspect(OPTIONS).test()
+                .expectErrorMatches {
+                    it is BiDeploymentInspectionException.Inconsistent &&
+                        it.message!!.contains(expectedMessage)
+                }
+                .verify()
+        }
+    }
+
+    @Test
+    fun `should defer requested configuration changes to the generator for deploy and reset`() {
+        val identity = BiConsumerIdentity.deterministic(DESCRIPTOR)
+        val expectedGroup = "wow-bi.${identity.value}.example_order_command_consumer"
+        val client = StubClickHouseCatalogClient(
+            records(
+                catalogRecord(
+                    database = OPTIONS.consumerDatabase,
+                    name = "example_order_command_queue",
+                    engine = "Kafka",
+                    engineFull = "Kafka('localhost:9093', 'wow.example.order.command', " +
+                        "'$expectedGroup', 'JSONAsString')",
+                    comment = queueComment(identity.value),
+                )
+            )
+        )
+        val changedOptions = OPTIONS.copy(
+            kafkaBootstrapServers = "changed-kafka:9092",
+            topicPrefix = "changed.",
+            kafkaOffsetStorage = KafkaOffsetStorage.KEEPER,
+            kafkaKeeperPathPrefix = "/changed",
+        )
+        val inspector = ClickHouseBiDeploymentInspector(client)
+
+        inspector.inspect(changedOptions).test()
+            .assertNext { inspection ->
+                val available = inspection as BiDeploymentInspection.Available
+                available.deployment.objects.single().metadata.assert().isNotNull()
+            }
+            .verifyComplete()
+
+        inspector.inspect(changedOptions, BiScriptOperation.Reset(true)).test()
+            .assertNext { inspection ->
+                val available = inspection as BiDeploymentInspection.Available
+                available.deployment.objects.single().metadata.assert().isNotNull()
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `should not validate another deployment queue against the requested configuration`() {
+        val foreignOptions = OPTIONS.copy(
+            consumerGroupNamespace = "foreign",
+            kafkaBootstrapServers = "foreign-kafka:9092",
+            topicPrefix = "foreign.",
+        )
+        val foreignDescriptor = BiDeploymentDescriptor.from(foreignOptions)
+        val foreignIdentity = BiConsumerIdentity.deterministic(foreignDescriptor)
+        val foreignGroup = "wow-bi.${foreignIdentity.value}.example_order_command_consumer"
+        val inspector = ClickHouseBiDeploymentInspector(
+            StubClickHouseCatalogClient(
+                records(
+                    catalogRecord(
+                        database = foreignOptions.consumerDatabase,
+                        name = "example_order_command_queue",
+                        engine = "Kafka",
+                        engineFull = "Kafka('foreign-kafka:9092', 'foreign.example.order.command', " +
+                            "'$foreignGroup', 'JSONAsString')",
+                        comment = queueComment(foreignIdentity.value, foreignOptions),
+                    )
+                )
+            )
+        )
+
+        inspector.inspect(OPTIONS).test()
+            .assertNext { inspection ->
+                val available = inspection as BiDeploymentInspection.Available
+                available.deployment.objects.single().metadata!!.deploymentId.assert()
+                    .isEqualTo(foreignDescriptor.deploymentId)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `should keep reset inspection strict for queue ownership identity and format`() {
+        val identity = BiConsumerIdentity.deterministic(DESCRIPTOR)
+        val expectedGroup = "wow-bi.${identity.value}.example_order_command_consumer"
+        val invalidDefinitions = listOf(
+            "Kafka('localhost:9093', 'wow.example.order.command', 'wrong-group', 'JSONAsString')" to
+                "unexpected Kafka consumer group",
+            "Kafka('localhost:9093', 'wow.example.order.command', '$expectedGroup', 'JSONEachRow')" to
+                "unexpected Kafka format",
+        )
+
+        invalidDefinitions.forEach { (engineFull, expectedMessage) ->
+            val inspector = ClickHouseBiDeploymentInspector(
+                StubClickHouseCatalogClient(
+                    records(
+                        catalogRecord(
+                            database = OPTIONS.consumerDatabase,
+                            name = "example_order_command_queue",
+                            engine = "Kafka",
+                            engineFull = engineFull,
+                            comment = queueComment(identity.value),
+                        )
+                    )
+                )
+            )
+
+            inspector.inspect(OPTIONS, BiScriptOperation.Reset(true)).test()
+                .expectErrorMatches {
+                    it is BiDeploymentInspectionException.Inconsistent &&
+                        it.message!!.contains(expectedMessage)
+                }
+                .verify()
+        }
+    }
+
+    @Test
+    fun `should keep reset inspection strict for the owned queue name`() {
+        val identity = BiConsumerIdentity.deterministic(DESCRIPTOR)
+        val queueName = "example_order_unknown_queue"
+        val expectedGroup = "wow-bi.${identity.value}.example_order_unknown_consumer"
+        val inspector = ClickHouseBiDeploymentInspector(
+            StubClickHouseCatalogClient(
+                records(
+                    catalogRecord(
+                        database = OPTIONS.consumerDatabase,
+                        name = queueName,
+                        engine = "Kafka",
+                        engineFull = "Kafka('localhost:9093', 'wow.example.order.unknown', " +
+                            "'$expectedGroup', 'JSONAsString')",
+                        comment = queueComment(identity.value),
+                    )
+                )
+            )
+        )
+
+        inspector.inspect(OPTIONS, BiScriptOperation.Reset(true)).test()
+            .expectErrorMatches {
+                it is BiDeploymentInspectionException.Inconsistent &&
+                    it.message!!.contains("unsupported queue name")
+            }
+            .verify()
+    }
+
+    @Test
+    fun `should fail closed when an owned Kafka queue Keeper identity drifted`() {
+        val options = OPTIONS.copy(kafkaOffsetStorage = KafkaOffsetStorage.KEEPER)
+        val descriptor = BiDeploymentDescriptor.from(options)
+        val identity = BiConsumerIdentity.deterministic(descriptor)
+        val expectedGroup = "wow-bi.${identity.value}.example_order_command_consumer"
+        val expectedPath = "${options.kafkaKeeperPathPrefix}/${identity.value}/example_order_command_queue"
+        val invalidDefinitions = listOf(
+            "Kafka('localhost:9093', 'wow.example.order.command', '$expectedGroup', 'JSONAsString') " +
+                "SETTINGS kafka_keeper_path = '/unexpected', kafka_replica_name = '${identity.value}'" to
+                "unexpected Kafka Keeper path",
+            "Kafka('localhost:9093', 'wow.example.order.command', '$expectedGroup', 'JSONAsString') " +
+                "SETTINGS kafka_keeper_path = '$expectedPath', kafka_replica_name = 'other'" to
+                "unexpected Kafka Keeper replica name",
+        )
+
+        invalidDefinitions.forEach { (engineFull, expectedMessage) ->
+            val client = StubClickHouseCatalogClient(
+                records(
+                    catalogRecord(
+                        database = options.consumerDatabase,
+                        name = "example_order_command_queue",
+                        engine = "Kafka",
+                        engineFull = engineFull,
+                        comment = queueComment(identity.value, options),
+                    )
+                )
+            )
+
+            ClickHouseBiDeploymentInspector(client).inspect(options).test()
                 .expectErrorMatches {
                     it is BiDeploymentInspectionException.Inconsistent &&
                         it.message!!.contains(expectedMessage)
@@ -332,6 +588,364 @@ class ClickHouseBiDeploymentInspectorTest {
     }
 
     @Test
+    fun `should drain and close a native response that arrives after inspection timeout`() {
+        val client = mockk<Client>(relaxed = true)
+        val response = mockk<QueryResponse>(relaxed = true)
+        val responseFuture = CompletableFuture<QueryResponse>()
+        val queryStarted = CountDownLatch(1)
+        every {
+            client.query(any<String>(), any<Map<String, Any>>(), any<QuerySettings>())
+        } answers {
+            queryStarted.countDown()
+            responseFuture
+        }
+        val timeoutScheduler = VirtualTimeScheduler.create()
+
+        try {
+            ClickHouseBiDeploymentInspector(
+                NativeClickHouseCatalogClient(client),
+                Duration.ofMillis(10),
+                timeoutScheduler,
+            ).inspect(OPTIONS).test()
+                .then {
+                    queryStarted.await(1, TimeUnit.SECONDS).assert().isTrue()
+                    timeoutScheduler.advanceTimeBy(Duration.ofMillis(10))
+                }
+                .expectError(BiDeploymentInspectionException.Timeout::class.java)
+                .verify()
+
+            responseFuture.complete(response).assert().isTrue()
+            verify(exactly = 1, timeout = 1_000) { response.close() }
+            responseFuture.isCancelled.assert().isFalse()
+        } finally {
+            timeoutScheduler.dispose()
+        }
+    }
+
+    @Test
+    fun `should isolate cancellation between concurrent native inspections`() {
+        val client = mockk<Client>(relaxed = true)
+        val responseA = mockk<QueryResponse>(relaxed = true)
+        val responseB = mockk<QueryResponse>(relaxed = true)
+        val readerB = mockk<ClickHouseBinaryFormatReader>(relaxed = true)
+        val responseFutureA = CompletableFuture<QueryResponse>()
+        val responseFutureB = CompletableFuture<QueryResponse>()
+        val queryStartedA = CountDownLatch(1)
+        val queryStartedB = CountDownLatch(1)
+        val optionsA = OPTIONS.copy(database = "bi_a", consumerDatabase = "bi_a_consumer")
+        val optionsB = OPTIONS.copy(database = "bi_b", consumerDatabase = "bi_b_consumer")
+        every {
+            client.query(any<String>(), any<Map<String, Any>>(), any<QuerySettings>())
+        } answers {
+            when (secondArg<Map<String, Any>>()["database"]) {
+                optionsA.database -> {
+                    queryStartedA.countDown()
+                    responseFutureA
+                }
+
+                optionsB.database -> {
+                    queryStartedB.countDown()
+                    responseFutureB
+                }
+
+                else -> error("Unexpected catalog query parameters: ${secondArg<Map<String, Any>>()}")
+            }
+        }
+        every { client.newBinaryFormatReader(responseB) } returns readerB
+        every { readerB.next() } returns null
+        val inspector = ClickHouseBiDeploymentInspector(NativeClickHouseCatalogClient(client))
+        val resultB = AtomicReference<BiDeploymentInspection?>()
+        val errorB = AtomicReference<Throwable?>()
+        val completedB = CountDownLatch(1)
+        val subscriptionA = inspector.inspect(optionsA).subscribe()
+        var subscriptionB: reactor.core.Disposable? = null
+
+        try {
+            queryStartedA.await(1, TimeUnit.SECONDS).assert().isTrue()
+            subscriptionB = inspector.inspect(optionsB).subscribe(
+                resultB::set,
+                {
+                    errorB.set(it)
+                    completedB.countDown()
+                },
+                completedB::countDown,
+            )
+            queryStartedB.await(1, TimeUnit.SECONDS).assert().isTrue()
+
+            subscriptionA.dispose()
+            responseFutureB.complete(responseB).assert().isTrue()
+
+            completedB.await(1, TimeUnit.SECONDS).assert().isTrue()
+            errorB.get().assert().isNull()
+            (resultB.get() is BiDeploymentInspection.Available).assert().isTrue()
+            responseFutureA.complete(responseA).assert().isTrue()
+            verify(exactly = 1, timeout = 1_000) { responseA.close() }
+            verify(exactly = 1) { responseB.close() }
+        } finally {
+            subscriptionA.dispose()
+            subscriptionB?.dispose()
+            inspector.close()
+        }
+    }
+
+    @Test
+    fun `should not start a native query when cancellation already happened`() {
+        val client = mockk<Client>(relaxed = true)
+        val cancellation = ClickHouseQueryCancellation().apply { cancel() }
+
+        try {
+            val failure = assertThrows<ClientException> {
+                NativeClickHouseCatalogClient(client).query(
+                    sql = "SELECT catalog",
+                    parameters = emptyMap(),
+                    columns = CATALOG_COLUMNS,
+                    cancellation = cancellation,
+                )
+            }
+
+            failure.message.assert().contains("query was cancelled")
+            verify(exactly = 0) {
+                client.query(any<String>(), any<Map<String, Any>>(), any<QuerySettings>())
+            }
+        } finally {
+            Thread.interrupted()
+        }
+    }
+
+    @Test
+    fun `should close native response exactly once when cancellation wins before claim`() {
+        val client = mockk<Client>(relaxed = true)
+        val response = mockk<QueryResponse>(relaxed = true)
+        val cancellation = ClickHouseQueryCancellation()
+        val responseFuture = object : CompletableFuture<QueryResponse>() {
+            override fun get(): QueryResponse {
+                cancellation.cancel()
+                return super.get()
+            }
+        }.apply {
+            complete(response)
+        }
+        every {
+            client.query(any<String>(), any<Map<String, Any>>(), any<QuerySettings>())
+        } returns responseFuture
+        val executor = Executors.newSingleThreadExecutor()
+
+        try {
+            val failure = CompletableFuture.supplyAsync(
+                {
+                    runCatching {
+                        NativeClickHouseCatalogClient(client).query(
+                            sql = "SELECT catalog",
+                            parameters = emptyMap(),
+                            columns = CATALOG_COLUMNS,
+                            cancellation = cancellation,
+                        )
+                    }.exceptionOrNull()
+                },
+                executor,
+            ).get(1, TimeUnit.SECONDS)
+
+            (failure is ClientException).assert().isTrue()
+            failure?.message.assert().contains("query was cancelled")
+            verify(exactly = 1) { response.close() }
+            verify(exactly = 0) { client.newBinaryFormatReader(response) }
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `should close native response exactly once when claim wins before cancellation`() {
+        val client = mockk<Client>(relaxed = true)
+        val response = mockk<QueryResponse>(relaxed = true)
+        val reader = mockk<ClickHouseBinaryFormatReader>(relaxed = true)
+        val cancellation = ClickHouseQueryCancellation()
+        val readerStarted = CountDownLatch(1)
+        val releaseReader = CountDownLatch(1)
+        every {
+            client.query(any<String>(), any<Map<String, Any>>(), any<QuerySettings>())
+        } returns CompletableFuture.completedFuture(response)
+        every { client.newBinaryFormatReader(response) } returns reader
+        every { response.close() } answers {
+            releaseReader.countDown()
+        }
+        every { reader.next() } answers {
+            readerStarted.countDown()
+            while (true) {
+                try {
+                    releaseReader.await()
+                    break
+                } catch (_: InterruptedException) {
+                    // Cancellation interrupts the query thread after the response was claimed.
+                }
+            }
+            null
+        }
+        val executor = Executors.newSingleThreadExecutor()
+
+        try {
+            val result = CompletableFuture.supplyAsync(
+                {
+                    NativeClickHouseCatalogClient(client).query(
+                        sql = "SELECT catalog",
+                        parameters = emptyMap(),
+                        columns = CATALOG_COLUMNS,
+                        cancellation = cancellation,
+                    )
+                },
+                executor,
+            )
+            readerStarted.await(1, TimeUnit.SECONDS).assert().isTrue()
+
+            cancellation.cancel()
+            releaseReader.await(1, TimeUnit.SECONDS).assert().isTrue()
+
+            result.get(1, TimeUnit.SECONDS).assert().isEmpty()
+            verify(exactly = 1) { reader.close() }
+            verify(exactly = 1) { response.close() }
+        } finally {
+            releaseReader.countDown()
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `should emit inspection timeout without waiting for graceful response close`() {
+        val client = mockk<Client>(relaxed = true)
+        val response = mockk<QueryResponse>(relaxed = true)
+        val reader = mockk<ClickHouseBinaryFormatReader>(relaxed = true)
+        val responseFuture = CompletableFuture.completedFuture(response)
+        val readerStarted = CountDownLatch(1)
+        val releaseReader = CountDownLatch(1)
+        val closeStarted = CountDownLatch(1)
+        val releaseClose = CountDownLatch(1)
+        every {
+            client.query(any<String>(), any<Map<String, Any>>(), any<QuerySettings>())
+        } returns responseFuture
+        every { client.newBinaryFormatReader(response) } returns reader
+        every { reader.next() } answers {
+            readerStarted.countDown()
+            while (true) {
+                try {
+                    releaseReader.await()
+                    break
+                } catch (_: InterruptedException) {
+                    // Simulate a socket read that ignores thread interruption.
+                }
+            }
+            null
+        }
+        every { response.close() } answers {
+            closeStarted.countDown()
+            releaseClose.await(500, TimeUnit.MILLISECONDS)
+        }
+        val timeoutScheduler = VirtualTimeScheduler.create()
+
+        try {
+            ClickHouseBiDeploymentInspector(
+                NativeClickHouseCatalogClient(client),
+                Duration.ofMillis(10),
+                timeoutScheduler,
+            ).inspect(OPTIONS).test()
+                .then {
+                    readerStarted.await(1, TimeUnit.SECONDS).assert().isTrue()
+                    assertTimeoutPreemptively(Duration.ofMillis(200)) {
+                        timeoutScheduler.advanceTimeBy(Duration.ofMillis(10))
+                    }
+                }
+                .expectError(BiDeploymentInspectionException.Timeout::class.java)
+                .verify(Duration.ofMillis(200))
+
+            closeStarted.await(1, TimeUnit.SECONDS).assert().isTrue()
+        } finally {
+            releaseReader.countDown()
+            releaseClose.countDown()
+            timeoutScheduler.dispose()
+        }
+        verify(exactly = 1, timeout = 1_000) { response.close() }
+    }
+
+    @Test
+    fun `should drain and close a native response that arrives after execution timeout`() {
+        val client = mockk<Client>(relaxed = true)
+        val response = mockk<QueryResponse>(relaxed = true)
+        val responseFuture = CompletableFuture<QueryResponse>()
+        every {
+            client.query(any<String>(), any<Map<String, Any>>(), any<QuerySettings>())
+        } returns responseFuture
+
+        val failure = assertThrows<ClientException> {
+            NativeClickHouseCatalogClient(client, Duration.ofMillis(10)).query(
+                sql = "SELECT catalog",
+                parameters = emptyMap(),
+                columns = CATALOG_COLUMNS,
+            )
+        }
+
+        failure.message.assert().contains("query timed out")
+        (failure.cause is TimeoutException).assert().isTrue()
+        responseFuture.complete(response).assert().isTrue()
+        verify(exactly = 1, timeout = 1_000) { response.close() }
+        responseFuture.isCancelled.assert().isFalse()
+    }
+
+    @Test
+    fun `should close native reader and response after reading catalog records`() {
+        val client = mockk<Client>(relaxed = true)
+        val response = mockk<QueryResponse>(relaxed = true)
+        val reader = mockk<ClickHouseBinaryFormatReader>(relaxed = true)
+        val values = mapOf(
+            "database" to OPTIONS.database,
+            "name" to "foreign_view",
+            "engine" to "View",
+            "engine_full" to "View",
+            "create_table_query" to "CREATE VIEW",
+            "comment" to "",
+        )
+        every {
+            client.query(any<String>(), any<Map<String, Any>>(), any<QuerySettings>())
+        } returns CompletableFuture.completedFuture(response)
+        every { client.newBinaryFormatReader(response) } returns reader
+        every { reader.next() } returns values andThen null
+        every { reader.getString(any<String>()) } answers { values[firstArg()] }
+
+        val records = NativeClickHouseCatalogClient(client).query(
+            sql = "SELECT catalog",
+            parameters = emptyMap(),
+            columns = CATALOG_COLUMNS,
+        )
+
+        records.single().toObservedObject().name.assert().isEqualTo("foreign_view")
+        verify(exactly = 1) { reader.close() }
+        verify(exactly = 1) { response.close() }
+    }
+
+    @Test
+    fun `should close native reader and response when reading a catalog record fails`() {
+        val client = mockk<Client>(relaxed = true)
+        val response = mockk<QueryResponse>(relaxed = true)
+        val reader = mockk<ClickHouseBinaryFormatReader>(relaxed = true)
+        val failure = IllegalStateException("catalog read failed")
+        every {
+            client.query(any<String>(), any<Map<String, Any>>(), any<QuerySettings>())
+        } returns CompletableFuture.completedFuture(response)
+        every { client.newBinaryFormatReader(response) } returns reader
+        every { reader.next() } throws failure
+
+        val actual = assertThrows<IllegalStateException> {
+            NativeClickHouseCatalogClient(client).query(
+                sql = "SELECT catalog",
+                parameters = emptyMap(),
+                columns = CATALOG_COLUMNS,
+            )
+        }
+
+        (actual === failure).assert().isTrue()
+        verify(exactly = 1) { reader.close() }
+        verify(exactly = 1) { response.close() }
+    }
+
+    @Test
     fun `should classify native client failures as unavailable inspection`() {
         val failure = ClientException("upstream credentials were rejected")
         val client = StubClickHouseCatalogClient { _, _, _ -> throw failure }
@@ -377,6 +991,7 @@ class ClickHouseBiDeploymentInspectorTest {
         )
         return StubClickHouseCatalogClient { sql, parameters, _ ->
             parameters["cluster"].assert().isEqualTo(CLUSTER.name)
+            sql.assert().contains("show_table_uuid_in_table_create_query_if_not_nil = 0")
             if (responses.size == 2) {
                 sql.assert().contains("system.one", "clusterAllReplicas")
             } else {
@@ -417,15 +1032,22 @@ class ClickHouseBiDeploymentInspectorTest {
         }
     )
 
-    private fun queueComment(identity: String?): String = BiObjectMetadataCodec.encode(
-        BiObjectMetadata(
-            deploymentId = DESCRIPTOR.deploymentId,
-            configurationFingerprint = DESCRIPTOR.configurationFingerprint,
-            aggregate = "example.order",
-            kind = BiObjectKind.QUEUE,
-            consumerIdentity = identity,
+    private fun queueComment(
+        identity: String?,
+        options: BiScriptOptions = OPTIONS,
+    ): String {
+        val descriptor = BiDeploymentDescriptor.from(options)
+        return BiObjectMetadataCodec.encode(
+            BiObjectMetadata(
+                deploymentId = descriptor.deploymentId,
+                configurationFingerprint = descriptor.configurationFingerprint,
+                topologyFingerprint = descriptor.topologyFingerprint,
+                aggregate = "example.order",
+                kind = BiObjectKind.QUEUE,
+                consumerIdentity = identity,
+            )
         )
-    )
+    }
 
     private class StubClickHouseCatalogClient(
         private val response: (
@@ -462,6 +1084,7 @@ class ClickHouseBiDeploymentInspectorTest {
             BiObjectMetadata(
                 deploymentId = DESCRIPTOR.deploymentId,
                 configurationFingerprint = DESCRIPTOR.configurationFingerprint,
+                topologyFingerprint = DESCRIPTOR.topologyFingerprint,
                 aggregate = "example.order",
                 kind = BiObjectKind.VIEW,
             )

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseClientOptionsTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseClientOptionsTest.kt
@@ -36,11 +36,28 @@ class ClickHouseClientOptionsTest {
     }
 
     @Test
-    fun `should allow driver zero semantics for socket and execution timeouts`() {
+    fun `should allow a zero execution timeout while requiring a socket deadline`() {
         ClickHouseClientOptions(
             endpoints = listOf(ENDPOINT),
-            socketTimeout = Duration.ZERO,
             executionTimeout = Duration.ZERO,
+        )
+
+        assertThrows<IllegalArgumentException> {
+            ClickHouseClientOptions(
+                endpoints = listOf(ENDPOINT),
+                socketTimeout = Duration.ZERO,
+            )
+        }.message.assert().isEqualTo("socketTimeout must be greater than zero")
+    }
+
+    @Test
+    fun `should accept the minimum one millisecond timeout boundary`() {
+        ClickHouseClientOptions(
+            endpoints = listOf(ENDPOINT),
+            connectionTimeout = Duration.ofMillis(1),
+            connectionRequestTimeout = Duration.ofMillis(1),
+            socketTimeout = Duration.ofMillis(1),
+            executionTimeout = Duration.ofMillis(1),
         )
     }
 
@@ -118,15 +135,39 @@ class ClickHouseClientOptionsTest {
             {
                 ClickHouseClientOptions(
                     endpoints = listOf(ENDPOINT),
+                    connectionTimeout = Duration.ofNanos(1),
+                )
+            } to "connectionTimeout must be at least 1 millisecond",
+            {
+                ClickHouseClientOptions(
+                    endpoints = listOf(ENDPOINT),
                     connectionRequestTimeout = Duration.ofMillis(-1),
                 )
             } to "connectionRequestTimeout must be greater than zero",
             {
                 ClickHouseClientOptions(
                     endpoints = listOf(ENDPOINT),
+                    connectionRequestTimeout = Duration.ofNanos(1),
+                )
+            } to "connectionRequestTimeout must be at least 1 millisecond",
+            {
+                ClickHouseClientOptions(
+                    endpoints = listOf(ENDPOINT),
                     socketTimeout = Duration.ofMillis(-1),
                 )
-            } to "socketTimeout must not be negative",
+            } to "socketTimeout must be greater than zero",
+            {
+                ClickHouseClientOptions(
+                    endpoints = listOf(ENDPOINT),
+                    socketTimeout = Duration.ofNanos(1),
+                )
+            } to "socketTimeout must be at least 1 millisecond",
+            {
+                ClickHouseClientOptions(
+                    endpoints = listOf(ENDPOINT),
+                    executionTimeout = Duration.ofNanos(1),
+                )
+            } to "executionTimeout must be zero or at least 1 millisecond",
             {
                 ClickHouseClientOptions(
                     endpoints = listOf(ENDPOINT),

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/renderer/ClickHouseScriptRendererTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/renderer/ClickHouseScriptRendererTest.kt
@@ -72,12 +72,12 @@ class ClickHouseScriptRendererTest {
         val sql = (renderer.renderGlobalStatements() + command + stateEvent + stateLast + expansion)
             .joinToString("\n")
 
-        command.assert().hasSize(6)
-        stateEvent.assert().hasSize(7)
+        command.assert().hasSize(5)
+        stateEvent.assert().hasSize(6)
         stateLast.assert().hasSize(4)
         sql.assert().doesNotContain("ON CLUSTER", "Replicated", "Distributed", "_local", "/clickhouse/")
         sql.assert().contains("ENGINE = ReplacingMergeTree")
-        command[4].assert().contains("TO \"bi_db\".\"bi_aggregate_command_store\"")
+        command.any { it.contains("TO \"bi_db\".\"bi_aggregate_command_store\"") }.assert().isTrue()
         command.last().assert().contains("bi_aggregate_command", "bi_aggregate_command_store", "FINAL")
         stateEvent.any { it.contains("TO \"bi_db\".\"bi_aggregate_state_store\"") }.assert().isTrue()
         stateEvent.any { it.contains("FROM \"bi_db\".\"bi_aggregate_state\"") }.assert().isTrue()
@@ -99,6 +99,18 @@ class ClickHouseScriptRendererTest {
             "bi_aggregate_state_last_items",
             "bi_aggregate_state_last_root",
         )
+    }
+
+    @Test
+    fun `should preserve the lexical JSON of an event body`() {
+        val aggregate = MetadataSearcher.localAggregates.single { it.aggregateName == "aggregate" }
+        val eventView = ClickHouseScriptRenderer()
+            .renderStateEventStatements(aggregate)
+            .joinToString("\n")
+
+        eventView.assert()
+            .contains("JSONExtractRaw(\"events\".2, 'body') AS \"event_body\"")
+            .doesNotContain("JSONExtract(\"events\".2, 'body', 'String') AS \"event_body\"")
     }
 
     @Test
@@ -183,8 +195,8 @@ class ClickHouseScriptRendererTest {
 
         global.assert().hasSize(2)
         clear.assert().hasSize(17)
-        command.assert().hasSize(7)
-        stateEvent.assert().hasSize(8)
+        command.assert().hasSize(6)
+        stateEvent.assert().hasSize(7)
         stateLast.assert().hasSize(5)
         command.joinToString("\n").assert()
             .contains(

--- a/wow-bi/src/test/resources/expected_bi_cluster_script.sql
+++ b/wow-bi/src/test/resources/expected_bi_cluster_script.sql
@@ -4,18 +4,9 @@ CREATE DATABASE IF NOT EXISTS "bi_db" ON CLUSTER '{cluster}';
 CREATE DATABASE IF NOT EXISTS "bi_db_consumer" ON CLUSTER '{cluster}';
 -- global --
 -- lifecycle --
--- bi.aggregate.pause-ingress --
-DROP VIEW IF EXISTS "bi_db_consumer"."bi_aggregate_command_consumer" ON CLUSTER '{cluster}' SYNC;
-
-DROP TABLE IF EXISTS "bi_db_consumer"."bi_aggregate_command_queue" ON CLUSTER '{cluster}' SYNC;
-
-DROP VIEW IF EXISTS "bi_db_consumer"."bi_aggregate_state_consumer" ON CLUSTER '{cluster}' SYNC;
-
-DROP TABLE IF EXISTS "bi_db_consumer"."bi_aggregate_state_queue" ON CLUSTER '{cluster}' SYNC;
--- bi.aggregate.pause-ingress --
 -- lifecycle --
--- bi.aggregate.command --
-CREATE TABLE IF NOT EXISTS "bi_db"."bi_aggregate_command_store_local" ON CLUSTER '{cluster}'
+-- bi.aggregate.commandStorage --
+CREATE TABLE "bi_db"."bi_aggregate_command_store_local" ON CLUSTER '{cluster}'
 (
     "id" String,
     "context_name" String,
@@ -37,53 +28,16 @@ CREATE TABLE IF NOT EXISTS "bi_db"."bi_aggregate_command_store_local" ON CLUSTER
 ) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}', '{replica}')
   PARTITION BY toYYYYMM("create_time")
   ORDER BY "id"
-  COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+  COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
-CREATE TABLE IF NOT EXISTS "bi_db"."bi_aggregate_command_store" ON CLUSTER '{cluster}'
+CREATE TABLE "bi_db"."bi_aggregate_command_store" ON CLUSTER '{cluster}'
 AS "bi_db"."bi_aggregate_command_store_local"
 ENGINE = Distributed('{cluster}', "bi_db",
                      'bi_aggregate_command_store_local', sipHash64("aggregate_id"))
-COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
-
-DROP VIEW IF EXISTS "bi_db_consumer"."bi_aggregate_command_consumer" ON CLUSTER '{cluster}' SYNC;
-
-DROP TABLE IF EXISTS "bi_db_consumer"."bi_aggregate_command_queue" ON CLUSTER '{cluster}' SYNC;
-
-CREATE TABLE IF NOT EXISTS "bi_db_consumer"."bi_aggregate_command_queue" ON CLUSTER '{cluster}'
-("data" String)
-ENGINE = Kafka('localhost:9093', 'wow.bi.aggregate.command',
-               'wow-bi.4293daaf07b6609833555520ba03033b.bi_aggregate_command_consumer', 'JSONAsString')
-COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","aggregate":"bi.aggregate","kind":"QUEUE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
-
-CREATE MATERIALIZED VIEW IF NOT EXISTS "bi_db_consumer"."bi_aggregate_command_consumer" ON CLUSTER '{cluster}'
-TO "bi_db"."bi_aggregate_command_store"
-AS (
-SELECT JSONExtractString("data", 'id') AS "id",
-       JSONExtractString("data", 'contextName') AS "context_name",
-       JSONExtractString("data", 'aggregateName') AS "aggregate_name",
-       JSONExtractString("data", 'name') AS "name",
-       JSONExtract("data", 'header', 'Map(String, String)') AS "header",
-       JSONExtractString("data", 'aggregateId') AS "aggregate_id",
-       JSONExtractString("data", 'tenantId') AS "tenant_id",
-       JSONExtractString("data", 'ownerId') AS "owner_id",
-       JSONExtractString("data", 'spaceId') AS "space_id",
-       JSONExtractString("data", 'requestId') AS "request_id",
-       JSONExtract("data", 'aggregateVersion', 'Nullable(UInt32)') AS "aggregate_version",
-       JSONExtractBool("data", 'isCreate') AS "is_create",
-       JSONExtractBool("data", 'isVoid') AS "is_void",
-       JSONExtractBool("data", 'allowCreate') AS "allow_create",
-       JSONExtractString("data", 'bodyType') AS "body_type",
-       simpleJSONExtractRaw(replaceOne("data", concat('"header":', simpleJSONExtractRaw("data", 'header')), '"header":{}'), 'body') AS "body",
-       toDateTime64(JSONExtractInt("data", 'createTime') / 1000.0, 3, 'Asia/Shanghai') AS "create_time"
-FROM "bi_db_consumer"."bi_aggregate_command_queue"
-) COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
-
-CREATE OR REPLACE VIEW "bi_db"."bi_aggregate_command" ON CLUSTER '{cluster}'
-AS (SELECT * FROM "bi_db"."bi_aggregate_command_store" FINAL)
-COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
--- bi.aggregate.command --
+COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+-- bi.aggregate.commandStorage --
 -- bi.aggregate.stateStorage --
-CREATE TABLE IF NOT EXISTS "bi_db"."bi_aggregate_state_store_local" ON CLUSTER '{cluster}'
+CREATE TABLE "bi_db"."bi_aggregate_state_store_local" ON CLUSTER '{cluster}'
 (
     "id" String,
     "context_name" String,
@@ -106,16 +60,16 @@ CREATE TABLE IF NOT EXISTS "bi_db"."bi_aggregate_state_store_local" ON CLUSTER '
 ) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}', '{replica}', "version")
       PARTITION BY toYYYYMM("create_time")
       ORDER BY ("aggregate_id", "version")
-      COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+      COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
-CREATE TABLE IF NOT EXISTS "bi_db"."bi_aggregate_state_store" ON CLUSTER '{cluster}'
+CREATE TABLE "bi_db"."bi_aggregate_state_store" ON CLUSTER '{cluster}'
 AS "bi_db"."bi_aggregate_state_store_local"
 ENGINE = Distributed('{cluster}', "bi_db",
                      'bi_aggregate_state_store_local', sipHash64("aggregate_id"))
-COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 -- bi.aggregate.stateStorage --
 -- bi.aggregate.stateLast --
-CREATE TABLE IF NOT EXISTS "bi_db"."bi_aggregate_state_last_store_local" ON CLUSTER '{cluster}'
+CREATE TABLE "bi_db"."bi_aggregate_state_last_store_local" ON CLUSTER '{cluster}'
 (
     "id" String,
     "context_name" String,
@@ -138,29 +92,27 @@ CREATE TABLE IF NOT EXISTS "bi_db"."bi_aggregate_state_last_store_local" ON CLUS
 ) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}', '{replica}', "version")
       PARTITION BY toYYYYMM("first_event_time")
       ORDER BY ("aggregate_id")
-      COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+      COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
-CREATE TABLE IF NOT EXISTS "bi_db"."bi_aggregate_state_last_store" ON CLUSTER '{cluster}'
+CREATE TABLE "bi_db"."bi_aggregate_state_last_store" ON CLUSTER '{cluster}'
 AS "bi_db"."bi_aggregate_state_last_store_local"
 ENGINE = Distributed('{cluster}', "bi_db",
                      'bi_aggregate_state_last_store_local', sipHash64("aggregate_id"))
-COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
-DROP VIEW IF EXISTS "bi_db_consumer"."bi_aggregate_state_last_consumer" ON CLUSTER '{cluster}' SYNC;
-
-CREATE MATERIALIZED VIEW IF NOT EXISTS "bi_db_consumer"."bi_aggregate_state_last_consumer" ON CLUSTER '{cluster}'
+CREATE MATERIALIZED VIEW "bi_db_consumer"."bi_aggregate_state_last_consumer" ON CLUSTER '{cluster}'
 TO "bi_db"."bi_aggregate_state_last_store"
 AS (
 SELECT *
 FROM "bi_db"."bi_aggregate_state_store"
-) COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
-CREATE OR REPLACE VIEW "bi_db"."bi_aggregate_state_last" ON CLUSTER '{cluster}'
+CREATE VIEW "bi_db"."bi_aggregate_state_last" ON CLUSTER '{cluster}'
 AS (SELECT * FROM "bi_db"."bi_aggregate_state_last_store" FINAL)
-COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 -- bi.aggregate.stateLast --
 -- bi.aggregate.expansion --
-CREATE OR REPLACE VIEW "bi_db"."bi_aggregate_state_last_root" ON CLUSTER '{cluster}' AS (
+CREATE VIEW "bi_db"."bi_aggregate_state_last_root" ON CLUSTER '{cluster}' AS (
 WITH
 JSONExtractRaw("__source"."state", 'item') AS "item",
 JSONExtractRaw("__source"."state", 'nested') AS "nested",
@@ -230,9 +182,9 @@ JSONExtract("__source"."state", 'zonedDateTime', 'String') AS "zoned_date_time",
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
-CREATE OR REPLACE VIEW "bi_db"."bi_aggregate_state_last_root_items" ON CLUSTER '{cluster}' AS (
+CREATE VIEW "bi_db"."bi_aggregate_state_last_root_items" ON CLUSTER '{cluster}' AS (
 WITH
 arrayJoin(arrayZip(arrayEnumerate(JSONExtractArrayRaw("__source"."state", 'items')),
                    JSONExtractArrayRaw("__source"."state", 'items'))) AS "__cursor__items",
@@ -304,9 +256,9 @@ concat('/items/', toString(tupleElement("__cursor__items", 1) - 1)) AS "__path",
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
-CREATE OR REPLACE VIEW "bi_db"."bi_aggregate_state_last_root_like_list_item" ON CLUSTER '{cluster}' AS (
+CREATE VIEW "bi_db"."bi_aggregate_state_last_root_like_list_item" ON CLUSTER '{cluster}' AS (
 WITH
 arrayJoin(arrayZip(arrayEnumerate(JSONExtractArrayRaw("__source"."state", 'likeListItem')),
                    JSONExtractArrayRaw("__source"."state", 'likeListItem'))) AS "__cursor__like_list_item",
@@ -378,9 +330,9 @@ concat('/likeListItem/', toString(tupleElement("__cursor__like_list_item", 1) - 
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
-CREATE OR REPLACE VIEW "bi_db"."bi_aggregate_state_last_root_nested_list" ON CLUSTER '{cluster}' AS (
+CREATE VIEW "bi_db"."bi_aggregate_state_last_root_nested_list" ON CLUSTER '{cluster}' AS (
 WITH
 arrayJoin(arrayZip(arrayEnumerate(JSONExtractArrayRaw("__source"."state", 'nestedList')),
                    JSONExtractArrayRaw("__source"."state", 'nestedList'))) AS "__cursor__nested_list",
@@ -453,9 +405,9 @@ concat('/nestedList/', toString(tupleElement("__cursor__nested_list", 1) - 1)) A
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
-CREATE OR REPLACE VIEW "bi_db"."bi_aggregate_state_last_root_nested_list_list" ON CLUSTER '{cluster}' AS (
+CREATE VIEW "bi_db"."bi_aggregate_state_last_root_nested_list_list" ON CLUSTER '{cluster}' AS (
 WITH
 arrayJoin(arrayZip(arrayEnumerate(JSONExtractArrayRaw("__source"."state", 'nestedList')),
                    JSONExtractArrayRaw("__source"."state", 'nestedList'))) AS "__cursor__nested_list",
@@ -535,9 +487,9 @@ concat('/nestedList/', toString(tupleElement("__cursor__nested_list", 1) - 1), '
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
-CREATE OR REPLACE VIEW "bi_db"."bi_aggregate_state_last_root_set" ON CLUSTER '{cluster}' AS (
+CREATE VIEW "bi_db"."bi_aggregate_state_last_root_set" ON CLUSTER '{cluster}' AS (
 WITH
 arrayJoin(arrayZip(arrayEnumerate(JSONExtractArrayRaw("__source"."state", 'set')),
                    JSONExtractArrayRaw("__source"."state", 'set'))) AS "__cursor__set",
@@ -609,14 +561,19 @@ concat('/set/', toString(tupleElement("__cursor__set", 1) - 1)) AS "__path",
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 -- bi.aggregate.expansion --
+-- bi.aggregate.commandPublic --
+CREATE VIEW "bi_db"."bi_aggregate_command" ON CLUSTER '{cluster}'
+AS (SELECT * FROM "bi_db"."bi_aggregate_command_store" FINAL)
+COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+-- bi.aggregate.commandPublic --
 -- bi.aggregate.statePublic --
-CREATE OR REPLACE VIEW "bi_db"."bi_aggregate_state" ON CLUSTER '{cluster}'
+CREATE VIEW "bi_db"."bi_aggregate_state" ON CLUSTER '{cluster}'
 AS (SELECT * FROM "bi_db"."bi_aggregate_state_store" FINAL)
-COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
-CREATE OR REPLACE VIEW "bi_db"."bi_aggregate_state_event" ON CLUSTER '{cluster}'
+CREATE VIEW "bi_db"."bi_aggregate_state_event" ON CLUSTER '{cluster}'
 AS (
 WITH arrayJoin(arrayZip(arrayEnumerate("body"),
                         "body")) AS "events"
@@ -637,28 +594,57 @@ SELECT "id",
        JSONExtract("events".2, 'name', 'String') AS "event_name",
        JSONExtract("events".2, 'revision', 'String') AS "event_revision",
        JSONExtract("events".2, 'bodyType', 'String') AS "event_body_type",
-       JSONExtract("events".2, 'body', 'String') AS "event_body",
+       JSONExtractRaw("events".2, 'body') AS "event_body",
        "first_operator",
        "first_event_time",
        "create_time",
        "tags",
        "deleted"
 FROM "bi_db"."bi_aggregate_state"
-) COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 -- bi.aggregate.statePublic --
+-- deployment-anchor --
+CREATE VIEW "bi_db_consumer"."__wow_bi_deployment" ON CLUSTER '{cluster}' AS (SELECT 1 AS "alive" WHERE 0) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":null,"kind":"ANCHOR","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+-- deployment-anchor --
+-- bi.aggregate.commandIngress --
+CREATE TABLE "bi_db_consumer"."bi_aggregate_command_queue" ON CLUSTER '{cluster}'
+("data" String)
+ENGINE = Kafka('localhost:9093', 'wow.bi.aggregate.command',
+               'wow-bi.4293daaf07b6609833555520ba03033b.bi_aggregate_command_consumer', 'JSONAsString')
+COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"QUEUE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+
+CREATE MATERIALIZED VIEW "bi_db_consumer"."bi_aggregate_command_consumer" ON CLUSTER '{cluster}'
+TO "bi_db"."bi_aggregate_command_store"
+AS (
+SELECT JSONExtractString("data", 'id') AS "id",
+       JSONExtractString("data", 'contextName') AS "context_name",
+       JSONExtractString("data", 'aggregateName') AS "aggregate_name",
+       JSONExtractString("data", 'name') AS "name",
+       JSONExtract("data", 'header', 'Map(String, String)') AS "header",
+       JSONExtractString("data", 'aggregateId') AS "aggregate_id",
+       JSONExtractString("data", 'tenantId') AS "tenant_id",
+       JSONExtractString("data", 'ownerId') AS "owner_id",
+       JSONExtractString("data", 'spaceId') AS "space_id",
+       JSONExtractString("data", 'requestId') AS "request_id",
+       JSONExtract("data", 'aggregateVersion', 'Nullable(UInt32)') AS "aggregate_version",
+       JSONExtractBool("data", 'isCreate') AS "is_create",
+       JSONExtractBool("data", 'isVoid') AS "is_void",
+       JSONExtractBool("data", 'allowCreate') AS "allow_create",
+       JSONExtractString("data", 'bodyType') AS "body_type",
+       simpleJSONExtractRaw(replaceOne("data", concat('"header":', simpleJSONExtractRaw("data", 'header')), '"header":{}'), 'body') AS "body",
+       toDateTime64(JSONExtractInt("data", 'createTime') / 1000.0, 3, 'Asia/Shanghai') AS "create_time"
+FROM "bi_db_consumer"."bi_aggregate_command_queue"
+) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+-- bi.aggregate.commandIngress --
 -- bi.aggregate.stateIngress --
-DROP VIEW IF EXISTS "bi_db_consumer"."bi_aggregate_state_consumer" ON CLUSTER '{cluster}' SYNC;
-
-DROP TABLE IF EXISTS "bi_db_consumer"."bi_aggregate_state_queue" ON CLUSTER '{cluster}' SYNC;
-
-CREATE TABLE IF NOT EXISTS "bi_db_consumer"."bi_aggregate_state_queue" ON CLUSTER '{cluster}'
+CREATE TABLE "bi_db_consumer"."bi_aggregate_state_queue" ON CLUSTER '{cluster}'
 (
     "data" String
 ) ENGINE = Kafka('localhost:9093', 'wow.bi.aggregate.state',
                  'wow-bi.4293daaf07b6609833555520ba03033b.bi_aggregate_state_consumer', 'JSONAsString')
-COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","aggregate":"bi.aggregate","kind":"QUEUE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"QUEUE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS "bi_db_consumer"."bi_aggregate_state_consumer" ON CLUSTER '{cluster}'
+CREATE MATERIALIZED VIEW "bi_db_consumer"."bi_aggregate_state_consumer" ON CLUSTER '{cluster}'
 TO "bi_db"."bi_aggregate_state_store"
 AS (
 SELECT JSONExtractString("data", 'id') AS "id",
@@ -680,8 +666,5 @@ SELECT JSONExtractString("data", 'id') AS "id",
        JSONExtract("data", 'tags', 'Map(String, Array(String))') AS "tags",
        JSONExtractBool("data", 'deleted') AS "deleted"
 FROM "bi_db_consumer"."bi_aggregate_state_queue"
-) COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 -- bi.aggregate.stateIngress --
--- deployment-anchor --
-CREATE OR REPLACE VIEW "bi_db_consumer"."__wow_bi_deployment" ON CLUSTER '{cluster}' AS (SELECT 1 AS "alive" WHERE 0) COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","aggregate":null,"kind":"ANCHOR","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
--- deployment-anchor --

--- a/wow-bi/src/test/resources/expected_bi_standalone_script.sql
+++ b/wow-bi/src/test/resources/expected_bi_standalone_script.sql
@@ -4,18 +4,9 @@ CREATE DATABASE IF NOT EXISTS "bi_db";
 CREATE DATABASE IF NOT EXISTS "bi_db_consumer";
 -- global --
 -- lifecycle --
--- bi.aggregate.pause-ingress --
-DROP VIEW IF EXISTS "bi_db_consumer"."bi_aggregate_command_consumer" SYNC;
-
-DROP TABLE IF EXISTS "bi_db_consumer"."bi_aggregate_command_queue" SYNC;
-
-DROP VIEW IF EXISTS "bi_db_consumer"."bi_aggregate_state_consumer" SYNC;
-
-DROP TABLE IF EXISTS "bi_db_consumer"."bi_aggregate_state_queue" SYNC;
--- bi.aggregate.pause-ingress --
 -- lifecycle --
--- bi.aggregate.command --
-CREATE TABLE IF NOT EXISTS "bi_db"."bi_aggregate_command_store"
+-- bi.aggregate.commandStorage --
+CREATE TABLE "bi_db"."bi_aggregate_command_store"
 (
     "id" String,
     "context_name" String,
@@ -37,47 +28,10 @@ CREATE TABLE IF NOT EXISTS "bi_db"."bi_aggregate_command_store"
 ) ENGINE = ReplacingMergeTree
   PARTITION BY toYYYYMM("create_time")
   ORDER BY "id"
-  COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
-
-DROP VIEW IF EXISTS "bi_db_consumer"."bi_aggregate_command_consumer" SYNC;
-
-DROP TABLE IF EXISTS "bi_db_consumer"."bi_aggregate_command_queue" SYNC;
-
-CREATE TABLE IF NOT EXISTS "bi_db_consumer"."bi_aggregate_command_queue"
-("data" String)
-ENGINE = Kafka('localhost:9093', 'wow.bi.aggregate.command',
-               'wow-bi.39b2524473ea17aea282d31d216a901c.bi_aggregate_command_consumer', 'JSONAsString')
-COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","aggregate":"bi.aggregate","kind":"QUEUE","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
-
-CREATE MATERIALIZED VIEW IF NOT EXISTS "bi_db_consumer"."bi_aggregate_command_consumer"
-TO "bi_db"."bi_aggregate_command_store"
-AS (
-SELECT JSONExtractString("data", 'id') AS "id",
-       JSONExtractString("data", 'contextName') AS "context_name",
-       JSONExtractString("data", 'aggregateName') AS "aggregate_name",
-       JSONExtractString("data", 'name') AS "name",
-       JSONExtract("data", 'header', 'Map(String, String)') AS "header",
-       JSONExtractString("data", 'aggregateId') AS "aggregate_id",
-       JSONExtractString("data", 'tenantId') AS "tenant_id",
-       JSONExtractString("data", 'ownerId') AS "owner_id",
-       JSONExtractString("data", 'spaceId') AS "space_id",
-       JSONExtractString("data", 'requestId') AS "request_id",
-       JSONExtract("data", 'aggregateVersion', 'Nullable(UInt32)') AS "aggregate_version",
-       JSONExtractBool("data", 'isCreate') AS "is_create",
-       JSONExtractBool("data", 'isVoid') AS "is_void",
-       JSONExtractBool("data", 'allowCreate') AS "allow_create",
-       JSONExtractString("data", 'bodyType') AS "body_type",
-       simpleJSONExtractRaw(replaceOne("data", concat('"header":', simpleJSONExtractRaw("data", 'header')), '"header":{}'), 'body') AS "body",
-       toDateTime64(JSONExtractInt("data", 'createTime') / 1000.0, 3, 'Asia/Shanghai') AS "create_time"
-FROM "bi_db_consumer"."bi_aggregate_command_queue"
-) COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
-
-CREATE OR REPLACE VIEW "bi_db"."bi_aggregate_command"
-AS (SELECT * FROM "bi_db"."bi_aggregate_command_store" FINAL)
-COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
--- bi.aggregate.command --
+  COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+-- bi.aggregate.commandStorage --
 -- bi.aggregate.stateStorage --
-CREATE TABLE IF NOT EXISTS "bi_db"."bi_aggregate_state_store"
+CREATE TABLE "bi_db"."bi_aggregate_state_store"
 (
     "id" String,
     "context_name" String,
@@ -100,10 +54,10 @@ CREATE TABLE IF NOT EXISTS "bi_db"."bi_aggregate_state_store"
 ) ENGINE = ReplacingMergeTree("version")
       PARTITION BY toYYYYMM("create_time")
       ORDER BY ("aggregate_id", "version")
-      COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+      COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 -- bi.aggregate.stateStorage --
 -- bi.aggregate.stateLast --
-CREATE TABLE IF NOT EXISTS "bi_db"."bi_aggregate_state_last_store"
+CREATE TABLE "bi_db"."bi_aggregate_state_last_store"
 (
     "id" String,
     "context_name" String,
@@ -126,23 +80,21 @@ CREATE TABLE IF NOT EXISTS "bi_db"."bi_aggregate_state_last_store"
 ) ENGINE = ReplacingMergeTree("version")
       PARTITION BY toYYYYMM("first_event_time")
       ORDER BY ("aggregate_id")
-      COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+      COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 
-DROP VIEW IF EXISTS "bi_db_consumer"."bi_aggregate_state_last_consumer" SYNC;
-
-CREATE MATERIALIZED VIEW IF NOT EXISTS "bi_db_consumer"."bi_aggregate_state_last_consumer"
+CREATE MATERIALIZED VIEW "bi_db_consumer"."bi_aggregate_state_last_consumer"
 TO "bi_db"."bi_aggregate_state_last_store"
 AS (
 SELECT *
 FROM "bi_db"."bi_aggregate_state_store"
-) COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 
-CREATE OR REPLACE VIEW "bi_db"."bi_aggregate_state_last"
+CREATE VIEW "bi_db"."bi_aggregate_state_last"
 AS (SELECT * FROM "bi_db"."bi_aggregate_state_last_store" FINAL)
-COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 -- bi.aggregate.stateLast --
 -- bi.aggregate.expansion --
-CREATE OR REPLACE VIEW "bi_db"."bi_aggregate_state_last_root" AS (
+CREATE VIEW "bi_db"."bi_aggregate_state_last_root" AS (
 WITH
 JSONExtractRaw("__source"."state", 'item') AS "item",
 JSONExtractRaw("__source"."state", 'nested') AS "nested",
@@ -212,9 +164,9 @@ JSONExtract("__source"."state", 'zonedDateTime', 'String') AS "zoned_date_time",
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 
-CREATE OR REPLACE VIEW "bi_db"."bi_aggregate_state_last_root_items" AS (
+CREATE VIEW "bi_db"."bi_aggregate_state_last_root_items" AS (
 WITH
 arrayJoin(arrayZip(arrayEnumerate(JSONExtractArrayRaw("__source"."state", 'items')),
                    JSONExtractArrayRaw("__source"."state", 'items'))) AS "__cursor__items",
@@ -286,9 +238,9 @@ concat('/items/', toString(tupleElement("__cursor__items", 1) - 1)) AS "__path",
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 
-CREATE OR REPLACE VIEW "bi_db"."bi_aggregate_state_last_root_like_list_item" AS (
+CREATE VIEW "bi_db"."bi_aggregate_state_last_root_like_list_item" AS (
 WITH
 arrayJoin(arrayZip(arrayEnumerate(JSONExtractArrayRaw("__source"."state", 'likeListItem')),
                    JSONExtractArrayRaw("__source"."state", 'likeListItem'))) AS "__cursor__like_list_item",
@@ -360,9 +312,9 @@ concat('/likeListItem/', toString(tupleElement("__cursor__like_list_item", 1) - 
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 
-CREATE OR REPLACE VIEW "bi_db"."bi_aggregate_state_last_root_nested_list" AS (
+CREATE VIEW "bi_db"."bi_aggregate_state_last_root_nested_list" AS (
 WITH
 arrayJoin(arrayZip(arrayEnumerate(JSONExtractArrayRaw("__source"."state", 'nestedList')),
                    JSONExtractArrayRaw("__source"."state", 'nestedList'))) AS "__cursor__nested_list",
@@ -435,9 +387,9 @@ concat('/nestedList/', toString(tupleElement("__cursor__nested_list", 1) - 1)) A
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 
-CREATE OR REPLACE VIEW "bi_db"."bi_aggregate_state_last_root_nested_list_list" AS (
+CREATE VIEW "bi_db"."bi_aggregate_state_last_root_nested_list_list" AS (
 WITH
 arrayJoin(arrayZip(arrayEnumerate(JSONExtractArrayRaw("__source"."state", 'nestedList')),
                    JSONExtractArrayRaw("__source"."state", 'nestedList'))) AS "__cursor__nested_list",
@@ -517,9 +469,9 @@ concat('/nestedList/', toString(tupleElement("__cursor__nested_list", 1) - 1), '
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 
-CREATE OR REPLACE VIEW "bi_db"."bi_aggregate_state_last_root_set" AS (
+CREATE VIEW "bi_db"."bi_aggregate_state_last_root_set" AS (
 WITH
 arrayJoin(arrayZip(arrayEnumerate(JSONExtractArrayRaw("__source"."state", 'set')),
                    JSONExtractArrayRaw("__source"."state", 'set'))) AS "__cursor__set",
@@ -591,14 +543,19 @@ concat('/set/', toString(tupleElement("__cursor__set", 1) - 1)) AS "__path",
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 -- bi.aggregate.expansion --
+-- bi.aggregate.commandPublic --
+CREATE VIEW "bi_db"."bi_aggregate_command"
+AS (SELECT * FROM "bi_db"."bi_aggregate_command_store" FINAL)
+COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+-- bi.aggregate.commandPublic --
 -- bi.aggregate.statePublic --
-CREATE OR REPLACE VIEW "bi_db"."bi_aggregate_state"
+CREATE VIEW "bi_db"."bi_aggregate_state"
 AS (SELECT * FROM "bi_db"."bi_aggregate_state_store" FINAL)
-COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 
-CREATE OR REPLACE VIEW "bi_db"."bi_aggregate_state_event"
+CREATE VIEW "bi_db"."bi_aggregate_state_event"
 AS (
 WITH arrayJoin(arrayZip(arrayEnumerate("body"),
                         "body")) AS "events"
@@ -619,28 +576,57 @@ SELECT "id",
        JSONExtract("events".2, 'name', 'String') AS "event_name",
        JSONExtract("events".2, 'revision', 'String') AS "event_revision",
        JSONExtract("events".2, 'bodyType', 'String') AS "event_body_type",
-       JSONExtract("events".2, 'body', 'String') AS "event_body",
+       JSONExtractRaw("events".2, 'body') AS "event_body",
        "first_operator",
        "first_event_time",
        "create_time",
        "tags",
        "deleted"
 FROM "bi_db"."bi_aggregate_state"
-) COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 -- bi.aggregate.statePublic --
+-- deployment-anchor --
+CREATE VIEW "bi_db_consumer"."__wow_bi_deployment" AS (SELECT 1 AS "alive" WHERE 0) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":null,"kind":"ANCHOR","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+-- deployment-anchor --
+-- bi.aggregate.commandIngress --
+CREATE TABLE "bi_db_consumer"."bi_aggregate_command_queue"
+("data" String)
+ENGINE = Kafka('localhost:9093', 'wow.bi.aggregate.command',
+               'wow-bi.39b2524473ea17aea282d31d216a901c.bi_aggregate_command_consumer', 'JSONAsString')
+COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"QUEUE","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+
+CREATE MATERIALIZED VIEW "bi_db_consumer"."bi_aggregate_command_consumer"
+TO "bi_db"."bi_aggregate_command_store"
+AS (
+SELECT JSONExtractString("data", 'id') AS "id",
+       JSONExtractString("data", 'contextName') AS "context_name",
+       JSONExtractString("data", 'aggregateName') AS "aggregate_name",
+       JSONExtractString("data", 'name') AS "name",
+       JSONExtract("data", 'header', 'Map(String, String)') AS "header",
+       JSONExtractString("data", 'aggregateId') AS "aggregate_id",
+       JSONExtractString("data", 'tenantId') AS "tenant_id",
+       JSONExtractString("data", 'ownerId') AS "owner_id",
+       JSONExtractString("data", 'spaceId') AS "space_id",
+       JSONExtractString("data", 'requestId') AS "request_id",
+       JSONExtract("data", 'aggregateVersion', 'Nullable(UInt32)') AS "aggregate_version",
+       JSONExtractBool("data", 'isCreate') AS "is_create",
+       JSONExtractBool("data", 'isVoid') AS "is_void",
+       JSONExtractBool("data", 'allowCreate') AS "allow_create",
+       JSONExtractString("data", 'bodyType') AS "body_type",
+       simpleJSONExtractRaw(replaceOne("data", concat('"header":', simpleJSONExtractRaw("data", 'header')), '"header":{}'), 'body') AS "body",
+       toDateTime64(JSONExtractInt("data", 'createTime') / 1000.0, 3, 'Asia/Shanghai') AS "create_time"
+FROM "bi_db_consumer"."bi_aggregate_command_queue"
+) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+-- bi.aggregate.commandIngress --
 -- bi.aggregate.stateIngress --
-DROP VIEW IF EXISTS "bi_db_consumer"."bi_aggregate_state_consumer" SYNC;
-
-DROP TABLE IF EXISTS "bi_db_consumer"."bi_aggregate_state_queue" SYNC;
-
-CREATE TABLE IF NOT EXISTS "bi_db_consumer"."bi_aggregate_state_queue"
+CREATE TABLE "bi_db_consumer"."bi_aggregate_state_queue"
 (
     "data" String
 ) ENGINE = Kafka('localhost:9093', 'wow.bi.aggregate.state',
                  'wow-bi.39b2524473ea17aea282d31d216a901c.bi_aggregate_state_consumer', 'JSONAsString')
-COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","aggregate":"bi.aggregate","kind":"QUEUE","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"QUEUE","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 
-CREATE MATERIALIZED VIEW IF NOT EXISTS "bi_db_consumer"."bi_aggregate_state_consumer"
+CREATE MATERIALIZED VIEW "bi_db_consumer"."bi_aggregate_state_consumer"
 TO "bi_db"."bi_aggregate_state_store"
 AS (
 SELECT JSONExtractString("data", 'id') AS "id",
@@ -662,8 +648,5 @@ SELECT JSONExtractString("data", 'id') AS "id",
        JSONExtract("data", 'tags', 'Map(String, Array(String))') AS "tags",
        JSONExtractBool("data", 'deleted') AS "deleted"
 FROM "bi_db_consumer"."bi_aggregate_state_queue"
-) COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 -- bi.aggregate.stateIngress --
--- deployment-anchor --
-CREATE OR REPLACE VIEW "bi_db_consumer"."__wow_bi_deployment" AS (SELECT 1 AS "alive" WHERE 0) COMMENT 'wow-bi:{"protocolVersion":1,"layoutVersion":6,"deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","aggregate":null,"kind":"ANCHOR","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
--- deployment-anchor --

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/Https.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/Https.kt
@@ -28,6 +28,7 @@ object Https {
         const val GONE = "410"
         const val UNSUPPORTED_MEDIA_TYPE = "415"
         const val TOO_MANY_REQUESTS = "429"
+        const val INTERNAL_SERVER_ERROR = "500"
         const val BAD_GATEWAY = "502"
         const val SERVICE_UNAVAILABLE = "503"
         const val GATEWAY_TIMEOUT = "504"

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/global/GenerateBIScriptRouteContributor.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/global/GenerateBIScriptRouteContributor.kt
@@ -50,7 +50,10 @@ object GenerateBIScriptRouteContributor : RouteContributor {
                 path = BuiltInHttpRoutePaths.Global.BI_SCRIPT,
                 handlerKey = BuiltInHttpRouteHandlerKeys.Global.BI_SCRIPT,
                 summary = "Generate BI Sync Script",
-                accept = listOf(Https.MediaType.APPLICATION_SQL, Https.MediaType.APPLICATION_JSON),
+                accept = listOf(
+                    Https.MediaType.APPLICATION_SQL,
+                    Https.MediaType.APPLICATION_JSON,
+                ),
                 requestBody = HttpRequestBody(
                     required = true,
                     description = "BI script option overrides.",
@@ -84,6 +87,11 @@ object GenerateBIScriptRouteContributor : RouteContributor {
                         componentContext,
                         Https.Code.GATEWAY_TIMEOUT,
                         "ClickHouse catalog inspection timed out.",
+                    ),
+                    errorResponse(
+                        componentContext,
+                        Https.Code.INTERNAL_SERVER_ERROR,
+                        "Unexpected BI script generation failure.",
                     ),
                 ),
                 tags = wowTags()

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/contributor/global/GenerateBIScriptRouteContributorTest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/contributor/global/GenerateBIScriptRouteContributorTest.kt
@@ -63,6 +63,7 @@ internal class GenerateBIScriptRouteContributorTest {
                 Https.Code.BAD_GATEWAY,
                 Https.Code.SERVICE_UNAVAILABLE,
                 Https.Code.GATEWAY_TIMEOUT,
+                Https.Code.INTERNAL_SERVER_ERROR,
             )
         contract.responses.first().content.map(HttpContent::mediaType).assert().containsExactly(
             Https.MediaType.APPLICATION_SQL,
@@ -90,6 +91,7 @@ internal class GenerateBIScriptRouteContributorTest {
             Https.Code.BAD_GATEWAY,
             Https.Code.SERVICE_UNAVAILABLE,
             Https.Code.GATEWAY_TIMEOUT,
+            Https.Code.INTERNAL_SERVER_ERROR,
         ).forEach { statusCode ->
             responses.single { it.statusCode == statusCode }.run {
                 description.assert().isNotNull()

--- a/wow-openapi/src/test/resources/openapi/example-domain-contract.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-contract.snapshot.json
@@ -1706,7 +1706,7 @@
   "parameterNames" : [ ],
   "path" : "/wow/bi/script",
   "requestBody" : true,
-  "responseCodes" : [ "200", "400", "406", "415", "502", "503", "504" ],
+  "responseCodes" : [ "200", "400", "406", "415", "500", "502", "503", "504" ],
   "tagNames" : [ "wow" ]
 }, {
   "accept" : [ "application/json" ],

--- a/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
@@ -12019,6 +12019,20 @@
           "415" : {
             "$ref" : "#/components/responses/wow.UnsupportedMediaType"
           },
+          "500" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/wow.api.DefaultErrorInfo"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          },
           "502" : {
             "content" : {
               "application/json" : {

--- a/wow-spring-boot-starter/build.gradle.kts
+++ b/wow-spring-boot-starter/build.gradle.kts
@@ -59,6 +59,7 @@ dependencies {
     "elasticsearchSupportImplementation"(project(":wow-elasticsearch"))
     "elasticsearchSupportImplementation"("org.springframework.boot:spring-boot-starter-elasticsearch")
     "opentelemetrySupportImplementation"(project(":wow-opentelemetry"))
+    "openapiSupportApi"(project(":wow-bi"))
     "openapiSupportImplementation"(project(":wow-openapi"))
     "openapiSupportImplementation"("org.springdoc:springdoc-openapi-starter-common")
     api("org.springframework:spring-webflux")

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/openapi/ConditionalOnOpenAPIEnabled.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/openapi/ConditionalOnOpenAPIEnabled.kt
@@ -15,7 +15,6 @@ package me.ahoo.wow.spring.boot.starter.openapi
 
 import me.ahoo.wow.spring.boot.starter.ConditionalOnWowEnabled
 import me.ahoo.wow.spring.boot.starter.ENABLED_SUFFIX_KEY
-import me.ahoo.wow.spring.boot.starter.mongo.ENABLED_KEY
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/openapi/OpenAPIAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/openapi/OpenAPIAutoConfiguration.kt
@@ -19,16 +19,20 @@ import me.ahoo.wow.openapi.RouterSpecs
 import me.ahoo.wow.openapi.context.OpenAPIComponentContext
 import me.ahoo.wow.openapi.contributor.DefaultRouteContributors
 import me.ahoo.wow.openapi.contributor.global.GenerateBIScriptRouteContributor
+import me.ahoo.wow.spring.boot.starter.ConditionalOnWowEnabled
 import me.ahoo.wow.spring.boot.starter.WowAutoConfiguration.Companion.WOW_CURRENT_BOUNDED_CONTEXT
 import me.ahoo.wow.spring.boot.starter.bi.BiScriptProperties
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 
 @AutoConfiguration
-@ConditionalOnOpenAPIEnabled
+@ConditionalOnWowEnabled
+@ConditionalOnClass(name = ["me.ahoo.wow.openapi.RouterSpecs"])
 @EnableConfigurationProperties(OpenAPIProperties::class, BiScriptProperties::class)
 class OpenAPIAutoConfiguration {
 
@@ -61,8 +65,13 @@ class OpenAPIAutoConfiguration {
         ).build()
     }
 
-    @Bean
-    fun wowOpenApiCustomizer(routerSpecs: RouterSpecs): WowOpenApiCustomizer {
-        return WowOpenApiCustomizer(routerSpecs)
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnOpenAPIEnabled
+    @ConditionalOnClass(name = ["org.springdoc.core.customizers.OpenApiCustomizer"])
+    class SpringdocConfiguration {
+        @Bean
+        fun wowOpenApiCustomizer(routerSpecs: RouterSpecs): WowOpenApiCustomizer {
+            return WowOpenApiCustomizer(routerSpecs)
+        }
     }
 }

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/bi/BiDeploymentInspectorAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/bi/BiDeploymentInspectorAutoConfiguration.kt
@@ -66,7 +66,7 @@ class BiDeploymentInspectorAutoConfiguration {
             val inspectorProperties = biScriptProperties.inspector
             inspectorProperties.timeout.validateTimeout("inspector.timeout")
             val properties = inspectorProperties.clickhouse
-            properties.validate()
+            properties.validate(inspectorProperties.timeout)
             return ClickHouseBiDeploymentInspector(
                 clientOptions = properties.toClientOptions(),
                 inspectionTimeout = inspectorProperties.timeout,
@@ -75,7 +75,7 @@ class BiDeploymentInspectorAutoConfiguration {
     }
 }
 
-private fun BiClickHouseInspectorProperties.validate() {
+private fun BiClickHouseInspectorProperties.validate(inspectionTimeout: java.time.Duration) {
     require(endpoints.isNotEmpty()) {
         "inspector.clickhouse.endpoints must not be empty when inspector.type=CLICKHOUSE"
     }
@@ -90,9 +90,11 @@ private fun BiClickHouseInspectorProperties.validate() {
     connectionRequestTimeout.validateTimeout("inspector.clickhouse.connection-request-timeout")
     socketTimeout.validateTimeout(
         property = "inspector.clickhouse.socket-timeout",
-        allowZero = true,
         maxMillis = Int.MAX_VALUE.toLong(),
     )
+    require(socketTimeout <= inspectionTimeout) {
+        "inspector.clickhouse.socket-timeout must not exceed inspector.timeout"
+    }
     executionTimeout.validateTimeout(
         property = "inspector.clickhouse.execution-timeout",
         allowZero = true,

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/openapi/OpenAPIAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/openapi/OpenAPIAutoConfigurationTest.kt
@@ -8,6 +8,7 @@ import me.ahoo.wow.openapi.contract.BuiltInHttpRoutePaths
 import me.ahoo.wow.spring.boot.starter.enableWow
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.FilteredClassLoader
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 
@@ -25,6 +26,34 @@ class OpenAPIAutoConfigurationTest {
                 context.assert()
                     .hasSingleBean(RouterSpecs::class.java)
                     .hasSingleBean(WowOpenApiCustomizer::class.java)
+            }
+    }
+
+    @Test
+    fun `should keep route catalog when OpenAPI documentation is disabled`() {
+        contextRunner
+            .enableWow()
+            .withPropertyValues("wow.openapi.enabled=false")
+            .withUserConfiguration(OpenAPIAutoConfiguration::class.java)
+            .run { context: AssertableApplicationContext ->
+                context.assert()
+                    .hasNotFailed()
+                    .hasSingleBean(RouterSpecs::class.java)
+                    .doesNotHaveBean("wowOpenApiCustomizer")
+            }
+    }
+
+    @Test
+    fun `should keep route catalog without Springdoc`() {
+        contextRunner
+            .enableWow()
+            .withClassLoader(FilteredClassLoader("org.springdoc.core.customizers.OpenApiCustomizer"))
+            .withUserConfiguration(OpenAPIAutoConfiguration::class.java)
+            .run { context: AssertableApplicationContext ->
+                context.assert()
+                    .hasNotFailed()
+                    .hasSingleBean(RouterSpecs::class.java)
+                    .doesNotHaveBean("wowOpenApiCustomizer")
             }
     }
 

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
@@ -526,20 +526,49 @@ internal class WebFluxAutoConfigurationTest {
     @Test
     fun `should reject a BI response when every supported media type is unacceptable`() {
         webFluxContextRunner().run { context ->
-            context.biScriptClient().post()
-                .uri(BuiltInHttpRoutePaths.Global.BI_SCRIPT)
-                .contentType(MediaType.APPLICATION_JSON)
-                .header("Accept", "*/*;q=1, application/json;q=0, application/sql;q=0")
-                .bodyValue("{}")
-                .exchange()
-                .expectStatus().isEqualTo(HttpStatus.NOT_ACCEPTABLE)
-                .expectHeader().valueEquals("Wow-Error-Code", "NotAcceptable")
+            listOf(
+                "*/*;q=1, application/json;q=0, application/sql;q=0",
+                MediaType.TEXT_PLAIN_VALUE,
+            ).forEach { accept ->
+                context.biScriptClient().post()
+                    .uri(BuiltInHttpRoutePaths.Global.BI_SCRIPT)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .header("Accept", accept)
+                    .bodyValue("{}")
+                    .exchange()
+                    .expectStatus().isEqualTo(HttpStatus.NOT_ACCEPTABLE)
+                    .expectHeader().valueEquals("Wow-Error-Code", "NotAcceptable")
+            }
         }
     }
 
     @Test
+    fun `should build runtime routes when OpenAPI documentation is disabled`() {
+        webFluxContextRunner()
+            .withPropertyValues("wow.openapi.enabled=false")
+            .run { context ->
+                context.assert()
+                    .hasNotFailed()
+                    .hasBean("commandRouterFunction")
+                    .doesNotHaveBean("wowOpenApiCustomizer")
+            }
+    }
+
+    @Test
+    fun `should build runtime routes without Springdoc`() {
+        webFluxContextRunner()
+            .withClassLoader(FilteredClassLoader("org.springdoc.core.customizers.OpenApiCustomizer"))
+            .run { context ->
+                context.assert()
+                    .hasNotFailed()
+                    .hasBean("commandRouterFunction")
+                    .doesNotHaveBean("wowOpenApiCustomizer")
+            }
+    }
+
+    @Test
     fun `should return BI inspection failures without the global exception handler`() {
-        val unavailableInspector = BiDeploymentInspector {
+        val unavailableInspector = BiDeploymentInspector { _, _ ->
             Mono.error(BiDeploymentInspectionException.Unavailable())
         }
         webFluxContextRunner()
@@ -589,6 +618,12 @@ internal class WebFluxAutoConfigurationTest {
                     .getHttpFactory(BuiltInHttpRouteHandlerKeys.Global.BI_SCRIPT)
                     .assert()
                     .isNull()
+                context.biScriptClient().post()
+                    .uri(BuiltInHttpRoutePaths.Global.BI_SCRIPT)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue("{}")
+                    .exchange()
+                    .expectStatus().isNotFound
             }
     }
 
@@ -621,7 +656,7 @@ internal class WebFluxAutoConfigurationTest {
 
     @Test
     fun `should back off the default BI deployment inspector`() {
-        val customInspector = BiDeploymentInspector {
+        val customInspector = BiDeploymentInspector { _, _ ->
             Mono.just(BiDeploymentInspection.Available(me.ahoo.wow.bi.ObservedBiDeployment(emptyList())))
         }
         webFluxContextRunner()

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/bi/BiDeploymentInspectorAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/bi/BiDeploymentInspectorAutoConfigurationTest.kt
@@ -139,8 +139,12 @@ class BiDeploymentInspectorAutoConfigurationTest {
                 "inspector.clickhouse.connection-timeout is too large",
             "inspector.clickhouse.connection-request-timeout=0s" to
                 "inspector.clickhouse.connection-request-timeout must be greater than zero",
+            "inspector.clickhouse.socket-timeout=0s" to
+                "inspector.clickhouse.socket-timeout must be greater than zero",
             "inspector.clickhouse.socket-timeout=-1ms" to
-                "inspector.clickhouse.socket-timeout must not be negative",
+                "inspector.clickhouse.socket-timeout must be greater than zero",
+            "inspector.clickhouse.socket-timeout=31s" to
+                "inspector.clickhouse.socket-timeout must not exceed inspector.timeout",
             "inspector.clickhouse.socket-timeout=2147483648ms" to
                 "inspector.clickhouse.socket-timeout must not exceed ${Int.MAX_VALUE} milliseconds",
             "inspector.clickhouse.execution-timeout=2147483648ms" to
@@ -166,7 +170,7 @@ class BiDeploymentInspectorAutoConfigurationTest {
 
     @Test
     fun `should let a custom inspector override ClickHouse configuration`() {
-        val customInspector = BiDeploymentInspector {
+        val customInspector = BiDeploymentInspector { _, _ ->
             Mono.just(BiDeploymentInspection.Available(ObservedBiDeployment(emptyList())))
         }
         contextRunner

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/WebFluxErrorStrategy.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/WebFluxErrorStrategy.kt
@@ -14,6 +14,9 @@
 package me.ahoo.wow.webflux.exception
 
 import me.ahoo.wow.api.exception.ErrorInfo
+import me.ahoo.wow.api.exception.ErrorInfoCapable
+import me.ahoo.wow.exception.ErrorCodes
+import me.ahoo.wow.exception.ErrorInfoConverterRegistrar
 import me.ahoo.wow.exception.toErrorInfo
 import me.ahoo.wow.openapi.CommonComponent
 import me.ahoo.wow.serialization.toJsonString
@@ -25,6 +28,8 @@ import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
 import org.springframework.web.server.ServerWebExchange
 import reactor.core.publisher.Mono
+import java.io.FileNotFoundException
+import java.util.concurrent.TimeoutException
 
 interface WebFluxErrorStrategy {
     fun toServerResponse(request: ServerRequest, throwable: Throwable): Mono<ServerResponse>
@@ -60,6 +65,21 @@ private fun Throwable.httpStatus(errorInfo: ErrorInfo) =
 private fun Throwable.toWebFluxErrorInfo(): ErrorInfo {
     return when (this) {
         is BindingResult -> toBindingErrorInfo()
-        else -> toErrorInfo()
+        is ErrorInfoCapable,
+        is ErrorInfo,
+        is ErrorResponse,
+        is IllegalArgumentException,
+        is IllegalStateException,
+        is TimeoutException,
+        is FileNotFoundException,
+        -> toErrorInfo()
+
+        else -> if (ErrorInfoConverterRegistrar.get(javaClass) != null) {
+            toErrorInfo()
+        } else {
+            ErrorInfo.of(ErrorCodes.INTERNAL_SERVER_ERROR, UNEXPECTED_SERVER_ERROR_MESSAGE)
+        }
     }
 }
+
+private const val UNEXPECTED_SERVER_ERROR_MESSAGE = "Unexpected server error"

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/HttpRoutePredicateFactory.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/HttpRoutePredicateFactory.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.webflux.route
 
+import me.ahoo.wow.openapi.contract.BuiltInHttpRouteHandlerKeys
 import me.ahoo.wow.openapi.contract.HttpRouteContract
 import org.springframework.http.HttpMethod
 import org.springframework.http.MediaType
@@ -21,10 +22,19 @@ import org.springframework.web.reactive.function.server.RequestPredicates
 
 internal class HttpRoutePredicateFactory {
     fun create(contract: HttpRouteContract): RequestPredicate {
-        val acceptMediaTypes = MediaType.parseMediaTypes(contract.accept).toTypedArray()
+        val acceptMediaTypes = contract.runtimeAcceptMediaTypes()
         val httpMethod = HttpMethod.valueOf(contract.method)
         return RequestPredicates.path(contract.path)
             .and(RequestPredicates.method(httpMethod))
             .and(RequestPredicates.accept(*acceptMediaTypes))
     }
 }
+
+private fun HttpRouteContract.runtimeAcceptMediaTypes(): Array<MediaType> =
+    if (handlerKey in HANDLER_NEGOTIATED_ACCEPT_KEYS) {
+        arrayOf(MediaType.ALL)
+    } else {
+        MediaType.parseMediaTypes(accept).toTypedArray()
+    }
+
+private val HANDLER_NEGOTIATED_ACCEPT_KEYS = setOf(BuiltInHttpRouteHandlerKeys.Global.BI_SCRIPT)

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/global/GenerateBIScriptHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/global/GenerateBIScriptHandlerFunction.kt
@@ -74,14 +74,14 @@ class GenerateBIScriptHandlerFunction(
                     responseMediaType = request.preferredResponseMediaType(),
                 )
             }
-            .onErrorResume { exceptionHandler.handle(request, it) }
+            .onErrorResume { error -> exceptionHandler.handle(request, error) }
     }
 
     private fun generateResponse(
         requestOptions: BiScriptOptions,
         operation: BiScriptOperation,
         responseMediaType: MediaType,
-    ): Mono<ServerResponse> = deploymentInspector.inspect(requestOptions).flatMap { inspection ->
+    ): Mono<ServerResponse> = deploymentInspector.inspect(requestOptions, operation).flatMap { inspection ->
         Mono.fromCallable {
             BiScriptGenerator(requestOptions).generate(MetadataSearcher.localAggregates, operation, inspection)
         }.subscribeOn(Schedulers.boundedElastic())

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/WebFluxErrorStrategyTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/WebFluxErrorStrategyTest.kt
@@ -73,6 +73,28 @@ class WebFluxErrorStrategyTest {
     }
 
     @Test
+    fun `should map an unclassified throwable to a safe internal server response`() {
+        val failure = NullPointerException("sensitive implementation detail")
+
+        WebTestClient.bindToRouterFunction(
+            route(POST("/test")) { request ->
+                DefaultWebFluxErrorStrategy.toServerResponse(request, failure)
+            }
+        ).build()
+            .post()
+            .uri("/test")
+            .exchange()
+            .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+            .expectHeader().valueEquals(ERROR_CODE, ErrorCodes.INTERNAL_SERVER_ERROR)
+            .expectBody(String::class.java)
+            .consumeWith { result ->
+                result.responseBody!!.assert()
+                    .contains(ErrorCodes.INTERNAL_SERVER_ERROR, "Unexpected server error")
+                    .doesNotContain("sensitive implementation detail")
+            }
+    }
+
+    @Test
     fun `should map BI inspection failures to upstream HTTP statuses`() {
         val request = MockServerRequest.builder()
             .method(HttpMethod.POST)
@@ -108,6 +130,24 @@ class WebFluxErrorStrategyTest {
         exchange.response.statusCode.assert().isEqualTo(HttpStatus.BAD_REQUEST)
         exchange.response.headers.contentType.assert().isEqualTo(MediaType.APPLICATION_JSON)
         exchange.response.headers.getFirst(ERROR_CODE).assert().isEqualTo(ErrorCodes.ILLEGAL_ARGUMENT)
+    }
+
+    @Test
+    fun `should write an unclassified throwable as a safe internal server error`() {
+        val exchange = MockServerWebExchange.from(
+            MockServerHttpRequest.get("/test").build()
+        )
+
+        DefaultWebFluxErrorStrategy.writeToExchange(
+            exchange,
+            NullPointerException("sensitive implementation detail"),
+        ).test().verifyComplete()
+
+        exchange.response.statusCode.assert().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        exchange.response.headers.getFirst(ERROR_CODE).assert().isEqualTo(ErrorCodes.INTERNAL_SERVER_ERROR)
+        exchange.response.bodyAsString.block()!!.assert()
+            .contains(ErrorCodes.INTERNAL_SERVER_ERROR, "Unexpected server error")
+            .doesNotContain("sensitive implementation detail")
     }
 
     @Test

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/WebFluxErrorStrategyTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/WebFluxErrorStrategyTest.kt
@@ -49,6 +49,7 @@ import org.springframework.web.server.ServerWebExchange
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.kotlin.test.test
+import java.io.FileNotFoundException
 import java.net.URI
 import java.nio.charset.StandardCharsets
 
@@ -122,6 +123,28 @@ class WebFluxErrorStrategyTest {
             previous?.let { converter ->
                 ErrorInfoConverterRegistrar.register(RegisteredWebFluxFailure::class.java, converter)
             }
+        }
+    }
+
+    @Test
+    fun `should preserve explicit safe exception mappings`() {
+        val request = MockServerRequest.builder()
+            .method(HttpMethod.POST)
+            .uri(URI.create("/test"))
+            .build()
+        val cases = listOf(
+            Triple(IllegalStateException("bad state"), ErrorCodes.ILLEGAL_STATE, HttpStatus.BAD_REQUEST),
+            Triple(FileNotFoundException("missing"), ErrorCodes.NOT_FOUND, HttpStatus.NOT_FOUND),
+        )
+
+        cases.forEach { (failure, expectedCode, expectedStatus) ->
+            DefaultWebFluxErrorStrategy.toServerResponse(request, failure)
+                .test()
+                .consumeNextWith { response ->
+                    response.statusCode().assert().isEqualTo(expectedStatus)
+                    response.headers().getFirst(ERROR_CODE).assert().isEqualTo(expectedCode)
+                }
+                .verifyComplete()
         }
     }
 

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/WebFluxErrorStrategyTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/WebFluxErrorStrategyTest.kt
@@ -19,8 +19,11 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.exception.ErrorInfo
 import me.ahoo.wow.bi.BiDeploymentInspectionException
 import me.ahoo.wow.exception.ErrorCodes
+import me.ahoo.wow.exception.ErrorInfoConverter
+import me.ahoo.wow.exception.ErrorInfoConverterRegistrar
 import me.ahoo.wow.openapi.CommonComponent.Header.ERROR_CODE
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -92,6 +95,34 @@ class WebFluxErrorStrategyTest {
                     .contains(ErrorCodes.INTERNAL_SERVER_ERROR, "Unexpected server error")
                     .doesNotContain("sensitive implementation detail")
             }
+    }
+
+    @Test
+    fun `should honor a registered converter for an otherwise unclassified throwable`() {
+        val errorCode = "CUSTOM_WEBFLUX_FAILURE"
+        val previous = ErrorInfoConverterRegistrar.register(
+            RegisteredWebFluxFailure::class.java,
+            ErrorInfoConverter<Throwable> { ErrorInfo.of(errorCode, "mapped failure") },
+        )
+        val request = MockServerRequest.builder()
+            .method(HttpMethod.POST)
+            .uri(URI.create("/test"))
+            .build()
+
+        try {
+            DefaultWebFluxErrorStrategy.toServerResponse(request, RegisteredWebFluxFailure())
+                .test()
+                .consumeNextWith { response ->
+                    response.statusCode().assert().isEqualTo(HttpStatus.BAD_REQUEST)
+                    response.headers().getFirst(ERROR_CODE).assert().isEqualTo(errorCode)
+                }
+                .verifyComplete()
+        } finally {
+            ErrorInfoConverterRegistrar.unregister(RegisteredWebFluxFailure::class.java)
+            previous?.let { converter ->
+                ErrorInfoConverterRegistrar.register(RegisteredWebFluxFailure::class.java, converter)
+            }
+        }
     }
 
     @Test
@@ -284,3 +315,5 @@ class WebFluxErrorStrategyTest {
         return builder.toString()
     }
 }
+
+private class RegisteredWebFluxFailure : RuntimeException()

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/HttpRoutePredicateFactoryTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/HttpRoutePredicateFactoryTest.kt
@@ -14,6 +14,8 @@
 package me.ahoo.wow.webflux.route
 
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.openapi.contract.BuiltInHttpRouteHandlerKeys
+import me.ahoo.wow.openapi.contract.HttpResponse
 import me.ahoo.wow.openapi.contract.HttpRouteContract
 import me.ahoo.wow.openapi.contract.HttpRouteHandlerMetadata
 import org.junit.jupiter.api.Test
@@ -66,17 +68,56 @@ class HttpRoutePredicateFactoryTest {
         predicate.test(request).assert().isFalse()
     }
 
+    @Test
+    fun `should let BI handler negotiate unsupported accept`() {
+        val contract = routeContract(
+            method = "GET",
+            path = "/test/{id}",
+            accept = MediaType.APPLICATION_JSON_VALUE,
+            handlerKey = BuiltInHttpRouteHandlerKeys.Global.BI_SCRIPT,
+        )
+        val predicate = factory.create(contract)
+        val request = serverRequest(
+            MockServerHttpRequest
+                .get("/test/aggregate-id")
+                .accept(MediaType.TEXT_PLAIN)
+        )
+
+        predicate.test(request).assert().isTrue()
+    }
+
+    @Test
+    fun `should not infer handler-managed negotiation from a declared not acceptable response`() {
+        val contract = routeContract(
+            method = "GET",
+            path = "/test/{id}",
+            accept = MediaType.APPLICATION_JSON_VALUE,
+            responses = listOf(HttpResponse(statusCode = "406")),
+        )
+        val predicate = factory.create(contract)
+        val request = serverRequest(
+            MockServerHttpRequest
+                .get("/test/aggregate-id")
+                .accept(MediaType.TEXT_PLAIN)
+        )
+
+        predicate.test(request).assert().isFalse()
+    }
+
     private fun routeContract(
         method: String,
         path: String,
-        accept: String
+        accept: String,
+        handlerKey: String = "handler.key",
+        responses: List<HttpResponse> = emptyList(),
     ): HttpRouteContract {
         return HttpRouteContract(
             routeId = "test.route",
             method = method,
             path = path,
             accept = listOf(accept),
-            handlerKey = "handler.key",
+            responses = responses,
+            handlerKey = handlerKey,
             handlerMetadata = HttpRouteHandlerMetadata.None
         )
     }

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/bi/BiScriptRequestMapperTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/bi/BiScriptRequestMapperTest.kt
@@ -100,7 +100,7 @@ class BiScriptRequestMapperTest {
 
     @Test
     fun `should reject catalog scope overrides for a fixed deployment inspector`() {
-        val inspector = BiDeploymentInspector { Mono.just(BiDeploymentInspection.Unavailable) }
+        val inspector = BiDeploymentInspector { _, _ -> Mono.just(BiDeploymentInspection.Unavailable) }
         val requests = listOf(
             BiScriptRequest(database = BASE_OPTIONS.database),
             BiScriptRequest(consumerDatabase = BASE_OPTIONS.consumerDatabase),

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/bi/GenerateBIScriptHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/bi/GenerateBIScriptHandlerFunctionTest.kt
@@ -22,24 +22,32 @@ import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.annotation.AggregateRoot
+import me.ahoo.wow.bi.BiDeploymentDescriptor
 import me.ahoo.wow.bi.BiDeploymentInspection
 import me.ahoo.wow.bi.BiDeploymentInspectionException
 import me.ahoo.wow.bi.BiDeploymentInspector
+import me.ahoo.wow.bi.BiObjectKind
+import me.ahoo.wow.bi.BiObjectMetadata
 import me.ahoo.wow.bi.BiScriptDiagnostic
 import me.ahoo.wow.bi.BiScriptGenerator
+import me.ahoo.wow.bi.BiScriptOperation
 import me.ahoo.wow.bi.BiScriptOptions
 import me.ahoo.wow.bi.ClickHouseTopology
 import me.ahoo.wow.bi.NoOpBiDeploymentInspector
 import me.ahoo.wow.bi.ObservedBiDeployment
+import me.ahoo.wow.bi.ObservedBiObject
 import me.ahoo.wow.configuration.MetadataSearcher
 import me.ahoo.wow.configuration.NamedAggregateTypeSearcher
 import me.ahoo.wow.configuration.TypeNamedAggregateSearcher
+import me.ahoo.wow.exception.ErrorCodes
 import me.ahoo.wow.modeling.MaterializedNamedAggregate
 import me.ahoo.wow.openapi.contract.BuiltInHttpRouteHandlerKeys
 import me.ahoo.wow.openapi.contract.bi.BiScriptOperationMode
 import me.ahoo.wow.openapi.contract.bi.BiScriptRequest
 import me.ahoo.wow.openapi.contract.bi.BiScriptTopologyMode
 import me.ahoo.wow.openapi.contract.bi.BiScriptTopologyRequest
+import me.ahoo.wow.webflux.exception.RequestExceptionHandler
+import me.ahoo.wow.webflux.exception.WebFluxErrorStrategy
 import me.ahoo.wow.webflux.exception.WebFluxRequestExceptionHandler
 import me.ahoo.wow.webflux.route.global.GenerateBIScriptHandlerFunction
 import me.ahoo.wow.webflux.route.global.GenerateBIScriptHandlerFunctionFactory
@@ -52,7 +60,9 @@ import org.springframework.mock.http.server.reactive.MockServerHttpRequest
 import org.springframework.mock.web.reactive.function.server.MockServerRequest
 import org.springframework.mock.web.server.MockServerWebExchange
 import org.springframework.web.reactive.function.server.HandlerStrategies
+import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.server.ServerWebExchange
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
 import reactor.kotlin.test.test
@@ -211,7 +221,7 @@ class GenerateBIScriptHandlerFunctionTest {
         )
 
         failures.forEach { (failure, expectedStatus, expectedCode) ->
-            val deploymentInspector = BiDeploymentInspector {
+            val deploymentInspector = BiDeploymentInspector { _, _ ->
                 Mono.error<BiDeploymentInspection>(failure)
             }
             val response = handler(deploymentInspector = deploymentInspector)
@@ -225,10 +235,98 @@ class GenerateBIScriptHandlerFunctionTest {
     }
 
     @Test
+    fun `should map an unexpected generation failure to a safe internal server error`() {
+        val deploymentInspector = BiDeploymentInspector { _, _ ->
+            Mono.error<BiDeploymentInspection>(NullPointerException("sensitive implementation detail"))
+        }
+
+        val response = handler(deploymentInspector = deploymentInspector)
+            .handle(MockServerRequest.builder().body(BiScriptRequest().toMono()))
+            .block()!!
+
+        response.statusCode().assert().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        response.headers().getFirst("Wow-Error-Code").assert().isEqualTo(ErrorCodes.INTERNAL_SERVER_ERROR)
+        response.writeBody().assert()
+            .contains(ErrorCodes.INTERNAL_SERVER_ERROR, "Unexpected server error")
+            .doesNotContain("sensitive implementation detail")
+    }
+
+    @Test
+    fun `should preserve an unexpected failure for a custom request exception handler`() {
+        val failure = NullPointerException("custom-handler-detail")
+        val deploymentInspector = BiDeploymentInspector { _, _ ->
+            Mono.error<BiDeploymentInspection>(failure)
+        }
+        lateinit var received: Throwable
+        val customExceptionHandler = object : RequestExceptionHandler {
+            override fun handle(
+                request: ServerRequest,
+                throwable: Throwable,
+            ): Mono<ServerResponse> {
+                received = throwable
+                return ServerResponse.status(HttpStatus.CONFLICT).build()
+            }
+        }
+
+        val response = handler(
+            deploymentInspector = deploymentInspector,
+            exceptionHandler = customExceptionHandler,
+        ).handle(MockServerRequest.builder().body(BiScriptRequest().toMono())).block()!!
+
+        response.statusCode().assert().isEqualTo(HttpStatus.CONFLICT)
+        received.assert().isSameAs(failure)
+    }
+
+    @Test
+    fun `should preserve an unexpected failure for a custom webflux error strategy`() {
+        val failure = NullPointerException("custom-strategy-detail")
+        val deploymentInspector = BiDeploymentInspector { _, _ ->
+            Mono.error<BiDeploymentInspection>(failure)
+        }
+        lateinit var received: Throwable
+        val customErrorStrategy = object : WebFluxErrorStrategy {
+            override fun toServerResponse(request: ServerRequest, throwable: Throwable): Mono<ServerResponse> {
+                received = throwable
+                return ServerResponse.status(HttpStatus.CONFLICT).build()
+            }
+
+            override fun writeToExchange(exchange: ServerWebExchange, throwable: Throwable): Mono<Void> = Mono.empty()
+        }
+
+        val response = handler(
+            deploymentInspector = deploymentInspector,
+            exceptionHandler = WebFluxRequestExceptionHandler(customErrorStrategy),
+        ).handle(MockServerRequest.builder().body(BiScriptRequest().toMono())).block()!!
+
+        response.statusCode().assert().isEqualTo(HttpStatus.CONFLICT)
+        received.assert().isSameAs(failure)
+    }
+
+    @Test
     fun `should expose explicit destructive reset over HTTP`() {
+        val descriptor = BiDeploymentDescriptor.from(BASE_OPTIONS)
         val handler = handler(
-            deploymentInspector = BiDeploymentInspector {
-                Mono.just(BiDeploymentInspection.Available(ObservedBiDeployment(emptyList())))
+            deploymentInspector = BiDeploymentInspector { _, _ ->
+                Mono.just(
+                    BiDeploymentInspection.Available(
+                        ObservedBiDeployment(
+                            listOf(
+                                ObservedBiObject(
+                                    database = BASE_OPTIONS.database,
+                                    name = "example_cart_state_last_store",
+                                    engine = "Distributed",
+                                    metadata = BiObjectMetadata(
+                                        deploymentId = descriptor.deploymentId,
+                                        configurationFingerprint = descriptor.configurationFingerprint,
+                                        topologyFingerprint = descriptor.topologyFingerprint,
+                                        aggregate = "example.cart",
+                                        kind = BiObjectKind.STORE,
+                                    ),
+                                )
+                            )
+                        )
+                    )
+                )
             }
         )
         val request = MockServerRequest.builder()
@@ -243,6 +341,60 @@ class GenerateBIScriptHandlerFunctionTest {
         val body = handler.handle(request).block()!!.writeBody()
         body.assert()
             .contains("\"destructive\":true", "DROP TABLE IF EXISTS", "_state_last_store")
+    }
+
+    @Test
+    fun `should inspect changed configuration with reset semantics over HTTP`() {
+        val descriptor = BiDeploymentDescriptor.from(BASE_OPTIONS)
+        lateinit var inspectedOptions: BiScriptOptions
+        lateinit var inspectedOperation: BiScriptOperation
+        val deploymentInspector = object : BiDeploymentInspector {
+            override fun inspect(options: BiScriptOptions): Mono<BiDeploymentInspection> =
+                error("The handler must provide the requested operation")
+
+            override fun inspect(
+                options: BiScriptOptions,
+                operation: BiScriptOperation,
+            ): Mono<BiDeploymentInspection> {
+                inspectedOptions = options
+                inspectedOperation = operation
+                return Mono.just(
+                    BiDeploymentInspection.Available(
+                        ObservedBiDeployment(
+                            listOf(
+                                ObservedBiObject(
+                                    database = BASE_OPTIONS.consumerDatabase,
+                                    name = "__wow_bi_deployment",
+                                    engine = "View",
+                                    metadata = BiObjectMetadata(
+                                        deploymentId = descriptor.deploymentId,
+                                        configurationFingerprint = descriptor.configurationFingerprint,
+                                        topologyFingerprint = descriptor.topologyFingerprint,
+                                        kind = BiObjectKind.ANCHOR,
+                                        consumerIdentity = descriptor.configurationFingerprint,
+                                    ),
+                                )
+                            )
+                        )
+                    )
+                )
+            }
+        }
+        val request = MockServerRequest.builder()
+            .body(
+                BiScriptRequest(
+                    operation = BiScriptOperationMode.RESET,
+                    replayFromEarliestConfirmed = true,
+                    kafkaBootstrapServers = "changed-kafka:9092",
+                ).toMono()
+            )
+
+        val response = handler(deploymentInspector = deploymentInspector).handle(request).block()!!
+
+        response.statusCode().assert().isEqualTo(HttpStatus.OK)
+        response.writeBody().assert().contains("changed-kafka:9092")
+        inspectedOptions.kafkaBootstrapServers.assert().isEqualTo("changed-kafka:9092")
+        inspectedOperation.assert().isEqualTo(BiScriptOperation.Reset(true))
     }
 
     @Test
@@ -319,10 +471,11 @@ class GenerateBIScriptHandlerFunctionTest {
     private fun handler(
         options: BiScriptOptions = BASE_OPTIONS,
         deploymentInspector: BiDeploymentInspector = NoOpBiDeploymentInspector,
+        exceptionHandler: RequestExceptionHandler = WebFluxRequestExceptionHandler(),
     ): GenerateBIScriptHandlerFunction = GenerateBIScriptHandlerFunction(
         options = options,
         deploymentInspector = deploymentInspector,
-        exceptionHandler = WebFluxRequestExceptionHandler(),
+        exceptionHandler = exceptionHandler,
     )
 
     private fun ServerResponse.writeBody(): String {


### PR DESCRIPTION
## Goal

Make Wow BI deployment generation fail closed against stale or incompatible ClickHouse state, provide a crash-safe reset protocol, and enable the BI script endpoint by default.

Completion requires the runtime contract, WebFlux route, OpenAPI schema, Spring Boot configuration, generated SQL snapshots, integration coverage, and bilingual documentation to remain aligned.

## Changes

- Introduce deployment protocol v2 with mandatory topology fingerprints and operation-aware inspection.
- Make `RESET` crash-safe by writing a `RESETTING` anchor before destructive DDL, rebuilding the durable object graph, switching the anchor to `STABLE`, and enabling Kafka ingress last.
- Validate owned ClickHouse objects against their exact physical engines in standalone and cluster topologies.
- Harden the native ClickHouse inspector with bounded socket/inspection timeouts, isolated cancellation tokens, pre-cancel guards, and exactly-once response cleanup.
- Enable `wow.bi.script.enabled` by default across Spring configuration, WebFlux routing, and OpenAPI registration. Setting it to `false` removes both the route and its OpenAPI operation.
- Document that aggregate IDs are unique within a named aggregate across tenants; tenant ID is routing and isolation context, not a separate aggregate-ID namespace.
- Update unit tests, Testcontainers integration tests, generated SQL/OpenAPI snapshots, examples, and English/Chinese documentation.

## Verification

- `./gradlew :wow-bi:check --no-parallel --console=plain` — passed.
- `./gradlew :wow-bi:integrationTest --no-parallel --console=plain` — passed.
- `./gradlew :wow-openapi:check :wow-webflux:check :wow-spring-boot-starter:check :example-server:check --no-parallel --console=plain` — passed.
- `pnpm docs:build` in `documentation/` — passed; only the existing bundle-size warning was emitted.
- `git diff --check` — passed.
- Independent final diff review found no remaining P0, P1, or P2 findings.

## Risks and Notes

This is an intentional breaking change:

- Protocol v1 anchors are rejected instead of being adopted.
- Custom `BiDeploymentInspector` implementations must implement the operation-aware two-argument contract.
- ClickHouse `socketTimeout` must be positive and must not exceed the total inspection timeout.
- Existing legacy BI objects must be manually removed and recreated under protocol v2. Topology changes are not performed through `RESET`.
- The BI script endpoint is now registered by default but does not add authentication. Applications must protect it through their security policy or set `wow.bi.script.enabled=false`.

Before v2 metadata is adopted, rollback is a normal code revert. After v2 anchors or objects have been created, rollback may require manual BI object cleanup before redeploying the earlier implementation.