### PR TITLE
test(kafka): stabilize decode failure readiness

### DIFF
--- a/wow-kafka/src/integrationTest/kotlin/me/ahoo/wow/kafka/KafkaCommandBusTest.kt
+++ b/wow-kafka/src/integrationTest/kotlin/me/ahoo/wow/kafka/KafkaCommandBusTest.kt
@@ -230,30 +230,26 @@ internal class KafkaCommandBusTest : CommandBusSpec() {
         val bus = KafkaCommandBus(
             topicConverter = topicConverter,
             senderOptions = kafka.senderOptions(),
-            receiverOptions = kafka.receiverOptions(),
+            receiverOptions = kafka.receiverOptions()
+                .consumerProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
+                .consumerProperty(ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, false),
         )
         val rawSender = KafkaSender.create(kafka.senderOptions())
         val receiverGroup = generateGlobalId()
-        val ready = Sinks.empty<Void>()
 
         try {
-            bus.receive(MessageSubscription(namedAggregate, receiverGroup))
-                .contextWrite {
-                    it.writeReceiverOptionsCustomizer { options ->
-                        options.subscription(setOf(record.topic()))
-                            .addAssignListener {
-                                ready.tryEmitEmpty()
+            // Create the random topic before subscribing so readiness does not depend on consumer auto-creation.
+            rawSender.createOutbound()
+                .send(Mono.just(record))
+                .then()
+                .thenMany(
+                    bus.receive(MessageSubscription(namedAggregate, receiverGroup))
+                        .contextWrite {
+                            it.writeReceiverOptionsCustomizer { options ->
+                                options.subscription(setOf(record.topic()))
                             }
-                    }
-                }
-                .doOnSubscribe {
-                    ready.asMono()
-                        .then(
-                            rawSender.createOutbound()
-                                .send(Mono.just(record))
-                                .then(),
-                        ).subscribe()
-                }
+                        }
+                )
                 .test()
                 .expectErrorSatisfies {
                     it.assert().isInstanceOf(KafkaRecordDecodeException::class.java)


### PR DESCRIPTION
## Goal
Make the Kafka command-bus decode-failure integration tests deterministic.

PR #2803 exposed the same shared helper timing out in two consecutive Integration Test attempts, each on a different decode-failure case. The helper subscribed to a random, initially absent topic and waited for partition assignment before producing the record. Assignment therefore depended on consumer-side topic auto-creation and could stall for the full two-minute verifier timeout.

Completion criteria:
- topic existence no longer depends on consumer assignment;
- all decode-failure cases still exercise the production Kafka receive and decode path;
- no production implementation changes.

## Changes
- Produce the invalid record before subscribing, which creates the random test topic deterministically.
- Configure the consumer with `auto.offset.reset=earliest` so it reads the pre-existing record.
- Disable consumer topic auto-creation to prevent the old readiness dependency from returning.
- Remove the assignment-listener sink and nested fire-and-forget subscription from the shared test helper.

## Verification
- CI failure evidence on the previous helper:
  - Integration Test attempt 1: `should fail closed without exposing an undecodable payload` timed out in `assertDecodeFailure`.
  - Integration Test attempt 2: `should reject a record whose topic does not match the decoded aggregate` timed out in the same helper.
  - Run: https://github.com/Ahoo-Wang/Wow/actions/runs/29922747058
- `./gradlew :wow-kafka:compileIntegrationTestKotlin --rerun-tasks --no-daemon --no-parallel --console=plain` — passed.
- `./gradlew :wow-kafka:check --rerun-tasks --no-daemon --no-parallel --console=plain` — BUILD SUCCESSFUL.
- `git diff --check` — passed.
- Local `:wow-kafka:integrationTest` could not enter the test body because Testcontainers could not connect to a Docker environment. The GitHub Actions Integration Test is the required real-Kafka verification.
- `detektIntegrationTest` currently fails on 13 pre-existing baseline findings across integration tests; none point to the new lines, so unrelated cleanup is intentionally excluded.

## Risks and Notes
- Test-only change; no public API, runtime, configuration, serialization, or data-layout impact.
- The producer still relies on the test broker allowing producer-side auto topic creation, which is already required by the existing test fixture and other Kafka integration tests.
- Rollback is the single commit in this PR.