### PR TITLE
fix(core): synchronize in-memory bus sink lifecycle

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/InMemoryMessageBus.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/InMemoryMessageBus.kt
@@ -53,15 +53,35 @@ abstract class InMemoryMessageBus<M, E : MessageExchange<*, M>> : LocalMessageBu
      * Map of sinks keyed by materialized named aggregates.
      */
     private val sinks: MutableMap<NamedAggregate, Sinks.Many<M>> = ConcurrentHashMap()
+    private val lifecycleLock = Any()
+
+    @Volatile
+    private var closing = false
 
     /**
      * Computes or retrieves the sink for the given named aggregate.
      *
      * @param namedAggregate The named aggregate for which to get the sink
-     * @return The sink for the aggregate
+     * @return The sink for the aggregate, or null while the bus is closing
      */
-    private fun computeSink(namedAggregate: NamedAggregate): Sinks.Many<M> =
-        sinks.computeIfAbsent(namedAggregate.materialize()) { sinkSupplier(it).concurrent() }
+    private fun computeSink(namedAggregate: NamedAggregate): Sinks.Many<M>? {
+        if (closing) {
+            return null
+        }
+        val materialized = namedAggregate.materialize()
+        sinks[materialized]?.let {
+            return it
+        }
+        return synchronized(lifecycleLock) {
+            if (closing) {
+                null
+            } else {
+                sinks[materialized] ?: sinkSupplier(materialized).concurrent().also {
+                    sinks[materialized] = it
+                }
+            }
+        }
+    }
 
     /**
      * Returns the number of subscribers for the specified named aggregate.
@@ -87,6 +107,12 @@ abstract class InMemoryMessageBus<M, E : MessageExchange<*, M>> : LocalMessageBu
         return Mono.fromRunnable {
             val sink = computeSink(message)
             message.withReadOnly()
+            if (sink == null) {
+                log.debug {
+                    "Send [$message], but the message bus is closing."
+                }
+                return@fromRunnable
+            }
             val emitResult = sink.tryEmitNext(message)
             if (emitResult == Sinks.EmitResult.FAIL_ZERO_SUBSCRIBER) {
                 log.debug {
@@ -116,8 +142,8 @@ abstract class InMemoryMessageBus<M, E : MessageExchange<*, M>> : LocalMessageBu
      * @return A flux of message exchanges
      */
     override fun receive(subscription: MessageSubscription): Flux<E> {
-        val sources = subscription.namedAggregates.map {
-            computeSink(it).asFlux()
+        val sources = subscription.namedAggregates.mapNotNull {
+            computeSink(it)?.asFlux()
         }
 
         return Flux.merge(sources).map {
@@ -126,18 +152,31 @@ abstract class InMemoryMessageBus<M, E : MessageExchange<*, M>> : LocalMessageBu
     }
 
     override fun close() {
-        sinks.forEach { (aggregate, many) ->
-            val emitResult = many.tryEmitComplete()
-            if (emitResult.isSuccess) {
-                log.debug {
-                    "Close [${aggregate.aggregateName}] sink - [$emitResult]."
-                }
-            } else {
-                log.warn {
-                    "Close [${aggregate.aggregateName}] sink - [$emitResult]."
+        val detachedSinks = synchronized(lifecycleLock) {
+            if (closing) {
+                return
+            }
+            closing = true
+            sinks.entries.map { entry -> entry.key to entry.value }
+        }
+        try {
+            detachedSinks.forEach { (aggregate, many) ->
+                val emitResult = many.tryEmitComplete()
+                if (emitResult.isSuccess) {
+                    log.debug {
+                        "Close [${aggregate.aggregateName}] sink - [$emitResult]."
+                    }
+                } else {
+                    log.warn {
+                        "Close [${aggregate.aggregateName}] sink - [$emitResult]."
+                    }
                 }
             }
+        } finally {
+            synchronized(lifecycleLock) {
+                sinks.clear()
+                closing = false
+            }
         }
-        sinks.clear()
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/InMemoryMessageBusTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/InMemoryMessageBusTest.kt
@@ -18,9 +18,14 @@ import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.infra.sink.concurrent
 import me.ahoo.wow.messaging.handler.MessageExchange
 import org.junit.jupiter.api.Test
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Sinks
 import reactor.test.StepVerifier
+import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 
 class InMemoryMessageBusTest {
 
@@ -67,11 +72,98 @@ class InMemoryMessageBusTest {
 
         bus.subscriberCount(message).assert().isEqualTo(0)
     }
+
+    @Test
+    fun `close racing first sink creation should not orphan the receiving flux`() {
+        val sinkSupplierEntered = CountDownLatch(1)
+        val releaseSinkSupplier = CountDownLatch(1)
+        val bus = BlockingSinkInMemoryMessageBus(sinkSupplierEntered, releaseSinkSupplier)
+        val message = TestNamedMessage()
+        val received = AtomicReference<Flux<TestMessageExchange>>()
+        val receiveThread = Thread {
+            received.set(bus.receive(MessageSubscription(message)))
+        }.also(Thread::start)
+        sinkSupplierEntered.await(5, TimeUnit.SECONDS).assert().isTrue()
+        val closeThread = Thread(bus::close).also(Thread::start)
+
+        try {
+            awaitBlocked(closeThread)
+        } finally {
+            releaseSinkSupplier.countDown()
+        }
+        receiveThread.join(5_000)
+        closeThread.join(5_000)
+
+        receiveThread.isAlive.assert().isFalse()
+        closeThread.isAlive.assert().isFalse()
+        StepVerifier.create(checkNotNull(received.get()))
+            .expectComplete()
+            .verify(Duration.ofSeconds(1))
+        bus.subscriberCount(message).assert().isZero()
+    }
+
+    @Test
+    fun `close should not expose an empty registry before detached sinks complete`() {
+        val completionEntered = CountDownLatch(1)
+        val releaseCompletion = CountDownLatch(1)
+        val bus = TestInMemoryMessageBus()
+        val closingMessage = TestNamedMessage(aggregateName = "closing_aggregate")
+        val concurrentMessage = TestNamedMessage(aggregateName = "concurrent_aggregate")
+        val subscription = bus.receive(MessageSubscription(closingMessage))
+            .doOnComplete {
+                completionEntered.countDown()
+                check(releaseCompletion.await(5, TimeUnit.SECONDS)) {
+                    "Timed out waiting to release sink completion."
+                }
+            }
+            .subscribe()
+        val closeThread = Thread(bus::close).also(Thread::start)
+        completionEntered.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+        try {
+            StepVerifier.create(bus.send(concurrentMessage))
+                .verifyComplete()
+            concurrentMessage.isReadOnly.assert().isTrue()
+            StepVerifier.create(bus.receive(MessageSubscription(concurrentMessage)))
+                .expectComplete()
+                .verify(Duration.ofSeconds(1))
+        } finally {
+            releaseCompletion.countDown()
+            closeThread.join(5_000)
+            subscription.dispose()
+        }
+
+        closeThread.isAlive.assert().isFalse()
+        bus.subscriberCount(concurrentMessage).assert().isZero()
+    }
+
+    private fun awaitBlocked(thread: Thread) {
+        val deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos()
+        while (thread.state != Thread.State.BLOCKED && System.nanoTime() < deadline) {
+            Thread.yield()
+        }
+        thread.state.assert().isEqualTo(Thread.State.BLOCKED)
+    }
 }
 
 private class TestInMemoryMessageBus : InMemoryMessageBus<TestNamedMessage, TestMessageExchange>() {
     override val sinkSupplier: (NamedAggregate) -> Sinks.Many<TestNamedMessage> = {
         Sinks.unsafe().many().multicast().onBackpressureBuffer<TestNamedMessage>().concurrent()
+    }
+
+    override fun TestNamedMessage.createExchange(): TestMessageExchange = TestMessageExchange(this)
+}
+
+private class BlockingSinkInMemoryMessageBus(
+    private val sinkSupplierEntered: CountDownLatch,
+    private val releaseSinkSupplier: CountDownLatch,
+) : InMemoryMessageBus<TestNamedMessage, TestMessageExchange>() {
+    override val sinkSupplier: (NamedAggregate) -> Sinks.Many<TestNamedMessage> = {
+        sinkSupplierEntered.countDown()
+        check(releaseSinkSupplier.await(5, TimeUnit.SECONDS)) {
+            "Timed out waiting to release sink creation."
+        }
+        Sinks.unsafe().many().multicast().onBackpressureBuffer()
     }
 
     override fun TestNamedMessage.createExchange(): TestMessageExchange = TestMessageExchange(this)


### PR DESCRIPTION
## Goal
Prevent `InMemoryMessageBus.close()` from orphaning sinks across both concurrency windows: first sink creation racing the close snapshot, and replacement sink creation while detached sinks are still receiving terminal signals.

## Changes
- Add an explicit closing state that stops new sink creation until detached sinks are fully terminated.
- Linearize first-time sink creation with the close transition through a private lifecycle lock.
- Preserve the lock-free cached sink lookup used by the message send hot path outside shutdown.
- Keep detached sinks registered until terminal signals finish, while emitting those signals outside the lifecycle lock so subscriber callbacks cannot deadlock through lock re-entry.
- Complete receives and safely drop sends initiated during the closing window; sent messages are still marked read-only.
- Preserve existing sink recreation after `close()` completes.
- Add latch-controlled regression tests for the ConcurrentHashMap reservation race and the terminal-callback drain window.

## Verification
- Red phase 1: the first-sink creation race failed on the original implementation with `VerifySubscriber timed out` after 1 second.
- Red phase 2: the replacement-sink drain-window race failed on the initial PR implementation with the same controlled timeout.
- `./gradlew :wow-core:test --tests "me.ahoo.wow.messaging.InMemoryMessageBusTest" --rerun-tasks --no-daemon --console=plain` — 5 tests passed before the additional send assertion.
- `./gradlew :wow-core:check --rerun-tasks --no-daemon --console=plain` — BUILD SUCCESSFUL, 24 actionable tasks executed after the final test and implementation changes.
- `git diff --check` — passed.

## Risks and Notes
- No public API, configuration, serialization, or data layout changes.
- Sends that begin after the closing state is published are intentionally dropped instead of creating a sink that outlives the close operation; this affects only the concurrent shutdown window.
- Existing behavior that allows sinks to be created again after `close()` finishes is preserved.
- PR #2765 changes only the sink preparation call in this class. Its MPSC implementation is not included here; rebasing it will require retaining this lifecycle boundary while replacing `.concurrent()` with `.prepareConcurrentSink()`.