### PR TITLE
fix(core): make function registration atomic

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/function/SimpleMessageFunctionRegistrar.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/function/SimpleMessageFunctionRegistrar.kt
@@ -41,14 +41,19 @@ class SimpleMessageFunctionRegistrar<F : MessageFunction<*, *, *>> : MessageFunc
     private val registrar: CopyOnWriteArraySet<F> = CopyOnWriteArraySet()
     private val topicIndex: ConcurrentHashMap<MaterializedNamedAggregate, CopyOnWriteArraySet<F>> = ConcurrentHashMap()
     private val unindexedRegistrar: CopyOnWriteArraySet<F> = CopyOnWriteArraySet()
+    private val mutationLock = Any()
+    private val indexedTopics = HashMap<F, Set<MaterializedNamedAggregate>>()
 
-    private fun index(function: F) {
-        if (function.supportedTopics.isEmpty()) {
+    private fun index(
+        function: F,
+        supportedTopics: Set<MaterializedNamedAggregate>
+    ) {
+        if (supportedTopics.isEmpty()) {
             unindexedRegistrar.add(function)
             return
         }
-        function.supportedTopics.forEach { topic ->
-            topicIndex.compute(topic.materialize()) { _, functions ->
+        supportedTopics.forEach { topic ->
+            topicIndex.compute(topic) { _, functions ->
                 (functions ?: CopyOnWriteArraySet()).also {
                     it.add(function)
                 }
@@ -56,14 +61,16 @@ class SimpleMessageFunctionRegistrar<F : MessageFunction<*, *, *>> : MessageFunc
         }
     }
 
-    private fun deindex(function: F) {
-        if (function.supportedTopics.isEmpty()) {
+    private fun deindex(
+        function: F,
+        supportedTopics: Set<MaterializedNamedAggregate>
+    ) {
+        if (supportedTopics.isEmpty()) {
             unindexedRegistrar.remove(function)
             return
         }
-        function.supportedTopics.forEach { topic ->
-            val materializedTopic = topic.materialize()
-            topicIndex.computeIfPresent(materializedTopic) { _, functions ->
+        supportedTopics.forEach { topic ->
+            topicIndex.computeIfPresent(topic) { _, functions ->
                 functions.remove(function)
                 if (functions.isEmpty()) {
                     null
@@ -83,8 +90,16 @@ class SimpleMessageFunctionRegistrar<F : MessageFunction<*, *, *>> : MessageFunc
         log.info {
             "Register $function."
         }
-        if (registrar.add(function)) {
-            index(function)
+        synchronized(mutationLock) {
+            if (function in registrar) {
+                return
+            }
+            val supportedTopics = function.supportedTopics
+                .mapTo(LinkedHashSet()) { it.materialize() }
+            if (registrar.add(function)) {
+                indexedTopics[function] = supportedTopics
+                index(function, supportedTopics)
+            }
         }
     }
 
@@ -97,8 +112,10 @@ class SimpleMessageFunctionRegistrar<F : MessageFunction<*, *, *>> : MessageFunc
         log.info {
             "Unregister $function."
         }
-        if (registrar.remove(function)) {
-            deindex(function)
+        synchronized(mutationLock) {
+            if (registrar.remove(function)) {
+                deindex(function, indexedTopics.remove(function).orEmpty())
+            }
         }
     }
 
@@ -106,8 +123,7 @@ class SimpleMessageFunctionRegistrar<F : MessageFunction<*, *, *>> : MessageFunc
         val filteredRegistrar = SimpleMessageFunctionRegistrar<F>()
         val filteredFunctions = registrar.filter(predicate)
         filteredFunctions.forEach {
-            filteredRegistrar.registrar.add(it)
-            filteredRegistrar.index(it)
+            filteredRegistrar.register(it)
         }
         return filteredRegistrar
     }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/function/SimpleMessageFunctionRegistrarTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/function/SimpleMessageFunctionRegistrarTest.kt
@@ -21,6 +21,11 @@ import me.ahoo.wow.messaging.TestNamedMessage
 import me.ahoo.wow.messaging.handler.MessageExchange
 import me.ahoo.wow.modeling.MaterializedNamedAggregate
 import org.junit.jupiter.api.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.concurrent.thread
 
 class SimpleMessageFunctionRegistrarTest {
 
@@ -65,6 +70,43 @@ class SimpleMessageFunctionRegistrarTest {
     }
 
     @Test
+    fun `concurrent unregister cannot leave a function in topic index`() {
+        val indexEntered = CountDownLatch(1)
+        val releaseIndex = CountDownLatch(1)
+        val function = BlockingTopicsRegistrarFunction(topic, indexEntered, releaseIndex)
+        val registrar = SimpleMessageFunctionRegistrar<BlockingTopicsRegistrarFunction>()
+        val registerFailure = AtomicReference<Throwable?>()
+        val unregisterFailure = AtomicReference<Throwable?>()
+        val registerThread = thread(start = false, name = "registrar-register") {
+            runCatching { registrar.register(function) }
+                .onFailure(registerFailure::set)
+        }
+        val unregisterThread = thread(start = false, name = "registrar-unregister") {
+            runCatching { registrar.unregister(function) }
+                .onFailure(unregisterFailure::set)
+        }
+
+        try {
+            registerThread.start()
+            indexEntered.await(5, TimeUnit.SECONDS).assert().isTrue()
+            unregisterThread.start()
+            waitUntilBlockedOrTerminated(unregisterThread)
+        } finally {
+            releaseIndex.countDown()
+        }
+        registerThread.join(5_000)
+        unregisterThread.join(5_000)
+
+        registerThread.isAlive.assert().isFalse()
+        unregisterThread.isAlive.assert().isFalse()
+        registerFailure.get().assert().isNull()
+        unregisterFailure.get().assert().isNull()
+        registrar.functions.assert().isEmpty()
+        registrar.supportedFunctions(TestNamedMessage(body = TestMessageBody())).toList()
+            .assert().isEmpty()
+    }
+
+    @Test
     fun `filter creates a scoped registrar without mutating the source registrar`() {
         val matching = RegistrarFunction(id = "matching", supportedTopics = setOf(topic))
         val skipped = RegistrarFunction(id = "skipped", supportedTopics = setOf(topic))
@@ -79,6 +121,41 @@ class SimpleMessageFunctionRegistrarTest {
         filtered.supportedFunctions(TestNamedMessage(body = TestMessageBody())).toList()
             .assert().isEqualTo(listOf(matching))
     }
+
+    private fun waitUntilBlockedOrTerminated(thread: Thread) {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        while (thread.isAlive && thread.state != Thread.State.BLOCKED && System.nanoTime() < deadline) {
+            Thread.yield()
+        }
+        (thread.state == Thread.State.BLOCKED || !thread.isAlive).assert().isTrue()
+    }
+}
+
+private class BlockingTopicsRegistrarFunction(
+    private val topic: NamedAggregate,
+    private val indexEntered: CountDownLatch,
+    private val releaseIndex: CountDownLatch,
+) : MessageFunction<Any, MessageExchange<*, *>, String> {
+    private val blockRegisterOnce = AtomicBoolean()
+
+    override val processor: Any = Any()
+    override val contextName: String = "wow-core-test"
+    override val processorName: String = "BlockingRegistrarProcessor"
+    override val name: String = "blocking"
+    override val functionKind: FunctionKind = FunctionKind.EVENT
+    override val supportedType: Class<*> = TestMessageBody::class.java
+    override val supportedTopics: Set<NamedAggregate>
+        get() {
+            if (Thread.currentThread().name == "registrar-register" && blockRegisterOnce.compareAndSet(false, true)) {
+                indexEntered.countDown()
+                check(releaseIndex.await(5, TimeUnit.SECONDS)) { "Timed out waiting to release topic indexing." }
+            }
+            return setOf(topic)
+        }
+
+    override fun <A : Annotation> getAnnotation(annotationClass: Class<A>): A? = null
+
+    override fun invoke(exchange: MessageExchange<*, *>): String = name
 }
 
 private data class RegistrarFunction(


### PR DESCRIPTION
## Goal
Prevent concurrent register and unregister operations from leaving message functions in topic indexes after they have been removed from the primary registrar.

Completion criteria:
- Registrar and topic index mutations remain consistent after concurrent updates.
- Unregistration uses the exact materialized topics captured during registration.
- Message lookup remains lock-free.

## Changes
- Serialize register and unregister compound mutations with a dedicated mutation lock.
- Cache materialized topics at registration and use that snapshot for deindexing.
- Route filtered registrar construction through the same registration invariant.
- Add a controlled interleaving test for concurrent register and unregister.

## Verification
- Confirmed the regression test fails before the implementation: functions is empty while supportedFunctions still returns the unregistered handler.
- ./gradlew :wow-core:test --tests me.ahoo.wow.messaging.function.SimpleMessageFunctionRegistrarTest — passed.
- ./gradlew :wow-core:check — passed, including detekt, unit tests, and contract tests.

## Risks and Notes
- The lock applies only to low-frequency registration mutations; supportedFunctions remains lock-free.
- Registration order and idempotent duplicate handling are preserved.
- No public API, configuration, persistence, or migration changes.
- Rollback is a direct revert of this commit.