### PR TITLE
fix(elasticsearch): enforce index template readiness

### DIFF
--- a/documentation/docs/en/guide/advanced/module-dependencies.md
+++ b/documentation/docs/en/guide/advanced/module-dependencies.md
@@ -421,7 +421,7 @@ The `wow-spring-boot-starter` module declares the following optional feature cap
 | `redis-support` | `wow-redis` | `spring-boot-starter-data-redis-reactive` |
 | `kafka-support` | `wow-kafka` | (via reactor-kafka) |
 | `webflux-support` | `wow-bi`, `wow-webflux` | (via spring-webflux) |
-| `elasticsearch-support` | `wow-elasticsearch` | `spring-boot-starter-elasticsearch` |
+| `elasticsearch-support` | `wow-elasticsearch` | `spring-boot-starter-data-elasticsearch` |
 | `opentelemetry-support` | `wow-opentelemetry` | (via otel instrumentation) |
 | `openapi-support` | `wow-openapi` | `springdoc-openapi-starter-common` |
 | `cosec-support` | `wow-cosec` | (via wow-cosec) |

--- a/documentation/docs/en/guide/extensions/elasticsearch.md
+++ b/documentation/docs/en/guide/extensions/elasticsearch.md
@@ -85,6 +85,10 @@ wow:
       storage: elasticsearch
 ```
 
+Required index templates are installed before application startup completes. A failed or unacknowledged request fails
+startup. Set `wow.elasticsearch.auto-init-template=false` only when templates are managed externally. The built-in
+templates intentionally leave shard and replica counts to the cluster or to a higher-priority operator template.
+
 ## Index Naming Rules
 
 | Data Type | Index Naming Format | Example |
@@ -101,10 +105,6 @@ POST _index_template/wow-event-stream-template
     "wow.*.es"
   ],
   "template": {
-    "settings": {
-      "number_of_shards": 3,
-      "number_of_replicas": 2
-    },
     "mappings": {
       "properties": {
         "aggregateId": {
@@ -185,10 +185,6 @@ POST _index_template/wow-snapshot-template
     "wow.*.snapshot"
   ],
   "template": {
-    "settings": {
-      "number_of_shards": 3,
-      "number_of_replicas": 2
-    },
     "mappings": {
       "properties": {
         "contextName": {
@@ -275,6 +271,7 @@ POST _index_template/wow-order-snapshot-template
   "index_patterns": [
     "wow.*.order.snapshot"
   ],
+  "priority": 100,
   "template": {
     "mappings": {
       "properties": {
@@ -299,6 +296,10 @@ POST _index_template/wow-order-snapshot-template
   }
 }
 ```
+
+The higher priority makes the aggregate template win over Wow's default snapshot template. The shortened example
+shows only the custom fields; a production replacement must also include the required baseline snapshot mappings, or
+compose both baseline and custom mappings from component templates.
 
 ### Execute Full-Text Search
 

--- a/documentation/docs/en/reference/config/infrastructure.md
+++ b/documentation/docs/en/reference/config/infrastructure.md
@@ -97,9 +97,11 @@ wow:
 | Property | Type | Default | Description |
 |----------|------|---------|-------------|
 | `wow.elasticsearch.enabled` | Boolean | `true` | Enable Elasticsearch integration |
-| `wow.elasticsearch.auto-init-template` | Boolean | `true` | Automatically initialize index templates on startup |
+| `wow.elasticsearch.auto-init-template` | Boolean | `true` | Initialize required index templates before startup completes |
 
 Elasticsearch connection is configured through Spring Boot's standard `spring.elasticsearch.*` properties.
+When automatic initialization is enabled, a failed, empty, or unacknowledged template request fails application startup.
+Set `auto-init-template` to `false` only when templates are managed externally.
 
 ```yaml
 spring:

--- a/documentation/docs/zh/guide/advanced/module-dependencies.md
+++ b/documentation/docs/zh/guide/advanced/module-dependencies.md
@@ -421,7 +421,7 @@ dependencies {
 | `redis-support` | `wow-redis` | `spring-boot-starter-data-redis-reactive` |
 | `kafka-support` | `wow-kafka` | （通过 reactor-kafka） |
 | `webflux-support` | `wow-bi`、`wow-webflux` | （通过 spring-webflux） |
-| `elasticsearch-support` | `wow-elasticsearch` | `spring-boot-starter-elasticsearch` |
+| `elasticsearch-support` | `wow-elasticsearch` | `spring-boot-starter-data-elasticsearch` |
 | `opentelemetry-support` | `wow-opentelemetry` | （通过 otel instrumentation） |
 | `openapi-support` | `wow-openapi` | `springdoc-openapi-starter-common` |
 | `cosec-support` | `wow-cosec` | （通过 wow-cosec） |

--- a/documentation/docs/zh/guide/extensions/elasticsearch.md
+++ b/documentation/docs/zh/guide/extensions/elasticsearch.md
@@ -85,6 +85,10 @@ wow:
       storage: elasticsearch
 ```
 
+应用启动完成前会安装所需索引模板；请求失败或未确认会导致启动失败。仅当索引模板由外部系统管理时，才应设置
+`wow.elasticsearch.auto-init-template=false`。内置模板不会固定分片数和副本数，这些拓扑参数应由集群或更高优先级的
+运维模板管理。
+
 ## 索引命名规则
 
 | 数据类型 | 索引命名格式 | 示例 |
@@ -101,10 +105,6 @@ POST _index_template/wow-event-stream-template
     "wow.*.es"
   ],
   "template": {
-    "settings": {
-      "number_of_shards": 3,
-      "number_of_replicas": 2
-    },
     "mappings": {
       "properties": {
         "aggregateId": {
@@ -185,10 +185,6 @@ POST _index_template/wow-snapshot-template
     "wow.*.snapshot"
   ],
   "template": {
-    "settings": {
-      "number_of_shards": 3,
-      "number_of_replicas": 2
-    },
     "mappings": {
       "properties": {
         "contextName": {
@@ -275,6 +271,7 @@ POST _index_template/wow-order-snapshot-template
   "index_patterns": [
     "wow.*.order.snapshot"
   ],
+  "priority": 100,
   "template": {
     "mappings": {
       "properties": {
@@ -299,6 +296,9 @@ POST _index_template/wow-order-snapshot-template
   }
 }
 ```
+
+更高的优先级会使聚合模板覆盖 Wow 默认快照模板。上例为简洁起见只展示自定义字段；生产模板还必须包含快照所需的
+基础映射，或者通过 component template 组合基础映射与自定义映射。
 
 ::: tip
 如果需要中文分词支持，可以安装 [IK 分析器插件](https://github.com/medcl/elasticsearch-analysis-ik)，然后使用 `ik_max_word` 和 `ik_smart` 分析器。

--- a/documentation/docs/zh/reference/config/infrastructure.md
+++ b/documentation/docs/zh/reference/config/infrastructure.md
@@ -97,9 +97,11 @@ wow:
 | 属性 | 类型 | 默认值 | 描述 |
 |----------|------|---------|-------------|
 | `wow.elasticsearch.enabled` | Boolean | `true` | 启用 Elasticsearch 集成 |
-| `wow.elasticsearch.auto-init-template` | Boolean | `true` | 启动时自动初始化索引模板 |
+| `wow.elasticsearch.auto-init-template` | Boolean | `true` | 在应用启动完成前初始化所需索引模板 |
 
 Elasticsearch 连接通过 Spring Boot 标准的 `spring.elasticsearch.*` 属性进行配置。
+开启自动初始化时，模板请求失败、无响应结果或未确认都会导致应用启动失败。
+仅当索引模板由外部系统管理时，才应将 `auto-init-template` 设为 `false`。
 
 ```yaml
 spring:

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/IndexTemplateInitializer.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/IndexTemplateInitializer.kt
@@ -72,9 +72,37 @@ class IndexTemplateInitializer(private val elasticsearchOperations: ReactiveElas
     }
 
     fun initAll() {
-        initEventStreamTemplate().subscribe(InitSubscriber("InitEventStreamTemplate"))
-        initSnapshotTemplate().subscribe(InitSubscriber("InitSnapshotTemplate"))
+        ensureAllTemplates().block()
     }
 
+    fun ensureEventStreamTemplate(): Mono<Void> {
+        return initEventStreamTemplate().requireAcknowledged(EVENT_STREAM_TEMPLATE_NAME)
+    }
+
+    fun ensureSnapshotTemplate(): Mono<Void> {
+        return initSnapshotTemplate().requireAcknowledged(SNAPSHOT_TEMPLATE_NAME)
+    }
+
+    fun ensureAllTemplates(): Mono<Void> {
+        return ensureEventStreamTemplate().then(Mono.defer(::ensureSnapshotTemplate))
+    }
+
+    private fun Mono<Boolean>.requireAcknowledged(templateName: String): Mono<Void> {
+        return switchIfEmpty(
+            Mono.error(
+                IllegalStateException("Elasticsearch index template [$templateName] returned no acknowledgement."),
+            ),
+        ).flatMap { acknowledged ->
+            if (acknowledged) {
+                Mono.empty()
+            } else {
+                Mono.error(
+                    IllegalStateException("Elasticsearch index template [$templateName] was not acknowledged."),
+                )
+            }
+        }
+    }
+
+    @Deprecated("Template initialization is now awaited and failures are propagated by initAll().")
     class InitSubscriber(override val name: String) : SafeSubscriber<Boolean>()
 }

--- a/wow-elasticsearch/src/main/resources/templates/wow-event-stream-template.json
+++ b/wow-elasticsearch/src/main/resources/templates/wow-event-stream-template.json
@@ -3,10 +3,6 @@
     "wow.*.es"
   ],
   "template": {
-    "settings": {
-      "number_of_shards": 3,
-      "number_of_replicas": 2
-    },
     "mappings": {
       "properties": {
         "aggregateId": {

--- a/wow-elasticsearch/src/main/resources/templates/wow-snapshot-template.json
+++ b/wow-elasticsearch/src/main/resources/templates/wow-snapshot-template.json
@@ -3,10 +3,6 @@
     "wow.*.snapshot"
   ],
   "template": {
-    "settings": {
-      "number_of_shards": 3,
-      "number_of_replicas": 2
-    },
     "mappings": {
       "properties": {
         "contextName": {

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/IndexTemplateInitializerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/IndexTemplateInitializerTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.elasticsearch
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.data.elasticsearch.core.ReactiveElasticsearchOperations
+import org.springframework.data.elasticsearch.core.ReactiveIndexOperations
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates
+import reactor.core.publisher.Mono
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicInteger
+
+class IndexTemplateInitializerTest {
+    private val indexOperations = mockk<ReactiveIndexOperations>()
+    private val elasticsearchOperations = mockk<ReactiveElasticsearchOperations> {
+        every { indexOps(any<IndexCoordinates>()) } returns indexOperations
+    }
+    private val initializer = IndexTemplateInitializer(elasticsearchOperations)
+
+    @Test
+    fun `init all should complete both template requests before returning`() {
+        val completedRequests = AtomicInteger()
+        every { indexOperations.putIndexTemplate(any()) } returns Mono.delay(Duration.ofMillis(25))
+            .map { true }
+            .doOnSuccess { completedRequests.incrementAndGet() }
+
+        initializer.initAll()
+
+        completedRequests.get().assert().isEqualTo(2)
+        verify(exactly = 1) {
+            indexOperations.putIndexTemplate(match { it.name == "wow-event-stream-template" })
+        }
+        verify(exactly = 1) {
+            indexOperations.putIndexTemplate(match { it.name == "wow-snapshot-template" })
+        }
+    }
+
+    @Test
+    fun `init all should propagate request failure`() {
+        val failure = IllegalStateException("template initialization failed")
+        every { indexOperations.putIndexTemplate(any()) } returns Mono.error(failure)
+
+        val actual = assertThrows<IllegalStateException> {
+            initializer.initAll()
+        }
+
+        actual.assert().isSameAs(failure)
+    }
+
+    @Test
+    fun `init all should reject unacknowledged request`() {
+        every { indexOperations.putIndexTemplate(any()) } returns Mono.just(false)
+
+        assertThrows<IllegalStateException> {
+            initializer.initAll()
+        }
+    }
+
+    @Test
+    fun `init all should reject missing acknowledgement`() {
+        every { indexOperations.putIndexTemplate(any()) } returns Mono.empty()
+
+        assertThrows<IllegalStateException> {
+            initializer.initAll()
+        }
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `legacy init subscriber should retain its name`() {
+        IndexTemplateInitializer.InitSubscriber("legacy").name.assert().isEqualTo("legacy")
+    }
+}

--- a/wow-spring-boot-starter/build.gradle.kts
+++ b/wow-spring-boot-starter/build.gradle.kts
@@ -57,7 +57,7 @@ dependencies {
     "webfluxSupportImplementation"(project(":wow-webflux"))
     "cosecSupportImplementation"(project(":wow-cosec"))
     "elasticsearchSupportImplementation"(project(":wow-elasticsearch"))
-    "elasticsearchSupportImplementation"("org.springframework.boot:spring-boot-starter-elasticsearch")
+    "elasticsearchSupportImplementation"("org.springframework.boot:spring-boot-starter-data-elasticsearch")
     "opentelemetrySupportImplementation"(project(":wow-opentelemetry"))
     "openapiSupportApi"(project(":wow-bi"))
     "openapiSupportImplementation"(project(":wow-openapi"))

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ConditionalOnElasticsearchStorage.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ConditionalOnElasticsearchStorage.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package me.ahoo.wow.spring.boot.starter.elasticsearch
+
+import me.ahoo.wow.spring.boot.starter.eventsourcing.StorageType
+import me.ahoo.wow.spring.boot.starter.eventsourcing.routing.ConditionalOnEventStoreStorage
+import me.ahoo.wow.spring.boot.starter.eventsourcing.routing.ConditionalOnSnapshotStoreStorage
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition
+import org.springframework.context.annotation.Conditional
+import org.springframework.context.annotation.ConfigurationCondition.ConfigurationPhase
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+@Conditional(OnElasticsearchStorageCondition::class)
+annotation class ConditionalOnElasticsearchStorage
+
+class OnElasticsearchStorageCondition : AnyNestedCondition(ConfigurationPhase.REGISTER_BEAN) {
+    @ConditionalOnEventStoreStorage(StorageType.ELASTICSEARCH)
+    interface EventStoreUsesElasticsearch
+
+    @ConditionalOnSnapshotStoreStorage(StorageType.ELASTICSEARCH)
+    interface SnapshotStoreUsesElasticsearch
+}

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfiguration.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.spring.boot.starter.elasticsearch
 
+import co.elastic.clients.json.JsonpMapper
 import co.elastic.clients.json.jackson.Jackson3JsonpMapper
 import me.ahoo.wow.elasticsearch.IndexTemplateInitializer
 import me.ahoo.wow.elasticsearch.WowJsonpMapper
@@ -34,20 +35,27 @@ import me.ahoo.wow.spring.boot.starter.eventsourcing.snapshot.ConditionalOnSnaps
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.elasticsearch.autoconfigure.ElasticsearchClientAutoConfiguration
 import org.springframework.boot.elasticsearch.autoconfigure.ElasticsearchRestClientAutoConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
 import org.springframework.data.elasticsearch.core.ReactiveElasticsearchOperations
 
-@AutoConfiguration(after = [ElasticsearchRestClientAutoConfiguration::class])
+@AutoConfiguration(
+    after = [ElasticsearchRestClientAutoConfiguration::class],
+    before = [ElasticsearchClientAutoConfiguration::class],
+)
 @ConditionalOnWowEnabled
 @ConditionalOnElasticsearchEnabled
+@ConditionalOnElasticsearchStorage
 @ConditionalOnClass(ElasticsearchEventStore::class)
 @EnableConfigurationProperties(ElasticsearchProperties::class)
 class ElasticsearchEventSourcingAutoConfiguration(private val elasticsearchProperties: ElasticsearchProperties) {
 
     @Bean
+    @ConditionalOnMissingBean(JsonpMapper::class)
     fun jackson3JsonpMapper(): Jackson3JsonpMapper {
         return WowJsonpMapper
     }
@@ -55,8 +63,12 @@ class ElasticsearchEventSourcingAutoConfiguration(private val elasticsearchPrope
     @Bean
     @ConditionalOnEventStoreStorage(StorageType.ELASTICSEARCH)
     fun elasticsearchEventStore(
-        elasticsearchClient: ReactiveElasticsearchClient
+        elasticsearchClient: ReactiveElasticsearchClient,
+        indexTemplateInitializer: IndexTemplateInitializer,
     ): ElasticsearchEventStore {
+        if (elasticsearchProperties.autoInitTemplate) {
+            indexTemplateInitializer.ensureEventStreamTemplate().block()
+        }
         return ElasticsearchEventStore(elasticsearchClient)
     }
 
@@ -70,13 +82,8 @@ class ElasticsearchEventSourcingAutoConfiguration(private val elasticsearchPrope
     }
 
     @Bean
-    @ConditionalOnEventStoreStorage(StorageType.ELASTICSEARCH)
     fun indexTemplateInitializer(elasticsearchOperations: ReactiveElasticsearchOperations): IndexTemplateInitializer {
-        val initializer = IndexTemplateInitializer(elasticsearchOperations)
-        if (elasticsearchProperties.autoInitTemplate) {
-            initializer.initAll()
-        }
-        return initializer
+        return IndexTemplateInitializer(elasticsearchOperations)
     }
 
     @Bean
@@ -102,8 +109,12 @@ class ElasticsearchEventSourcingAutoConfiguration(private val elasticsearchPrope
     @ConditionalOnSnapshotEnabled
     @ConditionalOnSnapshotStoreStorage(StorageType.ELASTICSEARCH)
     fun elasticsearchSnapshotStore(
-        elasticsearchClient: ReactiveElasticsearchClient
+        elasticsearchClient: ReactiveElasticsearchClient,
+        indexTemplateInitializer: IndexTemplateInitializer,
     ): ElasticsearchSnapshotStore {
+        if (elasticsearchProperties.autoInitTemplate) {
+            indexTemplateInitializer.ensureSnapshotTemplate().block()
+        }
         return ElasticsearchSnapshotStore(elasticsearchClient)
     }
 

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfigurationTest.kt
@@ -13,11 +13,14 @@
 
 package me.ahoo.wow.spring.boot.starter.elasticsearch
 
+import co.elastic.clients.json.JsonpMapper
 import co.elastic.clients.json.jackson.Jackson3JsonpMapper
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.elasticsearch.IndexTemplateInitializer
+import me.ahoo.wow.elasticsearch.WowJsonpMapper
 import me.ahoo.wow.elasticsearch.eventsourcing.ElasticsearchEventStore
 import me.ahoo.wow.elasticsearch.eventsourcing.ElasticsearchSnapshotStore
 import me.ahoo.wow.elasticsearch.query.event.ElasticsearchEventStreamQueryServiceFactory
@@ -26,20 +29,74 @@ import me.ahoo.wow.spring.boot.starter.enableWow
 import me.ahoo.wow.spring.boot.starter.eventsourcing.StorageType
 import me.ahoo.wow.spring.boot.starter.eventsourcing.routing.EventStoreBinding
 import me.ahoo.wow.spring.boot.starter.eventsourcing.routing.SnapshotStoreBinding
+import me.ahoo.wow.spring.boot.starter.eventsourcing.routing.StorageRoutingProperties
 import me.ahoo.wow.spring.boot.starter.eventsourcing.snapshot.SnapshotProperties
 import me.ahoo.wow.spring.boot.starter.eventsourcing.store.EventStoreProperties
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.data.elasticsearch.autoconfigure.DataElasticsearchAutoConfiguration
+import org.springframework.boot.elasticsearch.autoconfigure.ElasticsearchClientAutoConfiguration
+import org.springframework.boot.elasticsearch.autoconfigure.ElasticsearchRestClientAutoConfiguration
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
 import org.springframework.data.elasticsearch.core.ReactiveElasticsearchOperations
 import org.springframework.data.elasticsearch.core.ReactiveIndexOperations
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates
+import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
 
 internal class ElasticsearchEventSourcingAutoConfigurationTest {
     private val contextRunner = ApplicationContextRunner()
+
+    @Test
+    fun `should auto configure reactive elasticsearch infrastructure from feature dependencies`() {
+        ApplicationContextRunner()
+            .enableWow()
+            .withConfiguration(
+                AutoConfigurations.of(
+                    ElasticsearchRestClientAutoConfiguration::class.java,
+                    ElasticsearchClientAutoConfiguration::class.java,
+                    DataElasticsearchAutoConfiguration::class.java,
+                    ElasticsearchEventSourcingAutoConfiguration::class.java,
+                ),
+            )
+            .withPropertyValues(
+                "${EventStoreProperties.STORAGE}=${StorageType.ELASTICSEARCH_NAME}",
+                "${SnapshotProperties.STORAGE}=${StorageType.MONGO_NAME}",
+                "${ElasticsearchProperties.PREFIX}.auto-init-template=false",
+            )
+            .run { context ->
+                context.assert()
+                    .hasNotFailed()
+                    .hasSingleBean(ReactiveElasticsearchClient::class.java)
+                    .hasSingleBean(ReactiveElasticsearchOperations::class.java)
+                    .hasSingleBean(IndexTemplateInitializer::class.java)
+                    .hasSingleBean(ElasticsearchEventStore::class.java)
+                    .hasSingleBean(JsonpMapper::class.java)
+                context.getBean(JsonpMapper::class.java).assert().isSameAs(WowJsonpMapper)
+            }
+    }
+
+    @Test
+    fun `should not load elasticsearch beans when no storage route uses elasticsearch`() {
+        val indexOperations = successfulIndexOperations()
+        elasticsearchContextRunner(indexOperations)
+            .withPropertyValues(
+                "${EventStoreProperties.STORAGE}=${StorageType.MONGO_NAME}",
+                "${SnapshotProperties.STORAGE}=${StorageType.MONGO_NAME}",
+            )
+            .run { context ->
+                context.assert()
+                    .hasNotFailed()
+                    .doesNotHaveBean(JsonpMapper::class.java)
+                    .doesNotHaveBean(IndexTemplateInitializer::class.java)
+                    .doesNotHaveBean(ElasticsearchEventStore::class.java)
+                    .doesNotHaveBean(ElasticsearchSnapshotStore::class.java)
+                verify(exactly = 0) { indexOperations.putIndexTemplate(any()) }
+            }
+    }
 
     @Test
     fun `should not load context when elasticsearch is disabled`() {
@@ -102,5 +159,140 @@ internal class ElasticsearchEventSourcingAutoConfigurationTest {
                 snapshotBinding.storage.assert().isEqualTo(StorageType.ELASTICSEARCH)
                 snapshotBinding.snapshotStore.assert().isSameAs(snapshotStore)
             }
+    }
+
+    @Test
+    fun `should initialize only event stream template for elasticsearch event route`() {
+        val indexOperations = successfulIndexOperations()
+        elasticsearchContextRunner(indexOperations)
+            .withPropertyValues(
+                "${EventStoreProperties.STORAGE}=${StorageType.MONGO_NAME}",
+                "${SnapshotProperties.STORAGE}=${StorageType.MONGO_NAME}",
+                "${StorageRoutingProperties.AGGREGATES}.order.event.storage=${StorageType.ELASTICSEARCH_NAME}",
+            )
+            .run { context ->
+                context.assert()
+                    .hasNotFailed()
+                    .hasSingleBean(IndexTemplateInitializer::class.java)
+                    .hasSingleBean(ElasticsearchEventStore::class.java)
+                    .doesNotHaveBean(ElasticsearchSnapshotStore::class.java)
+                verify(exactly = 1) {
+                    indexOperations.putIndexTemplate(match { it.name == "wow-event-stream-template" })
+                }
+                verify(exactly = 0) {
+                    indexOperations.putIndexTemplate(match { it.name == "wow-snapshot-template" })
+                }
+            }
+    }
+
+    @Test
+    fun `should initialize only snapshot template for elasticsearch snapshot route`() {
+        val indexOperations = successfulIndexOperations()
+        elasticsearchContextRunner(indexOperations)
+            .withPropertyValues(
+                "${EventStoreProperties.STORAGE}=${StorageType.MONGO_NAME}",
+                "${SnapshotProperties.STORAGE}=${StorageType.MONGO_NAME}",
+                "${StorageRoutingProperties.AGGREGATES}.cart.snapshot.storage=${StorageType.ELASTICSEARCH_NAME}",
+            )
+            .run { context ->
+                context.assert()
+                    .hasNotFailed()
+                    .hasSingleBean(IndexTemplateInitializer::class.java)
+                    .doesNotHaveBean(ElasticsearchEventStore::class.java)
+                    .hasSingleBean(ElasticsearchSnapshotStore::class.java)
+                verify(exactly = 0) {
+                    indexOperations.putIndexTemplate(match { it.name == "wow-event-stream-template" })
+                }
+                verify(exactly = 1) {
+                    indexOperations.putIndexTemplate(match { it.name == "wow-snapshot-template" })
+                }
+            }
+    }
+
+    @Test
+    fun `should not initialize templates when auto initialization is disabled`() {
+        val indexOperations = successfulIndexOperations()
+        elasticsearchContextRunner(indexOperations)
+            .withPropertyValues(
+                "${EventStoreProperties.STORAGE}=${StorageType.ELASTICSEARCH_NAME}",
+                "${SnapshotProperties.STORAGE}=${StorageType.ELASTICSEARCH_NAME}",
+                "${ElasticsearchProperties.PREFIX}.auto-init-template=false",
+            )
+            .run { context ->
+                context.assert().hasNotFailed()
+                verify(exactly = 0) { indexOperations.putIndexTemplate(any()) }
+            }
+    }
+
+    @Test
+    fun `should back off when a custom jsonp mapper is provided`() {
+        val customMapper = mockk<JsonpMapper>()
+        val indexOperations = successfulIndexOperations()
+        elasticsearchContextRunner(indexOperations)
+            .withPropertyValues(
+                "${EventStoreProperties.STORAGE}=${StorageType.ELASTICSEARCH_NAME}",
+                "${SnapshotProperties.STORAGE}=${StorageType.MONGO_NAME}",
+                "${ElasticsearchProperties.PREFIX}.auto-init-template=false",
+            )
+            .withBean(JsonpMapper::class.java, { customMapper })
+            .run { context ->
+                context.assert()
+                    .hasNotFailed()
+                    .hasSingleBean(JsonpMapper::class.java)
+                    .doesNotHaveBean(Jackson3JsonpMapper::class.java)
+                context.getBean(JsonpMapper::class.java).assert().isSameAs(customMapper)
+            }
+    }
+
+    @Test
+    fun `should fail startup when template initialization fails`() {
+        val failure = IllegalStateException("template initialization failed")
+        val indexOperations = mockk<ReactiveIndexOperations> {
+            every { putIndexTemplate(any()) } returns Mono.error(failure)
+        }
+
+        elasticsearchContextRunner(indexOperations)
+            .withPropertyValues(
+                "${EventStoreProperties.STORAGE}=${StorageType.ELASTICSEARCH_NAME}",
+                "${SnapshotProperties.STORAGE}=${StorageType.MONGO_NAME}",
+            )
+            .run { context ->
+                context.startupFailure.assert().isNotNull()
+            }
+    }
+
+    @Test
+    fun `should fail startup when template initialization is not acknowledged`() {
+        val indexOperations = mockk<ReactiveIndexOperations> {
+            every { putIndexTemplate(any()) } returns Mono.just(false)
+        }
+
+        elasticsearchContextRunner(indexOperations)
+            .withPropertyValues(
+                "${EventStoreProperties.STORAGE}=${StorageType.ELASTICSEARCH_NAME}",
+                "${SnapshotProperties.STORAGE}=${StorageType.MONGO_NAME}",
+            )
+            .run { context ->
+                context.startupFailure.assert().isNotNull()
+            }
+    }
+
+    private fun successfulIndexOperations(): ReactiveIndexOperations = mockk {
+        every { putIndexTemplate(any()) } returns true.toMono()
+    }
+
+    private fun elasticsearchContextRunner(indexOperations: ReactiveIndexOperations): ApplicationContextRunner {
+        val elasticsearchOperations = mockk<ReactiveElasticsearchOperations> {
+            every { indexOps(any<IndexCoordinates>()) } returns indexOperations
+        }
+        return contextRunner
+            .enableWow()
+            .withBean(ReactiveElasticsearchClient::class.java, {
+                mock(ReactiveElasticsearchClient::class.java)
+            })
+            .withBean(ReactiveElasticsearchOperations::class.java, {
+                elasticsearchOperations
+            })
+            .withUserConfiguration(ElasticsearchEventSourcingAutoConfiguration::class.java)
     }
 }


### PR DESCRIPTION
## Goal

Ensure Elasticsearch-backed event and snapshot stores are not exposed before their required index templates are ready, and make the `elasticsearch-support` capability provide the reactive Spring Data infrastructure that Wow actually injects.

## Changes

- Replace `spring-boot-starter-elasticsearch` with `spring-boot-starter-data-elasticsearch` for the Elasticsearch feature variant.
- Activate Wow Elasticsearch auto-configuration only when an event or snapshot route uses Elasticsearch.
- Await only the templates required by the active storage routes during store creation.
- Fail startup when template initialization errors, completes without a result, or returns `acknowledged=false`.
- Order the Wow `JsonpMapper` before client auto-configuration and back off for a user-provided mapper.
- Keep `IndexTemplateInitializer.initAll(): Unit` and the legacy subscriber type binary-compatible.
- Remove ineffective hard-coded shard and replica counts from bundled templates; cluster settings or higher-priority operator templates now own topology.
- Document fail-fast behavior, the Spring Data starter dependency, and custom template priority requirements.

## Verification

- `./gradlew :wow-elasticsearch:check :wow-spring-boot-starter:check :wow-elasticsearch:jacocoTestReport` — passed.
- `./gradlew :wow-elasticsearch:integrationTest` — passed against the container-backed Elasticsearch suite.
- `pnpm docs:build` in `documentation` — passed.
- Local Jacoco reports cover all executable lines added to `IndexTemplateInitializer`, the Elasticsearch auto-configuration, and the storage condition.

## Risks and Notes

- **Behavior change:** with `wow.elasticsearch.auto-init-template=true` (the default), an unreachable Elasticsearch cluster, insufficient template permissions, an empty response, or `acknowledged=false` now fails application startup instead of logging and continuing.
- Set `wow.elasticsearch.auto-init-template=false` only when templates are managed externally; this is also the rollback switch for the new fail-fast behavior.
- Existing indices are not modified. Removing bundled shard/replica counts affects only indices created after the updated template is installed. Operators that require fixed topology should provide a higher-priority template.
- No data migration is performed or required by this PR.