### PR TITLE
docs: add KaiCode'26 award recognition

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   <a href="https://github.com/Ahoo-Wang/Wow/actions/workflows/integration-test.yml"><img src="https://github.com/Ahoo-Wang/Wow/actions/workflows/integration-test.yml/badge.svg" alt="CI"/></a>
   <a href="https://kotlin.link/"><img src="https://kotlin.link/awesome-kotlin.svg" alt="Awesome Kotlin"/></a>
   <a href="https://deepwiki.com/Ahoo-Wang/Wow"><img src="https://deepwiki.com/badge.svg" alt="DeepWiki"/></a>
+  <a href="https://www.kaicode.org/2026.html"><img src="https://img.shields.io/badge/KaiCode%2726-Excellent%20Award-gold" alt="KaiCode'26 Excellent Award"/></a>
 </p>
 
 <p align="center">
@@ -55,6 +56,10 @@ Wow was built to change that. After years of production validation, it distills 
 - **Business Intelligence** — State events and commands serve as rich, real-time data sources, reducing ETL to simple SQL scripts
 - **Operation Audit** — Every command and its resulting domain events are recorded with clear business semantics
 - **Engineering Quality** — In API testing, Wow-based projects showed only **1/3** the bug count of traditional-architecture projects at the same skill level
+
+## Recognition
+
+Wow received the [KaiCode’26 Excellent Award](https://www.kaicode.org/2026.html). The official results highlighted its modular DDD/CQRS design, disciplined multi-reviewer code review, Testcontainers-based integration testing, enforced test coverage thresholds, Detekt static analysis, bilingual documentation, and long history of semantically versioned releases on Maven Central.
 
 ## Features
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,6 +17,7 @@
   <a href="https://github.com/Ahoo-Wang/Wow/actions/workflows/integration-test.yml"><img src="https://github.com/Ahoo-Wang/Wow/actions/workflows/integration-test.yml/badge.svg" alt="CI"/></a>
   <a href="https://kotlin.link/"><img src="https://kotlin.link/awesome-kotlin.svg" alt="Awesome Kotlin"/></a>
   <a href="https://deepwiki.com/Ahoo-Wang/Wow"><img src="https://deepwiki.com/badge.svg" alt="DeepWiki"/></a>
+  <a href="https://www.kaicode.org/2026.html"><img src="https://img.shields.io/badge/KaiCode%2726-Excellent%20Award-gold" alt="KaiCode'26 Excellent Award"/></a>
 </p>
 
 <p align="center">
@@ -57,6 +58,10 @@ Wow 正是为改变这一现状而生。历经多年生产环境验证，将 DDD
 - **工程质量** — 在 API 测试中，基于 Wow 的项目缺陷数仅为同等研发水平传统架构项目的 **1/3**
 
 > 值得一提的是，领域驱动设计和事件溯源并非微服务架构的专属，_Wow_ 框架不仅适用于微服务开发，同样也可用于构建基于领域驱动设计的单体应用程序。
+
+## 荣誉
+
+Wow 荣获 [KaiCode’26 Excellent Award](https://www.kaicode.org/2026.html)。官方结果页重点提及了项目的模块化 DDD/CQRS 设计、规范且由多位评审者参与的代码审查、基于 Testcontainers 的集成测试、强制执行的测试覆盖率阈值、Detekt 静态分析、双语文档，以及长期的 Maven Central 语义化版本发布记录。
 
 ## 特性一览
 

--- a/documentation/docs/en/index.md
+++ b/documentation/docs/en/index.md
@@ -58,3 +58,7 @@ features:
   details: Provide richer data sources with clear business semantics (including state events and commands). With extremely low ETL cost, help real-time data analysis and operation audit, provide strong support for business decision-making.
   link: /guide/bi
 ---
+
+## Recognition
+
+Wow received the [KaiCode’26 Excellent Award](https://www.kaicode.org/2026.html). The official results highlighted its modular DDD/CQRS design, disciplined multi-reviewer code review, Testcontainers-based integration testing, enforced test coverage thresholds, Detekt static analysis, bilingual documentation, and long history of semantically versioned releases on Maven Central.

--- a/documentation/docs/zh/index.md
+++ b/documentation/docs/zh/index.md
@@ -58,3 +58,7 @@ features:
   details: 提供更丰富且具有明确业务语义的数据源（包括状态事件和命令）。具有极低的ETL成本，助力实时数据分析和操作审计，为业务决策提供有力支持。
   link: /zh/guide/bi
 ---
+
+## 荣誉
+
+Wow 荣获 [KaiCode’26 Excellent Award](https://www.kaicode.org/2026.html)。官方结果页重点提及了项目的模块化 DDD/CQRS 设计、规范且由多位评审者参与的代码审查、基于 Testcontainers 的集成测试、强制执行的测试覆盖率阈值、Detekt 静态分析、双语文档，以及长期的 Maven Central 语义化版本发布记录。


### PR DESCRIPTION
## Goal

Publicly record Wow receiving the KaiCode’26 Excellent Award in the English and Chinese project entry points, using the official results page as the factual source and avoiding certification-style or promotional claims.

## Changes

- Add a linked KaiCode’26 Excellent Award badge to both root READMEs.
- Add concise `Recognition` / `荣誉` sections to the English and Chinese READMEs.
- Add the same bilingual recognition to the English and Chinese documentation homepages.
- Summarize the engineering practices highlighted by the official results.

## Verification

- `cd documentation && pnpm docs:build` — passed; VitePress rendered the recognition and official link on both homepages.
- `git diff --check` — passed.

## Risks and Notes

- Documentation-only change; no application code, APIs, Gradle configuration, CI, dependencies, or release configuration are affected.
- The award link points directly to the official KaiCode’26 results page and was verified during implementation. VitePress has `ignoreDeadLinks: true`, so future external-link availability is not enforced by the build.
