### PR TITLE
ci(security): strengthen static analysis checks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,33 +11,35 @@
 # limitations under the License.
 #
 
-name: Static Analysis
+name: CodeQL
 on:
+  push:
+    branches:
+      - main
   pull_request:
-    paths:
-      - '.github/workflows/static-analysis.yml'
-      - 'build.gradle.kts'
-      - 'settings.gradle.kts'
-      - 'gradle.properties'
-      - 'gradlew'
-      - 'gradle/**'
-      - 'config/**'
-      - 'wow-*/**'
-      - 'test/**'
-      - 'example/**'
-      - 'compensation/**'
+    branches:
+      - main
+  schedule:
+    - cron: '21 19 * * 4'
+  workflow_dispatch:
+
 permissions:
+  actions: read
   contents: read
+  security-events: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
 env:
   CI: GITHUB_ACTIONS
 
 jobs:
-  static-analysis:
-    name: Static Analysis
+  analyze:
+    name: Analyze Java and Kotlin
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -47,9 +49,16 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          server-id: github
           cache: gradle
-          settings-path: ${{ github.workspace }}
 
-      - name: Run static analysis
-        run: ./gradlew detekt --no-auto-correct --stacktrace
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
+        with:
+          languages: java-kotlin
+          build-mode: manual
+
+      - name: Build Java and Kotlin sources
+        run: ./gradlew classes --no-daemon
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -11,45 +11,28 @@
 # limitations under the License.
 #
 
-name: Static Analysis
+name: Dependency Review
 on:
   pull_request:
-    paths:
-      - '.github/workflows/static-analysis.yml'
-      - 'build.gradle.kts'
-      - 'settings.gradle.kts'
-      - 'gradle.properties'
-      - 'gradlew'
-      - 'gradle/**'
-      - 'config/**'
-      - 'wow-*/**'
-      - 'test/**'
-      - 'example/**'
-      - 'compensation/**'
+    branches:
+      - main
+
 permissions:
   contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
-env:
-  CI: GITHUB_ACTIONS
 
 jobs:
-  static-analysis:
-    name: Static Analysis
+  dependency-review:
+    name: Review dependency changes
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+      - name: Review dependencies
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
-          java-version: '17'
-          distribution: 'temurin'
-          server-id: github
-          cache: gradle
-          settings-path: ${{ github.workspace }}
-
-      - name: Run static analysis
-        run: ./gradlew detekt --no-auto-correct --stacktrace
+          fail-on-severity: high

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -150,7 +150,7 @@ allprojects {
     configure<DetektExtension> {
         config.setFrom(files("${rootProject.rootDir}/config/detekt/detekt.yml"))
         buildUponDefaultConfig = true
-        autoCorrect = true
+        autoCorrect = false
     }
     dependencies {
         detektPlugins(dependenciesProject)

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -15,11 +15,11 @@ style:
   UnusedPrivateMember:
     active: false
   ProtectedMemberInFinalClass:
-    active: false
+    active: true
   MagicNumber:
     active: false
   UnnecessaryAbstractClass:
-    active: false
+    active: true
   LoopWithTooManyJumpStatements:
     active: false
   WildcardImport:
@@ -33,9 +33,9 @@ naming:
     active: false
 exceptions:
   SwallowedException:
-    active: false
+    active: true
   ThrowingExceptionsWithoutMessageOrCause:
-    active: false
+    active: true
 performance:
   SpreadOperator:
     active: false

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/annotation/AggregateMetadataParser.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/annotation/AggregateMetadataParser.kt
@@ -81,6 +81,7 @@ object AggregateMetadataParser : CacheableMetadataParser() {
             } catch (e: NoSuchElementException) {
                 throw IllegalStateException(
                     "Failed to parse CommandAggregate[$commandAggregateType] metadata: Not defined Constructor[ctor(aggregateId) or ctor(stateAggregate)].",
+                    e,
                 )
             }
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/serialization/event/DomainEventRecord.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/serialization/event/DomainEventRecord.kt
@@ -102,7 +102,8 @@ interface DomainEventRecord :
         }
         return try {
             bodyType.toType<Any>()
-        } catch (classNotFoundException: ClassNotFoundException) {
+        } catch (ignoredClassNotFoundException: ClassNotFoundException) {
+            // Preserve unknown event payloads as JsonDomainEvent so they remain readable and replayable.
             null
         }
     }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/modeling/annotation/AggregateMetadataParserTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/modeling/annotation/AggregateMetadataParserTest.kt
@@ -18,6 +18,7 @@ import me.ahoo.test.asserts.assertThrownBy
 import me.ahoo.wow.api.annotation.ORDER_FIRST
 import me.ahoo.wow.api.annotation.ORDER_LAST
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class AggregateMetadataParserTest {
 
@@ -52,9 +53,11 @@ class AggregateMetadataParserTest {
 
     @Test
     fun `parser rejects command aggregates without one parameter constructor`() {
-        assertThrownBy<IllegalStateException> {
+        val exception = assertThrows<IllegalStateException> {
             aggregateMetadata<MockCommandAggregateWithoutConstructor, MockCommandAggregateWithoutConstructor>()
         }
+
+        exception.cause.assert().isInstanceOf(NoSuchElementException::class.java)
     }
 
     @Test


### PR DESCRIPTION
## Goal

Strengthen the project's static-analysis and dependency security gates based on the verified Kaicode evaluation findings. CI should report violations without modifying source files, preserve exception context, and add SAST and pull-request dependency review coverage.

## Changes

- Disable Detekt auto-correction globally and explicitly run CI with `--no-auto-correct`.
- Enable the low-noise `ProtectedMemberInFinalClass`, `UnnecessaryAbstractClass`, `SwallowedException`, and `ThrowingExceptionsWithoutMessageOrCause` rules while leaving the previously identified high-noise rules disabled.
- Preserve the constructor lookup failure as the cause of `IllegalStateException`, and document the intentional unknown-event fallback to `JsonDomainEvent`.
- Add CodeQL analysis for Java and Kotlin on pull requests, pushes to `main`, a weekly schedule, and manual dispatch.
- Add Dependency Review for pull requests, failing on newly introduced high or critical vulnerabilities.
- Apply least-privilege workflow permissions and pin third-party actions to immutable commit SHAs.

## Verification

- `./gradlew :wow-core:test --tests "me.ahoo.wow.modeling.annotation.AggregateMetadataParserTest" --tests "me.ahoo.wow.serialization.JsonSerializerPolymorphicTest" --no-daemon` — passed.
- `./gradlew detekt --no-auto-correct --stacktrace --no-daemon` — passed across 31 Detekt tasks.
- `./gradlew classes --no-daemon` — passed across 81 tasks and validates the CodeQL manual build command.
- Parsed the three changed workflow YAML files with Ruby Psych — passed.
- `git diff --check` — passed.

## Risks and Notes

- The new GitHub workflows require their first remote run before CodeQL upload and Dependency Review behavior can be confirmed end to end.
- GitHub reported 20 existing Dependabot alerts on the default branch during push (1 high, 16 moderate, and 3 low). This PR gates newly introduced high/critical dependency vulnerabilities; it does not remediate existing alerts.
- No public API or persistence contract changes are introduced.