### PR TITLE
refactor(bi)!: enforce current-layout ownership and recovery

### DIFF
--- a/documentation/docs/.vitepress/configs/sidebar.en.ts
+++ b/documentation/docs/.vitepress/configs/sidebar.en.ts
@@ -73,6 +73,7 @@ export const sidebarEn: DefaultTheme.Sidebar = {
                 {text: 'Test Suite', link: 'test-suite'},
                 {text: 'Test Runtime', link: 'test-runtime'},
                 {text: 'Business Intelligence', link: 'bi'},
+                {text: 'BI Deployment and Recovery', link: 'bi-operations'},
                 {text: 'Event Compensation', link: 'event-compensation'},
             ],
         },

--- a/documentation/docs/.vitepress/configs/sidebar.zh.ts
+++ b/documentation/docs/.vitepress/configs/sidebar.zh.ts
@@ -73,6 +73,7 @@ export const sidebarZh: DefaultTheme.Sidebar = {
                 {text: '测试套件', link: 'test-suite'},
                 {text: '测试运行体系', link: 'test-runtime'},
                 {text: '商业智能', link: 'bi'},
+                {text: 'BI 部署与恢复', link: 'bi-operations'},
                 {text: '事件补偿', link: 'event-compensation'},
             ],
         },

--- a/documentation/docs/en/guide/bi-operations.md
+++ b/documentation/docs/en/guide/bi-operations.md
@@ -1,0 +1,118 @@
+---
+title: BI Deployment and Recovery
+description: Release, Reset, interruption recovery, rollback, and acceptance procedures for the current Wow BI layout.
+---
+
+# BI Deployment and Recovery
+
+This runbook applies only to the current BI layout. The BI module does not read earlier layouts, perform in-place
+migration, or promise compatibility with earlier clients, registries, or SQL files.
+
+## Operational Boundary
+
+- `DEPLOY` performs non-destructive reconciliation. It installs a clean scope, resumes interrupted create/drop
+  work, updates computed views, and restores missing Kafka ingress.
+- `RESET` performs a destructive rebuild. It requires both `replayFromEarliestConfirmed=true` and a configured
+  `consumerGroupNamespace`.
+- The SQL executor must preserve response order and stop on the first error.
+- One writer must own the complete physical BI object namespace. The same external lock must cover generation,
+  inspection, and execution.
+- `wow.bi.script.enabled` is enabled by default on the assumption that `/wow/bi/script` is exposed only through a
+  security gateway.
+
+Production must use `wow.bi.script.inspector.type=CLICKHOUSE`. The default NoOp inspector is suitable only for an
+initial deployment or offline preview; it cannot safely Reset or clean stale objects.
+
+## Operation Decision
+
+```mermaid
+flowchart TD
+    A[Regenerate with the CLICKHOUSE inspector] --> B{Inspection result}
+    B -->|Current layout and no durable contract drift| C[DEPLOY]
+    B -->|Computed-view definition drift only| C
+    B -->|PENDING_CREATE / PENDING_UPDATE / PENDING_DROP| C
+    B -->|Missing ACTIVE/RETIRED or surviving TOMBSTONE| D[Confirmed RESET]
+    B -->|Store or Queue contract drift| D
+    B -->|Registry shape mismatch or earlier layout| E[Stop consumers and archive the old scope]
+    E --> F[Drop the incompatible registry or complete old scope]
+    F --> D
+    B -->|Anchor is RESETTING| G[Continue RESET with identical configuration]
+```
+
+| Observed state | Operation | Meaning |
+|---|---|---|
+| First deployment with no old BI objects in the target scope | `DEPLOY` | Creates the current layout, registry, and `STABLE` anchor |
+| Stable current layout with matching contracts | `DEPLOY` | Produces idempotent reconciliation SQL |
+| View or consumer materialized-view definition changed | `DEPLOY` | Registry passes through `PENDING_UPDATE` and returns to `ACTIVE` |
+| `PENDING_CREATE`, `PENDING_UPDATE`, or `PENDING_DROP` | `DEPLOY` | Regenerate with identical configuration; do not replay old SQL |
+| A registry-referenced `ACTIVE/RETIRED` object is missing, or a `TOMBSTONE` object survives | Confirmed `RESET` | Deploy fails closed; Reset uses the registry ownership scope to clean and rebuild |
+| Store, Kafka Queue, or topology contract drift | Confirmed `RESET` | No in-place mutation is attempted |
+| Registry Engine, replication path, sorting key, Comment, or column schema differs | Manual archive/drop, then `RESET` | The inspector does not trust an incompatible registry or infer ownership from it |
+| Anchor is `RESETTING` | Continue `RESET` with the original configuration | Reuses the recorded consumer identity; Deploy is rejected |
+| Anchor is `STABLE` but Kafka ingress is incomplete | `DEPLOY` | Restores Queue and consumer materialized views |
+
+## Preflight
+
+1. Pin the application, `wow-bi`, and OpenAPI client versions; do not let old and new nodes operate the BI scope
+   concurrently.
+2. Verify that the gateway protects `/wow/bi/script`, or explicitly set `wow.bi.script.enabled=false`.
+3. Configure the ClickHouse inspector, a unique `consumerGroupNamespace`, and the correct ClickHouse topology.
+4. Verify that `database`, `consumerDatabase`, topology mode, cluster name, installation, and topic configuration
+   have not changed unexpectedly.
+5. Stop old BI consumers and acquire an external lock covering the full physical object namespace.
+6. Back up or archive the old BI databases, Kafka offset evidence, and current application version.
+7. Confirm `auto.offset.reset=earliest` for a new consumer generation and Keeper availability when Keeper offsets
+   are enabled.
+8. Generate and review the script and diagnostics before execution. Do not execute a script with unexplained
+   diagnostics.
+
+## Execute Deploy
+
+1. Regenerate `DEPLOY` inside the same locked change window.
+2. Retain the request configuration, diagnostics, and SQL summary as audit evidence.
+3. Execute statements in strict order and stop immediately at the first failure.
+4. After failure, inspect again and generate a new script. Do not guess a resume point or replay the original SQL.
+5. After success, verify a `STABLE` anchor, expected latest registry states, and complete Kafka ingress.
+
+A computed-object update records `PENDING_UPDATE`, repairs the View or consumer materialized view, and then confirms
+`ACTIVE`. Store and Queue identities do not change merely because a computed view changed.
+
+## Execute Reset
+
+Reset deletes and rebuilds data and ingestion inside the owned scope. Use it only when the business accepts a full
+Kafka replay:
+
+1. Stop every old consumer and retain the external lock.
+2. Verify backups, Kafka retention, and `auto.offset.reset=earliest`.
+3. Regenerate with `operation=RESET` and `replayFromEarliestConfirmed=true`.
+4. Confirm `destructive=true` before executing statements in order.
+5. If execution stops:
+   - when the anchor is `RESETTING`, regenerate `RESET` with the identical physical-scope configuration;
+   - when the anchor is already `STABLE`, generate `DEPLOY` to finish ingress;
+   - never replay the original Reset SQL.
+6. After Reset, run one authoritative `DEPLOY` to establish and confirm the exact current registry.
+
+## Acceptance
+
+- The anchor is `STABLE`, and its registry revision is not ahead of registry HEAD.
+- The registry Engine, replication path, sorting key, Comment, and complete column schema pass inspector validation.
+- Required objects exist, no `TOMBSTONE` object survives, and no unexplained pending registry state remains.
+- View queries and materialized-view `TO` targets match the current renderer definitions.
+- Kafka Queue and consumer materialized views consume successfully; sample the earliest and latest offsets and
+  business data.
+- In cluster mode, every replica agrees on objects, Comments, Engines, and column schemas.
+
+## Rollback
+
+BI has no in-place backward-compatible rollback. An earlier application may not understand current registry states
+and must not be introduced while the scope is in `PENDING_UPDATE` or `RESETTING`:
+
+1. Prefer completing `DEPLOY` or interruption recovery with the current version.
+2. If the version must be reverted, restore the earlier application, BI database, and matching offset/configuration
+   snapshot together.
+3. Do not point an old inspector at the current registry or overwrite the current layout with old SQL.
+4. Emergency isolation may set `wow.bi.script.enabled=false`, but that only removes the HTTP route, OpenAPI
+   operation, and inspector; it does not roll back ClickHouse data.
+
+See the [Migration Guide](./migration) for the cross-module upgrade order and
+[BI Script Configuration](./configuration#bi-script-configuration) for properties.

--- a/documentation/docs/en/guide/bi.md
+++ b/documentation/docs/en/guide/bi.md
@@ -40,7 +40,7 @@ val sql: String = result.script
 val diagnostics: List<BiScriptDiagnostic> = result.diagnostics
 ```
 
-The public contract also includes `BiScriptOperation`, `BiDeploymentInspector`, `BiDeploymentInspection`, `ObservedBiDeployment`, and `KafkaOffsetStorage`. Callers no longer persist or submit a manifest. `Deploy` reconciles against ownership markers in the ClickHouse catalog. `Reset` is the only operation that drops data stores and requires explicit confirmation that the new Kafka group replays from earliest.
+The public contract also includes `BiScriptOperation`, `BiDeploymentInspector`, `BiDeploymentInspection`, `ObservedBiDeployment`, and `KafkaOffsetStorage`. Callers no longer persist or submit a manifest. `Deploy` reconciles against ownership markers in the ClickHouse catalog. `Reset` is the only destructive operation and rebuilds the current layout.
 
 `BiScriptResult` contains:
 
@@ -64,7 +64,16 @@ The default `unsupportedTypeStrategy` is `RAW_JSON`. With `FAIL`, an unsupported
 
 ### HTTP Route
 
-The Spring WebFlux route and its Swagger/OpenAPI operation are enabled by default. This does not add authentication, so the application security policy must protect the management endpoint; set `wow.bi.script.enabled=false` to remove both. Configure a deployment-unique `wow.bi.script.consumer-group-namespace` whenever `DEPLOY` generates Kafka consumers and for every `RESET`, including an empty aggregate scope. Missing configuration returns `400` instead of preventing application startup. An empty `DEPLOY` without a namespace remains unanchored; supplying one gives the empty scope a durable deployment identity that later aggregate additions can reuse. While disabled, the Starter does not construct or validate BI generation options or an inspector. The route uses the same `BiScriptOptions`:
+The Spring WebFlux route and its Swagger/OpenAPI operation are enabled by default and are both omitted when
+`wow.bi.script.enabled=false`. The default assumes that the service is exposed only through a security gateway:
+the Starter does not add authentication, and the route shares the main application port and WebFlux filter chain,
+so the gateway must restrict `/wow/bi/script`. Disable the route explicitly in any environment that does not meet
+this deployment precondition. Configure a deployment-unique `wow.bi.script.consumer-group-namespace` whenever `DEPLOY`
+generates Kafka consumers and for every `RESET`, including an empty aggregate scope. Missing configuration returns
+`400` instead of preventing application startup. An empty `DEPLOY` without a namespace remains unanchored; supplying
+one gives the empty scope a durable deployment identity that later aggregate additions can reuse. While disabled,
+the Starter does not construct or validate BI generation options or an inspector. The route uses the same
+`BiScriptOptions`:
 
 ```yaml
 wow:
@@ -113,18 +122,31 @@ When `topology` is present, `topology.mode` is mandatory. In `CLUSTER` mode, omi
 
 By default the Starter injects `NoOpBiDeploymentInspector`. It returns explicit `Unavailable`: ordinary `DEPLOY` remains available for an initial deployment or offline preview but emits `INSPECTION_UNAVAILABLE`, cannot clean up stale objects, and cannot recover a consumer identity created by `RESET`; configuration changes can therefore select a different consumer group. `RESET` is rejected. For full reconciliation, configure `wow.bi.script.inspector.type=CLICKHOUSE` together with `inspector.clickhouse.endpoints` to enable the official ClickHouse Java `client-v2` implementation. Errors from a real inspector propagate and are never degraded to NoOp; selecting `CLICKHOUSE` without the client-v2 classes fails startup. A custom `BiDeploymentInspector` bean still has the highest priority.
 
+The production request path passes one immutable preparation through ClickHouse inspection and final rendering. For a stable deployment, the inspector compares every desired View and consumer materialized view against the renderer-owned query manifest. It canonicalizes both SELECT bodies with ClickHouse `formatQuerySingleLineOrNull`, reads the observed body from `system.tables.as_select`, and validates a materialized view's exact `TO` target separately. A mismatch emits `COMPUTED_OBJECT_DRIFT` and keeps the inspection available so the generated `DEPLOY` can repair it: the ownership registry first persists the new definition fingerprint as `PENDING_UPDATE`; ordinary Views use `CREATE OR REPLACE`, consumer materialized views are paused and recreated; after verification the registry returns to `ACTIVE`, while stores and Kafka queue identities are retained. Durable store or queue contract drift remains fail-closed and requires `RESET`.
+
 To intentionally rebuild all BI data, send `operation=RESET` with `replayFromEarliestConfirmed=true`. Reset also requires a configured `consumerGroupNamespace` so its recovery state has a durable canonical anchor. Only an available inspector can enumerate all owned catalog objects. Every generated object and a zero-row deployment anchor store protocol/layout version, deployment phase, fingerprint, aggregate owner, object kind, and identity in `system.tables.comment`. Service restarts recover from that catalog state without Wow service memory or an external manifest.
 
-Metadata protocol v2 makes Reset recoverable across process or SQL-client interruption. Generated statements must be executed in order and the executor must stop on the first error:
+Before reading HEAD/OBJECT state, the inspector validates the ownership registry's engine, replication path, sorting key, comment, and complete column schema. An ordinary `DEPLOY` still rejects missing registry-referenced `ACTIVE/RETIRED` objects or surviving `TOMBSTONE` objects. A confirmed `RESET` treats those conditions as recoverable physical drift, retains the registry's exact ownership scope, and generates complete cleanup and rebuild SQL.
+
+The current metadata protocol makes Reset recoverable across process or SQL-client interruption. Generated statements must be executed in order and the executor must stop on the first error:
 
 1. Write the canonical anchor as `RESETTING` with a new consumer identity.
-2. Keep that anchor while dropping all other owned objects and rebuilding the durable table/view graph.
+2. Keep that anchor, drop the old ownership registry, then drop other owned objects and rebuild the durable
+   table/view graph.
 3. Replace the anchor as `STABLE`.
 4. Create Kafka queue tables and Kafka consumer materialized views last.
 
-If execution stops, never replay the original SQL file blindly: inspect the catalog and regenerate from its current phase. While the anchor is `RESETTING`, generate `RESET` with the same configuration; the generator reuses the recorded identity, while `DEPLOY` is rejected. If the anchor is already `STABLE` but Kafka ingress is incomplete, generate `DEPLOY` to finish it. Replaying a completed Reset could delete rebuilt data while reusing already-committed Kafka offsets; generating another Reset after `STABLE` deliberately begins a new reset epoch and identity instead. Protocol v2 intentionally rejects v1 ownership markers; adopting v2 requires stopping the old consumers and explicitly cleaning or rebuilding the old scope. External coordination must guarantee one writer for the entire physical BI object namespace, not merely one writer per `deploymentId`; deployments that share databases and normalized object names can otherwise race after inspection. ClickHouse `ON CLUSTER` DDL is not a cross-replica transaction, so replica divergence remains a fail-closed operational recovery case.
+Dropping the old registry after the `RESETTING` anchor is intentional: its former `ACTIVE` rows must not reject the
+temporarily absent objects during interrupted-reset inspection. The next authoritative `DEPLOY` bootstraps a fresh
+exact registry from the rebuilt catalog. Until that deploy finishes, inspection uses the explicit no-registry
+bootstrap path rather than treating the stale pre-reset snapshot as authoritative.
+
+If execution stops, never replay the original SQL file blindly: inspect the catalog and regenerate from its current phase. While the anchor is `RESETTING`, generate `RESET` with the same configuration; the generator reuses the recorded identity, while `DEPLOY` is rejected. If the anchor is already `STABLE` but Kafka ingress is incomplete, generate `DEPLOY` to finish it. Replaying a completed Reset could delete rebuilt data while reusing already-committed Kafka offsets; generating another Reset after `STABLE` deliberately creates a new reset identity. Metadata and ownership-registry rows from earlier BI layouts are rejected rather than interpreted or migrated; stop old consumers, remove or archive the old BI databases, and deploy a clean current-layout scope. External coordination must guarantee one writer for the entire physical BI object namespace, not merely one writer per `deploymentId`; deployments that share databases and normalized object names can otherwise race after inspection. ClickHouse `ON CLUSTER` DDL is not a cross-replica transaction, so replica divergence remains a fail-closed operational recovery case.
 
 `DEPLOY` and `RESET` reconcile only the current physical ownership scope; they do not migrate `database`, `consumerDatabase`, `consumerGroupNamespace`, topology mode, cluster name, or installation. Visible topology-fingerprint drift is rejected. A scope change can make old objects undiscoverable, so stop old consumers, explicitly clean the old scope, and only then deploy the new scope.
+
+See [BI Deployment and Recovery](./bi-operations) for production rollout, operation selection, interruption
+recovery, acceptance, and rollback procedures.
 
 ## Generated SQL Contract
 
@@ -239,21 +261,22 @@ SELECT "events".1 AS "event_sequence",
 
 The same header-masking lexical extraction is used for top-level `state`, preventing a nested header key named `state` from replacing the authoritative state token.
 
-The writable state store is partitioned monthly by `create_time` and ordered by `(aggregate_id, version)`. This key relies on Wow's aggregate identity contract: within one named aggregate, `aggregate_id` is unique across all tenants; `tenant_id` is not a namespace in which an ID may be reused. Standalone mode writes `example_order_state_store`; cluster mode writes through the distributed store into `example_order_state_store_local`. `example_order_state` is always a deduplicated read view.
+The writable state store is partitioned monthly by `create_time` and ordered by `(tenant_id, aggregate_id, version)`. `tenant_id` is the aggregate-ID namespace, so different tenants may reuse the same `aggregate_id` without colliding. In cluster mode, state and latest-state stores are sharded with `sipHash64(tenant_id, aggregate_id)`. Standalone mode writes `example_order_state_store`; cluster mode writes through the distributed store into `example_order_state_store_local`. `example_order_state` is always a deduplicated read view.
 
 ### Latest State
 
-The latest-state store receives all columns from the state store and is partitioned by first-event time. Its `ORDER BY aggregate_id` likewise requires aggregate IDs to remain unique across tenants within the named aggregate. `example_order_state_last` is the authoritative public view and always applies `FINAL`; storage tables are intentionally separated behind the `*_store` suffix.
+The latest-state store receives all columns from the state store and is partitioned by first-event time. Its sorting key is `(tenant_id, aggregate_id)`, matching the state identity boundary. `example_order_state_last` is the authoritative public view and always applies `FINAL`; storage tables are intentionally separated behind the `*_store` suffix.
 
 ```sql
 CREATE TABLE IF NOT EXISTS "bi_db"."example_order_state_last_store"
 (
+    "tenant_id" String,
     "aggregate_id" String,
     "version" UInt32,
     "first_event_time" DateTime64(3, 'Asia/Shanghai')
 ) ENGINE = ReplacingMergeTree("version")
   PARTITION BY toYYYYMM("first_event_time")
-  ORDER BY "aggregate_id";
+  ORDER BY ("tenant_id", "aggregate_id");
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS "bi_db_consumer"."example_order_state_last_consumer"
 TO "bi_db"."example_order_state_last_store"
@@ -268,6 +291,7 @@ Cluster mode retains the replicated local table and targets its distributed faca
 ```sql
 CREATE TABLE IF NOT EXISTS "bi_db"."example_order_state_last_store_local" ON CLUSTER '{cluster}'
 (
+    "tenant_id" String,
     "aggregate_id" String,
     "version" UInt32,
     "first_event_time" DateTime64(3, 'Asia/Shanghai')
@@ -275,7 +299,7 @@ CREATE TABLE IF NOT EXISTS "bi_db"."example_order_state_last_store_local" ON CLU
     '/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}',
     '{replica}', "version")
 PARTITION BY toYYYYMM("first_event_time")
-ORDER BY "aggregate_id";
+ORDER BY ("tenant_id", "aggregate_id");
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS "bi_db_consumer"."example_order_state_last_consumer"
 TO "bi_db"."example_order_state_last_store"

--- a/documentation/docs/zh/guide/bi-operations.md
+++ b/documentation/docs/zh/guide/bi-operations.md
@@ -1,0 +1,108 @@
+---
+title: BI 部署与恢复
+description: Wow BI 当前布局的发布、Reset、中断恢复、回滚与验收手册。
+---
+
+# BI 部署与恢复
+
+本手册只适用于当前 BI 布局。BI 模块不读取旧布局、不执行原地迁移，也不承诺旧客户端、
+旧 registry 或旧 SQL 的兼容性。
+
+## 操作边界
+
+- `DEPLOY`：非破坏性对账。可首次安装、补齐中断的创建/删除、更新计算视图，以及恢复缺失的
+  Kafka ingress。
+- `RESET`：破坏性重建。必须同时提交 `replayFromEarliestConfirmed=true`，并配置
+  `consumerGroupNamespace`。
+- SQL 执行器必须严格按返回顺序执行，并在第一条错误处停止。
+- 同一物理 BI 对象命名空间只能有一个写者。生成、检查、执行三个阶段都必须纳入同一外部锁。
+- `wow.bi.script.enabled` 默认开启，前提是 `/wow/bi/script` 仅通过安全网关暴露。
+
+生产环境必须使用 `wow.bi.script.inspector.type=CLICKHOUSE`。默认的 NoOp inspector 只适合首次部署
+或离线预览，不能安全执行 Reset 或清理旧对象。
+
+## 操作决策
+
+```mermaid
+flowchart TD
+    A[使用 CLICKHOUSE inspector 重新生成脚本] --> B{inspection 结果}
+    B -->|当前布局且无持久契约漂移| C[DEPLOY]
+    B -->|仅计算视图定义变化| C
+    B -->|PENDING_CREATE / PENDING_UPDATE / PENDING_DROP| C
+    B -->|缺失 ACTIVE/RETIRED 或残留 TOMBSTONE| D[确认 RESET]
+    B -->|Store 或 Queue 契约漂移| D
+    B -->|registry 物理契约不匹配或旧布局| E[停止 consumer 并归档旧范围]
+    E --> F[删除不兼容 registry 或整个旧范围]
+    F --> D
+    B -->|anchor 为 RESETTING| G[使用相同配置继续 RESET]
+```
+
+| 观测状态 | 操作 | 说明 |
+|---|---|---|
+| 首次部署，目标范围内没有旧 BI 对象 | `DEPLOY` | 建立当前布局、registry 与 `STABLE` anchor |
+| 当前布局稳定且契约一致 | `DEPLOY` | 生成幂等对账 SQL |
+| View 或 consumer materialized view 定义变化 | `DEPLOY` | registry 经 `PENDING_UPDATE` 更新后回到 `ACTIVE` |
+| `PENDING_CREATE`、`PENDING_UPDATE` 或 `PENDING_DROP` | `DEPLOY` | 使用相同配置重新生成，不要重放旧 SQL |
+| registry 引用的 `ACTIVE/RETIRED` 对象缺失，或 `TOMBSTONE` 对象仍存在 | 确认的 `RESET` | 普通 Deploy 会 fail-closed；Reset 使用 registry 的归属范围清理和重建 |
+| Store、Kafka Queue 或拓扑契约漂移 | 确认的 `RESET` | 不执行原地变更 |
+| registry Engine、复制路径、排序键、Comment 或列结构不匹配 | 手动归档/删除后 `RESET` | inspector 不信任不兼容 registry，不能直接从中推断归属 |
+| anchor 为 `RESETTING` | 使用原配置继续 `RESET` | 保留已记录的 consumer identity；此时拒绝 Deploy |
+| anchor 为 `STABLE` 但 Kafka ingress 不完整 | `DEPLOY` | 补齐 Queue 和 consumer materialized view |
+
+## 发布前检查
+
+1. 固定应用、`wow-bi` 和 OpenAPI 客户端版本，禁止新旧节点同时操作 BI 范围。
+2. 确认安全网关保护 `/wow/bi/script`，或显式设置 `wow.bi.script.enabled=false`。
+3. 配置 ClickHouse inspector、唯一的 `consumerGroupNamespace` 和正确的 ClickHouse 拓扑。
+4. 确认 `database`、`consumerDatabase`、拓扑模式、cluster name、installation 和 topic 配置没有意外变化。
+5. 停止旧 BI consumer，获取覆盖整个物理对象命名空间的外部互斥锁。
+6. 备份或归档旧 BI 数据库、Kafka offset 证据和当前应用版本。
+7. 确认新 consumer generation 的 `auto.offset.reset=earliest`；使用 Keeper offset 时确认 Keeper 可用。
+8. 先生成并审阅脚本及 diagnostics，不得执行含未解释诊断的脚本。
+
+## 执行 Deploy
+
+1. 在持有外部锁的同一变更窗口中重新生成 `DEPLOY`。
+2. 保存请求配置、diagnostics 和 SQL 摘要作为审计证据。
+3. 严格顺序执行 SQL；第一条失败后立即停止。
+4. 失败后重新 inspection 并生成新脚本。不得从失败位置猜测续跑，也不得重放原 SQL 文件。
+5. 成功后检查 anchor 为 `STABLE`，registry 最新状态符合预期，Kafka ingress 已建立。
+
+计算对象更新会先写入 `PENDING_UPDATE`，再修复 View 或 consumer materialized view，最后确认
+`ACTIVE`。Store 与 Queue identity 不会因为计算视图更新而变化。
+
+## 执行 Reset
+
+Reset 会删除并重建归属范围内的数据和消费链路，只能在业务明确接受全量 Kafka 重放时执行：
+
+1. 停止所有旧 consumer，并保持外部锁。
+2. 验证备份、Kafka 保留期和 `auto.offset.reset=earliest`。
+3. 以 `operation=RESET`、`replayFromEarliestConfirmed=true` 重新生成脚本。
+4. 确认返回结果的 `destructive=true`，再逐条执行。
+5. 若执行中断：
+   - anchor 为 `RESETTING`：使用完全相同的物理范围配置重新生成 `RESET`；
+   - anchor 已为 `STABLE`：生成 `DEPLOY` 补齐 ingress；
+   - 不得重放原 Reset SQL。
+6. Reset 完成后再执行一次 authoritative `DEPLOY`，建立并确认精确的当前 registry。
+
+## 验收
+
+- anchor 为 `STABLE`，且其 registry revision 不领先于 registry HEAD。
+- registry 的 Engine、复制路径、排序键、Comment 和完整列结构通过 inspector 校验。
+- 所需对象存在；没有残留的 `TOMBSTONE` 对象；registry 无未解释的 pending 状态。
+- View 查询和 materialized view 的 `TO` target 与当前 renderer 定义一致。
+- Kafka Queue 与 consumer materialized view 正常消费；抽样核对最早、最新 offset 和业务数据。
+- 集群拓扑下所有副本的对象、Comment、Engine 和列结构一致。
+
+## 回滚
+
+BI 没有原地向后兼容回滚。旧版本可能无法识别当前 registry 状态，尤其不能在
+`PENDING_UPDATE` 或 `RESETTING` 时直接回滚应用：
+
+1. 首选使用当前版本完成 `DEPLOY` 或中断恢复。
+2. 必须回退版本时，同时恢复旧应用、旧 BI 数据库和与其匹配的 offset/配置快照。
+3. 不要让旧 inspector 读取当前 registry，也不要使用旧 SQL 覆盖当前布局。
+4. 紧急隔离可设置 `wow.bi.script.enabled=false`，但这只移除 HTTP 路由、OpenAPI operation 和
+   inspector，不会回滚 ClickHouse 数据。
+
+版本升级的跨模块顺序参见[迁移指南](./migration)，配置项参见[BI 脚本配置](./configuration#bi-脚本配置)。

--- a/documentation/docs/zh/guide/bi.md
+++ b/documentation/docs/zh/guide/bi.md
@@ -40,13 +40,13 @@ val sql: String = result.script
 val diagnostics: List<BiScriptDiagnostic> = result.diagnostics
 ```
 
-公开契约还包含 `BiScriptOperation`、`BiDeploymentInspector`、`BiDeploymentInspection`、`ObservedBiDeployment` 与 `KafkaOffsetStorage`。调用方不再保存或提交 manifest；`Deploy` 根据 ClickHouse catalog 中的 ownership marker 对账，`Reset` 是唯一会删除数据表的操作，并要求明确确认新 Kafka group 会从 earliest 重放。
+公开契约还包含 `BiScriptOperation`、`BiDeploymentInspector`、`BiDeploymentInspection`、`ObservedBiDeployment` 与 `KafkaOffsetStorage`。调用方不再保存或提交 manifest；`Deploy` 根据 ClickHouse catalog 中的 ownership marker 对账。`Reset` 是唯一的破坏性操作，用于重建当前布局。
 
 `BiScriptResult` 包含：
 
 | 字段 | 含义 |
 |------|------|
-| `script` | 完整 ClickHouse 部署 SQL；`Deploy` 保留数据表，`Reset` 才包含破坏性清理。 |
+| `script` | 完整 ClickHouse 部署 SQL；`Deploy` 保留数据表，`Reset` 包含破坏性清理。 |
 | `diagnostics` | 按聚合和属性路径稳定排序的不可变诊断列表。 |
 | `destructive` | 生成的操作是否删除数据表。 |
 
@@ -64,7 +64,14 @@ val diagnostics: List<BiScriptDiagnostic> = result.diagnostics
 
 ### HTTP 路由
 
-Spring WebFlux 路由及其 Swagger/OpenAPI operation 默认开启。启用本身不会增加鉴权，因此应用安全策略必须保护该管理端点；配置 `wow.bi.script.enabled=false` 会同时移除二者。`DEPLOY` 生成 Kafka consumer 时，以及所有 `RESET`（包括空聚合作用域），都必须配置部署唯一的 `wow.bi.script.consumer-group-namespace`；缺少配置时请求返回 `400`，不会阻止应用启动。未配置 namespace 的空 `DEPLOY` 不会创建 anchor；配置后，空作用域也会获得可供后续聚合复用的持久部署身份。禁用时 Starter 不构造或校验 BI 生成选项和 inspector。该路由使用同一个 `BiScriptOptions`：
+Spring WebFlux 路由及其 Swagger/OpenAPI operation 默认开启；配置 `wow.bi.script.enabled=false`
+会同时移除二者。该默认值以“服务仅通过安全网关暴露”为部署前提：Starter 本身不增加鉴权，该路由与主应用
+共用端口和 WebFlux filter chain，因此网关必须限制 `/wow/bi/script`。不满足此前提的环境必须显式关闭路由。
+`DEPLOY` 生成 Kafka consumer 时，以及所有
+`RESET`（包括空聚合作用域），都必须配置部署唯一的 `wow.bi.script.consumer-group-namespace`；缺少配置时请求
+返回 `400`，不会阻止应用启动。未配置 namespace 的空 `DEPLOY` 不会创建 anchor；配置后，空作用域也会获得
+可供后续聚合复用的持久部署身份。禁用时 Starter 不构造或校验 BI 生成选项和 inspector。该路由使用同一个
+`BiScriptOptions`：
 
 ```yaml
 wow:
@@ -113,18 +120,29 @@ JSON 请求体必填。`{}` 保持服务端 `BiScriptOptions` 不变；非 `null
 
 Starter 默认注入 `NoOpBiDeploymentInspector`。它返回显式 `Unavailable`：普通 `DEPLOY` 仅适合首次部署或离线预览，同时会产生 `INSPECTION_UNAVAILABLE` 诊断；它无法清理旧对象，也无法恢复 `RESET` 创建的 consumer identity，配置变化还可能选择新的 consumer group。`RESET` 会被拒绝。需要完整对账时，配置 `wow.bi.script.inspector.type=CLICKHOUSE` 及 `inspector.clickhouse.endpoints`，即可启用 ClickHouse 官方 Java `client-v2` 实现。真实 inspector 查询失败会直接传播错误，不会降级为 NoOp；选择 `CLICKHOUSE` 但缺少 client-v2 类时应用启动失败。自定义 `BiDeploymentInspector` Bean 仍具有最高优先级。
 
+生产请求链会把同一份 immutable preparation 依次交给 ClickHouse inspection 与最终 renderer。对稳定 deployment，inspector 会用 renderer 共享的 query manifest 核验每个目标 View 和 consumer materialized view：在 ClickHouse 端以 `formatQuerySingleLineOrNull` 规范化 SELECT body，从 `system.tables.as_select` 读取真实查询，并单独校验 materialized view 的精确 `TO` target。发现差异时返回 `COMPUTED_OBJECT_DRIFT`，但仍保持 inspection 可用，使生成的 `DEPLOY` 能完成修复：ownership registry 先持久化 `PENDING_UPDATE` 的新定义指纹；普通 View 使用 `CREATE OR REPLACE`，consumer materialized view 会先暂停再重建；确认成功后 registry 转为 `ACTIVE`，而 store 与 Kafka queue identity 保持不变。持久 store 或 queue 的契约漂移仍然 fail-closed，必须执行 `RESET`。
+
 如需有意重建全部 BI 数据，请发送 `operation=RESET` 与 `replayFromEarliestConfirmed=true`。Reset 还要求配置 `consumerGroupNamespace`，以便在 canonical anchor 中持久化恢复状态。只有可用 inspector 能从 ClickHouse catalog 枚举全部 owned 对象。每个生成对象和零行 deployment anchor 都把协议/布局版本、deployment phase、fingerprint、聚合 owner、对象类型和 identity 写入 `system.tables.comment`；服务重启后直接从 catalog 恢复，不依赖 Wow 服务内存或外部 manifest。
 
-元数据协议 v2 使 Reset 能从进程或 SQL 客户端中断中恢复。生成语句必须按顺序执行，并且执行器必须在首个错误处停止：
+Inspector 会先核验 ownership registry 自身的 engine、复制路径、排序键、comment 和完整列结构，再读取其中的 HEAD/OBJECT 状态。普通 `DEPLOY` 仍会拒绝 registry 引用的 `ACTIVE/RETIRED` 对象缺失或 `TOMBSTONE` 对象残留；已确认的 `RESET` 将这些情况视为可恢复物理漂移，保留 registry 中的精确归属范围并生成完整清理与重建 SQL。
+
+当前元数据协议使 Reset 能从进程或 SQL 客户端中断中恢复。生成语句必须按顺序执行，并且执行器必须在首个错误处停止：
 
 1. 先把 canonical anchor 写为 `RESETTING`，并记录新的 consumer identity。
-2. 保留该 anchor，删除其余全部 owned 对象并重建持久表/视图图。
+2. 保留该 anchor，删除旧 ownership registry，再删除其余 owned 对象并重建持久表/视图图。
 3. 把 anchor 替换为 `STABLE`。
 4. 最后创建 Kafka queue 表和 Kafka consumer 物化视图。
 
-执行中断后绝不能盲目重放原 SQL 文件，必须重新 inspection，并根据 catalog 当前 phase 重新生成。如果 anchor 是 `RESETTING`，应使用相同配置重新生成 `RESET`；生成器会复用已记录的 identity，而 `DEPLOY` 会被拒绝。如果 anchor 已是 `STABLE`、但 Kafka ingress 尚未完成，应生成 `DEPLOY` 补齐。重放已完成的 Reset 可能先删除重建数据、却继续复用已经提交 offset 的 Kafka identity；进入 `STABLE` 后重新生成 Reset 则会有意开启新的 reset epoch 和 identity。协议 v2 会有意拒绝 v1 ownership marker；采用 v2 前必须停止旧 consumer，并显式清理或重建旧范围。外部协调必须保证整个 BI 物理对象命名空间只有一个写者，而不只是每个 `deploymentId` 一个写者；共享数据库和规范化对象名的 deployment 仍可能在 inspection 后发生竞争。ClickHouse `ON CLUSTER` DDL 不是跨副本事务，副本分歧仍是 fail-closed 的运维恢复场景。
+在 `RESETTING` anchor 之后删除旧 registry 是有意设计：旧 `ACTIVE` 条目不能在中断恢复检查时拒绝
+暂时不存在的对象。下一次 authoritative `DEPLOY` 会根据重建后的 catalog 引导生成新的 exact
+registry；该 Deploy 完成前，inspection 使用显式的“无 registry bootstrap”路径，而不会继续信任
+Reset 前的过期快照。
+
+执行中断后绝不能盲目重放原 SQL 文件，必须重新 inspection，并根据 catalog 当前 phase 重新生成。如果 anchor 是 `RESETTING`，应使用相同配置重新生成 `RESET`；生成器会复用已记录的 identity，而 `DEPLOY` 会被拒绝。如果 anchor 已是 `STABLE`、但 Kafka ingress 尚未完成，应生成 `DEPLOY` 补齐。重放已完成的 Reset 可能先删除重建数据、却继续复用已经提交 offset 的 Kafka identity；进入 `STABLE` 后重新生成 Reset 则会有意创建新的 reset identity。旧 BI 布局的 metadata 与 ownership registry 会被拒绝，不会被解释或迁移；升级时必须停止旧 consumer，删除或归档旧 BI 数据库，再部署干净的当前布局。外部协调必须保证整个 BI 物理对象命名空间只有一个写者，而不只是每个 `deploymentId` 一个写者；共享数据库和规范化对象名的 deployment 仍可能在 inspection 后发生竞争。ClickHouse `ON CLUSTER` DDL 不是跨副本事务，副本分歧仍是 fail-closed 的运维恢复场景。
 
 `DEPLOY` 与 `RESET` 只对账当前物理归属范围，不迁移 `database`、`consumerDatabase`、`consumerGroupNamespace`、拓扑模式、cluster name 或 installation。可见的 topology fingerprint 漂移会被拒绝；范围变化可能使旧对象不可发现，因此必须先停止旧 consumer、显式清理旧范围，再部署新范围。
+
+生产发布、操作选择、中断恢复、验收与回滚步骤参见 [BI 部署与恢复](./bi-operations)。
 
 ## 生成的 SQL 契约
 
@@ -239,21 +257,22 @@ SELECT "events".1 AS "event_sequence",
 
 顶层 `state` 使用相同的 header 屏蔽词法提取，避免 header 中名为 `state` 的嵌套字段替换权威状态 token。
 
-可写状态存储按 `create_time` 月分区，以 `(aggregate_id, version)` 排序。该排序键依赖 Wow 的聚合标识契约：在同一个命名聚合范围内，`aggregate_id` 必须跨所有租户保持唯一，`tenant_id` 不是可复用聚合 ID 的命名空间。独立模式写入 `example_order_state_store`；集群模式通过分布式 store 写入 `example_order_state_store_local`。`example_order_state` 始终是去重读取视图。
+可写状态存储按 `create_time` 月分区，以 `(tenant_id, aggregate_id, version)` 排序。`tenant_id` 是聚合 ID 的命名空间，因此不同租户可以复用相同的 `aggregate_id` 而不会发生冲突。集群模式下，状态与最新状态存储都使用 `sipHash64(tenant_id, aggregate_id)` 分片。独立模式写入 `example_order_state_store`；集群模式通过分布式 store 写入 `example_order_state_store_local`。`example_order_state` 始终是去重读取视图。
 
 ### 最新状态
 
-最新状态存储从状态 store 接收全部列，并按首次事件时间分区。其 `ORDER BY aggregate_id` 同样要求聚合 ID 在命名聚合范围内跨租户保持唯一。`example_order_state_last` 是始终执行 `FINAL` 的权威公共视图；可写存储统一隔离在 `*_store` 后缀之后。
+最新状态存储从状态 store 接收全部列，并按首次事件时间分区。其排序键为 `(tenant_id, aggregate_id)`，与状态身份边界保持一致。`example_order_state_last` 是始终执行 `FINAL` 的权威公共视图；可写存储统一隔离在 `*_store` 后缀之后。
 
 ```sql
 CREATE TABLE IF NOT EXISTS "bi_db"."example_order_state_last_store"
 (
+    "tenant_id" String,
     "aggregate_id" String,
     "version" UInt32,
     "first_event_time" DateTime64(3, 'Asia/Shanghai')
 ) ENGINE = ReplacingMergeTree("version")
   PARTITION BY toYYYYMM("first_event_time")
-  ORDER BY "aggregate_id";
+  ORDER BY ("tenant_id", "aggregate_id");
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS "bi_db_consumer"."example_order_state_last_consumer"
 TO "bi_db"."example_order_state_last_store"
@@ -268,6 +287,7 @@ AS SELECT * FROM "bi_db"."example_order_state_last_store" FINAL;
 ```sql
 CREATE TABLE IF NOT EXISTS "bi_db"."example_order_state_last_store_local" ON CLUSTER '{cluster}'
 (
+    "tenant_id" String,
     "aggregate_id" String,
     "version" UInt32,
     "first_event_time" DateTime64(3, 'Asia/Shanghai')
@@ -275,7 +295,7 @@ CREATE TABLE IF NOT EXISTS "bi_db"."example_order_state_last_store_local" ON CLU
     '/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}',
     '{replica}', "version")
 PARTITION BY toYYYYMM("first_event_time")
-ORDER BY "aggregate_id";
+ORDER BY ("tenant_id", "aggregate_id");
 
 CREATE MATERIALIZED VIEW IF NOT EXISTS "bi_db_consumer"."example_order_state_last_consumer"
 TO "bi_db"."example_order_state_last_store"

--- a/wow-bi/config/detekt/boundary.yml
+++ b/wow-bi/config/detekt/boundary.yml
@@ -1,0 +1,42 @@
+complexity:
+  LongParameterList:
+    active: true
+    functionThreshold: 5
+    constructorThreshold: 7
+    ignoreDataClasses: true
+    excludes:
+      - '**/src/test/**'
+      - '**/src/integrationTest/**'
+  NestedBlockDepth:
+    active: true
+    threshold: 4
+  TooManyFunctions:
+    active: true
+    thresholdInFiles: 11
+    thresholdInClasses: 10
+    thresholdInInterfaces: 6
+    thresholdInObjects: 10
+    thresholdInEnums: 6
+    excludes:
+      - '**/src/test/**'
+      - '**/src/integrationTest/**'
+exceptions:
+  SwallowedException:
+    active: true
+  ThrowingExceptionsWithoutMessageOrCause:
+    active: true
+style:
+  UnusedPrivateMember:
+    active: true
+  ProtectedMemberInFinalClass:
+    active: true
+  UnnecessaryAbstractClass:
+    active: true
+  LoopWithTooManyJumpStatements:
+    active: true
+naming:
+  MemberNameEqualsClassName:
+    active: true
+performance:
+  SpreadOperator:
+    active: true

--- a/wow-bi/src/integrationTest/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspectorIntegrationTest.kt
+++ b/wow-bi/src/integrationTest/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspectorIntegrationTest.kt
@@ -16,6 +16,8 @@ package me.ahoo.wow.bi
 import com.clickhouse.client.api.ClientException
 import me.ahoo.test.asserts.assert
 import me.ahoo.test.asserts.assertThrownBy
+import me.ahoo.wow.bi.renderer.ClickHouseOwnershipRegistryRenderer
+import me.ahoo.wow.configuration.MetadataSearcher
 import org.junit.jupiter.api.Test
 import org.testcontainers.clickhouse.ClickHouseContainer
 import org.testcontainers.utility.DockerImageName
@@ -25,6 +27,155 @@ import java.sql.DriverManager
 import java.time.Duration
 
 class ClickHouseBiDeploymentInspectorIntegrationTest {
+    @Test
+    fun `should persist and restore an ownership registry through real ClickHouse SQL`() {
+        ClickHouseContainer(DockerImageName.parse(CLICKHOUSE_IMAGE)).use { clickHouse ->
+            clickHouse.start()
+            val options = BiScriptOptions(
+                database = DATABASE,
+                consumerDatabase = CONSUMER_DATABASE,
+                consumerGroupNamespace = "native-registry-integration",
+                topology = ClickHouseTopology.Standalone,
+            )
+            val descriptor = BiDeploymentDescriptor.from(options)
+            val key = BiObjectKey(DATABASE, "registry_owned_view")
+            val registry = BiOwnershipRegistry.empty(descriptor.deploymentId)
+                .beginCreate(
+                    BiOwnershipRegistration(
+                        key = key,
+                        kind = BiObjectKind.VIEW,
+                        aggregate = "integration.catalog",
+                        consumerIdentity = BiConsumerIdentity.deterministic(descriptor).value,
+                        definitionFingerprint = "f".repeat(32),
+                    )
+                )
+                .markMutationVerified(key)
+            val renderer = ClickHouseOwnershipRegistryRenderer(options, descriptor.deploymentId)
+            val metadata = BiObjectMetadata(
+                deploymentId = descriptor.deploymentId,
+                configurationFingerprint = descriptor.configurationFingerprint,
+                topologyFingerprint = descriptor.topologyFingerprint,
+                aggregate = "integration.catalog",
+                kind = BiObjectKind.VIEW,
+            )
+            DriverManager.getConnection(
+                clickHouse.jdbcUrl,
+                clickHouse.username,
+                clickHouse.password,
+            ).use { connection ->
+                connection.createStatement().use { statement ->
+                    statement.execute("CREATE DATABASE $DATABASE")
+                    statement.execute("CREATE DATABASE $CONSUMER_DATABASE")
+                    statement.execute(
+                        "CREATE VIEW ${key.database}.${key.name} AS SELECT 1 AS id " +
+                            "COMMENT '${BiObjectMetadataCodec.encode(metadata)}'"
+                    )
+                    renderer.renderCreateStatements(registry.name).forEach(statement::execute)
+                    statement.execute(renderer.renderSnapshotStatement(registry))
+                }
+            }
+
+            NativeClickHouseCatalogClient.create(
+                ClickHouseClientOptions(
+                    endpoints = listOf(URI.create(clickHouse.httpUrl)),
+                    username = clickHouse.username,
+                    password = clickHouse.password,
+                )
+            ).use { catalogClient ->
+                val snapshot = ClickHouseCatalogReader(catalogClient).read(
+                    ClickHouseCatalogReadRequest(
+                        options = options,
+                        operation = BiScriptOperation.Reset(true),
+                        desiredObjectKeys = setOf(key),
+                        desiredObjects = null,
+                        cancellation = ClickHouseQueryCancellation(),
+                    )
+                )
+
+                snapshot.ownershipRegistry?.revision.assert().isEqualTo(registry.revision)
+                snapshot.ownershipRegistry?.snapshotFingerprint().assert()
+                    .isEqualTo(registry.snapshotFingerprint())
+                snapshot.objects.map(ClickHouseCatalogObject::key).assert().contains(key)
+            }
+        }
+    }
+
+    @Test
+    fun `should restore the same ownership registry from every configured cluster replica`() {
+        ClickHouseContainer(DockerImageName.parse(CLICKHOUSE_IMAGE))
+            .withCopyFileToContainer(
+                MountableFile.forClasspathResource(CLUSTER_CONFIG_RESOURCE),
+                CLUSTER_CONFIG_PATH,
+            ).use { clickHouse ->
+                clickHouse.start()
+                val options = BiScriptOptions(
+                    database = DATABASE,
+                    consumerDatabase = CONSUMER_DATABASE,
+                    consumerGroupNamespace = "native-registry-cluster-integration",
+                    topology = ClickHouseTopology.Cluster(name = CLUSTER, installation = "test"),
+                )
+                val descriptor = BiDeploymentDescriptor.from(options)
+                val key = BiObjectKey(DATABASE, "cluster_registry_owned_view")
+                val registry = BiOwnershipRegistry.empty(descriptor.deploymentId)
+                    .beginCreate(
+                        BiOwnershipRegistration(
+                            key = key,
+                            kind = BiObjectKind.VIEW,
+                            aggregate = "integration.catalog",
+                            consumerIdentity = BiConsumerIdentity.deterministic(descriptor).value,
+                            definitionFingerprint = "e".repeat(32),
+                        )
+                    )
+                    .markMutationVerified(key)
+                val renderer = ClickHouseOwnershipRegistryRenderer(options, descriptor.deploymentId)
+                val metadata = BiObjectMetadata(
+                    deploymentId = descriptor.deploymentId,
+                    configurationFingerprint = descriptor.configurationFingerprint,
+                    topologyFingerprint = descriptor.topologyFingerprint,
+                    aggregate = "integration.catalog",
+                    kind = BiObjectKind.VIEW,
+                )
+                DriverManager.getConnection(
+                    clickHouse.jdbcUrl,
+                    clickHouse.username,
+                    clickHouse.password,
+                ).use { connection ->
+                    connection.createStatement().use { statement ->
+                        statement.execute("CREATE DATABASE $DATABASE ON CLUSTER '$CLUSTER'")
+                        statement.execute("CREATE DATABASE $CONSUMER_DATABASE ON CLUSTER '$CLUSTER'")
+                        statement.execute(
+                            "CREATE VIEW ${key.database}.${key.name} ON CLUSTER '$CLUSTER' AS SELECT 1 AS id " +
+                                "COMMENT '${BiObjectMetadataCodec.encode(metadata)}'"
+                        )
+                        renderer.renderCreateStatements(registry.name).forEach(statement::execute)
+                        statement.execute(renderer.renderSnapshotStatement(registry))
+                    }
+                }
+
+                NativeClickHouseCatalogClient.create(
+                    ClickHouseClientOptions(
+                        endpoints = listOf(URI.create(clickHouse.httpUrl)),
+                        username = clickHouse.username,
+                        password = clickHouse.password,
+                    )
+                ).use { catalogClient ->
+                    val snapshot = ClickHouseCatalogReader(catalogClient).read(
+                        ClickHouseCatalogReadRequest(
+                            options = options,
+                            operation = BiScriptOperation.Reset(true),
+                            desiredObjectKeys = setOf(key),
+                            desiredObjects = null,
+                            cancellation = ClickHouseQueryCancellation(),
+                        )
+                    )
+
+                    snapshot.ownershipRegistry?.snapshotFingerprint().assert()
+                        .isEqualTo(registry.snapshotFingerprint())
+                    snapshot.objects.map(ClickHouseCatalogObject::key).assert().contains(key)
+                }
+            }
+    }
+
     @Test
     fun `should apply execution timeout to a real ClickHouse request`() {
         ClickHouseContainer(DockerImageName.parse(CLICKHOUSE_IMAGE)).use { clickHouse ->
@@ -51,6 +202,7 @@ class ClickHouseBiDeploymentInspectorIntegrationTest {
     }
 
     @Test
+    @Suppress("LongMethod") // Keeps one real catalog lifecycle and its cross-object assertions together.
     fun `should inspect the real ClickHouse system catalog through client v2`() {
         ClickHouseContainer(DockerImageName.parse(CLICKHOUSE_IMAGE)).use { clickHouse ->
             clickHouse.start()
@@ -63,6 +215,9 @@ class ClickHouseBiDeploymentInspectorIntegrationTest {
             )
             val descriptor = BiDeploymentDescriptor.from(options)
             val identity = BiConsumerIdentity.deterministic(descriptor)
+            val aggregate = MetadataSearcher.localAggregates.first()
+            val desiredForeignKey = BiScriptGenerator(options).desiredObjectKeys(setOf(aggregate))
+                .first()
             val storeMetadata = BiObjectMetadata(
                 deploymentId = descriptor.deploymentId,
                 configurationFingerprint = descriptor.configurationFingerprint,
@@ -86,13 +241,19 @@ class ClickHouseBiDeploymentInspectorIntegrationTest {
                 consumerIdentity = identity.value,
             )
             val expectedGroup = "wow-bi.${identity.value}.catalog_command_consumer"
-            DriverManager.getConnection(clickHouse.jdbcUrl, clickHouse.username, clickHouse.password).use { connection ->
+            DriverManager.getConnection(
+                clickHouse.jdbcUrl,
+                clickHouse.username,
+                clickHouse.password,
+            ).use { connection ->
                 connection.createStatement().use { statement ->
                     statement.execute("CREATE DATABASE $DATABASE")
                     statement.execute("CREATE DATABASE $CONSUMER_DATABASE")
                     statement.execute(
-                        "CREATE TABLE $DATABASE.$TABLE (id UInt64) " +
-                            "ENGINE = ReplacingMergeTree ORDER BY id " +
+                        "CREATE TABLE $DATABASE.$TABLE " +
+                            "(${commandStoreColumns()}) " +
+                            "ENGINE = ReplacingMergeTree " +
+                            "PARTITION BY toYYYYMM(create_time) ORDER BY id " +
                             "COMMENT '${BiObjectMetadataCodec.encode(storeMetadata)}'"
                     )
                     statement.execute(
@@ -106,6 +267,12 @@ class ClickHouseBiDeploymentInspectorIntegrationTest {
                         "CREATE VIEW $CONSUMER_DATABASE.__wow_bi_deployment AS " +
                             "SELECT 1 AS alive WHERE 0 " +
                             "COMMENT '${BiObjectMetadataCodec.encode(anchorMetadata)}'"
+                    )
+                    statement.execute(
+                        "CREATE VIEW ${desiredForeignKey.database}.${desiredForeignKey.name} AS SELECT 1 AS id"
+                    )
+                    statement.execute(
+                        "CREATE VIEW $DATABASE.unrelated_foreign_view AS SELECT 1 AS id"
                     )
                 }
             }
@@ -121,10 +288,11 @@ class ClickHouseBiDeploymentInspectorIntegrationTest {
                 inspectionTimeout = Duration.ofSeconds(10),
             ).use { inspector ->
                 val available = inspector.inspect(options).block() as BiDeploymentInspection.Available
-                val observed = available.deployment.objects.single { it.key == BiObjectKey(DATABASE, TABLE) }
-                val queue = available.deployment.objects.single {
+                val observed = available.deployment.objects.singleOrNull { it.key == BiObjectKey(DATABASE, TABLE) }
+                    ?: error("Missing owned table from ${available.deployment.objects.map(ObservedBiObject::key)}")
+                val queue = available.deployment.objects.singleOrNull {
                     it.key == BiObjectKey(CONSUMER_DATABASE, QUEUE)
-                }
+                } ?: error("Missing owned queue from ${available.deployment.objects.map(ObservedBiObject::key)}")
 
                 observed.database.assert().isEqualTo(DATABASE)
                 observed.name.assert().isEqualTo(TABLE)
@@ -138,6 +306,20 @@ class ClickHouseBiDeploymentInspectorIntegrationTest {
                     .startsWith("Kafka(")
                     .contains("'$expectedGroup'", "SETTINGS kafka_num_consumers = 2")
                 queue.metadata.assert().isEqualTo(queueMetadata)
+
+                val scoped = inspector.inspect(
+                    options,
+                    BiScriptOperation.Deploy,
+                    BiScriptGenerator(options).prepare(setOf(aggregate)),
+                ).block()
+                    as BiDeploymentInspection.Available
+                val scopedKeys = scoped.deployment.objects.map(ObservedBiObject::key).toSet()
+                scopedKeys.assert()
+                    .contains(desiredForeignKey)
+                    .contains(BiObjectKey(DATABASE, TABLE))
+                    .contains(BiObjectKey(CONSUMER_DATABASE, QUEUE))
+                    .contains(BiObjectKey(CONSUMER_DATABASE, "__wow_bi_deployment"))
+                    .doesNotContain(BiObjectKey(DATABASE, "unrelated_foreign_view"))
 
                 val changedOptions = options.copy(
                     kafkaBootstrapServers = "changed-kafka:9092",
@@ -175,6 +357,102 @@ class ClickHouseBiDeploymentInspectorIntegrationTest {
     }
 
     @Test
+    @Suppress("LongMethod", "NestedBlockDepth") // Drift mutations must stay within one live inspector lifecycle.
+    fun `should reject an owned store with drifted physical keys`() {
+        ClickHouseContainer(DockerImageName.parse(CLICKHOUSE_IMAGE)).use { clickHouse ->
+            clickHouse.start()
+            val options = BiScriptOptions(
+                database = DATABASE,
+                consumerDatabase = CONSUMER_DATABASE,
+                topology = ClickHouseTopology.Standalone,
+            )
+            val descriptor = BiDeploymentDescriptor.from(options)
+            val storeMetadata = BiObjectMetadata(
+                deploymentId = descriptor.deploymentId,
+                configurationFingerprint = descriptor.configurationFingerprint,
+                topologyFingerprint = descriptor.topologyFingerprint,
+                aggregate = "integration.catalog",
+                kind = BiObjectKind.STORE,
+            )
+            DriverManager.getConnection(
+                clickHouse.jdbcUrl,
+                clickHouse.username,
+                clickHouse.password,
+            ).use { connection ->
+                connection.createStatement().use { statement ->
+                    statement.execute("CREATE DATABASE $DATABASE")
+                    statement.execute("CREATE DATABASE $CONSUMER_DATABASE")
+                    statement.execute(
+                        "CREATE TABLE $DATABASE.$TABLE " +
+                            "(id String, create_time DateTime64(3, 'Asia/Shanghai')) " +
+                            "ENGINE = ReplacingMergeTree ORDER BY id " +
+                            "COMMENT '${BiObjectMetadataCodec.encode(storeMetadata)}'"
+                    )
+                }
+            }
+
+            ClickHouseBiDeploymentInspector(
+                clientOptions = ClickHouseClientOptions(
+                    endpoints = listOf(URI.create(clickHouse.httpUrl)),
+                    username = clickHouse.username,
+                    password = clickHouse.password,
+                    connectionTimeout = Duration.ofSeconds(5),
+                    socketTimeout = Duration.ofSeconds(10),
+                ),
+                inspectionTimeout = Duration.ofSeconds(10),
+            ).use { inspector ->
+                assertThrownBy<BiDeploymentInspectionException.Inconsistent> {
+                    inspector.inspect(options).block()
+                }.hasMessageContaining("unexpected partition key")
+
+                DriverManager.getConnection(
+                    clickHouse.jdbcUrl,
+                    clickHouse.username,
+                    clickHouse.password,
+                ).use { connection ->
+                    connection.createStatement().use { statement ->
+                        statement.execute("DROP TABLE $DATABASE.$TABLE")
+                        statement.execute(
+                            "CREATE TABLE $DATABASE.$TABLE " +
+                                "(id String, create_time DateTime64(3, 'Asia/Shanghai')) " +
+                                "ENGINE = ReplacingMergeTree " +
+                                "PARTITION BY toYYYYMM(create_time) ORDER BY create_time " +
+                                "COMMENT '${BiObjectMetadataCodec.encode(storeMetadata)}'"
+                        )
+                    }
+                }
+                assertThrownBy<BiDeploymentInspectionException.Inconsistent> {
+                    inspector.inspect(options).block()
+                }.hasMessageContaining("unexpected sorting key")
+
+                DriverManager.getConnection(
+                    clickHouse.jdbcUrl,
+                    clickHouse.username,
+                    clickHouse.password,
+                ).use { connection ->
+                    connection.createStatement().use { statement ->
+                        statement.execute("DROP TABLE $DATABASE.$TABLE")
+                        statement.execute(
+                            "CREATE TABLE $DATABASE.$TABLE " +
+                                "(${commandStoreColumns(tenantIdType = "UInt64")}) " +
+                                "ENGINE = ReplacingMergeTree " +
+                                "PARTITION BY toYYYYMM(create_time) ORDER BY id " +
+                                "COMMENT '${BiObjectMetadataCodec.encode(storeMetadata)}'"
+                        )
+                    }
+                }
+                assertThrownBy<BiDeploymentInspectionException.Inconsistent> {
+                    inspector.inspect(options).block()
+                }.hasMessageContaining("unexpected column schema")
+                    .hasMessageContaining("tenant_id")
+
+                val resetInspection = inspector.inspect(options, BiScriptOperation.Reset(true)).block()
+                (resetInspection is BiDeploymentInspection.Available).assert().isTrue()
+            }
+        }
+    }
+
+    @Test
     fun `should inspect every configured cluster replica`() {
         ClickHouseContainer(DockerImageName.parse(CLICKHOUSE_IMAGE))
             .withCopyFileToContainer(
@@ -188,12 +466,25 @@ class ClickHouseBiDeploymentInspectorIntegrationTest {
                     consumerGroupNamespace = "native-inspector-cluster-integration",
                     topology = ClickHouseTopology.Cluster(name = CLUSTER, installation = "test"),
                 )
-                DriverManager.getConnection(clickHouse.jdbcUrl, clickHouse.username, clickHouse.password).use { connection ->
+                val descriptor = BiDeploymentDescriptor.from(options)
+                val viewName = "cluster_owned_view"
+                val metadata = BiObjectMetadata(
+                    deploymentId = descriptor.deploymentId,
+                    configurationFingerprint = descriptor.configurationFingerprint,
+                    topologyFingerprint = descriptor.topologyFingerprint,
+                    aggregate = "integration.catalog",
+                    kind = BiObjectKind.VIEW,
+                )
+                DriverManager.getConnection(
+                    clickHouse.jdbcUrl,
+                    clickHouse.username,
+                    clickHouse.password,
+                ).use { connection ->
                     connection.createStatement().use { statement ->
                         statement.execute("CREATE DATABASE $DATABASE")
                         statement.execute(
-                            "CREATE TABLE $DATABASE.$TABLE (id UInt64) " +
-                                "ENGINE = MergeTree ORDER BY id"
+                            "CREATE VIEW $DATABASE.$viewName AS SELECT 1 AS id " +
+                                "COMMENT '${BiObjectMetadataCodec.encode(metadata)}'"
                         )
                     }
                 }
@@ -207,20 +498,58 @@ class ClickHouseBiDeploymentInspectorIntegrationTest {
                 ).use { inspector ->
                     val available = inspector.inspect(options).block() as BiDeploymentInspection.Available
 
-                    available.deployment.objects.single().name.assert().isEqualTo(TABLE)
+                    available.deployment.objects.single().name.assert().isEqualTo(viewName)
                 }
-            }
+        }
     }
+
+    private fun ClickHouseBiDeploymentInspector.inspect(
+        options: BiScriptOptions,
+        operation: BiScriptOperation = BiScriptOperation.Deploy,
+    ): reactor.core.publisher.Mono<BiDeploymentInspection> =
+        inspect(options, operation, BiScriptGenerator(options).prepare(emptySet()))
 
     private companion object {
         const val CLICKHOUSE_IMAGE = "clickhouse/clickhouse-server:24.8.14.39-alpine"
         const val DATABASE = "wow_bi_native_inspector"
         const val CONSUMER_DATABASE = "wow_bi_native_inspector_consumer"
-        const val TABLE = "catalog_store"
+        const val TABLE = "catalog_command_store"
         const val QUEUE = "catalog_command_queue"
         const val KAFKA_BOOTSTRAP_SERVERS = "kafka-a:9092,kafka-b:9092"
         const val CLUSTER = "test_cluster"
+
+        fun commandStoreColumns(tenantIdType: String = "String"): String = """
+            id String,
+            context_name String,
+            aggregate_name String,
+            name String,
+            header Map(String, String),
+            aggregate_id String,
+            tenant_id $tenantIdType,
+            owner_id String,
+            space_id String,
+            request_id String,
+            aggregate_version Nullable(UInt32),
+            is_create Bool,
+            is_void Bool,
+            allow_create Bool,
+            body_type String,
+            body String,
+            create_time DateTime64(3, 'Asia/Shanghai')
+        """.trimIndent()
         const val CLUSTER_CONFIG_RESOURCE = "clickhouse-test-cluster.xml"
         const val CLUSTER_CONFIG_PATH = "/etc/clickhouse-server/config.d/clickhouse-test-cluster.xml"
+
+        fun executeStatements(clickHouse: ClickHouseContainer, statements: List<String>) {
+            DriverManager.getConnection(
+                clickHouse.jdbcUrl,
+                clickHouse.username,
+                clickHouse.password,
+            ).use { connection ->
+                connection.createStatement().use { statement ->
+                    statements.forEach(statement::execute)
+                }
+            }
+        }
     }
 }

--- a/wow-bi/src/integrationTest/kotlin/me/ahoo/wow/bi/ClickHouseCatalogScaleIntegrationTest.kt
+++ b/wow-bi/src/integrationTest/kotlin/me/ahoo/wow/bi/ClickHouseCatalogScaleIntegrationTest.kt
@@ -1,0 +1,342 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.configuration.MetadataSearcher
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import org.testcontainers.clickhouse.ClickHouseContainer
+import org.testcontainers.containers.Network
+import org.testcontainers.lifecycle.Startables
+import org.testcontainers.utility.DockerImageName
+import org.testcontainers.utility.MountableFile
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
+import java.sql.DriverManager
+import java.time.Duration
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.stream.Stream
+import kotlin.math.ceil
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@EnabledIfEnvironmentVariable(named = "WOW_BI_CATALOG_SCALE", matches = "(?i:true|1)")
+class ClickHouseCatalogScaleIntegrationTest {
+    private lateinit var network: Network
+    private lateinit var primary: ClickHouseContainer
+    private lateinit var replica: ClickHouseContainer
+
+    @BeforeAll
+    @Suppress("TooGenericExceptionCaught") // Any startup failure must close every partially started container.
+    fun startCluster() {
+        network = Network.newNetwork()
+        primary = clickHouse(NODE_1)
+        replica = clickHouse(NODE_2)
+        try {
+            Startables.deepStart(Stream.of(primary, replica)).join()
+            seedCatalog(primary)
+            seedCatalog(replica)
+            assertClusterReady()
+        } catch (error: Throwable) {
+            closeCluster()
+            throw error
+        }
+    }
+
+    @AfterAll
+    fun closeCluster() {
+        if (::primary.isInitialized) {
+            primary.close()
+        }
+        if (::replica.isInitialized) {
+            replica.close()
+        }
+        if (::network.isInitialized) {
+            network.close()
+        }
+    }
+
+    @Test
+    @Suppress("LongMethod") // Keeps measured setup, concurrent requests, and percentile assertions together.
+    fun `should inspect ten thousand catalog objects across two replicas under fifty concurrent requests`() {
+        val options = BiScriptOptions(
+            database = CATALOG_DATABASE,
+            consumerDatabase = CONSUMER_DATABASE,
+            consumerGroupNamespace = "catalog-scale",
+            topology = ClickHouseTopology.Cluster(
+                name = CLUSTER,
+                installation = "catalog-scale",
+            ),
+        )
+        val aggregate = MetadataSearcher.localAggregates.first()
+        val latencies = ConcurrentLinkedQueue<Long>()
+        ClickHouseBiDeploymentInspector(
+            clientOptions = clientOptions(primary),
+            inspectionTimeout = INSPECTION_TIMEOUT,
+        ).use { inspector ->
+            val outcomes = Flux.range(0, REQUEST_COUNT)
+                .flatMap({ request ->
+                    Mono.defer {
+                        val startedAt = System.nanoTime()
+                        inspector.inspect(
+                            options,
+                            BiScriptOperation.Deploy,
+                            BiScriptGenerator(options).prepare(setOf(aggregate)),
+                        )
+                            .map<ScaleOutcome> { inspection ->
+                                val latencyMillis = Duration.ofNanos(System.nanoTime() - startedAt).toMillis()
+                                latencies.add(latencyMillis)
+                                ScaleOutcome.Success(request, inspection)
+                            }
+                            .onErrorResume { error ->
+                                Mono.just(ScaleOutcome.Failure(request, error))
+                            }
+                    }
+                }, REQUEST_COUNT)
+                .collectList()
+                .block(SCALE_TIMEOUT)
+                .orEmpty()
+
+            outcomes.assert().hasSize(REQUEST_COUNT)
+            val failures = outcomes.filterIsInstance<ScaleOutcome.Failure>()
+            check(failures.isEmpty()) {
+                "Scale inspection failures: ${failures.joinToString { "#${it.request}:${it.error}" }}"
+            }
+            outcomes.filterIsInstance<ScaleOutcome.Success>().all { outcome ->
+                outcome.inspection is BiDeploymentInspection.Available &&
+                    outcome.inspection.deployment.objects.isEmpty()
+            }.assert().isTrue()
+        }
+
+        val queryStats = queryStats(primary) + queryStats(replica)
+        check(queryStats.queryCount >= REQUEST_COUNT) {
+            "Expected at least $REQUEST_COUNT finished scoped catalog queries, but observed $queryStats"
+        }
+        val latencyStats = LatencyStats.from(latencies)
+        writeReport(
+            "catalog-scale.json",
+            """
+            {
+              "catalogObjectsPerReplica": $CATALOG_SIZE,
+              "replicas": 2,
+              "requests": $REQUEST_COUNT,
+              "concurrency": $REQUEST_COUNT,
+              "successes": $REQUEST_COUNT,
+              "latencyMillis": ${latencyStats.toJson()},
+              "queryLog": ${queryStats.toJson()}
+            }
+            """.trimIndent(),
+        )
+    }
+
+    private fun clickHouse(alias: String): ClickHouseContainer =
+        ClickHouseContainer(DockerImageName.parse(CLICKHOUSE_IMAGE))
+            .withNetwork(network)
+            .withNetworkAliases(alias)
+            .withCopyFileToContainer(
+                MountableFile.forClasspathResource(CLUSTER_CONFIG_RESOURCE),
+                CLUSTER_CONFIG_PATH,
+            )
+
+    private fun seedCatalog(container: ClickHouseContainer) {
+        val client = "clickhouse-client --user ${container.username} --password ${container.password} --multiquery"
+        val seedScript = """
+            set -eu
+            $client --query "CREATE DATABASE $CATALOG_DATABASE ENGINE = Memory; CREATE DATABASE $CONSUMER_DATABASE ENGINE = Memory;"
+            seq 1 $CATALOG_SIZE | awk '{
+                printf "CREATE VIEW $CATALOG_DATABASE.scale_view_%05d AS SELECT %d AS id;\n", ${'$'}1, ${'$'}1
+            }' | $client
+        """.trimIndent()
+        val result = container.execInContainer("sh", "-c", seedScript)
+        check(result.exitCode == 0) {
+            "Failed to seed ClickHouse node [${container.containerName}]: ${result.stderr}\n${result.stdout}"
+        }
+        connection(container).use { connection ->
+            connection.createStatement().use { statement ->
+                statement.executeQuery(
+                    "SELECT count() FROM system.tables WHERE database = '$CATALOG_DATABASE'"
+                ).use { rows ->
+                    rows.next().assert().isTrue()
+                    rows.getInt(1).assert().isEqualTo(CATALOG_SIZE)
+                }
+            }
+        }
+    }
+
+    private fun assertClusterReady() {
+        connection(primary).use { connection ->
+            connection.createStatement().use { statement ->
+                statement.executeQuery(
+                    "SELECT count(), uniqExact(hostName()) " +
+                        "FROM clusterAllReplicas('$CLUSTER', system.one)"
+                ).use { rows ->
+                    rows.next().assert().isTrue()
+                    rows.getInt(1).assert().isEqualTo(2)
+                    rows.getInt(2).assert().isEqualTo(2)
+                }
+                statement.executeQuery(
+                    "SELECT hostName(), count() " +
+                        "FROM clusterAllReplicas('$CLUSTER', system.tables) " +
+                        "WHERE database = '$CATALOG_DATABASE' " +
+                        "GROUP BY hostName() ORDER BY hostName()"
+                ).use { rows ->
+                    val catalogSizes = buildList {
+                        while (rows.next()) {
+                            add(rows.getString(1) to rows.getInt(2))
+                        }
+                    }
+                    catalogSizes.assert().hasSize(2)
+                    catalogSizes.all { (_, size) -> size == CATALOG_SIZE }.assert().isTrue()
+                }
+            }
+        }
+    }
+
+    private fun queryStats(container: ClickHouseContainer): QueryStats {
+        connection(container).use { connection ->
+            connection.createStatement().use { statement ->
+                statement.execute("SYSTEM FLUSH LOGS")
+                statement.executeQuery(
+                    """
+                    SELECT count(),
+                           coalesce(sum(read_rows), 0),
+                           coalesce(sum(read_bytes), 0),
+                           coalesce(sum(result_rows), 0),
+                           coalesce(max(memory_usage), 0),
+                           coalesce(quantileExact(0.95)(query_duration_ms), 0)
+                    FROM system.query_log
+                    WHERE type = 'QueryFinish'
+                      AND event_time >= now() - INTERVAL 10 MINUTE
+                      AND query LIKE '%system.tables%'
+                      AND query LIKE '%startsWith(comment%'
+                    """.trimIndent()
+                ).use { rows ->
+                    rows.next().assert().isTrue()
+                    return QueryStats(
+                        queryCount = rows.getLong(1),
+                        readRows = rows.getLong(2),
+                        readBytes = rows.getLong(3),
+                        resultRows = rows.getLong(4),
+                        maxMemoryUsage = rows.getLong(5),
+                        p95QueryDurationMillis = rows.getLong(6),
+                    )
+                }
+            }
+        }
+    }
+
+    private fun connection(container: ClickHouseContainer) =
+        DriverManager.getConnection(container.jdbcUrl, container.username, container.password)
+
+    private fun clientOptions(container: ClickHouseContainer): ClickHouseClientOptions = ClickHouseClientOptions(
+        endpoints = listOf(URI.create(container.httpUrl)),
+        username = container.username,
+        password = container.password,
+        connectionTimeout = Duration.ofSeconds(5),
+        connectionRequestTimeout = Duration.ofSeconds(30),
+        socketTimeout = Duration.ofSeconds(30),
+        executionTimeout = Duration.ofSeconds(30),
+    )
+
+    private fun writeReport(fileName: String, content: String) {
+        val reportDirectory = Path.of("build", "reports", "wow-bi", "catalog-scale")
+        Files.createDirectories(reportDirectory)
+        Files.writeString(reportDirectory.resolve(fileName), content + System.lineSeparator())
+    }
+
+    private sealed interface ScaleOutcome {
+        data class Success(
+            val request: Int,
+            val inspection: BiDeploymentInspection,
+        ) : ScaleOutcome
+
+        data class Failure(
+            val request: Int,
+            val error: Throwable,
+        ) : ScaleOutcome
+    }
+
+    private data class LatencyStats(
+        val min: Long,
+        val p50: Long,
+        val p95: Long,
+        val p99: Long,
+        val max: Long,
+    ) {
+        fun toJson(): String =
+            "{\"min\":$min,\"p50\":$p50,\"p95\":$p95,\"p99\":$p99,\"max\":$max}"
+
+        companion object {
+            fun from(values: Collection<Long>): LatencyStats {
+                val sorted = values.sorted()
+                check(sorted.isNotEmpty()) { "No successful scale inspection latency was recorded" }
+                return LatencyStats(
+                    min = sorted.first(),
+                    p50 = sorted.percentile(0.50),
+                    p95 = sorted.percentile(0.95),
+                    p99 = sorted.percentile(0.99),
+                    max = sorted.last(),
+                )
+            }
+
+            private fun List<Long>.percentile(value: Double): Long {
+                val index = ceil(size * value).toInt().coerceIn(1, size) - 1
+                return this[index]
+            }
+        }
+    }
+
+    private data class QueryStats(
+        val queryCount: Long,
+        val readRows: Long,
+        val readBytes: Long,
+        val resultRows: Long,
+        val maxMemoryUsage: Long,
+        val p95QueryDurationMillis: Long,
+    ) {
+        operator fun plus(other: QueryStats): QueryStats = QueryStats(
+            queryCount = queryCount + other.queryCount,
+            readRows = readRows + other.readRows,
+            readBytes = readBytes + other.readBytes,
+            resultRows = resultRows + other.resultRows,
+            maxMemoryUsage = maxOf(maxMemoryUsage, other.maxMemoryUsage),
+            p95QueryDurationMillis = maxOf(p95QueryDurationMillis, other.p95QueryDurationMillis),
+        )
+
+        fun toJson(): String = """
+            {"queryCount":$queryCount,"readRows":$readRows,"readBytes":$readBytes,"resultRows":$resultRows,"maxMemoryUsage":$maxMemoryUsage,"p95QueryDurationMillis":$p95QueryDurationMillis}
+        """.trimIndent()
+    }
+
+    private companion object {
+        const val CLICKHOUSE_IMAGE = "clickhouse/clickhouse-server:24.8.14.39-alpine"
+        const val CLUSTER = "wow_bi_scale_cluster"
+        const val NODE_1 = "wow-bi-scale-node-1"
+        const val NODE_2 = "wow-bi-scale-node-2"
+        const val CATALOG_DATABASE = "wow_bi_catalog_scale"
+        const val CONSUMER_DATABASE = "wow_bi_catalog_scale_consumer"
+        const val CATALOG_SIZE = 10_000
+        const val REQUEST_COUNT = 50
+        val INSPECTION_TIMEOUT: Duration = Duration.ofSeconds(60)
+        val SCALE_TIMEOUT: Duration = Duration.ofMinutes(3)
+        const val CLUSTER_CONFIG_RESOURCE = "clickhouse-scale-cluster.xml"
+        const val CLUSTER_CONFIG_PATH = "/etc/clickhouse-server/config.d/clickhouse-scale-cluster.xml"
+    }
+}

--- a/wow-bi/src/integrationTest/kotlin/me/ahoo/wow/bi/ClickHouseExpansionIntegrationTest.kt
+++ b/wow-bi/src/integrationTest/kotlin/me/ahoo/wow/bi/ClickHouseExpansionIntegrationTest.kt
@@ -75,7 +75,8 @@ class ClickHouseExpansionIntegrationTest {
         val namedAggregate = aggregateMetadata<ClickHouseExpansionAggregate, ClickHouseExpansionState>()
         val generator = BiScriptGenerator(options)
         val namedAggregates = setOf(namedAggregate)
-        val result = generator.generate(namedAggregates)
+        val preparation = generator.prepare(namedAggregates)
+        val result = generator.generate(preparation)
         result.diagnostics
             .filter { it.path == "claimedArrayList" || it.path == "claimedMap" }
             .associate { it.path to it.code }
@@ -147,11 +148,18 @@ class ClickHouseExpansionIntegrationTest {
                 ).use { inspector ->
                     repeat(2) {
                         val authoritativeDeploy = generator.generate(
-                            namedAggregates,
-                            inspection = inspector.inspect(options).block()!!,
+                            preparation,
+                            inspection = inspector.inspect(options, BiScriptOperation.Deploy, preparation).block()!!,
                         )
                         connection.assertAuthoritativeDeployIsIdempotent(authoritativeDeploy, case)
                     }
+                    connection.assertComputedViewDriftIsRepaired(generator, preparation, inspector, options, case)
+                    connection.assertComputedConsumerTargetDriftIsRepaired(
+                        generator,
+                        preparation,
+                        inspector,
+                        options,
+                    )
                 }
             }
         }
@@ -184,6 +192,9 @@ class ClickHouseExpansionIntegrationTest {
         result: BiScriptResult,
         case: TopologyCase,
     ) {
+        result.diagnostics.none { diagnostic ->
+            diagnostic.code == BiScriptDiagnosticCode.COMPUTED_OBJECT_DRIFT
+        }.assert().isTrue()
         val before = listOf(COMMAND_STORE_TABLE, STATE_STORE_TABLE, STATE_LAST_STORE_TABLE)
             .associateWith { table -> queryCount("SELECT count() FROM ${qualified(DATABASE, table)}") }
         val queueUuids = queueUuids()
@@ -204,6 +215,100 @@ class ClickHouseExpansionIntegrationTest {
                 .assert().isEqualTo(expectedCount)
         }
         queueUuids().assert().isEqualTo(queueUuids)
+    }
+
+    private fun Connection.assertComputedViewDriftIsRepaired(
+        generator: BiScriptGenerator,
+        preparation: BiScriptPreparation,
+        inspector: ClickHouseBiDeploymentInspector,
+        options: BiScriptOptions,
+        case: TopologyCase,
+    ) {
+        val before = listOf(COMMAND_STORE_TABLE, STATE_STORE_TABLE, STATE_LAST_STORE_TABLE)
+            .associateWith { table -> queryCount("SELECT count() FROM ${qualified(DATABASE, table)}") }
+        val queueUuids = queueUuids()
+        val comment = queryRows(
+            "SELECT comment FROM system.tables WHERE database = ${literal(DATABASE)} " +
+                "AND name = ${literal(ROOT_VIEW)}",
+            listOf("comment"),
+        ).single().required("comment")
+        executeSql(
+            "CREATE OR REPLACE VIEW ${qualified(DATABASE, ROOT_VIEW)} AS " +
+                "SELECT * FROM ${qualified(DATABASE, STATE_LAST_STORE_TABLE)} FINAL " +
+                "COMMENT ${literal(comment)}"
+        )
+
+        val inspection = inspector.inspect(options, BiScriptOperation.Deploy, preparation).block()!!
+        val repair = generator.generate(preparation, inspection = inspection)
+        repair.diagnostics.single { diagnostic ->
+            diagnostic.code == BiScriptDiagnosticCode.COMPUTED_OBJECT_DRIFT &&
+                diagnostic.path.endsWith(".$ROOT_VIEW")
+        }.message.assert().contains("definition drift", "SELECT")
+
+        repair.statements.forEach(::executeSql)
+
+        assertGeneratedObjects(case)
+        before.forEach { (table, expectedCount) ->
+            queryCount("SELECT count() FROM ${qualified(DATABASE, table)}").assert().isEqualTo(expectedCount)
+        }
+        queueUuids().assert().isEqualTo(queueUuids)
+        val converged = generator.generate(
+            preparation,
+            inspection = inspector.inspect(options, BiScriptOperation.Deploy, preparation).block()!!,
+        )
+        converged.diagnostics.none { diagnostic ->
+            diagnostic.code == BiScriptDiagnosticCode.COMPUTED_OBJECT_DRIFT
+        }.assert().isTrue()
+    }
+
+    private fun Connection.assertComputedConsumerTargetDriftIsRepaired(
+        generator: BiScriptGenerator,
+        preparation: BiScriptPreparation,
+        inspector: ClickHouseBiDeploymentInspector,
+        options: BiScriptOptions,
+    ) {
+        val consumer = "${STATE_LAST_TABLE}_consumer"
+        val driftTarget = "__wow_bi_drift_target"
+        val before = listOf(COMMAND_STORE_TABLE, STATE_STORE_TABLE, STATE_LAST_STORE_TABLE)
+            .associateWith { table -> queryCount("SELECT count() FROM ${qualified(DATABASE, table)}") }
+        val queueUuids = queueUuids()
+        val comment = queryRows(
+            "SELECT comment FROM system.tables WHERE database = ${literal(CONSUMER_DATABASE)} " +
+                "AND name = ${literal(consumer)}",
+            listOf("comment"),
+        ).single().required("comment")
+        executeSql("DROP VIEW ${qualified(CONSUMER_DATABASE, consumer)}")
+        executeSql(
+            "CREATE TABLE ${qualified(DATABASE, driftTarget)} ENGINE = Memory AS " +
+                "SELECT * FROM ${qualified(DATABASE, STATE_LAST_STORE_TABLE)} WHERE 0"
+        )
+        executeSql(
+            "CREATE MATERIALIZED VIEW ${qualified(CONSUMER_DATABASE, consumer)} " +
+                "TO ${qualified(DATABASE, driftTarget)} AS (SELECT * FROM " +
+                "${qualified(DATABASE, STATE_STORE_TABLE)}) COMMENT ${literal(comment)}"
+        )
+
+        val inspection = inspector.inspect(options, BiScriptOperation.Deploy, preparation).block()!!
+        val repair = generator.generate(preparation, inspection = inspection)
+        repair.diagnostics.single { diagnostic ->
+            diagnostic.code == BiScriptDiagnosticCode.COMPUTED_OBJECT_DRIFT &&
+                diagnostic.path.endsWith(".$consumer")
+        }.message.assert().contains("definition drift", "TARGET")
+
+        repair.statements.forEach(::executeSql)
+        executeSql("DROP TABLE ${qualified(DATABASE, driftTarget)}")
+
+        before.forEach { (table, expectedCount) ->
+            queryCount("SELECT count() FROM ${qualified(DATABASE, table)}").assert().isEqualTo(expectedCount)
+        }
+        queueUuids().assert().isEqualTo(queueUuids)
+        val converged = generator.generate(
+            preparation,
+            inspection = inspector.inspect(options, BiScriptOperation.Deploy, preparation).block()!!,
+        )
+        converged.diagnostics.none { diagnostic ->
+            diagnostic.code == BiScriptDiagnosticCode.COMPUTED_OBJECT_DRIFT
+        }.assert().isTrue()
     }
 
     private fun Connection.queueUuids(): Map<String, String> =
@@ -240,32 +345,39 @@ class ClickHouseExpansionIntegrationTest {
     }
 
     private fun Connection.assertLatestStateReadsAreDeduplicated() {
-        (1..2).forEach { version ->
-            executeSql(
-                """
-                INSERT INTO ${qualified(DATABASE, STATE_STORE_TABLE)}
-                (id, context_name, aggregate_name, header, aggregate_id, tenant_id, owner_id, space_id,
-                 command_id, request_id, version, state, body, first_operator, first_event_time,
-                 create_time, tags, deleted)
-                VALUES ('latest-$version', 'bi-integration-service', 'nullable', map(),
-                        'aggregate-latest', '', '', '', '', '', $version, '{}', [], '',
-                        toDateTime64(0, 3, 'UTC'), toDateTime64(0, 3, 'UTC'), map(), false)
-                """.trimIndent()
-            )
+        listOf("tenant-a", "tenant-b").forEach { tenantId ->
+            for (version in 1..2) {
+                executeSql(
+                    """
+                    INSERT INTO ${qualified(DATABASE, STATE_STORE_TABLE)}
+                    (id, context_name, aggregate_name, header, aggregate_id, tenant_id, owner_id, space_id,
+                     command_id, request_id, version, state, body, first_operator, first_event_time,
+                     create_time, tags, deleted)
+                    VALUES ('latest-$tenantId-$version', 'bi-integration-service', 'nullable', map(),
+                            'aggregate-latest', '$tenantId', '', '', '', '', $version, '{}', [], '',
+                            toDateTime64(0, 3, 'UTC'), toDateTime64(0, 3, 'UTC'), map(), false)
+                    """.trimIndent()
+                )
+            }
         }
         queryCount(
             "SELECT count() FROM ${qualified(DATABASE, STATE_LAST_TABLE)} " +
                 "WHERE aggregate_id = 'aggregate-latest'"
-        ).assert().isEqualTo(1L)
+        ).assert().isEqualTo(2L)
         queryRows(
-            "SELECT version FROM ${qualified(DATABASE, STATE_LAST_TABLE)} " +
-                "WHERE aggregate_id = 'aggregate-latest'",
-            listOf("version"),
-        ).single().required("version").assert().isEqualTo("2")
+            "SELECT tenant_id, version FROM ${qualified(DATABASE, STATE_LAST_TABLE)} " +
+                "WHERE aggregate_id = 'aggregate-latest' ORDER BY tenant_id",
+            listOf("tenant_id", "version"),
+        ).assert().isEqualTo(
+            listOf(
+                mapOf("tenant_id" to "tenant-a", "version" to "2"),
+                mapOf("tenant_id" to "tenant-b", "version" to "2"),
+            )
+        )
         queryCount(
             "SELECT count() FROM ${qualified(DATABASE, ROOT_VIEW)} " +
                 "WHERE __aggregate_id = 'aggregate-latest'"
-        ).assert().isEqualTo(1L)
+        ).assert().isEqualTo(2L)
     }
 
     private fun topologyCases(): List<TopologyCase> = listOf(
@@ -295,6 +407,13 @@ class ClickHouseExpansionIntegrationTest {
         ClickHouseContainer(DockerImageName.parse(CLICKHOUSE_IMAGE)).apply(case.configureContainer)
 
     private fun Connection.assertGeneratedObjects(case: TopologyCase) {
+        val options = BiScriptOptions(
+            database = DATABASE,
+            consumerDatabase = CONSUMER_DATABASE,
+            topology = case.topology,
+            timezone = "UTC",
+            consumerGroupNamespace = "integration-test",
+        )
         val objects = queryRows(
             sql = "SELECT database, name, engine FROM system.tables " +
                 "WHERE database IN (${literal(DATABASE)}, ${literal(CONSUMER_DATABASE)})",
@@ -304,12 +423,14 @@ class ClickHouseExpansionIntegrationTest {
             keySelector = { it.required("database") },
             valueTransform = { it.required("name") },
         ).mapValues { (_, names) -> names.toSet() }
-            .assert().isEqualTo(expectedGeneratedObjects(case.topology))
+            .assert().isEqualTo(expectedGeneratedObjects(case.topology, options))
         queryRows(
             sql = "SELECT comment FROM system.tables " +
                 "WHERE database IN (${literal(DATABASE)}, ${literal(CONSUMER_DATABASE)})",
             columns = listOf("comment"),
-        ).map { it.required("comment") }.all { it.startsWith("wow-bi:") }.assert().isTrue()
+        ).map { it.required("comment") }
+            .all { comment -> comment.startsWith("wow-bi:") || comment.startsWith("wow-bi-registry:") }
+            .assert().isTrue()
 
         if (case.topology == ClickHouseTopology.Standalone) {
             val forbiddenPredicates = (
@@ -528,11 +649,19 @@ class ClickHouseExpansionIntegrationTest {
     private fun qualified(database: String, table: String): String =
         "${identifier(database)}.${identifier(table)}"
 
-    private fun expectedGeneratedObjects(topology: ClickHouseTopology): Map<String, Set<String>> =
-        when (topology) {
+    private fun expectedGeneratedObjects(
+        topology: ClickHouseTopology,
+        options: BiScriptOptions,
+    ): Map<String, Set<String>> {
+        val expected = when (topology) {
             is ClickHouseTopology.Cluster -> EXPECTED_CLUSTER_OBJECTS
             ClickHouseTopology.Standalone -> EXPECTED_STANDALONE_OBJECTS
         }
+        val registryName = BiOwnershipRegistry.empty(
+            BiDeploymentDescriptor.from(options).deploymentId,
+        ).name
+        return expected + (CONSUMER_DATABASE to checkNotNull(expected[CONSUMER_DATABASE]) + registryName)
+    }
 
     private companion object {
         const val CLICKHOUSE_IMAGE = "clickhouse/clickhouse-server:24.8.14.39-alpine"

--- a/wow-bi/src/integrationTest/kotlin/me/ahoo/wow/bi/ClickHouseFormParameterScaleIntegrationTest.kt
+++ b/wow-bi/src/integrationTest/kotlin/me/ahoo/wow/bi/ClickHouseFormParameterScaleIntegrationTest.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable
+import org.testcontainers.clickhouse.ClickHouseContainer
+import org.testcontainers.utility.DockerImageName
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Duration
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@EnabledIfEnvironmentVariable(named = "WOW_BI_CATALOG_SCALE", matches = "(?i:true|1)")
+class ClickHouseFormParameterScaleIntegrationTest {
+    private lateinit var clickHouse: ClickHouseContainer
+
+    @BeforeAll
+    fun startClickHouse() {
+        clickHouse = ClickHouseContainer(DockerImageName.parse(CLICKHOUSE_IMAGE))
+        clickHouse.start()
+    }
+
+    @AfterAll
+    fun closeClickHouse() {
+        if (::clickHouse.isInitialized) {
+            clickHouse.close()
+        }
+    }
+
+    @Test
+    fun `should accept large desired-name arrays through ClickHouse form parameters`() {
+        NativeClickHouseCatalogClient.create(clientOptions()).use { client ->
+            val probes = FORM_PARAMETER_SIZES.map { size ->
+                probe(client, size)
+            }
+            writeReport(
+                probes.joinToString(prefix = "[\n", postfix = "\n]", separator = ",\n") { it.toJson() },
+            )
+        }
+    }
+
+    @Suppress("TooGenericExceptionCaught") // Preserve the failed probe size while retaining the original client error.
+    private fun probe(client: ClickHouseCatalogClient, size: Int): FormParameterProbe {
+        val names = List(size) { index ->
+            if (index == 0) {
+                SENTINEL
+            } else {
+                "desired_${index.toString().padStart(5, '0')}"
+            }
+        }
+        val parameterPlan = ClickHouseStringArrayParameterPlan.create(
+            expression = "name",
+            parameterName = "names",
+            values = names,
+        )
+        val payloadBytes = parameterPlan.parameters.values.sumOf { value ->
+            value.toByteArray(Charsets.UTF_8).size.toLong()
+        }
+        val maxParameterBytes = parameterPlan.parameters.values.maxOf { value ->
+            value.toByteArray(Charsets.UTF_8).size
+        }
+        val lengthExpression = parameterPlan.parameters.keys.joinToString(" + ") { name ->
+            "length({$name:Array(String)})"
+        }
+        val firstParameterName = parameterPlan.parameters.keys.first()
+        val startedAt = System.nanoTime()
+        val rows = try {
+            client.query(
+                sql = """
+                    SELECT throwIf(
+                        $lengthExpression != {expected:UInt64}
+                            OR {$firstParameterName:Array(String)}[1] != {sentinel:String},
+                        'ClickHouse form parameter content mismatch'
+                    ) AS accepted
+                """.trimIndent(),
+                parameters = parameterPlan.parameters + mapOf(
+                    "expected" to size.toLong(),
+                    "sentinel" to SENTINEL,
+                ),
+                columns = listOf("accepted"),
+            )
+        } catch (error: Exception) {
+            throw IllegalStateException(
+                "ClickHouse form parameter probe failed at size [$size], payloadBytes [$payloadBytes]",
+                error,
+            )
+        }
+        rows.assert().hasSize(1)
+        return FormParameterProbe(
+            size = size,
+            payloadBytes = payloadBytes,
+            parameterCount = parameterPlan.parameters.size,
+            maxParameterBytes = maxParameterBytes,
+            latencyMillis = Duration.ofNanos(System.nanoTime() - startedAt).toMillis(),
+        )
+    }
+
+    private fun clientOptions(): ClickHouseClientOptions = ClickHouseClientOptions(
+        endpoints = listOf(URI.create(clickHouse.httpUrl)),
+        username = clickHouse.username,
+        password = clickHouse.password,
+        connectionTimeout = Duration.ofSeconds(5),
+        connectionRequestTimeout = Duration.ofSeconds(30),
+        socketTimeout = Duration.ofSeconds(30),
+        executionTimeout = Duration.ofSeconds(30),
+    )
+
+    private fun writeReport(content: String) {
+        val reportDirectory = Path.of("build", "reports", "wow-bi", "catalog-scale")
+        Files.createDirectories(reportDirectory)
+        Files.writeString(
+            reportDirectory.resolve("form-parameter-scale.json"),
+            content + System.lineSeparator(),
+        )
+    }
+
+    private data class FormParameterProbe(
+        val size: Int,
+        val payloadBytes: Long,
+        val parameterCount: Int,
+        val maxParameterBytes: Int,
+        val latencyMillis: Long,
+    ) {
+        fun toJson(): String =
+            "  {\"size\":$size,\"payloadBytes\":$payloadBytes," +
+                "\"parameterCount\":$parameterCount,\"maxParameterBytes\":$maxParameterBytes," +
+                "\"latencyMillis\":$latencyMillis}"
+    }
+
+    private companion object {
+        const val CLICKHOUSE_IMAGE = "clickhouse/clickhouse-server:24.8.14.39-alpine"
+        const val SENTINEL = "desired_'\\_你好"
+        val FORM_PARAMETER_SIZES = listOf(1_000, 5_000, 10_000)
+    }
+}

--- a/wow-bi/src/integrationTest/kotlin/me/ahoo/wow/bi/KafkaClickHouseIntegrationTest.kt
+++ b/wow-bi/src/integrationTest/kotlin/me/ahoo/wow/bi/KafkaClickHouseIntegrationTest.kt
@@ -38,7 +38,11 @@ import java.util.concurrent.TimeUnit
 
 class KafkaClickHouseIntegrationTest {
     @Test
-    @Suppress("LongMethod")
+    @Suppress(
+        "LongMethod",
+        "CyclomaticComplexMethod",
+        "NestedBlockDepth",
+    ) // Ordered multi-container lifecycle scenario.
     fun `should consume Kafka messages and replay from earliest after reset`() {
         Network.newNetwork().use { network ->
             kafka(network).use { kafka ->
@@ -72,147 +76,162 @@ class KafkaClickHouseIntegrationTest {
                             }
                             firstDeploy.statements.forEach { statement -> connection.executeStatement(statement) }
 
-                        connection.awaitLong("SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "command_store")}", 1)
-                        connection.awaitLong("SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "state_store")}", 2)
-                        connection.awaitLong(
-                            "SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "state_event")}",
-                            2,
-                        )
-                        connection.queryString(
-                            "SELECT event_body FROM $DATABASE.${naming.toTableName(aggregate, "state_event")} " +
-                                "WHERE version = 2",
-                        ).assert().isEqualTo("{\"value\":2}")
-                        connection.awaitLong(
-                            "SELECT version FROM $DATABASE.${naming.toTableName(aggregate, "state_last")} " +
-                                "WHERE aggregate_id = '$AGGREGATE_ID'",
-                            2,
-                        )
-                        connection.queryCommand(naming.toTableName(aggregate, "command")).assert().isEqualTo(
-                            CommandProjection(
-                                isVoid = true,
-                                body = "{\"value\":42}",
-                                createTime = -1,
+                            connection.awaitLong(
+                                "SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "command_store")}",
+                                1,
                             )
-                        )
-                        connection.awaitLong(
-                            "SELECT nullable_scalar FROM $DATABASE.${naming.toTableName(aggregate, "state_last_root")} " +
-                                "WHERE __aggregate_id = '$AGGREGATE_ID'",
-                            2,
-                        )
-                        val queueUuids = listOf("command", "state").associateWith { suffix ->
+                            connection.awaitLong(
+                                "SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "state_store")}",
+                                2,
+                            )
+                            connection.awaitLong(
+                                "SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "state_event")}",
+                                2,
+                            )
                             connection.queryString(
-                                "SELECT toString(uuid) FROM system.tables " +
-                                    "WHERE database = '$CONSUMER_DATABASE' AND " +
-                                "name = '${naming.toTableName(aggregate, "${suffix}_queue")}'",
+                                "SELECT event_body FROM $DATABASE.${naming.toTableName(aggregate, "state_event")} " +
+                                    "WHERE version = 2",
+                            ).assert().isEqualTo("{\"value\":2}")
+                            connection.awaitLong(
+                                "SELECT version FROM $DATABASE.${naming.toTableName(aggregate, "state_last")} " +
+                                    "WHERE aggregate_id = '$AGGREGATE_ID'",
+                                2,
                             )
-                        }
-                        queueUuids.values.forEach { uuid -> uuid.assert().isNotEqualTo(NIL_UUID) }
-
-                        val redeploy = generator.generate(
-                            setOf(aggregate),
-                            BiScriptOperation.Deploy,
-                            inspector.inspectAvailable(options),
-                        )
-                        redeploy.assertDoesNotMutateQueues(naming, aggregate)
-                        redeploy.statements.forEach { statement -> connection.executeStatement(statement) }
-                        connection.queryLong(
-                            "SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "state_store")}"
-                        ).assert().isEqualTo(2)
-                        queueUuids.forEach { (suffix, uuid) ->
-                            connection.queryString(
-                                "SELECT toString(uuid) FROM system.tables " +
-                                    "WHERE database = '$CONSUMER_DATABASE' AND " +
-                                    "name = '${naming.toTableName(aggregate, "${suffix}_queue")}'",
-                            ).assert().isEqualTo(uuid)
-                        }
-
-                        producer(kafka).use { producer ->
-                            producer.sendJson(commandTopic, "command-2", commandMessage("command-2", 84))
-                            producer.sendJson(stateTopic, "state-3", stateMessage(version = 3, scalar = 3))
-                        }
-                        connection.awaitLong("SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "command_store")}", 2)
-                        connection.awaitLong("SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "state_store")}", 3)
-
-                        val reset = generator.generate(
-                            setOf(aggregate),
-                            BiScriptOperation.Reset(replayFromEarliestConfirmed = true),
-                            inspector.inspectAvailable(options, BiScriptOperation.Reset(true)),
-                        )
-                        val resetIdentity = consumerIdentity(reset.script)
-                        resetIdentity.assert().isNotEqualTo(consumerIdentity(firstDeploy.script))
-                        val firstDurableStatement = reset.indexOfStatement(
-                            "CREATE TABLE IF NOT EXISTS \"$DATABASE\".\"${
-                                naming.toTableName(aggregate, "command_store")
-                            }\""
-                        )
-                        reset.statements.take(firstDurableStatement)
-                            .forEach { statement -> connection.executeStatement(statement) }
-
-                        val resettingInspection = inspector.inspectAvailable(
-                            options,
-                            BiScriptOperation.Reset(true),
-                        )
-                        resettingInspection.anchorMetadata().phase.assert().isEqualTo(BiDeploymentPhase.RESETTING)
-                        resettingInspection.consumerIdentity().assert().isEqualTo(resetIdentity)
-                        assertThrows<IllegalArgumentException> {
-                            generator.generate(setOf(aggregate), BiScriptOperation.Deploy, resettingInspection)
-                        }.message.assert().contains("RESETTING")
-
-                        val retryReset = generator.generate(
-                            setOf(aggregate),
-                            BiScriptOperation.Reset(replayFromEarliestConfirmed = true),
-                            resettingInspection,
-                        )
-                        consumerIdentity(retryReset.script).assert().isEqualTo(resetIdentity)
-                        val stableAnchorStatement = retryReset.indexOfAnchorStatement(BiDeploymentPhase.STABLE)
-                        retryReset.statements.take(stableAnchorStatement + 1)
-                            .forEach { statement -> connection.executeStatement(statement) }
-
-                        val stableInspection = inspector.inspectAvailable(options)
-                        stableInspection.anchorMetadata().phase.assert().isEqualTo(BiDeploymentPhase.STABLE)
-                        stableInspection.consumerIdentity().assert().isEqualTo(resetIdentity)
-                        listOf("command", "state").flatMap { suffix ->
-                            listOf(
-                                naming.toTableName(aggregate, "${suffix}_queue"),
-                                naming.toTableName(aggregate, "${suffix}_consumer"),
+                            connection.queryCommand(naming.toTableName(aggregate, "command")).assert().isEqualTo(
+                                CommandProjection(
+                                    isVoid = true,
+                                    body = "{\"value\":42}",
+                                    createTime = -1,
+                                )
                             )
-                        }.forEach { table ->
+                            connection.awaitLong(
+                                "SELECT nullable_scalar FROM $DATABASE.${naming.toTableName(aggregate, "state_last_root")} " +
+                                    "WHERE __aggregate_id = '$AGGREGATE_ID'",
+                                2,
+                            )
+                            val queueUuids = listOf("command", "state").associateWith { suffix ->
+                                connection.queryString(
+                                    "SELECT toString(uuid) FROM system.tables " +
+                                        "WHERE database = '$CONSUMER_DATABASE' AND " +
+                                        "name = '${naming.toTableName(aggregate, "${suffix}_queue")}'",
+                                )
+                            }
+                            queueUuids.values.forEach { uuid -> uuid.assert().isNotEqualTo(NIL_UUID) }
+
+                            val redeploy = generator.generate(
+                                setOf(aggregate),
+                                BiScriptOperation.Deploy,
+                                inspector.inspectAvailable(options),
+                            )
+                            redeploy.assertDoesNotMutateQueues(naming, aggregate)
+                            redeploy.statements.forEach { statement -> connection.executeStatement(statement) }
                             connection.queryLong(
-                                "SELECT count() FROM system.tables WHERE database = '$CONSUMER_DATABASE' " +
-                                    "AND name = '$table'"
-                            ).assert().isZero()
-                        }
+                                "SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "state_store")}"
+                            ).assert().isEqualTo(2)
+                            queueUuids.forEach { (suffix, uuid) ->
+                                connection.queryString(
+                                    "SELECT toString(uuid) FROM system.tables " +
+                                        "WHERE database = '$CONSUMER_DATABASE' AND " +
+                                        "name = '${naming.toTableName(aggregate, "${suffix}_queue")}'",
+                                ).assert().isEqualTo(uuid)
+                            }
 
-                        val deployAfterReset = generator.generate(
-                            setOf(aggregate),
-                            BiScriptOperation.Deploy,
-                            stableInspection,
-                        )
-                        consumerIdentity(deployAfterReset.script).assert().isEqualTo(resetIdentity)
-                        deployAfterReset.statements.forEach { statement -> connection.executeStatement(statement) }
-                        inspector.inspectAvailable(options).consumerIdentity().assert().isEqualTo(resetIdentity)
-                        connection.awaitLong(
-                            "SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "command_store")}",
-                            2,
-                        )
-                        connection.awaitLong(
-                            "SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "state_store")}",
-                            3,
-                        )
-                        connection.awaitLong(
-                            "SELECT version FROM $DATABASE.${naming.toTableName(aggregate, "state_last")} " +
-                                "WHERE aggregate_id = '$AGGREGATE_ID'",
-                            3,
-                        )
-                        producer(kafka).use { producer ->
-                            producer.sendJson(stateTopic, "state-4", stateMessage(version = 4, scalar = 4))
-                        }
-                        connection.awaitLong("SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "state_store")}", 4)
-                        connection.awaitLong(
-                            "SELECT version FROM $DATABASE.${naming.toTableName(aggregate, "state_last")} " +
-                                "WHERE aggregate_id = '$AGGREGATE_ID'",
-                            4,
-                        )
+                            producer(kafka).use { producer ->
+                                producer.sendJson(commandTopic, "command-2", commandMessage("command-2", 84))
+                                producer.sendJson(stateTopic, "state-3", stateMessage(version = 3, scalar = 3))
+                            }
+                            connection.awaitLong(
+                                "SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "command_store")}",
+                                2,
+                            )
+                            connection.awaitLong(
+                                "SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "state_store")}",
+                                3,
+                            )
+
+                            val reset = generator.generate(
+                                setOf(aggregate),
+                                BiScriptOperation.Reset(replayFromEarliestConfirmed = true),
+                                inspector.inspectAvailable(options, BiScriptOperation.Reset(true)),
+                            )
+                            val resetIdentity = consumerIdentity(reset.script)
+                            resetIdentity.assert().isNotEqualTo(consumerIdentity(firstDeploy.script))
+                            val firstDurableStatement = reset.indexOfStatement(
+                                "CREATE TABLE IF NOT EXISTS \"$DATABASE\".\"${
+                                    naming.toTableName(aggregate, "command_store")
+                                }\""
+                            )
+                            reset.statements.take(firstDurableStatement)
+                                .forEach { statement -> connection.executeStatement(statement) }
+
+                            val resettingInspection = inspector.inspectAvailable(
+                                options,
+                                BiScriptOperation.Reset(true),
+                            )
+                            resettingInspection.anchorMetadata().phase.assert().isEqualTo(BiDeploymentPhase.RESETTING)
+                            resettingInspection.consumerIdentity().assert().isEqualTo(resetIdentity)
+                            assertThrows<IllegalArgumentException> {
+                                generator.generate(setOf(aggregate), BiScriptOperation.Deploy, resettingInspection)
+                            }.message.assert().contains("RESETTING")
+
+                            val retryReset = generator.generate(
+                                setOf(aggregate),
+                                BiScriptOperation.Reset(replayFromEarliestConfirmed = true),
+                                resettingInspection,
+                            )
+                            consumerIdentity(retryReset.script).assert().isEqualTo(resetIdentity)
+                            val stableAnchorStatement = retryReset.indexOfAnchorStatement(BiDeploymentPhase.STABLE)
+                            retryReset.statements.take(stableAnchorStatement + 1)
+                                .forEach { statement -> connection.executeStatement(statement) }
+
+                            val stableInspection = inspector.inspectAvailable(options)
+                            stableInspection.anchorMetadata().phase.assert().isEqualTo(BiDeploymentPhase.STABLE)
+                            stableInspection.consumerIdentity().assert().isEqualTo(resetIdentity)
+                            listOf("command", "state").flatMap { suffix ->
+                                listOf(
+                                    naming.toTableName(aggregate, "${suffix}_queue"),
+                                    naming.toTableName(aggregate, "${suffix}_consumer"),
+                                )
+                            }.forEach { table ->
+                                connection.queryLong(
+                                    "SELECT count() FROM system.tables WHERE database = '$CONSUMER_DATABASE' " +
+                                        "AND name = '$table'"
+                                ).assert().isZero()
+                            }
+
+                            val deployAfterReset = generator.generate(
+                                setOf(aggregate),
+                                BiScriptOperation.Deploy,
+                                stableInspection,
+                            )
+                            consumerIdentity(deployAfterReset.script).assert().isEqualTo(resetIdentity)
+                            deployAfterReset.statements.forEach { statement -> connection.executeStatement(statement) }
+                            inspector.inspectAvailable(options).consumerIdentity().assert().isEqualTo(resetIdentity)
+                            connection.awaitLong(
+                                "SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "command_store")}",
+                                2,
+                            )
+                            connection.awaitLong(
+                                "SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "state_store")}",
+                                3,
+                            )
+                            connection.awaitLong(
+                                "SELECT version FROM $DATABASE.${naming.toTableName(aggregate, "state_last")} " +
+                                    "WHERE aggregate_id = '$AGGREGATE_ID'",
+                                3,
+                            )
+                            producer(kafka).use { producer ->
+                                producer.sendJson(stateTopic, "state-4", stateMessage(version = 4, scalar = 4))
+                            }
+                            connection.awaitLong(
+                                "SELECT count() FROM $DATABASE.${naming.toTableName(aggregate, "state_store")}",
+                                4,
+                            )
+                            connection.awaitLong(
+                                "SELECT version FROM $DATABASE.${naming.toTableName(aggregate, "state_last")} " +
+                                    "WHERE aggregate_id = '$AGGREGATE_ID'",
+                                4,
+                            )
                         }
                     }
                 }
@@ -256,7 +275,13 @@ class KafkaClickHouseIntegrationTest {
         options: BiScriptOptions,
         operation: BiScriptOperation = BiScriptOperation.Deploy,
     ): BiDeploymentInspection.Available =
-        inspect(options, operation).block() as BiDeploymentInspection.Available
+        inspect(
+            options,
+            operation,
+            BiScriptGenerator(options).prepare(
+                setOf(aggregateMetadata<ClickHouseExpansionAggregate, ClickHouseExpansionState>())
+            ),
+        ).block() as BiDeploymentInspection.Available
 
     private fun producer(container: ConfluentKafkaContainer): KafkaProducer<String, String> = KafkaProducer(
         mapOf(

--- a/wow-bi/src/integrationTest/resources/clickhouse-scale-cluster.xml
+++ b/wow-bi/src/integrationTest/resources/clickhouse-scale-cluster.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<!--
+  Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<clickhouse>
+    <remote_servers>
+        <wow_bi_scale_cluster>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>wow-bi-scale-node-1</host>
+                    <port>9000</port>
+                    <user>test</user>
+                    <password>test</password>
+                </replica>
+                <replica>
+                    <host>wow-bi-scale-node-2</host>
+                    <port>9000</port>
+                    <user>test</user>
+                    <password>test</password>
+                </replica>
+            </shard>
+        </wow_bi_scale_cluster>
+    </remote_servers>
+</clickhouse>

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiDeploymentInspection.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiDeploymentInspection.kt
@@ -137,6 +137,11 @@ data class ObservedBiObject(
 
 data class BiObjectKey(val database: String, val name: String)
 
+internal data class BiOwnedObject(
+    val key: BiObjectKey,
+    val kind: BiObjectKind,
+)
+
 enum class BiObjectKind {
     ANCHOR,
     STORE,

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiDeploymentInspection.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiDeploymentInspection.kt
@@ -13,11 +13,13 @@
 
 package me.ahoo.wow.bi
 
+import com.fasterxml.jackson.annotation.JsonInclude
 import me.ahoo.wow.api.exception.ErrorInfo
 import me.ahoo.wow.api.exception.ErrorInfoCapable
 import me.ahoo.wow.serialization.JsonSerializer
 import reactor.core.publisher.Mono
 import java.security.MessageDigest
+import java.util.Collections
 import java.util.UUID
 
 fun interface BiDeploymentInspector {
@@ -27,10 +29,8 @@ fun interface BiDeploymentInspector {
     fun inspect(
         options: BiScriptOptions,
         operation: BiScriptOperation,
+        preparation: BiScriptPreparation,
     ): Mono<BiDeploymentInspection>
-
-    fun inspect(options: BiScriptOptions): Mono<BiDeploymentInspection> =
-        inspect(options, BiScriptOperation.Deploy)
 }
 
 data object NoOpBiDeploymentInspector : BiDeploymentInspector {
@@ -39,6 +39,7 @@ data object NoOpBiDeploymentInspector : BiDeploymentInspector {
     override fun inspect(
         options: BiScriptOptions,
         operation: BiScriptOperation,
+        preparation: BiScriptPreparation,
     ): Mono<BiDeploymentInspection> =
         Mono.just(BiDeploymentInspection.Unavailable)
 }
@@ -46,7 +47,35 @@ data object NoOpBiDeploymentInspector : BiDeploymentInspector {
 sealed interface BiDeploymentInspection {
     data object Unavailable : BiDeploymentInspection
 
-    data class Available(val deployment: ObservedBiDeployment) : BiDeploymentInspection
+    class Available private constructor(
+        val deployment: ObservedBiDeployment,
+        internal val reconciliation: BiReconciliationSnapshot,
+    ) : BiDeploymentInspection {
+        constructor(deployment: ObservedBiDeployment) : this(deployment, BiReconciliationSnapshot.EMPTY)
+
+        internal companion object {
+            fun reconciled(
+                deployment: ObservedBiDeployment,
+                repairableComputedDrifts: List<RepairableBiObjectDrift>,
+                ownershipRegistry: BiOwnershipRegistry?,
+            ): Available = Available(
+                deployment,
+                BiReconciliationSnapshot(
+                    Collections.unmodifiableList(ArrayList(repairableComputedDrifts)),
+                    ownershipRegistry,
+                ),
+            )
+        }
+    }
+}
+
+internal data class BiReconciliationSnapshot(
+    val repairableComputedDrifts: List<RepairableBiObjectDrift>,
+    val ownershipRegistry: BiOwnershipRegistry?,
+) {
+    companion object {
+        val EMPTY = BiReconciliationSnapshot(emptyList(), null)
+    }
 }
 
 sealed class BiDeploymentInspectionException(
@@ -131,6 +160,7 @@ data class BiObjectMetadata(
     val aggregate: String? = null,
     val kind: BiObjectKind,
     val consumerIdentity: String? = null,
+    val registryRevision: Long? = null,
 ) {
     init {
         require(protocolVersion == CURRENT_PROTOCOL_VERSION) {
@@ -156,20 +186,19 @@ data class BiObjectMetadata(
         require(phase != BiDeploymentPhase.RESETTING || consumerIdentity != null) {
             "BI RESETTING deployment anchor requires a consumer identity"
         }
+        registryRevision?.let { require(it >= 0) { "registryRevision must not be negative" } }
     }
 
     companion object {
-        const val CURRENT_PROTOCOL_VERSION: Int = 2
-        const val CURRENT_LAYOUT_VERSION: Int = 6
+        const val CURRENT_PROTOCOL_VERSION: Int = 3
+        const val CURRENT_LAYOUT_VERSION: Int = 7
         private val DIGEST_PATTERN = Regex("[0-9a-f]{32}")
     }
 }
 
 object BiObjectMetadataCodec {
-    private const val PREFIX = "wow-bi:"
-
-    fun encode(metadata: BiObjectMetadata): String {
-        return PREFIX + JsonSerializer.writeValueAsString(
+    fun encode(metadata: BiObjectMetadata): String =
+        BI_OBJECT_METADATA_PREFIX + JsonSerializer.writeValueAsString(
             BiObjectMetadataWire(
                 protocolVersion = metadata.protocolVersion,
                 layoutVersion = metadata.layoutVersion,
@@ -180,23 +209,26 @@ object BiObjectMetadataCodec {
                 aggregate = metadata.aggregate,
                 kind = metadata.kind,
                 consumerIdentity = metadata.consumerIdentity,
+                registryRevision = metadata.registryRevision,
             )
         )
-    }
 
     fun decode(comment: String): BiObjectMetadata? {
-        if (!comment.startsWith(PREFIX)) {
+        if (!comment.startsWith(BI_OBJECT_METADATA_PREFIX)) {
             return null
         }
-        val wire = JsonSerializer.readValue(comment.removePrefix(PREFIX), BiObjectMetadataWire::class.java)
+        val wire = JsonSerializer.readValue(
+            comment.removePrefix(BI_OBJECT_METADATA_PREFIX),
+            BiObjectMetadataWire::class.java,
+        )
         require(wire.protocolVersion == BiObjectMetadata.CURRENT_PROTOCOL_VERSION) {
             "Unsupported BI object metadata protocol version: ${wire.protocolVersion}"
         }
         val phase = requireNotNull(wire.phase) {
-            "BI object metadata protocol v2 requires phase"
+            "BI object metadata protocol v${wire.protocolVersion} requires phase"
         }
         val topologyFingerprint = requireNotNull(wire.topologyFingerprint) {
-            "BI object metadata protocol v2 requires topologyFingerprint"
+            "BI object metadata protocol v${wire.protocolVersion} requires topologyFingerprint"
         }
         return BiObjectMetadata(
             protocolVersion = wire.protocolVersion,
@@ -208,10 +240,14 @@ object BiObjectMetadataCodec {
             aggregate = wire.aggregate,
             kind = wire.kind,
             consumerIdentity = wire.consumerIdentity,
+            registryRevision = wire.registryRevision,
         )
     }
 }
 
+internal const val BI_OBJECT_METADATA_PREFIX: String = "wow-bi:"
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
 private data class BiObjectMetadataWire(
     val protocolVersion: Int,
     val layoutVersion: Int,
@@ -222,6 +258,7 @@ private data class BiObjectMetadataWire(
     val aggregate: String? = null,
     val kind: BiObjectKind,
     val consumerIdentity: String? = null,
+    val registryRevision: Long? = null,
 )
 
 @JvmInline

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiExpectedObjectDefinition.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiExpectedObjectDefinition.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+internal data class ExpectedBiQuery(
+    val selectSql: String,
+    val target: BiObjectKey? = null,
+) {
+    init {
+        require(selectSql.isNotBlank()) { "selectSql must not be blank" }
+    }
+}
+
+internal data class CanonicalExpectedBiQuery(
+    val selectSql: String,
+    val target: BiObjectKey? = null,
+)
+
+internal data class RepairableBiObjectDrift(
+    val key: BiObjectKey,
+    val aggregate: String,
+    val kind: BiObjectKind,
+    val mismatches: Set<BiComputedDefinitionField>,
+)
+
+internal enum class BiComputedDefinitionField {
+    SELECT,
+    TARGET,
+}

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiFingerprint.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiFingerprint.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+import java.security.MessageDigest
+
+internal fun biOwnershipDigest(value: String): String =
+    MessageDigest.getInstance("SHA-256")
+        .digest(value.toByteArray(Charsets.UTF_8))
+        .take(16)
+        .joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiObservedDeploymentPolicy.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiObservedDeploymentPolicy.kt
@@ -134,10 +134,15 @@ internal class BiObservedDeploymentPolicy(private val options: BiScriptOptions) 
                 require(observed.engine == desired.expectedEngine) {
                     "BI deployment anchor [${observed.database}.${observed.name}] must use the View engine"
                 }
-            } else {
+            } else if (operation == BiScriptOperation.Deploy) {
                 require(observed.engine == desired.expectedEngine) {
                     "BI object [${observed.database}.${observed.name}] has incompatible engine " +
                         "[${observed.engine}]; expected engine [${desired.expectedEngine}]"
+                }
+            } else {
+                require(desired.kind.acceptsEngine(observed.engine, allowStoreDrift = true)) {
+                    "BI object [${observed.database}.${observed.name}] kind [${desired.kind}] has incompatible " +
+                        "engine [${observed.engine}] for RESET"
                 }
             }
         } else if (metadata?.deploymentId == descriptor.deploymentId) {
@@ -153,12 +158,17 @@ internal class BiObservedDeploymentPolicy(private val options: BiScriptOptions) 
         }
     }
 
-    private fun BiObjectKind.acceptsEngine(engine: String): Boolean = when (this) {
+    private fun BiObjectKind.acceptsEngine(
+        engine: String,
+        allowStoreDrift: Boolean = false,
+    ): Boolean = when (this) {
         BiObjectKind.ANCHOR,
         BiObjectKind.VIEW,
         -> engine == "View"
 
-        BiObjectKind.STORE -> engine in STORE_ENGINES
+        BiObjectKind.STORE ->
+            if (allowStoreDrift) engine !in VIEW_ENGINES && engine != "Kafka" else engine in STORE_ENGINES
+
         BiObjectKind.QUEUE -> engine == "Kafka"
         BiObjectKind.CONSUMER -> engine == "MaterializedView"
     }
@@ -172,5 +182,6 @@ internal class BiObservedDeploymentPolicy(private val options: BiScriptOptions) 
             "ReplicatedReplacingMergeTree",
             "Distributed",
         )
+        val VIEW_ENGINES: Set<String> = setOf("View", "MaterializedView")
     }
 }

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiObservedDeploymentPolicy.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiObservedDeploymentPolicy.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+import me.ahoo.wow.bi.renderer.ClickHouseScriptRenderer
+
+internal class BiObservedDeploymentPolicy(private val options: BiScriptOptions) {
+    fun validate(
+        deployment: ObservedBiDeployment,
+        descriptor: BiDeploymentDescriptor,
+        desiredObjects: List<DesiredBiObject>,
+        operation: BiScriptOperation,
+    ) = with(deployment) {
+        val desiredByKey = desiredObjects.associateBy(DesiredBiObject::key)
+        validateDeploymentTopology(descriptor)
+        validateDeploymentAnchor(descriptor, operation)
+        objects.forEach { observed ->
+            validateObservedObject(observed, desiredByKey[observed.key], descriptor, operation)
+        }
+        if (operation == BiScriptOperation.Deploy) {
+            consumerIdentity(this, descriptor)
+        }
+    }
+
+    fun ownedBy(deployment: ObservedBiDeployment, descriptor: BiDeploymentDescriptor): List<ObservedBiObject> =
+        deployment.ownedObjects.filter { it.metadata?.deploymentId == descriptor.deploymentId }
+
+    fun resettingAnchor(
+        deployment: ObservedBiDeployment,
+        descriptor: BiDeploymentDescriptor,
+    ): ObservedBiObject? = deployment.objects.firstOrNull { observed ->
+        observed.key == desiredAnchorKey() &&
+            observed.metadata?.deploymentId == descriptor.deploymentId &&
+            observed.metadata.phase == BiDeploymentPhase.RESETTING
+    }
+
+    fun consumerIdentity(
+        deployment: ObservedBiDeployment,
+        descriptor: BiDeploymentDescriptor,
+    ): BiConsumerIdentity? {
+        val ownedObjects = ownedBy(deployment, descriptor)
+        val identities = ownedObjects.mapNotNull { observed -> observed.metadata?.consumerIdentity }
+            .map(::BiConsumerIdentity)
+            .distinct()
+        require(identities.size <= 1) {
+            "Observed BI deployment contains mixed consumer identities: ${identities.map(BiConsumerIdentity::value)}"
+        }
+        require(ownedObjects.isEmpty() || identities.isNotEmpty()) {
+            "Observed BI deployment is missing its consumer identity anchor"
+        }
+        return identities.singleOrNull()
+    }
+
+    private fun ObservedBiDeployment.validateDeploymentTopology(descriptor: BiDeploymentDescriptor) {
+        val currentObjects = ownedBy(this, descriptor)
+        if (currentObjects.isEmpty()) {
+            return
+        }
+        val observedTopologies = currentObjects.map { observed ->
+            requireNotNull(observed.metadata).topologyFingerprint
+        }.distinct()
+        require(observedTopologies.size <= 1) {
+            "Observed BI deployment contains mixed topology fingerprints: $observedTopologies"
+        }
+        require(observedTopologies.single() == descriptor.topologyFingerprint) {
+            "Observed BI deployment topology differs from the requested topology and cannot be changed through " +
+                "DEPLOY or RESET"
+        }
+    }
+
+    private fun ObservedBiDeployment.validateDeploymentAnchor(
+        descriptor: BiDeploymentDescriptor,
+        operation: BiScriptOperation,
+    ) {
+        val deploymentAnchors = objects.filter { observed ->
+            observed.metadata?.deploymentId == descriptor.deploymentId &&
+                observed.metadata.kind == BiObjectKind.ANCHOR
+        }
+        require(deploymentAnchors.size <= 1) {
+            "Observed BI deployment contains multiple deployment anchors: " +
+                deploymentAnchors.map { anchor -> "${anchor.database}.${anchor.name}" }.sorted()
+        }
+        deploymentAnchors.singleOrNull()?.let { anchor ->
+            val canonicalAnchor = desiredAnchorKey()
+            require(anchor.key == canonicalAnchor) {
+                "Observed BI deployment anchor must use canonical key " +
+                    "[${canonicalAnchor.database}.${canonicalAnchor.name}], but found " +
+                    "[${anchor.database}.${anchor.name}]"
+            }
+        }
+        resettingAnchor(this, descriptor)?.let { anchor ->
+            val metadata = checkNotNull(anchor.metadata)
+            when (operation) {
+                BiScriptOperation.Deploy -> throw IllegalArgumentException(
+                    "Observed BI deployment is RESETTING; retry RESET with the same configuration"
+                )
+
+                is BiScriptOperation.Reset -> require(
+                    metadata.configurationFingerprint == descriptor.configurationFingerprint
+                ) {
+                    "Observed BI deployment is RESETTING with a different configuration; " +
+                        "retry RESET with the original configuration"
+                }
+            }
+        }
+    }
+
+    private fun validateObservedObject(
+        observed: ObservedBiObject,
+        desired: DesiredBiObject?,
+        descriptor: BiDeploymentDescriptor,
+        operation: BiScriptOperation,
+    ) {
+        val metadata = observed.metadata
+        if (desired != null) {
+            require(metadata != null && metadata.deploymentId == descriptor.deploymentId) {
+                "BI object [${observed.database}.${observed.name}] is occupied by a foreign catalog object"
+            }
+            require(metadata.kind == desired.kind && metadata.aggregate == desired.aggregate) {
+                "BI object [${observed.database}.${observed.name}] has inconsistent ownership metadata"
+            }
+            if (desired.kind == BiObjectKind.ANCHOR) {
+                require(observed.engine == desired.expectedEngine) {
+                    "BI deployment anchor [${observed.database}.${observed.name}] must use the View engine"
+                }
+            } else {
+                require(observed.engine == desired.expectedEngine) {
+                    "BI object [${observed.database}.${observed.name}] has incompatible engine " +
+                        "[${observed.engine}]; expected engine [${desired.expectedEngine}]"
+                }
+            }
+        } else if (metadata?.deploymentId == descriptor.deploymentId) {
+            require(metadata.kind.acceptsEngine(observed.engine)) {
+                "BI object [${observed.database}.${observed.name}] kind [${metadata.kind}] has incompatible engine " +
+                    "[${observed.engine}]"
+            }
+        }
+        if (metadata?.deploymentId == descriptor.deploymentId && operation == BiScriptOperation.Deploy) {
+            require(metadata.configurationFingerprint == descriptor.configurationFingerprint) {
+                "Observed BI deployment configuration differs from the requested configuration; use RESET"
+            }
+        }
+    }
+
+    private fun BiObjectKind.acceptsEngine(engine: String): Boolean = when (this) {
+        BiObjectKind.ANCHOR,
+        BiObjectKind.VIEW,
+        -> engine == "View"
+
+        BiObjectKind.STORE -> engine in STORE_ENGINES
+        BiObjectKind.QUEUE -> engine == "Kafka"
+        BiObjectKind.CONSUMER -> engine == "MaterializedView"
+    }
+
+    private fun desiredAnchorKey(): BiObjectKey =
+        BiObjectKey(options.consumerDatabase, ClickHouseScriptRenderer.DEPLOYMENT_ANCHOR)
+
+    private companion object {
+        val STORE_ENGINES: Set<String> = setOf(
+            "ReplacingMergeTree",
+            "ReplicatedReplacingMergeTree",
+            "Distributed",
+        )
+    }
+}

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiOwnershipRegistry.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiOwnershipRegistry.kt
@@ -1,0 +1,217 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+import java.security.MessageDigest
+import java.util.Collections
+
+internal enum class BiRegistryEntryStatus {
+    PENDING_CREATE,
+    PENDING_UPDATE,
+    ACTIVE,
+    PENDING_DROP,
+    RETIRED,
+    TOMBSTONE,
+}
+
+internal data class BiOwnershipRegistration(
+    val key: BiObjectKey,
+    val kind: BiObjectKind,
+    val aggregate: String?,
+    val consumerIdentity: String?,
+    val definitionFingerprint: String,
+)
+
+internal data class BiOwnershipRegistryEntry(
+    val key: BiObjectKey,
+    val kind: BiObjectKind,
+    val aggregate: String?,
+    val consumerIdentity: String?,
+    val definitionFingerprint: String,
+    val revision: Long,
+    val status: BiRegistryEntryStatus,
+) {
+    init {
+        require(revision > 0) { "registry entry revision must be positive" }
+        definitionFingerprint.requireDigest("definitionFingerprint")
+        consumerIdentity?.let(::BiConsumerIdentity)
+        require(kind == BiObjectKind.ANCHOR || aggregate != null) {
+            "BI registry entry [$kind] requires an aggregate owner"
+        }
+    }
+}
+
+/**
+ * Immutable current-layout ownership state.
+ *
+ * Persisting a returned revision before executing its DDL provides the write-ahead side of create/update/drop recovery.
+ */
+internal class BiOwnershipRegistry private constructor(
+    val deploymentId: String,
+    val revision: Long,
+    entries: List<BiOwnershipRegistryEntry>,
+) {
+    val entries: List<BiOwnershipRegistryEntry> =
+        Collections.unmodifiableList(ArrayList(entries))
+
+    init {
+        deploymentId.requireDigest("deploymentId")
+        require(revision >= 0) { "registry revision must not be negative" }
+        require(entries.map(BiOwnershipRegistryEntry::key).distinct().size == entries.size) {
+            "BI ownership registry contains duplicate object keys"
+        }
+        require(entries.all { it.revision <= revision }) {
+            "BI ownership registry entry revision is ahead of the registry"
+        }
+    }
+
+    val name: String
+        get() = "__wow_bi_registry_$deploymentId"
+
+    fun beginCreate(registration: BiOwnershipRegistration): BiOwnershipRegistry = with(registration) {
+        require(
+            entries.none {
+                it.key == key &&
+                    it.status != BiRegistryEntryStatus.TOMBSTONE &&
+                    it.status != BiRegistryEntryStatus.RETIRED
+            }
+        ) {
+            "BI registry object [${key.database}.${key.name}] is already registered"
+        }
+        replaceEntry(toRegistryEntry(revision + 1, BiRegistryEntryStatus.PENDING_CREATE))
+    }
+
+    fun beginUpdate(registration: BiOwnershipRegistration): BiOwnershipRegistry = with(registration) {
+        val current = requireEntry(key)
+        require(current.status == BiRegistryEntryStatus.ACTIVE) {
+            "BI registry update requires ACTIVE, but was ${current.status}"
+        }
+        replaceEntry(toRegistryEntry(revision + 1, BiRegistryEntryStatus.PENDING_UPDATE))
+    }
+
+    fun markMutationVerified(key: BiObjectKey): BiOwnershipRegistry {
+        val current = requireEntry(key)
+        require(
+            current.status == BiRegistryEntryStatus.PENDING_CREATE ||
+                current.status == BiRegistryEntryStatus.PENDING_UPDATE
+        ) {
+            "BI registry mutation verification requires PENDING_CREATE or PENDING_UPDATE, but was ${current.status}"
+        }
+        return transition(key, current.status, BiRegistryEntryStatus.ACTIVE)
+    }
+
+    fun retire(key: BiObjectKey): BiOwnershipRegistry =
+        transition(key, BiRegistryEntryStatus.ACTIVE, BiRegistryEntryStatus.RETIRED)
+
+    fun beginDrop(key: BiObjectKey): BiOwnershipRegistry {
+        val current = requireEntry(key)
+        require(current.status in setOf(BiRegistryEntryStatus.ACTIVE, BiRegistryEntryStatus.RETIRED)) {
+            "BI registry drop requires ACTIVE or RETIRED, but was ${current.status}"
+        }
+        return replaceEntry(current.copy(revision = revision + 1, status = BiRegistryEntryStatus.PENDING_DROP))
+    }
+
+    fun markAbsenceVerified(key: BiObjectKey): BiOwnershipRegistry =
+        transition(key, BiRegistryEntryStatus.PENDING_DROP, BiRegistryEntryStatus.TOMBSTONE)
+
+    private fun transition(
+        key: BiObjectKey,
+        expected: BiRegistryEntryStatus,
+        next: BiRegistryEntryStatus,
+    ): BiOwnershipRegistry {
+        val current = requireEntry(key)
+        require(current.status == expected) {
+            "BI registry transition requires $expected, but was ${current.status}"
+        }
+        return replaceEntry(current.copy(revision = revision + 1, status = next))
+    }
+
+    private fun requireEntry(key: BiObjectKey): BiOwnershipRegistryEntry =
+        requireNotNull(entries.firstOrNull { it.key == key }) {
+            "BI registry object [${key.database}.${key.name}] is not registered"
+        }
+
+    private fun replaceEntry(entry: BiOwnershipRegistryEntry): BiOwnershipRegistry {
+        val updated = entries.filterNot { it.key == entry.key } + entry
+        return BiOwnershipRegistry(
+            deploymentId = deploymentId,
+            revision = entry.revision,
+            entries = updated.sortedWith(compareBy({ it.key.database }, { it.key.name })),
+        )
+    }
+
+    companion object {
+        fun empty(deploymentId: String): BiOwnershipRegistry =
+            BiOwnershipRegistry(deploymentId, revision = 0, entries = emptyList())
+
+        fun restore(
+            deploymentId: String,
+            revision: Long,
+            entries: List<BiOwnershipRegistryEntry>,
+        ): BiOwnershipRegistry = BiOwnershipRegistry(deploymentId, revision, entries)
+    }
+}
+
+private fun BiOwnershipRegistration.toRegistryEntry(
+    revision: Long,
+    status: BiRegistryEntryStatus,
+): BiOwnershipRegistryEntry = BiOwnershipRegistryEntry(
+    key = key,
+    kind = kind,
+    aggregate = aggregate,
+    consumerIdentity = consumerIdentity,
+    definitionFingerprint = definitionFingerprint,
+    revision = revision,
+    status = status,
+)
+
+internal fun BiOwnershipRegistry.snapshotFingerprint(): String = biRegistryDigest(
+    entries.joinToString("\u0000") { entry ->
+        listOf(
+            entry.key.database,
+            entry.key.name,
+            entry.kind.name,
+            entry.aggregate.orEmpty(),
+            entry.consumerIdentity.orEmpty(),
+            entry.definitionFingerprint,
+            entry.revision,
+            entry.status.name,
+        ).joinToString("\u0001")
+    }
+)
+
+internal fun BiOwnershipRegistryEntry.rowFingerprint(): String = biRegistryDigest(
+    listOf(
+        key.database,
+        key.name,
+        kind.name,
+        aggregate.orEmpty(),
+        consumerIdentity.orEmpty(),
+        definitionFingerprint,
+        revision,
+        status.name,
+    ).joinToString("\u0000")
+)
+
+private fun biRegistryDigest(value: String): String =
+    MessageDigest.getInstance("SHA-256")
+        .digest(value.toByteArray(Charsets.UTF_8))
+        .take(16)
+        .joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
+
+private val BI_DIGEST_PATTERN = Regex("[0-9a-f]{32}")
+
+private fun String.requireDigest(name: String) {
+    require(BI_DIGEST_PATTERN.matches(this)) { "Invalid BI $name: $this" }
+}

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiOwnershipRegistryPlan.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiOwnershipRegistryPlan.kt
@@ -1,0 +1,206 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+internal data class BiOwnershipRegistryPlan(
+    val beforeMutation: BiOwnershipRegistry,
+    val afterVerification: BiOwnershipRegistry,
+    val bootstrap: Boolean,
+    val intentChanged: Boolean,
+) {
+    val verificationChanged: Boolean
+        get() = beforeMutation.revision != afterVerification.revision
+
+    companion object {
+        fun create(
+            descriptor: BiDeploymentDescriptor,
+            consumerIdentity: BiConsumerIdentity,
+            desiredObjects: List<DesiredBiObject>,
+            current: BiOwnershipRegistry?,
+        ): BiOwnershipRegistryPlan {
+            var before = current ?: BiOwnershipRegistry.empty(descriptor.deploymentId)
+            require(before.deploymentId == descriptor.deploymentId) {
+                "BI ownership registry belongs to a different deployment"
+            }
+            val registryObjects = desiredObjects.filter { desired -> desired.kind != BiObjectKind.ANCHOR }
+            val desiredByKey = registryObjects.associateBy(DesiredBiObject::key)
+            before = before.reconcileDesired(registryObjects, consumerIdentity)
+            before = before.reconcileUndesired(desiredByKey.keys)
+            val after = before.verifyPending(desiredByKey.keys)
+            return BiOwnershipRegistryPlan(
+                beforeMutation = before,
+                afterVerification = after,
+                bootstrap = current == null,
+                intentChanged = current != null && current.revision != before.revision ||
+                    current == null && before.revision > 0,
+            )
+        }
+    }
+}
+
+internal fun BiOwnershipRegistryEntry.requireSameContract(registration: BiOwnershipRegistration) {
+    check(
+        kind == registration.kind &&
+            aggregate == registration.aggregate &&
+            consumerIdentity == registration.consumerIdentity &&
+            definitionFingerprint == registration.definitionFingerprint
+    ) {
+        "BI object [${key.database}.${key.name}] registration contract differs from the desired contract"
+    }
+}
+
+private fun BiOwnershipRegistryEntry.requireUpdatableComputedContract(
+    registration: BiOwnershipRegistration
+) {
+    check(
+        kind in COMPUTED_OBJECT_KINDS &&
+            kind == registration.kind &&
+            aggregate == registration.aggregate &&
+            consumerIdentity == registration.consumerIdentity
+    ) {
+        "BI object [${key.database}.${key.name}] registration contract differs from the desired contract"
+    }
+}
+
+internal fun DesiredBiObject.toRegistration(consumerIdentity: BiConsumerIdentity): BiOwnershipRegistration =
+    BiOwnershipRegistration(
+        key = key,
+        kind = kind,
+        aggregate = aggregate,
+        consumerIdentity = consumerIdentity.value,
+        definitionFingerprint = ownershipDefinitionFingerprint(),
+    )
+
+private fun DesiredBiObject.ownershipDefinitionFingerprint(): String =
+    biOwnershipDefinitionFingerprint(
+        BiOwnershipDefinition(
+            key = key,
+            kind = kind,
+            aggregate = aggregate,
+            expectedEngine = expectedEngine,
+            expectedQuery = expectedQuery,
+        )
+    )
+
+internal data class BiOwnershipDefinition(
+    val key: BiObjectKey,
+    val kind: BiObjectKind,
+    val aggregate: String?,
+    val expectedEngine: String,
+    val expectedQuery: ExpectedBiQuery?,
+)
+
+internal fun biOwnershipDefinitionFingerprint(definition: BiOwnershipDefinition): String = with(definition) {
+    biOwnershipDigest(
+        listOf(
+            key.database,
+            key.name,
+            kind.name,
+            aggregate.orEmpty(),
+            expectedEngine,
+            expectedQuery?.selectSql.orEmpty(),
+            expectedQuery?.target?.database.orEmpty(),
+            expectedQuery?.target?.name.orEmpty(),
+        ).joinToString("\u0000")
+    )
+}
+
+private fun BiOwnershipRegistry.reconcileDesired(
+    desiredObjects: List<DesiredBiObject>,
+    consumerIdentity: BiConsumerIdentity,
+): BiOwnershipRegistry {
+    var result = this
+    desiredObjects.sortedDesiredObjects().forEach { desired ->
+        val existing = result.entries.firstOrNull { entry -> entry.key == desired.key }
+        val registration = desired.toRegistration(consumerIdentity)
+        result = when (existing?.status) {
+            null,
+            BiRegistryEntryStatus.TOMBSTONE,
+            -> result.beginCreate(registration)
+
+            BiRegistryEntryStatus.PENDING_CREATE,
+            -> result.also { existing.requireSameContract(registration) }
+
+            BiRegistryEntryStatus.PENDING_UPDATE ->
+                result.also { existing.requireSameContract(registration) }
+
+            BiRegistryEntryStatus.ACTIVE ->
+                if (runCatching { existing.requireSameContract(registration) }.isSuccess) {
+                    result
+                } else {
+                    existing.requireUpdatableComputedContract(registration)
+                    result.beginUpdate(registration)
+                }
+
+            BiRegistryEntryStatus.RETIRED -> result.beginCreate(registration)
+            BiRegistryEntryStatus.PENDING_DROP ->
+                error("Desired BI object [${desired.key.database}.${desired.key.name}] is pending drop")
+        }
+    }
+    return result
+}
+
+private fun BiOwnershipRegistry.reconcileUndesired(desiredKeys: Set<BiObjectKey>): BiOwnershipRegistry {
+    var result = this
+    entries.filter { entry -> entry.key !in desiredKeys }.sortedRegistryEntries().forEach { entry ->
+        result = when (entry.status) {
+            BiRegistryEntryStatus.ACTIVE ->
+                if (entry.kind == BiObjectKind.STORE) result.retire(entry.key) else result.beginDrop(entry.key)
+
+            BiRegistryEntryStatus.RETIRED,
+            BiRegistryEntryStatus.PENDING_DROP,
+            BiRegistryEntryStatus.TOMBSTONE,
+            -> result
+
+            BiRegistryEntryStatus.PENDING_UPDATE ->
+                error(
+                    "Undesired BI object [${entry.key.database}.${entry.key.name}] is still pending update"
+                )
+
+            BiRegistryEntryStatus.PENDING_CREATE ->
+                error(
+                    "Undesired BI object [${entry.key.database}.${entry.key.name}] is still pending create"
+                )
+        }
+    }
+    return result
+}
+
+private fun BiOwnershipRegistry.verifyPending(desiredKeys: Set<BiObjectKey>): BiOwnershipRegistry {
+    var result = this
+    entries.sortedRegistryEntries().forEach { entry ->
+        result = when {
+            entry.status == BiRegistryEntryStatus.PENDING_CREATE && entry.key in desiredKeys ->
+                result.markMutationVerified(entry.key)
+
+            entry.status == BiRegistryEntryStatus.PENDING_UPDATE && entry.key in desiredKeys ->
+                result.markMutationVerified(entry.key)
+
+            entry.status == BiRegistryEntryStatus.PENDING_DROP && entry.key !in desiredKeys ->
+                result.markAbsenceVerified(entry.key)
+
+            else -> result
+        }
+    }
+    return result
+}
+
+private fun List<DesiredBiObject>.sortedDesiredObjects(): List<DesiredBiObject> =
+    sortedWith(compareBy({ it.key.database }, { it.key.name }))
+
+private fun List<BiOwnershipRegistryEntry>.sortedRegistryEntries(): List<BiOwnershipRegistryEntry> =
+    sortedWith(compareBy({ it.key.database }, { it.key.name }))
+
+private val COMPUTED_OBJECT_KINDS: Set<BiObjectKind> =
+    setOf(BiObjectKind.VIEW, BiObjectKind.CONSUMER)

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiPreparationPlanner.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiPreparationPlanner.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.bi.expansion.BiTableNaming
+import me.ahoo.wow.bi.expansion.plan.StateExpansionPlanner
+import me.ahoo.wow.bi.renderer.ClickHouseScriptRenderer
+import me.ahoo.wow.modeling.toStringWithAlias
+
+internal class BiPreparationPlanner(private val options: BiScriptOptions) {
+    private val definitionRenderer = ClickHouseScriptRenderer(options)
+
+    fun plan(namedAggregates: Set<NamedAggregate>): BiScriptPreparation {
+        val plannedAggregates = planAggregates(namedAggregates)
+        val desiredObjects = desiredObjects(plannedAggregates) +
+            if (options.consumerGroupNamespace != null) listOf(desiredAnchor()) else emptyList()
+        validateDesiredObjectNames(desiredObjects)
+        return BiScriptPreparation.create(
+            options = options,
+            namedAggregates = namedAggregates,
+            plannedAggregates = plannedAggregates,
+            desiredObjects = desiredObjects,
+        )
+    }
+
+    private fun planAggregates(namedAggregates: Set<NamedAggregate>): List<PlannedAggregate> {
+        val planner = StateExpansionPlanner(options)
+        return namedAggregates
+            .sortedWith(compareBy<NamedAggregate> { it.contextName }.thenBy { it.aggregateName })
+            .map { namedAggregate -> PlannedAggregate(namedAggregate, planner.plan(namedAggregate)) }
+    }
+
+    private fun desiredObjects(plannedAggregates: List<PlannedAggregate>): List<DesiredBiObject> {
+        val naming = BiTableNaming(options)
+        return plannedAggregates.flatMap { planned -> desiredObjects(planned, naming) }
+    }
+
+    private fun desiredObjects(
+        planned: PlannedAggregate,
+        naming: BiTableNaming,
+    ): List<DesiredBiObject> = with(planned) {
+        val aggregate = namedAggregate.toStringWithAlias()
+        val expectedQueries = definitionRenderer.expectedComputedQueries(namedAggregate, plan)
+        val computed = DesiredComputedFactory(aggregate, expectedQueries)
+        val command = naming.toTableName(namedAggregate, "command")
+        val state = naming.toTableName(namedAggregate, "state")
+        val stateLast = naming.toTableName(namedAggregate, "state_last")
+        val statePhysical = naming.toTableName(namedAggregate, ClickHouseScriptRenderer.STATE_SUFFIX)
+        val stateLastPhysical =
+            naming.toTableName(namedAggregate, ClickHouseScriptRenderer.STATE_LAST_SUFFIX)
+        buildList {
+            listOf(command, statePhysical, stateLastPhysical).forEach { table -> addDesiredStores(table, aggregate) }
+            add(computed.view(command))
+            add(computed.view(state))
+            add(computed.view("${state}_event"))
+            add(computed.view(stateLast))
+            plan.views.forEach { view ->
+                add(computed.view(view.targetTableName))
+            }
+            listOf(command, statePhysical).forEach { table ->
+                add(
+                    DesiredBiObject(
+                        BiObjectKey(options.consumerDatabase, "${table}_queue"),
+                        aggregate,
+                        BiObjectKind.QUEUE,
+                        QUEUE_ENGINE,
+                    )
+                )
+                add(computed.consumer("${table}_consumer"))
+            }
+            add(computed.consumer("${stateLastPhysical}_consumer"))
+        }
+    }
+
+    private inner class DesiredComputedFactory(
+        private val aggregate: String,
+        private val expectedQueries: Map<BiObjectKey, ExpectedBiQuery>,
+    ) {
+        fun view(name: String): DesiredBiObject = create(BiObjectKey(options.database, name), BiObjectKind.VIEW)
+
+        fun consumer(name: String): DesiredBiObject =
+            create(BiObjectKey(options.consumerDatabase, name), BiObjectKind.CONSUMER)
+
+        private fun create(key: BiObjectKey, kind: BiObjectKind): DesiredBiObject = DesiredBiObject(
+            key = key,
+            aggregate = aggregate,
+            kind = kind,
+            expectedEngine = if (kind == BiObjectKind.VIEW) VIEW_ENGINE else CONSUMER_ENGINE,
+            expectedQuery = checkNotNull(expectedQueries[key]) {
+                "Missing expected BI query for [${key.database}.${key.name}]"
+            },
+        )
+    }
+
+    private fun MutableList<DesiredBiObject>.addDesiredStores(table: String, aggregate: String) {
+        val store = "${table}_store"
+        val storeEngine = when (options.topology) {
+            is ClickHouseTopology.Cluster -> "Distributed"
+            ClickHouseTopology.Standalone -> "ReplacingMergeTree"
+        }
+        add(DesiredBiObject(BiObjectKey(options.database, store), aggregate, BiObjectKind.STORE, storeEngine))
+        if (options.topology is ClickHouseTopology.Cluster) {
+            add(
+                DesiredBiObject(
+                    BiObjectKey(options.database, "${store}_local"),
+                    aggregate,
+                    BiObjectKind.STORE,
+                    "ReplicatedReplacingMergeTree",
+                )
+            )
+        }
+    }
+
+    private fun desiredAnchor(): DesiredBiObject = DesiredBiObject(
+        BiObjectKey(options.consumerDatabase, ClickHouseScriptRenderer.DEPLOYMENT_ANCHOR),
+        null,
+        BiObjectKind.ANCHOR,
+        VIEW_ENGINE,
+    )
+
+    private fun validateDesiredObjectNames(objects: List<DesiredBiObject>) {
+        val collision = objects.groupBy(DesiredBiObject::key).entries.firstOrNull { it.value.size > 1 }
+        require(collision == null) {
+            "BI object name collision [${collision!!.key.database}.${collision.key.name}] between aggregates " +
+                collision.value.mapNotNull(DesiredBiObject::aggregate).distinct().sorted()
+                    .joinToString(prefix = "[", postfix = "]")
+        }
+    }
+
+    private companion object {
+        const val VIEW_ENGINE: String = "View"
+        const val QUEUE_ENGINE: String = "Kafka"
+        const val CONSUMER_ENGINE: String = "MaterializedView"
+    }
+}

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiScriptAssembly.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiScriptAssembly.kt
@@ -64,7 +64,6 @@ internal class BiScriptAssembler(private val options: BiScriptOptions) {
             ClickHouseOwnershipRegistryRenderer(
                 options = options,
                 deploymentId = descriptor.deploymentId,
-                createIfNotExists = observed != null,
             )
         }
         val renderedAggregates = plannedAggregates.map { planned ->

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiScriptAssembly.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiScriptAssembly.kt
@@ -1,0 +1,424 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+import me.ahoo.wow.bi.renderer.CatalogMutationMode
+import me.ahoo.wow.bi.renderer.ClickHouseAggregateRenderPlan
+import me.ahoo.wow.bi.renderer.ClickHouseOwnershipRegistryRenderer
+import me.ahoo.wow.bi.renderer.ClickHouseScriptRenderer
+import me.ahoo.wow.modeling.toStringWithAlias
+import java.util.Collections
+
+internal class BiScriptAssembler(private val options: BiScriptOptions) {
+    private val observedPolicy = BiObservedDeploymentPolicy(options)
+    private val diagnostics = BiScriptDiagnostics(options, observedPolicy)
+
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
+    fun assemble(
+        preparation: BiScriptPreparation,
+        operation: BiScriptOperation,
+        inspection: BiDeploymentInspection,
+    ): BiScriptResult {
+        val plannedAggregates = preparation.plannedAggregates
+        val descriptor = BiDeploymentDescriptor.from(options)
+        val shouldRenderDeploymentAnchor = options.consumerGroupNamespace != null
+        require(operation !is BiScriptOperation.Reset || shouldRenderDeploymentAnchor) {
+            "consumerGroupNamespace must be configured before RESET so its recovery state can be persisted"
+        }
+        val desiredObjects = preparation.desiredObjects
+        val observed = (inspection as? BiDeploymentInspection.Available)?.deployment
+        observed?.let { deployment -> observedPolicy.validate(deployment, descriptor, desiredObjects, operation) }
+        val consumerIdentity = resolveConsumerIdentity(operation, descriptor, observed)
+        val retainedQueueKeys = resolveRetainedQueueKeys(operation, desiredObjects, descriptor, observed)
+        val renderer = ClickHouseScriptRenderer(
+            options,
+            consumerIdentity,
+            descriptor,
+            if (observed == null) CatalogMutationMode.CREATE_ONLY else CatalogMutationMode.RECONCILE,
+            retainedQueueKeys,
+        )
+        val registryPlan = if (operation == BiScriptOperation.Deploy && shouldRenderDeploymentAnchor) {
+            BiOwnershipRegistryPlan.create(
+                descriptor = descriptor,
+                consumerIdentity = consumerIdentity,
+                desiredObjects = desiredObjects,
+                current = (inspection as? BiDeploymentInspection.Available)
+                    ?.reconciliation
+                    ?.ownershipRegistry,
+            )
+        } else {
+            null
+        }
+        val registryRenderer = registryPlan?.let {
+            ClickHouseOwnershipRegistryRenderer(
+                options = options,
+                deploymentId = descriptor.deploymentId,
+                createIfNotExists = observed != null,
+            )
+        }
+        val renderedAggregates = plannedAggregates.map { planned ->
+            val aggregate = planned.namedAggregate.toStringWithAlias()
+            renderer.renderAggregate(planned.namedAggregate, planned.plan, aggregate)
+        }
+
+        val globalSection = ScriptSection("global", renderer.renderGlobalStatements())
+        val registryCreateSection = registryPlan?.let { plan ->
+            ScriptSection(
+                "ownership-registry",
+                checkNotNull(registryRenderer).renderCreateStatements(plan.afterVerification.name),
+            )
+        }
+        val registryIntentSection = registryPlan
+            ?.takeIf(BiOwnershipRegistryPlan::intentChanged)
+            ?.let { plan ->
+                ScriptSection(
+                    "ownership-registry-intent",
+                    listOf(checkNotNull(registryRenderer).renderSnapshotStatement(plan.beforeMutation)),
+                )
+            }
+        val lifecycleSections = renderLifecycle(
+            LifecycleRenderContext(operation, plannedAggregates, desiredObjects, descriptor, observed, renderer)
+        )
+        val durableAggregateSections = durableAggregateSections(renderedAggregates)
+        val ingressSections = ingressSections(renderedAggregates)
+        val resetIntentSection = if (operation is BiScriptOperation.Reset) {
+            ScriptSection(
+                "deployment-reset-intent",
+                listOf(renderer.renderAnchorStatement(BiDeploymentPhase.RESETTING)),
+            )
+        } else {
+            null
+        }
+        val resetRegistrySection = if (operation is BiScriptOperation.Reset) {
+            (inspection as? BiDeploymentInspection.Available)
+                ?.reconciliation
+                ?.ownershipRegistry
+                ?.let { registry ->
+                    ScriptSection(
+                        "reset-ownership-registry",
+                        listOf(
+                            ClickHouseOwnershipRegistryRenderer(
+                                options = options,
+                                deploymentId = descriptor.deploymentId,
+                            ).renderDropStatement(registry.name)
+                        ),
+                    )
+                }
+        } else {
+            null
+        }
+        val registryConfirmationSection = registryPlan
+            ?.takeIf { plan -> plan.verificationChanged || plan.bootstrap }
+            ?.let { plan ->
+                ScriptSection(
+                    "ownership-registry-confirmation",
+                    listOf(checkNotNull(registryRenderer).renderSnapshotStatement(plan.afterVerification)),
+                )
+            }
+        val anchorSection = if (shouldRenderDeploymentAnchor) {
+            val registryRevision = registryPlan?.afterVerification?.revision
+            ScriptSection(
+                "deployment-anchor",
+                listOf(
+                    renderer.renderAnchorStatement(
+                        phase = BiDeploymentPhase.STABLE,
+                        registryRevision = registryRevision,
+                    )
+                ),
+            )
+        } else {
+            null
+        }
+        val orderedSections = if (operation == BiScriptOperation.Deploy) {
+            listOf(globalSection) +
+                listOfNotNull(registryCreateSection, registryIntentSection) +
+                lifecycleSections +
+                durableAggregateSections +
+                ingressSections +
+                listOfNotNull(registryConfirmationSection, anchorSection)
+        } else {
+            listOf(globalSection) + listOfNotNull(resetIntentSection, resetRegistrySection) + lifecycleSections +
+                durableAggregateSections + listOfNotNull(anchorSection) + ingressSections
+        }
+        val statements = Collections.unmodifiableList(ArrayList(orderedSections.flatMap(ScriptSection::statements)))
+        val script = buildString {
+            appendSection(globalSection)
+            registryCreateSection?.let { section -> appendSection(section) }
+            registryIntentSection?.let { section -> appendSection(section) }
+            appendLine("-- lifecycle --")
+            resetIntentSection?.let { section -> appendSection(section) }
+            resetRegistrySection?.let { section -> appendSection(section) }
+            lifecycleSections.forEach { section -> appendSection(section) }
+            appendLine("-- lifecycle --")
+            durableAggregateSections.forEach { section -> appendSection(section) }
+            if (operation == BiScriptOperation.Deploy) {
+                ingressSections.forEach { section -> appendSection(section) }
+                registryConfirmationSection?.let { section -> appendSection(section) }
+                anchorSection?.let { section -> appendSection(section) }
+            } else {
+                anchorSection?.let { section -> appendSection(section) }
+                ingressSections.forEach { section -> appendSection(section) }
+            }
+        }
+        return BiScriptResult(
+            script = script,
+            statements = statements,
+            diagnostics = Collections.unmodifiableList(
+                ArrayList(
+                    diagnostics.collect(
+                        BiScriptDiagnosticsContext(
+                            plannedAggregates,
+                            inspection,
+                            operation,
+                            desiredObjects,
+                            descriptor,
+                            observed,
+                        )
+                    )
+                )
+            ),
+            operation = operation,
+            destructive = operation is BiScriptOperation.Reset,
+        )
+    }
+
+    private fun durableAggregateSections(
+        renderedAggregates: List<ClickHouseAggregateRenderPlan>,
+    ): List<ScriptSection> = renderedAggregates.flatMap { rendered ->
+        val name = rendered.aggregate
+        listOf(
+            ScriptSection("$name.commandStorage", rendered.command.storage),
+            ScriptSection("$name.stateStorage", rendered.state.storage),
+            ScriptSection("$name.stateLast", rendered.stateLast),
+            ScriptSection("$name.expansion", rendered.expansion),
+            ScriptSection("$name.commandPublic", rendered.command.publicViews),
+            ScriptSection("$name.statePublic", rendered.state.publicViews),
+        )
+    }
+
+    private fun ingressSections(
+        renderedAggregates: List<ClickHouseAggregateRenderPlan>,
+    ): List<ScriptSection> = renderedAggregates.flatMap { rendered ->
+        val name = rendered.aggregate
+        listOf(
+            ScriptSection("$name.commandIngress", rendered.command.ingress),
+            ScriptSection("$name.stateIngress", rendered.state.ingress),
+        )
+    }
+
+    private fun resolveRetainedQueueKeys(
+        operation: BiScriptOperation,
+        desiredObjects: List<DesiredBiObject>,
+        descriptor: BiDeploymentDescriptor,
+        observed: ObservedBiDeployment?,
+    ): Set<BiObjectKey> {
+        if (operation != BiScriptOperation.Deploy || observed == null) {
+            return emptySet()
+        }
+        val desiredQueueKeys = desiredObjects.asSequence()
+            .filter { it.kind == BiObjectKind.QUEUE }
+            .map(DesiredBiObject::key)
+            .toSet()
+        return observedPolicy.ownedBy(observed, descriptor).asSequence()
+            .filter { it.metadata?.kind == BiObjectKind.QUEUE && it.key in desiredQueueKeys }
+            .map(ObservedBiObject::key)
+            .toSet()
+    }
+
+    private fun renderLifecycle(context: LifecycleRenderContext): List<ScriptSection> = with(context) {
+        buildList {
+            when (operation) {
+                BiScriptOperation.Deploy -> {
+                    if (observed != null) {
+                        plannedAggregates.forEach { planned ->
+                            add(
+                                ScriptSection(
+                                    "${planned.namedAggregate.toStringWithAlias()}.pause-ingress",
+                                    renderer.renderPauseIngressStatements(planned.namedAggregate),
+                                )
+                            )
+                        }
+                    }
+                    val desiredKeys = desiredObjects.map(DesiredBiObject::key).toSet()
+                    val staleObjects = observed?.let { deployment -> observedPolicy.ownedBy(deployment, descriptor) }
+                        .orEmpty()
+                        .filter { it.key !in desiredKeys && it.metadata?.kind != BiObjectKind.STORE }
+                    if (staleObjects.isNotEmpty()) {
+                        add(
+                            ScriptSection(
+                                "reconcile-observed-catalog",
+                                renderer.renderDropObservedStatements(staleObjects),
+                            )
+                        )
+                    }
+                }
+
+                is BiScriptOperation.Reset -> {
+                    val anchorKey = BiObjectKey(
+                        options.consumerDatabase,
+                        ClickHouseScriptRenderer.DEPLOYMENT_ANCHOR,
+                    )
+                    val ownedObjects = observedPolicy.ownedBy(checkNotNull(observed), descriptor)
+                        .filterNot { it.key == anchorKey }
+                    if (ownedObjects.isNotEmpty()) {
+                        add(
+                            ScriptSection(
+                                "reset-observed-catalog",
+                                renderer.renderDropObservedStatements(ownedObjects),
+                            )
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun resolveConsumerIdentity(
+        operation: BiScriptOperation,
+        descriptor: BiDeploymentDescriptor,
+        observed: ObservedBiDeployment?,
+    ): BiConsumerIdentity = when (operation) {
+        BiScriptOperation.Deploy -> observed?.let { deployment ->
+            observedPolicy.consumerIdentity(deployment, descriptor)
+        } ?: BiConsumerIdentity.deterministic(descriptor)
+
+        is BiScriptOperation.Reset -> observed?.let { deployment ->
+            observedPolicy.resettingAnchor(deployment, descriptor)?.metadata?.consumerIdentity
+        }?.let(::BiConsumerIdentity) ?: BiConsumerIdentity.random()
+    }
+
+    private fun StringBuilder.appendSection(section: ScriptSection) {
+        appendLine("-- ${section.name} --")
+        if (section.statements.isNotEmpty()) {
+            appendLine(section.statements.joinToString("\n\n"))
+        }
+        appendLine("-- ${section.name} --")
+    }
+
+    private data class LifecycleRenderContext(
+        val operation: BiScriptOperation,
+        val plannedAggregates: List<PlannedAggregate>,
+        val desiredObjects: List<DesiredBiObject>,
+        val descriptor: BiDeploymentDescriptor,
+        val observed: ObservedBiDeployment?,
+        val renderer: ClickHouseScriptRenderer,
+    )
+
+    private data class ScriptSection(val name: String, val statements: List<String>)
+}
+
+internal class BiScriptDiagnostics(
+    private val options: BiScriptOptions,
+    private val observedPolicy: BiObservedDeploymentPolicy,
+) {
+    fun collect(context: BiScriptDiagnosticsContext): List<BiScriptDiagnostic> = with(context) {
+        buildList {
+            if (plannedAggregates.isNotEmpty()) {
+                addAll(topologyDiagnostics())
+            }
+            if (inspection is BiDeploymentInspection.Unavailable) {
+                add(inspectionUnavailableDiagnostic())
+            }
+            addAll(retainedStoreDiagnostics(operation, desiredObjects, descriptor, observed))
+            addAll(computedObjectDriftDiagnostics(inspection, operation))
+            addAll(plannedAggregates.flatMap { it.plan.diagnostics })
+        }
+    }
+
+    private fun computedObjectDriftDiagnostics(
+        inspection: BiDeploymentInspection,
+        operation: BiScriptOperation,
+    ): List<BiScriptDiagnostic> {
+        if (operation != BiScriptOperation.Deploy) {
+            return emptyList()
+        }
+        return (inspection as? BiDeploymentInspection.Available)
+            ?.reconciliation
+            ?.repairableComputedDrifts
+            .orEmpty()
+            .sortedWith(compareBy<RepairableBiObjectDrift> { it.key.database }.thenBy { it.key.name })
+            .map { drift ->
+                val fields = drift.mismatches.map(BiComputedDefinitionField::name).sorted().joinToString()
+                BiScriptDiagnostic(
+                    code = BiScriptDiagnosticCode.COMPUTED_OBJECT_DRIFT,
+                    aggregate = drift.aggregate,
+                    path = "lifecycle.reconcile.${drift.key.database}.${drift.key.name}",
+                    sourceType = "ClickHouseCatalog",
+                    decision = BiScriptMappingDecision.RECONCILIATION_PLANNED,
+                    message = "Computed object [${drift.key.database}.${drift.key.name}] has repairable " +
+                        "definition drift [$fields]; generated DEPLOY reconciles it.",
+                )
+            }
+    }
+
+    private fun retainedStoreDiagnostics(
+        operation: BiScriptOperation,
+        desiredObjects: List<DesiredBiObject>,
+        descriptor: BiDeploymentDescriptor,
+        observed: ObservedBiDeployment?,
+    ): List<BiScriptDiagnostic> {
+        if (operation is BiScriptOperation.Reset) {
+            return emptyList()
+        }
+        val desiredKeys = desiredObjects.map(DesiredBiObject::key).toSet()
+        return observed?.let { deployment -> observedPolicy.ownedBy(deployment, descriptor) }.orEmpty()
+            .filter { it.key !in desiredKeys && it.metadata?.kind == BiObjectKind.STORE }
+            .mapNotNull { it.metadata?.aggregate }
+            .distinct()
+            .sorted()
+            .map { aggregate ->
+                BiScriptDiagnostic(
+                    code = BiScriptDiagnosticCode.ORPHANED_DATA_TABLE,
+                    aggregate = aggregate,
+                    path = "lifecycle.reconcile",
+                    sourceType = "ObservedBiDeployment",
+                    decision = BiScriptMappingDecision.DATA_TABLE_RETAINED,
+                    message = "Aggregate was removed; its observed data stores were retained.",
+                )
+            }
+    }
+
+    private fun inspectionUnavailableDiagnostic(): BiScriptDiagnostic = BiScriptDiagnostic(
+        code = BiScriptDiagnosticCode.INSPECTION_UNAVAILABLE,
+        aggregate = "*",
+        path = "lifecycle.inspection",
+        sourceType = "BiDeploymentInspector",
+        decision = BiScriptMappingDecision.RECONCILIATION_SKIPPED,
+        message = "BI deployment inspection is unavailable; generated current desired state without stale-object reconciliation.",
+    )
+
+    private fun topologyDiagnostics(): List<BiScriptDiagnostic> = when (options.topology) {
+        is ClickHouseTopology.Cluster -> listOf(
+            BiScriptDiagnostic(
+                code = BiScriptDiagnosticCode.CLUSTER_INTERNAL_REPLICATION_REQUIRED,
+                aggregate = "*",
+                path = "topology.cluster",
+                sourceType = "ClickHouseTopology.Cluster",
+                decision = BiScriptMappingDecision.EXTERNAL_CONFIGURATION_REQUIRED,
+                message = "Configure internal_replication=true for every shard before applying clustered BI DDL.",
+            )
+        )
+
+        ClickHouseTopology.Standalone -> emptyList()
+    }
+}
+
+internal data class BiScriptDiagnosticsContext(
+    val plannedAggregates: List<PlannedAggregate>,
+    val inspection: BiDeploymentInspection,
+    val operation: BiScriptOperation,
+    val desiredObjects: List<DesiredBiObject>,
+    val descriptor: BiDeploymentDescriptor,
+    val observed: ObservedBiDeployment?,
+)

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiScriptAssembly.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiScriptAssembly.kt
@@ -152,7 +152,8 @@ internal class BiScriptAssembler(private val options: BiScriptOptions) {
                 ingressSections +
                 listOfNotNull(registryConfirmationSection, anchorSection)
         } else {
-            listOf(globalSection) + listOfNotNull(resetIntentSection, resetRegistrySection) + lifecycleSections +
+            listOf(globalSection) + listOfNotNull(resetIntentSection) + lifecycleSections +
+                listOfNotNull(resetRegistrySection) +
                 durableAggregateSections + listOfNotNull(anchorSection) + ingressSections
         }
         val statements = Collections.unmodifiableList(ArrayList(orderedSections.flatMap(ScriptSection::statements)))
@@ -162,8 +163,8 @@ internal class BiScriptAssembler(private val options: BiScriptOptions) {
             registryIntentSection?.let { section -> appendSection(section) }
             appendLine("-- lifecycle --")
             resetIntentSection?.let { section -> appendSection(section) }
-            resetRegistrySection?.let { section -> appendSection(section) }
             lifecycleSections.forEach { section -> appendSection(section) }
+            resetRegistrySection?.let { section -> appendSection(section) }
             appendLine("-- lifecycle --")
             durableAggregateSections.forEach { section -> appendSection(section) }
             if (operation == BiScriptOperation.Deploy) {
@@ -255,14 +256,16 @@ internal class BiScriptAssembler(private val options: BiScriptOptions) {
                         }
                     }
                     val desiredKeys = desiredObjects.map(DesiredBiObject::key).toSet()
-                    val staleObjects = observed?.let { deployment -> observedPolicy.ownedBy(deployment, descriptor) }
+                    val staleObjects = observed?.let { deployment ->
+                        resolveOwnedCatalogObjects(deployment, descriptor, ownershipRegistry)
+                    }
                         .orEmpty()
-                        .filter { it.key !in desiredKeys && it.metadata?.kind != BiObjectKind.STORE }
+                        .filter { it.key !in desiredKeys && it.kind != BiObjectKind.STORE }
                     if (staleObjects.isNotEmpty()) {
                         add(
                             ScriptSection(
                                 "reconcile-observed-catalog",
-                                renderer.renderDropObservedStatements(staleObjects),
+                                renderer.renderDropOwnedStatements(staleObjects),
                             )
                         )
                     }
@@ -273,7 +276,7 @@ internal class BiScriptAssembler(private val options: BiScriptOptions) {
                         options.consumerDatabase,
                         ClickHouseScriptRenderer.DEPLOYMENT_ANCHOR,
                     )
-                    val ownedObjects = resolveResetOwnedObjects(
+                    val ownedObjects = resolveOwnedCatalogObjects(
                         deployment = checkNotNull(observed),
                         descriptor = descriptor,
                         ownershipRegistry = ownershipRegistry,
@@ -292,7 +295,7 @@ internal class BiScriptAssembler(private val options: BiScriptOptions) {
         }
     }
 
-    private fun resolveResetOwnedObjects(
+    private fun resolveOwnedCatalogObjects(
         deployment: ObservedBiDeployment,
         descriptor: BiDeploymentDescriptor,
         ownershipRegistry: BiOwnershipRegistry?,

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiScriptAssembly.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiScriptAssembly.kt
@@ -37,7 +37,9 @@ internal class BiScriptAssembler(private val options: BiScriptOptions) {
             "consumerGroupNamespace must be configured before RESET so its recovery state can be persisted"
         }
         val desiredObjects = preparation.desiredObjects
-        val observed = (inspection as? BiDeploymentInspection.Available)?.deployment
+        val availableInspection = inspection as? BiDeploymentInspection.Available
+        val observed = availableInspection?.deployment
+        val ownershipRegistry = availableInspection?.reconciliation?.ownershipRegistry
         observed?.let { deployment -> observedPolicy.validate(deployment, descriptor, desiredObjects, operation) }
         val consumerIdentity = resolveConsumerIdentity(operation, descriptor, observed)
         val retainedQueueKeys = resolveRetainedQueueKeys(operation, desiredObjects, descriptor, observed)
@@ -53,9 +55,7 @@ internal class BiScriptAssembler(private val options: BiScriptOptions) {
                 descriptor = descriptor,
                 consumerIdentity = consumerIdentity,
                 desiredObjects = desiredObjects,
-                current = (inspection as? BiDeploymentInspection.Available)
-                    ?.reconciliation
-                    ?.ownershipRegistry,
+                current = ownershipRegistry,
             )
         } else {
             null
@@ -88,7 +88,15 @@ internal class BiScriptAssembler(private val options: BiScriptOptions) {
                 )
             }
         val lifecycleSections = renderLifecycle(
-            LifecycleRenderContext(operation, plannedAggregates, desiredObjects, descriptor, observed, renderer)
+            LifecycleRenderContext(
+                operation,
+                plannedAggregates,
+                desiredObjects,
+                descriptor,
+                observed,
+                ownershipRegistry,
+                renderer,
+            )
         )
         val durableAggregateSections = durableAggregateSections(renderedAggregates)
         val ingressSections = ingressSections(renderedAggregates)
@@ -101,20 +109,17 @@ internal class BiScriptAssembler(private val options: BiScriptOptions) {
             null
         }
         val resetRegistrySection = if (operation is BiScriptOperation.Reset) {
-            (inspection as? BiDeploymentInspection.Available)
-                ?.reconciliation
-                ?.ownershipRegistry
-                ?.let { registry ->
-                    ScriptSection(
-                        "reset-ownership-registry",
-                        listOf(
-                            ClickHouseOwnershipRegistryRenderer(
-                                options = options,
-                                deploymentId = descriptor.deploymentId,
-                            ).renderDropStatement(registry.name)
-                        ),
-                    )
-                }
+            ownershipRegistry?.let { registry ->
+                ScriptSection(
+                    "reset-ownership-registry",
+                    listOf(
+                        ClickHouseOwnershipRegistryRenderer(
+                            options = options,
+                            deploymentId = descriptor.deploymentId,
+                        ).renderDropStatement(registry.name)
+                    ),
+                )
+            }
         } else {
             null
         }
@@ -269,19 +274,46 @@ internal class BiScriptAssembler(private val options: BiScriptOptions) {
                         options.consumerDatabase,
                         ClickHouseScriptRenderer.DEPLOYMENT_ANCHOR,
                     )
-                    val ownedObjects = observedPolicy.ownedBy(checkNotNull(observed), descriptor)
+                    val ownedObjects = resolveResetOwnedObjects(
+                        deployment = checkNotNull(observed),
+                        descriptor = descriptor,
+                        ownershipRegistry = ownershipRegistry,
+                    )
                         .filterNot { it.key == anchorKey }
                     if (ownedObjects.isNotEmpty()) {
                         add(
                             ScriptSection(
                                 "reset-observed-catalog",
-                                renderer.renderDropObservedStatements(ownedObjects),
+                                renderer.renderDropOwnedStatements(ownedObjects),
                             )
                         )
                     }
                 }
             }
         }
+    }
+
+    private fun resolveResetOwnedObjects(
+        deployment: ObservedBiDeployment,
+        descriptor: BiDeploymentDescriptor,
+        ownershipRegistry: BiOwnershipRegistry?,
+    ): List<BiOwnedObject> {
+        val ownedByKey = observedPolicy.ownedBy(deployment, descriptor).associate { observed ->
+            observed.key to BiOwnedObject(
+                key = observed.key,
+                kind = checkNotNull(observed.metadata).kind,
+            )
+        }.toMutableMap()
+        if (ownershipRegistry == null) {
+            return ownedByKey.values.toList()
+        }
+        val observedKeys = deployment.objects.mapTo(hashSetOf(), ObservedBiObject::key)
+        ownershipRegistry.entries.asSequence()
+            .filter { entry -> entry.key in observedKeys }
+            .forEach { entry ->
+                ownedByKey[entry.key] = BiOwnedObject(entry.key, entry.kind)
+            }
+        return ownedByKey.values.toList()
     }
 
     private fun resolveConsumerIdentity(
@@ -312,6 +344,7 @@ internal class BiScriptAssembler(private val options: BiScriptOptions) {
         val desiredObjects: List<DesiredBiObject>,
         val descriptor: BiDeploymentDescriptor,
         val observed: ObservedBiDeployment?,
+        val ownershipRegistry: BiOwnershipRegistry?,
         val renderer: ClickHouseScriptRenderer,
     )
 

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiScriptGenerator.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiScriptGenerator.kt
@@ -14,545 +14,108 @@
 package me.ahoo.wow.bi
 
 import me.ahoo.wow.api.modeling.NamedAggregate
-import me.ahoo.wow.bi.expansion.BiTableNaming
 import me.ahoo.wow.bi.expansion.plan.StateExpansionPlan
-import me.ahoo.wow.bi.expansion.plan.StateExpansionPlanner
-import me.ahoo.wow.bi.renderer.CatalogMutationMode
-import me.ahoo.wow.bi.renderer.ClickHouseScriptRenderer
-import me.ahoo.wow.modeling.toStringWithAlias
 import java.util.Collections
 
-class BiScriptGenerator(private val options: BiScriptOptions = BiScriptOptions()) {
+/**
+ * Opaque immutable expansion plan for one BI script request.
+ *
+ * Create it with [BiScriptGenerator.prepare], pass it to [BiDeploymentInspector.inspect], and render it with
+ * [BiScriptGenerator.generate]. The same generator options must be used throughout the request.
+ */
+class BiScriptPreparation private constructor(
+    internal val options: BiScriptOptions,
+    namedAggregates: Set<NamedAggregate>,
+    plannedAggregates: List<PlannedAggregate>,
+    desiredObjects: List<DesiredBiObject>,
+) {
+    internal val namedAggregates: Set<NamedAggregate> =
+        Collections.unmodifiableSet(LinkedHashSet(namedAggregates))
+    internal val plannedAggregates: List<PlannedAggregate> =
+        Collections.unmodifiableList(ArrayList(plannedAggregates))
+    internal val desiredObjects: List<DesiredBiObject> =
+        Collections.unmodifiableList(ArrayList(desiredObjects))
+    internal val desiredObjectKeys: Set<BiObjectKey> = Collections.unmodifiableSet(
+        desiredObjects.mapTo(linkedSetOf(), DesiredBiObject::key)
+    )
 
-    @Suppress("CyclomaticComplexMethod", "LongMethod")
+    internal companion object {
+        fun create(
+            options: BiScriptOptions,
+            namedAggregates: Set<NamedAggregate>,
+            plannedAggregates: List<PlannedAggregate>,
+            desiredObjects: List<DesiredBiObject>,
+        ): BiScriptPreparation {
+            return BiScriptPreparation(options, namedAggregates, plannedAggregates, desiredObjects)
+        }
+    }
+}
+
+internal data class PlannedAggregate(
+    val namedAggregate: NamedAggregate,
+    val plan: StateExpansionPlan,
+)
+
+internal data class DesiredBiObject(
+    val key: BiObjectKey,
+    val aggregate: String?,
+    val kind: BiObjectKind,
+    val expectedEngine: String,
+    val expectedQuery: ExpectedBiQuery? = null,
+)
+
+class BiScriptGenerator(private val options: BiScriptOptions = BiScriptOptions()) {
+    private val preparationPlanner = BiPreparationPlanner(options)
+    private val assembler = BiScriptAssembler(options)
+
     fun generate(
         namedAggregates: Set<NamedAggregate>,
         operation: BiScriptOperation = BiScriptOperation.Deploy,
         inspection: BiDeploymentInspection = BiDeploymentInspection.Unavailable,
     ): BiScriptResult {
+        validateGenerationRequest(namedAggregates, operation, inspection)
+        return assembler.assemble(preparationPlanner.plan(namedAggregates), operation, inspection)
+    }
+
+    fun generate(
+        preparation: BiScriptPreparation,
+        operation: BiScriptOperation = BiScriptOperation.Deploy,
+        inspection: BiDeploymentInspection = BiDeploymentInspection.Unavailable,
+    ): BiScriptResult {
+        require(preparation.options == options) {
+            "BI script preparation was prepared with different BI script options"
+        }
+        validateGenerationRequest(preparation.namedAggregates, operation, inspection)
+        return assembler.assemble(preparation, operation, inspection)
+    }
+
+    /**
+     * Builds an immutable, request-scoped expansion plan that can be shared by catalog inspection and rendering.
+     */
+    fun prepare(namedAggregates: Set<NamedAggregate>): BiScriptPreparation {
+        validateConsumerGroupNamespace(namedAggregates)
+        return preparationPlanner.plan(namedAggregates)
+    }
+
+    private fun validateGenerationRequest(
+        namedAggregates: Set<NamedAggregate>,
+        operation: BiScriptOperation,
+        inspection: BiDeploymentInspection,
+    ) {
+        validateConsumerGroupNamespace(namedAggregates)
+        require(operation !is BiScriptOperation.Reset || inspection is BiDeploymentInspection.Available) {
+            "RESET requires an available BI deployment inspection"
+        }
+    }
+
+    private fun validateConsumerGroupNamespace(namedAggregates: Set<NamedAggregate>) {
         if (namedAggregates.isNotEmpty()) {
             requireNotNull(options.consumerGroupNamespace) {
                 "consumerGroupNamespace must be configured before generating BI Kafka consumers"
             }
         }
-        require(operation !is BiScriptOperation.Reset || inspection is BiDeploymentInspection.Available) {
-            "RESET requires an available BI deployment inspection"
-        }
-
-        val planner = StateExpansionPlanner(options)
-        val plannedAggregates = namedAggregates
-            .sortedWith(compareBy<NamedAggregate> { it.contextName }.thenBy { it.aggregateName })
-            .map { namedAggregate -> PlannedAggregate(namedAggregate, planner.plan(namedAggregate)) }
-        val descriptor = BiDeploymentDescriptor.from(options)
-        val shouldRenderDeploymentAnchor = options.consumerGroupNamespace != null
-        require(operation !is BiScriptOperation.Reset || shouldRenderDeploymentAnchor) {
-            "consumerGroupNamespace must be configured before RESET so its recovery state can be persisted"
-        }
-        val desiredObjects = plannedAggregates.desiredObjects() +
-            if (shouldRenderDeploymentAnchor) listOf(desiredAnchor()) else emptyList()
-        validateDesiredObjectNames(desiredObjects)
-        val observed = (inspection as? BiDeploymentInspection.Available)?.deployment
-        observed?.validate(descriptor, desiredObjects, operation)
-        val consumerIdentity = resolveConsumerIdentity(operation, descriptor, observed)
-        val retainedQueueKeys = resolveRetainedQueueKeys(operation, desiredObjects, descriptor, observed)
-        val renderer = ClickHouseScriptRenderer(
-            options,
-            consumerIdentity,
-            descriptor,
-            if (observed == null) CatalogMutationMode.CREATE_ONLY else CatalogMutationMode.RECONCILE,
-            retainedQueueKeys,
-        )
-
-        val globalSection = ScriptSection("global", renderer.renderGlobalStatements())
-        val lifecycleSections = renderLifecycle(
-            operation,
-            plannedAggregates,
-            desiredObjects,
-            descriptor,
-            observed,
-            renderer,
-        )
-        val durableAggregateSections = plannedAggregates.flatMap { planned ->
-            val name = planned.namedAggregate.toStringWithAlias()
-            listOf(
-                ScriptSection("$name.commandStorage", renderer.renderCommandStorageStatements(planned.namedAggregate)),
-                ScriptSection("$name.stateStorage", renderer.renderStateStorageStatements(planned.namedAggregate)),
-                ScriptSection("$name.stateLast", renderer.renderStateLastStatements(planned.namedAggregate)),
-                ScriptSection("$name.expansion", renderer.renderExpansionStatements(planned.plan, name)),
-                ScriptSection("$name.commandPublic", renderer.renderCommandPublicStatements(planned.namedAggregate)),
-                ScriptSection("$name.statePublic", renderer.renderStatePublicStatements(planned.namedAggregate)),
-            )
-        }
-        val ingressSections = plannedAggregates.flatMap { planned ->
-            val name = planned.namedAggregate.toStringWithAlias()
-            listOf(
-                ScriptSection("$name.commandIngress", renderer.renderCommandIngressStatements(planned.namedAggregate)),
-                ScriptSection("$name.stateIngress", renderer.renderStateIngressStatements(planned.namedAggregate)),
-            )
-        }
-        val resetIntentSection = if (operation is BiScriptOperation.Reset) {
-            ScriptSection(
-                "deployment-reset-intent",
-                listOf(renderer.renderAnchorStatement(BiDeploymentPhase.RESETTING)),
-            )
-        } else {
-            null
-        }
-        val anchorSection = if (shouldRenderDeploymentAnchor) {
-            ScriptSection(
-                "deployment-anchor",
-                listOf(renderer.renderAnchorStatement(BiDeploymentPhase.STABLE)),
-            )
-        } else {
-            null
-        }
-        val orderedSections = listOf(globalSection) + listOfNotNull(resetIntentSection) + lifecycleSections +
-            durableAggregateSections + listOfNotNull(anchorSection) + ingressSections
-        val statements = Collections.unmodifiableList(
-            ArrayList(orderedSections.flatMap(ScriptSection::statements))
-        )
-        val script = buildString {
-            appendSection(globalSection)
-            appendLine("-- lifecycle --")
-            resetIntentSection?.let { section -> appendSection(section) }
-            lifecycleSections.forEach { section -> appendSection(section) }
-            appendLine("-- lifecycle --")
-            durableAggregateSections.forEach { section -> appendSection(section) }
-            anchorSection?.let { section -> appendSection(section) }
-            ingressSections.forEach { section -> appendSection(section) }
-        }
-        val diagnostics = buildList {
-            if (plannedAggregates.isNotEmpty()) {
-                addAll(topologyDiagnostics())
-            }
-            if (inspection is BiDeploymentInspection.Unavailable) {
-                add(inspectionUnavailableDiagnostic())
-            }
-            addAll(retainedStoreDiagnostics(operation, desiredObjects, descriptor, observed))
-            addAll(plannedAggregates.flatMap { it.plan.diagnostics })
-        }
-        return BiScriptResult(
-            script = script,
-            statements = statements,
-            diagnostics = Collections.unmodifiableList(ArrayList(diagnostics)),
-            operation = operation,
-            destructive = operation is BiScriptOperation.Reset,
-        )
     }
 
-    private fun resolveRetainedQueueKeys(
-        operation: BiScriptOperation,
-        desiredObjects: List<DesiredBiObject>,
-        descriptor: BiDeploymentDescriptor,
-        observed: ObservedBiDeployment?,
-    ): Set<BiObjectKey> {
-        if (operation != BiScriptOperation.Deploy || observed == null) {
-            return emptySet()
-        }
-        val desiredQueueKeys = desiredObjects.asSequence()
-            .filter { it.kind == BiObjectKind.QUEUE }
-            .map(DesiredBiObject::key)
-            .toSet()
-        return observed.ownedBy(descriptor).asSequence()
-            .filter { it.metadata?.kind == BiObjectKind.QUEUE && it.key in desiredQueueKeys }
-            .map(ObservedBiObject::key)
-            .toSet()
-    }
-
-    private fun renderLifecycle(
-        operation: BiScriptOperation,
-        plannedAggregates: List<PlannedAggregate>,
-        desiredObjects: List<DesiredBiObject>,
-        descriptor: BiDeploymentDescriptor,
-        observed: ObservedBiDeployment?,
-        renderer: ClickHouseScriptRenderer,
-    ): List<ScriptSection> = buildList {
-        when (operation) {
-            BiScriptOperation.Deploy -> {
-                if (observed != null) {
-                    plannedAggregates.forEach { planned ->
-                        add(
-                            ScriptSection(
-                                "${planned.namedAggregate.toStringWithAlias()}.pause-ingress",
-                                renderer.renderPauseIngressStatements(planned.namedAggregate),
-                            )
-                        )
-                    }
-                }
-                val desiredKeys = desiredObjects.map(DesiredBiObject::key).toSet()
-                val staleObjects = observed?.ownedBy(descriptor).orEmpty()
-                    .filter { it.key !in desiredKeys && it.metadata?.kind != BiObjectKind.STORE }
-                if (staleObjects.isNotEmpty()) {
-                    add(
-                        ScriptSection("reconcile-observed-catalog", renderer.renderDropObservedStatements(staleObjects))
-                    )
-                }
-            }
-
-            is BiScriptOperation.Reset -> {
-                val anchorKey = desiredAnchor().key
-                val ownedObjects = checkNotNull(observed).ownedBy(descriptor)
-                    .filterNot { it.key == anchorKey }
-                if (ownedObjects.isNotEmpty()) {
-                    add(ScriptSection("reset-observed-catalog", renderer.renderDropObservedStatements(ownedObjects)))
-                }
-            }
-        }
-    }
-
-    private fun resolveConsumerIdentity(
-        operation: BiScriptOperation,
-        descriptor: BiDeploymentDescriptor,
-        observed: ObservedBiDeployment?,
-    ): BiConsumerIdentity = when (operation) {
-        BiScriptOperation.Deploy ->
-            observed?.consumerIdentity(descriptor) ?: BiConsumerIdentity.deterministic(descriptor)
-        is BiScriptOperation.Reset ->
-            observed?.resettingAnchor(descriptor)?.metadata?.consumerIdentity
-                ?.let(::BiConsumerIdentity)
-                ?: BiConsumerIdentity.random()
-    }
-
-    private fun ObservedBiDeployment.resettingAnchor(
-        descriptor: BiDeploymentDescriptor,
-    ): ObservedBiObject? = objects.firstOrNull { observed ->
-        observed.key == desiredAnchor().key &&
-            observed.metadata?.deploymentId == descriptor.deploymentId &&
-            observed.metadata.phase == BiDeploymentPhase.RESETTING
-    }
-
-    private fun ObservedBiDeployment.consumerIdentity(descriptor: BiDeploymentDescriptor): BiConsumerIdentity? {
-        val ownedObjects = ownedBy(descriptor)
-        val identities = ownedObjects.mapNotNull { observed -> observed.metadata?.consumerIdentity }
-            .map(::BiConsumerIdentity)
-            .distinct()
-        require(identities.size <= 1) {
-            "Observed BI deployment contains mixed consumer identities: ${identities.map(BiConsumerIdentity::value)}"
-        }
-        require(ownedObjects.isEmpty() || identities.isNotEmpty()) {
-            "Observed BI deployment is missing its consumer identity anchor"
-        }
-        return identities.singleOrNull()
-    }
-
-    private fun ObservedBiDeployment.validate(
-        descriptor: BiDeploymentDescriptor,
-        desiredObjects: List<DesiredBiObject>,
-        operation: BiScriptOperation,
-    ) {
-        val desiredByKey = desiredObjects.associateBy(DesiredBiObject::key)
-        validateDeploymentTopology(descriptor)
-        validateDeploymentAnchor(descriptor, operation)
-        objects.forEach { observed ->
-            validateObservedObject(
-                observed = observed,
-                desired = desiredByKey[observed.key],
-                descriptor = descriptor,
-                operation = operation,
-            )
-        }
-        if (operation == BiScriptOperation.Deploy) {
-            consumerIdentity(descriptor)
-        }
-    }
-
-    private fun ObservedBiDeployment.validateDeploymentTopology(
-        descriptor: BiDeploymentDescriptor,
-    ) {
-        val currentObjects = ownedBy(descriptor)
-        if (currentObjects.isEmpty()) {
-            return
-        }
-        val observedTopologies = currentObjects.map { observed ->
-            requireNotNull(observed.metadata).topologyFingerprint
-        }.distinct()
-        require(observedTopologies.size <= 1) {
-            "Observed BI deployment contains mixed topology fingerprints: $observedTopologies"
-        }
-        require(observedTopologies.single() == descriptor.topologyFingerprint) {
-            "Observed BI deployment topology differs from the requested topology and cannot be migrated through " +
-                "DEPLOY or RESET"
-        }
-    }
-
-    private fun ObservedBiDeployment.validateDeploymentAnchor(
-        descriptor: BiDeploymentDescriptor,
-        operation: BiScriptOperation,
-    ) {
-        val deploymentAnchors = objects.filter { observed ->
-            observed.metadata?.deploymentId == descriptor.deploymentId &&
-                observed.metadata.kind == BiObjectKind.ANCHOR
-        }
-        require(deploymentAnchors.size <= 1) {
-            "Observed BI deployment contains multiple deployment anchors: " +
-                deploymentAnchors.map { anchor -> "${anchor.database}.${anchor.name}" }.sorted()
-        }
-        deploymentAnchors.singleOrNull()?.let { anchor ->
-            val canonicalAnchor = desiredAnchor().key
-            require(anchor.key == canonicalAnchor) {
-                "Observed BI deployment anchor must use canonical key " +
-                    "[${canonicalAnchor.database}.${canonicalAnchor.name}], but found " +
-                    "[${anchor.database}.${anchor.name}]"
-            }
-        }
-        resettingAnchor(descriptor)?.let { anchor ->
-            val metadata = checkNotNull(anchor.metadata)
-            when (operation) {
-                BiScriptOperation.Deploy -> throw IllegalArgumentException(
-                    "Observed BI deployment is RESETTING; retry RESET with the same configuration"
-                )
-
-                is BiScriptOperation.Reset -> require(
-                    metadata.configurationFingerprint == descriptor.configurationFingerprint
-                ) {
-                    "Observed BI deployment is RESETTING with a different configuration; " +
-                        "retry RESET with the original configuration"
-                }
-            }
-        }
-    }
-
-    private fun validateObservedObject(
-        observed: ObservedBiObject,
-        desired: DesiredBiObject?,
-        descriptor: BiDeploymentDescriptor,
-        operation: BiScriptOperation,
-    ) {
-        val metadata = observed.metadata
-        if (desired != null) {
-            require(
-                metadata != null &&
-                    metadata.deploymentId == descriptor.deploymentId
-            ) {
-                "BI object [${observed.database}.${observed.name}] is occupied by a foreign catalog object"
-            }
-            require(metadata.kind == desired.kind && metadata.aggregate == desired.aggregate) {
-                "BI object [${observed.database}.${observed.name}] has inconsistent ownership metadata"
-            }
-            if (desired.kind == BiObjectKind.ANCHOR) {
-                require(observed.engine == desired.expectedEngine) {
-                    "BI deployment anchor [${observed.database}.${observed.name}] must use the View engine"
-                }
-            } else {
-                require(observed.engine == desired.expectedEngine) {
-                    "BI object [${observed.database}.${observed.name}] has incompatible engine " +
-                        "[${observed.engine}]; expected engine [${desired.expectedEngine}]"
-                }
-            }
-        } else if (metadata?.deploymentId == descriptor.deploymentId) {
-            require(metadata.kind.acceptsEngine(observed.engine)) {
-                "BI object [${observed.database}.${observed.name}] kind [${metadata.kind}] has incompatible engine " +
-                    "[${observed.engine}]"
-            }
-        }
-        if (metadata?.deploymentId == descriptor.deploymentId && operation == BiScriptOperation.Deploy) {
-            require(metadata.configurationFingerprint == descriptor.configurationFingerprint) {
-                "Observed BI deployment configuration differs from the requested configuration; use RESET"
-            }
-        }
-    }
-
-    private fun BiObjectKind.acceptsEngine(engine: String): Boolean = when (this) {
-        BiObjectKind.ANCHOR,
-        BiObjectKind.VIEW,
-        -> engine == "View"
-
-        BiObjectKind.STORE -> engine in STORE_ENGINES
-        BiObjectKind.QUEUE -> engine == "Kafka"
-        BiObjectKind.CONSUMER -> engine == "MaterializedView"
-    }
-
-    private fun ObservedBiDeployment.ownedBy(descriptor: BiDeploymentDescriptor): List<ObservedBiObject> =
-        ownedObjects.filter { it.metadata?.deploymentId == descriptor.deploymentId }
-
-    private fun List<PlannedAggregate>.desiredObjects(): List<DesiredBiObject> {
-        val naming = BiTableNaming(options)
-        return flatMap { planned -> planned.desiredObjects(naming) }
-    }
-
-    private fun PlannedAggregate.desiredObjects(naming: BiTableNaming): List<DesiredBiObject> {
-        val aggregate = namedAggregate.toStringWithAlias()
-        val command = naming.toTableName(namedAggregate, "command")
-        val state = naming.toTableName(namedAggregate, "state")
-        val stateLast = naming.toTableName(namedAggregate, "state_last")
-        return buildList {
-            listOf(command, state, stateLast).forEach { table ->
-                addDesiredStores(table, aggregate)
-            }
-            add(DesiredBiObject(BiObjectKey(options.database, command), aggregate, BiObjectKind.VIEW, VIEW_ENGINE))
-            add(DesiredBiObject(BiObjectKey(options.database, state), aggregate, BiObjectKind.VIEW, VIEW_ENGINE))
-            add(
-                DesiredBiObject(
-                    BiObjectKey(options.database, "${state}_event"),
-                    aggregate,
-                    BiObjectKind.VIEW,
-                    VIEW_ENGINE,
-                )
-            )
-            add(DesiredBiObject(BiObjectKey(options.database, stateLast), aggregate, BiObjectKind.VIEW, VIEW_ENGINE))
-            plan.views.forEach { view ->
-                add(
-                    DesiredBiObject(
-                        BiObjectKey(options.database, view.targetTableName),
-                        aggregate,
-                        BiObjectKind.VIEW,
-                        VIEW_ENGINE,
-                    )
-                )
-            }
-            listOf(command, state).forEach { table ->
-                add(
-                    DesiredBiObject(
-                        BiObjectKey(options.consumerDatabase, "${table}_queue"),
-                        aggregate,
-                        BiObjectKind.QUEUE,
-                        QUEUE_ENGINE,
-                    )
-                )
-                add(
-                    DesiredBiObject(
-                        BiObjectKey(options.consumerDatabase, "${table}_consumer"),
-                        aggregate,
-                        BiObjectKind.CONSUMER,
-                        CONSUMER_ENGINE,
-                    )
-                )
-            }
-            add(
-                DesiredBiObject(
-                    BiObjectKey(options.consumerDatabase, "${stateLast}_consumer"),
-                    aggregate,
-                    BiObjectKind.CONSUMER,
-                    CONSUMER_ENGINE,
-                )
-            )
-        }
-    }
-
-    private fun MutableList<DesiredBiObject>.addDesiredStores(
-        table: String,
-        aggregate: String,
-    ) {
-        val store = "${table}_store"
-        val storeEngine = when (options.topology) {
-            is ClickHouseTopology.Cluster -> "Distributed"
-            ClickHouseTopology.Standalone -> "ReplacingMergeTree"
-        }
-        add(DesiredBiObject(BiObjectKey(options.database, store), aggregate, BiObjectKind.STORE, storeEngine))
-        if (options.topology is ClickHouseTopology.Cluster) {
-            add(
-                DesiredBiObject(
-                    BiObjectKey(options.database, "${store}_local"),
-                    aggregate,
-                    BiObjectKind.STORE,
-                    "ReplicatedReplacingMergeTree",
-                )
-            )
-        }
-    }
-
-    private fun desiredAnchor(): DesiredBiObject =
-        DesiredBiObject(
-            BiObjectKey(options.consumerDatabase, ClickHouseScriptRenderer.DEPLOYMENT_ANCHOR),
-            null,
-            BiObjectKind.ANCHOR,
-            VIEW_ENGINE,
-        )
-
-    private fun validateDesiredObjectNames(objects: List<DesiredBiObject>) {
-        val collision = objects.groupBy(DesiredBiObject::key).entries.firstOrNull { it.value.size > 1 }
-        require(collision == null) {
-            "BI object name collision [${collision!!.key.database}.${collision.key.name}] between aggregates " +
-                collision.value.mapNotNull(DesiredBiObject::aggregate).distinct().sorted()
-                    .joinToString(prefix = "[", postfix = "]")
-        }
-    }
-
-    private fun retainedStoreDiagnostics(
-        operation: BiScriptOperation,
-        desiredObjects: List<DesiredBiObject>,
-        descriptor: BiDeploymentDescriptor,
-        observed: ObservedBiDeployment?,
-    ): List<BiScriptDiagnostic> {
-        if (operation is BiScriptOperation.Reset) {
-            return emptyList()
-        }
-        val desiredKeys = desiredObjects.map(DesiredBiObject::key).toSet()
-        return observed?.ownedBy(descriptor).orEmpty()
-            .filter { it.key !in desiredKeys && it.metadata?.kind == BiObjectKind.STORE }
-            .mapNotNull { it.metadata?.aggregate }
-            .distinct()
-            .sorted()
-            .map { aggregate ->
-                BiScriptDiagnostic(
-                    code = BiScriptDiagnosticCode.ORPHANED_DATA_TABLE,
-                    aggregate = aggregate,
-                    path = "lifecycle.reconcile",
-                    sourceType = "ObservedBiDeployment",
-                    decision = BiScriptMappingDecision.DATA_TABLE_RETAINED,
-                    message = "Aggregate was removed; its observed data stores were retained.",
-                )
-            }
-    }
-
-    private fun inspectionUnavailableDiagnostic(): BiScriptDiagnostic = BiScriptDiagnostic(
-        code = BiScriptDiagnosticCode.INSPECTION_UNAVAILABLE,
-        aggregate = "*",
-        path = "lifecycle.inspection",
-        sourceType = "BiDeploymentInspector",
-        decision = BiScriptMappingDecision.RECONCILIATION_SKIPPED,
-        message = "BI deployment inspection is unavailable; generated current desired state without stale-object reconciliation.",
-    )
-
-    private fun topologyDiagnostics(): List<BiScriptDiagnostic> = when (options.topology) {
-        is ClickHouseTopology.Cluster -> listOf(
-            BiScriptDiagnostic(
-                code = BiScriptDiagnosticCode.CLUSTER_INTERNAL_REPLICATION_REQUIRED,
-                aggregate = "*",
-                path = "topology.cluster",
-                sourceType = "ClickHouseTopology.Cluster",
-                decision = BiScriptMappingDecision.EXTERNAL_CONFIGURATION_REQUIRED,
-                message = "Configure internal_replication=true for every shard before applying clustered BI DDL.",
-            )
-        )
-
-        ClickHouseTopology.Standalone -> emptyList()
-    }
-
-    private fun StringBuilder.appendSection(section: ScriptSection) {
-        appendLine("-- ${section.name} --")
-        if (section.statements.isNotEmpty()) {
-            appendLine(section.statements.joinToString("\n\n"))
-        }
-        appendLine("-- ${section.name} --")
-    }
-
-    private data class PlannedAggregate(
-        val namedAggregate: NamedAggregate,
-        val plan: StateExpansionPlan,
-    )
-
-    private data class DesiredBiObject(
-        val key: BiObjectKey,
-        val aggregate: String?,
-        val kind: BiObjectKind,
-        val expectedEngine: String,
-    )
-
-    private data class ScriptSection(
-        val name: String,
-        val statements: List<String>,
-    )
-
-    private companion object {
-        const val VIEW_ENGINE: String = "View"
-        const val QUEUE_ENGINE: String = "Kafka"
-        const val CONSUMER_ENGINE: String = "MaterializedView"
-
-        val STORE_ENGINES: Set<String> = setOf(
-            "ReplacingMergeTree",
-            "ReplicatedReplacingMergeTree",
-            "Distributed",
-        )
-    }
+    internal fun desiredObjectKeys(namedAggregates: Set<NamedAggregate>): Set<BiObjectKey> =
+        prepare(namedAggregates).desiredObjectKeys
 }

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiScriptResult.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/BiScriptResult.kt
@@ -28,6 +28,7 @@ enum class BiScriptDiagnosticCode {
     INSPECTION_UNAVAILABLE,
     ORPHANED_DATA_TABLE,
     CLUSTER_INTERNAL_REPLICATION_REQUIRED,
+    COMPUTED_OBJECT_DRIFT,
 }
 
 enum class BiScriptMappingDecision {
@@ -36,6 +37,7 @@ enum class BiScriptMappingDecision {
     RECONCILIATION_SKIPPED,
     DATA_TABLE_RETAINED,
     EXTERNAL_CONFIGURATION_REQUIRED,
+    RECONCILIATION_PLANNED,
 }
 
 data class BiScriptDiagnostic(

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspector.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspector.kt
@@ -13,34 +13,22 @@
 
 package me.ahoo.wow.bi
 
-import com.clickhouse.client.api.Client
 import com.clickhouse.client.api.ClientException
-import com.clickhouse.client.api.query.QueryResponse
-import com.clickhouse.client.api.query.QuerySettings
-import com.clickhouse.data.ClickHouseFormat
-import me.ahoo.wow.bi.renderer.ClickHouseSqlSyntax
 import reactor.core.publisher.Mono
 import reactor.core.scheduler.Scheduler
 import reactor.core.scheduler.Schedulers
-import tools.jackson.core.JacksonException
 import java.time.Duration
-import java.time.temporal.ChronoUnit
-import java.util.concurrent.CancellationException
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.ExecutionException
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeoutException
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicReference
 
-private const val CLICKHOUSE_CATALOG_CLEANUP_THREADS: Int = 4
-private const val CLICKHOUSE_CATALOG_CLEANUP_TTL_SECONDS: Int = 60
-private val CLICKHOUSE_CATALOG_CLEANUP_SCHEDULER: Scheduler = Schedulers.newBoundedElastic(
-    CLICKHOUSE_CATALOG_CLEANUP_THREADS,
-    Schedulers.DEFAULT_BOUNDED_ELASTIC_QUEUESIZE,
-    "wow-bi-catalog-cleanup",
-    CLICKHOUSE_CATALOG_CLEANUP_TTL_SECONDS,
+private const val CLICKHOUSE_CATALOG_INSPECTION_THREADS: Int = 4
+private const val CLICKHOUSE_CATALOG_INSPECTION_QUEUE_SIZE: Int = 256
+private const val CLICKHOUSE_CATALOG_INSPECTION_TTL_SECONDS: Int = 60
+private val CLICKHOUSE_CATALOG_INSPECTION_SCHEDULER: Scheduler = Schedulers.newBoundedElastic(
+    CLICKHOUSE_CATALOG_INSPECTION_THREADS,
+    CLICKHOUSE_CATALOG_INSPECTION_QUEUE_SIZE,
+    "wow-bi-catalog-inspection",
+    CLICKHOUSE_CATALOG_INSPECTION_TTL_SECONDS,
     true,
 )
 
@@ -53,7 +41,10 @@ class ClickHouseBiDeploymentInspector internal constructor(
     private val catalogClient: ClickHouseCatalogClient,
     private val inspectionTimeout: Duration = DEFAULT_INSPECTION_TIMEOUT,
     private val timeoutScheduler: Scheduler = Schedulers.parallel(),
+    private val inspectionScheduler: Scheduler = CLICKHOUSE_CATALOG_INSPECTION_SCHEDULER,
 ) : BiDeploymentInspector, AutoCloseable {
+    private val catalogReader = ClickHouseCatalogReader(catalogClient)
+
     constructor(
         clientOptions: ClickHouseClientOptions,
         inspectionTimeout: Duration = DEFAULT_INSPECTION_TIMEOUT,
@@ -69,267 +60,102 @@ class ClickHouseBiDeploymentInspector internal constructor(
     override fun inspect(
         options: BiScriptOptions,
         operation: BiScriptOperation,
-    ): Mono<BiDeploymentInspection> =
-        Mono.defer {
-            val cancellation = ClickHouseQueryCancellation()
-            Mono.fromCallable<BiDeploymentInspection> {
-                try {
-                    val deployment = when (val topology = options.topology) {
-                        ClickHouseTopology.Standalone -> inspectStandalone(options, operation, cancellation)
-                        is ClickHouseTopology.Cluster -> inspectCluster(options, topology, operation, cancellation)
-                    }
-                    BiDeploymentInspection.Available(deployment)
-                } catch (error: BiDeploymentInspectionException) {
-                    error.cancelledInspectionOrThrow(cancellation)
-                } catch (error: IllegalArgumentException) {
-                    BiDeploymentInspectionException.Inconsistent(
-                        error.message ?: "ClickHouse BI catalog is inconsistent",
-                        error,
-                    ).cancelledInspectionOrThrow(cancellation)
-                } catch (error: IllegalStateException) {
-                    BiDeploymentInspectionException.Inconsistent(
-                        error.message ?: "ClickHouse BI catalog is inconsistent",
-                        error,
-                    ).cancelledInspectionOrThrow(cancellation)
-                } catch (error: ClientException) {
-                    error.toInspectionException().cancelledInspectionOrThrow(cancellation)
-                } catch (error: InterruptedException) {
-                    Thread.currentThread().interrupt()
-                    error.cancelledInspectionOrThrow(cancellation)
-                } finally {
-                    if (cancellation.isCancelled) {
-                        Thread.interrupted()
-                    }
-                }
-            }
-                .subscribeOn(Schedulers.boundedElastic())
-                .doOnCancel(cancellation::cancel)
-                .timeout(inspectionTimeout, timeoutScheduler)
+        preparation: BiScriptPreparation,
+    ): Mono<BiDeploymentInspection> {
+        require(preparation.options == options) {
+            "BI inspection preparation belongs to different script options"
         }
-            .onErrorMap(TimeoutException::class.java) { error ->
-                BiDeploymentInspectionException.Timeout(
-                    message = "ClickHouse BI deployment inspection timed out",
-                    cause = error,
+        return Mono.just(preparation)
+            .flatMap {
+                inspectCatalog(
+                    options = options,
+                    operation = operation,
+                    preparation = it,
                 )
             }
+            .onErrorMap(RejectedExecutionException::class.java, ::inspectionOverloaded)
+    }
+
+    private fun inspectCatalog(
+        options: BiScriptOptions,
+        operation: BiScriptOperation,
+        preparation: BiScriptPreparation,
+    ): Mono<BiDeploymentInspection> = Mono.defer {
+        val cancellation = ClickHouseQueryCancellation()
+        Mono.fromCallable<BiDeploymentInspection> {
+            inspectCatalogBlocking(options, operation, preparation, cancellation)
+        }
+            .subscribeOn(inspectionScheduler)
+            .doOnCancel(cancellation::cancel)
+            .timeout(inspectionTimeout, timeoutScheduler)
+    }
+        .onErrorMap(TimeoutException::class.java) { error ->
+            BiDeploymentInspectionException.Timeout(
+                message = "ClickHouse BI deployment inspection timed out",
+                cause = error,
+            )
+        }
+        .onErrorMap(RejectedExecutionException::class.java) { error ->
+            inspectionOverloaded(error)
+        }
+
+    private fun inspectCatalogBlocking(
+        options: BiScriptOptions,
+        operation: BiScriptOperation,
+        preparation: BiScriptPreparation,
+        cancellation: ClickHouseQueryCancellation,
+    ): BiDeploymentInspection {
+        try {
+            val snapshot = catalogReader.read(
+                ClickHouseCatalogReadRequest(
+                    options = options,
+                    operation = operation,
+                    desiredObjectKeys = preparation.desiredObjectKeys,
+                    desiredObjects = preparation.desiredObjects,
+                    cancellation = cancellation,
+                )
+            )
+            val validated = ClickHouseBiDeploymentValidator.validate(
+                options,
+                operation,
+                snapshot,
+                preparation.desiredObjects,
+            )
+            return BiDeploymentInspection.Available.reconciled(
+                deployment = validated.deployment,
+                repairableComputedDrifts = validated.repairableDrifts,
+                ownershipRegistry = snapshot.ownershipRegistry,
+            )
+        } catch (error: BiDeploymentInspectionException) {
+            return error.cancelledInspectionOrThrow(cancellation)
+        } catch (error: IllegalArgumentException) {
+            return BiDeploymentInspectionException.Inconsistent(
+                error.message ?: "ClickHouse BI catalog is inconsistent",
+                error,
+            ).cancelledInspectionOrThrow(cancellation)
+        } catch (error: IllegalStateException) {
+            return BiDeploymentInspectionException.Inconsistent(
+                error.message ?: "ClickHouse BI catalog is inconsistent",
+                error,
+            ).cancelledInspectionOrThrow(cancellation)
+        } catch (error: ClientException) {
+            return error.toInspectionException().cancelledInspectionOrThrow(cancellation)
+        } catch (error: InterruptedException) {
+            Thread.currentThread().interrupt()
+            return error.cancelledInspectionOrThrow(cancellation)
+        } finally {
+            if (cancellation.isCancelled) {
+                Thread.interrupted()
+            }
+        }
+    }
 
     override fun close() {
         catalogClient.close()
     }
 
-    private fun inspectStandalone(
-        options: BiScriptOptions,
-        operation: BiScriptOperation,
-        cancellation: ClickHouseQueryCancellation,
-    ): ObservedBiDeployment {
-        val records = catalogClient.query(
-            sql = STANDALONE_CATALOG_QUERY,
-            parameters = options.catalogParameters(),
-            columns = CATALOG_COLUMNS,
-            cancellation = cancellation,
-        )
-        return validateObjects(options, operation, records.map(ClickHouseCatalogRecord::toObservedObject))
-    }
-
-    private fun inspectCluster(
-        options: BiScriptOptions,
-        cluster: ClickHouseTopology.Cluster,
-        operation: BiScriptOperation,
-        cancellation: ClickHouseQueryCancellation,
-    ): ObservedBiDeployment {
-        val parameters = options.catalogParameters() + ("cluster" to cluster.name)
-        val nodes = catalogClient.query(
-            sql = CLUSTER_NODES_QUERY,
-            parameters = mapOf("cluster" to cluster.name),
-            columns = NODE_COLUMNS,
-            cancellation = cancellation,
-        ).map(ClickHouseCatalogRecord::toNode).toSet()
-        check(nodes.isNotEmpty()) {
-            "ClickHouse BI cluster [${cluster.name}] returned no replicas"
-        }
-
-        val objects = catalogClient.query(
-            sql = CLUSTER_CATALOG_QUERY,
-            parameters = parameters,
-            columns = NODE_COLUMNS + CATALOG_COLUMNS,
-            cancellation = cancellation,
-        ).map { record -> NodeObject(record.toNode(), record.toObservedObject()) }
-        validateClusterCatalog(cluster.name, nodes, objects)
-        return validateObjects(options, operation, objects.map(NodeObject::objectValue))
-    }
-
-    private fun validateClusterCatalog(
-        cluster: String,
-        nodes: Set<ClickHouseCatalogNode>,
-        objects: List<NodeObject>,
-    ) {
-        val observedNodes = objects.mapTo(mutableSetOf(), NodeObject::node)
-        check(observedNodes.all(nodes::contains)) {
-            "ClickHouse BI cluster [$cluster] catalog contains an unknown replica"
-        }
-
-        objects.groupBy { it.objectValue.key }.forEach { (key, replicas) ->
-            if (replicas.none { it.objectValue.metadata != null }) {
-                return@forEach
-            }
-            check(replicas.size == nodes.size && replicas.mapTo(mutableSetOf(), NodeObject::node) == nodes) {
-                "ClickHouse BI catalog object [${key.database}.${key.name}] is missing from a replica"
-            }
-            val definitions = replicas.map { it.objectValue.toCatalogDefinition() }.distinct()
-            check(definitions.size == 1) {
-                "ClickHouse BI catalog object [${key.database}.${key.name}] differs across replicas"
-            }
-        }
-    }
-
-    private fun validateObjects(
-        options: BiScriptOptions,
-        operation: BiScriptOperation,
-        objects: List<ObservedBiObject>,
-    ): ObservedBiDeployment {
-        val uniqueObjects = objects.groupBy(ObservedBiObject::key).map { (key, replicas) ->
-            val definitions = replicas.map(ObservedBiObject::toCatalogDefinition).distinct()
-            check(definitions.size == 1 || replicas.none { it.metadata != null }) {
-                "ClickHouse BI catalog object [${key.database}.${key.name}] has duplicate definitions"
-            }
-            replicas.first()
-        }.sortedWith(compareBy<ObservedBiObject> { it.database }.thenBy { it.name })
-        val descriptor = BiDeploymentDescriptor.from(options)
-        val requestedDeploymentMetadata = uniqueObjects.asSequence()
-            .mapNotNull(ObservedBiObject::metadata)
-            .filter { metadata -> metadata.deploymentId == descriptor.deploymentId }
-            .toList()
-        val requestedDeploymentIsStable = requestedDeploymentMetadata.all { metadata ->
-            metadata.phase == BiDeploymentPhase.STABLE &&
-                metadata.configurationFingerprint == descriptor.configurationFingerprint
-        }
-        uniqueObjects.filter { it.metadata?.kind == BiObjectKind.QUEUE }
-            .forEach { queue ->
-                val validateRequestedConfiguration =
-                    operation == BiScriptOperation.Deploy &&
-                        requestedDeploymentIsStable &&
-                        queue.metadata?.deploymentId == descriptor.deploymentId
-                validateQueueIdentity(options, queue, validateRequestedConfiguration)
-            }
-        return ObservedBiDeployment(uniqueObjects)
-    }
-
-    private fun validateQueueIdentity(
-        options: BiScriptOptions,
-        queue: ObservedBiObject,
-        validateRequestedConfiguration: Boolean,
-    ) {
-        check(queue.engine == "Kafka") {
-            "Owned BI queue [${queue.database}.${queue.name}] must use the Kafka engine"
-        }
-        val metadata = checkNotNull(queue.metadata)
-        val identity = checkNotNull(metadata.consumerIdentity) {
-            "Owned BI queue [${queue.database}.${queue.name}] is missing consumerIdentity"
-        }
-        val consumerName = queue.name.removeSuffix("_queue") + "_consumer"
-        val expectedGroup = "wow-bi.$identity.$consumerName"
-        val arguments = queue.engineFull.functionArguments("Kafka").orEmpty()
-        val actualGroup = arguments.getOrNull(KAFKA_GROUP_ARGUMENT_INDEX)
-        check(actualGroup == ClickHouseSqlSyntax.stringLiteral(expectedGroup)) {
-            "Owned BI queue [${queue.database}.${queue.name}] has an unexpected Kafka consumer group"
-        }
-        val streamKind = when {
-            queue.name.endsWith("_command_queue") -> "command"
-            queue.name.endsWith("_state_queue") -> "state"
-            else -> error("Owned BI queue [${queue.database}.${queue.name}] has an unsupported queue name")
-        }
-        check(arguments.getOrNull(KAFKA_FORMAT_ARGUMENT_INDEX) == ClickHouseSqlSyntax.stringLiteral(KAFKA_FORMAT)) {
-            "Owned BI queue [${queue.database}.${queue.name}] has an unexpected Kafka format"
-        }
-        if (!validateRequestedConfiguration) {
-            return
-        }
-        check(
-            arguments.getOrNull(KAFKA_BROKERS_ARGUMENT_INDEX) ==
-                ClickHouseSqlSyntax.stringLiteral(options.kafkaBootstrapServers)
-        ) {
-            "Owned BI queue [${queue.database}.${queue.name}] has unexpected Kafka bootstrap servers"
-        }
-        val expectedTopic = "${options.topicPrefix}${checkNotNull(metadata.aggregate)}.$streamKind"
-        check(arguments.getOrNull(KAFKA_TOPIC_ARGUMENT_INDEX) == ClickHouseSqlSyntax.stringLiteral(expectedTopic)) {
-            "Owned BI queue [${queue.database}.${queue.name}] has an unexpected Kafka topic"
-        }
-        val actualKeeperPath = queue.engineFull.settingLiteral(KAFKA_KEEPER_PATH_SETTING)
-        val actualReplicaName = queue.engineFull.settingLiteral(KAFKA_REPLICA_NAME_SETTING)
-        when (options.kafkaOffsetStorage) {
-            KafkaOffsetStorage.BROKER -> check(actualKeeperPath == null && actualReplicaName == null) {
-                "Owned BI queue [${queue.database}.${queue.name}] has unexpected Keeper offset settings"
-            }
-
-            KafkaOffsetStorage.KEEPER -> {
-                val expectedKeeperPath = "${options.kafkaKeeperPathPrefix.trimEnd('/')}/$identity/${queue.name}"
-                check(actualKeeperPath == ClickHouseSqlSyntax.stringLiteral(expectedKeeperPath)) {
-                    "Owned BI queue [${queue.database}.${queue.name}] has an unexpected Kafka Keeper path"
-                }
-                val expectedReplicaName = when (options.topology) {
-                    is ClickHouseTopology.Cluster -> "{replica}"
-                    ClickHouseTopology.Standalone -> identity
-                }
-                check(actualReplicaName == ClickHouseSqlSyntax.stringLiteral(expectedReplicaName)) {
-                    "Owned BI queue [${queue.database}.${queue.name}] has an unexpected Kafka Keeper replica name"
-                }
-            }
-        }
-    }
-
-    private data class NodeObject(
-        val node: ClickHouseCatalogNode,
-        val objectValue: ObservedBiObject,
-    )
-
     private companion object {
         val DEFAULT_INSPECTION_TIMEOUT: Duration = Duration.ofSeconds(30)
-        const val KAFKA_BROKERS_ARGUMENT_INDEX: Int = 0
-        const val KAFKA_TOPIC_ARGUMENT_INDEX: Int = 1
-        const val KAFKA_GROUP_ARGUMENT_INDEX: Int = 2
-        const val KAFKA_FORMAT_ARGUMENT_INDEX: Int = 3
-        const val KAFKA_FORMAT: String = "JSONAsString"
-        const val KAFKA_KEEPER_PATH_SETTING: String = "kafka_keeper_path"
-        const val KAFKA_REPLICA_NAME_SETTING: String = "kafka_replica_name"
-
-        val NODE_COLUMNS = listOf("host_name", "tcp_port")
-        val CATALOG_COLUMNS = listOf(
-            "database",
-            "name",
-            "engine",
-            "engine_full",
-            "create_table_query",
-            "comment",
-        )
-
-        val STANDALONE_CATALOG_QUERY: String = """
-            SELECT database, name, engine, engine_full, create_table_query, comment
-            FROM system.tables
-            WHERE database IN ({database:String}, {consumerDatabase:String})
-            SETTINGS show_table_uuid_in_table_create_query_if_not_nil = 0
-        """.trimIndent()
-
-        val CLUSTER_NODES_QUERY: String = """
-            SELECT hostName() AS host_name, tcpPort() AS tcp_port
-            FROM clusterAllReplicas({cluster:String}, system.one)
-            SETTINGS skip_unavailable_shards = 0,
-                     show_table_uuid_in_table_create_query_if_not_nil = 0
-        """.trimIndent()
-
-        val CLUSTER_CATALOG_QUERY: String = """
-            SELECT hostName() AS host_name,
-                   tcpPort() AS tcp_port,
-                   database,
-                   name,
-                   engine,
-                   engine_full,
-                   create_table_query,
-                   comment
-            FROM clusterAllReplicas({cluster:String}, system.tables)
-            WHERE database IN ({database:String}, {consumerDatabase:String})
-            SETTINGS skip_unavailable_shards = 0,
-                     show_table_uuid_in_table_create_query_if_not_nil = 0
-        """.trimIndent()
 
         fun createCatalogClient(
             options: ClickHouseClientOptions,
@@ -344,328 +170,6 @@ class ClickHouseBiDeploymentInspector internal constructor(
     }
 }
 
-internal interface ClickHouseCatalogClient : AutoCloseable {
-    fun query(
-        sql: String,
-        parameters: Map<String, Any>,
-        columns: List<String>,
-    ): List<ClickHouseCatalogRecord>
-
-    fun query(
-        sql: String,
-        parameters: Map<String, Any>,
-        columns: List<String>,
-        cancellation: ClickHouseQueryCancellation,
-    ): List<ClickHouseCatalogRecord> = query(sql, parameters, columns)
-}
-
-internal class ClickHouseQueryCancellation {
-    private val cancelled = AtomicBoolean()
-    private val callbacks = CopyOnWriteArrayList<() -> Unit>()
-
-    val isCancelled: Boolean
-        get() = cancelled.get()
-
-    fun invokeOnCancel(callback: () -> Unit): AutoCloseable {
-        if (cancelled.get()) {
-            callback()
-            return AutoCloseable { }
-        }
-        callbacks += callback
-        if (cancelled.get() && callbacks.remove(callback)) {
-            callback()
-        }
-        return AutoCloseable { callbacks.remove(callback) }
-    }
-
-    fun cancel() {
-        if (!cancelled.compareAndSet(false, true)) {
-            return
-        }
-        callbacks.forEach { callback ->
-            if (callbacks.remove(callback)) {
-                callback()
-            }
-        }
-    }
-}
-
-internal data class ClickHouseCatalogNode(
-    val hostName: String,
-    val tcpPort: Int,
-)
-
-internal data class ClickHouseCatalogRecord(
-    private val values: Map<String, String?>,
-) {
-    fun toNode(): ClickHouseCatalogNode = ClickHouseCatalogNode(
-        hostName = required("host_name"),
-        tcpPort = required("tcp_port").toIntOrNull()?.takeIf { it in 1..65535 }
-            ?: error("ClickHouse BI catalog column [tcp_port] must be a valid port"),
-    )
-
-    fun toObservedObject(): ObservedBiObject {
-        val database = required("database")
-        val name = required("name")
-        val metadata = try {
-            BiObjectMetadataCodec.decode(values["comment"].orEmpty())
-        } catch (error: JacksonException) {
-            throw BiDeploymentInspectionException.Inconsistent(
-                "ClickHouse BI catalog object [$database.$name] contains invalid ownership metadata",
-                error,
-            )
-        }
-        return ObservedBiObject(
-            database = database,
-            name = name,
-            engine = required("engine"),
-            engineFull = values["engine_full"].orEmpty(),
-            createTableQuery = values["create_table_query"].orEmpty(),
-            metadata = metadata,
-        )
-    }
-
-    private fun required(column: String): String {
-        val value = values[column]
-        check(!value.isNullOrBlank()) {
-            "ClickHouse BI catalog column [$column] must not be blank"
-        }
-        return value
-    }
-}
-
-internal class NativeClickHouseCatalogClient internal constructor(
-    private val client: Client,
-    private val executionTimeout: Duration = Duration.ZERO,
-) : ClickHouseCatalogClient {
-    override fun query(
-        sql: String,
-        parameters: Map<String, Any>,
-        columns: List<String>,
-    ): List<ClickHouseCatalogRecord> = query(
-        sql = sql,
-        parameters = parameters,
-        columns = columns,
-        cancellation = ClickHouseQueryCancellation(),
-    )
-
-    override fun query(
-        sql: String,
-        parameters: Map<String, Any>,
-        columns: List<String>,
-        cancellation: ClickHouseQueryCancellation,
-    ): List<ClickHouseCatalogRecord> {
-        if (cancellation.isCancelled) {
-            throwCancelledQuery()
-        }
-        val settings = QuerySettings()
-            .setFormat(ClickHouseFormat.RowBinaryWithNamesAndTypes)
-            .waitEndOfQuery(true)
-        val responseFuture = client.query(sql, parameters, settings)
-        val responseLifecycle = QueryResponseLifecycle(responseFuture)
-        val queryThread = Thread.currentThread()
-        val cancellationRegistration = cancellation.invokeOnCancel {
-            if (responseLifecycle.cancel()) {
-                queryThread.interrupt()
-                responseLifecycle.cleanupCancelled()
-            }
-        }
-        try {
-            val response = responseFuture.awaitResponse(responseLifecycle)
-            return responseLifecycle.use {
-                client.newBinaryFormatReader(response).use { reader ->
-                    buildList {
-                        while (reader.next() != null) {
-                            add(ClickHouseCatalogRecord(columns.associateWith(reader::getString)))
-                        }
-                    }
-                }
-            }
-        } finally {
-            cancellationRegistration.close()
-        }
-    }
-
-    private fun CompletableFuture<QueryResponse>.awaitResponse(
-        responseLifecycle: QueryResponseLifecycle,
-    ): QueryResponse {
-        val response = try {
-            if (executionTimeout.isZero) {
-                get()
-            } else {
-                get(executionTimeout.toNanos(), TimeUnit.NANOSECONDS)
-            }
-        } catch (error: InterruptedException) {
-            responseLifecycle.abandon()
-            Thread.currentThread().interrupt()
-            throwInterruptedQuery(error)
-        } catch (error: TimeoutException) {
-            responseLifecycle.abandon()
-            throwTimedOutQuery(error)
-        } catch (error: CancellationException) {
-            responseLifecycle.abandon()
-            throwCancelledQuery(error)
-        } catch (error: ExecutionException) {
-            responseLifecycle.abandon()
-            throwFailedQuery(error.cause)
-        }
-        if (!responseLifecycle.claim(response)) {
-            throwCancelledQuery()
-        }
-        return response
-    }
-
-    private fun throwInterruptedQuery(cause: InterruptedException): Nothing =
-        throw ClientException("ClickHouse BI catalog query was interrupted", cause)
-
-    private fun throwTimedOutQuery(cause: TimeoutException): Nothing =
-        throw ClientException("ClickHouse BI catalog query timed out", cause)
-
-    private fun throwFailedQuery(cause: Throwable?): Nothing =
-        throw ClientException("Failed to get ClickHouse BI catalog query response", cause)
-
-    private fun throwCancelledQuery(): Nothing =
-        throw ClientException("ClickHouse BI catalog query was cancelled")
-
-    private fun throwCancelledQuery(cause: CancellationException): Nothing =
-        throw ClientException("ClickHouse BI catalog query was cancelled", cause)
-
-    private class QueryResponseLifecycle(
-        responseFuture: CompletableFuture<QueryResponse>,
-    ) : AutoCloseable {
-        private val state = AtomicReference(QueryResponseState.PENDING)
-        private val response = AtomicReference<QueryResponse?>()
-        private val responseClosed = AtomicBoolean()
-        private val cleanupScheduled = AtomicBoolean()
-
-        init {
-            responseFuture.whenComplete { completedResponse, _ ->
-                if (completedResponse != null) {
-                    response.compareAndSet(null, completedResponse)
-                    if (state.get() == QueryResponseState.CANCELLED) {
-                        cleanupCancelled()
-                    }
-                }
-            }
-        }
-
-        fun claim(completedResponse: QueryResponse): Boolean {
-            response.compareAndSet(null, completedResponse)
-            if (state.compareAndSet(QueryResponseState.PENDING, QueryResponseState.CLAIMED)) {
-                return true
-            }
-            closeResponse(propagateFailure = false)
-            return false
-        }
-
-        fun abandon() {
-            if (transitionToCancelled()) {
-                cleanupCancelled()
-            }
-        }
-
-        fun cancel(): Boolean = transitionToCancelled()
-
-        fun cleanupCancelled() {
-            if (state.get() != QueryResponseState.CANCELLED || response.get() == null) {
-                return
-            }
-            if (cleanupScheduled.compareAndSet(false, true)) {
-                CLICKHOUSE_CATALOG_CLEANUP_SCHEDULER.schedule {
-                    closeResponse(propagateFailure = false)
-                }
-            }
-        }
-
-        private fun transitionToCancelled(): Boolean {
-            while (true) {
-                when (val currentState = state.get()) {
-                    QueryResponseState.PENDING,
-                    QueryResponseState.CLAIMED,
-                    -> if (state.compareAndSet(currentState, QueryResponseState.CANCELLED)) {
-                        return true
-                    }
-
-                    QueryResponseState.CANCELLED,
-                    QueryResponseState.COMPLETED,
-                    -> return false
-                }
-            }
-        }
-
-        override fun close() {
-            while (true) {
-                when (val currentState = state.get()) {
-                    QueryResponseState.PENDING,
-                    QueryResponseState.CLAIMED,
-                    -> if (state.compareAndSet(currentState, QueryResponseState.COMPLETED)) {
-                        closeResponse(propagateFailure = true)
-                        return
-                    }
-
-                    QueryResponseState.CANCELLED -> {
-                        closeResponse(propagateFailure = false)
-                        return
-                    }
-
-                    QueryResponseState.COMPLETED -> return
-                }
-            }
-        }
-
-        private fun closeResponse(propagateFailure: Boolean) {
-            val claimedResponse = response.get() ?: return
-            if (!responseClosed.compareAndSet(false, true)) {
-                return
-            }
-            if (propagateFailure) {
-                claimedResponse.close()
-            } else {
-                runCatching { claimedResponse.close() }
-            }
-        }
-    }
-
-    private enum class QueryResponseState {
-        PENDING,
-        CLAIMED,
-        CANCELLED,
-        COMPLETED,
-    }
-
-    override fun close() {
-        client.close()
-    }
-
-    companion object {
-        fun create(options: ClickHouseClientOptions): NativeClickHouseCatalogClient {
-            val builder = Client.Builder()
-            options.endpoints.forEach { endpoint -> builder.addEndpoint(endpoint.toASCIIString()) }
-            val client = builder
-                .setUsername(options.username)
-                .setPassword(options.password)
-                .enableConnectionPool(options.connectionPoolEnabled)
-                .setConnectTimeout(options.connectionTimeout.toMillis())
-                .setConnectionRequestTimeout(options.connectionRequestTimeout.toMillis(), ChronoUnit.MILLIS)
-                .setSocketTimeout(options.socketTimeout.toMillis())
-                .setExecutionTimeout(options.executionTimeout.toMillis(), ChronoUnit.MILLIS)
-                .useAsyncRequests(true)
-                .setMaxConnections(options.maxConnections)
-                .setMaxRetries(options.maxRetries)
-                .setClientName(CLIENT_NAME)
-                .build()
-            return NativeClickHouseCatalogClient(client, options.executionTimeout)
-        }
-
-        private const val CLIENT_NAME = "wow-bi"
-    }
-}
-
-private fun BiScriptOptions.catalogParameters(): Map<String, Any> = mapOf(
-    "database" to database,
-    "consumerDatabase" to consumerDatabase,
-)
-
 private fun Throwable.cancelledInspectionOrThrow(
     cancellation: ClickHouseQueryCancellation,
 ): BiDeploymentInspection {
@@ -675,19 +179,11 @@ private fun Throwable.cancelledInspectionOrThrow(
     throw this
 }
 
-private fun ObservedBiObject.toCatalogDefinition(): ClickHouseCatalogDefinition = ClickHouseCatalogDefinition(
-    engine = engine,
-    engineFull = engineFull,
-    createTableQuery = createTableQuery,
-    metadata = metadata,
-)
-
-private data class ClickHouseCatalogDefinition(
-    val engine: String,
-    val engineFull: String,
-    val createTableQuery: String,
-    val metadata: BiObjectMetadata?,
-)
+private fun inspectionOverloaded(error: RejectedExecutionException): BiDeploymentInspectionException.Unavailable =
+    BiDeploymentInspectionException.Unavailable(
+        message = "ClickHouse BI catalog inspection is overloaded",
+        cause = error,
+    )
 
 private fun ClientException.toInspectionException(): BiDeploymentInspectionException {
     if (generateSequence<Throwable>(this) { error -> error.cause }.any(Throwable::isTimeout)) {
@@ -704,112 +200,3 @@ private fun ClientException.toInspectionException(): BiDeploymentInspectionExcep
 
 private fun Throwable.isTimeout(): Boolean =
     this is TimeoutException || javaClass.simpleName.endsWith("TimeoutException")
-
-private fun String.functionArguments(functionName: String): List<String>? =
-    FunctionArgumentsParser(trim(), functionName).parse()
-
-private fun String.settingLiteral(name: String): String? =
-    Regex("""\b${Regex.escape(name)}\s*=\s*('(?:\\.|''|[^'])*')""")
-        .find(this)
-        ?.groupValues
-        ?.get(1)
-
-private class FunctionArgumentsParser(
-    private val expression: String,
-    private val functionName: String,
-) {
-    private var index: Int = 0
-    private var argumentStart: Int = 0
-    private var activeQuote: Char? = null
-    private var nestedDepth: Int = 0
-    private val arguments = mutableListOf<String>()
-
-    fun parse(): List<String>? {
-        if (!moveToArgumentsStart()) {
-            return null
-        }
-        while (index < expression.length) {
-            val action = activeQuote?.let { quote -> consumeQuoted(expression[index], quote) }
-                ?: consumeUnquoted(expression[index])
-            when (action) {
-                ParseAction.COMPLETE -> return arguments
-                ParseAction.INVALID -> return null
-                ParseAction.CONTINUE -> index++
-            }
-        }
-        return null
-    }
-
-    private fun moveToArgumentsStart(): Boolean {
-        if (!expression.startsWith(functionName)) {
-            return false
-        }
-        index = functionName.length
-        while (index < expression.length && expression[index].isWhitespace()) {
-            index++
-        }
-        if (expression.getOrNull(index) != '(') {
-            return false
-        }
-        argumentStart = ++index
-        return true
-    }
-
-    private fun consumeQuoted(character: Char, quote: Char): ParseAction {
-        when {
-            character == '\\' -> index++
-            character == quote && expression.getOrNull(index + 1) == quote -> index++
-            character == quote -> activeQuote = null
-        }
-        return ParseAction.CONTINUE
-    }
-
-    private fun consumeUnquoted(character: Char): ParseAction = when (character) {
-        '\'', '"' -> {
-            activeQuote = character
-            ParseAction.CONTINUE
-        }
-        '(', '[', '{' -> {
-            nestedDepth++
-            ParseAction.CONTINUE
-        }
-        ']', '}' -> closeNestedExpression()
-        ',' -> splitArgument()
-        ')' -> closeFunction()
-        else -> ParseAction.CONTINUE
-    }
-
-    private fun closeNestedExpression(): ParseAction {
-        if (nestedDepth == 0) {
-            return ParseAction.INVALID
-        }
-        nestedDepth--
-        return ParseAction.CONTINUE
-    }
-
-    private fun splitArgument(): ParseAction {
-        if (nestedDepth == 0) {
-            arguments += expression.substring(argumentStart, index).trim()
-            argumentStart = index + 1
-        }
-        return ParseAction.CONTINUE
-    }
-
-    private fun closeFunction(): ParseAction {
-        if (nestedDepth > 0) {
-            nestedDepth--
-            return ParseAction.CONTINUE
-        }
-        val lastArgument = expression.substring(argumentStart, index).trim()
-        if (lastArgument.isNotEmpty() || arguments.isNotEmpty()) {
-            arguments += lastArgument
-        }
-        return ParseAction.COMPLETE
-    }
-
-    private enum class ParseAction {
-        CONTINUE,
-        COMPLETE,
-        INVALID,
-    }
-}

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentValidator.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentValidator.kt
@@ -1,0 +1,246 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+import me.ahoo.wow.bi.renderer.ClickHouseSqlSyntax
+
+internal object ClickHouseBiDeploymentValidator {
+    fun validate(
+        options: BiScriptOptions,
+        operation: BiScriptOperation,
+        snapshot: ClickHouseCatalogSnapshot,
+        desiredObjects: List<DesiredBiObject>?,
+    ): ValidatedBiDeployment {
+        val objects = snapshot.objects
+        val uniqueObjects = uniqueCatalogObjects(objects)
+        val descriptor = BiDeploymentDescriptor.from(options)
+        val deploymentStable = requestedDeploymentIsStable(descriptor, uniqueObjects)
+        val validationContext = CatalogObjectValidationContext(
+            options,
+            operation,
+            descriptor,
+            deploymentStable,
+        )
+        validateStores(validationContext, objects)
+        validateQueues(validationContext, uniqueObjects)
+        return ValidatedBiDeployment(
+            deployment = ObservedBiDeployment(uniqueObjects.map(ClickHouseCatalogObject::observed)),
+            repairableDrifts = repairableComputedDrifts(
+                ComputedDriftValidationContext(
+                    operation = operation,
+                    requestedDeploymentIsStable = deploymentStable,
+                    descriptor = descriptor,
+                    objects = uniqueObjects,
+                    desiredObjects = desiredObjects,
+                    expectedQueries = snapshot.expectedQueries,
+                )
+            ),
+        )
+    }
+
+    private fun uniqueCatalogObjects(objects: List<ClickHouseCatalogObject>): List<ClickHouseCatalogObject> =
+        objects.groupBy(ClickHouseCatalogObject::key).map { (key, replicas) ->
+            val definitions = replicas.map(ClickHouseCatalogObject::toCatalogDefinition).distinct()
+            check(definitions.size == 1 || replicas.none { it.observed.metadata != null }) {
+                "ClickHouse BI catalog object [${key.database}.${key.name}] has duplicate definitions"
+            }
+            replicas.first()
+        }.sortedWith(
+            compareBy<ClickHouseCatalogObject> { it.observed.database }
+                .thenBy { it.observed.name }
+        )
+
+    private fun validateStores(
+        context: CatalogObjectValidationContext,
+        objects: List<ClickHouseCatalogObject>,
+    ) = with(context) {
+        if (operation == BiScriptOperation.Deploy && deploymentStable) {
+            objects.filter { catalogObject ->
+                catalogObject.observed.metadata?.let { metadata ->
+                    metadata.kind == BiObjectKind.STORE &&
+                        metadata.deploymentId == descriptor.deploymentId
+                } == true
+            }.forEach { store -> ClickHouseStoreShapeValidator.validate(options, store) }
+        }
+    }
+
+    private fun validateQueues(
+        context: CatalogObjectValidationContext,
+        objects: List<ClickHouseCatalogObject>,
+    ) = with(context) {
+        objects.filter { it.observed.metadata?.kind == BiObjectKind.QUEUE }
+            .forEach { queue ->
+                val validateRequestedConfiguration =
+                    operation == BiScriptOperation.Deploy &&
+                        deploymentStable &&
+                        queue.observed.metadata?.deploymentId == descriptor.deploymentId
+                validateQueueIdentity(options, queue.observed, validateRequestedConfiguration)
+            }
+    }
+
+    private fun repairableComputedDrifts(context: ComputedDriftValidationContext): List<RepairableBiObjectDrift> =
+        with(context) {
+            if (operation != BiScriptOperation.Deploy || !requestedDeploymentIsStable || desiredObjects == null) {
+                return emptyList()
+            }
+            val desiredByKey = desiredObjects.associateBy(DesiredBiObject::key)
+            return objects.mapNotNull { catalogObject ->
+                val observed = catalogObject.observed
+                val desired = desiredByKey[observed.key] ?: return@mapNotNull null
+                val metadata = observed.metadata ?: return@mapNotNull null
+                val expected = expectedQueries[observed.key] ?: return@mapNotNull null
+                if (!isComparableComputedObject(desired, observed, metadata, descriptor)) {
+                    return@mapNotNull null
+                }
+                val mismatches = buildSet {
+                    if (catalogObject.asSelect != expected.selectSql) {
+                        add(BiComputedDefinitionField.SELECT)
+                    }
+                    if (
+                        desired.kind == BiObjectKind.CONSUMER &&
+                        ClickHouseMaterializedViewTargetParser.parse(observed.createTableQuery) != expected.target
+                    ) {
+                        add(BiComputedDefinitionField.TARGET)
+                    }
+                }
+                if (mismatches.isEmpty()) {
+                    null
+                } else {
+                    RepairableBiObjectDrift(
+                        key = observed.key,
+                        aggregate = checkNotNull(desired.aggregate),
+                        kind = desired.kind,
+                        mismatches = mismatches,
+                    )
+                }
+            }
+        }
+
+    private fun isComparableComputedObject(
+        desired: DesiredBiObject,
+        observed: ObservedBiObject,
+        metadata: BiObjectMetadata,
+        descriptor: BiDeploymentDescriptor,
+    ): Boolean {
+        if (desired.expectedQuery == null || desired.kind !in COMPUTED_KINDS) {
+            return false
+        }
+        if (metadata.deploymentId != descriptor.deploymentId) {
+            return false
+        }
+        if (metadata.configurationFingerprint != descriptor.configurationFingerprint) {
+            return false
+        }
+        if (metadata.topologyFingerprint != descriptor.topologyFingerprint) {
+            return false
+        }
+        if (metadata.kind != desired.kind || metadata.aggregate != desired.aggregate) {
+            return false
+        }
+        return observed.engine == desired.expectedEngine
+    }
+
+    private fun validateQueueIdentity(
+        options: BiScriptOptions,
+        queue: ObservedBiObject,
+        validateRequestedConfiguration: Boolean,
+    ) {
+        check(queue.engine == "Kafka") {
+            "Owned BI queue [${queue.database}.${queue.name}] must use the Kafka engine"
+        }
+        val metadata = checkNotNull(queue.metadata)
+        val identity = checkNotNull(metadata.consumerIdentity) {
+            "Owned BI queue [${queue.database}.${queue.name}] is missing consumerIdentity"
+        }
+        val consumerName = queue.name.removeSuffix("_queue") + "_consumer"
+        val expectedGroup = "wow-bi.$identity.$consumerName"
+        val arguments = queue.engineFull.functionArguments("Kafka").orEmpty()
+        val actualGroup = arguments.getOrNull(KAFKA_GROUP_ARGUMENT_INDEX)
+        check(actualGroup == ClickHouseSqlSyntax.stringLiteral(expectedGroup)) {
+            "Owned BI queue [${queue.database}.${queue.name}] has an unexpected Kafka consumer group"
+        }
+        val streamKind = when {
+            queue.name.endsWith("_command_queue") -> "command"
+            queue.name.endsWith("_state_queue") -> "state"
+            else -> error("Owned BI queue [${queue.database}.${queue.name}] has an unsupported queue name")
+        }
+        check(arguments.getOrNull(KAFKA_FORMAT_ARGUMENT_INDEX) == ClickHouseSqlSyntax.stringLiteral(KAFKA_FORMAT)) {
+            "Owned BI queue [${queue.database}.${queue.name}] has an unexpected Kafka format"
+        }
+        if (!validateRequestedConfiguration) {
+            return
+        }
+        check(
+            arguments.getOrNull(KAFKA_BROKERS_ARGUMENT_INDEX) ==
+                ClickHouseSqlSyntax.stringLiteral(options.kafkaBootstrapServers)
+        ) {
+            "Owned BI queue [${queue.database}.${queue.name}] has unexpected Kafka bootstrap servers"
+        }
+        val expectedTopic = "${options.topicPrefix}${checkNotNull(metadata.aggregate)}.$streamKind"
+        check(arguments.getOrNull(KAFKA_TOPIC_ARGUMENT_INDEX) == ClickHouseSqlSyntax.stringLiteral(expectedTopic)) {
+            "Owned BI queue [${queue.database}.${queue.name}] has an unexpected Kafka topic"
+        }
+        val actualKeeperPath = queue.engineFull.settingLiteral(KAFKA_KEEPER_PATH_SETTING)
+        val actualReplicaName = queue.engineFull.settingLiteral(KAFKA_REPLICA_NAME_SETTING)
+        when (options.kafkaOffsetStorage) {
+            KafkaOffsetStorage.BROKER -> check(actualKeeperPath == null && actualReplicaName == null) {
+                "Owned BI queue [${queue.database}.${queue.name}] has unexpected Keeper offset settings"
+            }
+
+            KafkaOffsetStorage.KEEPER -> {
+                val expectedKeeperPath = "${options.kafkaKeeperPathPrefix.trimEnd('/')}/$identity/${queue.name}"
+                check(actualKeeperPath == ClickHouseSqlSyntax.stringLiteral(expectedKeeperPath)) {
+                    "Owned BI queue [${queue.database}.${queue.name}] has an unexpected Kafka Keeper path"
+                }
+                val expectedReplicaName = when (options.topology) {
+                    is ClickHouseTopology.Cluster -> "{replica}"
+                    ClickHouseTopology.Standalone -> identity
+                }
+                check(actualReplicaName == ClickHouseSqlSyntax.stringLiteral(expectedReplicaName)) {
+                    "Owned BI queue [${queue.database}.${queue.name}] has an unexpected Kafka Keeper replica name"
+                }
+            }
+        }
+    }
+
+    private const val KAFKA_BROKERS_ARGUMENT_INDEX: Int = 0
+    private const val KAFKA_TOPIC_ARGUMENT_INDEX: Int = 1
+    private const val KAFKA_GROUP_ARGUMENT_INDEX: Int = 2
+    private const val KAFKA_FORMAT_ARGUMENT_INDEX: Int = 3
+    private const val KAFKA_FORMAT: String = "JSONAsString"
+    private const val KAFKA_KEEPER_PATH_SETTING: String = "kafka_keeper_path"
+    private const val KAFKA_REPLICA_NAME_SETTING: String = "kafka_replica_name"
+    private val COMPUTED_KINDS = setOf(BiObjectKind.VIEW, BiObjectKind.CONSUMER)
+}
+
+private data class ComputedDriftValidationContext(
+    val operation: BiScriptOperation,
+    val requestedDeploymentIsStable: Boolean,
+    val descriptor: BiDeploymentDescriptor,
+    val objects: List<ClickHouseCatalogObject>,
+    val desiredObjects: List<DesiredBiObject>?,
+    val expectedQueries: Map<BiObjectKey, CanonicalExpectedBiQuery>,
+)
+
+private data class CatalogObjectValidationContext(
+    val options: BiScriptOptions,
+    val operation: BiScriptOperation,
+    val descriptor: BiDeploymentDescriptor,
+    val deploymentStable: Boolean,
+)
+
+internal data class ValidatedBiDeployment(
+    val deployment: ObservedBiDeployment,
+    val repairableDrifts: List<RepairableBiObjectDrift>,
+)

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentValidator.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentValidator.kt
@@ -85,7 +85,12 @@ internal object ClickHouseBiDeploymentValidator {
                     operation == BiScriptOperation.Deploy &&
                         deploymentStable &&
                         queue.observed.metadata?.deploymentId == descriptor.deploymentId
-                validateQueueIdentity(options, queue.observed, validateRequestedConfiguration)
+                validateQueueIdentity(
+                    options = options,
+                    queue = queue.observed,
+                    validateConsumerGroup = operation == BiScriptOperation.Deploy,
+                    validateRequestedConfiguration = validateRequestedConfiguration,
+                )
             }
     }
 
@@ -154,6 +159,7 @@ internal object ClickHouseBiDeploymentValidator {
     private fun validateQueueIdentity(
         options: BiScriptOptions,
         queue: ObservedBiObject,
+        validateConsumerGroup: Boolean,
         validateRequestedConfiguration: Boolean,
     ) {
         check(queue.engine == "Kafka") {
@@ -167,8 +173,10 @@ internal object ClickHouseBiDeploymentValidator {
         val expectedGroup = "wow-bi.$identity.$consumerName"
         val arguments = queue.engineFull.functionArguments("Kafka").orEmpty()
         val actualGroup = arguments.getOrNull(KAFKA_GROUP_ARGUMENT_INDEX)
-        check(actualGroup == ClickHouseSqlSyntax.stringLiteral(expectedGroup)) {
-            "Owned BI queue [${queue.database}.${queue.name}] has an unexpected Kafka consumer group"
+        if (validateConsumerGroup) {
+            check(actualGroup == ClickHouseSqlSyntax.stringLiteral(expectedGroup)) {
+                "Owned BI queue [${queue.database}.${queue.name}] has an unexpected Kafka consumer group"
+            }
         }
         val streamKind = when {
             queue.name.endsWith("_command_queue") -> "command"

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseCatalogClient.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseCatalogClient.kt
@@ -1,0 +1,464 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+import com.clickhouse.client.api.Client
+import com.clickhouse.client.api.ClientException
+import com.clickhouse.client.api.query.QueryResponse
+import com.clickhouse.client.api.query.QuerySettings
+import com.clickhouse.data.ClickHouseFormat
+import reactor.core.scheduler.Scheduler
+import reactor.core.scheduler.Schedulers
+import tools.jackson.core.JacksonException
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+import java.util.concurrent.CancellationException
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+private const val CLICKHOUSE_CATALOG_CLEANUP_THREADS: Int = 4
+private const val CLICKHOUSE_CATALOG_CLEANUP_TTL_SECONDS: Int = 60
+private val CLICKHOUSE_CATALOG_CLEANUP_SCHEDULER: Scheduler = Schedulers.newBoundedElastic(
+    CLICKHOUSE_CATALOG_CLEANUP_THREADS,
+    Schedulers.DEFAULT_BOUNDED_ELASTIC_QUEUESIZE,
+    "wow-bi-catalog-cleanup",
+    CLICKHOUSE_CATALOG_CLEANUP_TTL_SECONDS,
+    true,
+)
+
+internal interface ClickHouseCatalogClient : AutoCloseable {
+    fun query(
+        sql: String,
+        parameters: Map<String, Any>,
+        columns: List<String>,
+    ): List<ClickHouseCatalogRecord>
+
+    fun query(
+        sql: String,
+        parameters: Map<String, Any>,
+        columns: List<String>,
+        cancellation: ClickHouseQueryCancellation,
+    ): List<ClickHouseCatalogRecord> = query(sql, parameters, columns)
+}
+
+internal class ClickHouseQueryCancellation {
+    private val cancelled = AtomicBoolean()
+    private val callbacks = CopyOnWriteArrayList<() -> Unit>()
+
+    val isCancelled: Boolean
+        get() = cancelled.get()
+
+    fun invokeOnCancel(callback: () -> Unit): AutoCloseable {
+        if (cancelled.get()) {
+            callback()
+            return AutoCloseable { }
+        }
+        callbacks += callback
+        if (cancelled.get() && callbacks.remove(callback)) {
+            callback()
+        }
+        return AutoCloseable { callbacks.remove(callback) }
+    }
+
+    fun cancel() {
+        if (!cancelled.compareAndSet(false, true)) {
+            return
+        }
+        callbacks.forEach { callback ->
+            if (callbacks.remove(callback)) {
+                callback()
+            }
+        }
+    }
+}
+
+internal data class ClickHouseCatalogNode(
+    val hostName: String,
+    val tcpPort: Int,
+)
+
+@Suppress("TooManyFunctions") // Typed accessors isolate the untyped ClickHouse wire record at one boundary.
+internal data class ClickHouseCatalogRecord(
+    private val values: Map<String, String?>,
+) {
+    fun toObjectKey(): BiObjectKey = BiObjectKey(
+        database = required("database"),
+        name = required("name"),
+    )
+
+    fun toNode(): ClickHouseCatalogNode = ClickHouseCatalogNode(
+        hostName = required("host_name"),
+        tcpPort = required("tcp_port").toIntOrNull()?.takeIf { it in 1..65535 }
+            ?: error("ClickHouse BI catalog column [tcp_port] must be a valid port"),
+    )
+
+    fun toObservedObject(): ObservedBiObject {
+        val database = required("database")
+        val name = required("name")
+        val metadata = try {
+            BiObjectMetadataCodec.decode(values["comment"].orEmpty())
+        } catch (error: JacksonException) {
+            throw BiDeploymentInspectionException.Inconsistent(
+                "ClickHouse BI catalog object [$database.$name] contains invalid ownership metadata",
+                error,
+            )
+        }
+        return ObservedBiObject(
+            database = database,
+            name = name,
+            engine = required("engine"),
+            engineFull = values["engine_full"].orEmpty(),
+            createTableQuery = values["create_table_query"].orEmpty(),
+            metadata = metadata,
+        )
+    }
+
+    fun toCatalogObject(): ClickHouseCatalogObject = ClickHouseCatalogObject(
+        observed = toObservedObject(),
+        partitionKey = values["partition_key"].orEmpty(),
+        sortingKey = values["sorting_key"].orEmpty(),
+        asSelect = values["as_select"].orEmpty(),
+    )
+
+    fun toCanonicalExpectedQuery(): Pair<BiObjectKey, String> = BiObjectKey(
+        database = required("database"),
+        name = required("name"),
+    ) to required("canonical_select")
+
+    fun toCatalogColumn(): ClickHouseCatalogColumn = ClickHouseCatalogColumn(
+        database = required("database"),
+        table = required("table"),
+        name = required("name"),
+        type = required("type"),
+        position = required("position").toIntOrNull()?.takeIf { it > 0 }
+            ?: error("ClickHouse BI catalog column [position] must be positive"),
+    )
+
+    fun toRegistryEntry(): BiOwnershipRegistryEntry = BiOwnershipRegistryEntry(
+        key = BiObjectKey(
+            database = required("object_database"),
+            name = required("object_name"),
+        ),
+        kind = BiObjectKind.valueOf(required("kind")),
+        aggregate = nullable("aggregate"),
+        consumerIdentity = nullable("consumer_identity"),
+        definitionFingerprint = required("definition_fingerprint"),
+        revision = required("revision").toLong(),
+        status = BiRegistryEntryStatus.valueOf(required("status")),
+    )
+
+    fun toRegistryRow(): ClickHouseRegistryRow = ClickHouseRegistryRow(
+        entry = toRegistryEntry(),
+        rowFingerprint = required("row_fingerprint"),
+    )
+
+    fun toRegistryHead(): ClickHouseRegistryHead = ClickHouseRegistryHead(
+        revision = required("revision").toLong(),
+        snapshotFingerprint = required("snapshot_fingerprint"),
+        rowFingerprint = required("row_fingerprint"),
+    )
+
+    fun toRegistryTableDefinition(): ClickHouseRegistryTableDefinition =
+        ClickHouseRegistryTableDefinition(
+            key = toObjectKey(),
+            engine = required("engine"),
+            engineFull = required("engine_full"),
+            comment = required("comment"),
+            sortingKey = required("sorting_key"),
+        )
+
+    private fun required(column: String): String {
+        val value = values[column]
+        check(!value.isNullOrBlank()) {
+            "ClickHouse BI catalog column [$column] must not be blank"
+        }
+        return value
+    }
+
+    private fun nullable(column: String): String? = values[column]?.takeIf(String::isNotBlank)
+}
+
+internal data class ClickHouseRegistryHead(
+    val revision: Long,
+    val snapshotFingerprint: String,
+    val rowFingerprint: String,
+)
+
+internal data class ClickHouseRegistryRow(
+    val entry: BiOwnershipRegistryEntry,
+    val rowFingerprint: String,
+)
+
+internal data class ClickHouseRegistryTableDefinition(
+    val key: BiObjectKey,
+    val engine: String,
+    val engineFull: String,
+    val comment: String,
+    val sortingKey: String,
+)
+
+internal data class ClickHouseCatalogObject(
+    val observed: ObservedBiObject,
+    val partitionKey: String,
+    val sortingKey: String,
+    val asSelect: String = "",
+    val columns: List<ClickHouseCatalogColumn> = emptyList(),
+) {
+    val key: BiObjectKey
+        get() = observed.key
+}
+
+internal data class ClickHouseCatalogColumn(
+    val database: String,
+    val table: String,
+    val name: String,
+    val type: String,
+    val position: Int,
+) {
+    val key: BiObjectKey
+        get() = BiObjectKey(database, table)
+}
+
+internal class NativeClickHouseCatalogClient internal constructor(
+    private val client: Client,
+    private val executionTimeout: Duration = Duration.ZERO,
+) : ClickHouseCatalogClient {
+    override fun query(
+        sql: String,
+        parameters: Map<String, Any>,
+        columns: List<String>,
+    ): List<ClickHouseCatalogRecord> = query(
+        sql = sql,
+        parameters = parameters,
+        columns = columns,
+        cancellation = ClickHouseQueryCancellation(),
+    )
+
+    override fun query(
+        sql: String,
+        parameters: Map<String, Any>,
+        columns: List<String>,
+        cancellation: ClickHouseQueryCancellation,
+    ): List<ClickHouseCatalogRecord> {
+        if (cancellation.isCancelled) {
+            throwCancelledQuery()
+        }
+        val settings = QuerySettings()
+            .setFormat(ClickHouseFormat.RowBinaryWithNamesAndTypes)
+            .waitEndOfQuery(true)
+        val responseFuture = client.query(sql, parameters, settings)
+        val responseLifecycle = QueryResponseLifecycle(responseFuture)
+        val queryThread = Thread.currentThread()
+        val cancellationRegistration = cancellation.invokeOnCancel {
+            if (responseLifecycle.cancel()) {
+                queryThread.interrupt()
+                responseLifecycle.cleanupCancelled()
+            }
+        }
+        try {
+            val response = responseFuture.awaitResponse(responseLifecycle)
+            return responseLifecycle.use {
+                client.newBinaryFormatReader(response).use { reader ->
+                    buildList {
+                        while (reader.next() != null) {
+                            add(ClickHouseCatalogRecord(columns.associateWith(reader::getString)))
+                        }
+                    }
+                }
+            }
+        } finally {
+            cancellationRegistration.close()
+        }
+    }
+
+    private fun CompletableFuture<QueryResponse>.awaitResponse(
+        responseLifecycle: QueryResponseLifecycle,
+    ): QueryResponse {
+        val response = try {
+            if (executionTimeout.isZero) {
+                get()
+            } else {
+                get(executionTimeout.toNanos(), TimeUnit.NANOSECONDS)
+            }
+        } catch (error: InterruptedException) {
+            responseLifecycle.abandon()
+            Thread.currentThread().interrupt()
+            throwInterruptedQuery(error)
+        } catch (error: TimeoutException) {
+            responseLifecycle.abandon()
+            throwTimedOutQuery(error)
+        } catch (error: CancellationException) {
+            responseLifecycle.abandon()
+            throwCancelledQuery(error)
+        } catch (error: ExecutionException) {
+            responseLifecycle.abandon()
+            throwFailedQuery(error.cause)
+        }
+        if (!responseLifecycle.claim(response)) {
+            throwCancelledQuery()
+        }
+        return response
+    }
+
+    private fun throwInterruptedQuery(cause: InterruptedException): Nothing =
+        throw ClientException("ClickHouse BI catalog query was interrupted", cause)
+
+    private fun throwTimedOutQuery(cause: TimeoutException): Nothing =
+        throw ClientException("ClickHouse BI catalog query timed out", cause)
+
+    private fun throwFailedQuery(cause: Throwable?): Nothing =
+        throw ClientException("Failed to get ClickHouse BI catalog query response", cause)
+
+    private fun throwCancelledQuery(): Nothing =
+        throw ClientException("ClickHouse BI catalog query was cancelled")
+
+    private fun throwCancelledQuery(cause: CancellationException): Nothing =
+        throw ClientException("ClickHouse BI catalog query was cancelled", cause)
+
+    private class QueryResponseLifecycle(
+        responseFuture: CompletableFuture<QueryResponse>,
+    ) : AutoCloseable {
+        private val state = AtomicReference(QueryResponseState.PENDING)
+        private val response = AtomicReference<QueryResponse?>()
+        private val responseClosed = AtomicBoolean()
+        private val cleanupScheduled = AtomicBoolean()
+
+        init {
+            responseFuture.whenComplete { completedResponse, _ ->
+                if (completedResponse != null) {
+                    response.compareAndSet(null, completedResponse)
+                    if (state.get() == QueryResponseState.CANCELLED) {
+                        cleanupCancelled()
+                    }
+                }
+            }
+        }
+
+        fun claim(completedResponse: QueryResponse): Boolean {
+            response.compareAndSet(null, completedResponse)
+            if (state.compareAndSet(QueryResponseState.PENDING, QueryResponseState.CLAIMED)) {
+                return true
+            }
+            closeResponse(propagateFailure = false)
+            return false
+        }
+
+        fun abandon() {
+            if (transitionToCancelled()) {
+                cleanupCancelled()
+            }
+        }
+
+        fun cancel(): Boolean = transitionToCancelled()
+
+        fun cleanupCancelled() {
+            if (state.get() != QueryResponseState.CANCELLED || response.get() == null) {
+                return
+            }
+            if (cleanupScheduled.compareAndSet(false, true)) {
+                CLICKHOUSE_CATALOG_CLEANUP_SCHEDULER.schedule {
+                    closeResponse(propagateFailure = false)
+                }
+            }
+        }
+
+        private fun transitionToCancelled(): Boolean {
+            while (true) {
+                when (val currentState = state.get()) {
+                    QueryResponseState.PENDING,
+                    QueryResponseState.CLAIMED,
+                    -> if (state.compareAndSet(currentState, QueryResponseState.CANCELLED)) {
+                        return true
+                    }
+
+                    QueryResponseState.CANCELLED,
+                    QueryResponseState.COMPLETED,
+                    -> return false
+                }
+            }
+        }
+
+        override fun close() {
+            while (true) {
+                when (val currentState = state.get()) {
+                    QueryResponseState.PENDING,
+                    QueryResponseState.CLAIMED,
+                    -> if (state.compareAndSet(currentState, QueryResponseState.COMPLETED)) {
+                        closeResponse(propagateFailure = true)
+                        return
+                    }
+
+                    QueryResponseState.CANCELLED -> {
+                        closeResponse(propagateFailure = false)
+                        return
+                    }
+
+                    QueryResponseState.COMPLETED -> return
+                }
+            }
+        }
+
+        private fun closeResponse(propagateFailure: Boolean) {
+            val claimedResponse = response.get() ?: return
+            if (!responseClosed.compareAndSet(false, true)) {
+                return
+            }
+            if (propagateFailure) {
+                claimedResponse.close()
+            } else {
+                runCatching { claimedResponse.close() }
+            }
+        }
+    }
+
+    private enum class QueryResponseState {
+        PENDING,
+        CLAIMED,
+        CANCELLED,
+        COMPLETED,
+    }
+
+    override fun close() {
+        client.close()
+    }
+
+    companion object {
+        fun create(options: ClickHouseClientOptions): NativeClickHouseCatalogClient {
+            val builder = Client.Builder()
+            options.endpoints.forEach { endpoint -> builder.addEndpoint(endpoint.toASCIIString()) }
+            val client = builder
+                .setUsername(options.username)
+                .setPassword(options.password)
+                .enableConnectionPool(options.connectionPoolEnabled)
+                .setConnectTimeout(options.connectionTimeout.toMillis())
+                .setConnectionRequestTimeout(options.connectionRequestTimeout.toMillis(), ChronoUnit.MILLIS)
+                .setSocketTimeout(options.socketTimeout.toMillis())
+                .setExecutionTimeout(options.executionTimeout.toMillis(), ChronoUnit.MILLIS)
+                .useAsyncRequests(true)
+                .setMaxConnections(options.maxConnections)
+                .setMaxRetries(options.maxRetries)
+                .setClientName(CLIENT_NAME)
+                .useHttpFormDataForQuery(true)
+                .build()
+            return NativeClickHouseCatalogClient(client, options.executionTimeout)
+        }
+
+        private const val CLIENT_NAME = "wow-bi"
+    }
+}

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseCatalogReader.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseCatalogReader.kt
@@ -1,0 +1,964 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+import me.ahoo.wow.bi.renderer.ClickHouseScriptRenderer
+import me.ahoo.wow.serialization.JsonSerializer
+
+private const val DATABASE_TABLES_PREDICATE = "__DATABASE_TABLES_PREDICATE__"
+private const val CONSUMER_DATABASE_TABLES_PREDICATE = "__CONSUMER_DATABASE_TABLES_PREDICATE__"
+private const val TABLES_PREDICATE = "__TABLES_PREDICATE__"
+private const val EXPECTED_DEFINITIONS_EXPRESSION = "__EXPECTED_DEFINITIONS_EXPRESSION__"
+
+internal class ClickHouseCatalogReader(private val catalogClient: ClickHouseCatalogClient) {
+    fun read(request: ClickHouseCatalogReadRequest): ClickHouseCatalogSnapshot = with(request) {
+        val registry = OwnershipRegistryReader(catalogClient).read(options, cancellation)
+        val registryKeys = registry?.entries
+            ?.mapTo(linkedSetOf(), BiOwnershipRegistryEntry::key)
+            .orEmpty()
+        val anchorKey = BiObjectKey(options.consumerDatabase, ClickHouseScriptRenderer.DEPLOYMENT_ANCHOR)
+        val effectiveKeys = when {
+            registry != null -> desiredObjectKeys.orEmpty() + registryKeys + anchorKey
+            else -> desiredObjectKeys
+        }
+        val objects = when (val topology = options.topology) {
+            ClickHouseTopology.Standalone -> readStandalone(
+                StandaloneReadContext(options, operation, cancellation),
+                effectiveKeys,
+                registry != null,
+            )
+            is ClickHouseTopology.Cluster -> readCluster(
+                ClusterReadContext(options, topology, operation, cancellation),
+                effectiveKeys,
+                registry != null,
+            )
+        }
+        validateRegistryAnchor(registry, objects, operation)
+        registry?.validateCatalogPresence(objects, operation)
+        return ClickHouseCatalogSnapshot(
+            objects = objects,
+            expectedQueries = canonicalizeExpectedQueries(request, objects),
+            ownershipRegistry = registry,
+        )
+    }
+
+    private class OwnershipRegistryReader(private val catalogClient: ClickHouseCatalogClient) {
+        fun read(
+            options: BiScriptOptions,
+            cancellation: ClickHouseQueryCancellation,
+        ): BiOwnershipRegistry? = when (val topology = options.topology) {
+            ClickHouseTopology.Standalone -> readStandaloneOwnershipRegistry(options, cancellation)
+            is ClickHouseTopology.Cluster -> readClusterOwnershipRegistry(options, topology, cancellation)
+        }
+
+        private fun readStandaloneOwnershipRegistry(
+            options: BiScriptOptions,
+            cancellation: ClickHouseQueryCancellation,
+        ): BiOwnershipRegistry? {
+            val deploymentId = BiDeploymentDescriptor.from(options).deploymentId
+            val registryName = BiOwnershipRegistry.empty(deploymentId).name
+            val registryKey = BiObjectKey(options.consumerDatabase, registryName)
+            val registryParameters = options.catalogParameters() + mapOf(
+                "registryDatabase" to options.consumerDatabase,
+                "registryTable" to registryName,
+            )
+            val registryTables = catalogClient.query(
+                sql = REGISTRY_TABLE_QUERY,
+                parameters = registryParameters,
+                columns = REGISTRY_TABLE_COLUMNS,
+                cancellation = cancellation,
+            ).filter { record -> record.toObjectKey() == registryKey }
+                .map(ClickHouseCatalogRecord::toRegistryTableDefinition)
+            if (registryTables.isEmpty()) {
+                return null
+            }
+            check(registryTables.size == 1) {
+                "ClickHouse BI ownership registry [${registryKey.database}.${registryKey.name}] is duplicated"
+            }
+            val registryColumns = catalogClient.query(
+                sql = REGISTRY_COLUMNS_QUERY,
+                parameters = registryParameters,
+                columns = COLUMN_COLUMNS,
+                cancellation = cancellation,
+            ).map(ClickHouseCatalogRecord::toCatalogColumn)
+            ClickHouseOwnershipRegistryShapeValidator.validate(
+                topology = options.topology,
+                deploymentId = deploymentId,
+                table = registryTables.single(),
+                columns = registryColumns,
+            )
+            val heads = catalogClient.query(
+                sql = REGISTRY_HEAD_QUERY,
+                parameters = registryParameters + ("deploymentId" to deploymentId),
+                columns = REGISTRY_HEAD_COLUMNS,
+                cancellation = cancellation,
+            ).map(ClickHouseCatalogRecord::toRegistryHead)
+            val head = resolveRegistryHead(heads) ?: return null
+            val rows = catalogClient.query(
+                sql = REGISTRY_ENTRIES_QUERY,
+                parameters = registryParameters + ("deploymentId" to deploymentId),
+                columns = REGISTRY_COLUMNS,
+                cancellation = cancellation,
+            ).map(ClickHouseCatalogRecord::toRegistryRow)
+            return restoreRegistry(deploymentId, head, rows)
+        }
+
+        private fun readClusterOwnershipRegistry(
+            options: BiScriptOptions,
+            topology: ClickHouseTopology.Cluster,
+            cancellation: ClickHouseQueryCancellation,
+        ): BiOwnershipRegistry? {
+            val deploymentId = BiDeploymentDescriptor.from(options).deploymentId
+            val registryName = BiOwnershipRegistry.empty(deploymentId).name
+            val clusterParameters = mapOf("cluster" to topology.name)
+            val context = ClusterRegistryReadContext(
+                topology = topology,
+                cancellation = cancellation,
+                deploymentId = deploymentId,
+                registryKey = BiObjectKey(options.consumerDatabase, registryName),
+                clusterParameters = clusterParameters,
+                registryParameters = clusterParameters + mapOf(
+                    "registryDatabase" to options.consumerDatabase,
+                    "registryTable" to registryName,
+                    "deploymentId" to deploymentId,
+                ),
+            )
+            val nodes = readClusterNodes(context)
+            if (!readAndValidateRegistryTables(context, nodes)) {
+                return null
+            }
+            val head = readConsistentHead(context, nodes) ?: return null
+            return readConsistentRegistry(context, nodes, head)
+        }
+
+        private fun readClusterNodes(context: ClusterRegistryReadContext): Set<ClickHouseCatalogNode> {
+            val nodes = catalogClient.query(
+                sql = CLUSTER_NODES_QUERY,
+                parameters = context.clusterParameters,
+                columns = NODE_COLUMNS,
+                cancellation = context.cancellation,
+            ).map(ClickHouseCatalogRecord::toNode).toSet()
+            check(nodes.isNotEmpty()) {
+                "ClickHouse BI cluster [${context.topology.name}] returned no replicas"
+            }
+            return nodes
+        }
+
+        private fun readAndValidateRegistryTables(
+            context: ClusterRegistryReadContext,
+            nodes: Set<ClickHouseCatalogNode>,
+        ): Boolean {
+            val tablesByNode = catalogClient.query(
+                sql = CLUSTER_REGISTRY_TABLE_QUERY,
+                parameters = context.registryParameters,
+                columns = NODE_COLUMNS + REGISTRY_TABLE_COLUMNS,
+                cancellation = context.cancellation,
+            ).filter { record -> record.toObjectKey() == context.registryKey }
+                .groupBy(ClickHouseCatalogRecord::toNode)
+            if (tablesByNode.isEmpty()) {
+                return false
+            }
+            check(tablesByNode.keys == nodes) {
+                "ClickHouse BI ownership registry is missing from a cluster replica"
+            }
+            val columnsByNode = catalogClient.query(
+                sql = CLUSTER_REGISTRY_COLUMNS_QUERY,
+                parameters = context.registryParameters,
+                columns = NODE_COLUMNS + COLUMN_COLUMNS,
+                cancellation = context.cancellation,
+            ).groupBy(ClickHouseCatalogRecord::toNode)
+            nodes.forEach { node ->
+                val tables = tablesByNode.getValue(node)
+                check(tables.size == 1) {
+                    "ClickHouse BI ownership registry is duplicated on a cluster replica"
+                }
+                ClickHouseOwnershipRegistryShapeValidator.validate(
+                    topology = context.topology,
+                    deploymentId = context.deploymentId,
+                    table = tables.single().toRegistryTableDefinition(),
+                    columns = columnsByNode[node].orEmpty().map(ClickHouseCatalogRecord::toCatalogColumn),
+                )
+            }
+            return true
+        }
+
+        private fun readConsistentHead(
+            context: ClusterRegistryReadContext,
+            nodes: Set<ClickHouseCatalogNode>,
+        ): ClickHouseRegistryHead? {
+            val headsByNode = catalogClient.query(
+                sql = CLUSTER_REGISTRY_HEAD_QUERY,
+                parameters = context.registryParameters,
+                columns = NODE_COLUMNS + REGISTRY_HEAD_COLUMNS,
+                cancellation = context.cancellation,
+            ).groupBy(ClickHouseCatalogRecord::toNode)
+            val heads = nodes.associateWith { node ->
+                resolveRegistryHead(headsByNode[node].orEmpty().map(ClickHouseCatalogRecord::toRegistryHead))
+            }
+            if (heads.values.all { head -> head == null }) {
+                return null
+            }
+            check(heads.values.none { head -> head == null }) {
+                "ClickHouse BI ownership registry HEAD is missing from a cluster replica"
+            }
+            return heads.values.filterNotNull().distinct().also { distinctHeads ->
+                check(distinctHeads.size == 1) {
+                    "ClickHouse BI ownership registry HEAD differs across replicas"
+                }
+            }.single()
+        }
+
+        private fun readConsistentRegistry(
+            context: ClusterRegistryReadContext,
+            nodes: Set<ClickHouseCatalogNode>,
+            head: ClickHouseRegistryHead,
+        ): BiOwnershipRegistry {
+            val rowsByNode = catalogClient.query(
+                sql = CLUSTER_REGISTRY_ENTRIES_QUERY,
+                parameters = context.registryParameters,
+                columns = NODE_COLUMNS + REGISTRY_COLUMNS,
+                cancellation = context.cancellation,
+            ).groupBy(ClickHouseCatalogRecord::toNode)
+            val registries = nodes.map { node ->
+                restoreRegistry(
+                    deploymentId = context.deploymentId,
+                    head = head,
+                    rows = rowsByNode[node].orEmpty().map(ClickHouseCatalogRecord::toRegistryRow),
+                )
+            }
+            val snapshots = registries.map { registry ->
+                RegistryReplicaSnapshot(
+                    revision = registry.revision,
+                    fingerprint = registry.snapshotFingerprint(),
+                    entries = registry.entries,
+                )
+            }.distinct()
+            check(snapshots.size == 1) {
+                "ClickHouse BI ownership registry object snapshot differs across replicas"
+            }
+            return registries.first()
+        }
+
+        private fun resolveRegistryHead(heads: List<ClickHouseRegistryHead>): ClickHouseRegistryHead? {
+            if (heads.isEmpty()) {
+                // CREATE TABLE is intentionally before the write-ahead HEAD.
+                return null
+            }
+            val latestRevision = heads.maxOf(ClickHouseRegistryHead::revision)
+            val latestHeads = heads.filter { head -> head.revision == latestRevision }.distinct()
+            check(latestHeads.size == 1) {
+                "ClickHouse BI ownership registry has conflicting HEAD rows at " +
+                    "revision=$latestRevision"
+            }
+            return latestHeads.single().also { head ->
+                check(head.rowFingerprint == head.snapshotFingerprint) {
+                    "ClickHouse BI ownership registry HEAD row fingerprint is invalid"
+                }
+            }
+        }
+
+        private fun restoreRegistry(
+            deploymentId: String,
+            head: ClickHouseRegistryHead,
+            rows: List<ClickHouseRegistryRow>,
+        ): BiOwnershipRegistry {
+            check(rows.all { row -> row.entry.revision <= head.revision }) {
+                "ClickHouse BI ownership registry object revision is ahead of its HEAD"
+            }
+            val entries = rows.groupBy { row -> row.entry.key }.map { (key, keyRows) ->
+                val latestObjectRevision = keyRows.maxOf { row -> row.entry.revision }
+                val latestRows = keyRows.filter { row -> row.entry.revision == latestObjectRevision }.distinct()
+                check(latestRows.size == 1) {
+                    "ClickHouse BI ownership registry has conflicting object rows for " +
+                        "[${key.database}.${key.name}] at revision=$latestObjectRevision"
+                }
+                latestRows.single().also { row ->
+                    check(row.entry.rowFingerprint() == row.rowFingerprint) {
+                        "ClickHouse BI ownership registry object row fingerprint is invalid for " +
+                            "[${key.database}.${key.name}]"
+                    }
+                }.entry
+            }.sortedWith(compareBy({ it.key.database }, { it.key.name }))
+            val registry = BiOwnershipRegistry.restore(
+                deploymentId = deploymentId,
+                revision = head.revision,
+                entries = entries,
+            )
+            check(registry.snapshotFingerprint() == head.snapshotFingerprint) {
+                "ClickHouse BI ownership registry HEAD fingerprint does not match its object snapshot"
+            }
+            return registry
+        }
+    }
+
+    private fun canonicalizeExpectedQueries(
+        request: ClickHouseCatalogReadRequest,
+        objects: List<ClickHouseCatalogObject>,
+    ): Map<BiObjectKey, CanonicalExpectedBiQuery> = with(request) {
+        if (!shouldCanonicalizeExpectedQueries(objects)) {
+            return emptyMap()
+        }
+        val requestedObjects = requireNotNull(desiredObjects)
+        val observedKeys = objects.mapTo(hashSetOf(), ClickHouseCatalogObject::key)
+        val desiredQueries = requestedObjects.asSequence()
+            .filter { desired -> desired.key in observedKeys }
+            .mapNotNull { desired -> desired.expectedQuery?.let { desired.key to it } }
+            .toMap()
+        if (desiredQueries.isEmpty()) {
+            return emptyMap()
+        }
+        val definitionPlan = ClickHouseStringArrayParameterPlan.create(
+            expression = "definition",
+            parameterName = "expectedDefinitions",
+            values = desiredQueries.map { (key, query) ->
+                JsonSerializer.writeValueAsString(ExpectedQueryWire(key.database, key.name, query.selectSql))
+            },
+        )
+        val canonicalSelects = catalogClient.query(
+            sql = EXPECTED_QUERY_CANONICALIZATION_QUERY.replace(
+                EXPECTED_DEFINITIONS_EXPRESSION,
+                definitionPlan.arrayExpression,
+            ),
+            parameters = definitionPlan.parameters,
+            columns = EXPECTED_QUERY_COLUMNS,
+            cancellation = cancellation,
+        ).map(ClickHouseCatalogRecord::toCanonicalExpectedQuery).toMap()
+        check(canonicalSelects.keys == desiredQueries.keys) {
+            "ClickHouse did not canonicalize every expected BI computed-object query"
+        }
+        return desiredQueries.mapValues { (key, query) ->
+            CanonicalExpectedBiQuery(
+                selectSql = checkNotNull(canonicalSelects[key]),
+                target = query.target,
+            )
+        }
+    }
+
+    private fun readStandalone(
+        context: StandaloneReadContext,
+        desiredObjectKeys: Set<BiObjectKey>?,
+        registryAuthoritative: Boolean,
+    ): List<ClickHouseCatalogObject> = with(context) {
+        val query = if (desiredObjectKeys == null) {
+            ClickHouseCatalogQuery(STANDALONE_CATALOG_QUERY, options.catalogParameters())
+        } else if (registryAuthoritative) {
+            options.catalogScopeQuery(desiredObjectKeys, STANDALONE_SCOPED_CATALOG_QUERY, false)
+        } else {
+            val candidates = discoverObjectKeys(
+                query = options.catalogScopeQuery(desiredObjectKeys, STANDALONE_CATALOG_DISCOVERY_QUERY, true),
+                cancellation = cancellation,
+            )
+            if (candidates.isEmpty()) {
+                return emptyList()
+            }
+            options.catalogScopeQuery(candidates, STANDALONE_SCOPED_CATALOG_QUERY, false)
+        }
+        val objects = catalogClient.query(
+            sql = query.sql,
+            parameters = query.parameters,
+            columns = CATALOG_COLUMNS,
+            cancellation = cancellation,
+        ).map(ClickHouseCatalogRecord::toCatalogObject)
+        return loadStandaloneStoreColumns(options, operation, objects, cancellation)
+    }
+
+    private fun readCluster(
+        context: ClusterReadContext,
+        desiredObjectKeys: Set<BiObjectKey>?,
+        registryAuthoritative: Boolean,
+    ): List<ClickHouseCatalogObject> = with(context) {
+        val nodes = catalogClient.query(
+            sql = CLUSTER_NODES_QUERY,
+            parameters = mapOf("cluster" to cluster.name),
+            columns = NODE_COLUMNS,
+            cancellation = cancellation,
+        ).map(ClickHouseCatalogRecord::toNode).toSet()
+        check(nodes.isNotEmpty()) {
+            "ClickHouse BI cluster [${cluster.name}] returned no replicas"
+        }
+        val query = if (desiredObjectKeys == null) {
+            ClickHouseCatalogQuery(CLUSTER_CATALOG_QUERY, options.catalogParameters())
+        } else if (registryAuthoritative) {
+            options.catalogScopeQuery(desiredObjectKeys, CLUSTER_SCOPED_CATALOG_QUERY, false)
+        } else {
+            val discoveryQuery = options.catalogScopeQuery(
+                desiredObjectKeys,
+                CLUSTER_CATALOG_DISCOVERY_QUERY,
+                true,
+            )
+            val candidates = discoverObjectKeys(
+                query = discoveryQuery.copy(parameters = discoveryQuery.parameters + ("cluster" to cluster.name)),
+                cancellation = cancellation,
+            )
+            if (candidates.isEmpty()) {
+                return emptyList()
+            }
+            options.catalogScopeQuery(candidates, CLUSTER_SCOPED_CATALOG_QUERY, false)
+        }
+        var objects = catalogClient.query(
+            sql = query.sql,
+            parameters = query.parameters + ("cluster" to cluster.name),
+            columns = NODE_COLUMNS + CATALOG_COLUMNS,
+            cancellation = cancellation,
+        ).map { record -> NodeObject(record.toNode(), record.toCatalogObject()) }
+        validateClusterCatalog(cluster.name, nodes, objects)
+        objects = loadClusterStoreColumns(context, objects)
+        return objects.map(NodeObject::objectValue)
+    }
+
+    private fun discoverObjectKeys(
+        query: ClickHouseCatalogQuery,
+        cancellation: ClickHouseQueryCancellation,
+    ): Set<BiObjectKey> = catalogClient.query(
+        sql = query.sql,
+        parameters = query.parameters,
+        columns = OBJECT_KEY_COLUMNS,
+        cancellation = cancellation,
+    ).mapTo(linkedSetOf(), ClickHouseCatalogRecord::toObjectKey)
+
+    private fun loadStandaloneStoreColumns(
+        options: BiScriptOptions,
+        operation: BiScriptOperation,
+        objects: List<ClickHouseCatalogObject>,
+        cancellation: ClickHouseQueryCancellation,
+    ): List<ClickHouseCatalogObject> {
+        val stores = storesRequiringShapeValidation(options, operation, objects)
+        if (stores.isEmpty()) {
+            return objects
+        }
+        val tablePlan = ClickHouseStringArrayParameterPlan.create(
+            expression = "table",
+            parameterName = "tables",
+            values = stores.map { it.observed.name }.distinct(),
+        )
+        val columnsByTable = catalogClient.query(
+            sql = STANDALONE_COLUMNS_QUERY.replace(TABLES_PREDICATE, tablePlan.predicate),
+            parameters = mapOf("database" to options.database) + tablePlan.parameters,
+            columns = COLUMN_COLUMNS,
+            cancellation = cancellation,
+        ).map(ClickHouseCatalogRecord::toCatalogColumn)
+            .groupBy(ClickHouseCatalogColumn::key)
+        val storeKeys = stores.mapTo(mutableSetOf(), ClickHouseCatalogObject::key)
+        return objects.map { catalogObject ->
+            if (catalogObject.key in storeKeys) {
+                catalogObject.copy(columns = columnsByTable[catalogObject.key].orEmpty().sortedBy { it.position })
+            } else {
+                catalogObject
+            }
+        }
+    }
+
+    private fun loadClusterStoreColumns(
+        context: ClusterReadContext,
+        objects: List<NodeObject>,
+    ): List<NodeObject> = with(context) {
+        val stores = storesRequiringShapeValidation(options, operation, objects.map(NodeObject::objectValue))
+        if (stores.isEmpty()) {
+            return objects
+        }
+        val storeKeys = stores.mapTo(mutableSetOf(), ClickHouseCatalogObject::key)
+        val tablePlan = ClickHouseStringArrayParameterPlan.create(
+            expression = "table",
+            parameterName = "tables",
+            values = stores.map { it.observed.name }.distinct(),
+        )
+        val columnsByNodeAndTable = catalogClient.query(
+            sql = CLUSTER_COLUMNS_QUERY.replace(TABLES_PREDICATE, tablePlan.predicate),
+            parameters = mapOf(
+                "cluster" to cluster.name,
+                "database" to options.database,
+            ) + tablePlan.parameters,
+            columns = NODE_COLUMNS + COLUMN_COLUMNS,
+            cancellation = cancellation,
+        ).map { record -> NodeColumn(record.toNode(), record.toCatalogColumn()) }
+            .groupBy { NodeColumnKey(it.node, it.column.key) }
+        return objects.map { nodeObject ->
+            if (nodeObject.objectValue.key !in storeKeys) {
+                return@map nodeObject
+            }
+            val columns = columnsByNodeAndTable[NodeColumnKey(nodeObject.node, nodeObject.objectValue.key)]
+                .orEmpty()
+                .map(NodeColumn::column)
+                .sortedBy(ClickHouseCatalogColumn::position)
+            nodeObject.copy(objectValue = nodeObject.objectValue.copy(columns = columns))
+        }
+    }
+
+    private fun storesRequiringShapeValidation(
+        options: BiScriptOptions,
+        operation: BiScriptOperation,
+        objects: List<ClickHouseCatalogObject>,
+    ): List<ClickHouseCatalogObject> {
+        if (operation != BiScriptOperation.Deploy) {
+            return emptyList()
+        }
+        val descriptor = BiDeploymentDescriptor.from(options)
+        if (!requestedDeploymentIsStable(descriptor, objects)) {
+            return emptyList()
+        }
+        return objects.filter { catalogObject ->
+            catalogObject.observed.metadata?.let { metadata ->
+                metadata.kind == BiObjectKind.STORE && metadata.deploymentId == descriptor.deploymentId
+            } == true
+        }
+    }
+
+    private fun validateClusterCatalog(
+        cluster: String,
+        nodes: Set<ClickHouseCatalogNode>,
+        objects: List<NodeObject>,
+    ) {
+        val observedNodes = objects.mapTo(mutableSetOf(), NodeObject::node)
+        check(observedNodes.all(nodes::contains)) {
+            "ClickHouse BI cluster [$cluster] catalog contains an unknown replica"
+        }
+        objects.groupBy { it.objectValue.key }.forEach { (key, replicas) ->
+            if (replicas.none { it.objectValue.observed.metadata != null }) {
+                return@forEach
+            }
+            check(replicas.size == nodes.size && replicas.mapTo(mutableSetOf(), NodeObject::node) == nodes) {
+                "ClickHouse BI catalog object [${key.database}.${key.name}] is missing from a replica"
+            }
+            val definitions = replicas.map { it.objectValue.toCatalogDefinition() }.distinct()
+            check(definitions.size == 1) {
+                "ClickHouse BI catalog object [${key.database}.${key.name}] differs across replicas"
+            }
+        }
+    }
+
+    private data class ClusterReadContext(
+        val options: BiScriptOptions,
+        val cluster: ClickHouseTopology.Cluster,
+        val operation: BiScriptOperation,
+        val cancellation: ClickHouseQueryCancellation,
+    )
+
+    private data class StandaloneReadContext(
+        val options: BiScriptOptions,
+        val operation: BiScriptOperation,
+        val cancellation: ClickHouseQueryCancellation,
+    )
+
+    private data class ClusterRegistryReadContext(
+        val topology: ClickHouseTopology.Cluster,
+        val cancellation: ClickHouseQueryCancellation,
+        val deploymentId: String,
+        val registryKey: BiObjectKey,
+        val clusterParameters: Map<String, Any>,
+        val registryParameters: Map<String, Any>,
+    )
+
+    private data class NodeObject(val node: ClickHouseCatalogNode, val objectValue: ClickHouseCatalogObject)
+    private data class NodeColumn(val node: ClickHouseCatalogNode, val column: ClickHouseCatalogColumn)
+    private data class NodeColumnKey(val node: ClickHouseCatalogNode, val key: BiObjectKey)
+    private data class RegistryReplicaSnapshot(
+        val revision: Long,
+        val fingerprint: String,
+        val entries: List<BiOwnershipRegistryEntry>,
+    )
+
+    private companion object {
+        val NODE_COLUMNS = listOf("host_name", "tcp_port")
+        val CATALOG_COLUMNS = listOf(
+            "database",
+            "name",
+            "engine",
+            "engine_full",
+            "create_table_query",
+            "as_select",
+            "comment",
+            "partition_key",
+            "sorting_key",
+        )
+        val EXPECTED_QUERY_COLUMNS = listOf("database", "name", "canonical_select")
+        val OBJECT_KEY_COLUMNS = listOf("database", "name")
+        val COLUMN_COLUMNS = listOf("database", "table", "name", "type", "position")
+        val REGISTRY_COLUMNS = listOf(
+            "object_database",
+            "object_name",
+            "kind",
+            "aggregate",
+            "consumer_identity",
+            "definition_fingerprint",
+            "revision",
+            "status",
+            "row_fingerprint",
+        )
+        val REGISTRY_HEAD_COLUMNS = listOf(
+            "revision",
+            "snapshot_fingerprint",
+            "row_fingerprint",
+        )
+
+        val REGISTRY_TABLE_COLUMNS = listOf(
+            "database",
+            "name",
+            "engine",
+            "engine_full",
+            "comment",
+            "sorting_key",
+        )
+
+        val REGISTRY_TABLE_QUERY: String = """
+            SELECT database, name, engine, engine_full, comment, sorting_key
+            FROM system.tables
+            WHERE database = {registryDatabase:String}
+              AND name = {registryTable:String}
+        """.trimIndent()
+
+        val CLUSTER_REGISTRY_TABLE_QUERY: String = """
+            SELECT hostName() AS host_name, tcpPort() AS tcp_port,
+                   database, name, engine, engine_full, comment, sorting_key
+            FROM clusterAllReplicas({cluster:String}, system.tables)
+            WHERE database = {registryDatabase:String}
+              AND name = {registryTable:String}
+            SETTINGS skip_unavailable_shards = 0
+        """.trimIndent()
+
+        val REGISTRY_COLUMNS_QUERY: String = """
+            SELECT database, table, name, type, position
+            FROM system.columns
+            WHERE database = {registryDatabase:String}
+              AND table = {registryTable:String}
+            ORDER BY position
+        """.trimIndent()
+
+        val CLUSTER_REGISTRY_COLUMNS_QUERY: String = """
+            SELECT hostName() AS host_name, tcpPort() AS tcp_port,
+                   database, table, name, type, position
+            FROM clusterAllReplicas({cluster:String}, system.columns)
+            WHERE database = {registryDatabase:String}
+              AND table = {registryTable:String}
+            ORDER BY host_name, tcp_port, position
+            SETTINGS skip_unavailable_shards = 0
+        """.trimIndent()
+
+        val REGISTRY_HEAD_QUERY: String = """
+            SELECT revision,
+                   definition_fingerprint AS snapshot_fingerprint, row_fingerprint
+            FROM {registryDatabase:Identifier}.{registryTable:Identifier}
+            WHERE deployment_id = {deploymentId:String}
+              AND row_kind = 'HEAD'
+            ORDER BY revision DESC
+        """.trimIndent()
+
+        val CLUSTER_REGISTRY_HEAD_QUERY: String = """
+            SELECT hostName() AS host_name, tcpPort() AS tcp_port,
+                   revision,
+                   definition_fingerprint AS snapshot_fingerprint, row_fingerprint
+            FROM clusterAllReplicas(
+                {cluster:String},
+                {registryDatabase:Identifier}.{registryTable:Identifier}
+            )
+            WHERE deployment_id = {deploymentId:String}
+              AND row_kind = 'HEAD'
+            ORDER BY host_name, tcp_port, revision DESC
+            SETTINGS skip_unavailable_shards = 0
+        """.trimIndent()
+
+        val REGISTRY_ENTRIES_QUERY: String = """
+            SELECT object_database, object_name, kind,
+                   aggregate, consumer_identity, definition_fingerprint,
+                   revision, status, row_fingerprint
+            FROM {registryDatabase:Identifier}.{registryTable:Identifier}
+            WHERE deployment_id = {deploymentId:String}
+              AND row_kind = 'OBJECT'
+            ORDER BY object_database, object_name, revision DESC
+        """.trimIndent()
+
+        val CLUSTER_REGISTRY_ENTRIES_QUERY: String = """
+            SELECT hostName() AS host_name, tcpPort() AS tcp_port,
+                   object_database, object_name, kind,
+                   aggregate, consumer_identity, definition_fingerprint,
+                   revision, status, row_fingerprint
+            FROM clusterAllReplicas(
+                {cluster:String},
+                {registryDatabase:Identifier}.{registryTable:Identifier}
+            )
+            WHERE deployment_id = {deploymentId:String}
+              AND row_kind = 'OBJECT'
+            ORDER BY host_name, tcp_port, object_database, object_name, revision DESC
+            SETTINGS skip_unavailable_shards = 0
+        """.trimIndent()
+
+        val STANDALONE_CATALOG_QUERY: String = """
+            SELECT database, name, engine, engine_full, create_table_query,
+                   formatQuerySingleLineOrNull(as_select) AS as_select,
+                   comment, partition_key, sorting_key
+            FROM system.tables
+            WHERE database IN ({database:String}, {consumerDatabase:String})
+            SETTINGS show_table_uuid_in_table_create_query_if_not_nil = 0
+        """.trimIndent()
+
+        val STANDALONE_CATALOG_DISCOVERY_QUERY: String = """
+            SELECT database, name
+            FROM system.tables
+            WHERE database IN ({database:String}, {consumerDatabase:String})
+              AND (startsWith(comment, {ownershipPrefix:String})
+                   OR (database = {database:String} AND $DATABASE_TABLES_PREDICATE)
+                   OR (database = {consumerDatabase:String}
+                       AND $CONSUMER_DATABASE_TABLES_PREDICATE))
+        """.trimIndent()
+
+        val STANDALONE_SCOPED_CATALOG_QUERY: String = """
+            SELECT database, name, engine, engine_full, create_table_query,
+                   formatQuerySingleLineOrNull(as_select) AS as_select,
+                   comment, partition_key, sorting_key
+            FROM system.tables
+            WHERE (database = {database:String} AND $DATABASE_TABLES_PREDICATE)
+               OR (database = {consumerDatabase:String} AND $CONSUMER_DATABASE_TABLES_PREDICATE)
+            SETTINGS show_table_uuid_in_table_create_query_if_not_nil = 0
+        """.trimIndent()
+
+        val CLUSTER_NODES_QUERY: String = """
+            SELECT hostName() AS host_name, tcpPort() AS tcp_port
+            FROM clusterAllReplicas({cluster:String}, system.one)
+            SETTINGS skip_unavailable_shards = 0,
+                     show_table_uuid_in_table_create_query_if_not_nil = 0
+        """.trimIndent()
+
+        val CLUSTER_CATALOG_QUERY: String = """
+            SELECT hostName() AS host_name,
+                   tcpPort() AS tcp_port,
+                   database,
+                   name,
+                   engine,
+                   engine_full,
+                   create_table_query,
+                   formatQuerySingleLineOrNull(as_select) AS as_select,
+                   comment,
+                   partition_key,
+                   sorting_key
+            FROM clusterAllReplicas({cluster:String}, system.tables)
+            WHERE database IN ({database:String}, {consumerDatabase:String})
+            SETTINGS skip_unavailable_shards = 0,
+                     show_table_uuid_in_table_create_query_if_not_nil = 0
+        """.trimIndent()
+
+        val CLUSTER_CATALOG_DISCOVERY_QUERY: String = """
+            SELECT DISTINCT database, name
+            FROM clusterAllReplicas({cluster:String}, system.tables)
+            WHERE database IN ({database:String}, {consumerDatabase:String})
+              AND (startsWith(comment, {ownershipPrefix:String})
+                   OR (database = {database:String} AND $DATABASE_TABLES_PREDICATE)
+                   OR (database = {consumerDatabase:String}
+                       AND $CONSUMER_DATABASE_TABLES_PREDICATE))
+            SETTINGS skip_unavailable_shards = 0,
+                     max_parallel_replicas = 1
+        """.trimIndent()
+
+        val CLUSTER_SCOPED_CATALOG_QUERY: String = """
+            SELECT hostName() AS host_name,
+                   tcpPort() AS tcp_port,
+                   database,
+                   name,
+                   engine,
+                   engine_full,
+                   create_table_query,
+                   formatQuerySingleLineOrNull(as_select) AS as_select,
+                   comment,
+                   partition_key,
+                   sorting_key
+            FROM clusterAllReplicas({cluster:String}, system.tables)
+            WHERE (database = {database:String} AND $DATABASE_TABLES_PREDICATE)
+               OR (database = {consumerDatabase:String} AND $CONSUMER_DATABASE_TABLES_PREDICATE)
+            SETTINGS skip_unavailable_shards = 0,
+                     show_table_uuid_in_table_create_query_if_not_nil = 0
+        """.trimIndent()
+
+        val STANDALONE_COLUMNS_QUERY: String = """
+            SELECT database, table, name, type, position
+            FROM system.columns
+            WHERE database = {database:String}
+              AND $TABLES_PREDICATE
+        """.trimIndent()
+
+        val CLUSTER_COLUMNS_QUERY: String = """
+            SELECT hostName() AS host_name,
+                   tcpPort() AS tcp_port,
+                   database,
+                   table,
+                   name,
+                   type,
+                   position
+            FROM clusterAllReplicas({cluster:String}, system.columns)
+            WHERE database = {database:String}
+              AND $TABLES_PREDICATE
+            SETTINGS skip_unavailable_shards = 0,
+                     max_parallel_replicas = 1
+        """.trimIndent()
+
+        val EXPECTED_QUERY_CANONICALIZATION_QUERY: String = """
+            SELECT JSONExtractString(definition, 'database') AS database,
+                   JSONExtractString(definition, 'name') AS name,
+                   formatQuerySingleLineOrNull(JSONExtractString(definition, 'selectSql')) AS canonical_select
+            FROM (
+                SELECT arrayJoin($EXPECTED_DEFINITIONS_EXPRESSION) AS definition
+            )
+        """.trimIndent()
+    }
+}
+
+private fun validateRegistryAnchor(
+    registry: BiOwnershipRegistry?,
+    objects: List<ClickHouseCatalogObject>,
+    operation: BiScriptOperation,
+) {
+    val anchor = objects.asSequence()
+        .map(ClickHouseCatalogObject::observed)
+        .mapNotNull(ObservedBiObject::metadata)
+        .singleOrNull { metadata -> metadata.kind == BiObjectKind.ANCHOR }
+        ?: return
+    val anchorRevision = anchor.registryRevision ?: 0
+    if (registry == null) {
+        check(anchorRevision == 0L || operation is BiScriptOperation.Reset) {
+            "ClickHouse BI deployment anchor requires ownership registry revision $anchorRevision, " +
+                "but the registry is missing; explicit repair is required"
+        }
+        return
+    }
+    check(anchorRevision <= registry.revision) {
+        "ClickHouse BI deployment anchor registry revision $anchorRevision is ahead of " +
+            "ownership registry revision ${registry.revision}"
+    }
+}
+
+private fun BiOwnershipRegistry.validateCatalogPresence(
+    objects: List<ClickHouseCatalogObject>,
+    operation: BiScriptOperation,
+) {
+    if (operation is BiScriptOperation.Reset) {
+        return
+    }
+    val observedKeys = objects.mapTo(hashSetOf(), ClickHouseCatalogObject::key)
+    val requiredKeys = entries.asSequence()
+        .filter { entry ->
+            entry.status in setOf(BiRegistryEntryStatus.ACTIVE, BiRegistryEntryStatus.RETIRED)
+        }
+        .map(BiOwnershipRegistryEntry::key)
+        .filterNot { key -> key in observedKeys }
+        .toList()
+    check(requiredKeys.isEmpty()) {
+        "ClickHouse BI ownership registry references missing ACTIVE/RETIRED objects: " +
+            requiredKeys.joinToString { key -> "${key.database}.${key.name}" }
+    }
+    val presentTombstones = entries.asSequence()
+        .filter { entry -> entry.status == BiRegistryEntryStatus.TOMBSTONE }
+        .map(BiOwnershipRegistryEntry::key)
+        .filter { key -> key in observedKeys }
+        .toList()
+    check(presentTombstones.isEmpty()) {
+        "ClickHouse BI ownership registry TOMBSTONE objects still exist: " +
+            presentTombstones.joinToString { key -> "${key.database}.${key.name}" }
+    }
+}
+
+internal data class ClickHouseCatalogReadRequest(
+    val options: BiScriptOptions,
+    val operation: BiScriptOperation,
+    val desiredObjectKeys: Set<BiObjectKey>?,
+    val desiredObjects: List<DesiredBiObject>?,
+    val cancellation: ClickHouseQueryCancellation,
+)
+
+internal data class ClickHouseCatalogSnapshot(
+    val objects: List<ClickHouseCatalogObject>,
+    val expectedQueries: Map<BiObjectKey, CanonicalExpectedBiQuery>,
+    val ownershipRegistry: BiOwnershipRegistry?,
+)
+
+private data class ExpectedQueryWire(
+    val database: String,
+    val name: String,
+    val selectSql: String,
+)
+
+private data class ClickHouseCatalogQuery(val sql: String, val parameters: Map<String, Any>)
+
+private fun BiScriptOptions.catalogParameters(): Map<String, Any> = mapOf(
+    "database" to database,
+    "consumerDatabase" to consumerDatabase,
+)
+
+private fun BiScriptOptions.catalogScopeQuery(
+    objectKeys: Set<BiObjectKey>,
+    sql: String,
+    includeOwnershipPrefix: Boolean,
+): ClickHouseCatalogQuery {
+    val namesByDatabase = objectKeys.groupBy(BiObjectKey::database, BiObjectKey::name)
+    val databasePlan = ClickHouseStringArrayParameterPlan.create(
+        expression = "name",
+        parameterName = "databaseTables",
+        values = namesByDatabase[database].orEmpty().sorted(),
+    )
+    val consumerDatabasePlan = ClickHouseStringArrayParameterPlan.create(
+        expression = "name",
+        parameterName = "consumerDatabaseTables",
+        values = namesByDatabase[consumerDatabase].orEmpty().sorted(),
+    )
+    val parameters = mutableMapOf<String, Any>(
+        "database" to database,
+        "consumerDatabase" to consumerDatabase,
+    )
+    if (includeOwnershipPrefix) {
+        parameters["ownershipPrefix"] = BI_OBJECT_METADATA_PREFIX
+    }
+    parameters.putAll(databasePlan.parameters)
+    parameters.putAll(consumerDatabasePlan.parameters)
+    return ClickHouseCatalogQuery(
+        sql = sql
+            .replace(DATABASE_TABLES_PREDICATE, databasePlan.predicate)
+            .replace(CONSUMER_DATABASE_TABLES_PREDICATE, consumerDatabasePlan.predicate),
+        parameters = parameters,
+    )
+}
+
+private fun ClickHouseCatalogReadRequest.shouldCanonicalizeExpectedQueries(
+    objects: List<ClickHouseCatalogObject>,
+): Boolean {
+    if (desiredObjects == null) {
+        return false
+    }
+    if (operation != BiScriptOperation.Deploy) {
+        return false
+    }
+    return requestedDeploymentIsStable(BiDeploymentDescriptor.from(options), objects)
+}
+
+internal fun requestedDeploymentIsStable(
+    descriptor: BiDeploymentDescriptor,
+    objects: List<ClickHouseCatalogObject>,
+): Boolean = objects.asSequence()
+    .mapNotNull { it.observed.metadata }
+    .filter { metadata -> metadata.deploymentId == descriptor.deploymentId }
+    .all { metadata ->
+        metadata.phase == BiDeploymentPhase.STABLE &&
+            metadata.configurationFingerprint == descriptor.configurationFingerprint
+    }
+
+internal fun ClickHouseCatalogObject.toCatalogDefinition(): ClickHouseCatalogDefinition = ClickHouseCatalogDefinition(
+    engine = observed.engine,
+    engineFull = observed.engineFull,
+    createTableQuery = observed.createTableQuery,
+    asSelect = asSelect,
+    metadata = observed.metadata,
+)
+
+internal data class ClickHouseCatalogDefinition(
+    val engine: String,
+    val engineFull: String,
+    val createTableQuery: String,
+    val asSelect: String,
+    val metadata: BiObjectMetadata?,
+)

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseEngineExpression.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseEngineExpression.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+internal fun String.functionArguments(functionName: String): List<String>? =
+    FunctionArgumentsParser(trim(), functionName).parse()
+
+internal fun String.settingLiteral(name: String): String? =
+    Regex("""\b${Regex.escape(name)}\s*=\s*('(?:\\.|''|[^'])*')""")
+        .find(this)
+        ?.groupValues
+        ?.get(1)
+
+private class FunctionArgumentsParser(
+    private val expression: String,
+    private val functionName: String,
+) {
+    private var index: Int = 0
+    private var argumentStart: Int = 0
+    private var activeQuote: Char? = null
+    private var nestedDepth: Int = 0
+    private val arguments = mutableListOf<String>()
+
+    fun parse(): List<String>? {
+        if (!moveToArgumentsStart()) {
+            return null
+        }
+        while (index < expression.length) {
+            val action = activeQuote?.let { quote -> consumeQuoted(expression[index], quote) }
+                ?: consumeUnquoted(expression[index])
+            when (action) {
+                ParseAction.COMPLETE -> return arguments
+                ParseAction.INVALID -> return null
+                ParseAction.CONTINUE -> index++
+            }
+        }
+        return null
+    }
+
+    private fun moveToArgumentsStart(): Boolean {
+        if (!expression.startsWith(functionName)) {
+            return false
+        }
+        index = functionName.length
+        while (index < expression.length && expression[index].isWhitespace()) {
+            index++
+        }
+        if (expression.getOrNull(index) != '(') {
+            return false
+        }
+        argumentStart = ++index
+        return true
+    }
+
+    private fun consumeQuoted(character: Char, quote: Char): ParseAction {
+        when {
+            character == '\\' -> index++
+            character == quote && expression.getOrNull(index + 1) == quote -> index++
+            character == quote -> activeQuote = null
+        }
+        return ParseAction.CONTINUE
+    }
+
+    private fun consumeUnquoted(character: Char): ParseAction = when (character) {
+        '\'', '"' -> {
+            activeQuote = character
+            ParseAction.CONTINUE
+        }
+        '(', '[', '{' -> {
+            nestedDepth++
+            ParseAction.CONTINUE
+        }
+        ']', '}' -> closeNestedExpression()
+        ',' -> splitArgument()
+        ')' -> closeFunction()
+        else -> ParseAction.CONTINUE
+    }
+
+    private fun closeNestedExpression(): ParseAction {
+        if (nestedDepth == 0) {
+            return ParseAction.INVALID
+        }
+        nestedDepth--
+        return ParseAction.CONTINUE
+    }
+
+    private fun splitArgument(): ParseAction {
+        if (nestedDepth == 0) {
+            arguments += expression.substring(argumentStart, index).trim()
+            argumentStart = index + 1
+        }
+        return ParseAction.CONTINUE
+    }
+
+    private fun closeFunction(): ParseAction {
+        if (nestedDepth > 0) {
+            nestedDepth--
+            return ParseAction.CONTINUE
+        }
+        val lastArgument = expression.substring(argumentStart, index).trim()
+        if (lastArgument.isNotEmpty() || arguments.isNotEmpty()) {
+            arguments += lastArgument
+        }
+        return ParseAction.COMPLETE
+    }
+
+    private enum class ParseAction {
+        CONTINUE,
+        COMPLETE,
+        INVALID,
+    }
+}

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseMaterializedViewTargetParser.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseMaterializedViewTargetParser.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+/** Extracts the `TO database.table` header from ClickHouse's canonical MATERIALIZED VIEW DDL. */
+internal object ClickHouseMaterializedViewTargetParser {
+    fun parse(createTableQuery: String): BiObjectKey? {
+        val tokens = ClickHouseDdlTokenizer(createTableQuery).tokenize() ?: return null
+        if (!tokens.startsWithKeywords("CREATE", "MATERIALIZED", "VIEW")) {
+            return null
+        }
+        val asIndex = tokens.indexOfFirst { token -> token.isKeyword("AS") }
+        if (asIndex < 0) {
+            return null
+        }
+        val toIndexes = tokens.indices.filter { index -> index < asIndex && tokens[index].isKeyword("TO") }
+        if (toIndexes.size != 1) {
+            return null
+        }
+        val targetStart = toIndexes.single() + 1
+        val database = tokens.getOrNull(targetStart)?.identifierValue ?: return null
+        if (tokens.getOrNull(targetStart + 1) != ClickHouseDdlToken.Dot) {
+            return null
+        }
+        val table = tokens.getOrNull(targetStart + 2)?.identifierValue ?: return null
+        return BiObjectKey(database, table)
+    }
+}
+
+private sealed interface ClickHouseDdlToken {
+    data class Word(val value: String) : ClickHouseDdlToken
+    data class Identifier(val value: String) : ClickHouseDdlToken
+    data class StringLiteral(val value: String) : ClickHouseDdlToken
+    data object Dot : ClickHouseDdlToken
+    data class Symbol(val value: Char) : ClickHouseDdlToken
+}
+
+private val ClickHouseDdlToken.identifierValue: String?
+    get() = when (this) {
+        is ClickHouseDdlToken.Identifier -> value
+        is ClickHouseDdlToken.Word -> value
+        else -> null
+    }
+
+private fun ClickHouseDdlToken.isKeyword(expected: String): Boolean =
+    this is ClickHouseDdlToken.Word && value.equals(expected, ignoreCase = true)
+
+private fun List<ClickHouseDdlToken>.startsWithKeywords(vararg keywords: String): Boolean =
+    keywords.indices.all { index -> getOrNull(index)?.isKeyword(keywords[index]) == true }
+
+private class ClickHouseDdlTokenizer(private val sql: String) {
+    private var index: Int = 0
+
+    fun tokenize(): List<ClickHouseDdlToken>? = buildList {
+        while (index < sql.length) {
+            when (val character = sql[index]) {
+                in WHITESPACE -> index++
+                '.', ',', '(', ')', ';' -> {
+                    add(if (character == '.') ClickHouseDdlToken.Dot else ClickHouseDdlToken.Symbol(character))
+                    index++
+                }
+
+                '\'', '"', '`' -> add(readQuoted(character) ?: return null)
+                else -> add(readWord())
+            }
+        }
+    }
+
+    private fun readQuoted(quote: Char): ClickHouseDdlToken? {
+        index++
+        val value = StringBuilder()
+        while (index < sql.length) {
+            val character = sql[index++]
+            when {
+                character == '\\' && index < sql.length -> value.append(sql[index++])
+                character == quote && sql.getOrNull(index) == quote -> {
+                    value.append(quote)
+                    index++
+                }
+
+                character == quote -> return if (quote == '\'') {
+                    ClickHouseDdlToken.StringLiteral(value.toString())
+                } else {
+                    ClickHouseDdlToken.Identifier(value.toString())
+                }
+
+                else -> value.append(character)
+            }
+        }
+        return null
+    }
+
+    private fun readWord(): ClickHouseDdlToken.Word {
+        val start = index
+        while (index < sql.length && sql[index] !in TOKEN_BOUNDARIES) {
+            index++
+        }
+        return ClickHouseDdlToken.Word(sql.substring(start, index))
+    }
+
+    private companion object {
+        val WHITESPACE = setOf(' ', '\t', '\r', '\n')
+        val TOKEN_BOUNDARIES = WHITESPACE + setOf('.', ',', '(', ')', ';', '\'', '"', '`')
+    }
+}

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseOwnershipRegistryShapeValidator.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseOwnershipRegistryShapeValidator.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+import me.ahoo.wow.bi.renderer.ClickHouseOwnershipRegistryRenderer
+import me.ahoo.wow.bi.renderer.ClickHouseSqlSyntax
+
+internal object ClickHouseOwnershipRegistryShapeValidator {
+    fun validate(
+        topology: ClickHouseTopology,
+        deploymentId: String,
+        table: ClickHouseRegistryTableDefinition,
+        columns: List<ClickHouseCatalogColumn>,
+    ) {
+        val expectedEngine = when (topology) {
+            ClickHouseTopology.Standalone -> STANDALONE_ENGINE
+            is ClickHouseTopology.Cluster -> CLUSTER_ENGINE
+        }
+        check(table.engine == expectedEngine) {
+            "ClickHouse BI ownership registry [${table.key.qualifiedName}] must use the $expectedEngine engine"
+        }
+        check(table.engineFull.functionArguments(expectedEngine) == expectedEngineArguments(topology, deploymentId)) {
+            "ClickHouse BI ownership registry [${table.key.qualifiedName}] has an unexpected engine definition"
+        }
+        check(table.comment == "${ClickHouseOwnershipRegistryRenderer.REGISTRY_COMMENT_PREFIX}$deploymentId") {
+            "ClickHouse BI ownership registry [${table.key.qualifiedName}] has an unexpected ownership comment"
+        }
+        check(table.sortingKey.normalizedKey() == EXPECTED_SORTING_KEY) {
+            "ClickHouse BI ownership registry [${table.key.qualifiedName}] has an unexpected sorting key"
+        }
+        val actualColumns = columns.sortedBy(ClickHouseCatalogColumn::position).map { column ->
+            column.name to column.type
+        }
+        check(actualColumns == EXPECTED_COLUMNS) {
+            "ClickHouse BI ownership registry [${table.key.qualifiedName}] has an unexpected column schema: " +
+                "actual=$actualColumns, expected=$EXPECTED_COLUMNS"
+        }
+    }
+
+    private fun expectedEngineArguments(
+        topology: ClickHouseTopology,
+        deploymentId: String,
+    ): List<String> = when (topology) {
+        ClickHouseTopology.Standalone -> listOf(REVISION_COLUMN)
+        is ClickHouseTopology.Cluster -> listOf(
+            ClickHouseSqlSyntax.stringLiteral(
+                "/clickhouse/${topology.installation}/${topology.name}/control/wow-bi/$deploymentId"
+            ),
+            ClickHouseSqlSyntax.stringLiteral("{shard}-{replica}"),
+            REVISION_COLUMN,
+        )
+    }
+
+    private fun String.normalizedKey(): String =
+        trim().removeSurrounding("(", ")").replace(" ", "")
+
+    private val BiObjectKey.qualifiedName: String
+        get() = "$database.$name"
+
+    private const val STANDALONE_ENGINE = "ReplacingMergeTree"
+    private const val CLUSTER_ENGINE = "ReplicatedReplacingMergeTree"
+    private const val REVISION_COLUMN = "revision"
+    private const val EXPECTED_SORTING_KEY =
+        "deployment_id,row_kind,object_database,object_name"
+    private val EXPECTED_COLUMNS = listOf(
+        "deployment_id" to "FixedString(32)",
+        "row_kind" to "LowCardinality(String)",
+        "object_database" to "String",
+        "object_name" to "String",
+        "kind" to "LowCardinality(String)",
+        "aggregate" to "Nullable(String)",
+        "consumer_identity" to "Nullable(FixedString(32))",
+        "definition_fingerprint" to "FixedString(32)",
+        "revision" to "UInt64",
+        "status" to "LowCardinality(String)",
+        "row_fingerprint" to "FixedString(32)",
+        "recorded_at" to "DateTime64(3, 'UTC')",
+    )
+}

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseStoreShapeValidator.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseStoreShapeValidator.kt
@@ -1,0 +1,232 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+import me.ahoo.wow.bi.renderer.ClickHouseSqlSyntax
+
+internal object ClickHouseStoreShapeValidator {
+    private const val LOCAL_TABLE_SUFFIX: String = "_local"
+    private const val REPLACING_MERGE_TREE_ENGINE: String = "ReplacingMergeTree"
+    private const val REPLICATED_REPLACING_MERGE_TREE_ENGINE: String = "ReplicatedReplacingMergeTree"
+    private const val DISTRIBUTED_ENGINE: String = "Distributed"
+
+    fun validate(options: BiScriptOptions, store: ClickHouseCatalogObject) {
+        val observed = store.observed
+        val physicalName = when (options.topology) {
+            ClickHouseTopology.Standalone -> observed.name
+            is ClickHouseTopology.Cluster -> observed.name.removeSuffix(LOCAL_TABLE_SUFFIX)
+        }
+        val layout = StoreLayout.from(physicalName)
+        when (val topology = options.topology) {
+            ClickHouseTopology.Standalone -> validateStandalone(options, store, layout)
+            is ClickHouseTopology.Cluster -> validateCluster(options, topology, store, layout)
+        }
+    }
+
+    private fun validateStandalone(
+        options: BiScriptOptions,
+        store: ClickHouseCatalogObject,
+        layout: StoreLayout,
+    ) {
+        val observed = store.observed
+        check(observed.engine == REPLACING_MERGE_TREE_ENGINE) {
+            "Owned BI store [${observed.qualifiedName}] must use the $REPLACING_MERGE_TREE_ENGINE engine"
+        }
+        val expectedInvocation = layout.replacingMergeTreeInvocation(REPLACING_MERGE_TREE_ENGINE)
+        check(observed.engineFull.engineInvocation() == expectedInvocation) {
+            "Owned BI store [${observed.qualifiedName}] has an unexpected engine definition"
+        }
+        store.validateKeys(layout)
+        store.validateColumns(layout, options.timezone)
+    }
+
+    private fun validateCluster(
+        options: BiScriptOptions,
+        topology: ClickHouseTopology.Cluster,
+        store: ClickHouseCatalogObject,
+        layout: StoreLayout,
+    ) {
+        val observed = store.observed
+        if (observed.name.endsWith(LOCAL_TABLE_SUFFIX)) {
+            check(observed.engine == REPLICATED_REPLACING_MERGE_TREE_ENGINE) {
+                "Owned BI store [${observed.qualifiedName}] must use the " +
+                    "$REPLICATED_REPLACING_MERGE_TREE_ENGINE engine"
+            }
+            validateReplicatedStoreEngine(observed, layout)
+            store.validateKeys(layout)
+        } else {
+            check(observed.engine == DISTRIBUTED_ENGINE) {
+                "Owned BI store [${observed.qualifiedName}] must use the $DISTRIBUTED_ENGINE engine"
+            }
+            validateDistributedStoreEngine(topology, observed, layout)
+            check(store.partitionKey.isEmpty() && store.sortingKey.isEmpty()) {
+                "Owned BI distributed store [${observed.qualifiedName}] must not define local table keys"
+            }
+        }
+        store.validateColumns(layout, options.timezone)
+    }
+
+    private fun validateReplicatedStoreEngine(observed: ObservedBiObject, layout: StoreLayout) {
+        val actualArguments = observed.engineFull.functionArguments(REPLICATED_REPLACING_MERGE_TREE_ENGINE)
+        val expectedArgumentCount = if (layout.versionColumn == null) 2 else 3
+        val versionMatches = layout.versionColumn == null || actualArguments?.getOrNull(2) == layout.versionColumn
+        check(actualArguments?.size == expectedArgumentCount && versionMatches) {
+            "Owned BI store [${observed.qualifiedName}] has an unexpected replicated engine definition"
+        }
+    }
+
+    private fun validateDistributedStoreEngine(
+        topology: ClickHouseTopology.Cluster,
+        observed: ObservedBiObject,
+        layout: StoreLayout,
+    ) {
+        val expectedArguments = listOf(
+            ClickHouseSqlSyntax.stringLiteral(topology.name),
+            ClickHouseSqlSyntax.stringLiteral(observed.database),
+            ClickHouseSqlSyntax.stringLiteral("${observed.name}$LOCAL_TABLE_SUFFIX"),
+            layout.shardingKey,
+        )
+        val actualArguments = observed.engineFull.functionArguments(DISTRIBUTED_ENGINE)
+        check(actualArguments == expectedArguments) {
+            "Owned BI store [${observed.qualifiedName}] has an unexpected distributed engine definition"
+        }
+    }
+
+    private fun ClickHouseCatalogObject.validateKeys(layout: StoreLayout) {
+        val name = observed.qualifiedName
+        check(partitionKey == layout.partitionKey) {
+            "Owned BI store [$name] has an unexpected partition key [$partitionKey]; " +
+                "expected [${layout.partitionKey}]"
+        }
+        check(sortingKey == layout.sortingKey) {
+            "Owned BI store [$name] has an unexpected sorting key [$sortingKey]; expected [${layout.sortingKey}]"
+        }
+    }
+
+    private fun ClickHouseCatalogObject.validateColumns(layout: StoreLayout, timezone: String) {
+        val expected = layout.expectedColumns(timezone)
+        val actual = columns.map { it.name to it.type }
+        check(actual == expected) {
+            "Owned BI store [${observed.qualifiedName}] has an unexpected column schema: " +
+                "actual=$actual, expected=$expected"
+        }
+    }
+
+    private enum class StoreLayout(
+        private val suffix: String,
+        val partitionKey: String,
+        val sortingKey: String,
+        val versionColumn: String?,
+        val shardingKey: String,
+    ) {
+        COMMAND(
+            suffix = "_command_store",
+            partitionKey = "toYYYYMM(create_time)",
+            sortingKey = "id",
+            versionColumn = null,
+            shardingKey = "sipHash64(aggregate_id)",
+        ),
+        STATE(
+            suffix = "_state_store",
+            partitionKey = "toYYYYMM(create_time)",
+            sortingKey = "tenant_id, aggregate_id, version",
+            versionColumn = "version",
+            shardingKey = "sipHash64(tenant_id, aggregate_id)",
+        ),
+        STATE_LAST(
+            suffix = "_state_last_store",
+            partitionKey = "toYYYYMM(first_event_time)",
+            sortingKey = "tenant_id, aggregate_id",
+            versionColumn = "version",
+            shardingKey = "sipHash64(tenant_id, aggregate_id)",
+        ),
+        ;
+
+        fun replacingMergeTreeInvocation(engine: String): String =
+            versionColumn?.let { "$engine($it)" } ?: engine
+
+        fun expectedColumns(timezone: String): List<Pair<String, String>> = when (this) {
+            COMMAND -> commandStoreColumns(timezone)
+            STATE, STATE_LAST -> stateStoreColumns(timezone)
+        }
+
+        companion object {
+            fun from(tableName: String): StoreLayout = entries.firstOrNull {
+                tableName.length > it.suffix.length && tableName.endsWith(it.suffix)
+            } ?: error("Owned BI store [$tableName] has an unsupported store name")
+        }
+    }
+}
+
+private val ObservedBiObject.qualifiedName: String
+    get() = "$database.$name"
+
+private fun String.engineInvocation(): String {
+    val clauseIndex = listOf(
+        " PARTITION BY ",
+        " PRIMARY KEY ",
+        " ORDER BY ",
+        " SAMPLE BY ",
+        " TTL ",
+        " SETTINGS ",
+    ).asSequence()
+        .map(::indexOf)
+        .filter { it >= 0 }
+        .minOrNull()
+    return if (clauseIndex == null) trim() else substring(0, clauseIndex).trim()
+}
+
+private fun commandStoreColumns(timezone: String): List<Pair<String, String>> = listOf(
+    "id" to "String",
+    "context_name" to "String",
+    "aggregate_name" to "String",
+    "name" to "String",
+    "header" to "Map(String, String)",
+    "aggregate_id" to "String",
+    "tenant_id" to "String",
+    "owner_id" to "String",
+    "space_id" to "String",
+    "request_id" to "String",
+    "aggregate_version" to "Nullable(UInt32)",
+    "is_create" to "Bool",
+    "is_void" to "Bool",
+    "allow_create" to "Bool",
+    "body_type" to "String",
+    "body" to "String",
+    "create_time" to dateTime64Type(timezone),
+)
+
+private fun stateStoreColumns(timezone: String): List<Pair<String, String>> = listOf(
+    "id" to "String",
+    "context_name" to "String",
+    "aggregate_name" to "String",
+    "header" to "Map(String, String)",
+    "aggregate_id" to "String",
+    "tenant_id" to "String",
+    "owner_id" to "String",
+    "space_id" to "String",
+    "command_id" to "String",
+    "request_id" to "String",
+    "version" to "UInt32",
+    "state" to "String",
+    "body" to "Array(String)",
+    "first_operator" to "String",
+    "first_event_time" to dateTime64Type(timezone),
+    "create_time" to dateTime64Type(timezone),
+    "tags" to "Map(String, Array(String))",
+    "deleted" to "Bool",
+)
+
+private fun dateTime64Type(timezone: String): String =
+    "DateTime64(3, ${ClickHouseSqlSyntax.stringLiteral(timezone)})"

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseStoreShapeValidator.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseStoreShapeValidator.kt
@@ -63,7 +63,7 @@ internal object ClickHouseStoreShapeValidator {
                 "Owned BI store [${observed.qualifiedName}] must use the " +
                     "$REPLICATED_REPLACING_MERGE_TREE_ENGINE engine"
             }
-            validateReplicatedStoreEngine(observed, layout)
+            validateReplicatedStoreEngine(topology, observed, layout)
             store.validateKeys(layout)
         } else {
             check(observed.engine == DISTRIBUTED_ENGINE) {
@@ -77,11 +77,23 @@ internal object ClickHouseStoreShapeValidator {
         store.validateColumns(layout, options.timezone)
     }
 
-    private fun validateReplicatedStoreEngine(observed: ObservedBiObject, layout: StoreLayout) {
+    private fun validateReplicatedStoreEngine(
+        topology: ClickHouseTopology.Cluster,
+        observed: ObservedBiObject,
+        layout: StoreLayout,
+    ) {
+        val expectedArguments = buildList {
+            add(
+                ClickHouseSqlSyntax.stringLiteral(
+                    "/clickhouse/${topology.installation}/${topology.name}/tables/" +
+                        "{shard}/{database}/{table}"
+                )
+            )
+            add(ClickHouseSqlSyntax.stringLiteral("{replica}"))
+            layout.versionColumn?.let(::add)
+        }
         val actualArguments = observed.engineFull.functionArguments(REPLICATED_REPLACING_MERGE_TREE_ENGINE)
-        val expectedArgumentCount = if (layout.versionColumn == null) 2 else 3
-        val versionMatches = layout.versionColumn == null || actualArguments?.getOrNull(2) == layout.versionColumn
-        check(actualArguments?.size == expectedArgumentCount && versionMatches) {
+        check(actualArguments == expectedArguments) {
             "Owned BI store [${observed.qualifiedName}] has an unexpected replicated engine definition"
         }
     }

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseStoreShapeValidator.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseStoreShapeValidator.kt
@@ -86,7 +86,7 @@ internal object ClickHouseStoreShapeValidator {
             add(
                 ClickHouseSqlSyntax.stringLiteral(
                     "/clickhouse/${topology.installation}/${topology.name}/tables/" +
-                        "{shard}/{database}/{table}"
+                        "{shard}/${observed.database}/${observed.name}"
                 )
             )
             add(ClickHouseSqlSyntax.stringLiteral("{replica}"))
@@ -94,7 +94,8 @@ internal object ClickHouseStoreShapeValidator {
         }
         val actualArguments = observed.engineFull.functionArguments(REPLICATED_REPLACING_MERGE_TREE_ENGINE)
         check(actualArguments == expectedArguments) {
-            "Owned BI store [${observed.qualifiedName}] has an unexpected replicated engine definition"
+            "Owned BI store [${observed.qualifiedName}] has unexpected replicated engine arguments " +
+                "$actualArguments; expected $expectedArguments"
         }
     }
 

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseStringArrayParameterPlan.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/ClickHouseStringArrayParameterPlan.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+import me.ahoo.wow.bi.renderer.ClickHouseSqlSyntax
+
+internal data class ClickHouseStringArrayParameterPlan(
+    val predicate: String,
+    val parameters: Map<String, String>,
+) {
+    val arrayExpression: String = parameters.keys.joinToString(
+        prefix = if (parameters.size == 1) "" else "arrayConcat(",
+        postfix = if (parameters.size == 1) "" else ")",
+    ) { name -> "{$name:Array(String)}" }
+
+    companion object {
+        const val MAX_PARAMETER_BYTES: Int = 64 * 1024
+
+        fun create(
+            expression: String,
+            parameterName: String,
+            values: Collection<String>,
+        ): ClickHouseStringArrayParameterPlan {
+            require(expression.isNotBlank()) { "expression must not be blank" }
+            require(parameterName.isNotBlank()) { "parameterName must not be blank" }
+            val parameterValues = values
+                .map(ClickHouseSqlSyntax::stringLiteral)
+                .toClickHouseArrayParameters(parameterName)
+            val predicates = parameterValues.keys.map { name ->
+                "$expression IN {$name:Array(String)}"
+            }
+            return ClickHouseStringArrayParameterPlan(
+                predicate = if (predicates.size == 1) {
+                    predicates.single()
+                } else {
+                    predicates.joinToString(prefix = "(", postfix = ")", separator = " OR ")
+                },
+                parameters = parameterValues,
+            )
+        }
+
+        private fun List<String>.toClickHouseArrayParameters(parameterName: String): Map<String, String> {
+            if (isEmpty()) {
+                return mapOf(parameterName to "[]")
+            }
+            val chunks = mutableListOf<MutableList<String>>()
+            var currentChunk = mutableListOf<String>()
+            var currentBytes = ARRAY_BRACKETS_BYTES
+            for (literal in this) {
+                val literalBytes = literal.toByteArray(Charsets.UTF_8).size
+                require(literalBytes + ARRAY_BRACKETS_BYTES <= MAX_PARAMETER_BYTES) {
+                    "ClickHouse Array(String) value exceeds the safe HTTP form field size [$MAX_PARAMETER_BYTES]"
+                }
+                val separatorBytes = if (currentChunk.isEmpty()) 0 else ARRAY_SEPARATOR_BYTES
+                if (currentBytes + separatorBytes + literalBytes > MAX_PARAMETER_BYTES) {
+                    chunks.add(currentChunk)
+                    currentChunk = mutableListOf()
+                    currentBytes = ARRAY_BRACKETS_BYTES
+                }
+                if (currentChunk.isNotEmpty()) {
+                    currentBytes += ARRAY_SEPARATOR_BYTES
+                }
+                currentChunk.add(literal)
+                currentBytes += literalBytes
+            }
+            chunks.add(currentChunk)
+            return chunks.mapIndexed { index, chunk ->
+                val name = if (index == 0) parameterName else "$parameterName$index"
+                name to chunk.joinToString(prefix = "[", postfix = "]")
+            }.toMap()
+        }
+
+        private const val ARRAY_BRACKETS_BYTES = 2
+        private const val ARRAY_SEPARATOR_BYTES = 2
+    }
+}

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/expansion/plan/StateExpansionCollectionCollector.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/expansion/plan/StateExpansionCollectionCollector.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi.expansion.plan
+
+import me.ahoo.wow.bi.expansion.type.JacksonWireShapeInspector
+import me.ahoo.wow.bi.expansion.type.ResolvedType
+import me.ahoo.wow.bi.type.ClickHouseType
+import me.ahoo.wow.bi.type.JsonTokenShape
+import me.ahoo.wow.bi.type.ScalarMapping
+
+internal class StateExpansionCollectionCollector(
+    private val fallbackCollector: StateExpansionFallbackCollector,
+) {
+    fun collect(request: PropertyPlanningRequest) {
+        val elementType = request.type.arguments.firstOrNull()
+        if (!JacksonWireShapeInspector.matches(request.type, JsonTokenShape.ARRAY) || elementType == null) {
+            fallbackCollector.collectRaw(request)
+            return
+        }
+        val elementMapping = elementType.verifiedScalarMapping()
+        if (elementMapping != null) {
+            collectScalar(request, elementType, elementMapping)
+            return
+        }
+        if (elementType.isOpaqueCollectionElement()) {
+            fallbackCollector.collectRaw(request)
+            return
+        }
+        collectObject(request, elementType)
+    }
+
+    private fun collectScalar(
+        request: PropertyPlanningRequest,
+        elementType: ResolvedType,
+        elementMapping: ScalarMapping,
+    ) {
+        request.draft.columns.add(
+            ColumnPlan(
+                name = request.name,
+                path = request.path,
+                targetName = request.targetName,
+                type = ClickHouseType.Array(elementType.toScalarType(elementMapping, nullableAncestor = false)),
+                extraction = ColumnExtraction.JsonValue(request.parent.source, request.name),
+                placement = ColumnPlacement.SELECT,
+            )
+        )
+        if (request.type.requiresRawCompanion()) {
+            request.draft.columns.add(rawCompanionColumn(request.toRawColumnRequest()))
+        }
+    }
+
+    private fun collectObject(request: PropertyPlanningRequest, elementType: ResolvedType) {
+        val cursorReference = ColumnReference.Alias(cursorTargetName(request.targetName))
+        val elementReference = ColumnReference.Alias(request.targetName)
+        val collectionPointer = request.parent.pointer +
+            JsonPointerSegment.Property(encodePointerSegment(request.name))
+        val elementPointer = collectionPointer + JsonPointerSegment.Index(cursorReference)
+        request.draft.columns.add(rawObjectArrayColumn(request.toRawColumnRequest()))
+        if (request.type.requiresRawCompanion()) {
+            request.draft.columns.add(
+                rawCompanionColumn(
+                    request = request.toRawColumnRequest(),
+                    inherited = false,
+                )
+            )
+        }
+        request.draft.collectionRequests.add(
+            CollectionRequest(
+                name = request.name,
+                path = request.path,
+                source = request.parent.source,
+                targetName = request.targetName,
+                tableSuffix = relativeTargetName(request.draft.anchorTargetName, request.targetName),
+                cursor = CollectionCursorPlan(
+                    source = request.parent.source,
+                    property = request.name,
+                    cursor = cursorReference,
+                    element = elementReference,
+                ),
+                pointer = elementPointer,
+                elementNode = PlanningNode(
+                    path = request.path,
+                    pointer = elementPointer,
+                    source = elementReference,
+                    targetName = request.targetName,
+                    type = elementType,
+                    depth = request.parent.depth + 1,
+                    nullableAncestor = request.parent.nullableAncestor ||
+                        request.type.requiresRawCompanion() ||
+                        elementType.requiresRawCompanion(),
+                ),
+                rawElementCompanion = elementType.requiresRawCompanion(),
+            )
+        )
+    }
+}

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/expansion/plan/StateExpansionColumns.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/expansion/plan/StateExpansionColumns.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi.expansion.plan
+
+import me.ahoo.wow.bi.type.ClickHouseType
+
+internal data class RawColumnRequest(
+    val name: String,
+    val path: String,
+    val targetName: String,
+    val source: ColumnReference,
+)
+
+internal fun PropertyPlanningRequest.toRawColumnRequest(): RawColumnRequest = RawColumnRequest(
+    name = name,
+    path = path,
+    targetName = targetName,
+    source = parent.source,
+)
+
+internal fun rawValueColumn(request: RawColumnRequest): ColumnPlan {
+    return ColumnPlan(
+        name = request.name,
+        path = request.path,
+        targetName = request.targetName,
+        type = ClickHouseType.String,
+        extraction = ColumnExtraction.JsonRaw(request.source, request.name),
+        placement = ColumnPlacement.SELECT,
+    )
+}
+
+internal fun rawObjectArrayColumn(request: RawColumnRequest): ColumnPlan {
+    return ColumnPlan(
+        name = request.name,
+        path = request.path,
+        targetName = request.targetName,
+        type = ClickHouseType.Array(ClickHouseType.String),
+        extraction = ColumnExtraction.JsonArray(request.source, request.name),
+        placement = ColumnPlacement.SELECT,
+        inherited = false,
+    )
+}
+
+internal fun rawCompanionColumn(
+    request: RawColumnRequest,
+    inherited: Boolean = true,
+): ColumnPlan {
+    return ColumnPlan(
+        name = request.name,
+        path = request.path,
+        targetName = rawTargetName(request.targetName),
+        type = ClickHouseType.String,
+        extraction = ColumnExtraction.JsonRaw(request.source, request.name),
+        placement = ColumnPlacement.SELECT,
+        inherited = inherited,
+    )
+}
+
+internal fun validateColumnTargets(draft: ViewDraft, session: StateExpansionPlanningSession) {
+    val reservedProperty = draft.propertyTargetNames
+        .sorted()
+        .firstOrNull {
+            it.startsWith(RAW_TARGET_PREFIX) ||
+                it.startsWith(ExpansionViewPlan.CURSOR_TARGET_PREFIX)
+        }
+    require(reservedProperty == null) {
+        "Reserved namespace collision for aggregate [${session.aggregate}] in view " +
+            "[${draft.targetTableName}] at target [$reservedProperty]."
+    }
+
+    val duplicates = (draft.columns.map(ColumnPlan::targetName) + ExpansionViewPlan.METADATA_TARGET_NAMES)
+        .groupingBy { it }
+        .eachCount()
+        .filterValues { it > 1 }
+        .keys
+        .sorted()
+    require(duplicates.isEmpty()) {
+        "Target name collision for aggregate [${session.aggregate}] in view [${draft.targetTableName}]: " +
+            "duplicate target(s) ${duplicates.joinToString(prefix = "[", postfix = "]")}."
+    }
+}

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/expansion/plan/StateExpansionFallbackCollector.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/expansion/plan/StateExpansionFallbackCollector.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi.expansion.plan
+
+import me.ahoo.wow.bi.BiScriptDiagnostic
+import me.ahoo.wow.bi.BiScriptDiagnosticCode
+import me.ahoo.wow.bi.BiScriptMappingDecision
+import me.ahoo.wow.bi.UnsupportedTypeStrategy
+import me.ahoo.wow.bi.type.ClickHouseType
+
+internal class StateExpansionFallbackCollector(
+    private val session: StateExpansionPlanningSession,
+) {
+    fun collectDepth(request: PropertyPlanningRequest) {
+        request.draft.columns.add(rawValueColumn(request.toRawColumnRequest()))
+        val sourceType = request.type.javaType.toCanonical()
+        session.diagnostics.add(
+            BiScriptDiagnostic(
+                code = BiScriptDiagnosticCode.MAX_DEPTH_REACHED,
+                aggregate = session.aggregate,
+                path = request.path,
+                sourceType = sourceType,
+                decision = BiScriptMappingDecision.MAX_DEPTH_RAW_JSON,
+                message = "Max expansion depth reached at [${request.path}] with type [$sourceType]; " +
+                    "the value is projected as scoped JSON and remains authoritative in __state.",
+            )
+        )
+    }
+
+    fun collectOpaque(node: PlanningNode, draft: ViewDraft) {
+        val path = node.path.ifBlank { ROOT_PATH }
+        val sourceType = node.type.javaType.toCanonical()
+        require(session.options.unsupportedTypeStrategy == UnsupportedTypeStrategy.RAW_JSON) {
+            "Unsupported property [$path] for aggregate [${session.aggregate}] with type [$sourceType]."
+        }
+        draft.columns.add(
+            ColumnPlan(
+                name = node.targetName,
+                path = path,
+                targetName = node.targetName,
+                type = ClickHouseType.String,
+                extraction = ColumnExtraction.Reference(node.source),
+                placement = ColumnPlacement.SELECT,
+            )
+        )
+        session.diagnostics.add(
+            BiScriptDiagnostic(
+                code = BiScriptDiagnosticCode.RAW_JSON_FALLBACK,
+                aggregate = session.aggregate,
+                path = path,
+                sourceType = sourceType,
+                decision = BiScriptMappingDecision.RAW_JSON,
+                message = "Unsupported property [$path] with type [$sourceType] is projected as scoped JSON; " +
+                    "the authoritative lexical value remains in __state.",
+            )
+        )
+    }
+
+    fun collectRaw(request: PropertyPlanningRequest) {
+        val sourceType = request.type.javaType.toCanonical()
+        require(session.options.unsupportedTypeStrategy == UnsupportedTypeStrategy.RAW_JSON) {
+            "Unsupported property [${request.path}] for aggregate [${session.aggregate}] with type [$sourceType]."
+        }
+        request.draft.columns.add(rawValueColumn(request.toRawColumnRequest()))
+        session.diagnostics.add(
+            BiScriptDiagnostic(
+                code = BiScriptDiagnosticCode.RAW_JSON_FALLBACK,
+                aggregate = session.aggregate,
+                path = request.path,
+                sourceType = sourceType,
+                decision = BiScriptMappingDecision.RAW_JSON,
+                message = "Unsupported property [${request.path}] with type [$sourceType] is projected as scoped JSON; " +
+                    "the authoritative lexical value remains in __state.",
+            )
+        )
+    }
+}
+
+private const val ROOT_PATH: String = "$"

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/expansion/plan/StateExpansionNames.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/expansion/plan/StateExpansionNames.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi.expansion.plan
+
+import me.ahoo.wow.naming.NamingConverter
+import java.security.MessageDigest
+
+internal const val RAW_TARGET_PREFIX: String = "__raw__"
+
+internal fun childPath(parentPath: String, name: String): String =
+    if (parentPath.isBlank()) name else "$parentPath.$name"
+
+internal fun childTargetName(parent: PlanningNode, name: String): String {
+    val propertyName = NamingConverter.PASCAL_TO_SNAKE.convert(name)
+    return if (parent.depth == 0) propertyName else "${parent.targetName}__$propertyName"
+}
+
+internal fun rawTargetName(targetName: String): String = "$RAW_TARGET_PREFIX$targetName"
+
+internal fun cursorTargetName(targetName: String): String =
+    "${ExpansionViewPlan.CURSOR_TARGET_PREFIX}$targetName"
+
+internal fun encodePointerSegment(value: String): String =
+    value.replace("~", "~0").replace("/", "~1")
+
+internal fun relativeTargetName(anchorTargetName: String, targetName: String): String =
+    if (anchorTargetName == STATE_COLUMN) {
+        targetName
+    } else {
+        targetName.removePrefix("${anchorTargetName}__")
+    }
+
+internal fun String.toObjectNameSegment(): String {
+    if (all { it.isLetterOrDigit() || it == '_' || it == '-' }) {
+        return this
+    }
+    val digest = MessageDigest.getInstance("SHA-256")
+        .digest(toByteArray(Charsets.UTF_8))
+        .take(OBJECT_NAME_HASH_BYTES)
+        .joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
+    return "field_$digest"
+}
+
+private const val OBJECT_NAME_HASH_BYTES: Int = 16

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/expansion/plan/StateExpansionPlanner.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/expansion/plan/StateExpansionPlanner.kt
@@ -15,32 +15,21 @@ package me.ahoo.wow.bi.expansion.plan
 
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.bi.BiScriptDiagnostic
-import me.ahoo.wow.bi.BiScriptDiagnosticCode
-import me.ahoo.wow.bi.BiScriptMappingDecision
 import me.ahoo.wow.bi.BiScriptOptions
-import me.ahoo.wow.bi.UnsupportedTypeStrategy
 import me.ahoo.wow.bi.expansion.BiTableNaming
-import me.ahoo.wow.bi.expansion.type.JacksonWireShapeInspector
-import me.ahoo.wow.bi.expansion.type.JsonWireShape
 import me.ahoo.wow.bi.expansion.type.Nullability
-import me.ahoo.wow.bi.expansion.type.ResolvedJsonProperty
 import me.ahoo.wow.bi.expansion.type.ResolvedType
 import me.ahoo.wow.bi.type.ClickHouseType
-import me.ahoo.wow.bi.type.ClickHouseTypeMapping.scalarMapping
-import me.ahoo.wow.bi.type.JsonTokenShape
-import me.ahoo.wow.bi.type.ScalarMapping
 import me.ahoo.wow.configuration.requiredAggregateType
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
-import me.ahoo.wow.naming.NamingConverter
 import me.ahoo.wow.serialization.JsonSerializer
-import java.security.MessageDigest
 import java.util.Collections
 
 internal class StateExpansionPlanner(private val options: BiScriptOptions = BiScriptOptions()) {
     private val naming = BiTableNaming(options)
 
     fun plan(namedAggregate: NamedAggregate): StateExpansionPlan {
-        val context = PlanningContext(
+        val session = StateExpansionPlanningSession(
             aggregate = "${namedAggregate.contextName}.${namedAggregate.aggregateName}",
             options = options,
         )
@@ -65,17 +54,19 @@ internal class StateExpansionPlanner(private val options: BiScriptOptions = BiSc
         )
 
         buildView(
-            node = rootNode,
-            sourceTableName = sourceTableName,
-            targetTableName = "${sourceTableName}_root",
-            inheritedColumns = emptyList(),
-            recovery = ExpansionRecoveryPlan(emptyList(), emptyList(), null),
-            context = context,
+            request = ViewPlanningRequest(
+                node = rootNode,
+                sourceTableName = sourceTableName,
+                targetTableName = "${sourceTableName}_root",
+                inheritedColumns = emptyList(),
+                recovery = ExpansionRecoveryPlan(emptyList(), emptyList(), null),
+            ),
+            session = session,
         )
         return StateExpansionPlan(
-            views = unmodifiableCopy(context.views),
+            views = unmodifiableCopy(session.views),
             diagnostics = unmodifiableCopy(
-                context.diagnostics.sortedWith(
+                session.diagnostics.sortedWith(
                     compareBy<BiScriptDiagnostic>(BiScriptDiagnostic::path)
                         .thenBy { it.code.name }
                 )
@@ -84,695 +75,65 @@ internal class StateExpansionPlanner(private val options: BiScriptOptions = BiSc
     }
 
     private fun buildView(
-        node: PlanningNode,
-        sourceTableName: String,
-        targetTableName: String,
-        inheritedColumns: List<ColumnPlan>,
-        recovery: ExpansionRecoveryPlan,
-        context: PlanningContext,
-        arrayJoin: CollectionRequest? = null,
+        request: ViewPlanningRequest,
+        session: StateExpansionPlanningSession,
     ) {
         val draft = ViewDraft(
-            targetTableName = targetTableName,
-            anchorTargetName = node.targetName,
-            columns = inheritedColumns.toMutableList(),
+            targetTableName = request.targetTableName,
+            anchorTargetName = request.node.targetName,
+            columns = request.inheritedColumns.toMutableList(),
         )
-        arrayJoin?.let { request ->
-            if (request.rawElementCompanion) {
+        request.arrayJoin?.let { collection ->
+            if (collection.rawElementCompanion) {
                 draft.columns.add(
                     ColumnPlan(
-                        name = request.name,
-                        path = request.path,
-                        targetName = rawTargetName(request.targetName),
+                        name = collection.name,
+                        path = collection.path,
+                        targetName = rawTargetName(collection.targetName),
                         type = ClickHouseType.String,
-                        extraction = ColumnExtraction.Reference(ColumnReference.Alias(request.targetName)),
+                        extraction = ColumnExtraction.Reference(ColumnReference.Alias(collection.targetName)),
                         placement = ColumnPlacement.SELECT,
                     )
                 )
             }
         }
 
-        collectObjectProperties(node, draft, context)
-        validateColumnTargets(draft, context)
+        session.propertyCollector.collectObjectProperties(request.node, draft)
+        validateColumnTargets(draft, session)
 
         val frozenColumns = unmodifiableCopy(draft.columns.sortedBy(ColumnPlan::targetName))
-        context.views.add(
+        session.views.add(
             ExpansionViewPlan(
-                targetTableName = targetTableName,
-                sourceTableName = sourceTableName,
+                targetTableName = request.targetTableName,
+                sourceTableName = request.sourceTableName,
                 columns = frozenColumns,
-                recovery = recovery,
+                recovery = request.recovery,
             )
         )
 
         val finalInheritedColumns = frozenColumns.filter(ColumnPlan::inherited)
-        draft.collectionRequests.forEach { request ->
+        draft.collectionRequests.forEach { collection ->
             val childRecovery = ExpansionRecoveryPlan(
-                cursors = recovery.cursors + request.cursor,
-                pointer = request.pointer,
-                currentIndex = request.cursor.cursor,
+                cursors = request.recovery.cursors + collection.cursor,
+                pointer = collection.pointer,
+                currentIndex = collection.cursor.cursor,
             )
             buildView(
-                node = request.elementNode,
-                sourceTableName = sourceTableName,
-                targetTableName = "${targetTableName}_${request.tableSuffix.toObjectNameSegment()}",
-                inheritedColumns = finalInheritedColumns,
-                recovery = childRecovery,
-                context = context,
-                arrayJoin = request,
-            )
-        }
-    }
-
-    private fun collectObjectProperties(
-        parent: PlanningNode,
-        draft: ViewDraft,
-        context: PlanningContext,
-    ) {
-        when (val shape = JacksonWireShapeInspector.inspect(parent.type)) {
-            is JsonWireShape.ExpandableObject -> collectResolvedProperties(parent, shape.properties, draft, context)
-            is JsonWireShape.Opaque -> collectOpaqueNode(parent, draft, context)
-        }
-    }
-
-    private fun collectResolvedProperties(
-        parent: PlanningNode,
-        properties: List<ResolvedJsonProperty>,
-        draft: ViewDraft,
-        context: PlanningContext,
-    ) {
-        properties.forEach { property ->
-            collectProperty(parent, property, draft, context)
-        }
-    }
-
-    private fun collectProperty(
-        parent: PlanningNode,
-        property: ResolvedJsonProperty,
-        draft: ViewDraft,
-        context: PlanningContext,
-    ) {
-        val name = property.serializedName
-        val type = property.type
-        val path = childPath(parent.path, name)
-        val targetName = childTargetName(parent, name)
-        draft.propertyTargetNames.add(targetName)
-
-        if (parent.depth + 1 > context.options.maxExpansionDepth && !type.canRenderDirectly()) {
-            collectDepthFallback(name, path, targetName, parent.source, type, draft, context)
-            return
-        }
-
-        if (collectScalarProperty(parent, name, path, targetName, type, draft, context)) {
-            return
-        }
-        when {
-            type.javaType.isMapLikeType -> collectMap(
-                parent = parent,
-                name = name,
-                path = path,
-                targetName = targetName,
-                type = type,
-                draft = draft,
-                context = context,
-            )
-
-            type.javaType.isCollectionLikeType || type.javaType.isArrayType -> collectCollection(
-                parent = parent,
-                name = name,
-                path = path,
-                targetName = targetName,
-                type = type,
-                draft = draft,
-                context = context,
-            )
-
-            isUnsupportedPlatformObject(type) -> collectRawFallback(
-                name = name,
-                path = path,
-                targetName = targetName,
-                source = parent.source,
-                type = type,
-                draft = draft,
-                context = context,
-            )
-
-            else -> collectObjectProperty(parent, name, path, targetName, type, draft, context)
-        }
-    }
-
-    private fun collectScalarProperty(
-        parent: PlanningNode,
-        name: String,
-        path: String,
-        targetName: String,
-        type: ResolvedType,
-        draft: ViewDraft,
-        context: PlanningContext,
-    ): Boolean {
-        val scalarMapping = type.rawClass.scalarMapping() ?: return false
-        if (JacksonWireShapeInspector.matches(type, scalarMapping.tokenShape)) {
-            collectScalar(parent, name, path, targetName, type, scalarMapping, draft)
-        } else {
-            collectRawFallback(name, path, targetName, parent.source, type, draft, context)
-        }
-        return true
-    }
-
-    private fun collectObjectProperty(
-        parent: PlanningNode,
-        name: String,
-        path: String,
-        targetName: String,
-        type: ResolvedType,
-        draft: ViewDraft,
-        context: PlanningContext,
-    ) {
-        when (val shape = JacksonWireShapeInspector.inspect(type)) {
-            is JsonWireShape.ExpandableObject -> collectNestedObject(
-                parent = parent,
-                name = name,
-                path = path,
-                targetName = targetName,
-                type = type,
-                properties = shape.properties,
-                draft = draft,
-                context = context,
-            )
-
-            is JsonWireShape.Opaque -> collectRawFallback(
-                name = name,
-                path = path,
-                targetName = targetName,
-                source = parent.source,
-                type = type,
-                draft = draft,
-                context = context,
-            )
-        }
-    }
-
-    private fun collectScalar(
-        parent: PlanningNode,
-        name: String,
-        path: String,
-        targetName: String,
-        type: ResolvedType,
-        scalarMapping: ScalarMapping,
-        draft: ViewDraft,
-    ) {
-        draft.columns.add(
-            ColumnPlan(
-                name = name,
-                path = path,
-                targetName = targetName,
-                type = type.toScalarType(scalarMapping, parent.nullableAncestor),
-                extraction = ColumnExtraction.JsonValue(parent.source, name),
-                placement = ColumnPlacement.SELECT,
-            )
-        )
-        if (type.requiresRawCompanion()) {
-            draft.columns.add(rawCompanionColumn(name, path, targetName, parent.source))
-        }
-    }
-
-    private fun collectNestedObject(
-        parent: PlanningNode,
-        name: String,
-        path: String,
-        targetName: String,
-        type: ResolvedType,
-        properties: List<ResolvedJsonProperty>,
-        draft: ViewDraft,
-        context: PlanningContext,
-    ) {
-        draft.columns.add(
-            ColumnPlan(
-                name = name,
-                path = path,
-                targetName = targetName,
-                type = ClickHouseType.String,
-                extraction = ColumnExtraction.JsonRaw(parent.source, name),
-                placement = ColumnPlacement.WITH,
-            )
-        )
-        if (type.requiresRawCompanion()) {
-            draft.columns.add(rawCompanionColumn(name, path, targetName, parent.source))
-        }
-
-        collectResolvedProperties(
-            parent = PlanningNode(
-                path = path,
-                pointer = parent.pointer + JsonPointerSegment.Property(encodePointerSegment(name)),
-                source = ColumnReference.Alias(targetName),
-                targetName = targetName,
-                type = type,
-                depth = parent.depth + 1,
-                nullableAncestor = parent.nullableAncestor || type.requiresRawCompanion(),
-            ),
-            properties = properties,
-            draft = draft,
-            context = context,
-        )
-    }
-
-    private fun collectMap(
-        parent: PlanningNode,
-        name: String,
-        path: String,
-        targetName: String,
-        type: ResolvedType,
-        draft: ViewDraft,
-        context: PlanningContext,
-    ) {
-        val valueType = type.arguments.getOrNull(1)
-        val valueMapping = type.supportedMapValueMapping()
-        if (!JacksonWireShapeInspector.matches(type, JsonTokenShape.MAP) ||
-            valueType == null ||
-            valueMapping == null
-        ) {
-            collectRawFallback(name, path, targetName, parent.source, type, draft, context)
-            return
-        }
-
-        draft.columns.add(
-            ColumnPlan(
-                name = name,
-                path = path,
-                targetName = targetName,
-                type = ClickHouseType.Map(
-                    keyType = ClickHouseType.String,
-                    valueType = valueType.toScalarType(valueMapping, nullableAncestor = false),
+                request = ViewPlanningRequest(
+                    node = collection.elementNode,
+                    sourceTableName = request.sourceTableName,
+                    targetTableName = "${request.targetTableName}_${collection.tableSuffix.toObjectNameSegment()}",
+                    inheritedColumns = finalInheritedColumns,
+                    recovery = childRecovery,
+                    arrayJoin = collection,
                 ),
-                extraction = ColumnExtraction.JsonValue(parent.source, name),
-                placement = ColumnPlacement.SELECT,
-            )
-        )
-        if (type.requiresRawCompanion()) {
-            draft.columns.add(rawCompanionColumn(name, path, targetName, parent.source))
-        }
-    }
-
-    private fun collectCollection(
-        parent: PlanningNode,
-        name: String,
-        path: String,
-        targetName: String,
-        type: ResolvedType,
-        draft: ViewDraft,
-        context: PlanningContext,
-    ) {
-        val elementType = type.arguments.firstOrNull()
-        if (!JacksonWireShapeInspector.matches(type, JsonTokenShape.ARRAY) || elementType == null) {
-            collectRawFallback(name, path, targetName, parent.source, type, draft, context)
-            return
-        }
-        val elementMapping = elementType.verifiedScalarMapping()
-        if (elementMapping != null) {
-            collectScalarCollection(parent, name, path, targetName, type, elementType, elementMapping, draft)
-            return
-        }
-        if (elementType.isOpaqueCollectionElement()) {
-            collectRawFallback(name, path, targetName, parent.source, type, draft, context)
-            return
-        }
-        collectObjectCollection(parent, name, path, targetName, type, elementType, draft)
-    }
-
-    private fun collectScalarCollection(
-        parent: PlanningNode,
-        name: String,
-        path: String,
-        targetName: String,
-        type: ResolvedType,
-        elementType: ResolvedType,
-        elementMapping: ScalarMapping,
-        draft: ViewDraft,
-    ) {
-        draft.columns.add(
-            ColumnPlan(
-                name = name,
-                path = path,
-                targetName = targetName,
-                type = ClickHouseType.Array(elementType.toScalarType(elementMapping, nullableAncestor = false)),
-                extraction = ColumnExtraction.JsonValue(parent.source, name),
-                placement = ColumnPlacement.SELECT,
-            )
-        )
-        if (type.requiresRawCompanion()) {
-            draft.columns.add(rawCompanionColumn(name, path, targetName, parent.source))
-        }
-    }
-
-    private fun collectObjectCollection(
-        parent: PlanningNode,
-        name: String,
-        path: String,
-        targetName: String,
-        type: ResolvedType,
-        elementType: ResolvedType,
-        draft: ViewDraft,
-    ) {
-        val cursorReference = ColumnReference.Alias(cursorTargetName(targetName))
-        val elementReference = ColumnReference.Alias(targetName)
-        val collectionPointer = parent.pointer + JsonPointerSegment.Property(encodePointerSegment(name))
-        val elementPointer = collectionPointer + JsonPointerSegment.Index(cursorReference)
-        draft.columns.add(rawObjectArrayColumn(name, path, targetName, parent.source))
-        if (type.requiresRawCompanion()) {
-            draft.columns.add(
-                rawCompanionColumn(
-                    name = name,
-                    path = path,
-                    targetName = targetName,
-                    source = parent.source,
-                    inherited = false,
-                )
+                session = session,
             )
         }
-        draft.collectionRequests.add(
-            CollectionRequest(
-                name = name,
-                path = path,
-                source = parent.source,
-                targetName = targetName,
-                tableSuffix = relativeTargetName(draft.anchorTargetName, targetName),
-                cursor = CollectionCursorPlan(
-                    source = parent.source,
-                    property = name,
-                    cursor = cursorReference,
-                    element = elementReference,
-                ),
-                pointer = elementPointer,
-                elementNode = PlanningNode(
-                    path = path,
-                    pointer = elementPointer,
-                    source = elementReference,
-                    targetName = targetName,
-                    type = elementType,
-                    depth = parent.depth + 1,
-                    nullableAncestor = parent.nullableAncestor ||
-                        type.requiresRawCompanion() ||
-                        elementType.requiresRawCompanion(),
-                ),
-                rawElementCompanion = elementType.requiresRawCompanion(),
-            )
-        )
     }
-
-    private fun collectDepthFallback(
-        name: String,
-        path: String,
-        targetName: String,
-        source: ColumnReference,
-        type: ResolvedType,
-        draft: ViewDraft,
-        context: PlanningContext,
-    ) {
-        draft.columns.add(rawValueColumn(name, path, targetName, source))
-        val sourceType = type.javaType.toCanonical()
-        context.diagnostics.add(
-            BiScriptDiagnostic(
-                code = BiScriptDiagnosticCode.MAX_DEPTH_REACHED,
-                aggregate = context.aggregate,
-                path = path,
-                sourceType = sourceType,
-                decision = BiScriptMappingDecision.MAX_DEPTH_RAW_JSON,
-                message = "Max expansion depth reached at [$path] with type [$sourceType]; " +
-                    "the value is projected as scoped JSON and remains authoritative in __state.",
-            )
-        )
-    }
-
-    private fun collectOpaqueNode(
-        node: PlanningNode,
-        draft: ViewDraft,
-        context: PlanningContext,
-    ) {
-        val path = node.path.ifBlank { ROOT_PATH }
-        val sourceType = node.type.javaType.toCanonical()
-        require(context.options.unsupportedTypeStrategy == UnsupportedTypeStrategy.RAW_JSON) {
-            "Unsupported property [$path] for aggregate [${context.aggregate}] with type [$sourceType]."
-        }
-        draft.columns.add(
-            ColumnPlan(
-                name = node.targetName,
-                path = path,
-                targetName = node.targetName,
-                type = ClickHouseType.String,
-                extraction = ColumnExtraction.Reference(node.source),
-                placement = ColumnPlacement.SELECT,
-            )
-        )
-        context.diagnostics.add(
-            BiScriptDiagnostic(
-                code = BiScriptDiagnosticCode.RAW_JSON_FALLBACK,
-                aggregate = context.aggregate,
-                path = path,
-                sourceType = sourceType,
-                decision = BiScriptMappingDecision.RAW_JSON,
-                message = "Unsupported property [$path] with type [$sourceType] is projected as scoped JSON; " +
-                    "the authoritative lexical value remains in __state.",
-            )
-        )
-    }
-
-    private fun collectRawFallback(
-        name: String,
-        path: String,
-        targetName: String,
-        source: ColumnReference,
-        type: ResolvedType,
-        draft: ViewDraft,
-        context: PlanningContext,
-    ) {
-        val sourceType = type.javaType.toCanonical()
-        require(context.options.unsupportedTypeStrategy == UnsupportedTypeStrategy.RAW_JSON) {
-            "Unsupported property [$path] for aggregate [${context.aggregate}] with type [$sourceType]."
-        }
-        draft.columns.add(rawValueColumn(name, path, targetName, source))
-        context.diagnostics.add(
-            BiScriptDiagnostic(
-                code = BiScriptDiagnosticCode.RAW_JSON_FALLBACK,
-                aggregate = context.aggregate,
-                path = path,
-                sourceType = sourceType,
-                decision = BiScriptMappingDecision.RAW_JSON,
-                message = "Unsupported property [$path] with type [$sourceType] is projected as scoped JSON; " +
-                    "the authoritative lexical value remains in __state.",
-            )
-        )
-    }
-
-    private fun rawValueColumn(
-        name: String,
-        path: String,
-        targetName: String,
-        source: ColumnReference,
-    ): ColumnPlan {
-        return ColumnPlan(
-            name = name,
-            path = path,
-            targetName = targetName,
-            type = ClickHouseType.String,
-            extraction = ColumnExtraction.JsonRaw(source, name),
-            placement = ColumnPlacement.SELECT,
-        )
-    }
-
-    private fun rawObjectArrayColumn(
-        name: String,
-        path: String,
-        targetName: String,
-        source: ColumnReference,
-    ): ColumnPlan {
-        return ColumnPlan(
-            name = name,
-            path = path,
-            targetName = targetName,
-            type = ClickHouseType.Array(ClickHouseType.String),
-            extraction = ColumnExtraction.JsonArray(source, name),
-            placement = ColumnPlacement.SELECT,
-            inherited = false,
-        )
-    }
-
-    private fun rawCompanionColumn(
-        name: String,
-        path: String,
-        targetName: String,
-        source: ColumnReference,
-        inherited: Boolean = true,
-    ): ColumnPlan {
-        return ColumnPlan(
-            name = name,
-            path = path,
-            targetName = rawTargetName(targetName),
-            type = ClickHouseType.String,
-            extraction = ColumnExtraction.JsonRaw(source, name),
-            placement = ColumnPlacement.SELECT,
-            inherited = inherited,
-        )
-    }
-
-    private fun validateColumnTargets(draft: ViewDraft, context: PlanningContext) {
-        val reservedProperty = draft.propertyTargetNames
-            .sorted()
-            .firstOrNull {
-                it.startsWith(RAW_TARGET_PREFIX) ||
-                    it.startsWith(ExpansionViewPlan.CURSOR_TARGET_PREFIX)
-            }
-        require(reservedProperty == null) {
-            "Reserved namespace collision for aggregate [${context.aggregate}] in view " +
-                "[${draft.targetTableName}] at target [$reservedProperty]."
-        }
-
-        val duplicates = (draft.columns.map(ColumnPlan::targetName) + ExpansionViewPlan.METADATA_TARGET_NAMES)
-            .groupingBy { it }
-            .eachCount()
-            .filterValues { it > 1 }
-            .keys
-            .sorted()
-        require(duplicates.isEmpty()) {
-            "Target name collision for aggregate [${context.aggregate}] in view [${draft.targetTableName}]: " +
-                "duplicate target(s) ${duplicates.joinToString(prefix = "[", postfix = "]")}."
-        }
-    }
-}
-
-private fun ResolvedType.canRenderDirectly(): Boolean {
-    if (verifiedScalarMapping() != null) {
-        return true
-    }
-    if (javaType.isMapLikeType) {
-        return JacksonWireShapeInspector.matches(this, JsonTokenShape.MAP) && hasSupportedMapShape()
-    }
-    if (javaType.isCollectionLikeType || javaType.isArrayType) {
-        return JacksonWireShapeInspector.matches(this, JsonTokenShape.ARRAY) &&
-            arguments.firstOrNull()?.verifiedScalarMapping() != null
-    }
-    return false
-}
-
-private fun ResolvedType.hasSupportedMapShape(): Boolean = supportedMapValueMapping() != null
-
-private fun ResolvedType.supportedMapValueMapping(): ScalarMapping? {
-    val keyType = arguments.getOrNull(0)
-    if (keyType?.rawClass != String::class.java ||
-        keyType.nullability != Nullability.NON_NULL ||
-        keyType.verifiedScalarMapping() == null
-    ) {
-        return null
-    }
-    return arguments.getOrNull(1)?.verifiedScalarMapping()
-}
-
-private fun childPath(parentPath: String, name: String): String =
-    if (parentPath.isBlank()) name else "$parentPath.$name"
-
-private fun childTargetName(parent: PlanningNode, name: String): String {
-    val propertyName = NamingConverter.PASCAL_TO_SNAKE.convert(name)
-    return if (parent.depth == 0) propertyName else "${parent.targetName}__$propertyName"
-}
-
-private fun rawTargetName(targetName: String): String = "$RAW_TARGET_PREFIX$targetName"
-
-private fun cursorTargetName(targetName: String): String =
-    "${ExpansionViewPlan.CURSOR_TARGET_PREFIX}$targetName"
-
-private fun encodePointerSegment(value: String): String =
-    value.replace("~", "~0").replace("/", "~1")
-
-private fun relativeTargetName(anchorTargetName: String, targetName: String): String =
-    if (anchorTargetName == STATE_COLUMN) {
-        targetName
-    } else {
-        targetName.removePrefix("${anchorTargetName}__")
-    }
-
-private fun String.toObjectNameSegment(): String {
-    if (all { it.isLetterOrDigit() || it == '_' || it == '-' }) {
-        return this
-    }
-    val digest = MessageDigest.getInstance("SHA-256")
-        .digest(toByteArray(Charsets.UTF_8))
-        .take(OBJECT_NAME_HASH_BYTES)
-        .joinToString("") { byte -> "%02x".format(byte.toInt() and 0xff) }
-    return "field_$digest"
 }
 
 private fun <T> unmodifiableCopy(values: Collection<T>): List<T> =
     Collections.unmodifiableList(ArrayList(values))
 
-private const val STATE_COLUMN = "state"
-private const val STATE_LAST_SUFFIX = "state_last"
-private const val RAW_TARGET_PREFIX = "__raw__"
-private const val ROOT_PATH = "$"
-private const val OBJECT_NAME_HASH_BYTES = 16
-
-private fun ResolvedType.verifiedScalarMapping(): ScalarMapping? {
-    val mapping = rawClass.scalarMapping() ?: return null
-    return mapping.takeIf { JacksonWireShapeInspector.matches(this, it.tokenShape) }
-}
-
-private fun ResolvedType.toScalarType(
-    mapping: ScalarMapping,
-    nullableAncestor: Boolean,
-): ClickHouseType {
-    val scalar = mapping.clickHouseType
-    return if (requiresRawCompanion() || nullableAncestor) {
-        ClickHouseType.Nullable(scalar)
-    } else {
-        scalar
-    }
-}
-
-private fun ResolvedType.requiresRawCompanion(): Boolean = nullability != Nullability.NON_NULL
-
-private fun isUnsupportedPlatformObject(type: ResolvedType): Boolean {
-    val packageName = type.rawClass.packageName
-    return packageName.startsWith("java.") ||
-        packageName.startsWith("javax.") ||
-        packageName.startsWith("kotlin.")
-}
-
-private fun ResolvedType.isOpaqueCollectionElement(): Boolean {
-    return isUnsupportedPlatformObject(this) || JacksonWireShapeInspector.inspect(this) is JsonWireShape.Opaque
-}
-
-private data class PlanningNode(
-    val path: String,
-    val pointer: List<JsonPointerSegment>,
-    val source: ColumnReference,
-    val targetName: String,
-    val type: ResolvedType,
-    val depth: Int,
-    val nullableAncestor: Boolean,
-)
-
-private data class CollectionRequest(
-    val name: String,
-    val path: String,
-    val source: ColumnReference,
-    val targetName: String,
-    val tableSuffix: String,
-    val cursor: CollectionCursorPlan,
-    val pointer: List<JsonPointerSegment>,
-    val elementNode: PlanningNode,
-    val rawElementCompanion: Boolean,
-)
-
-private data class ViewDraft(
-    val targetTableName: String,
-    val anchorTargetName: String,
-    val columns: MutableList<ColumnPlan>,
-    val propertyTargetNames: MutableList<String> = mutableListOf(),
-    val collectionRequests: MutableList<CollectionRequest> = mutableListOf(),
-)
-
-private class PlanningContext(
-    val aggregate: String,
-    val options: BiScriptOptions,
-) {
-    val views: MutableList<ExpansionViewPlan> = mutableListOf()
-    val diagnostics: MutableList<BiScriptDiagnostic> = mutableListOf()
-}
+private const val STATE_LAST_SUFFIX: String = "state_last"

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/expansion/plan/StateExpansionPlanningModel.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/expansion/plan/StateExpansionPlanningModel.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi.expansion.plan
+
+import me.ahoo.wow.bi.BiScriptDiagnostic
+import me.ahoo.wow.bi.BiScriptOptions
+import me.ahoo.wow.bi.expansion.type.ResolvedType
+
+internal const val STATE_COLUMN: String = "state"
+
+internal data class ViewPlanningRequest(
+    val node: PlanningNode,
+    val sourceTableName: String,
+    val targetTableName: String,
+    val inheritedColumns: List<ColumnPlan>,
+    val recovery: ExpansionRecoveryPlan,
+    val arrayJoin: CollectionRequest? = null,
+)
+
+internal data class PropertyPlanningRequest(
+    val parent: PlanningNode,
+    val name: String,
+    val path: String,
+    val targetName: String,
+    val type: ResolvedType,
+    val draft: ViewDraft,
+)
+
+internal data class PlanningNode(
+    val path: String,
+    val pointer: List<JsonPointerSegment>,
+    val source: ColumnReference,
+    val targetName: String,
+    val type: ResolvedType,
+    val depth: Int,
+    val nullableAncestor: Boolean,
+)
+
+internal data class CollectionRequest(
+    val name: String,
+    val path: String,
+    val source: ColumnReference,
+    val targetName: String,
+    val tableSuffix: String,
+    val cursor: CollectionCursorPlan,
+    val pointer: List<JsonPointerSegment>,
+    val elementNode: PlanningNode,
+    val rawElementCompanion: Boolean,
+)
+
+internal data class ViewDraft(
+    val targetTableName: String,
+    val anchorTargetName: String,
+    val columns: MutableList<ColumnPlan>,
+    val propertyTargetNames: MutableList<String> = mutableListOf(),
+    val collectionRequests: MutableList<CollectionRequest> = mutableListOf(),
+)
+
+internal class StateExpansionPlanningSession(
+    val aggregate: String,
+    val options: BiScriptOptions,
+) {
+    val views: MutableList<ExpansionViewPlan> = mutableListOf()
+    val diagnostics: MutableList<BiScriptDiagnostic> = mutableListOf()
+    val propertyCollector: StateExpansionPropertyCollector = StateExpansionPropertyCollector(this)
+}

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/expansion/plan/StateExpansionPropertyCollector.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/expansion/plan/StateExpansionPropertyCollector.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi.expansion.plan
+
+import me.ahoo.wow.bi.expansion.type.JacksonWireShapeInspector
+import me.ahoo.wow.bi.expansion.type.JsonWireShape
+import me.ahoo.wow.bi.expansion.type.ResolvedJsonProperty
+import me.ahoo.wow.bi.type.ClickHouseType
+import me.ahoo.wow.bi.type.ClickHouseTypeMapping.scalarMapping
+import me.ahoo.wow.bi.type.JsonTokenShape
+import me.ahoo.wow.bi.type.ScalarMapping
+
+internal class StateExpansionPropertyCollector(
+    private val session: StateExpansionPlanningSession,
+) {
+    private val fallbackCollector = StateExpansionFallbackCollector(session)
+    private val collectionCollector = StateExpansionCollectionCollector(fallbackCollector)
+
+    fun collectObjectProperties(parent: PlanningNode, draft: ViewDraft) {
+        when (val shape = JacksonWireShapeInspector.inspect(parent.type)) {
+            is JsonWireShape.ExpandableObject -> collectResolvedProperties(parent, shape.properties, draft)
+            is JsonWireShape.Opaque -> fallbackCollector.collectOpaque(parent, draft)
+        }
+    }
+
+    private fun collectResolvedProperties(
+        parent: PlanningNode,
+        properties: List<ResolvedJsonProperty>,
+        draft: ViewDraft,
+    ) {
+        properties.forEach { property -> collectProperty(parent, property, draft) }
+    }
+
+    private fun collectProperty(
+        parent: PlanningNode,
+        property: ResolvedJsonProperty,
+        draft: ViewDraft,
+    ) {
+        val request = PropertyPlanningRequest(
+            parent = parent,
+            name = property.serializedName,
+            path = childPath(parent.path, property.serializedName),
+            targetName = childTargetName(parent, property.serializedName),
+            type = property.type,
+            draft = draft,
+        )
+        draft.propertyTargetNames.add(request.targetName)
+
+        if (parent.depth + 1 > session.options.maxExpansionDepth && !request.type.canRenderDirectly()) {
+            fallbackCollector.collectDepth(request)
+            return
+        }
+        if (collectScalarProperty(request)) {
+            return
+        }
+        when {
+            request.type.javaType.isMapLikeType -> collectMap(request)
+            request.type.javaType.isCollectionLikeType || request.type.javaType.isArrayType ->
+                collectionCollector.collect(request)
+
+            isUnsupportedPlatformObject(request.type) -> fallbackCollector.collectRaw(request)
+            else -> collectObjectProperty(request)
+        }
+    }
+
+    private fun collectScalarProperty(request: PropertyPlanningRequest): Boolean {
+        val scalarMapping = request.type.rawClass.scalarMapping() ?: return false
+        if (JacksonWireShapeInspector.matches(request.type, scalarMapping.tokenShape)) {
+            collectScalar(request, scalarMapping)
+        } else {
+            fallbackCollector.collectRaw(request)
+        }
+        return true
+    }
+
+    private fun collectObjectProperty(request: PropertyPlanningRequest) {
+        when (val shape = JacksonWireShapeInspector.inspect(request.type)) {
+            is JsonWireShape.ExpandableObject -> collectNestedObject(request, shape.properties)
+            is JsonWireShape.Opaque -> fallbackCollector.collectRaw(request)
+        }
+    }
+
+    private fun collectScalar(request: PropertyPlanningRequest, scalarMapping: ScalarMapping) {
+        request.draft.columns.add(
+            ColumnPlan(
+                name = request.name,
+                path = request.path,
+                targetName = request.targetName,
+                type = request.type.toScalarType(scalarMapping, request.parent.nullableAncestor),
+                extraction = ColumnExtraction.JsonValue(request.parent.source, request.name),
+                placement = ColumnPlacement.SELECT,
+            )
+        )
+        if (request.type.requiresRawCompanion()) {
+            request.draft.columns.add(rawCompanionColumn(request.toRawColumnRequest()))
+        }
+    }
+
+    private fun collectNestedObject(
+        request: PropertyPlanningRequest,
+        properties: List<ResolvedJsonProperty>,
+    ) {
+        request.draft.columns.add(
+            ColumnPlan(
+                name = request.name,
+                path = request.path,
+                targetName = request.targetName,
+                type = ClickHouseType.String,
+                extraction = ColumnExtraction.JsonRaw(request.parent.source, request.name),
+                placement = ColumnPlacement.WITH,
+            )
+        )
+        if (request.type.requiresRawCompanion()) {
+            request.draft.columns.add(rawCompanionColumn(request.toRawColumnRequest()))
+        }
+        collectResolvedProperties(
+            parent = PlanningNode(
+                path = request.path,
+                pointer = request.parent.pointer +
+                    JsonPointerSegment.Property(encodePointerSegment(request.name)),
+                source = ColumnReference.Alias(request.targetName),
+                targetName = request.targetName,
+                type = request.type,
+                depth = request.parent.depth + 1,
+                nullableAncestor = request.parent.nullableAncestor || request.type.requiresRawCompanion(),
+            ),
+            properties = properties,
+            draft = request.draft,
+        )
+    }
+
+    private fun collectMap(request: PropertyPlanningRequest) {
+        val valueType = request.type.arguments.getOrNull(1)
+        val valueMapping = request.type.supportedMapValueMapping()
+        if (!JacksonWireShapeInspector.matches(request.type, JsonTokenShape.MAP) ||
+            valueType == null ||
+            valueMapping == null
+        ) {
+            fallbackCollector.collectRaw(request)
+            return
+        }
+        request.draft.columns.add(
+            ColumnPlan(
+                name = request.name,
+                path = request.path,
+                targetName = request.targetName,
+                type = ClickHouseType.Map(
+                    keyType = ClickHouseType.String,
+                    valueType = valueType.toScalarType(valueMapping, nullableAncestor = false),
+                ),
+                extraction = ColumnExtraction.JsonValue(request.parent.source, request.name),
+                placement = ColumnPlacement.SELECT,
+            )
+        )
+        if (request.type.requiresRawCompanion()) {
+            request.draft.columns.add(rawCompanionColumn(request.toRawColumnRequest()))
+        }
+    }
+}

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/expansion/plan/StateExpansionTypePolicy.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/expansion/plan/StateExpansionTypePolicy.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi.expansion.plan
+
+import me.ahoo.wow.bi.expansion.type.JacksonWireShapeInspector
+import me.ahoo.wow.bi.expansion.type.JsonWireShape
+import me.ahoo.wow.bi.expansion.type.Nullability
+import me.ahoo.wow.bi.expansion.type.ResolvedType
+import me.ahoo.wow.bi.type.ClickHouseType
+import me.ahoo.wow.bi.type.ClickHouseTypeMapping.scalarMapping
+import me.ahoo.wow.bi.type.JsonTokenShape
+import me.ahoo.wow.bi.type.ScalarMapping
+
+internal fun ResolvedType.canRenderDirectly(): Boolean {
+    if (verifiedScalarMapping() != null) {
+        return true
+    }
+    if (javaType.isMapLikeType) {
+        return JacksonWireShapeInspector.matches(this, JsonTokenShape.MAP) && hasSupportedMapShape()
+    }
+    if (javaType.isCollectionLikeType || javaType.isArrayType) {
+        return JacksonWireShapeInspector.matches(this, JsonTokenShape.ARRAY) &&
+            arguments.firstOrNull()?.verifiedScalarMapping() != null
+    }
+    return false
+}
+
+private fun ResolvedType.hasSupportedMapShape(): Boolean = supportedMapValueMapping() != null
+
+internal fun ResolvedType.supportedMapValueMapping(): ScalarMapping? {
+    val keyType = arguments.getOrNull(0)
+    if (keyType?.rawClass != String::class.java ||
+        keyType.nullability != Nullability.NON_NULL ||
+        keyType.verifiedScalarMapping() == null
+    ) {
+        return null
+    }
+    return arguments.getOrNull(1)?.verifiedScalarMapping()
+}
+
+internal fun ResolvedType.verifiedScalarMapping(): ScalarMapping? {
+    val mapping = rawClass.scalarMapping() ?: return null
+    return mapping.takeIf { JacksonWireShapeInspector.matches(this, it.tokenShape) }
+}
+
+internal fun ResolvedType.toScalarType(
+    mapping: ScalarMapping,
+    nullableAncestor: Boolean,
+): ClickHouseType {
+    val scalar = mapping.clickHouseType
+    return if (requiresRawCompanion() || nullableAncestor) {
+        ClickHouseType.Nullable(scalar)
+    } else {
+        scalar
+    }
+}
+
+internal fun ResolvedType.requiresRawCompanion(): Boolean = nullability != Nullability.NON_NULL
+
+internal fun isUnsupportedPlatformObject(type: ResolvedType): Boolean {
+    val packageName = type.rawClass.packageName
+    return packageName.startsWith("java.") ||
+        packageName.startsWith("javax.") ||
+        packageName.startsWith("kotlin.")
+}
+
+internal fun ResolvedType.isOpaqueCollectionElement(): Boolean {
+    return isUnsupportedPlatformObject(this) || JacksonWireShapeInspector.inspect(this) is JsonWireShape.Opaque
+}

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/expansion/type/JacksonWireShapeInspector.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/expansion/type/JacksonWireShapeInspector.kt
@@ -158,7 +158,7 @@ internal object JacksonWireShapeInspector {
     private data class PropertySignature(val name: String, val type: String)
 
     private class ObjectShapeVisitor : JsonFormatVisitorWrapper.Base() {
-        var properties: MutableList<PropertySignature>? = null
+        var properties: List<PropertySignature>? = null
             private set
 
         override fun expectObjectFormat(type: JavaType): JsonObjectFormatVisitor {

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/expansion/type/JsonPropertyTypeResolver.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/expansion/type/JsonPropertyTypeResolver.kt
@@ -40,6 +40,11 @@ import kotlin.reflect.jvm.javaField
 import kotlin.reflect.jvm.javaGetter
 
 internal object JsonPropertyTypeResolver {
+    private data class JavaTypeResolutionContext(
+        val rootClass: Class<*>,
+        val property: BeanPropertyDefinition,
+    )
+
     fun resolve(type: Class<*>): List<ResolvedJsonProperty> {
         return resolve(JsonSerializer.constructType(type), emptyMap(), emptyMap())
     }
@@ -90,17 +95,23 @@ internal object JsonPropertyTypeResolver {
         val declaringMember = requireNotNull(property.accessor?.member) {
             "Unable to resolve serialization accessor for ${rootClass.name}.${property.name}"
         }
-        val kotlinProperty = rootClass.kotlinProperty(declaringMember)
+        val kotlinProperty = TypeHierarchyResolver.run {
+            rootClass.kotlinProperty(declaringMember)
+        }
         if (kotlinProperty != null) {
-            val typeParameterBindings = findTypeParameterBindings(
-                rootClass = rootClass.kotlin,
-                targetClass = declaringMember.declaringClass.kotlin,
-                rootBindings = kotlinRootBindings,
-            )
-            val shape = kotlinProperty.returnType.toShape(
-                substitutions = typeParameterBindings,
-                declarationOrigin = ResolvedTypeOrigin.KOTLIN,
-            )
+            val typeParameterBindings = KotlinTypeShapeResolver.run {
+                findTypeParameterBindings(
+                    rootClass = rootClass.kotlin,
+                    targetClass = declaringMember.declaringClass.kotlin,
+                    rootBindings = kotlinRootBindings,
+                )
+            }
+            val shape = KotlinTypeShapeResolver.run {
+                kotlinProperty.returnType.toShape(
+                    substitutions = typeParameterBindings,
+                    declarationOrigin = ResolvedTypeOrigin.KOTLIN,
+                )
+            }
             return ResolvedJsonProperty(
                 serializedName = property.name,
                 type = property.primaryType.resolveKotlinType(shape),
@@ -109,340 +120,375 @@ internal object JsonPropertyTypeResolver {
             )
         }
 
-        val javaTypeParameterBindingPaths = findJavaTypeParameterBindings(
-            rootClass = rootClass,
-            targetClass = declaringMember.declaringClass,
-            rootBindings = javaRootBindings,
-        )
+        val javaTypeParameterBindingPaths = TypeHierarchyResolver.run {
+            findJavaTypeParameterBindings(
+                rootClass = rootClass,
+                targetClass = declaringMember.declaringClass,
+                rootBindings = javaRootBindings,
+            )
+        }
         return ResolvedJsonProperty(
             serializedName = property.name,
-            type = resolveJavaType(
-                rootClass = rootClass,
-                property = property,
-                javaType = property.primaryType,
-                evidence = javaTypeParameterBindingPaths.flatMap { bindings ->
-                    property.javaAnnotationEvidence(bindings)
-                } +
-                    declaringMember.inheritedKotlinEvidence(rootClass, kotlinRootBindings) +
-                    declaringMember.inheritedJavaEvidence(rootClass, javaRootBindings),
-                path = property.name,
-            ),
+            type = JavaAnnotationEvidenceResolver.run {
+                resolveJavaType(
+                    context = JavaTypeResolutionContext(rootClass, property),
+                    javaType = property.primaryType,
+                    evidence = javaTypeParameterBindingPaths.flatMap { bindings ->
+                        property.javaAnnotationEvidence(bindings)
+                    } +
+                        TypeHierarchyResolver.run {
+                            declaringMember.inheritedKotlinEvidence(rootClass, kotlinRootBindings)
+                        } +
+                        TypeHierarchyResolver.run {
+                            declaringMember.inheritedJavaEvidence(rootClass, javaRootBindings)
+                        },
+                    path = property.name,
+                )
+            },
             origin = ResolvedTypeOrigin.JAVA,
             declaringMember = declaringMember,
         )
     }
 
-    private fun Class<*>.kotlinProperty(member: Member): KProperty1<*, *>? {
-        if (getDeclaredAnnotation(Metadata::class.java) == null) {
-            return null
-        }
-        return kotlin.memberProperties.firstOrNull { property ->
-            when (member) {
-                is Method -> property.javaGetter == member
-                is Field -> property.javaField == member
-                else -> false
+    private object TypeHierarchyResolver {
+        fun Class<*>.kotlinProperty(member: Member): KProperty1<*, *>? {
+            if (getDeclaredAnnotation(Metadata::class.java) == null) {
+                return null
+            }
+            return kotlin.memberProperties.firstOrNull { property ->
+                when (member) {
+                    is Method -> property.javaGetter == member
+                    is Field -> property.javaField == member
+                    else -> false
+                }
             }
         }
-    }
 
-    private fun Member.inheritedKotlinEvidence(
-        rootClass: Class<*>,
-        rootBindings: Map<KTypeParameter, KotlinTypeShape>,
-    ): List<JavaAnnotationEvidence> {
-        val method = this as? Method ?: return emptyList()
-        val contracts = rootClass.allSupertypes()
-            .mapNotNull { supertype ->
-                val overriddenMethod = supertype.declaredMethods.firstOrNull { candidate ->
-                    candidate.name == method.name &&
-                        candidate.parameterTypes.contentEquals(method.parameterTypes) &&
-                        !candidate.isBridge
-                } ?: return@mapNotNull null
-                val property = supertype.kotlinProperty(overriddenMethod) ?: return@mapNotNull null
-                val bindings = findTypeParameterBindings(
-                    rootClass = rootClass.kotlin,
-                    targetClass = supertype.kotlin,
-                    rootBindings = rootBindings,
-                )
-                InheritedKotlinContract(
-                    declaringClass = supertype,
-                    evidence = property.returnType.toShape(
-                        substitutions = bindings,
-                        declarationOrigin = ResolvedTypeOrigin.KOTLIN,
-                    ).toEvidence(),
-                )
-            }
-        return contracts.filter { candidate ->
-            contracts.none { other ->
-                other !== candidate &&
-                    candidate.declaringClass.isAssignableFrom(other.declaringClass)
-            }
-        }.map(InheritedKotlinContract::evidence)
-    }
-
-    private fun Member.inheritedJavaEvidence(
-        rootClass: Class<*>,
-        rootBindings: Map<TypeVariable<*>, JavaAnnotationEvidence>,
-    ): List<JavaAnnotationEvidence> {
-        val method = this as? Method ?: return emptyList()
-        val contracts = rootClass.allSupertypes()
-            .filter { it.getDeclaredAnnotation(Metadata::class.java) == null }
-            .flatMap { supertype ->
-                val overriddenMethod = supertype.declaredMethods.firstOrNull { candidate ->
-                    candidate.name == method.name &&
-                        candidate.parameterTypes.contentEquals(method.parameterTypes) &&
-                        !candidate.isBridge
-                } ?: return@flatMap emptyList()
-                findJavaTypeParameterBindings(
-                    rootClass = rootClass,
-                    targetClass = supertype,
-                    rootBindings = rootBindings,
-                ).map { bindings ->
-                    InheritedJavaContract(
+        fun Member.inheritedKotlinEvidence(
+            rootClass: Class<*>,
+            rootBindings: Map<KTypeParameter, KotlinTypeShape>,
+        ): List<JavaAnnotationEvidence> {
+            val method = this as? Method ?: return emptyList()
+            val contracts = rootClass.allSupertypes()
+                .mapNotNull { supertype ->
+                    val overriddenMethod = supertype.declaredMethods.firstOrNull { candidate ->
+                        candidate.name == method.name &&
+                            candidate.parameterTypes.contentEquals(method.parameterTypes) &&
+                            !candidate.isBridge
+                    } ?: return@mapNotNull null
+                    val property = supertype.kotlinProperty(overriddenMethod) ?: return@mapNotNull null
+                    val bindings = KotlinTypeShapeResolver.run {
+                        findTypeParameterBindings(
+                            rootClass = rootClass.kotlin,
+                            targetClass = supertype.kotlin,
+                            rootBindings = rootBindings,
+                        )
+                    }
+                    InheritedKotlinContract(
                         declaringClass = supertype,
-                        evidence = overriddenMethod.annotatedReturnType.toEvidence(
-                            declarationAnnotations = overriddenMethod.annotations.asIterable(),
-                            substitutions = bindings,
-                        ),
+                        evidence = KotlinTypeShapeResolver.run {
+                            property.returnType.toShape(
+                                substitutions = bindings,
+                                declarationOrigin = ResolvedTypeOrigin.KOTLIN,
+                            )
+                        }.toEvidence(),
                     )
                 }
-            }
-        return contracts.filter { candidate ->
-            contracts.none { other ->
-                other !== candidate &&
-                    candidate.declaringClass != other.declaringClass &&
-                    candidate.declaringClass.isAssignableFrom(other.declaringClass)
-            }
-        }.map(InheritedJavaContract::evidence)
-    }
-
-    private fun Class<*>.allSupertypes(): List<Class<*>> {
-        val discovered = linkedSetOf<Class<*>>()
-
-        fun visit(type: Class<*>) {
-            type.interfaces.sortedBy(Class<*>::getName).forEach { supertype ->
-                if (discovered.add(supertype)) {
-                    visit(supertype)
+            return contracts.filter { candidate ->
+                contracts.none { other ->
+                    other !== candidate &&
+                        candidate.declaringClass.isAssignableFrom(other.declaringClass)
                 }
-            }
-            type.superclass?.takeIf { it != Any::class.java }?.let { supertype ->
-                if (discovered.add(supertype)) {
-                    visit(supertype)
+            }.map(InheritedKotlinContract::evidence)
+        }
+
+        fun Member.inheritedJavaEvidence(
+            rootClass: Class<*>,
+            rootBindings: Map<TypeVariable<*>, JavaAnnotationEvidence>,
+        ): List<JavaAnnotationEvidence> {
+            val method = this as? Method ?: return emptyList()
+            val contracts = rootClass.allSupertypes()
+                .filter { it.getDeclaredAnnotation(Metadata::class.java) == null }
+                .flatMap { supertype ->
+                    val overriddenMethod = supertype.declaredMethods.firstOrNull { candidate ->
+                        candidate.name == method.name &&
+                            candidate.parameterTypes.contentEquals(method.parameterTypes) &&
+                            !candidate.isBridge
+                    } ?: return@flatMap emptyList()
+                    findJavaTypeParameterBindings(
+                        rootClass = rootClass,
+                        targetClass = supertype,
+                        rootBindings = rootBindings,
+                    ).map { bindings ->
+                        InheritedJavaContract(
+                            declaringClass = supertype,
+                            evidence = JavaAnnotationEvidenceResolver.run {
+                                overriddenMethod.annotatedReturnType.toEvidence(
+                                    declarationAnnotations = overriddenMethod.annotations.asIterable(),
+                                    substitutions = bindings,
+                                )
+                            },
+                        )
+                    }
                 }
-            }
+            return contracts.filter { candidate ->
+                contracts.none { other ->
+                    other !== candidate &&
+                        candidate.declaringClass != other.declaringClass &&
+                        candidate.declaringClass.isAssignableFrom(other.declaringClass)
+                }
+            }.map(InheritedJavaContract::evidence)
         }
 
-        visit(this)
-        return discovered.toList()
-    }
+        private fun Class<*>.allSupertypes(): List<Class<*>> {
+            val discovered = linkedSetOf<Class<*>>()
 
-    private fun findJavaTypeParameterBindings(
-        rootClass: Class<*>,
-        targetClass: Class<*>,
-        rootBindings: Map<TypeVariable<*>, JavaAnnotationEvidence>,
-    ): List<Map<TypeVariable<*>, JavaAnnotationEvidence>> {
-        return findJavaTypeParameterBindings(
-            currentClass = rootClass,
-            currentBindings = rootBindings,
-            targetClass = targetClass,
-            visited = emptySet(),
-        ).ifEmpty { listOf(emptyMap()) }
-    }
-
-    private fun findJavaTypeParameterBindings(
-        currentClass: Class<*>,
-        currentBindings: Map<TypeVariable<*>, JavaAnnotationEvidence>,
-        targetClass: Class<*>,
-        visited: Set<Class<*>>,
-    ): List<Map<TypeVariable<*>, JavaAnnotationEvidence>> {
-        if (currentClass == targetClass) {
-            return listOf(currentBindings)
-        }
-        if (currentClass in visited) {
-            return emptyList()
-        }
-        val currentPath = visited + currentClass
-
-        val supertypes = buildList {
-            addAll(currentClass.annotatedInterfaces)
-            currentClass.annotatedSuperclass?.let { superclass -> add(superclass) }
-        }
-            .mapNotNull { annotatedType ->
-                annotatedType.rawClass()?.let { rawClass -> rawClass to annotatedType }
-            }
-            .filter { (rawClass) -> targetClass.isAssignableFrom(rawClass) }
-            .sortedBy { (rawClass) -> rawClass.name }
-        return supertypes.flatMap { (superClass, annotatedType) ->
-            val annotatedArguments = (annotatedType as? AnnotatedParameterizedType)
-                ?.annotatedActualTypeArguments
-                .orEmpty()
-            val superBindings = buildMap<TypeVariable<*>, JavaAnnotationEvidence> {
-                superClass.typeParameters.forEachIndexed { index, parameter ->
-                    annotatedArguments.getOrNull(index)?.let { argument ->
-                        put(parameter, argument.toEvidence(substitutions = currentBindings))
+            fun visit(type: Class<*>) {
+                type.interfaces.sortedBy(Class<*>::getName).forEach { supertype ->
+                    if (discovered.add(supertype)) {
+                        visit(supertype)
+                    }
+                }
+                type.superclass?.takeIf { it != Any::class.java }?.let { supertype ->
+                    if (discovered.add(supertype)) {
+                        visit(supertype)
                     }
                 }
             }
-            findJavaTypeParameterBindings(
-                currentClass = superClass,
-                currentBindings = superBindings,
+
+            visit(this)
+            return discovered.toList()
+        }
+
+        fun findJavaTypeParameterBindings(
+            rootClass: Class<*>,
+            targetClass: Class<*>,
+            rootBindings: Map<TypeVariable<*>, JavaAnnotationEvidence>,
+        ): List<Map<TypeVariable<*>, JavaAnnotationEvidence>> {
+            return findJavaTypeParameterBindings(
+                currentClass = rootClass,
+                currentBindings = rootBindings,
                 targetClass = targetClass,
-                visited = currentPath,
+                visited = emptySet(),
+            ).ifEmpty { listOf(emptyMap()) }
+        }
+
+        private fun findJavaTypeParameterBindings(
+            currentClass: Class<*>,
+            currentBindings: Map<TypeVariable<*>, JavaAnnotationEvidence>,
+            targetClass: Class<*>,
+            visited: Set<Class<*>>,
+        ): List<Map<TypeVariable<*>, JavaAnnotationEvidence>> {
+            if (currentClass == targetClass) {
+                return listOf(currentBindings)
+            }
+            if (currentClass in visited) {
+                return emptyList()
+            }
+            val currentPath = visited + currentClass
+
+            val supertypes = buildList {
+                addAll(currentClass.annotatedInterfaces)
+                currentClass.annotatedSuperclass?.let { superclass -> add(superclass) }
+            }
+                .mapNotNull { annotatedType ->
+                    annotatedType.rawClass()?.let { rawClass -> rawClass to annotatedType }
+                }
+                .filter { (rawClass) -> targetClass.isAssignableFrom(rawClass) }
+                .sortedBy { (rawClass) -> rawClass.name }
+            return supertypes.flatMap { (superClass, annotatedType) ->
+                val annotatedArguments = (annotatedType as? AnnotatedParameterizedType)
+                    ?.annotatedActualTypeArguments
+                    .orEmpty()
+                val superBindings = buildMap<TypeVariable<*>, JavaAnnotationEvidence> {
+                    superClass.typeParameters.forEachIndexed { index, parameter ->
+                        annotatedArguments.getOrNull(index)?.let { argument ->
+                            put(
+                                parameter,
+                                JavaAnnotationEvidenceResolver.run {
+                                    argument.toEvidence(substitutions = currentBindings)
+                                },
+                            )
+                        }
+                    }
+                }
+                findJavaTypeParameterBindings(
+                    currentClass = superClass,
+                    currentBindings = superBindings,
+                    targetClass = targetClass,
+                    visited = currentPath,
+                )
+            }
+        }
+
+        private fun AnnotatedType.rawClass(): Class<*>? {
+            return when (val reflectedType = type) {
+                is Class<*> -> reflectedType
+                is ParameterizedType -> reflectedType.rawType as? Class<*>
+                else -> null
+            }
+        }
+
+        fun KClass<*>.declarationOrigin(): ResolvedTypeOrigin {
+            return if (java.getDeclaredAnnotation(Metadata::class.java) == null) {
+                ResolvedTypeOrigin.JAVA
+            } else {
+                ResolvedTypeOrigin.KOTLIN
+            }
+        }
+
+        fun KotlinTypeShape.toEvidence(): JavaAnnotationEvidence {
+            return JavaAnnotationEvidence(
+                signals = setOf(nullability),
+                arguments = arguments.map { argument ->
+                    argument?.toEvidence() ?: JavaAnnotationEvidence(emptySet(), emptyList())
+                },
             )
         }
     }
 
-    private fun AnnotatedType.rawClass(): Class<*>? {
-        return when (val reflectedType = type) {
-            is Class<*> -> reflectedType
-            is ParameterizedType -> reflectedType.rawType as? Class<*>
-            else -> null
+    private object KotlinTypeShapeResolver {
+        fun findTypeParameterBindings(
+            rootClass: KClass<*>,
+            targetClass: KClass<*>,
+            rootBindings: Map<KTypeParameter, KotlinTypeShape>,
+        ): Map<KTypeParameter, KotlinTypeShape> {
+            return findTypeParameterBindings(
+                currentClass = rootClass,
+                currentBindings = rootBindings,
+                targetClass = targetClass,
+                visited = mutableSetOf(),
+            ).orEmpty()
         }
-    }
 
-    private fun KClass<*>.declarationOrigin(): ResolvedTypeOrigin {
-        return if (java.getDeclaredAnnotation(Metadata::class.java) == null) {
-            ResolvedTypeOrigin.JAVA
-        } else {
-            ResolvedTypeOrigin.KOTLIN
-        }
-    }
+        private fun findTypeParameterBindings(
+            currentClass: KClass<*>,
+            currentBindings: Map<KTypeParameter, KotlinTypeShape>,
+            targetClass: KClass<*>,
+            visited: MutableSet<KClass<*>>,
+        ): Map<KTypeParameter, KotlinTypeShape>? {
+            if (currentClass == targetClass) {
+                return currentBindings
+            }
+            if (!visited.add(currentClass)) {
+                return null
+            }
 
-    private fun findTypeParameterBindings(
-        rootClass: KClass<*>,
-        targetClass: KClass<*>,
-        rootBindings: Map<KTypeParameter, KotlinTypeShape>,
-    ): Map<KTypeParameter, KotlinTypeShape> {
-        return findTypeParameterBindings(
-            currentClass = rootClass,
-            currentBindings = rootBindings,
-            targetClass = targetClass,
-            visited = mutableSetOf(),
-        ).orEmpty()
-    }
-
-    private fun findTypeParameterBindings(
-        currentClass: KClass<*>,
-        currentBindings: Map<KTypeParameter, KotlinTypeShape>,
-        targetClass: KClass<*>,
-        visited: MutableSet<KClass<*>>,
-    ): Map<KTypeParameter, KotlinTypeShape>? {
-        if (currentClass == targetClass) {
-            return currentBindings
-        }
-        if (!visited.add(currentClass)) {
+            currentClass.supertypes.forEach { supertype ->
+                val superClass = supertype.classifier as? KClass<*> ?: return@forEach
+                val superBindings = superClass.typeParameters.mapIndexedNotNull { index, parameter ->
+                    val argument = supertype.arguments.getOrNull(index)?.type ?: return@mapIndexedNotNull null
+                    parameter to argument.toShape(
+                        substitutions = currentBindings,
+                        declarationOrigin = TypeHierarchyResolver.run { currentClass.declarationOrigin() },
+                    )
+                }.toMap()
+                findTypeParameterBindings(
+                    currentClass = superClass,
+                    currentBindings = superBindings,
+                    targetClass = targetClass,
+                    visited = visited,
+                )?.let { return it }
+            }
             return null
         }
 
-        currentClass.supertypes.forEach { supertype ->
-            val superClass = supertype.classifier as? KClass<*> ?: return@forEach
-            val superBindings = superClass.typeParameters.mapIndexedNotNull { index, parameter ->
-                val argument = supertype.arguments.getOrNull(index)?.type ?: return@mapIndexedNotNull null
-                parameter to argument.toShape(
-                    substitutions = currentBindings,
-                    declarationOrigin = currentClass.declarationOrigin(),
-                )
-            }.toMap()
-            findTypeParameterBindings(
-                currentClass = superClass,
-                currentBindings = superBindings,
-                targetClass = targetClass,
-                visited = visited,
-            )?.let { return it }
-        }
-        return null
-    }
-
-    private fun KType.toShape(
-        substitutions: Map<KTypeParameter, KotlinTypeShape>,
-        declarationOrigin: ResolvedTypeOrigin,
-    ): KotlinTypeShape {
-        val typeParameter = classifier as? KTypeParameter
-        if (typeParameter != null) {
-            val useSiteNullability = explicitNullability()
-            val substituted = substitutions[typeParameter]
-            if (substituted != null) {
-                return substituted.copy(
-                    nullability = combineNullability(
-                        substituted.nullability,
-                        useSiteNullability,
+        fun KType.toShape(
+            substitutions: Map<KTypeParameter, KotlinTypeShape>,
+            declarationOrigin: ResolvedTypeOrigin,
+        ): KotlinTypeShape {
+            val typeParameter = classifier as? KTypeParameter
+            if (typeParameter != null) {
+                val useSiteNullability = explicitNullability()
+                val substituted = substitutions[typeParameter]
+                if (substituted != null) {
+                    return substituted.copy(
+                        nullability = combineNullability(
+                            substituted.nullability,
+                            useSiteNullability,
+                        )
                     )
+                }
+                return KotlinTypeShape(
+                    nullability = useSiteNullability,
+                    arguments = emptyList(),
                 )
             }
+            val declaredArguments = arguments.map { projection ->
+                projection.type?.toShape(substitutions, declarationOrigin)
+            }
             return KotlinTypeShape(
-                nullability = useSiteNullability,
-                arguments = emptyList(),
+                nullability = concreteNullability(declarationOrigin),
+                arguments = semanticContainerArguments(declaredArguments) ?: declaredArguments,
             )
         }
-        val declaredArguments = arguments.map { projection ->
-            projection.type?.toShape(substitutions, declarationOrigin)
-        }
-        return KotlinTypeShape(
-            nullability = concreteNullability(declarationOrigin),
-            arguments = semanticContainerArguments(declaredArguments) ?: declaredArguments,
-        )
-    }
 
-    private fun KType.concreteNullability(declarationOrigin: ResolvedTypeOrigin): Nullability {
-        val explicitNullability = explicitNullability()
-        if (explicitNullability != Nullability.UNKNOWN) {
-            return explicitNullability
+        private fun KType.concreteNullability(declarationOrigin: ResolvedTypeOrigin): Nullability {
+            val explicitNullability = explicitNullability()
+            if (explicitNullability != Nullability.UNKNOWN) {
+                return explicitNullability
+            }
+            val rawClass = classifier as? KClass<*>
+            return if (rawClass?.java?.isPrimitive == true || declarationOrigin == ResolvedTypeOrigin.KOTLIN) {
+                Nullability.NON_NULL
+            } else {
+                Nullability.UNKNOWN
+            }
         }
-        val rawClass = classifier as? KClass<*>
-        return if (rawClass?.java?.isPrimitive == true || declarationOrigin == ResolvedTypeOrigin.KOTLIN) {
-            Nullability.NON_NULL
-        } else {
-            Nullability.UNKNOWN
-        }
-    }
 
-    private fun KType.explicitNullability(): Nullability {
-        val signals = annotations.mapNotNull { it.toNullability() }.toMutableSet()
-        if (isMarkedNullable) {
-            signals.add(Nullability.NULLABLE)
+        private fun KType.explicitNullability(): Nullability {
+            val signals = annotations.mapNotNull { annotation ->
+                JavaAnnotationEvidenceResolver.run { annotation.toNullability() }
+            }.toMutableSet()
+            if (isMarkedNullable) {
+                signals.add(Nullability.NULLABLE)
+            }
+            require(!(signals.contains(Nullability.NULLABLE) && signals.contains(Nullability.NON_NULL))) {
+                "Conflicting nullability annotations on generic type [$this]."
+            }
+            return when {
+                signals.contains(Nullability.NULLABLE) -> Nullability.NULLABLE
+                signals.contains(Nullability.NON_NULL) -> Nullability.NON_NULL
+                else -> Nullability.UNKNOWN
+            }
         }
-        require(!(signals.contains(Nullability.NULLABLE) && signals.contains(Nullability.NON_NULL))) {
-            "Conflicting nullability annotations on generic type [$this]."
-        }
-        return when {
-            signals.contains(Nullability.NULLABLE) -> Nullability.NULLABLE
-            signals.contains(Nullability.NON_NULL) -> Nullability.NON_NULL
-            else -> Nullability.UNKNOWN
-        }
-    }
 
-    private fun KType.semanticContainerArguments(
-        declaredArguments: List<KotlinTypeShape?>,
-    ): List<KotlinTypeShape?>? {
-        val rawClass = classifier as? KClass<*> ?: return null
-        val semanticClass = when {
-            Map::class.java.isAssignableFrom(rawClass.java) -> Map::class
-            Collection::class.java.isAssignableFrom(rawClass.java) -> Collection::class
-            else -> return null
+        private fun KType.semanticContainerArguments(
+            declaredArguments: List<KotlinTypeShape?>,
+        ): List<KotlinTypeShape?>? {
+            val rawClass = classifier as? KClass<*> ?: return null
+            val semanticClass = when {
+                Map::class.java.isAssignableFrom(rawClass.java) -> Map::class
+                Collection::class.java.isAssignableFrom(rawClass.java) -> Collection::class
+                else -> return null
+            }
+            val declaredBindings = rawClass.typeParameters.mapIndexedNotNull { index, parameter ->
+                declaredArguments.getOrNull(index)?.let { argument -> parameter to argument }
+            }.toMap()
+            val semanticBindings = findTypeParameterBindings(
+                rootClass = rawClass,
+                targetClass = semanticClass,
+                rootBindings = declaredBindings,
+            )
+            return semanticClass.typeParameters.map(semanticBindings::get)
         }
-        val declaredBindings = rawClass.typeParameters.mapIndexedNotNull { index, parameter ->
-            declaredArguments.getOrNull(index)?.let { argument -> parameter to argument }
-        }.toMap()
-        val semanticBindings = findTypeParameterBindings(
-            rootClass = rawClass,
-            targetClass = semanticClass,
-            rootBindings = declaredBindings,
-        )
-        return semanticClass.typeParameters.map(semanticBindings::get)
+
+        private fun combineNullability(
+            first: Nullability,
+            second: Nullability,
+        ): Nullability {
+            return when {
+                first == Nullability.NULLABLE || second == Nullability.NULLABLE -> Nullability.NULLABLE
+                first == Nullability.NON_NULL || second == Nullability.NON_NULL -> Nullability.NON_NULL
+                else -> Nullability.UNKNOWN
+            }
+        }
     }
 
     private fun ResolvedType.toShape(): KotlinTypeShape {
         return KotlinTypeShape(
             nullability = nullability,
             arguments = arguments.map { argument -> argument.toShape() },
-        )
-    }
-
-    private fun KotlinTypeShape.toEvidence(): JavaAnnotationEvidence {
-        return JavaAnnotationEvidence(
-            signals = setOf(nullability),
-            arguments = arguments.map { argument ->
-                argument?.toEvidence() ?: JavaAnnotationEvidence(emptySet(), emptyList())
-            },
         )
     }
 
@@ -454,7 +500,7 @@ internal object JsonPropertyTypeResolver {
     }
 
     private fun JavaType.resolveKotlinType(shape: KotlinTypeShape?): ResolvedType {
-        val argumentTypes = argumentTypes()
+        val argumentTypes = JavaAnnotationEvidenceResolver.run { argumentTypes() }
         return ResolvedType(
             javaType = this,
             nullability = if (isPrimitive) Nullability.NON_NULL else shape?.nullability ?: Nullability.UNKNOWN,
@@ -464,155 +510,144 @@ internal object JsonPropertyTypeResolver {
         )
     }
 
-    private fun resolveJavaType(
-        rootClass: Class<*>,
-        property: BeanPropertyDefinition,
-        javaType: JavaType,
-        evidence: List<JavaAnnotationEvidence>,
-        path: String,
-    ): ResolvedType {
-        val signals = evidence.flatMapTo(mutableSetOf()) { it.signals }
-        if (javaType.isPrimitive) {
-            signals.add(Nullability.NON_NULL)
+    private object JavaAnnotationEvidenceResolver {
+        fun resolveJavaType(
+            context: JavaTypeResolutionContext,
+            javaType: JavaType,
+            evidence: List<JavaAnnotationEvidence>,
+            path: String,
+        ): ResolvedType = with(context) {
+            val signals = evidence.flatMapTo(mutableSetOf()) { it.signals }
+            if (javaType.isPrimitive) {
+                signals.add(Nullability.NON_NULL)
+            }
+            require(!(signals.contains(Nullability.NULLABLE) && signals.contains(Nullability.NON_NULL))) {
+                "Conflicting nullability annotations for ${rootClass.name}.${property.name} at $path"
+            }
+            val nullability = when {
+                signals.contains(Nullability.NULLABLE) -> Nullability.NULLABLE
+                signals.contains(Nullability.NON_NULL) -> Nullability.NON_NULL
+                else -> Nullability.UNKNOWN
+            }
+            return ResolvedType(
+                javaType = javaType,
+                nullability = nullability,
+                arguments = javaType.argumentTypes().mapIndexed { index, argumentType ->
+                    resolveJavaType(
+                        context = context,
+                        javaType = argumentType,
+                        evidence = evidence.mapNotNull { it.arguments.getOrNull(index) },
+                        path = "$path[$index]",
+                    )
+                },
+            )
         }
-        require(!(signals.contains(Nullability.NULLABLE) && signals.contains(Nullability.NON_NULL))) {
-            "Conflicting nullability annotations for ${rootClass.name}.${property.name} at $path"
-        }
-        val nullability = when {
-            signals.contains(Nullability.NULLABLE) -> Nullability.NULLABLE
-            signals.contains(Nullability.NON_NULL) -> Nullability.NON_NULL
-            else -> Nullability.UNKNOWN
-        }
-        return ResolvedType(
-            javaType = javaType,
-            nullability = nullability,
-            arguments = javaType.argumentTypes().mapIndexed { index, argumentType ->
-                resolveJavaType(
-                    rootClass = rootClass,
-                    property = property,
-                    javaType = argumentType,
-                    evidence = evidence.mapNotNull { it.arguments.getOrNull(index) },
-                    path = "$path[$index]",
-                )
-            },
-        )
-    }
 
-    private fun BeanPropertyDefinition.javaAnnotationEvidence(
-        substitutions: Map<TypeVariable<*>, JavaAnnotationEvidence>,
-    ): List<JavaAnnotationEvidence> {
-        return buildList {
-            getter?.annotated?.let { method ->
-                add(
-                    method.annotatedReturnType.toEvidence(
-                        declarationAnnotations = method.annotations.asIterable(),
-                        substitutions = substitutions,
-                    )
-                )
-            }
-            field?.annotated?.let { field ->
-                add(
-                    field.annotatedType.toEvidence(
-                        declarationAnnotations = field.annotations.asIterable(),
-                        substitutions = substitutions,
-                    )
-                )
-            }
-            constructorParameters.forEachRemaining { parameter ->
-                parameter.reflectionParameter()?.let { reflectionParameter ->
+        fun BeanPropertyDefinition.javaAnnotationEvidence(
+            substitutions: Map<TypeVariable<*>, JavaAnnotationEvidence>,
+        ): List<JavaAnnotationEvidence> {
+            return buildList {
+                getter?.annotated?.let { method ->
                     add(
-                        reflectionParameter.annotatedType.toEvidence(
-                            declarationAnnotations = reflectionParameter.annotations.asIterable(),
+                        method.annotatedReturnType.toEvidence(
+                            declarationAnnotations = method.annotations.asIterable(),
+                            substitutions = substitutions,
+                        )
+                    )
+                }
+                field?.annotated?.let { field ->
+                    add(
+                        field.annotatedType.toEvidence(
+                            declarationAnnotations = field.annotations.asIterable(),
+                            substitutions = substitutions,
+                        )
+                    )
+                }
+                constructorParameters.forEachRemaining { parameter ->
+                    parameter.reflectionParameter()?.let { reflectionParameter ->
+                        add(
+                            reflectionParameter.annotatedType.toEvidence(
+                                declarationAnnotations = reflectionParameter.annotations.asIterable(),
+                                substitutions = substitutions,
+                            )
+                        )
+                    }
+                }
+                recordComponent()?.let { component ->
+                    add(
+                        component.annotatedType.toEvidence(
+                            declarationAnnotations = component.annotations.asIterable(),
                             substitutions = substitutions,
                         )
                     )
                 }
             }
-            recordComponent()?.let { component ->
-                add(
-                    component.annotatedType.toEvidence(
-                        declarationAnnotations = component.annotations.asIterable(),
-                        substitutions = substitutions,
-                    )
+        }
+
+        private fun BeanPropertyDefinition.recordComponent(): RecordComponent? {
+            val member = accessor?.member ?: return null
+            val declaringClass = member.declaringClass
+            if (!declaringClass.isRecord) {
+                return null
+            }
+            return declaringClass.recordComponents.firstOrNull { component ->
+                when (member) {
+                    is Method -> component.accessor == member
+                    is Field -> component.name == member.name
+                    else -> false
+                }
+            }
+        }
+
+        private fun AnnotatedParameter.reflectionParameter(): Parameter? {
+            return (owner.member as? Executable)?.parameters?.getOrNull(index)
+        }
+
+        fun AnnotatedType.toEvidence(
+            declarationAnnotations: Iterable<Annotation> = emptyList(),
+            substitutions: Map<TypeVariable<*>, JavaAnnotationEvidence> = emptyMap(),
+        ): JavaAnnotationEvidence {
+            val signals = (declarationAnnotations + annotations.asIterable())
+                .mapNotNull { it.toNullability() }
+                .toSet()
+            val substituted = (type as? TypeVariable<*>)?.let(substitutions::get)
+            if (substituted != null) {
+                return JavaAnnotationEvidence(
+                    signals = signals.ifEmpty { substituted.signals },
+                    arguments = substituted.arguments,
                 )
             }
+            val arguments = when (this) {
+                is AnnotatedParameterizedType -> annotatedActualTypeArguments.map {
+                    it.toEvidence(substitutions = substitutions)
+                }
+                is AnnotatedArrayType -> listOf(
+                    annotatedGenericComponentType.toEvidence(substitutions = substitutions)
+                )
+                else -> emptyList()
+            }
+            return JavaAnnotationEvidence(signals = signals, arguments = arguments)
         }
-    }
 
-    private fun BeanPropertyDefinition.recordComponent(): RecordComponent? {
-        val member = accessor?.member ?: return null
-        val declaringClass = member.declaringClass
-        if (!declaringClass.isRecord) {
-            return null
-        }
-        return declaringClass.recordComponents.firstOrNull { component ->
-            when (member) {
-                is Method -> component.accessor == member
-                is Field -> component.name == member.name
-                else -> false
+        fun Annotation.toNullability(): Nullability? {
+            return when (annotationClass.java.simpleName) {
+                "Nullable", "CheckForNull" -> Nullability.NULLABLE
+                "NotNull", "NonNull" -> Nullability.NON_NULL
+                else -> null
             }
         }
-    }
 
-    private fun AnnotatedParameter.reflectionParameter(): Parameter? {
-        return (owner.member as? Executable)?.parameters?.getOrNull(index)
-    }
-
-    private fun AnnotatedType.toEvidence(
-        declarationAnnotations: Iterable<Annotation> = emptyList(),
-        substitutions: Map<TypeVariable<*>, JavaAnnotationEvidence> = emptyMap(),
-    ): JavaAnnotationEvidence {
-        val signals = (declarationAnnotations + annotations.asIterable())
-            .mapNotNull { it.toNullability() }
-            .toSet()
-        val substituted = (type as? TypeVariable<*>)?.let(substitutions::get)
-        if (substituted != null) {
-            return JavaAnnotationEvidence(
-                signals = signals.ifEmpty { substituted.signals },
-                arguments = substituted.arguments,
-            )
-        }
-        val arguments = when (this) {
-            is AnnotatedParameterizedType -> annotatedActualTypeArguments.map {
-                it.toEvidence(substitutions = substitutions)
+        fun JavaType.argumentTypes(): List<JavaType> {
+            if (isArrayType) {
+                return listOf(contentType)
             }
-            is AnnotatedArrayType -> listOf(
-                annotatedGenericComponentType.toEvidence(substitutions = substitutions)
-            )
-            else -> emptyList()
-        }
-        return JavaAnnotationEvidence(signals = signals, arguments = arguments)
-    }
-
-    private fun Annotation.toNullability(): Nullability? {
-        return when (annotationClass.java.simpleName) {
-            "Nullable", "CheckForNull" -> Nullability.NULLABLE
-            "NotNull", "NonNull" -> Nullability.NON_NULL
-            else -> null
-        }
-    }
-
-    private fun JavaType.argumentTypes(): List<JavaType> {
-        if (isArrayType) {
-            return listOf(contentType)
-        }
-        if (isMapLikeType) {
-            return listOfNotNull(keyType, contentType)
-        }
-        if (isCollectionLikeType) {
-            return listOfNotNull(contentType)
-        }
-        return (0 until containedTypeCount()).mapNotNull(::containedType)
-    }
-
-    private fun combineNullability(
-        first: Nullability,
-        second: Nullability,
-    ): Nullability {
-        return when {
-            first == Nullability.NULLABLE || second == Nullability.NULLABLE -> Nullability.NULLABLE
-            first == Nullability.NON_NULL || second == Nullability.NON_NULL -> Nullability.NON_NULL
-            else -> Nullability.UNKNOWN
+            if (isMapLikeType) {
+                return listOfNotNull(keyType, contentType)
+            }
+            if (isCollectionLikeType) {
+                return listOfNotNull(contentType)
+            }
+            return (0 until containedTypeCount()).mapNotNull(::containedType)
         }
     }
 

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseCommandRenderer.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseCommandRenderer.kt
@@ -1,0 +1,175 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi.renderer
+
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.bi.BiObjectKey
+import me.ahoo.wow.bi.BiObjectKind
+import me.ahoo.wow.bi.ExpectedBiQuery
+import me.ahoo.wow.modeling.toStringWithAlias
+
+internal class ClickHouseCommandRenderer(private val context: ClickHouseRenderContext) {
+    fun expectedQueries(namedAggregate: NamedAggregate): Map<BiObjectKey, ExpectedBiQuery> = with(context) {
+        val table = naming.toTableName(namedAggregate, ClickHouseScriptRenderer.COMMAND_SUFFIX)
+        val storeTable = storageTable(table)
+        val queueTable = "${table}_queue"
+        mapOf(
+            BiObjectKey(options.consumerDatabase, "${table}_consumer") to ExpectedBiQuery(
+                selectSql = renderConsumerSelect(queueTable),
+                target = BiObjectKey(options.database, storeTable),
+            ),
+            BiObjectKey(options.database, table) to ExpectedBiQuery(renderPublicViewSelect(storeTable)),
+        )
+    }
+
+    fun render(namedAggregate: NamedAggregate): ClickHouseStreamRenderPlan = with(context) {
+        val aggregate = namedAggregate.toStringWithAlias()
+        val table = naming.toTableName(namedAggregate, ClickHouseScriptRenderer.COMMAND_SUFFIX)
+        val storeTable = storageTable(table)
+        val physicalTable = topology.physicalTableName(storeTable)
+        val queueTable = "${table}_queue"
+        val consumerTable = "${table}_consumer"
+        val topic = naming.toTopicName(namedAggregate, ClickHouseScriptRenderer.COMMAND_SUFFIX)
+        val storeComment = metadataComment(BiObjectKind.STORE, aggregate)
+        val viewComment = metadataComment(BiObjectKind.VIEW, aggregate)
+        val queueComment = metadataComment(BiObjectKind.QUEUE, aggregate)
+        val consumerComment = metadataComment(BiObjectKind.CONSUMER, aggregate)
+        ClickHouseStreamRenderPlan(
+            storage = immutableStatements(
+                buildList {
+                    add(renderStore(physicalTable, storeComment))
+                    topology.distributedFacade(
+                        DistributedFacadeSpec(
+                            database = options.database,
+                            logicalTableName = storeTable,
+                            physicalTableName = physicalTable,
+                            shardingKey = "sipHash64(${identifier("aggregate_id")})",
+                            createIfNotExists = catalogMutationMode == CatalogMutationMode.RECONCILE,
+                        )
+                    )?.withTableComment(storeComment)?.let(::add)
+                }
+            ),
+            ingress = immutableStatements(
+                buildList {
+                    if (catalogMutationMode == CatalogMutationMode.RECONCILE) {
+                        add(dropView(options.consumerDatabase, consumerTable))
+                    }
+                    if (!isQueueRetained(queueTable)) {
+                        add(renderQueue(queueTable, topic, consumerTable, queueComment))
+                    }
+                    add(renderConsumer(consumerTable, storeTable, queueTable, consumerComment))
+                }
+            ),
+            publicViews = immutableStatements(
+                listOf(renderPublicView(table, storeTable, viewComment))
+            ),
+        )
+    }
+
+    private fun renderStore(physicalTable: String, comment: String): String = with(context) {
+        """
+            $tableCreateClause ${qualified(options.database, physicalTable)}${scopeClause()}
+            (
+                ${identifier("id")} String,
+                ${identifier("context_name")} String,
+                ${identifier("aggregate_name")} String,
+                ${identifier("name")} String,
+                ${identifier("header")} Map(String, String),
+                ${identifier("aggregate_id")} String,
+                ${identifier("tenant_id")} String,
+                ${identifier("owner_id")} String,
+                ${identifier("space_id")} String,
+                ${identifier("request_id")} String,
+                ${identifier("aggregate_version")} Nullable(UInt32),
+                ${identifier("is_create")} Bool,
+                ${identifier("is_void")} Bool,
+                ${identifier("allow_create")} Bool,
+                ${identifier("body_type")} String,
+                ${identifier("body")} String,
+                ${identifier("create_time")} DateTime64(3, ${literal(options.timezone)})
+            ) ${topology.engineSql(ReplacingMergeTreeSpec(null))}
+              PARTITION BY toYYYYMM(${identifier("create_time")})
+              ORDER BY ${identifier("id")}
+              COMMENT $comment;
+        """.trimIndent()
+    }
+
+    private fun renderQueue(
+        queueTable: String,
+        topic: String,
+        consumerTable: String,
+        comment: String,
+    ): String = with(context) {
+        """
+            CREATE TABLE ${qualified(options.consumerDatabase, queueTable)}${scopeClause()}
+            (${identifier("data")} String)
+            ENGINE = Kafka(${literal(options.kafkaBootstrapServers)}, ${literal(topic)},
+                           ${literal(consumerGroup(consumerTable))}, ${literal("JSONAsString")})
+            ${kafkaSettings(queueTable, comment)};
+        """.trimIndent()
+    }
+
+    private fun renderConsumer(
+        consumerTable: String,
+        storeTable: String,
+        queueTable: String,
+        comment: String,
+    ): String = with(context) {
+        buildString {
+            appendLine(
+                "$materializedViewCreateClause ${qualified(options.consumerDatabase, consumerTable)}${scopeClause()}"
+            )
+            appendLine("TO ${qualified(options.database, storeTable)}")
+            appendLine("AS (")
+            appendLine(renderConsumerSelect(queueTable))
+            append(") COMMENT $comment;")
+        }
+    }
+
+    private fun renderConsumerSelect(queueTable: String): String = with(context) {
+        val aggregateVersionJson = jsonValue("data", "aggregateVersion", "Nullable(UInt32)")
+        """
+            SELECT ${jsonString("data", "id")} AS ${identifier("id")},
+                   ${jsonString("data", "contextName")} AS ${identifier("context_name")},
+                   ${jsonString("data", "aggregateName")} AS ${identifier("aggregate_name")},
+                   ${jsonString("data", "name")} AS ${identifier("name")},
+                   ${jsonValue("data", "header", "Map(String, String)")} AS ${identifier("header")},
+                   ${jsonString("data", "aggregateId")} AS ${identifier("aggregate_id")},
+                   ${jsonString("data", "tenantId")} AS ${identifier("tenant_id")},
+                   ${jsonString("data", "ownerId")} AS ${identifier("owner_id")},
+                   ${jsonString("data", "spaceId")} AS ${identifier("space_id")},
+                   ${jsonString("data", "requestId")} AS ${identifier("request_id")},
+                   $aggregateVersionJson AS ${identifier("aggregate_version")},
+                   ${jsonBool("data", "isCreate")} AS ${identifier("is_create")},
+                   ${jsonBool("data", "isVoid")} AS ${identifier("is_void")},
+                   ${jsonBool("data", "allowCreate")} AS ${identifier("allow_create")},
+                   ${jsonString("data", "bodyType")} AS ${identifier("body_type")},
+                   ${jsonTopLevelLexicalRaw("data", "body")} AS ${identifier("body")},
+                   ${epochMillis("data", "createTime")} AS ${identifier("create_time")}
+            FROM ${qualified(options.consumerDatabase, queueTable)}
+        """.trimIndent()
+    }
+
+    private fun renderPublicView(table: String, storeTable: String, comment: String): String = with(context) {
+        """
+            $viewCreateClause ${qualified(options.database, table)}${scopeClause()}
+            AS (${renderPublicViewSelect(storeTable)})
+            COMMENT $comment;
+        """.trimIndent()
+    }
+
+    private fun renderPublicViewSelect(storeTable: String): String = with(context) {
+        "SELECT * FROM ${qualified(options.database, storeTable)} FINAL"
+    }
+}

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseExpansionRenderer.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseExpansionRenderer.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi.renderer
+
+import me.ahoo.wow.bi.BiObjectKey
+import me.ahoo.wow.bi.BiObjectKind
+import me.ahoo.wow.bi.ExpectedBiQuery
+import me.ahoo.wow.bi.expansion.plan.CollectionCursorPlan
+import me.ahoo.wow.bi.expansion.plan.ColumnExtraction
+import me.ahoo.wow.bi.expansion.plan.ColumnPlacement
+import me.ahoo.wow.bi.expansion.plan.ColumnPlan
+import me.ahoo.wow.bi.expansion.plan.ColumnReference
+import me.ahoo.wow.bi.expansion.plan.ExpansionViewPlan
+import me.ahoo.wow.bi.expansion.plan.JsonPointerSegment
+import me.ahoo.wow.bi.expansion.plan.StateExpansionPlan
+
+/** Keeps emitted DDL and drift-manifest SQL on the same SELECT builder. */
+@Suppress("TooManyFunctions")
+internal class ClickHouseExpansionRenderer(private val context: ClickHouseRenderContext) {
+    fun expectedQueries(plan: StateExpansionPlan): Map<BiObjectKey, ExpectedBiQuery> = with(context) {
+        plan.views.associate { view ->
+            BiObjectKey(options.database, view.targetTableName) to ExpectedBiQuery(renderSelect(view))
+        }
+    }
+
+    fun render(plan: StateExpansionPlan, aggregate: String): List<String> =
+        immutableStatements(plan.views.map { view -> renderView(view, aggregate) })
+
+    private fun renderView(view: ExpansionViewPlan, aggregate: String): String = with(context) {
+        buildString {
+            appendLine(
+                "$viewCreateClause ${qualified(options.database, view.targetTableName)}${scopeClause()} AS ("
+            )
+            appendLine(renderSelect(view))
+            append(") COMMENT ${metadataComment(BiObjectKind.VIEW, aggregate)};")
+        }
+    }
+
+    private fun renderSelect(view: ExpansionViewPlan): String = with(context) {
+        val domainWithColumns = view.columns
+            .filter { it.placement == ColumnPlacement.WITH }
+            .map(::renderColumn)
+        val withSql = (view.recovery.cursors.flatMap(::renderCursor) + domainWithColumns)
+            .joinToString(",\n")
+        val domainSelectColumns = view.columns
+            .filter { it.placement == ColumnPlacement.SELECT }
+            .map(::renderColumn)
+        val selectSql = (domainSelectColumns + renderRecovery(view) + metadataColumns.map(::renderColumn))
+            .joinToString(",\n")
+        buildString {
+            if (withSql.isNotBlank()) {
+                appendLine("WITH")
+                appendLine(withSql)
+            }
+            appendLine("SELECT")
+            appendLine(selectSql)
+            append(
+                "FROM ${qualified(options.database, view.sourceTableName)} AS " +
+                    identifier(ClickHouseScriptRenderer.SOURCE_ALIAS)
+            )
+        }
+    }
+
+    private fun renderColumn(column: ColumnPlan): String =
+        "${renderExtraction(column)} AS ${identifier(column.targetName)}"
+
+    private fun renderCursor(cursor: CollectionCursorPlan): List<String> {
+        val elements = jsonArray(cursor.source, cursor.property)
+        return listOf(
+            "arrayJoin(arrayZip(arrayEnumerate($elements),\n" +
+                "                   $elements)) AS ${renderReference(cursor.cursor)}",
+            "tupleElement(${renderReference(cursor.cursor)}, 2) AS ${renderReference(cursor.element)}",
+        )
+    }
+
+    private fun renderRecovery(view: ExpansionViewPlan): List<String> = buildList {
+        add(
+            "${renderReference(ColumnReference.Input(ClickHouseScriptRenderer.STATE_COLUMN))} AS " +
+                identifier(ClickHouseScriptRenderer.STATE_TARGET)
+        )
+        view.recovery.currentIndex?.let { currentIndex ->
+            add(
+                "toUInt64(${renderZeroBasedIndex(currentIndex)}) AS " +
+                    identifier(ClickHouseScriptRenderer.INDEX_TARGET)
+            )
+        }
+        add("${renderPointer(view.recovery.pointer)} AS ${identifier(ClickHouseScriptRenderer.PATH_TARGET)}")
+    }
+
+    private fun renderPointer(pointer: List<JsonPointerSegment>): String {
+        if (pointer.isEmpty()) {
+            return literal("")
+        }
+        val expressions = pointer.mapIndexed { index, segment ->
+            when (segment) {
+                is JsonPointerSegment.Property -> {
+                    val indexSuffix = if (pointer.getOrNull(index + 1) is JsonPointerSegment.Index) "/" else ""
+                    literal("/${segment.encoded}$indexSuffix")
+                }
+
+                is JsonPointerSegment.Index -> "toString(${renderZeroBasedIndex(segment.reference)})"
+            }
+        }
+        return "concat(${expressions.joinToString(", ")})"
+    }
+
+    private fun renderZeroBasedIndex(reference: ColumnReference): String =
+        "tupleElement(${renderReference(reference)}, 1) - 1"
+
+    private fun renderExtraction(column: ColumnPlan): String = when (val extraction = column.extraction) {
+        is ColumnExtraction.Reference -> renderReference(extraction.source)
+        is ColumnExtraction.JsonValue -> jsonValue(extraction.source, extraction.property, column.type.toSql())
+        is ColumnExtraction.JsonString -> jsonString(extraction.source, extraction.property)
+        is ColumnExtraction.JsonRaw -> jsonRaw(extraction.source, extraction.property)
+        is ColumnExtraction.JsonArray -> jsonArray(extraction.source, extraction.property)
+    }
+}

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseJsonExpressions.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseJsonExpressions.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi.renderer
+
+import me.ahoo.wow.bi.expansion.plan.ColumnReference
+
+internal fun jsonValue(source: String, property: String, sqlType: String): String =
+    "JSONExtract(${identifier(source)}, ${literal(property)}, ${literal(sqlType)})"
+
+internal fun jsonValue(source: ColumnReference, property: String, sqlType: String): String =
+    "JSONExtract(${renderReference(source)}, ${literal(property)}, ${literal(sqlType)})"
+
+internal fun jsonString(source: String, property: String): String =
+    "JSONExtractString(${identifier(source)}, ${literal(property)})"
+
+internal fun jsonString(source: ColumnReference, property: String): String =
+    "JSONExtractString(${renderReference(source)}, ${literal(property)})"
+
+internal fun jsonRaw(source: String, property: String): String =
+    "JSONExtractRaw(${identifier(source)}, ${literal(property)})"
+
+internal fun jsonRaw(source: ColumnReference, property: String): String =
+    "JSONExtractRaw(${renderReference(source)}, ${literal(property)})"
+
+internal fun jsonArray(source: String, property: String): String =
+    "JSONExtractArrayRaw(${identifier(source)}, ${literal(property)})"
+
+internal fun jsonArray(source: ColumnReference, property: String): String =
+    "JSONExtractArrayRaw(${renderReference(source)}, ${literal(property)})"
+
+internal fun renderReference(reference: ColumnReference): String = when (reference) {
+    is ColumnReference.Input ->
+        "${identifier(ClickHouseScriptRenderer.SOURCE_ALIAS)}.${identifier(reference.name)}"
+    is ColumnReference.Alias -> identifier(reference.name)
+}

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseLifecycleRenderer.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseLifecycleRenderer.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi.renderer
+
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.bi.BiDeploymentPhase
+import me.ahoo.wow.bi.BiObjectKind
+import me.ahoo.wow.bi.ObservedBiObject
+
+internal class ClickHouseLifecycleRenderer(private val context: ClickHouseRenderContext) {
+    fun renderGlobal(): List<String> = with(context) {
+        immutableStatements(
+            "CREATE DATABASE IF NOT EXISTS ${identifier(options.database)}${scopeClause()};",
+            "CREATE DATABASE IF NOT EXISTS ${identifier(options.consumerDatabase)}${scopeClause()};",
+        )
+    }
+
+    fun renderDropObserved(objects: List<ObservedBiObject>): List<String> = with(context) {
+        immutableStatements(
+            objects.sortedWith(
+                compareBy<ObservedBiObject> { it.metadata?.kind == BiObjectKind.STORE }
+                    .thenBy { it.metadata?.kind == BiObjectKind.STORE && it.name.endsWith("_local") }
+                    .thenByDescending { it.name.length }
+                    .thenBy { it.database }
+                    .thenBy { it.name }
+            ).map { observed ->
+                when (observed.metadata?.kind) {
+                    BiObjectKind.ANCHOR, BiObjectKind.VIEW, BiObjectKind.CONSUMER ->
+                        dropView(observed.database, observed.name)
+                    BiObjectKind.STORE, BiObjectKind.QUEUE -> drop(observed.database, observed.name)
+                    null -> error("Cannot drop an unowned BI catalog object: ${observed.database}.${observed.name}")
+                }
+            }
+        )
+    }
+
+    fun renderAnchor(phase: BiDeploymentPhase, registryRevision: Long? = null): String = with(context) {
+        val comment = metadataComment(BiObjectKind.ANCHOR, null, phase, registryRevision)
+        "$viewCreateClause ${qualified(options.consumerDatabase, ClickHouseScriptRenderer.DEPLOYMENT_ANCHOR)}" +
+            "${scopeClause()} AS (SELECT 1 AS ${identifier("alive")} WHERE 0) COMMENT $comment;"
+    }
+
+    fun renderPauseIngress(namedAggregate: NamedAggregate): List<String> = with(context) {
+        val commandTable = naming.toTableName(namedAggregate, ClickHouseScriptRenderer.COMMAND_SUFFIX)
+        val stateTable = naming.toTableName(namedAggregate, ClickHouseScriptRenderer.STATE_SUFFIX)
+        immutableStatements(
+            dropView(options.consumerDatabase, "${commandTable}_consumer"),
+            dropView(options.consumerDatabase, "${stateTable}_consumer"),
+        )
+    }
+}

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseLifecycleRenderer.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseLifecycleRenderer.kt
@@ -16,6 +16,7 @@ package me.ahoo.wow.bi.renderer
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.bi.BiDeploymentPhase
 import me.ahoo.wow.bi.BiObjectKind
+import me.ahoo.wow.bi.BiOwnedObject
 import me.ahoo.wow.bi.ObservedBiObject
 
 internal class ClickHouseLifecycleRenderer(private val context: ClickHouseRenderContext) {
@@ -26,20 +27,29 @@ internal class ClickHouseLifecycleRenderer(private val context: ClickHouseRender
         )
     }
 
-    fun renderDropObserved(objects: List<ObservedBiObject>): List<String> = with(context) {
+    fun renderDropObserved(objects: List<ObservedBiObject>): List<String> =
+        renderDropOwned(
+            objects.map { observed ->
+                val kind = checkNotNull(observed.metadata?.kind) {
+                    "Cannot drop an unowned BI catalog object: ${observed.database}.${observed.name}"
+                }
+                BiOwnedObject(observed.key, kind)
+            }
+        )
+
+    fun renderDropOwned(objects: List<BiOwnedObject>): List<String> = with(context) {
         immutableStatements(
             objects.sortedWith(
-                compareBy<ObservedBiObject> { it.metadata?.kind == BiObjectKind.STORE }
-                    .thenBy { it.metadata?.kind == BiObjectKind.STORE && it.name.endsWith("_local") }
-                    .thenByDescending { it.name.length }
-                    .thenBy { it.database }
-                    .thenBy { it.name }
-            ).map { observed ->
-                when (observed.metadata?.kind) {
+                compareBy<BiOwnedObject> { it.kind == BiObjectKind.STORE }
+                    .thenBy { it.kind == BiObjectKind.STORE && it.key.name.endsWith("_local") }
+                    .thenByDescending { it.key.name.length }
+                    .thenBy { it.key.database }
+                    .thenBy { it.key.name }
+            ).map { owned ->
+                when (owned.kind) {
                     BiObjectKind.ANCHOR, BiObjectKind.VIEW, BiObjectKind.CONSUMER ->
-                        dropView(observed.database, observed.name)
-                    BiObjectKind.STORE, BiObjectKind.QUEUE -> drop(observed.database, observed.name)
-                    null -> error("Cannot drop an unowned BI catalog object: ${observed.database}.${observed.name}")
+                        dropView(owned.key.database, owned.key.name)
+                    BiObjectKind.STORE, BiObjectKind.QUEUE -> drop(owned.key.database, owned.key.name)
                 }
             }
         )

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseMessageJsonExpressions.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseMessageJsonExpressions.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi.renderer
+
+internal fun jsonTopLevelLexicalRaw(source: String, property: String): String {
+    val sourceIdentifier = identifier(source)
+    val headerProperty = literal("header")
+    return "simpleJSONExtractRaw(" +
+        "replaceOne($sourceIdentifier, " +
+        "concat(${literal("\"header\":")}, simpleJSONExtractRaw($sourceIdentifier, $headerProperty)), " +
+        "${literal("\"header\":{}")}), ${literal(property)})"
+}
+
+internal fun jsonUInt(source: String, property: String): String =
+    "JSONExtractUInt(${identifier(source)}, ${literal(property)})"
+
+internal fun jsonInt(source: String, property: String): String =
+    "JSONExtractInt(${identifier(source)}, ${literal(property)})"
+
+internal fun jsonBool(source: String, property: String): String =
+    "JSONExtractBool(${identifier(source)}, ${literal(property)})"
+
+internal fun jsonTupleValue(
+    source: String,
+    tupleIndex: Int,
+    property: String,
+    sqlType: String,
+): String =
+    "JSONExtract(${identifier(source)}.$tupleIndex, ${literal(property)}, ${literal(sqlType)})"
+
+internal fun jsonTupleRaw(source: String, tupleIndex: Int, property: String): String =
+    "JSONExtractRaw(${identifier(source)}.$tupleIndex, ${literal(property)})"

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseOwnershipRegistryRenderer.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseOwnershipRegistryRenderer.kt
@@ -29,7 +29,6 @@ import me.ahoo.wow.bi.snapshotFingerprint
 internal class ClickHouseOwnershipRegistryRenderer(
     private val options: BiScriptOptions,
     private val deploymentId: String,
-    private val createIfNotExists: Boolean = true,
 ) {
     init {
         require(DEPLOYMENT_ID_PATTERN.matches(deploymentId)) {
@@ -39,9 +38,8 @@ internal class ClickHouseOwnershipRegistryRenderer(
 
     fun renderCreateStatements(registryName: String): List<String> {
         val comment = literal("$REGISTRY_COMMENT_PREFIX$deploymentId")
-        val ifNotExists = if (createIfNotExists) " IF NOT EXISTS" else ""
         val create = """
-            CREATE TABLE$ifNotExists ${qualified(options.consumerDatabase, registryName)}${scopeClause()}
+            CREATE TABLE IF NOT EXISTS ${qualified(options.consumerDatabase, registryName)}${scopeClause()}
             (
                 ${identifier("deployment_id")} FixedString(32),
                 ${identifier("row_kind")} LowCardinality(String),

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseOwnershipRegistryRenderer.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseOwnershipRegistryRenderer.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi.renderer
+
+import me.ahoo.wow.bi.BiOwnershipRegistry
+import me.ahoo.wow.bi.BiOwnershipRegistryEntry
+import me.ahoo.wow.bi.BiScriptOptions
+import me.ahoo.wow.bi.ClickHouseTopology
+import me.ahoo.wow.bi.rowFingerprint
+import me.ahoo.wow.bi.snapshotFingerprint
+
+/**
+ * Renders the durable ownership registry used to avoid catalog-wide discovery.
+ *
+ * Registry rows are append-only revisions. ReplacingMergeTree makes retries idempotent while retaining enough state
+ * for an interrupted create/drop to be resumed from PENDING_CREATE/PENDING_DROP instead of guessing from comments.
+ */
+internal class ClickHouseOwnershipRegistryRenderer(
+    private val options: BiScriptOptions,
+    private val deploymentId: String,
+    private val createIfNotExists: Boolean = true,
+) {
+    init {
+        require(DEPLOYMENT_ID_PATTERN.matches(deploymentId)) {
+            "Invalid BI registry deploymentId: $deploymentId"
+        }
+    }
+
+    fun renderCreateStatements(registryName: String): List<String> {
+        val comment = literal("$REGISTRY_COMMENT_PREFIX$deploymentId")
+        val ifNotExists = if (createIfNotExists) " IF NOT EXISTS" else ""
+        val create = """
+            CREATE TABLE$ifNotExists ${qualified(options.consumerDatabase, registryName)}${scopeClause()}
+            (
+                ${identifier("deployment_id")} FixedString(32),
+                ${identifier("row_kind")} LowCardinality(String),
+                ${identifier("object_database")} String,
+                ${identifier("object_name")} String,
+                ${identifier("kind")} LowCardinality(String),
+                ${identifier("aggregate")} Nullable(String),
+                ${identifier("consumer_identity")} Nullable(FixedString(32)),
+                ${identifier("definition_fingerprint")} FixedString(32),
+                ${identifier("revision")} UInt64,
+                ${identifier("status")} LowCardinality(String),
+                ${identifier("row_fingerprint")} FixedString(32),
+                ${identifier("recorded_at")} DateTime64(3, 'UTC') DEFAULT now64(3)
+            ) ${registryEngine()}
+              ORDER BY (${identifier("deployment_id")}, ${identifier("row_kind")},
+                        ${identifier("object_database")},
+                        ${identifier("object_name")})
+              COMMENT $comment;
+        """.trimIndent()
+        return immutableStatements(create)
+    }
+
+    fun renderSnapshotStatement(registry: BiOwnershipRegistry): String {
+        require(registry.deploymentId == deploymentId) {
+            "BI ownership registry deploymentId does not match its renderer"
+        }
+        val values = (
+            listOf(registry.renderHeadValues()) +
+                registry.entries.map { entry -> entry.renderValues() }
+            ).joinToString(",\n")
+        return """
+            INSERT INTO ${qualified(options.consumerDatabase, registry.name)}
+            (${identifier("deployment_id")}, ${identifier("row_kind")},
+             ${identifier("object_database")}, ${identifier("object_name")}, ${identifier("kind")},
+             ${identifier("aggregate")}, ${identifier("consumer_identity")},
+             ${identifier("definition_fingerprint")}, ${identifier("revision")}, ${identifier("status")},
+             ${identifier("row_fingerprint")})
+            VALUES
+            $values;
+        """.trimIndent()
+    }
+
+    fun renderDropStatement(registryName: String): String =
+        "DROP TABLE IF EXISTS ${qualified(options.consumerDatabase, registryName)}${scopeClause()};"
+
+    private fun BiOwnershipRegistry.renderHeadValues(): String = listOf(
+        literal(deploymentId),
+        literal(HEAD_ROW_KIND),
+        literal(""),
+        literal(""),
+        literal("ANCHOR"),
+        "NULL",
+        "NULL",
+        literal(snapshotFingerprint()),
+        revision.toString(),
+        literal("ACTIVE"),
+        literal(snapshotFingerprint()),
+    ).joinToString(prefix = "(", postfix = ")")
+
+    private fun BiOwnershipRegistryEntry.renderValues(): String = listOf(
+        literal(deploymentId),
+        literal(OBJECT_ROW_KIND),
+        literal(key.database),
+        literal(key.name),
+        literal(kind.name),
+        aggregate?.let(::literal) ?: "NULL",
+        consumerIdentity?.let(::literal) ?: "NULL",
+        literal(definitionFingerprint),
+        revision.toString(),
+        literal(status.name),
+        literal(rowFingerprint()),
+    ).joinToString(prefix = "(", postfix = ")")
+
+    private fun scopeClause(): String =
+        (options.topology as? ClickHouseTopology.Cluster)?.let { cluster ->
+            " ON CLUSTER ${literal(cluster.name)}"
+        }.orEmpty()
+
+    private fun registryEngine(): String = when (val configuredTopology = options.topology) {
+        ClickHouseTopology.Standalone -> "ENGINE = ReplacingMergeTree(${identifier("revision")})"
+        is ClickHouseTopology.Cluster -> {
+            val path = "/clickhouse/${configuredTopology.installation}/${configuredTopology.name}/" +
+                "control/wow-bi/$deploymentId"
+            "ENGINE = ReplicatedReplacingMergeTree(${literal(path)}, " +
+                "${literal("{shard}-{replica}")}, ${identifier("revision")})"
+        }
+    }
+
+    companion object {
+        internal const val REGISTRY_COMMENT_PREFIX: String = "wow-bi-registry:"
+        internal const val HEAD_ROW_KIND: String = "HEAD"
+        internal const val OBJECT_ROW_KIND: String = "OBJECT"
+        private val DEPLOYMENT_ID_PATTERN = Regex("[0-9a-f]{32}")
+    }
+}

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseRenderContext.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseRenderContext.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi.renderer
+
+import me.ahoo.wow.bi.BiConsumerIdentity
+import me.ahoo.wow.bi.BiDeploymentDescriptor
+import me.ahoo.wow.bi.BiDeploymentPhase
+import me.ahoo.wow.bi.BiObjectKey
+import me.ahoo.wow.bi.BiObjectKind
+import me.ahoo.wow.bi.BiObjectMetadata
+import me.ahoo.wow.bi.BiObjectMetadataCodec
+import me.ahoo.wow.bi.BiScriptOptions
+import me.ahoo.wow.bi.ClickHouseTopology
+import me.ahoo.wow.bi.KafkaOffsetStorage
+import me.ahoo.wow.bi.expansion.BiTableNaming
+import me.ahoo.wow.bi.expansion.plan.ColumnExtraction
+import me.ahoo.wow.bi.expansion.plan.ColumnPlacement
+import me.ahoo.wow.bi.expansion.plan.ColumnPlan
+import me.ahoo.wow.bi.expansion.plan.ColumnReference
+import me.ahoo.wow.bi.type.ClickHouseType
+
+internal class ClickHouseRenderContext(
+    val options: BiScriptOptions,
+    val consumerIdentity: BiConsumerIdentity,
+    val deployment: BiDeploymentDescriptor,
+    val catalogMutationMode: CatalogMutationMode,
+    private val retainedQueueKeys: Set<BiObjectKey>,
+) {
+    val naming = BiTableNaming(options)
+    val topology = options.topology.toDdl()
+    val metadataColumns = buildMetadataColumns(options.timezone)
+
+    fun consumerGroup(consumerTable: String): String =
+        "wow-bi.${consumerIdentity.value}.$consumerTable"
+
+    fun kafkaSettings(queueTable: String, comment: String): String {
+        val settings = buildList {
+            if (options.kafkaOffsetStorage == KafkaOffsetStorage.KEEPER) {
+                val keeperPath = "${options.kafkaKeeperPathPrefix.trimEnd('/')}/" +
+                    "${consumerIdentity.value}/$queueTable"
+                add("kafka_keeper_path = ${literal(keeperPath)}")
+                val replicaName = when (options.topology) {
+                    is ClickHouseTopology.Cluster -> "{replica}"
+                    ClickHouseTopology.Standalone -> consumerIdentity.value
+                }
+                add("kafka_replica_name = ${literal(replicaName)}")
+            }
+        }
+        val engineSettings = settings.takeIf { it.isNotEmpty() }
+            ?.let { "SETTINGS ${it.joinToString(",\n                         ")}" }
+            .orEmpty()
+        val querySettings = if (options.kafkaOffsetStorage == KafkaOffsetStorage.KEEPER) {
+            "\nSETTINGS allow_experimental_kafka_offsets_storage_in_keeper = 1"
+        } else {
+            ""
+        }
+        return listOf(engineSettings, "COMMENT $comment", querySettings)
+            .filter(String::isNotBlank)
+            .joinToString("\n")
+    }
+
+    fun metadataComment(
+        kind: BiObjectKind,
+        aggregate: String?,
+        phase: BiDeploymentPhase = BiDeploymentPhase.STABLE,
+        registryRevision: Long? = null,
+    ): String = literal(
+        BiObjectMetadataCodec.encode(
+            BiObjectMetadata(
+                deploymentId = deployment.deploymentId,
+                configurationFingerprint = deployment.configurationFingerprint,
+                topologyFingerprint = deployment.topologyFingerprint,
+                phase = phase,
+                aggregate = aggregate,
+                kind = kind,
+                consumerIdentity = consumerIdentity.value,
+                registryRevision = if (kind == BiObjectKind.ANCHOR) registryRevision else null,
+            )
+        )
+    )
+
+    fun isQueueRetained(queueTable: String): Boolean =
+        BiObjectKey(options.consumerDatabase, queueTable) in retainedQueueKeys
+
+    fun epochMillis(source: String, property: String): String =
+        "toDateTime64(${jsonInt(source, property)} / 1000.0, 3, ${literal(options.timezone)})"
+}
+
+private fun buildMetadataColumns(timezone: String): List<ColumnPlan> = listOf(
+    metadataColumn("id", ClickHouseType.String),
+    metadataColumn("aggregate_id", ClickHouseType.String),
+    metadataColumn("tenant_id", ClickHouseType.String),
+    metadataColumn("owner_id", ClickHouseType.String),
+    metadataColumn("space_id", ClickHouseType.String),
+    metadataColumn("command_id", ClickHouseType.String),
+    metadataColumn("request_id", ClickHouseType.String),
+    metadataColumn("version", ClickHouseType.UInt32),
+    metadataColumn("first_operator", ClickHouseType.String),
+    metadataColumn("first_event_time", ClickHouseType.DateTime64(3, timezone)),
+    metadataColumn("create_time", ClickHouseType.DateTime64(3, timezone)),
+    metadataColumn(
+        "tags",
+        ClickHouseType.Map(
+            ClickHouseType.String,
+            ClickHouseType.Array(ClickHouseType.String),
+        ),
+    ),
+    metadataColumn("deleted", ClickHouseType.Bool),
+)
+
+private fun metadataColumn(name: String, type: ClickHouseType): ColumnPlan = ColumnPlan(
+    name = name,
+    path = name,
+    targetName = "__$name",
+    type = type,
+    extraction = ColumnExtraction.Reference(ColumnReference.Input(name)),
+    placement = ColumnPlacement.SELECT,
+)

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseScriptRenderer.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseScriptRenderer.kt
@@ -18,6 +18,7 @@ import me.ahoo.wow.bi.BiConsumerIdentity
 import me.ahoo.wow.bi.BiDeploymentDescriptor
 import me.ahoo.wow.bi.BiDeploymentPhase
 import me.ahoo.wow.bi.BiObjectKey
+import me.ahoo.wow.bi.BiOwnedObject
 import me.ahoo.wow.bi.BiScriptOptions
 import me.ahoo.wow.bi.ExpectedBiQuery
 import me.ahoo.wow.bi.ObservedBiObject
@@ -71,6 +72,9 @@ internal class ClickHouseScriptRenderer(
 
     fun renderDropObservedStatements(objects: List<ObservedBiObject>): List<String> =
         lifecycle.renderDropObserved(objects)
+
+    fun renderDropOwnedStatements(objects: List<BiOwnedObject>): List<String> =
+        lifecycle.renderDropOwned(objects)
 
     fun renderAnchorStatement(
         phase: BiDeploymentPhase,

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseScriptRenderer.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseScriptRenderer.kt
@@ -18,715 +18,112 @@ import me.ahoo.wow.bi.BiConsumerIdentity
 import me.ahoo.wow.bi.BiDeploymentDescriptor
 import me.ahoo.wow.bi.BiDeploymentPhase
 import me.ahoo.wow.bi.BiObjectKey
-import me.ahoo.wow.bi.BiObjectKind
-import me.ahoo.wow.bi.BiObjectMetadata
-import me.ahoo.wow.bi.BiObjectMetadataCodec
 import me.ahoo.wow.bi.BiScriptOptions
-import me.ahoo.wow.bi.ClickHouseTopology
-import me.ahoo.wow.bi.KafkaOffsetStorage
+import me.ahoo.wow.bi.ExpectedBiQuery
 import me.ahoo.wow.bi.ObservedBiObject
-import me.ahoo.wow.bi.expansion.BiTableNaming
-import me.ahoo.wow.bi.expansion.plan.CollectionCursorPlan
-import me.ahoo.wow.bi.expansion.plan.ColumnExtraction
-import me.ahoo.wow.bi.expansion.plan.ColumnPlacement
-import me.ahoo.wow.bi.expansion.plan.ColumnPlan
-import me.ahoo.wow.bi.expansion.plan.ColumnReference
-import me.ahoo.wow.bi.expansion.plan.ExpansionViewPlan
-import me.ahoo.wow.bi.expansion.plan.JsonPointerSegment
 import me.ahoo.wow.bi.expansion.plan.StateExpansionPlan
-import me.ahoo.wow.bi.renderer.ClickHouseSqlSyntax.quoteIdentifier
-import me.ahoo.wow.bi.renderer.ClickHouseSqlSyntax.stringLiteral
-import me.ahoo.wow.bi.type.ClickHouseType
-import me.ahoo.wow.modeling.toStringWithAlias
-import java.util.Collections
 
 internal enum class CatalogMutationMode {
     RECONCILE,
     CREATE_ONLY,
 }
 
-// Keeping the complete ClickHouse graph here preserves shared naming, quoting, and ownership semantics.
-@Suppress("LargeClass")
+internal data class ClickHouseStreamRenderPlan(
+    val storage: List<String>,
+    val ingress: List<String>,
+    val publicViews: List<String>,
+)
+
+internal data class ClickHouseAggregateRenderPlan(
+    val aggregate: String,
+    val command: ClickHouseStreamRenderPlan,
+    val state: ClickHouseStreamRenderPlan,
+    val stateLast: List<String>,
+    val expansion: List<String>,
+)
+
+/**
+ * Composes the focused renderers that produce the current BI SQL graph.
+ */
+@Suppress("TooManyFunctions")
 internal class ClickHouseScriptRenderer(
-    private val options: BiScriptOptions = BiScriptOptions(consumerGroupNamespace = "test"),
-    private val consumerIdentity: BiConsumerIdentity =
+    options: BiScriptOptions = BiScriptOptions(consumerGroupNamespace = "test"),
+    consumerIdentity: BiConsumerIdentity =
         BiConsumerIdentity.deterministic(BiDeploymentDescriptor.from(options)),
-    private val deployment: BiDeploymentDescriptor = BiDeploymentDescriptor.from(options),
-    private val catalogMutationMode: CatalogMutationMode = CatalogMutationMode.RECONCILE,
-    private val retainedQueueKeys: Set<BiObjectKey> = emptySet(),
+    deployment: BiDeploymentDescriptor = BiDeploymentDescriptor.from(options),
+    catalogMutationMode: CatalogMutationMode = CatalogMutationMode.RECONCILE,
+    retainedQueueKeys: Set<BiObjectKey> = emptySet(),
 ) {
-    private val naming = BiTableNaming(options)
-    private val topology = options.topology.toDdl()
-    private val metadataColumns = buildMetadataColumns(options.timezone)
-
-    fun renderGlobal(): String = renderGlobalStatements().joinToString(STATEMENT_SEPARATOR)
-
-    fun renderGlobalStatements(): List<String> = immutableStatements(
-        "CREATE DATABASE IF NOT EXISTS ${identifier(options.database)}${scopeClause()};",
-        "CREATE DATABASE IF NOT EXISTS ${identifier(options.consumerDatabase)}${scopeClause()};",
+    private val context = ClickHouseRenderContext(
+        options = options,
+        consumerIdentity = consumerIdentity,
+        deployment = deployment,
+        catalogMutationMode = catalogMutationMode,
+        retainedQueueKeys = retainedQueueKeys,
     )
+    private val lifecycle = ClickHouseLifecycleRenderer(context)
+    private val command = ClickHouseCommandRenderer(context)
+    private val stateEvent = ClickHouseStateEventRenderer(context)
+    private val stateLast = ClickHouseStateLastRenderer(context)
+    private val expansion = ClickHouseExpansionRenderer(context)
 
-    fun renderClear(namedAggregate: NamedAggregate, expansionTables: List<String>): String =
-        renderClearStatements(namedAggregate, expansionTables).joinToString(STATEMENT_SEPARATOR)
+    fun renderGlobalStatements(): List<String> = lifecycle.renderGlobal()
 
-    fun renderClearStatements(namedAggregate: NamedAggregate, expansionTables: List<String>): List<String> {
-        val commandTable = naming.toTableName(namedAggregate, COMMAND_SUFFIX)
-        val stateTable = naming.toTableName(namedAggregate, STATE_SUFFIX)
-        val stateLastTable = naming.toTableName(namedAggregate, STATE_LAST_SUFFIX)
-        return immutableStatements(
-            buildList {
-                add(dropView(options.consumerDatabase, "${commandTable}_consumer"))
-                add(drop(options.consumerDatabase, "${commandTable}_queue"))
-                add(dropView(options.consumerDatabase, "${stateTable}_consumer"))
-                add(drop(options.consumerDatabase, "${stateTable}_queue"))
-                add(dropView(options.consumerDatabase, "${stateLastTable}_consumer"))
-                expansionTables.asReversed().forEach { add(dropView(options.database, it)) }
-                add(dropView(options.database, "${stateTable}_event"))
-                add(dropView(options.database, commandTable))
-                add(dropView(options.database, stateTable))
-                add(dropView(options.database, stateLastTable))
-                listOf(commandTable, stateTable, stateLastTable).forEach { table ->
-                    topology.dropTableNames(storageTable(table)).forEach { add(drop(options.database, it)) }
-                }
-            }
-        )
-    }
+    fun renderDropObservedStatements(objects: List<ObservedBiObject>): List<String> =
+        lifecycle.renderDropObserved(objects)
 
-    fun renderDropExpansionStatements(expansionTables: List<String>): List<String> =
-        immutableStatements(expansionTables.asReversed().map { dropView(options.database, it) })
-
-    fun renderDropObservedStatements(objects: List<ObservedBiObject>): List<String> = immutableStatements(
-        objects.sortedWith(
-            compareBy<ObservedBiObject> { it.metadata?.kind == BiObjectKind.STORE }
-                .thenBy { it.metadata?.kind == BiObjectKind.STORE && it.name.endsWith("_local") }
-                .thenByDescending { it.name.length }
-                .thenBy { it.database }
-                .thenBy { it.name }
-        ).map { observed ->
-            when (observed.metadata?.kind) {
-                BiObjectKind.ANCHOR, BiObjectKind.VIEW, BiObjectKind.CONSUMER ->
-                    dropView(observed.database, observed.name)
-                BiObjectKind.STORE, BiObjectKind.QUEUE -> drop(observed.database, observed.name)
-                null -> error("Cannot drop an unowned BI catalog object: ${observed.database}.${observed.name}")
-            }
-        }
-    )
-
-    fun renderAnchorStatement(phase: BiDeploymentPhase): String {
-        val comment = metadataComment(BiObjectKind.ANCHOR, null, phase)
-        return "$viewCreateClause ${qualified(options.consumerDatabase, DEPLOYMENT_ANCHOR)}" +
-            "${scopeClause()} AS (SELECT 1 AS ${identifier("alive")} WHERE 0) COMMENT $comment;"
-    }
-
-    @Suppress("LongMethod")
-    fun renderCommand(namedAggregate: NamedAggregate): String =
-        renderCommandStatements(namedAggregate).joinToString(STATEMENT_SEPARATOR)
-
-    fun renderCommandStatements(namedAggregate: NamedAggregate): List<String> =
-        renderCommandGraphStatements(namedAggregate)
+    fun renderAnchorStatement(
+        phase: BiDeploymentPhase,
+        registryRevision: Long? = null,
+    ): String = lifecycle.renderAnchor(phase, registryRevision)
 
     fun renderCommandStorageStatements(namedAggregate: NamedAggregate): List<String> =
-        renderCommandGraphStatements(namedAggregate).take(commandStorageStatementCount())
+        command.render(namedAggregate).storage
 
     fun renderCommandPublicStatements(namedAggregate: NamedAggregate): List<String> =
-        renderCommandGraphStatements(namedAggregate).takeLast(COMMAND_PUBLIC_STATEMENT_COUNT)
+        command.render(namedAggregate).publicViews
 
     fun renderCommandIngressStatements(namedAggregate: NamedAggregate): List<String> =
-        renderCommandGraphStatements(namedAggregate)
-            .drop(commandStorageStatementCount())
-            .dropLast(COMMAND_PUBLIC_STATEMENT_COUNT)
-
-    @Suppress("LongMethod")
-    private fun renderCommandGraphStatements(namedAggregate: NamedAggregate): List<String> {
-        val aggregate = namedAggregate.toStringWithAlias()
-        val storeComment = metadataComment(BiObjectKind.STORE, aggregate)
-        val viewComment = metadataComment(BiObjectKind.VIEW, aggregate)
-        val queueComment = metadataComment(BiObjectKind.QUEUE, aggregate)
-        val consumerComment = metadataComment(BiObjectKind.CONSUMER, aggregate)
-        val table = naming.toTableName(namedAggregate, COMMAND_SUFFIX)
-        val storeTable = storageTable(table)
-        val physicalTable = topology.physicalTableName(storeTable)
-        val queueTable = "${table}_queue"
-        val consumerTable = "${table}_consumer"
-        val topic = naming.toTopicName(namedAggregate, COMMAND_SUFFIX)
-        val aggregateVersionJson = jsonValue("data", "aggregateVersion", "Nullable(UInt32)")
-        return immutableStatements(
-            buildList {
-                add(
-                    """
-                $tableCreateClause ${qualified(options.database, physicalTable)}${scopeClause()}
-                (
-                    ${identifier("id")} String,
-                    ${identifier("context_name")} String,
-                    ${identifier("aggregate_name")} String,
-                    ${identifier("name")} String,
-                    ${identifier("header")} Map(String, String),
-                    ${identifier("aggregate_id")} String,
-                    ${identifier("tenant_id")} String,
-                    ${identifier("owner_id")} String,
-                    ${identifier("space_id")} String,
-                    ${identifier("request_id")} String,
-                    ${identifier("aggregate_version")} Nullable(UInt32),
-                    ${identifier("is_create")} Bool,
-                    ${identifier("is_void")} Bool,
-                    ${identifier("allow_create")} Bool,
-                    ${identifier("body_type")} String,
-                    ${identifier("body")} String,
-                    ${identifier("create_time")} DateTime64(3, ${literal(options.timezone)})
-                ) ${topology.engineSql(ReplacingMergeTreeSpec(null))}
-                  PARTITION BY toYYYYMM(${identifier("create_time")})
-                  ORDER BY ${identifier("id")}
-                  COMMENT $storeComment;
-                    """.trimIndent()
-                )
-                topology.distributedFacade(
-                    database = options.database,
-                    logicalTableName = storeTable,
-                    physicalTableName = physicalTable,
-                    shardingKey = "sipHash64(${identifier("aggregate_id")})",
-                    createIfNotExists = catalogMutationMode == CatalogMutationMode.RECONCILE,
-                )?.withTableComment(storeComment)?.let(::add)
-                if (catalogMutationMode == CatalogMutationMode.RECONCILE) {
-                    add(dropView(options.consumerDatabase, consumerTable))
-                }
-                if (!isQueueRetained(queueTable)) {
-                    add(
-                        """
-                CREATE TABLE ${qualified(options.consumerDatabase, queueTable)}${scopeClause()}
-                (${identifier("data")} String)
-                ENGINE = Kafka(${literal(options.kafkaBootstrapServers)}, ${literal(topic)},
-                               ${literal(consumerGroup(consumerTable))}, ${literal("JSONAsString")})
-                ${kafkaSettings(queueTable, queueComment)};
-                        """.trimIndent()
-                    )
-                }
-                add(
-                    """
-                $materializedViewCreateClause ${qualified(
-                        options.consumerDatabase,
-                        consumerTable
-                    )}${scopeClause()}
-                TO ${qualified(options.database, storeTable)}
-                AS (
-                SELECT ${jsonString("data", "id")} AS ${identifier("id")},
-                       ${jsonString("data", "contextName")} AS ${identifier("context_name")},
-                       ${jsonString("data", "aggregateName")} AS ${identifier("aggregate_name")},
-                       ${jsonString("data", "name")} AS ${identifier("name")},
-                       ${jsonValue("data", "header", "Map(String, String)")} AS ${identifier("header")},
-                       ${jsonString("data", "aggregateId")} AS ${identifier("aggregate_id")},
-                       ${jsonString("data", "tenantId")} AS ${identifier("tenant_id")},
-                       ${jsonString("data", "ownerId")} AS ${identifier("owner_id")},
-                       ${jsonString("data", "spaceId")} AS ${identifier("space_id")},
-                       ${jsonString("data", "requestId")} AS ${identifier("request_id")},
-                       $aggregateVersionJson AS ${identifier("aggregate_version")},
-                       ${jsonBool("data", "isCreate")} AS ${identifier("is_create")},
-                       ${jsonBool("data", "isVoid")} AS ${identifier("is_void")},
-                       ${jsonBool("data", "allowCreate")} AS ${identifier("allow_create")},
-                       ${jsonString("data", "bodyType")} AS ${identifier("body_type")},
-                       ${jsonTopLevelLexicalRaw("data", "body")} AS ${identifier("body")},
-                       ${epochMillis("data", "createTime")} AS ${identifier("create_time")}
-                FROM ${qualified(options.consumerDatabase, queueTable)}
-                ) COMMENT $consumerComment;
-                    """.trimIndent()
-                )
-                add(
-                    """
-                $viewCreateClause ${qualified(options.database, table)}${scopeClause()}
-                AS (SELECT * FROM ${qualified(options.database, storeTable)} FINAL)
-                COMMENT $viewComment;
-                    """.trimIndent()
-                )
-            }
-        )
-    }
-
-    @Suppress("LongMethod")
-    fun renderStateEvent(namedAggregate: NamedAggregate): String =
-        renderStateEventStatements(namedAggregate).joinToString(STATEMENT_SEPARATOR)
-
-    fun renderStateEventStatements(namedAggregate: NamedAggregate): List<String> = immutableStatements(
-        renderStateStorageStatements(namedAggregate) +
-            renderStatePublicStatements(namedAggregate) +
-            renderStateIngressStatements(namedAggregate)
-    )
+        command.render(namedAggregate).ingress
 
     fun renderStateStorageStatements(namedAggregate: NamedAggregate): List<String> =
-        renderStateEventGraphStatements(namedAggregate).take(stateStorageStatementCount())
+        stateEvent.render(namedAggregate).storage
 
     fun renderStatePublicStatements(namedAggregate: NamedAggregate): List<String> =
-        renderStateEventGraphStatements(namedAggregate).takeLast(STATE_PUBLIC_STATEMENT_COUNT)
+        stateEvent.render(namedAggregate).publicViews
 
     fun renderStateIngressStatements(namedAggregate: NamedAggregate): List<String> =
-        renderStateEventGraphStatements(namedAggregate)
-            .drop(stateStorageStatementCount())
-            .dropLast(STATE_PUBLIC_STATEMENT_COUNT)
+        stateEvent.render(namedAggregate).ingress
 
-    fun renderPauseIngressStatements(namedAggregate: NamedAggregate): List<String> {
-        val commandTable = naming.toTableName(namedAggregate, COMMAND_SUFFIX)
-        val stateTable = naming.toTableName(namedAggregate, STATE_SUFFIX)
-        return immutableStatements(
-            dropView(options.consumerDatabase, "${commandTable}_consumer"),
-            dropView(options.consumerDatabase, "${stateTable}_consumer"),
-        )
-    }
+    fun renderPauseIngressStatements(namedAggregate: NamedAggregate): List<String> =
+        lifecycle.renderPauseIngress(namedAggregate)
 
-    private fun stateStorageStatementCount(): Int =
-        if (options.topology is ClickHouseTopology.Cluster) 2 else 1
-
-    private fun commandStorageStatementCount(): Int =
-        if (options.topology is ClickHouseTopology.Cluster) 2 else 1
-
-    @Suppress("LongMethod")
-    private fun renderStateEventGraphStatements(namedAggregate: NamedAggregate): List<String> {
-        val aggregate = namedAggregate.toStringWithAlias()
-        val storeComment = metadataComment(BiObjectKind.STORE, aggregate)
-        val viewComment = metadataComment(BiObjectKind.VIEW, aggregate)
-        val queueComment = metadataComment(BiObjectKind.QUEUE, aggregate)
-        val consumerComment = metadataComment(BiObjectKind.CONSUMER, aggregate)
-        val table = naming.toTableName(namedAggregate, STATE_SUFFIX)
-        val storeTable = storageTable(table)
-        val physicalTable = topology.physicalTableName(storeTable)
-        val eventTable = "${table}_event"
-        val queueTable = "${table}_queue"
-        val consumerTable = "${table}_consumer"
-        val topic = naming.toTopicName(namedAggregate, STATE_SUFFIX)
-        return immutableStatements(
-            buildList {
-                add(
-                    """
-            $tableCreateClause ${qualified(options.database, physicalTable)}${scopeClause()}
-            (
-                ${identifier("id")} String,
-                ${identifier("context_name")} String,
-                ${identifier("aggregate_name")} String,
-                ${identifier("header")} Map(String, String),
-                ${identifier("aggregate_id")} String,
-                ${identifier("tenant_id")} String,
-                ${identifier("owner_id")} String,
-                ${identifier("space_id")} String,
-                ${identifier("command_id")} String,
-                ${identifier("request_id")} String,
-                ${identifier("version")} UInt32,
-                ${identifier("state")} String,
-                ${identifier("body")} Array(String),
-                ${identifier("first_operator")} String,
-                ${identifier("first_event_time")} DateTime64(3, ${literal(options.timezone)}),
-                ${identifier("create_time")} DateTime64(3, ${literal(options.timezone)}),
-                ${identifier("tags")} Map(String, Array(String)),
-                ${identifier("deleted")} Bool
-            ) ${topology.engineSql(ReplacingMergeTreeSpec("version"))}
-                  PARTITION BY toYYYYMM(${identifier("create_time")})
-                  ORDER BY (${identifier("aggregate_id")}, ${identifier("version")})
-                  COMMENT $storeComment;
-                    """.trimIndent()
-                )
-                topology.distributedFacade(
-                    database = options.database,
-                    logicalTableName = storeTable,
-                    physicalTableName = physicalTable,
-                    shardingKey = "sipHash64(${identifier("aggregate_id")})",
-                    createIfNotExists = catalogMutationMode == CatalogMutationMode.RECONCILE,
-                )?.withTableComment(storeComment)?.let(::add)
-                if (catalogMutationMode == CatalogMutationMode.RECONCILE) {
-                    add(dropView(options.consumerDatabase, consumerTable))
-                }
-                if (!isQueueRetained(queueTable)) {
-                    add(
-                        """
-            CREATE TABLE ${qualified(options.consumerDatabase, queueTable)}${scopeClause()}
-            (
-                ${identifier("data")} String
-            ) ENGINE = Kafka(${literal(options.kafkaBootstrapServers)}, ${literal(topic)},
-                             ${literal(consumerGroup(consumerTable))}, ${literal("JSONAsString")})
-            ${kafkaSettings(queueTable, queueComment)};
-                        """.trimIndent()
-                    )
-                }
-                add(
-                    """
-            $materializedViewCreateClause ${qualified(options.consumerDatabase, consumerTable)}${scopeClause()}
-            TO ${qualified(options.database, storeTable)}
-            AS (
-            SELECT ${jsonString("data", "id")} AS ${identifier("id")},
-                   ${jsonString("data", "contextName")} AS ${identifier("context_name")},
-                   ${jsonString("data", "aggregateName")} AS ${identifier("aggregate_name")},
-                   ${jsonValue("data", "header", "Map(String, String)")} AS ${identifier("header")},
-                   ${jsonString("data", "aggregateId")} AS ${identifier("aggregate_id")},
-                   ${jsonString("data", "tenantId")} AS ${identifier("tenant_id")},
-                   ${jsonString("data", "ownerId")} AS ${identifier("owner_id")},
-                   ${jsonString("data", "spaceId")} AS ${identifier("space_id")},
-                   ${jsonString("data", "commandId")} AS ${identifier("command_id")},
-                   ${jsonString("data", "requestId")} AS ${identifier("request_id")},
-                   ${jsonUInt("data", "version")} AS ${identifier("version")},
-                   ${jsonTopLevelLexicalRaw("data", "state")} AS ${identifier("state")},
-                   ${jsonArray("data", "body")} AS ${identifier("body")},
-                   ${jsonString("data", "firstOperator")} AS ${identifier("first_operator")},
-                   ${epochMillis("data", "firstEventTime")} AS ${identifier("first_event_time")},
-                   ${epochMillis("data", "createTime")} AS ${identifier("create_time")},
-                   ${jsonValue("data", "tags", "Map(String, Array(String))")} AS ${identifier("tags")},
-                   ${jsonBool("data", "deleted")} AS ${identifier("deleted")}
-            FROM ${qualified(options.consumerDatabase, queueTable)}
-            ) COMMENT $consumerComment;
-                    """.trimIndent()
-                )
-                add(
-                    """
-            $viewCreateClause ${qualified(options.database, table)}${scopeClause()}
-            AS (SELECT * FROM ${qualified(options.database, storeTable)} FINAL)
-            COMMENT $viewComment;
-                    """.trimIndent()
-                )
-                add(
-                    """
-            $viewCreateClause ${qualified(options.database, eventTable)}${scopeClause()}
-            AS (
-            WITH arrayJoin(arrayZip(arrayEnumerate(${identifier("body")}),
-                                    ${identifier("body")})) AS ${identifier("events")}
-            SELECT ${identifier("id")},
-                   ${identifier("context_name")},
-                   ${identifier("aggregate_name")},
-                   ${identifier("header")},
-                   ${identifier("aggregate_id")},
-                   ${identifier("tenant_id")},
-                   ${identifier("owner_id")},
-                   ${identifier("space_id")},
-                   ${identifier("command_id")},
-                   ${identifier("request_id")},
-                   ${identifier("version")},
-                   ${identifier("state")},
-                   ${identifier("events")}.1 AS ${identifier("event_sequence")},
-                   ${jsonTupleValue("events", 2, "id", "String")} AS ${identifier("event_id")},
-                   ${jsonTupleValue("events", 2, "name", "String")} AS ${identifier("event_name")},
-                   ${jsonTupleValue("events", 2, "revision", "String")} AS ${identifier("event_revision")},
-                   ${jsonTupleValue("events", 2, "bodyType", "String")} AS ${identifier("event_body_type")},
-                   ${jsonTupleRaw("events", 2, "body")} AS ${identifier("event_body")},
-                   ${identifier("first_operator")},
-                   ${identifier("first_event_time")},
-                   ${identifier("create_time")},
-                   ${identifier("tags")},
-                   ${identifier("deleted")}
-            FROM ${qualified(options.database, table)}
-            ) COMMENT $viewComment;
-                    """.trimIndent()
-                )
-            }
-        )
-    }
-
-    fun renderStateLast(namedAggregate: NamedAggregate): String =
-        renderStateLastStatements(namedAggregate).joinToString(STATEMENT_SEPARATOR)
-
-    @Suppress("LongMethod")
-    fun renderStateLastStatements(namedAggregate: NamedAggregate): List<String> {
-        val aggregate = namedAggregate.toStringWithAlias()
-        val storeComment = metadataComment(BiObjectKind.STORE, aggregate)
-        val viewComment = metadataComment(BiObjectKind.VIEW, aggregate)
-        val consumerComment = metadataComment(BiObjectKind.CONSUMER, aggregate)
-        val stateTable = naming.toTableName(namedAggregate, STATE_SUFFIX)
-        val stateStoreTable = storageTable(stateTable)
-        val table = naming.toTableName(namedAggregate, STATE_LAST_SUFFIX)
-        val storeTable = storageTable(table)
-        val physicalTable = topology.physicalTableName(storeTable)
-        val consumerTable = "${table}_consumer"
-        return immutableStatements(
-            buildList {
-                add(
-                    """
-            $tableCreateClause ${qualified(options.database, physicalTable)}${scopeClause()}
-            (
-                ${identifier("id")} String,
-                ${identifier("context_name")} String,
-                ${identifier("aggregate_name")} String,
-                ${identifier("header")} Map(String, String),
-                ${identifier("aggregate_id")} String,
-                ${identifier("tenant_id")} String,
-                ${identifier("owner_id")} String,
-                ${identifier("space_id")} String,
-                ${identifier("command_id")} String,
-                ${identifier("request_id")} String,
-                ${identifier("version")} UInt32,
-                ${identifier("state")} String,
-                ${identifier("body")} Array(String),
-                ${identifier("first_operator")} String,
-                ${identifier("first_event_time")} DateTime64(3, ${literal(options.timezone)}),
-                ${identifier("create_time")} DateTime64(3, ${literal(options.timezone)}),
-                ${identifier("tags")} Map(String, Array(String)),
-                ${identifier("deleted")} Bool
-            ) ${topology.engineSql(ReplacingMergeTreeSpec("version"))}
-                  PARTITION BY toYYYYMM(${identifier("first_event_time")})
-                  ORDER BY (${identifier("aggregate_id")})
-                  COMMENT $storeComment;
-                    """.trimIndent()
-                )
-                topology.distributedFacade(
-                    database = options.database,
-                    logicalTableName = storeTable,
-                    physicalTableName = physicalTable,
-                    shardingKey = "sipHash64(${identifier("aggregate_id")})",
-                    createIfNotExists = catalogMutationMode == CatalogMutationMode.RECONCILE,
-                )?.withTableComment(storeComment)?.let(::add)
-                if (catalogMutationMode == CatalogMutationMode.RECONCILE) {
-                    add(dropView(options.consumerDatabase, consumerTable))
-                }
-                add(
-                    """
-            $materializedViewCreateClause ${qualified(options.consumerDatabase, consumerTable)}${scopeClause()}
-            TO ${qualified(options.database, storeTable)}
-            AS (
-            SELECT *
-            FROM ${qualified(options.database, stateStoreTable)}
-            ) COMMENT $consumerComment;
-                    """.trimIndent()
-                )
-                add(
-                    """
-            $viewCreateClause ${qualified(options.database, table)}${scopeClause()}
-            AS (SELECT * FROM ${qualified(options.database, storeTable)} FINAL)
-            COMMENT $viewComment;
-                    """.trimIndent()
-                )
-            }
-        )
-    }
-
-    fun renderExpansion(plan: StateExpansionPlan): String =
-        renderExpansionStatements(plan).joinToString(STATEMENT_SEPARATOR)
+    fun renderStateLastStatements(namedAggregate: NamedAggregate): List<String> = stateLast.render(namedAggregate)
 
     fun renderExpansionStatements(plan: StateExpansionPlan, aggregate: String = "test.aggregate"): List<String> =
-        immutableStatements(plan.views.map { view -> renderExpansionView(view, aggregate) })
+        expansion.render(plan, aggregate)
 
-    private fun renderExpansionView(view: ExpansionViewPlan, aggregate: String): String {
-        val domainWithColumns = view.columns
-            .filter { it.placement == ColumnPlacement.WITH }
-            .map(::renderColumn)
-        val withSql = (view.recovery.cursors.flatMap(::renderCursor) + domainWithColumns)
-            .joinToString(",\n")
-        val domainSelectColumns = view.columns
-            .filter { it.placement == ColumnPlacement.SELECT }
-            .map(::renderColumn)
-        val selectSql = (domainSelectColumns + renderRecovery(view) + metadataColumns.map(::renderColumn))
-            .joinToString(",\n")
-        return buildString {
-            appendLine(
-                "$viewCreateClause ${qualified(options.database, view.targetTableName)}" +
-                    "${scopeClause()} AS ("
-            )
-            if (withSql.isNotBlank()) {
-                appendLine("WITH")
-                appendLine(withSql)
-            }
-            appendLine("SELECT")
-            appendLine(selectSql)
-            appendLine(
-                "FROM ${qualified(options.database, view.sourceTableName)} AS ${identifier(SOURCE_ALIAS)}"
-            )
-            appendLine(") COMMENT ${metadataComment(BiObjectKind.VIEW, aggregate)};")
-        }.trimEnd()
-    }
-
-    private fun renderColumn(column: ColumnPlan): String =
-        "${renderExtraction(column)} AS ${identifier(column.targetName)}"
-
-    private fun renderCursor(cursor: CollectionCursorPlan): List<String> {
-        val elements = jsonArray(cursor.source, cursor.property)
-        return listOf(
-            "arrayJoin(arrayZip(arrayEnumerate($elements),\n" +
-                "                   $elements)) AS ${renderReference(cursor.cursor)}",
-            "tupleElement(${renderReference(cursor.cursor)}, 2) AS ${renderReference(cursor.element)}",
-        )
-    }
-
-    private fun renderRecovery(view: ExpansionViewPlan): List<String> = buildList {
-        add("${renderReference(ColumnReference.Input(STATE_COLUMN))} AS ${identifier(STATE_TARGET)}")
-        view.recovery.currentIndex?.let { currentIndex ->
-            add("toUInt64(${renderZeroBasedIndex(currentIndex)}) AS ${identifier(INDEX_TARGET)}")
-        }
-        add("${renderPointer(view.recovery.pointer)} AS ${identifier(PATH_TARGET)}")
-    }
-
-    private fun renderPointer(pointer: List<JsonPointerSegment>): String {
-        if (pointer.isEmpty()) {
-            return literal("")
-        }
-        val expressions = pointer.mapIndexed { index, segment ->
-            when (segment) {
-                is JsonPointerSegment.Property -> {
-                    val indexSuffix = if (pointer.getOrNull(index + 1) is JsonPointerSegment.Index) "/" else ""
-                    literal("/${segment.encoded}$indexSuffix")
-                }
-
-                is JsonPointerSegment.Index -> "toString(${renderZeroBasedIndex(segment.reference)})"
-            }
-        }
-        return "concat(${expressions.joinToString(", ")})"
-    }
-
-    private fun renderZeroBasedIndex(reference: ColumnReference): String =
-        "tupleElement(${renderReference(reference)}, 1) - 1"
-
-    private fun renderExtraction(column: ColumnPlan): String = when (val extraction = column.extraction) {
-        is ColumnExtraction.Reference -> renderReference(extraction.source)
-        is ColumnExtraction.JsonValue -> jsonValue(extraction.source, extraction.property, column.type.toSql())
-        is ColumnExtraction.JsonString -> jsonString(extraction.source, extraction.property)
-        is ColumnExtraction.JsonRaw -> jsonRaw(extraction.source, extraction.property)
-        is ColumnExtraction.JsonArray -> jsonArray(extraction.source, extraction.property)
-    }
-
-    private fun drop(database: String, table: String): String =
-        "DROP TABLE IF EXISTS ${qualified(database, table)}${scopeClause()} SYNC;"
-
-    private fun dropView(database: String, view: String): String =
-        "DROP VIEW IF EXISTS ${qualified(database, view)}${scopeClause()} SYNC;"
-
-    private fun storageTable(table: String): String = "${table}_store"
-
-    private fun consumerGroup(consumerTable: String): String {
-        return "wow-bi.${consumerIdentity.value}.$consumerTable"
-    }
-
-    private fun kafkaSettings(queueTable: String, comment: String): String {
-        val settings = buildList {
-            if (options.kafkaOffsetStorage == KafkaOffsetStorage.KEEPER) {
-                val keeperPath = "${options.kafkaKeeperPathPrefix.trimEnd('/')}/" +
-                    "${consumerIdentity.value}/$queueTable"
-                add("kafka_keeper_path = ${literal(keeperPath)}")
-                val replicaName = when (options.topology) {
-                    is ClickHouseTopology.Cluster -> "{replica}"
-                    ClickHouseTopology.Standalone -> consumerIdentity.value
-                }
-                add("kafka_replica_name = ${literal(replicaName)}")
-            }
-        }
-        val engineSettings = settings.takeIf { it.isNotEmpty() }
-            ?.let { "SETTINGS ${it.joinToString(",\n                         ")}" }
-            .orEmpty()
-        val querySettings = if (options.kafkaOffsetStorage == KafkaOffsetStorage.KEEPER) {
-            "\nSETTINGS allow_experimental_kafka_offsets_storage_in_keeper = 1"
-        } else {
-            ""
-        }
-        return listOf(engineSettings, "COMMENT $comment", querySettings)
-            .filter(String::isNotBlank)
-            .joinToString("\n")
-    }
-
-    private fun String.withTableComment(comment: String): String =
-        removeSuffix(";") + "\nCOMMENT $comment;"
-
-    private fun immutableStatements(vararg statements: String): List<String> =
-        immutableStatements(statements.asList())
-
-    private fun immutableStatements(statements: Collection<String>): List<String> =
-        Collections.unmodifiableList(ArrayList(statements))
-
-    private fun qualified(database: String, table: String): String =
-        "${identifier(database)}.${identifier(table)}"
-
-    private fun identifier(value: String): String = quoteIdentifier(value)
-
-    private fun literal(value: String): String = stringLiteral(value)
-
-    private fun metadataComment(
-        kind: BiObjectKind,
-        aggregate: String?,
-        phase: BiDeploymentPhase = BiDeploymentPhase.STABLE,
-    ): String = literal(
-        BiObjectMetadataCodec.encode(
-            BiObjectMetadata(
-                deploymentId = deployment.deploymentId,
-                configurationFingerprint = deployment.configurationFingerprint,
-                topologyFingerprint = deployment.topologyFingerprint,
-                phase = phase,
-                aggregate = aggregate,
-                kind = kind,
-                consumerIdentity = consumerIdentity.value,
-            )
-        )
+    fun renderAggregate(
+        namedAggregate: NamedAggregate,
+        plan: StateExpansionPlan,
+        aggregate: String,
+    ): ClickHouseAggregateRenderPlan = ClickHouseAggregateRenderPlan(
+        aggregate = aggregate,
+        command = command.render(namedAggregate),
+        state = stateEvent.render(namedAggregate),
+        stateLast = stateLast.render(namedAggregate),
+        expansion = expansion.render(plan, aggregate),
     )
 
-    private fun scopeClause(): String = topology.scopeClause.takeIf(String::isNotEmpty)?.let { " $it" }.orEmpty()
-
-    private fun jsonValue(source: String, property: String, sqlType: String): String =
-        "JSONExtract(${identifier(source)}, ${literal(property)}, ${literal(sqlType)})"
-
-    private fun jsonValue(source: ColumnReference, property: String, sqlType: String): String =
-        "JSONExtract(${renderReference(source)}, ${literal(property)}, ${literal(sqlType)})"
-
-    private fun jsonString(source: String, property: String): String =
-        "JSONExtractString(${identifier(source)}, ${literal(property)})"
-
-    private fun jsonString(source: ColumnReference, property: String): String =
-        "JSONExtractString(${renderReference(source)}, ${literal(property)})"
-
-    private fun jsonRaw(source: String, property: String): String =
-        "JSONExtractRaw(${identifier(source)}, ${literal(property)})"
-
-    private fun jsonTopLevelLexicalRaw(source: String, property: String): String {
-        val sourceIdentifier = identifier(source)
-        val headerProperty = literal("header")
-        return "simpleJSONExtractRaw(" +
-            "replaceOne($sourceIdentifier, " +
-            "concat(${literal("\"header\":")}, simpleJSONExtractRaw($sourceIdentifier, $headerProperty)), " +
-            "${literal("\"header\":{}")}), ${literal(property)})"
+    fun expectedComputedQueries(
+        namedAggregate: NamedAggregate,
+        plan: StateExpansionPlan,
+    ): Map<BiObjectKey, ExpectedBiQuery> = buildMap {
+        putAll(command.expectedQueries(namedAggregate))
+        putAll(stateEvent.expectedQueries(namedAggregate))
+        putAll(stateLast.expectedQueries(namedAggregate))
+        putAll(expansion.expectedQueries(plan))
     }
-
-    private fun jsonRaw(source: ColumnReference, property: String): String =
-        "JSONExtractRaw(${renderReference(source)}, ${literal(property)})"
-
-    private fun jsonArray(source: String, property: String): String =
-        "JSONExtractArrayRaw(${identifier(source)}, ${literal(property)})"
-
-    private fun jsonArray(source: ColumnReference, property: String): String =
-        "JSONExtractArrayRaw(${renderReference(source)}, ${literal(property)})"
-
-    private fun renderReference(reference: ColumnReference): String = when (reference) {
-        is ColumnReference.Input -> "${identifier(SOURCE_ALIAS)}.${identifier(reference.name)}"
-        is ColumnReference.Alias -> identifier(reference.name)
-    }
-
-    private fun jsonUInt(source: String, property: String): String =
-        "JSONExtractUInt(${identifier(source)}, ${literal(property)})"
-
-    private fun jsonInt(source: String, property: String): String =
-        "JSONExtractInt(${identifier(source)}, ${literal(property)})"
-
-    private fun jsonBool(source: String, property: String): String =
-        "JSONExtractBool(${identifier(source)}, ${literal(property)})"
-
-    private fun jsonTupleValue(
-        source: String,
-        tupleIndex: Int,
-        property: String,
-        sqlType: String,
-    ): String =
-        "JSONExtract(${identifier(source)}.$tupleIndex, ${literal(property)}, ${literal(sqlType)})"
-
-    private fun jsonTupleRaw(source: String, tupleIndex: Int, property: String): String =
-        "JSONExtractRaw(${identifier(source)}.$tupleIndex, ${literal(property)})"
-
-    private val tableCreateClause: String
-        get() = when (catalogMutationMode) {
-            CatalogMutationMode.RECONCILE -> "CREATE TABLE IF NOT EXISTS"
-            CatalogMutationMode.CREATE_ONLY -> "CREATE TABLE"
-        }
-
-    private val materializedViewCreateClause: String
-        get() = when (catalogMutationMode) {
-            CatalogMutationMode.RECONCILE -> "CREATE MATERIALIZED VIEW IF NOT EXISTS"
-            CatalogMutationMode.CREATE_ONLY -> "CREATE MATERIALIZED VIEW"
-        }
-
-    private val viewCreateClause: String
-        get() = when (catalogMutationMode) {
-            CatalogMutationMode.RECONCILE -> "CREATE OR REPLACE VIEW"
-            CatalogMutationMode.CREATE_ONLY -> "CREATE VIEW"
-        }
-
-    private fun isQueueRetained(queueTable: String): Boolean =
-        BiObjectKey(options.consumerDatabase, queueTable) in retainedQueueKeys
-
-    private fun epochMillis(source: String, property: String): String =
-        "toDateTime64(${jsonInt(source, property)} / 1000.0, 3, ${literal(options.timezone)})"
 
     companion object {
         const val DEPLOYMENT_ANCHOR = "__wow_bi_deployment"
@@ -738,39 +135,5 @@ internal class ClickHouseScriptRenderer(
         const val PATH_TARGET = "__path"
         const val INDEX_TARGET = "__index"
         const val SOURCE_ALIAS = "__source"
-        const val STATEMENT_SEPARATOR = "\n\n"
-        const val COMMAND_PUBLIC_STATEMENT_COUNT: Int = 1
-        const val STATE_PUBLIC_STATEMENT_COUNT: Int = 2
     }
 }
-
-private fun buildMetadataColumns(timezone: String): List<ColumnPlan> = listOf(
-    metadataColumn("id", ClickHouseType.String),
-    metadataColumn("aggregate_id", ClickHouseType.String),
-    metadataColumn("tenant_id", ClickHouseType.String),
-    metadataColumn("owner_id", ClickHouseType.String),
-    metadataColumn("space_id", ClickHouseType.String),
-    metadataColumn("command_id", ClickHouseType.String),
-    metadataColumn("request_id", ClickHouseType.String),
-    metadataColumn("version", ClickHouseType.UInt32),
-    metadataColumn("first_operator", ClickHouseType.String),
-    metadataColumn("first_event_time", ClickHouseType.DateTime64(3, timezone)),
-    metadataColumn("create_time", ClickHouseType.DateTime64(3, timezone)),
-    metadataColumn(
-        "tags",
-        ClickHouseType.Map(
-            ClickHouseType.String,
-            ClickHouseType.Array(ClickHouseType.String),
-        ),
-    ),
-    metadataColumn("deleted", ClickHouseType.Bool),
-)
-
-private fun metadataColumn(name: String, type: ClickHouseType): ColumnPlan = ColumnPlan(
-    name = name,
-    path = name,
-    targetName = "__$name",
-    type = type,
-    extraction = ColumnExtraction.Reference(ColumnReference.Input(name)),
-    placement = ColumnPlacement.SELECT,
-)

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseSqlPrimitives.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseSqlPrimitives.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi.renderer
+
+import me.ahoo.wow.bi.renderer.ClickHouseSqlSyntax.quoteIdentifier
+import me.ahoo.wow.bi.renderer.ClickHouseSqlSyntax.stringLiteral
+import java.util.Collections
+
+internal fun ClickHouseRenderContext.drop(database: String, table: String): String =
+    "DROP TABLE IF EXISTS ${qualified(database, table)}${scopeClause()} SYNC;"
+
+internal fun ClickHouseRenderContext.dropView(database: String, view: String): String =
+    "DROP VIEW IF EXISTS ${qualified(database, view)}${scopeClause()} SYNC;"
+
+internal fun storageTable(table: String): String = "${table}_store"
+
+internal fun immutableStatements(vararg statements: String): List<String> =
+    immutableStatements(statements.asList())
+
+internal fun immutableStatements(statements: Collection<String>): List<String> =
+    Collections.unmodifiableList(ArrayList(statements))
+
+internal fun qualified(database: String, table: String): String =
+    "${identifier(database)}.${identifier(table)}"
+
+internal fun identifier(value: String): String = quoteIdentifier(value)
+
+internal fun literal(value: String): String = stringLiteral(value)
+
+internal fun String.withTableComment(comment: String): String =
+    removeSuffix(";") + "\nCOMMENT $comment;"
+
+internal fun ClickHouseRenderContext.scopeClause(): String =
+    topology.scopeClause.takeIf(String::isNotEmpty)?.let { " $it" }.orEmpty()
+
+internal val ClickHouseRenderContext.tableCreateClause: String
+    get() = when (catalogMutationMode) {
+        CatalogMutationMode.RECONCILE -> "CREATE TABLE IF NOT EXISTS"
+        CatalogMutationMode.CREATE_ONLY -> "CREATE TABLE"
+    }
+
+internal val ClickHouseRenderContext.materializedViewCreateClause: String
+    get() = when (catalogMutationMode) {
+        CatalogMutationMode.RECONCILE -> "CREATE MATERIALIZED VIEW IF NOT EXISTS"
+        CatalogMutationMode.CREATE_ONLY -> "CREATE MATERIALIZED VIEW"
+    }
+
+internal val ClickHouseRenderContext.viewCreateClause: String
+    get() = when (catalogMutationMode) {
+        CatalogMutationMode.RECONCILE -> "CREATE OR REPLACE VIEW"
+        CatalogMutationMode.CREATE_ONLY -> "CREATE VIEW"
+    }

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseStateEventRenderer.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseStateEventRenderer.kt
@@ -1,0 +1,227 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi.renderer
+
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.bi.BiObjectKey
+import me.ahoo.wow.bi.BiObjectKind
+import me.ahoo.wow.bi.ExpectedBiQuery
+import me.ahoo.wow.modeling.toStringWithAlias
+
+/** Keeps emitted DDL and drift-manifest SQL on the same SELECT builders. */
+@Suppress("TooManyFunctions")
+internal class ClickHouseStateEventRenderer(private val context: ClickHouseRenderContext) {
+    fun expectedQueries(namedAggregate: NamedAggregate): Map<BiObjectKey, ExpectedBiQuery> = with(context) {
+        val table = naming.toTableName(namedAggregate, ClickHouseScriptRenderer.STATE_SUFFIX)
+        val physicalBase = naming.toTableName(namedAggregate, ClickHouseScriptRenderer.STATE_SUFFIX)
+        val storeTable = storageTable(physicalBase)
+        val eventTable = "${table}_event"
+        val queueTable = "${physicalBase}_queue"
+        mapOf(
+            BiObjectKey(options.consumerDatabase, "${physicalBase}_consumer") to ExpectedBiQuery(
+                selectSql = renderConsumerSelect(queueTable),
+                target = BiObjectKey(options.database, storeTable),
+            ),
+            BiObjectKey(options.database, table) to ExpectedBiQuery(renderStateViewSelect(storeTable)),
+            BiObjectKey(options.database, eventTable) to ExpectedBiQuery(renderEventViewSelect(table)),
+        )
+    }
+
+    fun render(namedAggregate: NamedAggregate): ClickHouseStreamRenderPlan = with(context) {
+        val aggregate = namedAggregate.toStringWithAlias()
+        val table = naming.toTableName(namedAggregate, ClickHouseScriptRenderer.STATE_SUFFIX)
+        val physicalBase = naming.toTableName(namedAggregate, ClickHouseScriptRenderer.STATE_SUFFIX)
+        val storeTable = storageTable(physicalBase)
+        val physicalTable = topology.physicalTableName(storeTable)
+        val eventTable = "${table}_event"
+        val queueTable = "${physicalBase}_queue"
+        val consumerTable = "${physicalBase}_consumer"
+        val topic = naming.toTopicName(namedAggregate, ClickHouseScriptRenderer.STATE_SUFFIX)
+        val storeComment = metadataComment(BiObjectKind.STORE, aggregate)
+        val viewComment = metadataComment(BiObjectKind.VIEW, aggregate)
+        val queueComment = metadataComment(BiObjectKind.QUEUE, aggregate)
+        val consumerComment = metadataComment(BiObjectKind.CONSUMER, aggregate)
+        ClickHouseStreamRenderPlan(
+            storage = immutableStatements(
+                buildList {
+                    add(renderStore(physicalTable, storeComment))
+                    topology.distributedFacade(
+                        DistributedFacadeSpec(
+                            database = options.database,
+                            logicalTableName = storeTable,
+                            physicalTableName = physicalTable,
+                            shardingKey = "sipHash64(${identifier("tenant_id")}, ${identifier("aggregate_id")})",
+                            createIfNotExists = catalogMutationMode == CatalogMutationMode.RECONCILE,
+                        )
+                    )?.withTableComment(storeComment)?.let(::add)
+                }
+            ),
+            ingress = immutableStatements(
+                buildList {
+                    if (catalogMutationMode == CatalogMutationMode.RECONCILE) {
+                        add(dropView(options.consumerDatabase, consumerTable))
+                    }
+                    if (!isQueueRetained(queueTable)) {
+                        add(renderQueue(queueTable, topic, consumerTable, queueComment))
+                    }
+                    add(renderConsumer(consumerTable, storeTable, queueTable, consumerComment))
+                }
+            ),
+            publicViews = immutableStatements(
+                listOf(
+                    renderStateView(table, storeTable, viewComment),
+                    renderEventView(eventTable, table, viewComment),
+                )
+            ),
+        )
+    }
+
+    private fun renderStore(physicalTable: String, comment: String): String = with(context) {
+        """
+            $tableCreateClause ${qualified(options.database, physicalTable)}${scopeClause()}
+            (
+                ${identifier("id")} String,
+                ${identifier("context_name")} String,
+                ${identifier("aggregate_name")} String,
+                ${identifier("header")} Map(String, String),
+                ${identifier("aggregate_id")} String,
+                ${identifier("tenant_id")} String,
+                ${identifier("owner_id")} String,
+                ${identifier("space_id")} String,
+                ${identifier("command_id")} String,
+                ${identifier("request_id")} String,
+                ${identifier("version")} UInt32,
+                ${identifier("state")} String,
+                ${identifier("body")} Array(String),
+                ${identifier("first_operator")} String,
+                ${identifier("first_event_time")} DateTime64(3, ${literal(options.timezone)}),
+                ${identifier("create_time")} DateTime64(3, ${literal(options.timezone)}),
+                ${identifier("tags")} Map(String, Array(String)),
+                ${identifier("deleted")} Bool
+            ) ${topology.engineSql(ReplacingMergeTreeSpec("version"))}
+                  PARTITION BY toYYYYMM(${identifier("create_time")})
+                  ORDER BY (${identifier("tenant_id")}, ${identifier("aggregate_id")}, ${identifier("version")})
+                  COMMENT $comment;
+        """.trimIndent()
+    }
+
+    private fun renderQueue(
+        queueTable: String,
+        topic: String,
+        consumerTable: String,
+        comment: String,
+    ): String = with(context) {
+        """
+            CREATE TABLE ${qualified(options.consumerDatabase, queueTable)}${scopeClause()}
+            (
+                ${identifier("data")} String
+            ) ENGINE = Kafka(${literal(options.kafkaBootstrapServers)}, ${literal(topic)},
+                             ${literal(consumerGroup(consumerTable))}, ${literal("JSONAsString")})
+            ${kafkaSettings(queueTable, comment)};
+        """.trimIndent()
+    }
+
+    private fun renderConsumer(
+        consumerTable: String,
+        storeTable: String,
+        queueTable: String,
+        comment: String,
+    ): String = with(context) {
+        buildString {
+            appendLine(
+                "$materializedViewCreateClause ${qualified(options.consumerDatabase, consumerTable)}${scopeClause()}"
+            )
+            appendLine("TO ${qualified(options.database, storeTable)}")
+            appendLine("AS (")
+            appendLine(renderConsumerSelect(queueTable))
+            append(") COMMENT $comment;")
+        }
+    }
+
+    private fun renderConsumerSelect(queueTable: String): String = with(context) {
+        """
+            SELECT ${jsonString("data", "id")} AS ${identifier("id")},
+                   ${jsonString("data", "contextName")} AS ${identifier("context_name")},
+                   ${jsonString("data", "aggregateName")} AS ${identifier("aggregate_name")},
+                   ${jsonValue("data", "header", "Map(String, String)")} AS ${identifier("header")},
+                   ${jsonString("data", "aggregateId")} AS ${identifier("aggregate_id")},
+                   ${jsonString("data", "tenantId")} AS ${identifier("tenant_id")},
+                   ${jsonString("data", "ownerId")} AS ${identifier("owner_id")},
+                   ${jsonString("data", "spaceId")} AS ${identifier("space_id")},
+                   ${jsonString("data", "commandId")} AS ${identifier("command_id")},
+                   ${jsonString("data", "requestId")} AS ${identifier("request_id")},
+                   ${jsonUInt("data", "version")} AS ${identifier("version")},
+                   ${jsonTopLevelLexicalRaw("data", "state")} AS ${identifier("state")},
+                   ${jsonArray("data", "body")} AS ${identifier("body")},
+                   ${jsonString("data", "firstOperator")} AS ${identifier("first_operator")},
+                   ${epochMillis("data", "firstEventTime")} AS ${identifier("first_event_time")},
+                   ${epochMillis("data", "createTime")} AS ${identifier("create_time")},
+                   ${jsonValue("data", "tags", "Map(String, Array(String))")} AS ${identifier("tags")},
+                   ${jsonBool("data", "deleted")} AS ${identifier("deleted")}
+            FROM ${qualified(options.consumerDatabase, queueTable)}
+        """.trimIndent()
+    }
+
+    private fun renderStateView(table: String, storeTable: String, comment: String): String = with(context) {
+        """
+            $viewCreateClause ${qualified(options.database, table)}${scopeClause()}
+            AS (${renderStateViewSelect(storeTable)})
+            COMMENT $comment;
+        """.trimIndent()
+    }
+
+    private fun renderStateViewSelect(storeTable: String): String = with(context) {
+        "SELECT * FROM ${qualified(options.database, storeTable)} FINAL"
+    }
+
+    private fun renderEventView(eventTable: String, stateTable: String, comment: String): String = with(context) {
+        buildString {
+            appendLine("$viewCreateClause ${qualified(options.database, eventTable)}${scopeClause()}")
+            appendLine("AS (")
+            appendLine(renderEventViewSelect(stateTable))
+            append(") COMMENT $comment;")
+        }
+    }
+
+    private fun renderEventViewSelect(stateTable: String): String = with(context) {
+        """
+            WITH arrayJoin(arrayZip(arrayEnumerate(${identifier("body")}),
+                                    ${identifier("body")})) AS ${identifier("events")}
+            SELECT ${identifier("id")},
+                   ${identifier("context_name")},
+                   ${identifier("aggregate_name")},
+                   ${identifier("header")},
+                   ${identifier("aggregate_id")},
+                   ${identifier("tenant_id")},
+                   ${identifier("owner_id")},
+                   ${identifier("space_id")},
+                   ${identifier("command_id")},
+                   ${identifier("request_id")},
+                   ${identifier("version")},
+                   ${identifier("state")},
+                   ${identifier("events")}.1 AS ${identifier("event_sequence")},
+                   ${jsonTupleValue("events", 2, "id", "String")} AS ${identifier("event_id")},
+                   ${jsonTupleValue("events", 2, "name", "String")} AS ${identifier("event_name")},
+                   ${jsonTupleValue("events", 2, "revision", "String")} AS ${identifier("event_revision")},
+                   ${jsonTupleValue("events", 2, "bodyType", "String")} AS ${identifier("event_body_type")},
+                   ${jsonTupleRaw("events", 2, "body")} AS ${identifier("event_body")},
+                   ${identifier("first_operator")},
+                   ${identifier("first_event_time")},
+                   ${identifier("create_time")},
+                   ${identifier("tags")},
+                   ${identifier("deleted")}
+            FROM ${qualified(options.database, stateTable)}
+        """.trimIndent()
+    }
+}

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseStateLastRenderer.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseStateLastRenderer.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi.renderer
+
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.bi.BiObjectKey
+import me.ahoo.wow.bi.BiObjectKind
+import me.ahoo.wow.bi.ExpectedBiQuery
+import me.ahoo.wow.modeling.toStringWithAlias
+
+internal class ClickHouseStateLastRenderer(private val context: ClickHouseRenderContext) {
+    fun expectedQueries(namedAggregate: NamedAggregate): Map<BiObjectKey, ExpectedBiQuery> = with(context) {
+        val statePhysicalBase =
+            naming.toTableName(namedAggregate, ClickHouseScriptRenderer.STATE_SUFFIX)
+        val stateStoreTable = storageTable(statePhysicalBase)
+        val table = naming.toTableName(namedAggregate, ClickHouseScriptRenderer.STATE_LAST_SUFFIX)
+        val physicalBase =
+            naming.toTableName(namedAggregate, ClickHouseScriptRenderer.STATE_LAST_SUFFIX)
+        val storeTable = storageTable(physicalBase)
+        mapOf(
+            BiObjectKey(options.consumerDatabase, "${physicalBase}_consumer") to ExpectedBiQuery(
+                selectSql = renderConsumerSelect(stateStoreTable),
+                target = BiObjectKey(options.database, storeTable),
+            ),
+            BiObjectKey(options.database, table) to ExpectedBiQuery(renderPublicViewSelect(storeTable)),
+        )
+    }
+
+    fun render(namedAggregate: NamedAggregate): List<String> = with(context) {
+        val aggregate = namedAggregate.toStringWithAlias()
+        val statePhysicalBase =
+            naming.toTableName(namedAggregate, ClickHouseScriptRenderer.STATE_SUFFIX)
+        val stateStoreTable = storageTable(statePhysicalBase)
+        val table = naming.toTableName(namedAggregate, ClickHouseScriptRenderer.STATE_LAST_SUFFIX)
+        val physicalBase =
+            naming.toTableName(namedAggregate, ClickHouseScriptRenderer.STATE_LAST_SUFFIX)
+        val storeTable = storageTable(physicalBase)
+        val physicalTable = topology.physicalTableName(storeTable)
+        val consumerTable = "${physicalBase}_consumer"
+        val storeComment = metadataComment(BiObjectKind.STORE, aggregate)
+        val viewComment = metadataComment(BiObjectKind.VIEW, aggregate)
+        val consumerComment = metadataComment(BiObjectKind.CONSUMER, aggregate)
+        immutableStatements(
+            buildList {
+                add(renderStore(physicalTable, storeComment))
+                topology.distributedFacade(
+                    DistributedFacadeSpec(
+                        database = options.database,
+                        logicalTableName = storeTable,
+                        physicalTableName = physicalTable,
+                        shardingKey = "sipHash64(${identifier("tenant_id")}, ${identifier("aggregate_id")})",
+                        createIfNotExists = catalogMutationMode == CatalogMutationMode.RECONCILE,
+                    )
+                )?.withTableComment(storeComment)?.let(::add)
+                if (catalogMutationMode == CatalogMutationMode.RECONCILE) {
+                    add(dropView(options.consumerDatabase, consumerTable))
+                }
+                add(renderConsumer(consumerTable, storeTable, stateStoreTable, consumerComment))
+                add(renderPublicView(table, storeTable, viewComment))
+            }
+        )
+    }
+
+    private fun renderStore(physicalTable: String, comment: String): String = with(context) {
+        """
+            $tableCreateClause ${qualified(options.database, physicalTable)}${scopeClause()}
+            (
+                ${identifier("id")} String,
+                ${identifier("context_name")} String,
+                ${identifier("aggregate_name")} String,
+                ${identifier("header")} Map(String, String),
+                ${identifier("aggregate_id")} String,
+                ${identifier("tenant_id")} String,
+                ${identifier("owner_id")} String,
+                ${identifier("space_id")} String,
+                ${identifier("command_id")} String,
+                ${identifier("request_id")} String,
+                ${identifier("version")} UInt32,
+                ${identifier("state")} String,
+                ${identifier("body")} Array(String),
+                ${identifier("first_operator")} String,
+                ${identifier("first_event_time")} DateTime64(3, ${literal(options.timezone)}),
+                ${identifier("create_time")} DateTime64(3, ${literal(options.timezone)}),
+                ${identifier("tags")} Map(String, Array(String)),
+                ${identifier("deleted")} Bool
+            ) ${topology.engineSql(ReplacingMergeTreeSpec("version"))}
+                  PARTITION BY toYYYYMM(${identifier("first_event_time")})
+                  ORDER BY (${identifier("tenant_id")}, ${identifier("aggregate_id")})
+                  COMMENT $comment;
+        """.trimIndent()
+    }
+
+    private fun renderConsumer(
+        consumerTable: String,
+        storeTable: String,
+        stateStoreTable: String,
+        comment: String,
+    ): String = with(context) {
+        buildString {
+            appendLine(
+                "$materializedViewCreateClause ${qualified(options.consumerDatabase, consumerTable)}${scopeClause()}"
+            )
+            appendLine("TO ${qualified(options.database, storeTable)}")
+            appendLine("AS (")
+            appendLine(renderConsumerSelect(stateStoreTable))
+            append(") COMMENT $comment;")
+        }
+    }
+
+    private fun renderConsumerSelect(stateStoreTable: String): String = with(context) {
+        """
+            SELECT *
+            FROM ${qualified(options.database, stateStoreTable)}
+        """.trimIndent()
+    }
+
+    private fun renderPublicView(table: String, storeTable: String, comment: String): String = with(context) {
+        """
+            $viewCreateClause ${qualified(options.database, table)}${scopeClause()}
+            AS (${renderPublicViewSelect(storeTable)})
+            COMMENT $comment;
+        """.trimIndent()
+    }
+
+    private fun renderPublicViewSelect(storeTable: String): String = with(context) {
+        "SELECT * FROM ${qualified(options.database, storeTable)} FINAL"
+    }
+}

--- a/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseTopologyDdl.kt
+++ b/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseTopologyDdl.kt
@@ -19,6 +19,14 @@ import me.ahoo.wow.bi.renderer.ClickHouseSqlSyntax.stringLiteral
 
 internal data class ReplacingMergeTreeSpec(val versionColumn: String?)
 
+internal data class DistributedFacadeSpec(
+    val database: String,
+    val logicalTableName: String,
+    val physicalTableName: String,
+    val shardingKey: String,
+    val createIfNotExists: Boolean,
+)
+
 internal interface ClickHouseTopologyDdl {
     val scopeClause: String
 
@@ -26,13 +34,7 @@ internal interface ClickHouseTopologyDdl {
 
     fun engineSql(spec: ReplacingMergeTreeSpec): String
 
-    fun distributedFacade(
-        database: String,
-        logicalTableName: String,
-        physicalTableName: String,
-        shardingKey: String,
-        createIfNotExists: Boolean,
-    ): String?
+    fun distributedFacade(spec: DistributedFacadeSpec): String?
 
     fun dropTableNames(logicalTableName: String): List<String>
 }
@@ -59,19 +61,13 @@ private class ClusterTopologyDdl(private val topology: ClickHouseTopology.Cluste
         } ?: "ENGINE = ReplicatedReplacingMergeTree($path, $replica)"
     }
 
-    override fun distributedFacade(
-        database: String,
-        logicalTableName: String,
-        physicalTableName: String,
-        shardingKey: String,
-        createIfNotExists: Boolean,
-    ): String {
-        val ifNotExistsClause = if (createIfNotExists) " IF NOT EXISTS" else ""
+    override fun distributedFacade(spec: DistributedFacadeSpec): String {
+        val ifNotExistsClause = if (spec.createIfNotExists) " IF NOT EXISTS" else ""
         return """
-            CREATE TABLE$ifNotExistsClause ${qualified(database, logicalTableName)} $scopeClause
-            AS ${qualified(database, physicalTableName)}
-            ENGINE = Distributed(${stringLiteral(topology.name)}, ${quoteIdentifier(database)},
-                                 ${stringLiteral(physicalTableName)}, $shardingKey);
+            CREATE TABLE$ifNotExistsClause ${topologyQualified(spec.database, spec.logicalTableName)} $scopeClause
+            AS ${topologyQualified(spec.database, spec.physicalTableName)}
+            ENGINE = Distributed(${stringLiteral(topology.name)}, ${quoteIdentifier(spec.database)},
+                                 ${stringLiteral(spec.physicalTableName)}, ${spec.shardingKey});
         """.trimIndent()
     }
 
@@ -89,16 +85,10 @@ private data object StandaloneTopologyDdl : ClickHouseTopologyDdl {
             "ENGINE = ReplacingMergeTree(${quoteIdentifier(versionColumn)})"
         } ?: "ENGINE = ReplacingMergeTree"
 
-    override fun distributedFacade(
-        database: String,
-        logicalTableName: String,
-        physicalTableName: String,
-        shardingKey: String,
-        createIfNotExists: Boolean,
-    ): String? = null
+    override fun distributedFacade(spec: DistributedFacadeSpec): String? = null
 
     override fun dropTableNames(logicalTableName: String): List<String> = listOf(logicalTableName)
 }
 
-private fun qualified(database: String, table: String): String =
+private fun topologyQualified(database: String, table: String): String =
     "${quoteIdentifier(database)}.${quoteIdentifier(table)}"

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiDeploymentInspectorTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiDeploymentInspectorTest.kt
@@ -21,18 +21,20 @@ import reactor.core.publisher.Mono
 class BiDeploymentInspectorTest {
     @Test
     fun `no-op inspector should report unavailable instead of an empty deployment`() {
-        NoOpBiDeploymentInspector.inspect(BiScriptOptions()).block().assert()
+        val options = BiScriptOptions()
+        val preparation = BiScriptGenerator(options).prepare(emptySet())
+        NoOpBiDeploymentInspector.inspect(options, BiScriptOperation.Deploy, preparation).block().assert()
             .isEqualTo(BiDeploymentInspection.Unavailable)
         NoOpBiDeploymentInspector.allowsDynamicScope.assert().isTrue()
 
         val inspectedOperations = mutableListOf<BiScriptOperation>()
-        val authoritative = BiDeploymentInspector { _, operation ->
+        val authoritative = BiDeploymentInspector { _, operation, _ ->
             inspectedOperations += operation
             Mono.just(BiDeploymentInspection.Available(ObservedBiDeployment(emptyList())))
         }
         authoritative.allowsDynamicScope.assert().isFalse()
-        authoritative.inspect(BiScriptOptions()).block()
-        authoritative.inspect(BiScriptOptions(), BiScriptOperation.Reset(true)).block()
+        authoritative.inspect(options, BiScriptOperation.Deploy, preparation).block()
+        authoritative.inspect(options, BiScriptOperation.Reset(true), preparation).block()
         inspectedOperations.assert().containsExactly(
             BiScriptOperation.Deploy,
             BiScriptOperation.Reset(true),
@@ -57,65 +59,28 @@ class BiDeploymentInspectorTest {
     }
 
     @Test
-    fun `object metadata codec should reject protocol v1`() {
+    fun `object metadata codec should reject legacy metadata`() {
         val legacy = """
-            wow-bi:{
-              "protocolVersion": 1,
-              "layoutVersion": 6,
-              "deploymentId": "${"a".repeat(32)}",
-              "configurationFingerprint": "${"b".repeat(32)}",
-              "aggregate": null,
-              "kind": "ANCHOR",
-              "consumerIdentity": "${"c".repeat(32)}"
-            }
-        """.trimIndent()
-
-        assertThrows<IllegalArgumentException> {
-            BiObjectMetadataCodec.decode(legacy)
-        }.message.assert().contains("Unsupported BI object metadata protocol version: 1")
-    }
-
-    @Test
-    fun `object metadata codec should fail closed when protocol v2 phase is missing`() {
-        val incomplete = """
-            wow-bi:{
-              "protocolVersion": 2,
-              "layoutVersion": 6,
-              "deploymentId": "${"a".repeat(32)}",
-              "configurationFingerprint": "${"b".repeat(32)}",
-              "aggregate": null,
-              "kind": "ANCHOR",
-              "consumerIdentity": "${"c".repeat(32)}"
-            }
-        """.trimIndent()
-
-        assertThrows<IllegalArgumentException> {
-            BiObjectMetadataCodec.decode(incomplete)
-        }.message.assert().contains("protocol v2 requires phase")
-    }
-
-    @Test
-    fun `object metadata codec should fail closed when protocol v2 topology fingerprint is missing`() {
-        val incomplete = """
             wow-bi:{
               "protocolVersion": 2,
               "layoutVersion": 6,
               "phase": "STABLE",
               "deploymentId": "${"a".repeat(32)}",
               "configurationFingerprint": "${"b".repeat(32)}",
+              "topologyFingerprint": "${"c".repeat(32)}",
               "aggregate": null,
               "kind": "ANCHOR",
-              "consumerIdentity": "${"c".repeat(32)}"
+              "consumerIdentity": "${"d".repeat(32)}"
             }
         """.trimIndent()
 
         assertThrows<IllegalArgumentException> {
-            BiObjectMetadataCodec.decode(incomplete)
-        }.message.assert().contains("protocol v2 requires topologyFingerprint")
+            BiObjectMetadataCodec.decode(legacy)
+        }.message.assert().contains("Unsupported BI object metadata protocol version: 2")
     }
 
     @Test
-    fun `object metadata codec should fail closed for an unknown wire protocol`() {
+    fun `object metadata codec should fail closed for an invalid v3 layout pair`() {
         val unknown = """
             wow-bi:{
               "protocolVersion": 3,
@@ -123,6 +88,7 @@ class BiDeploymentInspectorTest {
               "phase": "STABLE",
               "deploymentId": "${"a".repeat(32)}",
               "configurationFingerprint": "${"b".repeat(32)}",
+              "topologyFingerprint": "${"d".repeat(32)}",
               "aggregate": null,
               "kind": "ANCHOR",
               "consumerIdentity": "${"c".repeat(32)}"
@@ -131,7 +97,7 @@ class BiDeploymentInspectorTest {
 
         assertThrows<IllegalArgumentException> {
             BiObjectMetadataCodec.decode(unknown)
-        }.message.assert().contains("Unsupported BI object metadata protocol version: 3")
+        }.message.assert().contains("Unsupported BI object metadata layout version: 6")
     }
 
     @Test

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiOwnershipRegistryPlanTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiOwnershipRegistryPlanTest.kt
@@ -84,13 +84,6 @@ class BiOwnershipRegistryPlanTest {
 
     @Test
     fun `existing computed object should update its definition through a verified transition`() {
-        val desiredView = DesiredBiObject(
-            key = BiObjectKey(options.database, "order_state"),
-            aggregate = "order",
-            kind = BiObjectKind.VIEW,
-            expectedEngine = "View",
-            expectedQuery = ExpectedBiQuery("SELECT * FROM order_state_store FINAL"),
-        )
         val current = activeRegistry(desiredView)
         val evolvedView = desiredView.copy(
             expectedQuery = ExpectedBiQuery("SELECT * FROM order_state_store FINAL WHERE deleted = false")
@@ -113,6 +106,106 @@ class BiOwnershipRegistryPlanTest {
             .isNotEqualTo(current.entries.single().definitionFingerprint)
     }
 
+    @Test
+    fun `unchanged active registration should not write another revision`() {
+        val current = activeRegistry(desiredStore)
+
+        val plan = BiOwnershipRegistryPlan.create(
+            descriptor = descriptor,
+            consumerIdentity = consumerIdentity,
+            desiredObjects = listOf(desiredStore),
+            current = current,
+        )
+
+        plan.intentChanged.assert().isFalse()
+        plan.verificationChanged.assert().isFalse()
+        plan.beforeMutation.assert().isEqualTo(current)
+        plan.afterVerification.assert().isEqualTo(current)
+    }
+
+    @Test
+    fun `pending create and update should resume verification without rewriting intent`() {
+        listOf(BiRegistryEntryStatus.PENDING_CREATE, BiRegistryEntryStatus.PENDING_UPDATE)
+            .forEach { status ->
+                val current = registryWith(desiredView, status)
+
+                val plan = BiOwnershipRegistryPlan.create(
+                    descriptor = descriptor,
+                    consumerIdentity = consumerIdentity,
+                    desiredObjects = listOf(desiredView),
+                    current = current,
+                )
+
+                plan.intentChanged.assert().isFalse()
+                plan.verificationChanged.assert().isTrue()
+                plan.beforeMutation.assert().isEqualTo(current)
+                plan.afterVerification.entries.single().status.assert()
+                    .isEqualTo(BiRegistryEntryStatus.ACTIVE)
+            }
+    }
+
+    @Test
+    fun `undesired computed object should complete drop through a tombstone`() {
+        val current = activeRegistry(desiredView)
+
+        val plan = BiOwnershipRegistryPlan.create(
+            descriptor = descriptor,
+            consumerIdentity = consumerIdentity,
+            desiredObjects = emptyList(),
+            current = current,
+        )
+
+        plan.beforeMutation.entries.single().status.assert()
+            .isEqualTo(BiRegistryEntryStatus.PENDING_DROP)
+        plan.afterVerification.entries.single().status.assert()
+            .isEqualTo(BiRegistryEntryStatus.TOMBSTONE)
+    }
+
+    @Test
+    fun `desired object should reject an interrupted pending drop`() {
+        val current = registryWith(desiredView, BiRegistryEntryStatus.PENDING_DROP)
+
+        assertThrows<IllegalStateException> {
+            BiOwnershipRegistryPlan.create(
+                descriptor = descriptor,
+                consumerIdentity = consumerIdentity,
+                desiredObjects = listOf(desiredView),
+                current = current,
+            )
+        }.message.assert().contains("is pending drop")
+    }
+
+    @Test
+    fun `undesired object should reject unverified create or update intent`() {
+        listOf(BiRegistryEntryStatus.PENDING_CREATE, BiRegistryEntryStatus.PENDING_UPDATE)
+            .forEach { status ->
+                val current = registryWith(desiredView, status)
+
+                assertThrows<IllegalStateException> {
+                    BiOwnershipRegistryPlan.create(
+                        descriptor = descriptor,
+                        consumerIdentity = consumerIdentity,
+                        desiredObjects = emptyList(),
+                        current = current,
+                    )
+                }.message.assert().contains("is still pending")
+            }
+    }
+
+    @Test
+    fun `registry from another deployment should be rejected`() {
+        val foreign = BiOwnershipRegistry.empty("ffffffffffffffffffffffffffffffff")
+
+        assertThrows<IllegalArgumentException> {
+            BiOwnershipRegistryPlan.create(
+                descriptor = descriptor,
+                consumerIdentity = consumerIdentity,
+                desiredObjects = emptyList(),
+                current = foreign,
+            )
+        }.message.assert().contains("different deployment")
+    }
+
     private fun activeRegistry(desired: DesiredBiObject): BiOwnershipRegistry {
         val initialPlan = BiOwnershipRegistryPlan.create(
             descriptor = descriptor,
@@ -122,4 +215,29 @@ class BiOwnershipRegistryPlanTest {
         )
         return initialPlan.afterVerification
     }
+
+    private fun registryWith(
+        desired: DesiredBiObject,
+        status: BiRegistryEntryStatus,
+    ): BiOwnershipRegistry {
+        val registration = desired.toRegistration(consumerIdentity)
+        val entry = BiOwnershipRegistryEntry(
+            key = registration.key,
+            kind = registration.kind,
+            aggregate = registration.aggregate,
+            consumerIdentity = registration.consumerIdentity,
+            definitionFingerprint = registration.definitionFingerprint,
+            revision = 1,
+            status = status,
+        )
+        return BiOwnershipRegistry.restore(descriptor.deploymentId, revision = 1, entries = listOf(entry))
+    }
+
+    private val desiredView = DesiredBiObject(
+        key = BiObjectKey(options.database, "order_state"),
+        aggregate = "order",
+        kind = BiObjectKind.VIEW,
+        expectedEngine = "View",
+        expectedQuery = ExpectedBiQuery("SELECT * FROM order_state_store FINAL"),
+    )
 }

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiOwnershipRegistryPlanTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiOwnershipRegistryPlanTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class BiOwnershipRegistryPlanTest {
+    private val options = BiScriptOptions(
+        topology = ClickHouseTopology.Standalone,
+        consumerGroupNamespace = "orders",
+    )
+    private val descriptor = BiDeploymentDescriptor.from(options)
+    private val consumerIdentity = BiConsumerIdentity.deterministic(descriptor)
+    private val desiredStore = DesiredBiObject(
+        key = BiObjectKey(options.database, "order_state_store"),
+        aggregate = "order",
+        kind = BiObjectKind.STORE,
+        expectedEngine = "ReplacingMergeTree",
+    )
+
+    @Test
+    fun `retiring an undesired store should persist the write-ahead mutation`() {
+        val current = activeRegistry(desiredStore)
+
+        val plan = BiOwnershipRegistryPlan.create(
+            descriptor = descriptor,
+            consumerIdentity = consumerIdentity,
+            desiredObjects = emptyList(),
+            current = current,
+        )
+
+        plan.intentChanged.assert().isTrue()
+        plan.verificationChanged.assert().isFalse()
+        plan.beforeMutation.entries.single().status.assert().isEqualTo(BiRegistryEntryStatus.RETIRED)
+        plan.afterVerification.assert().isEqualTo(plan.beforeMutation)
+    }
+
+    @Test
+    fun `desired retired object should be reactivated through verified create transition`() {
+        val retired = activeRegistry(desiredStore).retire(desiredStore.key)
+
+        val plan = BiOwnershipRegistryPlan.create(
+            descriptor = descriptor,
+            consumerIdentity = consumerIdentity,
+            desiredObjects = listOf(desiredStore),
+            current = retired,
+        )
+
+        plan.intentChanged.assert().isTrue()
+        plan.verificationChanged.assert().isTrue()
+        plan.beforeMutation.entries.single().status.assert()
+            .isEqualTo(BiRegistryEntryStatus.PENDING_CREATE)
+        plan.afterVerification.entries.single().status.assert()
+            .isEqualTo(BiRegistryEntryStatus.ACTIVE)
+    }
+
+    @Test
+    fun `existing active registration should reject a different desired contract`() {
+        val current = activeRegistry(desiredStore)
+        val incompatible = desiredStore.copy(expectedEngine = "MergeTree")
+
+        assertThrows<IllegalStateException> {
+            BiOwnershipRegistryPlan.create(
+                descriptor = descriptor,
+                consumerIdentity = consumerIdentity,
+                desiredObjects = listOf(incompatible),
+                current = current,
+            )
+        }.message.assert().contains("registration contract")
+    }
+
+    @Test
+    fun `existing computed object should update its definition through a verified transition`() {
+        val desiredView = DesiredBiObject(
+            key = BiObjectKey(options.database, "order_state"),
+            aggregate = "order",
+            kind = BiObjectKind.VIEW,
+            expectedEngine = "View",
+            expectedQuery = ExpectedBiQuery("SELECT * FROM order_state_store FINAL"),
+        )
+        val current = activeRegistry(desiredView)
+        val evolvedView = desiredView.copy(
+            expectedQuery = ExpectedBiQuery("SELECT * FROM order_state_store FINAL WHERE deleted = false")
+        )
+
+        val plan = BiOwnershipRegistryPlan.create(
+            descriptor = descriptor,
+            consumerIdentity = consumerIdentity,
+            desiredObjects = listOf(evolvedView),
+            current = current,
+        )
+
+        plan.intentChanged.assert().isTrue()
+        plan.verificationChanged.assert().isTrue()
+        plan.beforeMutation.entries.single().status.assert()
+            .isEqualTo(BiRegistryEntryStatus.PENDING_UPDATE)
+        plan.afterVerification.entries.single().status.assert()
+            .isEqualTo(BiRegistryEntryStatus.ACTIVE)
+        plan.afterVerification.entries.single().definitionFingerprint.assert()
+            .isNotEqualTo(current.entries.single().definitionFingerprint)
+    }
+
+    private fun activeRegistry(desired: DesiredBiObject): BiOwnershipRegistry {
+        val initialPlan = BiOwnershipRegistryPlan.create(
+            descriptor = descriptor,
+            consumerIdentity = consumerIdentity,
+            desiredObjects = listOf(desired),
+            current = null,
+        )
+        return initialPlan.afterVerification
+    }
+}

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiOwnershipRegistryTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiOwnershipRegistryTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class BiOwnershipRegistryTest {
+    @Test
+    fun `registry entries should reject invalid ownership invariants`() {
+        assertThrows<IllegalArgumentException> {
+            entry(revision = 0)
+        }.message.assert().contains("revision must be positive")
+        assertThrows<IllegalArgumentException> {
+            entry(aggregate = null)
+        }.message.assert().contains("requires an aggregate owner")
+        assertThrows<IllegalArgumentException> {
+            entry(definitionFingerprint = "invalid")
+        }.message.assert().contains("definitionFingerprint")
+    }
+
+    @Test
+    fun `restored registry should reject invalid revision and key invariants`() {
+        val entry = entry()
+
+        assertThrows<IllegalArgumentException> {
+            BiOwnershipRegistry.restore(DEPLOYMENT_ID, revision = -1, entries = emptyList())
+        }.message.assert().contains("must not be negative")
+        assertThrows<IllegalArgumentException> {
+            BiOwnershipRegistry.restore(DEPLOYMENT_ID, revision = 1, entries = listOf(entry, entry))
+        }.message.assert().contains("duplicate object keys")
+        assertThrows<IllegalArgumentException> {
+            BiOwnershipRegistry.restore(DEPLOYMENT_ID, revision = 0, entries = listOf(entry))
+        }.message.assert().contains("entry revision is ahead")
+    }
+
+    @Test
+    fun `registry should reject illegal mutation transitions`() {
+        val pending = BiOwnershipRegistry.empty(DEPLOYMENT_ID).beginCreate(REGISTRATION)
+
+        assertThrows<IllegalArgumentException> {
+            pending.beginCreate(REGISTRATION)
+        }.message.assert().contains("already registered")
+        assertThrows<IllegalArgumentException> {
+            pending.beginUpdate(REGISTRATION)
+        }.message.assert().contains("update requires ACTIVE")
+        assertThrows<IllegalArgumentException> {
+            pending.beginDrop(KEY)
+        }.message.assert().contains("drop requires ACTIVE or RETIRED")
+        assertThrows<IllegalArgumentException> {
+            pending.retire(KEY)
+        }.message.assert().contains("transition requires ACTIVE")
+
+        val active = pending.markMutationVerified(KEY)
+        assertThrows<IllegalArgumentException> {
+            active.markMutationVerified(KEY)
+        }.message.assert().contains("mutation verification requires")
+        assertThrows<IllegalArgumentException> {
+            active.markAbsenceVerified(KEY)
+        }.message.assert().contains("transition requires PENDING_DROP")
+    }
+
+    @Test
+    fun `registry should reject mutations for an unknown object`() {
+        val empty = BiOwnershipRegistry.empty(DEPLOYMENT_ID)
+
+        assertThrows<IllegalArgumentException> {
+            empty.beginUpdate(REGISTRATION)
+        }.message.assert().contains("is not registered")
+        assertThrows<IllegalArgumentException> {
+            empty.beginDrop(KEY)
+        }.message.assert().contains("is not registered")
+    }
+
+    private fun entry(
+        aggregate: String? = "order",
+        definitionFingerprint: String = DEFINITION_FINGERPRINT,
+        revision: Long = 1,
+    ): BiOwnershipRegistryEntry = BiOwnershipRegistryEntry(
+        key = KEY,
+        kind = BiObjectKind.VIEW,
+        aggregate = aggregate,
+        consumerIdentity = null,
+        definitionFingerprint = definitionFingerprint,
+        revision = revision,
+        status = BiRegistryEntryStatus.ACTIVE,
+    )
+
+    private companion object {
+        const val DEPLOYMENT_ID = "11111111111111111111111111111111"
+        const val DEFINITION_FINGERPRINT = "22222222222222222222222222222222"
+        val KEY = BiObjectKey("bi_db", "order_state")
+        val REGISTRATION = BiOwnershipRegistration(
+            key = KEY,
+            kind = BiObjectKind.VIEW,
+            aggregate = "order",
+            consumerIdentity = null,
+            definitionFingerprint = DEFINITION_FINGERPRINT,
+        )
+    }
+}

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiPublicApiTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiPublicApiTest.kt
@@ -26,6 +26,7 @@ import kotlin.reflect.full.declaredMemberProperties
 
 class BiPublicApiTest {
     @Test
+    @Suppress("LongMethod")
     fun `should expose only the supported Kotlin API types`() {
         val publicTypes = productionTypes()
             .filter { it.isEffectivelyPublic() }
@@ -61,6 +62,7 @@ class BiPublicApiTest {
             BiScriptOperation.Reset::class.qualifiedName,
             BiScriptOptions::class.qualifiedName,
             BiScriptOptions.Companion::class.qualifiedName,
+            BiScriptPreparation::class.qualifiedName,
             BiScriptResult::class.qualifiedName,
             ClickHouseBiDeploymentInspector::class.qualifiedName,
             ClickHouseClientOptions::class.qualifiedName,

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiScriptGeneratorTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiScriptGeneratorTest.kt
@@ -86,6 +86,18 @@ class BiScriptGeneratorTest {
     }
 
     @Test
+    fun `bootstrap registry creation should be retryable before its first head is written`() {
+        val options = BiScriptOptions(consumerGroupNamespace = "test")
+        val registryName = BiOwnershipRegistry.empty(
+            BiDeploymentDescriptor.from(options).deploymentId
+        ).name
+
+        generator(options).generate(setOf(aggregate)).script.assert().contains(
+            "CREATE TABLE IF NOT EXISTS \"${options.consumerDatabase}\".\"$registryName\""
+        )
+    }
+
+    @Test
     fun `should match complete scripts for every topology`() {
         val clusterScript = generator().generate(setOf(aggregate)).script
         val standaloneScript = BiScriptGenerator(
@@ -274,7 +286,11 @@ class BiScriptGeneratorTest {
         result.diagnostics.single { it.code == BiScriptDiagnosticCode.INSPECTION_UNAVAILABLE }
             .decision.assert().isEqualTo(BiScriptMappingDecision.RECONCILIATION_SKIPPED)
         result.script.assert().contains("__wow_bi_deployment", "wow-bi:")
-        result.statements.drop(2).joinToString("\n").assert()
+        result.statements
+            .drop(2)
+            .filterNot { it.contains("__wow_bi_registry_") }
+            .joinToString("\n")
+            .assert()
             .doesNotContain("DROP ", "CREATE OR REPLACE", "IF NOT EXISTS")
             .contains(
                 "CREATE TABLE \"bi_db\".\"bi_aggregate_command_store_local\"",

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiScriptGeneratorTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiScriptGeneratorTest.kt
@@ -398,6 +398,48 @@ class BiScriptGeneratorTest {
     }
 
     @Test
+    fun `should delete registry owned objects whose catalog comment is missing during reset`() {
+        val options = BiScriptOptions(consumerGroupNamespace = "test")
+        val descriptor = BiDeploymentDescriptor.from(options)
+        val identity = BiConsumerIdentity.deterministic(descriptor)
+        val key = BiObjectKey("bi_db", "bi_sibling_command_store")
+        val registry = BiOwnershipRegistry.empty(descriptor.deploymentId)
+            .beginCreate(
+                BiOwnershipRegistration(
+                    key = key,
+                    kind = BiObjectKind.STORE,
+                    aggregate = "bi-service.sibling",
+                    consumerIdentity = identity.value,
+                    definitionFingerprint = "a".repeat(32),
+                )
+            ).markMutationVerified(key)
+        val inspection = BiDeploymentInspection.Available.reconciled(
+            deployment = ObservedBiDeployment(
+                listOf(
+                    anchor(options = options, identity = identity),
+                    ObservedBiObject(
+                        database = key.database,
+                        name = key.name,
+                        engine = "ReplacingMergeTree",
+                    ),
+                )
+            ),
+            repairableComputedDrifts = emptyList(),
+            ownershipRegistry = registry,
+        )
+
+        val result = generator(options).generate(
+            setOf(aggregate),
+            BiScriptOperation.Reset(true),
+            inspection,
+        )
+
+        result.script.assert().contains(
+            "DROP TABLE IF EXISTS \"${key.database}\".\"${key.name}\""
+        )
+    }
+
+    @Test
     fun `should drop the ownership registry after persisting reset intent`() {
         val options = BiScriptOptions(consumerGroupNamespace = "test")
         val descriptor = BiDeploymentDescriptor.from(options)

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiScriptGeneratorTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiScriptGeneratorTest.kt
@@ -450,6 +450,53 @@ class BiScriptGeneratorTest {
             inspection,
         )
 
+        val objectDrop = result.script.indexOf(
+            "DROP TABLE IF EXISTS \"${key.database}\".\"${key.name}\""
+        )
+        val registryDrop = result.script.indexOf(
+            "DROP TABLE IF EXISTS \"${options.consumerDatabase}\".\"${registry.name}\""
+        )
+        objectDrop.assert().isGreaterThanOrEqualTo(0)
+        objectDrop.assert().isLessThan(registryDrop)
+    }
+
+    @Test
+    fun `should reconcile registry owned stale objects whose catalog comment is missing during deploy`() {
+        val options = BiScriptOptions(consumerGroupNamespace = "test")
+        val descriptor = BiDeploymentDescriptor.from(options)
+        val identity = BiConsumerIdentity.deterministic(descriptor)
+        val key = BiObjectKey(options.consumerDatabase, "bi_sibling_command_queue")
+        val registry = BiOwnershipRegistry.empty(descriptor.deploymentId)
+            .beginCreate(
+                BiOwnershipRegistration(
+                    key = key,
+                    kind = BiObjectKind.QUEUE,
+                    aggregate = "bi-service.sibling",
+                    consumerIdentity = identity.value,
+                    definitionFingerprint = "a".repeat(32),
+                )
+            ).markMutationVerified(key)
+        val inspection = BiDeploymentInspection.Available.reconciled(
+            deployment = ObservedBiDeployment(
+                listOf(
+                    anchor(options = options, identity = identity),
+                    ObservedBiObject(
+                        database = key.database,
+                        name = key.name,
+                        engine = "Kafka",
+                    ),
+                )
+            ),
+            repairableComputedDrifts = emptyList(),
+            ownershipRegistry = registry,
+        )
+
+        val result = generator(options).generate(
+            setOf(aggregate),
+            BiScriptOperation.Deploy,
+            inspection,
+        )
+
         result.script.assert().contains(
             "DROP TABLE IF EXISTS \"${key.database}\".\"${key.name}\""
         )
@@ -725,6 +772,26 @@ class BiScriptGeneratorTest {
                 availableInspection(distributedStoreUsingLocalEngine),
             )
         }.message.assert().contains("expected engine", "Distributed")
+    }
+
+    @Test
+    fun `should let reset repair a desired store engine drift`() {
+        val driftedStore = observed(
+            database = "bi_db",
+            name = "bi_aggregate_command_store",
+            kind = BiObjectKind.STORE,
+            aggregate = "bi.aggregate",
+        ).copy(engine = "MergeTree")
+
+        val result = generator().generate(
+            setOf(aggregate),
+            BiScriptOperation.Reset(true),
+            availableInspection(anchor(), driftedStore),
+        )
+
+        result.script.assert().contains(
+            "DROP TABLE IF EXISTS \"bi_db\".\"bi_aggregate_command_store\""
+        )
     }
 
     @Test

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiScriptGeneratorTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiScriptGeneratorTest.kt
@@ -28,6 +28,32 @@ class BiScriptGeneratorTest {
     private val sibling = namedAggregate("sibling")
 
     @Test
+    fun `should reuse a request scoped preparation and reject different options`() {
+        val originalGenerator = generator()
+        val requestAggregates = linkedSetOf(aggregate)
+        val preparation = originalGenerator.prepare(requestAggregates)
+        requestAggregates.clear()
+
+        preparation.namedAggregates.assert().containsExactly(aggregate)
+        assertThrows<UnsupportedOperationException> {
+            @Suppress("UNCHECKED_CAST")
+            (preparation.desiredObjects as MutableList<DesiredBiObject>).clear()
+        }
+
+        originalGenerator.generate(preparation).assert()
+            .isEqualTo(originalGenerator.generate(setOf(aggregate)))
+
+        val changedOptions = BiScriptOptions(
+            consumerGroupNamespace = "test",
+            topicPrefix = "changed.",
+            maxExpansionDepth = 1,
+        )
+        assertThrows<IllegalArgumentException> {
+            BiScriptGenerator(changedOptions).generate(preparation)
+        }.message.assert().contains("prepared with different BI script options")
+    }
+
+    @Test
     fun `should generate complete default sections with lossless fallbacks`() {
         val result = generator().generate(setOf(aggregate))
 
@@ -369,6 +395,31 @@ class BiScriptGeneratorTest {
             "DROP TABLE IF EXISTS \"bi_db_consumer\".\"bi_sibling_command_queue\"",
             "DROP TABLE IF EXISTS \"bi_db\".\"bi_sibling_command_store\"",
         )
+    }
+
+    @Test
+    fun `should drop the ownership registry after persisting reset intent`() {
+        val options = BiScriptOptions(consumerGroupNamespace = "test")
+        val descriptor = BiDeploymentDescriptor.from(options)
+        val registry = BiOwnershipRegistry.empty(descriptor.deploymentId)
+        val inspection = BiDeploymentInspection.Available.reconciled(
+            deployment = ObservedBiDeployment(listOf(anchor(options = options))),
+            repairableComputedDrifts = emptyList(),
+            ownershipRegistry = registry,
+        )
+
+        val result = generator(options).generate(
+            setOf(aggregate),
+            BiScriptOperation.Reset(true),
+            inspection,
+        )
+
+        val resetIntent = result.script.indexOf("deployment-reset-intent")
+        val registryDrop = result.script.indexOf(
+            "DROP TABLE IF EXISTS \"${options.consumerDatabase}\".\"${registry.name}\""
+        )
+        resetIntent.assert().isLessThan(registryDrop)
+        registryDrop.assert().isGreaterThanOrEqualTo(0)
     }
 
     @Test
@@ -733,7 +784,7 @@ class BiScriptGeneratorTest {
     }
 
     @Test
-    fun `should reject topology migration through deploy or reset`() {
+    fun `should reject topology changes through deploy or reset`() {
         val currentOptions = BiScriptOptions(
             consumerGroupNamespace = "test",
             topology = ClickHouseTopology.Cluster(name = "current-cluster", installation = "current-installation"),
@@ -750,7 +801,7 @@ class BiScriptGeneratorTest {
             listOf(BiScriptOperation.Deploy, BiScriptOperation.Reset(true)).forEach { operation ->
                 assertThrows<IllegalArgumentException> {
                     generator(changedOptions).generate(setOf(aggregate), operation, inspection)
-                }.message.assert().contains("topology", "cannot be migrated")
+                }.message.assert().contains("topology", "cannot be changed")
             }
         }
     }

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiScriptOptionsTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/BiScriptOptionsTest.kt
@@ -237,6 +237,7 @@ class BiScriptOptionsTest {
             BiScriptDiagnosticCode.INSPECTION_UNAVAILABLE,
             BiScriptDiagnosticCode.ORPHANED_DATA_TABLE,
             BiScriptDiagnosticCode.CLUSTER_INTERNAL_REPLICATION_REQUIRED,
+            BiScriptDiagnosticCode.COMPUTED_OBJECT_DRIFT,
         )
         BiScriptMappingDecision.entries.assert().containsExactly(
             BiScriptMappingDecision.RAW_JSON,
@@ -244,6 +245,7 @@ class BiScriptOptionsTest {
             BiScriptMappingDecision.RECONCILIATION_SKIPPED,
             BiScriptMappingDecision.DATA_TABLE_RETAINED,
             BiScriptMappingDecision.EXTERNAL_CONFIGURATION_REQUIRED,
+            BiScriptMappingDecision.RECONCILIATION_PLANNED,
         )
     }
 }

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspectorTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspectorTest.kt
@@ -22,9 +22,13 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.configuration.MetadataSearcher
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.assertTimeoutPreemptively
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
 import reactor.kotlin.test.test
 import reactor.test.scheduler.VirtualTimeScheduler
 import tools.jackson.core.JacksonException
@@ -79,23 +83,28 @@ class ClickHouseBiDeploymentInspectorTest {
     }
 
     @Test
-    fun `should inspect an authoritative empty standalone catalog off the caller thread`() {
+    fun `should inspect an authoritative empty standalone catalog on the dedicated scheduler`() {
         val queryThread = AtomicReference<String>()
         val client = StubClickHouseCatalogClient { sql, parameters, columns ->
             queryThread.set(Thread.currentThread().name)
-            sql.assert()
-                .contains(
-                    "FROM system.tables",
-                    "show_table_uuid_in_table_create_query_if_not_nil = 0",
-                )
-                .doesNotContain("clusterAllReplicas")
+            if (sql.contains("registryTable")) {
+                columns.assert().containsExactlyElementsOf(REGISTRY_TABLE_COLUMNS)
+                return@StubClickHouseCatalogClient emptyList()
+            }
+            sql.assert().contains("FROM system.tables").doesNotContain("clusterAllReplicas")
+            if (columns == CATALOG_COLUMNS) {
+                sql.assert().contains("show_table_uuid_in_table_create_query_if_not_nil = 0")
+            }
             parameters.assert().isEqualTo(
                 mapOf(
                     "database" to OPTIONS.database,
                     "consumerDatabase" to OPTIONS.consumerDatabase,
+                    "ownershipPrefix" to BI_OBJECT_METADATA_PREFIX,
+                    "databaseTables" to "[]",
+                    "consumerDatabaseTables" to "['__wow_bi_deployment']",
                 )
             )
-            columns.assert().containsExactlyElementsOf(CATALOG_COLUMNS)
+            columns.assert().containsExactlyElementsOf(OBJECT_KEY_COLUMNS)
             emptyList()
         }
 
@@ -103,7 +112,338 @@ class ClickHouseBiDeploymentInspectorTest {
             as BiDeploymentInspection.Available
 
         inspection.deployment.objects.assert().isEmpty()
-        queryThread.get().assert().startsWith("boundedElastic-")
+        queryThread.get().assert().startsWith("wow-bi-catalog-inspection-")
+    }
+
+    @Test
+    fun `should scope the standalone catalog query to desired and owned objects`() {
+        val aggregate = MetadataSearcher.localAggregates.single { it.aggregateName == "aggregate" }
+        val queryCount = AtomicInteger()
+        val candidateName = "bi_aggregate_command_store"
+        val client = StubClickHouseCatalogClient { sql, parameters, columns ->
+            queryCount.incrementAndGet()
+            when (columns) {
+                REGISTRY_TABLE_COLUMNS -> {
+                    parameters["registryDatabase"].assert().isEqualTo(OPTIONS.consumerDatabase)
+                    parameters["registryTable"].toString().assert().startsWith("__wow_bi_registry_")
+                    emptyList()
+                }
+
+                OBJECT_KEY_COLUMNS -> {
+                    sql.assert()
+                        .contains(
+                            "startsWith(comment, {ownershipPrefix:String})",
+                            "name IN {databaseTables:Array(String)}",
+                            "name IN {consumerDatabaseTables:Array(String)}",
+                        )
+                        .doesNotContain("create_table_query")
+                    parameters["ownershipPrefix"].assert().isEqualTo("wow-bi:")
+                    parameters["databaseTables"].toString().assert().contains(
+                        candidateName,
+                        "bi_aggregate_state_store",
+                        "bi_aggregate_state_last_store",
+                    )
+                    parameters["consumerDatabaseTables"].toString().assert().contains(
+                        "bi_aggregate_command_queue",
+                        "bi_aggregate_state_consumer",
+                        "__wow_bi_deployment",
+                    )
+                    listOf(catalogRecord(database = OPTIONS.database, name = candidateName))
+                }
+
+                CATALOG_COLUMNS -> {
+                    sql.assert()
+                        .contains("create_table_query", "name IN {databaseTables:Array(String)}")
+                        .doesNotContain("startsWith(comment", "ownershipPrefix")
+                    parameters.containsKey("ownershipPrefix").assert().isFalse()
+                    parameters["databaseTables"].toString().assert().contains(candidateName)
+                    emptyList()
+                }
+
+                else -> error("Unexpected catalog columns: $columns")
+            }
+        }
+
+        val inspection = ClickHouseBiDeploymentInspector(client)
+            .inspect(OPTIONS, BiScriptOperation.Deploy, setOf(aggregate))
+            .block() as BiDeploymentInspection.Available
+
+        inspection.deployment.objects.assert().isEmpty()
+        queryCount.get().assert().isEqualTo(3)
+    }
+
+    @Test
+    fun `should prepare the scoped catalog on the caller scheduler`() {
+        val aggregate = MetadataSearcher.localAggregates.single { it.aggregateName == "aggregate" }
+        val planningThread = AtomicReference<String>()
+        val recordingAggregate = object : NamedAggregate {
+            override val contextName: String
+                get() {
+                    planningThread.compareAndSet(null, Thread.currentThread().name)
+                    return aggregate.contextName
+                }
+            override val aggregateName: String
+                get() {
+                    planningThread.compareAndSet(null, Thread.currentThread().name)
+                    return aggregate.aggregateName
+                }
+        }
+        val requestScheduler = Schedulers.newSingle("request-event-loop")
+        try {
+            val inspection = Mono.defer {
+                ClickHouseBiDeploymentInspector(StubClickHouseCatalogClient(emptyList()))
+                    .inspect(OPTIONS, BiScriptOperation.Deploy, setOf(recordingAggregate))
+            }.subscribeOn(requestScheduler).block() as BiDeploymentInspection.Available
+
+            inspection.deployment.objects.assert().isEmpty()
+            planningThread.get().assert()
+                .startsWith("request-event-loop")
+        } finally {
+            requestScheduler.dispose()
+        }
+    }
+
+    @Test
+    fun `should reuse prepared desired object keys without replanning during inspection`() {
+        val aggregate = MetadataSearcher.localAggregates.single { it.aggregateName == "aggregate" }
+        var rejectMetadataAccess = false
+        val guardedAggregate = object : NamedAggregate {
+            override val contextName: String
+                get() {
+                    check(!rejectMetadataAccess) { "prepared inspection must not read aggregate metadata again" }
+                    return aggregate.contextName
+                }
+            override val aggregateName: String
+                get() {
+                    check(!rejectMetadataAccess) { "prepared inspection must not read aggregate metadata again" }
+                    return aggregate.aggregateName
+                }
+        }
+        val preparation = BiScriptGenerator(OPTIONS).prepare(setOf(guardedAggregate))
+        rejectMetadataAccess = true
+
+        val inspection = ClickHouseBiDeploymentInspector(StubClickHouseCatalogClient(emptyList()))
+            .inspect(OPTIONS, BiScriptOperation.Deploy, preparation)
+            .block() as BiDeploymentInspection.Available
+
+        inspection.deployment.objects.assert().isEmpty()
+    }
+
+    @Test
+    @Suppress("LongMethod") // Keeps the prepared manifest, catalog fixture, and generated diagnostic in one proof.
+    fun `should report repairable computed definition drift from prepared inspection`() {
+        val aggregate = MetadataSearcher.localAggregates.single { it.aggregateName == "aggregate" }
+        val generator = BiScriptGenerator(OPTIONS)
+        val preparation = generator.prepare(setOf(aggregate))
+        val desiredView = preparation.desiredObjects.first { desired -> desired.kind == BiObjectKind.VIEW }
+        val viewMetadata = BiObjectMetadata(
+            deploymentId = DESCRIPTOR.deploymentId,
+            configurationFingerprint = DESCRIPTOR.configurationFingerprint,
+            topologyFingerprint = DESCRIPTOR.topologyFingerprint,
+            aggregate = desiredView.aggregate,
+            kind = BiObjectKind.VIEW,
+        )
+        val anchorMetadata = BiObjectMetadata(
+            deploymentId = DESCRIPTOR.deploymentId,
+            configurationFingerprint = DESCRIPTOR.configurationFingerprint,
+            topologyFingerprint = DESCRIPTOR.topologyFingerprint,
+            kind = BiObjectKind.ANCHOR,
+            consumerIdentity = BiConsumerIdentity.deterministic(DESCRIPTOR).value,
+        )
+        val catalog = records(
+            catalogRecord(
+                database = desiredView.key.database,
+                name = desiredView.key.name,
+                comment = BiObjectMetadataCodec.encode(viewMetadata),
+                createTableQuery = "CREATE VIEW ${desiredView.key.database}.${desiredView.key.name} " +
+                    "AS SELECT 1 AS drifted",
+                asSelect = "SELECT 1 AS drifted",
+            ),
+            catalogRecord(
+                database = OPTIONS.consumerDatabase,
+                name = "__wow_bi_deployment",
+                comment = BiObjectMetadataCodec.encode(anchorMetadata),
+                createTableQuery = "CREATE VIEW ${OPTIONS.consumerDatabase}.__wow_bi_deployment " +
+                    "AS SELECT 1 AS alive WHERE 0",
+                asSelect = "SELECT 1 AS alive WHERE 0",
+            ),
+        )
+        val client = StubClickHouseCatalogClient { sql, _, _ ->
+            if (sql.contains("formatQuerySingleLineOrNull(JSONExtractString")) {
+                listOf(
+                    ClickHouseCatalogRecord(
+                        mapOf(
+                            "database" to desiredView.key.database,
+                            "name" to desiredView.key.name,
+                            "canonical_select" to checkNotNull(desiredView.expectedQuery).selectSql,
+                        )
+                    )
+                )
+            } else {
+                catalog
+            }
+        }
+
+        val inspection = ClickHouseBiDeploymentInspector(client)
+            .inspect(OPTIONS, BiScriptOperation.Deploy, preparation)
+            .block() as BiDeploymentInspection.Available
+        val result = generator.generate(preparation, inspection = inspection)
+
+        result.diagnostics.any { diagnostic ->
+            diagnostic.message.contains("definition drift") && diagnostic.message.contains(desiredView.key.name)
+        }.assert().isTrue()
+        result.script.assert().contains(
+            "CREATE OR REPLACE VIEW \"${desiredView.key.database}\".\"${desiredView.key.name}\""
+        )
+    }
+
+    @Test
+    fun `should scope every cluster replica catalog query to desired and owned objects`() {
+        val aggregate = MetadataSearcher.localAggregates.single { it.aggregateName == "aggregate" }
+        val candidateName = "bi_aggregate_command_store"
+        val queryCount = AtomicInteger()
+        val client = StubClickHouseCatalogClient { sql, parameters, columns ->
+            queryCount.incrementAndGet()
+            when {
+                sql.contains("system.one") -> listOf(nodeRecord(NODE_A), nodeRecord(NODE_B))
+                sql.contains("registryTable") -> emptyList()
+                columns == OBJECT_KEY_COLUMNS -> {
+                    sql.assert().contains(
+                        "SELECT DISTINCT database, name",
+                        "clusterAllReplicas",
+                        "startsWith(comment, {ownershipPrefix:String})",
+                        "name IN {databaseTables:Array(String)}",
+                    ).doesNotContain("create_table_query")
+                    parameters["cluster"].assert().isEqualTo(CLUSTER.name)
+                    parameters["ownershipPrefix"].assert().isEqualTo("wow-bi:")
+                    parameters["databaseTables"].toString().assert().contains(candidateName)
+                    listOf(catalogRecord(database = CLUSTER_OPTIONS.database, name = candidateName))
+                }
+
+                else -> {
+                    columns.assert().containsExactlyElementsOf(NODE_COLUMNS + CATALOG_COLUMNS)
+                    sql.assert()
+                        .contains("clusterAllReplicas", "create_table_query", "name IN {databaseTables:Array(String)}")
+                        .doesNotContain("startsWith(comment", "ownershipPrefix")
+                    parameters["cluster"].assert().isEqualTo(CLUSTER.name)
+                    parameters.containsKey("ownershipPrefix").assert().isFalse()
+                    parameters["databaseTables"].toString().assert().contains(candidateName)
+                    emptyList()
+                }
+            }
+        }
+
+        val inspection = ClickHouseBiDeploymentInspector(client)
+            .inspect(CLUSTER_OPTIONS, BiScriptOperation.Deploy, setOf(aggregate))
+            .block() as BiDeploymentInspection.Available
+
+        inspection.deployment.objects.assert().isEmpty()
+        queryCount.get().assert().isEqualTo(5)
+    }
+
+    @Test
+    fun `should bound concurrent catalog inspections`() {
+        val activeQueries = AtomicInteger()
+        val maximumActiveQueries = AtomicInteger()
+        val firstFourQueries = CountDownLatch(4)
+        val unexpectedFifthQuery = CountDownLatch(1)
+        val releaseQueries = CountDownLatch(1)
+        val client = StubClickHouseCatalogClient { _, _, _ ->
+            val active = activeQueries.incrementAndGet()
+            maximumActiveQueries.accumulateAndGet(active, ::maxOf)
+            if (active > 4) {
+                unexpectedFifthQuery.countDown()
+            }
+            firstFourQueries.countDown()
+            try {
+                releaseQueries.await(5, TimeUnit.SECONDS).assert().isTrue()
+                emptyList()
+            } finally {
+                activeQueries.decrementAndGet()
+            }
+        }
+
+        val futures = List(8) {
+            ClickHouseBiDeploymentInspector(client).inspect(OPTIONS).toFuture()
+        }
+        try {
+            firstFourQueries.await(5, TimeUnit.SECONDS).assert().isTrue()
+            unexpectedFifthQuery.await(250, TimeUnit.MILLISECONDS).assert().isFalse()
+        } finally {
+            releaseQueries.countDown()
+        }
+        CompletableFuture.allOf(*futures.toTypedArray()).get(5, TimeUnit.SECONDS)
+
+        maximumActiveQueries.get().assert().isEqualTo(4)
+    }
+
+    @Test
+    fun `should classify a saturated inspection scheduler as unavailable`() {
+        val queryStarted = CountDownLatch(1)
+        val releaseQuery = CountDownLatch(1)
+        val scheduler = Schedulers.newBoundedElastic(1, 1, "saturated-bi-inspection")
+        val client = StubClickHouseCatalogClient { _, _, _ ->
+            queryStarted.countDown()
+            releaseQuery.await(5, TimeUnit.SECONDS).assert().isTrue()
+            emptyList()
+        }
+        val inspector = ClickHouseBiDeploymentInspector(
+            catalogClient = client,
+            inspectionScheduler = scheduler,
+        )
+        val active = inspector.inspect(OPTIONS).toFuture()
+        try {
+            queryStarted.await(5, TimeUnit.SECONDS).assert().isTrue()
+            val queued = inspector.inspect(OPTIONS).toFuture()
+
+            inspector.inspect(OPTIONS).test()
+                .expectErrorMatches { error ->
+                    error is BiDeploymentInspectionException.Unavailable &&
+                        error.message == "ClickHouse BI catalog inspection is overloaded"
+                }
+                .verify()
+
+            releaseQuery.countDown()
+            CompletableFuture.allOf(active, queued).get(5, TimeUnit.SECONDS)
+        } finally {
+            releaseQuery.countDown()
+            scheduler.dispose()
+        }
+    }
+
+    @Test
+    fun `should classify rejected scoped planning as unavailable`() {
+        val aggregate = MetadataSearcher.localAggregates.single { it.aggregateName == "aggregate" }
+        val queryStarted = CountDownLatch(1)
+        val releaseQuery = CountDownLatch(1)
+        val scheduler = Schedulers.newBoundedElastic(1, 1, "saturated-bi-scope")
+        val client = StubClickHouseCatalogClient { _, _, _ ->
+            queryStarted.countDown()
+            releaseQuery.await(5, TimeUnit.SECONDS).assert().isTrue()
+            emptyList()
+        }
+        val inspector = ClickHouseBiDeploymentInspector(
+            catalogClient = client,
+            inspectionScheduler = scheduler,
+        )
+        val active = inspector.inspect(OPTIONS).toFuture()
+        try {
+            queryStarted.await(5, TimeUnit.SECONDS).assert().isTrue()
+            val queued = inspector.inspect(OPTIONS).toFuture()
+
+            inspector.inspect(OPTIONS, BiScriptOperation.Deploy, setOf(aggregate)).test()
+                .expectErrorMatches { error ->
+                    error is BiDeploymentInspectionException.Unavailable &&
+                        error.message == "ClickHouse BI catalog inspection is overloaded"
+                }
+                .verify()
+
+            releaseQuery.countDown()
+            CompletableFuture.allOf(active, queued).get(5, TimeUnit.SECONDS)
+        } finally {
+            releaseQuery.countDown()
+            scheduler.dispose()
+        }
     }
 
     @Test
@@ -135,6 +475,148 @@ class ClickHouseBiDeploymentInspectorTest {
             as BiDeploymentInspection.Available
 
         available.deployment.objects.single().metadata.assert().isEqualTo(metadata)
+    }
+
+    @Test
+    fun `should validate every standalone store physical shape`() {
+        val stores = listOf(
+            catalogRecord(
+                name = "example_order_command_store",
+                engine = "ReplacingMergeTree",
+                engineFull = "ReplacingMergeTree PARTITION BY toYYYYMM(create_time) ORDER BY id SETTINGS x = 1",
+                comment = storeComment(),
+                partitionKey = "toYYYYMM(create_time)",
+                sortingKey = "id",
+            ),
+            catalogRecord(
+                name = "example_order_state_store",
+                engine = "ReplacingMergeTree",
+                engineFull = "ReplacingMergeTree(version) PARTITION BY toYYYYMM(create_time) " +
+                    "ORDER BY (tenant_id, aggregate_id, version)",
+                comment = storeComment(),
+                partitionKey = "toYYYYMM(create_time)",
+                sortingKey = "tenant_id, aggregate_id, version",
+            ),
+            catalogRecord(
+                name = "example_order_state_last_store",
+                engine = "ReplacingMergeTree",
+                engineFull = "ReplacingMergeTree(version) PARTITION BY toYYYYMM(first_event_time) " +
+                    "ORDER BY (tenant_id, aggregate_id)",
+                comment = storeComment(),
+                partitionKey = "toYYYYMM(first_event_time)",
+                sortingKey = "tenant_id, aggregate_id",
+            ),
+        )
+
+        val available = ClickHouseBiDeploymentInspector(StubClickHouseCatalogClient(stores))
+            .inspect(OPTIONS)
+            .block() as BiDeploymentInspection.Available
+
+        available.deployment.objects.assert().hasSize(3)
+    }
+
+    @Test
+    fun `should reject a standalone store with a drifted column type`() {
+        val store = catalogRecord(
+            name = "example_order_command_store",
+            engine = "ReplacingMergeTree",
+            engineFull = "ReplacingMergeTree PARTITION BY toYYYYMM(create_time) ORDER BY id",
+            comment = storeComment(),
+            partitionKey = "toYYYYMM(create_time)",
+            sortingKey = "id",
+        )
+        val client = StubClickHouseCatalogClient { sql, _, _ ->
+            if (sql.contains("system.columns")) {
+                expectedColumnRecords(listOf(store), "tenant_id" to "UInt64")
+            } else {
+                listOf(store)
+            }
+        }
+
+        ClickHouseBiDeploymentInspector(client).inspect(OPTIONS).test()
+            .expectErrorMatches { error ->
+                error is BiDeploymentInspectionException.Inconsistent &&
+                    error.message!!.contains("unexpected column schema") &&
+                    error.message!!.contains("tenant_id")
+            }
+            .verify()
+    }
+
+    @Test
+    fun `should reject standalone store engine and naming drift`() {
+        val invalidEngine = catalogRecord(
+            name = "example_order_state_store",
+            engine = "ReplacingMergeTree",
+            engineFull = "ReplacingMergeTree PARTITION BY toYYYYMM(create_time) " +
+                "ORDER BY (tenant_id, aggregate_id, version)",
+            comment = storeComment(),
+            partitionKey = "toYYYYMM(create_time)",
+            sortingKey = "tenant_id, aggregate_id, version",
+        )
+        ClickHouseBiDeploymentInspector(StubClickHouseCatalogClient(listOf(invalidEngine))).inspect(OPTIONS).test()
+            .expectErrorMatches { error ->
+                error is BiDeploymentInspectionException.Inconsistent &&
+                    error.message!!.contains("unexpected engine definition")
+            }
+            .verify()
+
+        val unsupportedName = invalidEngine.copyWithName("example_order_store")
+        ClickHouseBiDeploymentInspector(StubClickHouseCatalogClient(listOf(unsupportedName))).inspect(OPTIONS).test()
+            .expectErrorMatches { error ->
+                error is BiDeploymentInspectionException.Inconsistent &&
+                    error.message!!.contains("unsupported store name")
+            }
+            .verify()
+    }
+
+    @Test
+    fun `should validate cluster local and distributed store physical shapes`() {
+        val local = catalogRecord(
+            name = "example_order_state_store_local",
+            engine = "ReplicatedReplacingMergeTree",
+            engineFull = "ReplicatedReplacingMergeTree('/expanded/path', '{replica}', version) " +
+                "PARTITION BY toYYYYMM(create_time) ORDER BY (tenant_id, aggregate_id, version)",
+            comment = storeComment(CLUSTER_OPTIONS),
+            partitionKey = "toYYYYMM(create_time)",
+            sortingKey = "tenant_id, aggregate_id, version",
+        )
+        val distributed = catalogRecord(
+            name = "example_order_state_store",
+            engine = "Distributed",
+            engineFull = "Distributed('test-cluster', 'bi_db', 'example_order_state_store_local', " +
+                "sipHash64(tenant_id, aggregate_id))",
+            comment = storeComment(CLUSTER_OPTIONS),
+        )
+        val client = clusterClient(
+            local.withNode(NODE_A),
+            local.withNode(NODE_B),
+            distributed.withNode(NODE_A),
+            distributed.withNode(NODE_B),
+        )
+
+        val available = ClickHouseBiDeploymentInspector(client).inspect(CLUSTER_OPTIONS).block()
+            as BiDeploymentInspection.Available
+
+        available.deployment.objects.assert().hasSize(2)
+    }
+
+    @Test
+    fun `should keep reset available for repairing drifted store keys`() {
+        val drifted = catalogRecord(
+            name = "example_order_command_store",
+            engine = "ReplacingMergeTree",
+            engineFull = "ReplacingMergeTree ORDER BY create_time",
+            comment = storeComment(),
+            sortingKey = "create_time",
+        )
+        val inspector = ClickHouseBiDeploymentInspector(StubClickHouseCatalogClient(listOf(drifted)))
+
+        inspector.inspect(OPTIONS).test()
+            .expectError(BiDeploymentInspectionException.Inconsistent::class.java)
+            .verify()
+        inspector.inspect(OPTIONS, BiScriptOperation.Reset(true)).test()
+            .expectNextMatches { it is BiDeploymentInspection.Available }
+            .verifyComplete()
     }
 
     @Test
@@ -923,7 +1405,7 @@ class ClickHouseBiDeploymentInspectorTest {
             (resultB.get() is BiDeploymentInspection.Available).assert().isTrue()
             responseFutureA.complete(responseA).assert().isTrue()
             verify(exactly = 1, timeout = 1_000) { responseA.close() }
-            verify(exactly = 1) { responseB.close() }
+            verify(exactly = 2) { responseB.close() }
         } finally {
             subscriptionA.dispose()
             subscriptionB?.dispose()
@@ -1318,21 +1800,27 @@ class ClickHouseBiDeploymentInspectorTest {
     }
 
     private fun clusterClient(vararg catalog: ClickHouseCatalogRecord): StubClickHouseCatalogClient {
-        val responses = ArrayDeque(
-            listOf(
-                listOf(nodeRecord(NODE_A), nodeRecord(NODE_B)),
-                catalog.toList(),
-            )
-        )
-        return StubClickHouseCatalogClient { sql, parameters, _ ->
+        return StubClickHouseCatalogClient { sql, parameters, columns ->
             parameters["cluster"].assert().isEqualTo(CLUSTER.name)
-            sql.assert().contains("show_table_uuid_in_table_create_query_if_not_nil = 0")
-            if (responses.size == 2) {
-                sql.assert().contains("system.one", "clusterAllReplicas")
-            } else {
-                sql.assert().contains("system.tables", "clusterAllReplicas")
+            when {
+                sql.contains("system.one") -> {
+                    sql.assert().contains("show_table_uuid_in_table_create_query_if_not_nil = 0")
+                    listOf(nodeRecord(NODE_A), nodeRecord(NODE_B))
+                }
+
+                sql.contains("registryTable") -> emptyList()
+                sql.contains("system.columns") -> expectedColumnRecords(catalog.toList())
+                else -> {
+                    sql.assert().contains(
+                        "system.tables",
+                        "clusterAllReplicas",
+                    )
+                    if (columns == CATALOG_COLUMNS) {
+                        sql.assert().contains("show_table_uuid_in_table_create_query_if_not_nil = 0")
+                    }
+                    catalog.toList()
+                }
             }
-            responses.removeFirst()
         }
     }
 
@@ -1352,6 +1840,10 @@ class ClickHouseBiDeploymentInspectorTest {
         engine: String = "View",
         engineFull: String = "View",
         comment: String = "",
+        createTableQuery: String = "CREATE VIEW",
+        asSelect: String = "",
+        partitionKey: String = "",
+        sortingKey: String = "",
     ): ClickHouseCatalogRecord = ClickHouseCatalogRecord(
         buildMap {
             node?.let {
@@ -1362,10 +1854,40 @@ class ClickHouseBiDeploymentInspectorTest {
             put("name", name)
             put("engine", engine)
             put("engine_full", engineFull)
-            put("create_table_query", "CREATE VIEW")
+            put("create_table_query", createTableQuery)
+            put("as_select", asSelect)
             put("comment", comment)
+            put("partition_key", partitionKey)
+            put("sorting_key", sortingKey)
         }
     )
+
+    private fun ClickHouseCatalogRecord.withNode(node: ClickHouseCatalogNode): ClickHouseCatalogRecord {
+        val catalogObject = toCatalogObject()
+        return catalogRecord(
+            node = node,
+            database = catalogObject.observed.database,
+            name = catalogObject.observed.name,
+            engine = catalogObject.observed.engine,
+            engineFull = catalogObject.observed.engineFull,
+            comment = catalogObject.observed.metadata?.let(BiObjectMetadataCodec::encode).orEmpty(),
+            partitionKey = catalogObject.partitionKey,
+            sortingKey = catalogObject.sortingKey,
+        )
+    }
+
+    private fun ClickHouseCatalogRecord.copyWithName(name: String): ClickHouseCatalogRecord {
+        val catalogObject = toCatalogObject()
+        return catalogRecord(
+            database = catalogObject.observed.database,
+            name = name,
+            engine = catalogObject.observed.engine,
+            engineFull = catalogObject.observed.engineFull,
+            comment = catalogObject.observed.metadata?.let(BiObjectMetadataCodec::encode).orEmpty(),
+            partitionKey = catalogObject.partitionKey,
+            sortingKey = catalogObject.sortingKey,
+        )
+    }
 
     private fun queueComment(
         identity: String?,
@@ -1384,14 +1906,29 @@ class ClickHouseBiDeploymentInspectorTest {
         )
     }
 
-    private class StubClickHouseCatalogClient(
+    private fun storeComment(options: BiScriptOptions = OPTIONS): String {
+        val descriptor = BiDeploymentDescriptor.from(options)
+        return BiObjectMetadataCodec.encode(
+            BiObjectMetadata(
+                deploymentId = descriptor.deploymentId,
+                configurationFingerprint = descriptor.configurationFingerprint,
+                topologyFingerprint = descriptor.topologyFingerprint,
+                aggregate = "example.order",
+                kind = BiObjectKind.STORE,
+            )
+        )
+    }
+
+    private inner class StubClickHouseCatalogClient(
         private val response: (
             sql: String,
             parameters: Map<String, Any>,
             columns: List<String>,
         ) -> List<ClickHouseCatalogRecord>,
     ) : ClickHouseCatalogClient {
-        constructor(records: List<ClickHouseCatalogRecord>) : this({ _, _, _ -> records })
+        constructor(records: List<ClickHouseCatalogRecord>) : this({ sql, _, _ ->
+            if (sql.contains("system.columns")) expectedColumnRecords(records) else records
+        })
 
         var closed: Boolean = false
             private set
@@ -1407,6 +1944,57 @@ class ClickHouseBiDeploymentInspectorTest {
         }
     }
 
+    private fun expectedColumnRecords(
+        records: List<ClickHouseCatalogRecord>,
+        override: Pair<String, String>? = null,
+    ): List<ClickHouseCatalogRecord> = records.flatMap { record ->
+        val catalogObject = record.toCatalogObject()
+        if (catalogObject.observed.metadata?.kind != BiObjectKind.STORE) {
+            return@flatMap emptyList()
+        }
+        val node = runCatching(record::toNode).getOrNull()
+        val logicalName = catalogObject.observed.name.removeSuffix("_local")
+        val columns = if (logicalName.endsWith("_command_store")) COMMAND_STORE_COLUMNS else STATE_STORE_COLUMNS
+        columns.mapIndexed { index, (name, type) ->
+            catalogColumnRecord(
+                node = node,
+                database = catalogObject.observed.database,
+                table = catalogObject.observed.name,
+                name = name,
+                type = override?.takeIf { it.first == name }?.second ?: type,
+                position = index + 1,
+            )
+        }
+    }
+
+    private fun catalogColumnRecord(
+        node: ClickHouseCatalogNode?,
+        database: String,
+        table: String,
+        name: String,
+        type: String,
+        position: Int,
+    ): ClickHouseCatalogRecord = ClickHouseCatalogRecord(
+        buildMap {
+            node?.let {
+                put("host_name", it.hostName)
+                put("tcp_port", it.tcpPort.toString())
+            }
+            put("database", database)
+            put("table", table)
+            put("name", name)
+            put("type", type)
+            put("position", position.toString())
+        }
+    )
+
+    private fun ClickHouseBiDeploymentInspector.inspect(
+        options: BiScriptOptions,
+        operation: BiScriptOperation = BiScriptOperation.Deploy,
+        namedAggregates: Set<NamedAggregate> = emptySet(),
+    ): Mono<BiDeploymentInspection> =
+        inspect(options, operation, BiScriptGenerator(options).prepare(namedAggregates))
+
     private companion object {
         val OPTIONS = BiScriptOptions(consumerGroupNamespace = "test", topology = ClickHouseTopology.Standalone)
         val DESCRIPTOR = BiDeploymentDescriptor.from(OPTIONS)
@@ -1415,6 +2003,16 @@ class ClickHouseBiDeploymentInspectorTest {
         val NODE_A = ClickHouseCatalogNode("clickhouse-a", 9000)
         val NODE_B = ClickHouseCatalogNode("clickhouse-b", 9000)
         val NODE_C = ClickHouseCatalogNode("clickhouse-c", 9000)
+        val NODE_COLUMNS = listOf("host_name", "tcp_port")
+        val OBJECT_KEY_COLUMNS = listOf("database", "name")
+        val REGISTRY_TABLE_COLUMNS = listOf(
+            "database",
+            "name",
+            "engine",
+            "engine_full",
+            "comment",
+            "sorting_key",
+        )
         val OWNED_COMMENT = BiObjectMetadataCodec.encode(
             BiObjectMetadata(
                 deploymentId = DESCRIPTOR.deploymentId,
@@ -1430,7 +2028,49 @@ class ClickHouseBiDeploymentInspectorTest {
             "engine",
             "engine_full",
             "create_table_query",
+            "as_select",
             "comment",
+            "partition_key",
+            "sorting_key",
+        )
+        val COMMAND_STORE_COLUMNS = listOf(
+            "id" to "String",
+            "context_name" to "String",
+            "aggregate_name" to "String",
+            "name" to "String",
+            "header" to "Map(String, String)",
+            "aggregate_id" to "String",
+            "tenant_id" to "String",
+            "owner_id" to "String",
+            "space_id" to "String",
+            "request_id" to "String",
+            "aggregate_version" to "Nullable(UInt32)",
+            "is_create" to "Bool",
+            "is_void" to "Bool",
+            "allow_create" to "Bool",
+            "body_type" to "String",
+            "body" to "String",
+            "create_time" to "DateTime64(3, 'Asia/Shanghai')",
+        )
+        val STATE_STORE_COLUMNS = listOf(
+            "id" to "String",
+            "context_name" to "String",
+            "aggregate_name" to "String",
+            "header" to "Map(String, String)",
+            "aggregate_id" to "String",
+            "tenant_id" to "String",
+            "owner_id" to "String",
+            "space_id" to "String",
+            "command_id" to "String",
+            "request_id" to "String",
+            "version" to "UInt32",
+            "state" to "String",
+            "body" to "Array(String)",
+            "first_operator" to "String",
+            "first_event_time" to "DateTime64(3, 'Asia/Shanghai')",
+            "create_time" to "DateTime64(3, 'Asia/Shanghai')",
+            "tags" to "Map(String, Array(String))",
+            "deleted" to "Bool",
         )
     }
 }

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspectorTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspectorTest.kt
@@ -1170,38 +1170,55 @@ class ClickHouseBiDeploymentInspectorTest {
     }
 
     @Test
-    fun `should keep reset inspection strict for queue ownership identity and format`() {
+    fun `should allow reset to repair Kafka consumer group drift`() {
         val identity = BiConsumerIdentity.deterministic(DESCRIPTOR)
-        val expectedGroup = "wow-bi.${identity.value}.example_order_command_consumer"
-        val invalidDefinitions = listOf(
-            "Kafka('localhost:9093', 'wow.example.order.command', 'wrong-group', 'JSONAsString')" to
-                "unexpected Kafka consumer group",
-            "Kafka('localhost:9093', 'wow.example.order.command', '$expectedGroup', 'JSONEachRow')" to
-                "unexpected Kafka format",
-        )
-
-        invalidDefinitions.forEach { (engineFull, expectedMessage) ->
-            val inspector = ClickHouseBiDeploymentInspector(
-                StubClickHouseCatalogClient(
-                    records(
-                        catalogRecord(
-                            database = OPTIONS.consumerDatabase,
-                            name = "example_order_command_queue",
-                            engine = "Kafka",
-                            engineFull = engineFull,
-                            comment = queueComment(identity.value),
-                        )
+        val driftedEngine =
+            "Kafka('localhost:9093', 'wow.example.order.command', 'wrong-group', 'JSONAsString')"
+        val inspector = ClickHouseBiDeploymentInspector(
+            StubClickHouseCatalogClient(
+                records(
+                    catalogRecord(
+                        database = OPTIONS.consumerDatabase,
+                        name = "example_order_command_queue",
+                        engine = "Kafka",
+                        engineFull = driftedEngine,
+                        comment = queueComment(identity.value),
                     )
                 )
             )
+        )
 
-            inspector.inspect(OPTIONS, BiScriptOperation.Reset(true)).test()
-                .expectErrorMatches {
-                    it is BiDeploymentInspectionException.Inconsistent &&
-                        it.message!!.contains(expectedMessage)
-                }
-                .verify()
-        }
+        inspector.inspect(OPTIONS, BiScriptOperation.Reset(true)).test()
+            .expectNextCount(1)
+            .verifyComplete()
+    }
+
+    @Test
+    fun `should keep reset inspection strict for the Kafka format`() {
+        val identity = BiConsumerIdentity.deterministic(DESCRIPTOR)
+        val expectedGroup = "wow-bi.${identity.value}.example_order_command_consumer"
+        val invalidEngine =
+            "Kafka('localhost:9093', 'wow.example.order.command', '$expectedGroup', 'JSONEachRow')"
+        val inspector = ClickHouseBiDeploymentInspector(
+            StubClickHouseCatalogClient(
+                records(
+                    catalogRecord(
+                        database = OPTIONS.consumerDatabase,
+                        name = "example_order_command_queue",
+                        engine = "Kafka",
+                        engineFull = invalidEngine,
+                        comment = queueComment(identity.value),
+                    )
+                )
+            )
+        )
+
+        inspector.inspect(OPTIONS, BiScriptOperation.Reset(true)).test()
+            .expectErrorMatches {
+                it is BiDeploymentInspectionException.Inconsistent &&
+                    it.message!!.contains("unexpected Kafka format")
+            }
+            .verify()
     }
 
     @Test

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspectorTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspectorTest.kt
@@ -574,7 +574,8 @@ class ClickHouseBiDeploymentInspectorTest {
         val local = catalogRecord(
             name = "example_order_state_store_local",
             engine = "ReplicatedReplacingMergeTree",
-            engineFull = "ReplicatedReplacingMergeTree('/expanded/path', '{replica}', version) " +
+            engineFull = "ReplicatedReplacingMergeTree(" +
+                "'/clickhouse/test/test-cluster/tables/{shard}/{database}/{table}', '{replica}', version) " +
                 "PARTITION BY toYYYYMM(create_time) ORDER BY (tenant_id, aggregate_id, version)",
             comment = storeComment(CLUSTER_OPTIONS),
             partitionKey = "toYYYYMM(create_time)",
@@ -598,6 +599,48 @@ class ClickHouseBiDeploymentInspectorTest {
             as BiDeploymentInspection.Available
 
         available.deployment.objects.assert().hasSize(2)
+    }
+
+    @Test
+    fun `should reject mismatched replicated store path and replica`() {
+        val distributed = catalogRecord(
+            name = "example_order_state_store",
+            engine = "Distributed",
+            engineFull = "Distributed('test-cluster', 'bi_db', 'example_order_state_store_local', " +
+                "sipHash64(tenant_id, aggregate_id))",
+            comment = storeComment(CLUSTER_OPTIONS),
+        )
+        val invalidInvocations = listOf(
+            "ReplicatedReplacingMergeTree('/clickhouse/other/test-cluster/tables/" +
+                "{shard}/{database}/{table}', '{replica}', version)",
+            "ReplicatedReplacingMergeTree('/clickhouse/test/test-cluster/tables/" +
+                "{shard}/{database}/{table}', 'other-replica', version)",
+        )
+
+        invalidInvocations.forEach { invalidInvocation ->
+            val invalidLocal = catalogRecord(
+                name = "example_order_state_store_local",
+                engine = "ReplicatedReplacingMergeTree",
+                engineFull = "$invalidInvocation PARTITION BY toYYYYMM(create_time) " +
+                    "ORDER BY (tenant_id, aggregate_id, version)",
+                comment = storeComment(CLUSTER_OPTIONS),
+                partitionKey = "toYYYYMM(create_time)",
+                sortingKey = "tenant_id, aggregate_id, version",
+            )
+            val client = clusterClient(
+                invalidLocal.withNode(NODE_A),
+                invalidLocal.withNode(NODE_B),
+                distributed.withNode(NODE_A),
+                distributed.withNode(NODE_B),
+            )
+
+            ClickHouseBiDeploymentInspector(client).inspect(CLUSTER_OPTIONS).test()
+                .expectErrorMatches { error ->
+                    error is BiDeploymentInspectionException.Inconsistent &&
+                        error.message!!.contains("unexpected replicated engine definition")
+                }
+                .verify()
+        }
     }
 
     @Test

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspectorTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseBiDeploymentInspectorTest.kt
@@ -575,7 +575,8 @@ class ClickHouseBiDeploymentInspectorTest {
             name = "example_order_state_store_local",
             engine = "ReplicatedReplacingMergeTree",
             engineFull = "ReplicatedReplacingMergeTree(" +
-                "'/clickhouse/test/test-cluster/tables/{shard}/{database}/{table}', '{replica}', version) " +
+                "'/clickhouse/test/test-cluster/tables/{shard}/bi_db/" +
+                "example_order_state_store_local', '{replica}', version) " +
                 "PARTITION BY toYYYYMM(create_time) ORDER BY (tenant_id, aggregate_id, version)",
             comment = storeComment(CLUSTER_OPTIONS),
             partitionKey = "toYYYYMM(create_time)",
@@ -612,9 +613,9 @@ class ClickHouseBiDeploymentInspectorTest {
         )
         val invalidInvocations = listOf(
             "ReplicatedReplacingMergeTree('/clickhouse/other/test-cluster/tables/" +
-                "{shard}/{database}/{table}', '{replica}', version)",
+                "{shard}/bi_db/example_order_state_store_local', '{replica}', version)",
             "ReplicatedReplacingMergeTree('/clickhouse/test/test-cluster/tables/" +
-                "{shard}/{database}/{table}', 'other-replica', version)",
+                "{shard}/bi_db/example_order_state_store_local', 'other-replica', version)",
         )
 
         invalidInvocations.forEach { invalidInvocation ->
@@ -637,7 +638,7 @@ class ClickHouseBiDeploymentInspectorTest {
             ClickHouseBiDeploymentInspector(client).inspect(CLUSTER_OPTIONS).test()
                 .expectErrorMatches { error ->
                     error is BiDeploymentInspectionException.Inconsistent &&
-                        error.message!!.contains("unexpected replicated engine definition")
+                        error.message!!.contains("unexpected replicated engine arguments")
                 }
                 .verify()
         }

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseEngineExpressionTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseEngineExpressionTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+
+class ClickHouseEngineExpressionTest {
+    @Test
+    fun `should preserve nested and quoted function arguments`() {
+        val expression = "Kafka('broker-a:9092,broker-b:9092', concat('topic,', tuple(1, 2)), 'group', 'JSON')"
+
+        expression.functionArguments("Kafka").assert().containsExactly(
+            "'broker-a:9092,broker-b:9092'",
+            "concat('topic,', tuple(1, 2))",
+            "'group'",
+            "'JSON'",
+        )
+    }
+
+    @Test
+    fun `should reject malformed function expressions`() {
+        "Kafka('broker', tuple(1, 2)".functionArguments("Kafka").assert().isNull()
+        "Kafka('broker']".functionArguments("Kafka").assert().isNull()
+        "MergeTree()".functionArguments("Kafka").assert().isNull()
+    }
+
+    @Test
+    fun `should read escaped setting literals`() {
+        "SETTINGS kafka_group_name = 'wow\\'s-group', kafka_format = 'JSONAsString'"
+            .settingLiteral("kafka_group_name")
+            .assert()
+            .isEqualTo("'wow\\'s-group'")
+    }
+}

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseMaterializedViewTargetParserTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseMaterializedViewTargetParserTest.kt
@@ -23,16 +23,34 @@ class ClickHouseMaterializedViewTargetParserTest {
             "CREATE MATERIALIZED VIEW `consumer db`.`to` TO \"target.db\".\"target table\" " +
                 "(`value` String) AS (SELECT 'TO ignored' AS value)"
         ).assert().isEqualTo(BiObjectKey("target.db", "target table"))
+        ClickHouseMaterializedViewTargetParser.parse(
+            "CREATE MATERIALIZED VIEW db.mv TO \"target\"\"db\".`target\\`table` AS SELECT 1"
+        ).assert().isEqualTo(BiObjectKey("target\"db", "target`table"))
+        ClickHouseMaterializedViewTargetParser.parse(
+            "CREATE MATERIALIZED VIEW db.mv TO target_db.target_table AS SELECT 1"
+        ).assert().isEqualTo(BiObjectKey("target_db", "target_table"))
     }
 
     @Test
     fun `should fail closed for unsupported or malformed ddl`() {
         ClickHouseMaterializedViewTargetParser.parse("CREATE VIEW db.view AS SELECT 1").assert().isNull()
         ClickHouseMaterializedViewTargetParser.parse(
+            "CREATE MATERIALIZED VIEW db.mv TO db.target"
+        ).assert().isNull()
+        ClickHouseMaterializedViewTargetParser.parse(
             "CREATE MATERIALIZED VIEW db.mv TO target AS SELECT 1"
         ).assert().isNull()
         ClickHouseMaterializedViewTargetParser.parse(
+            "CREATE MATERIALIZED VIEW db.mv TO 'db'.target AS SELECT 1"
+        ).assert().isNull()
+        ClickHouseMaterializedViewTargetParser.parse(
+            "CREATE MATERIALIZED VIEW db.mv TO db.'target' AS SELECT 1"
+        ).assert().isNull()
+        ClickHouseMaterializedViewTargetParser.parse(
             "CREATE MATERIALIZED VIEW db.mv TO db.first TO db.second AS SELECT 1"
+        ).assert().isNull()
+        ClickHouseMaterializedViewTargetParser.parse(
+            "CREATE MATERIALIZED VIEW db.mv TO \"unterminated AS SELECT 1"
         ).assert().isNull()
     }
 }

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseMaterializedViewTargetParserTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseMaterializedViewTargetParserTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+
+class ClickHouseMaterializedViewTargetParserTest {
+    @Test
+    fun `should extract exact quoted materialized view target`() {
+        ClickHouseMaterializedViewTargetParser.parse(
+            "CREATE MATERIALIZED VIEW `consumer db`.`to` TO \"target.db\".\"target table\" " +
+                "(`value` String) AS (SELECT 'TO ignored' AS value)"
+        ).assert().isEqualTo(BiObjectKey("target.db", "target table"))
+    }
+
+    @Test
+    fun `should fail closed for unsupported or malformed ddl`() {
+        ClickHouseMaterializedViewTargetParser.parse("CREATE VIEW db.view AS SELECT 1").assert().isNull()
+        ClickHouseMaterializedViewTargetParser.parse(
+            "CREATE MATERIALIZED VIEW db.mv TO target AS SELECT 1"
+        ).assert().isNull()
+        ClickHouseMaterializedViewTargetParser.parse(
+            "CREATE MATERIALIZED VIEW db.mv TO db.first TO db.second AS SELECT 1"
+        ).assert().isNull()
+    }
+}

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseOwnershipRegistryInspectionTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseOwnershipRegistryInspectionTest.kt
@@ -1,0 +1,292 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class ClickHouseOwnershipRegistryInspectionTest {
+    @Test
+    fun `should use exact registry keys without ownership prefix discovery`() {
+        val fixture = RegistryInspectionFixture()
+
+        val snapshot = ClickHouseCatalogReader(fixture.client).read(fixture.request)
+
+        snapshot.ownershipRegistry?.entries?.single()?.key.assert().isEqualTo(fixture.registeredKey)
+        snapshot.objects.map(ClickHouseCatalogObject::key).assert().containsExactly(fixture.registeredKey)
+        fixture.queries.single { query -> query.columns == CATALOG_COLUMNS }.sql.assert()
+            .contains("name IN {databaseTables:Array(String)}")
+            .doesNotContain("startsWith(comment", "ownershipPrefix")
+    }
+
+    @Test
+    fun `deploy should reject an active registry entry whose catalog object is missing`() {
+        val fixture = RegistryInspectionFixture(includeRegisteredObject = false)
+
+        assertThrows<IllegalStateException> {
+            ClickHouseCatalogReader(fixture.client).read(fixture.request)
+        }.message.assert().contains("missing ACTIVE/RETIRED", fixture.registeredKey.name)
+    }
+
+    @Test
+    fun `reset should retain registry ownership when an active catalog object is missing`() {
+        val fixture = RegistryInspectionFixture(includeRegisteredObject = false)
+
+        val snapshot = ClickHouseCatalogReader(fixture.client).read(
+            fixture.request.copy(operation = BiScriptOperation.Reset(true))
+        )
+
+        snapshot.ownershipRegistry?.entries?.single()?.key.assert().isEqualTo(fixture.registeredKey)
+        snapshot.objects.assert().isEmpty()
+    }
+
+    @Test
+    fun `should reject an ownership registry with an incompatible engine`() {
+        val fixture = RegistryInspectionFixture(registryEngine = "Memory")
+
+        assertThrows<IllegalStateException> {
+            ClickHouseCatalogReader(fixture.client).read(fixture.request)
+        }.message.assert().contains("ownership registry", "ReplacingMergeTree")
+    }
+
+    @Test
+    fun `should reject conflicting registry heads at the same revision`() {
+        val fixture = RegistryInspectionFixture(conflictingHead = true)
+
+        assertThrows<IllegalStateException> {
+            ClickHouseCatalogReader(fixture.client).read(fixture.request)
+        }.message.assert().contains("conflicting HEAD")
+    }
+
+    @Test
+    fun `should reject conflicting registry object rows at the same revision`() {
+        val fixture = RegistryInspectionFixture(conflictingEntry = true)
+
+        assertThrows<IllegalStateException> {
+            ClickHouseCatalogReader(fixture.client).read(fixture.request)
+        }.message.assert().contains("conflicting object rows", fixture.registeredKey.name)
+    }
+
+    private class RegistryInspectionFixture(
+        includeRegisteredObject: Boolean = true,
+        private val conflictingHead: Boolean = false,
+        private val conflictingEntry: Boolean = false,
+        private val registryEngine: String = "ReplacingMergeTree",
+    ) {
+        val options = BiScriptOptions(
+            consumerGroupNamespace = "orders",
+            topology = ClickHouseTopology.Standalone,
+        )
+        private val descriptor = BiDeploymentDescriptor.from(options)
+        val registeredKey = BiObjectKey(options.database, "orders_state_store")
+        private val registry = BiOwnershipRegistry.empty(descriptor.deploymentId)
+            .beginCreate(
+                BiOwnershipRegistration(
+                    key = registeredKey,
+                    kind = BiObjectKind.STORE,
+                    aggregate = "orders.order",
+                    consumerIdentity = "b".repeat(32),
+                    definitionFingerprint = "c".repeat(32),
+                )
+            )
+            .markMutationVerified(registeredKey)
+        val queries = mutableListOf<RecordedQuery>()
+        val client = object : ClickHouseCatalogClient {
+            @Suppress("LongMethod") // One fake client response matrix models the ordered registry read protocol.
+            override fun query(
+                sql: String,
+                parameters: Map<String, Any>,
+                columns: List<String>,
+            ): List<ClickHouseCatalogRecord> {
+                queries += RecordedQuery(sql, parameters, columns)
+                return when (columns) {
+                    REGISTRY_TABLE_COLUMNS -> listOf(
+                        record(
+                            "database" to options.consumerDatabase,
+                            "name" to registry.name,
+                            "engine" to registryEngine,
+                            "engine_full" to "$registryEngine(revision)",
+                            "comment" to "wow-bi-registry:${descriptor.deploymentId}",
+                            "sorting_key" to
+                                "deployment_id, row_kind, object_database, object_name",
+                        )
+                    )
+
+                    COLUMN_COLUMNS -> REGISTRY_SCHEMA.mapIndexed { index, (name, type) ->
+                        record(
+                            "database" to options.consumerDatabase,
+                            "table" to registry.name,
+                            "name" to name,
+                            "type" to type,
+                            "position" to (index + 1).toString(),
+                        )
+                    }
+
+                    REGISTRY_HEAD_COLUMNS -> buildList {
+                        add(
+                            record(
+                                "revision" to registry.revision.toString(),
+                                "snapshot_fingerprint" to registry.snapshotFingerprint(),
+                                "row_fingerprint" to registry.snapshotFingerprint(),
+                            )
+                        )
+                        if (conflictingHead) {
+                            add(
+                                record(
+                                    "revision" to registry.revision.toString(),
+                                    "snapshot_fingerprint" to "d".repeat(32),
+                                    "row_fingerprint" to "d".repeat(32),
+                                )
+                            )
+                        }
+                    }
+
+                    REGISTRY_COLUMNS -> buildList {
+                        registry.entries.forEach { entry ->
+                            add(
+                                record(
+                                    "object_database" to entry.key.database,
+                                    "object_name" to entry.key.name,
+                                    "kind" to entry.kind.name,
+                                    "aggregate" to entry.aggregate,
+                                    "consumer_identity" to entry.consumerIdentity,
+                                    "definition_fingerprint" to entry.definitionFingerprint,
+                                    "revision" to entry.revision.toString(),
+                                    "status" to entry.status.name,
+                                    "row_fingerprint" to entry.rowFingerprint(),
+                                )
+                            )
+                            if (conflictingEntry) {
+                                add(
+                                    record(
+                                        "object_database" to entry.key.database,
+                                        "object_name" to entry.key.name,
+                                        "kind" to entry.kind.name,
+                                        "aggregate" to entry.aggregate,
+                                        "consumer_identity" to entry.consumerIdentity,
+                                        "definition_fingerprint" to "e".repeat(32),
+                                        "revision" to entry.revision.toString(),
+                                        "status" to entry.status.name,
+                                        "row_fingerprint" to "e".repeat(32),
+                                    )
+                                )
+                            }
+                        }
+                    }
+
+                    CATALOG_COLUMNS -> if (includeRegisteredObject) {
+                        listOf(
+                            record(
+                                "database" to registeredKey.database,
+                                "name" to registeredKey.name,
+                                "engine" to "ReplacingMergeTree",
+                                "engine_full" to "ReplacingMergeTree(version)",
+                                "create_table_query" to "CREATE TABLE ${registeredKey.name}",
+                                "as_select" to "",
+                                "comment" to BiObjectMetadataCodec.encode(
+                                    BiObjectMetadata(
+                                        deploymentId = descriptor.deploymentId,
+                                        configurationFingerprint = descriptor.configurationFingerprint,
+                                        topologyFingerprint = descriptor.topologyFingerprint,
+                                        aggregate = "orders.order",
+                                        kind = BiObjectKind.STORE,
+                                        consumerIdentity = "b".repeat(32),
+                                    )
+                                ),
+                                "partition_key" to "toYYYYMM(create_time)",
+                                "sorting_key" to "(tenant_id, aggregate_id, version)",
+                            )
+                        )
+                    } else {
+                        emptyList()
+                    }
+
+                    else -> error("Unexpected columns: $columns")
+                }
+            }
+
+            override fun close() = Unit
+        }
+        val request = ClickHouseCatalogReadRequest(
+            options = options,
+            operation = BiScriptOperation.Deploy,
+            desiredObjectKeys = setOf(registeredKey),
+            desiredObjects = null,
+            cancellation = ClickHouseQueryCancellation(),
+        )
+    }
+
+    private data class RecordedQuery(
+        val sql: String,
+        val parameters: Map<String, Any>,
+        val columns: List<String>,
+    )
+
+    companion object {
+        private val REGISTRY_TABLE_COLUMNS = listOf(
+            "database",
+            "name",
+            "engine",
+            "engine_full",
+            "comment",
+            "sorting_key",
+        )
+        private val COLUMN_COLUMNS = listOf("database", "table", "name", "type", "position")
+        private val REGISTRY_SCHEMA = listOf(
+            "deployment_id" to "FixedString(32)",
+            "row_kind" to "LowCardinality(String)",
+            "object_database" to "String",
+            "object_name" to "String",
+            "kind" to "LowCardinality(String)",
+            "aggregate" to "Nullable(String)",
+            "consumer_identity" to "Nullable(FixedString(32))",
+            "definition_fingerprint" to "FixedString(32)",
+            "revision" to "UInt64",
+            "status" to "LowCardinality(String)",
+            "row_fingerprint" to "FixedString(32)",
+            "recorded_at" to "DateTime64(3, 'UTC')",
+        )
+        private val REGISTRY_HEAD_COLUMNS = listOf(
+            "revision",
+            "snapshot_fingerprint",
+            "row_fingerprint",
+        )
+        private val REGISTRY_COLUMNS = listOf(
+            "object_database",
+            "object_name",
+            "kind",
+            "aggregate",
+            "consumer_identity",
+            "definition_fingerprint",
+            "revision",
+            "status",
+            "row_fingerprint",
+        )
+        private val CATALOG_COLUMNS = listOf(
+            "database",
+            "name",
+            "engine",
+            "engine_full",
+            "create_table_query",
+            "as_select",
+            "comment",
+            "partition_key",
+            "sorting_key",
+        )
+
+        private fun record(vararg values: Pair<String, String?>): ClickHouseCatalogRecord =
+            ClickHouseCatalogRecord(mapOf(*values))
+    }
+}

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseStoreShapeValidatorTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseStoreShapeValidatorTest.kt
@@ -1,0 +1,205 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+
+class ClickHouseStoreShapeValidatorTest {
+    private val options = BiScriptOptions(
+        consumerGroupNamespace = "test",
+        topology = ClickHouseTopology.Standalone,
+    )
+
+    @Test
+    fun `should accept the complete standalone command store shape`() {
+        assertDoesNotThrow {
+            ClickHouseStoreShapeValidator.validate(options, commandStore())
+        }
+    }
+
+    @Test
+    fun `should reject ordered column type drift`() {
+        val store = commandStore(
+            columns = commandColumns.map { column ->
+                if (column.name == "tenant_id") column.copy(type = "UInt64") else column
+            },
+        )
+
+        val failure = assertThrows<IllegalStateException> {
+            ClickHouseStoreShapeValidator.validate(options, store)
+        }
+
+        failure.message.assert().contains("unexpected column schema", "tenant_id", "UInt64")
+    }
+
+    @Test
+    fun `should reject state stores with obsolete key layout`() {
+        assertThrows<IllegalStateException> {
+            ClickHouseStoreShapeValidator.validate(
+                options,
+                stateStore(
+                    name = "example_order_state_store",
+                    sortingKey = "aggregate_id, version",
+                ),
+            )
+        }.message.assert().contains("unexpected sorting key", "tenant_id, aggregate_id, version")
+    }
+
+    @Test
+    fun `should require tenant aware sorting for current state stores`() {
+        assertDoesNotThrow {
+            ClickHouseStoreShapeValidator.validate(
+                options,
+                stateStore(
+                    name = "example_order_state_store",
+                    sortingKey = "tenant_id, aggregate_id, version",
+                ),
+            )
+        }
+
+        assertThrows<IllegalStateException> {
+            ClickHouseStoreShapeValidator.validate(
+                options,
+                stateStore(
+                    name = "example_order_state_store",
+                    sortingKey = "aggregate_id, version",
+                ),
+            )
+        }.message.assert().contains("tenant_id, aggregate_id, version")
+    }
+
+    @Test
+    fun `should require tenant aware cluster sharding for current state stores`() {
+        val clusterOptions = options.copy(
+            topology = ClickHouseTopology.Cluster(name = "cluster", installation = "installation")
+        )
+        val v7Distributed = stateStore(
+            name = "example_order_state_store",
+            engine = "Distributed",
+            engineFull = "Distributed('cluster', 'bi_db', 'example_order_state_store_local', " +
+                "sipHash64(tenant_id, aggregate_id))",
+            partitionKey = "",
+            sortingKey = "",
+        )
+
+        assertDoesNotThrow {
+            ClickHouseStoreShapeValidator.validate(clusterOptions, v7Distributed)
+        }
+        assertThrows<IllegalStateException> {
+            ClickHouseStoreShapeValidator.validate(
+                clusterOptions,
+                v7Distributed.copy(
+                    observed = v7Distributed.observed.copy(
+                        engineFull = "Distributed('cluster', 'bi_db', 'example_order_state_store_local', " +
+                            "sipHash64(aggregate_id))"
+                    )
+                ),
+            )
+        }.message.assert().contains("unexpected distributed engine definition")
+    }
+
+    private fun commandStore(columns: List<ClickHouseCatalogColumn> = commandColumns) = ClickHouseCatalogObject(
+        observed = ObservedBiObject(
+            database = options.database,
+            name = "example_order_command_store",
+            engine = "ReplacingMergeTree",
+            engineFull = "ReplacingMergeTree PARTITION BY toYYYYMM(create_time) ORDER BY id SETTINGS x = 1",
+        ),
+        partitionKey = "toYYYYMM(create_time)",
+        sortingKey = "id",
+        columns = columns,
+    )
+
+    private fun stateStore(
+        name: String,
+        engine: String = "ReplacingMergeTree",
+        engineFull: String = "ReplacingMergeTree(version)",
+        partitionKey: String = "toYYYYMM(create_time)",
+        sortingKey: String,
+    ) = ClickHouseCatalogObject(
+        observed = ObservedBiObject(
+            database = options.database,
+            name = name,
+            engine = engine,
+            engineFull = engineFull,
+        ),
+        partitionKey = partitionKey,
+        sortingKey = sortingKey,
+        columns = STATE_COLUMNS.mapIndexed { index, (columnName, type) ->
+            ClickHouseCatalogColumn(
+                database = options.database,
+                table = name,
+                name = columnName,
+                type = type,
+                position = index + 1,
+            )
+        },
+    )
+
+    private val commandColumns: List<ClickHouseCatalogColumn>
+        get() = COMMAND_COLUMNS.mapIndexed { index, (name, type) ->
+            ClickHouseCatalogColumn(
+                database = options.database,
+                table = "example_order_command_store",
+                name = name,
+                type = type,
+                position = index + 1,
+            )
+        }
+
+    private companion object {
+        val COMMAND_COLUMNS = listOf(
+            "id" to "String",
+            "context_name" to "String",
+            "aggregate_name" to "String",
+            "name" to "String",
+            "header" to "Map(String, String)",
+            "aggregate_id" to "String",
+            "tenant_id" to "String",
+            "owner_id" to "String",
+            "space_id" to "String",
+            "request_id" to "String",
+            "aggregate_version" to "Nullable(UInt32)",
+            "is_create" to "Bool",
+            "is_void" to "Bool",
+            "allow_create" to "Bool",
+            "body_type" to "String",
+            "body" to "String",
+            "create_time" to "DateTime64(3, 'Asia/Shanghai')",
+        )
+        val STATE_COLUMNS = listOf(
+            "id" to "String",
+            "context_name" to "String",
+            "aggregate_name" to "String",
+            "header" to "Map(String, String)",
+            "aggregate_id" to "String",
+            "tenant_id" to "String",
+            "owner_id" to "String",
+            "space_id" to "String",
+            "command_id" to "String",
+            "request_id" to "String",
+            "version" to "UInt32",
+            "state" to "String",
+            "body" to "Array(String)",
+            "first_operator" to "String",
+            "first_event_time" to "DateTime64(3, 'Asia/Shanghai')",
+            "create_time" to "DateTime64(3, 'Asia/Shanghai')",
+            "tags" to "Map(String, Array(String))",
+            "deleted" to "Bool",
+        )
+    }
+}

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseStoreShapeValidatorTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseStoreShapeValidatorTest.kt
@@ -112,6 +112,79 @@ class ClickHouseStoreShapeValidatorTest {
         }.message.assert().contains("unexpected distributed engine definition")
     }
 
+    @Test
+    fun `should accept ClickHouse-expanded database and table replication macros`() {
+        val clusterOptions = options.copy(
+            topology = ClickHouseTopology.Cluster(name = "cluster", installation = "installation")
+        )
+        val localStore = stateStore(
+            name = "example_order_state_store_local",
+            engine = "ReplicatedReplacingMergeTree",
+            engineFull = "ReplicatedReplacingMergeTree(" +
+                "'/clickhouse/installation/cluster/tables/{shard}/bi_db/" +
+                "example_order_state_store_local', '{replica}', version)",
+            sortingKey = "tenant_id, aggregate_id, version",
+        )
+
+        assertDoesNotThrow {
+            ClickHouseStoreShapeValidator.validate(clusterOptions, localStore)
+        }
+    }
+
+    @Test
+    fun `should reject engines that do not match the configured topology`() {
+        val standaloneStore = commandStore()
+        assertThrows<IllegalStateException> {
+            ClickHouseStoreShapeValidator.validate(
+                options,
+                standaloneStore.copy(
+                    observed = standaloneStore.observed.copy(engine = "MergeTree")
+                ),
+            )
+        }.message.assert().contains("must use the ReplacingMergeTree engine")
+
+        val clusterOptions = options.copy(
+            topology = ClickHouseTopology.Cluster(name = "cluster", installation = "installation")
+        )
+        val localStore = stateStore(
+            name = "example_order_state_store_local",
+            engine = "ReplacingMergeTree",
+            sortingKey = "tenant_id, aggregate_id, version",
+        )
+        assertThrows<IllegalStateException> {
+            ClickHouseStoreShapeValidator.validate(clusterOptions, localStore)
+        }.message.assert().contains("must use the ReplicatedReplacingMergeTree engine")
+
+        val distributedStore = stateStore(
+            name = "example_order_state_store",
+            engine = "ReplacingMergeTree",
+            partitionKey = "",
+            sortingKey = "",
+        )
+        assertThrows<IllegalStateException> {
+            ClickHouseStoreShapeValidator.validate(clusterOptions, distributedStore)
+        }.message.assert().contains("must use the Distributed engine")
+    }
+
+    @Test
+    fun `should reject local table keys on a distributed facade`() {
+        val clusterOptions = options.copy(
+            topology = ClickHouseTopology.Cluster(name = "cluster", installation = "installation")
+        )
+        val distributedStore = stateStore(
+            name = "example_order_state_store",
+            engine = "Distributed",
+            engineFull = "Distributed('cluster', 'bi_db', 'example_order_state_store_local', " +
+                "sipHash64(tenant_id, aggregate_id))",
+            partitionKey = "toYYYYMM(create_time)",
+            sortingKey = "tenant_id, aggregate_id, version",
+        )
+
+        assertThrows<IllegalStateException> {
+            ClickHouseStoreShapeValidator.validate(clusterOptions, distributedStore)
+        }.message.assert().contains("must not define local table keys")
+    }
+
     private fun commandStore(columns: List<ClickHouseCatalogColumn> = commandColumns) = ClickHouseCatalogObject(
         observed = ObservedBiObject(
             database = options.database,

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseStringArrayParameterPlanTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/ClickHouseStringArrayParameterPlanTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi
+
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+
+class ClickHouseStringArrayParameterPlanTest {
+    @Test
+    fun `should split array literals below the safe HTTP form field size`() {
+        val values = List(10_000) { index -> "desired_${index.toString().padStart(5, '0')}" }
+
+        val plan = ClickHouseStringArrayParameterPlan.create(
+            expression = "name",
+            parameterName = "databaseTables",
+            values = values,
+        )
+
+        plan.parameters.assert().hasSize(3)
+        plan.parameters.keys.assert().containsExactly("databaseTables", "databaseTables1", "databaseTables2")
+        plan.parameters.values.all { value ->
+            value.toByteArray(Charsets.UTF_8).size <= ClickHouseStringArrayParameterPlan.MAX_PARAMETER_BYTES
+        }.assert().isTrue()
+        plan.parameters.values.joinToString().assert().contains("desired_00000", "desired_09999")
+        plan.predicate.assert().contains(
+            "name IN {databaseTables:Array(String)}",
+            "name IN {databaseTables1:Array(String)}",
+            "name IN {databaseTables2:Array(String)}",
+            " OR ",
+        )
+        plan.arrayExpression.assert().contains(
+            "arrayConcat(",
+            "{databaseTables:Array(String)}",
+            "{databaseTables2:Array(String)}",
+        )
+    }
+
+    @Test
+    fun `should preserve an empty array parameter and escape string literals`() {
+        val emptyPlan = ClickHouseStringArrayParameterPlan.create("name", "names", emptyList())
+        emptyPlan.predicate.assert().isEqualTo("name IN {names:Array(String)}")
+        emptyPlan.parameters.assert().isEqualTo(mapOf("names" to "[]"))
+        emptyPlan.arrayExpression.assert().isEqualTo("{names:Array(String)}")
+
+        val escapedPlan = ClickHouseStringArrayParameterPlan.create(
+            expression = "name",
+            parameterName = "names",
+            values = listOf("quote'", "slash\\", "你好"),
+        )
+        escapedPlan.parameters["names"].assert().isEqualTo("['quote''', 'slash\\\\', '你好']")
+    }
+}

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/expansion/BiTestFixtures.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/expansion/BiTestFixtures.kt
@@ -39,24 +39,26 @@ class BIAggregateState(override val id: String) : Identifier {
     var kotlinDuration: kotlin.time.Duration = kotlin.time.Duration.parse("PT1H")
     var date = java.util.Date()
     var sqlDate = java.sql.Date(System.currentTimeMillis())
-    var uuid = UUID.randomUUID()
-    var localDate = java.time.LocalDate.now()
-    var localDateTime = java.time.LocalDateTime.now()
-    var localTime = java.time.LocalTime.now()
-    var instant = java.time.Instant.now()
-    var zonedDateTime = java.time.ZonedDateTime.now()
-    var offsetDateTime = java.time.OffsetDateTime.now()
-    var offsetTime = java.time.OffsetTime.now()
-    var yearMonth = java.time.YearMonth.now()
-    var monthDay = java.time.MonthDay.now()
-    var period = java.time.Period.ZERO
-    var year = java.time.Year.now()
+    var uuid: UUID = UUID.randomUUID()
+    var localDate: java.time.LocalDate = java.time.LocalDate.now()
+    var localDateTime: java.time.LocalDateTime = java.time.LocalDateTime.now()
+    var localTime: java.time.LocalTime = java.time.LocalTime.now()
+    var instant: java.time.Instant = java.time.Instant.now()
+    var zonedDateTime: java.time.ZonedDateTime = java.time.ZonedDateTime.now()
+    var offsetDateTime: java.time.OffsetDateTime = java.time.OffsetDateTime.now()
+    var offsetTime: java.time.OffsetTime = java.time.OffsetTime.now()
+    var yearMonth: java.time.YearMonth = java.time.YearMonth.now()
+    var monthDay: java.time.MonthDay = java.time.MonthDay.now()
+    var period: java.time.Period = java.time.Period.ZERO
+    var year: java.time.Year = java.time.Year.now()
     var defaultEnum = DefaultWireEnum.VALUE
     var numericEnum = NumericWireEnum.VALUE
     var month = java.time.Month.JANUARY
     var dayOfWeek = java.time.DayOfWeek.MONDAY
     var nested: Nested = Nested(id = "", name = "", child = NestedChild(id = "", name = ""))
     var stringList: List<String> = emptyList()
+
+    @Suppress("ArrayPrimitive") // Boxed Array<Int> is the wire-shape fixture under test.
     var intArray: Array<Int> = kotlin.emptyArray()
     var map: Map<String, String> = emptyMap()
     var mapItem: Map<String, Item> = emptyMap()

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/expansion/plan/StateExpansionPlannerTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/expansion/plan/StateExpansionPlannerTest.kt
@@ -927,6 +927,7 @@ private data class OpaqueCardPayment(val lastFour: String) : OpaquePayment
 @AggregateRoot
 private class OpaqueRootAggregate(private val state: OpaqueRootState)
 
+@Suppress("UnnecessaryAbstractClass") // Abstract root state is the unsupported shape under test.
 private abstract class OpaqueRootState : Identifier
 
 private val siblingAggregateMetadata = aggregateMetadata<SiblingAggregate, SiblingState>()

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/expansion/type/JacksonWireShapeInspectorTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/expansion/type/JacksonWireShapeInspectorTest.kt
@@ -169,6 +169,7 @@ private data class OrdinaryBean(val name: String)
 
 private interface PaymentContract
 
+@Suppress("UnnecessaryAbstractClass") // Abstract polymorphic shape is the inspection case under test.
 private abstract class AbstractPayment
 
 private sealed interface Payment

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/expansion/type/JsonPropertyTypeResolverTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/expansion/type/JsonPropertyTypeResolverTest.kt
@@ -22,11 +22,26 @@ import me.ahoo.wow.bi.expansion.LikeLinkString
 import me.ahoo.wow.bi.expansion.LikeListItem
 import me.ahoo.wow.bi.expansion.LikeMapString
 import me.ahoo.wow.example.transfer.domain.AccountState
+import me.ahoo.wow.serialization.JsonSerializer
 import org.junit.jupiter.api.Test
 import kotlin.reflect.full.memberProperties
 import kotlin.reflect.jvm.javaGetter
 
 class JsonPropertyTypeResolverTest {
+    @Test
+    fun `should resolve the same Java contract through every entry point`() {
+        val javaType = JsonSerializer.constructType(JavaNullabilityFixture::class.java)
+        val resolvedType = ResolvedType(
+            javaType = javaType,
+            nullability = Nullability.UNKNOWN,
+            arguments = emptyList(),
+        )
+
+        JsonPropertyTypeResolver.resolve(JavaNullabilityFixture::class.java).assert()
+            .isEqualTo(JsonPropertyTypeResolver.resolve(javaType))
+            .isEqualTo(JsonPropertyTypeResolver.resolve(resolvedType))
+    }
+
     @Test
     fun `should preserve recursive Kotlin nullability`() {
         val properties = JsonPropertyTypeResolver.resolve(KotlinFixture::class.java)

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/renderer/ClickHouseOwnershipRegistryRendererTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/renderer/ClickHouseOwnershipRegistryRendererTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.bi.renderer
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.bi.BiObjectKey
+import me.ahoo.wow.bi.BiObjectKind
+import me.ahoo.wow.bi.BiOwnershipRegistration
+import me.ahoo.wow.bi.BiOwnershipRegistry
+import me.ahoo.wow.bi.BiRegistryEntryStatus
+import me.ahoo.wow.bi.BiScriptOptions
+import me.ahoo.wow.bi.ClickHouseTopology
+import org.junit.jupiter.api.Test
+
+class ClickHouseOwnershipRegistryRendererTest {
+    @Test
+    fun `should render a standalone replacing registry and an immutable revision snapshot`() {
+        val registry = activeRegistry()
+        val renderer = ClickHouseOwnershipRegistryRenderer(
+            BiScriptOptions(
+                consumerGroupNamespace = "orders",
+                topology = ClickHouseTopology.Standalone,
+            ),
+            registry.deploymentId,
+        )
+
+        val createStatements = renderer.renderCreateStatements(registry.name)
+        createStatements.size.assert().isEqualTo(1)
+        createStatements.single().assert().contains(
+            "CREATE TABLE IF NOT EXISTS \"bi_db_consumer\".\"${registry.name}\"",
+            "ENGINE = ReplacingMergeTree(\"revision\")",
+            "ORDER BY (\"deployment_id\", \"row_kind\",",
+            "\"object_database\",",
+            "\"object_name\")",
+            "wow-bi-registry:${registry.deploymentId}",
+        )
+        renderer.renderSnapshotStatement(registry).assert().contains(
+            "INSERT INTO \"bi_db_consumer\".\"${registry.name}\"",
+            "'wow_db', 'orders_order_state_store'",
+            "'STORE', 'orders.order'",
+            "'ACTIVE'",
+            "'HEAD'",
+            "'OBJECT'",
+        )
+    }
+
+    @Test
+    fun `should render replicated local registry and distributed facade for a cluster`() {
+        val registry = activeRegistry()
+        val renderer = ClickHouseOwnershipRegistryRenderer(
+            BiScriptOptions(
+                consumerGroupNamespace = "orders",
+                topology = ClickHouseTopology.Cluster(name = "analytics", installation = "prod"),
+            ),
+            registry.deploymentId,
+        )
+
+        renderer.renderCreateStatements(registry.name).size.assert().isEqualTo(1)
+        renderer.renderCreateStatements(registry.name).joinToString("\n").assert().contains(
+            "\"${registry.name}\" ON CLUSTER 'analytics'",
+            "ReplicatedReplacingMergeTree",
+            "/clickhouse/prod/analytics/control/wow-bi/${registry.deploymentId}",
+            "{shard}-{replica}",
+        ).doesNotContain(
+            "${registry.name}_local",
+            "ENGINE = Distributed",
+        )
+    }
+
+    @Test
+    fun `should persist tombstones instead of deleting registry history`() {
+        val active = activeRegistry()
+        val tombstoned = active.beginDrop(active.entries.single().key)
+            .markAbsenceVerified(active.entries.single().key)
+        val statement = ClickHouseOwnershipRegistryRenderer(
+            BiScriptOptions(
+                consumerGroupNamespace = "orders",
+                topology = ClickHouseTopology.Standalone,
+            ),
+            active.deploymentId,
+        ).renderSnapshotStatement(tombstoned)
+
+        statement.assert().contains(
+            "'${BiRegistryEntryStatus.TOMBSTONE}'",
+            ", ${tombstoned.revision}, '${BiRegistryEntryStatus.TOMBSTONE}'",
+        )
+    }
+
+    private fun activeRegistry(): BiOwnershipRegistry {
+        val key = BiObjectKey("wow_db", "orders_order_state_store")
+        return BiOwnershipRegistry.empty("a".repeat(32))
+            .beginCreate(
+                BiOwnershipRegistration(
+                    key = key,
+                    kind = BiObjectKind.STORE,
+                    aggregate = "orders.order",
+                    consumerIdentity = "b".repeat(32),
+                    definitionFingerprint = "c".repeat(32),
+                )
+            )
+            .markMutationVerified(key)
+    }
+}

--- a/wow-bi/src/test/kotlin/me/ahoo/wow/bi/renderer/ClickHouseScriptRendererTest.kt
+++ b/wow-bi/src/test/kotlin/me/ahoo/wow/bi/renderer/ClickHouseScriptRendererTest.kt
@@ -33,13 +33,9 @@ import org.junit.jupiter.api.assertThrows
 
 class ClickHouseScriptRendererTest {
     @Test
-    fun `should reverse expansion drops and reject unowned observed objects`() {
+    fun `should reject unowned observed objects`() {
         val renderer = ClickHouseScriptRenderer()
 
-        renderer.renderDropExpansionStatements(listOf("root_view", "child_view")).assert().containsExactly(
-            "DROP VIEW IF EXISTS \"bi_db\".\"child_view\" ON CLUSTER '{cluster}' SYNC;",
-            "DROP VIEW IF EXISTS \"bi_db\".\"root_view\" ON CLUSTER '{cluster}' SYNC;",
-        )
         assertThrows<IllegalStateException> {
             renderer.renderDropObservedStatements(
                 listOf(ObservedBiObject(database = "bi_db", name = "foreign", engine = "View"))
@@ -65,8 +61,12 @@ class ClickHouseScriptRendererTest {
             diagnostics = emptyList(),
         )
 
-        val command = renderer.renderCommandStatements(aggregate)
-        val stateEvent = renderer.renderStateEventStatements(aggregate)
+        val command = renderer.renderCommandStorageStatements(aggregate) +
+            renderer.renderCommandIngressStatements(aggregate) +
+            renderer.renderCommandPublicStatements(aggregate)
+        val stateEvent = renderer.renderStateStorageStatements(aggregate) +
+            renderer.renderStateIngressStatements(aggregate) +
+            renderer.renderStatePublicStatements(aggregate)
         val stateLast = renderer.renderStateLastStatements(aggregate)
         val expansion = renderer.renderExpansionStatements(expansionPlan)
         val sql = (renderer.renderGlobalStatements() + command + stateEvent + stateLast + expansion)
@@ -87,25 +87,21 @@ class ClickHouseScriptRendererTest {
         stateLast.last().assert().contains("bi_aggregate_state_last", "bi_aggregate_state_last_store", "FINAL")
         expansion.single().assert().contains("FROM \"bi_db\".\"bi_aggregate_state_last\"")
 
-        val clear = renderer.renderClearStatements(
-            aggregate,
-            listOf("bi_aggregate_state_last_root", "bi_aggregate_state_last_items"),
-        )
-        clear.assert().hasSize(14)
-        clear.take(11).joinToString("\n").assert().doesNotContain("_local")
-        clear.subList(5, 7).map { statement ->
-            statement.substringAfterLast(".\"").substringBefore('"')
-        }.assert().containsExactly(
-            "bi_aggregate_state_last_items",
-            "bi_aggregate_state_last_root",
-        )
+        stateEvent.joinToString("\n").assert()
+            .contains("ORDER BY (\"tenant_id\", \"aggregate_id\", \"version\")")
+        stateLast.joinToString("\n").assert()
+            .contains("ORDER BY (\"tenant_id\", \"aggregate_id\")")
     }
 
     @Test
     fun `should preserve the lexical JSON of an event body`() {
         val aggregate = MetadataSearcher.localAggregates.single { it.aggregateName == "aggregate" }
-        val eventView = ClickHouseScriptRenderer()
-            .renderStateEventStatements(aggregate)
+        val renderer = ClickHouseScriptRenderer()
+        val eventView = (
+            renderer.renderStateStorageStatements(aggregate) +
+                renderer.renderStateIngressStatements(aggregate) +
+                renderer.renderStatePublicStatements(aggregate)
+            )
             .joinToString("\n")
 
         eventView.assert()
@@ -188,13 +184,16 @@ class ClickHouseScriptRendererTest {
         val aggregate = MetadataSearcher.localAggregates.single { it.aggregateName == "aggregate" }
         val renderer = ClickHouseScriptRenderer()
         val global = renderer.renderGlobalStatements()
-        val clear = renderer.renderClearStatements(aggregate, listOf("root_view", "child_view"))
-        val command = renderer.renderCommandStatements(aggregate)
-        val stateEvent = renderer.renderStateEventStatements(aggregate)
+        val commandStorage = renderer.renderCommandStorageStatements(aggregate)
+        val command = commandStorage +
+            renderer.renderCommandIngressStatements(aggregate) +
+            renderer.renderCommandPublicStatements(aggregate)
+        val stateEvent = renderer.renderStateStorageStatements(aggregate) +
+            renderer.renderStateIngressStatements(aggregate) +
+            renderer.renderStatePublicStatements(aggregate)
         val stateLast = renderer.renderStateLastStatements(aggregate)
 
         global.assert().hasSize(2)
-        clear.assert().hasSize(17)
         command.assert().hasSize(6)
         stateEvent.assert().hasSize(7)
         stateLast.assert().hasSize(5)
@@ -210,39 +209,14 @@ class ClickHouseScriptRendererTest {
                     "concat('\"header\":', simpleJSONExtractRaw(\"data\", 'header')), " +
                     "'\"header\":{}'), 'state') AS \"state\""
             )
-        clear.assert().containsExactly(
-            "DROP VIEW IF EXISTS \"bi_db_consumer\".\"bi_aggregate_command_consumer\" ON CLUSTER '{cluster}' SYNC;",
-            "DROP TABLE IF EXISTS \"bi_db_consumer\".\"bi_aggregate_command_queue\" ON CLUSTER '{cluster}' SYNC;",
-            "DROP VIEW IF EXISTS \"bi_db_consumer\".\"bi_aggregate_state_consumer\" ON CLUSTER '{cluster}' SYNC;",
-            "DROP TABLE IF EXISTS \"bi_db_consumer\".\"bi_aggregate_state_queue\" ON CLUSTER '{cluster}' SYNC;",
-            "DROP VIEW IF EXISTS \"bi_db_consumer\".\"bi_aggregate_state_last_consumer\" ON CLUSTER '{cluster}' SYNC;",
-            "DROP VIEW IF EXISTS \"bi_db\".\"child_view\" ON CLUSTER '{cluster}' SYNC;",
-            "DROP VIEW IF EXISTS \"bi_db\".\"root_view\" ON CLUSTER '{cluster}' SYNC;",
-            "DROP VIEW IF EXISTS \"bi_db\".\"bi_aggregate_state_event\" ON CLUSTER '{cluster}' SYNC;",
-            "DROP VIEW IF EXISTS \"bi_db\".\"bi_aggregate_command\" ON CLUSTER '{cluster}' SYNC;",
-            "DROP VIEW IF EXISTS \"bi_db\".\"bi_aggregate_state\" ON CLUSTER '{cluster}' SYNC;",
-            "DROP VIEW IF EXISTS \"bi_db\".\"bi_aggregate_state_last\" ON CLUSTER '{cluster}' SYNC;",
-            "DROP TABLE IF EXISTS \"bi_db\".\"bi_aggregate_command_store\" ON CLUSTER '{cluster}' SYNC;",
-            "DROP TABLE IF EXISTS \"bi_db\".\"bi_aggregate_command_store_local\" ON CLUSTER '{cluster}' SYNC;",
-            "DROP TABLE IF EXISTS \"bi_db\".\"bi_aggregate_state_store\" ON CLUSTER '{cluster}' SYNC;",
-            "DROP TABLE IF EXISTS \"bi_db\".\"bi_aggregate_state_store_local\" ON CLUSTER '{cluster}' SYNC;",
-            "DROP TABLE IF EXISTS \"bi_db\".\"bi_aggregate_state_last_store\" ON CLUSTER '{cluster}' SYNC;",
-            "DROP TABLE IF EXISTS \"bi_db\".\"bi_aggregate_state_last_store_local\" ON CLUSTER '{cluster}' SYNC;",
-        )
-        listOf(global, clear, command, stateEvent, stateLast).flatten().forEach { statement ->
+        listOf(global, command, stateEvent, stateLast).flatten().forEach { statement ->
             statement.lineSequence().none { it.trimStart().startsWith("--") }.assert().isTrue()
             statement.trimEnd().endsWith(';').assert().isTrue()
         }
-        renderer.renderGlobal().assert().isEqualTo(global.joinToString("\n\n"))
-        renderer.renderClear(aggregate, listOf("root_view", "child_view"))
-            .assert().isEqualTo(clear.joinToString("\n\n"))
-        renderer.renderCommand(aggregate).assert().isEqualTo(command.joinToString("\n\n"))
-        renderer.renderStateEvent(aggregate).assert().isEqualTo(stateEvent.joinToString("\n\n"))
-        renderer.renderStateLast(aggregate).assert().isEqualTo(stateLast.joinToString("\n\n"))
 
         assertThrows<UnsupportedOperationException> {
             @Suppress("UNCHECKED_CAST")
-            (command as MutableList<String>).clear()
+            (commandStorage as MutableList<String>).clear()
         }
     }
 
@@ -279,7 +253,6 @@ class ClickHouseScriptRendererTest {
                 .assert()
                 .isEqualTo(1)
         }
-        renderer.renderExpansion(plan).assert().isEqualTo(statements.joinToString("\n\n"))
     }
 
     @Test
@@ -338,7 +311,7 @@ class ClickHouseScriptRendererTest {
                 database = "bi\"db",
                 topology = ClickHouseTopology.Cluster(name = "cluster'name"),
             )
-        ).renderExpansion(plan)
+        ).renderExpansionStatements(plan).joinToString("\n\n")
 
         script.assert().contains(
             "CREATE OR REPLACE VIEW \"bi\\\"db\".\"target\\\"table\" " +
@@ -397,9 +370,9 @@ class ClickHouseScriptRendererTest {
             recovery = rootRecovery(),
         )
 
-        val script = ClickHouseScriptRenderer().renderExpansion(
+        val script = ClickHouseScriptRenderer().renderExpansionStatements(
             StateExpansionPlan(views = listOf(view), diagnostics = emptyList())
-        )
+        ).joinToString("\n\n")
 
         script.assert().contains(
             "JSONExtract(\"__source\".\"state\", 'scalar', 'Nullable(Int32)')"
@@ -430,9 +403,9 @@ class ClickHouseScriptRendererTest {
             recovery = rootRecovery(),
         )
 
-        val script = ClickHouseScriptRenderer().renderExpansion(
+        val script = ClickHouseScriptRenderer().renderExpansionStatements(
             StateExpansionPlan(views = listOf(view), diagnostics = emptyList())
-        )
+        ).joinToString("\n\n")
 
         script.assert().contains(
             "JSONExtract(\"__source\".\"state\", 'id', 'String') AS \"id\""
@@ -450,9 +423,9 @@ class ClickHouseScriptRendererTest {
             recovery = rootRecovery(),
         )
 
-        val script = ClickHouseScriptRenderer().renderExpansion(
+        val script = ClickHouseScriptRenderer().renderExpansionStatements(
             StateExpansionPlan(views = listOf(emptyView), diagnostics = emptyList())
-        )
+        ).joinToString("\n\n")
 
         listOf(
             "\"__source\".\"id\" AS \"__id\"",

--- a/wow-bi/src/test/resources/expected_bi_cluster_script.sql
+++ b/wow-bi/src/test/resources/expected_bi_cluster_script.sql
@@ -3,6 +3,58 @@ CREATE DATABASE IF NOT EXISTS "bi_db" ON CLUSTER '{cluster}';
 
 CREATE DATABASE IF NOT EXISTS "bi_db_consumer" ON CLUSTER '{cluster}';
 -- global --
+-- ownership-registry --
+CREATE TABLE "bi_db_consumer"."__wow_bi_registry_82ea723bc0a7d5fe1a1f3dfcfd696fd4" ON CLUSTER '{cluster}'
+(
+    "deployment_id" FixedString(32),
+    "row_kind" LowCardinality(String),
+    "object_database" String,
+    "object_name" String,
+    "kind" LowCardinality(String),
+    "aggregate" Nullable(String),
+    "consumer_identity" Nullable(FixedString(32)),
+    "definition_fingerprint" FixedString(32),
+    "revision" UInt64,
+    "status" LowCardinality(String),
+    "row_fingerprint" FixedString(32),
+    "recorded_at" DateTime64(3, 'UTC') DEFAULT now64(3)
+) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/{installation}/{cluster}/control/wow-bi/82ea723bc0a7d5fe1a1f3dfcfd696fd4', '{shard}-{replica}', "revision")
+  ORDER BY ("deployment_id", "row_kind",
+            "object_database",
+            "object_name")
+  COMMENT 'wow-bi-registry:82ea723bc0a7d5fe1a1f3dfcfd696fd4';
+-- ownership-registry --
+-- ownership-registry-intent --
+            INSERT INTO "bi_db_consumer"."__wow_bi_registry_82ea723bc0a7d5fe1a1f3dfcfd696fd4"
+            ("deployment_id", "row_kind",
+             "object_database", "object_name", "kind",
+             "aggregate", "consumer_identity",
+             "definition_fingerprint", "revision", "status",
+             "row_fingerprint")
+            VALUES
+            ('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'HEAD', '', '', 'ANCHOR', NULL, NULL, 'c318bf736603d4ec318fdd7724415d54', 21, 'ACTIVE', 'c318bf736603d4ec318fdd7724415d54'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_command', 'VIEW', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'e3ca93221fb69e69307397d550596dde', 1, 'PENDING_CREATE', 'ade2670e7fd4d81d2215e4e61eb27680'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_command_store', 'STORE', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', '19f1974c0a6a4adbfa537cc62c184c49', 2, 'PENDING_CREATE', 'c70a84c2d017660d870b3fb73f1c030e'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_command_store_local', 'STORE', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'e449b5eba702a027ec086eb5341193f0', 3, 'PENDING_CREATE', '973a597dbd8a7e9f2a35c3456a055004'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state', 'VIEW', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', '3b3547863c66bb4cfd019706fb95b7cf', 4, 'PENDING_CREATE', '2a3b8fe54d5994454b6d6ae1d2b82710'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_event', 'VIEW', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'fea61ceb1eb904cabb5a06771fc000c3', 5, 'PENDING_CREATE', '2c01df13f911425f322eb6eb7d236377'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last', 'VIEW', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'fcd6e180c2e46af865b8b2c7ef508a29', 6, 'PENDING_CREATE', 'c010f20cf6a1a9a269236484018c6fc5'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root', 'VIEW', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', '8dc2846436332dbf2b28b6c9a292feda', 7, 'PENDING_CREATE', '54609785be676b8837e2b1dc4f4a7fe9'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root_items', 'VIEW', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', '5288161b7e2e79c86bde4625a5ee3146', 8, 'PENDING_CREATE', '63844c4b96deec65e20d1b7cbda5e411'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root_like_list_item', 'VIEW', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'b9cc60b7579fe160946edef5de09546a', 9, 'PENDING_CREATE', '1a94a936eb30f7568b010aa283a8e183'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root_nested_list', 'VIEW', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'ab350eb9bd5fd2d6cca4da415536f1e4', 10, 'PENDING_CREATE', 'e850a21fbe0d5843909869faadd4ad8d'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root_nested_list_list', 'VIEW', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'db37b35ab8457dea1f6e297c08ff4f42', 11, 'PENDING_CREATE', 'b37d6be5398ac33a29dc2fa33462dc39'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root_set', 'VIEW', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'f025fbc43ac309d7476466879132d692', 12, 'PENDING_CREATE', 'b9eb9fe73ae763d356dd868d501e2514'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_store', 'STORE', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'bd592ff1dac6203316f97f39f6c85c99', 13, 'PENDING_CREATE', 'd809f930ed3dff1bc27c14904deeb6c4'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_store_local', 'STORE', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'a1dc9b4a073719d0a994079e667e39b8', 14, 'PENDING_CREATE', 'd04ca7da7c1c9b45784e5fdd43bce73b'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_store', 'STORE', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'cca42da69a71bcf60b13328448de10f5', 15, 'PENDING_CREATE', '13b1715b5865597179dc1c2af89511a9'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_store_local', 'STORE', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', '7fec1b46d373f8edf723361151c04c2e', 16, 'PENDING_CREATE', '8cb0527e793fd1de4a8d4225cbfd97c2'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db_consumer', 'bi_aggregate_command_consumer', 'CONSUMER', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'd0b7e4ae55416fc74121b0e5b51fa8ef', 17, 'PENDING_CREATE', 'd04cdd032540324e6e11acfa03e0bb34'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db_consumer', 'bi_aggregate_command_queue', 'QUEUE', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', '70bbe76ac011a77178f47a8c903c969e', 18, 'PENDING_CREATE', '67c9b720a440c2fb945c6c9fea7ec043'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db_consumer', 'bi_aggregate_state_consumer', 'CONSUMER', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', '3727156e7faf5b4d5fec45de245d7eec', 19, 'PENDING_CREATE', '3097ff4c8ff985d2796fe1f31a496f13'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db_consumer', 'bi_aggregate_state_last_consumer', 'CONSUMER', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', '9ec74f00d27a11e981f37d97bcb60d61', 20, 'PENDING_CREATE', 'c8473010825170fab270ccf9d47edc04'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db_consumer', 'bi_aggregate_state_queue', 'QUEUE', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', '537ddfef61d8614c6a2664da809e2662', 21, 'PENDING_CREATE', '6813e6fa2156ebc030a0952dc9e36e2d');
+-- ownership-registry-intent --
 -- lifecycle --
 -- lifecycle --
 -- bi.aggregate.commandStorage --
@@ -28,13 +80,13 @@ CREATE TABLE "bi_db"."bi_aggregate_command_store_local" ON CLUSTER '{cluster}'
 ) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}', '{replica}')
   PARTITION BY toYYYYMM("create_time")
   ORDER BY "id"
-  COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+  COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
 CREATE TABLE "bi_db"."bi_aggregate_command_store" ON CLUSTER '{cluster}'
 AS "bi_db"."bi_aggregate_command_store_local"
 ENGINE = Distributed('{cluster}', "bi_db",
                      'bi_aggregate_command_store_local', sipHash64("aggregate_id"))
-COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 -- bi.aggregate.commandStorage --
 -- bi.aggregate.stateStorage --
 CREATE TABLE "bi_db"."bi_aggregate_state_store_local" ON CLUSTER '{cluster}'
@@ -59,14 +111,14 @@ CREATE TABLE "bi_db"."bi_aggregate_state_store_local" ON CLUSTER '{cluster}'
     "deleted" Bool
 ) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}', '{replica}', "version")
       PARTITION BY toYYYYMM("create_time")
-      ORDER BY ("aggregate_id", "version")
-      COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+      ORDER BY ("tenant_id", "aggregate_id", "version")
+      COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
 CREATE TABLE "bi_db"."bi_aggregate_state_store" ON CLUSTER '{cluster}'
 AS "bi_db"."bi_aggregate_state_store_local"
 ENGINE = Distributed('{cluster}', "bi_db",
-                     'bi_aggregate_state_store_local', sipHash64("aggregate_id"))
-COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+                     'bi_aggregate_state_store_local', sipHash64("tenant_id", "aggregate_id"))
+COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 -- bi.aggregate.stateStorage --
 -- bi.aggregate.stateLast --
 CREATE TABLE "bi_db"."bi_aggregate_state_last_store_local" ON CLUSTER '{cluster}'
@@ -91,25 +143,25 @@ CREATE TABLE "bi_db"."bi_aggregate_state_last_store_local" ON CLUSTER '{cluster}
     "deleted" Bool
 ) ENGINE = ReplicatedReplacingMergeTree('/clickhouse/{installation}/{cluster}/tables/{shard}/{database}/{table}', '{replica}', "version")
       PARTITION BY toYYYYMM("first_event_time")
-      ORDER BY ("aggregate_id")
-      COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+      ORDER BY ("tenant_id", "aggregate_id")
+      COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
 CREATE TABLE "bi_db"."bi_aggregate_state_last_store" ON CLUSTER '{cluster}'
 AS "bi_db"."bi_aggregate_state_last_store_local"
 ENGINE = Distributed('{cluster}', "bi_db",
-                     'bi_aggregate_state_last_store_local', sipHash64("aggregate_id"))
-COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+                     'bi_aggregate_state_last_store_local', sipHash64("tenant_id", "aggregate_id"))
+COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
 CREATE MATERIALIZED VIEW "bi_db_consumer"."bi_aggregate_state_last_consumer" ON CLUSTER '{cluster}'
 TO "bi_db"."bi_aggregate_state_last_store"
 AS (
 SELECT *
 FROM "bi_db"."bi_aggregate_state_store"
-) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+) COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
 CREATE VIEW "bi_db"."bi_aggregate_state_last" ON CLUSTER '{cluster}'
 AS (SELECT * FROM "bi_db"."bi_aggregate_state_last_store" FINAL)
-COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 -- bi.aggregate.stateLast --
 -- bi.aggregate.expansion --
 CREATE VIEW "bi_db"."bi_aggregate_state_last_root" ON CLUSTER '{cluster}' AS (
@@ -182,7 +234,7 @@ JSONExtract("__source"."state", 'zonedDateTime', 'String') AS "zoned_date_time",
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+) COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
 CREATE VIEW "bi_db"."bi_aggregate_state_last_root_items" ON CLUSTER '{cluster}' AS (
 WITH
@@ -256,7 +308,7 @@ concat('/items/', toString(tupleElement("__cursor__items", 1) - 1)) AS "__path",
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+) COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
 CREATE VIEW "bi_db"."bi_aggregate_state_last_root_like_list_item" ON CLUSTER '{cluster}' AS (
 WITH
@@ -330,7 +382,7 @@ concat('/likeListItem/', toString(tupleElement("__cursor__like_list_item", 1) - 
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+) COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
 CREATE VIEW "bi_db"."bi_aggregate_state_last_root_nested_list" ON CLUSTER '{cluster}' AS (
 WITH
@@ -405,7 +457,7 @@ concat('/nestedList/', toString(tupleElement("__cursor__nested_list", 1) - 1)) A
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+) COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
 CREATE VIEW "bi_db"."bi_aggregate_state_last_root_nested_list_list" ON CLUSTER '{cluster}' AS (
 WITH
@@ -487,7 +539,7 @@ concat('/nestedList/', toString(tupleElement("__cursor__nested_list", 1) - 1), '
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+) COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
 CREATE VIEW "bi_db"."bi_aggregate_state_last_root_set" ON CLUSTER '{cluster}' AS (
 WITH
@@ -561,17 +613,17 @@ concat('/set/', toString(tupleElement("__cursor__set", 1) - 1)) AS "__path",
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+) COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 -- bi.aggregate.expansion --
 -- bi.aggregate.commandPublic --
 CREATE VIEW "bi_db"."bi_aggregate_command" ON CLUSTER '{cluster}'
 AS (SELECT * FROM "bi_db"."bi_aggregate_command_store" FINAL)
-COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 -- bi.aggregate.commandPublic --
 -- bi.aggregate.statePublic --
 CREATE VIEW "bi_db"."bi_aggregate_state" ON CLUSTER '{cluster}'
 AS (SELECT * FROM "bi_db"."bi_aggregate_state_store" FINAL)
-COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
 CREATE VIEW "bi_db"."bi_aggregate_state_event" ON CLUSTER '{cluster}'
 AS (
@@ -601,17 +653,14 @@ SELECT "id",
        "tags",
        "deleted"
 FROM "bi_db"."bi_aggregate_state"
-) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+) COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 -- bi.aggregate.statePublic --
--- deployment-anchor --
-CREATE VIEW "bi_db_consumer"."__wow_bi_deployment" ON CLUSTER '{cluster}' AS (SELECT 1 AS "alive" WHERE 0) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":null,"kind":"ANCHOR","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
--- deployment-anchor --
 -- bi.aggregate.commandIngress --
 CREATE TABLE "bi_db_consumer"."bi_aggregate_command_queue" ON CLUSTER '{cluster}'
 ("data" String)
 ENGINE = Kafka('localhost:9093', 'wow.bi.aggregate.command',
                'wow-bi.4293daaf07b6609833555520ba03033b.bi_aggregate_command_consumer', 'JSONAsString')
-COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"QUEUE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"QUEUE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
 CREATE MATERIALIZED VIEW "bi_db_consumer"."bi_aggregate_command_consumer" ON CLUSTER '{cluster}'
 TO "bi_db"."bi_aggregate_command_store"
@@ -634,7 +683,7 @@ SELECT JSONExtractString("data", 'id') AS "id",
        simpleJSONExtractRaw(replaceOne("data", concat('"header":', simpleJSONExtractRaw("data", 'header')), '"header":{}'), 'body') AS "body",
        toDateTime64(JSONExtractInt("data", 'createTime') / 1000.0, 3, 'Asia/Shanghai') AS "create_time"
 FROM "bi_db_consumer"."bi_aggregate_command_queue"
-) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+) COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 -- bi.aggregate.commandIngress --
 -- bi.aggregate.stateIngress --
 CREATE TABLE "bi_db_consumer"."bi_aggregate_state_queue" ON CLUSTER '{cluster}'
@@ -642,7 +691,7 @@ CREATE TABLE "bi_db_consumer"."bi_aggregate_state_queue" ON CLUSTER '{cluster}'
     "data" String
 ) ENGINE = Kafka('localhost:9093', 'wow.bi.aggregate.state',
                  'wow-bi.4293daaf07b6609833555520ba03033b.bi_aggregate_state_consumer', 'JSONAsString')
-COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"QUEUE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"QUEUE","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 
 CREATE MATERIALIZED VIEW "bi_db_consumer"."bi_aggregate_state_consumer" ON CLUSTER '{cluster}'
 TO "bi_db"."bi_aggregate_state_store"
@@ -666,5 +715,39 @@ SELECT JSONExtractString("data", 'id') AS "id",
        JSONExtract("data", 'tags', 'Map(String, Array(String))') AS "tags",
        JSONExtractBool("data", 'deleted') AS "deleted"
 FROM "bi_db_consumer"."bi_aggregate_state_queue"
-) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
+) COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"4293daaf07b6609833555520ba03033b"}';
 -- bi.aggregate.stateIngress --
+-- ownership-registry-confirmation --
+            INSERT INTO "bi_db_consumer"."__wow_bi_registry_82ea723bc0a7d5fe1a1f3dfcfd696fd4"
+            ("deployment_id", "row_kind",
+             "object_database", "object_name", "kind",
+             "aggregate", "consumer_identity",
+             "definition_fingerprint", "revision", "status",
+             "row_fingerprint")
+            VALUES
+            ('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'HEAD', '', '', 'ANCHOR', NULL, NULL, 'bea8eff79d2387dc0cd0a96cc71327d3', 42, 'ACTIVE', 'bea8eff79d2387dc0cd0a96cc71327d3'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_command', 'VIEW', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'e3ca93221fb69e69307397d550596dde', 22, 'ACTIVE', '4112c38bfa8fd8db0a46bf700f5a2c3b'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_command_store', 'STORE', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', '19f1974c0a6a4adbfa537cc62c184c49', 23, 'ACTIVE', '1660125ba5bddfcd1227b65d5fe740a9'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_command_store_local', 'STORE', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'e449b5eba702a027ec086eb5341193f0', 24, 'ACTIVE', '5934fa76b202e69634bbc095db333b02'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state', 'VIEW', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', '3b3547863c66bb4cfd019706fb95b7cf', 25, 'ACTIVE', '1c1fff733ae96d78b834087323b25c83'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_event', 'VIEW', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'fea61ceb1eb904cabb5a06771fc000c3', 26, 'ACTIVE', 'b6439b4f9af18dd46bdc31f454374db0'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last', 'VIEW', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'fcd6e180c2e46af865b8b2c7ef508a29', 27, 'ACTIVE', '8cc48b46f2e1ac96cf7e89d7752ddd6a'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root', 'VIEW', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', '8dc2846436332dbf2b28b6c9a292feda', 28, 'ACTIVE', 'dea984e41c0389e9214965ded4180599'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root_items', 'VIEW', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', '5288161b7e2e79c86bde4625a5ee3146', 29, 'ACTIVE', 'f9d3277274af1db4669e3c5cea8ce8a6'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root_like_list_item', 'VIEW', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'b9cc60b7579fe160946edef5de09546a', 30, 'ACTIVE', '4ece3103af394e412c65f929e3a32831'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root_nested_list', 'VIEW', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'ab350eb9bd5fd2d6cca4da415536f1e4', 31, 'ACTIVE', 'dbd22d8b9350b3c3b8176956fc5b74a3'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root_nested_list_list', 'VIEW', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'db37b35ab8457dea1f6e297c08ff4f42', 32, 'ACTIVE', '4870a9a2e593870b3bd194774799614d'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root_set', 'VIEW', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'f025fbc43ac309d7476466879132d692', 33, 'ACTIVE', 'bfb88bc96eebc10891671da7598ce70d'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_store', 'STORE', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'bd592ff1dac6203316f97f39f6c85c99', 34, 'ACTIVE', 'c7c2067f5944eb77a9f9fddb883a4e4b'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_store_local', 'STORE', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'a1dc9b4a073719d0a994079e667e39b8', 35, 'ACTIVE', '0eada9a53c9cc6c20b179f142da99f87'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_store', 'STORE', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'cca42da69a71bcf60b13328448de10f5', 36, 'ACTIVE', '4e1fb7838951df2d0fb1d46ccf1d15e0'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_store_local', 'STORE', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', '7fec1b46d373f8edf723361151c04c2e', 37, 'ACTIVE', 'b96e76345c927530fac88d0516177ef7'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db_consumer', 'bi_aggregate_command_consumer', 'CONSUMER', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', 'd0b7e4ae55416fc74121b0e5b51fa8ef', 38, 'ACTIVE', 'fed2c0b18dcfb76978e2edf04e7796b8'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db_consumer', 'bi_aggregate_command_queue', 'QUEUE', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', '70bbe76ac011a77178f47a8c903c969e', 39, 'ACTIVE', 'f533fe5289f8cae3d62cfab3ef56dc73'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db_consumer', 'bi_aggregate_state_consumer', 'CONSUMER', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', '3727156e7faf5b4d5fec45de245d7eec', 40, 'ACTIVE', '1bf1c76fa430ef8928a2849ffe7076b8'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db_consumer', 'bi_aggregate_state_last_consumer', 'CONSUMER', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', '9ec74f00d27a11e981f37d97bcb60d61', 41, 'ACTIVE', '6e4dcf60c15190a7b987dff6e517301e'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db_consumer', 'bi_aggregate_state_queue', 'QUEUE', 'bi.aggregate', '4293daaf07b6609833555520ba03033b', '537ddfef61d8614c6a2664da809e2662', 42, 'ACTIVE', 'f7157e2464fe133be3e25935ad28d8a0');
+-- ownership-registry-confirmation --
+-- deployment-anchor --
+CREATE VIEW "bi_db_consumer"."__wow_bi_deployment" ON CLUSTER '{cluster}' AS (SELECT 1 AS "alive" WHERE 0) COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"4293daaf07b6609833555520ba03033b","topologyFingerprint":"1a217ccdf2c6535f9f8bb381c79fd1d1","kind":"ANCHOR","consumerIdentity":"4293daaf07b6609833555520ba03033b","registryRevision":42}';
+-- deployment-anchor --

--- a/wow-bi/src/test/resources/expected_bi_cluster_script.sql
+++ b/wow-bi/src/test/resources/expected_bi_cluster_script.sql
@@ -4,7 +4,7 @@ CREATE DATABASE IF NOT EXISTS "bi_db" ON CLUSTER '{cluster}';
 CREATE DATABASE IF NOT EXISTS "bi_db_consumer" ON CLUSTER '{cluster}';
 -- global --
 -- ownership-registry --
-CREATE TABLE "bi_db_consumer"."__wow_bi_registry_82ea723bc0a7d5fe1a1f3dfcfd696fd4" ON CLUSTER '{cluster}'
+CREATE TABLE IF NOT EXISTS "bi_db_consumer"."__wow_bi_registry_82ea723bc0a7d5fe1a1f3dfcfd696fd4" ON CLUSTER '{cluster}'
 (
     "deployment_id" FixedString(32),
     "row_kind" LowCardinality(String),

--- a/wow-bi/src/test/resources/expected_bi_standalone_script.sql
+++ b/wow-bi/src/test/resources/expected_bi_standalone_script.sql
@@ -3,6 +3,55 @@ CREATE DATABASE IF NOT EXISTS "bi_db";
 
 CREATE DATABASE IF NOT EXISTS "bi_db_consumer";
 -- global --
+-- ownership-registry --
+CREATE TABLE "bi_db_consumer"."__wow_bi_registry_82ea723bc0a7d5fe1a1f3dfcfd696fd4"
+(
+    "deployment_id" FixedString(32),
+    "row_kind" LowCardinality(String),
+    "object_database" String,
+    "object_name" String,
+    "kind" LowCardinality(String),
+    "aggregate" Nullable(String),
+    "consumer_identity" Nullable(FixedString(32)),
+    "definition_fingerprint" FixedString(32),
+    "revision" UInt64,
+    "status" LowCardinality(String),
+    "row_fingerprint" FixedString(32),
+    "recorded_at" DateTime64(3, 'UTC') DEFAULT now64(3)
+) ENGINE = ReplacingMergeTree("revision")
+  ORDER BY ("deployment_id", "row_kind",
+            "object_database",
+            "object_name")
+  COMMENT 'wow-bi-registry:82ea723bc0a7d5fe1a1f3dfcfd696fd4';
+-- ownership-registry --
+-- ownership-registry-intent --
+            INSERT INTO "bi_db_consumer"."__wow_bi_registry_82ea723bc0a7d5fe1a1f3dfcfd696fd4"
+            ("deployment_id", "row_kind",
+             "object_database", "object_name", "kind",
+             "aggregate", "consumer_identity",
+             "definition_fingerprint", "revision", "status",
+             "row_fingerprint")
+            VALUES
+            ('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'HEAD', '', '', 'ANCHOR', NULL, NULL, '68d5a74f1d8d6da186dcff97cb73b674', 18, 'ACTIVE', '68d5a74f1d8d6da186dcff97cb73b674'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_command', 'VIEW', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', 'e3ca93221fb69e69307397d550596dde', 1, 'PENDING_CREATE', '9c855f356ce0edc294296bf06aa4acd8'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_command_store', 'STORE', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', '93d0420f3902feab49950f2ae72ca819', 2, 'PENDING_CREATE', '473cf28e44e27a6e3b423b5fd29be2e8'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state', 'VIEW', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', '3b3547863c66bb4cfd019706fb95b7cf', 3, 'PENDING_CREATE', '24fec1b13ecc7fa30246c82a23f3cb69'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_event', 'VIEW', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', 'fea61ceb1eb904cabb5a06771fc000c3', 4, 'PENDING_CREATE', '480de714bfedaf6103301725afbada2f'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last', 'VIEW', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', 'fcd6e180c2e46af865b8b2c7ef508a29', 5, 'PENDING_CREATE', 'e5381a24088662616b43492ff9253bc8'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root', 'VIEW', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', '8dc2846436332dbf2b28b6c9a292feda', 6, 'PENDING_CREATE', 'ddd6c76ee05c58e81aafff3ff5338da6'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root_items', 'VIEW', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', '5288161b7e2e79c86bde4625a5ee3146', 7, 'PENDING_CREATE', 'a6f1a695ecf974765a1afdb544a9a958'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root_like_list_item', 'VIEW', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', 'b9cc60b7579fe160946edef5de09546a', 8, 'PENDING_CREATE', '7a9c7ebc0280cdb77a0836088d539281'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root_nested_list', 'VIEW', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', 'ab350eb9bd5fd2d6cca4da415536f1e4', 9, 'PENDING_CREATE', 'abb8e8ebedb76f31d0ad9273f70c4874'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root_nested_list_list', 'VIEW', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', 'db37b35ab8457dea1f6e297c08ff4f42', 10, 'PENDING_CREATE', 'f8f538207c7cc0547737f2fcac0fec37'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root_set', 'VIEW', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', 'f025fbc43ac309d7476466879132d692', 11, 'PENDING_CREATE', 'adb3080f2b8ca3c5b819160913d5ba9b'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_store', 'STORE', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', '82d348a3fdefe67a7555b9e4350f9c45', 12, 'PENDING_CREATE', 'cb0427f91915e81d94bb05f80fab305b'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_store', 'STORE', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', '4ddaa3dee5231b5697cb890cbdda6d99', 13, 'PENDING_CREATE', '460e59014b366705312232e89c53f97c'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db_consumer', 'bi_aggregate_command_consumer', 'CONSUMER', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', 'd0b7e4ae55416fc74121b0e5b51fa8ef', 14, 'PENDING_CREATE', 'd9ac026e9d42652a51c2ca3050eab9d5'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db_consumer', 'bi_aggregate_command_queue', 'QUEUE', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', '70bbe76ac011a77178f47a8c903c969e', 15, 'PENDING_CREATE', '9703bd4860f06f54e7ac48f870f587e4'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db_consumer', 'bi_aggregate_state_consumer', 'CONSUMER', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', '3727156e7faf5b4d5fec45de245d7eec', 16, 'PENDING_CREATE', 'bb2bc6b56f78e11977798cbad75d18f6'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db_consumer', 'bi_aggregate_state_last_consumer', 'CONSUMER', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', '9ec74f00d27a11e981f37d97bcb60d61', 17, 'PENDING_CREATE', '9858af91138527c02307cbd70be8d4a1'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db_consumer', 'bi_aggregate_state_queue', 'QUEUE', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', '537ddfef61d8614c6a2664da809e2662', 18, 'PENDING_CREATE', 'f6116c67c0f7cbc56922dc7cd9ad9bbd');
+-- ownership-registry-intent --
 -- lifecycle --
 -- lifecycle --
 -- bi.aggregate.commandStorage --
@@ -28,7 +77,7 @@ CREATE TABLE "bi_db"."bi_aggregate_command_store"
 ) ENGINE = ReplacingMergeTree
   PARTITION BY toYYYYMM("create_time")
   ORDER BY "id"
-  COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+  COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 -- bi.aggregate.commandStorage --
 -- bi.aggregate.stateStorage --
 CREATE TABLE "bi_db"."bi_aggregate_state_store"
@@ -53,8 +102,8 @@ CREATE TABLE "bi_db"."bi_aggregate_state_store"
     "deleted" Bool
 ) ENGINE = ReplacingMergeTree("version")
       PARTITION BY toYYYYMM("create_time")
-      ORDER BY ("aggregate_id", "version")
-      COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+      ORDER BY ("tenant_id", "aggregate_id", "version")
+      COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 -- bi.aggregate.stateStorage --
 -- bi.aggregate.stateLast --
 CREATE TABLE "bi_db"."bi_aggregate_state_last_store"
@@ -79,19 +128,19 @@ CREATE TABLE "bi_db"."bi_aggregate_state_last_store"
     "deleted" Bool
 ) ENGINE = ReplacingMergeTree("version")
       PARTITION BY toYYYYMM("first_event_time")
-      ORDER BY ("aggregate_id")
-      COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+      ORDER BY ("tenant_id", "aggregate_id")
+      COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"STORE","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 
 CREATE MATERIALIZED VIEW "bi_db_consumer"."bi_aggregate_state_last_consumer"
 TO "bi_db"."bi_aggregate_state_last_store"
 AS (
 SELECT *
 FROM "bi_db"."bi_aggregate_state_store"
-) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+) COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 
 CREATE VIEW "bi_db"."bi_aggregate_state_last"
 AS (SELECT * FROM "bi_db"."bi_aggregate_state_last_store" FINAL)
-COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 -- bi.aggregate.stateLast --
 -- bi.aggregate.expansion --
 CREATE VIEW "bi_db"."bi_aggregate_state_last_root" AS (
@@ -164,7 +213,7 @@ JSONExtract("__source"."state", 'zonedDateTime', 'String') AS "zoned_date_time",
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+) COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 
 CREATE VIEW "bi_db"."bi_aggregate_state_last_root_items" AS (
 WITH
@@ -238,7 +287,7 @@ concat('/items/', toString(tupleElement("__cursor__items", 1) - 1)) AS "__path",
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+) COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 
 CREATE VIEW "bi_db"."bi_aggregate_state_last_root_like_list_item" AS (
 WITH
@@ -312,7 +361,7 @@ concat('/likeListItem/', toString(tupleElement("__cursor__like_list_item", 1) - 
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+) COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 
 CREATE VIEW "bi_db"."bi_aggregate_state_last_root_nested_list" AS (
 WITH
@@ -387,7 +436,7 @@ concat('/nestedList/', toString(tupleElement("__cursor__nested_list", 1) - 1)) A
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+) COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 
 CREATE VIEW "bi_db"."bi_aggregate_state_last_root_nested_list_list" AS (
 WITH
@@ -469,7 +518,7 @@ concat('/nestedList/', toString(tupleElement("__cursor__nested_list", 1) - 1), '
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+) COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 
 CREATE VIEW "bi_db"."bi_aggregate_state_last_root_set" AS (
 WITH
@@ -543,17 +592,17 @@ concat('/set/', toString(tupleElement("__cursor__set", 1) - 1)) AS "__path",
 "__source"."tags" AS "__tags",
 "__source"."deleted" AS "__deleted"
 FROM "bi_db"."bi_aggregate_state_last" AS "__source"
-) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+) COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 -- bi.aggregate.expansion --
 -- bi.aggregate.commandPublic --
 CREATE VIEW "bi_db"."bi_aggregate_command"
 AS (SELECT * FROM "bi_db"."bi_aggregate_command_store" FINAL)
-COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 -- bi.aggregate.commandPublic --
 -- bi.aggregate.statePublic --
 CREATE VIEW "bi_db"."bi_aggregate_state"
 AS (SELECT * FROM "bi_db"."bi_aggregate_state_store" FINAL)
-COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 
 CREATE VIEW "bi_db"."bi_aggregate_state_event"
 AS (
@@ -583,17 +632,14 @@ SELECT "id",
        "tags",
        "deleted"
 FROM "bi_db"."bi_aggregate_state"
-) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+) COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"VIEW","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 -- bi.aggregate.statePublic --
--- deployment-anchor --
-CREATE VIEW "bi_db_consumer"."__wow_bi_deployment" AS (SELECT 1 AS "alive" WHERE 0) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":null,"kind":"ANCHOR","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
--- deployment-anchor --
 -- bi.aggregate.commandIngress --
 CREATE TABLE "bi_db_consumer"."bi_aggregate_command_queue"
 ("data" String)
 ENGINE = Kafka('localhost:9093', 'wow.bi.aggregate.command',
                'wow-bi.39b2524473ea17aea282d31d216a901c.bi_aggregate_command_consumer', 'JSONAsString')
-COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"QUEUE","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"QUEUE","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 
 CREATE MATERIALIZED VIEW "bi_db_consumer"."bi_aggregate_command_consumer"
 TO "bi_db"."bi_aggregate_command_store"
@@ -616,7 +662,7 @@ SELECT JSONExtractString("data", 'id') AS "id",
        simpleJSONExtractRaw(replaceOne("data", concat('"header":', simpleJSONExtractRaw("data", 'header')), '"header":{}'), 'body') AS "body",
        toDateTime64(JSONExtractInt("data", 'createTime') / 1000.0, 3, 'Asia/Shanghai') AS "create_time"
 FROM "bi_db_consumer"."bi_aggregate_command_queue"
-) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+) COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 -- bi.aggregate.commandIngress --
 -- bi.aggregate.stateIngress --
 CREATE TABLE "bi_db_consumer"."bi_aggregate_state_queue"
@@ -624,7 +670,7 @@ CREATE TABLE "bi_db_consumer"."bi_aggregate_state_queue"
     "data" String
 ) ENGINE = Kafka('localhost:9093', 'wow.bi.aggregate.state',
                  'wow-bi.39b2524473ea17aea282d31d216a901c.bi_aggregate_state_consumer', 'JSONAsString')
-COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"QUEUE","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"QUEUE","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 
 CREATE MATERIALIZED VIEW "bi_db_consumer"."bi_aggregate_state_consumer"
 TO "bi_db"."bi_aggregate_state_store"
@@ -648,5 +694,36 @@ SELECT JSONExtractString("data", 'id') AS "id",
        JSONExtract("data", 'tags', 'Map(String, Array(String))') AS "tags",
        JSONExtractBool("data", 'deleted') AS "deleted"
 FROM "bi_db_consumer"."bi_aggregate_state_queue"
-) COMMENT 'wow-bi:{"protocolVersion":2,"layoutVersion":6,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
+) COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","aggregate":"bi.aggregate","kind":"CONSUMER","consumerIdentity":"39b2524473ea17aea282d31d216a901c"}';
 -- bi.aggregate.stateIngress --
+-- ownership-registry-confirmation --
+            INSERT INTO "bi_db_consumer"."__wow_bi_registry_82ea723bc0a7d5fe1a1f3dfcfd696fd4"
+            ("deployment_id", "row_kind",
+             "object_database", "object_name", "kind",
+             "aggregate", "consumer_identity",
+             "definition_fingerprint", "revision", "status",
+             "row_fingerprint")
+            VALUES
+            ('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'HEAD', '', '', 'ANCHOR', NULL, NULL, 'fc7f24133a7bcb19533f3811b07085e6', 36, 'ACTIVE', 'fc7f24133a7bcb19533f3811b07085e6'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_command', 'VIEW', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', 'e3ca93221fb69e69307397d550596dde', 19, 'ACTIVE', '34bd11516920fc2485d774ce77b2e605'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_command_store', 'STORE', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', '93d0420f3902feab49950f2ae72ca819', 20, 'ACTIVE', '0d8354f9864a393bd9dcda0b6480500d'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state', 'VIEW', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', '3b3547863c66bb4cfd019706fb95b7cf', 21, 'ACTIVE', '559e8ef665729bc2106d4d43442e6d6c'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_event', 'VIEW', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', 'fea61ceb1eb904cabb5a06771fc000c3', 22, 'ACTIVE', '4b0515b004bc6545eb3fc03a8ffe7d63'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last', 'VIEW', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', 'fcd6e180c2e46af865b8b2c7ef508a29', 23, 'ACTIVE', 'd60c5022dfa5f03fc20bff36b29cc266'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root', 'VIEW', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', '8dc2846436332dbf2b28b6c9a292feda', 24, 'ACTIVE', '44f98ba99526e19a6923e7e3f1060825'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root_items', 'VIEW', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', '5288161b7e2e79c86bde4625a5ee3146', 25, 'ACTIVE', '9da2933e64381a2c74ff74145911bdf2'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root_like_list_item', 'VIEW', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', 'b9cc60b7579fe160946edef5de09546a', 26, 'ACTIVE', 'e139f4af9e3f53eca694cd0f93f386ca'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root_nested_list', 'VIEW', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', 'ab350eb9bd5fd2d6cca4da415536f1e4', 27, 'ACTIVE', '059d56e9a2b5626d5d4c77f97f82731b'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root_nested_list_list', 'VIEW', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', 'db37b35ab8457dea1f6e297c08ff4f42', 28, 'ACTIVE', '581a7e2e5ab9ca012f7dc05c0fdff739'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_root_set', 'VIEW', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', 'f025fbc43ac309d7476466879132d692', 29, 'ACTIVE', 'cc4f52d7e03be1bdd904c2ec2e627bdb'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_last_store', 'STORE', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', '82d348a3fdefe67a7555b9e4350f9c45', 30, 'ACTIVE', '6b34d76855884e1ac938426d0c9a37a7'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db', 'bi_aggregate_state_store', 'STORE', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', '4ddaa3dee5231b5697cb890cbdda6d99', 31, 'ACTIVE', '31e3f1b6902ad455dd85401bd3861d8f'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db_consumer', 'bi_aggregate_command_consumer', 'CONSUMER', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', 'd0b7e4ae55416fc74121b0e5b51fa8ef', 32, 'ACTIVE', '69e2546c2522185b0c5e1d93c4cb1047'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db_consumer', 'bi_aggregate_command_queue', 'QUEUE', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', '70bbe76ac011a77178f47a8c903c969e', 33, 'ACTIVE', '006ee08332e67da6d56b5cc91088baae'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db_consumer', 'bi_aggregate_state_consumer', 'CONSUMER', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', '3727156e7faf5b4d5fec45de245d7eec', 34, 'ACTIVE', '515cc34042986d090883ae299d196caa'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db_consumer', 'bi_aggregate_state_last_consumer', 'CONSUMER', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', '9ec74f00d27a11e981f37d97bcb60d61', 35, 'ACTIVE', '0ed2c53c7e8b28c1ad898d98024393af'),
+('82ea723bc0a7d5fe1a1f3dfcfd696fd4', 'OBJECT', 'bi_db_consumer', 'bi_aggregate_state_queue', 'QUEUE', 'bi.aggregate', '39b2524473ea17aea282d31d216a901c', '537ddfef61d8614c6a2664da809e2662', 36, 'ACTIVE', '41af22bcf61783b7b77791cbc27f0d68');
+-- ownership-registry-confirmation --
+-- deployment-anchor --
+CREATE VIEW "bi_db_consumer"."__wow_bi_deployment" AS (SELECT 1 AS "alive" WHERE 0) COMMENT 'wow-bi:{"protocolVersion":3,"layoutVersion":7,"phase":"STABLE","deploymentId":"82ea723bc0a7d5fe1a1f3dfcfd696fd4","configurationFingerprint":"39b2524473ea17aea282d31d216a901c","topologyFingerprint":"a9268847ae91435222ea21e31ac14c47","kind":"ANCHOR","consumerIdentity":"39b2524473ea17aea282d31d216a901c","registryRevision":36}';
+-- deployment-anchor --

--- a/wow-bi/src/test/resources/expected_bi_standalone_script.sql
+++ b/wow-bi/src/test/resources/expected_bi_standalone_script.sql
@@ -4,7 +4,7 @@ CREATE DATABASE IF NOT EXISTS "bi_db";
 CREATE DATABASE IF NOT EXISTS "bi_db_consumer";
 -- global --
 -- ownership-registry --
-CREATE TABLE "bi_db_consumer"."__wow_bi_registry_82ea723bc0a7d5fe1a1f3dfcfd696fd4"
+CREATE TABLE IF NOT EXISTS "bi_db_consumer"."__wow_bi_registry_82ea723bc0a7d5fe1a1f3dfcfd696fd4"
 (
     "deployment_id" FixedString(32),
     "row_kind" LowCardinality(String),

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/bi/BiDeploymentInspectorAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/bi/BiDeploymentInspectorAutoConfiguration.kt
@@ -79,7 +79,7 @@ private fun BiClickHouseInspectorProperties.validate(inspectionTimeout: java.tim
     require(endpoints.isNotEmpty()) {
         "inspector.clickhouse.endpoints must not be empty when inspector.type=CLICKHOUSE"
     }
-    endpoints.forEachIndexed { index, endpoint -> endpoint.validate(index) }
+    endpoints.forEachIndexed { index, endpoint -> endpoint.validateEndpoint(index) }
     require(endpoints.distinct().size == endpoints.size) {
         "inspector.clickhouse.endpoints must not contain duplicates"
     }
@@ -108,7 +108,7 @@ private fun BiClickHouseInspectorProperties.validate(inspectionTimeout: java.tim
     }
 }
 
-private fun java.net.URI.validate(index: Int) {
+private fun java.net.URI.validateEndpoint(index: Int) {
     require(scheme.equals("http", ignoreCase = true) || scheme.equals("https", ignoreCase = true)) {
         "inspector.clickhouse.endpoints[$index] must use http or https"
     }

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
@@ -954,7 +954,7 @@ internal class WebFluxAutoConfigurationTest {
         val httpHandlerBuilder = WebHttpHandlerBuilder.webHandler(webHandler)
         getBeanProvider(WebExceptionHandler::class.java).ifAvailable(httpHandlerBuilder::exceptionHandler)
         val httpHandler = httpHandlerBuilder.build()
-        return WebTestClient.bindToServer(HttpHandlerConnector(httpHandler)).build()
+        return WebTestClient.bindToServer(HttpHandlerConnector(httpHandler)).buildBiScriptClient()
     }
 
     private fun AssertableApplicationContext.generateBiScript(
@@ -972,7 +972,8 @@ internal class WebFluxAutoConfigurationTest {
             .POST(contract.path, factory.create(contract))
             .build()
         return WebTestClient.bindToRouterFunction(routerFunction)
-            .build()
+            .configureClient()
+            .buildBiScriptClient()
             .post()
             .uri(contract.path)
             .contentType(MediaType.APPLICATION_JSON)
@@ -985,6 +986,11 @@ internal class WebFluxAutoConfigurationTest {
             .returnResult()
             .responseBody!!
     }
+
+    private fun WebTestClient.Builder.buildBiScriptClient(): WebTestClient =
+        codecs { configurer ->
+            configurer.defaultCodecs().maxInMemorySize(BI_SCRIPT_TEST_MAX_IN_MEMORY_SIZE)
+        }.build()
 
     private fun String.assertExplicitBiScript(expectedOptions: BiScriptOptions) {
         assert().isEqualTo(BiScriptGenerator(expectedOptions).generate(MetadataSearcher.localAggregates).script)
@@ -1006,6 +1012,10 @@ internal class WebFluxAutoConfigurationTest {
         generateSequence(this) { it.cause }
             .mapNotNull { it.message }
             .joinToString("\n")
+
+    private companion object {
+        const val BI_SCRIPT_TEST_MAX_IN_MEMORY_SIZE: Int = 1024 * 1024
+    }
 
     private class TestHttpRouteHandlerFunctionFactory(
         override val handlerKey: String

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
@@ -568,7 +568,7 @@ internal class WebFluxAutoConfigurationTest {
 
     @Test
     fun `should return BI inspection failures without the global exception handler`() {
-        val unavailableInspector = BiDeploymentInspector { _, _ ->
+        val unavailableInspector = BiDeploymentInspector { _, _, _ ->
             Mono.error(BiDeploymentInspectionException.Unavailable())
         }
         webFluxContextRunner()
@@ -656,7 +656,7 @@ internal class WebFluxAutoConfigurationTest {
 
     @Test
     fun `should back off the default BI deployment inspector`() {
-        val customInspector = BiDeploymentInspector { _, _ ->
+        val customInspector = BiDeploymentInspector { _, _, _ ->
             Mono.just(BiDeploymentInspection.Available(me.ahoo.wow.bi.ObservedBiDeployment(emptyList())))
         }
         webFluxContextRunner()

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/bi/BiDeploymentInspectorAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/bi/BiDeploymentInspectorAutoConfigurationTest.kt
@@ -54,6 +54,7 @@ class BiDeploymentInspectorAutoConfigurationTest {
     fun `should explicitly configure the native ClickHouse inspector`() {
         contextRunner
             .withPropertyValues(
+                "${BiScriptProperties.PREFIX}.enabled=true",
                 "${BiScriptProperties.PREFIX}.inspector.type=CLICKHOUSE",
                 "${BiScriptProperties.PREFIX}.inspector.timeout=4s",
                 "${BiScriptProperties.PREFIX}.inspector.clickhouse.endpoints[0]=http://clickhouse-1:8123/",
@@ -104,7 +105,10 @@ class BiDeploymentInspectorAutoConfigurationTest {
     @Test
     fun `should fail startup when ClickHouse inspection lacks endpoints`() {
         contextRunner
-            .withPropertyValues("${BiScriptProperties.PREFIX}.inspector.type=CLICKHOUSE")
+            .withPropertyValues(
+                "${BiScriptProperties.PREFIX}.enabled=true",
+                "${BiScriptProperties.PREFIX}.inspector.type=CLICKHOUSE",
+            )
             .run { context ->
                 context.startupFailure.assert().isNotNull()
                 context.startupFailure!!.causeChainMessages().assert()
@@ -157,6 +161,7 @@ class BiDeploymentInspectorAutoConfigurationTest {
         invalidConfigurations.forEach { (property, expectedMessage) ->
             contextRunner
                 .withPropertyValues(
+                    "${BiScriptProperties.PREFIX}.enabled=true",
                     "${BiScriptProperties.PREFIX}.inspector.type=CLICKHOUSE",
                     "${BiScriptProperties.PREFIX}.inspector.clickhouse.endpoints[0]=http://clickhouse:8123",
                     "${BiScriptProperties.PREFIX}.$property",
@@ -170,12 +175,15 @@ class BiDeploymentInspectorAutoConfigurationTest {
 
     @Test
     fun `should let a custom inspector override ClickHouse configuration`() {
-        val customInspector = BiDeploymentInspector { _, _ ->
+        val customInspector = BiDeploymentInspector { _, _, _ ->
             Mono.just(BiDeploymentInspection.Available(ObservedBiDeployment(emptyList())))
         }
         contextRunner
             .withBean(BiDeploymentInspector::class.java, { customInspector })
-            .withPropertyValues("${BiScriptProperties.PREFIX}.inspector.type=CLICKHOUSE")
+            .withPropertyValues(
+                "${BiScriptProperties.PREFIX}.enabled=true",
+                "${BiScriptProperties.PREFIX}.inspector.type=CLICKHOUSE",
+            )
             .run { context ->
                 context.assert().hasNotFailed().hasSingleBean(BiDeploymentInspector::class.java)
                 context.getBean(BiDeploymentInspector::class.java).assert().isSameAs(customInspector)

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/ServerRequestExtensions.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/ServerRequestExtensions.kt
@@ -15,7 +15,60 @@ package me.ahoo.wow.webflux.route
 
 import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.server.NotAcceptableStatusException
+
+private val STREAMING_RESPONSE_MEDIA_TYPES = listOf(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM)
+
+private data class ResponsePreference(
+    val mediaType: MediaType,
+    val quality: Double,
+    val acceptOrder: Int,
+    val responseOrder: Int,
+)
 
 internal fun ServerRequest.acceptsEventStream(): Boolean {
-    return headers().accept().firstOrNull() == MediaType.TEXT_EVENT_STREAM
+    return preferredResponseMediaType(STREAMING_RESPONSE_MEDIA_TYPES) == MediaType.TEXT_EVENT_STREAM
+}
+
+internal fun ServerRequest.preferredResponseMediaType(supportedMediaTypes: List<MediaType>): MediaType {
+    require(supportedMediaTypes.isNotEmpty()) {
+        "supportedMediaTypes must not be empty."
+    }
+    val requestedMediaTypes = headers().accept()
+    if (requestedMediaTypes.isEmpty()) {
+        return supportedMediaTypes.first()
+    }
+    return supportedMediaTypes.mapIndexedNotNull { responseOrder, responseMediaType ->
+        val effectiveAccept = requestedMediaTypes.withIndex()
+            .filter { (_, acceptedMediaType) -> acceptedMediaType.accepts(responseMediaType) }
+            .maxWithOrNull(
+                compareBy<IndexedValue<MediaType>> { (_, mediaType) -> mediaType.specificity() }
+                    .thenBy { (index) -> -index }
+            ) ?: return@mapIndexedNotNull null
+        ResponsePreference(
+            mediaType = responseMediaType,
+            quality = effectiveAccept.value.qualityValue,
+            acceptOrder = effectiveAccept.index,
+            responseOrder = responseOrder,
+        )
+    }.filter { it.quality > 0.0 }
+        .sortedWith(
+            compareByDescending<ResponsePreference> { it.quality }
+                .thenBy { it.acceptOrder }
+                .thenBy { it.responseOrder }
+        )
+        .firstOrNull()
+        ?.mediaType
+        ?: throw NotAcceptableStatusException(supportedMediaTypes)
+}
+
+private fun MediaType.accepts(responseMediaType: MediaType): Boolean =
+    isCompatibleWith(responseMediaType) ||
+        (responseMediaType == MediaType.APPLICATION_JSON && subtype.endsWith("+json"))
+
+private fun MediaType.specificity(): Int = when {
+    isWildcardType -> 0
+    subtype == "*" -> 1
+    subtype.startsWith("*+") -> 2
+    else -> 3
 }

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/global/GenerateBIScriptHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/global/GenerateBIScriptHandlerFunction.kt
@@ -89,9 +89,8 @@ class GenerateBIScriptHandlerFunction internal constructor(
         operation: BiScriptOperation,
         responseMediaType: MediaType,
     ): Mono<ServerResponse> {
-        val namedAggregates = MetadataSearcher.localAggregates
         val generator = BiScriptGenerator(requestOptions)
-        return Mono.fromCallable { generator.prepare(namedAggregates) }
+        return Mono.fromCallable { generator.prepare(MetadataSearcher.localAggregates) }
             .subscribeOn(generationScheduler)
             .mapGenerationOverload()
             .flatMap { preparation ->

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/global/GenerateBIScriptHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/global/GenerateBIScriptHandlerFunction.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.webflux.route.global
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import me.ahoo.wow.bi.BiDeploymentInspectionException
 import me.ahoo.wow.bi.BiDeploymentInspector
 import me.ahoo.wow.bi.BiScriptDiagnostic
 import me.ahoo.wow.bi.BiScriptGenerator
@@ -29,40 +30,46 @@ import me.ahoo.wow.openapi.contract.bi.BiScriptRequest
 import me.ahoo.wow.openapi.contract.bi.BiScriptResponse
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.route.NoMetadataRouteHandlerFunctionFactorySupport
+import me.ahoo.wow.webflux.route.preferredResponseMediaType
 import org.springframework.http.MediaType
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
-import org.springframework.web.server.NotAcceptableStatusException
 import reactor.core.publisher.Mono
+import reactor.core.scheduler.Scheduler
 import reactor.core.scheduler.Schedulers
+import java.util.concurrent.RejectedExecutionException
 
 private val APPLICATION_SQL_MEDIA_TYPE = MediaType.parseMediaType("application/sql")
 private val SUPPORTED_RESPONSE_MEDIA_TYPES = listOf(APPLICATION_SQL_MEDIA_TYPE, MediaType.APPLICATION_JSON)
-
-private data class ResponsePreference(
-    val mediaType: MediaType,
-    val quality: Double,
-    val acceptOrder: Int,
-    val responseOrder: Int,
+private const val BI_SCRIPT_GENERATION_THREADS: Int = 4
+private const val BI_SCRIPT_GENERATION_QUEUE_SIZE: Int = 256
+private const val BI_SCRIPT_GENERATION_TTL_SECONDS: Int = 60
+private val BI_SCRIPT_GENERATION_SCHEDULER: Scheduler = Schedulers.newBoundedElastic(
+    BI_SCRIPT_GENERATION_THREADS,
+    BI_SCRIPT_GENERATION_QUEUE_SIZE,
+    "wow-bi-script-generation",
+    BI_SCRIPT_GENERATION_TTL_SECONDS,
+    true,
 )
 
-private fun MediaType.accepts(responseMediaType: MediaType): Boolean =
-    isCompatibleWith(responseMediaType) ||
-        (responseMediaType == MediaType.APPLICATION_JSON && subtype.endsWith("+json"))
-
-private fun MediaType.specificity(): Int = when {
-    isWildcardType -> 0
-    subtype == "*" -> 1
-    subtype.startsWith("*+") -> 2
-    else -> 3
-}
-
-class GenerateBIScriptHandlerFunction(
+class GenerateBIScriptHandlerFunction internal constructor(
     private val options: BiScriptOptions,
     private val deploymentInspector: BiDeploymentInspector,
     private val exceptionHandler: RequestExceptionHandler,
+    private val generationScheduler: Scheduler,
 ) : HandlerFunction<ServerResponse> {
+    constructor(
+        options: BiScriptOptions,
+        deploymentInspector: BiDeploymentInspector,
+        exceptionHandler: RequestExceptionHandler,
+    ) : this(
+        options = options,
+        deploymentInspector = deploymentInspector,
+        exceptionHandler = exceptionHandler,
+        generationScheduler = BI_SCRIPT_GENERATION_SCHEDULER,
+    )
+
     override fun handle(request: ServerRequest): Mono<ServerResponse> {
         return request.bodyToMono(BiScriptRequest::class.java)
             .switchIfEmpty(Mono.error(IllegalArgumentException("BI script request body must not be empty")))
@@ -71,7 +78,7 @@ class GenerateBIScriptHandlerFunction(
                 generateResponse(
                     requestOptions = body.toBiScriptOptions(options),
                     operation = body.toBiScriptOperation(),
-                    responseMediaType = request.preferredResponseMediaType(),
+                    responseMediaType = request.preferredResponseMediaType(SUPPORTED_RESPONSE_MEDIA_TYPES),
                 )
             }
             .onErrorResume { error -> exceptionHandler.handle(request, error) }
@@ -81,49 +88,38 @@ class GenerateBIScriptHandlerFunction(
         requestOptions: BiScriptOptions,
         operation: BiScriptOperation,
         responseMediaType: MediaType,
-    ): Mono<ServerResponse> = deploymentInspector.inspect(requestOptions, operation).flatMap { inspection ->
-        Mono.fromCallable {
-            BiScriptGenerator(requestOptions).generate(MetadataSearcher.localAggregates, operation, inspection)
-        }.subscribeOn(Schedulers.boundedElastic())
-    }.flatMap { result ->
-        logDiagnostics(result.diagnostics)
-        val response = ServerResponse.ok()
-            .header(BiScriptHeaders.DIAGNOSTIC_COUNT, result.diagnostics.size.toString())
-        if (responseMediaType == MediaType.APPLICATION_JSON) {
-            response.contentType(MediaType.APPLICATION_JSON).bodyValue(result.toResponse())
-        } else {
-            response.contentType(APPLICATION_SQL_MEDIA_TYPE).bodyValue(result.script)
-        }
+    ): Mono<ServerResponse> {
+        val namedAggregates = MetadataSearcher.localAggregates
+        val generator = BiScriptGenerator(requestOptions)
+        return Mono.fromCallable { generator.prepare(namedAggregates) }
+            .subscribeOn(generationScheduler)
+            .mapGenerationOverload()
+            .flatMap { preparation ->
+                deploymentInspector.inspect(requestOptions, operation, preparation).flatMap { inspection ->
+                    Mono.fromCallable {
+                        generator.generate(preparation, operation, inspection)
+                    }.subscribeOn(generationScheduler)
+                        .mapGenerationOverload()
+                }
+            }.flatMap { result ->
+                logDiagnostics(result.diagnostics)
+                val response = ServerResponse.ok()
+                    .header(BiScriptHeaders.DIAGNOSTIC_COUNT, result.diagnostics.size.toString())
+                if (responseMediaType == MediaType.APPLICATION_JSON) {
+                    response.contentType(MediaType.APPLICATION_JSON).bodyValue(result.toResponse())
+                } else {
+                    response.contentType(APPLICATION_SQL_MEDIA_TYPE).bodyValue(result.script)
+                }
+            }
     }
 
-    private fun ServerRequest.preferredResponseMediaType(): MediaType {
-        val requested = headers().accept()
-        if (requested.isEmpty()) {
-            return APPLICATION_SQL_MEDIA_TYPE
+    private fun <T : Any> Mono<T>.mapGenerationOverload(): Mono<T> =
+        onErrorMap(RejectedExecutionException::class.java) { error ->
+            BiDeploymentInspectionException.Unavailable(
+                message = "Wow BI script generation is overloaded",
+                cause = error,
+            )
         }
-        return SUPPORTED_RESPONSE_MEDIA_TYPES.mapIndexedNotNull { responseOrder, responseMediaType ->
-            val effectiveAccept = requested.withIndex()
-                .filter { (_, acceptedMediaType) -> acceptedMediaType.accepts(responseMediaType) }
-                .maxWithOrNull(
-                    compareBy<IndexedValue<MediaType>> { (_, mediaType) -> mediaType.specificity() }
-                        .thenBy { (index) -> -index }
-                ) ?: return@mapIndexedNotNull null
-            ResponsePreference(
-                mediaType = responseMediaType,
-                quality = effectiveAccept.value.qualityValue,
-                acceptOrder = effectiveAccept.index,
-                responseOrder = responseOrder,
-            )
-        }.filter { it.quality > 0.0 }
-            .sortedWith(
-                compareByDescending<ResponsePreference> { it.quality }
-                    .thenBy { it.acceptOrder }
-                    .thenBy { it.responseOrder }
-            )
-            .firstOrNull()
-            ?.mediaType
-            ?: throw NotAcceptableStatusException(SUPPORTED_RESPONSE_MEDIA_TYPES)
-    }
 
     private fun BiScriptResult.toResponse(): BiScriptResponse = BiScriptResponse(
         script = script,

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/ServerRequestExtensionsTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/ServerRequestExtensionsTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.route
+
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.mock.web.reactive.function.server.MockServerRequest
+import org.springframework.web.server.NotAcceptableStatusException
+
+class ServerRequestExtensionsTest {
+    @Test
+    fun `should accept parameterized event stream`() {
+        val request = request(MediaType.TEXT_EVENT_STREAM_VALUE + ";q=0.9")
+
+        request.acceptsEventStream().assert().isTrue()
+    }
+
+    @Test
+    fun `should prefer event stream with higher quality`() {
+        val request = request("application/json;q=0.1, text/event-stream;q=1")
+
+        request.acceptsEventStream().assert().isTrue()
+    }
+
+    @Test
+    fun `should reject event stream with zero quality`() {
+        val request = request("text/event-stream;q=0, application/json;q=1")
+
+        request.acceptsEventStream().assert().isFalse()
+    }
+
+    @Test
+    fun `should keep json as wildcard default`() {
+        val request = request(MediaType.ALL_VALUE)
+
+        request.acceptsEventStream().assert().isFalse()
+    }
+
+    @Test
+    fun `should honor a specific json rejection over wildcard`() {
+        val request = request("application/json;q=0, */*;q=1")
+
+        request.acceptsEventStream().assert().isTrue()
+    }
+
+    @Test
+    fun `should honor a specific event stream rejection over wildcard`() {
+        val request = request("text/event-stream;q=0, */*;q=1")
+
+        request.acceptsEventStream().assert().isFalse()
+    }
+
+    @Test
+    fun `should reject unsupported response media types`() {
+        assertThrows<NotAcceptableStatusException> {
+            request(MediaType.TEXT_PLAIN_VALUE).acceptsEventStream()
+        }
+    }
+
+    @Test
+    fun `should reject when every supported response type has zero quality`() {
+        assertThrows<NotAcceptableStatusException> {
+            request("*/*;q=1, application/json;q=0, text/event-stream;q=0").acceptsEventStream()
+        }
+    }
+
+    private fun request(accept: String): MockServerRequest {
+        return MockServerRequest.builder()
+            .header(HttpHeaders.ACCEPT, accept)
+            .build()
+    }
+}

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/bi/BiScriptRequestMapperTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/bi/BiScriptRequestMapperTest.kt
@@ -100,7 +100,7 @@ class BiScriptRequestMapperTest {
 
     @Test
     fun `should reject catalog scope overrides for a fixed deployment inspector`() {
-        val inspector = BiDeploymentInspector { _, _ -> Mono.just(BiDeploymentInspection.Unavailable) }
+        val inspector = BiDeploymentInspector { _, _, _ -> Mono.just(BiDeploymentInspection.Unavailable) }
         val requests = listOf(
             BiScriptRequest(database = BASE_OPTIONS.database),
             BiScriptRequest(consumerDatabase = BASE_OPTIONS.consumerDatabase),
@@ -164,7 +164,8 @@ class BiScriptRequestMapperTest {
     fun `should reject operation-specific fields in the wrong mode`() {
         runCatching {
             BiScriptRequest(replayFromEarliestConfirmed = true).toBiScriptOperation()
-        }.exceptionOrNull()!!.message.assert().isEqualTo("replayFromEarliestConfirmed is only valid for RESET")
+        }.exceptionOrNull()!!.message.assert()
+            .isEqualTo("replayFromEarliestConfirmed is only valid for RESET")
 
         val resetWithoutConfirmation = BiScriptRequest(
             operation = BiScriptOperationMode.RESET,

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/bi/GenerateBIScriptHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/bi/GenerateBIScriptHandlerFunctionTest.kt
@@ -22,6 +22,7 @@ import io.mockk.mockkObject
 import io.mockk.unmockkObject
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.annotation.AggregateRoot
+import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.bi.BiDeploymentDescriptor
 import me.ahoo.wow.bi.BiDeploymentInspection
 import me.ahoo.wow.bi.BiDeploymentInspectionException
@@ -32,6 +33,7 @@ import me.ahoo.wow.bi.BiScriptDiagnostic
 import me.ahoo.wow.bi.BiScriptGenerator
 import me.ahoo.wow.bi.BiScriptOperation
 import me.ahoo.wow.bi.BiScriptOptions
+import me.ahoo.wow.bi.BiScriptPreparation
 import me.ahoo.wow.bi.ClickHouseTopology
 import me.ahoo.wow.bi.NoOpBiDeploymentInspector
 import me.ahoo.wow.bi.ObservedBiDeployment
@@ -64,9 +66,13 @@ import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
 import org.springframework.web.server.ServerWebExchange
 import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
 import reactor.kotlin.core.publisher.toMono
 import reactor.kotlin.test.test
 import java.lang.reflect.Modifier
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class GenerateBIScriptHandlerFunctionTest {
     @Test
@@ -100,6 +106,109 @@ class GenerateBIScriptHandlerFunctionTest {
                     assert().contains("'analytics.example.order.command'")
                 }
             }.verifyComplete()
+    }
+
+    @Test
+    fun `should pass one request scoped preparation through inspection and generation`() {
+        var preparedInspectionInvoked = false
+        val inspector = object : BiDeploymentInspector {
+            override fun inspect(
+                options: BiScriptOptions,
+                operation: BiScriptOperation,
+                preparation: BiScriptPreparation,
+            ): Mono<BiDeploymentInspection> {
+                preparedInspectionInvoked = true
+                return Mono.just(BiDeploymentInspection.Unavailable)
+            }
+        }
+
+        handler(deploymentInspector = inspector)
+            .handle(MockServerRequest.builder().body(BiScriptRequest().toMono()))
+            .test()
+            .consumeNextWith { response -> response.statusCode().assert().isEqualTo(HttpStatus.OK) }
+            .verifyComplete()
+
+        preparedInspectionInvoked.assert().isTrue()
+    }
+
+    @Test
+    fun `should generate BI scripts on the dedicated generation scheduler`() {
+        val accessedThreads = ConcurrentLinkedQueue<String>()
+        val aggregate = ThreadRecordingNamedAggregate(
+            contextName = "webflux-bi-test",
+            aggregateName = "generation-scheduler",
+            accessedThreads = accessedThreads,
+        )
+        val aggregateTypes = NamedAggregateTypeSearcher(
+            mapOf(
+                MaterializedNamedAggregate("webflux-bi-test", "generation-scheduler") to
+                    DiagnosticAggregate::class.java
+            )
+        )
+        val namedAggregates = TypeNamedAggregateSearcher(
+            mapOf(DiagnosticAggregate::class.java to aggregate)
+        )
+        val requestScheduler = Schedulers.newSingle("request-event-loop")
+        mockkObject(MetadataSearcher)
+        try {
+            every { MetadataSearcher.localAggregates } returns setOf(aggregate)
+            every { MetadataSearcher.namedAggregateType } returns aggregateTypes
+            every { MetadataSearcher.typeNamedAggregate } returns namedAggregates
+
+            val response = handler(
+                BiScriptOptions(
+                    topology = ClickHouseTopology.Standalone,
+                    consumerGroupNamespace = "test",
+                )
+            ).handle(MockServerRequest.builder().body(BiScriptRequest().toMono()))
+                .subscribeOn(requestScheduler)
+                .block()!!
+
+            response.statusCode().assert().isEqualTo(HttpStatus.OK)
+            accessedThreads.assert().isNotEmpty()
+            accessedThreads.all { threadName ->
+                threadName.startsWith("wow-bi-script-generation-")
+            }.assert().isTrue()
+        } finally {
+            requestScheduler.dispose()
+            unmockkObject(MetadataSearcher)
+        }
+    }
+
+    @Test
+    fun `should classify a saturated generation scheduler as unavailable`() {
+        val scheduler = Schedulers.newBoundedElastic(
+            1,
+            1,
+            "saturated-bi-generation",
+            60,
+            true,
+        )
+        val activeStarted = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        scheduler.schedule {
+            activeStarted.countDown()
+            release.await()
+        }
+        activeStarted.await(5, TimeUnit.SECONDS).assert().isTrue()
+        scheduler.schedule { release.await() }
+        try {
+            val response = GenerateBIScriptHandlerFunction(
+                options = BASE_OPTIONS,
+                deploymentInspector = NoOpBiDeploymentInspector,
+                exceptionHandler = WebFluxRequestExceptionHandler(),
+                generationScheduler = scheduler,
+            ).handle(MockServerRequest.builder().body(BiScriptRequest().toMono()))
+                .block()!!
+
+            response.statusCode().assert().isEqualTo(HttpStatus.SERVICE_UNAVAILABLE)
+            response.headers().getFirst("Wow-Error-Code").assert()
+                .isEqualTo(BiDeploymentInspectionException.UNAVAILABLE_ERROR_CODE)
+            response.writeBody().assert().contains("Wow BI script generation is overloaded")
+        } finally {
+            release.countDown()
+            scheduler.dispose()
+        }
     }
 
     @Test
@@ -221,7 +330,7 @@ class GenerateBIScriptHandlerFunctionTest {
         )
 
         failures.forEach { (failure, expectedStatus, expectedCode) ->
-            val deploymentInspector = BiDeploymentInspector { _, _ ->
+            val deploymentInspector = BiDeploymentInspector { _, _, _ ->
                 Mono.error<BiDeploymentInspection>(failure)
             }
             val response = handler(deploymentInspector = deploymentInspector)
@@ -236,7 +345,7 @@ class GenerateBIScriptHandlerFunctionTest {
 
     @Test
     fun `should map an unexpected generation failure to a safe internal server error`() {
-        val deploymentInspector = BiDeploymentInspector { _, _ ->
+        val deploymentInspector = BiDeploymentInspector { _, _, _ ->
             Mono.error<BiDeploymentInspection>(NullPointerException("sensitive implementation detail"))
         }
 
@@ -254,7 +363,7 @@ class GenerateBIScriptHandlerFunctionTest {
     @Test
     fun `should preserve an unexpected failure for a custom request exception handler`() {
         val failure = NullPointerException("custom-handler-detail")
-        val deploymentInspector = BiDeploymentInspector { _, _ ->
+        val deploymentInspector = BiDeploymentInspector { _, _, _ ->
             Mono.error<BiDeploymentInspection>(failure)
         }
         lateinit var received: Throwable
@@ -280,7 +389,7 @@ class GenerateBIScriptHandlerFunctionTest {
     @Test
     fun `should preserve an unexpected failure for a custom webflux error strategy`() {
         val failure = NullPointerException("custom-strategy-detail")
-        val deploymentInspector = BiDeploymentInspector { _, _ ->
+        val deploymentInspector = BiDeploymentInspector { _, _, _ ->
             Mono.error<BiDeploymentInspection>(failure)
         }
         lateinit var received: Throwable
@@ -306,7 +415,7 @@ class GenerateBIScriptHandlerFunctionTest {
     fun `should expose explicit destructive reset over HTTP`() {
         val descriptor = BiDeploymentDescriptor.from(BASE_OPTIONS)
         val handler = handler(
-            deploymentInspector = BiDeploymentInspector { _, _ ->
+            deploymentInspector = BiDeploymentInspector { _, _, _ ->
                 Mono.just(
                     BiDeploymentInspection.Available(
                         ObservedBiDeployment(
@@ -349,12 +458,10 @@ class GenerateBIScriptHandlerFunctionTest {
         lateinit var inspectedOptions: BiScriptOptions
         lateinit var inspectedOperation: BiScriptOperation
         val deploymentInspector = object : BiDeploymentInspector {
-            override fun inspect(options: BiScriptOptions): Mono<BiDeploymentInspection> =
-                error("The handler must provide the requested operation")
-
             override fun inspect(
                 options: BiScriptOptions,
                 operation: BiScriptOperation,
+                preparation: BiScriptPreparation,
             ): Mono<BiDeploymentInspection> {
                 inspectedOptions = options
                 inspectedOperation = operation
@@ -522,4 +629,25 @@ private class DiagnosticAggregate(private val state: DiagnosticState)
 private class DiagnosticState(val id: String) {
     val otherValues: Map<String, Any> = emptyMap()
     val values: Map<String, Any> = emptyMap()
+}
+
+private class ThreadRecordingNamedAggregate(
+    contextName: String,
+    aggregateName: String,
+    private val accessedThreads: ConcurrentLinkedQueue<String>,
+) : NamedAggregate {
+    private val rawContextName = contextName
+    private val rawAggregateName = aggregateName
+
+    override val contextName: String
+        get() {
+            accessedThreads.add(Thread.currentThread().name)
+            return rawContextName
+        }
+
+    override val aggregateName: String
+        get() {
+            accessedThreads.add(Thread.currentThread().name)
+            return rawAggregateName
+        }
 }

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/bi/GenerateBIScriptHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/bi/GenerateBIScriptHandlerFunctionTest.kt
@@ -134,6 +134,7 @@ class GenerateBIScriptHandlerFunctionTest {
     @Test
     fun `should generate BI scripts on the dedicated generation scheduler`() {
         val accessedThreads = ConcurrentLinkedQueue<String>()
+        val metadataLookupThreads = ConcurrentLinkedQueue<String>()
         val aggregate = ThreadRecordingNamedAggregate(
             contextName = "webflux-bi-test",
             aggregateName = "generation-scheduler",
@@ -151,7 +152,10 @@ class GenerateBIScriptHandlerFunctionTest {
         val requestScheduler = Schedulers.newSingle("request-event-loop")
         mockkObject(MetadataSearcher)
         try {
-            every { MetadataSearcher.localAggregates } returns setOf(aggregate)
+            every { MetadataSearcher.localAggregates } answers {
+                metadataLookupThreads.add(Thread.currentThread().name)
+                setOf(aggregate)
+            }
             every { MetadataSearcher.namedAggregateType } returns aggregateTypes
             every { MetadataSearcher.typeNamedAggregate } returns namedAggregates
 
@@ -165,6 +169,10 @@ class GenerateBIScriptHandlerFunctionTest {
                 .block()!!
 
             response.statusCode().assert().isEqualTo(HttpStatus.OK)
+            metadataLookupThreads.assert().isNotEmpty()
+            metadataLookupThreads.all { threadName ->
+                threadName.startsWith("wow-bi-script-generation-")
+            }.assert().isTrue()
             accessedThreads.assert().isNotEmpty()
             accessedThreads.all { threadName ->
                 threadName.startsWith("wow-bi-script-generation-")


### PR DESCRIPTION
## Summary

- split BI preparation, validation, catalog inspection, ownership registry, script assembly, and focused ClickHouse renderers into explicit internal boundaries
- add fail-closed ownership registry shape validation and recoverable `PENDING_CREATE` / `PENDING_UPDATE` / `PENDING_DROP` transitions
- keep durable Store and Kafka Queue contract drift destructive while allowing computed View definitions to reconcile through `DEPLOY`
- make confirmed `RESET` recover missing `ACTIVE` / `RETIRED` objects and surviving `TOMBSTONE` objects without weakening ordinary `DEPLOY`
- pass one immutable request-scoped preparation through HTTP inspection and generation on a bounded BI scheduler
- keep `wow.bi.script.enabled=true` as the default, assuming the endpoint is protected by the service security gateway
- add catalog/form-parameter scale coverage and bilingual deployment/recovery runbooks

## Why

The previous implementation coupled catalog inspection and SQL rendering to large positional statement lists and did not model computed-object updates or registry physical drift explicitly. That made interrupted deployment recovery, definition evolution, and future renderer maintenance error-prone. The new current-layout-only model makes ownership, mutation intent, verification, and destructive boundaries explicit without carrying compatibility branches for earlier BI layouts.

## Impact

This is a breaking BI change:

- only the current metadata, registry schema, and layout are supported
- an incompatible registry Engine, replication path, sorting key, comment, or column schema is rejected fail-closed
- old binaries must not be introduced while the registry is in `PENDING_UPDATE` or the anchor is `RESETTING`
- Store, Queue, topology, or physical-scope drift requires an explicitly confirmed `RESET`
- physical table names remain semantic and do not include layout-version suffixes

The public HTTP endpoint remains enabled by default. Deployments that do not expose `/wow/bi/script` exclusively through a security gateway must set `wow.bi.script.enabled=false`.

## Validation

Validated from a clean detached worktree:

- `./gradlew :wow-bi:check :wow-webflux:check :wow-spring-boot-starter:check :wow-openapi:check`
- VitePress production build including both BI operations guides
- real ClickHouse integration suite
- catalog scale: 10,000 objects per replica, 2 replicas, 50 concurrent inspections, 50/50 successes
- form-parameter scale: 1,000 / 5,000 / 10,000 desired names
- `git diff --check`

The scale results are local container measurements and are not production SLA guarantees.
