### PR TITLE
fix(spring): preserve dispatcher lifecycle state

### DIFF
--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/MessageDispatcherLauncher.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/MessageDispatcherLauncher.kt
@@ -16,28 +16,64 @@ package me.ahoo.wow.spring
 import me.ahoo.wow.messaging.dispatcher.MessageDispatcher
 import org.springframework.context.SmartLifecycle
 import java.time.Duration
-import java.util.concurrent.atomic.AtomicBoolean
 
 open class MessageDispatcherLauncher(
     private val messageDispatcher: MessageDispatcher,
     private val shutdownTimeout: Duration
 ) : SmartLifecycle {
-    private val running = AtomicBoolean(false)
+    private enum class LifecycleState {
+        STOPPED,
+        STARTING,
+        RUNNING,
+        STOP_REQUIRED
+    }
+
+    private val lifecycleMonitor = Any()
+
+    @Volatile
+    private var lifecycleState = LifecycleState.STOPPED
+
+    // MessageDispatcher does not expose a narrower recoverable failure type.
+    @Suppress("TooGenericExceptionCaught")
     override fun start() {
-        if (!running.compareAndSet(false, true)) {
-            return
+        synchronized(lifecycleMonitor) {
+            if (lifecycleState != LifecycleState.STOPPED) {
+                return
+            }
+            lifecycleState = LifecycleState.STARTING
+            try {
+                messageDispatcher.start()
+                lifecycleState = LifecycleState.RUNNING
+            } catch (startFailure: RuntimeException) {
+                lifecycleState = LifecycleState.STOP_REQUIRED
+                try {
+                    stopDispatcher()
+                } catch (cleanupFailure: RuntimeException) {
+                    if (cleanupFailure !== startFailure) {
+                        startFailure.addSuppressed(cleanupFailure)
+                    }
+                }
+                throw startFailure
+            }
         }
-        messageDispatcher.start()
     }
 
     override fun stop() {
-        if (!running.compareAndSet(true, false)) {
-            return
+        synchronized(lifecycleMonitor) {
+            if (lifecycleState == LifecycleState.STOPPED) {
+                return
+            }
+            lifecycleState = LifecycleState.STOP_REQUIRED
+            stopDispatcher()
         }
-        messageDispatcher.stop(shutdownTimeout)
     }
 
     override fun isRunning(): Boolean {
-        return running.get()
+        return lifecycleState != LifecycleState.STOPPED
+    }
+
+    private fun stopDispatcher() {
+        messageDispatcher.stop(shutdownTimeout)
+        lifecycleState = LifecycleState.STOPPED
     }
 }

--- a/wow-spring/src/test/kotlin/me/ahoo/wow/spring/MessageDispatcherLauncherTest.kt
+++ b/wow-spring/src/test/kotlin/me/ahoo/wow/spring/MessageDispatcherLauncherTest.kt
@@ -5,9 +5,13 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import me.ahoo.test.asserts.assert
+import me.ahoo.test.asserts.assertThrownBy
 import me.ahoo.wow.messaging.dispatcher.MessageDispatcher
 import org.junit.jupiter.api.Test
 import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 class MessageDispatcherLauncherTest {
 
@@ -31,5 +35,133 @@ class MessageDispatcherLauncherTest {
         }
         messageDispatcherLauncher.isRunning.assert().isFalse()
         confirmVerified(messageDispatcher)
+    }
+
+    @Test
+    fun `should allow start retry after dispatcher start fails`() {
+        val messageDispatcher = mockk<MessageDispatcher> {
+            every { start() } throws IllegalStateException("start failed") andThen Unit
+            every { stop(any()) } returns Unit
+        }
+        val launcher = MessageDispatcherLauncher(messageDispatcher, Duration.ofSeconds(60))
+
+        assertThrownBy<IllegalStateException> {
+            launcher.start()
+        }
+        launcher.isRunning.assert().isFalse()
+
+        launcher.start()
+
+        launcher.isRunning.assert().isTrue()
+        verify(exactly = 2) {
+            messageDispatcher.start()
+        }
+        verify(exactly = 1) {
+            messageDispatcher.stop(Duration.ofSeconds(60))
+        }
+        confirmVerified(messageDispatcher)
+    }
+
+    @Test
+    fun `should retain cleanup responsibility when start and cleanup fail`() {
+        val startFailure = IllegalStateException("start failed")
+        val cleanupFailure = IllegalStateException("cleanup failed")
+        val messageDispatcher = mockk<MessageDispatcher> {
+            every { start() } throws startFailure
+            every { stop(any()) } throws cleanupFailure andThen Unit
+        }
+        val launcher = MessageDispatcherLauncher(messageDispatcher, Duration.ofSeconds(60))
+
+        val thrown = runCatching {
+            launcher.start()
+        }.exceptionOrNull()!!
+
+        thrown.assert().isSameAs(startFailure)
+        thrown.suppressedExceptions.assert().containsExactly(cleanupFailure)
+        launcher.isRunning.assert().isTrue()
+
+        launcher.stop()
+
+        launcher.isRunning.assert().isFalse()
+        verify(exactly = 1) {
+            messageDispatcher.start()
+        }
+        verify(exactly = 2) {
+            messageDispatcher.stop(Duration.ofSeconds(60))
+        }
+        confirmVerified(messageDispatcher)
+    }
+
+    @Test
+    fun `should allow stop retry after dispatcher stop fails`() {
+        val messageDispatcher = mockk<MessageDispatcher> {
+            every { start() } returns Unit
+            every { stop(any()) } throws IllegalStateException("stop failed") andThen Unit
+        }
+        val launcher = MessageDispatcherLauncher(messageDispatcher, Duration.ofSeconds(60))
+        launcher.start()
+
+        assertThrownBy<IllegalStateException> {
+            launcher.stop()
+        }
+        launcher.isRunning.assert().isTrue()
+
+        launcher.stop()
+
+        launcher.isRunning.assert().isFalse()
+        verify(exactly = 1) {
+            messageDispatcher.start()
+        }
+        verify(exactly = 2) {
+            messageDispatcher.stop(Duration.ofSeconds(60))
+        }
+        confirmVerified(messageDispatcher)
+    }
+
+    @Test
+    fun `should serialize concurrent start and stop`() {
+        val startEntered = CountDownLatch(1)
+        val releaseStart = CountDownLatch(1)
+        val stopAttempted = CountDownLatch(1)
+        val stopEntered = CountDownLatch(1)
+        val messageDispatcher = mockk<MessageDispatcher> {
+            every { start() } answers {
+                startEntered.countDown()
+                check(releaseStart.await(5, TimeUnit.SECONDS))
+            }
+            every { stop(any()) } answers {
+                stopEntered.countDown()
+            }
+        }
+        val launcher = MessageDispatcherLauncher(messageDispatcher, Duration.ofSeconds(60))
+        val executor = Executors.newFixedThreadPool(2)
+
+        try {
+            val startFuture = executor.submit {
+                launcher.start()
+            }
+            check(startEntered.await(5, TimeUnit.SECONDS))
+            val stopFuture = executor.submit {
+                stopAttempted.countDown()
+                launcher.stop()
+            }
+
+            check(stopAttempted.await(5, TimeUnit.SECONDS))
+            stopEntered.await(200, TimeUnit.MILLISECONDS).assert().isFalse()
+            releaseStart.countDown()
+            startFuture.get(5, TimeUnit.SECONDS)
+            stopFuture.get(5, TimeUnit.SECONDS)
+
+            launcher.isRunning.assert().isFalse()
+            stopEntered.count.assert().isZero()
+            verify(exactly = 1) {
+                messageDispatcher.start()
+                messageDispatcher.stop(Duration.ofSeconds(60))
+            }
+            confirmVerified(messageDispatcher)
+        } finally {
+            releaseStart.countDown()
+            executor.shutdownNow()
+        }
     }
 }


### PR DESCRIPTION
## Goal
Prevent `MessageDispatcherLauncher` from publishing an incorrect lifecycle state when the underlying dispatcher fails to start or stop, and prevent concurrent lifecycle operations from crossing.

Completion criteria:
- a failed start remains retryable and does not report running;
- a failed stop remains retryable and continues to report running;
- start and stop execute serially per launcher.

## Changes
- Replace the optimistic `AtomicBoolean` transition with a single lifecycle monitor.
- Commit `running` only after the delegated start or stop succeeds.
- Keep `isRunning()` lock-free and visible through a volatile state field.
- Add regression tests for start failure, stop failure, retry behavior, and concurrent start/stop serialization.

## Verification
- Red test on the previous implementation: `./gradlew :wow-spring:test --tests "me.ahoo.wow.spring.MessageDispatcherLauncherTest" --rerun-tasks --no-daemon --console=plain` — 4 tests, 3 expected failures.
- Focused test after the fix: same command — 4/4 passed.
- `./gradlew :wow-spring:check --rerun-tasks --no-daemon --console=plain` — BUILD SUCCESSFUL.
- `git diff --check` — passed.
- `javap -classpath wow-spring/build/classes/kotlin/main -public -s me.ahoo.wow.spring.MessageDispatcherLauncher` — public constructor and `start`, `stop`, and `isRunning` descriptors unchanged.

## Risks and Notes
- No public API, configuration, serialization, or data-layout changes.
- Lifecycle calls for the same launcher are now serialized. A concurrent caller waits for the in-progress start or stop operation instead of invoking the dispatcher concurrently.
- Exceptions are still propagated unchanged; the launcher retains the last successfully committed state so callers can retry.
- Rollback is the single commit in this PR.