### PR TITLE
fix(redis): harden scanning and auto-configuration

### DIFF
--- a/documentation/docs/en/guide/extensions/redis.md
+++ b/documentation/docs/en/guide/extensions/redis.md
@@ -31,9 +31,9 @@ flowchart TB
             SS["State Stream"]
         end
         subgraph Storage["Storage"]
-            EH["Event Hash"]
-            SH["Snapshot Hash"]
-            PK["Prepare Key"]
+            EH["Event ZSET"]
+            SH["Snapshot String"]
+            PK["Prepare Hash"]
         end
     end
     
@@ -109,6 +109,8 @@ wow:
     state:
       bus:
         type: redis
+  prepare:
+    storage: redis
   redis:
     enabled: true
     message-bus:
@@ -126,10 +128,10 @@ The Redis command bus uses Redis Streams for message delivery:
 ### Stream Naming Rules
 
 ```
-{prefix}{contextName}.{aggregateName}.command
+{contextAlias}.{aggregateName}:command
 ```
 
-Example: `wow.order-service.order.command`
+Example: `order-service.order:command`
 
 ### Consumer Groups
 
@@ -150,6 +152,10 @@ cover the longest handler execution, retry, and graceful-shutdown duration. Reco
 default. Set `wow.redis.message-bus.recovery.enabled=false` only as a temporary rollback; doing so
 restores the previous behavior in which abandoned PEL records can remain stranded.
 
+Pending recovery and live delivery run concurrently. Redis Streams does not guarantee that an older
+recovered record is delivered before a newer live record, so handlers must tolerate recovery-time
+reordering as well as duplicate delivery.
+
 Records without the `msg` field or with invalid JSON no longer terminate the consumer. They remain
 pending for manual diagnosis, while a payload-free error and a `RedisMessageBusObservation.RecordDecodeFailed`
 observation are emitted. Applications can register non-blocking `RedisMessageBusObserver` beans for
@@ -160,13 +166,13 @@ metrics or alerting.
 ### Domain Event Stream
 
 ```
-{prefix}{contextName}.{aggregateName}.event
+{contextAlias}.{aggregateName}:event
 ```
 
 ### State Event Stream
 
 ```
-{prefix}{contextName}.{aggregateName}.state
+{contextAlias}.{aggregateName}:state
 ```
 
 ## Event Store
@@ -198,24 +204,28 @@ Request IDs are stored in the bucket-aligned SET key shown above.
 
 ## Snapshot Storage
 
-Snapshots are stored using Hash structure:
+Snapshots are stored as String values:
 
 ```
-Key: {prefix}{contextName}.{aggregateName}:{aggregateId}:snapshot
+Key: {contextAlias}.{aggregateName}:snapshot:{aggregateId}@{tenantId}
 Value: {snapshotJson}
 ```
 
 ## Prepare Key
 
-PrepareKey uses String structure:
+PrepareKey uses a Hash:
 
 ```
-Key: {prefix}prepare:{keyName}:{key}
-Value: {preparedValue}
-TTL: Based on configuration or permanent
+Key: prepare:{key}
+Field: value = {preparedValueJson}
+Field: ttlAt = {expirationTimestamp}
 ```
 
 ## Connection Pool Configuration
+
+Connection pooling requires Apache Commons Pool 2 on the application classpath. The
+`redis-support` capability does not add that optional dependency; without it, the pool settings
+below are not applied.
 
 ```yaml
 spring:
@@ -271,25 +281,29 @@ spring:
 
 ## Performance Optimization
 
-### Pipeline Batch Operations
+### Batch Operations
 
-The Redis extension automatically uses Pipeline to optimize batch operations, reducing network round trips.
+The event store uses Lua scripts for atomic append operations. Snapshot and message-bus operations
+are issued individually; the extension does not automatically pipeline arbitrary batch work.
 
 ### Memory Optimization
 
-1. **Set Reasonable TTL**: Set expiration time for temporary data
-2. **Compressed Storage**: Enable data compression to reduce memory usage
-3. **Monitor Memory**: Regularly check memory usage
+1. **Separate authoritative data from cache data**: Do not apply cache eviction policies to EventStore keys
+2. **Capacity-plan Streams**: Acknowledgement removes records from the PEL, not from the Stream; Wow does not automatically trim Streams
+3. **Monitor memory and persistence**: Configure persistence, replication, and alerting according to the durability requirement
 
 ### Recommended Configuration
 
 ```yaml
 # Redis server configuration recommendations
 maxmemory 4gb
-maxmemory-policy allkeys-lru
+maxmemory-policy noeviction
 tcp-keepalive 300
 timeout 0
 ```
+
+`allkeys-lru` can evict event streams, idempotency indexes, aggregate indexes, or snapshots
+independently and must not be used when Redis is the authoritative EventStore.
 
 ## Troubleshooting
 
@@ -376,6 +390,8 @@ wow:
         type: redis
         local-first:
           enabled: true
+  prepare:
+    storage: redis
   redis:
     enabled: true
 ```
@@ -384,6 +400,6 @@ wow:
 
 1. **Enable LocalFirst Mode**: Process local messages first to reduce network latency
 2. **Use Cluster Mode**: Use Redis cluster in production for high availability and scalability
-3. **Configure Connection Pool Properly**: Configure appropriate connection pool size based on concurrency
+3. **Configure Connection Pool Properly**: Add Commons Pool 2 and size the pool based on measured concurrency
 4. **Monitor Memory Usage**: Regularly monitor Redis memory usage to avoid OOM
 5. **Enable Persistence**: Configure RDB or AOF persistence to prevent data loss

--- a/documentation/docs/zh/guide/extensions/redis.md
+++ b/documentation/docs/zh/guide/extensions/redis.md
@@ -31,9 +31,9 @@ flowchart TB
             SS["State Stream"]
         end
         subgraph Storage["存储"]
-            EH["Event Hash"]
-            SH["Snapshot Hash"]
-            PK["Prepare Key"]
+            EH["Event ZSET"]
+            SH["Snapshot String"]
+            PK["Prepare Hash"]
         end
     end
     
@@ -109,6 +109,8 @@ wow:
     state:
       bus:
         type: redis
+  prepare:
+    storage: redis
   redis:
     enabled: true
     message-bus:
@@ -126,10 +128,10 @@ Redis 命令总线使用 Redis Streams 实现消息传递：
 ### Stream 命名规则
 
 ```
-{prefix}{contextName}.{aggregateName}.command
+{contextAlias}.{aggregateName}:command
 ```
 
-示例：`wow.order-service.order.command`
+示例：`order-service.order:command`
 
 ### 消费者组
 
@@ -149,6 +151,9 @@ Redis 消息总线会在 `min-idle-time` 后恢复旧 consumer 遗留在 Pending
 重试和优雅停机时间。恢复默认开启。仅应在临时回滚时设置
 `wow.redis.message-bus.recovery.enabled=false`；关闭后会恢复旧行为，使被遗留的 PEL 记录可能永久滞留。
 
+Pending 恢复与实时消费并发运行。Redis Streams 不保证较旧的恢复消息一定先于较新的实时消息交付，
+因此 handler 除了处理重复投递，还必须容忍恢复期间的乱序。
+
 缺少 `msg` 字段或 JSON 非法的记录不会再终止 consumer。此类记录保留在 PEL 中供人工诊断，同时输出
 不含 payload 的错误日志和 `RedisMessageBusObservation.RecordDecodeFailed` 观测事件。应用可注册非阻塞的
 `RedisMessageBusObserver` Bean 接入指标或告警。
@@ -158,13 +163,13 @@ Redis 消息总线会在 `min-idle-time` 后恢复旧 consumer 遗留在 Pending
 ### 领域事件 Stream
 
 ```
-{prefix}{contextName}.{aggregateName}.event
+{contextAlias}.{aggregateName}:event
 ```
 
 ### 状态事件 Stream
 
 ```
-{prefix}{contextName}.{aggregateName}.state
+{contextAlias}.{aggregateName}:state
 ```
 
 ## 事件存储
@@ -196,24 +201,27 @@ Member: {aggregateId}\u0000{tenantId}
 
 ## 快照存储
 
-快照使用 Hash 结构存储：
+快照使用 String value 存储：
 
 ```
-Key: {prefix}{contextName}.{aggregateName}:{aggregateId}:snapshot
+Key: {contextAlias}.{aggregateName}:snapshot:{aggregateId}@{tenantId}
 Value: {snapshotJson}
 ```
 
 ## 预分配 Key
 
-PrepareKey 使用 String 结构：
+PrepareKey 使用 Hash 结构：
 
 ```
-Key: {prefix}prepare:{keyName}:{key}
-Value: {preparedValue}
-TTL: 根据配置或永久
+Key: prepare:{key}
+Field: value = {preparedValueJson}
+Field: ttlAt = {expirationTimestamp}
 ```
 
 ## 连接池配置
+
+连接池需要应用 classpath 中存在 Apache Commons Pool 2。`redis-support` capability 不会引入这个
+可选依赖；缺少它时，下面的连接池参数不会生效。
 
 ```yaml
 spring:
@@ -269,25 +277,28 @@ spring:
 
 ## 性能优化
 
-### Pipeline 批量操作
+### 批量操作
 
-Redis 扩展自动使用 Pipeline 优化批量操作，减少网络往返次数。
+EventStore 使用 Lua 脚本保证追加操作的原子性。Snapshot 与 MessageBus 操作逐条发送，扩展不会自动
+对任意批处理启用 Pipeline。
 
 ### 内存优化
 
-1. **合理设置 TTL**：为临时数据设置过期时间
-2. **压缩存储**：启用数据压缩减少内存占用
-3. **监控内存**：定期检查内存使用情况
+1. **隔离权威数据与缓存数据**：不要对 EventStore Key 使用缓存淘汰策略
+2. **规划 Stream 容量**：ACK 只会从 PEL 移除记录，不会删除 Stream 记录；Wow 当前不会自动 trim Stream
+3. **监控内存与持久化**：根据持久性要求配置持久化、复制和告警
 
 ### 建议配置
 
 ```yaml
 # Redis 服务端配置建议
 maxmemory 4gb
-maxmemory-policy allkeys-lru
+maxmemory-policy noeviction
 tcp-keepalive 300
 timeout 0
 ```
+
+Redis 作为权威 EventStore 时不得使用 `allkeys-lru`；它可能独立淘汰事件流、幂等索引、聚合索引或快照。
 
 ## 故障排查
 
@@ -374,6 +385,8 @@ wow:
         type: redis
         local-first:
           enabled: true
+  prepare:
+    storage: redis
   redis:
     enabled: true
 ```
@@ -382,6 +395,6 @@ wow:
 
 1. **启用 LocalFirst 模式**：本地消息优先处理，减少网络延迟
 2. **使用集群模式**：生产环境使用 Redis 集群保证高可用和扩展性
-3. **合理配置连接池**：根据并发量配置适当的连接池大小
+3. **合理配置连接池**：引入 Commons Pool 2，并根据实测并发量配置连接池大小
 4. **监控内存使用**：定期监控 Redis 内存使用，避免 OOM
 5. **启用持久化**：配置 RDB 或 AOF 持久化防止数据丢失

--- a/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStore.kt
+++ b/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStore.kt
@@ -118,7 +118,9 @@ class RedisEventStore(
         if (afterId == AggregateIdScanner.LAST_ID) {
             return Flux.empty()
         }
-        val range = Range.open(toAggregateIdIndexMemberLowerBound(afterId), AggregateIdScanner.LAST_ID)
+        val range = Range.rightUnbounded(
+            Range.Bound.exclusive(toAggregateIdIndexMemberLowerBound(afterId))
+        )
         val rangeLimit = Limit.limit().count(limit)
         return Flux.range(0, AGGREGATE_ID_INDEX_BUCKETS)
             .flatMap(

--- a/wow-redis/src/test/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStoreScanTest.kt
+++ b/wow-redis/src/test/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStoreScanTest.kt
@@ -162,7 +162,8 @@ class RedisEventStoreScanTest {
             it.contains("001").assert().isFalse()
             it.contains("001" + "\u0000" + TenantId.DEFAULT_TENANT_ID).assert().isFalse()
             it.contains("002" + "\u0000" + TenantId.DEFAULT_TENANT_ID).assert().isTrue()
-            it.contains(AggregateIdScanner.LAST_ID).assert().isFalse()
+            it.contains("~order" + "\u0000" + TenantId.DEFAULT_TENANT_ID).assert().isTrue()
+            it.contains("订单-1" + "\u0000" + TenantId.DEFAULT_TENANT_ID).assert().isTrue()
         }
         limitSlots.forEach {
             it.count.assert().isEqualTo(2)

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareAutoConfiguration.kt
@@ -16,13 +16,20 @@ import me.ahoo.wow.infra.prepare.PrepareKeyFactory
 import me.ahoo.wow.infra.prepare.proxy.DefaultPrepareKeyProxyFactory
 import me.ahoo.wow.infra.prepare.proxy.PrepareKeyProxyFactory
 import me.ahoo.wow.spring.boot.starter.ConditionalOnWowEnabled
+import me.ahoo.wow.spring.boot.starter.mongo.MongoEventSourcingAutoConfiguration
+import me.ahoo.wow.spring.boot.starter.redis.RedisEventSourcingAutoConfiguration
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
 
-@AutoConfiguration
+@AutoConfiguration(
+    after = [
+        MongoEventSourcingAutoConfiguration::class,
+        RedisEventSourcingAutoConfiguration::class,
+    ],
+)
 @ConditionalOnWowEnabled
 @ConditionalOnPrepareEnabled
 @EnableConfigurationProperties(PrepareProperties::class)

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/redis/RedisMessageBusAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/redis/RedisMessageBusAutoConfiguration.kt
@@ -25,11 +25,14 @@ import me.ahoo.wow.spring.boot.starter.BusType
 import me.ahoo.wow.spring.boot.starter.ConditionalOnWowEnabled
 import me.ahoo.wow.spring.boot.starter.command.CommandAutoConfiguration
 import me.ahoo.wow.spring.boot.starter.command.CommandProperties
+import me.ahoo.wow.spring.boot.starter.event.EventAutoConfiguration
 import me.ahoo.wow.spring.boot.starter.event.EventProperties
+import me.ahoo.wow.spring.boot.starter.eventsourcing.state.StateAutoConfiguration
 import me.ahoo.wow.spring.boot.starter.eventsourcing.state.StateProperties
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.data.redis.autoconfigure.DataRedisReactiveAutoConfiguration
@@ -37,7 +40,11 @@ import org.springframework.context.annotation.Bean
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate
 
 @AutoConfiguration(
-    before = [CommandAutoConfiguration::class],
+    before = [
+        CommandAutoConfiguration::class,
+        EventAutoConfiguration::class,
+        StateAutoConfiguration::class,
+    ],
     after = [DataRedisReactiveAutoConfiguration::class],
 )
 @ConditionalOnWowEnabled
@@ -51,6 +58,7 @@ class RedisMessageBusAutoConfiguration {
         CommandProperties.BUS_TYPE,
         havingValue = BusType.REDIS_NAME,
     )
+    @ConditionalOnMissingBean(DistributedCommandBus::class)
     fun redisCommandBus(
         redisTemplate: ReactiveStringRedisTemplate,
         recoveryProperties: RedisStreamRecoveryProperties,
@@ -68,6 +76,7 @@ class RedisMessageBusAutoConfiguration {
         EventProperties.BUS_TYPE,
         havingValue = BusType.REDIS_NAME,
     )
+    @ConditionalOnMissingBean(DistributedDomainEventBus::class)
     fun redisDomainEventBus(
         redisTemplate: ReactiveStringRedisTemplate,
         recoveryProperties: RedisStreamRecoveryProperties,
@@ -85,6 +94,7 @@ class RedisMessageBusAutoConfiguration {
         StateProperties.BUS_TYPE,
         havingValue = BusType.REDIS_NAME,
     )
+    @ConditionalOnMissingBean(DistributedStateEventBus::class)
     fun redisStateEventBus(
         redisTemplate: ReactiveStringRedisTemplate,
         recoveryProperties: RedisStreamRecoveryProperties,

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareAutoConfigurationTest.kt
@@ -38,14 +38,18 @@ import me.ahoo.wow.spring.boot.starter.openapi.OpenAPIAutoConfiguration
 import me.ahoo.wow.spring.boot.starter.opentelemetry.WowOpenTelemetryAutoConfiguration
 import me.ahoo.wow.spring.boot.starter.projection.ProjectionDispatcherAutoConfiguration
 import me.ahoo.wow.spring.boot.starter.query.QueryAutoConfiguration
+import me.ahoo.wow.spring.boot.starter.redis.RedisEventSourcingAutoConfiguration
+import me.ahoo.wow.spring.boot.starter.redis.RedisProperties
 import me.ahoo.wow.spring.boot.starter.saga.StatelessSagaAutoConfiguration
 import me.ahoo.wow.spring.boot.starter.webflux.WebFluxAutoConfiguration
 import me.ahoo.wow.spring.boot.starter.webflux.WowWebClientAutoConfiguration
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.getBean
+import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate
 
 class PrepareAutoConfigurationTest {
     private val contextRunner = ApplicationContextRunner()
@@ -63,6 +67,30 @@ class PrepareAutoConfigurationTest {
                     .hasSingleBean(PrepareKeyProxyFactory::class.java)
                     .hasSingleBean(PrepareProperties::class.java)
                     .hasSingleBean(PrepareKeyInitializer::class.java)
+            }
+    }
+
+    @Test
+    fun `should create prepare proxy factory after redis prepare key factory`() {
+        contextRunner
+            .enableWow()
+            .withPropertyValues(
+                "${PrepareProperties.STORAGE}=${PrepareStorage.REDIS_NAME}",
+            )
+            .withBean(ReactiveStringRedisTemplate::class.java, {
+                mockk<ReactiveStringRedisTemplate>()
+            })
+            .withConfiguration(
+                AutoConfigurations.of(
+                    PrepareAutoConfiguration::class.java,
+                    RedisEventSourcingAutoConfiguration::class.java,
+                )
+            )
+            .run { context: AssertableApplicationContext ->
+                context.assert()
+                    .hasSingleBean(PrepareKeyFactory::class.java)
+                    .hasSingleBean(PrepareKeyProxyFactory::class.java)
+                    .hasSingleBean(RedisProperties::class.java)
             }
     }
 

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/redis/RedisMessageBusAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/redis/RedisMessageBusAutoConfigurationTest.kt
@@ -4,6 +4,14 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.command.DistributedCommandBus
+import me.ahoo.wow.event.DistributedDomainEventBus
+import me.ahoo.wow.event.LocalFirstDomainEventBus
+import me.ahoo.wow.eventsourcing.EventStore
+import me.ahoo.wow.eventsourcing.state.DistributedStateEventBus
+import me.ahoo.wow.eventsourcing.state.LocalFirstStateEventBus
+import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory
+import me.ahoo.wow.modeling.state.StateAggregateFactory
 import me.ahoo.wow.redis.bus.AbstractRedisMessageBus
 import me.ahoo.wow.redis.bus.RedisCommandBus
 import me.ahoo.wow.redis.bus.RedisDomainEventBus
@@ -14,9 +22,12 @@ import me.ahoo.wow.redis.bus.RedisStreamRecoveryOptions
 import me.ahoo.wow.spring.boot.starter.BusType
 import me.ahoo.wow.spring.boot.starter.command.CommandProperties
 import me.ahoo.wow.spring.boot.starter.enableWow
+import me.ahoo.wow.spring.boot.starter.event.EventAutoConfiguration
 import me.ahoo.wow.spring.boot.starter.event.EventProperties
+import me.ahoo.wow.spring.boot.starter.eventsourcing.state.StateAutoConfiguration
 import me.ahoo.wow.spring.boot.starter.eventsourcing.state.StateProperties
 import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate
@@ -59,6 +70,66 @@ class RedisMessageBusAutoConfigurationTest {
                     .enabled
                     .assert()
                     .isTrue()
+            }
+    }
+
+    @Test
+    fun `should configure local-first buses after redis distributed buses`() {
+        contextRunner
+            .enableWow()
+            .withPropertyValues(
+                "${EventProperties.BUS_TYPE}=${BusType.REDIS_NAME}",
+                "${StateProperties.BUS_TYPE}=${BusType.REDIS_NAME}",
+            )
+            .withBean(EventStore::class.java, { mockk<EventStore>() })
+            .withBean(StateAggregateFactory::class.java, { ConstructorStateAggregateFactory })
+            .withBean(ReactiveStringRedisTemplate::class.java, {
+                mockk<ReactiveStringRedisTemplate> {
+                    every { opsForStream<String, String>() } returns mockk()
+                }
+            })
+            .withConfiguration(
+                AutoConfigurations.of(
+                    EventAutoConfiguration::class.java,
+                    StateAutoConfiguration::class.java,
+                    RedisMessageBusAutoConfiguration::class.java,
+                )
+            )
+            .run { context: AssertableApplicationContext ->
+                context.assert()
+                    .hasSingleBean(RedisDomainEventBus::class.java)
+                    .hasSingleBean(RedisStateEventBus::class.java)
+                    .hasSingleBean(LocalFirstDomainEventBus::class.java)
+                    .hasSingleBean(LocalFirstStateEventBus::class.java)
+            }
+    }
+
+    @Test
+    fun `should back off when custom distributed buses exist`() {
+        contextRunner
+            .enableWow()
+            .withPropertyValues(
+                "${CommandProperties.BUS_TYPE}=${BusType.REDIS_NAME}",
+                "${EventProperties.BUS_TYPE}=${BusType.REDIS_NAME}",
+                "${StateProperties.BUS_TYPE}=${BusType.REDIS_NAME}",
+            )
+            .withBean(ReactiveStringRedisTemplate::class.java, {
+                mockk<ReactiveStringRedisTemplate> {
+                    every { opsForStream<String, String>() } returns mockk()
+                }
+            })
+            .withBean(DistributedCommandBus::class.java, { mockk<DistributedCommandBus>() })
+            .withBean(DistributedDomainEventBus::class.java, { mockk<DistributedDomainEventBus>() })
+            .withBean(DistributedStateEventBus::class.java, { mockk<DistributedStateEventBus>() })
+            .withUserConfiguration(RedisMessageBusAutoConfiguration::class.java)
+            .run { context: AssertableApplicationContext ->
+                context.assert()
+                    .hasSingleBean(DistributedCommandBus::class.java)
+                    .hasSingleBean(DistributedDomainEventBus::class.java)
+                    .hasSingleBean(DistributedStateEventBus::class.java)
+                    .doesNotHaveBean(RedisCommandBus::class.java)
+                    .doesNotHaveBean(RedisDomainEventBus::class.java)
+                    .doesNotHaveBean(RedisStateEventBus::class.java)
             }
     }
 


### PR DESCRIPTION
## Goal

Fix Redis correctness and Spring Boot auto-configuration gaps without changing the Redis key layout or introducing a data migration.

## Changes

- Remove the artificial `"~"` upper bound from aggregate ID index scans so valid high-lexicographical IDs, including Unicode IDs, are returned.
- Order Prepare auto-configuration after Mongo and Redis storage factories so `PrepareKeyProxyFactory` is created reliably.
- Order Redis distributed buses before Command, Event, and State auto-configuration so LocalFirst buses are assembled consistently.
- Back off Redis bus beans when applications provide custom `DistributedCommandBus`, `DistributedDomainEventBus`, or `DistributedStateEventBus` implementations.
- Add regression tests that reproduce each auto-configuration and scan failure before the fix.
- Correct the English and Chinese Redis documentation for Stream keys, storage structures, Prepare configuration, connection pooling prerequisites, recovery ordering, Stream retention, and production eviction policy.

## Verification

- `./gradlew :wow-redis:check :wow-spring-boot-starter:check` — passed
- `pnpm docs:build` in `documentation` — passed
- `git diff --check` — passed

## Risks and Notes

- No Redis keys or stored values are rewritten by this PR.
- Applications that define a custom distributed bus now keep that implementation instead of also receiving a conflicting default Redis bus.
- Aggregate scans can now return IDs that were previously skipped because they sorted at or above `"~"`.
- Redis pending recovery still runs concurrently with live delivery; the documentation now explicitly states that recovery-time reordering is possible.
- The previously released Redis EventStore key-layout migration gap is intentionally out of scope and requires a separate migration design and rollout plan.

Rollback is a normal commit revert; no data rollback is required.