### PR TITLE
perf(command): replace ingress lock with atomic MPSC sink

### DIFF
--- a/wow-benchmarks/results/reports/command-ingress-mpsc-confirmation.md
+++ b/wow-benchmarks/results/reports/command-ingress-mpsc-confirmation.md
@@ -15,17 +15,17 @@
 - `current-production`：当前默认 `InMemoryCommandBus`，使用 `MpscUnicastManySink`；
 - `legacy-lock`：显式注入旧版 unsafe unicast sink，并用 `ConcurrentManySink` 包装。
 
-四线程结果从 `163,681.38 ± 5,061.44 ops/s` 提升到
-`201,068.01 ± 6,588.78 ops/s`，点估计提升 **22.84%**。两组 JMH error
-区间不重叠，且规范化分配量只增加 **9.28 B/op（0.24%）**。
+四线程结果从 `161,912.38 ± 2,576.38 ops/s` 提升到
+`200,570.23 ± 2,724.71 ops/s`，点估计提升 **23.88%**。两组 JMH error
+区间不重叠，且规范化分配量只增加 **8.84 B/op（0.23%）**。
 
 clean run 达到以下预设阈值：
 
 | 验收项 | 标准 | 结果 | 判定 |
 |---|---:|---:|---|
-| 四线程吞吐量 | 提升至少 10% | +22.84% | PASS |
-| 测量区分度 | JMH error 区间不重叠 | `[194,479.23, 207,656.79]` vs `[158,619.94, 168,742.82]` | PASS |
-| 分配回归 | 不超过 1% | +0.24% | PASS |
+| 四线程吞吐量 | 提升至少 10% | +23.88% | PASS |
+| 测量区分度 | JMH error 区间不重叠 | `[197,845.52, 203,294.94]` vs `[159,336.00, 164,488.76]` | PASS |
+| 分配回归 | 不超过 1% | +0.23% | PASS |
 | 正确性 | 相关 test/check 全部通过 | 后续章节记录 | PASS |
 
 ## 优化范围
@@ -38,6 +38,8 @@ clean run 达到以下预设阈值：
 3. terminal/cancellation claim 后立即拒绝新值；物理控制信号等待已 admission 的 `onNext` 返回，并在所有已委派路径返回后才完成 close settlement；
 4. 用 opaque `Flux`/`Subscription` 隐藏 factory-owned queue，阻止下游直接 fusion 或暴露 raw sink；
 5. 保留自定义 sink 的兼容行为：非 MPSC sink 仍由 `ConcurrentManySink` 包装。
+6. close 期间不再暴露待结算 sink 的旧 subscriber；普通 sink 的 terminal callback 抛错时，
+   仅在 `Scannable` 已确认终止或取消后移除，保留未接受 terminal 的重试能力。
 
 ### Reactor Sink 语义兼容
 
@@ -96,9 +98,9 @@ Scheduler；`publishOn` 继续承担调用线程隔离。
 | 项 | 值 |
 |---|---|
 | Project version | `8.9.1` |
-| Source commit | `597356669e65f2dd8f7ea3ebc5b4df39075e6335` |
+| Source commit | `060a2ea297cda413d87da673375a450ce9eaada5` |
 | Source dirty | `false` |
-| JMH JAR SHA-256 | `893594fe72368432bfcd6f96826b384205221a2a50884c9c3c81f53238993dc9` |
+| JMH JAR SHA-256 | `30cb80352ed56f959179629274b8e928ef0056d6c9c285c4f2ee40b6248b84f2` |
 | JVM | OpenJDK 17.0.7+7-LTS |
 | OS | Mac OS X 26.5.2 aarch64 |
 | CPU | 14 available processors |
@@ -110,7 +112,7 @@ Scheduler；`publishOn` 继续承担调用线程隔离。
 | JVM args | `-Xmx4g -Xms4g -XX:+UseG1GC -XX:+AlwaysPreTouch` 及 profiling 辅助参数 |
 | Profiler | `gc` |
 
-同一个 run ID `2e4e599e-a1e9-4b35-97ff-d9661d67974e` 依次运行 t1 和 t4。
+同一个 run ID `8d49668d-386d-414b-a68e-89f8fa49ac46` 依次运行 t1 和 t4。
 
 ## 配对 A/B 结果
 
@@ -118,37 +120,37 @@ Scheduler；`publishOn` 继续承担调用线程隔离。
 
 | Threads | Strategy | Score | JMH Error | Error interval |
 |---:|---|---:|---:|---:|
-| 1 | `current-production` | 93,714.58 ops/s | ±5,209.91 | `[88,504.67, 98,924.48]` |
-| 1 | `legacy-lock` | 93,595.39 ops/s | ±6,267.48 | `[87,327.91, 99,862.87]` |
-| 4 | `current-production` | **201,068.01 ops/s** | ±6,588.78 | `[194,479.23, 207,656.79]` |
-| 4 | `legacy-lock` | 163,681.38 ops/s | ±5,061.44 | `[158,619.94, 168,742.82]` |
+| 1 | `current-production` | 94,194.12 ops/s | ±1,237.31 | `[92,956.82, 95,431.43]` |
+| 1 | `legacy-lock` | 93,788.72 ops/s | ±1,634.11 | `[92,154.61, 95,422.84]` |
+| 4 | `current-production` | **200,570.23 ops/s** | ±2,724.71 | `[197,845.52, 203,294.94]` |
+| 4 | `legacy-lock` | 161,912.38 ops/s | ±2,576.38 | `[159,336.00, 164,488.76]` |
 
-- t1 点估计为 `+0.13%`，error 区间重叠，单线程吞吐没有可区分变化；
-- t4 点估计为 **+22.84%**，且 error 区间不重叠，是本轮主要收益证据；
-- `current-production` 的 t4/t1 扩展比为 `2.15×`，`legacy-lock` 为 `1.75×`。
+- t1 点估计为 `+0.43%`，error 区间重叠，单线程吞吐没有可区分变化；
+- t4 点估计为 **+23.88%**，且 error 区间不重叠，是本轮主要收益证据；
+- `current-production` 的 t4/t1 扩展比为 `2.13×`，`legacy-lock` 为 `1.73×`。
 
 ### Allocation
 
 | Threads | Strategy | `gc.alloc.rate.norm` | JMH Error |
 |---:|---|---:|---:|
-| 1 | `current-production` | 3,937.40 B/op | ±0.77 |
-| 1 | `legacy-lock` | 3,913.40 B/op | ±0.81 |
-| 4 | `current-production` | 3,928.27 B/op | ±0.34 |
-| 4 | `legacy-lock` | 3,919.00 B/op | ±0.41 |
+| 1 | `current-production` | 3,937.38 B/op | ±0.26 |
+| 1 | `legacy-lock` | 3,913.37 B/op | ±0.37 |
+| 4 | `current-production` | 3,928.22 B/op | ±0.39 |
+| 4 | `legacy-lock` | 3,919.38 B/op | ±0.51 |
 
-t4 每条命令增加 `9.28 B/op`，即 `0.24%`；验收使用与主要吞吐结论相同的 t4 数据。
+t4 每条命令增加 `8.84 B/op`，即 `0.23%`；验收使用与主要吞吐结论相同的 t4 数据。
 
 ### 原始证据
 
 | Threads | Result SHA-256 | Manifest SHA-256 |
 |---:|---|---|
-| 1 | `05da1870bd3f82b1850d7e1bf2e8947386e50dd4d054499663573d2631b2af90` | `1dd37b68c1d3bc571a1b6d7de5fb608b7978715e6911e33aff30e4486fdfdb14` |
-| 4 | `4da089386f3d9cb39b4f1b07655ac37d9dd548a785f9bda94b9d759ba54477d5` | `a0a43ae38a3e1fb2a59c3db20a065bfec7f17ce1f3e21b27d39b91bb930096c5` |
+| 1 | `df9047ae1ad6533f2d4cd327a6526ab5197199068ecb7dbf8c9734835aea0531` | `7a180d1d2f3f169807b57375fdf7d2489a7f1155f3af215c0594d94a0bd4be09` |
+| 4 | `0c8784b7b248c1dd79898eaccc45a531915bce7aaeee64b7b5078642a592bc5f` | `6a858cbd267d5ecaec5b93dda17a9e095d35de71734f7351abb172c8508572ed` |
 
 本地原始文件位于：
 
 ```text
-wow-benchmarks/results/jmh/confirmation/command-ingress-e2e-clean-final/
+wow-benchmarks/results/jmh/confirmation/framework-e2e/
 ```
 
 该目录按仓库规则被 `.gitignore` 排除；上表 hash 用于确认报告对应的原始 JSON 和
@@ -253,10 +255,10 @@ wow-benchmarks/results/jmh/confirmation/scheduler-pool-simulated-io-e2e/
 
 | Suite | Tests | Failures |
 |---|---:|---:|
-| `wow-core:test` | 804 | 0 |
+| `wow-core:test` | 808 | 0 |
 | `wow-core:contractTest` | 128 | 0 |
 | `wow-benchmarks:test` | 13 | 0 |
-| Total | 945 | 0 |
+| Total | 949 | 0 |
 
 `wow-core:detekt`、核心单测/契约测试、benchmark check、JMH compilation 和
 `git diff --check` 同时通过。
@@ -268,6 +270,8 @@ wow-benchmarks/results/jmh/confirmation/scheduler-pool-simulated-io-e2e/
 - active `onNext` 与 terminal、cancel、close 的竞态；
 - terminal/cancel 物理委派返回、双控制路径 settlement 与 close CAS 线性化；
 - exceptional close settlement 后移除终止 sink 并允许同 aggregate 重建；
+- async close 期间隐藏旧 subscriber，避免 `LocalFirstMessageBus` 错误标记消息已本地处理；
+- 普通 Reactor sink 的 terminal callback 抛错后移除已终止实例，未接受 terminal 时保留重试；
 - late subscriber、第二订阅者、overflow、drop/discard 和 retry handler；
 - Reactor native/custom 差分语义、callback failure cancellation 和 Flux scan；
 - terminal claim/delegation 位状态不变量；

--- a/wow-benchmarks/results/reports/command-ingress-mpsc-confirmation.md
+++ b/wow-benchmarks/results/reports/command-ingress-mpsc-confirmation.md
@@ -1,0 +1,357 @@
+# Command Ingress MPSC 优化基准确认报告
+
+## 摘要
+
+> Evidence status: **CONFIRMED_CLEAN**（command ingress 配对 A/B）。t1/t4 manifest
+> 记录了 `source.dirty=false`、同一 commit、同一 JMH JAR SHA-256 和同一 run ID。
+> Scheduler pool 与 simulated-I/O 章节来自更早的诊断运行，只用于解释默认配置为何不变，
+> 不承担 command ingress 收益验收。
+
+本报告验证 `InMemoryCommandBus` 将命令入口从 `ConcurrentManySink` 的
+`ReentrantLock` 串行化切换为原子 MPSC admission 后的吞吐量收益。
+
+本轮 clean confirmation 使用同一个 JMH JAR 内的配对 A/B：
+
+- `current-production`：当前默认 `InMemoryCommandBus`，使用 `MpscUnicastManySink`；
+- `legacy-lock`：显式注入旧版 unsafe unicast sink，并用 `ConcurrentManySink` 包装。
+
+四线程结果从 `163,681.38 ± 5,061.44 ops/s` 提升到
+`201,068.01 ± 6,588.78 ops/s`，点估计提升 **22.84%**。两组 JMH error
+区间不重叠，且规范化分配量只增加 **9.28 B/op（0.24%）**。
+
+clean run 达到以下预设阈值：
+
+| 验收项 | 标准 | 结果 | 判定 |
+|---|---:|---:|---|
+| 四线程吞吐量 | 提升至少 10% | +22.84% | PASS |
+| 测量区分度 | JMH error 区间不重叠 | `[194,479.23, 207,656.79]` vs `[158,619.94, 168,742.82]` | PASS |
+| 分配回归 | 不超过 1% | +0.24% | PASS |
+| 正确性 | 相关 test/check 全部通过 | 后续章节记录 | PASS |
+
+## 优化范围
+
+旧实现会在 `ConcurrentManySink.tryEmitNext` 外层持有 `ReentrantLock`，多调用线程向
+同一个本地命令总线发送命令时形成入口锁竞争。优化后的 MPSC sink：
+
+1. 使用 Reactor `Queues.unboundedMultiproducer` 接收多生产者 offer；
+2. 使用一个 `AtomicLong` 管理 active admission，以及 terminal/cancellation 的 claim、delegation、settlement 与 close 线性化；
+3. terminal/cancellation claim 后立即拒绝新值；物理控制信号等待已 admission 的 `onNext` 返回，并在所有已委派路径返回后才完成 close settlement；
+4. 用 opaque `Flux`/`Subscription` 隐藏 factory-owned queue，阻止下游直接 fusion 或暴露 raw sink；
+5. 保留自定义 sink 的兼容行为：非 MPSC sink 仍由 `ConcurrentManySink` 包装。
+
+### Reactor Sink 语义兼容
+
+仓库和 Reactor API 中都不存在 `Skink` 类型；本轮将该要求解释为 Reactor
+`Sinks.Many` 语义兼容。项目解析到的精确版本为 `reactor-core:3.8.6`，审计依据是对应
+sources JAR 中的 `Sinks`、`InternalManySink` 与 `SinkManyUnicast` 实现，并使用同一个
+MPSC queue 分别构造原生 unicast sink 与 Wow sink 做差分测试。
+
+差分测试覆盖：
+
+- 订阅前 warmup buffer、按 demand 排空以及 buffer 后延迟 terminal；
+- 单订阅限制、late subscriber 与 terminal 后立即 cancel；
+- `tryEmit*` 的 `FAIL_CANCELLED`/`FAIL_TERMINATED`，以及 `emit*` 的 drop/discard；
+- error replay、callback 异常触发的取消，以及两个已 admission producer 的竞态；
+- `ACTUAL`、`inners()`、`BUFFERED`、`CAPACITY`、`PREFETCH`、`CANCELLED`、
+  `TERMINATED`、`ERROR` 和 `asFlux()` 视图扫描。
+
+审计中实际复现并修复了四类差异：close settled 后的 late cancel 未传到 raw
+subscription、`ACTUAL/inners()` 暴露内部 subscriber、逻辑取消到物理 cancel 之间仍可能
+向下游传值、`asFlux()` 未转发安全 `Scannable` 属性。最终差分套件 `16/16` 通过。
+
+fusion、`Fuseable.QueueSubscription`、实现类身份和默认 `stepName` 有意不与
+`SinkManyUnicast` 对齐：`OpaqueFlux`/`OpaqueSubscription` 必须阻止外部取得并直接
+`poll` factory-owned MPSC queue；这些不属于 `Sinks.Many` 的公开信号契约。
+
+生产命令调度仍保留：
+
+```text
+groupBy(hash % parallelism)
+  -> flatMap(concurrency = parallelism)
+  -> publishOn(aggregateScheduler)
+  -> concatMap(handleExchange)
+```
+
+本轮没有将生产默认改为 `Schedulers.immediate()`，也没有共享所有聚合类型的
+Scheduler；`publishOn` 继续承担调用线程隔离。
+
+## 基准方法
+
+### 配对 A/B 场景
+
+`CommandIngressE2EDiagnosticBenchmark.sendAndWaitProcessed` 使用真实的：
+
+- `CommandGateway.sendAndWaitForProcessed`；
+- `InMemoryCommandBus`；
+- `CommandDispatcher` 和 `groupBy -> publishOn -> concatMap`；
+- aggregate processor、domain/state event bus 和 processed notifier。
+
+为了放大框架入口开销并避免 I/O 混淆，场景使用 `NoopEventStore`、
+`NoOpValidator` 和 `NoOpIdempotencyChecker`。每次 invocation 创建新的 aggregate ID，
+并在调用线程上等待 `PROCESSED` 结果。`@State(Scope.Benchmark)` 让所有 JMH 线程共享
+同一个 dispatcher 和 command bus，因此 t4 能直接测量多生产者入口竞争。
+
+### JMH 配置
+
+| 项 | 值 |
+|---|---|
+| Project version | `8.9.1` |
+| Source commit | `597356669e65f2dd8f7ea3ebc5b4df39075e6335` |
+| Source dirty | `false` |
+| JMH JAR SHA-256 | `893594fe72368432bfcd6f96826b384205221a2a50884c9c3c81f53238993dc9` |
+| JVM | OpenJDK 17.0.7+7-LTS |
+| OS | Mac OS X 26.5.2 aarch64 |
+| CPU | 14 available processors |
+| Memory | 24 GiB |
+| Warmup | `2 × 3s` |
+| Measurement | `3 × 5s` |
+| Forks | 2 |
+| Mode | `thrpt` |
+| JVM args | `-Xmx4g -Xms4g -XX:+UseG1GC -XX:+AlwaysPreTouch` 及 profiling 辅助参数 |
+| Profiler | `gc` |
+
+同一个 run ID `2e4e599e-a1e9-4b35-97ff-d9661d67974e` 依次运行 t1 和 t4。
+
+## 配对 A/B 结果
+
+### Throughput
+
+| Threads | Strategy | Score | JMH Error | Error interval |
+|---:|---|---:|---:|---:|
+| 1 | `current-production` | 93,714.58 ops/s | ±5,209.91 | `[88,504.67, 98,924.48]` |
+| 1 | `legacy-lock` | 93,595.39 ops/s | ±6,267.48 | `[87,327.91, 99,862.87]` |
+| 4 | `current-production` | **201,068.01 ops/s** | ±6,588.78 | `[194,479.23, 207,656.79]` |
+| 4 | `legacy-lock` | 163,681.38 ops/s | ±5,061.44 | `[158,619.94, 168,742.82]` |
+
+- t1 点估计为 `+0.13%`，error 区间重叠，单线程吞吐没有可区分变化；
+- t4 点估计为 **+22.84%**，且 error 区间不重叠，是本轮主要收益证据；
+- `current-production` 的 t4/t1 扩展比为 `2.15×`，`legacy-lock` 为 `1.75×`。
+
+### Allocation
+
+| Threads | Strategy | `gc.alloc.rate.norm` | JMH Error |
+|---:|---|---:|---:|
+| 1 | `current-production` | 3,937.40 B/op | ±0.77 |
+| 1 | `legacy-lock` | 3,913.40 B/op | ±0.81 |
+| 4 | `current-production` | 3,928.27 B/op | ±0.34 |
+| 4 | `legacy-lock` | 3,919.00 B/op | ±0.41 |
+
+t4 每条命令增加 `9.28 B/op`，即 `0.24%`；验收使用与主要吞吐结论相同的 t4 数据。
+
+### 原始证据
+
+| Threads | Result SHA-256 | Manifest SHA-256 |
+|---:|---|---|
+| 1 | `05da1870bd3f82b1850d7e1bf2e8947386e50dd4d054499663573d2631b2af90` | `1dd37b68c1d3bc571a1b6d7de5fb608b7978715e6911e33aff30e4486fdfdb14` |
+| 4 | `4da089386f3d9cb39b4f1b07655ac37d9dd548a785f9bda94b9d759ba54477d5` | `a0a43ae38a3e1fb2a59c3db20a065bfec7f17ce1f3e21b27d39b91bb930096c5` |
+
+本地原始文件位于：
+
+```text
+wow-benchmarks/results/jmh/confirmation/command-ingress-e2e-clean-final/
+```
+
+该目录按仓库规则被 `.gitignore` 排除；上表 hash 用于确认报告对应的原始 JSON 和
+SUCCESS manifest。manifest 记录的 clean source commit 和 JMH JAR hash 可由复现命令验证。
+
+## 历史生产基准复跑
+
+原有 `CommandWriteE2EBenchmark.sendAndWaitProcessed` 曾在生产默认
+`scenario=ceiling;schedulerStrategy=PARALLEL` 下复跑成功：
+
+| Threads | Throughput | Allocation |
+|---:|---:|---:|
+| 1 | 91,632.93 ± 1,149.23 ops/s | 3,937.47 ± 0.51 B/op |
+| 4 | 185,408.07 ± 26,230.25 ops/s | 3,928.55 ± 1.00 B/op |
+
+该历史 dirty 复跑验证默认生产路径可执行且结果量级与配对 benchmark 一致；由于它早于
+最终状态机修复、且没有在同一个 JAR 中包含旧实现，不承担最终正确性或收益因果归因，
+收益确认仍以本报告最新配对 A/B 为准。
+
+原始 result SHA-256：
+
+- t1：`34b9688665f77658dc655d92d4c4e9a9dcaf1a4bc25b5ef372bcb68cbd135f80`
+- t4：`956a34b51c1308e8c46dea683d2e48b1a899086e4e412117fe9318428bbc1478`
+
+## Scheduler Pool 评估
+
+### Ceiling 场景扫描
+
+为了区分入口锁优化与 Scheduler 配置，保持 `current-production` MPSC、16 个 JMH
+调用线程和同一命令链，只改变每个 aggregate Scheduler 的 pool size：
+
+| Pool size | Throughput | JMH Error | Relative to CPU=14 |
+|---:|---:|---:|---:|
+| 1 | 206,563.93 ops/s | ±33,566.72 | -7.91% |
+| 2 | 258,860.44 ops/s | ±59,646.81 | +15.41% |
+| 4 | **315,041.62 ops/s** | ±54,909.81 | **+40.45%** |
+| CPU=14 | 224,303.57 ops/s | ±7,230.12 | baseline |
+
+pool size 4 的区间 `[260,131.81, 369,951.43]` 与 CPU=14 的
+`[217,073.45, 231,533.69]` 不重叠。不过该结论仅适用于 16 个 closed-loop 调用线程、
+Noop store 和短 CPU 路径；真实 Mongo/Redis I/O、CPU-heavy command function、热点分布、
+连接池限制以及多 aggregate 类型尚未覆盖，因此本轮没有修改生产 Scheduler 默认值。
+
+Scheduler sweep run ID：`e2d5dfa7-b1a5-458f-ae32-b4cf469a128a`，result SHA-256：
+`9ab9a5f9def8397b2af22e2ca24c8e9a689233007e055f4f2a5bfdb7be41f4c4`。
+
+### 可控模拟 I/O 矩阵
+
+为了验证 ceiling 结论是否会随 I/O 延迟变化，`SimulatedIoCommandWriteBenchmark`
+新增 `schedulerPoolSize` 参数，使用 `PARALLEL` 策略和 16 个 closed-loop JMH 调用线程，
+配对比较 pool size 4 与本机 CPU=14。历史 `0` 行实际使用直接 `InMemoryEventStore`，非零行
+使用通过 `delaySubscription` 增加异步 timer handoff 的 `DelayEventStore`；因此 `0` 行只能作为
+direct ceiling，不能与非零行组成拓扑完全一致的延迟曲线。
+
+| I/O delay | Pool 4 throughput | CPU=14 throughput | Relative | Error interval overlap | Pool 4 allocation delta |
+|---:|---:|---:|---:|---:|---:|
+| `direct`（历史参数 `0`） | 285,487.87 ± 10,252.47 ops/s | 208,519.11 ± 7,811.06 ops/s | **+36.91%** | No | +10.57 B/op (+0.23%) |
+| `20us` | 132,016.24 ± 5,675.27 ops/s | 104,171.01 ± 1,649.26 ops/s | **+26.73%** | No | +32.45 B/op (+0.45%) |
+| `100us` | 81,240.10 ± 575.98 ops/s | 79,395.92 ± 456.04 ops/s | +2.32% | No | -17.67 B/op (-0.24%) |
+| `500us` | 18,196.00 ± 382.72 ops/s | 18,164.05 ± 384.93 ops/s | +0.18% | **Yes** | +32.65 B/op (+0.43%) |
+
+关键区间：
+
+- `direct`：pool 4 `[275,235.41, 295,740.34]`，CPU=14 `[200,708.05, 216,330.18]`；
+- `20us`：pool 4 `[126,340.97, 137,691.51]`，CPU=14 `[102,521.75, 105,820.26]`；
+- `100us`：pool 4 `[80,664.12, 81,816.08]`，CPU=14 `[78,939.88, 79,851.96]`；
+- `500us`：pool 4 `[17,813.29, 18,578.72]`，CPU=14 `[17,779.11, 18,548.98]`。
+
+矩阵说明 Scheduler pool 的影响有明确边界：direct ceiling 与 `20us` 异步链路中，14 个 rail
+的调度与队列协调成本高于 4 个 rail；在相同 DelayEventStore 拓扑内，当每次 EventStore
+operation 的配置延迟增加到 `500us`
+时，pool size 差异无法区分，结果与 I/O 成本开始主导一致。因此，**不把生产默认从 CPU 改为
+4** 是当前证据下更合理的选择：固定为 4 会过拟合这台 14 核机器上的短链路，
+尚未验证 CPU-heavy command、真实 Mongo/Redis、多 aggregate 类型竞争与生产延迟分布。
+
+本次矩阵 run ID：`52d83882-e413-414c-acdf-9b3c1426c189`。
+
+| Artifact | SHA-256 |
+|---|---|
+| JMH JAR | `c6f7315de84263382c4a4bc0c04f501ec658fbc34d7e331885aaaa415d35648e` |
+| Result JSON | `a65f5bc545e2199bb177d75da97005ec61455c3d2c4992f8715d1eed34bc810e` |
+| Human output | `ac6d0a68eb4f94a1ef5ff5a8ea41cbfd80e9a9b6be09b6c910c447ff287fe2e0` |
+| SUCCESS manifest | `ba6cdcdc791cca023f488d01b6cdb9765f8d47b3569d71ae5b1cb5f23d5ff68b` |
+
+原始文件保存在被 `.gitignore` 排除的：
+
+```text
+wow-benchmarks/results/jmh/confirmation/scheduler-pool-simulated-io-e2e/
+```
+
+## 正确性验证
+
+实现与回归过程中新增并发、terminal、取消和 Reactor 差分语义测试；最终树运行：
+
+```bash
+./gradlew :wow-core:detekt :wow-core:test :wow-core:contractTest \
+  :wow-benchmarks:check :wow-benchmarks:jmhJar \
+  --no-parallel --console=plain
+```
+
+结果：
+
+| Suite | Tests | Failures |
+|---|---:|---:|
+| `wow-core:test` | 804 | 0 |
+| `wow-core:contractTest` | 128 | 0 |
+| `wow-benchmarks:test` | 13 | 0 |
+| Total | 945 | 0 |
+
+`wow-core:detekt`、核心单测/契约测试、benchmark check、JMH compilation 和
+`git diff --check` 同时通过。
+
+专项测试覆盖：
+
+- 四生产者 exactly-once 与每生产者内部顺序；
+- complete/error 竞争只允许一个 winner；
+- active `onNext` 与 terminal、cancel、close 的竞态；
+- terminal/cancel 物理委派返回、双控制路径 settlement 与 close CAS 线性化；
+- exceptional close settlement 后移除终止 sink 并允许同 aggregate 重建；
+- late subscriber、第二订阅者、overflow、drop/discard 和 retry handler；
+- Reactor native/custom 差分语义、callback failure cancellation 和 Flux scan；
+- terminal claim/delegation 位状态不变量；
+- 自定义 sink 继续使用 `ConcurrentManySink`。
+
+## 复现命令
+
+### 入口配对 A/B
+
+```bash
+./gradlew :wow-benchmarks:benchmarkConfirmE2E \
+  -PbenchmarkConfirmE2EThreads=1,4 \
+  '-PbenchmarkConfirmE2EIncludes=me.ahoo.wow.benchmark.e2e.CommandIngressE2EDiagnosticBenchmark.sendAndWaitProcessed' \
+  '-PbenchmarkConfirmE2EParameters=ingressStrategy=current-production,legacy-lock;schedulerPoolSize=cpu' \
+  --no-parallel --console=plain
+```
+
+### Scheduler pool 扫描
+
+```bash
+./gradlew :wow-benchmarks:benchmarkConfirmE2E \
+  -PbenchmarkConfirmE2EThreads=16 \
+  '-PbenchmarkConfirmE2EIncludes=me.ahoo.wow.benchmark.e2e.CommandIngressE2EDiagnosticBenchmark.sendAndWaitProcessed' \
+  '-PbenchmarkConfirmE2EParameters=ingressStrategy=current-production;schedulerPoolSize=1,2,4,cpu' \
+  --no-parallel --console=plain
+```
+
+### 生产默认基准
+
+```bash
+./gradlew :wow-benchmarks:benchmarkConfirmE2E \
+  -PbenchmarkConfirmE2EThreads=1,4 \
+  '-PbenchmarkConfirmE2EIncludes=me.ahoo.wow.benchmark.e2e.CommandWriteE2EBenchmark.sendAndWaitProcessed' \
+  '-PbenchmarkConfirmE2EParameters=scenario=ceiling;schedulerStrategy=PARALLEL' \
+  --no-parallel --console=plain
+```
+
+### Scheduler pool 模拟 I/O 矩阵
+
+```bash
+./gradlew :wow-benchmarks:benchmarkConfirmE2E \
+  -PbenchmarkConfirmE2EThreads=16 \
+  '-PbenchmarkConfirmE2EIncludes=me.ahoo.wow.benchmark.e2e.SimulatedIoCommandWriteBenchmark.sendAndWaitProcessed' \
+  '-PbenchmarkConfirmE2EParameters=ioDelay=direct,async-0,20us,100us,500us;schedulerStrategy=PARALLEL;schedulerPoolSize=4,cpu' \
+  --no-parallel --console=plain
+```
+
+clean rerun 的前置条件是 `git status --porcelain` 为空、实现位于可追溯 commit，
+且 t1/t4 manifest 的 commit 与 JMH JAR SHA-256 完全一致。本轮 confirmation 已满足这些
+条件。以上命令会使用同一个
+`framework-e2e` 输出文件名，必须严格串行运行，并在下一组运行前保存 JSON、human output
+和 SUCCESS manifest。当前 Gradle task 会在 JMH 取得全局锁前清理目标文件，不能并发执行
+同一 suite/profile/thread 组合。
+
+## 适用边界与后续工作
+
+1. 收益适用于通过本地 `InMemoryCommandBus` 进入 dispatcher 的并发命令；远程 transport
+   或 I/O 主导路径的相对收益可能更低。
+2. MPSC 仍使用 unbounded queue，与旧实现的 backpressure buffer 语义相同，没有新增容量上限。
+3. 本报告是 throughput + allocation confirmation，不包含 p95/p99 latency、context switch、
+   queue depth 和真实 Mongo/Redis 数据。
+4. 历史数据中 pool size 4 在 `direct/20us/100us` 中优于 CPU=14，但收益在 `500us`
+   时降至无法区分；`async-0` 已加入基准以统一异步拓扑，但尚待 clean rerun。这证明不存在
+   由当前基准支持的通用 pool size 新默认。后续应在真实
+   工作负载下评估 Wow 专用 `schedulerPoolSize`/`stripeCount` 配置，避免依赖全局
+   Reactor 系统属性。
+5. 基准基础设施应将输出清理移到全局 JMH 锁之后，或使用 run-scoped 临时文件再原子发布，
+   避免并发运行破坏旧证据。
+6. command ingress 配对 A/B 已由 clean source confirmation 验收；Scheduler sweep 和
+   simulated-I/O 矩阵仍是诊断数据。若未来修改热路径或 Reactor 版本，必须重新运行配对 A/B
+   与语义差分套件。
+
+## 变更产物
+
+| 文件 | 作用 |
+|---|---|
+| `wow-core/.../infra/sink/MpscUnicastManySink.kt` | 原子 MPSC admission、控制路径结算状态机及 opaque publisher |
+| `wow-core/.../command/InMemoryCommandBus.kt` | 默认使用 MPSC sink |
+| `wow-core/.../messaging/InMemoryMessageBus.kt` | MPSC close settlement 协调、精确移除及失败保留 |
+| `wow-core/.../infra/sink/MpscUnicastManySinkTest.kt` | sink 并发、终止及协议测试 |
+| `wow-core/.../infra/sink/MpscUnicastManySinkSemanticsTest.kt` | Reactor 3.8.6 native/custom 差分语义测试 |
+| `wow-core/.../command/InMemoryCommandBusAtomicSinkTest.kt` | command bus 集成并发测试 |
+| `wow-benchmarks/.../CommandIngressE2EDiagnosticBenchmark.kt` | 同 JAR 入口 A/B 与 pool sweep |
+| `wow-benchmarks/.../BenchmarkAggregateSchedulerSupplier.kt` | benchmark-only pool size 参数 |
+| `wow-benchmarks/.../SchedulerStrategies.kt` | 为 PARALLEL benchmark supplier 传递 pool size |
+| `wow-benchmarks/.../SimulatedIoCommandWriteBenchmark.kt` | 增加 `schedulerPoolSize` 维度，验证 I/O 延迟边界 |
+| 本报告 | 收益验收、原始证据 hash、复现命令和适用边界 |

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/BenchmarkAggregateSchedulerSupplier.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/BenchmarkAggregateSchedulerSupplier.kt
@@ -22,12 +22,20 @@ import reactor.core.scheduler.Scheduler
 import reactor.core.scheduler.Schedulers
 import java.util.concurrent.ConcurrentHashMap
 
-class BenchmarkAggregateSchedulerSupplier : AggregateSchedulerSupplier {
+class BenchmarkAggregateSchedulerSupplier(
+    private val schedulerPoolSize: Int = Schedulers.DEFAULT_POOL_SIZE,
+) : AggregateSchedulerSupplier {
+    init {
+        require(schedulerPoolSize > 0) {
+            "schedulerPoolSize must be greater than 0."
+        }
+    }
+
     private val schedulers: MutableMap<MaterializedNamedAggregate, Scheduler> = ConcurrentHashMap()
 
     override fun getOrInitialize(namedAggregate: NamedAggregate): Scheduler =
         schedulers.computeIfAbsent(namedAggregate.materialize()) {
-            Schedulers.newParallel("BenchmarkAggregate-${it.aggregateName}", Schedulers.DEFAULT_POOL_SIZE)
+            Schedulers.newParallel("BenchmarkAggregate-${it.aggregateName}", schedulerPoolSize)
         }
 
     @Suppress("ForbiddenVoid")

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/e2e/CommandIngressE2EDiagnosticBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/e2e/CommandIngressE2EDiagnosticBenchmark.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.benchmark.e2e
+
+import me.ahoo.wow.BenchmarkAggregateSchedulerSupplier
+import me.ahoo.wow.api.command.CommandMessage
+import me.ahoo.wow.benchmark.fixture.BenchmarkAggregates
+import me.ahoo.wow.benchmark.fixture.BenchmarkCommands
+import me.ahoo.wow.benchmark.fixture.BenchmarkIdempotency
+import me.ahoo.wow.benchmark.scenario.CommandDispatcherScenario
+import me.ahoo.wow.benchmark.scenario.consumeWowResult
+import me.ahoo.wow.command.InMemoryCommandBus
+import me.ahoo.wow.command.validation.NoOpValidator
+import me.ahoo.wow.event.InMemoryDomainEventBus
+import me.ahoo.wow.eventsourcing.NoopEventStore
+import me.ahoo.wow.eventsourcing.snapshot.InMemorySnapshotStore
+import me.ahoo.wow.eventsourcing.state.InMemoryStateEventBus
+import me.ahoo.wow.example.api.cart.AddCartItem
+import me.ahoo.wow.infra.idempotency.DefaultAggregateIdempotencyCheckerProvider
+import me.ahoo.wow.infra.idempotency.NoOpIdempotencyChecker
+import me.ahoo.wow.infra.sink.concurrent
+import me.ahoo.wow.modeling.materialize
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.TearDown
+import org.openjdk.jmh.infra.Blackhole
+import reactor.core.publisher.Sinks
+import reactor.core.scheduler.Schedulers
+import java.util.concurrent.atomic.AtomicInteger
+
+@State(Scope.Benchmark)
+open class CommandIngressE2EDiagnosticBenchmark {
+    @Param(
+        "current-production",
+        "legacy-lock",
+    )
+    lateinit var ingressStrategy: String
+
+    @Param("cpu")
+    lateinit var schedulerPoolSize: String
+
+    private lateinit var scenario: CommandDispatcherScenario
+    private val failures = AtomicInteger()
+
+    @Setup(Level.Iteration)
+    fun setup() {
+        failures.set(0)
+        scenario = CommandDispatcherScenario.create(
+            commandBus = createCommandBus(),
+            eventStore = NoopEventStore,
+            snapshotRepository = InMemorySnapshotStore(),
+            domainEventBus = InMemoryDomainEventBus(),
+            stateEventBus = InMemoryStateEventBus(),
+            schedulerSupplier = BenchmarkAggregateSchedulerSupplier(resolveSchedulerPoolSize()),
+            validator = NoOpValidator,
+            idempotencyCheckerProvider = DefaultAggregateIdempotencyCheckerProvider {
+                NoOpIdempotencyChecker
+            },
+            namedAggregate = BenchmarkAggregates.cartMetadata.namedAggregate.materialize(),
+        )
+    }
+
+    @TearDown(Level.Iteration)
+    fun tearDown() {
+        val failureCount = failures.get()
+        try {
+            check(failureCount == 0) {
+                "Command ingress E2E diagnostic [$ingressStrategy] recorded $failureCount failure(s)."
+            }
+        } finally {
+            scenario.close()
+        }
+    }
+
+    @Benchmark
+    fun sendAndWaitProcessed(blackhole: Blackhole) {
+        blackhole.consumeWowResult(onError = { failures.incrementAndGet() }) {
+            scenario.commandGateway
+                .sendAndWaitForProcessed(createCommandMessage())
+                .block()
+        }
+    }
+
+    private fun createCommandBus(): InMemoryCommandBus =
+        when (ingressStrategy) {
+            "current-production" -> InMemoryCommandBus()
+            "legacy-lock" -> InMemoryCommandBus {
+                Sinks.unsafe()
+                    .many()
+                    .unicast()
+                    .onBackpressureBuffer<CommandMessage<*>>()
+                    .concurrent()
+            }
+
+            else -> error("Unsupported command ingress strategy: $ingressStrategy")
+        }
+
+    private fun resolveSchedulerPoolSize(): Int =
+        when (schedulerPoolSize) {
+            "cpu" -> Schedulers.DEFAULT_POOL_SIZE
+            else -> schedulerPoolSize.toInt().also {
+                require(it > 0) {
+                    "schedulerPoolSize must be greater than 0."
+                }
+            }
+        }
+
+    private fun createCommandMessage(): CommandMessage<AddCartItem> =
+        BenchmarkCommands.commandPathAddCartItem()
+}

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/e2e/SimulatedIoCommandWriteBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/e2e/SimulatedIoCommandWriteBenchmark.kt
@@ -28,6 +28,7 @@ import org.openjdk.jmh.annotations.Setup
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.TearDown
 import org.openjdk.jmh.infra.Blackhole
+import reactor.core.scheduler.Schedulers
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -35,10 +36,11 @@ import java.util.concurrent.atomic.AtomicInteger
  * Sweeps the "simulated I/O latency vs cross-thread handoff" trade-off curve for
  * `sendAndWaitProcessed`, without requiring a real database.
  *
- * Uses [DelayEventStore] (in-memory store with an injected per-operation delay) so the
- * event-store I/O cost is a controlled variable. Combined with [schedulerStrategy], this
- * answers: how much I/O latency is needed before the dispatcher's `publishOn` cross-thread
- * handoff becomes negligible relative to the total command-write latency.
+ * The `direct` profile uses [InMemoryEventStore] as a pure framework ceiling. The asynchronous
+ * profiles all use [DelayEventStore] (including `async-0`) so timer handoff topology remains
+ * constant while the injected per-operation delay changes. Combined with [schedulerStrategy],
+ * this answers how much I/O latency is needed before the dispatcher's `publishOn` cross-thread
+ * handoff becomes negligible relative to total command-write latency.
  *
  * The sweep fills the gap between the two previously measured extremes:
  * - NoopEventStore (0 I/O): cross-thread ~95% of dispatch-chain cost.
@@ -49,11 +51,14 @@ import java.util.concurrent.atomic.AtomicInteger
 @State(Scope.Benchmark)
 @Suppress("VarCouldBeVal") // JMH injects @Param fields via reflection, so they must be `var`.
 open class SimulatedIoCommandWriteBenchmark {
-    @Param("0", "20us", "100us", "500us", "2ms")
-    private var ioDelay: String = "0"
+    @Param("direct", "async-0", "20us", "100us", "500us", "2ms")
+    private var ioDelay: String = "direct"
 
     @Param("PARALLEL", "IMMEDIATE")
     private var schedulerStrategy: String = SchedulerStrategy.PARALLEL.name
+
+    @Param("cpu")
+    private var schedulerPoolSize: String = "cpu"
 
     private lateinit var commandDispatcherScenario: CommandDispatcherScenario
     private val failures = AtomicInteger()
@@ -61,18 +66,17 @@ open class SimulatedIoCommandWriteBenchmark {
     @Setup(Level.Iteration)
     fun setup() {
         failures.set(0)
-        val delay = parseDelay(ioDelay)
-        // Bypass DelayEventStore for the zero-delay row: delaySubscription(Duration.ZERO) still
-        // schedules a timer task, which would add an unrelated reactor-scheduler handoff and
-        // contaminate the "pure framework" baseline point this row is meant to provide.
-        val eventStore = if (delay.isZero) {
-            InMemoryEventStore()
-        } else {
-            DelayEventStore(delaySupplier = { delay })
+        val eventStore = when (ioDelay) {
+            "direct" -> InMemoryEventStore()
+            else -> {
+                val delay = parseDelay(ioDelay)
+                DelayEventStore(delaySupplier = { delay })
+            }
         }
         commandDispatcherScenario = CommandDispatcherScenario.create(
             eventStore = eventStore,
-            schedulerSupplier = SchedulerStrategy.valueOf(schedulerStrategy).toSchedulerSupplier(),
+            schedulerSupplier = SchedulerStrategy.valueOf(schedulerStrategy)
+                .toSchedulerSupplier(resolveSchedulerPoolSize(schedulerPoolSize)),
         )
     }
 
@@ -83,7 +87,8 @@ open class SimulatedIoCommandWriteBenchmark {
             if (failureCount > 0) {
                 throw IllegalStateException(
                     "Simulated I/O command write recorded $failureCount failure(s) " +
-                        "[ioDelay=$ioDelay, schedulerStrategy=$schedulerStrategy].",
+                        "[ioDelay=$ioDelay, schedulerStrategy=$schedulerStrategy, " +
+                        "schedulerPoolSize=$schedulerPoolSize].",
                 )
             }
         } finally {
@@ -103,10 +108,23 @@ open class SimulatedIoCommandWriteBenchmark {
     private companion object {
         fun parseDelay(value: String): Duration =
             when {
-                value == "0" -> Duration.ZERO
+                value == "async-0" -> Duration.ZERO
                 value.endsWith("us") -> Duration.ofNanos(value.removeSuffix("us").toLong() * 1_000L)
                 value.endsWith("ms") -> Duration.ofMillis(value.removeSuffix("ms").toLong())
-                else -> error("Unsupported ioDelay value: $value (expected '0', '<n>us', or '<n>ms')")
+                else -> error(
+                    "Unsupported ioDelay value: $value " +
+                        "(expected 'direct', 'async-0', '<n>us', or '<n>ms')",
+                )
+            }
+
+        fun resolveSchedulerPoolSize(value: String): Int =
+            when (value) {
+                "cpu" -> Schedulers.DEFAULT_POOL_SIZE
+                else -> value.toInt().also {
+                    require(it > 0) {
+                        "schedulerPoolSize must be greater than 0."
+                    }
+                }
             }
     }
 }

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/scenario/SchedulerStrategies.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/scenario/SchedulerStrategies.kt
@@ -37,15 +37,17 @@ enum class SchedulerStrategy {
 
 /**
  * Maps a [SchedulerStrategy] to the [AggregateSchedulerSupplier] it implies, so every
- * end-to-end command-write benchmark can expose the scheduler's performance impact via a
- * single `@Param` without duplicating the wiring.
+ * end-to-end command-write benchmark can expose the scheduler's strategy and pool-size
+ * impact without duplicating the wiring.
  *
  * - [SchedulerStrategy.PARALLEL] -> [BenchmarkAggregateSchedulerSupplier] (production default).
  * - [SchedulerStrategy.IMMEDIATE] -> [ImmediateAggregateSchedulerSupplier] (no thread switch).
  */
-fun SchedulerStrategy.toSchedulerSupplier(): AggregateSchedulerSupplier =
+fun SchedulerStrategy.toSchedulerSupplier(
+    schedulerPoolSize: Int = Schedulers.DEFAULT_POOL_SIZE,
+): AggregateSchedulerSupplier =
     when (this) {
-        SchedulerStrategy.PARALLEL -> BenchmarkAggregateSchedulerSupplier()
+        SchedulerStrategy.PARALLEL -> BenchmarkAggregateSchedulerSupplier(schedulerPoolSize)
         SchedulerStrategy.IMMEDIATE -> ImmediateAggregateSchedulerSupplier
     }
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/InMemoryCommandBus.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/InMemoryCommandBus.kt
@@ -14,7 +14,7 @@ package me.ahoo.wow.command
 
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.modeling.NamedAggregate
-import me.ahoo.wow.infra.sink.concurrent
+import me.ahoo.wow.infra.sink.mpscUnicastManySink
 import me.ahoo.wow.messaging.InMemoryMessageBus
 import reactor.core.publisher.Sinks
 import reactor.core.publisher.Sinks.Many
@@ -25,18 +25,19 @@ import reactor.core.publisher.Sinks.Many
  * making it suitable for single-instance or testing scenarios.
  *
  * @param sinkSupplier Function that creates a unicast sink for each named aggregate.
- *                     Defaults to unicast with backpressure buffer.
+ *                     Defaults to an atomic MPSC unicast sink with backpressure buffer.
  * @author ahoo wang
  */
 class InMemoryCommandBus(
     /**
      * Supplier for creating sinks for command distribution.
-     * Uses unicast mode to ensure each command reaches exactly one consumer.
+     * Uses atomic MPSC admission and unicast mode to support concurrent senders while
+     * ensuring each command reaches exactly one consumer.
      *
      * @see Sinks.UnicastSpec
      */
     override val sinkSupplier: (NamedAggregate) -> Many<CommandMessage<*>> = {
-        Sinks.unsafe().many().unicast().onBackpressureBuffer<CommandMessage<*>>().concurrent()
+        mpscUnicastManySink()
     }
 ) : InMemoryMessageBus<CommandMessage<*>, ServerCommandExchange<*>>(),
     LocalCommandBus {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/sink/MpscUnicastManySink.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/sink/MpscUnicastManySink.kt
@@ -75,7 +75,6 @@ internal class MpscUnicastManySink<T : Any> private constructor(
     private val closeFailure = AtomicReference<Throwable?>()
     private val settlementLock = Any()
     private var downstreamOperations = 0
-    private val downstreamTerminated = AtomicBoolean()
     override val closeSettled = CompletableFuture<Unit>()
     private val flux = OpaqueFlux(
         source = sink.asFlux(),
@@ -85,7 +84,6 @@ internal class MpscUnicastManySink<T : Any> private constructor(
         isCancellationRequested = ::isCancellationRequested,
         beginDownstreamOperation = ::beginDownstreamOperation,
         endDownstreamOperation = ::endDownstreamOperation,
-        markDownstreamTerminated = ::markDownstreamTerminated,
         scanAttribute = ::scanUnsafe,
         innerScannables = ::inners,
     )
@@ -261,11 +259,6 @@ internal class MpscUnicastManySink<T : Any> private constructor(
         }
     }
 
-    private fun markDownstreamTerminated() {
-        downstreamTerminated.set(true)
-        tryCompleteCloseSettlement()
-    }
-
     private fun tryCompleteCloseSettlement() {
         synchronized(settlementLock) {
             if (closeSettled.isDone || downstreamOperations != 0) {
@@ -313,20 +306,12 @@ internal class MpscUnicastManySink<T : Any> private constructor(
         if (current and (CANCELLATION_DELEGATED or TERMINAL_DELEGATED) == 0L) return false
         if (!isDelegationSettled(current, CANCELLATION_DELEGATED, CANCELLATION_SETTLED)) return false
         if (!isDelegationSettled(current, TERMINAL_DELEGATED, TERMINAL_SETTLED)) return false
-        return hasSettledCloseOutcome(current)
+        return true
     }
 
     private fun isDelegationSettled(current: Long, delegated: Long, settled: Long): Boolean {
         if (current and delegated == 0L) return true
         return current and settled != 0L
-    }
-
-    private fun hasSettledCloseOutcome(current: Long): Boolean {
-        if (current and CANCELLATION_SETTLED != 0L) return true
-        if (closeFailure.get() != null) return true
-        if (current and TERMINAL_SETTLED == 0L) return false
-        if (downstreamTerminated.get()) return true
-        return subscription.get() == null
     }
 
     @Suppress("TooGenericExceptionCaught")
@@ -512,7 +497,6 @@ private class OpaqueFlux<T : Any>(
     private val isCancellationRequested: () -> Boolean,
     private val beginDownstreamOperation: () -> Unit,
     private val endDownstreamOperation: () -> Unit,
-    private val markDownstreamTerminated: () -> Unit,
     private val scanAttribute: (Scannable.Attr<*>) -> Any?,
     private val innerScannables: () -> Stream<out Scannable>,
 ) : Flux<T>(),
@@ -539,7 +523,6 @@ private class OpaqueFlux<T : Any>(
                     isCancellationRequested = isCancellationRequested,
                     beginDownstreamOperation = beginDownstreamOperation,
                     endDownstreamOperation = endDownstreamOperation,
-                    markDownstreamTerminated = markDownstreamTerminated,
                 ),
             )
         } finally {
@@ -568,7 +551,6 @@ private class OpaqueSubscriber<T : Any>(
     private val isCancellationRequested: () -> Boolean,
     private val beginDownstreamOperation: () -> Unit,
     private val endDownstreamOperation: () -> Unit,
-    private val markDownstreamTerminated: () -> Unit,
 ) : CoreSubscriber<T>, Scannable {
     override fun currentContext(): Context = actual.currentContext()
 
@@ -593,22 +575,14 @@ private class OpaqueSubscriber<T : Any>(
     }
 
     override fun onError(throwable: Throwable) {
-        try {
-            if (!isCancellationRequested()) {
-                actual.onError(throwable)
-            }
-        } finally {
-            markDownstreamTerminated()
+        if (!isCancellationRequested()) {
+            actual.onError(throwable)
         }
     }
 
     override fun onComplete() {
-        try {
-            if (!isCancellationRequested()) {
-                actual.onComplete()
-            }
-        } finally {
-            markDownstreamTerminated()
+        if (!isCancellationRequested()) {
+            actual.onComplete()
         }
     }
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/sink/MpscUnicastManySink.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/sink/MpscUnicastManySink.kt
@@ -1,0 +1,649 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.infra.sink
+
+import org.reactivestreams.Subscription
+import reactor.core.CoreSubscriber
+import reactor.core.Exceptions
+import reactor.core.Scannable
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Operators
+import reactor.core.publisher.SignalType
+import reactor.core.publisher.Sinks
+import reactor.util.concurrent.Queues
+import reactor.util.context.Context
+import java.util.Queue
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+import java.util.stream.Stream
+
+private const val TERMINAL_CLAIMED = Long.MIN_VALUE
+private const val TERMINAL_DELEGATED = 1L shl 62
+private const val CANCELLATION_REQUESTED = 1L shl 61
+private const val CANCELLATION_DELEGATED = 1L shl 60
+private const val TERMINAL_SETTLED = 1L shl 59
+private const val CANCELLATION_SETTLED = 1L shl 58
+private const val CLOSE_SETTLED = 1L shl 57
+private const val ACTIVE_MASK = CLOSE_SETTLED - 1
+
+internal interface CloseSettlementAware {
+    val closeSettled: CompletableFuture<Unit>
+}
+
+/**
+ * Factory-owned unicast sink with lock-free multi-producer admission.
+ *
+ * The low 57 state bits count admitted `onNext` calls. The remaining bits claim,
+ * delegate and settle terminal or cancellation control signals. Claiming either
+ * control signal rejects new values immediately, while physical delegation is
+ * deferred until every already-admitted producer has returned. A final CAS marks
+ * close settlement only after every control path delegated before that CAS has
+ * returned. This preserves Reactive Streams signal ordering and prevents queue
+ * cleanup from racing an MPSC offer, without holding a lock across downstream work.
+ *
+ * The delegate is intentionally hidden behind [OpaqueFlux] so subscribers cannot
+ * expose or fuse directly with the factory-owned MPSC queue.
+ */
+internal class MpscUnicastManySink<T : Any> private constructor(
+    private val sink: Sinks.Many<T>,
+) : Sinks.Many<T>,
+    CloseSettlementAware {
+    private constructor(queue: Queue<T>) : this(
+        Sinks.unsafe()
+            .many()
+            .unicast()
+            .onBackpressureBuffer(queue),
+    )
+
+    private val state = AtomicLong()
+    private val terminalSignal = AtomicReference<TerminalSignal?>()
+    private val subscription = AtomicReference<Subscription?>()
+    private val actualSubscriber = AtomicReference<CoreSubscriber<in T>?>()
+    private val closeFailure = AtomicReference<Throwable?>()
+    private val settlementLock = Any()
+    private var downstreamOperations = 0
+    private val downstreamTerminated = AtomicBoolean()
+    override val closeSettled = CompletableFuture<Unit>()
+    private val flux = OpaqueFlux(
+        source = sink.asFlux(),
+        registerActual = { actualSubscriber.compareAndSet(null, it) },
+        registerSubscription = ::registerSubscription,
+        requestCancellation = ::requestCancellation,
+        isCancellationRequested = ::isCancellationRequested,
+        beginDownstreamOperation = ::beginDownstreamOperation,
+        endDownstreamOperation = ::endDownstreamOperation,
+        markDownstreamTerminated = ::markDownstreamTerminated,
+        scanAttribute = ::scanUnsafe,
+        innerScannables = ::inners,
+    )
+
+    companion object {
+        fun <T : Any> create(): MpscUnicastManySink<T> =
+            MpscUnicastManySink(Queues.unboundedMultiproducer<T>().get())
+    }
+
+    override fun tryEmitNext(t: T): Sinks.EmitResult {
+        val admissionFailure = tryAcquireNext()
+        if (admissionFailure != null) {
+            return admissionFailure
+        }
+        return try {
+            sink.tryEmitNext(t)
+        } finally {
+            releaseNext()
+        }
+    }
+
+    override fun tryEmitComplete(): Sinks.EmitResult =
+        tryClaimTerminal(TerminalSignal.Complete)
+
+    override fun tryEmitError(error: Throwable): Sinks.EmitResult =
+        tryClaimTerminal(TerminalSignal.Error(error))
+
+    private fun tryAcquireNext(): Sinks.EmitResult? {
+        while (true) {
+            val current = state.get()
+            if (current and TERMINAL_CLAIMED != 0L) {
+                return Sinks.EmitResult.FAIL_TERMINATED
+            }
+            if (current and CANCELLATION_REQUESTED != 0L) {
+                return Sinks.EmitResult.FAIL_CANCELLED
+            }
+            check(current and ACTIVE_MASK != ACTIVE_MASK) {
+                "MPSC unicast sink active admission count exhausted."
+            }
+            if (state.compareAndSet(current, current + 1)) {
+                return null
+            }
+        }
+    }
+
+    private fun releaseNext() {
+        val released = state.decrementAndGet()
+        check(released and ACTIVE_MASK != ACTIVE_MASK) {
+            "MPSC unicast sink active admission underflow."
+        }
+        if (released and ACTIVE_MASK == 0L) {
+            normalizeTerminalResult(drainControlSignals())
+        }
+    }
+
+    private fun tryClaimTerminal(signal: TerminalSignal): Sinks.EmitResult {
+        while (true) {
+            val current = state.get()
+            if (current and TERMINAL_CLAIMED != 0L) {
+                return Sinks.EmitResult.FAIL_TERMINATED
+            }
+            if (current and CANCELLATION_REQUESTED != 0L) {
+                return Sinks.EmitResult.FAIL_CANCELLED
+            }
+            if (sink.scanUnsafe(Scannable.Attr.CANCELLED) == true) {
+                return Sinks.EmitResult.FAIL_CANCELLED
+            }
+            if (state.compareAndSet(current, current or TERMINAL_CLAIMED)) {
+                break
+            }
+        }
+
+        terminalSignal.set(signal)
+        return normalizeTerminalResult(drainControlSignals())
+    }
+
+    private fun registerSubscription(delegate: Subscription) {
+        check(subscription.compareAndSet(null, delegate)) {
+            "Factory-owned MPSC unicast sink registered more than one lifecycle subscription."
+        }
+        drainControlSignals()
+    }
+
+    private fun requestCancellation() {
+        while (true) {
+            val current = state.get()
+            if (current and CLOSE_SETTLED != 0L) {
+                /*
+                 * A first subscriber can arrive after a terminal-only sink has
+                 * already settled. Its cancellation is ordered after that close
+                 * linearization point, but must still reach the raw subscription
+                 * so Reactor clears buffered values and suppresses late terminal
+                 * delivery.
+                 */
+                subscription.get()?.cancel()
+                return
+            }
+            if (current and CANCELLATION_REQUESTED != 0L) {
+                return
+            }
+            if (state.compareAndSet(current, current or CANCELLATION_REQUESTED)) {
+                break
+            }
+        }
+        normalizeTerminalResult(drainControlSignals())
+    }
+
+    private fun isCancellationRequested(): Boolean =
+        state.get() and CANCELLATION_REQUESTED != 0L
+
+    private fun drainControlSignals(): Sinks.EmitResult? {
+        if (state.get() and ACTIVE_MASK != 0L) {
+            return null
+        }
+        delegateCancellation()
+        return delegateTerminal()
+    }
+
+    private fun delegateCancellation() {
+        val delegate = subscription.get() ?: return
+        while (true) {
+            val current = state.get()
+            if (!canDelegateCancellation(current)) {
+                return
+            }
+            if (state.compareAndSet(current, current or CANCELLATION_DELEGATED)) {
+                settleControl(CANCELLATION_SETTLED) {
+                    delegate.cancel()
+                }
+                return
+            }
+        }
+    }
+
+    private fun delegateTerminal(): Sinks.EmitResult? {
+        val signal = terminalSignal.get() ?: return null
+        while (true) {
+            val current = state.get()
+            if (!canDelegateTerminal(current)) {
+                return null
+            }
+            if (state.compareAndSet(current, current or TERMINAL_DELEGATED)) {
+                break
+            }
+        }
+        return settleControl(TERMINAL_SETTLED) {
+            normalizeTerminalResult(
+                when (signal) {
+                    TerminalSignal.Complete -> sink.tryEmitComplete()
+                    is TerminalSignal.Error -> sink.tryEmitError(signal.error)
+                },
+            )
+        }
+    }
+
+    private fun beginDownstreamOperation() {
+        synchronized(settlementLock) {
+            downstreamOperations++
+        }
+    }
+
+    private fun endDownstreamOperation() {
+        val remaining = synchronized(settlementLock) {
+            downstreamOperations--
+            check(downstreamOperations >= 0) {
+                "MPSC unicast sink downstream operation count underflow."
+            }
+            downstreamOperations
+        }
+        if (remaining == 0) {
+            normalizeTerminalResult(drainControlSignals())
+            tryCompleteCloseSettlement()
+        }
+    }
+
+    private fun markDownstreamTerminated() {
+        downstreamTerminated.set(true)
+        tryCompleteCloseSettlement()
+    }
+
+    private fun tryCompleteCloseSettlement() {
+        synchronized(settlementLock) {
+            if (closeSettled.isDone || downstreamOperations != 0) {
+                return
+            }
+            completeCloseSettlementState()
+        }
+    }
+
+    private fun completeCloseSettlementState() {
+        while (true) {
+            val current = state.get()
+            if (!canSettleClose(current)) {
+                return
+            }
+            if (!state.compareAndSet(current, current or CLOSE_SETTLED)) {
+                continue
+            }
+            val failure = closeFailure.get()
+            if (failure == null) {
+                closeSettled.complete(Unit)
+            } else {
+                closeSettled.completeExceptionally(failure)
+            }
+            return
+        }
+    }
+
+    private fun canDelegateCancellation(current: Long): Boolean {
+        if (current and ACTIVE_MASK != 0L) return false
+        if (current and CANCELLATION_REQUESTED == 0L) return false
+        if (current and CANCELLATION_DELEGATED != 0L) return false
+        return current and CLOSE_SETTLED == 0L
+    }
+
+    private fun canDelegateTerminal(current: Long): Boolean {
+        if (current and ACTIVE_MASK != 0L) return false
+        if (current and TERMINAL_CLAIMED == 0L) return false
+        if (current and TERMINAL_DELEGATED != 0L) return false
+        return current and CLOSE_SETTLED == 0L
+    }
+
+    private fun canSettleClose(current: Long): Boolean {
+        if (current and CLOSE_SETTLED != 0L) return false
+        if (current and (CANCELLATION_DELEGATED or TERMINAL_DELEGATED) == 0L) return false
+        if (!isDelegationSettled(current, CANCELLATION_DELEGATED, CANCELLATION_SETTLED)) return false
+        if (!isDelegationSettled(current, TERMINAL_DELEGATED, TERMINAL_SETTLED)) return false
+        return hasSettledCloseOutcome(current)
+    }
+
+    private fun isDelegationSettled(current: Long, delegated: Long, settled: Long): Boolean {
+        if (current and delegated == 0L) return true
+        return current and settled != 0L
+    }
+
+    private fun hasSettledCloseOutcome(current: Long): Boolean {
+        if (current and CANCELLATION_SETTLED != 0L) return true
+        if (closeFailure.get() != null) return true
+        if (current and TERMINAL_SETTLED == 0L) return false
+        if (downstreamTerminated.get()) return true
+        return subscription.get() == null
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private inline fun <R> settleControl(settledState: Long, block: () -> R): R =
+        try {
+            block()
+        } catch (error: Throwable) {
+            recordCloseFailure(error)
+            throw error
+        } finally {
+            state.getAndUpdate { current -> current or settledState }
+            tryCompleteCloseSettlement()
+        }
+
+    private fun recordCloseFailure(error: Throwable) {
+        while (true) {
+            val current = closeFailure.get()
+            if (current == null) {
+                if (closeFailure.compareAndSet(null, error)) {
+                    return
+                }
+                continue
+            }
+            if (current !== error) {
+                synchronized(current) {
+                    current.addSuppressed(error)
+                }
+            }
+            return
+        }
+    }
+
+    private fun normalizeTerminalResult(result: Sinks.EmitResult?): Sinks.EmitResult =
+        when (result) {
+            null,
+            Sinks.EmitResult.OK,
+            Sinks.EmitResult.FAIL_CANCELLED,
+            -> Sinks.EmitResult.OK
+
+            else -> throw Sinks.EmissionException(
+                result,
+                "Factory-owned MPSC unicast delegate rejected a claimed terminal with [$result].",
+            )
+        }
+
+    override fun emitNext(t: T, failureHandler: Sinks.EmitFailureHandler) {
+        while (true) {
+            val emitResult = tryEmitNext(t)
+            if (emitResult.isSuccess) {
+                return
+            }
+            if (failureHandler.onEmitFailure(SignalType.ON_NEXT, emitResult)) {
+                continue
+            }
+            when (emitResult) {
+                Sinks.EmitResult.FAIL_ZERO_SUBSCRIBER -> return
+                Sinks.EmitResult.FAIL_OVERFLOW -> {
+                    Operators.onDiscard(t, currentContext())
+                    emitError(
+                        Exceptions.failWithOverflow("Backpressure overflow during Sinks.Many#emitNext"),
+                        failureHandler,
+                    )
+                    return
+                }
+
+                Sinks.EmitResult.FAIL_CANCELLED -> {
+                    Operators.onDiscard(t, currentContext())
+                    return
+                }
+
+                Sinks.EmitResult.FAIL_TERMINATED -> {
+                    Operators.onNextDropped(t, currentContext())
+                    return
+                }
+
+                Sinks.EmitResult.FAIL_NON_SERIALIZED -> throw nonSerialized(emitResult)
+                Sinks.EmitResult.OK -> return
+            }
+        }
+    }
+
+    override fun emitComplete(failureHandler: Sinks.EmitFailureHandler) {
+        while (true) {
+            val emitResult = tryEmitComplete()
+            if (emitResult.isSuccess) {
+                return
+            }
+            if (failureHandler.onEmitFailure(SignalType.ON_COMPLETE, emitResult)) {
+                continue
+            }
+            when (emitResult) {
+                Sinks.EmitResult.FAIL_NON_SERIALIZED -> throw nonSerialized(emitResult)
+                Sinks.EmitResult.FAIL_ZERO_SUBSCRIBER,
+                Sinks.EmitResult.FAIL_OVERFLOW,
+                Sinks.EmitResult.FAIL_CANCELLED,
+                Sinks.EmitResult.FAIL_TERMINATED,
+                Sinks.EmitResult.OK,
+                -> return
+            }
+        }
+    }
+
+    override fun emitError(error: Throwable, failureHandler: Sinks.EmitFailureHandler) {
+        while (true) {
+            val emitResult = tryEmitError(error)
+            if (emitResult.isSuccess) {
+                return
+            }
+            if (failureHandler.onEmitFailure(SignalType.ON_ERROR, emitResult)) {
+                continue
+            }
+            when (emitResult) {
+                Sinks.EmitResult.FAIL_TERMINATED -> {
+                    Operators.onErrorDropped(error, currentContext())
+                    return
+                }
+
+                Sinks.EmitResult.FAIL_NON_SERIALIZED -> throw nonSerialized(emitResult)
+                Sinks.EmitResult.FAIL_ZERO_SUBSCRIBER,
+                Sinks.EmitResult.FAIL_OVERFLOW,
+                Sinks.EmitResult.FAIL_CANCELLED,
+                Sinks.EmitResult.OK,
+                -> return
+            }
+        }
+    }
+
+    private fun nonSerialized(emitResult: Sinks.EmitResult): Sinks.EmissionException =
+        Sinks.EmissionException(
+            emitResult,
+            "Spec. Rule 1.3 - onSubscribe, onNext, onError and onComplete " +
+                "signaled to a Subscriber MUST be signaled serially.",
+        )
+
+    private fun currentContext(): Context =
+        (sink.scanUnsafe(Scannable.Attr.ACTUAL) as? CoreSubscriber<*>)?.currentContext()
+            ?: Context.empty()
+
+    override fun currentSubscriberCount(): Int = sink.currentSubscriberCount()
+
+    override fun asFlux(): Flux<T> = flux
+
+    override fun inners(): Stream<out Scannable> {
+        if (currentSubscriberCount() == 0) {
+            return Stream.empty()
+        }
+        return Stream.of(Scannable.from(checkNotNull(actualSubscriber.get())))
+    }
+
+    override fun scanUnsafe(key: Scannable.Attr<*>): Any? =
+        when (key) {
+            Scannable.Attr.ACTUAL -> actualSubscriber.get() ?: sink.scanUnsafe(key)
+            Scannable.Attr.TERMINATED -> state.get() and TERMINAL_CLAIMED != 0L
+            Scannable.Attr.CANCELLED ->
+                state.get() and CANCELLATION_REQUESTED != 0L ||
+                    sink.scanUnsafe(Scannable.Attr.CANCELLED) == true
+            Scannable.Attr.ERROR -> (terminalSignal.get() as? TerminalSignal.Error)?.error
+            else -> sink.scanUnsafe(key)
+        }
+
+    private sealed interface TerminalSignal {
+        data object Complete : TerminalSignal
+
+        class Error(val error: Throwable) : TerminalSignal
+    }
+}
+
+internal fun <T : Any> mpscUnicastManySink(): MpscUnicastManySink<T> =
+    MpscUnicastManySink.create()
+
+internal fun <T : Any> Sinks.Many<T>.prepareConcurrentSink(): Sinks.Many<T> =
+    if (this is MpscUnicastManySink<*>) {
+        this
+    } else {
+        concurrent()
+    }
+
+private class OpaqueFlux<T : Any>(
+    private val source: Flux<T>,
+    private val registerActual: (CoreSubscriber<in T>) -> Unit,
+    private val registerSubscription: (Subscription) -> Unit,
+    private val requestCancellation: () -> Unit,
+    private val isCancellationRequested: () -> Boolean,
+    private val beginDownstreamOperation: () -> Unit,
+    private val endDownstreamOperation: () -> Unit,
+    private val markDownstreamTerminated: () -> Unit,
+    private val scanAttribute: (Scannable.Attr<*>) -> Any?,
+    private val innerScannables: () -> Stream<out Scannable>,
+) : Flux<T>(),
+    Scannable {
+    private val firstSubscriber = AtomicBoolean()
+
+    override fun subscribe(actual: CoreSubscriber<in T>) {
+        beginDownstreamOperation()
+        if (!firstSubscriber.compareAndSet(false, true)) {
+            endDownstreamOperation()
+            Operators.error(
+                actual,
+                IllegalStateException("Sinks.many().unicast() sinks only allow a single Subscriber"),
+            )
+            return
+        }
+        registerActual(actual)
+        try {
+            source.subscribe(
+                OpaqueSubscriber(
+                    actual = actual,
+                    registerSubscription = registerSubscription,
+                    requestCancellation = requestCancellation,
+                    isCancellationRequested = isCancellationRequested,
+                    beginDownstreamOperation = beginDownstreamOperation,
+                    endDownstreamOperation = endDownstreamOperation,
+                    markDownstreamTerminated = markDownstreamTerminated,
+                ),
+            )
+        } finally {
+            endDownstreamOperation()
+        }
+    }
+
+    override fun inners(): Stream<out Scannable> = innerScannables()
+
+    override fun scanUnsafe(key: Scannable.Attr<*>): Any? =
+        when (key) {
+            /*
+             * Preserve the opaque boundary around the factory-owned queue while
+             * exposing the same public lifecycle and capacity attributes as the
+             * owning Sinks.Many view.
+             */
+            Scannable.Attr.PARENT -> null
+            else -> scanAttribute(key)
+        }
+}
+
+private class OpaqueSubscriber<T : Any>(
+    private val actual: CoreSubscriber<in T>,
+    private val registerSubscription: (Subscription) -> Unit,
+    private val requestCancellation: () -> Unit,
+    private val isCancellationRequested: () -> Boolean,
+    private val beginDownstreamOperation: () -> Unit,
+    private val endDownstreamOperation: () -> Unit,
+    private val markDownstreamTerminated: () -> Unit,
+) : CoreSubscriber<T>, Scannable {
+    override fun currentContext(): Context = actual.currentContext()
+
+    override fun onSubscribe(subscription: Subscription) {
+        registerSubscription(subscription)
+        actual.onSubscribe(
+            OpaqueSubscription(
+                delegate = subscription,
+                requestCancellation = requestCancellation,
+                beginDownstreamOperation = beginDownstreamOperation,
+                endDownstreamOperation = endDownstreamOperation,
+            ),
+        )
+    }
+
+    override fun onNext(value: T) {
+        if (isCancellationRequested()) {
+            Operators.onDiscard(value, currentContext())
+            return
+        }
+        actual.onNext(value)
+    }
+
+    override fun onError(throwable: Throwable) {
+        try {
+            if (!isCancellationRequested()) {
+                actual.onError(throwable)
+            }
+        } finally {
+            markDownstreamTerminated()
+        }
+    }
+
+    override fun onComplete() {
+        try {
+            if (!isCancellationRequested()) {
+                actual.onComplete()
+            }
+        } finally {
+            markDownstreamTerminated()
+        }
+    }
+
+    override fun scanUnsafe(key: Scannable.Attr<*>): Any? =
+        when (key) {
+            Scannable.Attr.ACTUAL -> actual
+            else -> null
+        }
+}
+
+private class OpaqueSubscription(
+    private val delegate: Subscription,
+    private val requestCancellation: () -> Unit,
+    private val beginDownstreamOperation: () -> Unit,
+    private val endDownstreamOperation: () -> Unit,
+) : Subscription {
+    private val cancelled = AtomicBoolean()
+
+    override fun request(elements: Long) {
+        if (cancelled.get()) {
+            return
+        }
+        beginDownstreamOperation()
+        try {
+            if (!cancelled.get()) {
+                delegate.request(elements)
+            }
+        } finally {
+            endDownstreamOperation()
+        }
+    }
+
+    override fun cancel() {
+        if (cancelled.compareAndSet(false, true)) {
+            requestCancellation()
+        }
+    }
+}

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/InMemoryMessageBus.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/InMemoryMessageBus.kt
@@ -17,12 +17,14 @@ import com.google.errorprone.annotations.ThreadSafe
 import io.github.oshai.kotlinlogging.KotlinLogging
 import me.ahoo.wow.api.messaging.Message
 import me.ahoo.wow.api.modeling.NamedAggregate
-import me.ahoo.wow.infra.sink.concurrent
+import me.ahoo.wow.infra.sink.CloseSettlementAware
+import me.ahoo.wow.infra.sink.prepareConcurrentSink
 import me.ahoo.wow.messaging.handler.MessageExchange
 import me.ahoo.wow.modeling.materialize
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.core.publisher.Sinks
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 
 /**
@@ -76,7 +78,7 @@ abstract class InMemoryMessageBus<M, E : MessageExchange<*, M>> : LocalMessageBu
             if (closing) {
                 null
             } else {
-                sinks[materialized] ?: sinkSupplier(materialized).concurrent().also {
+                sinks[materialized] ?: sinkSupplier(materialized).prepareConcurrentSink().also {
                     sinks[materialized] = it
                 }
             }
@@ -159,24 +161,114 @@ abstract class InMemoryMessageBus<M, E : MessageExchange<*, M>> : LocalMessageBu
             closing = true
             sinks.entries.map { entry -> entry.key to entry.value }
         }
+        val settledSinks = mutableListOf<Pair<NamedAggregate, Sinks.Many<M>>>()
+        val pendingSettlements = mutableListOf<PendingCloseSettlement<M>>()
+        var closeFailure: Throwable? = null
+        detachedSinks.forEach { (aggregate, many) ->
+            val attempt = tryCloseSink(aggregate, many)
+            attempt.settledSink?.let(settledSinks::add)
+            attempt.pendingSettlement?.let(pendingSettlements::add)
+            attempt.failure?.let { closeFailure = mergeCloseFailure(closeFailure, it) }
+        }
+        if (pendingSettlements.isEmpty()) {
+            finishClose(settledSinks)
+        } else {
+            CompletableFuture.allOf(*pendingSettlements.map { it.settled }.toTypedArray())
+                .whenComplete { _, error ->
+                    if (error != null) {
+                        log.warn(error) {
+                            "Failed to settle one or more in-memory sink close signals."
+                        }
+                    }
+                    /*
+                     * Exceptional settlement still means the MPSC close state machine
+                     * reached its final linearization point. That sink is terminal and
+                     * cannot be retried, so it must not remain cached and block a fresh
+                     * subscription for the same aggregate.
+                     */
+                    val asynchronouslySettled = pendingSettlements.map {
+                        it.aggregate to it.many
+                    }
+                    finishClose(settledSinks + asynchronouslySettled)
+                }
+        }
+        closeFailure?.let { throw it }
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun tryCloseSink(
+        aggregate: NamedAggregate,
+        many: Sinks.Many<M>,
+    ): CloseAttempt<M> =
         try {
-            detachedSinks.forEach { (aggregate, many) ->
-                val emitResult = many.tryEmitComplete()
-                if (emitResult.isSuccess) {
+            val emitResult = many.tryEmitComplete()
+            when {
+                emitResult.isSuccess ||
+                    emitResult == Sinks.EmitResult.FAIL_TERMINATED ||
+                    emitResult == Sinks.EmitResult.FAIL_CANCELLED -> {
                     log.debug {
                         "Close [${aggregate.aggregateName}] sink - [$emitResult]."
                     }
-                } else {
-                    log.warn {
-                        "Close [${aggregate.aggregateName}] sink - [$emitResult]."
+                    val settlement = many.closeSettlement()
+                    if (settlement == null) {
+                        CloseAttempt(settledSink = aggregate to many)
+                    } else {
+                        CloseAttempt(
+                            pendingSettlement = PendingCloseSettlement(aggregate, many, settlement),
+                        )
                     }
                 }
+
+                else -> CloseAttempt(
+                    failure = Sinks.EmissionException(
+                        emitResult,
+                        "In-memory [${aggregate.aggregateName}] sink rejected close with [$emitResult].",
+                    ),
+                )
             }
-        } finally {
-            synchronized(lifecycleLock) {
-                sinks.clear()
-                closing = false
+        } catch (error: Throwable) {
+            log.warn(error) {
+                "Failed to close [${aggregate.aggregateName}] sink."
             }
+            CloseAttempt(
+                pendingSettlement = many.closeSettlement()?.let {
+                    PendingCloseSettlement(aggregate, many, it)
+                },
+                failure = error,
+            )
+        }
+
+    private fun mergeCloseFailure(current: Throwable?, next: Throwable): Throwable {
+        if (current == null) {
+            return next
+        }
+        if (current !== next) {
+            current.addSuppressed(next)
+        }
+        return current
+    }
+
+    private fun Sinks.Many<M>.closeSettlement(): CompletableFuture<Unit>? =
+        (this as? CloseSettlementAware)?.closeSettled
+
+    private fun finishClose(detachedSinks: List<Pair<NamedAggregate, Sinks.Many<M>>>) {
+        synchronized(lifecycleLock) {
+            detachedSinks.forEach { (aggregate, many) ->
+                sinks.remove(aggregate, many)
+            }
+            closing = false
         }
     }
+
+    private data class PendingCloseSettlement<M : Any>(
+        val aggregate: NamedAggregate,
+        val many: Sinks.Many<M>,
+        val settled: CompletableFuture<Unit>,
+    )
+
+    private data class CloseAttempt<M : Any>(
+        val settledSink: Pair<NamedAggregate, Sinks.Many<M>>? = null,
+        val pendingSettlement: PendingCloseSettlement<M>? = null,
+        val failure: Throwable? = null,
+    )
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/InMemoryMessageBus.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/InMemoryMessageBus.kt
@@ -21,6 +21,7 @@ import me.ahoo.wow.infra.sink.CloseSettlementAware
 import me.ahoo.wow.infra.sink.prepareConcurrentSink
 import me.ahoo.wow.messaging.handler.MessageExchange
 import me.ahoo.wow.modeling.materialize
+import reactor.core.Scannable
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.core.publisher.Sinks
@@ -89,10 +90,16 @@ abstract class InMemoryMessageBus<M, E : MessageExchange<*, M>> : LocalMessageBu
      * Returns the number of subscribers for the specified named aggregate.
      *
      * @param namedAggregate The named aggregate to check
-     * @return The number of current subscribers, or 0 if no sink exists
+     * @return The number of current subscribers, or 0 if no sink exists or the bus is closing
      */
     override fun subscriberCount(namedAggregate: NamedAggregate): Int {
+        if (closing) {
+            return 0
+        }
         val sink = sinks[namedAggregate.materialize()] ?: return 0
+        if (closing) {
+            return 0
+        }
         return sink.currentSubscriberCount()
     }
 
@@ -243,8 +250,14 @@ abstract class InMemoryMessageBus<M, E : MessageExchange<*, M>> : LocalMessageBu
             log.warn(error) {
                 "Failed to close [${aggregate.aggregateName}] sink."
             }
+            val settlement = many.closeSettlement()
             CloseAttempt(
-                pendingSettlement = many.closeSettlement()?.let {
+                settledSink = if (settlement == null && many.isTerminatedOrCancelled()) {
+                    aggregate to many
+                } else {
+                    null
+                },
+                pendingSettlement = settlement?.let {
                     PendingCloseSettlement(aggregate, many, it)
                 },
                 failure = error,
@@ -263,6 +276,10 @@ abstract class InMemoryMessageBus<M, E : MessageExchange<*, M>> : LocalMessageBu
 
     private fun Sinks.Many<M>.closeSettlement(): CompletableFuture<Unit>? =
         (this as? CloseSettlementAware)?.closeSettled
+
+    private fun Sinks.Many<M>.isTerminatedOrCancelled(): Boolean =
+        scan(Scannable.Attr.TERMINATED) == true ||
+            scan(Scannable.Attr.CANCELLED) == true
 
     private fun finishClose(detachedSinks: List<Pair<NamedAggregate, Sinks.Many<M>>>) {
         synchronized(lifecycleLock) {

--- a/wow-core/src/main/kotlin/me/ahoo/wow/messaging/InMemoryMessageBus.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/messaging/InMemoryMessageBus.kt
@@ -203,6 +203,19 @@ abstract class InMemoryMessageBus<M, E : MessageExchange<*, M>> : LocalMessageBu
         try {
             val emitResult = many.tryEmitComplete()
             when {
+                emitResult == Sinks.EmitResult.FAIL_ZERO_SUBSCRIBER -> {
+                    /*
+                     * Some unicast sinks cannot retain a terminal before their
+                     * first subscriber. Nobody can observe that completion, so
+                     * detach the sink instead of waiting for a settlement that
+                     * cannot occur.
+                     */
+                    log.debug {
+                        "Close [${aggregate.aggregateName}] sink - [$emitResult]."
+                    }
+                    CloseAttempt(settledSink = aggregate to many)
+                }
+
                 emitResult.isSuccess ||
                     emitResult == Sinks.EmitResult.FAIL_TERMINATED ||
                     emitResult == Sinks.EmitResult.FAIL_CANCELLED -> {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/InMemoryCommandBusAtomicSinkTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/InMemoryCommandBusAtomicSinkTest.kt
@@ -1,0 +1,282 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.command
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.command.CommandMessage
+import me.ahoo.wow.command.wait.TestCommandMessage
+import me.ahoo.wow.infra.sink.ConcurrentManySink
+import me.ahoo.wow.infra.sink.MpscUnicastManySink
+import me.ahoo.wow.infra.sink.prepareConcurrentSink
+import me.ahoo.wow.messaging.MessageSubscription
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.BaseSubscriber
+import reactor.core.publisher.Sinks
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+class InMemoryCommandBusAtomicSinkTest {
+
+    @Test
+    fun `default supplier should create the exact atomic mpsc sink`() {
+        val message = TestCommandMessage()
+        val sink = InMemoryCommandBus().sinkSupplier(message)
+        val many: Sinks.Many<*> = sink
+
+        (many is MpscUnicastManySink<*>).assert().isTrue()
+        (many is ConcurrentManySink<*>).assert().isFalse()
+        sink.prepareConcurrentSink().assert().isSameAs(sink)
+    }
+
+    @Test
+    fun `four producers should send every command once through the bus and preserve producer order`() {
+        val producerCount = 4
+        val valuesPerProducer = 100
+        val total = producerCount * valuesPerProducer
+        val messages = (0 until producerCount).associateWith { producer ->
+            (0 until valuesPerProducer).map { sequence ->
+                TestCommandMessage(id = "$producer-$sequence")
+            }
+        }
+        val namedAggregate = messages.getValue(0).first()
+        val bus = InMemoryCommandBus()
+        val received = bus.receive(MessageSubscription(namedAggregate))
+            .take(total.toLong())
+            .collectList()
+            .toFuture()
+        bus.subscriberCount(namedAggregate).assert().isEqualTo(1)
+
+        val executor = Executors.newFixedThreadPool(producerCount)
+        val ready = CountDownLatch(producerCount)
+        val start = CountDownLatch(1)
+        try {
+            val futures = messages.map { (_, producerMessages) ->
+                executor.submit {
+                    ready.countDown()
+                    start.await()
+                    producerMessages.forEach { message ->
+                        bus.send(message).block(Duration.ofSeconds(5))
+                    }
+                }
+            }
+            ready.await(5, TimeUnit.SECONDS).assert().isTrue()
+            start.countDown()
+            futures.forEach { it.get(10, TimeUnit.SECONDS) }
+
+            val exchanges = checkNotNull(received.get(10, TimeUnit.SECONDS))
+            val actualIds = exchanges.map { it.message.id }
+            val expectedIds = messages.values.flatten().map { it.id }
+            actualIds.size.assert().isEqualTo(total)
+            actualIds.toSet().assert().isEqualTo(expectedIds.toSet())
+            repeat(producerCount) { producer ->
+                actualIds.filter { it.startsWith("$producer-") }
+                    .map { it.substringAfter('-').toInt() }
+                    .assert()
+                    .containsExactly(*(0 until valuesPerProducer).toList().toTypedArray())
+            }
+        } finally {
+            start.countDown()
+            received.cancel(true)
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+            bus.close()
+        }
+    }
+
+    @Test
+    @Suppress("LongMethod")
+    fun `close should not reopen the bus before an active atomic sink settles`() {
+        val message = TestCommandMessage()
+        val bus = InMemoryCommandBus()
+        val onNextEntered = CountDownLatch(1)
+        val releaseOnNext = CountDownLatch(1)
+        val terminal = CountDownLatch(1)
+        val completed = AtomicBoolean()
+        val observedError = AtomicReference<Throwable?>()
+        val subscription = bus.receive(MessageSubscription(message)).subscribe(
+            {
+                onNextEntered.countDown()
+                check(releaseOnNext.await(5, TimeUnit.SECONDS)) {
+                    "Timed out waiting to release the active command delivery."
+                }
+            },
+            {
+                observedError.set(it)
+                terminal.countDown()
+            },
+            {
+                completed.set(true)
+                terminal.countDown()
+            },
+        )
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val send = executor.submit { bus.send(message).block(Duration.ofSeconds(5)) }
+            onNextEntered.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+            val closingSink = cachedSinks(bus).single()
+            (closingSink is MpscUnicastManySink<*>).assert().isTrue()
+            bus.close()
+            cachedSinks(bus).assert().containsExactly(closingSink)
+            terminal.count.assert().isEqualTo(1)
+
+            val rejectedWhileClosing = TestCommandMessage()
+            bus.send(rejectedWhileClosing).block(Duration.ofSeconds(5))
+            rejectedWhileClosing.isReadOnly.assert().isTrue()
+            bus.receive(MessageSubscription(rejectedWhileClosing))
+                .collectList()
+                .block(Duration.ofSeconds(5))
+                .assert()
+                .isEmpty()
+            cachedSinks(bus).assert().containsExactly(closingSink)
+
+            releaseOnNext.countDown()
+            send.get(5, TimeUnit.SECONDS)
+            terminal.await(5, TimeUnit.SECONDS).assert().isTrue()
+            completed.get().assert().isTrue()
+            observedError.get().assert().isNull()
+            cachedSinks(bus).assert().isEmpty()
+
+            val reopenedSubscription = bus.receive(MessageSubscription(message)).subscribe()
+            try {
+                val reopenedSink = cachedSinks(bus).single()
+                reopenedSink.assert().isNotSameAs(closingSink)
+                (reopenedSink is MpscUnicastManySink<*>).assert().isTrue()
+            } finally {
+                reopenedSubscription.dispose()
+            }
+        } finally {
+            releaseOnNext.countDown()
+            subscription.dispose()
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+            bus.close()
+        }
+    }
+
+    @Test
+    fun `reentrant close should return without reopening before current delivery settles`() {
+        val message = TestCommandMessage()
+        val bus = InMemoryCommandBus()
+        val closeReturned = AtomicBoolean()
+        val completed = AtomicBoolean()
+        val subscription = bus.receive(MessageSubscription(message)).subscribe(
+            {
+                bus.close()
+                closeReturned.set(true)
+                cachedSinks(bus).assert().hasSize(1)
+            },
+            { throw AssertionError("Expected reentrant close completion.", it) },
+            { completed.set(true) },
+        )
+        try {
+            bus.send(message).block(Duration.ofSeconds(5))
+
+            closeReturned.get().assert().isTrue()
+            completed.get().assert().isTrue()
+            cachedSinks(bus).assert().isEmpty()
+        } finally {
+            subscription.dispose()
+            bus.close()
+        }
+    }
+
+    @Test
+    fun `reentrant close should wait for cancellation requested during active delivery`() {
+        val message = TestCommandMessage()
+        val bus = InMemoryCommandBus()
+        val closeReturned = AtomicBoolean()
+        bus.receive(MessageSubscription(message))
+        @Suppress("UNCHECKED_CAST")
+        val closingSink = cachedSinks(bus).single() as Sinks.Many<CommandMessage<*>>
+        val subscriber = object : BaseSubscriber<CommandMessage<*>>() {
+            override fun hookOnNext(value: CommandMessage<*>) {
+                val closingSink = cachedSinks(bus).single()
+                cancel()
+                closingSink.scanUnsafe(reactor.core.Scannable.Attr.CANCELLED)
+                    .assert()
+                    .isEqualTo(true)
+                bus.close()
+                closeReturned.set(true)
+                cachedSinks(bus).assert().containsExactly(closingSink)
+            }
+        }
+        closingSink.asFlux().subscribe(subscriber)
+        try {
+            bus.send(message).block(Duration.ofSeconds(5))
+
+            closeReturned.get().assert().isTrue()
+            cachedSinks(bus).assert().isEmpty()
+        } finally {
+            subscriber.dispose()
+            bus.close()
+        }
+    }
+
+    @Test
+    fun `close should wait for subscriber driven delivery of a buffered command`() {
+        val message = TestCommandMessage()
+        val bus = InMemoryCommandBus()
+        bus.send(message).block(Duration.ofSeconds(5))
+        val bufferedSink = cachedSinks(bus).single()
+        val onNextEntered = CountDownLatch(1)
+        val releaseOnNext = CountDownLatch(1)
+        val completed = AtomicBoolean()
+        val executor = Executors.newSingleThreadExecutor()
+        val subscription = AtomicReference<reactor.core.Disposable?>()
+        try {
+            val subscribing = executor.submit {
+                subscription.set(
+                    bus.receive(MessageSubscription(message)).subscribe(
+                        {
+                            onNextEntered.countDown()
+                            check(releaseOnNext.await(5, TimeUnit.SECONDS)) {
+                                "Timed out waiting to release buffered command delivery."
+                            }
+                        },
+                        { throw AssertionError("Expected buffered command completion.", it) },
+                        { completed.set(true) },
+                    ),
+                )
+            }
+            onNextEntered.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+            bus.close()
+            cachedSinks(bus).assert().containsExactly(bufferedSink)
+
+            releaseOnNext.countDown()
+            subscribing.get(5, TimeUnit.SECONDS)
+            completed.get().assert().isTrue()
+            cachedSinks(bus).assert().isEmpty()
+        } finally {
+            releaseOnNext.countDown()
+            subscription.get()?.dispose()
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+            bus.close()
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun cachedSinks(bus: InMemoryCommandBus): Collection<Sinks.Many<*>> {
+        val field = bus.javaClass.superclass.getDeclaredField("sinks")
+        field.isAccessible = true
+        val sinks = field.get(bus) as Map<*, Sinks.Many<*>>
+        return sinks.values
+    }
+}

--- a/wow-core/src/test/kotlin/me/ahoo/wow/infra/sink/MpscUnicastManySinkSemanticsTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/infra/sink/MpscUnicastManySinkSemanticsTest.kt
@@ -1,0 +1,305 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.infra.sink
+
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.TestFactory
+import org.reactivestreams.Subscription
+import reactor.core.CoreSubscriber
+import reactor.core.Scannable
+import reactor.core.publisher.Sinks
+import reactor.test.StepVerifier
+import reactor.util.concurrent.Queues
+import reactor.util.context.Context
+import java.time.Duration
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Observable compatibility checks against Reactor's native
+ * `Sinks.unsafe().many().unicast().onBackpressureBuffer(MPSC queue)`.
+ *
+ * Fusion is intentionally excluded: [MpscUnicastManySink] hides the factory-owned
+ * queue, while preserving the public [Sinks.Many] and Reactive Streams behavior.
+ */
+class MpscUnicastManySinkSemanticsTest {
+
+    @TestFactory
+    fun `should match native warmup backpressure and terminal ordering`(): List<DynamicTest> =
+        sinkCases.map { sinkCase ->
+            DynamicTest.dynamicTest(sinkCase.name) {
+                val sink = sinkCase.create()
+
+                sink.tryEmitNext(1).assert().isEqualTo(Sinks.EmitResult.OK)
+                sink.tryEmitNext(2).assert().isEqualTo(Sinks.EmitResult.OK)
+                sink.tryEmitComplete().assert().isEqualTo(Sinks.EmitResult.OK)
+                sink.scan(Scannable.Attr.BUFFERED).assert().isEqualTo(2)
+
+                StepVerifier.create(sink.asFlux(), 0)
+                    .then { sink.currentSubscriberCount().assert().isEqualTo(1) }
+                    .expectNoEvent(Duration.ofMillis(10))
+                    .thenRequest(1)
+                    .expectNext(1)
+                    .expectNoEvent(Duration.ofMillis(10))
+                    .thenRequest(1)
+                    .expectNext(2)
+                    .expectComplete()
+                    .verify(TEST_TIMEOUT)
+
+                sink.currentSubscriberCount().assert().isEqualTo(0)
+                StepVerifier.create(sink.asFlux())
+                    .expectErrorMatches {
+                        it is IllegalStateException &&
+                            it.message.orEmpty().contains("only allow a single Subscriber")
+                    }
+                    .verify(TEST_TIMEOUT)
+            }
+        }
+
+    @TestFactory
+    fun `should match native cancellation results and discard behavior`(): List<DynamicTest> =
+        sinkCases.map { sinkCase ->
+            DynamicTest.dynamicTest(sinkCase.name) {
+                val sink = sinkCase.create()
+
+                StepVerifier.create(sink.asFlux().take(1))
+                    .then {
+                        sink.emitNext(1, Sinks.EmitFailureHandler.FAIL_FAST)
+                        sink.emitNext(2, Sinks.EmitFailureHandler.FAIL_FAST)
+                    }
+                    .expectNext(1)
+                    .expectComplete()
+                    .verifyThenAssertThat(TEST_TIMEOUT)
+                    .hasDiscardedExactly(2)
+
+                sink.scan(Scannable.Attr.CANCELLED).assert().isEqualTo(true)
+                sink.tryEmitNext(3).assert().isEqualTo(Sinks.EmitResult.FAIL_CANCELLED)
+                sink.tryEmitComplete().assert().isEqualTo(Sinks.EmitResult.FAIL_CANCELLED)
+                sink.tryEmitError(IllegalStateException("cancelled"))
+                    .assert()
+                    .isEqualTo(Sinks.EmitResult.FAIL_CANCELLED)
+            }
+        }
+
+    @TestFactory
+    fun `should match native late cancellation after a buffered terminal`(): List<DynamicTest> =
+        sinkCases.map { sinkCase ->
+            DynamicTest.dynamicTest(sinkCase.name) {
+                val sink = sinkCase.create()
+
+                sink.tryEmitNext(1).assert().isEqualTo(Sinks.EmitResult.OK)
+                sink.tryEmitComplete().assert().isEqualTo(Sinks.EmitResult.OK)
+
+                StepVerifier.create(sink.asFlux(), 0)
+                    .thenCancel()
+                    .verifyThenAssertThat(TEST_TIMEOUT)
+                    .hasDiscardedExactly(1)
+
+                sink.currentSubscriberCount().assert().isEqualTo(0)
+                sink.scan(Scannable.Attr.CANCELLED).assert().isEqualTo(true)
+            }
+        }
+
+    @TestFactory
+    fun `should match native error replay and terminal results`(): List<DynamicTest> =
+        sinkCases.map { sinkCase ->
+            DynamicTest.dynamicTest(sinkCase.name) {
+                val sink = sinkCase.create()
+                val error = IllegalStateException("terminal")
+
+                sink.tryEmitNext(1).assert().isEqualTo(Sinks.EmitResult.OK)
+                sink.tryEmitError(error).assert().isEqualTo(Sinks.EmitResult.OK)
+                sink.tryEmitNext(2).assert().isEqualTo(Sinks.EmitResult.FAIL_TERMINATED)
+                sink.tryEmitComplete().assert().isEqualTo(Sinks.EmitResult.FAIL_TERMINATED)
+                sink.tryEmitError(IllegalStateException("late"))
+                    .assert()
+                    .isEqualTo(Sinks.EmitResult.FAIL_TERMINATED)
+                sink.scan(Scannable.Attr.TERMINATED).assert().isEqualTo(true)
+                sink.scan(Scannable.Attr.ERROR).assert().isSameAs(error)
+
+                StepVerifier.create(sink.asFlux(), 0)
+                    .thenRequest(1)
+                    .expectNext(1)
+                    .expectErrorMatches { it === error }
+                    .verify(TEST_TIMEOUT)
+            }
+        }
+
+    @TestFactory
+    fun `should match native emit API drop behavior after termination`(): List<DynamicTest> =
+        sinkCases.map { sinkCase ->
+            DynamicTest.dynamicTest(sinkCase.name) {
+                val sink = sinkCase.create()
+                val lateError = IllegalStateException("late")
+
+                StepVerifier.create(sink.asFlux())
+                    .then {
+                        sink.emitComplete(Sinks.EmitFailureHandler.FAIL_FAST)
+                        sink.emitNext(1, Sinks.EmitFailureHandler.FAIL_FAST)
+                        sink.emitError(lateError, Sinks.EmitFailureHandler.FAIL_FAST)
+                    }
+                    .expectComplete()
+                    .verifyThenAssertThat(TEST_TIMEOUT)
+                    .hasDroppedExactly(1)
+                    .hasDroppedErrorMatching { it === lateError }
+            }
+        }
+
+    @TestFactory
+    fun `should match native actual subscriber scans`(): List<DynamicTest> =
+        sinkCases.map { sinkCase ->
+            DynamicTest.dynamicTest(sinkCase.name) {
+                val sink = sinkCase.create()
+                val flux = sink.asFlux()
+                val fluxView = Scannable.from(flux)
+                val subscription = AtomicReference<Subscription>()
+                val subscriber = object : CoreSubscriber<Int>, Scannable {
+                    override fun currentContext(): Context = Context.empty()
+
+                    override fun onSubscribe(delegate: Subscription) {
+                        subscription.set(delegate)
+                    }
+
+                    override fun onNext(value: Int) = Unit
+
+                    override fun onError(throwable: Throwable) = Unit
+
+                    override fun onComplete() = Unit
+
+                    override fun scanUnsafe(key: Scannable.Attr<*>): Any? = null
+                }
+
+                flux.subscribe(subscriber)
+
+                sink.scan(Scannable.Attr.ACTUAL).assert().isSameAs(subscriber)
+                sink.inners().findFirst().orElseThrow().assert().isSameAs(subscriber)
+                fluxView.scan(Scannable.Attr.ACTUAL).assert().isSameAs(subscriber)
+                fluxView.inners().findFirst().orElseThrow().assert().isSameAs(subscriber)
+                subscription.get().cancel()
+                sink.inners().count().assert().isEqualTo(0)
+                fluxView.inners().count().assert().isEqualTo(0)
+            }
+        }
+
+    @TestFactory
+    fun `should match native flux view scans`(): List<DynamicTest> =
+        sinkCases.map { sinkCase ->
+            DynamicTest.dynamicTest(sinkCase.name) {
+                val sink = sinkCase.create()
+                val fluxView = Scannable.from(sink.asFlux())
+
+                sink.tryEmitNext(1).assert().isEqualTo(Sinks.EmitResult.OK)
+                fluxView.scan(Scannable.Attr.BUFFERED)
+                    .assert()
+                    .isEqualTo(sink.scan(Scannable.Attr.BUFFERED))
+                fluxView.scan(Scannable.Attr.CAPACITY)
+                    .assert()
+                    .isEqualTo(sink.scan(Scannable.Attr.CAPACITY))
+                fluxView.scan(Scannable.Attr.PREFETCH)
+                    .assert()
+                    .isEqualTo(sink.scan(Scannable.Attr.PREFETCH))
+                fluxView.scan(Scannable.Attr.TERMINATED)
+                    .assert()
+                    .isEqualTo(sink.scan(Scannable.Attr.TERMINATED))
+                fluxView.scan(Scannable.Attr.CANCELLED)
+                    .assert()
+                    .isEqualTo(sink.scan(Scannable.Attr.CANCELLED))
+                fluxView.scan(Scannable.Attr.ERROR)
+                    .assert()
+                    .isEqualTo(sink.scan(Scannable.Attr.ERROR))
+                fluxView.scan(Scannable.Attr.ACTUAL)
+                    .assert()
+                    .isEqualTo(sink.scan(Scannable.Attr.ACTUAL))
+
+                sink.tryEmitComplete().assert().isEqualTo(Sinks.EmitResult.OK)
+                fluxView.scan(Scannable.Attr.TERMINATED)
+                    .assert()
+                    .isEqualTo(sink.scan(Scannable.Attr.TERMINATED))
+            }
+        }
+
+    @TestFactory
+    fun `should match native cancellation after an on next callback failure`(): List<DynamicTest> =
+        sinkCases.map { sinkCase ->
+            DynamicTest.dynamicTest(sinkCase.name) {
+                val sink = sinkCase.create()
+                val callbackFailure = IllegalStateException("callback")
+                val firstEntered = CountDownLatch(1)
+                val secondOffered = CountDownLatch(1)
+                val received = ConcurrentLinkedQueue<Int>()
+                val errors = ConcurrentLinkedQueue<Throwable>()
+                val subscription = sink.asFlux()
+                    .subscribe(
+                        { value ->
+                            received.add(value)
+                            if (value == 1) {
+                                firstEntered.countDown()
+                                check(secondOffered.await(5, TimeUnit.SECONDS)) {
+                                    "Timed out waiting for the second value to be offered."
+                                }
+                                throw callbackFailure
+                            }
+                        },
+                        errors::add,
+                    )
+                val executor = Executors.newFixedThreadPool(2)
+                try {
+                    val first = executor.submit<Sinks.EmitResult> { sink.tryEmitNext(1) }
+                    firstEntered.await(5, TimeUnit.SECONDS).assert().isTrue()
+                    val second = executor.submit<Sinks.EmitResult> {
+                        sink.tryEmitNext(2).also {
+                            secondOffered.countDown()
+                        }
+                    }
+
+                    second.get(5, TimeUnit.SECONDS).assert().isEqualTo(Sinks.EmitResult.OK)
+                    first.get(5, TimeUnit.SECONDS).assert().isEqualTo(Sinks.EmitResult.OK)
+
+                    received.assert().containsExactly(1)
+                    errors.assert().containsExactly(callbackFailure)
+                    sink.scan(Scannable.Attr.CANCELLED).assert().isEqualTo(true)
+                } finally {
+                    secondOffered.countDown()
+                    subscription.dispose()
+                    executor.shutdownNow()
+                    executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+                }
+            }
+        }
+
+    private data class SinkCase(
+        val name: String,
+        val create: () -> Sinks.Many<Int>,
+    )
+
+    private companion object {
+        val TEST_TIMEOUT: Duration = Duration.ofSeconds(5)
+
+        val sinkCases = listOf(
+            SinkCase("reactor-native-unicast") {
+                Sinks.unsafe()
+                    .many()
+                    .unicast()
+                    .onBackpressureBuffer(Queues.unboundedMultiproducer<Int>().get())
+            },
+            SinkCase("wow-mpsc-unicast") {
+                mpscUnicastManySink()
+            },
+        )
+    }
+}

--- a/wow-core/src/test/kotlin/me/ahoo/wow/infra/sink/MpscUnicastManySinkTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/infra/sink/MpscUnicastManySinkTest.kt
@@ -844,6 +844,51 @@ class MpscUnicastManySinkTest {
     }
 
     @Test
+    fun `close settlement should not wait for downstream demand`() {
+        val sink = mpscUnicastManySink<Int>()
+        val subscription = AtomicReference<Subscription>()
+        val values = mutableListOf<Int>()
+        val completed = AtomicBoolean()
+        sink.asFlux().subscribe(
+            object : CoreSubscriber<Int> {
+                override fun currentContext(): Context = Context.empty()
+
+                override fun onSubscribe(delegate: Subscription) {
+                    subscription.set(delegate)
+                }
+
+                override fun onNext(value: Int) {
+                    values.add(value)
+                }
+
+                override fun onError(throwable: Throwable) {
+                    throw AssertionError("Expected completion.", throwable)
+                }
+
+                override fun onComplete() {
+                    completed.set(true)
+                }
+            },
+        )
+
+        try {
+            sink.tryEmitNext(1).assert().isEqualTo(Sinks.EmitResult.OK)
+            sink.tryEmitComplete().assert().isEqualTo(Sinks.EmitResult.OK)
+
+            sink.closeSettled.isDone.assert().isTrue()
+            values.assert().isEmpty()
+            completed.get().assert().isFalse()
+            sink.scan(Scannable.Attr.BUFFERED).assert().isEqualTo(1)
+
+            subscription.get().request(1)
+            values.assert().containsExactly(1)
+            completed.get().assert().isTrue()
+        } finally {
+            subscription.get().cancel()
+        }
+    }
+
+    @Test
     fun `close settlement should wait for a physically delegated cancellation to return`() {
         val delegate = BlockingRequestAndCancelManySink()
         val sink = sinkWithDelegate(delegate)

--- a/wow-core/src/test/kotlin/me/ahoo/wow/infra/sink/MpscUnicastManySinkTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/infra/sink/MpscUnicastManySinkTest.kt
@@ -1,0 +1,1540 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.infra.sink
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.infra.Decorator
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.reactivestreams.Subscription
+import reactor.core.CoreSubscriber
+import reactor.core.Exceptions
+import reactor.core.Fuseable
+import reactor.core.Scannable
+import reactor.core.publisher.BaseSubscriber
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Operators
+import reactor.core.publisher.SignalType
+import reactor.core.publisher.Sinks
+import reactor.test.StepVerifier
+import reactor.util.concurrent.Queues
+import reactor.util.context.Context
+import java.lang.reflect.InvocationTargetException
+import java.time.Duration
+import java.util.Queue
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executors
+import java.util.concurrent.Semaphore
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
+import java.util.stream.Stream
+
+@Suppress("LargeClass")
+class MpscUnicastManySinkTest {
+
+    companion object {
+        private val TEST_TIMEOUT: Duration = Duration.ofSeconds(5)
+    }
+
+    @Test
+    fun `should keep the factory owned mpsc sink unchanged when preparing concurrent emission`() {
+        val sink = mpscUnicastManySink<Int>()
+        val many: Sinks.Many<Int> = sink
+
+        sink.prepareConcurrentSink().assert().isSameAs(sink)
+        (many is ConcurrentManySink<*>).assert().isFalse()
+        (many is Decorator<*>).assert().isFalse()
+    }
+
+    @Test
+    fun `should keep an existing concurrent sink unchanged when preparing concurrent emission`() {
+        val sink = Sinks.unsafe().many().unicast().onBackpressureBuffer<Int>().concurrent()
+
+        sink.prepareConcurrentSink().assert().isSameAs(sink)
+    }
+
+    @Test
+    fun `should wrap an arbitrary raw sink when preparing concurrent emission`() {
+        val sink = Sinks.unsafe().many().multicast().onBackpressureBuffer<Int>()
+
+        val prepared = sink.prepareConcurrentSink()
+
+        (prepared is ConcurrentManySink<*>).assert().isTrue()
+        (prepared as ConcurrentManySink<Int>).delegate.assert().isSameAs(sink)
+    }
+
+    @Test
+    fun `should defer physical terminal until an admitted next returns`() {
+        val delegate = BlockingNextManySink()
+        val sink = sinkWithDelegate(delegate)
+        val executor = Executors.newFixedThreadPool(2)
+        val next = executor.submit<Sinks.EmitResult> { sink.tryEmitNext(1) }
+        try {
+            delegate.nextEntered.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+            val terminal = executor.submit<Sinks.EmitResult> { sink.tryEmitComplete() }
+            terminal.get(5, TimeUnit.SECONDS).assert().isEqualTo(Sinks.EmitResult.OK)
+            delegate.terminalCalled.count.assert().isEqualTo(1)
+        } finally {
+            delegate.releaseNext.countDown()
+            executor.shutdown()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+        }
+
+        next.get(5, TimeUnit.SECONDS).assert().isEqualTo(Sinks.EmitResult.OK)
+        delegate.calls.assert().containsExactly("next", "complete")
+    }
+
+    @Test
+    fun `should not complete the real unicast delegate while an admitted offer is paused`() {
+        val queue = PausingOfferQueue<Int>()
+        val sink = sinkWithQueue(queue)
+        val calls = ConcurrentLinkedQueue<String>()
+        val terminal = CountDownLatch(1)
+        val subscription = sink.asFlux().subscribe(
+            { calls.add("next:$it") },
+            { throw it },
+            {
+                calls.add("complete")
+                terminal.countDown()
+            },
+        )
+        val executor = Executors.newFixedThreadPool(2)
+        try {
+            val next = executor.submit<Sinks.EmitResult> { sink.tryEmitNext(1) }
+            queue.offerEntered.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+            executor.submit<Sinks.EmitResult> { sink.tryEmitComplete() }
+                .get(5, TimeUnit.SECONDS)
+                .assert()
+                .isEqualTo(Sinks.EmitResult.OK)
+            calls.assert().isEmpty()
+
+            queue.releaseOffer.countDown()
+            next.get(5, TimeUnit.SECONDS).assert().isEqualTo(Sinks.EmitResult.OK)
+            terminal.await(5, TimeUnit.SECONDS).assert().isTrue()
+            calls.assert().containsExactly("next:1", "complete")
+        } finally {
+            queue.releaseOffer.countDown()
+            subscription.dispose()
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+        }
+    }
+
+    @Test
+    fun `should claim only the first terminal even when the delegate accepts every terminal`() {
+        val delegate = AlwaysAcceptingManySink<Int>()
+        val sink = sinkWithDelegate(delegate)
+        val error = IllegalStateException("loser")
+
+        sink.tryEmitComplete().assert().isEqualTo(Sinks.EmitResult.OK)
+        sink.scanUnsafe(Scannable.Attr.ERROR).assert().isNull()
+        sink.tryEmitError(error).assert().isEqualTo(Sinks.EmitResult.FAIL_TERMINATED)
+
+        delegate.completeCalls.get().assert().isEqualTo(1)
+        delegate.errorCalls.get().assert().isEqualTo(0)
+    }
+
+    @Test
+    fun `should keep logical terminal success when cancellation wins after claim`() {
+        val delegate = CancellingTerminalManySink<Int>()
+        val sink = sinkWithDelegate(delegate)
+
+        sink.tryEmitComplete().assert().isEqualTo(Sinks.EmitResult.OK)
+
+        sink.scanUnsafe(Scannable.Attr.TERMINATED).assert().isEqualTo(true)
+        sink.scanUnsafe(Scannable.Attr.CANCELLED).assert().isEqualTo(true)
+        sink.tryEmitNext(1).assert().isEqualTo(Sinks.EmitResult.FAIL_TERMINATED)
+        sink.tryEmitComplete().assert().isEqualTo(Sinks.EmitResult.FAIL_TERMINATED)
+    }
+
+    @Test
+    fun `should keep logical terminal success when cancellation wins before last releaser delegates`() {
+        val delegate = BlockingNextManySink()
+        val sink = sinkWithDelegate(delegate)
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val next = executor.submit<Sinks.EmitResult> { sink.tryEmitNext(1) }
+            delegate.nextEntered.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+            sink.tryEmitComplete().assert().isEqualTo(Sinks.EmitResult.OK)
+            delegate.completeCalls.get().assert().isEqualTo(0)
+            delegate.cancelled = true
+            delegate.releaseNext.countDown()
+
+            next.get(5, TimeUnit.SECONDS).assert().isEqualTo(Sinks.EmitResult.OK)
+            delegate.completeCalls.get().assert().isEqualTo(1)
+            sink.scanUnsafe(Scannable.Attr.TERMINATED).assert().isEqualTo(true)
+        } finally {
+            delegate.releaseNext.countDown()
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+        }
+    }
+
+    @Test
+    fun `should reject an unexpected physical terminal result as an invariant violation`() {
+        val sink = sinkWithDelegate<Int>(
+            TerminalResultManySink(Sinks.EmitResult.FAIL_TERMINATED),
+        )
+
+        assertThrows<Sinks.EmissionException> {
+            sink.tryEmitComplete()
+        }
+
+        sink.scanUnsafe(Scannable.Attr.TERMINATED).assert().isEqualTo(true)
+        sink.tryEmitNext(1).assert().isEqualTo(Sinks.EmitResult.FAIL_TERMINATED)
+    }
+
+    @Test
+    fun `should reject terminal before claim when cancellation is already visible`() {
+        val delegate = BlockingNextManySink()
+        delegate.cancelled = true
+        val sink = sinkWithDelegate(delegate)
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val next = executor.submit<Sinks.EmitResult> { sink.tryEmitNext(1) }
+            delegate.nextEntered.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+            sink.tryEmitComplete().assert().isEqualTo(Sinks.EmitResult.FAIL_CANCELLED)
+            delegate.completeCalls.get().assert().isEqualTo(0)
+
+            delegate.releaseNext.countDown()
+            next.get(5, TimeUnit.SECONDS).assert().isEqualTo(Sinks.EmitResult.OK)
+        } finally {
+            delegate.releaseNext.countDown()
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+        }
+    }
+
+    @Test
+    fun `should expose logical error while its physical terminal is deferred`() {
+        val delegate = BlockingNextManySink()
+        val sink = sinkWithDelegate(delegate)
+        val error = IllegalStateException("deferred")
+        val executor = Executors.newFixedThreadPool(2)
+        try {
+            val next = executor.submit<Sinks.EmitResult> { sink.tryEmitNext(1) }
+            delegate.nextEntered.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+            sink.tryEmitError(error).assert().isEqualTo(Sinks.EmitResult.OK)
+            sink.scanUnsafe(Scannable.Attr.TERMINATED).assert().isEqualTo(true)
+            sink.scanUnsafe(Scannable.Attr.ERROR).assert().isSameAs(error)
+            delegate.terminalCalled.count.assert().isEqualTo(1)
+
+            delegate.releaseNext.countDown()
+            next.get(5, TimeUnit.SECONDS).assert().isEqualTo(Sinks.EmitResult.OK)
+            delegate.terminalCalled.await(5, TimeUnit.SECONDS).assert().isTrue()
+        } finally {
+            delegate.releaseNext.countDown()
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+        }
+
+        delegate.calls.assert().containsExactly("next", "error")
+    }
+
+    @Test
+    fun `should complete after a reentrant terminal returns from on next`() {
+        val sink = mpscUnicastManySink<Int>()
+        val calls = mutableListOf<String>()
+        val terminalResult = AtomicReference<Sinks.EmitResult>()
+        val terminal = CountDownLatch(1)
+        val subscription = sink.asFlux().subscribe(
+            {
+                calls.add("next-start")
+                terminalResult.set(sink.tryEmitComplete())
+                sink.tryEmitNext(2).assert().isEqualTo(Sinks.EmitResult.FAIL_TERMINATED)
+                calls.add("next-end")
+            },
+            { throw it },
+            {
+                calls.add("complete")
+                terminal.countDown()
+            },
+        )
+        try {
+            sink.tryEmitNext(1).assert().isEqualTo(Sinks.EmitResult.OK)
+            terminal.await(5, TimeUnit.SECONDS).assert().isTrue()
+            terminalResult.get().assert().isEqualTo(Sinks.EmitResult.OK)
+            calls.assert().containsExactly("next-start", "next-end", "complete")
+        } finally {
+            subscription.dispose()
+        }
+    }
+
+    @Test
+    fun `should error after a reentrant terminal returns from on next`() {
+        val sink = mpscUnicastManySink<Int>()
+        val calls = mutableListOf<String>()
+        val error = IllegalStateException("reentrant")
+        val terminalResult = AtomicReference<Sinks.EmitResult>()
+        val observedError = AtomicReference<Throwable?>()
+        val terminal = CountDownLatch(1)
+        val subscription = sink.asFlux().subscribe(
+            {
+                calls.add("next-start")
+                terminalResult.set(sink.tryEmitError(error))
+                sink.tryEmitNext(2).assert().isEqualTo(Sinks.EmitResult.FAIL_TERMINATED)
+                calls.add("next-end")
+            },
+            {
+                calls.add("error")
+                observedError.set(it)
+                terminal.countDown()
+            },
+            { throw AssertionError("Expected the reentrant error terminal.") },
+        )
+        try {
+            sink.tryEmitNext(1).assert().isEqualTo(Sinks.EmitResult.OK)
+            terminal.await(5, TimeUnit.SECONDS).assert().isTrue()
+            terminalResult.get().assert().isEqualTo(Sinks.EmitResult.OK)
+            observedError.get().assert().isSameAs(error)
+            calls.assert().containsExactly("next-start", "next-end", "error")
+        } finally {
+            subscription.dispose()
+        }
+    }
+
+    @Test
+    fun `should reject terminal when downstream cancellation happens before claim during active next`() {
+        val sink = mpscUnicastManySink<Int>()
+        val cancelled = CountDownLatch(1)
+        val releaseOnNext = CountDownLatch(1)
+        val completed = AtomicBoolean()
+        val observedError = AtomicReference<Throwable?>()
+        val subscriber = object : BaseSubscriber<Int>() {
+            override fun hookOnNext(value: Int) {
+                cancel()
+                cancelled.countDown()
+                check(releaseOnNext.await(5, TimeUnit.SECONDS)) {
+                    "Timed out waiting to release the cancelled onNext callback."
+                }
+            }
+
+            override fun hookOnComplete() {
+                completed.set(true)
+            }
+
+            override fun hookOnError(throwable: Throwable) {
+                observedError.set(throwable)
+            }
+        }
+        sink.asFlux().subscribe(subscriber)
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val next = executor.submit<Sinks.EmitResult> { sink.tryEmitNext(1) }
+            cancelled.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+            sink.tryEmitComplete().assert().isEqualTo(Sinks.EmitResult.FAIL_CANCELLED)
+            sink.tryEmitError(IllegalStateException("cancelled"))
+                .assert()
+                .isEqualTo(Sinks.EmitResult.FAIL_CANCELLED)
+            sink.scanUnsafe(Scannable.Attr.CANCELLED).assert().isEqualTo(true)
+            sink.scanUnsafe(Scannable.Attr.TERMINATED).assert().isEqualTo(false)
+
+            releaseOnNext.countDown()
+            next.get(5, TimeUnit.SECONDS).assert().isEqualTo(Sinks.EmitResult.OK)
+            sink.tryEmitNext(2).assert().isEqualTo(Sinks.EmitResult.FAIL_CANCELLED)
+            completed.get().assert().isFalse()
+            observedError.get().assert().isNull()
+        } finally {
+            releaseOnNext.countDown()
+            subscriber.dispose()
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+        }
+    }
+
+    @Test
+    fun `cancelling from the first buffered value should stop the same request drain`() {
+        val sink = mpscUnicastManySink<Int>()
+        val received = ConcurrentLinkedQueue<Int>()
+        val subscription = AtomicReference<Subscription>()
+        sink.tryEmitNext(1).assert().isEqualTo(Sinks.EmitResult.OK)
+        sink.tryEmitNext(2).assert().isEqualTo(Sinks.EmitResult.OK)
+
+        sink.asFlux().subscribe(
+            object : CoreSubscriber<Int> {
+                override fun currentContext(): Context = Context.empty()
+
+                override fun onSubscribe(delegate: Subscription) {
+                    subscription.set(delegate)
+                    delegate.request(2)
+                }
+
+                override fun onNext(value: Int) {
+                    received.add(value)
+                    subscription.get().cancel()
+                }
+
+                override fun onError(throwable: Throwable) {
+                    throw AssertionError("Expected cancellation without an error.", throwable)
+                }
+
+                override fun onComplete() = Unit
+            },
+        )
+
+        received.assert().containsExactly(1)
+        sink.scanUnsafe(Scannable.Attr.CANCELLED).assert().isEqualTo(true)
+    }
+
+    @Test
+    fun `request after logical cancellation should not drain a buffered value`() {
+        val sink = mpscUnicastManySink<Int>()
+        val received = ConcurrentLinkedQueue<Int>()
+        sink.tryEmitNext(1).assert().isEqualTo(Sinks.EmitResult.OK)
+
+        sink.asFlux().subscribe(
+            object : CoreSubscriber<Int> {
+                override fun currentContext(): Context = Context.empty()
+
+                override fun onSubscribe(subscription: Subscription) {
+                    subscription.cancel()
+                    subscription.request(1)
+                }
+
+                override fun onNext(value: Int) {
+                    received.add(value)
+                }
+
+                override fun onError(throwable: Throwable) {
+                    throw AssertionError("Expected cancellation without an error.", throwable)
+                }
+
+                override fun onComplete() = Unit
+            },
+        )
+
+        received.assert().isEmpty()
+        sink.scanUnsafe(Scannable.Attr.CANCELLED).assert().isEqualTo(true)
+    }
+
+    @Test
+    fun `cancellation should clear an admitted value paused before queue offer exactly once`() {
+        val queue = PausingOfferQueue<Int>()
+        val sink = sinkWithQueue(queue)
+        val discarded = ConcurrentLinkedQueue<Int>()
+        val subscriber = ZeroDemandSubscriber(discarded)
+        sink.asFlux().subscribe(subscriber)
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val next = executor.submit<Sinks.EmitResult> { sink.tryEmitNext(1) }
+            queue.offerEntered.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+            subscriber.cancel()
+            sink.scanUnsafe(Scannable.Attr.CANCELLED).assert().isEqualTo(true)
+            queue.releaseOffer.countDown()
+
+            next.get(5, TimeUnit.SECONDS).assert().isEqualTo(Sinks.EmitResult.OK)
+            queue.isEmpty().assert().isTrue()
+            discarded.assert().containsExactly(1)
+            sink.tryEmitNext(2).assert().isEqualTo(Sinks.EmitResult.FAIL_CANCELLED)
+        } finally {
+            queue.releaseOffer.countDown()
+            subscriber.dispose()
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+        }
+    }
+
+    @Test
+    fun `cancellation should discard an offered value exactly once after offer returns`() {
+        val queue = PausingAfterOfferQueue<Int>()
+        val sink = sinkWithQueue(queue)
+        val discarded = ConcurrentLinkedQueue<Int>()
+        val subscriber = ZeroDemandSubscriber(discarded)
+        sink.asFlux().subscribe(subscriber)
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val next = executor.submit<Sinks.EmitResult> { sink.tryEmitNext(1) }
+            queue.offered.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+            subscriber.cancel()
+            queue.releaseOffer.countDown()
+
+            next.get(5, TimeUnit.SECONDS).assert().isEqualTo(Sinks.EmitResult.OK)
+            queue.isEmpty().assert().isTrue()
+            discarded.assert().containsExactly(1)
+            sink.tryEmitNext(2).assert().isEqualTo(Sinks.EmitResult.FAIL_CANCELLED)
+        } finally {
+            queue.releaseOffer.countDown()
+            subscriber.dispose()
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+        }
+    }
+
+    @Test
+    fun `should drain buffered values before terminal when subscription is late`() {
+        val sink = mpscUnicastManySink<Int>()
+
+        sink.tryEmitNext(1).assert().isEqualTo(Sinks.EmitResult.OK)
+        sink.tryEmitNext(2).assert().isEqualTo(Sinks.EmitResult.OK)
+        sink.tryEmitComplete().assert().isEqualTo(Sinks.EmitResult.OK)
+
+        StepVerifier.create(sink.asFlux())
+            .expectNext(1, 2)
+            .expectComplete()
+            .verify(TEST_TIMEOUT)
+    }
+
+    @Test
+    fun `should deliver every concurrent value once and preserve each producer order`() {
+        val producerCount = 4
+        val valuesPerProducer = 250
+        val sink = mpscUnicastManySink<Int>()
+        val received = ConcurrentLinkedQueue<Int>()
+        val terminal = CountDownLatch(1)
+        val subscriberError = AtomicReference<Throwable?>()
+        val subscription = sink.asFlux().subscribe(
+            received::add,
+            {
+                subscriberError.set(it)
+                terminal.countDown()
+            },
+            terminal::countDown,
+        )
+        val executor = Executors.newFixedThreadPool(producerCount)
+        val ready = CountDownLatch(producerCount)
+        val start = CountDownLatch(1)
+        try {
+            val futures = (0 until producerCount).map { producer ->
+                executor.submit {
+                    ready.countDown()
+                    start.await()
+                    repeat(valuesPerProducer) { index ->
+                        val value = producer * valuesPerProducer + index
+                        sink.tryEmitNext(value).assert().isEqualTo(Sinks.EmitResult.OK)
+                    }
+                }
+            }
+            ready.await(5, TimeUnit.SECONDS).assert().isTrue()
+            start.countDown()
+            futures.forEach { it.get(5, TimeUnit.SECONDS) }
+            sink.tryEmitComplete().assert().isEqualTo(Sinks.EmitResult.OK)
+            terminal.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+            subscriberError.get().assert().isNull()
+            received.size.assert().isEqualTo(producerCount * valuesPerProducer)
+            received.toSet().size.assert().isEqualTo(producerCount * valuesPerProducer)
+            repeat(producerCount) { producer ->
+                val expected = (0 until valuesPerProducer).map { producer * valuesPerProducer + it }
+                received.filter { it / valuesPerProducer == producer }
+                    .assert()
+                    .containsExactly(*expected.toTypedArray())
+            }
+        } finally {
+            start.countDown()
+            subscription.dispose()
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+        }
+    }
+
+    @Test
+    fun `should allow only one winner when complete and error race`() {
+        val executor = Executors.newFixedThreadPool(2)
+        try {
+            repeat(64) { iteration ->
+                val sink = mpscUnicastManySink<Int>()
+                val error = IllegalStateException("terminal-$iteration")
+                val start = CyclicBarrier(3)
+                val terminal = CountDownLatch(1)
+                val completed = AtomicBoolean()
+                val observedError = AtomicReference<Throwable?>()
+                val subscription = sink.asFlux().subscribe(
+                    {},
+                    {
+                        observedError.set(it)
+                        terminal.countDown()
+                    },
+                    {
+                        completed.set(true)
+                        terminal.countDown()
+                    },
+                )
+                val complete = executor.submit<Sinks.EmitResult> {
+                    start.await(5, TimeUnit.SECONDS)
+                    sink.tryEmitComplete()
+                }
+                val fail = executor.submit<Sinks.EmitResult> {
+                    start.await(5, TimeUnit.SECONDS)
+                    sink.tryEmitError(error)
+                }
+
+                start.await(5, TimeUnit.SECONDS)
+                val results = listOf(
+                    complete.get(5, TimeUnit.SECONDS),
+                    fail.get(5, TimeUnit.SECONDS),
+                )
+
+                results.count(Sinks.EmitResult.OK::equals).assert().isEqualTo(1)
+                results.count(Sinks.EmitResult.FAIL_TERMINATED::equals).assert().isEqualTo(1)
+                terminal.await(5, TimeUnit.SECONDS).assert().isTrue()
+                if (results.first() == Sinks.EmitResult.OK) {
+                    completed.get().assert().isTrue()
+                    observedError.get().assert().isNull()
+                } else {
+                    completed.get().assert().isFalse()
+                    observedError.get().assert().isSameAs(error)
+                }
+                subscription.dispose()
+            }
+        } finally {
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+        }
+    }
+
+    @Test
+    fun `emit should drop next and error after terminal`() {
+        val sink = mpscUnicastManySink<Int>()
+        val error = IllegalStateException("late")
+
+        StepVerifier.create(sink.asFlux())
+            .then {
+                sink.emitComplete(Sinks.EmitFailureHandler.FAIL_FAST)
+                sink.emitNext(2, Sinks.EmitFailureHandler.FAIL_FAST)
+                sink.emitError(error, Sinks.EmitFailureHandler.FAIL_FAST)
+            }
+            .expectComplete()
+            .verifyThenAssertThat(TEST_TIMEOUT)
+            .hasDroppedExactly(2)
+            .hasDroppedErrorMatching { it === error }
+    }
+
+    @Test
+    fun `emit next should discard a value after downstream cancellation`() {
+        val sink = mpscUnicastManySink<Int>()
+
+        StepVerifier.create(sink.asFlux().take(1))
+            .then {
+                sink.emitNext(1, Sinks.EmitFailureHandler.FAIL_FAST)
+                sink.emitNext(2, Sinks.EmitFailureHandler.FAIL_FAST)
+            }
+            .expectNext(1)
+            .expectComplete()
+            .verifyThenAssertThat(TEST_TIMEOUT)
+            .hasDiscardedExactly(2)
+    }
+
+    @Test
+    fun `emit next should retry with the exact signal type`() {
+        val delegate = ScriptedNextManySink<Int>(
+            Sinks.EmitResult.FAIL_NON_SERIALIZED,
+            Sinks.EmitResult.OK,
+        )
+        val sink = sinkWithDelegate(delegate)
+        val failures = mutableListOf<Pair<SignalType, Sinks.EmitResult>>()
+
+        sink.emitNext(
+            1,
+            Sinks.EmitFailureHandler { signalType, emitResult ->
+                failures.add(signalType to emitResult)
+                true
+            },
+        )
+
+        delegate.nextCalls.get().assert().isEqualTo(2)
+        failures.assert().containsExactly(SignalType.ON_NEXT to Sinks.EmitResult.FAIL_NON_SERIALIZED)
+    }
+
+    @Test
+    fun `emit next retry should observe a terminal claimed by its failure handler`() {
+        val delegate = ScriptedNextManySink<Int>(Sinks.EmitResult.FAIL_NON_SERIALIZED)
+        val sink = sinkWithDelegate(delegate)
+        val failures = mutableListOf<Pair<SignalType, Sinks.EmitResult>>()
+
+        StepVerifier.create(sink.asFlux())
+            .then {
+                sink.emitNext(
+                    1,
+                    Sinks.EmitFailureHandler { signalType, emitResult ->
+                        failures.add(signalType to emitResult)
+                        if (emitResult == Sinks.EmitResult.FAIL_NON_SERIALIZED) {
+                            sink.tryEmitComplete().assert().isEqualTo(Sinks.EmitResult.OK)
+                            true
+                        } else {
+                            false
+                        }
+                    },
+                )
+            }
+            .expectComplete()
+            .verifyThenAssertThat(TEST_TIMEOUT)
+            .hasDroppedExactly(1)
+
+        failures.assert().containsExactly(
+            SignalType.ON_NEXT to Sinks.EmitResult.FAIL_NON_SERIALIZED,
+            SignalType.ON_NEXT to Sinks.EmitResult.FAIL_TERMINATED,
+        )
+        delegate.nextCalls.get().assert().isEqualTo(1)
+        delegate.completeCalls.get().assert().isEqualTo(1)
+    }
+
+    @Test
+    fun `emit terminal should retry cancellation without creating a logical claim`() {
+        val delegate = BlockingNextManySink()
+        delegate.cancelled = true
+        val sink = sinkWithDelegate(delegate)
+        val completeFailures = mutableListOf<Pair<SignalType, Sinks.EmitResult>>()
+        val errorFailures = mutableListOf<Pair<SignalType, Sinks.EmitResult>>()
+
+        sink.emitComplete(
+            Sinks.EmitFailureHandler { signalType, emitResult ->
+                completeFailures.add(signalType to emitResult)
+                completeFailures.size == 1
+            },
+        )
+        sink.emitError(
+            IllegalStateException("cancelled"),
+            Sinks.EmitFailureHandler { signalType, emitResult ->
+                errorFailures.add(signalType to emitResult)
+                errorFailures.size == 1
+            },
+        )
+
+        completeFailures.assert().containsExactly(
+            SignalType.ON_COMPLETE to Sinks.EmitResult.FAIL_CANCELLED,
+            SignalType.ON_COMPLETE to Sinks.EmitResult.FAIL_CANCELLED,
+        )
+        errorFailures.assert().containsExactly(
+            SignalType.ON_ERROR to Sinks.EmitResult.FAIL_CANCELLED,
+            SignalType.ON_ERROR to Sinks.EmitResult.FAIL_CANCELLED,
+        )
+        delegate.completeCalls.get().assert().isEqualTo(0)
+        delegate.errorCalls.get().assert().isEqualTo(0)
+        sink.scanUnsafe(Scannable.Attr.TERMINATED).assert().isEqualTo(false)
+    }
+
+    @Test
+    fun `emit next overflow should discard the value and terminate with overflow`() {
+        val delegate = OverflowingNextManySink<Int>()
+        val sink = sinkWithDelegate(delegate)
+
+        StepVerifier.create(sink.asFlux())
+            .then { sink.emitNext(1, Sinks.EmitFailureHandler.FAIL_FAST) }
+            .expectErrorMatches { Exceptions.isOverflow(it) }
+            .verifyThenAssertThat(TEST_TIMEOUT)
+            .hasDiscardedExactly(1)
+
+        Exceptions.isOverflow(delegate.observedError.get()).assert().isTrue()
+        delegate.errorCalls.get().assert().isEqualTo(1)
+    }
+
+    @Test
+    fun `should reject a second subscriber with the unicast contract`() {
+        val sink = mpscUnicastManySink<Int>()
+        val received = AtomicReference<Int?>()
+        val first = sink.asFlux().subscribe(received::set)
+        try {
+            StepVerifier.create(sink.asFlux())
+                .expectError(IllegalStateException::class.java)
+                .verify(TEST_TIMEOUT)
+
+            sink.tryEmitNext(1).assert().isEqualTo(Sinks.EmitResult.OK)
+            received.get().assert().isEqualTo(1)
+        } finally {
+            first.dispose()
+        }
+    }
+
+    @Test
+    fun `blocked rejected subscriber should not delay the lifecycle owner terminal`() {
+        val sink = mpscUnicastManySink<Int>()
+        val firstCompleted = CountDownLatch(1)
+        val first = sink.asFlux().subscribe({}, { throw AssertionError(it) }, firstCompleted::countDown)
+        val rejectedEntered = CountDownLatch(1)
+        val releaseRejected = CountDownLatch(1)
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val rejected = executor.submit {
+                sink.asFlux().subscribe(
+                    {},
+                    {
+                        rejectedEntered.countDown()
+                        check(releaseRejected.await(5, TimeUnit.SECONDS)) {
+                            "Timed out waiting to release the rejected subscriber."
+                        }
+                    },
+                )
+            }
+            rejectedEntered.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+            sink.tryEmitComplete().assert().isEqualTo(Sinks.EmitResult.OK)
+            firstCompleted.await(1, TimeUnit.SECONDS).assert().isTrue()
+            sink.closeSettled.isDone.assert().isTrue()
+
+            releaseRejected.countDown()
+            rejected.get(5, TimeUnit.SECONDS)
+        } finally {
+            releaseRejected.countDown()
+            first.dispose()
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+        }
+    }
+
+    @Test
+    fun `close settlement should wait for the lifecycle owner terminal callback`() {
+        val sink = mpscUnicastManySink<Int>()
+        val subscription = AtomicReference<Subscription>()
+        val terminalEntered = CountDownLatch(1)
+        val releaseTerminal = CountDownLatch(1)
+        sink.asFlux().subscribe(
+            object : CoreSubscriber<Int> {
+                override fun currentContext(): Context = Context.empty()
+
+                override fun onSubscribe(delegate: Subscription) {
+                    subscription.set(delegate)
+                    delegate.request(Long.MAX_VALUE)
+                }
+
+                override fun onNext(value: Int) = Unit
+
+                override fun onError(throwable: Throwable) {
+                    throw AssertionError("Expected completion.", throwable)
+                }
+
+                override fun onComplete() {
+                    terminalEntered.countDown()
+                    check(releaseTerminal.await(5, TimeUnit.SECONDS)) {
+                        "Timed out waiting to release the terminal callback."
+                    }
+                }
+            },
+        )
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val terminal = executor.submit<Sinks.EmitResult> { sink.tryEmitComplete() }
+            terminalEntered.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+            subscription.get().request(1)
+            sink.closeSettled.isDone.assert().isFalse()
+
+            releaseTerminal.countDown()
+            terminal.get(5, TimeUnit.SECONDS).assert().isEqualTo(Sinks.EmitResult.OK)
+            sink.closeSettled.get(5, TimeUnit.SECONDS)
+        } finally {
+            releaseTerminal.countDown()
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+        }
+    }
+
+    @Test
+    fun `close settlement should wait for a physically delegated cancellation to return`() {
+        val delegate = BlockingRequestAndCancelManySink()
+        val sink = sinkWithDelegate(delegate)
+        val subscription = AtomicReference<Subscription>()
+        sink.asFlux().subscribe(
+            object : CoreSubscriber<Int> {
+                override fun currentContext(): Context = Context.empty()
+
+                override fun onSubscribe(delegate: Subscription) {
+                    subscription.set(delegate)
+                }
+
+                override fun onNext(value: Int) = Unit
+
+                override fun onError(throwable: Throwable) {
+                    throw AssertionError("Expected cancellation without an error.", throwable)
+                }
+
+                override fun onComplete() = Unit
+            },
+        )
+        val executor = Executors.newFixedThreadPool(2)
+        try {
+            val request = executor.submit { subscription.get().request(1) }
+            delegate.requestEntered.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+            sink.tryEmitComplete().assert().isEqualTo(Sinks.EmitResult.OK)
+            sink.closeSettled.isDone.assert().isFalse()
+
+            val cancel = executor.submit { subscription.get().cancel() }
+            delegate.cancelEntered.await(5, TimeUnit.SECONDS).assert().isTrue()
+            delegate.releaseRequest.countDown()
+            request.get(5, TimeUnit.SECONDS)
+
+            sink.closeSettled.isDone.assert().isFalse()
+
+            delegate.releaseCancel.countDown()
+            cancel.get(5, TimeUnit.SECONDS)
+            sink.closeSettled.get(5, TimeUnit.SECONDS)
+        } finally {
+            delegate.releaseRequest.countDown()
+            delegate.releaseCancel.countDown()
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+        }
+    }
+
+    @Test
+    fun `close settlement should wait for a physically delegated terminal to return`() {
+        val delegate = BlockingTerminalReturnManySink()
+        val sink = sinkWithDelegate(delegate)
+        sink.asFlux().subscribe({}, { throw AssertionError(it) })
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val terminal = executor.submit<Sinks.EmitResult> { sink.tryEmitComplete() }
+            delegate.downstreamTerminalReturned.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+            sink.closeSettled.isDone.assert().isFalse()
+
+            delegate.releaseTerminalReturn.countDown()
+            terminal.get(5, TimeUnit.SECONDS).assert().isEqualTo(Sinks.EmitResult.OK)
+            sink.closeSettled.get(5, TimeUnit.SECONDS)
+        } finally {
+            delegate.releaseTerminalReturn.countDown()
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+        }
+    }
+
+    @Test
+    fun `close settlement should wait for every concurrently delegated control path`() {
+        val delegate = BlockingTerminalReturnManySink()
+        val sink = sinkWithDelegate(delegate)
+        val subscription = AtomicReference<Subscription>()
+        sink.asFlux().subscribe(
+            object : CoreSubscriber<Int> {
+                override fun currentContext(): Context = Context.empty()
+
+                override fun onSubscribe(delegate: Subscription) {
+                    subscription.set(delegate)
+                }
+
+                override fun onNext(value: Int) = Unit
+
+                override fun onError(throwable: Throwable) {
+                    throw AssertionError("Expected completion.", throwable)
+                }
+
+                override fun onComplete() = Unit
+            },
+        )
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val terminal = executor.submit<Sinks.EmitResult> { sink.tryEmitComplete() }
+            delegate.downstreamTerminalReturned.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+            subscription.get().cancel()
+            sink.closeSettled.isDone.assert().isFalse()
+
+            delegate.releaseTerminalReturn.countDown()
+            terminal.get(5, TimeUnit.SECONDS).assert().isEqualTo(Sinks.EmitResult.OK)
+            sink.closeSettled.get(5, TimeUnit.SECONDS)
+        } finally {
+            delegate.releaseTerminalReturn.countDown()
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+        }
+    }
+
+    @Test
+    fun `concurrent first subscribers should produce exactly one lifecycle owner`() {
+        val attempts = 100
+        val executor = Executors.newFixedThreadPool(2)
+        try {
+            repeat(attempts) {
+                val sink = mpscUnicastManySink<Int>()
+                val start = CyclicBarrier(3)
+                val values = ConcurrentLinkedQueue<Int>()
+                val errors = ConcurrentLinkedQueue<Throwable>()
+                val subscriptions = ConcurrentLinkedQueue<reactor.core.Disposable>()
+                val subscribers = List(2) {
+                    executor.submit {
+                        start.await(5, TimeUnit.SECONDS)
+                        subscriptions.add(sink.asFlux().subscribe(values::add, errors::add))
+                    }
+                }
+                start.await(5, TimeUnit.SECONDS)
+                subscribers.forEach { it.get(5, TimeUnit.SECONDS) }
+
+                sink.tryEmitNext(1).assert().isEqualTo(Sinks.EmitResult.OK)
+                values.assert().containsExactly(1)
+                errors.assert().hasSize(1)
+                errors.single().assert().isInstanceOf(IllegalStateException::class.java)
+                subscriptions.forEach(reactor.core.Disposable::dispose)
+            }
+        } finally {
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+        }
+    }
+
+    @Test
+    fun `should expose a stable flux and delegate subscriber scans and inners`() {
+        val sink = mpscUnicastManySink<Int>()
+        val flux = sink.asFlux()
+        val error = IllegalStateException("terminal")
+        val observedError = AtomicReference<Throwable?>()
+
+        flux.assert().isSameAs(sink.asFlux())
+        (flux is Sinks.Many<*>).assert().isFalse()
+        (flux is Fuseable).assert().isFalse()
+        Scannable.from(flux).scan(Scannable.Attr.PARENT).assert().isNull()
+        Scannable.from(flux).parents().noneMatch { it is Sinks.Many<*> }.assert().isTrue()
+        sink.currentSubscriberCount().assert().isEqualTo(0)
+        sink.inners().count().assert().isEqualTo(0)
+        sink.scanUnsafe(Scannable.Attr.CANCELLED).assert().isEqualTo(false)
+        sink.scanUnsafe(Scannable.Attr.TERMINATED).assert().isEqualTo(false)
+        sink.scanUnsafe(Scannable.Attr.ERROR).assert().isNull()
+        sink.scanUnsafe(Scannable.Attr.BUFFERED).assert().isEqualTo(0)
+        val capacity = sink.scanUnsafe(Scannable.Attr.CAPACITY)
+        capacity.assert().isNotNull()
+
+        sink.tryEmitNext(1).assert().isEqualTo(Sinks.EmitResult.OK)
+        sink.scanUnsafe(Scannable.Attr.BUFFERED).assert().isEqualTo(1)
+
+        val subscription = flux.subscribe({}, observedError::set)
+        sink.currentSubscriberCount().assert().isEqualTo(1)
+        sink.scanUnsafe(Scannable.Attr.BUFFERED).assert().isEqualTo(0)
+        sink.scanUnsafe(Scannable.Attr.CAPACITY).assert().isEqualTo(capacity)
+        sink.inners().count().assert().isEqualTo(1)
+        val inner = sink.inners().findFirst().orElseThrow()
+        inner.isScanAvailable.assert().isTrue()
+        inner.assert().isSameAs(subscription)
+        sink.scanUnsafe(Scannable.Attr.ACTUAL).assert().isSameAs(subscription)
+
+        sink.tryEmitError(error).assert().isEqualTo(Sinks.EmitResult.OK)
+
+        sink.scanUnsafe(Scannable.Attr.TERMINATED).assert().isEqualTo(true)
+        sink.scanUnsafe(Scannable.Attr.CANCELLED).assert().isEqualTo(false)
+        sink.scanUnsafe(Scannable.Attr.ERROR).assert().isSameAs(error)
+        observedError.get().assert().isSameAs(error)
+        sink.currentSubscriberCount().assert().isEqualTo(0)
+        sink.inners().count().assert().isEqualTo(0)
+        subscription.isDisposed.assert().isTrue()
+    }
+
+    @Test
+    fun `should not expose the raw sink through publisher or subscription`() {
+        val sink = mpscUnicastManySink<Int>()
+        val flux = sink.asFlux()
+        val exposedSubscription = AtomicReference<Subscription>()
+        val subscriberContext = Context.of("opaque", "context")
+        val subscriber = object : CoreSubscriber<Int>, Scannable {
+            override fun currentContext(): Context = subscriberContext
+
+            override fun onSubscribe(subscription: Subscription) {
+                exposedSubscription.set(subscription)
+                subscription.request(Long.MAX_VALUE)
+            }
+
+            override fun onNext(value: Int) = Unit
+
+            override fun onError(throwable: Throwable) = Unit
+
+            override fun onComplete() = Unit
+
+            override fun scanUnsafe(key: Scannable.Attr<*>): Any? = null
+        }
+
+        flux.subscribe(subscriber)
+
+        flux.assert().isSameAs(sink.asFlux())
+        (flux is Sinks.Many<*>).assert().isFalse()
+        Scannable.from(flux).scan(Scannable.Attr.PARENT).assert().isNull()
+        Scannable.from(flux).parents().noneMatch { it is Sinks.Many<*> }.assert().isTrue()
+        val subscription = checkNotNull(exposedSubscription.get())
+        (subscription is Sinks.Many<*>).assert().isFalse()
+        (subscription is Fuseable.QueueSubscription<*>).assert().isFalse()
+        Scannable.from(subscription).scan(Scannable.Attr.PARENT).assert().isNull()
+        Scannable.from(subscription).parents().noneMatch { it is Sinks.Many<*> }.assert().isTrue()
+        val inner = sink.inners().findFirst().orElseThrow()
+        inner.assert().isSameAs(subscriber)
+        (inner as CoreSubscriber<*>).currentContext().assert().isSameAs(subscriberContext)
+        inner.scan(Scannable.Attr.PARENT).assert().isNull()
+
+        subscription.cancel()
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T : Any> sinkWithQueue(queue: Queue<T>): MpscUnicastManySink<T> {
+        val constructor = MpscUnicastManySink::class.java.getDeclaredConstructor(Queue::class.java)
+        constructor.isAccessible = true
+        return constructor.newInstance(queue) as MpscUnicastManySink<T>
+    }
+}
+
+class MpscUnicastManySinkInvariantTest {
+
+    @Test
+    fun `should reject a corrupted exhausted admission count`() {
+        val sink = mpscUnicastManySink<Int>()
+        stateOf(sink).set((1L shl 60) - 1)
+
+        val error = assertThrows<IllegalStateException> {
+            sink.tryEmitNext(1)
+        }
+
+        error.message.assert().isEqualTo("MPSC unicast sink active admission count exhausted.")
+    }
+
+    @Test
+    fun `should reject a corrupted release underflow`() {
+        val sink = mpscUnicastManySink<Int>()
+
+        val invocation = assertThrows<InvocationTargetException> {
+            invokeReleaseNext(sink)
+        }
+        val error = checkNotNull(invocation.cause)
+
+        (error is IllegalStateException).assert().isTrue()
+        error.message.assert().isEqualTo("MPSC unicast sink active admission underflow.")
+    }
+
+    @Test
+    fun `should defer terminal delegation until a claimed signal is published`() {
+        val sink = mpscUnicastManySink<Int>()
+        stateOf(sink).set(1L shl 62)
+
+        invokeDelegateTerminal(sink).assert().isNull()
+    }
+
+    @Test
+    fun `should delegate terminal after the last admitted next returns`() {
+        val producerCount = 3
+        val delegate = BlockingMultipleNextManySink(producerCount)
+        val sink = sinkWithDelegate(delegate)
+        val executor = Executors.newFixedThreadPool(producerCount)
+        val allButLastReleased = CountDownLatch(producerCount - 1)
+        try {
+            val next = (0 until producerCount).map { value ->
+                executor.submit<Sinks.EmitResult> {
+                    sink.tryEmitNext(value).also {
+                        allButLastReleased.countDown()
+                    }
+                }
+            }
+            delegate.allNextEntered.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+            sink.tryEmitComplete().assert().isEqualTo(Sinks.EmitResult.OK)
+            delegate.completeCalls.get().assert().isEqualTo(0)
+
+            delegate.releaseNext.release(producerCount - 1)
+            allButLastReleased.await(5, TimeUnit.SECONDS).assert().isTrue()
+            delegate.completeCalls.get().assert().isEqualTo(0)
+
+            delegate.releaseNext.release()
+            next.forEach { it.get(5, TimeUnit.SECONDS).assert().isEqualTo(Sinks.EmitResult.OK) }
+            delegate.completeCalls.get().assert().isEqualTo(1)
+            sink.tryEmitNext(producerCount).assert().isEqualTo(Sinks.EmitResult.FAIL_TERMINATED)
+        } finally {
+            delegate.releaseNext.release(producerCount)
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+        }
+    }
+
+    @Test
+    fun `should release admission and deliver a claimed terminal when delegate next throws`() {
+        val failure = IllegalStateException("next failed")
+        val delegate = BlockingThrowingNextManySink(failure)
+        val sink = sinkWithDelegate(delegate)
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val next = executor.submit<Sinks.EmitResult> { sink.tryEmitNext(1) }
+            delegate.nextEntered.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+            sink.tryEmitComplete().assert().isEqualTo(Sinks.EmitResult.OK)
+            delegate.completeCalls.get().assert().isEqualTo(0)
+            delegate.releaseNext.countDown()
+
+            val execution = assertThrows<ExecutionException> {
+                next.get(5, TimeUnit.SECONDS)
+            }
+            execution.cause.assert().isSameAs(failure)
+            delegate.completeCalls.get().assert().isEqualTo(1)
+            sink.tryEmitNext(2).assert().isEqualTo(Sinks.EmitResult.FAIL_TERMINATED)
+        } finally {
+            delegate.releaseNext.countDown()
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+        }
+    }
+
+    @Test
+    fun `terminal claim should retry after losing its compare and set race`() {
+        val delegate = PausingFirstCancellationScanManySink<Int>()
+        val sink = sinkWithDelegate(delegate)
+        val error = IllegalStateException("winner")
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val loser = executor.submit<Sinks.EmitResult> { sink.tryEmitComplete() }
+            delegate.firstScanEntered.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+            sink.tryEmitError(error).assert().isEqualTo(Sinks.EmitResult.OK)
+            delegate.releaseFirstScan.countDown()
+
+            loser.get(5, TimeUnit.SECONDS).assert().isEqualTo(Sinks.EmitResult.FAIL_TERMINATED)
+            delegate.cancellationScans.get().assert().isEqualTo(2)
+            delegate.completeCalls.get().assert().isEqualTo(0)
+            delegate.errorCalls.get().assert().isEqualTo(1)
+            sink.scanUnsafe(Scannable.Attr.ERROR).assert().isSameAs(error)
+        } finally {
+            delegate.releaseFirstScan.countDown()
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+        }
+    }
+
+    @Test
+    fun `emit next should return when the delegate reports zero subscribers`() {
+        val delegate = ScriptedNextManySink<Int>(Sinks.EmitResult.FAIL_ZERO_SUBSCRIBER)
+        val sink = sinkWithDelegate(delegate)
+
+        sink.emitNext(1, Sinks.EmitFailureHandler.FAIL_FAST)
+
+        delegate.nextCalls.get().assert().isEqualTo(1)
+        sink.scanUnsafe(Scannable.Attr.TERMINATED).assert().isEqualTo(false)
+    }
+
+    @Test
+    fun `emit next should reject non serialized emission when the handler declines retry`() {
+        val delegate = ScriptedNextManySink<Int>(Sinks.EmitResult.FAIL_NON_SERIALIZED)
+        val sink = sinkWithDelegate(delegate)
+
+        val error = assertThrows<Sinks.EmissionException> {
+            sink.emitNext(1, Sinks.EmitFailureHandler.FAIL_FAST)
+        }
+
+        error.message.orEmpty().contains("Spec. Rule 1.3").assert().isTrue()
+        delegate.nextCalls.get().assert().isEqualTo(1)
+    }
+
+    @Test
+    fun `emit next overflow should use an empty context without an actual subscriber`() {
+        val delegate = OverflowingNextManySink<Int>()
+        val sink = sinkWithDelegate(delegate)
+
+        sink.emitNext(1, Sinks.EmitFailureHandler.FAIL_FAST)
+
+        Exceptions.isOverflow(delegate.observedError.get()).assert().isTrue()
+        delegate.errorCalls.get().assert().isEqualTo(1)
+    }
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun <T : Any> sinkWithDelegate(delegate: Sinks.Many<T>): MpscUnicastManySink<T> {
+    val constructor = MpscUnicastManySink::class.java.getDeclaredConstructor(Sinks.Many::class.java)
+    constructor.isAccessible = true
+    return constructor.newInstance(delegate) as MpscUnicastManySink<T>
+}
+
+private fun stateOf(sink: MpscUnicastManySink<*>): AtomicLong {
+    val field = MpscUnicastManySink::class.java.getDeclaredField("state")
+    field.isAccessible = true
+    return field.get(sink) as AtomicLong
+}
+
+private fun invokeReleaseNext(sink: MpscUnicastManySink<*>) {
+    val method = MpscUnicastManySink::class.java.getDeclaredMethod("releaseNext")
+    method.isAccessible = true
+    method.invoke(sink)
+}
+
+private fun invokeDelegateTerminal(sink: MpscUnicastManySink<*>): Sinks.EmitResult? {
+    val method = MpscUnicastManySink::class.java.getDeclaredMethod("delegateTerminal")
+    method.isAccessible = true
+    return method.invoke(sink) as Sinks.EmitResult?
+}
+
+private open class AlwaysAcceptingManySink<T : Any>(
+    protected val backing: Sinks.Many<T> =
+        Sinks.unsafe().many().unicast().onBackpressureBuffer(),
+) : Sinks.Many<T> by backing {
+    val completeCalls = AtomicInteger()
+    val errorCalls = AtomicInteger()
+
+    override fun tryEmitComplete(): Sinks.EmitResult {
+        completeCalls.incrementAndGet()
+        return Sinks.EmitResult.OK
+    }
+
+    override fun tryEmitError(error: Throwable): Sinks.EmitResult {
+        errorCalls.incrementAndGet()
+        return Sinks.EmitResult.OK
+    }
+
+    override fun inners(): Stream<out Scannable> = backing.inners()
+}
+
+private class CancellingTerminalManySink<T : Any> : AlwaysAcceptingManySink<T>() {
+    @Volatile
+    private var cancelled: Boolean = false
+
+    override fun tryEmitComplete(): Sinks.EmitResult {
+        completeCalls.incrementAndGet()
+        cancelled = true
+        return Sinks.EmitResult.FAIL_CANCELLED
+    }
+
+    override fun scanUnsafe(key: Scannable.Attr<*>): Any? =
+        if (key == Scannable.Attr.CANCELLED) {
+            cancelled
+        } else {
+            backing.scanUnsafe(key)
+        }
+}
+
+private class TerminalResultManySink<T : Any>(
+    private val result: Sinks.EmitResult,
+) : AlwaysAcceptingManySink<T>() {
+    override fun tryEmitComplete(): Sinks.EmitResult {
+        completeCalls.incrementAndGet()
+        return result
+    }
+}
+
+private class ScriptedNextManySink<T : Any>(
+    vararg results: Sinks.EmitResult,
+) : AlwaysAcceptingManySink<T>() {
+    private val results = ConcurrentLinkedQueue(results.toList())
+    val nextCalls = AtomicInteger()
+
+    override fun tryEmitNext(t: T): Sinks.EmitResult {
+        nextCalls.incrementAndGet()
+        return checkNotNull(results.poll()) {
+            "No scripted next result remains."
+        }
+    }
+
+    override fun tryEmitComplete(): Sinks.EmitResult {
+        completeCalls.incrementAndGet()
+        return backing.tryEmitComplete()
+    }
+}
+
+private class OverflowingNextManySink<T : Any> : AlwaysAcceptingManySink<T>() {
+    val observedError = AtomicReference<Throwable?>()
+
+    override fun tryEmitNext(t: T): Sinks.EmitResult = Sinks.EmitResult.FAIL_OVERFLOW
+
+    override fun tryEmitError(error: Throwable): Sinks.EmitResult {
+        errorCalls.incrementAndGet()
+        observedError.set(error)
+        return backing.tryEmitError(error)
+    }
+}
+
+private class PausingFirstCancellationScanManySink<T : Any> : AlwaysAcceptingManySink<T>() {
+    val firstScanEntered = CountDownLatch(1)
+    val releaseFirstScan = CountDownLatch(1)
+    val cancellationScans = AtomicInteger()
+
+    override fun scanUnsafe(key: Scannable.Attr<*>): Any? {
+        if (key != Scannable.Attr.CANCELLED) {
+            return backing.scanUnsafe(key)
+        }
+        if (cancellationScans.incrementAndGet() == 1) {
+            firstScanEntered.countDown()
+            check(releaseFirstScan.await(5, TimeUnit.SECONDS)) {
+                "Timed out waiting to release the first cancellation scan."
+            }
+        }
+        return false
+    }
+}
+
+private class BlockingNextManySink : AlwaysAcceptingManySink<Int>() {
+    val nextEntered = CountDownLatch(1)
+    val releaseNext = CountDownLatch(1)
+    val terminalCalled = CountDownLatch(1)
+    val calls = ConcurrentLinkedQueue<String>()
+
+    @Volatile
+    var cancelled: Boolean = false
+
+    override fun tryEmitNext(t: Int): Sinks.EmitResult {
+        nextEntered.countDown()
+        check(releaseNext.await(5, TimeUnit.SECONDS)) {
+            "Timed out waiting to release the controllable next call."
+        }
+        calls.add("next")
+        return Sinks.EmitResult.OK
+    }
+
+    override fun tryEmitComplete(): Sinks.EmitResult {
+        completeCalls.incrementAndGet()
+        calls.add("complete")
+        terminalCalled.countDown()
+        return if (cancelled) Sinks.EmitResult.FAIL_CANCELLED else Sinks.EmitResult.OK
+    }
+
+    override fun tryEmitError(error: Throwable): Sinks.EmitResult {
+        errorCalls.incrementAndGet()
+        calls.add("error")
+        terminalCalled.countDown()
+        return if (cancelled) Sinks.EmitResult.FAIL_CANCELLED else Sinks.EmitResult.OK
+    }
+
+    override fun scanUnsafe(key: Scannable.Attr<*>): Any? =
+        if (key == Scannable.Attr.CANCELLED) {
+            cancelled
+        } else {
+            backing.scanUnsafe(key)
+        }
+
+    override fun asFlux(): Flux<Int> = backing.asFlux()
+}
+
+private class BlockingMultipleNextManySink(
+    producerCount: Int,
+) : AlwaysAcceptingManySink<Int>() {
+    val allNextEntered = CountDownLatch(producerCount)
+    val releaseNext = Semaphore(0)
+
+    override fun tryEmitNext(t: Int): Sinks.EmitResult {
+        allNextEntered.countDown()
+        check(releaseNext.tryAcquire(5, TimeUnit.SECONDS)) {
+            "Timed out waiting to release a blocked next call."
+        }
+        return Sinks.EmitResult.OK
+    }
+}
+
+private class BlockingRequestAndCancelManySink : AlwaysAcceptingManySink<Int>() {
+    val requestEntered = CountDownLatch(1)
+    val releaseRequest = CountDownLatch(1)
+    val cancelEntered = CountDownLatch(1)
+    val releaseCancel = CountDownLatch(1)
+    private val subscriber = AtomicReference<org.reactivestreams.Subscriber<in Int>>()
+    private val source = Flux.from<Int> { actual ->
+        subscriber.set(actual)
+        actual.onSubscribe(
+            object : Subscription {
+                override fun request(elements: Long) {
+                    requestEntered.countDown()
+                    check(releaseRequest.await(5, TimeUnit.SECONDS)) {
+                        "Timed out waiting to release the controllable request."
+                    }
+                }
+
+                override fun cancel() {
+                    cancelEntered.countDown()
+                    check(releaseCancel.await(5, TimeUnit.SECONDS)) {
+                        "Timed out waiting to release the controllable cancellation."
+                    }
+                }
+            },
+        )
+    }
+
+    override fun tryEmitComplete(): Sinks.EmitResult {
+        completeCalls.incrementAndGet()
+        subscriber.get().onComplete()
+        return Sinks.EmitResult.OK
+    }
+
+    override fun asFlux(): Flux<Int> = source
+}
+
+private class BlockingTerminalReturnManySink : AlwaysAcceptingManySink<Int>() {
+    val downstreamTerminalReturned = CountDownLatch(1)
+    val releaseTerminalReturn = CountDownLatch(1)
+    private val subscriber = AtomicReference<org.reactivestreams.Subscriber<in Int>>()
+    private val source = Flux.from<Int> { actual ->
+        subscriber.set(actual)
+        actual.onSubscribe(
+            object : Subscription {
+                override fun request(elements: Long) = Unit
+
+                override fun cancel() = Unit
+            },
+        )
+    }
+
+    override fun tryEmitComplete(): Sinks.EmitResult {
+        completeCalls.incrementAndGet()
+        subscriber.get().onComplete()
+        downstreamTerminalReturned.countDown()
+        check(releaseTerminalReturn.await(5, TimeUnit.SECONDS)) {
+            "Timed out waiting to release the controllable terminal call."
+        }
+        return Sinks.EmitResult.OK
+    }
+
+    override fun asFlux(): Flux<Int> = source
+}
+
+private class BlockingThrowingNextManySink(
+    private val failure: Throwable,
+) : AlwaysAcceptingManySink<Int>() {
+    val nextEntered = CountDownLatch(1)
+    val releaseNext = CountDownLatch(1)
+
+    override fun tryEmitNext(t: Int): Sinks.EmitResult {
+        nextEntered.countDown()
+        check(releaseNext.await(5, TimeUnit.SECONDS)) {
+            "Timed out waiting to release the throwing next call."
+        }
+        throw failure
+    }
+}
+
+private class PausingOfferQueue<T : Any>(
+    private val delegate: Queue<T> = Queues.unboundedMultiproducer<T>().get(),
+) : Queue<T> by delegate {
+    val offerEntered = CountDownLatch(1)
+    val releaseOffer = CountDownLatch(1)
+
+    override fun offer(element: T): Boolean {
+        offerEntered.countDown()
+        check(releaseOffer.await(5, TimeUnit.SECONDS)) {
+            "Timed out waiting to release the controllable queue offer."
+        }
+        return delegate.offer(element)
+    }
+}
+
+private class PausingAfterOfferQueue<T : Any>(
+    private val delegate: Queue<T> = Queues.unboundedMultiproducer<T>().get(),
+) : Queue<T> by delegate {
+    val offered = CountDownLatch(1)
+    val releaseOffer = CountDownLatch(1)
+
+    override fun offer(element: T): Boolean {
+        val result = delegate.offer(element)
+        offered.countDown()
+        check(releaseOffer.await(5, TimeUnit.SECONDS)) {
+            "Timed out waiting to return from the controllable queue offer."
+        }
+        return result
+    }
+}
+
+private class ZeroDemandSubscriber<T : Any>(
+    private val discarded: MutableCollection<T>,
+) : BaseSubscriber<T>() {
+    override fun hookOnSubscribe(subscription: Subscription) = Unit
+
+    override fun currentContext(): Context =
+        Operators.enableOnDiscard(Context.empty()) { value ->
+            @Suppress("UNCHECKED_CAST")
+            discarded.add(value as T)
+        }
+}

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/InMemoryMessageBusTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/InMemoryMessageBusTest.kt
@@ -16,15 +16,21 @@ package me.ahoo.wow.messaging
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.infra.sink.concurrent
+import me.ahoo.wow.infra.sink.mpscUnicastManySink
 import me.ahoo.wow.messaging.handler.MessageExchange
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.reactivestreams.Subscription
+import reactor.core.CoreSubscriber
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Sinks
 import reactor.test.StepVerifier
+import reactor.util.context.Context
 import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
 class InMemoryMessageBusTest {
@@ -71,6 +77,26 @@ class InMemoryMessageBusTest {
             .verifyComplete()
 
         bus.subscriberCount(message).assert().isEqualTo(0)
+    }
+
+    @Test
+    fun `unaccepted terminal should keep the ordinary sink available for close retry`() {
+        val bus = RetryCloseInMemoryMessageBus()
+        val message = TestNamedMessage()
+        val completed = CountDownLatch(1)
+        val subscription = bus.receive(MessageSubscription(message)).subscribe({}, {}, completed::countDown)
+        try {
+            assertThrows<Sinks.EmissionException> {
+                bus.close()
+            }
+            bus.subscriberCount(message).assert().isEqualTo(1)
+
+            bus.close()
+            completed.await(5, TimeUnit.SECONDS).assert().isTrue()
+            bus.subscriberCount(message).assert().isZero()
+        } finally {
+            subscription.dispose()
+        }
     }
 
     @Test
@@ -137,6 +163,127 @@ class InMemoryMessageBusTest {
         bus.subscriberCount(concurrentMessage).assert().isZero()
     }
 
+    @Test
+    fun `throwing sink should not bypass a pending mpsc close settlement`() {
+        val bus = MixedCloseInMemoryMessageBus()
+        val activeMessage = TestNamedMessage(aggregateName = "active")
+        val throwingMessage = TestNamedMessage(aggregateName = "throwing")
+        val concurrentMessage = TestNamedMessage(aggregateName = "concurrent")
+        val onNextEntered = CountDownLatch(1)
+        val releaseOnNext = CountDownLatch(1)
+        val activeCompleted = CountDownLatch(1)
+        val activeSubscription = bus.receive(MessageSubscription(activeMessage)).subscribe(
+            {
+                onNextEntered.countDown()
+                check(releaseOnNext.await(5, TimeUnit.SECONDS)) {
+                    "Timed out waiting to release active MPSC delivery."
+                }
+            },
+            { throw AssertionError("Expected active MPSC completion.", it) },
+            { activeCompleted.countDown() },
+        )
+        val throwingSubscription = bus.receive(MessageSubscription(throwingMessage)).subscribe()
+        val executor = java.util.concurrent.Executors.newSingleThreadExecutor()
+        try {
+            val activeSend = executor.submit { bus.send(activeMessage).block(Duration.ofSeconds(5)) }
+            onNextEntered.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+            assertThrows<IllegalStateException> {
+                bus.close()
+            }
+            StepVerifier.create(bus.receive(MessageSubscription(concurrentMessage)))
+                .expectComplete()
+                .verify(Duration.ofSeconds(1))
+
+            releaseOnNext.countDown()
+            activeSend.get(5, TimeUnit.SECONDS)
+            activeCompleted.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+            val reopened = bus.receive(MessageSubscription(concurrentMessage)).subscribe()
+            try {
+                bus.subscriberCount(concurrentMessage).assert().isEqualTo(1)
+            } finally {
+                reopened.dispose()
+            }
+        } finally {
+            releaseOnNext.countDown()
+            activeSubscription.dispose()
+            throwingSubscription.dispose()
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+            bus.close()
+        }
+    }
+
+    @Test
+    fun `exceptionally settled mpsc sink should be removed before reopening the bus`() {
+        val bus = MpscInMemoryMessageBus()
+        val message = TestNamedMessage()
+        val completionFailure = IllegalStateException("completion failed")
+        val subscription = AtomicReference<Subscription>()
+        bus.receive(MessageSubscription(message)).subscribe(
+            object : CoreSubscriber<TestMessageExchange> {
+                override fun currentContext(): Context = Context.empty()
+
+                override fun onSubscribe(delegate: Subscription) {
+                    subscription.set(delegate)
+                    delegate.request(Long.MAX_VALUE)
+                }
+
+                override fun onNext(exchange: TestMessageExchange) = Unit
+
+                override fun onError(throwable: Throwable) = Unit
+
+                override fun onComplete() {
+                    throw completionFailure
+                }
+            },
+        )
+
+        assertThrows<IllegalStateException> {
+            bus.close()
+        }.assert().isSameAs(completionFailure)
+
+        val reopenedError = AtomicReference<Throwable?>()
+        val reopened = bus.receive(MessageSubscription(message)).subscribe({}, reopenedError::set)
+        try {
+            reopenedError.get().assert().isNull()
+            bus.subscriberCount(message).assert().isEqualTo(1)
+        } finally {
+            reopened.dispose()
+            subscription.get().cancel()
+            bus.close()
+        }
+    }
+
+    @Test
+    fun `shared close failure should not stop remaining sinks or leave the bus closing`() {
+        val failure = IllegalStateException("shared close failure")
+        val closeCalls = AtomicInteger()
+        val bus = SharedFailureInMemoryMessageBus(failure, closeCalls)
+        val firstMessage = TestNamedMessage(aggregateName = "first")
+        val secondMessage = TestNamedMessage(aggregateName = "second")
+        val reopenedMessage = TestNamedMessage(aggregateName = "reopened")
+        val first = bus.receive(MessageSubscription(firstMessage)).subscribe()
+        val second = bus.receive(MessageSubscription(secondMessage)).subscribe()
+        try {
+            assertThrows<IllegalStateException> {
+                bus.close()
+            }.assert().isSameAs(failure)
+            closeCalls.get().assert().isEqualTo(2)
+
+            val reopened = bus.receive(MessageSubscription(reopenedMessage)).subscribe()
+            try {
+                bus.subscriberCount(reopenedMessage).assert().isEqualTo(1)
+            } finally {
+                reopened.dispose()
+            }
+        } finally {
+            first.dispose()
+            second.dispose()
+        }
+    }
+
     private fun awaitBlocked(thread: Thread) {
         val deadline = System.nanoTime() + Duration.ofSeconds(5).toNanos()
         while (thread.state != Thread.State.BLOCKED && System.nanoTime() < deadline) {
@@ -167,6 +314,80 @@ private class BlockingSinkInMemoryMessageBus(
     }
 
     override fun TestNamedMessage.createExchange(): TestMessageExchange = TestMessageExchange(this)
+}
+
+private class RetryCloseInMemoryMessageBus : InMemoryMessageBus<TestNamedMessage, TestMessageExchange>() {
+    override val sinkSupplier: (NamedAggregate) -> Sinks.Many<TestNamedMessage> = {
+        RetryCompleteManySink()
+    }
+
+    override fun TestNamedMessage.createExchange(): TestMessageExchange = TestMessageExchange(this)
+}
+
+private class MixedCloseInMemoryMessageBus : InMemoryMessageBus<TestNamedMessage, TestMessageExchange>() {
+    override val sinkSupplier: (NamedAggregate) -> Sinks.Many<TestNamedMessage> = {
+        when (it.aggregateName) {
+            "active" -> mpscUnicastManySink()
+            "throwing" -> ThrowingCompleteManySink()
+            else -> Sinks.unsafe().many().multicast().onBackpressureBuffer()
+        }
+    }
+
+    override fun TestNamedMessage.createExchange(): TestMessageExchange = TestMessageExchange(this)
+}
+
+private class MpscInMemoryMessageBus : InMemoryMessageBus<TestNamedMessage, TestMessageExchange>() {
+    override val sinkSupplier: (NamedAggregate) -> Sinks.Many<TestNamedMessage> = {
+        mpscUnicastManySink()
+    }
+
+    override fun TestNamedMessage.createExchange(): TestMessageExchange = TestMessageExchange(this)
+}
+
+private class SharedFailureInMemoryMessageBus(
+    private val failure: Throwable,
+    private val closeCalls: AtomicInteger,
+) : InMemoryMessageBus<TestNamedMessage, TestMessageExchange>() {
+    override val sinkSupplier: (NamedAggregate) -> Sinks.Many<TestNamedMessage> = {
+        SharedFailureCompleteManySink(failure, closeCalls)
+    }
+
+    override fun TestNamedMessage.createExchange(): TestMessageExchange = TestMessageExchange(this)
+}
+
+private class ThrowingCompleteManySink<T : Any>(
+    private val attempts: AtomicInteger = AtomicInteger(),
+    private val backing: Sinks.Many<T> = Sinks.unsafe().many().multicast().onBackpressureBuffer(),
+) : Sinks.Many<T> by backing {
+    override fun tryEmitComplete(): Sinks.EmitResult =
+        if (attempts.getAndIncrement() == 0) {
+            throw IllegalStateException("close failed")
+        } else {
+            backing.tryEmitComplete()
+        }
+}
+
+private class SharedFailureCompleteManySink<T : Any>(
+    private val failure: Throwable,
+    private val closeCalls: AtomicInteger,
+    private val backing: Sinks.Many<T> = Sinks.unsafe().many().multicast().onBackpressureBuffer(),
+) : Sinks.Many<T> by backing {
+    override fun tryEmitComplete(): Sinks.EmitResult {
+        closeCalls.incrementAndGet()
+        throw failure
+    }
+}
+
+private class RetryCompleteManySink<T : Any>(
+    private val attempts: AtomicInteger = AtomicInteger(),
+    private val backing: Sinks.Many<T> = Sinks.unsafe().many().multicast().onBackpressureBuffer(),
+) : Sinks.Many<T> by backing {
+    override fun tryEmitComplete(): Sinks.EmitResult =
+        if (attempts.getAndIncrement() == 0) {
+            Sinks.EmitResult.FAIL_NON_SERIALIZED
+        } else {
+            backing.tryEmitComplete()
+        }
 }
 
 private class TestMessageExchange(

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/InMemoryMessageBusTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/InMemoryMessageBusTest.kt
@@ -100,6 +100,28 @@ class InMemoryMessageBusTest {
     }
 
     @Test
+    fun `zero subscriber completion should detach an unbuffered unicast sink`() {
+        val sinkCreations = AtomicInteger()
+        val bus = ZeroSubscriberCloseInMemoryMessageBus(sinkCreations)
+        val message = TestNamedMessage()
+
+        bus.send(message).block(Duration.ofSeconds(1))
+        sinkCreations.get().assert().isEqualTo(1)
+        bus.subscriberCount(message).assert().isZero()
+
+        bus.close()
+
+        val reopened = bus.receive(MessageSubscription(message)).subscribe()
+        try {
+            sinkCreations.get().assert().isEqualTo(2)
+            bus.subscriberCount(message).assert().isEqualTo(1)
+        } finally {
+            reopened.dispose()
+            bus.close()
+        }
+    }
+
+    @Test
     fun `close racing first sink creation should not orphan the receiving flux`() {
         val sinkSupplierEntered = CountDownLatch(1)
         val releaseSinkSupplier = CountDownLatch(1)
@@ -319,6 +341,17 @@ private class BlockingSinkInMemoryMessageBus(
 private class RetryCloseInMemoryMessageBus : InMemoryMessageBus<TestNamedMessage, TestMessageExchange>() {
     override val sinkSupplier: (NamedAggregate) -> Sinks.Many<TestNamedMessage> = {
         RetryCompleteManySink()
+    }
+
+    override fun TestNamedMessage.createExchange(): TestMessageExchange = TestMessageExchange(this)
+}
+
+private class ZeroSubscriberCloseInMemoryMessageBus(
+    private val sinkCreations: AtomicInteger,
+) : InMemoryMessageBus<TestNamedMessage, TestMessageExchange>() {
+    override val sinkSupplier: (NamedAggregate) -> Sinks.Many<TestNamedMessage> = {
+        sinkCreations.incrementAndGet()
+        Sinks.unsafe().many().unicast().onBackpressureError()
     }
 
     override fun TestNamedMessage.createExchange(): TestMessageExchange = TestMessageExchange(this)

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/InMemoryMessageBusTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/InMemoryMessageBusTest.kt
@@ -279,6 +279,44 @@ class InMemoryMessageBusTest {
     }
 
     @Test
+    fun `terminal callback failure should detach an ordinary terminated sink`() {
+        val bus = TestInMemoryMessageBus()
+        val message = TestNamedMessage()
+        val completionFailure = IllegalStateException("completion failed")
+        bus.receive(MessageSubscription(message)).subscribe(
+            object : CoreSubscriber<TestMessageExchange> {
+                override fun currentContext(): Context = Context.empty()
+
+                override fun onSubscribe(delegate: Subscription) {
+                    delegate.request(Long.MAX_VALUE)
+                }
+
+                override fun onNext(exchange: TestMessageExchange) = Unit
+
+                override fun onError(throwable: Throwable) = Unit
+
+                override fun onComplete() {
+                    throw completionFailure
+                }
+            },
+        )
+
+        assertThrows<IllegalStateException> {
+            bus.close()
+        }.assert().isSameAs(completionFailure)
+
+        val reopenedError = AtomicReference<Throwable?>()
+        val reopened = bus.receive(MessageSubscription(message)).subscribe({}, reopenedError::set)
+        try {
+            reopenedError.get().assert().isNull()
+            bus.subscriberCount(message).assert().isEqualTo(1)
+        } finally {
+            reopened.dispose()
+            bus.close()
+        }
+    }
+
+    @Test
     fun `shared close failure should not stop remaining sinks or leave the bus closing`() {
         val failure = IllegalStateException("shared close failure")
         val closeCalls = AtomicInteger()

--- a/wow-core/src/test/kotlin/me/ahoo/wow/messaging/LocalFirstMessageBusTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/messaging/LocalFirstMessageBusTest.kt
@@ -18,12 +18,18 @@ import me.ahoo.wow.api.Copyable
 import me.ahoo.wow.api.messaging.Header
 import me.ahoo.wow.api.messaging.Message
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.infra.sink.mpscUnicastManySink
 import me.ahoo.wow.messaging.handler.MessageExchange
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import reactor.core.publisher.Sinks
 import reactor.test.StepVerifier
+import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 
 class LocalFirstMessageBusTest {
 
@@ -71,6 +77,47 @@ class LocalFirstMessageBusTest {
         localBus.sent.assert().isEmpty()
         distributedBus.sent.single().assert().isSameAs(message)
         message.isLocalFirst().assert().isFalse()
+    }
+
+    @Test
+    fun `send skips an in-memory bus while its active sink is closing`() {
+        val localBus = MpscLocalBus()
+        val distributedBus = RecordingDistributedBus()
+        val bus = RecordingLocalFirstMessageBus(localBus, distributedBus)
+        val activeMessage = LocalFirstTestMessage(id = "active")
+        val fallbackMessage = LocalFirstTestMessage(id = "fallback")
+        val onNextEntered = CountDownLatch(1)
+        val releaseOnNext = CountDownLatch(1)
+        val localSubscription = localBus.receive(MessageSubscription(activeMessage)).subscribe {
+            onNextEntered.countDown()
+            check(releaseOnNext.await(5, TimeUnit.SECONDS)) {
+                "Timed out waiting to release the active local delivery."
+            }
+        }
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            val activeSend = executor.submit {
+                localBus.send(activeMessage).block(Duration.ofSeconds(5))
+            }
+            onNextEntered.await(5, TimeUnit.SECONDS).assert().isTrue()
+
+            localBus.close()
+            localBus.subscriberCount(activeMessage).assert().isZero()
+
+            StepVerifier.create(bus.send(fallbackMessage))
+                .verifyComplete()
+            distributedBus.sent.single().assert().isSameAs(fallbackMessage)
+            fallbackMessage.isLocalFirst().assert().isFalse()
+
+            releaseOnNext.countDown()
+            activeSend.get(5, TimeUnit.SECONDS)
+        } finally {
+            releaseOnNext.countDown()
+            localSubscription.dispose()
+            executor.shutdownNow()
+            executor.awaitTermination(5, TimeUnit.SECONDS).assert().isTrue()
+            localBus.close()
+        }
     }
 
     @Test
@@ -137,6 +184,15 @@ private class RecordingLocalFirstMessageBus(
     override val localBus: LocalMessageBus<LocalFirstTestMessage, LocalFirstTestExchange>,
     override val distributedBus: DistributedMessageBus<LocalFirstTestMessage, LocalFirstTestExchange>,
 ) : LocalFirstMessageBus<LocalFirstTestMessage, LocalFirstTestExchange>
+
+private class MpscLocalBus : InMemoryMessageBus<LocalFirstTestMessage, LocalFirstTestExchange>() {
+    override val sinkSupplier: (NamedAggregate) -> Sinks.Many<LocalFirstTestMessage> = {
+        mpscUnicastManySink()
+    }
+
+    override fun LocalFirstTestMessage.createExchange(): LocalFirstTestExchange =
+        LocalFirstTestExchange(this)
+}
 
 private class RecordingLocalBus(
     private val subscribers: Int = 0,


### PR DESCRIPTION
## Goal

Remove command-ingress lock contention without changing Reactor `Sinks.Many` behavior or the production aggregate scheduler default.

Completion criteria:

- preserve unicast, backpressure, terminal, cancellation, discard, and `Scannable` semantics;
- improve concurrent command throughput without a material allocation regression;
- keep custom sink compatibility and close/reopen lifecycle correctness;
- capture reproducible clean-source benchmark evidence.

## Changes

- Replace the default `InMemoryCommandBus` `ConcurrentManySink` lock wrapper with a factory-owned atomic MPSC unicast sink.
- Coordinate admitted producers with terminal/cancellation delegation and close settlement.
- Keep the internal MPSC queue opaque to downstream fusion and `QueueSubscription` access while matching Reactor 3.8.6 public sink semantics.
- Define close settlement by physical control-call completion rather than downstream terminal demand, preventing backpressured consumers from leaving the bus permanently closing.
- Report zero local subscribers while closing, detach zero-subscriber completions that cannot be observed, and detach ordinary sinks whose terminal callback throws after Reactor has already terminated them; genuinely unaccepted terminal signals remain retryable.
- Add native-Reactor differential tests, concurrency/state-machine tests, local-first routing regression tests, and command-bus integration coverage.
- Add paired current-production/legacy-lock JMH diagnostics and scheduler pool/simulated-I/O parameters.
- Add the clean confirmation report with result and manifest hashes.

## Verification

- `./gradlew :wow-core:detekt :wow-core:test :wow-core:contractTest :wow-benchmarks:check :wow-benchmarks:jmhJar --no-parallel --console=plain`
  - core tests: 808
  - contract tests: 128
  - benchmark tests: 13
  - total: 949, 0 failures
- Reactor 3.8.6 native/custom differential semantics: 16/16 passed.
- Final clean JMH run `8d49668d-386d-414b-a68e-89f8fa49ac46`:
  - source commit: `060a2ea297cda413d87da673375a450ce9eaada5`
  - `source.dirty=false`
  - JMH JAR SHA-256: `30cb80352ed56f959179629274b8e928ef0056d6c9c285c4f2ee40b6248b84f2`
  - threads=1: +0.43%, confidence intervals overlap
  - threads=4: 161,912.38 to 200,570.23 ops/s, +23.88%, confidence intervals do not overlap
  - threads=4 allocation: +8.84 B/op, +0.23%
- `./gradlew :wow-core:jacocoTestReport --no-parallel --console=plain`
  - the added close visibility and post-terminal failure branches are covered
- `./gradlew :wow-benchmarks:verifyBenchmarkReportFormatting :wow-benchmarks:check --no-parallel --console=plain`
- `git diff --check`

## Risks and Notes

- No public API or production scheduler-default change.
- The sink remains unbounded, matching the previous backpressure-buffer behavior.
- Close settlement means every control path physically delegated before the settlement CAS has returned; it does not wait for a buffered downstream terminal to be consumed.
- A closing in-memory bus reports zero local subscribers so `LocalFirstMessageBus` routes safely to the distributed bus during asynchronous settlement.
- Fusion implementation identity is intentionally not preserved because exposing `QueueSubscription` would allow direct access to the factory-owned MPSC queue; public signal semantics are covered by differential tests.
- The confirmed throughput result targets concurrent local `InMemoryCommandBus` ingress with a noop store. Relative gains can be lower on remote or I/O-dominated paths.
- Scheduler pool scans remain diagnostic only. The evidence does not support changing the production default from CPU-sized pools.
- The report does not include p95/p99 latency, real Mongo/Redis workloads, or production queue-depth distributions.
