### PR TITLE
fix(core): roll back synchronous prepare failures

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/prepare/PrepareKey.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/prepare/PrepareKey.kt
@@ -352,7 +352,7 @@ interface PrepareKey<V : Any> : Named {
     ): Mono<R> {
         return prepare(key, value)
             .flatMap { prepared ->
-                then(prepared).onErrorResume {
+                Mono.defer { then(prepared) }.onErrorResume {
                     val errorMono = Mono.error<R>(it)
                     if (!prepared) {
                         return@onErrorResume errorMono

--- a/wow-core/src/test/kotlin/me/ahoo/wow/infra/prepare/PrepareKeyTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/infra/prepare/PrepareKeyTest.kt
@@ -55,6 +55,24 @@ class PrepareKeyTest {
     }
 
     @Test
+    fun `using prepare rolls back successful preparation when operation throws synchronously`() {
+        val prepareKey = InMemoryPrepareKey<String>()
+        val failure = IllegalStateException("operation failed synchronously")
+
+        StepVerifier.create(
+            prepareKey.usingPrepare("reserved", "value") {
+                throw failure
+            }
+        )
+            .expectErrorMatches { it === failure }
+            .verify()
+
+        StepVerifier.create(prepareKey.getValue("reserved"))
+            .verifyComplete()
+        prepareKey.rolledBack.assert().isEqualTo(listOf("reserved" to "value"))
+    }
+
+    @Test
     fun `reprepare changing key prepares new key and rolls back old key`() {
         val prepareKey = InMemoryPrepareKey<String>()
         prepareKey.prepare("old-key", "old-value").block()


### PR DESCRIPTION
## Goal
Ensure PrepareKey releases a reservation when a successfully prepared operation throws synchronously before returning its Mono.

Completion criteria:
- Synchronous and reactive callback failures use the same conditional rollback path.
- A failed prepare attempt never rolls back another operation's reservation.

## Changes
- Execute the callback through Mono.defer so synchronous exceptions become inner reactive errors.
- Add a regression test that verifies the original exception is preserved and the successful reservation is removed.

## Verification
- Confirmed the regression test fails before the implementation because the reserved value remains stored.
- ./gradlew :wow-core:test --tests me.ahoo.wow.infra.prepare.PrepareKeyTest — passed.
- ./gradlew :wow-core:check — passed, including detekt, unit tests, and contract tests.

## Risks and Notes
- Callback execution remains subscription-time and occurs once per subscription, matching the existing reactive contract.
- Rollback remains conditional on this prepare call succeeding.
- No public API, configuration, persistence schema, or migration changes.
- Rollback is a direct revert of this commit.