### PR TITLE
feat(redis): recover abandoned stream messages

### DIFF
--- a/documentation/docs/en/guide/extensions/redis.md
+++ b/documentation/docs/en/guide/extensions/redis.md
@@ -79,6 +79,10 @@ implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive
 | Name                  | Data Type               | Description | Default Value |
 |---------------------|-----------------------|-------------|---------------|
 | `enabled`           | `Boolean`             | Whether to enable | `true` |
+| `message-bus.recovery.enabled` | `Boolean` | Recover abandoned pending messages | `true` |
+| `message-bus.recovery.min-idle-time` | `Duration` | Minimum idle time before recovery | `5m` |
+| `message-bus.recovery.interval` | `Duration` | Interval between pending-message sweeps | `30s` |
+| `message-bus.recovery.batch-size` | `Long` | Maximum records per `XPENDING` page | `100` |
 
 **YAML Configuration Example**
 
@@ -107,6 +111,12 @@ wow:
         type: redis
   redis:
     enabled: true
+    message-bus:
+      recovery:
+        enabled: true
+        min-idle-time: 5m
+        interval: 30s
+        batch-size: 100
 ```
 
 ## Command Bus
@@ -128,6 +138,22 @@ Each processor corresponds to a consumer group:
 ```
 {contextName}.{processorName}
 ```
+
+### Pending-message recovery
+
+The Redis message bus recovers records abandoned in an old consumer's Pending Entries List (PEL)
+after `min-idle-time`. It uses consumer leases, bounded `XPENDING` scans, and atomic `XCLAIM`.
+Recovery failures are isolated from live delivery and retried on the next sweep.
+
+Delivery remains at least once. Handlers must therefore be idempotent, and `min-idle-time` must
+cover the longest handler execution, retry, and graceful-shutdown duration. Recovery is enabled by
+default. Set `wow.redis.message-bus.recovery.enabled=false` only as a temporary rollback; doing so
+restores the previous behavior in which abandoned PEL records can remain stranded.
+
+Records without the `msg` field or with invalid JSON no longer terminate the consumer. They remain
+pending for manual diagnosis, while a payload-free error and a `RedisMessageBusObservation.RecordDecodeFailed`
+observation are emitted. Applications can register non-blocking `RedisMessageBusObserver` beans for
+metrics or alerting.
 
 ## Event Bus
 

--- a/documentation/docs/en/reference/config/infrastructure.md
+++ b/documentation/docs/en/reference/config/infrastructure.md
@@ -55,6 +55,10 @@ wow:
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `wow.redis.enabled` | Boolean | `true` | Enable Redis integration |
+| `wow.redis.message-bus.recovery.enabled` | Boolean | `true` | Recover abandoned Redis Stream pending messages |
+| `wow.redis.message-bus.recovery.min-idle-time` | Duration | `5m` | Minimum idle time before a pending message is recoverable |
+| `wow.redis.message-bus.recovery.interval` | Duration | `30s` | Interval between pending-message sweeps |
+| `wow.redis.message-bus.recovery.batch-size` | Long | `100` | Maximum records per `XPENDING` page |
 
 Redis connection is configured through Spring Boot's standard `spring.data.redis.*` properties.
 
@@ -68,6 +72,12 @@ spring:
 wow:
   redis:
     enabled: true
+    message-bus:
+      recovery:
+        enabled: true
+        min-idle-time: 5m
+        interval: 30s
+        batch-size: 100
 ```
 
 

--- a/documentation/docs/zh/guide/extensions/redis.md
+++ b/documentation/docs/zh/guide/extensions/redis.md
@@ -79,6 +79,10 @@ implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive
 | 名称                  | 数据类型                  | 说明          | 默认值    |
 |---------------------|-----------------------|-------------|--------|
 | `enabled`           | `Boolean`             | 是否启用        | `true` |
+| `message-bus.recovery.enabled` | `Boolean` | 是否恢复被遗留的 pending 消息 | `true` |
+| `message-bus.recovery.min-idle-time` | `Duration` | 触发恢复前的最小空闲时间 | `5m` |
+| `message-bus.recovery.interval` | `Duration` | pending 消息扫描间隔 | `30s` |
+| `message-bus.recovery.batch-size` | `Long` | 每页 `XPENDING` 最大记录数 | `100` |
 
 **YAML 配置样例**
 
@@ -107,6 +111,12 @@ wow:
         type: redis
   redis:
     enabled: true
+    message-bus:
+      recovery:
+        enabled: true
+        min-idle-time: 5m
+        interval: 30s
+        batch-size: 100
 ```
 
 ## 命令总线
@@ -128,6 +138,20 @@ Redis 命令总线使用 Redis Streams 实现消息传递：
 ```
 {contextName}.{processorName}
 ```
+
+### Pending 消息恢复
+
+Redis 消息总线会在 `min-idle-time` 后恢复旧 consumer 遗留在 Pending Entries List（PEL）中的记录。
+恢复流程使用 consumer lease、有界 `XPENDING` 扫描和原子 `XCLAIM`。恢复链路失败不会终止实时消费，
+而会在下一轮扫描时重试。
+
+消息语义仍为 at-least-once，因此 handler 必须幂等；`min-idle-time` 必须覆盖最长 handler 执行、
+重试和优雅停机时间。恢复默认开启。仅应在临时回滚时设置
+`wow.redis.message-bus.recovery.enabled=false`；关闭后会恢复旧行为，使被遗留的 PEL 记录可能永久滞留。
+
+缺少 `msg` 字段或 JSON 非法的记录不会再终止 consumer。此类记录保留在 PEL 中供人工诊断，同时输出
+不含 payload 的错误日志和 `RedisMessageBusObservation.RecordDecodeFailed` 观测事件。应用可注册非阻塞的
+`RedisMessageBusObserver` Bean 接入指标或告警。
 
 ## 事件总线
 

--- a/documentation/docs/zh/reference/config/infrastructure.md
+++ b/documentation/docs/zh/reference/config/infrastructure.md
@@ -55,6 +55,10 @@ wow:
 | 属性 | 类型 | 默认值 | 描述 |
 |----------|------|---------|-------------|
 | `wow.redis.enabled` | Boolean | `true` | 启用 Redis 集成 |
+| `wow.redis.message-bus.recovery.enabled` | Boolean | `true` | 恢复被遗留的 Redis Stream pending 消息 |
+| `wow.redis.message-bus.recovery.min-idle-time` | Duration | `5m` | pending 消息可恢复前的最小空闲时间 |
+| `wow.redis.message-bus.recovery.interval` | Duration | `30s` | pending 消息扫描间隔 |
+| `wow.redis.message-bus.recovery.batch-size` | Long | `100` | 每页 `XPENDING` 最大记录数 |
 
 Redis 连接通过 Spring Boot 标准的 `spring.data.redis.*` 属性进行配置。
 
@@ -68,6 +72,12 @@ spring:
 wow:
   redis:
     enabled: true
+    message-bus:
+      recovery:
+        enabled: true
+        min-idle-time: 5m
+        interval: 30s
+        batch-size: 100
 ```
 
 

--- a/wow-redis/src/integrationTest/kotlin/me/ahoo/wow/redis/bus/RedisCommandBusTest.kt
+++ b/wow-redis/src/integrationTest/kotlin/me/ahoo/wow/redis/bus/RedisCommandBusTest.kt
@@ -1,9 +1,20 @@
 package me.ahoo.wow.redis.bus
 
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.command.CommandBus
-import me.ahoo.wow.tck.container.RedisTestFixture
+import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.messaging.MessageSubscription
 import me.ahoo.wow.tck.command.CommandBusSpec
+import me.ahoo.wow.tck.container.RedisTestFixture
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import org.springframework.data.redis.connection.stream.ReadOffset
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.kotlin.test.test
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class RedisCommandBusTest : CommandBusSpec() {
     @JvmField
@@ -12,5 +23,155 @@ class RedisCommandBusTest : CommandBusSpec() {
 
     override fun createMessageBus(): CommandBus {
         return RedisCommandBus(redis.redisTemplate)
+    }
+
+    @Test
+    fun `should isolate an undecodable record and continue consuming valid messages`() {
+        val receiverGroup = generateGlobalId()
+        val subscription = MessageSubscription(namedAggregate, receiverGroup)
+        val topic = DefaultCommandTopicConverter.convert(namedAggregate)
+        val streamOps = redis.redisTemplate.opsForStream<String, String>()
+        streamOps.add(topic, mapOf("bootstrap" to "group-anchor")).block(Duration.ofSeconds(5))
+        streamOps.createGroup(topic, ReadOffset.latest(), receiverGroup).block(Duration.ofSeconds(5))
+        streamOps.add(topic, mapOf("unexpected" to "missing-message-field")).block(Duration.ofSeconds(5))
+        streamOps.add(topic, mapOf(MESSAGE_FIELD to "not-json")).block(Duration.ofSeconds(5))
+        val validMessage = createMessage()
+        val observations = mutableListOf<RedisMessageBusObservation>()
+        val bus = RedisCommandBus(
+            redisTemplate = redis.redisTemplate,
+            recoveryOptions = RedisStreamRecoveryOptions.DISABLED,
+            observer = RedisMessageBusObserver { observation ->
+                observations += observation
+                throw IllegalStateException("observer failed")
+            },
+            pollTimeout = Duration.ofMillis(50),
+        )
+        bus.send(validMessage).block(Duration.ofSeconds(5))
+
+        bus.receive(subscription)
+            .take(1)
+            .concatMap { exchange -> exchange.acknowledge().thenReturn(exchange) }
+            .test()
+            .assertNext { exchange -> exchange.message.id.assert().isEqualTo(validMessage.id) }
+            .expectComplete()
+            .verify(Duration.ofSeconds(5))
+
+        observations.filterIsInstance<RedisMessageBusObservation.RecordDecodeFailed>()
+            .map { observation -> observation.reason }
+            .assert()
+            .containsExactly(
+                RedisRecordDecodeFailureReason.MISSING_MESSAGE_FIELD,
+                RedisRecordDecodeFailureReason.DESERIALIZATION_FAILED,
+            )
+        streamOps.pending(topic, receiverGroup)
+            .block(Duration.ofSeconds(5))!!
+            .totalPendingMessages
+            .assert()
+            .isEqualTo(2)
+    }
+
+    @Test
+    fun `should recover and acknowledge idle messages from an old consumer`() {
+        val receiverGroup = generateGlobalId()
+        val subscription = MessageSubscription(namedAggregate, receiverGroup)
+        val messages = List(3) { createMessage() }
+        val oldBus = RedisCommandBus(
+            redisTemplate = redis.redisTemplate,
+            recoveryOptions = RedisStreamRecoveryOptions.DISABLED,
+            pollTimeout = Duration.ofMillis(20),
+        )
+        oldBus.receive(subscription)
+            .doOnSubscribe {
+                Mono.delay(Duration.ofMillis(100))
+                    .thenMany(Flux.fromIterable(messages).concatMap(oldBus::send))
+                    .then()
+                    .subscribe()
+            }
+            .take(messages.size.toLong())
+            .test()
+            .expectNextCount(messages.size.toLong())
+            .expectComplete()
+            .verify(Duration.ofSeconds(5))
+
+        val topic = DefaultCommandTopicConverter.convert(namedAggregate)
+        val streamOps = redis.redisTemplate.opsForStream<String, String>()
+        streamOps.pending(topic, receiverGroup)
+            .block(Duration.ofSeconds(5))!!
+            .totalPendingMessages
+            .assert()
+            .isEqualTo(messages.size.toLong())
+        Mono.delay(Duration.ofMillis(100)).block()
+
+        val recoveringBus = RedisCommandBus(
+            redisTemplate = redis.redisTemplate,
+            recoveryOptions = RedisStreamRecoveryOptions(
+                minIdleTime = Duration.ofMillis(50),
+                interval = Duration.ofMillis(20),
+                batchSize = 1,
+            ),
+            pollTimeout = Duration.ofMillis(20),
+        )
+        recoveringBus.receive(subscription)
+            .take(messages.size.toLong())
+            .concatMap { exchange -> exchange.acknowledge().thenReturn(exchange) }
+            .test()
+            .recordWith(::mutableListOf)
+            .expectNextCount(messages.size.toLong())
+            .consumeRecordedWith { exchanges ->
+                exchanges.map { exchange -> exchange.message.id }
+                    .assert()
+                    .containsExactlyElementsOf(messages.map { message -> message.id })
+            }
+            .expectComplete()
+            .verify(Duration.ofSeconds(5))
+
+        streamOps.pending(topic, receiverGroup)
+            .block(Duration.ofSeconds(5))!!
+            .totalPendingMessages
+            .assert()
+            .isEqualTo(0)
+    }
+
+    @Test
+    fun `should not recover from an active consumer lease`() {
+        val receiverGroup = generateGlobalId()
+        val subscription = MessageSubscription(namedAggregate, receiverGroup)
+        val message = createMessage()
+        val recoveryOptions = RedisStreamRecoveryOptions(
+            minIdleTime = Duration.ofMillis(100),
+            interval = Duration.ofMillis(20),
+            batchSize = 1,
+        )
+        val activeBus = RedisCommandBus(
+            redisTemplate = redis.redisTemplate,
+            recoveryOptions = recoveryOptions,
+            pollTimeout = Duration.ofSeconds(2),
+        )
+        val received = CountDownLatch(1)
+        val activeSubscription = activeBus.receive(subscription)
+            .doOnNext { received.countDown() }
+            .subscribe()
+        val recoveringBus = RedisCommandBus(
+            redisTemplate = redis.redisTemplate,
+            recoveryOptions = recoveryOptions,
+            pollTimeout = Duration.ofMillis(20),
+        )
+        try {
+            activeBus.send(message).block(Duration.ofSeconds(5))
+            received.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+            recoveringBus.receive(subscription)
+                .take(1)
+                .concatMap { exchange -> exchange.acknowledge().thenReturn(exchange) }
+                .test()
+                .expectSubscription()
+                .expectNoEvent(Duration.ofMillis(300))
+                .then(activeSubscription::dispose)
+                .assertNext { exchange -> exchange.message.id.assert().isEqualTo(message.id) }
+                .expectComplete()
+                .verify(Duration.ofSeconds(5))
+        } finally {
+            activeSubscription.dispose()
+        }
     }
 }

--- a/wow-redis/src/integrationTest/kotlin/me/ahoo/wow/redis/bus/RedisCommandBusTest.kt
+++ b/wow-redis/src/integrationTest/kotlin/me/ahoo/wow/redis/bus/RedisCommandBusTest.kt
@@ -138,8 +138,8 @@ class RedisCommandBusTest : CommandBusSpec() {
         val subscription = MessageSubscription(namedAggregate, receiverGroup)
         val message = createMessage()
         val recoveryOptions = RedisStreamRecoveryOptions(
-            minIdleTime = Duration.ofMillis(100),
-            interval = Duration.ofMillis(20),
+            minIdleTime = Duration.ofMillis(200),
+            interval = Duration.ofMillis(500),
             batchSize = 1,
         )
         val activeBus = RedisCommandBus(
@@ -165,11 +165,11 @@ class RedisCommandBusTest : CommandBusSpec() {
                 .concatMap { exchange -> exchange.acknowledge().thenReturn(exchange) }
                 .test()
                 .expectSubscription()
-                .expectNoEvent(Duration.ofMillis(300))
+                .expectNoEvent(Duration.ofSeconds(2))
                 .then(activeSubscription::dispose)
                 .assertNext { exchange -> exchange.message.id.assert().isEqualTo(message.id) }
                 .expectComplete()
-                .verify(Duration.ofSeconds(5))
+                .verify(Duration.ofSeconds(10))
         } finally {
             activeSubscription.dispose()
         }

--- a/wow-redis/src/main/kotlin/me/ahoo/wow/redis/bus/AbstractRedisMessageBus.kt
+++ b/wow-redis/src/main/kotlin/me/ahoo/wow/redis/bus/AbstractRedisMessageBus.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.redis.bus
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.lettuce.core.RedisBusyException
 import me.ahoo.wow.api.messaging.Message
 import me.ahoo.wow.api.modeling.AggregateIdCapable
@@ -32,6 +33,8 @@ import org.springframework.data.redis.stream.StreamReceiver
 import org.springframework.data.redis.stream.StreamReceiver.StreamReceiverOptions
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import reactor.core.publisher.SynchronousSink
+import tools.jackson.core.JacksonException
 import java.time.Duration
 
 const val MESSAGE_FIELD = "msg"
@@ -39,7 +42,9 @@ const val MESSAGE_FIELD = "msg"
 abstract class AbstractRedisMessageBus<M, E>(
     private val redisTemplate: ReactiveStringRedisTemplate,
     private val topicConverter: AggregateTopicConverter,
-    private val pollTimeout: Duration = Duration.ofSeconds(2)
+    private val pollTimeout: Duration = Duration.ofSeconds(2),
+    private val recoveryOptions: RedisStreamRecoveryOptions = RedisStreamRecoveryOptions.DEFAULT,
+    private val messageBusObserver: RedisMessageBusObserver = RedisMessageBusObserver.NOOP,
 ) : DistributedMessageBus<M, E>
     where M : Message<*, *>, M : AggregateIdCapable, M : NamedAggregate, E : MessageExchange<*, M> {
     private val streamOps = redisTemplate.opsForStream<String, String>()
@@ -91,17 +96,99 @@ abstract class AbstractRedisMessageBus<M, E>(
         group: String
     ): Flux<E> {
         val streamOffset = StreamOffset.create(topic, ReadOffset.lastConsumed())
-        return StreamReceiver.create(
+        val liveRecords = StreamReceiver.create(
             redisTemplate.connectionFactory,
             options
         )
-            .receive(consumer, streamOffset).map {
-                val message = requireNotNull(it.value[MESSAGE_FIELD]).toObject(messageType)
-                message.withReadOnly()
-                val acknowledgePublisher = streamOps.acknowledge(topic, group, it.id).then()
-                message.toExchange(acknowledgePublisher)
-            }
+            .receive(consumer, streamOffset)
+        val records = if (recoveryOptions.enabled) {
+            val leaseRegistry = DefaultRedisConsumerLeaseRegistry(redisTemplate, recoveryOptions)
+            val leasedLiveRecords = leaseRegistry.withLease(
+                topic = topic,
+                consumer = consumer,
+                source = liveRecords,
+            )
+            val recoveredRecords = RedisPendingMessageRecoverer(
+                streamOps = streamOps,
+                scanner = DefaultRedisPendingMessageScanner(
+                    redisTemplate = redisTemplate,
+                    streamOps = streamOps,
+                    observer = messageBusObserver,
+                ),
+                leaseRegistry = leaseRegistry,
+                options = recoveryOptions,
+                observer = messageBusObserver,
+            ).recover(topic, consumer)
+            Flux.merge(
+                leasedLiveRecords,
+                recoveredRecords,
+            )
+        } else {
+            liveRecords
+        }
+        return records.handle<E> { record, sink ->
+            record.decode(topic, group, consumer.name, sink)
+        }
+    }
+
+    private fun MapRecord<String, String, String>.decode(
+        topic: String,
+        group: String,
+        consumerName: String,
+        sink: SynchronousSink<E>,
+    ) {
+        val encodedMessage = value[MESSAGE_FIELD]
+        if (encodedMessage == null) {
+            reportDecodeFailure(
+                failure = RedisMessageBusObservation.RecordDecodeFailed(
+                    topic = topic,
+                    consumerGroup = group,
+                    recordId = id.value,
+                    messageType = messageType.name,
+                    reason = RedisRecordDecodeFailureReason.MISSING_MESSAGE_FIELD,
+                    failureType = null,
+                ),
+                consumerName = consumerName,
+            )
+            return
+        }
+        try {
+            val message = encodedMessage.toObject(messageType)
+            message.withReadOnly()
+            val acknowledgePublisher = streamOps.acknowledge(topic, group, id).then()
+            sink.next(message.toExchange(acknowledgePublisher))
+        } catch (failure: JacksonException) {
+            reportDecodeFailure(
+                failure = RedisMessageBusObservation.RecordDecodeFailed(
+                    topic = topic,
+                    consumerGroup = group,
+                    recordId = id.value,
+                    messageType = messageType.name,
+                    reason = RedisRecordDecodeFailureReason.DESERIALIZATION_FAILED,
+                    failureType = failure.javaClass.name,
+                ),
+                consumerName = consumerName,
+            )
+        }
+    }
+
+    private fun reportDecodeFailure(
+        failure: RedisMessageBusObservation.RecordDecodeFailed,
+        consumerName: String,
+    ) {
+        messageBusObserver.notifySafely(failure)
+        log.error {
+            "Failed to decode Redis Stream record [${failure.recordId}] from topic [${failure.topic}] " +
+                "for consumer group [${failure.consumerGroup}] as consumer [$consumerName] " +
+                "with message type [${failure.messageType}], reason [${failure.reason}], " +
+                "and failure type [${failure.failureType}]. " +
+                "The record remains pending; its payload was omitted from this log."
+        }
     }
 
     abstract fun M.toExchange(acknowledgePublisher: Mono<Void>): E
+
+    companion object {
+        private val log = KotlinLogging.logger {}
+    }
 }

--- a/wow-redis/src/main/kotlin/me/ahoo/wow/redis/bus/RedisCommandBus.kt
+++ b/wow-redis/src/main/kotlin/me/ahoo/wow/redis/bus/RedisCommandBus.kt
@@ -20,16 +20,46 @@ import org.springframework.data.redis.core.ReactiveStringRedisTemplate
 import reactor.core.publisher.Mono
 import java.time.Duration
 
-class RedisCommandBus(
+class RedisCommandBus private constructor(
     redisTemplate: ReactiveStringRedisTemplate,
-    topicConverter: CommandTopicConverter = DefaultCommandTopicConverter,
-    pollTimeout: Duration = Duration.ofSeconds(2)
+    topicConverter: CommandTopicConverter,
+    pollTimeout: Duration,
+    recoveryOptions: RedisStreamRecoveryOptions,
+    messageBusObserver: RedisMessageBusObserver,
 ) : DistributedCommandBus,
     AbstractRedisMessageBus<CommandMessage<*>, ServerCommandExchange<*>>(
         redisTemplate,
         topicConverter,
         pollTimeout,
+        recoveryOptions,
+        messageBusObserver,
     ) {
+    constructor(
+        redisTemplate: ReactiveStringRedisTemplate,
+        topicConverter: CommandTopicConverter = DefaultCommandTopicConverter,
+        pollTimeout: Duration = Duration.ofSeconds(2),
+    ) : this(
+        redisTemplate = redisTemplate,
+        topicConverter = topicConverter,
+        pollTimeout = pollTimeout,
+        recoveryOptions = RedisStreamRecoveryOptions.DEFAULT,
+        messageBusObserver = RedisMessageBusObserver.NOOP,
+    )
+
+    constructor(
+        redisTemplate: ReactiveStringRedisTemplate,
+        recoveryOptions: RedisStreamRecoveryOptions,
+        observer: RedisMessageBusObserver = RedisMessageBusObserver.NOOP,
+        topicConverter: CommandTopicConverter = DefaultCommandTopicConverter,
+        pollTimeout: Duration = Duration.ofSeconds(2),
+    ) : this(
+        redisTemplate = redisTemplate,
+        topicConverter = topicConverter,
+        pollTimeout = pollTimeout,
+        recoveryOptions = recoveryOptions,
+        messageBusObserver = observer,
+    )
+
     override val messageType: Class<CommandMessage<*>>
         get() = CommandMessage::class.java
 

--- a/wow-redis/src/main/kotlin/me/ahoo/wow/redis/bus/RedisConsumerLeaseRegistry.kt
+++ b/wow-redis/src/main/kotlin/me/ahoo/wow/redis/bus/RedisConsumerLeaseRegistry.kt
@@ -1,0 +1,229 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.redis.bus
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import me.ahoo.wow.id.GlobalIdGenerator
+import org.springframework.data.redis.connection.stream.Consumer
+import org.springframework.data.redis.core.ReactiveStreamOperations
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate
+import org.springframework.data.redis.core.script.RedisScript
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+import java.util.HexFormat
+
+internal interface RedisConsumerLeaseRegistry {
+    fun <T : Any> withLease(
+        topic: String,
+        consumer: Consumer,
+        source: Flux<T>,
+    ): Flux<T>
+
+    fun findActiveConsumers(
+        topic: String,
+        group: String,
+        consumerNames: Set<String>,
+    ): Mono<Set<String>>
+}
+
+internal class DefaultRedisConsumerLeaseRegistry(
+    private val redisTemplate: ReactiveStringRedisTemplate,
+    options: RedisStreamRecoveryOptions,
+) : RedisConsumerLeaseRegistry {
+    private val streamOps: ReactiveStreamOperations<String, String, String> = redisTemplate.opsForStream()
+    private val minIdleTime = options.minIdleTime
+    private val heartbeatInterval = options.interval
+    private val leaseDuration = heartbeatInterval.multipliedBy(3)
+
+    override fun <T : Any> withLease(
+        topic: String,
+        consumer: Consumer,
+        source: Flux<T>,
+    ): Flux<T> {
+        return acquire(topic, consumer)
+            .map<LeaseState>(LeaseState::Acquired)
+            .onErrorResume { failure ->
+                log.warn(failure) {
+                    "Failed to acquire a Redis consumer lease for [$topic/${consumer.group}/${consumer.name}]. " +
+                        "Live delivery will continue with Redis consumer activity as the recovery safety net."
+                }
+                Mono.just(LeaseState.Unavailable)
+            }
+            .flatMapMany { leaseState ->
+                when (leaseState) {
+                    is LeaseState.Acquired -> Flux.usingWhen(
+                        Mono.just(leaseState.lease),
+                        { lease -> source.withHeartbeat(lease) },
+                        ::release,
+                        { lease, _ -> release(lease) },
+                        ::release,
+                    )
+
+                    LeaseState.Unavailable -> source
+                }
+            }
+    }
+
+    override fun findActiveConsumers(
+        topic: String,
+        group: String,
+        consumerNames: Set<String>,
+    ): Mono<Set<String>> {
+        if (consumerNames.isEmpty()) {
+            return Mono.just(emptySet())
+        }
+        val leasedConsumers = Flux.fromIterable(consumerNames)
+            .flatMap(
+                { consumerName ->
+                    redisTemplate.hasKey(leaseKey(topic, group, consumerName))
+                        .filter { active -> active }
+                        .map { consumerName }
+                },
+                MAX_LOOKUP_CONCURRENCY,
+            )
+            .collectList()
+            .map { activeConsumers -> activeConsumers.toSet() }
+        val recentlyActiveConsumers = streamOps.consumers(topic, group)
+            .filter { consumer ->
+                consumer.consumerName() in consumerNames && consumer.idleTime() < minIdleTime
+            }
+            .map { consumer -> consumer.consumerName() }
+            .collectList()
+            .map { activeConsumers -> activeConsumers.toSet() }
+        return Mono.zip(leasedConsumers, recentlyActiveConsumers)
+            .map { active -> active.t1 + active.t2 }
+            .onErrorResume { failure ->
+                log.warn(failure) {
+                    "Failed to resolve active Redis Stream consumers for [$topic/$group]. " +
+                        "Skipping recovery for [${consumerNames.size}] candidate consumer(s)."
+                }
+                Mono.just(consumerNames)
+            }
+    }
+
+    private fun acquire(topic: String, consumer: Consumer): Mono<Lease> {
+        val lease = Lease(
+            key = leaseKey(topic, consumer.group, consumer.name),
+            token = GlobalIdGenerator.generateAsString(),
+        )
+        return redisTemplate.opsForValue()
+            .set(lease.key, lease.token, leaseDuration)
+            .flatMap { acquired ->
+                if (acquired) {
+                    Mono.just(lease)
+                } else {
+                    Mono.error(IllegalStateException("Failed to acquire Redis consumer lease [${lease.key}]."))
+                }
+            }
+    }
+
+    private fun heartbeat(lease: Lease): Mono<Void> {
+        return Flux.interval(heartbeatInterval)
+            .concatMap { renew(lease) }
+            .then()
+            .onErrorResume { failure ->
+                log.warn(failure) {
+                    "Failed to renew Redis consumer lease [${lease.key}]. Live delivery will continue with " +
+                        "Redis consumer activity as the recovery safety net."
+                }
+                Mono.empty()
+            }
+    }
+
+    private fun <T : Any> Flux<T>.withHeartbeat(lease: Lease): Flux<T> {
+        return publish { shared ->
+            Flux.merge(
+                shared,
+                heartbeat(lease)
+                    .takeUntilOther(shared.ignoreElements())
+                    .thenMany(Flux.empty()),
+            )
+        }
+    }
+
+    private fun renew(lease: Lease): Mono<Void> {
+        return redisTemplate.execute(
+            RENEW_SCRIPT,
+            listOf(lease.key),
+            listOf(lease.token, leaseDuration.toMillis().toString()),
+        ).next()
+            .flatMap { renewed ->
+                if (renewed == SCRIPT_SUCCEEDED) {
+                    Mono.empty()
+                } else {
+                    Mono.error(IllegalStateException("Redis consumer lease [${lease.key}] is no longer owned."))
+                }
+            }
+    }
+
+    private fun release(lease: Lease): Mono<Void> {
+        return redisTemplate.execute(
+            RELEASE_SCRIPT,
+            listOf(lease.key),
+            listOf(lease.token),
+        ).then()
+            .onErrorResume { failure ->
+                log.warn(failure) {
+                    "Failed to release Redis consumer lease [${lease.key}]; it will expire after [$leaseDuration]."
+                }
+                Mono.empty()
+            }
+    }
+
+    private fun leaseKey(topic: String, group: String, consumerName: String): String {
+        val identity = "$topic\u0000$group\u0000$consumerName"
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest(identity.toByteArray(StandardCharsets.UTF_8))
+        return "$LEASE_KEY_PREFIX:${HexFormat.of().formatHex(digest)}"
+    }
+
+    private data class Lease(
+        val key: String,
+        val token: String,
+    )
+
+    private sealed interface LeaseState {
+        data class Acquired(val lease: Lease) : LeaseState
+        data object Unavailable : LeaseState
+    }
+
+    companion object {
+        private const val LEASE_KEY_PREFIX = "wow:redis:message-bus:consumer-lease"
+        private const val MAX_LOOKUP_CONCURRENCY = 16
+        private const val SCRIPT_SUCCEEDED = 1L
+        private val log = KotlinLogging.logger {}
+
+        private val RENEW_SCRIPT = RedisScript.of(
+            """
+            if redis.call('GET', KEYS[1]) == ARGV[1] then
+                return redis.call('PEXPIRE', KEYS[1], ARGV[2])
+            end
+            return 0
+            """.trimIndent(),
+            Long::class.java,
+        )
+
+        private val RELEASE_SCRIPT = RedisScript.of(
+            """
+            if redis.call('GET', KEYS[1]) == ARGV[1] then
+                return redis.call('DEL', KEYS[1])
+            end
+            return 0
+            """.trimIndent(),
+            Long::class.java,
+        )
+    }
+}

--- a/wow-redis/src/main/kotlin/me/ahoo/wow/redis/bus/RedisDomainEventBus.kt
+++ b/wow-redis/src/main/kotlin/me/ahoo/wow/redis/bus/RedisDomainEventBus.kt
@@ -20,16 +20,46 @@ import org.springframework.data.redis.core.ReactiveStringRedisTemplate
 import reactor.core.publisher.Mono
 import java.time.Duration
 
-class RedisDomainEventBus(
+class RedisDomainEventBus private constructor(
     redisTemplate: ReactiveStringRedisTemplate,
-    topicConverter: EventStreamTopicConverter = DefaultEventStreamTopicConverter,
-    pollTimeout: Duration = Duration.ofSeconds(2)
+    topicConverter: EventStreamTopicConverter,
+    pollTimeout: Duration,
+    recoveryOptions: RedisStreamRecoveryOptions,
+    messageBusObserver: RedisMessageBusObserver,
 ) : DistributedDomainEventBus,
     AbstractRedisMessageBus<DomainEventStream, EventStreamExchange>(
         redisTemplate,
         topicConverter,
         pollTimeout,
+        recoveryOptions,
+        messageBusObserver,
     ) {
+    constructor(
+        redisTemplate: ReactiveStringRedisTemplate,
+        topicConverter: EventStreamTopicConverter = DefaultEventStreamTopicConverter,
+        pollTimeout: Duration = Duration.ofSeconds(2),
+    ) : this(
+        redisTemplate = redisTemplate,
+        topicConverter = topicConverter,
+        pollTimeout = pollTimeout,
+        recoveryOptions = RedisStreamRecoveryOptions.DEFAULT,
+        messageBusObserver = RedisMessageBusObserver.NOOP,
+    )
+
+    constructor(
+        redisTemplate: ReactiveStringRedisTemplate,
+        recoveryOptions: RedisStreamRecoveryOptions,
+        observer: RedisMessageBusObserver = RedisMessageBusObserver.NOOP,
+        topicConverter: EventStreamTopicConverter = DefaultEventStreamTopicConverter,
+        pollTimeout: Duration = Duration.ofSeconds(2),
+    ) : this(
+        redisTemplate = redisTemplate,
+        topicConverter = topicConverter,
+        pollTimeout = pollTimeout,
+        recoveryOptions = recoveryOptions,
+        messageBusObserver = observer,
+    )
+
     override val messageType: Class<DomainEventStream>
         get() = DomainEventStream::class.java
 

--- a/wow-redis/src/main/kotlin/me/ahoo/wow/redis/bus/RedisMessageBusObserver.kt
+++ b/wow-redis/src/main/kotlin/me/ahoo/wow/redis/bus/RedisMessageBusObserver.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.redis.bus
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+
+/**
+ * Receives synchronous Redis message-bus recovery and decode observations.
+ *
+ * Implementations must be non-blocking. Callback failures are isolated from message delivery.
+ * Metrics adapters should use the observation type, outcome, or [RedisRecordDecodeFailureReason]
+ * as low-cardinality dimensions instead of topic, consumer-group, record, or message-type values.
+ */
+fun interface RedisMessageBusObserver {
+    fun onObservation(observation: RedisMessageBusObservation)
+
+    companion object {
+        @JvmField
+        val NOOP: RedisMessageBusObserver = RedisMessageBusObserver { }
+    }
+}
+
+/**
+ * Message payloads and [Throwable] instances are deliberately excluded so observers cannot retain
+ * sensitive payloads or failure object graphs.
+ */
+sealed interface RedisMessageBusObservation {
+    val topic: String
+    val consumerGroup: String
+
+    data class PendingSweepStarted(
+        override val topic: String,
+        override val consumerGroup: String,
+        val totalPendingMessages: Long,
+        val minMessageId: String?,
+        val maxMessageId: String?,
+    ) : RedisMessageBusObservation
+
+    data class PendingScanFailed(
+        override val topic: String,
+        override val consumerGroup: String,
+        val failureType: String,
+    ) : RedisMessageBusObservation
+
+    data class PendingClaimCompleted(
+        override val topic: String,
+        override val consumerGroup: String,
+        val requestedMessages: Long,
+        val claimedMessages: Long,
+    ) : RedisMessageBusObservation
+
+    data class PendingClaimFailed(
+        override val topic: String,
+        override val consumerGroup: String,
+        val requestedMessages: Long,
+        val claimedMessages: Long,
+        val failureType: String,
+    ) : RedisMessageBusObservation
+
+    data class RecordDecodeFailed(
+        override val topic: String,
+        override val consumerGroup: String,
+        val recordId: String,
+        val messageType: String,
+        val reason: RedisRecordDecodeFailureReason,
+        val failureType: String?,
+    ) : RedisMessageBusObservation
+}
+
+enum class RedisRecordDecodeFailureReason {
+    MISSING_MESSAGE_FIELD,
+    DESERIALIZATION_FAILED,
+}
+
+/**
+ * Dispatches each observation to an immutable observer snapshot in iteration order.
+ */
+class CompositeRedisMessageBusObserver(
+    observers: Iterable<RedisMessageBusObserver>,
+) : RedisMessageBusObserver {
+    private val observers = observers.toList()
+
+    override fun onObservation(observation: RedisMessageBusObservation) {
+        observers.forEach { observer -> observer.notifySafely(observation) }
+    }
+}
+
+@Suppress("TooGenericExceptionCaught") // Observer failures must remain outside the delivery chain.
+internal fun RedisMessageBusObserver.notifySafely(observation: RedisMessageBusObservation) {
+    try {
+        onObservation(observation)
+    } catch (failure: Exception) {
+        observerLog.warn {
+            "Redis message-bus observer [${javaClass.name}] failed while processing " +
+                "observation [${observation.javaClass.name}] with failure type [${failure.javaClass.name}]."
+        }
+    }
+}
+
+private val observerLog = KotlinLogging.logger {}

--- a/wow-redis/src/main/kotlin/me/ahoo/wow/redis/bus/RedisPendingMessageRecoverer.kt
+++ b/wow-redis/src/main/kotlin/me/ahoo/wow/redis/bus/RedisPendingMessageRecoverer.kt
@@ -1,0 +1,180 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.redis.bus
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.data.redis.connection.stream.Consumer
+import org.springframework.data.redis.connection.stream.MapRecord
+import org.springframework.data.redis.core.ReactiveStreamOperations
+import reactor.core.publisher.Flux
+import java.util.concurrent.atomic.AtomicLong
+
+internal class RedisPendingMessageRecoverer(
+    private val streamOps: ReactiveStreamOperations<String, String, String>,
+    private val scanner: RedisPendingMessageScanner,
+    private val leaseRegistry: RedisConsumerLeaseRegistry,
+    private val options: RedisStreamRecoveryOptions,
+    private val observer: RedisMessageBusObserver = RedisMessageBusObserver.NOOP,
+) {
+    fun recover(
+        topic: String,
+        consumer: Consumer,
+    ): Flux<MapRecord<String, String, String>> {
+        if (!options.enabled) {
+            return Flux.empty()
+        }
+        return Flux.defer {
+            recoverSweep(
+                topic = topic,
+                consumer = consumer,
+                request = RedisPendingScanRequest(
+                    cursor = null,
+                    sweepEnd = null,
+                    count = options.batchSize,
+                ),
+            ).onErrorResume { failure ->
+                log.warn(failure) {
+                    "Redis Stream pending-message recovery failed for topic [$topic] and consumer group " +
+                        "[${consumer.group}]; live delivery remains active and recovery will retry after " +
+                        "[${options.interval}]."
+                }
+                Flux.empty()
+            }
+        }.repeatWhen { completedSweeps ->
+            completedSweeps.delayElements(options.interval)
+        }
+    }
+
+    private fun recoverSweep(
+        topic: String,
+        consumer: Consumer,
+        request: RedisPendingScanRequest,
+    ): Flux<MapRecord<String, String, String>> {
+        return scanner.scan(topic, consumer.group, request)
+            .doOnError { failure ->
+                observer.notifySafely(
+                    RedisMessageBusObservation.PendingScanFailed(
+                        topic = topic,
+                        consumerGroup = consumer.group,
+                        failureType = failure.javaClass.name,
+                    ),
+                )
+            }
+            .flatMapMany { page ->
+                val nextPage = if (page.complete) {
+                    Flux.empty()
+                } else {
+                    Flux.defer {
+                        recoverSweep(topic, consumer, page.nextRequest())
+                    }
+                }
+                recoverPage(topic, consumer, page).concatWith(nextPage)
+            }
+    }
+
+    private fun recoverPage(
+        topic: String,
+        consumer: Consumer,
+        page: RedisPendingMessagePage,
+    ): Flux<MapRecord<String, String, String>> {
+        val candidates = page.messages.asSequence()
+            .filter { pending -> pending.consumerName != consumer.name }
+            .filter { pending -> pending.elapsedTimeSinceLastDelivery >= options.minIdleTime }
+            .toList()
+        if (candidates.isEmpty()) {
+            return Flux.empty()
+        }
+        return leaseRegistry.findActiveConsumers(
+            topic = topic,
+            group = consumer.group,
+            consumerNames = candidates.mapTo(mutableSetOf()) { pending -> pending.consumerName },
+        ).flatMapMany { activeConsumers ->
+            val claimableMessages = candidates.filterNot { pending ->
+                pending.consumerName in activeConsumers
+            }
+            if (claimableMessages.isEmpty()) {
+                Flux.empty()
+            } else {
+                claim(topic, consumer, claimableMessages)
+            }
+        }
+    }
+
+    private fun RedisPendingMessagePage.nextRequest(): RedisPendingScanRequest {
+        return RedisPendingScanRequest(
+            cursor = requireNotNull(messages.lastOrNull()).id.value,
+            sweepEnd = requireNotNull(sweepEnd),
+            count = options.batchSize,
+        )
+    }
+
+    @Suppress("SpreadOperator") // Spring Data Redis exposes claimed record identifiers as varargs.
+    private fun claim(
+        topic: String,
+        consumer: Consumer,
+        pendingMessages: List<RedisPendingMessage>,
+    ): Flux<MapRecord<String, String, String>> {
+        val recordIds = pendingMessages.map { pending -> pending.id }.toTypedArray()
+        val minDeliveryCount = pendingMessages.minOf { pending -> pending.deliveryCount }
+        val maxDeliveryCount = pendingMessages.maxOf { pending -> pending.deliveryCount }
+        log.debug {
+            "Attempting to recover [${recordIds.size}] pending message(s) from Redis Stream [$topic] " +
+                "for consumer group [${consumer.group}] as consumer [${consumer.name}]; observed delivery count " +
+                "[$minDeliveryCount..$maxDeliveryCount] at XPENDING scan time."
+        }
+        val claimedCount = AtomicLong()
+        // The response is bounded by recordIds/options.batchSize. Materialize the complete XCLAIM
+        // response so downstream cancellation cannot hide the final claim outcome.
+        return streamOps.claim(
+            topic,
+            consumer.group,
+            consumer.name,
+            options.minIdleTime,
+            *recordIds,
+        ).doOnNext {
+            claimedCount.incrementAndGet()
+        }.collectList()
+            .doOnSuccess {
+                log.info {
+                    "Redis Stream pending-message recovery completed for topic [$topic] and consumer group " +
+                        "[${consumer.group}]: requested [${recordIds.size}], claimed [${claimedCount.get()}], " +
+                        "observed delivery count [$minDeliveryCount..$maxDeliveryCount] at XPENDING scan time."
+                }
+                observer.notifySafely(
+                    RedisMessageBusObservation.PendingClaimCompleted(
+                        topic = topic,
+                        consumerGroup = consumer.group,
+                        requestedMessages = recordIds.size.toLong(),
+                        claimedMessages = claimedCount.get(),
+                    ),
+                )
+            }
+            .doOnError { failure ->
+                observer.notifySafely(
+                    RedisMessageBusObservation.PendingClaimFailed(
+                        topic = topic,
+                        consumerGroup = consumer.group,
+                        requestedMessages = recordIds.size.toLong(),
+                        claimedMessages = claimedCount.get(),
+                        failureType = failure.javaClass.name,
+                    ),
+                )
+            }
+            .flatMapMany { claimedRecords -> Flux.fromIterable(claimedRecords) }
+    }
+
+    companion object {
+        private val log = KotlinLogging.logger {}
+    }
+}

--- a/wow-redis/src/main/kotlin/me/ahoo/wow/redis/bus/RedisPendingMessageScanner.kt
+++ b/wow-redis/src/main/kotlin/me/ahoo/wow/redis/bus/RedisPendingMessageScanner.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.redis.bus
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.data.redis.connection.stream.RecordId
+import org.springframework.data.redis.core.ReactiveStreamOperations
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate
+import org.springframework.data.redis.core.script.RedisScript
+import reactor.core.publisher.Mono
+import java.time.Duration
+
+internal data class RedisPendingMessage(
+    val id: RecordId,
+    val consumerName: String,
+    val elapsedTimeSinceLastDelivery: Duration,
+    val deliveryCount: Long,
+) {
+    init {
+        require(deliveryCount > 0) {
+            "Redis pending-message delivery count must be positive."
+        }
+    }
+}
+
+internal data class RedisPendingMessagePage(
+    val sweepEnd: String?,
+    val messages: List<RedisPendingMessage>,
+    val complete: Boolean,
+)
+
+internal data class RedisPendingScanRequest(
+    val cursor: String?,
+    val sweepEnd: String?,
+    val count: Long,
+)
+
+internal fun interface RedisPendingMessageScanner {
+    fun scan(
+        topic: String,
+        group: String,
+        request: RedisPendingScanRequest,
+    ): Mono<RedisPendingMessagePage>
+}
+
+/**
+ * Uses a small Lua wrapper because the bounded reactive XPENDING path encodes range bounds
+ * as ByteBuffer values while Lettuce expects String stream IDs.
+ */
+@Suppress("UNCHECKED_CAST")
+internal class DefaultRedisPendingMessageScanner(
+    private val redisTemplate: ReactiveStringRedisTemplate,
+    private val streamOps: ReactiveStreamOperations<String, String, String>,
+    private val observer: RedisMessageBusObserver = RedisMessageBusObserver.NOOP,
+) : RedisPendingMessageScanner {
+    override fun scan(
+        topic: String,
+        group: String,
+        request: RedisPendingScanRequest,
+    ): Mono<RedisPendingMessagePage> {
+        val sweepEndPublisher = request.sweepEnd?.let(Mono<String>::just) ?: pendingSweepEnd(topic, group)
+        return sweepEndPublisher.flatMap { sweepEnd ->
+            redisTemplate.execute(
+                PENDING_SCRIPT,
+                listOf(topic),
+                listOf(
+                    group,
+                    request.cursor?.let { "($it" } ?: "-",
+                    sweepEnd,
+                    request.count.toString(),
+                ),
+            ).next()
+                .defaultIfEmpty(emptyList())
+                .map { flattened -> flattened.toPage(sweepEnd, request.count) }
+        }.switchIfEmpty(
+            Mono.just(RedisPendingMessagePage(sweepEnd = null, messages = emptyList(), complete = true)),
+        )
+    }
+
+    private fun pendingSweepEnd(topic: String, group: String): Mono<String> {
+        return streamOps.pending(topic, group)
+            .doOnNext { summary ->
+                val hasPendingMessages = summary.totalPendingMessages > 0
+                val observation = RedisMessageBusObservation.PendingSweepStarted(
+                    topic = topic,
+                    consumerGroup = group,
+                    totalPendingMessages = summary.totalPendingMessages,
+                    minMessageId = if (hasPendingMessages) summary.minMessageId() else null,
+                    maxMessageId = if (hasPendingMessages) summary.maxMessageId() else null,
+                )
+                observer.notifySafely(observation)
+                if (hasPendingMessages) {
+                    log.debug {
+                        "Redis Stream pending-message sweep started for topic [$topic] and consumer group [$group]: " +
+                            "total [${summary.totalPendingMessages}], range " +
+                            "[${observation.minMessageId}..${observation.maxMessageId}]."
+                    }
+                }
+            }
+            .filter { summary -> summary.totalPendingMessages > 0 }
+            .map { summary -> requireNotNull(summary.maxMessageId()) }
+    }
+
+    private fun List<Any>.toPage(sweepEnd: String, count: Long): RedisPendingMessagePage {
+        require(size % FIELDS_PER_MESSAGE == 0) {
+            "Unexpected XPENDING response size: $size."
+        }
+        val messages = chunked(FIELDS_PER_MESSAGE).map { fields ->
+            RedisPendingMessage(
+                id = RecordId.of(fields[0].toString()),
+                consumerName = fields[1].toString(),
+                elapsedTimeSinceLastDelivery = Duration.ofMillis(fields[2].asLong()),
+                deliveryCount = fields[3].asLong(),
+            )
+        }
+        val complete = messages.size.toLong() < count || messages.lastOrNull()?.id?.value == sweepEnd
+        return RedisPendingMessagePage(
+            sweepEnd = sweepEnd,
+            messages = messages,
+            complete = complete,
+        )
+    }
+
+    private fun Any.asLong(): Long {
+        return when (this) {
+            is Number -> toLong()
+            else -> toString().toLong()
+        }
+    }
+
+    companion object {
+        private const val FIELDS_PER_MESSAGE = 4
+        private val log = KotlinLogging.logger {}
+
+        private val PENDING_SCRIPT: RedisScript<List<Any>> = RedisScript.of(
+            """
+            local rows = redis.call('XPENDING', KEYS[1], ARGV[1], ARGV[2], ARGV[3], ARGV[4])
+            local flattened = {}
+            for _, row in ipairs(rows) do
+                flattened[#flattened + 1] = row[1]
+                flattened[#flattened + 1] = row[2]
+                flattened[#flattened + 1] = row[3]
+                flattened[#flattened + 1] = row[4]
+            end
+            return flattened
+            """.trimIndent(),
+            List::class.java as Class<List<Any>>,
+        )
+    }
+}

--- a/wow-redis/src/main/kotlin/me/ahoo/wow/redis/bus/RedisStateEventBus.kt
+++ b/wow-redis/src/main/kotlin/me/ahoo/wow/redis/bus/RedisStateEventBus.kt
@@ -20,16 +20,46 @@ import org.springframework.data.redis.core.ReactiveStringRedisTemplate
 import reactor.core.publisher.Mono
 import java.time.Duration
 
-class RedisStateEventBus(
+class RedisStateEventBus private constructor(
     redisTemplate: ReactiveStringRedisTemplate,
-    topicConverter: StateEventTopicConverter = DefaultStateEventTopicConverter,
-    pollTimeout: Duration = Duration.ofSeconds(2)
+    topicConverter: StateEventTopicConverter,
+    pollTimeout: Duration,
+    recoveryOptions: RedisStreamRecoveryOptions,
+    messageBusObserver: RedisMessageBusObserver,
 ) : DistributedStateEventBus,
     AbstractRedisMessageBus<StateEvent<*>, StateEventExchange<*>>(
         redisTemplate,
         topicConverter,
         pollTimeout,
+        recoveryOptions,
+        messageBusObserver,
     ) {
+    constructor(
+        redisTemplate: ReactiveStringRedisTemplate,
+        topicConverter: StateEventTopicConverter = DefaultStateEventTopicConverter,
+        pollTimeout: Duration = Duration.ofSeconds(2),
+    ) : this(
+        redisTemplate = redisTemplate,
+        topicConverter = topicConverter,
+        pollTimeout = pollTimeout,
+        recoveryOptions = RedisStreamRecoveryOptions.DEFAULT,
+        messageBusObserver = RedisMessageBusObserver.NOOP,
+    )
+
+    constructor(
+        redisTemplate: ReactiveStringRedisTemplate,
+        recoveryOptions: RedisStreamRecoveryOptions,
+        observer: RedisMessageBusObserver = RedisMessageBusObserver.NOOP,
+        topicConverter: StateEventTopicConverter = DefaultStateEventTopicConverter,
+        pollTimeout: Duration = Duration.ofSeconds(2),
+    ) : this(
+        redisTemplate = redisTemplate,
+        topicConverter = topicConverter,
+        pollTimeout = pollTimeout,
+        recoveryOptions = recoveryOptions,
+        messageBusObserver = observer,
+    )
+
     override val messageType: Class<StateEvent<*>>
         get() = StateEvent::class.java
 

--- a/wow-redis/src/main/kotlin/me/ahoo/wow/redis/bus/RedisStreamRecoveryOptions.kt
+++ b/wow-redis/src/main/kotlin/me/ahoo/wow/redis/bus/RedisStreamRecoveryOptions.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.redis.bus
+
+import java.time.Duration
+
+data class RedisStreamRecoveryOptions(
+    val enabled: Boolean = true,
+    val minIdleTime: Duration = Duration.ofMinutes(5),
+    val interval: Duration = Duration.ofSeconds(30),
+    val batchSize: Long = 100
+) {
+    init {
+        require(minIdleTime >= MIN_DURATION) {
+            "minIdleTime must be at least 1 millisecond."
+        }
+        require(interval >= MIN_DURATION) {
+            "interval must be at least 1 millisecond."
+        }
+        require(batchSize > 0) {
+            "batchSize must be positive."
+        }
+    }
+
+    companion object {
+        private val MIN_DURATION = Duration.ofMillis(1)
+
+        @JvmField
+        val DEFAULT: RedisStreamRecoveryOptions = RedisStreamRecoveryOptions()
+
+        @JvmField
+        val DISABLED: RedisStreamRecoveryOptions = RedisStreamRecoveryOptions(enabled = false)
+    }
+}

--- a/wow-redis/src/test/kotlin/me/ahoo/wow/redis/bus/RedisConsumerLeaseRegistryTest.kt
+++ b/wow-redis/src/test/kotlin/me/ahoo/wow/redis/bus/RedisConsumerLeaseRegistryTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.redis.bus
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.springframework.data.redis.connection.stream.Consumer
+import org.springframework.data.redis.core.ReactiveStreamOperations
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate
+import org.springframework.data.redis.core.ReactiveValueOperations
+import org.springframework.data.redis.core.script.RedisScript
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+import java.time.Duration
+
+class RedisConsumerLeaseRegistryTest {
+    private val redisTemplate = mockk<ReactiveStringRedisTemplate>()
+    private val streamOps = mockk<ReactiveStreamOperations<String, String, String>>()
+
+    init {
+        every { redisTemplate.opsForStream<String, String>() } returns streamOps
+    }
+
+    @Test
+    fun `should return immediately for an empty consumer set`() {
+        val registry = DefaultRedisConsumerLeaseRegistry(redisTemplate, recoveryOptions())
+
+        StepVerifier.create(registry.findActiveConsumers("topic", "group", emptySet()))
+            .expectNext(emptySet())
+            .verifyComplete()
+    }
+
+    @Test
+    fun `should fail closed when consumer liveness lookup fails`() {
+        every { redisTemplate.hasKey(any()) } returns Mono.error(IllegalStateException("Redis unavailable"))
+        every { streamOps.consumers("topic", "group") } returns Flux.empty()
+        val registry = DefaultRedisConsumerLeaseRegistry(redisTemplate, recoveryOptions())
+
+        StepVerifier.create(
+            registry.findActiveConsumers("topic", "group", setOf("consumer-1", "consumer-2")),
+        )
+            .expectNext(setOf("consumer-1", "consumer-2"))
+            .verifyComplete()
+    }
+
+    @Test
+    fun `should continue live delivery when lease acquisition fails`() {
+        val valueOps = mockk<ReactiveValueOperations<String, String>>()
+        every { redisTemplate.opsForValue() } returns valueOps
+        every {
+            valueOps.set(any(), any(), any<Duration>())
+        } returns Mono.just(false)
+        val registry = DefaultRedisConsumerLeaseRegistry(redisTemplate, recoveryOptions())
+
+        StepVerifier.create(
+            registry.withLease(
+                topic = "topic",
+                consumer = Consumer.from("group", "consumer"),
+                source = Flux.just("message"),
+            ),
+        )
+            .expectNext("message")
+            .verifyComplete()
+    }
+
+    @Test
+    fun `should continue live delivery when lease renewal fails`() {
+        val valueOps = mockk<ReactiveValueOperations<String, String>>()
+        every { redisTemplate.opsForValue() } returns valueOps
+        every {
+            valueOps.set(any(), any(), any<Duration>())
+        } returns Mono.just(true)
+        every {
+            redisTemplate.execute(
+                any<RedisScript<Long>>(),
+                any<List<String>>(),
+                any<List<*>>(),
+            )
+        } returns Flux.just(0L)
+        val registry = DefaultRedisConsumerLeaseRegistry(redisTemplate, recoveryOptions())
+
+        StepVerifier.withVirtualTime {
+            registry.withLease(
+                topic = "topic",
+                consumer = Consumer.from("group", "consumer"),
+                source = Flux.never<String>(),
+            ).takeUntilOther(Mono.delay(Duration.ofSeconds(2)))
+        }
+            .expectSubscription()
+            .expectNoEvent(Duration.ofSeconds(2))
+            .thenAwait(Duration.ofMillis(1))
+            .verifyComplete()
+    }
+
+    private fun recoveryOptions(): RedisStreamRecoveryOptions {
+        return RedisStreamRecoveryOptions(
+            minIdleTime = Duration.ofSeconds(1),
+            interval = Duration.ofSeconds(1),
+        )
+    }
+}

--- a/wow-redis/src/test/kotlin/me/ahoo/wow/redis/bus/RedisMessageBusObserverTest.kt
+++ b/wow-redis/src/test/kotlin/me/ahoo/wow/redis/bus/RedisMessageBusObserverTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.redis.bus
+
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+
+class RedisMessageBusObserverTest {
+    @Test
+    fun `should isolate observer failures and preserve snapshot order`() {
+        val calls = mutableListOf<String>()
+        val observers = mutableListOf(
+            RedisMessageBusObserver {
+                calls += "first"
+                throw IllegalStateException("observer failed")
+            },
+            RedisMessageBusObserver { calls += "second" },
+        )
+        val composite = CompositeRedisMessageBusObserver(observers)
+        observers += RedisMessageBusObserver { calls += "late" }
+
+        composite.onObservation(
+            RedisMessageBusObservation.PendingScanFailed(
+                topic = "topic",
+                consumerGroup = "group",
+                failureType = IllegalStateException::class.java.name,
+            ),
+        )
+
+        calls.assert().containsExactly("first", "second")
+    }
+}

--- a/wow-redis/src/test/kotlin/me/ahoo/wow/redis/bus/RedisPendingMessageRecovererTest.kt
+++ b/wow-redis/src/test/kotlin/me/ahoo/wow/redis/bus/RedisPendingMessageRecovererTest.kt
@@ -61,12 +61,16 @@ class RedisPendingMessageRecovererTest {
             scanner.scan(topic, group, scanRequest())
         } returns Mono.just(page("1-0", listOf(pending("1-0", currentConsumer.name)), complete = true))
 
-        StepVerifier.create(
+        StepVerifier.withVirtualTime {
             recoverer(options(interval = Duration.ofDays(1)))
                 .recover(topic, currentConsumer)
-                .takeUntilOther(Mono.delay(Duration.ofMillis(20))),
-        ).verifyComplete()
+                .takeUntilOther(Mono.delay(Duration.ofSeconds(1)))
+        }
+            .expectSubscription()
+            .thenAwait(Duration.ofSeconds(1))
+            .verifyComplete()
 
+        verify(exactly = 1) { scanner.scan(topic, group, scanRequest()) }
         verify(exactly = 0) {
             streamOps.claim(
                 topic,
@@ -88,11 +92,14 @@ class RedisPendingMessageRecovererTest {
             leaseRegistry.findActiveConsumers(topic, group, setOf(activePeer))
         } returns Mono.just(setOf(activePeer))
 
-        StepVerifier.create(
+        StepVerifier.withVirtualTime {
             recoverer(options(interval = Duration.ofDays(1)))
                 .recover(topic, currentConsumer)
-                .takeUntilOther(Mono.delay(Duration.ofMillis(20))),
-        ).verifyComplete()
+                .takeUntilOther(Mono.delay(Duration.ofSeconds(1)))
+        }
+            .expectSubscription()
+            .thenAwait(Duration.ofSeconds(1))
+            .verifyComplete()
 
         verify(exactly = 1) {
             leaseRegistry.findActiveConsumers(topic, group, setOf(activePeer))
@@ -322,11 +329,14 @@ class RedisPendingMessageRecovererTest {
         } returns Flux.empty()
         val observations = mutableListOf<RedisMessageBusObservation>()
 
-        StepVerifier.create(
+        StepVerifier.withVirtualTime {
             recoverer(options(interval = Duration.ofDays(1)), observations)
                 .recover(topic, currentConsumer)
-                .takeUntilOther(Mono.delay(Duration.ofMillis(20))),
-        ).verifyComplete()
+                .takeUntilOther(Mono.delay(Duration.ofSeconds(1)))
+        }
+            .expectSubscription()
+            .thenAwait(Duration.ofSeconds(1))
+            .verifyComplete()
 
         observations.assert().containsExactly(
             RedisMessageBusObservation.PendingClaimCompleted(

--- a/wow-redis/src/test/kotlin/me/ahoo/wow/redis/bus/RedisPendingMessageRecovererTest.kt
+++ b/wow-redis/src/test/kotlin/me/ahoo/wow/redis/bus/RedisPendingMessageRecovererTest.kt
@@ -1,0 +1,395 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.redis.bus
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import org.springframework.data.redis.connection.stream.Consumer
+import org.springframework.data.redis.connection.stream.MapRecord
+import org.springframework.data.redis.connection.stream.RecordId
+import org.springframework.data.redis.core.ReactiveStreamOperations
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+import java.time.Duration
+
+class RedisPendingMessageRecovererTest {
+    private val topic = "topic"
+    private val group = "group"
+    private val currentConsumer = Consumer.from(group, "current")
+    private val streamOps = mockk<ReactiveStreamOperations<String, String, String>>()
+    private val scanner = mockk<RedisPendingMessageScanner>()
+    private val leaseRegistry = mockk<RedisConsumerLeaseRegistry>()
+
+    init {
+        every {
+            leaseRegistry.findActiveConsumers(any(), any(), any())
+        } returns Mono.just(emptySet())
+    }
+
+    @Test
+    fun `should not scan pending messages when recovery is disabled`() {
+        val recoverer = RedisPendingMessageRecoverer(
+            streamOps = streamOps,
+            scanner = scanner,
+            leaseRegistry = leaseRegistry,
+            options = RedisStreamRecoveryOptions.DISABLED,
+        )
+
+        StepVerifier.create(recoverer.recover(topic, currentConsumer)).verifyComplete()
+
+        verify(exactly = 0) { scanner.scan(any(), any(), any()) }
+    }
+
+    @Test
+    fun `should not claim messages owned by the current consumer`() {
+        every {
+            scanner.scan(topic, group, scanRequest())
+        } returns Mono.just(page("1-0", listOf(pending("1-0", currentConsumer.name)), complete = true))
+
+        StepVerifier.create(
+            recoverer(options(interval = Duration.ofDays(1)))
+                .recover(topic, currentConsumer)
+                .takeUntilOther(Mono.delay(Duration.ofMillis(20))),
+        ).verifyComplete()
+
+        verify(exactly = 0) {
+            streamOps.claim(
+                topic,
+                group,
+                currentConsumer.name,
+                any<Duration>(),
+                *anyVararg<RecordId>(),
+            )
+        }
+    }
+
+    @Test
+    fun `should not claim messages owned by an active peer`() {
+        val activePeer = "active-peer"
+        every {
+            scanner.scan(topic, group, scanRequest())
+        } returns Mono.just(page("1-0", listOf(pending("1-0", activePeer)), complete = true))
+        every {
+            leaseRegistry.findActiveConsumers(topic, group, setOf(activePeer))
+        } returns Mono.just(setOf(activePeer))
+
+        StepVerifier.create(
+            recoverer(options(interval = Duration.ofDays(1)))
+                .recover(topic, currentConsumer)
+                .takeUntilOther(Mono.delay(Duration.ofMillis(20))),
+        ).verifyComplete()
+
+        verify(exactly = 1) {
+            leaseRegistry.findActiveConsumers(topic, group, setOf(activePeer))
+        }
+        verify(exactly = 0) {
+            streamOps.claim(
+                topic,
+                group,
+                currentConsumer.name,
+                any<Duration>(),
+                *anyVararg<RecordId>(),
+            )
+        }
+    }
+
+    @Test
+    fun `should claim only inactive peers and report the outcome`() {
+        val activePending = pending("1-0", "active-peer")
+        val inactivePending = pending("2-0", "inactive-peer", deliveryCount = 7)
+        every {
+            scanner.scan(topic, group, scanRequest())
+        } returns Mono.just(page("2-0", listOf(activePending, inactivePending), complete = true))
+        every {
+            leaseRegistry.findActiveConsumers(topic, group, setOf("active-peer", "inactive-peer"))
+        } returns Mono.just(setOf("active-peer"))
+        val claimedRecord = mockk<MapRecord<String, String, String>>()
+        every {
+            streamOps.claim(
+                topic,
+                group,
+                currentConsumer.name,
+                Duration.ofSeconds(1),
+                inactivePending.id,
+            )
+        } returns Flux.just(claimedRecord)
+        val observations = mutableListOf<RedisMessageBusObservation>()
+
+        StepVerifier.create(
+            recoverer(options(interval = Duration.ofDays(1)), observations)
+                .recover(topic, currentConsumer)
+                .take(1),
+        )
+            .expectNext(claimedRecord)
+            .verifyComplete()
+
+        observations.assert().containsExactly(
+            RedisMessageBusObservation.PendingClaimCompleted(
+                topic = topic,
+                consumerGroup = group,
+                requestedMessages = 1,
+                claimedMessages = 1,
+            ),
+        )
+    }
+
+    @Test
+    fun `should retry a failed scan without terminating recovery`() {
+        val requests = mutableListOf<RedisPendingScanRequest>()
+        val inactivePending = pending("1-0", "inactive-peer")
+        every {
+            scanner.scan(topic, group, capture(requests))
+        } returnsMany listOf(
+            Mono.error(IllegalStateException("scan failed")),
+            Mono.just(page("1-0", listOf(inactivePending), complete = true)),
+        )
+        val claimedRecord = mockk<MapRecord<String, String, String>>()
+        every {
+            streamOps.claim(
+                topic,
+                group,
+                currentConsumer.name,
+                Duration.ofSeconds(1),
+                inactivePending.id,
+            )
+        } returns Flux.just(claimedRecord)
+        val observations = mutableListOf<RedisMessageBusObservation>()
+
+        StepVerifier.withVirtualTime {
+            recoverer(options(), observations).recover(topic, currentConsumer).take(1)
+        }
+            .expectSubscription()
+            .expectNoEvent(Duration.ofSeconds(1))
+            .thenAwait(Duration.ofMillis(1))
+            .expectNext(claimedRecord)
+            .verifyComplete()
+
+        requests.map(RedisPendingScanRequest::cursor).assert().containsExactly(null, null)
+        observations.first().assert().isEqualTo(
+            RedisMessageBusObservation.PendingScanFailed(
+                topic = topic,
+                consumerGroup = group,
+                failureType = IllegalStateException::class.java.name,
+            ),
+        )
+    }
+
+    @Test
+    fun `should retry a failed claim without terminating recovery`() {
+        val inactivePending = pending("1-0", "inactive-peer")
+        every {
+            scanner.scan(topic, group, scanRequest())
+        } returns Mono.just(page("1-0", listOf(inactivePending), complete = true))
+        val claimedRecord = mockk<MapRecord<String, String, String>>()
+        every {
+            streamOps.claim(
+                topic,
+                group,
+                currentConsumer.name,
+                Duration.ofSeconds(1),
+                inactivePending.id,
+            )
+        } returnsMany listOf(
+            Flux.error(IllegalStateException("claim failed")),
+            Flux.just(claimedRecord),
+        )
+        val observations = mutableListOf<RedisMessageBusObservation>()
+
+        StepVerifier.withVirtualTime {
+            recoverer(options(), observations).recover(topic, currentConsumer).take(1)
+        }
+            .expectSubscription()
+            .expectNoEvent(Duration.ofSeconds(1))
+            .thenAwait(Duration.ofMillis(1))
+            .expectNext(claimedRecord)
+            .verifyComplete()
+
+        observations.filterIsInstance<RedisMessageBusObservation.PendingClaimFailed>()
+            .assert()
+            .hasSize(1)
+        observations.last().assert().isEqualTo(
+            RedisMessageBusObservation.PendingClaimCompleted(
+                topic = topic,
+                consumerGroup = group,
+                requestedMessages = 1,
+                claimedMessages = 1,
+            ),
+        )
+    }
+
+    @Test
+    fun `should drain every page in a bounded sweep before waiting`() {
+        val oldPending = pending("3-0", "old")
+        val requests = mutableListOf<RedisPendingScanRequest>()
+        every {
+            scanner.scan(topic, group, capture(requests))
+        } returnsMany listOf(
+            Mono.just(
+                page(
+                    sweepEnd = "3-0",
+                    messages = listOf(
+                        pending("1-0", currentConsumer.name),
+                        pending("2-0", currentConsumer.name),
+                    ),
+                    complete = false,
+                ),
+            ),
+            Mono.just(page("3-0", listOf(oldPending), complete = true)),
+        )
+        val claimedRecord = mockk<MapRecord<String, String, String>>()
+        every {
+            streamOps.claim(
+                topic,
+                group,
+                currentConsumer.name,
+                Duration.ofSeconds(1),
+                oldPending.id,
+            )
+        } returns Flux.just(claimedRecord)
+
+        StepVerifier.create(
+            recoverer(options(interval = Duration.ofDays(1), batchSize = 2))
+                .recover(topic, currentConsumer)
+                .take(1),
+        )
+            .expectNext(claimedRecord)
+            .verifyComplete()
+
+        requests.map(RedisPendingScanRequest::cursor).assert().containsExactly(null, "2-0")
+        requests.map(RedisPendingScanRequest::sweepEnd).assert().containsExactly(null, "3-0")
+    }
+
+    @Test
+    fun `should revisit a pending message that was too young in the previous sweep`() {
+        val youngPending = pending("1-0", "old", elapsedTime = Duration.ZERO)
+        val idlePending = pending("1-0", "old", elapsedTime = Duration.ofSeconds(2))
+        every {
+            scanner.scan(topic, group, scanRequest())
+        } returnsMany listOf(
+            Mono.just(page("1-0", listOf(youngPending), complete = true)),
+            Mono.just(page("1-0", listOf(idlePending), complete = true)),
+        )
+        val claimedRecord = mockk<MapRecord<String, String, String>>()
+        every {
+            streamOps.claim(
+                topic,
+                group,
+                currentConsumer.name,
+                Duration.ofSeconds(1),
+                idlePending.id,
+            )
+        } returns Flux.just(claimedRecord)
+
+        StepVerifier.withVirtualTime {
+            recoverer(options()).recover(topic, currentConsumer).take(1)
+        }
+            .expectSubscription()
+            .expectNoEvent(Duration.ofSeconds(1))
+            .thenAwait(Duration.ofMillis(1))
+            .expectNext(claimedRecord)
+            .verifyComplete()
+    }
+
+    @Test
+    fun `should report when a claim race returns no records`() {
+        val inactivePending = pending("1-0", "inactive-peer")
+        every {
+            scanner.scan(topic, group, scanRequest())
+        } returns Mono.just(page("1-0", listOf(inactivePending), complete = true))
+        every {
+            streamOps.claim(
+                topic,
+                group,
+                currentConsumer.name,
+                Duration.ofSeconds(1),
+                inactivePending.id,
+            )
+        } returns Flux.empty()
+        val observations = mutableListOf<RedisMessageBusObservation>()
+
+        StepVerifier.create(
+            recoverer(options(interval = Duration.ofDays(1)), observations)
+                .recover(topic, currentConsumer)
+                .takeUntilOther(Mono.delay(Duration.ofMillis(20))),
+        ).verifyComplete()
+
+        observations.assert().containsExactly(
+            RedisMessageBusObservation.PendingClaimCompleted(
+                topic = topic,
+                consumerGroup = group,
+                requestedMessages = 1,
+                claimedMessages = 0,
+            ),
+        )
+    }
+
+    private fun recoverer(
+        options: RedisStreamRecoveryOptions,
+        observations: MutableList<RedisMessageBusObservation>? = null,
+    ): RedisPendingMessageRecoverer {
+        return RedisPendingMessageRecoverer(
+            streamOps = streamOps,
+            scanner = scanner,
+            leaseRegistry = leaseRegistry,
+            options = options,
+            observer = observations?.let { RedisMessageBusObserver(it::add) } ?: RedisMessageBusObserver.NOOP,
+        )
+    }
+
+    private fun pending(
+        id: String,
+        consumerName: String,
+        elapsedTime: Duration = Duration.ofSeconds(2),
+        deliveryCount: Long = 1,
+    ): RedisPendingMessage {
+        return RedisPendingMessage(
+            id = RecordId.of(id),
+            consumerName = consumerName,
+            elapsedTimeSinceLastDelivery = elapsedTime,
+            deliveryCount = deliveryCount,
+        )
+    }
+
+    private fun page(
+        sweepEnd: String,
+        messages: List<RedisPendingMessage>,
+        complete: Boolean,
+    ): RedisPendingMessagePage {
+        return RedisPendingMessagePage(sweepEnd, messages, complete)
+    }
+
+    private fun scanRequest(
+        cursor: String? = null,
+        sweepEnd: String? = null,
+        count: Long = 10,
+    ): RedisPendingScanRequest {
+        return RedisPendingScanRequest(cursor, sweepEnd, count)
+    }
+
+    private fun options(
+        minIdleTime: Duration = Duration.ofSeconds(1),
+        interval: Duration = Duration.ofSeconds(1),
+        batchSize: Long = 10,
+    ): RedisStreamRecoveryOptions {
+        return RedisStreamRecoveryOptions(
+            minIdleTime = minIdleTime,
+            interval = interval,
+            batchSize = batchSize,
+        )
+    }
+}

--- a/wow-redis/src/test/kotlin/me/ahoo/wow/redis/bus/RedisPendingMessageScannerTest.kt
+++ b/wow-redis/src/test/kotlin/me/ahoo/wow/redis/bus/RedisPendingMessageScannerTest.kt
@@ -1,0 +1,191 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.redis.bus
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.data.domain.Range
+import org.springframework.data.redis.connection.stream.PendingMessagesSummary
+import org.springframework.data.redis.connection.stream.RecordId
+import org.springframework.data.redis.core.ReactiveStreamOperations
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate
+import org.springframework.data.redis.core.script.RedisScript
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+import java.time.Duration
+
+class RedisPendingMessageScannerTest {
+    @Test
+    fun `should reject a non-positive pending delivery count`() {
+        assertThrows<IllegalArgumentException> {
+            RedisPendingMessage(
+                id = RecordId.of("1-0"),
+                consumerName = "consumer",
+                elapsedTimeSinceLastDelivery = Duration.ZERO,
+                deliveryCount = 0,
+            )
+        }
+    }
+
+    @Test
+    fun `should observe an empty pending snapshot`() {
+        val topic = "topic"
+        val group = "group"
+        val streamOps = mockk<ReactiveStreamOperations<String, String, String>>()
+        every { streamOps.pending(topic, group) } returns Mono.just(
+            PendingMessagesSummary(group, 0, Range.unbounded(), emptyMap()),
+        )
+        val observations = mutableListOf<RedisMessageBusObservation>()
+        val scanner = DefaultRedisPendingMessageScanner(
+            redisTemplate = mockk<ReactiveStringRedisTemplate>(),
+            streamOps = streamOps,
+            observer = RedisMessageBusObserver(observations::add),
+        )
+
+        StepVerifier.create(
+            scanner.scan(topic, group, RedisPendingScanRequest(cursor = null, sweepEnd = null, count = 10)),
+        )
+            .assertNext { page ->
+                page.complete.assert().isTrue()
+                page.sweepEnd.assert().isNull()
+                page.messages.assert().isEmpty()
+            }
+            .verifyComplete()
+
+        observations.assert().containsExactly(
+            RedisMessageBusObservation.PendingSweepStarted(
+                topic = topic,
+                consumerGroup = group,
+                totalPendingMessages = 0,
+                minMessageId = null,
+                maxMessageId = null,
+            ),
+        )
+    }
+
+    @Test
+    @Suppress("LongMethod") // Fixed-snapshot pagination and cursor assertions form one scenario.
+    fun `should scan a fixed pending snapshot with an exclusive cursor`() {
+        val topic = "topic"
+        val group = "group"
+        val streamOps = mockk<ReactiveStreamOperations<String, String, String>>()
+        every { streamOps.pending(topic, group) } returns Mono.just(
+            PendingMessagesSummary(
+                group,
+                3,
+                Range.closed("1-0", "3-0"),
+                mapOf("old" to 3),
+            ),
+        )
+        val redisTemplate = mockk<ReactiveStringRedisTemplate>()
+        val arguments = mutableListOf<List<*>>()
+        every {
+            redisTemplate.execute(
+                any<RedisScript<List<Any>>>(),
+                listOf(topic),
+                capture(arguments),
+            )
+        } returnsMany listOf(
+            Flux.just(
+                listOf(
+                    "1-0",
+                    "old",
+                    "1500",
+                    "2",
+                    "2-0",
+                    "old",
+                    2000L,
+                    3L,
+                ),
+            ),
+            Flux.just(listOf("3-0", "old", 2500L, 4L)),
+        )
+        val observations = mutableListOf<RedisMessageBusObservation>()
+        val scanner = DefaultRedisPendingMessageScanner(
+            redisTemplate = redisTemplate,
+            streamOps = streamOps,
+            observer = RedisMessageBusObserver(observations::add),
+        )
+
+        val firstPage = scanner.scan(
+            topic,
+            group,
+            RedisPendingScanRequest(cursor = null, sweepEnd = null, count = 2),
+        ).block()!!
+        firstPage.complete.assert().isFalse()
+        firstPage.sweepEnd.assert().isEqualTo("3-0")
+        firstPage.messages.map { pending -> pending.id.value }
+            .assert()
+            .containsExactly("1-0", "2-0")
+        firstPage.messages.map(RedisPendingMessage::deliveryCount)
+            .assert()
+            .containsExactly(2, 3)
+
+        val secondPage = scanner.scan(
+            topic,
+            group,
+            RedisPendingScanRequest(cursor = "2-0", sweepEnd = "3-0", count = 2),
+        ).block()!!
+        secondPage.complete.assert().isTrue()
+        secondPage.messages.single().elapsedTimeSinceLastDelivery
+            .assert()
+            .isEqualTo(Duration.ofMillis(2500))
+
+        arguments.assert().containsExactly(
+            listOf(group, "-", "3-0", "2"),
+            listOf(group, "(2-0", "3-0", "2"),
+        )
+        observations.single().assert().isEqualTo(
+            RedisMessageBusObservation.PendingSweepStarted(
+                topic = topic,
+                consumerGroup = group,
+                totalPendingMessages = 3,
+                minMessageId = "1-0",
+                maxMessageId = "3-0",
+            ),
+        )
+        verify(exactly = 1) { streamOps.pending(topic, group) }
+    }
+
+    @Test
+    fun `should reject a malformed pending response`() {
+        val redisTemplate = mockk<ReactiveStringRedisTemplate>()
+        every {
+            redisTemplate.execute(
+                any<RedisScript<List<Any>>>(),
+                listOf("topic"),
+                any<List<*>>(),
+            )
+        } returns Flux.just(listOf("1-0"))
+        val scanner = DefaultRedisPendingMessageScanner(
+            redisTemplate = redisTemplate,
+            streamOps = mockk(),
+        )
+
+        StepVerifier.create(
+            scanner.scan(
+                "topic",
+                "group",
+                RedisPendingScanRequest(cursor = null, sweepEnd = "1-0", count = 1),
+            ),
+        )
+            .expectError(IllegalArgumentException::class.java)
+            .verify()
+    }
+}

--- a/wow-redis/src/test/kotlin/me/ahoo/wow/redis/bus/RedisStreamRecoveryOptionsTest.kt
+++ b/wow-redis/src/test/kotlin/me/ahoo/wow/redis/bus/RedisStreamRecoveryOptionsTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.redis.bus
+
+import io.mockk.every
+import io.mockk.mockk
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate
+import java.time.Duration
+
+class RedisStreamRecoveryOptionsTest {
+    @Test
+    fun `should enable pending-message recovery by default`() {
+        RedisStreamRecoveryOptions.DEFAULT.assert().isEqualTo(RedisStreamRecoveryOptions())
+        RedisStreamRecoveryOptions.DEFAULT.enabled.assert().isTrue()
+        RedisStreamRecoveryOptions.DISABLED.enabled.assert().isFalse()
+    }
+
+    @Test
+    fun `should enable recovery for directly constructed message buses`() {
+        val redisTemplate = mockk<ReactiveStringRedisTemplate> {
+            every { opsForStream<String, String>() } returns mockk()
+        }
+        val commandBus = RedisCommandBus(redisTemplate)
+        val recoveryOptionsField = AbstractRedisMessageBus::class.java
+            .getDeclaredField("recoveryOptions")
+            .apply { isAccessible = true }
+
+        val recoveryOptions = recoveryOptionsField.get(commandBus) as RedisStreamRecoveryOptions
+
+        recoveryOptions.enabled.assert().isTrue()
+        RedisDomainEventBus(redisTemplate, RedisStreamRecoveryOptions.DISABLED)
+            .assert()
+            .isInstanceOf(RedisDomainEventBus::class.java)
+        RedisStateEventBus(redisTemplate, RedisStreamRecoveryOptions.DISABLED)
+            .assert()
+            .isInstanceOf(RedisStateEventBus::class.java)
+    }
+
+    @Test
+    fun `should reject unsupported recovery bounds`() {
+        runCatching {
+            RedisStreamRecoveryOptions(minIdleTime = Duration.ofNanos(1))
+        }.exceptionOrNull().assert().isInstanceOf(IllegalArgumentException::class.java)
+        runCatching {
+            RedisStreamRecoveryOptions(interval = Duration.ZERO)
+        }.exceptionOrNull().assert().isInstanceOf(IllegalArgumentException::class.java)
+        runCatching {
+            RedisStreamRecoveryOptions(batchSize = 0)
+        }.exceptionOrNull().assert().isInstanceOf(IllegalArgumentException::class.java)
+    }
+}

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/redis/RedisMessageBusAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/redis/RedisMessageBusAutoConfiguration.kt
@@ -16,8 +16,10 @@ package me.ahoo.wow.spring.boot.starter.redis
 import me.ahoo.wow.command.DistributedCommandBus
 import me.ahoo.wow.event.DistributedDomainEventBus
 import me.ahoo.wow.eventsourcing.state.DistributedStateEventBus
+import me.ahoo.wow.redis.bus.CompositeRedisMessageBusObserver
 import me.ahoo.wow.redis.bus.RedisCommandBus
 import me.ahoo.wow.redis.bus.RedisDomainEventBus
+import me.ahoo.wow.redis.bus.RedisMessageBusObserver
 import me.ahoo.wow.redis.bus.RedisStateEventBus
 import me.ahoo.wow.spring.boot.starter.BusType
 import me.ahoo.wow.spring.boot.starter.ConditionalOnWowEnabled
@@ -25,9 +27,11 @@ import me.ahoo.wow.spring.boot.starter.command.CommandAutoConfiguration
 import me.ahoo.wow.spring.boot.starter.command.CommandProperties
 import me.ahoo.wow.spring.boot.starter.event.EventProperties
 import me.ahoo.wow.spring.boot.starter.eventsourcing.state.StateProperties
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.data.redis.autoconfigure.DataRedisReactiveAutoConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate
@@ -39,6 +43,7 @@ import org.springframework.data.redis.core.ReactiveStringRedisTemplate
 @ConditionalOnWowEnabled
 @ConditionalOnRedisEnabled
 @ConditionalOnClass(RedisCommandBus::class)
+@EnableConfigurationProperties(RedisStreamRecoveryProperties::class)
 class RedisMessageBusAutoConfiguration {
 
     @Bean
@@ -46,8 +51,16 @@ class RedisMessageBusAutoConfiguration {
         CommandProperties.BUS_TYPE,
         havingValue = BusType.REDIS_NAME,
     )
-    fun redisCommandBus(redisTemplate: ReactiveStringRedisTemplate): DistributedCommandBus {
-        return RedisCommandBus(redisTemplate)
+    fun redisCommandBus(
+        redisTemplate: ReactiveStringRedisTemplate,
+        recoveryProperties: RedisStreamRecoveryProperties,
+        observers: ObjectProvider<RedisMessageBusObserver>,
+    ): DistributedCommandBus {
+        return RedisCommandBus(
+            redisTemplate = redisTemplate,
+            recoveryOptions = recoveryProperties.toOptions(),
+            observer = observers.toObserver(),
+        )
     }
 
     @Bean
@@ -55,8 +68,16 @@ class RedisMessageBusAutoConfiguration {
         EventProperties.BUS_TYPE,
         havingValue = BusType.REDIS_NAME,
     )
-    fun redisDomainEventBus(redisTemplate: ReactiveStringRedisTemplate): DistributedDomainEventBus {
-        return RedisDomainEventBus(redisTemplate)
+    fun redisDomainEventBus(
+        redisTemplate: ReactiveStringRedisTemplate,
+        recoveryProperties: RedisStreamRecoveryProperties,
+        observers: ObjectProvider<RedisMessageBusObserver>,
+    ): DistributedDomainEventBus {
+        return RedisDomainEventBus(
+            redisTemplate = redisTemplate,
+            recoveryOptions = recoveryProperties.toOptions(),
+            observer = observers.toObserver(),
+        )
     }
 
     @Bean
@@ -64,7 +85,24 @@ class RedisMessageBusAutoConfiguration {
         StateProperties.BUS_TYPE,
         havingValue = BusType.REDIS_NAME,
     )
-    fun redisStateEventBus(redisTemplate: ReactiveStringRedisTemplate): DistributedStateEventBus {
-        return RedisStateEventBus(redisTemplate)
+    fun redisStateEventBus(
+        redisTemplate: ReactiveStringRedisTemplate,
+        recoveryProperties: RedisStreamRecoveryProperties,
+        observers: ObjectProvider<RedisMessageBusObserver>,
+    ): DistributedStateEventBus {
+        return RedisStateEventBus(
+            redisTemplate = redisTemplate,
+            recoveryOptions = recoveryProperties.toOptions(),
+            observer = observers.toObserver(),
+        )
+    }
+
+    private fun ObjectProvider<RedisMessageBusObserver>.toObserver(): RedisMessageBusObserver {
+        val observers = orderedStream().toList()
+        return when (observers.size) {
+            0 -> RedisMessageBusObserver.NOOP
+            1 -> observers.single()
+            else -> CompositeRedisMessageBusObserver(observers)
+        }
     }
 }

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/redis/RedisStreamRecoveryProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/redis/RedisStreamRecoveryProperties.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.spring.boot.starter.redis
+
+import me.ahoo.wow.redis.bus.RedisStreamRecoveryOptions
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.bind.DefaultValue
+import java.time.Duration
+
+@ConfigurationProperties(prefix = RedisStreamRecoveryProperties.PREFIX)
+class RedisStreamRecoveryProperties(
+    @DefaultValue("true") var enabled: Boolean = true,
+    @DefaultValue("5m") var minIdleTime: Duration = Duration.ofMinutes(5),
+    @DefaultValue("30s") var interval: Duration = Duration.ofSeconds(30),
+    @DefaultValue("100") var batchSize: Long = 100,
+) {
+    fun toOptions(): RedisStreamRecoveryOptions {
+        return RedisStreamRecoveryOptions(
+            enabled = enabled,
+            minIdleTime = minIdleTime,
+            interval = interval,
+            batchSize = batchSize,
+        )
+    }
+
+    companion object {
+        const val PREFIX = "${RedisProperties.PREFIX}.message-bus.recovery"
+    }
+}

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/redis/RedisMessageBusAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/redis/RedisMessageBusAutoConfigurationTest.kt
@@ -2,10 +2,15 @@ package me.ahoo.wow.spring.boot.starter.redis
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.redis.bus.AbstractRedisMessageBus
 import me.ahoo.wow.redis.bus.RedisCommandBus
 import me.ahoo.wow.redis.bus.RedisDomainEventBus
+import me.ahoo.wow.redis.bus.RedisMessageBusObservation
+import me.ahoo.wow.redis.bus.RedisMessageBusObserver
 import me.ahoo.wow.redis.bus.RedisStateEventBus
+import me.ahoo.wow.redis.bus.RedisStreamRecoveryOptions
 import me.ahoo.wow.spring.boot.starter.BusType
 import me.ahoo.wow.spring.boot.starter.command.CommandProperties
 import me.ahoo.wow.spring.boot.starter.enableWow
@@ -15,9 +20,17 @@ import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate
+import java.time.Duration
 
 class RedisMessageBusAutoConfigurationTest {
     private val contextRunner = ApplicationContextRunner()
+
+    @Test
+    fun `should expose recovery property defaults without Spring binding`() {
+        RedisStreamRecoveryProperties().toOptions()
+            .assert()
+            .isEqualTo(RedisStreamRecoveryOptions.DEFAULT)
+    }
 
     @Test
     fun `should load context with redis message bus beans`() {
@@ -41,6 +54,100 @@ class RedisMessageBusAutoConfigurationTest {
                     .hasSingleBean(RedisCommandBus::class.java)
                     .hasSingleBean(RedisDomainEventBus::class.java)
                     .hasSingleBean(RedisStateEventBus::class.java)
+                    .hasSingleBean(RedisStreamRecoveryProperties::class.java)
+                context.getBean(RedisStreamRecoveryProperties::class.java)
+                    .enabled
+                    .assert()
+                    .isTrue()
+            }
+    }
+
+    @Test
+    fun `should bind redis pending-message recovery options`() {
+        contextRunner
+            .enableWow()
+            .withPropertyValues(
+                "${CommandProperties.BUS_TYPE}=${BusType.REDIS_NAME}",
+                "${RedisStreamRecoveryProperties.PREFIX}.enabled=false",
+                "${RedisStreamRecoveryProperties.PREFIX}.min-idle-time=2m",
+                "${RedisStreamRecoveryProperties.PREFIX}.interval=3s",
+                "${RedisStreamRecoveryProperties.PREFIX}.batch-size=25",
+            )
+            .withBean(ReactiveStringRedisTemplate::class.java, {
+                mockk<ReactiveStringRedisTemplate> {
+                    every { opsForStream<String, String>() } returns mockk()
+                }
+            })
+            .withUserConfiguration(RedisMessageBusAutoConfiguration::class.java)
+            .run { context ->
+                context.assert().hasNotFailed().hasSingleBean(RedisCommandBus::class.java)
+                val recovery = context.getBean(RedisStreamRecoveryProperties::class.java)
+                recovery.enabled.assert().isFalse()
+                recovery.minIdleTime.assert().isEqualTo(Duration.ofMinutes(2))
+                recovery.interval.assert().isEqualTo(Duration.ofSeconds(3))
+                recovery.batchSize.assert().isEqualTo(25)
+                recovery.toOptions().enabled.assert().isFalse()
+            }
+    }
+
+    @Test
+    fun `should compose every redis message-bus observer`() {
+        val failingObserver = mockk<RedisMessageBusObserver>()
+        every { failingObserver.onObservation(any()) } throws IllegalStateException("observer failed")
+        val recordingObserver = mockk<RedisMessageBusObserver>(relaxed = true)
+        contextRunner
+            .enableWow()
+            .withPropertyValues("${CommandProperties.BUS_TYPE}=${BusType.REDIS_NAME}")
+            .withBean(ReactiveStringRedisTemplate::class.java, {
+                mockk<ReactiveStringRedisTemplate> {
+                    every { opsForStream<String, String>() } returns mockk()
+                }
+            })
+            .withBean("failingRedisObserver", RedisMessageBusObserver::class.java, { failingObserver })
+            .withBean("recordingRedisObserver", RedisMessageBusObserver::class.java, { recordingObserver })
+            .withUserConfiguration(RedisMessageBusAutoConfiguration::class.java)
+            .run { context ->
+                context.assert().hasNotFailed().hasSingleBean(RedisCommandBus::class.java)
+                val observation = RedisMessageBusObservation.PendingScanFailed(
+                    topic = "topic",
+                    consumerGroup = "group",
+                    failureType = IllegalStateException::class.java.name,
+                )
+                val observerField = AbstractRedisMessageBus::class.java
+                    .getDeclaredField("messageBusObserver")
+                    .apply { isAccessible = true }
+                val observer = observerField.get(context.getBean(RedisCommandBus::class.java))
+                    as RedisMessageBusObserver
+
+                observer.onObservation(observation)
+
+                verify(exactly = 1) { failingObserver.onObservation(observation) }
+                verify(exactly = 1) { recordingObserver.onObservation(observation) }
+            }
+    }
+
+    @Test
+    fun `should reuse a single redis message-bus observer`() {
+        val singleObserver = mockk<RedisMessageBusObserver>()
+        contextRunner
+            .enableWow()
+            .withPropertyValues("${CommandProperties.BUS_TYPE}=${BusType.REDIS_NAME}")
+            .withBean(ReactiveStringRedisTemplate::class.java, {
+                mockk<ReactiveStringRedisTemplate> {
+                    every { opsForStream<String, String>() } returns mockk()
+                }
+            })
+            .withBean(RedisMessageBusObserver::class.java, { singleObserver })
+            .withUserConfiguration(RedisMessageBusAutoConfiguration::class.java)
+            .run { context ->
+                context.assert().hasNotFailed()
+                val observerField = AbstractRedisMessageBus::class.java
+                    .getDeclaredField("messageBusObserver")
+                    .apply { isAccessible = true }
+
+                observerField.get(context.getBean(RedisCommandBus::class.java))
+                    .assert()
+                    .isSameAs(singleObserver)
             }
     }
 }


### PR DESCRIPTION
## Goal

Prevent Redis Stream messages from remaining permanently stranded in a consumer group's Pending Entries List (PEL) after a process crash, while ensuring malformed records and recovery-path failures cannot terminate live message delivery.

## Changes

- Add bounded, fixed-snapshot `XPENDING` scans and atomic `XCLAIM` recovery for idle records owned by inactive consumers.
- Protect active consumers with token-owned Redis leases plus Redis consumer activity checks. Lease acquisition, renewal, release, scan, and claim failures are isolated from live delivery; uncertain liveness fails closed.
- Drain all pages in a bounded sweep under downstream backpressure, then wait for the configured interval before starting a new snapshot.
- Isolate records with a missing `msg` field or invalid JSON. They remain pending for diagnosis, while payload-free logs and `RedisMessageBusObservation.RecordDecodeFailed` observations are emitted.
- Add non-blocking `RedisMessageBusObserver` composition for metrics and alerting.
- Enable recovery by default through `wow.redis.message-bus.recovery.*`:
  - `enabled=true`
  - `min-idle-time=5m`
  - `interval=30s`
  - `batch-size=100`
- Preserve the existing three-argument JVM constructors for direct `RedisCommandBus`, `RedisDomainEventBus`, and `RedisStateEventBus` users.
- Document behavior, tuning, at-least-once semantics, rollback, and malformed-record operations in English and Chinese.

## Verification

- TDD baseline: the malformed-record regression test failed before the implementation with `StreamReadException`, then passed after isolation was implemented.
- `./gradlew :wow-redis:check :wow-spring-boot-starter:check :wow-redis:integrationTest`
- `./gradlew codeCoverageReport`
- `pnpm docs:build` in `documentation/`
- Local staged-patch analysis against the aggregate Jacoco XML: 510/510 executable lines covered (100% line coverage), 83/97 branches covered, estimated Codecov coverage-point ratio 97.69%.
- JVM signature inspection confirmed the original Redis message-bus constructor entry remains present.

The first full coverage rerun on the latest base encountered a transient timeout in the unchanged `KafkaCommandBusTest.receivePerformance`; the targeted test passed on immediate rerun, and the subsequent complete `codeCoverageReport` succeeded.

## Risks and Notes

- **Behavior change:** pending-message recovery is enabled by default. Deployments must keep handlers idempotent and set `min-idle-time` above the longest handler execution, retry, and graceful-shutdown duration.
- **Rollback:** set `wow.redis.message-bus.recovery.enabled=false`. This restores the previous behavior but can leave abandoned PEL records stranded.
- Malformed records are intentionally not acknowledged or deleted; operators can diagnose them from the record ID without payload leakage in framework logs.
- Delivery remains at least once. Recovery can redeliver after a real consumer failure.
- No Redis event/snapshot data layout migration is required.
- This PR intentionally excludes `PrepareKey` namespace/TTL changes, stream retention/trimming, MongoDB changes, and unrelated workspace modifications.