### PR TITLE
fix(elasticsearch): correct query and configuration contracts

### DIFF
--- a/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/event/ElasticsearchEventStreamQueryServiceTest.kt
+++ b/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/event/ElasticsearchEventStreamQueryServiceTest.kt
@@ -17,12 +17,19 @@ import me.ahoo.wow.elasticsearch.ReactiveElasticsearchClients
 import me.ahoo.wow.elasticsearch.TemplateInitializer.initEventStreamTemplate
 import me.ahoo.wow.elasticsearch.eventsourcing.ElasticsearchEventStore
 import me.ahoo.wow.eventsourcing.EventStore
+import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.query.dsl.condition
 import me.ahoo.wow.query.event.EventStreamQueryServiceFactory
+import me.ahoo.wow.query.event.count
 import me.ahoo.wow.tck.container.ElasticsearchTestFixture
+import me.ahoo.wow.tck.event.MockDomainEventStreams.generateEventStream
 import me.ahoo.wow.tck.query.EventStreamQueryServiceSpec
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
+import reactor.kotlin.test.test
 
 class ElasticsearchEventStreamQueryServiceTest : EventStreamQueryServiceSpec() {
     @JvmField
@@ -44,5 +51,42 @@ class ElasticsearchEventStreamQueryServiceTest : EventStreamQueryServiceSpec() {
 
     override fun createEventStreamQueryServiceFactory(): EventStreamQueryServiceFactory {
         return ElasticsearchEventStreamQueryServiceFactory(elasticsearchClient)
+    }
+
+    @Test
+    fun `should query event stream by stream id`() {
+        val eventStream = generateEventStream(namedAggregate.aggregateId(generateGlobalId()))
+        eventStore.append(eventStream).block()
+
+        condition { id(eventStream.id) }
+            .count(eventStreamQueryService)
+            .test()
+            .expectNext(1L)
+            .verifyComplete()
+    }
+
+    @Test
+    fun `should query null as a missing field`() {
+        val eventStream = generateEventStream(
+            namedAggregate.aggregateId(id = generateGlobalId(), tenantId = generateGlobalId())
+        )
+        eventStore.append(eventStream).block()
+
+        condition {
+            tenantId(eventStream.aggregateId.tenantId)
+            "missingField".isNull()
+        }
+            .count(eventStreamQueryService)
+            .test()
+            .expectNext(1L)
+            .verifyComplete()
+        condition {
+            tenantId(eventStream.aggregateId.tenantId)
+            "missingField".notNull()
+        }
+            .count(eventStreamQueryService)
+            .test()
+            .expectNext(0L)
+            .verifyComplete()
     }
 }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchConditionConverter.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchConditionConverter.kt
@@ -231,15 +231,18 @@ abstract class AbstractElasticsearchConditionConverter : AbstractConditionConver
     }
 
     override fun isNull(condition: Condition): Query {
-        return term {
-            it.field(condition.field)
-                .value(FieldValue.NULL)
+        return bool { builder ->
+            builder.mustNot {
+                it.exists {
+                    it.field(condition.field)
+                }
+            }
         }
     }
 
     override fun notNull(condition: Condition): Query {
-        return bool {
-            it.mustNot(isNull(condition))
+        return exists {
+            it.field(condition.field)
         }
     }
 

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryService.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryService.kt
@@ -119,12 +119,13 @@ abstract class AbstractElasticsearchQueryService<R : Any> : QueryService<R> {
     private fun search(searchRequest: SearchRequest): Mono<PagedList<DynamicDocument>> {
         return elasticsearchClient.search(searchRequest, Map::class.java)
             .map { result ->
-                val list = result.hits()?.hits()?.mapNotNull { hit ->
+                val hits = result.hits()
+                val list = hits.hits().mapNotNull { hit ->
                     hit.source()?.let {
                         (it as MutableMap<String, Any?>).toDynamicDocument()
                     }
-                } ?: emptyList()
-                PagedList(result.hits()?.total()?.value() ?: 0, list)
+                }
+                PagedList(hits.total()?.value() ?: 0, list)
             }
     }
 

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryService.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryService.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.elasticsearch.query
 
 import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import co.elastic.clients.elasticsearch.core.CountRequest
 import co.elastic.clients.elasticsearch.core.SearchRequest
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.DynamicDocument
@@ -22,8 +23,7 @@ import me.ahoo.wow.api.query.IPagedQuery
 import me.ahoo.wow.api.query.ISingleQuery
 import me.ahoo.wow.api.query.ListQuery
 import me.ahoo.wow.api.query.PagedList
-import me.ahoo.wow.api.query.PagedQuery
-import me.ahoo.wow.api.query.Pagination
+import me.ahoo.wow.api.query.Queryable
 import me.ahoo.wow.api.query.SimpleDynamicDocument.Companion.toDynamicDocument
 import me.ahoo.wow.api.query.isEmpty
 import me.ahoo.wow.elasticsearch.query.ElasticsearchProjectionConverter.toSourceFilter
@@ -59,14 +59,13 @@ abstract class AbstractElasticsearchQueryService<R : Any> : QueryService<R> {
     }
 
     override fun dynamicList(listQuery: IListQuery): Flux<DynamicDocument> {
-        val pagedQuery =
-            PagedQuery(
-                condition = listQuery.condition,
-                projection = listQuery.projection,
-                sort = listQuery.sort,
-                pagination = Pagination(index = 1, size = listQuery.limit.searchSize())
-            )
-        return dynamicPaged(pagedQuery).flatMapIterable { it.list }
+        val searchRequest = createSearchRequest(
+            query = listQuery,
+            from = 0,
+            size = listQuery.limit.searchSize(),
+            trackTotalHits = false,
+        )
+        return search(searchRequest).flatMapIterable { it.list }
     }
 
     override fun paged(pagedQuery: IPagedQuery): Mono<PagedList<R>> {
@@ -80,37 +79,60 @@ abstract class AbstractElasticsearchQueryService<R : Any> : QueryService<R> {
         }
     }
 
-    @Suppress("UNCHECKED_CAST")
     override fun dynamicPaged(pagedQuery: IPagedQuery): Mono<PagedList<DynamicDocument>> {
+        val searchRequest = createSearchRequest(
+            query = pagedQuery,
+            from = pagedQuery.pagination.offset(),
+            size = pagedQuery.pagination.size,
+            trackTotalHits = true,
+        )
+        return search(searchRequest)
+    }
+
+    private fun createSearchRequest(
+        query: Queryable<*>,
+        from: Int,
+        size: Int,
+        trackTotalHits: Boolean,
+    ): SearchRequest {
         val searchRequest = SearchRequest.of {
             it.index(indexName)
-                .query(conditionConverter.convert(pagedQuery.condition))
-                .from(pagedQuery.pagination.offset())
-                .size(pagedQuery.pagination.size)
+                .query(conditionConverter.convert(query.condition))
+                .from(from)
+                .size(size)
 
-            if (pagedQuery.sort.isNotEmpty()) {
-                it.sort(pagedQuery.sort.toSortOptions())
+            it.trackTotalHits { trackHits -> trackHits.enabled(trackTotalHits) }
+            if (query.sort.isNotEmpty()) {
+                it.sort(query.sort.toSortOptions())
             }
-            if (!pagedQuery.projection.isEmpty()) {
+            if (!query.projection.isEmpty()) {
                 it.source {
-                    it.filter(pagedQuery.projection.toSourceFilter())
+                    it.filter(query.projection.toSourceFilter())
                 }
             }
             it
         }
+        return searchRequest
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun search(searchRequest: SearchRequest): Mono<PagedList<DynamicDocument>> {
         return elasticsearchClient.search(searchRequest, Map::class.java)
-            .mapNotNull<PagedList<DynamicDocument>> { result ->
-                val list = result.hits()?.hits()?.map { hit ->
+            .map { result ->
+                val list = result.hits()?.hits()?.mapNotNull { hit ->
                     hit.source()?.let {
                         (it as MutableMap<String, Any?>).toDynamicDocument()
                     }
-                } as List<DynamicDocument>? ?: emptyList()
+                } ?: emptyList()
                 PagedList(result.hits()?.total()?.value() ?: 0, list)
             }
     }
 
     override fun count(condition: Condition): Mono<Long> {
-        val pagedQuery = PagedQuery(condition = condition, pagination = Pagination(index = 1, size = 0))
-        return dynamicPaged(pagedQuery).map { it.total }
+        val countRequest = CountRequest.of {
+            it.index(indexName)
+                .query(conditionConverter.convert(condition))
+        }
+        return elasticsearchClient.count(countRequest).map { it.count() }
     }
 }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/event/EventStreamConditionConverter.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/event/EventStreamConditionConverter.kt
@@ -23,10 +23,29 @@ import me.ahoo.wow.serialization.MessageRecords
 
 object EventStreamConditionConverter : AbstractElasticsearchConditionConverter() {
     override fun convert(condition: Condition): Query = internalConvert(condition)
+
+    override fun id(condition: Condition): Query {
+        return term {
+            it.field(MessageRecords.ID)
+                .value(condition.valueAs<String>())
+        }
+    }
+
+    override fun ids(condition: Condition): Query {
+        return terms {
+            it.field(MessageRecords.ID)
+                .terms { builder ->
+                    condition.valueAs<List<String>>().map {
+                        FieldValue.of(it)
+                    }.let { builder.value(it) }
+                }
+        }
+    }
+
     override fun aggregateId(condition: Condition): Query {
         return term {
             it.field(MessageRecords.AGGREGATE_ID)
-                .value(FieldValue.of(condition.value))
+                .value(condition.valueAs<String>())
         }
     }
 
@@ -34,7 +53,7 @@ object EventStreamConditionConverter : AbstractElasticsearchConditionConverter()
         return terms {
             it.field(MessageRecords.AGGREGATE_ID)
                 .terms { builder ->
-                    condition.valueAs<List<Any>>().map {
+                    condition.valueAs<List<String>>().map {
                         FieldValue.of(it)
                     }.toList().let { builder.value(it) }
                 }

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryServiceTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryServiceTest.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.elasticsearch.query
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.matchAll
+import co.elastic.clients.elasticsearch.core.CountRequest
+import co.elastic.clients.elasticsearch.core.CountResponse
+import co.elastic.clients.elasticsearch.core.SearchRequest
+import co.elastic.clients.elasticsearch.core.SearchResponse
+import co.elastic.clients.elasticsearch.core.search.TotalHitsRelation
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.DynamicDocument
+import me.ahoo.wow.api.query.ListQuery
+import me.ahoo.wow.api.query.PagedQuery
+import me.ahoo.wow.api.query.Projection
+import me.ahoo.wow.api.query.Sort
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.query.converter.ConditionConverter
+import org.junit.jupiter.api.Test
+import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
+import reactor.core.publisher.Mono
+
+class AbstractElasticsearchQueryServiceTest {
+    private val elasticsearchClient = mockk<ReactiveElasticsearchClient>()
+    private val conditionConverter = mockk<ConditionConverter<Query>> {
+        every { convert(any()) } returns matchAll { it }
+    }
+    private val queryService = TestElasticsearchQueryService(elasticsearchClient, conditionConverter)
+
+    @Test
+    fun `dynamic list should not track exact total hits`() {
+        val request = slot<SearchRequest>()
+        every { elasticsearchClient.search(capture(request), Map::class.java) } returns Mono.just(
+            searchResponse(total = null)
+        )
+
+        val result = queryService.dynamicList(
+            ListQuery(
+                condition = Condition.ALL,
+                projection = Projection(include = listOf("field")),
+                sort = listOf(Sort("field", Sort.Direction.ASC)),
+                limit = 7,
+            )
+        ).collectList().block()!!
+
+        request.captured.trackTotalHits()!!.enabled().assert().isFalse()
+        request.captured.size().assert().isEqualTo(7)
+        request.captured.source()!!.filter().includes().assert().containsExactly("field")
+        request.captured.sort().assert().hasSize(1)
+        result.assert().hasSize(1)
+    }
+
+    @Test
+    fun `dynamic paged should track exact total hits`() {
+        val request = slot<SearchRequest>()
+        every { elasticsearchClient.search(capture(request), Map::class.java) } returns Mono.just(
+            searchResponse(total = 42)
+        )
+
+        val result = queryService.dynamicPaged(PagedQuery(Condition.ALL)).block()!!
+
+        request.captured.trackTotalHits()!!.enabled().assert().isTrue()
+        result.total.assert().isEqualTo(42)
+        result.list.assert().hasSize(1)
+        result.list.single()["field"].assert().isEqualTo("value")
+    }
+
+    @Test
+    fun `count should use count api`() {
+        val request = slot<CountRequest>()
+        every { elasticsearchClient.count(capture(request)) } returns Mono.just(
+            CountResponse.of {
+                it.count(42)
+                    .shards { shards -> shards.failed(0).successful(1).total(1) }
+            }
+        )
+
+        val result = queryService.count(Condition.ALL).block()!!
+
+        request.captured.index().assert().containsExactly("test-index")
+        result.assert().isEqualTo(42)
+        verify(exactly = 0) { elasticsearchClient.search(any<SearchRequest>(), Map::class.java) }
+    }
+
+    private fun searchResponse(total: Long?): SearchResponse<Map<*, *>> {
+        return SearchResponse.of<Map<*, *>> {
+            it.took(1)
+                .timedOut(false)
+                .shards { shards -> shards.failed(0).successful(1).total(1) }
+                .hits { hits ->
+                    if (total != null) {
+                        hits.total { totalHits -> totalHits.relation(TotalHitsRelation.Eq).value(total) }
+                    }
+                    hits.hits { hit ->
+                        hit.index("test-index")
+                            .id("1")
+                            .source(mutableMapOf<String, Any?>("field" to "value"))
+                    }.hits { hit -> hit.index("test-index").id("2") }
+                }
+        }
+    }
+
+    private class TestElasticsearchQueryService(
+        override val elasticsearchClient: ReactiveElasticsearchClient,
+        override val conditionConverter: ConditionConverter<Query>,
+    ) : AbstractElasticsearchQueryService<DynamicDocument>() {
+        override val namedAggregate: NamedAggregate = MaterializedNamedAggregate("test", "aggregate")
+        override val indexName: String = "test-index"
+
+        override fun toTypedResult(document: DynamicDocument): DynamicDocument = document
+    }
+}

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchConditionConverterTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchConditionConverterTest.kt
@@ -487,9 +487,12 @@ class ElasticsearchConditionConverterTest {
         }
         assertConvert(
             query,
-            term {
-                it.field("field")
-                    .value(FieldValue.NULL)
+            bool { boolBuilder ->
+                boolBuilder.mustNot { builder ->
+                    builder.exists {
+                        it.field("field")
+                    }
+                }
             }
         )
     }
@@ -503,13 +506,8 @@ class ElasticsearchConditionConverterTest {
         }
         assertConvert(
             query,
-            bool { boolBuilder ->
-                boolBuilder.mustNot { builder ->
-                    builder.term {
-                        it.field("field")
-                            .value(FieldValue.NULL)
-                    }
-                }
+            exists {
+                it.field("field")
             }
         )
     }

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/event/EventStreamConditionConverterTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/event/EventStreamConditionConverterTest.kt
@@ -23,6 +23,23 @@ import org.junit.jupiter.api.Test
 
 class EventStreamConditionConverterTest {
     @Test
+    fun `should convert event stream id condition`() {
+        val actual = EventStreamConditionConverter.convert(condition { id("streamId") })
+
+        actual.term().field().assert().isEqualTo(MessageRecords.ID)
+        actual.term().value().stringValue().assert().isEqualTo("streamId")
+    }
+
+    @Test
+    fun `should convert event stream ids condition`() {
+        val actual = EventStreamConditionConverter.convert(condition { ids("streamId-1", "streamId-2") })
+
+        actual.terms().field().assert().isEqualTo(MessageRecords.ID)
+        actual.terms().terms().value().map { it.stringValue() }
+            .assert().containsExactly("streamId-1", "streamId-2")
+    }
+
+    @Test
     fun `should convert aggregate id condition`() {
         val condition = condition { aggregateId("aggregateId") }
         val actual = EventStreamConditionConverter.convert(condition)

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ConditionalOnElasticsearchEnabled.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ConditionalOnElasticsearchEnabled.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.spring.boot.starter.elasticsearch
+
+import me.ahoo.wow.spring.boot.starter.ENABLED_SUFFIX_KEY
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+
+const val ENABLED_KEY: String = ElasticsearchProperties.PREFIX + ENABLED_SUFFIX_KEY
+
+@ConditionalOnProperty(value = [ENABLED_KEY], matchIfMissing = true, havingValue = "true")
+annotation class ConditionalOnElasticsearchEnabled

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfiguration.kt
@@ -42,6 +42,7 @@ import org.springframework.data.elasticsearch.core.ReactiveElasticsearchOperatio
 
 @AutoConfiguration(after = [ElasticsearchRestClientAutoConfiguration::class])
 @ConditionalOnWowEnabled
+@ConditionalOnElasticsearchEnabled
 @ConditionalOnClass(ElasticsearchEventStore::class)
 @EnableConfigurationProperties(ElasticsearchProperties::class)
 class ElasticsearchEventSourcingAutoConfiguration(private val elasticsearchProperties: ElasticsearchProperties) {

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfigurationTest.kt
@@ -42,6 +42,24 @@ internal class ElasticsearchEventSourcingAutoConfigurationTest {
     private val contextRunner = ApplicationContextRunner()
 
     @Test
+    fun `should not load context when elasticsearch is disabled`() {
+        contextRunner
+            .enableWow()
+            .withPropertyValues("${ElasticsearchProperties.PREFIX}.enabled=false")
+            .withPropertyValues("${SnapshotProperties.STORAGE}=${StorageType.ELASTICSEARCH_NAME}")
+            .withPropertyValues("${EventStoreProperties.STORAGE}=${StorageType.ELASTICSEARCH_NAME}")
+            .withUserConfiguration(ElasticsearchEventSourcingAutoConfiguration::class.java)
+            .run { context: AssertableApplicationContext ->
+                context.assert()
+                    .hasNotFailed()
+                    .doesNotHaveBean(Jackson3JsonpMapper::class.java)
+                    .doesNotHaveBean(ElasticsearchEventStore::class.java)
+                    .doesNotHaveBean(ElasticsearchSnapshotStore::class.java)
+                    .doesNotHaveBean(IndexTemplateInitializer::class.java)
+            }
+    }
+
+    @Test
     fun `should load context with elasticsearch event sourcing beans`() {
         val elasticsearchTemplate = mockk<ReactiveElasticsearchOperations> {
             every { indexOps(any<IndexCoordinates>()) } returns mockk<ReactiveIndexOperations> {


### PR DESCRIPTION
## Goal

Correct Elasticsearch query semantics and make the existing `wow.elasticsearch.enabled` switch effective, while keeping list/single queries free from exact-total counting overhead.

## Changes

- Gate Elasticsearch event-sourcing auto-configuration with `wow.elasticsearch.enabled` (default remains `true`).
- Query event-stream `id`/`ids` against the serialized `id` field instead of Elasticsearch document `_id`.
- Implement `isNull` as missing-field semantics and `notNull` with an `exists` query.
- Split query execution by contract:
  - list/single: Search API with `track_total_hits=false`
  - paged: Search API with `track_total_hits=true` for an exact total
  - count: Elasticsearch Count API
- Add unit, auto-configuration, and container-backed integration coverage for the corrected behavior.

## Verification

- `./gradlew :wow-elasticsearch:test` — passed (47 tests).
- `./gradlew :wow-elasticsearch:check` — passed, including Detekt.
- `./gradlew :wow-elasticsearch:integrationTest --tests "me.ahoo.wow.elasticsearch.query.event.ElasticsearchEventStreamQueryServiceTest" --tests "me.ahoo.wow.elasticsearch.query.snapshot.ElasticsearchSnapshotQueryServiceTest"` — passed.
- `./gradlew :wow-spring-boot-starter:detekt :wow-spring-boot-starter:test --tests "me.ahoo.wow.spring.boot.starter.elasticsearch.ElasticsearchEventSourcingAutoConfigurationTest"` — passed.

## Risks and Notes

- This intentionally changes incorrect query behavior: event-stream `id` filters now match the stream ID, and null filters follow Elasticsearch missing-field semantics.
- Paged queries now compute exact totals and can cost more for very large result sets. List and single queries explicitly disable total tracking to avoid that cost.
- Deployments that set `wow.elasticsearch.enabled=false` but accidentally relied on Elasticsearch beans still being created must remove that setting or set it to `true`.
- There is no public API, index mapping, or stored-data migration. Rollback is a code revert; no data rollback is required.
