### PR TITLE
feat(mongo): add context guard and snapshot checkpoints

### DIFF
--- a/documentation/docs/en/guide/extensions/mongo.md
+++ b/documentation/docs/en/guide/extensions/mongo.md
@@ -63,11 +63,14 @@ Each aggregate type gets its own collection, partitioned by aggregate name. This
 
 This collection layout assumes that one MongoDB database serves exactly one bounded context. During startup, the
 Starter atomically claims the current `wow.context-name` in `wow_database_metadata`. Instances of the same context
-can restart safely; a different context pointing to that database fails before its EventStore/SnapshotStore is
-created and reports that a separate database is required. This guard remains active when `auto-init-schema` is
+can restart safely; a different context pointing to that database fails before its EventStore, SnapshotStore, query
+factory, or PrepareKeyFactory is created and reports that a separate database is required. This includes a dedicated
+`prepare-database` when event and snapshot storage use another backend, and remains active when `auto-init-schema` is
 disabled. For an existing unmarked database, the first upgraded instance checks every existing `*_event_stream`,
 `*_snapshot`, and `*_snapshot_checkpoint` collection for a document owned by another context before writing the
-marker. This one-time scan can be expensive on large legacy databases, so upgrade the database's real owner first.
+marker. Legacy `prepare_*` records contain no context metadata, so audit prepare database mappings before rollout;
+the first upgraded context claims an otherwise unmarked prepare-only database. The aggregate collection scan can be
+expensive on large legacy databases, so upgrade the database's real owner first.
 
 ## Installation
 
@@ -198,10 +201,10 @@ Collection names are derived from aggregate metadata using deterministic suffixe
 | Snapshot Checkpoint | `{aggregateName}_snapshot_checkpoint` | `order_snapshot_checkpoint` |
 | Prepare Key | `prepare_{name}` | `prepare_username_idx` |
 
-Event-stream and snapshot collection names intentionally remain backward compatible and do not include
+Event-stream, snapshot, and prepare collection names intentionally remain backward compatible and do not include
 `contextName`. Database ownership is recorded separately in `wow_database_metadata`; do not delete or edit this
-collection manually. To hand a database to another context, migrate or remove the original event-stream and snapshot
-data first, then remove the ownership marker before starting the new service.
+collection manually. To hand a database to another context, migrate or remove the original event-stream, snapshot,
+and prepare data first, then remove the ownership marker before starting the new service.
 
 ### Event Stream Collection (`{aggregateName}_event_stream`)
 

--- a/documentation/docs/en/guide/extensions/mongo.md
+++ b/documentation/docs/en/guide/extensions/mongo.md
@@ -61,6 +61,14 @@ graph TB
 
 Each aggregate type gets its own collection, partitioned by aggregate name. This design isolates hot aggregates from each other and enables per-aggregate sharding and index tuning.
 
+This collection layout assumes that one MongoDB database serves exactly one bounded context. During startup, the
+Starter atomically claims the current `wow.context-name` in `wow_database_metadata`. Instances of the same context
+can restart safely; a different context pointing to that database fails before its EventStore/SnapshotStore is
+created and reports that a separate database is required. This guard remains active when `auto-init-schema` is
+disabled. For an existing unmarked database, the first upgraded instance checks every existing `*_event_stream`,
+`*_snapshot`, and `*_snapshot_checkpoint` collection for a document owned by another context before writing the
+marker. This one-time scan can be expensive on large legacy databases, so upgrade the database's real owner first.
+
 ## Installation
 
 ::: code-group
@@ -187,7 +195,13 @@ Collection names are derived from aggregate metadata using deterministic suffixe
 |---|---|---|
 | Event Stream | `{aggregateName}_event_stream` | `order_event_stream` |
 | Snapshot | `{aggregateName}_snapshot` | `order_snapshot` |
+| Snapshot Checkpoint | `{aggregateName}_snapshot_checkpoint` | `order_snapshot_checkpoint` |
 | Prepare Key | `prepare_{name}` | `prepare_username_idx` |
+
+Event-stream and snapshot collection names intentionally remain backward compatible and do not include
+`contextName`. Database ownership is recorded separately in `wow_database_metadata`; do not delete or edit this
+collection manually. To hand a database to another context, migrate or remove the original event-stream and snapshot
+data first, then remove the ownership marker before starting the new service.
 
 ### Event Stream Collection (`{aggregateName}_event_stream`)
 
@@ -283,21 +297,21 @@ The key document-level transformation is the **primary key mapping**: event stre
 
 ## Schema Initialization and Indexes
 
-The `wow.mongo.auto-init-schema` flag (default `true`) controls whether collections and indexes are created automatically on startup. Two initializers handle this:
+The `wow.mongo.auto-init-schema` flag (default `true`) controls whether collections and indexes are created automatically on startup. Three focused initializers handle this:
 
 ### EventStreamSchemaInitializer
 
 On initialization, the `EventStreamSchemaInitializer.initSchema()` method:
 
 1. Ensures the collection exists via `database.ensureCollection(collectionName)`
-2. Creates a **hashed index** on `aggregateId` for fast aggregate-scoped queries
+2. Creates a **hashed index** on `aggregateId` for equality lookups and hashed sharding
 3. Creates the **unique compound index** `{aggregateId: 1, version: 1}` for optimistic concurrency control
 4. Creates either a global `requestId` unique index or a compound `{aggregateId, requestId}` unique index, depending on the `enableRequestIdUniqueIndex` flag (default `false` for sharded cluster compatibility)
 5. Creates hashed indexes on `tenantId` and `ownerId` for multi-tenancy filtering
 
 | Index | Fields | Type | Purpose |
 |---|---|---|---|
-| `aggregateId_hashed` | `aggregateId` | Hashed | Aggregate-scoped queries |
+| `aggregateId_hashed` | `aggregateId` | Hashed | Equality lookups and hashed sharding |
 | `aggregateId_1_version_1` | `aggregateId`, `version` | Unique | Optimistic concurrency -- prevents version conflicts |
 | `aggregateId_1_requestId_1` | `aggregateId`, `requestId` | Unique | Request idempotency (shard-safe variant) |
 | `requestId_1` | `requestId` | Unique | Request idempotency (non-sharded variant) |
@@ -316,6 +330,12 @@ The `SnapshotSchemaInitializer.initSchema()` creates:
 | `ownerId_hashed` | `ownerId` | Hashed | Owner-based filtering |
 | `_id_hashed` | `_id` | Hashed | Fast aggregate lookup by ID |
 | `deleted_hashed` | `deleted` | Hashed | Soft-delete filtering |
+
+### SnapshotCheckpointSchemaInitializer
+
+When `wow.eventsourcing.snapshot.checkpoint.enabled=true`,
+`SnapshotCheckpointSchemaInitializer` creates the `<aggregate>_snapshot_checkpoint` sidecar and its unique
+`{tenantId: 1, aggregateId: 1, version: 1}` index. The sidecar is not created while checkpointing remains disabled.
 
 ## Query Services
 

--- a/documentation/docs/en/guide/migration.md
+++ b/documentation/docs/en/guide/migration.md
@@ -49,11 +49,12 @@ database.
 
 Before rollout:
 
-1. Inspect every `*_event_stream`, `*_snapshot`, and `*_snapshot_checkpoint` collection in each configured
-   event-stream and snapshot database.
+1. Inspect every configured event-stream, snapshot, and prepare database. Check all `*_event_stream`, `*_snapshot`,
+   `*_snapshot_checkpoint`, and `prepare_*` collections.
 2. Confirm that each database belongs to only one `wow.context-name`; a mixed database must be split before upgrade.
 3. Upgrade the database's real owner first. The first upgraded instance scans legacy aggregate collections before
-   atomically claiming the marker.
+   atomically claiming the marker. Legacy `prepare_*` records contain no context metadata, so a prepare-only database
+   is claimed by the first upgraded context and must be audited before rollout.
 4. Audit existing managed indexes. Missing indexes are created, but incompatible key order, uniqueness, TTL,
    partial-filter, collation, sparse, or hidden options block startup and require a controlled migration.
 

--- a/documentation/docs/en/guide/migration.md
+++ b/documentation/docs/en/guide/migration.md
@@ -41,6 +41,40 @@ Before upgrading, check the following:
 2. **Configuration Changes**: Check for configuration property changes
 3. **Metadata Changes**: Regenerate metadata files
 
+## Mongo Ownership Guard and Snapshot Checkpoints
+
+This upgrade keeps aggregate-name-only Mongo collection names, but adds a durable
+`wow_database_metadata` ownership marker. The supported deployment layout is one bounded context per MongoDB
+database.
+
+Before rollout:
+
+1. Inspect every `*_event_stream`, `*_snapshot`, and `*_snapshot_checkpoint` collection in each configured
+   event-stream and snapshot database.
+2. Confirm that each database belongs to only one `wow.context-name`; a mixed database must be split before upgrade.
+3. Upgrade the database's real owner first. The first upgraded instance scans legacy aggregate collections before
+   atomically claiming the marker.
+4. Audit existing managed indexes. Missing indexes are created, but incompatible key order, uniqueness, TTL,
+   partial-filter, collation, sparse, or hidden options block startup and require a controlled migration.
+
+Do not edit the marker to bypass a context mismatch. Move or remove the old data, then remove the marker only when
+the database is intentionally reassigned.
+
+Historical snapshot checkpoints are disabled by default:
+
+```yaml
+wow:
+  eventsourcing:
+    snapshot:
+      checkpoint:
+        enabled: false
+        version-interval: 100
+```
+
+Enabling the feature creates `<aggregate>_snapshot_checkpoint` sidecars and stores only newly produced matching
+versions; it does not backfill history. Roll back by disabling the feature, and retain the sidecars until validation
+and retention decisions are complete.
+
 ## Migrating from Traditional Architecture
 
 ### Migration Strategy

--- a/documentation/docs/en/guide/snapshot.md
+++ b/documentation/docs/en/guide/snapshot.md
@@ -109,7 +109,21 @@ interface SnapshotStore : Named {
     fun <S : Any> save(snapshot: Snapshot<S>): Mono<Void>
     fun getVersion(aggregateId: AggregateId): Mono<Int>
 }
+
+interface VersionedSnapshotStore : SnapshotStore {
+    fun <S : Any> loadAtOrBefore(
+        aggregateId: AggregateId,
+        maxVersion: Int
+    ): Mono<Snapshot<S>>
+
+    fun <S : Any> saveCheckpoint(snapshot: Snapshot<S>): Mono<Void>
+}
 ```
+
+`SnapshotStore.save()` continues to maintain only the latest snapshot. `VersionedSnapshotStore`
+adds immutable historical checkpoints without changing that contract. It loads the greatest
+checkpoint no newer than a requested version. Duplicate aggregate/version writes are first-wins,
+and storage failures are propagated.
 
 ### In-Memory Implementation
 
@@ -152,13 +166,21 @@ wow:
       enabled: true  # Whether to enable snapshots
       strategy: all  # Snapshot strategy (all, version_offset)
       version-offset: 5  # Version offset (only valid for version_offset strategy)
+      checkpoint:
+        enabled: false  # Off by default; evaluate storage growth first
+        version-interval: 100
 ```
 
 | Property | Default | Description |
 |----------|---------|-------------|
-| `wow.snapshot.enabled` | `false` | Enable snapshot store |
-| `wow.snapshot.interval` | `100` | Events before new snapshot |
-| `wow.snapshot.store.type` | Event store backend | Snapshot storage backend |
+| `wow.eventsourcing.snapshot.enabled` | `true` | Enable latest snapshots |
+| `wow.eventsourcing.snapshot.checkpoint.enabled` | `false` | Enable immutable historical checkpoints |
+| `wow.eventsourcing.snapshot.checkpoint.version-interval` | `100` | Checkpoint version interval |
+
+Enabling the feature only accumulates newly produced matching versions; it does not backfill old
+history automatically. Roll back by disabling `checkpoint.enabled`. MongoDB stores checkpoints in
+the separate `<aggregate>_snapshot_checkpoint` sidecar.
+
 
 ## Aggregate Loading Optimization
 

--- a/documentation/docs/zh/guide/extensions/mongo.md
+++ b/documentation/docs/zh/guide/extensions/mongo.md
@@ -63,10 +63,13 @@ graph TB
 
 该集合布局假设一个 MongoDB database 只服务一个 bounded context。Starter 启动时会在
 `wow_database_metadata` 中原子认领当前 `wow.context-name`；同一 context 的实例可安全重复启动，
-不同 context 误连到该 database 时会在创建 EventStore/SnapshotStore 前失败，并提示配置独立数据库。
-该检查不受 `auto-init-schema` 影响。对于尚无所有权标记的存量 database，首次启动会先从已有
-`*_event_stream`、`*_snapshot` 和 `*_snapshot_checkpoint` 集合中查找属于其他 context 的文档，
-确认不存在历史混写后再写入标记。该全量校验只在首次认领时执行；大型存量数据库应优先升级其真实
+不同 context 误连到该 database 时会在创建 EventStore、SnapshotStore、查询 factory 或
+PrepareKeyFactory 前失败，并提示配置独立数据库。即使 event 与 snapshot 使用其他后端，独立的
+`prepare-database` 也会执行该检查；该检查不受 `auto-init-schema` 影响。对于尚无所有权标记的存量
+database，首次启动会先从已有 `*_event_stream`、`*_snapshot` 和 `*_snapshot_checkpoint` 集合中
+查找属于其他 context 的文档，确认不存在历史混写后再写入标记。存量 `prepare_*` 文档没有 context
+元数据，因此上线前必须审计 prepare database 映射；首个升级的 context 会认领尚未标记且仅含
+prepare 数据的 database。aggregate 全量校验只在首次认领时执行；大型存量数据库应优先升级其真实
 所有者服务，并预留扫描时间。
 
 ## 安装
@@ -198,9 +201,9 @@ wow:
 | 快照 Checkpoint | `{aggregateName}_snapshot_checkpoint` | `order_snapshot_checkpoint` |
 | PrepareKey | `prepare_{name}` | `prepare_username_idx` |
 
-事件流与快照集合名称刻意保持兼容，不会加入 `contextName`。bounded context 的数据库所有权由
-`wow_database_metadata` 单独记录；不要删除或手工改写该集合。若确需将数据库交给另一个 context，
-应先迁移或清空原事件流与快照数据，再删除所有权标记并启动新服务。
+事件流、快照与 PrepareKey 集合名称刻意保持兼容，不会加入 `contextName`。bounded context 的数据库
+所有权由 `wow_database_metadata` 单独记录；不要删除或手工改写该集合。若确需将数据库交给另一个
+context，应先迁移或清空原事件流、快照与 PrepareKey 数据，再删除所有权标记并启动新服务。
 
 ### 事件流集合 (`{aggregateName}_event_stream`)
 

--- a/documentation/docs/zh/guide/extensions/mongo.md
+++ b/documentation/docs/zh/guide/extensions/mongo.md
@@ -61,6 +61,14 @@ graph TB
 
 每种聚合类型拥有自己的集合，按聚合名称分区。这种设计将热聚合彼此隔离，并支持按聚合进行分片和索引调优。
 
+该集合布局假设一个 MongoDB database 只服务一个 bounded context。Starter 启动时会在
+`wow_database_metadata` 中原子认领当前 `wow.context-name`；同一 context 的实例可安全重复启动，
+不同 context 误连到该 database 时会在创建 EventStore/SnapshotStore 前失败，并提示配置独立数据库。
+该检查不受 `auto-init-schema` 影响。对于尚无所有权标记的存量 database，首次启动会先从已有
+`*_event_stream`、`*_snapshot` 和 `*_snapshot_checkpoint` 集合中查找属于其他 context 的文档，
+确认不存在历史混写后再写入标记。该全量校验只在首次认领时执行；大型存量数据库应优先升级其真实
+所有者服务，并预留扫描时间。
+
 ## 安装
 
 ::: code-group
@@ -187,7 +195,12 @@ wow:
 |---|---|---|
 | 事件流 | `{aggregateName}_event_stream` | `order_event_stream` |
 | 快照 | `{aggregateName}_snapshot` | `order_snapshot` |
+| 快照 Checkpoint | `{aggregateName}_snapshot_checkpoint` | `order_snapshot_checkpoint` |
 | PrepareKey | `prepare_{name}` | `prepare_username_idx` |
+
+事件流与快照集合名称刻意保持兼容，不会加入 `contextName`。bounded context 的数据库所有权由
+`wow_database_metadata` 单独记录；不要删除或手工改写该集合。若确需将数据库交给另一个 context，
+应先迁移或清空原事件流与快照数据，再删除所有权标记并启动新服务。
 
 ### 事件流集合 (`{aggregateName}_event_stream`)
 
@@ -283,21 +296,21 @@ wow:
 
 ## 模式初始化与索引
 
-`wow.mongo.auto-init-schema` 标志（默认 `true`）控制在启动时是否自动创建集合和索引。两个初始化器处理此过程：
+`wow.mongo.auto-init-schema` 标志（默认 `true`）控制在启动时是否自动创建集合和索引。三个职责单一的初始化器处理此过程：
 
 ### EventStreamSchemaInitializer
 
 在初始化时，`EventStreamSchemaInitializer.initSchema()` 方法：
 
 1. 通过 `database.ensureCollection(collectionName)` 确保集合存在
-2. 在 `aggregateId` 上创建 **哈希索引** 以支持快速的聚合范围查询
+2. 在 `aggregateId` 上创建 **哈希索引** 以支持等值查询和哈希分片
 3. 创建 **唯一复合索引** `{aggregateId: 1, version: 1}` 用于乐观并发控制
 4. 根据 `enableRequestIdUniqueIndex` 标志（默认为 `false` 以兼容分片集群），创建全局 `requestId` 唯一索引或复合 `{aggregateId, requestId}` 唯一索引
 5. 在 `tenantId` 和 `ownerId` 上创建哈希索引以支持多租户过滤
 
 | 索引 | 字段 | 类型 | 用途 |
 |---|---|---|---|
-| `aggregateId_hashed` | `aggregateId` | 哈希 | 聚合范围查询 |
+| `aggregateId_hashed` | `aggregateId` | 哈希 | 等值查询和哈希分片 |
 | `aggregateId_1_version_1` | `aggregateId`, `version` | 唯一 | 乐观并发控制——防止版本冲突 |
 | `aggregateId_1_requestId_1` | `aggregateId`, `requestId` | 唯一 | 请求幂等性（分片安全变体） |
 | `requestId_1` | `requestId` | 唯一 | 请求幂等性（非分片变体） |
@@ -316,6 +329,12 @@ wow:
 | `ownerId_hashed` | `ownerId` | 哈希 | 基于所有者的过滤 |
 | `_id_hashed` | `_id` | 哈希 | 按 ID 快速查找聚合 |
 | `deleted_hashed` | `deleted` | 哈希 | 软删除过滤 |
+
+### SnapshotCheckpointSchemaInitializer
+
+仅当 `wow.eventsourcing.snapshot.checkpoint.enabled=true` 时，
+`SnapshotCheckpointSchemaInitializer` 才会创建 `<aggregate>_snapshot_checkpoint` sidecar，以及唯一
+索引 `{tenantId: 1, aggregateId: 1, version: 1}`。checkpoint 保持关闭时不会创建该集合。
 
 ## 查询服务
 

--- a/documentation/docs/zh/guide/migration.md
+++ b/documentation/docs/zh/guide/migration.md
@@ -49,10 +49,12 @@ context。
 
 上线前：
 
-1. 检查各 event-stream 与 snapshot database 中所有 `*_event_stream`、`*_snapshot` 和
-   `*_snapshot_checkpoint` collection。
+1. 检查所有已配置的 event-stream、snapshot 与 prepare database，以及其中的 `*_event_stream`、
+   `*_snapshot`、`*_snapshot_checkpoint` 和 `prepare_*` collection。
 2. 确认每个 database 只属于一个 `wow.context-name`；历史混写数据库必须先拆分。
 3. 先升级数据库的真实所有者。第一个新版本实例会扫描存量 aggregate collection，再原子认领标记。
+   存量 `prepare_*` 文档没有 context 元数据，因此 prepare-only database 会由首个升级 context 认领，
+   上线前必须先审计其映射关系。
 4. 审计现有受管索引。缺失索引会创建；key 顺序、unique、TTL、partial filter、collation、sparse 或
    hidden 选项不兼容时会阻止启动，必须执行受控迁移。
 

--- a/documentation/docs/zh/guide/migration.md
+++ b/documentation/docs/zh/guide/migration.md
@@ -41,6 +41,38 @@ implementation("me.ahoo.wow:wow-spring-boot-starter:新版本号")
 2. **配置变更**：检查配置属性是否有变更
 3. **元数据变更**：重新生成元数据文件
 
+## Mongo 所有权保护与 Snapshot Checkpoint
+
+本次升级保留仅含 aggregate name 的 Mongo collection 命名，但新增持久化
+`wow_database_metadata` 所有权标记。支持的部署布局是一个 MongoDB database 只属于一个 bounded
+context。
+
+上线前：
+
+1. 检查各 event-stream 与 snapshot database 中所有 `*_event_stream`、`*_snapshot` 和
+   `*_snapshot_checkpoint` collection。
+2. 确认每个 database 只属于一个 `wow.context-name`；历史混写数据库必须先拆分。
+3. 先升级数据库的真实所有者。第一个新版本实例会扫描存量 aggregate collection，再原子认领标记。
+4. 审计现有受管索引。缺失索引会创建；key 顺序、unique、TTL、partial filter、collation、sparse 或
+   hidden 选项不兼容时会阻止启动，必须执行受控迁移。
+
+不要通过修改所有权标记绕过 context 冲突。应先迁移或删除旧数据；只有明确重新分配空数据库时才删除
+标记。
+
+历史 snapshot checkpoint 默认关闭：
+
+```yaml
+wow:
+  eventsourcing:
+    snapshot:
+      checkpoint:
+        enabled: false
+        version-interval: 100
+```
+
+启用后会创建 `<aggregate>_snapshot_checkpoint` sidecar，并且只保存升级后新产生的匹配版本，不会自动
+回填历史。回滚时关闭该功能；在完成验证与保留策略决策前保留 sidecar。
+
 ## 从传统架构迁移
 
 ### 迁移策略

--- a/documentation/docs/zh/guide/snapshot.md
+++ b/documentation/docs/zh/guide/snapshot.md
@@ -109,7 +109,20 @@ interface SnapshotStore : Named {
     fun <S : Any> save(snapshot: Snapshot<S>): Mono<Void>
     fun getVersion(aggregateId: AggregateId): Mono<Int>
 }
+
+interface VersionedSnapshotStore : SnapshotStore {
+    fun <S : Any> loadAtOrBefore(
+        aggregateId: AggregateId,
+        maxVersion: Int
+    ): Mono<Snapshot<S>>
+
+    fun <S : Any> saveCheckpoint(snapshot: Snapshot<S>): Mono<Void>
+}
 ```
+
+`SnapshotStore.save()` 仍只维护最新快照。`VersionedSnapshotStore` 在不改变该契约的前提下增加不可变
+历史 checkpoint：读取不大于目标版本的最大 checkpoint。相同 aggregate/version 的重复写入采用
+first-wins，存储错误会继续向上传播。
 
 ### 内存实现
 
@@ -152,13 +165,21 @@ wow:
       enabled: true  # 是否启用快照
       strategy: all  # 快照策略 (all, version_offset)
       version-offset: 5  # 版本偏移（仅对 version_offset 策略有效）
+      checkpoint:
+        enabled: false  # 默认关闭，先评估存储增长
+        version-interval: 100
 ```
 
 | 属性 | 默认值 | 描述 |
 |----------|---------|-------------|
-| `wow.snapshot.enabled` | `false` | 启用快照存储 |
-| `wow.snapshot.interval` | `100` | 创建新快照前的事件数 |
-| `wow.snapshot.store.type` | 事件存储后端 | 快照存储后端 |
+| `wow.eventsourcing.snapshot.enabled` | `true` | 启用最新快照 |
+| `wow.eventsourcing.snapshot.checkpoint.enabled` | `false` | 启用不可变历史 checkpoint |
+| `wow.eventsourcing.snapshot.checkpoint.version-interval` | `100` | checkpoint 版本间隔 |
+
+启用后只会从新产生的匹配版本开始积累 checkpoint，不会自动回填旧历史。回滚只需关闭
+`checkpoint.enabled`。MongoDB 将 checkpoint 存放在独立的
+`<aggregate>_snapshot_checkpoint` sidecar。
+
 
 ## 聚合加载优化
 

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/eventsourcing/snapshot/VersionedSnapshotStoreSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/eventsourcing/snapshot/VersionedSnapshotStoreSpec.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.wow.tck.eventsourcing.snapshot
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.modeling.AggregateId
+import me.ahoo.wow.eventsourcing.snapshot.SimpleSnapshot
+import me.ahoo.wow.eventsourcing.snapshot.Snapshot
+import me.ahoo.wow.eventsourcing.snapshot.VersionedSnapshotStore
+import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory.toStateAggregate
+import me.ahoo.wow.tck.mock.MockStateAggregate
+import org.junit.jupiter.api.Test
+import reactor.kotlin.test.test
+
+@Suppress("UnnecessaryAbstractClass")
+abstract class VersionedSnapshotStoreSpec : SnapshotStoreSpec() {
+    abstract override fun createSnapshotStore(): VersionedSnapshotStore
+
+    @Test
+    fun loadAtOrBeforeSelectsGreatestEligibleCheckpoint() {
+        val store = createSnapshotStore()
+        val aggregateId = aggregateMetadata.aggregateId(generateGlobalId())
+        store.saveCheckpoint(snapshot(aggregateId, 5, "v5")).block()
+        store.saveCheckpoint(snapshot(aggregateId, 10, "v10")).block()
+        store.saveCheckpoint(snapshot(aggregateId, 15, "v15")).block()
+
+        store.loadAtOrBefore<MockStateAggregate>(aggregateId, 12)
+            .test()
+            .consumeNextWith { checkpoint ->
+                checkpoint.version.assert().isEqualTo(10)
+                checkpoint.state.data.assert().isEqualTo("v10")
+            }
+            .verifyComplete()
+        store.loadAtOrBefore<MockStateAggregate>(aggregateId, 4)
+            .test()
+            .verifyComplete()
+    }
+
+    @Test
+    fun checkpointIsFirstWinsAndDoesNotReplaceLatestSnapshot() {
+        val store = createSnapshotStore()
+        val aggregateId = aggregateMetadata.aggregateId(generateGlobalId())
+        store.save(snapshot(aggregateId, 20, "latest")).block()
+        store.saveCheckpoint(snapshot(aggregateId, 10, "first")).block()
+        store.saveCheckpoint(snapshot(aggregateId, 10, "replacement")).block()
+
+        store.loadAtOrBefore<MockStateAggregate>(aggregateId, 10)
+            .test()
+            .consumeNextWith { checkpoint ->
+                checkpoint.state.data.assert().isEqualTo("first")
+            }
+            .verifyComplete()
+        store.load<MockStateAggregate>(aggregateId)
+            .test()
+            .consumeNextWith { latest ->
+                latest.version.assert().isEqualTo(20)
+                latest.state.data.assert().isEqualTo("latest")
+            }
+            .verifyComplete()
+    }
+
+    private fun snapshot(
+        aggregateId: AggregateId,
+        version: Int,
+        data: String,
+    ): Snapshot<MockStateAggregate> {
+        val state = MockStateAggregate(aggregateId.id)
+        state.javaClass.getDeclaredField("data").apply {
+            isAccessible = true
+            set(state, data)
+        }
+        val aggregate = aggregateMetadata.state.toStateAggregate(
+            aggregateId = aggregateId,
+            state = state,
+            version = version,
+        )
+        return SimpleSnapshot(aggregate, snapshotTime = version.toLong())
+    }
+}

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/AggregateSnapshotStoreRegistry.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/AggregateSnapshotStoreRegistry.kt
@@ -25,6 +25,10 @@ class AggregateSnapshotStoreRegistry(
             namedAggregate.materialize()
         }
 
+    internal val supportsHistoricalCheckpoints: Boolean =
+        defaultSnapshotStore is VersionedSnapshotStore &&
+            this.routes.values.all { store -> store is VersionedSnapshotStore }
+
     fun get(namedAggregate: NamedAggregate): SnapshotStore =
         routes[namedAggregate.materialize()] ?: defaultSnapshotStore
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/CompositeSnapshotStrategy.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/CompositeSnapshotStrategy.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.eventsourcing.snapshot
+
+import me.ahoo.wow.eventsourcing.state.StateEventExchange
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+/**
+ * Executes snapshot strategies sequentially for the same state event.
+ */
+class CompositeSnapshotStrategy(
+    private val strategies: List<SnapshotStrategy>,
+) : SnapshotStrategy {
+    init {
+        require(strategies.isNotEmpty()) {
+            "strategies must not be empty."
+        }
+    }
+
+    override fun onEvent(stateEventExchange: StateEventExchange<*>): Mono<Void> =
+        Flux.fromIterable(strategies)
+            .concatMap { strategy -> strategy.onEvent(stateEventExchange) }
+            .then()
+}

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/InMemorySnapshotStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/InMemorySnapshotStore.kt
@@ -19,12 +19,13 @@ import me.ahoo.wow.serialization.toObject
 import reactor.core.publisher.Mono
 import tools.jackson.databind.node.ObjectNode
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ConcurrentSkipListMap
 
 /**
  * In-memory implementation of SnapshotStore for testing and development.
  * Stores snapshots as JSON strings in a thread-safe map.
  */
-class InMemorySnapshotStore : SnapshotStore {
+class InMemorySnapshotStore : VersionedSnapshotStore {
     companion object {
         /**
          * The name of this repository.
@@ -42,6 +43,8 @@ class InMemorySnapshotStore : SnapshotStore {
      * Thread-safe storage for snapshots, keyed by aggregate ID.
      */
     private val aggregateIdMapSnapshot = ConcurrentHashMap<AggregateId, ObjectNode>()
+    private val aggregateIdMapCheckpoints =
+        ConcurrentHashMap<AggregateId, ConcurrentSkipListMap<Int, ObjectNode>>()
 
     /**
      * Loads a snapshot from the in-memory map by deserializing the JSON string.
@@ -64,4 +67,31 @@ class InMemorySnapshotStore : SnapshotStore {
         Mono.fromRunnable {
             aggregateIdMapSnapshot[snapshot.aggregateId] = snapshot.toJsonNode()
         }
+
+    override fun <S : Any> loadAtOrBefore(
+        aggregateId: AggregateId,
+        maxVersion: Int,
+    ): Mono<Snapshot<S>> {
+        require(maxVersion >= 0) {
+            "maxVersion must be greater than or equal to 0."
+        }
+        return Mono.defer {
+            val checkpoint = aggregateIdMapCheckpoints[aggregateId]
+                ?.floorEntry(maxVersion)
+                ?.value
+                ?.toObject<Snapshot<S>>()
+            Mono.justOrEmpty(checkpoint)
+        }
+    }
+
+    override fun <S : Any> saveCheckpoint(snapshot: Snapshot<S>): Mono<Void> {
+        require(snapshot.version > 0) {
+            "checkpoint version must be greater than 0."
+        }
+        return Mono.fromRunnable {
+            aggregateIdMapCheckpoints.computeIfAbsent(snapshot.aggregateId) {
+                ConcurrentSkipListMap()
+            }.putIfAbsent(snapshot.version, snapshot.toJsonNode())
+        }
+    }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/RoutingSnapshotStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/RoutingSnapshotStore.kt
@@ -17,7 +17,7 @@ import reactor.core.publisher.Mono
 
 class RoutingSnapshotStore(
     private val registry: AggregateSnapshotStoreRegistry
-) : SnapshotStore {
+) : VersionedSnapshotStore {
     override val name: String
         get() = NAME
 
@@ -29,6 +29,32 @@ class RoutingSnapshotStore(
 
     override fun <S : Any> save(snapshot: Snapshot<S>): Mono<Void> =
         registry.get(snapshot.aggregateId.namedAggregate).save(snapshot)
+
+    override fun <S : Any> loadAtOrBefore(
+        aggregateId: AggregateId,
+        maxVersion: Int,
+    ): Mono<Snapshot<S>> {
+        return Mono.defer {
+            val selectedStore = registry.get(aggregateId.namedAggregate)
+            if (selectedStore is VersionedSnapshotStore) {
+                selectedStore.loadAtOrBefore(aggregateId, maxVersion)
+            } else {
+                selectedStore.load<S>(aggregateId)
+                    .filter { snapshot -> snapshot.version <= maxVersion }
+            }
+        }
+    }
+
+    override fun <S : Any> saveCheckpoint(snapshot: Snapshot<S>): Mono<Void> {
+        return Mono.defer {
+            val selectedStore = registry.get(snapshot.aggregateId.namedAggregate)
+            check(selectedStore is VersionedSnapshotStore) {
+                "Snapshot store [${selectedStore.name}] selected for [${snapshot.aggregateId.namedAggregate}] " +
+                    "does not support historical checkpoints."
+            }
+            selectedStore.saveCheckpoint(snapshot)
+        }
+    }
 
     companion object {
         const val NAME = "routing"

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/RoutingSnapshotStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/RoutingSnapshotStore.kt
@@ -15,9 +15,9 @@ package me.ahoo.wow.eventsourcing.snapshot
 import me.ahoo.wow.api.modeling.AggregateId
 import reactor.core.publisher.Mono
 
-class RoutingSnapshotStore(
-    private val registry: AggregateSnapshotStoreRegistry
-) : VersionedSnapshotStore {
+open class RoutingSnapshotStore(
+    protected val registry: AggregateSnapshotStoreRegistry
+) : SnapshotStore {
     override val name: String
         get() = NAME
 
@@ -30,33 +30,32 @@ class RoutingSnapshotStore(
     override fun <S : Any> save(snapshot: Snapshot<S>): Mono<Void> =
         registry.get(snapshot.aggregateId.namedAggregate).save(snapshot)
 
+    companion object {
+        const val NAME = "routing"
+
+        fun create(registry: AggregateSnapshotStoreRegistry): RoutingSnapshotStore =
+            if (registry.supportsHistoricalCheckpoints) {
+                VersionedRoutingSnapshotStore(registry)
+            } else {
+                RoutingSnapshotStore(registry)
+            }
+    }
+}
+
+private class VersionedRoutingSnapshotStore(
+    registry: AggregateSnapshotStoreRegistry,
+) : RoutingSnapshotStore(registry),
+    VersionedSnapshotStore {
+
     override fun <S : Any> loadAtOrBefore(
         aggregateId: AggregateId,
         maxVersion: Int,
-    ): Mono<Snapshot<S>> {
-        return Mono.defer {
-            val selectedStore = registry.get(aggregateId.namedAggregate)
-            if (selectedStore is VersionedSnapshotStore) {
-                selectedStore.loadAtOrBefore(aggregateId, maxVersion)
-            } else {
-                selectedStore.load<S>(aggregateId)
-                    .filter { snapshot -> snapshot.version <= maxVersion }
-            }
-        }
-    }
+    ): Mono<Snapshot<S>> =
+        versionedStore(aggregateId).loadAtOrBefore(aggregateId, maxVersion)
 
-    override fun <S : Any> saveCheckpoint(snapshot: Snapshot<S>): Mono<Void> {
-        return Mono.defer {
-            val selectedStore = registry.get(snapshot.aggregateId.namedAggregate)
-            check(selectedStore is VersionedSnapshotStore) {
-                "Snapshot store [${selectedStore.name}] selected for [${snapshot.aggregateId.namedAggregate}] " +
-                    "does not support historical checkpoints."
-            }
-            selectedStore.saveCheckpoint(snapshot)
-        }
-    }
+    override fun <S : Any> saveCheckpoint(snapshot: Snapshot<S>): Mono<Void> =
+        versionedStore(snapshot.aggregateId).saveCheckpoint(snapshot)
 
-    companion object {
-        const val NAME = "routing"
-    }
+    private fun versionedStore(aggregateId: AggregateId): VersionedSnapshotStore =
+        registry.get(aggregateId.namedAggregate) as VersionedSnapshotStore
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt
@@ -56,7 +56,7 @@ interface SnapshotStore : Named {
  * No-operation implementation of SnapshotStore that does nothing.
  * Useful for testing or when snapshots are not needed.
  */
-object NoOpSnapshotStore : SnapshotStore {
+object NoOpSnapshotStore : VersionedSnapshotStore {
     /**
      * The name of this store.
      */
@@ -77,4 +77,11 @@ object NoOpSnapshotStore : SnapshotStore {
      * Does nothing, as this is a no-op store.
      */
     override fun <S : Any> save(snapshot: Snapshot<S>): Mono<Void> = Mono.empty()
+
+    override fun <S : Any> loadAtOrBefore(
+        aggregateId: AggregateId,
+        maxVersion: Int,
+    ): Mono<Snapshot<S>> = Mono.empty()
+
+    override fun <S : Any> saveCheckpoint(snapshot: Snapshot<S>): Mono<Void> = Mono.empty()
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/VersionIntervalCheckpointStrategy.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/VersionIntervalCheckpointStrategy.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.eventsourcing.snapshot
+
+import me.ahoo.wow.eventsourcing.state.StateEventExchange
+import reactor.core.publisher.Mono
+
+/**
+ * Writes immutable historical checkpoints at a fixed aggregate-version interval.
+ */
+class VersionIntervalCheckpointStrategy(
+    private val versionInterval: Int,
+    private val snapshotStore: VersionedSnapshotStore,
+) : SnapshotStrategy {
+    init {
+        require(versionInterval > 0) {
+            "versionInterval must be positive."
+        }
+    }
+
+    override fun onEvent(stateEventExchange: StateEventExchange<*>): Mono<Void> {
+        val stateEvent = stateEventExchange.message
+        if (stateEvent.version % versionInterval != 0) {
+            return Mono.empty()
+        }
+        return snapshotStore.saveCheckpoint(SimpleSnapshot(stateEvent))
+    }
+}

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/VersionedSnapshotStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/VersionedSnapshotStore.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.eventsourcing.snapshot
+
+import me.ahoo.wow.api.modeling.AggregateId
+import reactor.core.publisher.Mono
+
+/**
+ * Optional snapshot-store capability for immutable historical checkpoints.
+ *
+ * Historical checkpoints are deliberately separate from [SnapshotStore.save], whose contract
+ * remains "save the latest snapshot". A checkpoint identified by aggregate and version is
+ * immutable: repeated writes are idempotent and must not replace the first stored value.
+ */
+interface VersionedSnapshotStore : SnapshotStore {
+    /**
+     * Loads the greatest checkpoint version that is less than or equal to [maxVersion].
+     *
+     * Missing checkpoints complete empty. Backend, authentication, and timeout failures must be
+     * propagated rather than converted to an empty result.
+     */
+    fun <S : Any> loadAtOrBefore(
+        aggregateId: AggregateId,
+        maxVersion: Int,
+    ): Mono<Snapshot<S>>
+
+    /**
+     * Saves an immutable historical checkpoint without changing the latest snapshot.
+     */
+    fun <S : Any> saveCheckpoint(snapshot: Snapshot<S>): Mono<Void>
+}

--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricSnapshotStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricSnapshotStore.kt
@@ -17,7 +17,6 @@ import me.ahoo.wow.api.Wow
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.eventsourcing.snapshot.Snapshot
 import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
-import me.ahoo.wow.eventsourcing.snapshot.VersionedSnapshotStore
 import reactor.core.publisher.Mono
 
 /**
@@ -27,10 +26,10 @@ import reactor.core.publisher.Mono
  *
  * @property delegate the underlying snapshot store implementation
  */
-class MetricSnapshotStore(
+open class MetricSnapshotStore(
     delegate: SnapshotStore
 ) : AbstractMetricDecorator<SnapshotStore>(delegate),
-    VersionedSnapshotStore {
+    SnapshotStore {
     /**
      * The name of the snapshot store.
      * This delegates to the underlying snapshot store implementation.
@@ -84,33 +83,4 @@ class MetricSnapshotStore(
             .tagSource()
             .tag(Metrics.AGGREGATE_KEY, snapshot.aggregateId.aggregateName)
             .metrics()
-
-    override fun <S : Any> loadAtOrBefore(
-        aggregateId: AggregateId,
-        maxVersion: Int,
-    ): Mono<Snapshot<S>> {
-        val source = if (delegate is VersionedSnapshotStore) {
-            delegate.loadAtOrBefore<S>(aggregateId, maxVersion)
-        } else {
-            delegate.load<S>(aggregateId).filter { snapshot -> snapshot.version <= maxVersion }
-        }
-        return source
-            .name(Wow.WOW_PREFIX + "snapshot.checkpoint.load")
-            .tagSource()
-            .tag(Metrics.AGGREGATE_KEY, aggregateId.aggregateName)
-            .metrics()
-    }
-
-    override fun <S : Any> saveCheckpoint(snapshot: Snapshot<S>): Mono<Void> {
-        return Mono.defer {
-            check(delegate is VersionedSnapshotStore) {
-                "Snapshot store [${delegate.name}] does not support historical checkpoints."
-            }
-            delegate.saveCheckpoint(snapshot)
-        }
-            .name(Wow.WOW_PREFIX + "snapshot.checkpoint.save")
-            .tagSource()
-            .tag(Metrics.AGGREGATE_KEY, snapshot.aggregateId.aggregateName)
-            .metrics()
-    }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricSnapshotStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricSnapshotStore.kt
@@ -17,6 +17,7 @@ import me.ahoo.wow.api.Wow
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.eventsourcing.snapshot.Snapshot
 import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
+import me.ahoo.wow.eventsourcing.snapshot.VersionedSnapshotStore
 import reactor.core.publisher.Mono
 
 /**
@@ -29,7 +30,7 @@ import reactor.core.publisher.Mono
 class MetricSnapshotStore(
     delegate: SnapshotStore
 ) : AbstractMetricDecorator<SnapshotStore>(delegate),
-    SnapshotStore {
+    VersionedSnapshotStore {
     /**
      * The name of the snapshot store.
      * This delegates to the underlying snapshot store implementation.
@@ -83,4 +84,33 @@ class MetricSnapshotStore(
             .tagSource()
             .tag(Metrics.AGGREGATE_KEY, snapshot.aggregateId.aggregateName)
             .metrics()
+
+    override fun <S : Any> loadAtOrBefore(
+        aggregateId: AggregateId,
+        maxVersion: Int,
+    ): Mono<Snapshot<S>> {
+        val source = if (delegate is VersionedSnapshotStore) {
+            delegate.loadAtOrBefore<S>(aggregateId, maxVersion)
+        } else {
+            delegate.load<S>(aggregateId).filter { snapshot -> snapshot.version <= maxVersion }
+        }
+        return source
+            .name(Wow.WOW_PREFIX + "snapshot.checkpoint.load")
+            .tagSource()
+            .tag(Metrics.AGGREGATE_KEY, aggregateId.aggregateName)
+            .metrics()
+    }
+
+    override fun <S : Any> saveCheckpoint(snapshot: Snapshot<S>): Mono<Void> {
+        return Mono.defer {
+            check(delegate is VersionedSnapshotStore) {
+                "Snapshot store [${delegate.name}] does not support historical checkpoints."
+            }
+            delegate.saveCheckpoint(snapshot)
+        }
+            .name(Wow.WOW_PREFIX + "snapshot.checkpoint.save")
+            .tagSource()
+            .tag(Metrics.AGGREGATE_KEY, snapshot.aggregateId.aggregateName)
+            .metrics()
+    }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricVersionedSnapshotStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricVersionedSnapshotStore.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.metrics
+
+import me.ahoo.wow.api.Wow
+import me.ahoo.wow.api.modeling.AggregateId
+import me.ahoo.wow.eventsourcing.snapshot.Snapshot
+import me.ahoo.wow.eventsourcing.snapshot.VersionedSnapshotStore
+import reactor.core.publisher.Mono
+
+class MetricVersionedSnapshotStore(
+    private val checkpointStore: VersionedSnapshotStore,
+) : MetricSnapshotStore(checkpointStore),
+    VersionedSnapshotStore {
+
+    override fun <S : Any> loadAtOrBefore(
+        aggregateId: AggregateId,
+        maxVersion: Int,
+    ): Mono<Snapshot<S>> =
+        checkpointStore.loadAtOrBefore<S>(aggregateId, maxVersion)
+            .name(Wow.WOW_PREFIX + "snapshot.checkpoint.load")
+            .tagSource()
+            .tag(Metrics.AGGREGATE_KEY, aggregateId.aggregateName)
+            .metrics()
+
+    override fun <S : Any> saveCheckpoint(snapshot: Snapshot<S>): Mono<Void> =
+        checkpointStore.saveCheckpoint(snapshot)
+            .name(Wow.WOW_PREFIX + "snapshot.checkpoint.save")
+            .tagSource()
+            .tag(Metrics.AGGREGATE_KEY, snapshot.aggregateId.aggregateName)
+            .metrics()
+}

--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/Metrics.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/Metrics.kt
@@ -23,6 +23,7 @@ import me.ahoo.wow.event.dispatcher.DomainEventHandler
 import me.ahoo.wow.eventsourcing.EventStore
 import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
 import me.ahoo.wow.eventsourcing.snapshot.SnapshotStrategy
+import me.ahoo.wow.eventsourcing.snapshot.VersionedSnapshotStore
 import me.ahoo.wow.eventsourcing.snapshot.dispatcher.SnapshotHandler
 import me.ahoo.wow.eventsourcing.state.DistributedStateEventBus
 import me.ahoo.wow.eventsourcing.state.LocalStateEventBus
@@ -212,7 +213,11 @@ object Metrics {
      */
     fun SnapshotStore.metrizable(): SnapshotStore =
         metrizable {
-            MetricSnapshotStore(this)
+            if (this is VersionedSnapshotStore) {
+                MetricVersionedSnapshotStore(this)
+            } else {
+                MetricSnapshotStore(this)
+            }
         }
 
     /**

--- a/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/snapshot/RoutingSnapshotStoreTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/snapshot/RoutingSnapshotStoreTest.kt
@@ -114,10 +114,41 @@ class RoutingSnapshotStoreTest {
             .verify()
     }
 
+    @Test
+    fun `load at or before falls back to the latest snapshot for a legacy store`() {
+        val aggregateId = order.aggregateId("order-1")
+        val latest = snapshot(aggregateId)
+        val orderStore = RecordingSnapshotStore(loadedSnapshot = latest)
+        val routingStore = routingSnapshotStore(RecordingSnapshotStore(), orderStore)
+
+        StepVerifier.create(routingStore.loadAtOrBefore<MockStateAggregate>(aggregateId, latest.version))
+            .expectNext(latest)
+            .verifyComplete()
+        StepVerifier.create(routingStore.loadAtOrBefore<MockStateAggregate>(aggregateId, latest.version - 1))
+            .verifyComplete()
+
+        orderStore.lastOperation.assert().isEqualTo("load")
+        orderStore.lastAggregateId.assert().isEqualTo(aggregateId)
+    }
+
+    @Test
+    fun `save checkpoint rejects a legacy selected store`() {
+        val aggregateId = order.aggregateId("order-1")
+        val routingStore = routingSnapshotStore(RecordingSnapshotStore(), RecordingSnapshotStore())
+
+        StepVerifier.create(routingStore.saveCheckpoint(snapshot(aggregateId)))
+            .expectErrorSatisfies { error ->
+                error.assert()
+                    .isInstanceOf(IllegalStateException::class.java)
+                    .hasMessageContaining("does not support historical checkpoints")
+            }
+            .verify()
+    }
+
     private fun routingSnapshotStore(
         defaultStore: SnapshotStore,
         orderStore: SnapshotStore
-    ): SnapshotStore {
+    ): RoutingSnapshotStore {
         val routeKey = NamedAggregateStub(order.contextName, order.aggregateName)
         return RoutingSnapshotStore(
             AggregateSnapshotStoreRegistry(
@@ -128,7 +159,8 @@ class RoutingSnapshotStoreTest {
     }
 
     private class RecordingSnapshotStore(
-        private val failure: Throwable? = null
+        private val failure: Throwable? = null,
+        private val loadedSnapshot: Snapshot<MockStateAggregate>? = null,
     ) : SnapshotStore {
         override val name: String = "recording"
         var lastOperation: String? = null
@@ -136,7 +168,9 @@ class RoutingSnapshotStoreTest {
 
         override fun <S : Any> load(aggregateId: AggregateId): Mono<Snapshot<S>> {
             record("load", aggregateId)
-            return failure?.let { Mono.error(it) } ?: Mono.empty()
+            failure?.let { return Mono.error(it) }
+            @Suppress("UNCHECKED_CAST")
+            return loadedSnapshot?.let { Mono.just(it as Snapshot<S>) } ?: Mono.empty()
         }
 
         override fun getVersion(aggregateId: AggregateId): Mono<Int> {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/snapshot/RoutingSnapshotStoreTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/snapshot/RoutingSnapshotStoreTest.kt
@@ -114,37 +114,6 @@ class RoutingSnapshotStoreTest {
             .verify()
     }
 
-    @Test
-    fun `load at or before falls back to the latest snapshot for a legacy store`() {
-        val aggregateId = order.aggregateId("order-1")
-        val latest = snapshot(aggregateId)
-        val orderStore = RecordingSnapshotStore(loadedSnapshot = latest)
-        val routingStore = routingSnapshotStore(RecordingSnapshotStore(), orderStore)
-
-        StepVerifier.create(routingStore.loadAtOrBefore<MockStateAggregate>(aggregateId, latest.version))
-            .expectNext(latest)
-            .verifyComplete()
-        StepVerifier.create(routingStore.loadAtOrBefore<MockStateAggregate>(aggregateId, latest.version - 1))
-            .verifyComplete()
-
-        orderStore.lastOperation.assert().isEqualTo("load")
-        orderStore.lastAggregateId.assert().isEqualTo(aggregateId)
-    }
-
-    @Test
-    fun `save checkpoint rejects a legacy selected store`() {
-        val aggregateId = order.aggregateId("order-1")
-        val routingStore = routingSnapshotStore(RecordingSnapshotStore(), RecordingSnapshotStore())
-
-        StepVerifier.create(routingStore.saveCheckpoint(snapshot(aggregateId)))
-            .expectErrorSatisfies { error ->
-                error.assert()
-                    .isInstanceOf(IllegalStateException::class.java)
-                    .hasMessageContaining("does not support historical checkpoints")
-            }
-            .verify()
-    }
-
     private fun routingSnapshotStore(
         defaultStore: SnapshotStore,
         orderStore: SnapshotStore
@@ -160,7 +129,6 @@ class RoutingSnapshotStoreTest {
 
     private class RecordingSnapshotStore(
         private val failure: Throwable? = null,
-        private val loadedSnapshot: Snapshot<MockStateAggregate>? = null,
     ) : SnapshotStore {
         override val name: String = "recording"
         var lastOperation: String? = null
@@ -168,9 +136,7 @@ class RoutingSnapshotStoreTest {
 
         override fun <S : Any> load(aggregateId: AggregateId): Mono<Snapshot<S>> {
             record("load", aggregateId)
-            failure?.let { return Mono.error(it) }
-            @Suppress("UNCHECKED_CAST")
-            return loadedSnapshot?.let { Mono.just(it as Snapshot<S>) } ?: Mono.empty()
+            return failure?.let { Mono.error(it) } ?: Mono.empty()
         }
 
         override fun getVersion(aggregateId: AggregateId): Mono<Int> {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/snapshot/VersionIntervalCheckpointStrategyTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/snapshot/VersionIntervalCheckpointStrategyTest.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.eventsourcing.snapshot
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.event.toDomainEventStream
+import me.ahoo.wow.eventsourcing.state.SimpleStateEventExchange
+import me.ahoo.wow.eventsourcing.state.StateEvent.Companion.toStateEvent
+import me.ahoo.wow.eventsourcing.state.StateEventExchange
+import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
+import me.ahoo.wow.tck.mock.MockAggregateCreated
+import me.ahoo.wow.tck.mock.MockStateAggregate
+import me.ahoo.wow.test.aggregate.GivenInitializationCommand
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+
+class VersionIntervalCheckpointStrategyTest {
+    private val aggregateId = MOCK_AGGREGATE_METADATA.aggregateId("checkpoint-strategy")
+
+    @Test
+    fun `stores only versions matching the configured interval`() {
+        val store = InMemorySnapshotStore()
+        val strategy = VersionIntervalCheckpointStrategy(versionInterval = 5, snapshotStore = store)
+
+        strategy.onEvent(exchange(version = 4)).block()
+        StepVerifier.create(store.loadAtOrBefore<MockStateAggregate>(aggregateId, 4))
+            .verifyComplete()
+
+        strategy.onEvent(exchange(version = 5)).block()
+        StepVerifier.create(store.loadAtOrBefore<MockStateAggregate>(aggregateId, 5))
+            .assertNext { checkpoint ->
+                checkpoint.version.assert().isEqualTo(5)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `rejects a non-positive interval`() {
+        assertThrows<IllegalArgumentException> {
+            VersionIntervalCheckpointStrategy(versionInterval = 0, snapshotStore = InMemorySnapshotStore())
+        }
+    }
+
+    @Test
+    fun `composite strategy executes delegates sequentially`() {
+        val calls = mutableListOf<String>()
+        val strategy = CompositeSnapshotStrategy(
+            listOf(
+                recordingStrategy("latest", calls),
+                recordingStrategy("checkpoint", calls),
+            ),
+        )
+
+        StepVerifier.create(strategy.onEvent(exchange(version = 5)))
+            .verifyComplete()
+        calls.assert().containsExactly("latest", "checkpoint")
+    }
+
+    @Test
+    fun `composite strategy rejects an empty delegate list`() {
+        assertThrows<IllegalArgumentException> {
+            CompositeSnapshotStrategy(emptyList())
+        }
+    }
+
+    private fun recordingStrategy(
+        name: String,
+        calls: MutableList<String>,
+    ): SnapshotStrategy = object : SnapshotStrategy {
+        override fun onEvent(stateEventExchange: StateEventExchange<*>): Mono<Void> = Mono.fromRunnable {
+            calls += name
+        }
+    }
+
+    private fun exchange(version: Int): SimpleStateEventExchange<MockStateAggregate> {
+        val eventStream = MockAggregateCreated("v$version").toDomainEventStream(
+            upstream = GivenInitializationCommand(aggregateId),
+            aggregateVersion = version - 1,
+        )
+        return SimpleStateEventExchange(
+            eventStream.toStateEvent(MockStateAggregate(aggregateId.id))
+        )
+    }
+}

--- a/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/snapshot/VersionedSnapshotStoreTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/snapshot/VersionedSnapshotStoreTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.eventsourcing.snapshot
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.metrics.MetricSnapshotStore
+import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory.toStateAggregate
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
+import me.ahoo.wow.tck.mock.MockStateAggregate
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import reactor.test.StepVerifier
+
+class VersionedSnapshotStoreTest {
+    private val aggregateId = MOCK_AGGREGATE_METADATA.aggregateId("versioned-snapshot")
+
+    @Test
+    fun `load at or before chooses the greatest eligible checkpoint`() {
+        val store: VersionedSnapshotStore = InMemorySnapshotStore()
+        listOf(5, 10, 15).forEach { version ->
+            store.saveCheckpoint(snapshot(version, "v$version")).block()
+        }
+
+        StepVerifier.create(store.loadAtOrBefore<MockStateAggregate>(aggregateId, 12))
+            .assertNext { checkpoint ->
+                checkpoint.version.assert().isEqualTo(10)
+                checkpoint.state.data.assert().isEqualTo("v10")
+            }
+            .verifyComplete()
+        StepVerifier.create(store.loadAtOrBefore<MockStateAggregate>(aggregateId, 4))
+            .verifyComplete()
+    }
+
+    @Test
+    fun `checkpoint writes are first wins and do not replace latest snapshots`() {
+        val store: VersionedSnapshotStore = InMemorySnapshotStore()
+        store.save(snapshot(20, "latest")).block()
+        store.saveCheckpoint(snapshot(10, "first")).block()
+        store.saveCheckpoint(snapshot(10, "replacement")).block()
+
+        StepVerifier.create(store.loadAtOrBefore<MockStateAggregate>(aggregateId, 10))
+            .assertNext { checkpoint ->
+                checkpoint.state.data.assert().isEqualTo("first")
+            }
+            .verifyComplete()
+        StepVerifier.create(store.load<MockStateAggregate>(aggregateId))
+            .assertNext { latest ->
+                latest.version.assert().isEqualTo(20)
+                latest.state.data.assert().isEqualTo("latest")
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `routing and metric decorators preserve checkpoint operations`() {
+        val routing = RoutingSnapshotStore(
+            AggregateSnapshotStoreRegistry(
+                defaultSnapshotStore = InMemorySnapshotStore(),
+                routes = emptyMap(),
+            ),
+        )
+        val store: VersionedSnapshotStore = MetricSnapshotStore(routing)
+
+        store.saveCheckpoint(snapshot(10, "checkpoint")).block()
+
+        StepVerifier.create(store.loadAtOrBefore<MockStateAggregate>(aggregateId, 10))
+            .assertNext { checkpoint ->
+                checkpoint.version.assert().isEqualTo(10)
+                checkpoint.state.data.assert().isEqualTo("checkpoint")
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `rejects invalid checkpoint versions`() {
+        val store = InMemorySnapshotStore()
+
+        assertThrows<IllegalArgumentException> {
+            store.loadAtOrBefore<MockStateAggregate>(aggregateId, -1)
+        }
+        assertThrows<IllegalArgumentException> {
+            store.saveCheckpoint(snapshot(0, "invalid"))
+        }
+    }
+
+    private fun snapshot(version: Int, data: String): Snapshot<MockStateAggregate> {
+        val state = MockStateAggregate(aggregateId.id)
+        state.javaClass.getDeclaredField("data").apply {
+            isAccessible = true
+            set(state, data)
+        }
+        val aggregate = MOCK_AGGREGATE_METADATA.state.toStateAggregate(
+            aggregateId = aggregateId,
+            state = state,
+            version = version,
+        )
+        return SimpleSnapshot(aggregate, snapshotTime = version.toLong())
+    }
+}

--- a/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/snapshot/VersionedSnapshotStoreTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/snapshot/VersionedSnapshotStoreTest.kt
@@ -15,7 +15,7 @@ package me.ahoo.wow.eventsourcing.snapshot
 
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.modeling.AggregateId
-import me.ahoo.wow.metrics.MetricSnapshotStore
+import me.ahoo.wow.metrics.Metrics.metrizable
 import me.ahoo.wow.modeling.aggregateId
 import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory.toStateAggregate
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
@@ -67,13 +67,16 @@ class VersionedSnapshotStoreTest {
 
     @Test
     fun `routing and metric decorators preserve checkpoint operations`() {
-        val routing = RoutingSnapshotStore(
+        val routing = RoutingSnapshotStore.create(
             AggregateSnapshotStoreRegistry(
                 defaultSnapshotStore = InMemorySnapshotStore(),
                 routes = emptyMap(),
             ),
         )
-        val store: VersionedSnapshotStore = MetricSnapshotStore(routing)
+        val store = routing.metrizable()
+
+        (store is VersionedSnapshotStore).assert().isTrue()
+        store as VersionedSnapshotStore
 
         store.saveCheckpoint(snapshot(10, "checkpoint")).block()
 
@@ -98,37 +101,24 @@ class VersionedSnapshotStoreTest {
     }
 
     @Test
-    fun `routing and metric decorators reject checkpoint writes to a legacy store`() {
+    fun `routing and metric decorators do not advertise checkpoint support for legacy backends`() {
         val legacyStore = LegacySnapshotStore(snapshot(10, "latest"))
-        val routing = RoutingSnapshotStore(
+        val legacyDefaultRouting = RoutingSnapshotStore.create(
             AggregateSnapshotStoreRegistry(
                 defaultSnapshotStore = legacyStore,
                 routes = emptyMap(),
             ),
         )
+        val legacyRouteRouting = RoutingSnapshotStore.create(
+            AggregateSnapshotStoreRegistry(
+                defaultSnapshotStore = InMemorySnapshotStore(),
+                routes = mapOf(aggregateId.namedAggregate to legacyStore),
+            ),
+        )
 
-        StepVerifier.create(routing.saveCheckpoint(snapshot(10, "checkpoint")))
-            .expectErrorMessage(
-                "Snapshot store [legacy] selected for [${aggregateId.namedAggregate}] " +
-                    "does not support historical checkpoints.",
-            )
-            .verify()
-        StepVerifier.create(MetricSnapshotStore(legacyStore).saveCheckpoint(snapshot(10, "checkpoint")))
-            .expectErrorMessage("Snapshot store [legacy] does not support historical checkpoints.")
-            .verify()
-    }
-
-    @Test
-    fun `metric decorator falls back to a legacy latest snapshot`() {
-        val eligible = MetricSnapshotStore(LegacySnapshotStore(snapshot(10, "latest")))
-
-        StepVerifier.create(eligible.loadAtOrBefore<MockStateAggregate>(aggregateId, 10))
-            .assertNext { checkpoint ->
-                checkpoint.version.assert().isEqualTo(10)
-            }
-            .verifyComplete()
-        StepVerifier.create(eligible.loadAtOrBefore<MockStateAggregate>(aggregateId, 9))
-            .verifyComplete()
+        (legacyDefaultRouting is VersionedSnapshotStore).assert().isFalse()
+        (legacyRouteRouting is VersionedSnapshotStore).assert().isFalse()
+        (legacyStore.metrizable() is VersionedSnapshotStore).assert().isFalse()
     }
 
     @Test

--- a/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/snapshot/VersionedSnapshotStoreTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/snapshot/VersionedSnapshotStoreTest.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.eventsourcing.snapshot
 
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.metrics.MetricSnapshotStore
 import me.ahoo.wow.modeling.aggregateId
 import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory.toStateAggregate
@@ -21,6 +22,7 @@ import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import me.ahoo.wow.tck.mock.MockStateAggregate
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import reactor.core.publisher.Mono
 import reactor.test.StepVerifier
 
 class VersionedSnapshotStoreTest {
@@ -93,6 +95,63 @@ class VersionedSnapshotStoreTest {
         assertThrows<IllegalArgumentException> {
             store.saveCheckpoint(snapshot(0, "invalid"))
         }
+    }
+
+    @Test
+    fun `routing and metric decorators reject checkpoint writes to a legacy store`() {
+        val legacyStore = LegacySnapshotStore(snapshot(10, "latest"))
+        val routing = RoutingSnapshotStore(
+            AggregateSnapshotStoreRegistry(
+                defaultSnapshotStore = legacyStore,
+                routes = emptyMap(),
+            ),
+        )
+
+        StepVerifier.create(routing.saveCheckpoint(snapshot(10, "checkpoint")))
+            .expectErrorMessage(
+                "Snapshot store [legacy] selected for [${aggregateId.namedAggregate}] " +
+                    "does not support historical checkpoints.",
+            )
+            .verify()
+        StepVerifier.create(MetricSnapshotStore(legacyStore).saveCheckpoint(snapshot(10, "checkpoint")))
+            .expectErrorMessage("Snapshot store [legacy] does not support historical checkpoints.")
+            .verify()
+    }
+
+    @Test
+    fun `metric decorator falls back to a legacy latest snapshot`() {
+        val eligible = MetricSnapshotStore(LegacySnapshotStore(snapshot(10, "latest")))
+
+        StepVerifier.create(eligible.loadAtOrBefore<MockStateAggregate>(aggregateId, 10))
+            .assertNext { checkpoint ->
+                checkpoint.version.assert().isEqualTo(10)
+            }
+            .verifyComplete()
+        StepVerifier.create(eligible.loadAtOrBefore<MockStateAggregate>(aggregateId, 9))
+            .verifyComplete()
+    }
+
+    @Test
+    fun `no op store supports empty checkpoint operations`() {
+        StepVerifier.create(NoOpSnapshotStore.loadAtOrBefore<MockStateAggregate>(aggregateId, 10))
+            .verifyComplete()
+        StepVerifier.create(NoOpSnapshotStore.saveCheckpoint(snapshot(10, "checkpoint")))
+            .verifyComplete()
+    }
+
+    private class LegacySnapshotStore(
+        private val latest: Snapshot<MockStateAggregate>,
+    ) : SnapshotStore {
+        override val name: String = "legacy"
+
+        override fun <S : Any> load(aggregateId: AggregateId): Mono<Snapshot<S>> {
+            @Suppress("UNCHECKED_CAST")
+            return Mono.just(latest as Snapshot<S>)
+        }
+
+        override fun getVersion(aggregateId: AggregateId): Mono<Int> = Mono.just(latest.version)
+
+        override fun <S : Any> save(snapshot: Snapshot<S>): Mono<Void> = Mono.empty()
     }
 
     private fun snapshot(version: Int, data: String): Snapshot<MockStateAggregate> {

--- a/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/AggregateSchemaInitializerCompatibilityTest.kt
+++ b/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/AggregateSchemaInitializerCompatibilityTest.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.mongo
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.mongo.AggregateSchemaInitializer.createAggregateIdAndRequestIdUniqueIndex
+import me.ahoo.wow.mongo.AggregateSchemaInitializer.createAggregateIdAndVersionUniqueIndex
+import me.ahoo.wow.mongo.AggregateSchemaInitializer.createAggregateIdIndex
+import me.ahoo.wow.mongo.AggregateSchemaInitializer.createOwnerIdIndex
+import me.ahoo.wow.mongo.AggregateSchemaInitializer.createRequestIdUniqueIndex
+import me.ahoo.wow.mongo.AggregateSchemaInitializer.createTenantIdIndex
+import me.ahoo.wow.serialization.MessageRecords
+import me.ahoo.wow.tck.container.MongoTestFixture
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import reactor.kotlin.core.publisher.toFlux
+import reactor.kotlin.core.publisher.toMono
+
+@Suppress("DEPRECATION")
+class AggregateSchemaInitializerCompatibilityTest {
+    @JvmField
+    @RegisterExtension
+    val mongo = MongoTestFixture()
+
+    @AfterEach
+    fun cleanup() {
+        mongo.database().getCollection(COLLECTION_NAME).drop().toMono().block()
+    }
+
+    @Test
+    fun `deprecated public index helpers reconcile their managed indexes`() {
+        val collection = mongo.database().getCollection(COLLECTION_NAME)
+        collection.createAggregateIdIndex()
+        collection.createAggregateIdAndVersionUniqueIndex()
+        collection.createRequestIdUniqueIndex()
+        collection.createAggregateIdAndRequestIdUniqueIndex()
+        collection.createTenantIdIndex()
+        collection.createOwnerIdIndex()
+
+        val indexes = collection.listIndexes().toFlux().collectList().block()!!
+            .associateBy { it.getString("name") }
+        indexes.keys.assert().contains(
+            "${MessageRecords.AGGREGATE_ID}_hashed",
+            AggregateSchemaInitializer.AGGREGATE_ID_AND_VERSION_UNIQUE_INDEX_NAME,
+            AggregateSchemaInitializer.REQUEST_ID_UNIQUE_INDEX_NAME,
+            "${MessageRecords.AGGREGATE_ID}_1_${MessageRecords.REQUEST_ID}_1",
+            "${MessageRecords.TENANT_ID}_hashed",
+            "${MessageRecords.OWNER_ID}_hashed",
+        )
+        indexes[AggregateSchemaInitializer.AGGREGATE_ID_AND_VERSION_UNIQUE_INDEX_NAME]
+            ?.getBoolean("unique", false)
+            .assert()
+            .isTrue()
+        indexes[AggregateSchemaInitializer.REQUEST_ID_UNIQUE_INDEX_NAME]
+            ?.getBoolean("unique", false)
+            .assert()
+            .isTrue()
+        indexes["${MessageRecords.AGGREGATE_ID}_1_${MessageRecords.REQUEST_ID}_1"]
+            ?.getBoolean("unique", false)
+            .assert()
+            .isTrue()
+    }
+
+    companion object {
+        private const val COLLECTION_NAME = "aggregate_schema_initializer_compatibility"
+    }
+}

--- a/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/EventStreamSchemaInitializerTest.kt
+++ b/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/EventStreamSchemaInitializerTest.kt
@@ -13,9 +13,21 @@
 
 package me.ahoo.wow.mongo
 
+import com.mongodb.client.model.IndexOptions
+import com.mongodb.client.model.Indexes
 import com.mongodb.reactivestreams.client.MongoDatabase
+import me.ahoo.test.asserts.assert
+import me.ahoo.test.asserts.assertThrownBy
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.mongo.AggregateSchemaInitializer.AGGREGATE_ID_AND_VERSION_UNIQUE_INDEX_NAME
+import me.ahoo.wow.mongo.AggregateSchemaInitializer.REQUEST_ID_UNIQUE_INDEX_NAME
 import me.ahoo.wow.mongo.AggregateSchemaInitializer.toEventStreamCollectionName
+import me.ahoo.wow.serialization.MessageRecords
+import org.bson.Document
+import org.junit.jupiter.api.Test
+import reactor.kotlin.core.publisher.toFlux
+import reactor.kotlin.core.publisher.toMono
 
 class EventStreamSchemaInitializerTest : SchemaInitializerSpec() {
 
@@ -32,4 +44,180 @@ class EventStreamSchemaInitializerTest : SchemaInitializerSpec() {
     override fun getCollectionName(namedAggregate: NamedAggregate): String {
         return namedAggregate.toEventStreamCollectionName()
     }
+
+    override fun getExpectedIndexNames(): Set<String> = setOf(
+        "${MessageRecords.AGGREGATE_ID}_hashed",
+        AGGREGATE_ID_AND_VERSION_UNIQUE_INDEX_NAME,
+        "${MessageRecords.AGGREGATE_ID}_1_${MessageRecords.REQUEST_ID}_1",
+        "${MessageRecords.TENANT_ID}_hashed",
+        "${MessageRecords.OWNER_ID}_hashed",
+    )
+
+    override fun getExpectedUniqueIndexNames(): Set<String> = setOf(
+        AGGREGATE_ID_AND_VERSION_UNIQUE_INDEX_NAME,
+        "${MessageRecords.AGGREGATE_ID}_1_${MessageRecords.REQUEST_ID}_1",
+    )
+
+    @Test
+    fun `should reject incompatible existing index options`() {
+        val database = mongo.database()
+        val namedAggregate = MaterializedNamedAggregate("", "testIncompatibleEventStreamIndex")
+        val collection = database.getCollection(getCollectionName(namedAggregate))
+        collection.drop().toMono().block()
+        database.createCollection(getCollectionName(namedAggregate)).toMono().block()
+        collection.createIndex(
+            Indexes.ascending(MessageRecords.AGGREGATE_ID, MessageRecords.VERSION),
+            IndexOptions().name(AGGREGATE_ID_AND_VERSION_UNIQUE_INDEX_NAME),
+        ).toMono().block()
+
+        assertThrownBy<IllegalStateException> {
+            initAggregateSchema(database, namedAggregate)
+        }
+        collection.drop().toMono().block()
+    }
+
+    @Test
+    fun `should reject a custom name for managed index keys`() {
+        val database = mongo.database()
+        val namedAggregate = MaterializedNamedAggregate("", "testCustomManagedIndexName")
+        val collectionName = getCollectionName(namedAggregate)
+        val collection = database.getCollection(collectionName)
+        collection.drop().toMono().block()
+        database.createCollection(collectionName).toMono().block()
+        collection.createIndex(
+            Indexes.ascending(MessageRecords.AGGREGATE_ID, MessageRecords.VERSION),
+            IndexOptions().name("legacy_aggregate_version").unique(true),
+        ).toMono().block()
+
+        runCatching {
+            initAggregateSchema(database, namedAggregate)
+        }.exceptionOrNull()!!.message.assert()
+            .contains("same ordered keys", "legacy_aggregate_version")
+        collection.drop().toMono().block()
+    }
+
+    @Test
+    fun `should reject stale global request id uniqueness in aggregate scoped mode`() {
+        val database = mongo.database()
+        val namedAggregate = MaterializedNamedAggregate("", "testStaleRequestIdIndex")
+        val collection = database.getCollection(getCollectionName(namedAggregate))
+        collection.drop().toMono().block()
+        database.createCollection(getCollectionName(namedAggregate)).toMono().block()
+        collection.createIndex(
+            Indexes.ascending(MessageRecords.REQUEST_ID),
+            IndexOptions().name(REQUEST_ID_UNIQUE_INDEX_NAME).unique(true),
+        ).toMono().block()
+
+        assertThrownBy<IllegalStateException> {
+            initAggregateSchema(database, namedAggregate)
+        }
+        collection.drop().toMono().block()
+    }
+
+    @Test
+    fun `should reject custom named global request id uniqueness in aggregate scoped mode`() {
+        val database = mongo.database()
+        val namedAggregate = MaterializedNamedAggregate("", "testCustomGlobalRequestIdIndex")
+        val collectionName = getCollectionName(namedAggregate)
+        val collection = database.getCollection(collectionName)
+        collection.drop().toMono().block()
+        database.createCollection(collectionName).toMono().block()
+        collection.createIndex(
+            Indexes.descending(MessageRecords.REQUEST_ID),
+            IndexOptions().name("legacy_global_request_id").unique(true),
+        ).toMono().block()
+
+        runCatching {
+            initAggregateSchema(database, namedAggregate)
+        }.exceptionOrNull()!!.message.assert().contains("for [legacy_global_request_id]")
+        collection.drop().toMono().block()
+    }
+
+    @Test
+    fun `should initialize global request id uniqueness mode`() {
+        val database = mongo.database()
+        val namedAggregate = MaterializedNamedAggregate("", "testGlobalRequestIdIndex")
+        val collection = database.getCollection(getCollectionName(namedAggregate))
+        collection.drop().toMono().block()
+
+        EventStreamSchemaInitializer(database, enableRequestIdUniqueIndex = true).initSchema(namedAggregate)
+
+        val indexes = collection.listIndexes().toFlux().collectList().block()!!
+            .associateBy { it.getString("name") }
+        indexes[REQUEST_ID_UNIQUE_INDEX_NAME]?.getBoolean("unique", false).assert().isTrue()
+        indexes.containsKey("${MessageRecords.AGGREGATE_ID}_1_${MessageRecords.REQUEST_ID}_1")
+            .assert()
+            .isFalse()
+        collection.drop().toMono().block()
+    }
+
+    @Test
+    fun `should reject stale aggregate scoped request id index in global mode`() {
+        val database = mongo.database()
+        val namedAggregate = MaterializedNamedAggregate("", "testStaleAggregateRequestIdIndex")
+        val collectionName = getCollectionName(namedAggregate)
+        val collection = database.getCollection(collectionName)
+        collection.drop().toMono().block()
+        database.createCollection(collectionName).toMono().block()
+        collection.createIndex(
+            Indexes.ascending(MessageRecords.AGGREGATE_ID, MessageRecords.REQUEST_ID),
+            IndexOptions().unique(true),
+        ).toMono().block()
+
+        assertThrownBy<IllegalStateException> {
+            EventStreamSchemaInitializer(database, enableRequestIdUniqueIndex = true).initSchema(namedAggregate)
+        }
+        collection.drop().toMono().block()
+    }
+
+    @Test
+    fun `should reject custom named aggregate request id uniqueness in global mode`() {
+        val database = mongo.database()
+        val namedAggregate = MaterializedNamedAggregate("", "testCustomAggregateRequestIdIndex")
+        val collectionName = getCollectionName(namedAggregate)
+        val collection = database.getCollection(collectionName)
+        collection.drop().toMono().block()
+        database.createCollection(collectionName).toMono().block()
+        collection.createIndex(
+            Indexes.ascending(MessageRecords.REQUEST_ID, MessageRecords.AGGREGATE_ID),
+            IndexOptions().name("legacy_aggregate_request_id").unique(true),
+        ).toMono().block()
+
+        runCatching {
+            EventStreamSchemaInitializer(database, enableRequestIdUniqueIndex = true).initSchema(namedAggregate)
+        }.exceptionOrNull()!!.message.assert().contains("for [legacy_aggregate_request_id]")
+        collection.drop().toMono().block()
+    }
+
+    @Test
+    fun `should report required unique index creation failure for duplicate existing data`() {
+        val database = mongo.database()
+        val namedAggregate = MaterializedNamedAggregate("", "testDuplicateExistingData")
+        val collectionName = getCollectionName(namedAggregate)
+        val collection = database.getCollection(collectionName)
+        collection.drop().toMono().block()
+        database.createCollection(collectionName).toMono().block()
+        collection.insertMany(
+            listOf(
+                eventStreamDocument("aggregate-1", 1, "request-1"),
+                eventStreamDocument("aggregate-1", 1, "request-2"),
+            ),
+        ).toMono().block()
+
+        assertThrownBy<IllegalStateException> {
+            initAggregateSchema(database, namedAggregate)
+        }
+        collection.drop().toMono().block()
+    }
+
+    private fun eventStreamDocument(
+        aggregateId: String,
+        version: Int,
+        requestId: String,
+    ): Document = Document()
+        .append(MessageRecords.AGGREGATE_ID, aggregateId)
+        .append(MessageRecords.VERSION, version)
+        .append(MessageRecords.REQUEST_ID, requestId)
+        .append(MessageRecords.TENANT_ID, "tenant")
+        .append(MessageRecords.OWNER_ID, "owner")
 }

--- a/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/EventStreamSchemaInitializerTest.kt
+++ b/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/EventStreamSchemaInitializerTest.kt
@@ -77,6 +77,27 @@ class EventStreamSchemaInitializerTest : SchemaInitializerSpec() {
     }
 
     @Test
+    fun `should reject a managed index name with different ordered keys`() {
+        val database = mongo.database()
+        val namedAggregate = MaterializedNamedAggregate("", "testManagedIndexKeyMismatch")
+        val collectionName = getCollectionName(namedAggregate)
+        val collection = database.getCollection(collectionName)
+        collection.drop().toMono().block()
+        database.createCollection(collectionName).toMono().block()
+        collection.createIndex(
+            Indexes.descending(MessageRecords.AGGREGATE_ID, MessageRecords.VERSION),
+            IndexOptions().name(AGGREGATE_ID_AND_VERSION_UNIQUE_INDEX_NAME).unique(true),
+        ).toMono().block()
+
+        runCatching {
+            initAggregateSchema(database, namedAggregate)
+        }.exceptionOrNull()!!.message.assert()
+            .contains(AGGREGATE_ID_AND_VERSION_UNIQUE_INDEX_NAME)
+            .contains("existing index definition differs")
+        collection.drop().toMono().block()
+    }
+
+    @Test
     fun `should reject a custom name for managed index keys`() {
         val database = mongo.database()
         val namedAggregate = MaterializedNamedAggregate("", "testCustomManagedIndexName")
@@ -130,6 +151,30 @@ class EventStreamSchemaInitializerTest : SchemaInitializerSpec() {
         runCatching {
             initAggregateSchema(database, namedAggregate)
         }.exceptionOrNull()!!.message.assert().contains("for [legacy_global_request_id]")
+        collection.drop().toMono().block()
+    }
+
+    @Test
+    fun `should allow a custom non unique request id index in aggregate scoped mode`() {
+        val database = mongo.database()
+        val namedAggregate = MaterializedNamedAggregate("", "testNonUniqueRequestIdIndex")
+        val collectionName = getCollectionName(namedAggregate)
+        val collection = database.getCollection(collectionName)
+        collection.drop().toMono().block()
+        database.createCollection(collectionName).toMono().block()
+        collection.createIndex(
+            Indexes.ascending(MessageRecords.REQUEST_ID),
+            IndexOptions().name("custom_request_id"),
+        ).toMono().block()
+
+        initAggregateSchema(database, namedAggregate)
+
+        val indexes = collection.listIndexes().toFlux().collectList().block()!!
+            .associateBy { it.getString("name") }
+        indexes.containsKey("custom_request_id").assert().isTrue()
+        indexes.containsKey("${MessageRecords.AGGREGATE_ID}_1_${MessageRecords.REQUEST_ID}_1")
+            .assert()
+            .isTrue()
         collection.drop().toMono().block()
     }
 

--- a/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/EventStreamSchemaInitializerTest.kt
+++ b/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/EventStreamSchemaInitializerTest.kt
@@ -155,7 +155,7 @@ class EventStreamSchemaInitializerTest : SchemaInitializerSpec() {
     }
 
     @Test
-    fun `should allow a custom non unique request id index in aggregate scoped mode`() {
+    fun `should allow a default named non unique request id index in aggregate scoped mode`() {
         val database = mongo.database()
         val namedAggregate = MaterializedNamedAggregate("", "testNonUniqueRequestIdIndex")
         val collectionName = getCollectionName(namedAggregate)
@@ -164,14 +164,13 @@ class EventStreamSchemaInitializerTest : SchemaInitializerSpec() {
         database.createCollection(collectionName).toMono().block()
         collection.createIndex(
             Indexes.ascending(MessageRecords.REQUEST_ID),
-            IndexOptions().name("custom_request_id"),
         ).toMono().block()
 
         initAggregateSchema(database, namedAggregate)
 
         val indexes = collection.listIndexes().toFlux().collectList().block()!!
             .associateBy { it.getString("name") }
-        indexes.containsKey("custom_request_id").assert().isTrue()
+        indexes.containsKey(REQUEST_ID_UNIQUE_INDEX_NAME).assert().isTrue()
         indexes.containsKey("${MessageRecords.AGGREGATE_ID}_1_${MessageRecords.REQUEST_ID}_1")
             .assert()
             .isTrue()
@@ -212,6 +211,29 @@ class EventStreamSchemaInitializerTest : SchemaInitializerSpec() {
         assertThrownBy<IllegalStateException> {
             EventStreamSchemaInitializer(database, enableRequestIdUniqueIndex = true).initSchema(namedAggregate)
         }
+        collection.drop().toMono().block()
+    }
+
+    @Test
+    fun `should allow a default named non unique aggregate request id index in global mode`() {
+        val database = mongo.database()
+        val namedAggregate = MaterializedNamedAggregate("", "testNonUniqueAggregateRequestIdIndex")
+        val collectionName = getCollectionName(namedAggregate)
+        val collection = database.getCollection(collectionName)
+        collection.drop().toMono().block()
+        database.createCollection(collectionName).toMono().block()
+        collection.createIndex(
+            Indexes.ascending(MessageRecords.AGGREGATE_ID, MessageRecords.REQUEST_ID),
+        ).toMono().block()
+
+        EventStreamSchemaInitializer(database, enableRequestIdUniqueIndex = true).initSchema(namedAggregate)
+
+        val indexes = collection.listIndexes().toFlux().collectList().block()!!
+            .associateBy { it.getString("name") }
+        indexes.containsKey("${MessageRecords.AGGREGATE_ID}_1_${MessageRecords.REQUEST_ID}_1")
+            .assert()
+            .isTrue()
+        indexes[REQUEST_ID_UNIQUE_INDEX_NAME]?.getBoolean("unique", false).assert().isTrue()
         collection.drop().toMono().block()
     }
 

--- a/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/MongoDatabaseContextGuardTest.kt
+++ b/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/MongoDatabaseContextGuardTest.kt
@@ -1,0 +1,185 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.mongo
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.serialization.MessageRecords
+import me.ahoo.wow.tck.container.MongoTestFixture
+import org.bson.Document
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.RegisterExtension
+import reactor.kotlin.core.publisher.toMono
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+class MongoDatabaseContextGuardTest {
+    @JvmField
+    @RegisterExtension
+    val mongo = MongoTestFixture()
+
+    @AfterEach
+    fun cleanup() {
+        val database = mongo.database()
+        database.getCollection(MongoDatabaseContextGuard.METADATA_COLLECTION_NAME).drop().toMono().block()
+        COLLECTIONS.forEach { collection ->
+            database.getCollection(collection).drop().toMono().block()
+        }
+    }
+
+    @Test
+    fun `should reject a blank context name`() {
+        assertThrows<IllegalArgumentException> {
+            MongoDatabaseContextGuard(mongo.database()).ensureContext(" ")
+        }
+    }
+
+    @Test
+    fun `should claim an empty database and allow the same context`() {
+        val guard = MongoDatabaseContextGuard(mongo.database())
+        guard.ensureContext("order-service")
+        guard.ensureContext("order-service")
+
+        val marker = mongo.database()
+            .getCollection(MongoDatabaseContextGuard.METADATA_COLLECTION_NAME)
+            .find()
+            .first()
+            .toMono()
+            .block()!!
+        marker.getString(MessageRecords.CONTEXT_NAME).assert().isEqualTo("order-service")
+        marker.getInteger(MongoDatabaseContextGuard.LAYOUT_VERSION_FIELD).assert().isEqualTo(1)
+    }
+
+    @Test
+    fun `should reject a different context with actionable diagnostics`() {
+        val guard = MongoDatabaseContextGuard(mongo.database())
+        guard.ensureContext("order-service")
+
+        val error = assertThrows<IllegalStateException> {
+            guard.ensureContext("payment-service")
+        }
+
+        error.message.assert()
+            .contains(mongo.database().name)
+            .contains("order-service")
+            .contains("payment-service")
+            .contains("one bounded context per MongoDB database")
+    }
+
+    @Test
+    fun `should reject an unsupported ownership marker layout`() {
+        mongo.database()
+            .getCollection(MongoDatabaseContextGuard.METADATA_COLLECTION_NAME)
+            .insertOne(
+                Document(Documents.ID_FIELD, "boundedContext")
+                    .append(MessageRecords.CONTEXT_NAME, "order-service")
+                    .append(MongoDatabaseContextGuard.LAYOUT_VERSION_FIELD, 2),
+            )
+            .toMono()
+            .block()
+
+        val error = assertThrows<IllegalStateException> {
+            MongoDatabaseContextGuard(mongo.database()).ensureContext("order-service")
+        }
+        error.message.assert().contains("unsupported context ownership layout version", "[2]", "[1]")
+    }
+
+    @Test
+    fun `should atomically select one owner when different contexts claim concurrently`() {
+        val executor = Executors.newFixedThreadPool(2)
+        val start = CountDownLatch(1)
+        try {
+            val claims = listOf("order-service", "payment-service").map { contextName ->
+                executor.submit<Result<Unit>> {
+                    start.await()
+                    runCatching {
+                        MongoDatabaseContextGuard(mongo.database()).ensureContext(contextName)
+                    }
+                }
+            }
+            start.countDown()
+
+            val results = claims.map { claim -> claim.get(10, TimeUnit.SECONDS) }
+            results.count(Result<Unit>::isSuccess).assert().isEqualTo(1)
+            results.count(Result<Unit>::isFailure).assert().isEqualTo(1)
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `should reject a foreign context after a matching legacy document`() {
+        mongo.database()
+            .getCollection(TEST_EVENT_STREAM_COLLECTION)
+            .insertMany(
+                listOf(
+                    Document(MessageRecords.CONTEXT_NAME, "order-service"),
+                    Document(MessageRecords.CONTEXT_NAME, "payment-service"),
+                ),
+            )
+            .toMono()
+            .block()
+
+        val error = assertThrows<IllegalStateException> {
+            MongoDatabaseContextGuard(mongo.database()).ensureContext("order-service")
+        }
+
+        error.message.assert()
+            .contains(TEST_EVENT_STREAM_COLLECTION)
+            .contains("payment-service")
+            .contains("order-service")
+        mongo.database()
+            .getCollection(MongoDatabaseContextGuard.METADATA_COLLECTION_NAME)
+            .find()
+            .first()
+            .toMono()
+            .block()
+            .assert()
+            .isNull()
+    }
+
+    @Test
+    fun `should scan event snapshot and checkpoint collections before claiming`() {
+        listOf(TEST_EVENT_STREAM_COLLECTION, TEST_SNAPSHOT_COLLECTION, TEST_CHECKPOINT_COLLECTION)
+            .forEach { collectionName ->
+                mongo.database()
+                    .getCollection(collectionName)
+                    .insertOne(Document(MessageRecords.CONTEXT_NAME, "legacy-order-service"))
+                    .toMono()
+                    .block()
+
+                val error = assertThrows<IllegalStateException> {
+                    MongoDatabaseContextGuard(mongo.database()).ensureContext("payment-service")
+                }
+                error.message.assert()
+                    .contains(collectionName)
+                    .contains("legacy-order-service")
+                    .contains("payment-service")
+                mongo.database().getCollection(collectionName).drop().toMono().block()
+            }
+    }
+
+    companion object {
+        private const val TEST_EVENT_STREAM_COLLECTION = "contextGuardTest_event_stream"
+        private const val TEST_SNAPSHOT_COLLECTION = "contextGuardTest_snapshot"
+        private const val TEST_CHECKPOINT_COLLECTION = "contextGuardTest_snapshot_checkpoint"
+        private val COLLECTIONS = listOf(
+            TEST_EVENT_STREAM_COLLECTION,
+            TEST_SNAPSHOT_COLLECTION,
+            TEST_CHECKPOINT_COLLECTION,
+        )
+    }
+}

--- a/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/MongoDatabaseContextGuardTest.kt
+++ b/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/MongoDatabaseContextGuardTest.kt
@@ -98,6 +98,23 @@ class MongoDatabaseContextGuardTest {
     }
 
     @Test
+    fun `should reject an ownership marker without a layout version`() {
+        mongo.database()
+            .getCollection(MongoDatabaseContextGuard.METADATA_COLLECTION_NAME)
+            .insertOne(
+                Document(Documents.ID_FIELD, "boundedContext")
+                    .append(MessageRecords.CONTEXT_NAME, "order-service"),
+            )
+            .toMono()
+            .block()
+
+        val error = assertThrows<IllegalStateException> {
+            MongoDatabaseContextGuard(mongo.database()).ensureContext("order-service")
+        }
+        error.message.assert().contains("unsupported context ownership layout version", "[null]", "[1]")
+    }
+
+    @Test
     fun `should atomically select one owner when different contexts claim concurrently`() {
         val executor = Executors.newFixedThreadPool(2)
         val start = CountDownLatch(1)

--- a/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/MongoSnapshotStoreTest.kt
+++ b/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/MongoSnapshotStoreTest.kt
@@ -13,19 +13,107 @@
 
 package me.ahoo.wow.mongo
 
-import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
+import com.mongodb.MongoWriteException
+import com.mongodb.client.model.IndexOptions
+import com.mongodb.client.model.Indexes
+import me.ahoo.wow.api.modeling.AggregateId
+import me.ahoo.wow.eventsourcing.snapshot.SimpleSnapshot
+import me.ahoo.wow.eventsourcing.snapshot.Snapshot
+import me.ahoo.wow.eventsourcing.snapshot.VersionedSnapshotStore
+import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory.toStateAggregate
+import me.ahoo.wow.mongo.AggregateSchemaInitializer.toSnapshotCheckpointCollectionName
+import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.tck.container.MongoTestFixture
-import me.ahoo.wow.tck.eventsourcing.snapshot.SnapshotStoreSpec
+import me.ahoo.wow.tck.eventsourcing.snapshot.VersionedSnapshotStoreSpec
+import me.ahoo.wow.tck.mock.MockStateAggregate
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.RegisterExtension
+import org.bson.Document
+import reactor.kotlin.core.publisher.toMono
+import reactor.kotlin.test.test
 
-class MongoSnapshotStoreTest : SnapshotStoreSpec() {
+class MongoSnapshotStoreTest : VersionedSnapshotStoreSpec() {
     @JvmField
     @RegisterExtension
     val mongo = MongoTestFixture()
 
-    override fun createSnapshotStore(): SnapshotStore {
+    override fun createSnapshotStore(): VersionedSnapshotStore {
         val database = mongo.database()
         SnapshotSchemaInitializer(database).initSchema(aggregateMetadata)
+        SnapshotCheckpointSchemaInitializer(database).initSchema(aggregateMetadata)
         return MongoSnapshotStore(database)
+    }
+
+    @Test
+    fun `should propagate duplicate key errors from unrelated unique indexes`() {
+        val database = mongo.database()
+        val collectionName = aggregateMetadata.toSnapshotCheckpointCollectionName()
+        val collection = database.getCollection(collectionName)
+        collection.drop().toMono().block()
+        SnapshotCheckpointSchemaInitializer(database).initSchema(aggregateMetadata)
+        collection.createIndex(
+            Indexes.ascending(MessageRecords.CONTEXT_NAME),
+            IndexOptions().unique(true),
+        ).toMono().block()
+        val store = MongoSnapshotStore(database)
+        val aggregateId = aggregateMetadata.aggregateId(generateGlobalId())
+        try {
+            store.saveCheckpoint(snapshot(aggregateId, 5)).block()
+
+            store.saveCheckpoint(snapshot(aggregateId, 10))
+                .test()
+                .expectError(MongoWriteException::class.java)
+                .verify()
+        } finally {
+            collection.drop().toMono().block()
+        }
+    }
+
+    @Test
+    fun `should reject invalid checkpoint versions`() {
+        val store = MongoSnapshotStore(mongo.database())
+        val aggregateId = aggregateMetadata.aggregateId(generateGlobalId())
+
+        assertThrows<IllegalArgumentException> {
+            store.loadAtOrBefore<MockStateAggregate>(aggregateId, -1)
+        }
+        assertThrows<IllegalArgumentException> {
+            store.saveCheckpoint(snapshot(aggregateId, 0))
+        }
+    }
+
+    @Test
+    fun `should reject a checkpoint without its payload`() {
+        val database = mongo.database()
+        val aggregateId = aggregateMetadata.aggregateId(generateGlobalId())
+        val collection = database.getCollection(aggregateMetadata.toSnapshotCheckpointCollectionName())
+        collection.insertOne(
+            Document()
+                .append(MessageRecords.AGGREGATE_ID, aggregateId.id)
+                .append(MessageRecords.TENANT_ID, aggregateId.tenantId)
+                .append(MessageRecords.VERSION, 5),
+        ).toMono().block()
+
+        MongoSnapshotStore(database)
+            .loadAtOrBefore<MockStateAggregate>(aggregateId, 5)
+            .test()
+            .expectError(IllegalStateException::class.java)
+            .verify()
+    }
+
+    private fun snapshot(
+        aggregateId: AggregateId,
+        version: Int,
+    ): Snapshot<MockStateAggregate> {
+        val state = MockStateAggregate(aggregateId.id)
+        val aggregate = aggregateMetadata.state.toStateAggregate(
+            aggregateId = aggregateId,
+            state = state,
+            version = version,
+        )
+        return SimpleSnapshot(aggregate, snapshotTime = version.toLong())
     }
 }

--- a/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/SchemaInitializerSpec.kt
+++ b/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/SchemaInitializerSpec.kt
@@ -21,6 +21,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import reactor.kotlin.core.publisher.toFlux
 import reactor.kotlin.core.publisher.toMono
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 abstract class SchemaInitializerSpec {
     @JvmField
@@ -35,6 +38,8 @@ abstract class SchemaInitializerSpec {
     abstract fun initAllAggregateSchema(database: MongoDatabase)
     abstract fun initAggregateSchema(database: MongoDatabase, namedAggregate: NamedAggregate)
     abstract fun getCollectionName(namedAggregate: NamedAggregate): String
+    abstract fun getExpectedIndexNames(): Set<String>
+    open fun getExpectedUniqueIndexNames(): Set<String> = emptySet()
 
     @Test
     fun `should initialize aggregate schema`() {
@@ -48,5 +53,54 @@ abstract class SchemaInitializerSpec {
             it.assert().contains(collectionName)
         }
         database.getCollection(collectionName).drop().toMono().block()
+    }
+
+    @Test
+    fun `should reconcile indexes for existing collection`() {
+        val database = mongo.database()
+        val namedAggregate = me.ahoo.wow.modeling.MaterializedNamedAggregate("", "testReconcileSchema")
+        val collectionName = getCollectionName(namedAggregate)
+        val collection = database.getCollection(collectionName)
+        collection.drop().toMono().block()
+        database.createCollection(collectionName).toMono().block()
+
+        initAggregateSchema(database, namedAggregate)
+        initAggregateSchema(database, namedAggregate)
+
+        collection.listIndexes().toFlux().collectList().block()!!.let { indexes ->
+            val indexesByName = indexes.associateBy { it.getString("name") }
+            indexesByName.keys.containsAll(getExpectedIndexNames()).assert().isTrue()
+            getExpectedUniqueIndexNames().all { indexName ->
+                indexesByName[indexName]?.getBoolean("unique", false) == true
+            }.assert().isTrue()
+        }
+        collection.drop().toMono().block()
+    }
+
+    @Test
+    fun `should initialize aggregate schema concurrently`() {
+        val database = mongo.database()
+        val namedAggregate = me.ahoo.wow.modeling.MaterializedNamedAggregate("", "testConcurrentInitSchema")
+        val collectionName = getCollectionName(namedAggregate)
+        database.getCollection(collectionName).drop().toMono().block()
+        val executor = Executors.newFixedThreadPool(2)
+        val start = CountDownLatch(1)
+        try {
+            val initializations = List(2) {
+                executor.submit<Result<Unit>> {
+                    start.await()
+                    runCatching {
+                        initAggregateSchema(database, namedAggregate)
+                    }
+                }
+            }
+            start.countDown()
+            initializations.forEach { initialization ->
+                initialization.get(10, TimeUnit.SECONDS).getOrThrow()
+            }
+        } finally {
+            executor.shutdownNow()
+            database.getCollection(collectionName).drop().toMono().block()
+        }
     }
 }

--- a/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/SnapshotCheckpointSchemaInitializerTest.kt
+++ b/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/SnapshotCheckpointSchemaInitializerTest.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.mongo
+
+import com.mongodb.reactivestreams.client.MongoDatabase
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.mongo.AggregateSchemaInitializer.toSnapshotCheckpointCollectionName
+import me.ahoo.wow.serialization.MessageRecords
+
+class SnapshotCheckpointSchemaInitializerTest : SchemaInitializerSpec() {
+    override fun initAllAggregateSchema(database: MongoDatabase) {
+        SnapshotCheckpointSchemaInitializer(database).initAll()
+    }
+
+    override fun initAggregateSchema(database: MongoDatabase, namedAggregate: NamedAggregate) {
+        SnapshotCheckpointSchemaInitializer(database).initSchema(namedAggregate)
+    }
+
+    override fun getCollectionName(namedAggregate: NamedAggregate): String =
+        namedAggregate.toSnapshotCheckpointCollectionName()
+
+    override fun getExpectedIndexNames(): Set<String> = setOf(
+        "${MessageRecords.TENANT_ID}_1_${MessageRecords.AGGREGATE_ID}_1_${MessageRecords.VERSION}_1",
+    )
+
+    override fun getExpectedUniqueIndexNames(): Set<String> = getExpectedIndexNames()
+}

--- a/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/SnapshotSchemaInitializerTest.kt
+++ b/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/SnapshotSchemaInitializerTest.kt
@@ -14,8 +14,17 @@
 package me.ahoo.wow.mongo
 
 import com.mongodb.reactivestreams.client.MongoDatabase
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.mongo.AggregateSchemaInitializer.toSnapshotCheckpointCollectionName
 import me.ahoo.wow.mongo.AggregateSchemaInitializer.toSnapshotCollectionName
+import me.ahoo.wow.mongo.Documents.ID_FIELD
+import me.ahoo.wow.serialization.MessageRecords
+import me.ahoo.wow.serialization.state.StateAggregateRecords
+import org.junit.jupiter.api.Test
+import reactor.kotlin.core.publisher.toFlux
+import reactor.kotlin.core.publisher.toMono
 
 class SnapshotSchemaInitializerTest : SchemaInitializerSpec() {
 
@@ -29,5 +38,31 @@ class SnapshotSchemaInitializerTest : SchemaInitializerSpec() {
 
     override fun getCollectionName(namedAggregate: NamedAggregate): String {
         return namedAggregate.toSnapshotCollectionName()
+    }
+
+    override fun getExpectedIndexNames(): Set<String> = setOf(
+        "${MessageRecords.TENANT_ID}_hashed",
+        "${MessageRecords.OWNER_ID}_hashed",
+        "${ID_FIELD}_hashed",
+        "${StateAggregateRecords.DELETED}_hashed",
+    )
+
+    @Test
+    fun `should not initialize checkpoint schema when initializing latest snapshots`() {
+        val database = mongo.database()
+        val namedAggregate = MaterializedNamedAggregate("", "testCheckpointDisabled")
+        val checkpointCollectionName = namedAggregate.toSnapshotCheckpointCollectionName()
+        database.getCollection(checkpointCollectionName).drop().toMono().block()
+
+        SnapshotSchemaInitializer(database).initSchema(namedAggregate)
+
+        database.listCollectionNames()
+            .toFlux()
+            .collectList()
+            .block()!!
+            .contains(checkpointCollectionName)
+            .assert()
+            .isFalse()
+        database.getCollection(namedAggregate.toSnapshotCollectionName()).drop().toMono().block()
     }
 }

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/AggregateSchemaInitializer.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/AggregateSchemaInitializer.kt
@@ -13,25 +13,23 @@
 
 package me.ahoo.wow.mongo
 
-import com.mongodb.client.model.IndexOptions
-import com.mongodb.client.model.Indexes
-import com.mongodb.reactivestreams.client.MongoCollection
+import com.mongodb.MongoException
 import com.mongodb.reactivestreams.client.MongoDatabase
 import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.infra.accessor.function.reactive.toBlockable
-import me.ahoo.wow.serialization.MessageRecords
-import org.bson.Document
 import reactor.kotlin.core.publisher.toFlux
 import reactor.kotlin.core.publisher.toMono
 
+@Suppress("TooManyFunctions")
 object AggregateSchemaInitializer {
     private val log = KotlinLogging.logger {}
     const val AGGREGATE_ID_AND_VERSION_UNIQUE_INDEX_NAME = "aggregateId_1_version_1"
     const val REQUEST_ID_UNIQUE_INDEX_NAME = "requestId_1"
-    private val uniqueIndexOptions = IndexOptions().unique(true)
     private const val EVENT_STREAM_COLLECTION_SUFFIX = "_event_stream"
     private const val SNAPSHOT_COLLECTION_SUFFIX = "_snapshot"
+    private const val SNAPSHOT_CHECKPOINT_COLLECTION_SUFFIX = "_snapshot_checkpoint"
+
     fun NamedAggregate.toEventStreamCollectionName(): String {
         return "${this.aggregateName}$EVENT_STREAM_COLLECTION_SUFFIX"
     }
@@ -40,52 +38,38 @@ object AggregateSchemaInitializer {
         return "${this.aggregateName}$SNAPSHOT_COLLECTION_SUFFIX"
     }
 
+    fun NamedAggregate.toSnapshotCheckpointCollectionName(): String {
+        return "${this.aggregateName}$SNAPSHOT_CHECKPOINT_COLLECTION_SUFFIX"
+    }
+
     fun MongoDatabase.ensureCollection(collectionName: String): Boolean {
         listCollectionNames().toFlux().collectList().toBlockable().block()!!.let {
             if (it.contains(collectionName)) {
                 log.info {
-                    "Ensure Collection [$collectionName already exists,ignore create."
+                    "Ensure Collection [$collectionName] already exists, ignore create."
                 }
                 return false
             }
             log.info {
                 "Ensure Collection [$collectionName] Creating."
             }
-            this.createCollection(collectionName).toMono().block()
+            try {
+                this.createCollection(collectionName).toMono().block()
+            } catch (error: MongoException) {
+                if (error.code != NAMESPACE_EXISTS_CODE) {
+                    throw error
+                }
+                log.info {
+                    "Collection [$collectionName] was created concurrently, continue initialization."
+                }
+                return false
+            }
             log.info {
-                "Ensure Collection [$collectionName] Creating."
+                "Collection [$collectionName] created."
             }
             return true
         }
     }
 
-    fun MongoCollection<Document>.createAggregateIdIndex() {
-        createIndex(Indexes.hashed(MessageRecords.AGGREGATE_ID))
-            .toMono().toBlockable().block()
-    }
-
-    fun MongoCollection<Document>.createAggregateIdAndVersionUniqueIndex() {
-        createIndex(Indexes.ascending(MessageRecords.AGGREGATE_ID, MessageRecords.VERSION), uniqueIndexOptions)
-            .toMono().toBlockable().block()
-    }
-
-    fun MongoCollection<Document>.createRequestIdUniqueIndex() {
-        createIndex(Indexes.ascending(MessageRecords.REQUEST_ID), uniqueIndexOptions)
-            .toMono().toBlockable().block()
-    }
-
-    fun MongoCollection<Document>.createAggregateIdAndRequestIdUniqueIndex() {
-        createIndex(Indexes.ascending(MessageRecords.AGGREGATE_ID, MessageRecords.REQUEST_ID), uniqueIndexOptions)
-            .toMono().toBlockable().block()
-    }
-
-    fun MongoCollection<Document>.createTenantIdIndex() {
-        createIndex(Indexes.hashed(MessageRecords.TENANT_ID))
-            .toMono().toBlockable().block()
-    }
-
-    fun MongoCollection<Document>.createOwnerIdIndex() {
-        createIndex(Indexes.hashed(MessageRecords.OWNER_ID))
-            .toMono().toBlockable().block()
-    }
+    private const val NAMESPACE_EXISTS_CODE = 48
 }

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/AggregateSchemaInitializer.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/AggregateSchemaInitializer.kt
@@ -14,10 +14,13 @@
 package me.ahoo.wow.mongo
 
 import com.mongodb.MongoException
+import com.mongodb.reactivestreams.client.MongoCollection
 import com.mongodb.reactivestreams.client.MongoDatabase
 import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.infra.accessor.function.reactive.toBlockable
+import me.ahoo.wow.serialization.MessageRecords
+import org.bson.Document
 import reactor.kotlin.core.publisher.toFlux
 import reactor.kotlin.core.publisher.toMono
 
@@ -69,6 +72,44 @@ object AggregateSchemaInitializer {
             }
             return true
         }
+    }
+
+    @Deprecated("Use EventStreamSchemaInitializer or SnapshotSchemaInitializer to reconcile managed indexes.")
+    fun MongoCollection<Document>.createAggregateIdIndex() {
+        reconcileIndexes(listOf(hashedIndex(MessageRecords.AGGREGATE_ID)))
+    }
+
+    @Deprecated("Use EventStreamSchemaInitializer to reconcile managed indexes.")
+    fun MongoCollection<Document>.createAggregateIdAndVersionUniqueIndex() {
+        reconcileIndexes(
+            listOf(
+                ascendingIndex(MessageRecords.AGGREGATE_ID, MessageRecords.VERSION, unique = true),
+            ),
+        )
+    }
+
+    @Deprecated("Use EventStreamSchemaInitializer to reconcile managed indexes.")
+    fun MongoCollection<Document>.createRequestIdUniqueIndex() {
+        reconcileIndexes(listOf(ascendingIndex(MessageRecords.REQUEST_ID, unique = true)))
+    }
+
+    @Deprecated("Use EventStreamSchemaInitializer to reconcile managed indexes.")
+    fun MongoCollection<Document>.createAggregateIdAndRequestIdUniqueIndex() {
+        reconcileIndexes(
+            listOf(
+                ascendingIndex(MessageRecords.AGGREGATE_ID, MessageRecords.REQUEST_ID, unique = true),
+            ),
+        )
+    }
+
+    @Deprecated("Use EventStreamSchemaInitializer or SnapshotSchemaInitializer to reconcile managed indexes.")
+    fun MongoCollection<Document>.createTenantIdIndex() {
+        reconcileIndexes(listOf(hashedIndex(MessageRecords.TENANT_ID)))
+    }
+
+    @Deprecated("Use EventStreamSchemaInitializer or SnapshotSchemaInitializer to reconcile managed indexes.")
+    fun MongoCollection<Document>.createOwnerIdIndex() {
+        reconcileIndexes(listOf(hashedIndex(MessageRecords.OWNER_ID)))
     }
 
     private const val NAMESPACE_EXISTS_CODE = 48

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/EventStreamSchemaInitializer.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/EventStreamSchemaInitializer.kt
@@ -17,14 +17,9 @@ import com.mongodb.reactivestreams.client.MongoDatabase
 import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.configuration.MetadataSearcher
-import me.ahoo.wow.mongo.AggregateSchemaInitializer.createAggregateIdAndRequestIdUniqueIndex
-import me.ahoo.wow.mongo.AggregateSchemaInitializer.createAggregateIdAndVersionUniqueIndex
-import me.ahoo.wow.mongo.AggregateSchemaInitializer.createAggregateIdIndex
-import me.ahoo.wow.mongo.AggregateSchemaInitializer.createOwnerIdIndex
-import me.ahoo.wow.mongo.AggregateSchemaInitializer.createRequestIdUniqueIndex
-import me.ahoo.wow.mongo.AggregateSchemaInitializer.createTenantIdIndex
 import me.ahoo.wow.mongo.AggregateSchemaInitializer.ensureCollection
 import me.ahoo.wow.mongo.AggregateSchemaInitializer.toEventStreamCollectionName
+import me.ahoo.wow.serialization.MessageRecords
 
 class EventStreamSchemaInitializer(
     private val database: MongoDatabase,
@@ -53,18 +48,29 @@ class EventStreamSchemaInitializer(
         log.info {
             "Init NamedAggregate Schema [$namedAggregate] to Database:[${database.name}] CollectionName [$collectionName]"
         }
-        if (!database.ensureCollection(collectionName)) {
-            return
-        }
+        database.ensureCollection(collectionName)
         val eventStreamCollection = database.getCollection(collectionName)
-        eventStreamCollection.createAggregateIdIndex()
-        eventStreamCollection.createAggregateIdAndVersionUniqueIndex()
-        if (enableRequestIdUniqueIndex) {
-            eventStreamCollection.createRequestIdUniqueIndex()
+        val requestIdIndex = if (enableRequestIdUniqueIndex) {
+            ascendingIndex(MessageRecords.REQUEST_ID, unique = true)
         } else {
-            eventStreamCollection.createAggregateIdAndRequestIdUniqueIndex()
+            ascendingIndex(MessageRecords.AGGREGATE_ID, MessageRecords.REQUEST_ID, unique = true)
         }
-        eventStreamCollection.createTenantIdIndex()
-        eventStreamCollection.createOwnerIdIndex()
+        val forbiddenIndexes = if (enableRequestIdUniqueIndex) {
+            listOf(
+                ascendingIndex(MessageRecords.AGGREGATE_ID, MessageRecords.REQUEST_ID, unique = true),
+            )
+        } else {
+            listOf(ascendingIndex(MessageRecords.REQUEST_ID, unique = true))
+        }
+        eventStreamCollection.reconcileIndexes(
+            expectedIndexes = listOf(
+                hashedIndex(MessageRecords.AGGREGATE_ID),
+                ascendingIndex(MessageRecords.AGGREGATE_ID, MessageRecords.VERSION, unique = true),
+                requestIdIndex,
+                hashedIndex(MessageRecords.TENANT_ID),
+                hashedIndex(MessageRecords.OWNER_ID),
+            ),
+            forbiddenIndexes = forbiddenIndexes,
+        )
     }
 }

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoDatabaseContextGuard.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoDatabaseContextGuard.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.mongo
+
+import com.mongodb.client.model.Filters
+import com.mongodb.client.model.FindOneAndUpdateOptions
+import com.mongodb.client.model.Projections
+import com.mongodb.client.model.ReturnDocument
+import com.mongodb.client.model.Updates
+import com.mongodb.reactivestreams.client.MongoDatabase
+import me.ahoo.wow.serialization.MessageRecords
+import org.bson.Document
+import reactor.kotlin.core.publisher.toFlux
+import reactor.kotlin.core.publisher.toMono
+
+/**
+ * Enforces the default deployment invariant that one MongoDB database belongs to one bounded context.
+ *
+ * The aggregate collections intentionally remain named by aggregate name only. A durable ownership marker prevents
+ * independently deployed bounded contexts from silently sharing the same database. Existing unmarked databases are
+ * checked for foreign-context documents in every aggregate collection before the marker is claimed.
+ */
+class MongoDatabaseContextGuard(private val database: MongoDatabase) {
+
+    fun ensureContext(contextName: String) {
+        require(contextName.isNotBlank()) {
+            "MongoDB database contextName must not be blank."
+        }
+        findContextClaim()?.let { marker ->
+            validateMarker(marker, contextName)
+            return
+        }
+        validateExistingCollections(contextName)
+        val marker = checkNotNull(claimContext(contextName)) {
+            "MongoDB database [${database.name}] did not return its bounded context ownership marker."
+        }
+        validateMarker(marker, contextName)
+    }
+
+    private fun validateMarker(
+        marker: Document,
+        contextName: String,
+    ) {
+        val ownerContextName = marker.getString(MessageRecords.CONTEXT_NAME)
+        val layoutVersion = marker.getInteger(LAYOUT_VERSION_FIELD)
+        check(layoutVersion == CURRENT_LAYOUT_VERSION) {
+            "MongoDB database [${database.name}] has unsupported context ownership layout version " +
+                "[$layoutVersion]; expected [$CURRENT_LAYOUT_VERSION]."
+        }
+        check(ownerContextName == contextName) {
+            "MongoDB database [${database.name}] is owned by bounded context [$ownerContextName], but bounded context " +
+                "[$contextName] attempted to use it. The aggregate-name-only collection layout requires one bounded " +
+                "context per MongoDB database. Configure a separate event-stream/snapshot database for each bounded " +
+                "context."
+        }
+    }
+
+    private fun validateExistingCollections(contextName: String) {
+        database.listCollectionNames()
+            .toFlux()
+            .filter { collectionName ->
+                AGGREGATE_COLLECTION_SUFFIXES.any(collectionName::endsWith)
+            }.concatMap { collectionName ->
+                database.getCollection(collectionName)
+                    .find(Filters.ne(MessageRecords.CONTEXT_NAME, contextName))
+                    .projection(Projections.include(MessageRecords.CONTEXT_NAME))
+                    .limit(1)
+                    .first()
+                    .toMono()
+                    .map { document ->
+                        ExistingCollectionContext(
+                            collectionName = collectionName,
+                            contextName = document.getString(MessageRecords.CONTEXT_NAME),
+                        )
+                    }
+            }.collectList()
+            .block()
+            .orEmpty()
+            .forEach { existing ->
+                check(existing.contextName == contextName) {
+                    "MongoDB database [${database.name}] collection [${existing.collectionName}] belongs to bounded " +
+                        "context [${existing.contextName}], but bounded context [$contextName] attempted to use the " +
+                        "same aggregate-name-only layout. Use one bounded context per MongoDB database."
+                }
+            }
+    }
+
+    private fun findContextClaim(): Document? =
+        database.getCollection(METADATA_COLLECTION_NAME)
+            .find(Filters.eq(Documents.ID_FIELD, CONTEXT_OWNERSHIP_ID))
+            .first()
+            .toMono()
+            .block()
+
+    private fun claimContext(contextName: String): Document? =
+        database.getCollection(METADATA_COLLECTION_NAME)
+            .findOneAndUpdate(
+                Filters.eq(Documents.ID_FIELD, CONTEXT_OWNERSHIP_ID),
+                Updates.combine(
+                    Updates.setOnInsert(MessageRecords.CONTEXT_NAME, contextName),
+                    Updates.setOnInsert(LAYOUT_VERSION_FIELD, CURRENT_LAYOUT_VERSION),
+                ),
+                FindOneAndUpdateOptions()
+                    .upsert(true)
+                    .returnDocument(ReturnDocument.AFTER),
+            ).toMono()
+            .block()
+
+    private data class ExistingCollectionContext(
+        val collectionName: String,
+        val contextName: String?,
+    )
+
+    companion object {
+        const val METADATA_COLLECTION_NAME = "wow_database_metadata"
+        const val LAYOUT_VERSION_FIELD = "layoutVersion"
+        private const val CONTEXT_OWNERSHIP_ID = "boundedContext"
+        private const val CURRENT_LAYOUT_VERSION = 1
+        private val AGGREGATE_COLLECTION_SUFFIXES = listOf(
+            "_event_stream",
+            "_snapshot",
+            "_snapshot_checkpoint",
+        )
+    }
+}

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoDatabaseContextGuard.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoDatabaseContextGuard.kt
@@ -83,15 +83,14 @@ class MongoDatabaseContextGuard(private val database: MongoDatabase) {
                             contextName = document.getString(MessageRecords.CONTEXT_NAME),
                         )
                     }
-            }.collectList()
+            }.next()
             .block()
-            .orEmpty()
-            .forEach { existing ->
-                check(existing.contextName == contextName) {
+            ?.let { existing ->
+                error(
                     "MongoDB database [${database.name}] collection [${existing.collectionName}] belongs to bounded " +
                         "context [${existing.contextName}], but bounded context [$contextName] attempted to use the " +
-                        "same aggregate-name-only layout. Use one bounded context per MongoDB database."
-                }
+                        "same aggregate-name-only layout. Use one bounded context per MongoDB database.",
+                )
             }
     }
 

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoDatabaseContextGuard.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoDatabaseContextGuard.kt
@@ -27,9 +27,9 @@ import reactor.kotlin.core.publisher.toMono
 /**
  * Enforces the default deployment invariant that one MongoDB database belongs to one bounded context.
  *
- * The aggregate collections intentionally remain named by aggregate name only. A durable ownership marker prevents
- * independently deployed bounded contexts from silently sharing the same database. Existing unmarked databases are
- * checked for foreign-context documents in every aggregate collection before the marker is claimed.
+ * Physical aggregate and prepare collection names intentionally omit the bounded context. A durable ownership marker
+ * prevents independently deployed bounded contexts from silently sharing the same database. Existing unmarked
+ * databases are checked for foreign-context documents in every aggregate collection before the marker is claimed.
  */
 class MongoDatabaseContextGuard(private val database: MongoDatabase) {
 
@@ -60,9 +60,8 @@ class MongoDatabaseContextGuard(private val database: MongoDatabase) {
         }
         check(ownerContextName == contextName) {
             "MongoDB database [${database.name}] is owned by bounded context [$ownerContextName], but bounded context " +
-                "[$contextName] attempted to use it. The aggregate-name-only collection layout requires one bounded " +
-                "context per MongoDB database. Configure a separate event-stream/snapshot database for each bounded " +
-                "context."
+                "[$contextName] attempted to use it. The contextless physical collection layout requires one bounded " +
+                "context per MongoDB database. Configure a separate MongoDB database for each bounded context."
         }
     }
 

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoIndexReconciler.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoIndexReconciler.kt
@@ -79,9 +79,8 @@ private fun MongoCollection<Document>.requireNoForbiddenIndexes(
 ) {
     forbiddenIndexes.forEach { forbidden ->
         existingIndexes.firstOrNull { actual ->
-            val sameKeyUnique = MongoIndexCompatibility.hasSameKeyFields(actual, forbidden) &&
+            MongoIndexCompatibility.hasSameKeyFields(actual, forbidden) &&
                 MongoIndexCompatibility.isUnique(actual)
-            actual.getString("name") == forbidden.name || sameKeyUnique
         }?.let { actual ->
             throw MongoIndexSchemaMismatchException(
                 collectionName = namespace.fullName,

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoIndexReconciler.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoIndexReconciler.kt
@@ -1,0 +1,193 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.mongo
+
+import com.mongodb.MongoException
+import com.mongodb.client.model.IndexOptions
+import com.mongodb.reactivestreams.client.MongoCollection
+import io.github.oshai.kotlinlogging.KotlinLogging
+import me.ahoo.wow.infra.accessor.function.reactive.toBlockable
+import org.bson.Document
+import reactor.kotlin.core.publisher.toFlux
+import reactor.kotlin.core.publisher.toMono
+
+internal data class ManagedMongoIndex(
+    val name: String,
+    val keys: List<Pair<String, Any>>,
+    val unique: Boolean = false,
+) {
+    fun keysDocument(): Document = Document().also { document ->
+        keys.forEach { (field, direction) ->
+            document[field] = direction
+        }
+    }
+
+    fun options(): IndexOptions = IndexOptions()
+        .name(name)
+        .unique(unique)
+}
+
+internal class MongoIndexSchemaMismatchException(
+    collectionName: String,
+    indexName: String,
+    expected: ManagedMongoIndex,
+    actual: Document?,
+    reason: String,
+) : IllegalStateException(
+    "Mongo index schema mismatch in [$collectionName] for [$indexName]: $reason. " +
+        "Expected=$expected, actual=$actual. " +
+        "Apply a controlled drop/recreate migration before startup.",
+)
+
+internal fun ascendingIndex(
+    vararg fields: String,
+    unique: Boolean = false,
+): ManagedMongoIndex = ManagedMongoIndex(
+    name = fields.joinToString("_") { field -> "${field}_1" },
+    keys = fields.map { field -> field to 1 },
+    unique = unique,
+)
+
+internal fun hashedIndex(field: String): ManagedMongoIndex = ManagedMongoIndex(
+    name = "${field}_hashed",
+    keys = listOf(field to "hashed"),
+)
+
+internal fun MongoCollection<Document>.reconcileIndexes(
+    expectedIndexes: List<ManagedMongoIndex>,
+    forbiddenIndexes: List<ManagedMongoIndex> = emptyList(),
+) {
+    val existingIndexes = listIndexes().toFlux().collectList().toBlockable().block().orEmpty()
+    requireNoForbiddenIndexes(existingIndexes, forbiddenIndexes)
+    findMissingIndexes(existingIndexes, expectedIndexes).forEach(::createManagedIndex)
+}
+
+private fun MongoCollection<Document>.requireNoForbiddenIndexes(
+    existingIndexes: List<Document>,
+    forbiddenIndexes: List<ManagedMongoIndex>,
+) {
+    forbiddenIndexes.forEach { forbidden ->
+        existingIndexes.firstOrNull { actual ->
+            val sameKeyUnique = MongoIndexCompatibility.hasSameKeyFields(actual, forbidden) &&
+                MongoIndexCompatibility.isUnique(actual)
+            actual.getString("name") == forbidden.name || sameKeyUnique
+        }?.let { actual ->
+            throw MongoIndexSchemaMismatchException(
+                collectionName = namespace.fullName,
+                indexName = actual.getString("name") ?: forbidden.name,
+                expected = forbidden,
+                actual = actual,
+                reason = "index belongs to an incompatible managed index mode",
+            )
+        }
+    }
+}
+
+private fun MongoCollection<Document>.findMissingIndexes(
+    existingIndexes: List<Document>,
+    expectedIndexes: List<ManagedMongoIndex>,
+): List<ManagedMongoIndex> = expectedIndexes.filter { expected ->
+    val sameName = existingIndexes.firstOrNull { actual ->
+        actual.getString("name") == expected.name
+    }
+    if (sameName != null) {
+        MongoIndexCompatibility.requireCompatible(sameName, namespace.fullName, expected)
+        return@filter false
+    }
+
+    existingIndexes.firstOrNull { actual ->
+        MongoIndexCompatibility.hasSameOrderedKeys(actual, expected)
+    }?.let { sameKeys ->
+        throw MongoIndexSchemaMismatchException(
+            collectionName = namespace.fullName,
+            indexName = expected.name,
+            expected = expected,
+            actual = sameKeys,
+            reason = "an index with the same ordered keys uses a different managed definition",
+        )
+    }
+    true
+}
+
+private fun MongoCollection<Document>.createManagedIndex(expected: ManagedMongoIndex) {
+    mongoIndexLog.info {
+        "Creating Mongo index [${expected.name}] in [${namespace.fullName}]."
+    }
+    try {
+        createIndex(expected.keysDocument(), expected.options())
+            .toMono()
+            .toBlockable()
+            .block()
+    } catch (error: MongoException) {
+        throw IllegalStateException(
+            "Failed to create required Mongo index [${expected.name}] in [${namespace.fullName}]. " +
+                "Verify existing data and DDL privileges before retrying.",
+            error,
+        )
+    }
+}
+
+private object MongoIndexCompatibility {
+    fun requireCompatible(
+        actual: Document,
+        collectionName: String,
+        expected: ManagedMongoIndex,
+    ) {
+        if (isCompatible(actual, expected)) {
+            return
+        }
+        throw MongoIndexSchemaMismatchException(
+            collectionName = collectionName,
+            indexName = expected.name,
+            expected = expected,
+            actual = actual,
+            reason = "existing index definition differs from the managed definition",
+        )
+    }
+
+    private fun isCompatible(actual: Document, expected: ManagedMongoIndex): Boolean {
+        return hasSameOrderedKeys(actual, expected) &&
+            isUnique(actual) == expected.unique &&
+            actual["expireAfterSeconds"] == null &&
+            ((actual["sparse"] as? Boolean) ?: false).not() &&
+            actual["partialFilterExpression"] == null &&
+            actual["collation"] == null &&
+            ((actual["hidden"] as? Boolean) ?: false).not()
+    }
+
+    fun isUnique(actual: Document): Boolean = (actual["unique"] as? Boolean) ?: false
+
+    fun hasSameOrderedKeys(actual: Document, expected: ManagedMongoIndex): Boolean {
+        val actualKeys = actual["key"] as? Document ?: return false
+        return normalizedKeys(actualKeys) == normalizedKeys(expected.keys)
+    }
+
+    fun hasSameKeyFields(actual: Document, expected: ManagedMongoIndex): Boolean {
+        val actualKeys = actual["key"] as? Document ?: return false
+        val expectedFields = expected.keys.mapTo(mutableSetOf()) { (field, _) -> field }
+        return actualKeys.size == expectedFields.size && actualKeys.keys == expectedFields
+    }
+
+    private fun normalizedKeys(keys: Iterable<Pair<String, Any>>): List<Pair<String, Any>> =
+        keys.map { (field, value) ->
+            field to if (value is Number) value.toLong() else value
+        }
+
+    private fun normalizedKeys(keys: Document): List<Pair<String, Any>> =
+        keys.entries.map { (field, value) ->
+            field to if (value is Number) value.toLong() else checkNotNull(value)
+        }
+}
+
+private val mongoIndexLog = KotlinLogging.logger {}

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoSnapshotRepository.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoSnapshotRepository.kt
@@ -14,10 +14,11 @@ package me.ahoo.wow.mongo
 
 import com.mongodb.client.model.ReplaceOptions
 import com.mongodb.reactivestreams.client.MongoDatabase
-import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
+import me.ahoo.wow.eventsourcing.snapshot.VersionedSnapshotStore
 
 @Deprecated("Use MongoSnapshotStore.", ReplaceWith("MongoSnapshotStore(database)"))
-class MongoSnapshotRepository(database: MongoDatabase) : SnapshotStore by MongoSnapshotStore(database) {
+class MongoSnapshotRepository(database: MongoDatabase) :
+    VersionedSnapshotStore by MongoSnapshotStore(database) {
     companion object {
         const val NAME = "mongo"
         val DEFAULT_REPLACE_OPTIONS: ReplaceOptions = MongoSnapshotStore.DEFAULT_REPLACE_OPTIONS

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoSnapshotStore.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoSnapshotStore.kt
@@ -15,21 +15,27 @@ package me.ahoo.wow.mongo
 
 import com.mongodb.client.model.Filters
 import com.mongodb.client.model.ReplaceOptions
+import com.mongodb.client.model.Sorts
+import com.mongodb.client.model.UpdateOptions
+import com.mongodb.client.model.Updates
 import com.mongodb.reactivestreams.client.MongoDatabase
 import me.ahoo.wow.api.Version.Companion.UNINITIALIZED_VERSION
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.eventsourcing.snapshot.Snapshot
-import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
+import me.ahoo.wow.eventsourcing.snapshot.VersionedSnapshotStore
+import me.ahoo.wow.mongo.AggregateSchemaInitializer.toSnapshotCheckpointCollectionName
 import me.ahoo.wow.mongo.AggregateSchemaInitializer.toSnapshotCollectionName
 import me.ahoo.wow.serialization.MessageRecords
 import org.bson.Document
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
 
-class MongoSnapshotStore(private val database: MongoDatabase) : SnapshotStore {
+class MongoSnapshotStore(private val database: MongoDatabase) : VersionedSnapshotStore {
     companion object {
         const val NAME = "mongo"
         val DEFAULT_REPLACE_OPTIONS: ReplaceOptions = ReplaceOptions().upsert(true)
+        private const val PAYLOAD_FIELD = "payload"
+        private val CHECKPOINT_UPSERT_OPTIONS = UpdateOptions().upsert(true)
     }
 
     override val name: String
@@ -84,5 +90,65 @@ class MongoSnapshotStore(private val database: MongoDatabase) : SnapshotStore {
             .doOnNext {
                 check(it.wasAcknowledged())
             }.then()
+    }
+
+    override fun <S : Any> loadAtOrBefore(
+        aggregateId: AggregateId,
+        maxVersion: Int,
+    ): Mono<Snapshot<S>> {
+        require(maxVersion >= 0) {
+            "maxVersion must be greater than or equal to 0."
+        }
+        val collectionName = aggregateId.toSnapshotCheckpointCollectionName()
+        return database.getCollection(collectionName)
+            .find(
+                Filters.and(
+                    Filters.eq(MessageRecords.AGGREGATE_ID, aggregateId.id),
+                    Filters.eq(MessageRecords.TENANT_ID, aggregateId.tenantId),
+                    Filters.lte(MessageRecords.VERSION, maxVersion),
+                ),
+            )
+            .sort(Sorts.descending(MessageRecords.VERSION))
+            .limit(1)
+            .first()
+            .toMono()
+            .map { checkpoint ->
+                val payload = checkNotNull(checkpoint.get(PAYLOAD_FIELD, Document::class.java)) {
+                    "Mongo snapshot checkpoint payload is missing for [$aggregateId]."
+                }
+                mapSnapshot(aggregateId, payload)
+            }
+    }
+
+    override fun <S : Any> saveCheckpoint(snapshot: Snapshot<S>): Mono<Void> {
+        require(snapshot.version > 0) {
+            "checkpoint version must be greater than 0."
+        }
+        val aggregateId = snapshot.aggregateId
+        val collectionName = aggregateId.toSnapshotCheckpointCollectionName()
+        val checkpointId = Document(MessageRecords.TENANT_ID, aggregateId.tenantId)
+            .append(MessageRecords.AGGREGATE_ID, aggregateId.id)
+            .append(MessageRecords.VERSION, snapshot.version)
+        return database.getCollection(collectionName)
+            .updateOne(
+                Filters.eq(Documents.ID_FIELD, checkpointId),
+                Updates.combine(
+                    Updates.setOnInsert(MessageRecords.CONTEXT_NAME, aggregateId.contextName),
+                    Updates.setOnInsert(MessageRecords.AGGREGATE_NAME, aggregateId.aggregateName),
+                    Updates.setOnInsert(MessageRecords.AGGREGATE_ID, aggregateId.id),
+                    Updates.setOnInsert(MessageRecords.TENANT_ID, aggregateId.tenantId),
+                    Updates.setOnInsert(MessageRecords.VERSION, snapshot.version),
+                    Updates.setOnInsert(PAYLOAD_FIELD, snapshot.toDocument()),
+                ),
+                CHECKPOINT_UPSERT_OPTIONS,
+            )
+            .toMono()
+            .doOnNext { result ->
+                check(result.wasAcknowledged()) {
+                    "Mongo snapshot checkpoint write was not acknowledged for [$aggregateId] version " +
+                        "[${snapshot.version}]."
+                }
+            }
+            .then()
     }
 }

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/SnapshotCheckpointSchemaInitializer.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/SnapshotCheckpointSchemaInitializer.kt
@@ -18,11 +18,10 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.configuration.MetadataSearcher
 import me.ahoo.wow.mongo.AggregateSchemaInitializer.ensureCollection
-import me.ahoo.wow.mongo.AggregateSchemaInitializer.toSnapshotCollectionName
+import me.ahoo.wow.mongo.AggregateSchemaInitializer.toSnapshotCheckpointCollectionName
 import me.ahoo.wow.serialization.MessageRecords
-import me.ahoo.wow.serialization.state.StateAggregateRecords
 
-class SnapshotSchemaInitializer(private val database: MongoDatabase) {
+class SnapshotCheckpointSchemaInitializer(private val database: MongoDatabase) {
     companion object {
         private val log = KotlinLogging.logger {}
     }
@@ -34,18 +33,20 @@ class SnapshotSchemaInitializer(private val database: MongoDatabase) {
     }
 
     fun initSchema(namedAggregate: NamedAggregate) {
-        val collectionName = namedAggregate.toSnapshotCollectionName()
+        val collectionName = namedAggregate.toSnapshotCheckpointCollectionName()
         log.info {
-            "Init NamedAggregate Schema [$namedAggregate] to Database:[${database.name}] CollectionName [$collectionName]"
+            "Init NamedAggregate checkpoint schema [$namedAggregate] to Database:[${database.name}] " +
+                "CollectionName [$collectionName]"
         }
         database.ensureCollection(collectionName)
-        val snapshotCollection = database.getCollection(collectionName)
-        snapshotCollection.reconcileIndexes(
+        database.getCollection(collectionName).reconcileIndexes(
             listOf(
-                hashedIndex(MessageRecords.TENANT_ID),
-                hashedIndex(MessageRecords.OWNER_ID),
-                hashedIndex(Documents.ID_FIELD),
-                hashedIndex(StateAggregateRecords.DELETED),
+                ascendingIndex(
+                    MessageRecords.TENANT_ID,
+                    MessageRecords.AGGREGATE_ID,
+                    MessageRecords.VERSION,
+                    unique = true,
+                ),
             ),
         )
     }

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/MongoFailurePathTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/MongoFailurePathTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.mongo
+
+import com.mongodb.MongoException
+import com.mongodb.client.model.FindOneAndUpdateOptions
+import com.mongodb.client.model.UpdateOptions
+import com.mongodb.client.result.UpdateResult
+import com.mongodb.reactivestreams.client.FindPublisher
+import com.mongodb.reactivestreams.client.ListCollectionNamesPublisher
+import com.mongodb.reactivestreams.client.MongoCollection
+import com.mongodb.reactivestreams.client.MongoDatabase
+import io.mockk.every
+import io.mockk.mockk
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.eventsourcing.snapshot.SimpleSnapshot
+import me.ahoo.wow.eventsourcing.snapshot.Snapshot
+import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory.toStateAggregate
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
+import me.ahoo.wow.tck.mock.MockStateAggregate
+import org.bson.Document
+import org.bson.conversions.Bson
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+
+class MongoFailurePathTest {
+
+    @Test
+    fun `context guard rejects an empty ownership claim response`() {
+        val collection = mockk<MongoCollection<Document>>()
+        val findPublisher = mockk<FindPublisher<Document>>()
+        every { collection.find(any<Bson>()) } returns findPublisher
+        every { findPublisher.first() } returns Mono.empty()
+        every {
+            collection.findOneAndUpdate(
+                any<Bson>(),
+                any<Bson>(),
+                any<FindOneAndUpdateOptions>(),
+            )
+        } returns Mono.empty()
+        val database = mockk<MongoDatabase>()
+        every { database.name } returns "test"
+        every { database.getCollection(any()) } returns collection
+        every { database.listCollectionNames() } returns emptyCollectionNamesPublisher()
+
+        assertThrows<IllegalStateException> {
+            MongoDatabaseContextGuard(database).ensureContext("sales")
+        }.message.assert().contains("did not return its bounded context ownership marker")
+    }
+
+    @Test
+    fun `checkpoint save rejects an unacknowledged write`() {
+        val collection = mockk<MongoCollection<Document>>()
+        every {
+            collection.updateOne(
+                any<Bson>(),
+                any<Bson>(),
+                any<UpdateOptions>(),
+            )
+        } returns Mono.just(UpdateResult.unacknowledged())
+        val database = mockk<MongoDatabase>()
+        every { database.getCollection(any()) } returns collection
+        val snapshot = snapshot()
+
+        StepVerifier.create(MongoSnapshotStore(database).saveCheckpoint(snapshot))
+            .expectErrorSatisfies { error ->
+                error.assert()
+                    .isInstanceOf(IllegalStateException::class.java)
+                    .hasMessageContaining("checkpoint write was not acknowledged")
+            }
+            .verify()
+    }
+
+    @Test
+    fun `collection initialization propagates non namespace-exists errors`() {
+        val database = mockk<MongoDatabase>()
+        every { database.listCollectionNames() } returns emptyCollectionNamesPublisher()
+        every { database.createCollection("orders") } returns Mono.error(MongoException(13, "denied"))
+
+        assertThrows<MongoException> {
+            AggregateSchemaInitializer.run {
+                database.ensureCollection("orders")
+            }
+        }.code.assert().isEqualTo(13)
+    }
+
+    @Test
+    fun `ascending index applies default and explicit uniqueness`() {
+        ascendingIndex("tenantId").apply {
+            name.assert().isEqualTo("tenantId_1")
+            unique.assert().isFalse()
+        }
+        ascendingIndex("aggregateId", "version", unique = true).apply {
+            name.assert().isEqualTo("aggregateId_1_version_1")
+            unique.assert().isTrue()
+        }
+    }
+
+    private fun snapshot(): Snapshot<MockStateAggregate> {
+        val aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(generateGlobalId())
+        val state = MockStateAggregate(aggregateId.id)
+        val aggregate = MOCK_AGGREGATE_METADATA.state.toStateAggregate(
+            aggregateId = aggregateId,
+            state = state,
+            version = 10,
+        )
+        return SimpleSnapshot(aggregate, snapshotTime = 10)
+    }
+
+    private fun emptyCollectionNamesPublisher(): ListCollectionNamesPublisher =
+        mockk {
+            every { subscribe(any()) } answers {
+                firstArg<Subscriber<in String>>().complete()
+            }
+        }
+
+    private fun <T> Subscriber<in T>.complete() {
+        onSubscribe(
+            object : Subscription {
+                override fun request(numberOfElements: Long) {
+                    onComplete()
+                }
+
+                override fun cancel() = Unit
+            },
+        )
+    }
+}

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/routing/StorageRoutingAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/routing/StorageRoutingAutoConfiguration.kt
@@ -125,7 +125,7 @@ class StorageRoutingAutoConfiguration {
             defaultEventStorage = eventStoreProperties.storage,
             defaultSnapshotStorage = snapshotProperties.storage,
         ).resolveSnapshotRoutes(storageRoutingProperties)
-        return RoutingSnapshotStore(
+        return RoutingSnapshotStore.create(
             AggregateSnapshotStoreRegistry(
                 defaultSnapshotStore = resolvedRoutes.defaultSnapshotStore,
                 routes = resolvedRoutes.snapshotRoutes,

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/snapshot/SnapshotAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/snapshot/SnapshotAutoConfiguration.kt
@@ -14,11 +14,14 @@
 package me.ahoo.wow.spring.boot.starter.eventsourcing.snapshot
 
 import me.ahoo.wow.api.naming.NamedBoundedContext
+import me.ahoo.wow.eventsourcing.snapshot.CompositeSnapshotStrategy
 import me.ahoo.wow.eventsourcing.snapshot.InMemorySnapshotStore
 import me.ahoo.wow.eventsourcing.snapshot.SimpleSnapshotStrategy
 import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
 import me.ahoo.wow.eventsourcing.snapshot.SnapshotStrategy
+import me.ahoo.wow.eventsourcing.snapshot.VersionIntervalCheckpointStrategy
 import me.ahoo.wow.eventsourcing.snapshot.VersionOffsetSnapshotStrategy
+import me.ahoo.wow.eventsourcing.snapshot.VersionedSnapshotStore
 import me.ahoo.wow.eventsourcing.snapshot.dispatcher.DefaultSnapshotHandler
 import me.ahoo.wow.eventsourcing.snapshot.dispatcher.SnapshotDispatcher
 import me.ahoo.wow.eventsourcing.snapshot.dispatcher.SnapshotFunctionFilter
@@ -35,6 +38,7 @@ import me.ahoo.wow.spring.boot.starter.eventsourcing.StorageType
 import me.ahoo.wow.spring.boot.starter.eventsourcing.routing.ConditionalOnSnapshotStoreStorage
 import me.ahoo.wow.spring.boot.starter.eventsourcing.routing.SnapshotStoreBinding
 import me.ahoo.wow.spring.command.SnapshotDispatcherLauncher
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
@@ -45,11 +49,20 @@ import org.springframework.context.annotation.Bean
 @AutoConfiguration
 @ConditionalOnWowEnabled
 @ConditionalOnSnapshotEnabled
-@EnableConfigurationProperties(SnapshotProperties::class)
-class SnapshotAutoConfiguration(
+@EnableConfigurationProperties(SnapshotProperties::class, SnapshotCheckpointProperties::class)
+class SnapshotAutoConfiguration @Autowired constructor(
     private val wowProperties: WowProperties,
-    private val snapshotProperties: SnapshotProperties
+    private val snapshotProperties: SnapshotProperties,
+    private val checkpointProperties: SnapshotCheckpointProperties,
 ) {
+    constructor(
+        wowProperties: WowProperties,
+        snapshotProperties: SnapshotProperties,
+    ) : this(
+        wowProperties = wowProperties,
+        snapshotProperties = snapshotProperties,
+        checkpointProperties = SnapshotCheckpointProperties(),
+    )
 
     @Bean(name = ["inMemorySnapshotStore", "inMemorySnapshotRepository"])
     @ConditionalOnSnapshotStoreStorage(StorageType.IN_MEMORY)
@@ -75,9 +88,10 @@ class SnapshotAutoConfiguration(
     fun simpleSnapshotStrategy(
         snapshotStore: SnapshotStore
     ): SnapshotStrategy {
-        return SimpleSnapshotStrategy(
+        val latestStrategy = SimpleSnapshotStrategy(
             snapshotStore = snapshotStore,
         )
+        return latestStrategy.withCheckpoint(snapshotStore)
     }
 
     @Bean
@@ -88,9 +102,29 @@ class SnapshotAutoConfiguration(
     fun versionOffsetSnapshotStrategy(
         snapshotStore: SnapshotStore
     ): SnapshotStrategy {
-        return VersionOffsetSnapshotStrategy(
+        val latestStrategy = VersionOffsetSnapshotStrategy(
             versionOffset = snapshotProperties.versionOffset,
             snapshotStore = snapshotStore
+        )
+        return latestStrategy.withCheckpoint(snapshotStore)
+    }
+
+    private fun SnapshotStrategy.withCheckpoint(snapshotStore: SnapshotStore): SnapshotStrategy {
+        if (!checkpointProperties.enabled) {
+            return this
+        }
+        check(snapshotStore is VersionedSnapshotStore) {
+            "Snapshot store [${snapshotStore.name}] does not support historical checkpoints, " +
+                "but ${SnapshotCheckpointProperties.PREFIX}.enabled=true."
+        }
+        return CompositeSnapshotStrategy(
+            listOf(
+                this,
+                VersionIntervalCheckpointStrategy(
+                    versionInterval = checkpointProperties.versionInterval,
+                    snapshotStore = snapshotStore,
+                ),
+            ),
         )
     }
 

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/snapshot/SnapshotProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/snapshot/SnapshotProperties.kt
@@ -34,6 +34,22 @@ data class SnapshotProperties(
     }
 }
 
+@ConfigurationProperties(prefix = SnapshotCheckpointProperties.PREFIX)
+data class SnapshotCheckpointProperties(
+    @DefaultValue("false") val enabled: Boolean = false,
+    @DefaultValue("100") val versionInterval: Int = 100,
+) {
+    init {
+        require(versionInterval > 0) {
+            "versionInterval must be positive."
+        }
+    }
+
+    companion object {
+        const val PREFIX = "${SnapshotProperties.PREFIX}.checkpoint"
+    }
+}
+
 enum class Strategy {
     ALL,
     VERSION_OFFSET,

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfiguration.kt
@@ -15,17 +15,21 @@ package me.ahoo.wow.spring.boot.starter.mongo
 
 import com.mongodb.reactivestreams.client.MongoClient
 import com.mongodb.reactivestreams.client.MongoDatabase
+import me.ahoo.wow.api.naming.NamedBoundedContext
 import me.ahoo.wow.eventsourcing.EventStore
 import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
 import me.ahoo.wow.infra.prepare.PrepareKeyFactory
 import me.ahoo.wow.mongo.EventStreamSchemaInitializer
+import me.ahoo.wow.mongo.MongoDatabaseContextGuard
 import me.ahoo.wow.mongo.MongoEventStore
 import me.ahoo.wow.mongo.MongoSnapshotStore
+import me.ahoo.wow.mongo.SnapshotCheckpointSchemaInitializer
 import me.ahoo.wow.mongo.SnapshotSchemaInitializer
 import me.ahoo.wow.mongo.prepare.MongoPrepareKeyFactory
 import me.ahoo.wow.mongo.query.event.MongoEventStreamQueryServiceFactory
 import me.ahoo.wow.mongo.query.snapshot.MongoSnapshotQueryServiceFactory
 import me.ahoo.wow.spring.boot.starter.ConditionalOnWowEnabled
+import me.ahoo.wow.spring.boot.starter.WowAutoConfiguration
 import me.ahoo.wow.spring.boot.starter.eventsourcing.StorageType
 import me.ahoo.wow.spring.boot.starter.eventsourcing.routing.ConditionalOnEventStoreStorage
 import me.ahoo.wow.spring.boot.starter.eventsourcing.routing.ConditionalOnSnapshotStoreStorage
@@ -34,9 +38,11 @@ import me.ahoo.wow.spring.boot.starter.eventsourcing.routing.EventStreamQuerySer
 import me.ahoo.wow.spring.boot.starter.eventsourcing.routing.SnapshotQueryServiceFactoryBinding
 import me.ahoo.wow.spring.boot.starter.eventsourcing.routing.SnapshotStoreBinding
 import me.ahoo.wow.spring.boot.starter.eventsourcing.snapshot.ConditionalOnSnapshotEnabled
+import me.ahoo.wow.spring.boot.starter.eventsourcing.snapshot.SnapshotCheckpointProperties
 import me.ahoo.wow.spring.boot.starter.prepare.ConditionalOnPrepareEnabled
 import me.ahoo.wow.spring.boot.starter.prepare.PrepareProperties
 import me.ahoo.wow.spring.boot.starter.prepare.PrepareStorage
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
@@ -47,20 +53,31 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.mongodb.autoconfigure.MongoReactiveAutoConfiguration
 import org.springframework.context.annotation.Bean
 
-@AutoConfiguration(after = [MongoReactiveAutoConfiguration::class])
+@AutoConfiguration(after = [WowAutoConfiguration::class, MongoReactiveAutoConfiguration::class])
 @ConditionalOnWowEnabled
 @ConditionalOnMongoEnabled
 @ConditionalOnClass(MongoEventStore::class)
-@EnableConfigurationProperties(MongoProperties::class)
-class MongoEventSourcingAutoConfiguration(private val mongoProperties: MongoProperties) {
+@EnableConfigurationProperties(MongoProperties::class, SnapshotCheckpointProperties::class)
+class MongoEventSourcingAutoConfiguration @Autowired constructor(
+    private val mongoProperties: MongoProperties,
+    private val checkpointProperties: SnapshotCheckpointProperties,
+) {
+    constructor(mongoProperties: MongoProperties) : this(
+        mongoProperties = mongoProperties,
+        checkpointProperties = SnapshotCheckpointProperties(),
+    )
 
     @Bean
     @ConditionalOnEventStoreStorage(StorageType.MONGO)
     fun mongoEventStore(
         mongoClient: MongoClient,
-        dataMongoProperties: org.springframework.boot.mongodb.autoconfigure.MongoProperties?
+        dataMongoProperties: org.springframework.boot.mongodb.autoconfigure.MongoProperties?,
+        @Qualifier(WowAutoConfiguration.WOW_CURRENT_BOUNDED_CONTEXT)
+        currentBoundedContext: NamedBoundedContext,
     ): MongoEventStore {
         val eventStoreDatabase = getEventStreamDatabase(dataMongoProperties, mongoClient)
+        MongoDatabaseContextGuard(eventStoreDatabase)
+            .ensureContext(currentBoundedContext.contextName)
         if (mongoProperties.autoInitSchema) {
             EventStreamSchemaInitializer(eventStoreDatabase).initAll()
         }
@@ -80,9 +97,13 @@ class MongoEventSourcingAutoConfiguration(private val mongoProperties: MongoProp
     @ConditionalOnEventStoreStorage(StorageType.MONGO)
     fun mongoEventStreamQueryServiceFactory(
         mongoClient: MongoClient,
-        dataMongoProperties: org.springframework.boot.mongodb.autoconfigure.MongoProperties?
+        dataMongoProperties: org.springframework.boot.mongodb.autoconfigure.MongoProperties?,
+        @Qualifier(WowAutoConfiguration.WOW_CURRENT_BOUNDED_CONTEXT)
+        currentBoundedContext: NamedBoundedContext,
     ): MongoEventStreamQueryServiceFactory {
         val eventStoreDatabase = getEventStreamDatabase(dataMongoProperties, mongoClient)
+        MongoDatabaseContextGuard(eventStoreDatabase)
+            .ensureContext(currentBoundedContext.contextName)
         return MongoEventStreamQueryServiceFactory(eventStoreDatabase)
     }
 
@@ -111,11 +132,18 @@ class MongoEventSourcingAutoConfiguration(private val mongoProperties: MongoProp
     @ConditionalOnSnapshotStoreStorage(StorageType.MONGO)
     fun mongoSnapshotStore(
         mongoClient: MongoClient,
-        dataMongoProperties: org.springframework.boot.mongodb.autoconfigure.MongoProperties?
+        dataMongoProperties: org.springframework.boot.mongodb.autoconfigure.MongoProperties?,
+        @Qualifier(WowAutoConfiguration.WOW_CURRENT_BOUNDED_CONTEXT)
+        currentBoundedContext: NamedBoundedContext,
     ): MongoSnapshotStore {
         val snapshotDatabase = getMongoSnapshotDatabase(dataMongoProperties, mongoClient)
+        MongoDatabaseContextGuard(snapshotDatabase)
+            .ensureContext(currentBoundedContext.contextName)
         if (mongoProperties.autoInitSchema) {
             SnapshotSchemaInitializer(snapshotDatabase).initAll()
+            if (checkpointProperties.enabled) {
+                SnapshotCheckpointSchemaInitializer(snapshotDatabase).initAll()
+            }
         }
         return MongoSnapshotStore(snapshotDatabase)
     }
@@ -135,9 +163,13 @@ class MongoEventSourcingAutoConfiguration(private val mongoProperties: MongoProp
     @ConditionalOnSnapshotStoreStorage(StorageType.MONGO)
     fun mongoSnapshotQueryServiceFactory(
         mongoClient: MongoClient,
-        dataMongoProperties: org.springframework.boot.mongodb.autoconfigure.MongoProperties?
+        dataMongoProperties: org.springframework.boot.mongodb.autoconfigure.MongoProperties?,
+        @Qualifier(WowAutoConfiguration.WOW_CURRENT_BOUNDED_CONTEXT)
+        currentBoundedContext: NamedBoundedContext,
     ): MongoSnapshotQueryServiceFactory {
         val snapshotDatabase = getMongoSnapshotDatabase(dataMongoProperties, mongoClient)
+        MongoDatabaseContextGuard(snapshotDatabase)
+            .ensureContext(currentBoundedContext.contextName)
         return MongoSnapshotQueryServiceFactory(snapshotDatabase)
     }
 

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfiguration.kt
@@ -205,13 +205,17 @@ class MongoEventSourcingAutoConfiguration @Autowired constructor(
     @ConditionalOnMissingBean
     fun mongoPrepareKeyFactory(
         mongoClient: MongoClient,
-        dataMongoProperties: org.springframework.boot.mongodb.autoconfigure.MongoProperties?
+        dataMongoProperties: org.springframework.boot.mongodb.autoconfigure.MongoProperties?,
+        @Qualifier(WowAutoConfiguration.WOW_CURRENT_BOUNDED_CONTEXT)
+        currentBoundedContext: NamedBoundedContext,
     ): PrepareKeyFactory {
         val prepareDatabaseName = mongoProperties.prepareDatabase ?: dataMongoProperties?.mongoClientDatabase
         requireNotNull(prepareDatabaseName) {
             "${MongoProperties.PREFIX}.prepare-database must not be null!"
         }
         val prepareDatabase = mongoClient.getDatabase(prepareDatabaseName)
+        MongoDatabaseContextGuard(prepareDatabase)
+            .ensureContext(currentBoundedContext.contextName)
         return MongoPrepareKeyFactory(prepareDatabase)
     }
 }

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/routing/StorageRoutingAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/routing/StorageRoutingAutoConfigurationTest.kt
@@ -23,6 +23,7 @@ import me.ahoo.wow.eventsourcing.RoutingEventStore
 import me.ahoo.wow.eventsourcing.snapshot.RoutingSnapshotStore
 import me.ahoo.wow.eventsourcing.snapshot.Snapshot
 import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
+import me.ahoo.wow.eventsourcing.snapshot.VersionedSnapshotStore
 import me.ahoo.wow.modeling.MaterializedNamedAggregate
 import me.ahoo.wow.modeling.aggregateId
 import me.ahoo.wow.query.event.EventStreamQueryServiceFactory
@@ -254,6 +255,7 @@ class StorageRoutingAutoConfigurationTest {
                 context.getBean(EventStore::class.java).assert().isSameAs(stores.mongoEventStore)
                 val snapshotStore = context.getBean(SnapshotStore::class.java)
                 snapshotStore.assert().isSameAs(context.getBean(RoutingSnapshotStore::class.java))
+                (snapshotStore is VersionedSnapshotStore).assert().isFalse()
 
                 StepVerifier.create(snapshotStore.getVersion(cartAggregateId()))
                     .expectNext(7)

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/snapshot/SnapshotAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/snapshot/SnapshotAutoConfigurationTest.kt
@@ -29,6 +29,7 @@ import me.ahoo.wow.eventsourcing.state.StateEventBus
 import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory
 import me.ahoo.wow.modeling.state.StateAggregateFactory
 import me.ahoo.wow.spring.boot.starter.BusType
+import me.ahoo.wow.spring.boot.starter.WowProperties
 import me.ahoo.wow.spring.boot.starter.enableWow
 import me.ahoo.wow.spring.boot.starter.event.EventAutoConfiguration
 import me.ahoo.wow.spring.boot.starter.event.EventProperties
@@ -48,6 +49,18 @@ import reactor.core.publisher.Mono
 internal class SnapshotAutoConfigurationTest {
 
     private val contextRunner = ApplicationContextRunner()
+
+    @Test
+    fun `legacy constructor keeps checkpoints disabled by default`() {
+        val configuration = SnapshotAutoConfiguration(
+            wowProperties = WowProperties(contextName = "test"),
+            snapshotProperties = SnapshotProperties(),
+        )
+        val snapshotStore = configuration.inMemorySnapshotStore()
+
+        configuration.simpleSnapshotStrategy(snapshotStore).assert()
+            .isInstanceOf(SimpleSnapshotStrategy::class.java)
+    }
 
     @Test
     fun `should load context with snapshot beans`() {

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/snapshot/SnapshotAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/snapshot/SnapshotAutoConfigurationTest.kt
@@ -15,6 +15,7 @@ package me.ahoo.wow.spring.boot.starter.eventsourcing.snapshot
 
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.modeling.AggregateId
+import me.ahoo.wow.eventsourcing.snapshot.CompositeSnapshotStrategy
 import me.ahoo.wow.eventsourcing.snapshot.InMemorySnapshotStore
 import me.ahoo.wow.eventsourcing.snapshot.SimpleSnapshotStrategy
 import me.ahoo.wow.eventsourcing.snapshot.Snapshot
@@ -141,6 +142,88 @@ internal class SnapshotAutoConfigurationTest {
                 val binding = context.getBean(SnapshotStoreBinding::class.java)
                 binding.storage.assert().isEqualTo(StorageType.IN_MEMORY)
                 binding.snapshotStore.assert().isSameAs(snapshotStore)
+            }
+    }
+
+    @Test
+    fun `should compose immutable checkpoint strategy when explicitly enabled`() {
+        contextRunner
+            .enableWow()
+            .withBean(StateAggregateFactory::class.java, { ConstructorStateAggregateFactory })
+            .withBean(StateEventBus::class.java, { InMemoryStateEventBus() })
+            .withPropertyValues(
+                "${EventStoreProperties.STORAGE}=${StorageType.IN_MEMORY_NAME}",
+                "${SnapshotProperties.STORAGE}=${StorageType.IN_MEMORY_NAME}",
+                "${SnapshotCheckpointProperties.PREFIX}.enabled=true",
+                "${SnapshotCheckpointProperties.PREFIX}.version-interval=25",
+                "${EventProperties.BUS_TYPE}=${BusType.IN_MEMORY_NAME}",
+            )
+            .withUserConfiguration(
+                EventAutoConfiguration::class.java,
+                EventStoreAutoConfiguration::class.java,
+                SnapshotAutoConfiguration::class.java,
+            )
+            .run { context: AssertableApplicationContext ->
+                context.assert()
+                    .hasNotFailed()
+                    .hasSingleBean(CompositeSnapshotStrategy::class.java)
+                val checkpoint = context.getBean(SnapshotCheckpointProperties::class.java)
+                checkpoint.enabled.assert().isTrue()
+                checkpoint.versionInterval.assert().isEqualTo(25)
+            }
+    }
+
+    @Test
+    fun `should reject a non-positive checkpoint interval during binding`() {
+        contextRunner
+            .enableWow()
+            .withBean(StateAggregateFactory::class.java, { ConstructorStateAggregateFactory })
+            .withBean(StateEventBus::class.java, { InMemoryStateEventBus() })
+            .withPropertyValues(
+                "${EventStoreProperties.STORAGE}=${StorageType.IN_MEMORY_NAME}",
+                "${SnapshotProperties.STORAGE}=${StorageType.IN_MEMORY_NAME}",
+                "${SnapshotCheckpointProperties.PREFIX}.enabled=true",
+                "${SnapshotCheckpointProperties.PREFIX}.version-interval=0",
+                "${EventProperties.BUS_TYPE}=${BusType.IN_MEMORY_NAME}",
+            )
+            .withUserConfiguration(
+                EventAutoConfiguration::class.java,
+                EventStoreAutoConfiguration::class.java,
+                SnapshotAutoConfiguration::class.java,
+            )
+            .run { context ->
+                context.startupFailure.assert().isNotNull()
+            }
+    }
+
+    @Test
+    fun `should fail fast when the selected snapshot store lacks checkpoint support`() {
+        contextRunner
+            .enableWow()
+            .withBean(StateAggregateFactory::class.java, { ConstructorStateAggregateFactory })
+            .withBean(StateEventBus::class.java, { InMemoryStateEventBus() })
+            .withPropertyValues(
+                "${EventStoreProperties.STORAGE}=${StorageType.IN_MEMORY_NAME}",
+                "${SnapshotProperties.STORAGE}=${StorageType.IN_MEMORY_NAME}",
+                "${SnapshotCheckpointProperties.PREFIX}.enabled=true",
+                "${EventProperties.BUS_TYPE}=${BusType.IN_MEMORY_NAME}",
+            )
+            .withUserConfiguration(
+                EventAutoConfiguration::class.java,
+                EventStoreAutoConfiguration::class.java,
+                SnapshotAutoConfiguration::class.java,
+                SnapshotStoreDecoratorConfiguration::class.java,
+            )
+            .run { context ->
+                context.startupFailure.assert().isNotNull()
+                generateSequence(context.startupFailure) { error -> error.cause }
+                    .mapNotNull(Throwable::message)
+                    .toList()
+                    .assert()
+                    .anyMatch {
+                        it.contains("does not support historical checkpoints") &&
+                            it.contains("${SnapshotCheckpointProperties.PREFIX}.enabled=true")
+                    }
             }
     }
 

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/metrics/MetricsAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/metrics/MetricsAutoConfigurationTest.kt
@@ -1,6 +1,10 @@
 package me.ahoo.wow.spring.boot.starter.metrics
 
+import io.mockk.mockk
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.eventsourcing.snapshot.NoOpSnapshotStore
+import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
+import me.ahoo.wow.eventsourcing.snapshot.VersionedSnapshotStore
 import me.ahoo.wow.spring.boot.starter.enableWow
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
@@ -8,6 +12,17 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner
 
 class MetricsAutoConfigurationTest {
     private val contextRunner = ApplicationContextRunner()
+
+    @Test
+    fun `metrics post processor should preserve snapshot checkpoint capability`() {
+        val postProcessor = MetricsBeanPostProcessor()
+
+        val legacy = postProcessor.postProcessAfterInitialization(mockk<SnapshotStore>(), "legacySnapshotStore")
+        val versioned = postProcessor.postProcessAfterInitialization(NoOpSnapshotStore, "versionedSnapshotStore")
+
+        (legacy is VersionedSnapshotStore).assert().isFalse()
+        (versioned is VersionedSnapshotStore).assert().isTrue()
+    }
 
     @Test
     fun `should load context with metrics bean post processor`() {

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfigurationTest.kt
@@ -13,17 +13,30 @@
 
 package me.ahoo.wow.spring.boot.starter.mongo
 
+import com.mongodb.client.model.FindOneAndUpdateOptions
+import com.mongodb.reactivestreams.client.FindPublisher
+import com.mongodb.reactivestreams.client.ListCollectionNamesPublisher
 import com.mongodb.reactivestreams.client.MongoClient
+import com.mongodb.reactivestreams.client.MongoCollection
+import com.mongodb.reactivestreams.client.MongoDatabase
+import io.mockk.every
 import io.mockk.mockk
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.mongo.MongoDatabaseContextGuard
 import me.ahoo.wow.mongo.MongoEventStore
 import me.ahoo.wow.mongo.MongoSnapshotStore
 import me.ahoo.wow.mongo.prepare.MongoPrepareKeyFactory
+import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.spring.boot.starter.enableWow
 import me.ahoo.wow.spring.boot.starter.eventsourcing.StorageType
 import me.ahoo.wow.spring.boot.starter.eventsourcing.routing.EventStoreBinding
 import me.ahoo.wow.spring.boot.starter.eventsourcing.routing.SnapshotStoreBinding
+import org.bson.Document
+import org.bson.conversions.Bson
 import org.junit.jupiter.api.Test
+import org.reactivestreams.Publisher
+import org.reactivestreams.Subscriber
+import org.reactivestreams.Subscription
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 
@@ -40,9 +53,10 @@ class MongoEventSourcingAutoConfigurationTest {
                 "${MongoProperties.PREFIX}.prepare-database=testPrepare",
                 "${MongoProperties.PREFIX}.error-database=testError",
                 "${MongoProperties.PREFIX}.auto-init-schema=false",
+                "wow.context-name=order-service",
             )
             .withBean(MongoClient::class.java, {
-                mockk(relaxed = true)
+                mongoClient("order-service")
             })
             .withUserConfiguration(
                 MongoEventSourcingAutoConfiguration::class.java,
@@ -66,5 +80,101 @@ class MongoEventSourcingAutoConfigurationTest {
                 snapshotBinding.storage.assert().isEqualTo(StorageType.MONGO)
                 snapshotBinding.snapshotStore.assert().isSameAs(snapshotStore)
             }
+    }
+
+    @Test
+    fun `should reject a database owned by another context when auto init is disabled`() {
+        contextRunner
+            .enableWow()
+            .withPropertyValues(
+                "${MongoProperties.PREFIX}.event-stream-database=testEventStream",
+                "${MongoProperties.PREFIX}.snapshot-database=testSnapshot",
+                "${MongoProperties.PREFIX}.prepare-database=testPrepare",
+                "${MongoProperties.PREFIX}.auto-init-schema=false",
+                "wow.context-name=payment-service",
+            )
+            .withBean(MongoClient::class.java, {
+                mongoClient("order-service")
+            })
+            .withUserConfiguration(MongoEventSourcingAutoConfiguration::class.java)
+            .run { context ->
+                context.startupFailure.assert().isNotNull()
+                generateSequence(context.startupFailure) { error -> error.cause }
+                    .mapNotNull(Throwable::message)
+                    .toList()
+                    .assert()
+                    .anyMatch {
+                        it.contains("order-service") &&
+                            it.contains("payment-service") &&
+                            it.contains("one bounded context per MongoDB database")
+                    }
+            }
+    }
+
+    private fun mongoClient(ownerContextName: String): MongoClient {
+        val marker = Document()
+            .append(MessageRecords.CONTEXT_NAME, ownerContextName)
+            .append(MongoDatabaseContextGuard.LAYOUT_VERSION_FIELD, 1)
+        val markerCollection = mockk<MongoCollection<Document>>()
+        val markerPublisher = mockk<FindPublisher<Document>>()
+        every { markerCollection.find(any<Bson>()) } returns markerPublisher
+        every { markerPublisher.first() } returns publisherOf(marker)
+        every {
+            markerCollection.findOneAndUpdate(
+                any<Bson>(),
+                any<Bson>(),
+                any<FindOneAndUpdateOptions>(),
+            )
+        } returns publisherOf(marker)
+
+        val database = mockk<MongoDatabase>()
+        every { database.name } returns "testDatabase"
+        every { database.listCollectionNames() } returns emptyCollectionNamesPublisher()
+        every { database.getCollection(any()) } returns markerCollection
+
+        return mockk<MongoClient> {
+            every { getDatabase(any()) } returns database
+        }
+    }
+
+    private fun emptyCollectionNamesPublisher(): ListCollectionNamesPublisher {
+        return mockk {
+            every { subscribe(any()) } answers {
+                firstArg<Subscriber<in String>>().complete()
+            }
+        }
+    }
+
+    private fun <T> publisherOf(value: T): Publisher<T> {
+        return Publisher { subscriber ->
+            subscriber.onSubscribe(
+                object : Subscription {
+                    private var emitted = false
+
+                    override fun request(numberOfElements: Long) {
+                        if (emitted) {
+                            return
+                        }
+                        emitted = true
+                        subscriber.onNext(value)
+                        subscriber.onComplete()
+                    }
+
+                    override fun cancel() = Unit
+                },
+            )
+        }
+    }
+
+    private fun <T> Subscriber<in T>.complete() {
+        onSubscribe(
+            object : Subscription {
+                override fun request(numberOfElements: Long) {
+                    onComplete()
+                }
+
+                override fun cancel() = Unit
+            },
+        )
     }
 }

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfigurationTest.kt
@@ -55,18 +55,20 @@ class MongoEventSourcingAutoConfigurationTest {
     fun `legacy constructor keeps checkpoint schema initialization disabled`() {
         val configuration = MongoEventSourcingAutoConfiguration(
             MongoProperties(
-                autoInitSchema = false,
+                autoInitSchema = true,
                 eventStreamDatabase = null,
                 snapshotDatabase = "testSnapshot",
                 prepareDatabase = null,
             ),
         )
 
-        configuration.mongoSnapshotStore(
-            mongoClient = mongoClient("order-service"),
-            dataMongoProperties = null,
-            currentBoundedContext = MaterializedNamedBoundedContext("order-service"),
-        ).assert().isInstanceOf(MongoSnapshotStore::class.java)
+        withEmptyAggregateMetadata {
+            configuration.mongoSnapshotStore(
+                mongoClient = mongoClient("order-service"),
+                dataMongoProperties = null,
+                currentBoundedContext = MaterializedNamedBoundedContext("order-service"),
+            ).assert().isInstanceOf(MongoSnapshotStore::class.java)
+        }
     }
 
     @Test
@@ -80,17 +82,12 @@ class MongoEventSourcingAutoConfigurationTest {
             ),
             checkpointProperties = SnapshotCheckpointProperties(enabled = true),
         )
-        mockkObject(MetadataSearcher)
-        try {
-            every { MetadataSearcher.namedAggregateType } returns NamedAggregateTypeSearcher(emptyMap())
-
+        withEmptyAggregateMetadata {
             configuration.mongoSnapshotStore(
                 mongoClient = mongoClient("order-service"),
                 dataMongoProperties = null,
                 currentBoundedContext = MaterializedNamedBoundedContext("order-service"),
             ).assert().isInstanceOf(MongoSnapshotStore::class.java)
-        } finally {
-            unmockkObject(MetadataSearcher)
         }
     }
 
@@ -213,6 +210,16 @@ class MongoEventSourcingAutoConfigurationTest {
 
         return mockk<MongoClient> {
             every { getDatabase(any()) } returns database
+        }
+    }
+
+    private fun withEmptyAggregateMetadata(block: () -> Unit) {
+        mockkObject(MetadataSearcher)
+        try {
+            every { MetadataSearcher.namedAggregateType } returns NamedAggregateTypeSearcher(emptyMap())
+            block()
+        } finally {
+            unmockkObject(MetadataSearcher)
         }
     }
 

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfigurationTest.kt
@@ -21,16 +21,22 @@ import com.mongodb.reactivestreams.client.MongoCollection
 import com.mongodb.reactivestreams.client.MongoDatabase
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.configuration.MetadataSearcher
+import me.ahoo.wow.configuration.NamedAggregateTypeSearcher
 import me.ahoo.wow.mongo.MongoDatabaseContextGuard
 import me.ahoo.wow.mongo.MongoEventStore
 import me.ahoo.wow.mongo.MongoSnapshotStore
 import me.ahoo.wow.mongo.prepare.MongoPrepareKeyFactory
+import me.ahoo.wow.naming.MaterializedNamedBoundedContext
 import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.spring.boot.starter.enableWow
 import me.ahoo.wow.spring.boot.starter.eventsourcing.StorageType
 import me.ahoo.wow.spring.boot.starter.eventsourcing.routing.EventStoreBinding
 import me.ahoo.wow.spring.boot.starter.eventsourcing.routing.SnapshotStoreBinding
+import me.ahoo.wow.spring.boot.starter.eventsourcing.snapshot.SnapshotCheckpointProperties
 import org.bson.Document
 import org.bson.conversions.Bson
 import org.junit.jupiter.api.Test
@@ -42,6 +48,49 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner
 
 class MongoEventSourcingAutoConfigurationTest {
     private val contextRunner = ApplicationContextRunner()
+
+    @Test
+    fun `legacy constructor keeps checkpoint schema initialization disabled`() {
+        val configuration = MongoEventSourcingAutoConfiguration(
+            MongoProperties(
+                autoInitSchema = false,
+                eventStreamDatabase = null,
+                snapshotDatabase = "testSnapshot",
+                prepareDatabase = null,
+            ),
+        )
+
+        configuration.mongoSnapshotStore(
+            mongoClient = mongoClient("order-service"),
+            dataMongoProperties = null,
+            currentBoundedContext = MaterializedNamedBoundedContext("order-service"),
+        ).assert().isInstanceOf(MongoSnapshotStore::class.java)
+    }
+
+    @Test
+    fun `should initialize checkpoint schemas when explicitly enabled`() {
+        val configuration = MongoEventSourcingAutoConfiguration(
+            mongoProperties = MongoProperties(
+                autoInitSchema = true,
+                eventStreamDatabase = null,
+                snapshotDatabase = "testSnapshot",
+                prepareDatabase = null,
+            ),
+            checkpointProperties = SnapshotCheckpointProperties(enabled = true),
+        )
+        mockkObject(MetadataSearcher)
+        try {
+            every { MetadataSearcher.namedAggregateType } returns NamedAggregateTypeSearcher(emptyMap())
+
+            configuration.mongoSnapshotStore(
+                mongoClient = mongoClient("order-service"),
+                dataMongoProperties = null,
+                currentBoundedContext = MaterializedNamedBoundedContext("order-service"),
+            ).assert().isInstanceOf(MongoSnapshotStore::class.java)
+        } finally {
+            unmockkObject(MetadataSearcher)
+        }
+    }
 
     @Test
     fun `should load context with mongo event sourcing beans`() {

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfigurationTest.kt
@@ -37,6 +37,8 @@ import me.ahoo.wow.spring.boot.starter.eventsourcing.StorageType
 import me.ahoo.wow.spring.boot.starter.eventsourcing.routing.EventStoreBinding
 import me.ahoo.wow.spring.boot.starter.eventsourcing.routing.SnapshotStoreBinding
 import me.ahoo.wow.spring.boot.starter.eventsourcing.snapshot.SnapshotCheckpointProperties
+import me.ahoo.wow.spring.boot.starter.eventsourcing.snapshot.SnapshotProperties
+import me.ahoo.wow.spring.boot.starter.eventsourcing.store.EventStoreProperties
 import org.bson.Document
 import org.bson.conversions.Bson
 import org.junit.jupiter.api.Test
@@ -140,6 +142,34 @@ class MongoEventSourcingAutoConfigurationTest {
                 "${MongoProperties.PREFIX}.snapshot-database=testSnapshot",
                 "${MongoProperties.PREFIX}.prepare-database=testPrepare",
                 "${MongoProperties.PREFIX}.auto-init-schema=false",
+                "wow.context-name=payment-service",
+            )
+            .withBean(MongoClient::class.java, {
+                mongoClient("order-service")
+            })
+            .withUserConfiguration(MongoEventSourcingAutoConfiguration::class.java)
+            .run { context ->
+                context.startupFailure.assert().isNotNull()
+                generateSequence(context.startupFailure) { error -> error.cause }
+                    .mapNotNull(Throwable::message)
+                    .toList()
+                    .assert()
+                    .anyMatch {
+                        it.contains("order-service") &&
+                            it.contains("payment-service") &&
+                            it.contains("one bounded context per MongoDB database")
+                    }
+            }
+    }
+
+    @Test
+    fun `should guard a dedicated prepare database when event and snapshot use other storage`() {
+        contextRunner
+            .enableWow()
+            .withPropertyValues(
+                "${MongoProperties.PREFIX}.prepare-database=testPrepare",
+                "${EventStoreProperties.STORAGE}=${StorageType.IN_MEMORY_NAME}",
+                "${SnapshotProperties.STORAGE}=${StorageType.IN_MEMORY_NAME}",
                 "wow.context-name=payment-service",
             )
             .withBean(MongoClient::class.java, {


### PR DESCRIPTION
## Goal

Preserve the existing aggregate-name-only MongoDB collection layout while detecting unsupported cross-context database sharing before stores or query factories start. Add an opt-in immutable snapshot checkpoint capability without changing the latest-snapshot contract.

## Changes

- Add VersionedSnapshotStore, fixed-interval checkpointing, sequential strategy composition, routing and metrics propagation, and a reusable backend TCK.
- Add immutable MongoDB checkpoint sidecars with first-write-wins upserts and greatest-version-at-or-before reads.
- Atomically claim each MongoDB database for one bounded context in wow_database_metadata. Existing unmarked aggregate collections are checked before the first claim, including event streams, latest snapshots, and checkpoint sidecars.
- Reconcile required MongoDB indexes on existing collections, reject incompatible definitions with migration guidance, and tolerate concurrent collection creation.
- Initialize checkpoint schemas only when wow.eventsourcing.snapshot.checkpoint.enabled is true. The feature remains disabled by default and does not backfill history.
- Preserve the deprecated MongoSnapshotRepository capability and existing auto-configuration constructors.
- Document configuration, migration, rollback, ownership markers, and index behavior in English and Chinese.

## Verification

- ./gradlew :wow-core:check :wow-mongo:check :wow-mongo:integrationTest :wow-spring-boot-starter:check :wow-tck:check
- 1210 tests, 0 failures, 0 errors, 0 skipped
- pnpm docs:build
- git diff --check

## Risks and Notes

This intentionally changes startup behavior for unsafe deployments:

- A MongoDB database containing or claimed by another bounded context now fails startup, even when auto-init-schema is false.
- Existing managed indexes with incompatible key order, uniqueness, TTL, partial-filter, collation, sparse, or hidden options now fail startup instead of being ignored.
- The first claim of a legacy unmarked database scans matching aggregate collections and may be expensive on large databases.
- Checkpoints create additional sidecar storage and only accumulate versions produced after enablement.

Migration: audit all configured event-stream and snapshot databases, split any cross-context sharing, upgrade the real owner first, and migrate drifted indexes through controlled drop/recreate operations.

Rollback: disable snapshot checkpointing to stop new sidecar writes. For ownership failures, restore the correct database mapping; do not edit the ownership marker to bypass the guard. Existing latest-snapshot data and collection names remain unchanged.