### PR TITLE
fix(docs): keep award ribbons visible

### DIFF
--- a/documentation/docs/.vitepress/theme/KaiCodeAward.vue
+++ b/documentation/docs/.vitepress/theme/KaiCodeAward.vue
@@ -360,7 +360,7 @@ const copy = computed(() => isChinese.value
     position: absolute;
     bottom: -12px;
     height: auto;
-    opacity: 0;
+    opacity: 1;
     filter: drop-shadow(0 8px 12px rgba(24, 12, 3, 0.22));
 }
 
@@ -639,13 +639,9 @@ const copy = computed(() => isChinese.value
         transform: translateY(0) scale(1);
     }
 
-    78% {
-        opacity: 0.92;
-    }
-
     100% {
-        opacity: 0;
-        transform: translateY(-20px) scale(1.04);
+        opacity: 1;
+        transform: translateY(0) scale(1);
     }
 }
 


### PR DESCRIPTION
## Summary

- Keep the award banner’s left and right decorative ribbon clusters visible after their entrance animation.
- Preserve the existing one-shot Canvas confetti burst and the rest of the banner motion.
- Show the static ribbon clusters when reduced motion is preferred.

## Root cause

The final ribbon-cluster keyframe set `opacity: 0` and moved the assets upward, so both side decorations disappeared after 1.9 seconds.

## Impact

The KaiCode’26 award banner retains its celebratory side framing after the entrance animation completes.

## Validation

- `cd documentation && pnpm docs:build`
- `git diff --check`
- Browser verification after 2.4 seconds: both ribbon clusters remained visible with `opacity: 1`, and the page had no horizontal overflow.