### PR TITLE
fix(core): traverse domain events in a single pass

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStreamFactory.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStreamFactory.kt
@@ -16,11 +16,8 @@ package me.ahoo.wow.event
 import me.ahoo.wow.api.Version
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.event.DEFAULT_EVENT_SEQUENCE
-import me.ahoo.wow.api.event.DomainEvent
 import me.ahoo.wow.api.messaging.Header
-import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.api.modeling.OwnerId
-import me.ahoo.wow.api.modeling.SpaceId
 import me.ahoo.wow.api.modeling.SpaceIdCapable
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.messaging.DefaultHeader
@@ -94,16 +91,24 @@ fun Any.toDomainEventStream(
     val streamSpaceId = upstream.spaceId.ifBlank {
         stateSpaceId
     }
-    val events =
-        flatEvent().toDomainEvents(
-            streamVersion = streamVersion,
+    val commandId = upstream.commandId
+    val events = flatEvent().mapIndexedWithLast { index, event, isLast ->
+        val nonNullEvent = requireNotNull(event) {
+            "Domain event at index[$index] must not be null."
+        }
+        nonNullEvent.toDomainEvent(
+            id = generateGlobalId(),
+            version = streamVersion,
+            sequence = index + DEFAULT_EVENT_SEQUENCE,
+            isLast = isLast,
             aggregateId = aggregateId,
-            command = upstream,
             ownerId = streamOwnerId,
             spaceId = streamSpaceId,
-            eventStreamHeader = header,
+            commandId = commandId,
+            header = header.copy(),
             createTime = createTime,
         )
+    }
 
     return SimpleDomainEventStream(
         id = eventStreamId,
@@ -113,49 +118,22 @@ fun Any.toDomainEventStream(
     )
 }
 
-/**
- * Converts an iterable of event objects to a list of domain events.
- *
- * This internal function processes a collection of event objects, converting each
- * one to a DomainEvent with proper sequencing, versioning, and metadata. Events
- * are numbered sequentially starting from DEFAULT_EVENT_SEQUENCE.
- *
- * @param streamVersion The version number for the event stream
- * @param aggregateId The aggregate ID for all events
- * @param command The command that triggered these events
- * @param ownerId The owner ID for the events
- * @param eventStreamHeader The header to attach to each event
- * @param createTime The creation timestamp for all events
- * @return A list of domain events with proper sequencing
- *
- * @see DomainEvent
- * @see AggregateId
- * @see CommandMessage
- * @see DEFAULT_EVENT_SEQUENCE
- */
-private fun Iterable<*>.toDomainEvents(
-    streamVersion: Int,
-    aggregateId: AggregateId,
-    command: CommandMessage<*>,
-    ownerId: String,
-    spaceId: SpaceId,
-    eventStreamHeader: Header,
-    createTime: Long
-): List<DomainEvent<Any>> {
-    val eventCount = count()
-    return mapIndexed { index, event ->
-        val sequence = (index + DEFAULT_EVENT_SEQUENCE)
-        event!!.toDomainEvent(
-            id = generateGlobalId(),
-            version = streamVersion,
-            sequence = sequence,
-            isLast = sequence == eventCount,
-            aggregateId = aggregateId,
-            ownerId = ownerId,
-            spaceId = spaceId,
-            commandId = command.commandId,
-            header = eventStreamHeader.copy(),
-            createTime = createTime,
-        )
-    }.toList()
+private inline fun <T, R> Iterable<T>.mapIndexedWithLast(
+    transform: (index: Int, value: T, isLast: Boolean) -> R
+): List<R> {
+    val iterator = iterator()
+    val result = if (this is Collection<*>) ArrayList<R>(size) else ArrayList()
+    if (!iterator.hasNext()) {
+        return result
+    }
+
+    var index = 0
+    var value = iterator.next()
+    while (iterator.hasNext()) {
+        result += transform(index, value, false)
+        value = iterator.next()
+        index++
+    }
+    result += transform(index, value, true)
+    return result
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/event/DomainEventStreamFactoryTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/event/DomainEventStreamFactoryTest.kt
@@ -20,6 +20,7 @@ import me.ahoo.wow.modeling.aggregateId
 import me.ahoo.wow.modeling.toNamedAggregate
 import me.ahoo.wow.test.aggregate.GivenInitializationCommand
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class DomainEventStreamFactoryTest {
 
@@ -75,5 +76,59 @@ class DomainEventStreamFactoryTest {
 
         events[0].header["trace"] = "event-local"
         events[1].header["trace"].assert().isEqualTo("trace-1")
+        stream.header["trace"].assert().isEqualTo("trace-1")
+    }
+
+    @Test
+    fun `toDomainEventStream traverses one-shot iterable once`() {
+        val aggregateId = FIXTURE_NAMED_AGGREGATE.toNamedAggregate().aggregateId("one-shot-aggregate")
+        val upstream = GivenInitializationCommand(aggregateId = aggregateId)
+        val iterator = listOf(
+            FixtureNamedEvent("first"),
+            FixtureRevisedEvent("second"),
+        ).iterator()
+        var iteratorCalls = 0
+        val oneShotEvents = Iterable {
+            iteratorCalls++
+            check(iteratorCalls == 1) { "one-shot iterable was traversed more than once" }
+            iterator
+        }
+
+        val stream = oneShotEvents.toDomainEventStream(upstream = upstream)
+
+        iteratorCalls.assert().isOne()
+        stream.size.assert().isEqualTo(2)
+        stream.body[0].isLast.assert().isFalse()
+        stream.body[1].isLast.assert().isTrue()
+    }
+
+    @Test
+    fun `toDomainEventStream marks a single event as last and rejects an empty iterable`() {
+        val aggregateId = FIXTURE_NAMED_AGGREGATE.toNamedAggregate().aggregateId("event-count-boundary")
+        val upstream = GivenInitializationCommand(aggregateId = aggregateId)
+
+        val singleEventStream = listOf(FixtureNamedEvent("single"))
+            .toDomainEventStream(upstream = upstream)
+
+        singleEventStream.size.assert().isOne()
+        singleEventStream.body.single().sequence.assert().isEqualTo(DEFAULT_EVENT_SEQUENCE)
+        singleEventStream.body.single().isLast.assert().isTrue()
+
+        val error = assertThrows<IllegalArgumentException> {
+            emptyList<Any>().toDomainEventStream(upstream = upstream)
+        }
+        error.message.assert().isEqualTo("events can not be empty.")
+    }
+
+    @Test
+    fun `toDomainEventStream rejects null event with its index`() {
+        val aggregateId = FIXTURE_NAMED_AGGREGATE.toNamedAggregate().aggregateId("nullable-event-aggregate")
+        val upstream = GivenInitializationCommand(aggregateId = aggregateId)
+
+        val error = assertThrows<IllegalArgumentException> {
+            listOf<Any?>(FixtureNamedEvent("first"), null).toDomainEventStream(upstream = upstream)
+        }
+
+        error.message.assert().isEqualTo("Domain event at index[1] must not be null.")
     }
 }


### PR DESCRIPTION
## Goal
Ensure `DomainEventStreamFactory` correctly accepts every `Iterable` promised by `flatEvent()`, including one-shot and stateful iterables, without losing events or deriving an incorrect `isLast` marker.

## Changes
- Replace the `count()` plus `mapIndexed()` double traversal with a single-iterator look-ahead mapper.
- Preallocate the result list when the source is a `Collection`, while avoiding an intermediate materialized event list.
- Derive `isLast` from iterator state instead of a separately counted sequence.
- Replace the reachable `event!!` failure with an indexed `IllegalArgumentException` for null event values.
- Add regressions for one-shot traversal, multi-event and singleton `isLast`, empty-stream rejection, null diagnostics, and stream/event header isolation.

## Verification
- Red phase: `DomainEventStreamFactoryTest` failed because the one-shot iterable requested a second iterator and a null event produced `NullPointerException`.
- `./gradlew :wow-core:test --tests "me.ahoo.wow.event.DomainEventStreamFactoryTest" --rerun-tasks --no-daemon --console=plain` — 5 tests passed.
- `./gradlew :wow-core:check --rerun-tasks --no-daemon --console=plain` — BUILD SUCCESSFUL, 24 actionable tasks executed.
- `git diff --check` — passed.
- `javap -public -s me.ahoo.wow.event.DomainEventStreamFactoryKt` — existing public methods and default bridge descriptors are unchanged.

## Risks and Notes
- No public method, configuration, serialization, or data layout changes.
- Null elements were never valid domain events. Their failure changes from an unqualified `NullPointerException` to an indexed `IllegalArgumentException`.
- Event generation remains eager and preserves event order, sequence numbering, header copies, IDs, versions, ownership, space, command ID, and timestamps.