### PR TITLE
fix(opentelemetry): preserve reactive trace lifecycle

### DIFF
--- a/documentation/docs/en/guide/extensions/opentelemetry.md
+++ b/documentation/docs/en/guide/extensions/opentelemetry.md
@@ -57,3 +57,15 @@ implementation 'me.ahoo.wow:wow-opentelemetry'
 </dependency>
 ```
 :::
+
+## Configuration
+
+When `wow-opentelemetry` is on the classpath, Wow tracing auto-configuration is enabled by default. It can be disabled without removing the dependency:
+
+```yaml
+wow:
+  opentelemetry:
+    enabled: false
+```
+
+Initialize `GlobalOpenTelemetry` before the Wow application context creates tracing filters and decorators. Use the OpenTelemetry Java agent or register an SDK during application bootstrap; registering the SDK after Wow tracing instrumenters have initialized is too late.

--- a/documentation/docs/zh/guide/extensions/opentelemetry.md
+++ b/documentation/docs/zh/guide/extensions/opentelemetry.md
@@ -57,3 +57,15 @@ implementation 'me.ahoo.wow:wow-opentelemetry'
 </dependency>
 ```
 :::
+
+## 配置
+
+当 `wow-opentelemetry` 位于 classpath 时，Wow 默认开启链路追踪自动配置。无需移除依赖即可关闭：
+
+```yaml
+wow:
+  opentelemetry:
+    enabled: false
+```
+
+请在 Wow 应用上下文创建 tracing filters 和 decorators 前初始化 `GlobalOpenTelemetry`。可以使用 OpenTelemetry Java Agent，或在应用启动阶段注册 SDK；若在 Wow tracing instrumenters 初始化后才注册 SDK，则时机过晚。

--- a/wow-opentelemetry/build.gradle.kts
+++ b/wow-opentelemetry/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
     api(project(":wow-core"))
-    implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api")
+    api("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api")
     testImplementation(project(":wow-tck"))
     testImplementation("io.projectreactor:reactor-test")
     testImplementation("io.opentelemetry:opentelemetry-sdk")

--- a/wow-opentelemetry/src/contractTest/kotlin/me/ahoo/wow/opentelemetry/snapshot/TracingSnapshotStoreTest.kt
+++ b/wow-opentelemetry/src/contractTest/kotlin/me/ahoo/wow/opentelemetry/snapshot/TracingSnapshotStoreTest.kt
@@ -1,12 +1,12 @@
 package me.ahoo.wow.opentelemetry.snapshot
 
 import me.ahoo.wow.eventsourcing.snapshot.InMemorySnapshotStore
-import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
+import me.ahoo.wow.eventsourcing.snapshot.VersionedSnapshotStore
 import me.ahoo.wow.opentelemetry.Tracing.tracing
-import me.ahoo.wow.tck.eventsourcing.snapshot.SnapshotStoreSpec
+import me.ahoo.wow.tck.eventsourcing.snapshot.VersionedSnapshotStoreSpec
 
-class TracingSnapshotStoreTest : SnapshotStoreSpec() {
-    override fun createSnapshotStore(): SnapshotStore {
+class TracingSnapshotStoreTest : VersionedSnapshotStoreSpec() {
+    override fun createSnapshotStore(): VersionedSnapshotStore {
         return InMemorySnapshotStore().tracing()
     }
 }

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/ExchangeTraceMono.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/ExchangeTraceMono.kt
@@ -25,14 +25,21 @@ class ExchangeTraceMono<T : MessageExchange<*, *>>(
     private val request: T,
     private val source: Mono<Void>
 ) : Mono<Void>() {
+    @Suppress("TooGenericExceptionCaught")
     override fun subscribe(actual: CoreSubscriber<in Void>) {
         if (!instrumenter.shouldStart(parentContext, request)) {
             source.subscribe(actual)
             return
         }
         val otelContext = instrumenter.start(parentContext, request)
-        otelContext.makeCurrent().use {
-            source.subscribe(ExchangeTraceSubscriber(instrumenter, otelContext, request, actual))
+        val traceSubscriber = ExchangeTraceSubscriber(instrumenter, otelContext, request, actual)
+        try {
+            otelContext.makeCurrent().use {
+                source.subscribe(traceSubscriber)
+            }
+        } catch (error: Throwable) {
+            traceSubscriber.endSpan(error)
+            throw error
         }
     }
 }

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/ReactorTraceContext.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/ReactorTraceContext.kt
@@ -14,18 +14,22 @@
 package me.ahoo.wow.opentelemetry
 
 import io.opentelemetry.context.Context
-import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
-import me.ahoo.wow.messaging.handler.MessageExchange
-import reactor.core.CoreSubscriber
+import reactor.util.context.ContextView
 
-class ExchangeTraceSubscriber<T : MessageExchange<*, *>>(
-    instrumenter: Instrumenter<T, Unit>,
-    otelContext: Context,
-    private val exchange: T,
-    actual: CoreSubscriber<in Void>
-) : TraceSubscriber<T, Void>(instrumenter, otelContext, exchange, actual) {
+internal object ReactorTraceContext {
+    private val contextKey = Any()
 
-    override fun onComplete() {
-        complete(exchange.getError())
+    fun get(contextView: ContextView): Context {
+        if (contextView.hasKey(contextKey)) {
+            return contextView.get(contextKey)
+        }
+        return Context.current()
+    }
+
+    fun set(
+        reactorContext: reactor.util.context.Context,
+        otelContext: Context,
+    ): reactor.util.context.Context {
+        return reactorContext.put(contextKey, otelContext)
     }
 }

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/TraceFilter.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/TraceFilter.kt
@@ -13,7 +13,6 @@
 
 package me.ahoo.wow.opentelemetry
 
-import io.opentelemetry.context.Context
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
 import me.ahoo.wow.api.annotation.ORDER_FIRST
 import me.ahoo.wow.api.annotation.Order
@@ -29,8 +28,12 @@ open class TraceFilter<T : MessageExchange<*, *>>(private val instrumenter: Inst
         exchange: T,
         next: FilterChain<T>
     ): Mono<Void> {
-        val source = next.filter(exchange)
-        val parentContext = Context.current()
-        return ExchangeTraceMono(parentContext, instrumenter, exchange, source)
+        return Mono.deferContextual {
+            val parentContext = ReactorTraceContext.get(it)
+            val source = Mono.defer {
+                next.filter(exchange)
+            }
+            ExchangeTraceMono(parentContext, instrumenter, exchange, source)
+        }
     }
 }

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/TraceFlux.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/TraceFlux.kt
@@ -24,14 +24,21 @@ class TraceFlux<T : Any, O : Any>(
     private val request: T,
     private val source: Flux<O>
 ) : Flux<O>() {
+    @Suppress("TooGenericExceptionCaught")
     override fun subscribe(actual: CoreSubscriber<in O>) {
         if (!instrumenter.shouldStart(parentContext, request)) {
             source.subscribe(actual)
             return
         }
         val otelContext = instrumenter.start(parentContext, request)
-        otelContext.makeCurrent().use {
-            source.subscribe(TraceSubscriber(instrumenter, otelContext, request, actual))
+        val traceSubscriber = TraceSubscriber(instrumenter, otelContext, request, actual)
+        try {
+            otelContext.makeCurrent().use {
+                source.subscribe(traceSubscriber)
+            }
+        } catch (error: Throwable) {
+            traceSubscriber.endSpan(error)
+            throw error
         }
     }
 }

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/TraceMono.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/TraceMono.kt
@@ -24,14 +24,21 @@ class TraceMono<T : Any, O : Any>(
     private val request: T,
     private val source: Mono<O>
 ) : Mono<O>() {
+    @Suppress("TooGenericExceptionCaught")
     override fun subscribe(actual: CoreSubscriber<in O>) {
         if (!instrumenter.shouldStart(parentContext, request)) {
             source.subscribe(actual)
             return
         }
         val otelContext = instrumenter.start(parentContext, request)
-        otelContext.makeCurrent().use {
-            source.subscribe(TraceSubscriber(instrumenter, otelContext, request, actual))
+        val traceSubscriber = TraceSubscriber(instrumenter, otelContext, request, actual)
+        try {
+            otelContext.makeCurrent().use {
+                source.subscribe(traceSubscriber)
+            }
+        } catch (error: Throwable) {
+            traceSubscriber.endSpan(error)
+            throw error
         }
     }
 }

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/TraceSubscriber.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/TraceSubscriber.kt
@@ -17,32 +17,86 @@ import io.opentelemetry.context.Context
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
 import org.reactivestreams.Subscription
 import reactor.core.CoreSubscriber
+import java.util.concurrent.atomic.AtomicBoolean
 
 open class TraceSubscriber<T : Any, O : Any>(
     private val instrumenter: Instrumenter<T, Unit>,
     private val otelContext: Context,
     private val request: T,
-    private val actual: CoreSubscriber<in O>
+    protected val actual: CoreSubscriber<in O>
 ) : CoreSubscriber<O> {
+    private val ended = AtomicBoolean()
+
     override fun currentContext(): reactor.util.context.Context {
-        return actual.currentContext()
+        return ReactorTraceContext.set(actual.currentContext(), otelContext)
     }
 
     override fun onSubscribe(subscription: Subscription) {
-        actual.onSubscribe(subscription)
+        withContext {
+            actual.onSubscribe(TraceSubscription(subscription))
+        }
     }
 
     override fun onNext(signal: O) {
-        actual.onNext(signal)
+        withContext {
+            actual.onNext(signal)
+        }
     }
 
     override fun onError(throwable: Throwable) {
-        instrumenter.end(otelContext, request, null, throwable)
-        actual.onError(throwable)
+        terminate(throwable) {
+            actual.onError(throwable)
+        }
     }
 
     override fun onComplete() {
-        instrumenter.end(otelContext, request, null, null)
-        actual.onComplete()
+        complete(null)
+    }
+
+    protected fun complete(error: Throwable?) {
+        terminate(error) {
+            actual.onComplete()
+        }
+    }
+
+    internal fun endSpan(error: Throwable?): Boolean {
+        if (!ended.compareAndSet(false, true)) {
+            return false
+        }
+        instrumenter.end(otelContext, request, null, error)
+        return true
+    }
+
+    private fun terminate(error: Throwable?, signal: () -> Unit) {
+        if (!endSpan(error)) {
+            return
+        }
+        withContext(signal)
+    }
+
+    private fun withContext(block: () -> Unit) {
+        otelContext.makeCurrent().use {
+            block()
+        }
+    }
+
+    private inner class TraceSubscription(
+        private val delegate: Subscription,
+    ) : Subscription {
+        override fun request(n: Long) {
+            withContext {
+                delegate.request(n)
+            }
+        }
+
+        override fun cancel() {
+            try {
+                withContext {
+                    delegate.cancel()
+                }
+            } finally {
+                endSpan(null)
+            }
+        }
     }
 }

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/Tracing.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/Tracing.kt
@@ -20,6 +20,7 @@ import me.ahoo.wow.event.DistributedDomainEventBus
 import me.ahoo.wow.event.LocalDomainEventBus
 import me.ahoo.wow.eventsourcing.EventStore
 import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
+import me.ahoo.wow.eventsourcing.snapshot.VersionedSnapshotStore
 import me.ahoo.wow.eventsourcing.state.DistributedStateEventBus
 import me.ahoo.wow.eventsourcing.state.LocalStateEventBus
 import me.ahoo.wow.opentelemetry.eventsourcing.TracingEventStore
@@ -30,6 +31,7 @@ import me.ahoo.wow.opentelemetry.messaging.TracingLocalCommandBus
 import me.ahoo.wow.opentelemetry.messaging.TracingLocalEventBus
 import me.ahoo.wow.opentelemetry.messaging.TracingLocalStateEventBus
 import me.ahoo.wow.opentelemetry.snapshot.TracingSnapshotStore
+import me.ahoo.wow.opentelemetry.snapshot.TracingVersionedSnapshotStore
 import me.ahoo.wow.opentelemetry.wait.TracingCommandGateway
 
 object Tracing {
@@ -65,8 +67,17 @@ object Tracing {
     }
 
     fun SnapshotStore.tracing(): SnapshotStore {
+        if (this is VersionedSnapshotStore) {
+            return tracing()
+        }
         return tracing {
             TracingSnapshotStore(this)
+        }
+    }
+
+    fun VersionedSnapshotStore.tracing(): VersionedSnapshotStore {
+        return tracing {
+            TracingVersionedSnapshotStore(this)
         }
     }
 

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/eventsourcing/TracingEventStore.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/eventsourcing/TracingEventStore.kt
@@ -13,12 +13,12 @@
 
 package me.ahoo.wow.opentelemetry.eventsourcing
 
-import io.opentelemetry.context.Context
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.eventsourcing.EventStore
 import me.ahoo.wow.infra.Decorator
+import me.ahoo.wow.opentelemetry.ReactorTraceContext
 import me.ahoo.wow.opentelemetry.TraceFlux
 import me.ahoo.wow.opentelemetry.TraceMono
 import me.ahoo.wow.opentelemetry.Traced
@@ -27,33 +27,41 @@ import reactor.core.publisher.Mono
 
 class TracingEventStore(override val delegate: EventStore) : Traced, EventStore, Decorator<EventStore> {
     override fun append(eventStream: DomainEventStream): Mono<Void> {
-        return Mono.defer {
-            val parentContext = Context.current()
-            val source = delegate.append(eventStream)
+        return Mono.deferContextual {
+            val parentContext = ReactorTraceContext.get(it)
+            val source = Mono.defer {
+                delegate.append(eventStream)
+            }
             TraceMono(parentContext, EventStoreInstrumenter.APPEND_INSTRUMENTER, eventStream, source)
         }
     }
 
     override fun load(aggregateId: AggregateId, headVersion: Int, tailVersion: Int): Flux<DomainEventStream> {
-        return Flux.defer {
-            val parentContext = Context.current()
-            val source = delegate.load(aggregateId, headVersion, tailVersion)
+        return Flux.deferContextual {
+            val parentContext = ReactorTraceContext.get(it)
+            val source = Flux.defer {
+                delegate.load(aggregateId, headVersion, tailVersion)
+            }
             TraceFlux(parentContext, EventStoreInstrumenter.LOAD_INSTRUMENTER, aggregateId, source)
         }
     }
 
     override fun load(aggregateId: AggregateId, headEventTime: Long, tailEventTime: Long): Flux<DomainEventStream> {
-        return Flux.defer {
-            val parentContext = Context.current()
-            val source = delegate.load(aggregateId, headEventTime, tailEventTime)
+        return Flux.deferContextual {
+            val parentContext = ReactorTraceContext.get(it)
+            val source = Flux.defer {
+                delegate.load(aggregateId, headEventTime, tailEventTime)
+            }
             TraceFlux(parentContext, EventStoreInstrumenter.LOAD_INSTRUMENTER, aggregateId, source)
         }
     }
 
     override fun last(aggregateId: AggregateId): Mono<DomainEventStream> {
-        return Mono.defer {
-            val parentContext = Context.current()
-            val source = delegate.last(aggregateId)
+        return Mono.deferContextual {
+            val parentContext = ReactorTraceContext.get(it)
+            val source = Mono.defer {
+                delegate.last(aggregateId)
+            }
             TraceMono(parentContext, EventStoreInstrumenter.LOAD_INSTRUMENTER, aggregateId, source)
         }
     }

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/messaging/TracingMessageBus.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/messaging/TracingMessageBus.kt
@@ -13,13 +13,13 @@
 
 package me.ahoo.wow.opentelemetry.messaging
 
-import io.opentelemetry.context.Context
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
 import me.ahoo.wow.api.messaging.Message
 import me.ahoo.wow.infra.Decorator
 import me.ahoo.wow.messaging.MessageBus
 import me.ahoo.wow.messaging.MessageSubscription
 import me.ahoo.wow.messaging.handler.MessageExchange
+import me.ahoo.wow.opentelemetry.ReactorTraceContext
 import me.ahoo.wow.opentelemetry.TraceMono
 import me.ahoo.wow.opentelemetry.Traced
 import reactor.core.publisher.Flux
@@ -31,14 +31,18 @@ interface TracingMessageBus<M : Message<*, *>, E : MessageExchange<*, M>, B : Me
     Decorator<B> {
     val producerInstrumenter: Instrumenter<M, Unit>
     override fun send(message: M): Mono<Void> {
-        val source = delegate.send(message)
-        val parentContext = Context.current()
-        return TraceMono(
-            parentContext = parentContext,
-            instrumenter = producerInstrumenter,
-            request = message,
-            source = source,
-        )
+        return Mono.deferContextual {
+            val parentContext = ReactorTraceContext.get(it)
+            val source = Mono.defer {
+                delegate.send(message)
+            }
+            TraceMono(
+                parentContext = parentContext,
+                instrumenter = producerInstrumenter,
+                request = message,
+                source = source,
+            )
+        }
     }
 
     override fun receive(subscription: MessageSubscription): Flux<E> {

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/snapshot/SnapshotStoreInstrumenter.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/snapshot/SnapshotStoreInstrumenter.kt
@@ -40,6 +40,33 @@ object SnapshotStoreInstrumenter {
         ).addAttributesExtractor(AggregateIdAttributesExtractor)
             .setInstrumentationVersion(Wow.VERSION)
             .buildInstrumenter()
+
+    val VERSION_INSTRUMENTER: Instrumenter<AggregateId, Unit> =
+        Instrumenter.builder<AggregateId, Unit>(
+            GlobalOpenTelemetry.get(),
+            INSTRUMENTATION_NAME,
+            SnapshotStoreVersionSpanNameExtractor,
+        ).addAttributesExtractor(AggregateIdAttributesExtractor)
+            .setInstrumentationVersion(Wow.VERSION)
+            .buildInstrumenter()
+
+    val CHECKPOINT_SAVE_INSTRUMENTER: Instrumenter<AggregateId, Unit> =
+        Instrumenter.builder<AggregateId, Unit>(
+            GlobalOpenTelemetry.get(),
+            INSTRUMENTATION_NAME,
+            SnapshotStoreCheckpointSaveSpanNameExtractor,
+        ).addAttributesExtractor(AggregateIdAttributesExtractor)
+            .setInstrumentationVersion(Wow.VERSION)
+            .buildInstrumenter()
+
+    val CHECKPOINT_LOAD_INSTRUMENTER: Instrumenter<AggregateId, Unit> =
+        Instrumenter.builder<AggregateId, Unit>(
+            GlobalOpenTelemetry.get(),
+            INSTRUMENTATION_NAME,
+            SnapshotStoreCheckpointLoadSpanNameExtractor,
+        ).addAttributesExtractor(AggregateIdAttributesExtractor)
+            .setInstrumentationVersion(Wow.VERSION)
+            .buildInstrumenter()
 }
 
 object SnapshotStoreSaveSpanNameExtractor : SpanNameExtractor<AggregateId> {
@@ -51,5 +78,23 @@ object SnapshotStoreSaveSpanNameExtractor : SpanNameExtractor<AggregateId> {
 object SnapshotStoreLoadSpanNameExtractor : SpanNameExtractor<AggregateId> {
     override fun extract(request: AggregateId): String {
         return "${request.aggregateName}.snapshot.load"
+    }
+}
+
+object SnapshotStoreVersionSpanNameExtractor : SpanNameExtractor<AggregateId> {
+    override fun extract(request: AggregateId): String {
+        return "${request.aggregateName}.snapshot.version"
+    }
+}
+
+object SnapshotStoreCheckpointSaveSpanNameExtractor : SpanNameExtractor<AggregateId> {
+    override fun extract(request: AggregateId): String {
+        return "${request.aggregateName}.snapshot.checkpoint.save"
+    }
+}
+
+object SnapshotStoreCheckpointLoadSpanNameExtractor : SpanNameExtractor<AggregateId> {
+    override fun extract(request: AggregateId): String {
+        return "${request.aggregateName}.snapshot.checkpoint.load"
     }
 }

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/snapshot/TracingVersionedSnapshotStore.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/snapshot/TracingVersionedSnapshotStore.kt
@@ -15,47 +15,46 @@ package me.ahoo.wow.opentelemetry.snapshot
 
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.eventsourcing.snapshot.Snapshot
-import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
-import me.ahoo.wow.infra.Decorator
+import me.ahoo.wow.eventsourcing.snapshot.VersionedSnapshotStore
 import me.ahoo.wow.opentelemetry.ReactorTraceContext
 import me.ahoo.wow.opentelemetry.TraceMono
-import me.ahoo.wow.opentelemetry.Traced
 import reactor.core.publisher.Mono
 
-open class TracingSnapshotStore(override val delegate: SnapshotStore) :
-    Traced,
-    SnapshotStore,
-    Decorator<SnapshotStore> {
-    override val name: String
-        get() = delegate.name
+class TracingVersionedSnapshotStore(
+    private val checkpointStore: VersionedSnapshotStore,
+) : TracingSnapshotStore(checkpointStore),
+    VersionedSnapshotStore {
 
-    override fun <S : Any> load(aggregateId: AggregateId): Mono<Snapshot<S>> {
+    override fun <S : Any> loadAtOrBefore(
+        aggregateId: AggregateId,
+        maxVersion: Int,
+    ): Mono<Snapshot<S>> {
         return Mono.deferContextual {
             val parentContext = ReactorTraceContext.get(it)
             val source = Mono.defer {
-                delegate.load<S>(aggregateId)
+                checkpointStore.loadAtOrBefore<S>(aggregateId, maxVersion)
             }
-            TraceMono(parentContext, SnapshotStoreInstrumenter.LOAD_INSTRUMENTER, aggregateId, source)
+            TraceMono(
+                parentContext,
+                SnapshotStoreInstrumenter.CHECKPOINT_LOAD_INSTRUMENTER,
+                aggregateId,
+                source,
+            )
         }
     }
 
-    override fun getVersion(aggregateId: AggregateId): Mono<Int> {
+    override fun <S : Any> saveCheckpoint(snapshot: Snapshot<S>): Mono<Void> {
         return Mono.deferContextual {
             val parentContext = ReactorTraceContext.get(it)
             val source = Mono.defer {
-                delegate.getVersion(aggregateId)
+                checkpointStore.saveCheckpoint(snapshot)
             }
-            TraceMono(parentContext, SnapshotStoreInstrumenter.VERSION_INSTRUMENTER, aggregateId, source)
-        }
-    }
-
-    override fun <S : Any> save(snapshot: Snapshot<S>): Mono<Void> {
-        return Mono.deferContextual {
-            val parentContext = ReactorTraceContext.get(it)
-            val source = Mono.defer {
-                delegate.save(snapshot)
-            }
-            TraceMono(parentContext, SnapshotStoreInstrumenter.SAVE_INSTRUMENTER, snapshot.aggregateId, source)
+            TraceMono(
+                parentContext,
+                SnapshotStoreInstrumenter.CHECKPOINT_SAVE_INSTRUMENTER,
+                snapshot.aggregateId,
+                source,
+            )
         }
     }
 }

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/wait/TracingCommandGateway.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/wait/TracingCommandGateway.kt
@@ -13,7 +13,6 @@
 
 package me.ahoo.wow.opentelemetry.wait
 
-import io.opentelemetry.context.Context
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.command.CommandGateway
 import me.ahoo.wow.command.CommandResult
@@ -21,6 +20,7 @@ import me.ahoo.wow.command.ServerCommandExchange
 import me.ahoo.wow.command.wait.WaitPlan
 import me.ahoo.wow.infra.Decorator
 import me.ahoo.wow.messaging.MessageSubscription
+import me.ahoo.wow.opentelemetry.ReactorTraceContext
 import me.ahoo.wow.opentelemetry.TraceFlux
 import me.ahoo.wow.opentelemetry.TraceMono
 import me.ahoo.wow.opentelemetry.Traced
@@ -32,24 +32,34 @@ class TracingCommandGateway(override val delegate: CommandGateway) : Traced, Com
         command: CommandMessage<C>,
         waitPlan: WaitPlan
     ): Flux<CommandResult> {
-        return TraceFlux(
-            parentContext = Context.current(),
-            instrumenter = WaitPlanInstrumenter.INSTRUMENTER,
-            request = command,
-            source = delegate.sendAndWaitStream(command, waitPlan),
-        )
+        return Flux.deferContextual {
+            val source = Flux.defer {
+                delegate.sendAndWaitStream(command, waitPlan)
+            }
+            TraceFlux(
+                parentContext = ReactorTraceContext.get(it),
+                instrumenter = WaitPlanInstrumenter.INSTRUMENTER,
+                request = command,
+                source = source,
+            )
+        }
     }
 
     override fun <C : Any> sendAndWait(
         command: CommandMessage<C>,
         waitPlan: WaitPlan
     ): Mono<CommandResult> {
-        return TraceMono(
-            parentContext = Context.current(),
-            instrumenter = WaitPlanInstrumenter.INSTRUMENTER,
-            request = command,
-            source = delegate.sendAndWait(command, waitPlan),
-        )
+        return Mono.deferContextual {
+            val source = Mono.defer {
+                delegate.sendAndWait(command, waitPlan)
+            }
+            TraceMono(
+                parentContext = ReactorTraceContext.get(it),
+                instrumenter = WaitPlanInstrumenter.INSTRUMENTER,
+                request = command,
+                source = source,
+            )
+        }
     }
 
     override fun send(message: CommandMessage<*>): Mono<Void> {

--- a/wow-opentelemetry/src/test/kotlin/me/ahoo/wow/opentelemetry/TracePublisherTest.kt
+++ b/wow-opentelemetry/src/test/kotlin/me/ahoo/wow/opentelemetry/TracePublisherTest.kt
@@ -1,0 +1,325 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.opentelemetry
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.verify
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.ContextKey
+import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.command.CommandMessage
+import me.ahoo.wow.command.LocalCommandBus
+import me.ahoo.wow.messaging.handler.MessageExchange
+import me.ahoo.wow.opentelemetry.messaging.TracingLocalCommandBus
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import reactor.core.CoreSubscriber
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
+import reactor.kotlin.test.test
+
+class TracePublisherTest {
+
+    @Test
+    fun `should end span when subscription is cancelled`() {
+        val traceContext = Context.root()
+        val instrumenter = mockInstrumenter(traceContext)
+
+        TraceFlux(
+            parentContext = Context.root(),
+            instrumenter = instrumenter,
+            request = REQUEST,
+            source = Flux.never<Int>(),
+        ).test()
+            .thenCancel()
+            .verify()
+
+        verify(exactly = 1) {
+            instrumenter.end(traceContext, REQUEST, null, null)
+        }
+    }
+
+    @Test
+    fun `should end span exactly once when downstream cancels after first element`() {
+        val traceContext = Context.root()
+        val instrumenter = mockInstrumenter(traceContext)
+
+        TraceFlux(
+            parentContext = Context.root(),
+            instrumenter = instrumenter,
+            request = REQUEST,
+            source = Flux.just(1, 2),
+        ).take(1)
+            .test()
+            .expectNext(1)
+            .verifyComplete()
+
+        verify(exactly = 1) {
+            instrumenter.end(traceContext, REQUEST, null, null)
+        }
+    }
+
+    @Test
+    fun `should restore trace context for asynchronous signals`() {
+        val contextKey = ContextKey.named<String>("trace-publisher-test")
+        val traceContext = Context.root().with(contextKey, "active")
+        val instrumenter = mockInstrumenter(traceContext)
+
+        TraceMono(
+            parentContext = Context.root(),
+            instrumenter = instrumenter,
+            request = REQUEST,
+            source = Mono.just(1).publishOn(Schedulers.parallel()),
+        ).doOnNext {
+            Context.current()[contextKey].assert().isEqualTo("active")
+        }.test()
+            .expectNext(1)
+            .verifyComplete()
+
+        verify(exactly = 1) {
+            instrumenter.end(traceContext, REQUEST, null, null)
+        }
+    }
+
+    @Test
+    fun `should capture parent context when publisher is subscribed`() {
+        val contextKey = ContextKey.named<String>("subscription-context")
+        val subscriptionContext = Context.root().with(contextKey, "active")
+        val message = mockk<CommandMessage<*>>()
+        val delegate = mockk<LocalCommandBus> {
+            every { send(message) } returns Mono.empty()
+        }
+        val instrumenter = mockk<Instrumenter<CommandMessage<*>, Unit>> {
+            every { shouldStart(subscriptionContext, message) } returns true
+            every { start(subscriptionContext, message) } returns subscriptionContext
+            every { end(subscriptionContext, message, null, null) } just runs
+        }
+        val publisher = TracingLocalCommandBus(delegate, instrumenter).send(message)
+
+        subscriptionContext.makeCurrent().use {
+            publisher.block()
+        }
+
+        verify(exactly = 1) {
+            instrumenter.shouldStart(subscriptionContext, message)
+            instrumenter.end(subscriptionContext, message, null, null)
+        }
+    }
+
+    @Test
+    fun `should propagate trace context to nested publisher across thread boundary`() {
+        val contextKey = ContextKey.named<String>("nested-publisher-context")
+        val parentTraceContext = Context.root().with(contextKey, "parent")
+        val parentInstrumenter = mockInstrumenter(parentTraceContext)
+        val message = mockk<CommandMessage<*>>()
+        val delegate = mockk<LocalCommandBus> {
+            every { send(message) } returns Mono.empty()
+        }
+        val childInstrumenter = mockk<Instrumenter<CommandMessage<*>, Unit>> {
+            every { shouldStart(parentTraceContext, message) } returns true
+            every { start(parentTraceContext, message) } returns parentTraceContext
+            every { end(parentTraceContext, message, null, null) } just runs
+        }
+        val tracedBus = TracingLocalCommandBus(delegate, childInstrumenter)
+        val source = Mono.just(1)
+            .publishOn(Schedulers.parallel())
+            .flatMap {
+                tracedBus.send(message).thenReturn(it)
+            }
+
+        TraceMono(
+            parentContext = Context.root(),
+            instrumenter = parentInstrumenter,
+            request = REQUEST,
+            source = source,
+        ).test()
+            .expectNext(1)
+            .verifyComplete()
+
+        verify(exactly = 1) {
+            childInstrumenter.shouldStart(parentTraceContext, message)
+            childInstrumenter.end(parentTraceContext, message, null, null)
+        }
+    }
+
+    @Test
+    fun `should end span with source error`() {
+        val traceContext = Context.root()
+        val instrumenter = mockInstrumenter(traceContext)
+        val failure = IllegalStateException("source failed")
+
+        TraceMono(
+            parentContext = Context.root(),
+            instrumenter = instrumenter,
+            request = REQUEST,
+            source = Mono.error<Int>(failure),
+        ).test()
+            .expectErrorMatches { it === failure }
+            .verify()
+
+        verify(exactly = 1) {
+            instrumenter.end(traceContext, REQUEST, null, failure)
+        }
+    }
+
+    @Test
+    fun `should subscribe without tracing when instrumenter declines`() {
+        val monoInstrumenter = mockk<Instrumenter<String, Unit>> {
+            every { shouldStart(Context.root(), REQUEST) } returns false
+        }
+        val fluxInstrumenter = mockk<Instrumenter<String, Unit>> {
+            every { shouldStart(Context.root(), REQUEST) } returns false
+        }
+        val exchange = mockk<MessageExchange<*, *>>()
+        val exchangeInstrumenter = mockk<Instrumenter<MessageExchange<*, *>, Unit>> {
+            every { shouldStart(Context.root(), exchange) } returns false
+        }
+
+        TraceMono(
+            parentContext = Context.root(),
+            instrumenter = monoInstrumenter,
+            request = REQUEST,
+            source = Mono.just(1),
+        ).test()
+            .expectNext(1)
+            .verifyComplete()
+        TraceFlux(
+            parentContext = Context.root(),
+            instrumenter = fluxInstrumenter,
+            request = REQUEST,
+            source = Flux.just(1),
+        ).test()
+            .expectNext(1)
+            .verifyComplete()
+        ExchangeTraceMono(
+            parentContext = Context.root(),
+            instrumenter = exchangeInstrumenter,
+            request = exchange,
+            source = Mono.empty(),
+        ).test()
+            .verifyComplete()
+
+        verify(exactly = 0) {
+            monoInstrumenter.start(any(), any())
+            fluxInstrumenter.start(any(), any())
+            exchangeInstrumenter.start(any(), any())
+        }
+    }
+
+    @Test
+    fun `should end span when source throws during subscription`() {
+        val failure = IllegalStateException("subscribe failed")
+        val traceContext = Context.root()
+        val monoInstrumenter = mockInstrumenter(traceContext)
+        val fluxInstrumenter = mockInstrumenter(traceContext)
+        val actual = mockk<CoreSubscriber<Int>>(relaxed = true)
+
+        assertThrows<IllegalStateException> {
+            TraceMono(
+                parentContext = Context.root(),
+                instrumenter = monoInstrumenter,
+                request = REQUEST,
+                source = throwingMono<Int>(failure),
+            ).subscribe(actual)
+        }.assert().isSameAs(failure)
+        assertThrows<IllegalStateException> {
+            TraceFlux(
+                parentContext = Context.root(),
+                instrumenter = fluxInstrumenter,
+                request = REQUEST,
+                source = throwingFlux(failure),
+            ).subscribe(actual)
+        }.assert().isSameAs(failure)
+
+        verify(exactly = 1) {
+            monoInstrumenter.end(traceContext, REQUEST, null, failure)
+            fluxInstrumenter.end(traceContext, REQUEST, null, failure)
+        }
+    }
+
+    @Test
+    fun `should end exchange span when source throws during subscription`() {
+        val failure = IllegalStateException("subscribe failed")
+        val traceContext = Context.root()
+        val exchange = mockk<MessageExchange<*, *>>()
+        val instrumenter = mockk<Instrumenter<MessageExchange<*, *>, Unit>> {
+            every { shouldStart(Context.root(), exchange) } returns true
+            every { start(Context.root(), exchange) } returns traceContext
+            every { end(traceContext, exchange, null, failure) } just runs
+        }
+
+        assertThrows<IllegalStateException> {
+            ExchangeTraceMono(
+                parentContext = Context.root(),
+                instrumenter = instrumenter,
+                request = exchange,
+                source = throwingMono(failure),
+            ).subscribe(mockk<CoreSubscriber<Void>>(relaxed = true))
+        }.assert().isSameAs(failure)
+
+        verify(exactly = 1) {
+            instrumenter.end(traceContext, exchange, null, failure)
+        }
+    }
+
+    @Test
+    fun `should ignore repeated terminal signal`() {
+        val traceContext = Context.root()
+        val instrumenter = mockInstrumenter(traceContext)
+        val actual = mockk<CoreSubscriber<Int>>(relaxed = true)
+        val subscriber = TraceSubscriber(instrumenter, traceContext, REQUEST, actual)
+
+        subscriber.onComplete()
+        subscriber.onComplete()
+
+        verify(exactly = 1) {
+            instrumenter.end(traceContext, REQUEST, null, null)
+            actual.onComplete()
+        }
+    }
+
+    private fun <T : Any> throwingMono(failure: Throwable): Mono<T> {
+        return object : Mono<T>() {
+            override fun subscribe(actual: CoreSubscriber<in T>) {
+                throw failure
+            }
+        }
+    }
+
+    private fun throwingFlux(failure: Throwable): Flux<Int> {
+        return object : Flux<Int>() {
+            override fun subscribe(actual: CoreSubscriber<in Int>) {
+                throw failure
+            }
+        }
+    }
+
+    private fun mockInstrumenter(traceContext: Context): Instrumenter<String, Unit> {
+        return mockk {
+            every { shouldStart(any(), REQUEST) } returns true
+            every { start(any(), REQUEST) } returns traceContext
+            every { end(traceContext, REQUEST, null, null) } just runs
+            every { end(traceContext, REQUEST, null, any()) } just runs
+        }
+    }
+
+    companion object {
+        private const val REQUEST = "request"
+    }
+}

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/ConditionalOnOpenTelemetryEnabled.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/ConditionalOnOpenTelemetryEnabled.kt
@@ -13,7 +13,19 @@
 
 package me.ahoo.wow.spring.boot.starter.opentelemetry
 
+import me.ahoo.wow.api.Wow
+import me.ahoo.wow.spring.boot.starter.ENABLED_SUFFIX_KEY
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 
 @ConditionalOnClass(name = ["me.ahoo.wow.opentelemetry.WowInstrumenter"])
-annotation class ConditionalOnOpenTelemetryEnabled
+@ConditionalOnProperty(
+    value = [ConditionalOnOpenTelemetryEnabled.ENABLED_KEY],
+    matchIfMissing = true,
+    havingValue = "true",
+)
+annotation class ConditionalOnOpenTelemetryEnabled {
+    companion object {
+        const val ENABLED_KEY: String = Wow.WOW_PREFIX + "opentelemetry" + ENABLED_SUFFIX_KEY
+    }
+}

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/WowOpenTelemetryAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/WowOpenTelemetryAutoConfiguration.kt
@@ -45,21 +45,25 @@ class WowOpenTelemetryAutoConfiguration {
     }
 
     @Bean
+    @ConditionalOnMissingBean
     fun traceSnapshotFilter(): TraceSnapshotFilter {
         return TraceSnapshotFilter
     }
 
     @Bean
+    @ConditionalOnMissingBean
     fun traceStatelessSagaFilter(): TraceStatelessSagaFilter {
         return TraceStatelessSagaFilter
     }
 
     @Bean
+    @ConditionalOnMissingBean
     fun traceEventProcessorFilter(): TraceEventProcessorFilter {
         return TraceEventProcessorFilter
     }
 
     @Bean
+    @ConditionalOnMissingBean
     fun tracingBeanPostProcessor(): TracingBeanPostProcessor {
         return TracingBeanPostProcessor()
     }

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/WowOpenTelemetryAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/WowOpenTelemetryAutoConfigurationTest.kt
@@ -14,12 +14,15 @@
 package me.ahoo.wow.spring.boot.starter.opentelemetry
 
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.eventsourcing.snapshot.InMemorySnapshotStore
+import me.ahoo.wow.eventsourcing.snapshot.VersionedSnapshotStore
 import me.ahoo.wow.opentelemetry.aggregate.TraceAggregateFilter
 import me.ahoo.wow.opentelemetry.eventprocessor.TraceEventProcessorFilter
 import me.ahoo.wow.opentelemetry.projection.TraceProjectionFilter
 import me.ahoo.wow.opentelemetry.saga.TraceStatelessSagaFilter
 import me.ahoo.wow.opentelemetry.snapshot.TraceSnapshotFilter
 import me.ahoo.wow.spring.boot.starter.enableWow
+import me.ahoo.wow.spring.boot.starter.metrics.MetricsBeanPostProcessor
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
@@ -41,6 +44,54 @@ internal class WowOpenTelemetryAutoConfigurationTest {
                     .hasSingleBean(TraceSnapshotFilter::class.java)
                     .hasSingleBean(TraceStatelessSagaFilter::class.java)
                     .hasSingleBean(TraceEventProcessorFilter::class.java)
+                    .hasSingleBean(TracingBeanPostProcessor::class.java)
             }
+    }
+
+    @Test
+    fun `should disable open telemetry`() {
+        contextRunner
+            .enableWow()
+            .withPropertyValues("${ConditionalOnOpenTelemetryEnabled.ENABLED_KEY}=false")
+            .withUserConfiguration(
+                WowOpenTelemetryAutoConfiguration::class.java,
+            )
+            .run { context: AssertableApplicationContext ->
+                context.assert()
+                    .doesNotHaveBean(TraceAggregateFilter::class.java)
+                    .doesNotHaveBean(TraceProjectionFilter::class.java)
+                    .doesNotHaveBean(TraceSnapshotFilter::class.java)
+                    .doesNotHaveBean(TraceStatelessSagaFilter::class.java)
+                    .doesNotHaveBean(TraceEventProcessorFilter::class.java)
+                    .doesNotHaveBean(TracingBeanPostProcessor::class.java)
+            }
+    }
+
+    @Test
+    fun `should back off when custom trace filter exists`() {
+        contextRunner
+            .enableWow()
+            .withBean("customTraceSnapshotFilter", TraceSnapshotFilter::class.java, { TraceSnapshotFilter })
+            .withUserConfiguration(
+                WowOpenTelemetryAutoConfiguration::class.java,
+            )
+            .run { context: AssertableApplicationContext ->
+                context.assert().hasSingleBean(TraceSnapshotFilter::class.java)
+            }
+    }
+
+    @Test
+    fun `should preserve versioned snapshot store capability`() {
+        val tracedStore = TracingBeanPostProcessor().postProcessAfterInitialization(
+            InMemorySnapshotStore(),
+            "snapshotStore",
+        )
+        val metricStore = MetricsBeanPostProcessor().postProcessAfterInitialization(
+            tracedStore,
+            "snapshotStore",
+        )
+
+        tracedStore.assert().isInstanceOf(VersionedSnapshotStore::class.java)
+        metricStore.assert().isInstanceOf(VersionedSnapshotStore::class.java)
     }
 }


### PR DESCRIPTION
## Goal

Fix OpenTelemetry tracing correctness across Reactor subscription, asynchronous signal, cancellation, and versioned snapshot-store paths while keeping the Spring integration configurable and composable.

Completion criteria:

- propagate the active OpenTelemetry context across Reactor boundaries;
- end spans exactly once on completion, error, cancellation, and synchronous subscription failure;
- preserve `VersionedSnapshotStore` capabilities after tracing decoration;
- provide an explicit, default-enabled Spring configuration switch;
- cover the affected lifecycle and auto-configuration branches.

## Changes

- Added a Reactor context bridge and moved parent-context capture to subscription time for message buses, event stores, snapshot stores, command gateways, and tracing filters.
- Hardened trace publishers so asynchronous callbacks run with the span context and cancellation or synchronous subscribe failures end the span exactly once.
- Added a capability-preserving `TracingVersionedSnapshotStore` plus spans for version lookup and checkpoint load/save operations.
- Added `wow.opentelemetry.enabled` with `true` as the default and made default tracing filters/post-processor back off when applications provide custom beans.
- Exposed `opentelemetry-instrumentation-api` as an API dependency because its types appear in the module's public API.
- Documented the configuration switch and the required `GlobalOpenTelemetry` bootstrap ordering in English and Chinese.
- Added lifecycle, asynchronous propagation, cancellation, synchronous failure, duplicate-terminal, capability, and Spring auto-configuration tests.

## Verification

Passed:

```text
./gradlew :wow-opentelemetry:check \
  :wow-opentelemetry:jacocoTestReport \
  :wow-opentelemetry:jacocoTestCoverageVerification \
  :wow-spring-boot-starter:detekt \
  :wow-spring-boot-starter:test \
  --tests me.ahoo.wow.spring.boot.starter.opentelemetry.WowOpenTelemetryAutoConfigurationTest \
  --tests me.ahoo.wow.spring.boot.starter.eventsourcing.snapshot.SnapshotAutoConfigurationTest
```

The final JaCoCo report gives 100% instruction and branch coverage for `TraceMono`, `TraceFlux`, `ExchangeTraceMono`, and `ReactorTraceContext`; `TraceSubscriber` has 94% instruction and 100% branch coverage.

`git diff --check` also passed.

## Risks and Notes

- No public API removal or incompatible signature change is introduced.
- Tracing remains enabled by default when the module is on the classpath, but can now be disabled with `wow.opentelemetry.enabled=false`.
- Versioned snapshot operations emit additional spans.
- `GlobalOpenTelemetry` still needs to be initialized before Wow tracing instrumenters are first initialized. The documentation now makes this startup constraint explicit; removing the global initialization-order constraint should be handled as a separate instrumenter dependency-injection refactor.
- Rollback is a normal commit revert; no data or schema migration is involved.