### PR TITLE
fix(core): make local-first header disable case-insensitive

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/LocalFirstMessageBus.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/LocalFirstMessageBus.kt
@@ -66,13 +66,14 @@ fun <M : Message<*, *>> M.isLocalFirst(): Boolean = header.isLocalFirst()
  * Determines if this message should use local-first routing.
  *
  * Local-first routing is used when the aggregate is local and the header
- * doesn't explicitly disable local-first (set to false).
+ * doesn't explicitly disable local-first (set to `false`, compared case-insensitively
+ * so values like `FALSE`/`False` also disable routing).
  *
  * @return true if local-first routing should be used, false otherwise
  */
 fun <M> M.shouldLocalFirst(): Boolean
     where M : Message<*, *>, M : NamedAggregate =
-    isLocal() && header[LOCAL_FIRST_HEADER] != false.toString()
+    isLocal() && !header[LOCAL_FIRST_HEADER].equals(false.toString(), ignoreCase = true)
 
 /**
  * Checks if this message has been handled locally.

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/LocalFirstMessageBusTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/LocalFirstMessageBusTest.kt
@@ -74,6 +74,24 @@ class LocalFirstMessageBusTest {
     }
 
     @Test
+    fun `send skips local bus when local first is disabled case insensitively`() {
+        val localBus = RecordingLocalBus(subscribers = 1)
+        val distributedBus = RecordingDistributedBus()
+        val bus = RecordingLocalFirstMessageBus(localBus, distributedBus)
+        val message = LocalFirstTestMessage(
+            id = "message-id",
+            header = DefaultHeader.empty().with(LOCAL_FIRST_HEADER, "FALSE"),
+        )
+
+        StepVerifier.create(bus.send(message))
+            .verifyComplete()
+
+        localBus.sent.assert().isEmpty()
+        distributedBus.sent.single().assert().isSameAs(message)
+        message.isLocalFirst().assert().isFalse()
+    }
+
+    @Test
     fun `receive filters distributed messages already handled locally and acknowledges them`() {
         val localExchange = LocalFirstTestExchange(LocalFirstTestMessage(id = "local"))
         val filteredDistributedExchange = LocalFirstTestExchange(

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/LocalFirstMessageBusTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/LocalFirstMessageBusTest.kt
@@ -92,6 +92,21 @@ class LocalFirstMessageBusTest {
     }
 
     @Test
+    fun `send skips local bus when aggregate is not local`() {
+        val localBus = RecordingLocalBus(subscribers = 1)
+        val distributedBus = RecordingDistributedBus()
+        val bus = RecordingLocalFirstMessageBus(localBus, distributedBus)
+        val message = LocalFirstTestMessage(id = "message-id", aggregateName = "non_local_aggregate")
+
+        StepVerifier.create(bus.send(message))
+            .verifyComplete()
+
+        localBus.sent.assert().isEmpty()
+        distributedBus.sent.single().assert().isSameAs(message)
+        message.shouldLocalFirst().assert().isFalse()
+    }
+
+    @Test
     fun `receive filters distributed messages already handled locally and acknowledges them`() {
         val localExchange = LocalFirstTestExchange(LocalFirstTestMessage(id = "local"))
         val filteredDistributedExchange = LocalFirstTestExchange(
@@ -167,11 +182,11 @@ private class LocalFirstTestMessage(
     override val header: Header = DefaultHeader.empty(),
     override val body: String = "body",
     override val createTime: Long = 1,
+    override val aggregateName: String = "modeling_command_aggregate",
 ) : Message<LocalFirstTestMessage, String>,
     NamedAggregate,
     Copyable<LocalFirstTestMessage> {
     override val contextName: String = "wow-core-test"
-    override val aggregateName: String = "modeling_command_aggregate"
 
     override fun copy(): LocalFirstTestMessage =
         LocalFirstTestMessage(
@@ -179,6 +194,7 @@ private class LocalFirstTestMessage(
             header = header.copy(),
             body = body,
             createTime = createTime,
+            aggregateName = aggregateName,
         )
 }
 


### PR DESCRIPTION
## Goal

Make `shouldLocalFirst()` honor the `local_first` header disable value case-insensitively, so it agrees with `isLocalFirst()` and an explicit opt-out (e.g. `FALSE`/`False`) actually skips the local bus.

## Root Cause

`LocalFirstMessageBus` exposed two helpers that read the `local_first` header with different case handling:

- `Header.isLocalFirst()` — `this[LOCAL_FIRST_HEADER].toBoolean()` (case-insensitive)
- `M.shouldLocalFirst()` — `header[LOCAL_FIRST_HEADER] != false.toString()`, i.e. `!= "false"` (case-sensitive)

A header value like `FALSE` or `False` was therefore treated as **enabled** by `shouldLocalFirst()` but **disabled** by `isLocalFirst()`. `LocalFirstMessageBus.send()` calls `shouldLocalFirst()` first, so the message was still routed through the local bus despite the explicit opt-out, contradicting the documented "set to false to disable local-first" contract.

## Changes

- Compare the `local_first` header against `false` case-insensitively in `shouldLocalFirst()`, using `String?.equals(other, ignoreCase = true)`:
  - null-safe: a missing header still enables local-first (preserves the existing default).
  - Only the disable comparison becomes case-insensitive; behavior for missing, `true`, and other values is unchanged.
- Update the `shouldLocalFirst()` KDoc to state the case-insensitive disable contract.
- Add a red-first test `send skips local bus when local first is disabled case insensitively` that sets `LOCAL_FIRST_HEADER = "FALSE"` and asserts the local bus is skipped and the message goes to the distributed bus.

## Verification

Developed red-first: the new test failed before the implementation (`Expecting empty but was: [LocalFirstTestMessage]`) and passes after.

Passed:

- `./gradlew :wow-core:test --tests "me.ahoo.wow.messaging.LocalFirstMessageBusTest"`
- `./gradlew :wow-core:test --tests "*LocalFirst*"`
- `./gradlew :wow-core:contractTest --tests "*LocalFirst*"`
- `./gradlew :wow-core:test :wow-core:jacocoTestCoverageVerification`
- `./gradlew detekt`
- `git diff --check`

Confirmed `./gradlew detekt` (the CI command) is green both on clean `main` and with this change applied.

## Risks and Notes

- **Behavior change (narrow):** header values `FALSE`/`False`/`fAlSe` now correctly disable local-first routing, matching what `isLocalFirst()` already reported. Producers that wrote `local_first=false` (the lowercase form emitted by `withLocalFirst(false)`) are unaffected.
- No public API signature change, no data/schema migration. Rollback is a normal commit revert.