### PR TITLE
fix(metrics): prevent routed storage double counting

### DIFF
--- a/documentation/docs/en/guide/advanced/metrics.md
+++ b/documentation/docs/en/guide/advanced/metrics.md
@@ -83,6 +83,12 @@ Tags depend on the operation. Wow-defined tags are:
 
 Reactor adds tags such as `type`, `status`, and `exception` depending on the generated meter. Internal dispatcher routing keys are intentionally not exported as tags because they multiply time-series cardinality. A bounded-context tag is not currently emitted.
 
+### Storage Routing Ownership
+
+When aggregate-specific storage routing is enabled, event-store and snapshot-store metrics are recorded only by the selected leaf backend. `RoutingEventStore` and `RoutingSnapshotStore` are metric-transparent, so one storage operation produces one set of meters and the `source` tag identifies the physical backend such as `MongoEventStore` or `RedisEventStore`.
+
+Dashboards that previously selected `source=RoutingEventStore` or `source=RoutingSnapshotStore` must switch to the physical backend source. Queries that aggregate across `source` no longer double-count routed operations.
+
 ## Custom Metrics
 
 ### Manual Metrics Collection

--- a/documentation/docs/zh/guide/advanced/metrics.md
+++ b/documentation/docs/zh/guide/advanced/metrics.md
@@ -83,6 +83,12 @@ Wow 框架自动为以下组件收集指标：
 
 Reactor 会根据生成的 meter 添加 `type`、`status`、`exception` 等标签。内部 dispatcher 路由 key 会放大时序基数，因此不会作为标签导出。当前尚未生成限界上下文标签。
 
+### 存储路由指标归属
+
+启用聚合级存储路由时，EventStore 与 SnapshotStore 指标只由最终选中的物理 leaf backend 记录。`RoutingEventStore` 和 `RoutingSnapshotStore` 对指标透明，因此一次存储操作只产生一组 meter，`source` 标签标识 `MongoEventStore`、`RedisEventStore` 等实际后端。
+
+原先筛选 `source=RoutingEventStore` 或 `source=RoutingSnapshotStore` 的仪表盘需要切换到实际后端 source。跨 `source` 聚合的查询不再重复统计路由操作。
+
 ## 自定义指标
 
 ### 手动指标收集

--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/Metrics.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/Metrics.kt
@@ -30,6 +30,7 @@ import me.ahoo.wow.eventsourcing.snapshot.VersionedSnapshotStore
 import me.ahoo.wow.eventsourcing.snapshot.dispatcher.SnapshotHandler
 import me.ahoo.wow.eventsourcing.state.DistributedStateEventBus
 import me.ahoo.wow.eventsourcing.state.LocalStateEventBus
+import me.ahoo.wow.infra.Decorator.Companion.getOriginalDelegate
 import me.ahoo.wow.modeling.command.dispatcher.CommandHandler
 import me.ahoo.wow.projection.ProjectionHandler
 import me.ahoo.wow.saga.stateless.StatelessSagaHandler
@@ -208,7 +209,7 @@ object Metrics {
      * @return the metrizable event store
      */
     fun EventStore.metrizable(): EventStore {
-        if (this is RoutingEventStore) {
+        if (getOriginalDelegate() is RoutingEventStore) {
             return this
         }
         return metrizable {
@@ -235,7 +236,7 @@ object Metrics {
      * @return the metrizable snapshot store
      */
     fun SnapshotStore.metrizable(): SnapshotStore {
-        if (this is RoutingSnapshotStore) {
+        if (getOriginalDelegate() is RoutingSnapshotStore) {
             return this
         }
         return metrizable {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/Metrics.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/Metrics.kt
@@ -22,6 +22,8 @@ import me.ahoo.wow.event.DistributedDomainEventBus
 import me.ahoo.wow.event.LocalDomainEventBus
 import me.ahoo.wow.event.dispatcher.DomainEventHandler
 import me.ahoo.wow.eventsourcing.EventStore
+import me.ahoo.wow.eventsourcing.RoutingEventStore
+import me.ahoo.wow.eventsourcing.snapshot.RoutingSnapshotStore
 import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
 import me.ahoo.wow.eventsourcing.snapshot.SnapshotStrategy
 import me.ahoo.wow.eventsourcing.snapshot.VersionedSnapshotStore
@@ -201,13 +203,18 @@ object Metrics {
     /**
      * Wraps an EventStore with metrics collection capabilities.
      * Returns a MetricEventStore that collects metrics on event storage operations.
+     * RoutingEventStore remains transparent because the selected leaf store owns storage metrics.
      *
      * @return the metrizable event store
      */
-    fun EventStore.metrizable(): EventStore =
-        metrizable {
+    fun EventStore.metrizable(): EventStore {
+        if (this is RoutingEventStore) {
+            return this
+        }
+        return metrizable {
             MetricEventStore(this)
         }
+    }
 
     /**
      * Wraps a SnapshotStrategy with metrics collection capabilities.
@@ -223,17 +230,22 @@ object Metrics {
     /**
      * Wraps a SnapshotStore with metrics collection capabilities.
      * Returns a MetricSnapshotStore that collects metrics on snapshot storage operations.
+     * RoutingSnapshotStore remains transparent because the selected leaf store owns storage metrics.
      *
      * @return the metrizable snapshot store
      */
-    fun SnapshotStore.metrizable(): SnapshotStore =
-        metrizable {
+    fun SnapshotStore.metrizable(): SnapshotStore {
+        if (this is RoutingSnapshotStore) {
+            return this
+        }
+        return metrizable {
             if (this is VersionedSnapshotStore) {
                 MetricVersionedSnapshotStore(this)
             } else {
                 MetricSnapshotStore(this)
             }
         }
+    }
 
     /**
      * Wraps a CommandHandler with metrics collection capabilities.

--- a/wow-core/src/test/kotlin/me/ahoo/wow/metrics/MetricStorageOwnershipTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/metrics/MetricStorageOwnershipTest.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.metrics
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.modeling.AggregateId
+import me.ahoo.wow.event.DomainEventStream
+import me.ahoo.wow.eventsourcing.AggregateEventStoreRegistry
+import me.ahoo.wow.eventsourcing.EventStore
+import me.ahoo.wow.eventsourcing.RoutingEventStore
+import me.ahoo.wow.eventsourcing.snapshot.AggregateSnapshotStoreRegistry
+import me.ahoo.wow.eventsourcing.snapshot.RoutingSnapshotStore
+import me.ahoo.wow.eventsourcing.snapshot.Snapshot
+import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
+import me.ahoo.wow.metrics.Metrics.metrizable
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.modeling.aggregateId
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import io.micrometer.core.instrument.Metrics as MicrometerMetrics
+
+class MetricStorageOwnershipTest {
+
+    private val aggregateId = MaterializedNamedAggregate("sales", "Order").aggregateId("order-1")
+
+    @Test
+    fun `routing event store should preserve leaf metric ownership`() {
+        withMeterRegistry { meterRegistry ->
+            val leafStore = LeafEventStore().metrizable()
+            val routingStore = RoutingEventStore(
+                AggregateEventStoreRegistry(
+                    defaultEventStore = leafStore,
+                    routes = emptyMap(),
+                ),
+            )
+
+            val metricStore = routingStore.metrizable()
+            metricStore.assert().isSameAs(routingStore)
+            metricStore.load(aggregateId).blockLast()
+
+            meterRegistry.sources("wow.eventstore.load")
+                .assert().containsExactly(LeafEventStore::class.java.simpleName)
+        }
+    }
+
+    @Test
+    fun `routing snapshot store should preserve leaf metric ownership`() {
+        withMeterRegistry { meterRegistry ->
+            val leafStore = LeafSnapshotStore().metrizable()
+            val routingStore = RoutingSnapshotStore.create(
+                AggregateSnapshotStoreRegistry(
+                    defaultSnapshotStore = leafStore,
+                    routes = emptyMap(),
+                ),
+            )
+
+            val metricStore = routingStore.metrizable()
+            metricStore.assert().isSameAs(routingStore)
+            metricStore.getVersion(aggregateId).block()
+
+            meterRegistry.sources("wow.snapshot.getVersion")
+                .assert().containsExactly(LeafSnapshotStore::class.java.simpleName)
+        }
+    }
+
+    private fun withMeterRegistry(block: (SimpleMeterRegistry) -> Unit) {
+        val meterRegistry = SimpleMeterRegistry()
+        MicrometerMetrics.addRegistry(meterRegistry)
+        try {
+            block(meterRegistry)
+        } finally {
+            MicrometerMetrics.removeRegistry(meterRegistry)
+            meterRegistry.close()
+        }
+    }
+
+    private fun SimpleMeterRegistry.sources(metricName: String): Set<String> =
+        meters
+            .map { it.id }
+            .filter { it.name.startsWith(metricName) }
+            .mapNotNull { it.getTag(Metrics.SOURCE_KEY) }
+            .toSet()
+
+    private class LeafEventStore : EventStore {
+        override fun append(eventStream: DomainEventStream): Mono<Void> = Mono.empty()
+
+        override fun load(
+            aggregateId: AggregateId,
+            headVersion: Int,
+            tailVersion: Int,
+        ): Flux<DomainEventStream> = Flux.empty()
+
+        override fun load(
+            aggregateId: AggregateId,
+            headEventTime: Long,
+            tailEventTime: Long,
+        ): Flux<DomainEventStream> = Flux.empty()
+
+        override fun last(aggregateId: AggregateId): Mono<DomainEventStream> = Mono.empty()
+    }
+
+    private class LeafSnapshotStore : SnapshotStore {
+        override val name: String = "leaf"
+
+        override fun <S : Any> load(aggregateId: AggregateId): Mono<Snapshot<S>> = Mono.empty()
+
+        override fun getVersion(aggregateId: AggregateId): Mono<Int> = Mono.just(1)
+
+        override fun <S : Any> save(snapshot: Snapshot<S>): Mono<Void> = Mono.empty()
+    }
+}

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/metrics/MetricsBeanPostProcessor.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/metrics/MetricsBeanPostProcessor.kt
@@ -15,6 +15,8 @@ package me.ahoo.wow.spring.boot.starter.metrics
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.metrics.Metrics.metrizable
+import me.ahoo.wow.spring.boot.starter.eventsourcing.routing.EventStoreBinding
+import me.ahoo.wow.spring.boot.starter.eventsourcing.routing.SnapshotStoreBinding
 import org.springframework.beans.factory.config.BeanPostProcessor
 import org.springframework.core.Ordered
 
@@ -24,7 +26,7 @@ class MetricsBeanPostProcessor : BeanPostProcessor, Ordered {
     }
 
     override fun postProcessAfterInitialization(bean: Any, beanName: String): Any {
-        val metatableBean = bean.metrizable()
+        val metatableBean = bean.metrizableBean()
         if (metatableBean !== bean) {
             log.info {
                 "Magnetizable bean [$beanName] [${bean.javaClass.name}] -> [${metatableBean.javaClass.name}]"
@@ -36,4 +38,19 @@ class MetricsBeanPostProcessor : BeanPostProcessor, Ordered {
     override fun getOrder(): Int {
         return Ordered.LOWEST_PRECEDENCE
     }
+
+    private fun Any.metrizableBean(): Any =
+        when (this) {
+            is EventStoreBinding -> {
+                val metricEventStore = eventStore.metrizable()
+                if (metricEventStore === eventStore) this else copy(eventStore = metricEventStore)
+            }
+
+            is SnapshotStoreBinding -> {
+                val metricSnapshotStore = snapshotStore.metrizable()
+                if (metricSnapshotStore === snapshotStore) this else copy(snapshotStore = metricSnapshotStore)
+            }
+
+            else -> metrizable()
+        }
 }

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/metrics/MetricsAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/metrics/MetricsAutoConfigurationTest.kt
@@ -2,10 +2,16 @@ package me.ahoo.wow.spring.boot.starter.metrics
 
 import io.mockk.mockk
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.eventsourcing.EventStore
+import me.ahoo.wow.eventsourcing.snapshot.InMemorySnapshotStore
 import me.ahoo.wow.eventsourcing.snapshot.NoOpSnapshotStore
 import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
 import me.ahoo.wow.eventsourcing.snapshot.VersionedSnapshotStore
+import me.ahoo.wow.metrics.MetricEventStore
+import me.ahoo.wow.metrics.MetricVersionedSnapshotStore
 import me.ahoo.wow.spring.boot.starter.enableWow
+import me.ahoo.wow.spring.boot.starter.eventsourcing.routing.EventStoreBinding
+import me.ahoo.wow.spring.boot.starter.eventsourcing.routing.SnapshotStoreBinding
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
@@ -22,6 +28,42 @@ class MetricsAutoConfigurationTest {
 
         (legacy is VersionedSnapshotStore).assert().isFalse()
         (versioned is VersionedSnapshotStore).assert().isTrue()
+    }
+
+    @Test
+    fun `metrics post processor should decorate raw event store binding once`() {
+        val binding = EventStoreBinding(
+            name = "custom-event-store",
+            storage = null,
+            eventStore = mockk<EventStore>(),
+        )
+        val postProcessor = MetricsBeanPostProcessor()
+
+        val metricBinding = postProcessor
+            .postProcessAfterInitialization(binding, "customEventStoreBinding") as EventStoreBinding
+        val processedAgain = postProcessor
+            .postProcessAfterInitialization(metricBinding, "customEventStoreBinding")
+
+        metricBinding.eventStore.assert().isInstanceOf(MetricEventStore::class.java)
+        processedAgain.assert().isSameAs(metricBinding)
+    }
+
+    @Test
+    fun `metrics post processor should decorate raw versioned snapshot store binding once`() {
+        val binding = SnapshotStoreBinding(
+            name = "custom-snapshot-store",
+            storage = null,
+            snapshotStore = InMemorySnapshotStore(),
+        )
+        val postProcessor = MetricsBeanPostProcessor()
+
+        val metricBinding = postProcessor
+            .postProcessAfterInitialization(binding, "customSnapshotStoreBinding") as SnapshotStoreBinding
+        val processedAgain = postProcessor
+            .postProcessAfterInitialization(metricBinding, "customSnapshotStoreBinding")
+
+        metricBinding.snapshotStore.assert().isInstanceOf(MetricVersionedSnapshotStore::class.java)
+        processedAgain.assert().isSameAs(metricBinding)
     }
 
     @Test

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/WowOpenTelemetryAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/WowOpenTelemetryAutoConfigurationTest.kt
@@ -14,7 +14,12 @@
 package me.ahoo.wow.spring.boot.starter.opentelemetry
 
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.eventsourcing.AggregateEventStoreRegistry
+import me.ahoo.wow.eventsourcing.InMemoryEventStore
+import me.ahoo.wow.eventsourcing.RoutingEventStore
+import me.ahoo.wow.eventsourcing.snapshot.AggregateSnapshotStoreRegistry
 import me.ahoo.wow.eventsourcing.snapshot.InMemorySnapshotStore
+import me.ahoo.wow.eventsourcing.snapshot.RoutingSnapshotStore
 import me.ahoo.wow.eventsourcing.snapshot.VersionedSnapshotStore
 import me.ahoo.wow.opentelemetry.aggregate.TraceAggregateFilter
 import me.ahoo.wow.opentelemetry.eventprocessor.TraceEventProcessorFilter
@@ -92,6 +97,49 @@ internal class WowOpenTelemetryAutoConfigurationTest {
         )
 
         tracedStore.assert().isInstanceOf(VersionedSnapshotStore::class.java)
+        metricStore.assert().isInstanceOf(VersionedSnapshotStore::class.java)
+    }
+
+    @Test
+    fun `metrics should keep traced routing event store transparent`() {
+        val routingStore = RoutingEventStore(
+            AggregateEventStoreRegistry(
+                defaultEventStore = InMemoryEventStore(),
+                routes = emptyMap(),
+            ),
+        )
+        val tracedStore = TracingBeanPostProcessor().postProcessAfterInitialization(
+            routingStore,
+            "eventStore",
+        )
+
+        val metricStore = MetricsBeanPostProcessor().postProcessAfterInitialization(
+            tracedStore,
+            "eventStore",
+        )
+
+        metricStore.assert().isSameAs(tracedStore)
+    }
+
+    @Test
+    fun `metrics should keep traced routing snapshot store transparent`() {
+        val routingStore = RoutingSnapshotStore.create(
+            AggregateSnapshotStoreRegistry(
+                defaultSnapshotStore = InMemorySnapshotStore(),
+                routes = emptyMap(),
+            ),
+        )
+        val tracedStore = TracingBeanPostProcessor().postProcessAfterInitialization(
+            routingStore,
+            "snapshotStore",
+        )
+
+        val metricStore = MetricsBeanPostProcessor().postProcessAfterInitialization(
+            tracedStore,
+            "snapshotStore",
+        )
+
+        metricStore.assert().isSameAs(tracedStore)
         metricStore.assert().isInstanceOf(VersionedSnapshotStore::class.java)
     }
 }


### PR DESCRIPTION
## Goal

Give storage metrics a single, explicit owner so aggregate-specific storage routing does not record one physical operation twice.

## Root Cause

Storage backend beans are decorated first and stored in `EventStoreBinding` or `SnapshotStoreBinding`. The resulting `RoutingEventStore` or `RoutingSnapshotStore` bean was then decorated again by the same metrics post-processor.

A routed operation therefore passed through two metric decorators with the same base meter name and aggregate tag, differing only by `source`. Queries that aggregated across `source` counted the operation twice.

## Changes

- Keep `RoutingEventStore` metric-transparent.
- Keep `RoutingSnapshotStore`, including its versioned subtype, metric-transparent.
- Preserve metrics on the selected physical leaf backend.
- Add real `SimpleMeterRegistry` tests for event-store and snapshot-store ownership.
- Document the ownership contract and dashboard migration in English and Chinese.

## Verification

Passed:

- `./gradlew :wow-core:check :wow-core:jacocoTestReport :wow-core:jacocoTestCoverageVerification`
- Targeted Metrics, routing EventStore, and routing SnapshotStore tests
- `./gradlew :wow-core:detekt`
- `pnpm docs:build` in `documentation`
- `git diff --check`

The new tests were developed red-first. Before the fix, both routing stores were wrapped again; after the fix, real meter IDs contain only the leaf backend source. JaCoCo reports all branches in the changed production paths as covered.

## Risks and Migration

This intentionally removes these metric series:

- `source=RoutingEventStore`
- `source=RoutingSnapshotStore`

Dashboards and alerts must select the physical backend source, such as `MongoEventStore` or `RedisEventStore`. Queries that aggregate across `source` will now report one sample per physical operation rather than two.

There is no application data migration, dependency change, or Java/Kotlin API removal.