### PR TITLE
feat(benchmarks): make report metrics human-readable

### DIFF
--- a/wow-benchmarks/README.md
+++ b/wow-benchmarks/README.md
@@ -157,9 +157,10 @@ Every successful thread-level JMH run writes a neighboring `*.manifest.json` sid
 
 ## Reading The Report
 
-- `thrpt` scores are throughput, normally shown as `ops/s`. Higher is better.
-- `avgt` scores are average latency. The report converts tiny JMH `s/op` values to readable latency units such as `us/op`.
-- `gc.alloc.rate.norm` is normalized allocation per operation. Lower is usually better.
+- `thrpt` scores are throughput. Reports use decimal prefixes (`k`, `M`, `G`) so, for example, `1.57 k ops/s` means 1,570 operations per second. Higher is better.
+- `avgt` scores are average latency. Reports automatically select `ns/op`, `µs/op`, `ms/op`, or `s/op`.
+- `gc.alloc.rate.norm` is normalized allocation per operation. Reports use binary prefixes (`KiB`, `MiB`, `GiB`); lower is usually better.
+- `±` is the JMH-reported error. Compact units affect presentation only; reports retain raw precision for sorting, comparisons, and regression gates.
 - Quick reports contain throughput and allocation results only. They are useful for local regression checks, but the shorter run profile has wider variance than Baseline E2E.
 - `benchmarkCompare` displays baseline/current JMH errors when available. The current regression gate still uses the configured point-estimate threshold; the errors are diagnostic and do not yet change the status calculation.
 - Framework E2E reports isolate Wow command-pipeline overhead; they are not Redis, Mongo, or production deployment capacity numbers.

--- a/wow-benchmarks/gradle/benchmarking.gradle.kts
+++ b/wow-benchmarks/gradle/benchmarking.gradle.kts
@@ -1440,6 +1440,11 @@ data class FormattedBenchmarkScore(
     val unit: String,
 )
 
+data class BenchmarkMetricScale(
+    val multiplier: Double,
+    val unit: String,
+)
+
 fun benchmarkResultGroup(taskSpec: BenchmarkTaskSpec): BenchmarkResultGroup {
     val suite = taskSpec.suite
     val profile = taskSpec.profile
@@ -1848,15 +1853,11 @@ fun parseBenchmarkGroup(
     )
 }
 
-fun formatScoreError(scoreError: Double?): String {
-    return scoreError?.let { "+/-${String.format(Locale.US, "%.2f", it)}" } ?: "-"
-}
-
 fun latencyUnitSeconds(unit: String): Double? {
     return when (unit) {
         "s" -> 1.0
         "ms" -> 1.0e-3
-        "us" -> 1.0e-6
+        "us", "µs" -> 1.0e-6
         "ns" -> 1.0e-9
         else -> null
     }
@@ -1867,41 +1868,125 @@ fun latencyDisplayUnit(secondsPerOp: Double): String {
     return when {
         absoluteSeconds == 0.0 -> "s"
         absoluteSeconds < 1.0e-6 -> "ns"
-        absoluteSeconds < 1.0e-3 -> "us"
+        absoluteSeconds < 1.0e-3 -> "µs"
         absoluteSeconds < 1.0 -> "ms"
         else -> "s"
     }
 }
 
-fun formatBenchmarkScore(score: Double, scoreError: Double?, unit: String): FormattedBenchmarkScore {
+fun benchmarkMetricScale(values: List<Double>, unit: String): BenchmarkMetricScale {
+    val magnitude = values.maxOfOrNull { kotlin.math.abs(it) } ?: 0.0
     val latencySourceUnit = unit.removeSuffix("/op").takeIf { unit.endsWith("/op") }
-    val sourceSeconds = latencySourceUnit?.let { latencyUnitSeconds(it) }
+    val sourceSeconds = latencySourceUnit?.let(::latencyUnitSeconds)
     if (sourceSeconds != null) {
-        val secondsPerOp = score * sourceSeconds
-        val displayUnit = latencyDisplayUnit(secondsPerOp)
-        val displaySeconds = latencyUnitSeconds(displayUnit)!!
-        val displayScore = secondsPerOp / displaySeconds
-        val displayError = scoreError?.let { "+/-${String.format(Locale.US, "%.2f", it * sourceSeconds / displaySeconds)}" }
-            ?: "-"
-        return FormattedBenchmarkScore(
-            score = String.format(Locale.US, "%.2f", displayScore),
-            error = displayError,
+        val secondsPerOp = magnitude * sourceSeconds
+        val displayUnit = if (secondsPerOp == 0.0) {
+            latencySourceUnit.replace("us", "µs")
+        } else {
+            latencyDisplayUnit(secondsPerOp)
+        }
+        return BenchmarkMetricScale(
+            multiplier = sourceSeconds / latencyUnitSeconds(displayUnit)!!,
             unit = "$displayUnit/op",
         )
     }
+    if (unit.equals("B/op", ignoreCase = true)) {
+        val (divisor, displayUnit) = when {
+            magnitude >= 1024.0 * 1024.0 * 1024.0 -> 1024.0 * 1024.0 * 1024.0 to "GiB/op"
+            magnitude >= 1024.0 * 1024.0 -> 1024.0 * 1024.0 to "MiB/op"
+            magnitude >= 1024.0 -> 1024.0 to "KiB/op"
+            else -> 1.0 to "B/op"
+        }
+        return BenchmarkMetricScale(multiplier = 1.0 / divisor, unit = displayUnit)
+    }
+    if (unit.contains("ops", ignoreCase = true)) {
+        val (divisor, prefix) = when {
+            magnitude >= 1.0e12 -> 1.0e12 to "T"
+            magnitude >= 1.0e9 -> 1.0e9 to "G"
+            magnitude >= 1.0e6 -> 1.0e6 to "M"
+            magnitude >= 1.0e3 -> 1.0e3 to "k"
+            else -> 1.0 to ""
+        }
+        val displayUnit = if (prefix.isEmpty()) unit else "$prefix $unit"
+        return BenchmarkMetricScale(multiplier = 1.0 / divisor, unit = displayUnit)
+    }
+    return BenchmarkMetricScale(multiplier = 1.0, unit = unit)
+}
+
+fun formatMetricNumber(value: Double): String {
+    if (value == 0.0) {
+        return "0"
+    }
+    val formatted = if (kotlin.math.abs(value) < 0.01) {
+        String.format(Locale.US, "%.2g", value)
+    } else {
+        String.format(Locale.US, "%.2f", value)
+    }
+    return if (formatted.contains('e', ignoreCase = true)) {
+        formatted
+    } else {
+        formatted.trimEnd('0').trimEnd('.')
+    }
+}
+
+fun formatMetricError(error: Double?, scale: BenchmarkMetricScale): String {
+    return error?.let {
+        val scaledError = kotlin.math.abs(it * scale.multiplier)
+        if (scaledError in 0.0..<0.01 && scaledError != 0.0) {
+            "±<0.01"
+        } else {
+            "±${formatMetricNumber(scaledError)}"
+        }
+    } ?: "-"
+}
+
+fun formatBenchmarkMetric(
+    score: Double,
+    scoreError: Double?,
+    unit: String,
+    scaleReferenceValues: List<Double> = listOf(score),
+): FormattedBenchmarkScore {
+    val scale = benchmarkMetricScale(scaleReferenceValues, unit)
     return FormattedBenchmarkScore(
-        score = String.format(Locale.US, "%.2f", score),
-        error = formatScoreError(scoreError),
-        unit = unit,
+        score = formatMetricNumber(score * scale.multiplier),
+        error = formatMetricError(scoreError, scale),
+        unit = scale.unit,
     )
 }
 
-fun formatAllocationBytes(allocationBytesPerOp: Double?): String {
-    return allocationBytesPerOp?.let { String.format(Locale.US, "%.1f B/op", it) } ?: "-"
+fun formatBenchmarkScore(score: Double, scoreError: Double?, unit: String): FormattedBenchmarkScore {
+    return formatBenchmarkMetric(score, scoreError, unit)
 }
 
-fun formatAllocationError(allocationErrorBytesPerOp: Double?): String {
-    return allocationErrorBytesPerOp?.let { "+/-${String.format(Locale.US, "%.1f B/op", it)}" } ?: "-"
+fun formatAllocationBytes(allocationBytesPerOp: Double?): String {
+    return allocationBytesPerOp?.let { allocation ->
+        val formatted = formatBenchmarkMetric(allocation, null, "B/op")
+        "${formatted.score} ${formatted.unit}"
+    } ?: "-"
+}
+
+val verifyBenchmarkReportFormatting = tasks.register("verifyBenchmarkReportFormatting") {
+    description = "Verify human-readable benchmark metric formatting."
+    group = "verification"
+
+    doLast {
+        check(formatBenchmarkScore(1_573.91, 42.0, "ops/s") == FormattedBenchmarkScore("1.57", "±0.04", "k ops/s"))
+        check(
+            formatBenchmarkScore(668_849_367.69, 1_240_000.0, "ops/s") ==
+                FormattedBenchmarkScore("668.85", "±1.24", "M ops/s")
+        )
+        check(formatBenchmarkScore(0.000_85, 0.000_02, "ms/op") == FormattedBenchmarkScore("850", "±20", "ns/op"))
+        check(formatAllocationBytes(2_982_851.6) == "2.84 MiB/op")
+        check(formatAllocationBytes(272.0) == "272 B/op")
+        check(formatAllocationBytes(0.0) == "0 B/op")
+        check(formatMetricNumber(0.004_2) == "0.0042")
+        check(formatMetricError(0.004_2, BenchmarkMetricScale(1.0, "ops/s")) == "±<0.01")
+        check(formatAllocationBytes(null) == "-")
+    }
+}
+
+tasks.named("check") {
+    dependsOn(verifyBenchmarkReportFormatting)
 }
 
 fun StringBuilder.appendBenchmarkTable(rows: List<ParsedBenchmarkResult>) {
@@ -1930,9 +2015,10 @@ fun StringBuilder.appendThroughputBottlenecks(rows: List<ParsedBenchmarkResult>)
         .sortedBy { it.score }
         .take(10)
         .forEach { row ->
+            val score = formatBenchmarkScore(row.score, row.scoreError, row.unit)
             appendLine(
                 "| ${row.suite.displayName} | ${row.threads} | ${row.displayName} | " +
-                    "${String.format(Locale.US, "%.2f", row.score)} | ${formatScoreError(row.scoreError)} | ${row.unit} |"
+                    "${score.score} | ${score.error} | ${score.unit} |"
             )
         }
 }
@@ -1955,13 +2041,29 @@ fun StringBuilder.appendAllocationBottlenecks(rows: List<ParsedBenchmarkResult>)
     appendLine("|-------|---------|-----------|------|------------|-------|-------|------|")
     allocationBottleneckRows(rows)
         .forEach { row ->
+            val allocation = formatBenchmarkMetric(
+                score = row.allocationBytesPerOp!!,
+                scoreError = row.allocationErrorBytesPerOp,
+                unit = "B/op",
+            )
+            val score = formatBenchmarkScore(row.score, row.scoreError, row.unit)
             appendLine(
                 "| ${row.suite.displayName} | ${row.threads} | ${row.displayName} | ${row.mode} | " +
-                    "${formatAllocationBytes(row.allocationBytesPerOp)} | " +
-                    "${formatAllocationError(row.allocationErrorBytesPerOp)} | " +
-                    "${String.format(Locale.US, "%.2f", row.score)} | ${row.unit} |"
+                    "${allocation.score} ${allocation.unit} | " +
+                    "${if (allocation.error == "-") "-" else "${allocation.error} ${allocation.unit}"} | " +
+                    "${score.score} | ${score.unit} |"
             )
         }
+}
+
+fun StringBuilder.appendBenchmarkValueGuide() {
+    appendLine("## Reading Values")
+    appendLine()
+    appendLine("- Throughput uses decimal prefixes: `k` = 1,000, `M` = 1,000,000, `G` = 1,000,000,000.")
+    appendLine("- Allocation uses binary prefixes: `KiB` = 1,024 bytes, `MiB` = 1,048,576 bytes.")
+    appendLine("- Average latency is automatically scaled to `ns/op`, `µs/op`, `ms/op`, or `s/op`.")
+    appendLine("- `±` is the JMH-reported error. Scaling changes presentation only; calculations keep raw precision.")
+    appendLine()
 }
 
 fun renderGroupedBenchmarkReport(
@@ -2021,6 +2123,7 @@ fun renderGroupedBenchmarkReport(
     sb.appendLine("- Component results explain bottlenecks and are not standalone performance goals.")
     sb.appendLine("- Smoke results are excluded from performance reports.")
     sb.appendLine()
+    sb.appendBenchmarkValueGuide()
     sb.appendBenchmarkRunProvenance(allManifests)
     sb.appendBenchmarkEnvironment(
         version = version,
@@ -2155,6 +2258,7 @@ fun renderSingleBenchmarkReport(
     sb.appendLine()
     sb.appendLine(description)
     sb.appendLine()
+    sb.appendBenchmarkValueGuide()
     sb.appendBenchmarkRunProvenance(groupReport.manifests)
     sb.appendBenchmarkEnvironment(project.version.toString(), group.profile)
     if (includeInfrastructureRuntime) {
@@ -2189,6 +2293,7 @@ fun renderBottleneckBenchmarkReport(
     sb.appendLine()
     sb.appendLine(description)
     sb.appendLine()
+    sb.appendBenchmarkValueGuide()
     sb.appendBenchmarkRunProvenance(groupReport.manifests)
     sb.appendBenchmarkEnvironment(project.version.toString(), group.profile)
     sb.appendLine("## Source Files")
@@ -2741,14 +2846,6 @@ fun benchmarkMetricComparisons(
     }
 }
 
-fun formatComparisonNumber(value: Double?): String {
-    return value?.let { String.format(Locale.US, "%.6g", it) } ?: "-"
-}
-
-fun formatComparisonError(value: Double?): String {
-    return value?.let { "+/-${String.format(Locale.US, "%.6g", it)}" } ?: "-"
-}
-
 tasks.register("benchmarkCompare") {
     description = "Compare primary framework E2E benchmark results against baseline."
     group = "benchmark"
@@ -2797,29 +2894,35 @@ tasks.register("benchmarkCompare") {
             val latestRow = latest[benchmark]
 
             if (baseRow == null) {
+                val newRow = requireNotNull(latestRow)
+                val newScore = formatBenchmarkScore(newRow.score, newRow.scoreError, newRow.unit)
                 println(
-                    "| result | ${latestRow?.displayName ?: benchmark} | ${latestRow?.threads ?: "-"} | " +
-                        "${latestRow?.mode ?: "-"} | - | - | ${formatComparisonNumber(latestRow?.score)} | " +
-                        "${formatComparisonError(latestRow?.scoreError)} | ${latestRow?.unit ?: "-"} | NEW | - | NEW |"
+                    "| result | ${newRow.displayName} | ${newRow.threads} | ${newRow.mode} | " +
+                        "- | - | ${newScore.score} | ${newScore.error} | ${newScore.unit} | NEW | - | NEW |"
                 )
                 continue
             }
             if (latestRow == null) {
+                val removedScore = formatBenchmarkScore(baseRow.score, baseRow.scoreError, baseRow.unit)
                 println(
                     "| result | ${baseRow.displayName} | ${baseRow.threads} | ${baseRow.mode} | " +
-                        "${formatComparisonNumber(baseRow.score)} | ${formatComparisonError(baseRow.scoreError)} | " +
-                        "- | - | ${baseRow.unit} | REMOVED | - | REMOVED |"
+                        "${removedScore.score} | ${removedScore.error} | - | - | ${removedScore.unit} | " +
+                        "REMOVED | - | REMOVED |"
                 )
                 continue
             }
             comparisonsByKey.getValue(benchmark)
                 .forEach { comparison ->
+                    val scale = benchmarkMetricScale(
+                        values = listOf(comparison.baseline, comparison.current),
+                        unit = comparison.unit,
+                    )
                     println(
                         "| ${comparison.metric} | ${comparison.displayName} | ${comparison.threads} | ${comparison.mode} | " +
-                            "${formatComparisonNumber(comparison.baseline)} | " +
-                            "${formatComparisonError(comparison.baselineError)} | " +
-                            "${formatComparisonNumber(comparison.current)} | " +
-                            "${formatComparisonError(comparison.currentError)} | ${comparison.unit} | " +
+                            "${formatMetricNumber(comparison.baseline * scale.multiplier)} | " +
+                            "${formatMetricError(comparison.baselineError, scale)} | " +
+                            "${formatMetricNumber(comparison.current * scale.multiplier)} | " +
+                            "${formatMetricError(comparison.currentError, scale)} | ${scale.unit} | " +
                             "${comparison.deltaPercent?.let { String.format(Locale.US, "%+.1f%%", it) } ?: "n/a"} | " +
                             "${String.format(Locale.US, "%.1f%%", comparison.thresholdPercent)} | ${comparison.status()} |"
                     )

--- a/wow-benchmarks/results/reports/baseline-grouped.md
+++ b/wow-benchmarks/results/reports/baseline-grouped.md
@@ -8,6 +8,13 @@
 - Component results explain bottlenecks and are not standalone performance goals.
 - Smoke results are excluded from performance reports.
 
+## Reading Values
+
+- Throughput uses decimal prefixes: `k` = 1,000, `M` = 1,000,000, `G` = 1,000,000,000.
+- Allocation uses binary prefixes: `KiB` = 1,024 bytes, `MiB` = 1,048,576 bytes.
+- Average latency is automatically scaled to `ns/op`, `µs/op`, `ms/op`, or `s/op`.
+- `±` is the JMH-reported error. Scaling changes presentation only; calculations keep raw precision.
+
 ## Benchmark Run Provenance
 - **Source Commit**: `fcedf1090454ff7fdb511f303771d3c663ac9c6e`
 - **Source Dirty**: `false`
@@ -27,7 +34,7 @@
 - **Version**: 8.9.0
 - **JVM**: OpenJDK 64-Bit Server VM 17.0.7+7-LTS
 - **OS**: Mac OS X 26.5.2 aarch64
-- **Generated At**: 2026-07-22T19:44:30+08:00
+- **Generated At**: 2026-07-22T20:04:20+08:00
 - **CPU Cores**: 14
 - **Physical Memory**: 24.0 GiB
 - **Benchmark JVM Args**: see per-suite Run Profiles below
@@ -45,31 +52,31 @@
 
 | Suite | Threads | Benchmark | Score | Error | Unit |
 |-------|---------|-----------|-------|-------|------|
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 60673.32 | +/-12980.42 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 63212.03 | +/-7433.85 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 89366.68 | +/-2919.16 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 116094.60 | +/-6353.94 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 125394.65 | +/-8535.52 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 132123.98 | +/-37103.29 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 136071.38 | +/-5154.12 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 160275.23 | +/-10896.73 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 213381.55 | +/-31658.13 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 222971.20 | +/-20214.56 | ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 60.67 | ±12.98 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 63.21 | ±7.43 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 89.37 | ±2.92 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 116.09 | ±6.35 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 125.39 | ±8.54 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 132.12 | ±37.1 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 136.07 | ±5.15 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 160.28 | ±10.9 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 213.38 | ±31.66 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 222.97 | ±20.21 | k ops/s |
 
 ### Highest Allocation
 
 | Suite | Threads | Benchmark | Mode | Allocation | Error | Score | Unit |
 |-------|---------|-----------|------|------------|-------|-------|------|
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 13500.4 B/op | +/-76.0 B/op | 125394.65 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 13446.6 B/op | +/-9.0 B/op | 213381.55 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 13324.2 B/op | +/-25.3 B/op | 136071.38 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 13285.0 B/op | +/-5.5 B/op | 226039.65 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 12372.2 B/op | +/-2.5 B/op | 222971.20 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 12353.4 B/op | +/-49.2 B/op | 294719.46 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 4893.5 B/op | +/-80.1 B/op | 60673.32 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 4846.6 B/op | +/-84.5 B/op | 132123.98 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 4596.9 B/op | +/-2.7 B/op | 89366.68 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 4589.0 B/op | +/-3.2 B/op | 116094.60 | ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 13.18 KiB/op | ±0.07 KiB/op | 125.39 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 13.13 KiB/op | ±<0.01 KiB/op | 213.38 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 13.01 KiB/op | ±0.02 KiB/op | 136.07 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 12.97 KiB/op | ±<0.01 KiB/op | 226.04 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 12.08 KiB/op | ±<0.01 KiB/op | 222.97 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 12.06 KiB/op | ±0.05 KiB/op | 294.72 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 4.78 KiB/op | ±0.08 KiB/op | 60.67 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 4.73 KiB/op | ±0.08 KiB/op | 132.12 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 4.49 KiB/op | ±<0.01 KiB/op | 89.37 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 4.48 KiB/op | ±<0.01 KiB/op | 116.09 | k ops/s |
 
 ## Group Details
 
@@ -77,31 +84,31 @@
 
 | Suite | Threads | Benchmark | Score | Error | Unit |
 |-------|---------|-----------|-------|-------|------|
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 60673.32 | +/-12980.42 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 63212.03 | +/-7433.85 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 89366.68 | +/-2919.16 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 116094.60 | +/-6353.94 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 125394.65 | +/-8535.52 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 132123.98 | +/-37103.29 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 136071.38 | +/-5154.12 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 160275.23 | +/-10896.73 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 213381.55 | +/-31658.13 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 222971.20 | +/-20214.56 | ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 60.67 | ±12.98 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 63.21 | ±7.43 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 89.37 | ±2.92 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 116.09 | ±6.35 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 125.39 | ±8.54 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 132.12 | ±37.1 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 136.07 | ±5.15 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 160.28 | ±10.9 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 213.38 | ±31.66 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 222.97 | ±20.21 | k ops/s |
 
 ### Primary Framework E2E Highest Allocation
 
 | Suite | Threads | Benchmark | Mode | Allocation | Error | Score | Unit |
 |-------|---------|-----------|------|------------|-------|-------|------|
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 13500.4 B/op | +/-76.0 B/op | 125394.65 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 13446.6 B/op | +/-9.0 B/op | 213381.55 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 13324.2 B/op | +/-25.3 B/op | 136071.38 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 13285.0 B/op | +/-5.5 B/op | 226039.65 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 12372.2 B/op | +/-2.5 B/op | 222971.20 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 12353.4 B/op | +/-49.2 B/op | 294719.46 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 4893.5 B/op | +/-80.1 B/op | 60673.32 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 4846.6 B/op | +/-84.5 B/op | 132123.98 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 4596.9 B/op | +/-2.7 B/op | 89366.68 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 4589.0 B/op | +/-3.2 B/op | 116094.60 | ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 13.18 KiB/op | ±0.07 KiB/op | 125.39 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 13.13 KiB/op | ±<0.01 KiB/op | 213.38 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 13.01 KiB/op | ±0.02 KiB/op | 136.07 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 12.97 KiB/op | ±<0.01 KiB/op | 226.04 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 12.08 KiB/op | ±<0.01 KiB/op | 222.97 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 12.06 KiB/op | ±0.05 KiB/op | 294.72 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 4.78 KiB/op | ±0.08 KiB/op | 60.67 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 4.73 KiB/op | ±0.08 KiB/op | 132.12 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 4.49 KiB/op | ±<0.01 KiB/op | 89.37 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 4.48 KiB/op | ±<0.01 KiB/op | 116.09 | k ops/s |
 
 ## Primary Framework E2E Results
 
@@ -118,22 +125,22 @@
 
 | Suite | Benchmark | Threads | Mode | Score | Error | Unit | gc.alloc.rate.norm |
 |-------|-----------|---------|------|-------|-------|------|-------------------|
-| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=ceiling) | 1 | thrpt | 1479392.65 | +/-138522.96 | ops/s | 2260.2 B/op |
-| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=ceiling) | 4 | thrpt | 1209601.22 | +/-63617.22 | ops/s | 2261.3 B/op |
-| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=validated) | 1 | thrpt | 1316266.24 | +/-42163.19 | ops/s | 2668.2 B/op |
-| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=validated) | 4 | thrpt | 1283271.66 | +/-159073.29 | ops/s | 2669.9 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 294719.46 | +/-12676.14 | ops/s | 12353.4 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 222971.20 | +/-20214.56 | ops/s | 12372.2 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 1 | thrpt | 63212.03 | +/-7433.85 | ops/s | 3950.8 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 4 | thrpt | 160275.23 | +/-10896.73 | ops/s | 3951.4 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 213381.55 | +/-31658.13 | ops/s | 13446.6 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 125394.65 | +/-8535.52 | ops/s | 13500.4 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 1 | thrpt | 89366.68 | +/-2919.16 | ops/s | 4596.9 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 4 | thrpt | 116094.60 | +/-6353.94 | ops/s | 4589.0 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 226039.65 | +/-35495.67 | ops/s | 13285.0 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 136071.38 | +/-5154.12 | ops/s | 13324.2 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 1 | thrpt | 60673.32 | +/-12980.42 | ops/s | 4893.5 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 4 | thrpt | 132123.98 | +/-37103.29 | ops/s | 4846.6 B/op |
+| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=ceiling) | 1 | thrpt | 1.48 | ±0.14 | M ops/s | 2.21 KiB/op |
+| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=ceiling) | 4 | thrpt | 1.21 | ±0.06 | M ops/s | 2.21 KiB/op |
+| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=validated) | 1 | thrpt | 1.32 | ±0.04 | M ops/s | 2.61 KiB/op |
+| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=validated) | 4 | thrpt | 1.28 | ±0.16 | M ops/s | 2.61 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 294.72 | ±12.68 | k ops/s | 12.06 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 222.97 | ±20.21 | k ops/s | 12.08 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 1 | thrpt | 63.21 | ±7.43 | k ops/s | 3.86 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 4 | thrpt | 160.28 | ±10.9 | k ops/s | 3.86 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 213.38 | ±31.66 | k ops/s | 13.13 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 125.39 | ±8.54 | k ops/s | 13.18 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 1 | thrpt | 89.37 | ±2.92 | k ops/s | 4.49 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 4 | thrpt | 116.09 | ±6.35 | k ops/s | 4.48 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 226.04 | ±35.5 | k ops/s | 12.97 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 136.07 | ±5.15 | k ops/s | 13.01 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 1 | thrpt | 60.67 | ±12.98 | k ops/s | 4.78 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 4 | thrpt | 132.12 | ±37.1 | k ops/s | 4.73 KiB/op |
 
 ## Infrastructure E2E Results
 

--- a/wow-benchmarks/results/reports/quick-framework-e2e.md
+++ b/wow-benchmarks/results/reports/quick-framework-e2e.md
@@ -7,6 +7,13 @@
 
 Quick Framework E2E results are directional local feedback. Use Baseline E2E runs for formal performance conclusions. Framework E2E isolates command pipeline overhead with in-memory or noop stores.
 
+## Reading Values
+
+- Throughput uses decimal prefixes: `k` = 1,000, `M` = 1,000,000, `G` = 1,000,000,000.
+- Allocation uses binary prefixes: `KiB` = 1,024 bytes, `MiB` = 1,048,576 bytes.
+- Average latency is automatically scaled to `ns/op`, `µs/op`, `ms/op`, or `s/op`.
+- `±` is the JMH-reported error. Scaling changes presentation only; calculations keep raw precision.
+
 ## Benchmark Run Provenance
 - **Source Commit**: `07fcba8b412f7250b547425289ad0ef218ba8bde`
 - **Source Dirty**: `false`
@@ -26,7 +33,7 @@ Quick Framework E2E results are directional local feedback. Use Baseline E2E run
 - **Version**: 8.9.0
 - **JVM**: OpenJDK 64-Bit Server VM 17.0.7+7-LTS
 - **OS**: Mac OS X 26.5.2 aarch64
-- **Generated At**: 2026-07-22T18:21:34+08:00
+- **Generated At**: 2026-07-22T20:04:20+08:00
 - **CPU Cores**: 14
 - **Physical Memory**: 24.0 GiB
 - **Benchmark JVM Args**: `-Xmx1g -Xms1g -XX:+UseG1GC`
@@ -36,19 +43,19 @@ Quick Framework E2E results are directional local feedback. Use Baseline E2E run
 
 | Suite | Benchmark | Threads | Mode | Score | Error | Unit | gc.alloc.rate.norm |
 |-------|-----------|---------|------|-------|-------|------|-------------------|
-| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=ceiling) | 1 | thrpt | 686869.48 | - | ops/s | 2260.2 B/op |
-| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=ceiling) | 4 | thrpt | 675928.89 | - | ops/s | 2261.6 B/op |
-| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=validated) | 1 | thrpt | 663667.93 | - | ops/s | 2668.2 B/op |
-| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=validated) | 4 | thrpt | 679130.82 | - | ops/s | 2718.0 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 302779.76 | - | ops/s | 12371.7 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 224318.46 | - | ops/s | 12375.3 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 1 | thrpt | 91298.61 | - | ops/s | 3953.9 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 4 | thrpt | 158977.44 | - | ops/s | 3956.2 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 208208.96 | - | ops/s | 13495.1 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 143004.97 | - | ops/s | 13542.0 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 1 | thrpt | 81134.42 | - | ops/s | 4691.7 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 4 | thrpt | 133949.08 | - | ops/s | 4616.4 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 249836.37 | - | ops/s | 13312.9 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 167471.78 | - | ops/s | 13338.4 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 1 | thrpt | 91971.23 | - | ops/s | 4914.0 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 4 | thrpt | 147171.40 | - | ops/s | 4904.8 B/op |
+| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=ceiling) | 1 | thrpt | 686.87 | - | k ops/s | 2.21 KiB/op |
+| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=ceiling) | 4 | thrpt | 675.93 | - | k ops/s | 2.21 KiB/op |
+| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=validated) | 1 | thrpt | 663.67 | - | k ops/s | 2.61 KiB/op |
+| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=validated) | 4 | thrpt | 679.13 | - | k ops/s | 2.65 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 302.78 | - | k ops/s | 12.08 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 224.32 | - | k ops/s | 12.09 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 1 | thrpt | 91.3 | - | k ops/s | 3.86 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 4 | thrpt | 158.98 | - | k ops/s | 3.86 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 208.21 | - | k ops/s | 13.18 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 143 | - | k ops/s | 13.22 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 1 | thrpt | 81.13 | - | k ops/s | 4.58 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 4 | thrpt | 133.95 | - | k ops/s | 4.51 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 249.84 | - | k ops/s | 13 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 167.47 | - | k ops/s | 13.03 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 1 | thrpt | 91.97 | - | k ops/s | 4.8 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 4 | thrpt | 147.17 | - | k ops/s | 4.79 KiB/op |

--- a/wow-benchmarks/results/reports/quick-grouped.md
+++ b/wow-benchmarks/results/reports/quick-grouped.md
@@ -8,6 +8,13 @@
 - Component results explain bottlenecks and are not standalone performance goals.
 - Smoke results are excluded from performance reports.
 
+## Reading Values
+
+- Throughput uses decimal prefixes: `k` = 1,000, `M` = 1,000,000, `G` = 1,000,000,000.
+- Allocation uses binary prefixes: `KiB` = 1,024 bytes, `MiB` = 1,048,576 bytes.
+- Average latency is automatically scaled to `ns/op`, `µs/op`, `ms/op`, or `s/op`.
+- `±` is the JMH-reported error. Scaling changes presentation only; calculations keep raw precision.
+
 ## Benchmark Run Provenance
 - **Source Commit**: `07fcba8b412f7250b547425289ad0ef218ba8bde`
 - **Source Dirty**: `false`
@@ -30,7 +37,7 @@
 - **Version**: 8.9.0
 - **JVM**: OpenJDK 64-Bit Server VM 17.0.7+7-LTS
 - **OS**: Mac OS X 26.5.2 aarch64
-- **Generated At**: 2026-07-22T19:43:21+08:00
+- **Generated At**: 2026-07-22T20:04:20+08:00
 - **CPU Cores**: 14
 - **Physical Memory**: 24.0 GiB
 - **Benchmark JVM Args**: see per-suite Run Profiles below
@@ -48,31 +55,31 @@
 
 | Suite | Threads | Benchmark | Score | Error | Unit |
 |-------|---------|-----------|-------|-------|------|
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 81134.42 | - | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 91298.61 | - | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 91971.23 | - | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 133949.08 | - | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 143004.97 | - | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 147171.40 | - | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 158977.44 | - | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 167471.78 | - | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 208208.96 | - | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 224318.46 | - | ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 81.13 | - | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 91.3 | - | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 91.97 | - | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 133.95 | - | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 143 | - | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 147.17 | - | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 158.98 | - | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 167.47 | - | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 208.21 | - | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 224.32 | - | k ops/s |
 
 ### Highest Allocation
 
 | Suite | Threads | Benchmark | Mode | Allocation | Error | Score | Unit |
 |-------|---------|-----------|------|------------|-------|-------|------|
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 13542.0 B/op | - | 143004.97 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 13495.1 B/op | - | 208208.96 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 13338.4 B/op | - | 167471.78 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 13312.9 B/op | - | 249836.37 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 12375.3 B/op | - | 224318.46 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 12371.7 B/op | - | 302779.76 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 4914.0 B/op | - | 91971.23 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 4904.8 B/op | - | 147171.40 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 4691.7 B/op | - | 81134.42 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 4616.4 B/op | - | 133949.08 | ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 13.22 KiB/op | - | 143 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 13.18 KiB/op | - | 208.21 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 13.03 KiB/op | - | 167.47 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 13 KiB/op | - | 249.84 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 12.09 KiB/op | - | 224.32 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 12.08 KiB/op | - | 302.78 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 4.8 KiB/op | - | 91.97 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 4.79 KiB/op | - | 147.17 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 4.58 KiB/op | - | 81.13 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 4.51 KiB/op | - | 133.95 | k ops/s |
 
 ## Component Bottlenecks
 
@@ -80,31 +87,31 @@
 
 | Suite | Threads | Benchmark | Score | Error | Unit |
 |-------|---------|-----------|-------|-------|------|
-| Component | 1 | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=500) | 74469.55 | - | ops/s |
-| Component | 1 | CommandDispatcherChainComponentBenchmark.dispatchSingleHotAggregateThroughChain (handlerCost=NOOP, schedulerStrategy=PARALLEL) | 120042.09 | - | ops/s |
-| Component | 1 | SerializationComponentBenchmark.eventStreamSerializeDeserialize | 450569.05 | - | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithLocalWait | 455681.50 | - | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainStateEvents | 564959.75 | - | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithoutWait | 574927.18 | - | ops/s |
-| Component | 1 | SerializationComponentBenchmark.commandSerializeDeserialize | 607526.58 | - | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainEvent | 684281.24 | - | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateOnly | 769137.27 | - | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateWithoutRetry | 859762.08 | - | ops/s |
+| Component | 1 | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=500) | 74.47 | - | k ops/s |
+| Component | 1 | CommandDispatcherChainComponentBenchmark.dispatchSingleHotAggregateThroughChain (handlerCost=NOOP, schedulerStrategy=PARALLEL) | 120.04 | - | k ops/s |
+| Component | 1 | SerializationComponentBenchmark.eventStreamSerializeDeserialize | 450.57 | - | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithLocalWait | 455.68 | - | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainStateEvents | 564.96 | - | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithoutWait | 574.93 | - | k ops/s |
+| Component | 1 | SerializationComponentBenchmark.commandSerializeDeserialize | 607.53 | - | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainEvent | 684.28 | - | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateOnly | 769.14 | - | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateWithoutRetry | 859.76 | - | k ops/s |
 
 ### Highest Allocation
 
 | Suite | Threads | Benchmark | Mode | Allocation | Error | Score | Unit |
 |-------|---------|-----------|------|------------|-------|-------|------|
-| Component | 1 | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=500) | thrpt | 56627.9 B/op | - | 74469.55 | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithLocalWait | thrpt | 10520.0 B/op | - | 455681.50 | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithoutWait | thrpt | 8872.0 B/op | - | 574927.18 | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainStateEvents | thrpt | 8840.0 B/op | - | 564959.75 | ops/s |
-| Component | 1 | SerializationComponentBenchmark.eventStreamSerializeDeserialize | thrpt | 7920.0 B/op | - | 450569.05 | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainEvent | thrpt | 7512.0 B/op | - | 684281.24 | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateOnly | thrpt | 7144.0 B/op | - | 769137.27 | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateWithoutRetry | thrpt | 6032.0 B/op | - | 859762.08 | ops/s |
-| Component | 1 | SerializationComponentBenchmark.commandSerializeDeserialize | thrpt | 5648.0 B/op | - | 607526.58 | ops/s |
-| Component | 1 | AggregateRepositoryLoadComponentBenchmark.loadSnapshot | thrpt | 5264.0 B/op | - | 1050689.18 | ops/s |
+| Component | 1 | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=500) | thrpt | 55.3 KiB/op | - | 74.47 | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithLocalWait | thrpt | 10.27 KiB/op | - | 455.68 | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithoutWait | thrpt | 8.66 KiB/op | - | 574.93 | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainStateEvents | thrpt | 8.63 KiB/op | - | 564.96 | k ops/s |
+| Component | 1 | SerializationComponentBenchmark.eventStreamSerializeDeserialize | thrpt | 7.73 KiB/op | - | 450.57 | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainEvent | thrpt | 7.34 KiB/op | - | 684.28 | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateOnly | thrpt | 6.98 KiB/op | - | 769.14 | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateWithoutRetry | thrpt | 5.89 KiB/op | - | 859.76 | k ops/s |
+| Component | 1 | SerializationComponentBenchmark.commandSerializeDeserialize | thrpt | 5.52 KiB/op | - | 607.53 | k ops/s |
+| Component | 1 | AggregateRepositoryLoadComponentBenchmark.loadSnapshot | thrpt | 5.14 KiB/op | - | 1.05 | M ops/s |
 
 ## WebFlux Adapter Bottlenecks
 
@@ -112,31 +119,31 @@
 
 | Suite | Threads | Benchmark | Score | Error | Unit |
 |-------|---------|-----------|-------|-------|------|
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 1573.91 | - | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 5259.54 | - | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 5576.25 | - | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 8963.46 | - | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 18106.25 | - | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 19647.09 | - | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 28548.24 | - | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 34350.88 | - | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 47369.89 | - | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 64511.66 | - | ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 1.57 | - | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 5.26 | - | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 5.58 | - | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 8.96 | - | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 18.11 | - | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 19.65 | - | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 28.55 | - | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 34.35 | - | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 47.37 | - | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 64.51 | - | k ops/s |
 
 ### Highest Allocation
 
 | Suite | Threads | Benchmark | Mode | Allocation | Error | Score | Unit |
 |-------|---------|-----------|------|------------|-------|-------|------|
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2982851.6 B/op | - | 1573.91 | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2960991.6 B/op | - | 5259.54 | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 760399.9 B/op | - | 5576.25 | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 754925.9 B/op | - | 19647.09 | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 446260.1 B/op | - | 8963.46 | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 444420.0 B/op | - | 34350.88 | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 169049.7 B/op | - | 18106.25 | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 166383.0 B/op | - | 47369.89 | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 81728.4 B/op | - | 28548.24 | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 79940.0 B/op | - | 110843.89 | ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2.84 MiB/op | - | 1.57 | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2.82 MiB/op | - | 5.26 | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 742.58 KiB/op | - | 5.58 | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 737.23 KiB/op | - | 19.65 | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 435.8 KiB/op | - | 8.96 | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 434 KiB/op | - | 34.35 | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 165.09 KiB/op | - | 18.11 | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 162.48 KiB/op | - | 47.37 | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 79.81 KiB/op | - | 28.55 | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 78.07 KiB/op | - | 110.84 | k ops/s |
 
 ## Group Details
 
@@ -144,91 +151,91 @@
 
 | Suite | Threads | Benchmark | Score | Error | Unit |
 |-------|---------|-----------|-------|-------|------|
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 81134.42 | - | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 91298.61 | - | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 91971.23 | - | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 133949.08 | - | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 143004.97 | - | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 147171.40 | - | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 158977.44 | - | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 167471.78 | - | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 208208.96 | - | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 224318.46 | - | ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 81.13 | - | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 91.3 | - | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 91.97 | - | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 133.95 | - | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 143 | - | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 147.17 | - | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 158.98 | - | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 167.47 | - | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 208.21 | - | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 224.32 | - | k ops/s |
 
 ### Primary Framework E2E Highest Allocation
 
 | Suite | Threads | Benchmark | Mode | Allocation | Error | Score | Unit |
 |-------|---------|-----------|------|------------|-------|-------|------|
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 13542.0 B/op | - | 143004.97 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 13495.1 B/op | - | 208208.96 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 13338.4 B/op | - | 167471.78 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 13312.9 B/op | - | 249836.37 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 12375.3 B/op | - | 224318.46 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 12371.7 B/op | - | 302779.76 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 4914.0 B/op | - | 91971.23 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 4904.8 B/op | - | 147171.40 | ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 4691.7 B/op | - | 81134.42 | ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 4616.4 B/op | - | 133949.08 | ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 13.22 KiB/op | - | 143 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 13.18 KiB/op | - | 208.21 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 13.03 KiB/op | - | 167.47 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 13 KiB/op | - | 249.84 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 12.09 KiB/op | - | 224.32 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 12.08 KiB/op | - | 302.78 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 4.8 KiB/op | - | 91.97 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 4.79 KiB/op | - | 147.17 | k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 4.58 KiB/op | - | 81.13 | k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 4.51 KiB/op | - | 133.95 | k ops/s |
 
 ### Component Lowest Throughput
 
 | Suite | Threads | Benchmark | Score | Error | Unit |
 |-------|---------|-----------|-------|-------|------|
-| Component | 1 | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=500) | 74469.55 | - | ops/s |
-| Component | 1 | CommandDispatcherChainComponentBenchmark.dispatchSingleHotAggregateThroughChain (handlerCost=NOOP, schedulerStrategy=PARALLEL) | 120042.09 | - | ops/s |
-| Component | 1 | SerializationComponentBenchmark.eventStreamSerializeDeserialize | 450569.05 | - | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithLocalWait | 455681.50 | - | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainStateEvents | 564959.75 | - | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithoutWait | 574927.18 | - | ops/s |
-| Component | 1 | SerializationComponentBenchmark.commandSerializeDeserialize | 607526.58 | - | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainEvent | 684281.24 | - | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateOnly | 769137.27 | - | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateWithoutRetry | 859762.08 | - | ops/s |
+| Component | 1 | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=500) | 74.47 | - | k ops/s |
+| Component | 1 | CommandDispatcherChainComponentBenchmark.dispatchSingleHotAggregateThroughChain (handlerCost=NOOP, schedulerStrategy=PARALLEL) | 120.04 | - | k ops/s |
+| Component | 1 | SerializationComponentBenchmark.eventStreamSerializeDeserialize | 450.57 | - | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithLocalWait | 455.68 | - | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainStateEvents | 564.96 | - | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithoutWait | 574.93 | - | k ops/s |
+| Component | 1 | SerializationComponentBenchmark.commandSerializeDeserialize | 607.53 | - | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainEvent | 684.28 | - | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateOnly | 769.14 | - | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateWithoutRetry | 859.76 | - | k ops/s |
 
 ### Component Highest Allocation
 
 | Suite | Threads | Benchmark | Mode | Allocation | Error | Score | Unit |
 |-------|---------|-----------|------|------------|-------|-------|------|
-| Component | 1 | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=500) | thrpt | 56627.9 B/op | - | 74469.55 | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithLocalWait | thrpt | 10520.0 B/op | - | 455681.50 | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithoutWait | thrpt | 8872.0 B/op | - | 574927.18 | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainStateEvents | thrpt | 8840.0 B/op | - | 564959.75 | ops/s |
-| Component | 1 | SerializationComponentBenchmark.eventStreamSerializeDeserialize | thrpt | 7920.0 B/op | - | 450569.05 | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainEvent | thrpt | 7512.0 B/op | - | 684281.24 | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateOnly | thrpt | 7144.0 B/op | - | 769137.27 | ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateWithoutRetry | thrpt | 6032.0 B/op | - | 859762.08 | ops/s |
-| Component | 1 | SerializationComponentBenchmark.commandSerializeDeserialize | thrpt | 5648.0 B/op | - | 607526.58 | ops/s |
-| Component | 1 | AggregateRepositoryLoadComponentBenchmark.loadSnapshot | thrpt | 5264.0 B/op | - | 1050689.18 | ops/s |
+| Component | 1 | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=500) | thrpt | 55.3 KiB/op | - | 74.47 | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithLocalWait | thrpt | 10.27 KiB/op | - | 455.68 | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithoutWait | thrpt | 8.66 KiB/op | - | 574.93 | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainStateEvents | thrpt | 8.63 KiB/op | - | 564.96 | k ops/s |
+| Component | 1 | SerializationComponentBenchmark.eventStreamSerializeDeserialize | thrpt | 7.73 KiB/op | - | 450.57 | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainEvent | thrpt | 7.34 KiB/op | - | 684.28 | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateOnly | thrpt | 6.98 KiB/op | - | 769.14 | k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateWithoutRetry | thrpt | 5.89 KiB/op | - | 859.76 | k ops/s |
+| Component | 1 | SerializationComponentBenchmark.commandSerializeDeserialize | thrpt | 5.52 KiB/op | - | 607.53 | k ops/s |
+| Component | 1 | AggregateRepositoryLoadComponentBenchmark.loadSnapshot | thrpt | 5.14 KiB/op | - | 1.05 | M ops/s |
 
 ### WebFlux Adapter Lowest Throughput
 
 | Suite | Threads | Benchmark | Score | Error | Unit |
 |-------|---------|-----------|-------|-------|------|
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 1573.91 | - | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 5259.54 | - | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 5576.25 | - | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 8963.46 | - | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 18106.25 | - | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 19647.09 | - | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 28548.24 | - | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 34350.88 | - | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 47369.89 | - | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 64511.66 | - | ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 1.57 | - | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 5.26 | - | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 5.58 | - | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 8.96 | - | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 18.11 | - | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 19.65 | - | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 28.55 | - | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 34.35 | - | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 47.37 | - | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 64.51 | - | k ops/s |
 
 ### WebFlux Adapter Highest Allocation
 
 | Suite | Threads | Benchmark | Mode | Allocation | Error | Score | Unit |
 |-------|---------|-----------|------|------------|-------|-------|------|
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2982851.6 B/op | - | 1573.91 | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2960991.6 B/op | - | 5259.54 | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 760399.9 B/op | - | 5576.25 | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 754925.9 B/op | - | 19647.09 | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 446260.1 B/op | - | 8963.46 | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 444420.0 B/op | - | 34350.88 | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 169049.7 B/op | - | 18106.25 | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 166383.0 B/op | - | 47369.89 | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 81728.4 B/op | - | 28548.24 | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 79940.0 B/op | - | 110843.89 | ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2.84 MiB/op | - | 1.57 | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2.82 MiB/op | - | 5.26 | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 742.58 KiB/op | - | 5.58 | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 737.23 KiB/op | - | 19.65 | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 435.8 KiB/op | - | 8.96 | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 434 KiB/op | - | 34.35 | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 165.09 KiB/op | - | 18.11 | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 162.48 KiB/op | - | 47.37 | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 79.81 KiB/op | - | 28.55 | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 78.07 KiB/op | - | 110.84 | k ops/s |
 
 ## Primary Framework E2E Results
 
@@ -245,22 +252,22 @@
 
 | Suite | Benchmark | Threads | Mode | Score | Error | Unit | gc.alloc.rate.norm |
 |-------|-----------|---------|------|-------|-------|------|-------------------|
-| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=ceiling) | 1 | thrpt | 686869.48 | - | ops/s | 2260.2 B/op |
-| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=ceiling) | 4 | thrpt | 675928.89 | - | ops/s | 2261.6 B/op |
-| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=validated) | 1 | thrpt | 663667.93 | - | ops/s | 2668.2 B/op |
-| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=validated) | 4 | thrpt | 679130.82 | - | ops/s | 2718.0 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 302779.76 | - | ops/s | 12371.7 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 224318.46 | - | ops/s | 12375.3 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 1 | thrpt | 91298.61 | - | ops/s | 3953.9 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 4 | thrpt | 158977.44 | - | ops/s | 3956.2 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 208208.96 | - | ops/s | 13495.1 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 143004.97 | - | ops/s | 13542.0 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 1 | thrpt | 81134.42 | - | ops/s | 4691.7 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 4 | thrpt | 133949.08 | - | ops/s | 4616.4 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 249836.37 | - | ops/s | 13312.9 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 167471.78 | - | ops/s | 13338.4 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 1 | thrpt | 91971.23 | - | ops/s | 4914.0 B/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 4 | thrpt | 147171.40 | - | ops/s | 4904.8 B/op |
+| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=ceiling) | 1 | thrpt | 686.87 | - | k ops/s | 2.21 KiB/op |
+| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=ceiling) | 4 | thrpt | 675.93 | - | k ops/s | 2.21 KiB/op |
+| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=validated) | 1 | thrpt | 663.67 | - | k ops/s | 2.61 KiB/op |
+| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=validated) | 4 | thrpt | 679.13 | - | k ops/s | 2.65 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 302.78 | - | k ops/s | 12.08 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 224.32 | - | k ops/s | 12.09 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 1 | thrpt | 91.3 | - | k ops/s | 3.86 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 4 | thrpt | 158.98 | - | k ops/s | 3.86 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 208.21 | - | k ops/s | 13.18 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 143 | - | k ops/s | 13.22 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 1 | thrpt | 81.13 | - | k ops/s | 4.58 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 4 | thrpt | 133.95 | - | k ops/s | 4.51 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 249.84 | - | k ops/s | 13 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 167.47 | - | k ops/s | 13.03 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 1 | thrpt | 91.97 | - | k ops/s | 4.8 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 4 | thrpt | 147.17 | - | k ops/s | 4.79 KiB/op |
 
 ## Infrastructure E2E Results
 
@@ -288,33 +295,33 @@ Status: unavailable. Result files were not present. Run benchmarkQuickInfrastruc
 
 | Suite | Benchmark | Threads | Mode | Score | Error | Unit | gc.alloc.rate.norm |
 |-------|-----------|---------|------|-------|-------|------|-------------------|
-| Component | AggregateHandleComponentBenchmark.processCommandAggregate | 1 | thrpt | 1178260.56 | - | ops/s | 5176.0 B/op |
-| Component | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=10) | 1 | thrpt | 3315394.59 | - | ops/s | 1752.0 B/op |
-| Component | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=500) | 1 | thrpt | 74469.55 | - | ops/s | 56627.9 B/op |
-| Component | AggregateRepositoryLoadComponentBenchmark.loadEmptyStateAggregate | 1 | thrpt | 6002517.64 | - | ops/s | 1328.0 B/op |
-| Component | AggregateRepositoryLoadComponentBenchmark.loadSnapshot | 1 | thrpt | 1050689.18 | - | ops/s | 5264.0 B/op |
-| Component | CommandDispatcherChainComponentBenchmark.dispatchSingleHotAggregateThroughChain (handlerCost=NOOP, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 5940060.46 | - | ops/s | 624.0 B/op |
-| Component | CommandDispatcherChainComponentBenchmark.dispatchSingleHotAggregateThroughChain (handlerCost=NOOP, schedulerStrategy=PARALLEL) | 1 | thrpt | 120042.09 | - | ops/s | 710.2 B/op |
-| Component | CommandIdComponentBenchmark.generateGlobalIdAndCreateAggregateId | 1 | thrpt | 16575792.59 | - | ops/s | 272.0 B/op |
-| Component | CommandMessageComponentBenchmark.createCommandMessage | 1 | thrpt | 5039987.87 | - | ops/s | 1080.0 B/op |
-| Component | CommandMessageComponentBenchmark.readCommandMessageProperties | 1 | thrpt | 668849367.69 | - | ops/s | 0.0 B/op |
-| Component | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithLocalWait | 1 | thrpt | 455681.50 | - | ops/s | 10520.0 B/op |
-| Component | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithoutWait | 1 | thrpt | 574927.18 | - | ops/s | 8872.0 B/op |
-| Component | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainEvent | 1 | thrpt | 684281.24 | - | ops/s | 7512.0 B/op |
-| Component | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainStateEvents | 1 | thrpt | 564959.75 | - | ops/s | 8840.0 B/op |
-| Component | CommandPipelineComponentBenchmark.handleAggregateOnly | 1 | thrpt | 769137.27 | - | ops/s | 7144.0 B/op |
-| Component | CommandPipelineComponentBenchmark.handleAggregateWithoutRetry | 1 | thrpt | 859762.08 | - | ops/s | 6032.0 B/op |
-| Component | CommandValidationComponentBenchmark.validateCommandBody | 1 | thrpt | 7806847.66 | - | ops/s | 360.0 B/op |
-| Component | EventPublishComponentBenchmark.publishDomainEventStream | 1 | thrpt | 20455092.36 | - | ops/s | 168.0 B/op |
-| Component | EventStoreComponentBenchmark.appendInMemoryNewAggregateEventStream | 1 | thrpt | 14294165.52 | - | ops/s | 467.9 B/op |
-| Component | EventStoreComponentBenchmark.appendNoopEventStream | 1 | thrpt | 2731742591.68 | - | ops/s | 0.0 B/op |
-| Component | IdempotencyComponentBenchmark.checkKnownRequestId | 1 | thrpt | 20673244.39 | - | ops/s | 192.5 B/op |
-| Component | MongoDocumentComponentBenchmark.eventStreamToDocument | 1 | thrpt | 1266511.38 | - | ops/s | 4336.0 B/op |
-| Component | SerializationComponentBenchmark.commandSerializeDeserialize | 1 | thrpt | 607526.58 | - | ops/s | 5648.0 B/op |
-| Component | SerializationComponentBenchmark.eventStreamSerializeDeserialize | 1 | thrpt | 450569.05 | - | ops/s | 7920.0 B/op |
-| Component | WaitNotifyComponentBenchmark.notifyProcessed | 1 | thrpt | 3308915.46 | - | ops/s | 1496.0 B/op |
-| Component | WaitNotifyComponentBenchmark.registerWaitRegistration | 1 | thrpt | 31033100.12 | - | ops/s | 320.0 B/op |
-| Component | WaitNotifyComponentBenchmark.waitForProcessed | 1 | thrpt | 3007627.70 | - | ops/s | 1760.0 B/op |
+| Component | AggregateHandleComponentBenchmark.processCommandAggregate | 1 | thrpt | 1.18 | - | M ops/s | 5.05 KiB/op |
+| Component | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=10) | 1 | thrpt | 3.32 | - | M ops/s | 1.71 KiB/op |
+| Component | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=500) | 1 | thrpt | 74.47 | - | k ops/s | 55.3 KiB/op |
+| Component | AggregateRepositoryLoadComponentBenchmark.loadEmptyStateAggregate | 1 | thrpt | 6 | - | M ops/s | 1.3 KiB/op |
+| Component | AggregateRepositoryLoadComponentBenchmark.loadSnapshot | 1 | thrpt | 1.05 | - | M ops/s | 5.14 KiB/op |
+| Component | CommandDispatcherChainComponentBenchmark.dispatchSingleHotAggregateThroughChain (handlerCost=NOOP, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 5.94 | - | M ops/s | 624 B/op |
+| Component | CommandDispatcherChainComponentBenchmark.dispatchSingleHotAggregateThroughChain (handlerCost=NOOP, schedulerStrategy=PARALLEL) | 1 | thrpt | 120.04 | - | k ops/s | 710.21 B/op |
+| Component | CommandIdComponentBenchmark.generateGlobalIdAndCreateAggregateId | 1 | thrpt | 16.58 | - | M ops/s | 272 B/op |
+| Component | CommandMessageComponentBenchmark.createCommandMessage | 1 | thrpt | 5.04 | - | M ops/s | 1.05 KiB/op |
+| Component | CommandMessageComponentBenchmark.readCommandMessageProperties | 1 | thrpt | 668.85 | - | M ops/s | 2.7e-07 B/op |
+| Component | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithLocalWait | 1 | thrpt | 455.68 | - | k ops/s | 10.27 KiB/op |
+| Component | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithoutWait | 1 | thrpt | 574.93 | - | k ops/s | 8.66 KiB/op |
+| Component | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainEvent | 1 | thrpt | 684.28 | - | k ops/s | 7.34 KiB/op |
+| Component | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainStateEvents | 1 | thrpt | 564.96 | - | k ops/s | 8.63 KiB/op |
+| Component | CommandPipelineComponentBenchmark.handleAggregateOnly | 1 | thrpt | 769.14 | - | k ops/s | 6.98 KiB/op |
+| Component | CommandPipelineComponentBenchmark.handleAggregateWithoutRetry | 1 | thrpt | 859.76 | - | k ops/s | 5.89 KiB/op |
+| Component | CommandValidationComponentBenchmark.validateCommandBody | 1 | thrpt | 7.81 | - | M ops/s | 360.04 B/op |
+| Component | EventPublishComponentBenchmark.publishDomainEventStream | 1 | thrpt | 20.46 | - | M ops/s | 168 B/op |
+| Component | EventStoreComponentBenchmark.appendInMemoryNewAggregateEventStream | 1 | thrpt | 14.29 | - | M ops/s | 467.89 B/op |
+| Component | EventStoreComponentBenchmark.appendNoopEventStream | 1 | thrpt | 2.73 | - | G ops/s | 6.7e-08 B/op |
+| Component | IdempotencyComponentBenchmark.checkKnownRequestId | 1 | thrpt | 20.67 | - | M ops/s | 192.48 B/op |
+| Component | MongoDocumentComponentBenchmark.eventStreamToDocument | 1 | thrpt | 1.27 | - | M ops/s | 4.23 KiB/op |
+| Component | SerializationComponentBenchmark.commandSerializeDeserialize | 1 | thrpt | 607.53 | - | k ops/s | 5.52 KiB/op |
+| Component | SerializationComponentBenchmark.eventStreamSerializeDeserialize | 1 | thrpt | 450.57 | - | k ops/s | 7.73 KiB/op |
+| Component | WaitNotifyComponentBenchmark.notifyProcessed | 1 | thrpt | 3.31 | - | M ops/s | 1.46 KiB/op |
+| Component | WaitNotifyComponentBenchmark.registerWaitRegistration | 1 | thrpt | 31.03 | - | M ops/s | 320 B/op |
+| Component | WaitNotifyComponentBenchmark.waitForProcessed | 1 | thrpt | 3.01 | - | M ops/s | 1.72 KiB/op |
 
 ## WebFlux Adapter Results
 
@@ -331,33 +338,33 @@ Status: unavailable. Result files were not present. Run benchmarkQuickInfrastruc
 
 | Suite | Benchmark | Threads | Mode | Score | Error | Unit | gc.alloc.rate.norm |
 |-------|-----------|---------|------|-------|-------|------|-------------------|
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 1 | thrpt | 28548.24 | - | ops/s | 81728.4 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 4 | thrpt | 110843.89 | - | ops/s | 79940.0 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 1 | thrpt | 18106.25 | - | ops/s | 169049.7 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 4 | thrpt | 47369.89 | - | ops/s | 166383.0 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 1 | thrpt | 5576.25 | - | ops/s | 760399.9 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 4 | thrpt | 19647.09 | - | ops/s | 754925.9 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=1, traceWindowSize=10) | 1 | thrpt | 803604.02 | - | ops/s | 3310.0 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=1, traceWindowSize=10) | 4 | thrpt | 2335131.47 | - | ops/s | 3268.2 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 1 | thrpt | 64511.66 | - | ops/s | 37323.3 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 4 | thrpt | 260452.97 | - | ops/s | 36714.3 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 1 | thrpt | 1573.91 | - | ops/s | 2982851.6 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 4 | thrpt | 5259.54 | - | ops/s | 2960991.6 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=1, traceWindowSize=10) | 1 | thrpt | 747650.70 | - | ops/s | 3851.1 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=1, traceWindowSize=10) | 4 | thrpt | 1906565.36 | - | ops/s | 3809.3 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=10, traceWindowSize=10) | 1 | thrpt | 68097.86 | - | ops/s | 37772.3 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=10, traceWindowSize=10) | 4 | thrpt | 216517.36 | - | ops/s | 37251.3 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 1 | thrpt | 8963.46 | - | ops/s | 446260.1 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 4 | thrpt | 34350.88 | - | ops/s | 444420.0 B/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.commandResultJsonServerResponseOnly | 1 | thrpt | 831407.85 | - | ops/s | 4498.1 B/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.commandResultJsonServerResponseOnly | 4 | thrpt | 2264673.75 | - | ops/s | 4459.9 B/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.extractPreparedCommandMessage | 1 | thrpt | 3573198.45 | - | ops/s | 1382.2 B/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.extractPreparedCommandMessage | 4 | thrpt | 6743832.19 | - | ops/s | 1359.3 B/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.handlePreparedAddCartItemRequestWaitSent | 1 | thrpt | 118693.32 | - | ops/s | 11346.1 B/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.handlePreparedAddCartItemRequestWaitSent | 4 | thrpt | 234418.11 | - | ops/s | 11223.6 B/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.sendWaitSentCoreFromExtractedMessage | 1 | thrpt | 1052901.94 | - | ops/s | 3535.8 B/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.sendWaitSentCoreFromExtractedMessage | 4 | thrpt | 1012879.97 | - | ops/s | 3541.8 B/op |
-| WebFlux Adapter | WebFluxResponseBenchmark.commandResultSseServerResponseOnly | 1 | thrpt | 1835774.35 | - | ops/s | 3408.4 B/op |
-| WebFlux Adapter | WebFluxResponseBenchmark.commandResultSseServerResponseOnly | 4 | thrpt | 7125659.23 | - | ops/s | 3290.0 B/op |
-| WebFlux Adapter | WebFluxResponseBenchmark.fluxJsonStreamingArrayServerResponseOnly | 1 | thrpt | 5198585.40 | - | ops/s | 1075.5 B/op |
-| WebFlux Adapter | WebFluxResponseBenchmark.fluxJsonStreamingArrayServerResponseOnly | 4 | thrpt | 19596863.45 | - | ops/s | 1067.4 B/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 1 | thrpt | 28.55 | - | k ops/s | 79.81 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 4 | thrpt | 110.84 | - | k ops/s | 78.07 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 1 | thrpt | 18.11 | - | k ops/s | 165.09 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 4 | thrpt | 47.37 | - | k ops/s | 162.48 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 1 | thrpt | 5.58 | - | k ops/s | 742.58 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 4 | thrpt | 19.65 | - | k ops/s | 737.23 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=1, traceWindowSize=10) | 1 | thrpt | 803.6 | - | k ops/s | 3.23 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=1, traceWindowSize=10) | 4 | thrpt | 2.34 | - | M ops/s | 3.19 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 1 | thrpt | 64.51 | - | k ops/s | 36.45 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 4 | thrpt | 260.45 | - | k ops/s | 35.85 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 1 | thrpt | 1.57 | - | k ops/s | 2.84 MiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 4 | thrpt | 5.26 | - | k ops/s | 2.82 MiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=1, traceWindowSize=10) | 1 | thrpt | 747.65 | - | k ops/s | 3.76 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=1, traceWindowSize=10) | 4 | thrpt | 1.91 | - | M ops/s | 3.72 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=10, traceWindowSize=10) | 1 | thrpt | 68.1 | - | k ops/s | 36.89 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=10, traceWindowSize=10) | 4 | thrpt | 216.52 | - | k ops/s | 36.38 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 1 | thrpt | 8.96 | - | k ops/s | 435.8 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 4 | thrpt | 34.35 | - | k ops/s | 434 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.commandResultJsonServerResponseOnly | 1 | thrpt | 831.41 | - | k ops/s | 4.39 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.commandResultJsonServerResponseOnly | 4 | thrpt | 2.26 | - | M ops/s | 4.36 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.extractPreparedCommandMessage | 1 | thrpt | 3.57 | - | M ops/s | 1.35 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.extractPreparedCommandMessage | 4 | thrpt | 6.74 | - | M ops/s | 1.33 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.handlePreparedAddCartItemRequestWaitSent | 1 | thrpt | 118.69 | - | k ops/s | 11.08 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.handlePreparedAddCartItemRequestWaitSent | 4 | thrpt | 234.42 | - | k ops/s | 10.96 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.sendWaitSentCoreFromExtractedMessage | 1 | thrpt | 1.05 | - | M ops/s | 3.45 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.sendWaitSentCoreFromExtractedMessage | 4 | thrpt | 1.01 | - | M ops/s | 3.46 KiB/op |
+| WebFlux Adapter | WebFluxResponseBenchmark.commandResultSseServerResponseOnly | 1 | thrpt | 1.84 | - | M ops/s | 3.33 KiB/op |
+| WebFlux Adapter | WebFluxResponseBenchmark.commandResultSseServerResponseOnly | 4 | thrpt | 7.13 | - | M ops/s | 3.21 KiB/op |
+| WebFlux Adapter | WebFluxResponseBenchmark.fluxJsonStreamingArrayServerResponseOnly | 1 | thrpt | 5.2 | - | M ops/s | 1.05 KiB/op |
+| WebFlux Adapter | WebFluxResponseBenchmark.fluxJsonStreamingArrayServerResponseOnly | 4 | thrpt | 19.6 | - | M ops/s | 1.04 KiB/op |

--- a/wow-benchmarks/results/reports/quick-webflux.md
+++ b/wow-benchmarks/results/reports/quick-webflux.md
@@ -7,6 +7,13 @@
 
 Quick WebFlux results are short-loop local feedback for command dispatch, response construction, and aggregate tracing hotspots. The profile keeps the JMH GC profiler so gc.alloc.rate.norm remains available, but skips async profiler flamegraphs; run Exhaustive WebFlux for the complete benchmark matrix.
 
+## Reading Values
+
+- Throughput uses decimal prefixes: `k` = 1,000, `M` = 1,000,000, `G` = 1,000,000,000.
+- Allocation uses binary prefixes: `KiB` = 1,024 bytes, `MiB` = 1,048,576 bytes.
+- Average latency is automatically scaled to `ns/op`, `µs/op`, `ms/op`, or `s/op`.
+- `±` is the JMH-reported error. Scaling changes presentation only; calculations keep raw precision.
+
 ## Benchmark Run Provenance
 - **Source Commit**: `07fcba8b412f7250b547425289ad0ef218ba8bde`
 - **Source Dirty**: `false`
@@ -26,7 +33,7 @@ Quick WebFlux results are short-loop local feedback for command dispatch, respon
 - **Version**: 8.9.0
 - **JVM**: OpenJDK 64-Bit Server VM 17.0.7+7-LTS
 - **OS**: Mac OS X 26.5.2 aarch64
-- **Generated At**: 2026-07-22T18:21:34+08:00
+- **Generated At**: 2026-07-22T20:04:20+08:00
 - **CPU Cores**: 14
 - **Physical Memory**: 24.0 GiB
 - **Benchmark JVM Args**: `-Xmx1g -Xms1g -XX:+UseG1GC`
@@ -45,63 +52,63 @@ Quick WebFlux results are short-loop local feedback for command dispatch, respon
 
 | Suite | Threads | Benchmark | Score | Error | Unit |
 |-------|---------|-----------|-------|-------|------|
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 1573.91 | - | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 5259.54 | - | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 5576.25 | - | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 8963.46 | - | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 18106.25 | - | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 19647.09 | - | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 28548.24 | - | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 34350.88 | - | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 47369.89 | - | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 64511.66 | - | ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 1.57 | - | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 5.26 | - | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 5.58 | - | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 8.96 | - | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 18.11 | - | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 19.65 | - | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 28.55 | - | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 34.35 | - | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 47.37 | - | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 64.51 | - | k ops/s |
 
 ### Highest Allocation
 
 | Suite | Threads | Benchmark | Mode | Allocation | Error | Score | Unit |
 |-------|---------|-----------|------|------------|-------|-------|------|
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2982851.6 B/op | - | 1573.91 | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2960991.6 B/op | - | 5259.54 | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 760399.9 B/op | - | 5576.25 | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 754925.9 B/op | - | 19647.09 | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 446260.1 B/op | - | 8963.46 | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 444420.0 B/op | - | 34350.88 | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 169049.7 B/op | - | 18106.25 | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 166383.0 B/op | - | 47369.89 | ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 81728.4 B/op | - | 28548.24 | ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 79940.0 B/op | - | 110843.89 | ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2.84 MiB/op | - | 1.57 | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2.82 MiB/op | - | 5.26 | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 742.58 KiB/op | - | 5.58 | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 737.23 KiB/op | - | 19.65 | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 435.8 KiB/op | - | 8.96 | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 434 KiB/op | - | 34.35 | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 165.09 KiB/op | - | 18.11 | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 162.48 KiB/op | - | 47.37 | k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 79.81 KiB/op | - | 28.55 | k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 78.07 KiB/op | - | 110.84 | k ops/s |
 
 ## Results
 
 | Suite | Benchmark | Threads | Mode | Score | Error | Unit | gc.alloc.rate.norm |
 |-------|-----------|---------|------|-------|-------|------|-------------------|
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 1 | thrpt | 28548.24 | - | ops/s | 81728.4 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 4 | thrpt | 110843.89 | - | ops/s | 79940.0 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 1 | thrpt | 18106.25 | - | ops/s | 169049.7 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 4 | thrpt | 47369.89 | - | ops/s | 166383.0 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 1 | thrpt | 5576.25 | - | ops/s | 760399.9 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 4 | thrpt | 19647.09 | - | ops/s | 754925.9 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=1, traceWindowSize=10) | 1 | thrpt | 803604.02 | - | ops/s | 3310.0 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=1, traceWindowSize=10) | 4 | thrpt | 2335131.47 | - | ops/s | 3268.2 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 1 | thrpt | 64511.66 | - | ops/s | 37323.3 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 4 | thrpt | 260452.97 | - | ops/s | 36714.3 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 1 | thrpt | 1573.91 | - | ops/s | 2982851.6 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 4 | thrpt | 5259.54 | - | ops/s | 2960991.6 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=1, traceWindowSize=10) | 1 | thrpt | 747650.70 | - | ops/s | 3851.1 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=1, traceWindowSize=10) | 4 | thrpt | 1906565.36 | - | ops/s | 3809.3 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=10, traceWindowSize=10) | 1 | thrpt | 68097.86 | - | ops/s | 37772.3 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=10, traceWindowSize=10) | 4 | thrpt | 216517.36 | - | ops/s | 37251.3 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 1 | thrpt | 8963.46 | - | ops/s | 446260.1 B/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 4 | thrpt | 34350.88 | - | ops/s | 444420.0 B/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.commandResultJsonServerResponseOnly | 1 | thrpt | 831407.85 | - | ops/s | 4498.1 B/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.commandResultJsonServerResponseOnly | 4 | thrpt | 2264673.75 | - | ops/s | 4459.9 B/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.extractPreparedCommandMessage | 1 | thrpt | 3573198.45 | - | ops/s | 1382.2 B/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.extractPreparedCommandMessage | 4 | thrpt | 6743832.19 | - | ops/s | 1359.3 B/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.handlePreparedAddCartItemRequestWaitSent | 1 | thrpt | 118693.32 | - | ops/s | 11346.1 B/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.handlePreparedAddCartItemRequestWaitSent | 4 | thrpt | 234418.11 | - | ops/s | 11223.6 B/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.sendWaitSentCoreFromExtractedMessage | 1 | thrpt | 1052901.94 | - | ops/s | 3535.8 B/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.sendWaitSentCoreFromExtractedMessage | 4 | thrpt | 1012879.97 | - | ops/s | 3541.8 B/op |
-| WebFlux Adapter | WebFluxResponseBenchmark.commandResultSseServerResponseOnly | 1 | thrpt | 1835774.35 | - | ops/s | 3408.4 B/op |
-| WebFlux Adapter | WebFluxResponseBenchmark.commandResultSseServerResponseOnly | 4 | thrpt | 7125659.23 | - | ops/s | 3290.0 B/op |
-| WebFlux Adapter | WebFluxResponseBenchmark.fluxJsonStreamingArrayServerResponseOnly | 1 | thrpt | 5198585.40 | - | ops/s | 1075.5 B/op |
-| WebFlux Adapter | WebFluxResponseBenchmark.fluxJsonStreamingArrayServerResponseOnly | 4 | thrpt | 19596863.45 | - | ops/s | 1067.4 B/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 1 | thrpt | 28.55 | - | k ops/s | 79.81 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 4 | thrpt | 110.84 | - | k ops/s | 78.07 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 1 | thrpt | 18.11 | - | k ops/s | 165.09 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 4 | thrpt | 47.37 | - | k ops/s | 162.48 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 1 | thrpt | 5.58 | - | k ops/s | 742.58 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 4 | thrpt | 19.65 | - | k ops/s | 737.23 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=1, traceWindowSize=10) | 1 | thrpt | 803.6 | - | k ops/s | 3.23 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=1, traceWindowSize=10) | 4 | thrpt | 2.34 | - | M ops/s | 3.19 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 1 | thrpt | 64.51 | - | k ops/s | 36.45 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 4 | thrpt | 260.45 | - | k ops/s | 35.85 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 1 | thrpt | 1.57 | - | k ops/s | 2.84 MiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 4 | thrpt | 5.26 | - | k ops/s | 2.82 MiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=1, traceWindowSize=10) | 1 | thrpt | 747.65 | - | k ops/s | 3.76 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=1, traceWindowSize=10) | 4 | thrpt | 1.91 | - | M ops/s | 3.72 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=10, traceWindowSize=10) | 1 | thrpt | 68.1 | - | k ops/s | 36.89 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=10, traceWindowSize=10) | 4 | thrpt | 216.52 | - | k ops/s | 36.38 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 1 | thrpt | 8.96 | - | k ops/s | 435.8 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 4 | thrpt | 34.35 | - | k ops/s | 434 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.commandResultJsonServerResponseOnly | 1 | thrpt | 831.41 | - | k ops/s | 4.39 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.commandResultJsonServerResponseOnly | 4 | thrpt | 2.26 | - | M ops/s | 4.36 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.extractPreparedCommandMessage | 1 | thrpt | 3.57 | - | M ops/s | 1.35 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.extractPreparedCommandMessage | 4 | thrpt | 6.74 | - | M ops/s | 1.33 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.handlePreparedAddCartItemRequestWaitSent | 1 | thrpt | 118.69 | - | k ops/s | 11.08 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.handlePreparedAddCartItemRequestWaitSent | 4 | thrpt | 234.42 | - | k ops/s | 10.96 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.sendWaitSentCoreFromExtractedMessage | 1 | thrpt | 1.05 | - | M ops/s | 3.45 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.sendWaitSentCoreFromExtractedMessage | 4 | thrpt | 1.01 | - | M ops/s | 3.46 KiB/op |
+| WebFlux Adapter | WebFluxResponseBenchmark.commandResultSseServerResponseOnly | 1 | thrpt | 1.84 | - | M ops/s | 3.33 KiB/op |
+| WebFlux Adapter | WebFluxResponseBenchmark.commandResultSseServerResponseOnly | 4 | thrpt | 7.13 | - | M ops/s | 3.21 KiB/op |
+| WebFlux Adapter | WebFluxResponseBenchmark.fluxJsonStreamingArrayServerResponseOnly | 1 | thrpt | 5.2 | - | M ops/s | 1.05 KiB/op |
+| WebFlux Adapter | WebFluxResponseBenchmark.fluxJsonStreamingArrayServerResponseOnly | 4 | thrpt | 19.6 | - | M ops/s | 1.04 KiB/op |


### PR DESCRIPTION
## Goal

Make benchmark reports easier for humans to scan without changing raw JMH measurements, sorting, comparisons, or regression decisions.

Completion criteria:
- large throughput and allocation values use compact, explicit units;
- latency and error values use consistent human-readable notation;
- generated Quick and Baseline reports reflect the new presentation;
- formatting behavior is covered by a fast verification task.

## Changes

- Add a shared metric display scale for decimal throughput prefixes (`k/M/G/T ops/s`), binary allocation prefixes (`KiB/MiB/GiB per op`), and adaptive latency units.
- Use `±` for JMH errors, retain small non-zero errors as `±<0.01`, and remove insignificant trailing zeroes.
- Apply the same display rules to detailed tables, bottleneck summaries, and `benchmarkCompare`; baseline/current comparison values share one scale.
- Wire `verifyBenchmarkReportFormatting` into `check` with representative throughput, latency, allocation, zero, null, and small-error cases.
- Document the unit conventions and regenerate the Baseline, Quick Framework E2E, Quick grouped, and Quick WebFlux reports from existing provenance-backed JMH results.

## Verification

- `./gradlew :wow-benchmarks:verifyBenchmarkReportFormatting --console=plain` — passed.
- `./gradlew :wow-benchmarks:generateBenchmarkReport :wow-benchmarks:generateQuickWebFluxBenchmarkReport :wow-benchmarks:generateQuickBenchmarkReport :wow-benchmarks:generateBaselineBenchmarkReport :wow-benchmarks:check :wow-benchmarks:benchmarkCompare --console=plain --stacktrace` — passed.
- `benchmarkCompare` reported 32 stable metric comparisons, 0 regressions, and 0 coverage changes.
- `git diff --check` — passed.

## Risks and Notes

This is a presentation-format change for generated Markdown and console comparison tables. Consumers that scrape the old unscaled numeric Markdown cells must migrate to the raw JMH JSON or account for the displayed unit prefix. Raw benchmark JSON, baseline JSON, thresholds, sorting, and regression calculations retain full precision.

The reports were regenerated from existing provenance-backed JMH artifacts; no long-running benchmark suite was rerun. Rollback is a single commit revert and does not affect production runtime behavior or persisted data.