### PR TITLE
fix(core): make Bloom idempotency checks atomic

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/idempotency/BloomFilterIdempotencyChecker.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/idempotency/BloomFilterIdempotencyChecker.kt
@@ -13,8 +13,11 @@
 package me.ahoo.wow.infra.idempotency
 
 import com.google.common.hash.BloomFilter
+import com.google.common.util.concurrent.Striped
 import io.github.oshai.kotlinlogging.KotlinLogging
 import java.time.Duration
+import java.util.concurrent.locks.Lock
+import kotlin.concurrent.withLock
 
 /**
  * Idempotency checker implementation using Bloom filters for efficient duplicate detection.
@@ -38,11 +41,13 @@ class BloomFilterIdempotencyChecker(
     private val bloomFilterSupplier: () -> BloomFilter<String>
 ) : IdempotencyChecker {
     companion object {
+        private const val ELEMENT_LOCK_STRIPES = 256
         private val log = KotlinLogging.logger {}
     }
 
     private val ttlNanos = ttl.coerceAtLeast(Duration.ZERO).toNanos()
     private val refreshLock = Any()
+    private val elementLocks: Striped<Lock> = Striped.lock(ELEMENT_LOCK_STRIPES)
 
     @Volatile
     private var bloomFilter: BloomFilter<String>? = null
@@ -90,11 +95,13 @@ class BloomFilterIdempotencyChecker(
      * @return true if the element appears to be unique, false if it's a potential duplicate
      */
     override fun check(element: String): Boolean {
-        val currentBloomFilter = currentBloomFilter()
-        val contain = currentBloomFilter.mightContain(element)
-        if (!contain) {
-            currentBloomFilter.put(element)
+        return elementLocks.get(element).withLock {
+            val currentBloomFilter = currentBloomFilter()
+            val contain = currentBloomFilter.mightContain(element)
+            if (!contain) {
+                currentBloomFilter.put(element)
+            }
+            !contain
         }
-        return !contain
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/infra/idempotency/BloomFilterIdempotencyCheckerTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/infra/idempotency/BloomFilterIdempotencyCheckerTest.kt
@@ -18,7 +18,10 @@ import com.google.common.hash.Funnels
 import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import java.time.Duration
+import java.util.concurrent.Callable
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
@@ -100,6 +103,33 @@ class BloomFilterIdempotencyCheckerTest {
         firstResult.get().assert().isTrue()
         secondResult.get().assert().isTrue()
         creations.get().assert().isEqualTo(1)
+    }
+
+    @Test
+    fun `should allow the same element only once under concurrent checks`() {
+        val parallelism = 32
+        val executor = Executors.newFixedThreadPool(parallelism)
+        try {
+            repeat(100) { round ->
+                val checker = BloomFilterIdempotencyChecker(Duration.ofMinutes(1)) {
+                    BloomFilter.create(Funnels.stringFunnel(Charsets.UTF_8), 100_000)
+                }
+                checker.check("warmup-$round").assert().isTrue()
+                val barrier = CyclicBarrier(parallelism)
+                val allowed = executor.invokeAll(
+                    List(parallelism) {
+                        Callable {
+                            barrier.await(5, TimeUnit.SECONDS)
+                            checker.check("request-$round")
+                        }
+                    },
+                ).count { result -> result.get() }
+
+                allowed.assert().isEqualTo(1)
+            }
+        } finally {
+            executor.shutdownNow()
+        }
     }
 
     private fun awaitBlocked(thread: Thread) {


### PR DESCRIPTION
## Goal
Prevent concurrent checks for the same idempotency element from accepting the duplicate more than once.

Completion criteria:
- The Bloom filter check-and-put sequence is atomic for the same element.
- Existing TTL and filter refresh behavior remains unchanged.

## Changes
- Add a bounded 256-stripe lock set keyed by element.
- Execute mightContain and put under the same stripe lock.
- Add a 32-thread, 100-round regression test that asserts exactly one accepted result per element.

## Verification
- Confirmed the new regression test fails before the implementation: expected 1 accepted result but observed 4.
- ./gradlew :wow-core:test --tests me.ahoo.wow.infra.idempotency.BloomFilterIdempotencyCheckerTest — passed.
- ./gradlew :wow-core:check — passed, including detekt, unit tests, and contract tests.

## Risks and Notes
- Different elements that hash to the same stripe are serialized briefly; the lock set is bounded and avoids global check serialization.
- No public API, configuration, persistence, or migration changes.
- Rollback is a direct revert of this commit.