### PR TITLE
chore(skills): sync wow references with current code

### DIFF
--- a/skills/wow/references/annotations.md
+++ b/skills/wow/references/annotations.md
@@ -311,7 +311,7 @@ class Order(private val state: OrderState) { ... }
 **Parameters:**
 | Attribute | Default | Description |
 |---|---|---|
-| `resourceName` | lowercased class name | Custom API path segment |
+| `resourceName` | `""` (empty; falls back to lowercased class name at runtime) | Custom API path segment |
 | `enabled` | `true` | Set `false` to disable automatic route generation |
 | `spaced` | `false` | Space-separate the resource name in URL paths |
 | `owner` | `NEVER` | Ownership policy: `NEVER`, `ALWAYS`, or `AGGREGATE_ID` |

--- a/skills/wow/references/configuration.md
+++ b/skills/wow/references/configuration.md
@@ -97,7 +97,7 @@ wow:
 | `wow.command.bus.type` | BusType | `kafka` | Command bus implementation |
 | `wow.command.bus.local-first.enabled` | Boolean | `true` | Enable LocalFirst mode |
 | `wow.command.idempotency.enabled` | Boolean | `true` | Enable idempotency checking |
-| `wow.command.idempotency.bloom-filter.expected-insertions` | Int | `1000000` | Bloom filter capacity |
+| `wow.command.idempotency.bloom-filter.expected-insertions` | Long | `1000000` | Bloom filter capacity |
 | `wow.command.idempotency.bloom-filter.ttl` | Duration | `PT60S` | Bloom filter TTL |
 | `wow.command.idempotency.bloom-filter.fpp` | Double | `0.00001` | False positive probability |
 
@@ -129,8 +129,40 @@ wow:
 |----------|------|---------|-------------|
 | `wow.eventsourcing.snapshot.enabled` | Boolean | `true` | Enable snapshot functionality |
 | `wow.eventsourcing.snapshot.strategy` | Strategy | `all` | Snapshot strategy: `all` or `version_offset` |
-| `wow.eventsourcing.snapshot.version-offset` | Int | `10` | Version offset for VERSION_OFFSET strategy |
+| `wow.eventsourcing.snapshot.version-offset` | Int | `5` | Version offset for VERSION_OFFSET strategy (`DEFAULT_VERSION_OFFSET`) |
 | `wow.eventsourcing.snapshot.storage` | StorageType | `mongo` | Snapshot storage backend |
+
+### Snapshot Checkpoint
+
+Persist the latest snapshot version as an immutable checkpoint at a fixed version interval. The checkpoint is written via `VersionIntervalCheckpointStrategy`; it does not change projection or rebuild behavior on its own.
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `wow.eventsourcing.snapshot.checkpoint.enabled` | Boolean | `false` | Persist the snapshot version checkpoint |
+| `wow.eventsourcing.snapshot.checkpoint.version-interval` | Int | `100` | How often (in versions) to persist the checkpoint; must be positive |
+
+### Storage Routing
+
+Route different aggregates to different storage backends within a single service. When a matching route is configured, Wow installs a `RoutingEventStore` / `RoutingSnapshotStore`; unlisted aggregates fall back to the default storage. A configured channel **must set exactly one** of `storage` or `binding` — an empty channel (e.g. `event: {}`) fails fast at startup.
+
+```yaml
+wow:
+  eventsourcing:
+    storage-routing:
+      aggregates:
+        HotAggregate:
+          event:
+            storage: redis
+          snapshot:
+            storage: redis
+```
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `wow.eventsourcing.storage-routing.aggregates.<name>.event.storage` | StorageType | _(required if `binding` absent)_ | Event store backend for this aggregate |
+| `wow.eventsourcing.storage-routing.aggregates.<name>.event.binding` | String | _(required if `storage` absent)_ | Bound event store bean name |
+| `wow.eventsourcing.storage-routing.aggregates.<name>.snapshot.storage` | StorageType | _(required if `binding` absent)_ | Snapshot store backend for this aggregate |
+| `wow.eventsourcing.storage-routing.aggregates.<name>.snapshot.binding` | String | _(required if `storage` absent)_ | Bound snapshot store bean name |
 
 ## Infrastructure
 
@@ -188,6 +220,17 @@ wow:
 |----------|------|---------|-------------|
 | `wow.webflux.enabled` | Boolean | `true` | Enable WebFlux support |
 | `wow.webflux.global-error.enabled` | Boolean | `true` | Enable global error handling |
+| `wow.webflux.batch.concurrency` | Int | `1` | Concurrency for batch command requests |
+| `wow.webflux.batch.prefetch` | Int | `1` | Prefetch count for batch command requests |
+| `wow.webflux.command.request.appender.agent.enabled` | Boolean | `true` | Append client `User-Agent` to command request context (set `false` to disable) |
+| `wow.webflux.command.request.appender.ip.enabled` | Boolean | `true` | Append client IP to command request context (set `false` to disable) |
+
+### Observability Toggles
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `wow.opentelemetry.enabled` | Boolean | `true` | Enable OpenTelemetry tracing instrumentation (`matchIfMissing`; requires `wow-opentelemetry` on classpath) |
+| `wow.metrics.enabled` | Boolean | `true` | Enable Micrometer/Prometheus metrics collection (`matchIfMissing`) |
 
 ## Bus Types
 

--- a/skills/wow/references/modeling.md
+++ b/skills/wow/references/modeling.md
@@ -281,7 +281,7 @@ class Order(private val state: OrderState) { ... }
 Each aggregate gets a dedicated Reactor Scheduler to control concurrent execution:
 
 ```kotlin
-fun interface AggregateSchedulerSupplier {
+interface AggregateSchedulerSupplier : GracefullyStoppable {
     fun getOrInitialize(namedAggregate: NamedAggregate): Scheduler
 }
 ```

--- a/skills/wow/references/testing.md
+++ b/skills/wow/references/testing.md
@@ -44,9 +44,10 @@ class CartSpec : AggregateSpec<Cart, CartState>(
 | Method | Description |
 |--------|-------------|
 | `givenOwnerId(id)` | Set the owner ID for owner-aware aggregate scenarios |
-| `givenEvent(event)` | Initialize with a domain event |
-| `givenEvent(events)` | Initialize with multiple events |
-| `givenState(state, version)` | Initialize with direct state |
+| `givenSpaceId(id)` | Set the space ID for space-aware (multi-tenant) aggregate scenarios |
+| `givenEvent(event) { }` | Initialize with a domain event; trailing `block` (`WhenDsl`) is required |
+| `givenEvent(events) { }` | Initialize with multiple events; trailing `block` is required |
+| `givenState(state, version) { }` | Initialize with direct state; trailing `block` is required |
 | `inject { register(...) }` | Inject mock services |
 | `name("description")` | Name this test scenario |
 
@@ -208,10 +209,11 @@ class TransferSagaSpec : SagaSpec<TransferSaga>({
 
 | Method | Description |
 |--------|-------------|
-| `whenEvent(event, ownerId)` | Trigger saga with event |
+| `whenEvent(event, state, ownerId, spaceId) { }` | Trigger saga with event; `state`/`spaceId` optional. Trailing `block` is required. |
 | `name("description")` | Name this test scenario |
 | `functionFilter { }` | Filter message functions |
 | `functionName("name")` | Filter by function name |
+| `inject { }` | Register mock services for saga dependencies (extends `InjectServiceCapable`) |
 
 ### Saga ExpectDsl Methods
 


### PR DESCRIPTION
## Summary

Code-verified sync of the Wow agent-skill references (`skills/wow/references/*`) against the live source. Two parallel audits compared every documented config property/annotation/API against the actual `@ConfigurationProperties`, annotations, and test DSL — this PR fixes the contradictions and gaps found.

**Validation:** `skill_lint.py` (0 findings), `test_skill_lint.py` (8/8), `evals.json` valid, `git diff --check` clean.

## Factual contradictions fixed

| File | Fix | Code evidence |
|---|---|---|
| `configuration.md` | snapshot `version-offset` default `10` → `5` | `DEFAULT_VERSION_OFFSET = 5` (`VersionOffsetSnapshotStrategy.kt:24`) |
| `configuration.md` | bloom-filter `expected-insertions` type `Int` → `Long` | `CommandProperties.kt:46` (`val expectedInsertions: Long`) |
| `annotations.md` | `@AggregateRoute resourceName` default "lowercased class name" → `""` (falls back at runtime when empty) | `AggregateRoute.kt:61` (`val resourceName: String = ""`) |
| `modeling.md` | `AggregateSchedulerSupplier` `fun interface` → `interface` (it extends `GracefullyStoppable`) | `AggregateSchedulerSupplier.kt:41` |
| `testing.md` | Saga `whenEvent` signature completed (`state`/`spaceId` params, required trailing `block`); GivenDsl `givenEvent`/`givenState` note required `block`; added `givenSpaceId` and saga `inject` | `Dsl.kt:109-115`, `Dsl.kt:152` |

## Completeness gaps filled

Added business-service config groups to `configuration.md` (deployment-only `compensation` host/webhook intentionally excluded per the `skill_lint.py` policy rule):
- `wow.eventsourcing.snapshot.checkpoint.*` (enabled=false, version-interval=100)
- `wow.eventsourcing.storage-routing.*` (per-aggregate routing; documents the fail-fast "exactly one of storage/binding" rule)
- `wow.webflux.batch.*` and `wow.webflux.command.request.appender.*`
- `wow.opentelemetry.enabled` / `wow.metrics.enabled` (both default `true`, `matchIfMissing`)

## Scope

4 files, +53/−8, all under `skills/`. No code changes.