### PR TITLE
perf(command-wait): skip unobservable successful SENT signals

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
@@ -20,6 +20,7 @@ import me.ahoo.wow.command.validation.validateCommand
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.CommandWaitEndpoint
 import me.ahoo.wow.command.wait.CommandWaitNotifier
+import me.ahoo.wow.command.wait.SkipsSuccessfulSentSignal
 import me.ahoo.wow.command.wait.WaitCoordinator
 import me.ahoo.wow.command.wait.WaitHandle
 import me.ahoo.wow.command.wait.WaitPlan
@@ -269,8 +270,12 @@ class DefaultCommandGateway(
             waitPlan.propagate(commandWaitEndpoint, command.header)
             commandBus.send(command)
         }.doOnSuccess {
-            val waitSignal = command.commandSentSignal(waitPlan.waitCommandId)
-            waitHandle.next(waitSignal)
+            if (waitHandle !is SkipsSuccessfulSentSignal ||
+                waitPlan.target.stage == CommandStage.SENT
+            ) {
+                val waitSignal = command.commandSentSignal(waitPlan.waitCommandId)
+                waitHandle.next(waitSignal)
+            }
         }.doOnError {
             val waitSignal = command.commandSentSignal(waitPlan.waitCommandId, it)
             waitHandle.next(waitSignal)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitHandle.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitHandle.kt
@@ -46,12 +46,20 @@ interface WaitStreamHandle : WaitHandle {
     fun stream(): Flux<WaitSignal>
 }
 
+/**
+ * Internal capability indicating that a last-result handle does not need a successful
+ * SENT signal before a later target stage. Unknown/public SPI implementations keep the
+ * original notification behavior by default.
+ */
+internal interface SkipsSuccessfulSentSignal
+
 const val DEFAULT_WAIT_STREAM_QUEUE_LINK_SIZE: Int = 16
 
 internal class DefaultWaitLastHandle(
     override val plan: WaitPlan,
     private val onTerminate: () -> Unit,
-) : WaitLastHandle {
+) : WaitLastHandle,
+    SkipsSuccessfulSentSignal {
     override val waitCommandId: String = plan.waitCommandId
     private val sink = Sinks.one<WaitSignal>()
     private val lock = Any()

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTest.kt
@@ -22,11 +22,17 @@ import me.ahoo.wow.command.wait.CommandWait
 import me.ahoo.wow.command.wait.DefaultWaitCoordinator
 import me.ahoo.wow.command.wait.RecordingCommandWaitNotifier
 import me.ahoo.wow.command.wait.SimpleCommandWaitEndpoint
+import me.ahoo.wow.command.wait.SkipsSuccessfulSentSignal
 import me.ahoo.wow.command.wait.TestCommandMessage
 import me.ahoo.wow.command.wait.WaitCoordinator
+import me.ahoo.wow.command.wait.WaitLastHandle
+import me.ahoo.wow.command.wait.WaitPlan
+import me.ahoo.wow.command.wait.WaitSignal
 import me.ahoo.wow.command.wait.WaitTestEvent
 import me.ahoo.wow.command.wait.extractWaitPlan
 import me.ahoo.wow.command.wait.testAggregateId
+import me.ahoo.wow.command.wait.testFunction
+import me.ahoo.wow.command.wait.testNamedFunction
 import me.ahoo.wow.command.wait.testSignal
 import me.ahoo.wow.command.wait.waitPlanHeader
 import me.ahoo.wow.event.toDomainEventStream
@@ -310,6 +316,147 @@ class DefaultCommandGatewayTest {
     }
 
     @Test
+    fun `send and wait last skips successful sent signal before processed target`() {
+        val waitCoordinator = RecordingLastWaitCoordinator()
+        val gateway = commandGateway(waitCoordinator = waitCoordinator)
+        val command = TestCommandMessage(id = "command-id")
+        val waitPlan = CommandWait.processed("wait-command-id")
+
+        StepVerifier.create(gateway.sendAndWait(command, waitPlan))
+            .then {
+                waitCoordinator.lastHandle.signals.assert().isEmpty()
+                waitCoordinator.signal(
+                    testSignal(
+                        CommandStage.PROCESSED,
+                        waitCommandId = "wait-command-id",
+                        commandId = "command-id",
+                    )
+                ).assert().isTrue()
+            }
+            .assertNext {
+                it.stage.assert().isEqualTo(CommandStage.PROCESSED)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `default last wait handle supports skipping successful sent signal`() {
+        val handle = DefaultWaitCoordinator().createLast(CommandWait.processed("wait-command-id"))
+
+        (handle is SkipsSuccessfulSentSignal).assert().isTrue()
+
+        handle.cancel()
+    }
+
+    @Test
+    fun `send and wait chain completes without successful sent signal`() {
+        val waitCoordinator = RecordingLastWaitCoordinator()
+        val gateway = commandGateway(waitCoordinator = waitCoordinator)
+        val command = TestCommandMessage(id = "command-id")
+        val waitPlan = CommandWait.chain(
+            waitCommandId = "command-id",
+            function = testNamedFunction(),
+            tailStage = CommandStage.PROCESSED,
+            tailFunction = testNamedFunction(),
+        )
+
+        StepVerifier.create(gateway.sendAndWait(command, waitPlan))
+            .then {
+                waitCoordinator.lastHandle.signals.assert().isEmpty()
+                waitCoordinator.signal(
+                    testSignal(
+                        stage = CommandStage.SAGA_HANDLED,
+                        waitCommandId = "command-id",
+                        commandId = "command-id",
+                        function = testFunction(),
+                        commands = emptyList(),
+                    )
+                ).assert().isTrue()
+                waitCoordinator.signal(
+                    testSignal(
+                        stage = CommandStage.PROCESSED,
+                        waitCommandId = "command-id",
+                        commandId = "command-id",
+                    )
+                ).assert().isTrue()
+            }
+            .assertNext {
+                it.stage.assert().isEqualTo(CommandStage.SAGA_HANDLED)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `send and wait last retains successful sent signal for sent target`() {
+        val waitCoordinator = RecordingLastWaitCoordinator()
+        val gateway = commandGateway(waitCoordinator = waitCoordinator)
+        val command = TestCommandMessage(id = "command-id")
+
+        StepVerifier.create(gateway.sendAndWait(command, CommandWait.sent("wait-command-id")))
+            .assertNext {
+                it.stage.assert().isEqualTo(CommandStage.SENT)
+            }
+            .verifyComplete()
+
+        waitCoordinator.lastHandle.signals
+            .map { it.stage }
+            .assert()
+            .containsExactly(CommandStage.SENT)
+    }
+
+    @Test
+    fun `send and wait last retains successful sent signal for custom handle`() {
+        val waitCoordinator = RecordingLastWaitCoordinator(skipsSuccessfulSentSignal = false)
+        val gateway = commandGateway(waitCoordinator = waitCoordinator)
+        val command = TestCommandMessage(id = "command-id")
+        val waitPlan = CommandWait.processed("wait-command-id")
+
+        StepVerifier.create(gateway.sendAndWait(command, waitPlan))
+            .then {
+                waitCoordinator.lastHandle.signals
+                    .map { it.stage }
+                    .assert()
+                    .containsExactly(CommandStage.SENT)
+                waitCoordinator.signal(
+                    testSignal(
+                        CommandStage.PROCESSED,
+                        waitCommandId = "wait-command-id",
+                        commandId = "command-id",
+                    )
+                ).assert().isTrue()
+            }
+            .assertNext {
+                it.stage.assert().isEqualTo(CommandStage.PROCESSED)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `send and wait last retains failed sent signal`() {
+        val commandBus = RecordingCommandBus().apply {
+            sendResult = { Mono.error(IllegalStateException("bus failed")) }
+        }
+        val waitCoordinator = RecordingLastWaitCoordinator()
+        val gateway = commandGateway(
+            commandBus = commandBus,
+            waitCoordinator = waitCoordinator,
+        )
+
+        StepVerifier.create(
+            gateway.sendAndWait(
+                TestCommandMessage(id = "command-id"),
+                CommandWait.processed("wait-command-id"),
+            )
+        ).expectError(CommandResultException::class.java)
+            .verify()
+
+        waitCoordinator.lastHandle.signals.single().let {
+            it.stage.assert().isEqualTo(CommandStage.SENT)
+            it.succeeded.assert().isFalse()
+        }
+    }
+
+    @Test
     fun `send and wait maps failed final signal to command result exception`() {
         val waitCoordinator = DefaultWaitCoordinator()
         val gateway = commandGateway(waitCoordinator = waitCoordinator)
@@ -587,6 +734,39 @@ private class RecordingCommandBus : CommandBus {
 
     override fun receive(subscription: MessageSubscription): Flux<ServerCommandExchange<*>> = Flux.empty()
 }
+
+private class RecordingLastWaitCoordinator(
+    private val delegate: WaitCoordinator = DefaultWaitCoordinator(),
+    private val skipsSuccessfulSentSignal: Boolean = true,
+) : WaitCoordinator by delegate {
+    lateinit var lastHandle: RecordingWaitLastHandle
+        private set
+
+    override fun createLast(plan: WaitPlan): WaitLastHandle =
+        if (skipsSuccessfulSentSignal) {
+            SkippingSuccessfulSentRecordingWaitLastHandle(delegate.createLast(plan))
+        } else {
+            RecordingWaitLastHandle(delegate.createLast(plan))
+        }.also {
+            lastHandle = it
+        }
+}
+
+private open class RecordingWaitLastHandle(
+    private val delegate: WaitLastHandle,
+) : WaitLastHandle by delegate {
+    val signals: MutableList<WaitSignal> = mutableListOf()
+
+    override fun next(signal: WaitSignal): Boolean {
+        signals += signal
+        return delegate.next(signal)
+    }
+}
+
+private class SkippingSuccessfulSentRecordingWaitLastHandle(
+    delegate: WaitLastHandle,
+) : RecordingWaitLastHandle(delegate),
+    SkipsSuccessfulSentSignal
 
 private data class SelfValidatingCommand(
     val validated: AtomicInteger,


### PR DESCRIPTION
## Goal

Extract the measured command-wait optimization from #2817 into a focused change.
Remove redundant successful `SENT` delivery from the built-in last-result command-wait
path when the requested target is a later stage, without changing observable results
or public wait-handle compatibility.

Completion criteria:

- built-in last-result waits for non-`SENT` targets do not process an unobservable
  successful `SENT` signal;
- explicit `SENT` waits, streaming waits, custom `WaitLastHandle` implementations,
  and failed sends retain their current behavior;
- targeted and full `wow-core` checks pass;
- the focused candidate shows a reproducible improvement in a clean paired
  MongoDB/Redis pure-create-to-`PROCESSED` comparison.

## Changes

- Add an internal capability to the framework-owned last-result handle.
- Avoid constructing and delivering a successful `SENT` signal only when that
  capability is present and the target stage is later than `SENT`.
- Preserve failed `SENT` delivery and error propagation.
- Add regression coverage for the default capability, later-stage and chain waits,
  explicit `SENT`, custom handles, and failed sends.
- Keep the PR limited to three command-wait implementation/test files. It includes no
  scheduler, storage, Spring configuration, benchmark-framework, or research-document
  changes.

## Verification

- `./gradlew :wow-core:test --tests "me.ahoo.wow.command.DefaultCommandGatewayTest" --no-parallel --console=plain`
  - `BUILD SUCCESSFUL`
- `./gradlew :wow-core:check --no-parallel --console=plain`
  - `BUILD SUCCESSFUL`
- `git show --check HEAD`
  - passed
- Existing public JVM signatures for `DefaultCommandGateway`, `WaitHandle`,
  `WaitLastHandle`, and `WaitStreamHandle`
  - unchanged under `javap -public`

Controlled local real-backend E2E, pure command creation through `PROCESSED`:

- fixed 14 callers, scheduler pool 14, 896 stripes;
- one fork, 4 GiB G1 heap, `2 x 5s` warmup and `3 x 10s` measurement per period;
- eight balanced paired periods: `AB, BA, BA, AB, BA, AB, AB, BA`;
- identical neutral benchmark harness on both sides;
- MongoDB 8.3.4 and Redis 7.4.9, both healthy with zero restarts;
- paired log-ratio analysis, `n=8`, Student-t confidence bounds, no score-based
  exclusions.

| Backend | Baseline geometric mean | Candidate geometric mean | Geometric change | Two-sided 95% CI | One-sided 95% LCB | Incremental gate |
|---|---:|---:|---:|---:|---:|---|
| MongoDB | 21,371.88 ops/s | 21,508.32 ops/s | +0.64% | +0.16% to +1.12% | +0.26% | pass |
| Redis | 26,687.71 ops/s | 27,337.72 ops/s | +2.44% | +1.76% to +3.12% | +1.89% | pass |

The predeclared incremental gate was Redis point estimate at least `+2%` with a
one-sided lower bound above `0%`, and MongoDB non-inferiority with a lower bound no
worse than `-1%`. Both pass.

## Risks and Notes

- Public wait-handle method signatures are unchanged; the opt-in capability is
  internal and additive.
- Custom/public wait-handle implementations conservatively keep the existing
  successful-`SENT` notification behavior.
- Explicit `SENT`, stream, failed-send, cancellation, and error semantics remain
  unchanged.
- No API migration, configuration change, persistence change, or data migration is
  required.
- The benchmark is controlled local real-backend E2E evidence, not a
  production-capacity claim.
- This focused optimization does **not** meet the separate original target of at least
  20% throughput improvement.
- Rollback is a direct revert of this focused commit.

- [x] Public API and generated contracts are unchanged.
- [x] Tests cover the changed behavior and pass.
- [x] No user-facing documentation update is required for this internal optimization.
- [x] No credentials, generated output, benchmark artifacts, or local environment
  files are included.
