### PR TITLE
feat(snapshot): enforce monotonic snapshot saves

### DIFF
--- a/documentation/docs/en/guide/extensions/elasticsearch.md
+++ b/documentation/docs/en/guide/extensions/elasticsearch.md
@@ -115,9 +115,10 @@ overwritten and an individual 409 remains an event-version conflict for only
 that append. Bulk partial successes are returned to their corresponding callers.
 
 SnapshotStore batches use Bulk `update` with scripted upserts. Direct saves use
-the same atomic script: only an incoming snapshot with a higher
-`_source.version` replaces the stored source, while an equal or stale one is a
-no-op. This also keeps pre-upgrade documents safe when their Elasticsearch
+the same atomic script: an incoming snapshot whose version is greater than or
+equal to `_source.version` replaces the complete stored source, while a lower
+version is a no-op. Equal-version replacement supports snapshot regeneration.
+This also keeps pre-upgrade documents safe when their Elasticsearch
 `_version` is an internal write counter rather than the aggregate version; no
 version-metadata migration is required.
 

--- a/documentation/docs/en/guide/extensions/mongo.md
+++ b/documentation/docs/en/guide/extensions/mongo.md
@@ -66,7 +66,8 @@ Each aggregate type gets its own collection, partitioned by aggregate name. This
 when the candidate aggregate version is greater than or equal to the stored
 version and keeps the stored document for a lower candidate. A missing or
 non-integer stored version is treated as invalid metadata and repaired by the
-candidate. This pipeline form requires MongoDB 4.2 or later.
+candidate. The MQL expression used by this pipeline requires MongoDB 5.2 or
+later; the integration suite verifies MongoDB 6.0.6.
 
 This collection layout assumes that one MongoDB database serves exactly one bounded context. During startup, the
 Starter atomically claims the current `wow.context-name` in `wow_database_metadata`. Instances of the same context

--- a/documentation/docs/en/guide/extensions/mongo.md
+++ b/documentation/docs/en/guide/extensions/mongo.md
@@ -50,7 +50,7 @@ graph TB
     AR -->|"appendStream()"| MES
     MES -->|"insertOne"| ESColl
     AR -->|"save(Snapshot)"| MSR
-    MSR -->|"replaceOne (upsert)"| SSCol
+    MSR -->|"updateOne pipeline (upsert)"| SSCol
     CM -->|"prepare()"| MPK
     MPK -->|"replaceOne"| PKCol
     QS -->|"dynamicQuery()"| MESQ
@@ -60,6 +60,13 @@ graph TB
 ```
 
 Each aggregate type gets its own collection, partitioned by aggregate name. This design isolates hot aggregates from each other and enables per-aggregate sharding and index tuning.
+
+`MongoSnapshotStore.save()` uses one aggregation-pipeline `updateOne` with
+`$replaceWith` and `$cond`. The server atomically replaces the complete document
+when the candidate aggregate version is greater than or equal to the stored
+version and keeps the stored document for a lower candidate. A missing or
+non-integer stored version is treated as invalid metadata and repaired by the
+candidate. This pipeline form requires MongoDB 4.2 or later.
 
 This collection layout assumes that one MongoDB database serves exactly one bounded context. During startup, the
 Starter atomically claims the current `wow.context-name` in `wow_database_metadata`. Instances of the same context
@@ -508,7 +515,7 @@ classDiagram
     AbstractMongoQueryService <|-- MongoSnapshotQueryService
 ```
 
-The class hierarchy reveals two layers of abstraction: the **Wow core interfaces** (`AbstractEventStore`, `SnapshotStore`, `PrepareKey`, `QueryService`) define the framework contract in a storage-agnostic way, while the **Mongo-specific implementations** map those contracts onto MongoDB's reactive driver primitives (`insertOne`, `replaceOne`, `find`, `countDocuments`).
+The class hierarchy reveals two layers of abstraction: the **Wow core interfaces** (`AbstractEventStore`, `SnapshotStore`, `PrepareKey`, `QueryService`) define the framework contract in a storage-agnostic way, while the **Mongo-specific implementations** map those contracts onto MongoDB's reactive driver primitives (`insertOne`, aggregation-pipeline `updateOne`, `replaceOne`, `find`, `countDocuments`).
 
 ## Index Optimization Recommendations
 

--- a/documentation/docs/en/guide/extensions/redis.md
+++ b/documentation/docs/en/guide/extensions/redis.md
@@ -221,6 +221,13 @@ Key: v2:snapshot:{<scope>.<identity>}
 Value: {snapshotJson}
 ```
 
+`RedisSnapshotStore.save()` executes `GET`, aggregate-version comparison, and
+conditional `SET` in one Lua script. A candidate version greater than or equal
+to the stored JSON `version` replaces the complete value; a lower version is a
+successful no-op. Existing snapshot JSON must be valid and contain a numeric
+top-level `version`; malformed stored data causes the save to fail instead of
+silently bypassing the version guard.
+
 ### Upgrade boundary
 
 The runtime reads and writes canonical v2 only. It does not dual-read, dual-write, or migrate published incompatible
@@ -304,8 +311,9 @@ spring:
 
 ### Batch Operations
 
-The event store uses Lua scripts for atomic append operations. Snapshot and message-bus operations
-are issued individually; the extension does not automatically pipeline arbitrary batch work.
+The event and snapshot stores use Lua scripts for atomic writes. Snapshot and
+message-bus operations are issued individually; the extension does not
+automatically pipeline arbitrary batch work.
 
 ### Memory Optimization
 

--- a/documentation/docs/en/guide/extensions/tck.md
+++ b/documentation/docs/en/guide/extensions/tck.md
@@ -102,6 +102,9 @@ class RedisSnapshotStoreTest : SnapshotStoreSpec() {
 }
 ```
 
+The shared specification verifies lower-version no-op behavior, equal-version
+replacement, and concurrent saves retaining the highest aggregate version.
+
 ### RedisPrepareKey
 
 ```kotlin

--- a/documentation/docs/en/guide/migration.md
+++ b/documentation/docs/en/guide/migration.md
@@ -54,6 +54,24 @@ event and snapshot data before upgrading, stop all old-version writers, and remo
 confirming they are no longer needed. Rollback requires restoring the old runtime and retaining its checkpoint data;
 mixed-version deployment is unsupported.
 
+## Atomic SnapshotStore Saves
+
+`SnapshotStore.save()` keeps the same JVM signature and snapshot formats, but its
+storage contract is stronger: each aggregate must use one atomic compare-and-write
+operation. A candidate whose aggregate version is greater than or equal to the
+stored version replaces the complete snapshot; a lower candidate completes
+successfully without writing. Equal-version replacement is intentional so the
+snapshot-regeneration routes can repair a stale payload.
+
+Custom `SnapshotStore` implementations must use a backend CAS, conditional update,
+transaction, or equivalent atomic primitive. A client-side `load()` followed by an
+unconditional write is not conformant. Materialize the candidate once and derive the
+comparison version from that same payload. Stop and drain all old writers before
+relying on this guarantee: old MongoDB or Redis writers can still regress a newer
+snapshot, and an old Elasticsearch writer does not perform equal-version replacement.
+No data rewrite is required. Rollback restores the old save behavior, so do not run
+old and new writers concurrently.
+
 ## Redis EventStore Canonical v2 Layout (introduced in v8.9.0)
 
 When upgrading from v8.6.x or v8.8.x to v8.9.0, treat Redis persistence as a hard storage-format cutover. Redis

--- a/documentation/docs/en/guide/migration.md
+++ b/documentation/docs/en/guide/migration.md
@@ -72,6 +72,10 @@ snapshot, and an old Elasticsearch writer does not perform equal-version replace
 No data rewrite is required. Rollback restores the old save behavior, so do not run
 old and new writers concurrently.
 
+For `wow-mongo`, the guarded update uses MongoDB MQL expressions that require
+MongoDB 5.2 or later; the integration suite verifies MongoDB 6.0.6. Upgrade the
+MongoDB server before deploying this runtime when the existing server is older.
+
 ## Redis EventStore Canonical v2 Layout (introduced in v8.9.0)
 
 When upgrading from v8.6.x or v8.8.x to v8.9.0, treat Redis persistence as a hard storage-format cutover. Redis

--- a/documentation/docs/en/guide/snapshot.md
+++ b/documentation/docs/en/guide/snapshot.md
@@ -111,22 +111,39 @@ interface SnapshotStore : Named {
 }
 ```
 
-`SnapshotStore.save()` maintains the latest snapshot for each aggregate.
+`SnapshotStore.save()` atomically maintains the latest snapshot for each aggregate.
+A candidate whose aggregate version is greater than or equal to the stored version
+replaces the complete stored snapshot; only a lower-version candidate is a no-op.
+Allowing equal-version replacement lets snapshot regeneration repair state without
+changing the aggregate version. Storage implementations must enforce the comparison
+in the same atomic operation as the write to prevent out-of-order state events from
+regressing the snapshot.
 
 ### In-Memory Implementation
 
 ```kotlin
 class InMemorySnapshotStore : SnapshotStore {
-    private val aggregateIdMapSnapshot = ConcurrentHashMap<AggregateId, String>()
+    private val snapshots = ConcurrentHashMap<AggregateId, ObjectNode>()
 
     override fun <S : Any> load(aggregateId: AggregateId): Mono<Snapshot<S>> =
-        Mono.fromCallable {
-            aggregateIdMapSnapshot[aggregateId]?.toObject<Snapshot<S>>()
+        Mono.defer {
+            Mono.justOrEmpty(snapshots[aggregateId]?.toObject<Snapshot<S>>())
         }
 
     override fun <S : Any> save(snapshot: Snapshot<S>): Mono<Void> =
         Mono.fromRunnable {
-            aggregateIdMapSnapshot[snapshot.aggregateId] = snapshot.toJsonString()
+            val candidate = snapshot.toJsonNode<ObjectNode>()
+            val candidateVersion = candidate[MessageRecords.VERSION].asInt()
+            snapshots.compute(snapshot.aggregateId) { _, stored ->
+                if (
+                    stored == null ||
+                    candidateVersion >= stored[MessageRecords.VERSION].asInt()
+                ) {
+                    candidate
+                } else {
+                    stored
+                }
+            }
         }
 }
 ```
@@ -135,8 +152,10 @@ class InMemorySnapshotStore : SnapshotStore {
 
 | Backend | Module | Status |
 |---------|--------|--------|
+| In-memory | `wow-core` | Development/testing |
 | MongoDB | `wow-mongo` | Production-ready |
 | Redis | `wow-redis` | Production-ready |
+| Elasticsearch | `wow-elasticsearch` | Production-ready |
 
 ## Snapshot Processing Flow
 

--- a/documentation/docs/zh/guide/extensions/elasticsearch.md
+++ b/documentation/docs/zh/guide/extensions/elasticsearch.md
@@ -114,9 +114,9 @@ EventStore 使用 Bulk `create`，不会覆盖已有事件文档；单项 409 �
 对应 append 的事件版本冲突返回，Bulk 中其他成功项仍会返回给各自调用者。
 
 SnapshotStore 使用带 scripted upsert 的 Bulk `update`，direct 路径使用相同的
-原子脚本：只有 `_source.version` 更高的输入才会完整替换已存快照，相同或旧版本
-为 no-op。升级前文档的 Elasticsearch `_version` 是内部写入计数器时同样安全，
-不需要迁移版本元数据。
+原子脚本：输入版本大于或等于 `_source.version` 时完整替换已存快照，只有较低
+版本为 no-op。同版本覆盖支持快照重建。升级前文档的 Elasticsearch `_version`
+是内部写入计数器时同样安全，不需要迁移版本元数据。
 
 ## 索引命名规则
 

--- a/documentation/docs/zh/guide/extensions/mongo.md
+++ b/documentation/docs/zh/guide/extensions/mongo.md
@@ -50,7 +50,7 @@ graph TB
     AR -->|"appendStream()"| MES
     MES -->|"insertOne"| ESColl
     AR -->|"save(Snapshot)"| MSR
-    MSR -->|"replaceOne (upsert)"| SSCol
+    MSR -->|"updateOne pipeline (upsert)"| SSCol
     CM -->|"prepare()"| MPK
     MPK -->|"replaceOne"| PKCol
     QS -->|"dynamicQuery()"| MESQ
@@ -60,6 +60,11 @@ graph TB
 ```
 
 每种聚合类型拥有自己的集合，按聚合名称分区。这种设计将热聚合彼此隔离，并支持按聚合进行分片和索引调优。
+
+`MongoSnapshotStore.save()` 通过单次 aggregation-pipeline `updateOne` 配合
+`$replaceWith` 与 `$cond` 完成保存。候选聚合版本大于或等于已存版本时，服务端
+原子替换完整文档；版本较低时保留已存文档。缺失或非整数的已存版本被视为无效
+元数据，并由候选快照修复。该 pipeline 形式要求 MongoDB 4.2 或更高版本。
 
 该集合布局假设一个 MongoDB database 只服务一个 bounded context。Starter 启动时会在
 `wow_database_metadata` 中原子认领当前 `wow.context-name`；同一 context 的实例可安全重复启动，
@@ -507,7 +512,7 @@ classDiagram
     AbstractMongoQueryService <|-- MongoSnapshotQueryService
 ```
 
-类层级揭示了两层抽象：**Wow 核心接口**（`AbstractEventStore`、`SnapshotStore`、`PrepareKey`、`QueryService`）以存储无关的方式定义了框架契约，而 **Mongo 特定实现** 将这些契约映射到 MongoDB 的响应式驱动原语（`insertOne`、`replaceOne`、`find`、`countDocuments`）。
+类层级揭示了两层抽象：**Wow 核心接口**（`AbstractEventStore`、`SnapshotStore`、`PrepareKey`、`QueryService`）以存储无关的方式定义了框架契约，而 **Mongo 特定实现** 将这些契约映射到 MongoDB 的响应式驱动原语（`insertOne`、aggregation-pipeline `updateOne`、`replaceOne`、`find`、`countDocuments`）。
 
 ## 索引优化建议
 

--- a/documentation/docs/zh/guide/extensions/mongo.md
+++ b/documentation/docs/zh/guide/extensions/mongo.md
@@ -64,7 +64,8 @@ graph TB
 `MongoSnapshotStore.save()` 通过单次 aggregation-pipeline `updateOne` 配合
 `$replaceWith` 与 `$cond` 完成保存。候选聚合版本大于或等于已存版本时，服务端
 原子替换完整文档；版本较低时保留已存文档。缺失或非整数的已存版本被视为无效
-元数据，并由候选快照修复。该 pipeline 形式要求 MongoDB 4.2 或更高版本。
+元数据，并由候选快照修复。该 pipeline 使用的 MQL 表达式要求 MongoDB 5.2
+或更高版本；集成测试验证的版本为 MongoDB 6.0.6。
 
 该集合布局假设一个 MongoDB database 只服务一个 bounded context。Starter 启动时会在
 `wow_database_metadata` 中原子认领当前 `wow.context-name`；同一 context 的实例可安全重复启动，

--- a/documentation/docs/zh/guide/extensions/redis.md
+++ b/documentation/docs/zh/guide/extensions/redis.md
@@ -218,6 +218,11 @@ Key: v2:snapshot:{<scope>.<identity>}
 Value: {snapshotJson}
 ```
 
+`RedisSnapshotStore.save()` 在单个 Lua 脚本中执行 `GET`、聚合版本比较与条件
+`SET`。候选版本大于或等于已存 JSON 的顶层 `version` 时完整替换 value；版本
+较低时以成功 no-op 完成。既有快照 JSON 必须合法且包含数值型顶层 `version`；
+已存数据格式错误时保存会失败，不会静默绕过版本守卫。
+
 ### 升级边界
 
 运行时只读写 canonical v2，不会双读、双写或迁移已发布的不兼容布局。Spring Boot starter 启动时会
@@ -299,8 +304,8 @@ spring:
 
 ### 批量操作
 
-EventStore 使用 Lua 脚本保证追加操作的原子性。Snapshot 与 MessageBus 操作逐条发送，扩展不会自动
-对任意批处理启用 Pipeline。
+EventStore 与 SnapshotStore 使用 Lua 脚本保证写入原子性。Snapshot 与 MessageBus
+操作逐条发送，扩展不会自动对任意批处理启用 Pipeline。
 
 ### 内存优化
 

--- a/documentation/docs/zh/guide/extensions/tck.md
+++ b/documentation/docs/zh/guide/extensions/tck.md
@@ -102,6 +102,8 @@ class RedisSnapshotStoreTest : SnapshotStoreSpec() {
 }
 ```
 
+共享规范会验证低版本 no-op、同版本替换，以及并发保存后保留最高聚合版本。
+
 ### RedisPrepareKey
 
 ```kotlin

--- a/documentation/docs/zh/guide/migration.md
+++ b/documentation/docs/zh/guide/migration.md
@@ -67,6 +67,10 @@ event 与 snapshot 数据、停止全部旧版本 writer，并仅在确认不再
 也不会执行同版本覆盖。无需重写数据。回滚会恢复旧保存行为，因此新旧 writer
 不得并行运行。
 
+`wow-mongo` 的条件更新使用了要求 MongoDB 5.2 或更高版本的 MQL 表达式；
+集成测试验证的版本为 MongoDB 6.0.6。现有服务端版本较低时，必须先升级
+MongoDB，再部署此版本运行时。
+
 ## Redis EventStore Canonical v2 布局（v8.9.0 引入）
 
 从 v8.6.x 或 v8.8.x 升级到 v8.9.0 时，必须把 Redis 持久化视为存储格式硬切换。Redis EventStore、

--- a/documentation/docs/zh/guide/migration.md
+++ b/documentation/docs/zh/guide/migration.md
@@ -53,6 +53,20 @@ MongoDB 中既有的 `*_snapshot_checkpoint` collection 不再被读取、写入
 event 与 snapshot 数据、停止全部旧版本 writer，并仅在确认不再需要后清理这些 collection。回滚必须
 恢复旧运行时并保留其 checkpoint 数据；不支持新旧版本混合部署。
 
+## SnapshotStore 原子保存
+
+`SnapshotStore.save()` 的 JVM 签名与快照格式保持不变，但存储契约得到加强：
+每个聚合必须使用一次原子 compare-and-write。候选聚合版本大于或等于已存版本时
+完整替换快照；版本较低时正常完成且不写入。同版本覆盖是有意行为，使快照重建
+路由可以修复陈旧 payload。
+
+自定义 `SnapshotStore` 必须使用后端 CAS、条件更新、事务或等价的原子原语；
+客户端先 `load()` 再无条件写入不符合契约。候选快照应只物化一次，比较版本必须
+取自同一个待写 payload。在依赖此保证前，应停止全部旧 writer 并排空在途写入：
+旧 MongoDB 或 Redis writer 仍可能使新快照版本倒退，旧 Elasticsearch writer
+也不会执行同版本覆盖。无需重写数据。回滚会恢复旧保存行为，因此新旧 writer
+不得并行运行。
+
 ## Redis EventStore Canonical v2 布局（v8.9.0 引入）
 
 从 v8.6.x 或 v8.8.x 升级到 v8.9.0 时，必须把 Redis 持久化视为存储格式硬切换。Redis EventStore、

--- a/documentation/docs/zh/guide/snapshot.md
+++ b/documentation/docs/zh/guide/snapshot.md
@@ -111,22 +111,36 @@ interface SnapshotStore : Named {
 }
 ```
 
-`SnapshotStore.save()` 为每个聚合维护最新快照。
+`SnapshotStore.save()` 以原子方式为每个聚合维护最新快照。聚合版本大于或等于
+已存版本的候选快照会完整替换已存快照；只有较低版本为 no-op。同版本覆盖使快照
+重建可以在聚合版本不变时修复状态。存储实现必须在同一个原子操作中完成版本比较
+与写入，避免乱序状态事件导致快照版本倒退。
 
 ### 内存实现
 
 ```kotlin
 class InMemorySnapshotStore : SnapshotStore {
-    private val aggregateIdMapSnapshot = ConcurrentHashMap<AggregateId, String>()
+    private val snapshots = ConcurrentHashMap<AggregateId, ObjectNode>()
 
     override fun <S : Any> load(aggregateId: AggregateId): Mono<Snapshot<S>> =
-        Mono.fromCallable {
-            aggregateIdMapSnapshot[aggregateId]?.toObject<Snapshot<S>>()
+        Mono.defer {
+            Mono.justOrEmpty(snapshots[aggregateId]?.toObject<Snapshot<S>>())
         }
 
     override fun <S : Any> save(snapshot: Snapshot<S>): Mono<Void> =
         Mono.fromRunnable {
-            aggregateIdMapSnapshot[snapshot.aggregateId] = snapshot.toJsonString()
+            val candidate = snapshot.toJsonNode<ObjectNode>()
+            val candidateVersion = candidate[MessageRecords.VERSION].asInt()
+            snapshots.compute(snapshot.aggregateId) { _, stored ->
+                if (
+                    stored == null ||
+                    candidateVersion >= stored[MessageRecords.VERSION].asInt()
+                ) {
+                    candidate
+                } else {
+                    stored
+                }
+            }
         }
 }
 ```
@@ -135,8 +149,10 @@ class InMemorySnapshotStore : SnapshotStore {
 
 | 后端 | 模块 | 状态 |
 |---------|--------|--------|
+| 内存 | `wow-core` | 开发/测试 |
 | MongoDB | `wow-mongo` | 生产就绪 |
 | Redis | `wow-redis` | 生产就绪 |
+| Elasticsearch | `wow-elasticsearch` | 生产就绪 |
 
 ## 快照处理流程
 

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/eventsourcing/snapshot/SnapshotStoreSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/eventsourcing/snapshot/SnapshotStoreSpec.kt
@@ -29,8 +29,12 @@ import me.ahoo.wow.tck.mock.MockAggregateCreated
 import me.ahoo.wow.tck.mock.MockStateAggregate
 import me.ahoo.wow.test.aggregate.GivenInitializationCommand
 import org.junit.jupiter.api.Test
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
 import reactor.kotlin.test.test
 import java.time.Clock
+import kotlin.random.Random
 
 abstract class SnapshotStoreSpec {
 
@@ -162,6 +166,125 @@ abstract class SnapshotStoreSpec {
                 it.aggregateId.assert().isEqualTo(stateAggregate.aggregateId)
                 it.version.assert().isEqualTo(stateAggregate.version)
                 it.state.data.assert().isEqualTo(stateAggregate.state.data)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun saveShouldNotReplaceANewerStoredSnapshot() {
+        val snapshotStore = createSnapshotStore().metrizable()
+        val aggregateId = aggregateMetadata.aggregateId(generateGlobalId())
+        val command = GivenInitializationCommand(aggregateId)
+        val aggregateCreated = MockAggregateCreated(generateGlobalId())
+        val changed = MockAggregateChanged(generateGlobalId())
+        val initialEventStream = listOf(aggregateCreated).toDomainEventStream(
+            upstream = command,
+            aggregateVersion = Version.UNINITIALIZED_VERSION,
+        )
+
+        val olderStateAggregate = stateAggregateFactory.create(aggregateMetadata.state, aggregateId)
+        olderStateAggregate.onSourcing(initialEventStream)
+        val olderSnapshot: Snapshot<MockStateAggregate> =
+            SimpleSnapshot(delegate = olderStateAggregate, snapshotTime = Clock.systemUTC().millis())
+
+        val newerStateAggregate = stateAggregateFactory.create(aggregateMetadata.state, aggregateId)
+        newerStateAggregate.onSourcing(initialEventStream)
+        newerStateAggregate.onSourcing(
+            listOf(changed).toDomainEventStream(
+                upstream = command,
+                aggregateVersion = newerStateAggregate.version,
+            )
+        )
+        val newerSnapshot: Snapshot<MockStateAggregate> =
+            SimpleSnapshot(delegate = newerStateAggregate, snapshotTime = Clock.systemUTC().millis())
+
+        snapshotStore.save(newerSnapshot)
+            .then(Mono.defer { snapshotStore.save(olderSnapshot) })
+            .test()
+            .verifyComplete()
+
+        snapshotStore.load<MockStateAggregate>(aggregateId)
+            .test()
+            .consumeNextWith {
+                it.version.assert().isEqualTo(newerSnapshot.version)
+                it.state.data.assert().isEqualTo(newerSnapshot.state.data)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun saveShouldRetainTheHighestVersionUnderConcurrentWrites() {
+        val snapshotStore = createSnapshotStore().metrizable()
+        val aggregateId = aggregateMetadata.aggregateId(generateGlobalId())
+        val snapshots = (1..8).map { expectedVersion ->
+            val stateAggregate = stateAggregateFactory.create(aggregateMetadata.state, aggregateId)
+            repeat(expectedVersion) { eventIndex ->
+                val event = if (eventIndex == 0) {
+                    MockAggregateCreated("version-$expectedVersion")
+                } else {
+                    MockAggregateChanged("version-$expectedVersion")
+                }
+                stateAggregate.onSourcing(
+                    event.toDomainEventStream(
+                        upstream = GivenInitializationCommand(aggregateId),
+                        aggregateVersion = stateAggregate.version,
+                    )
+                )
+            }
+            SimpleSnapshot(delegate = stateAggregate, snapshotTime = expectedVersion.toLong())
+        }
+        val expected = snapshots.maxBy { it.version }
+        val concurrentSaves = snapshots
+            .shuffled(Random(0))
+            .map { candidate ->
+                Mono.defer { snapshotStore.save(candidate) }
+                    .subscribeOn(Schedulers.parallel())
+            }
+
+        Flux.merge(concurrentSaves)
+            .then(Mono.defer { snapshotStore.load<MockStateAggregate>(aggregateId) })
+            .test()
+            .consumeNextWith {
+                it.version.assert().isEqualTo(expected.version)
+                it.state.data.assert().isEqualTo(expected.state.data)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun saveShouldReplaceTheStoredSnapshotForTheSameVersion() {
+        val snapshotStore = createSnapshotStore().metrizable()
+        val aggregateId = aggregateMetadata.aggregateId(generateGlobalId())
+        val firstStateAggregate = stateAggregateFactory.create(aggregateMetadata.state, aggregateId)
+        firstStateAggregate.onSourcing(
+            listOf(MockAggregateCreated("first")).toDomainEventStream(
+                upstream = GivenInitializationCommand(aggregateId),
+                aggregateVersion = firstStateAggregate.version,
+            )
+        )
+        val replacementStateAggregate = stateAggregateFactory.create(aggregateMetadata.state, aggregateId)
+        replacementStateAggregate.onSourcing(
+            listOf(MockAggregateCreated("replacement")).toDomainEventStream(
+                upstream = GivenInitializationCommand(aggregateId),
+                aggregateVersion = replacementStateAggregate.version,
+            )
+        )
+        val firstSnapshot: Snapshot<MockStateAggregate> =
+            SimpleSnapshot(delegate = firstStateAggregate, snapshotTime = 1)
+        val replacementSnapshot: Snapshot<MockStateAggregate> =
+            SimpleSnapshot(delegate = replacementStateAggregate, snapshotTime = 2)
+
+        snapshotStore.save(firstSnapshot)
+            .then(Mono.defer { snapshotStore.save(replacementSnapshot) })
+            .test()
+            .verifyComplete()
+
+        snapshotStore.load<MockStateAggregate>(aggregateId)
+            .test()
+            .consumeNextWith {
+                it.version.assert().isEqualTo(firstSnapshot.version)
+                it.state.data.assert().isEqualTo(replacementSnapshot.state.data)
+                it.snapshotTime.assert().isEqualTo(replacementSnapshot.snapshotTime)
             }
             .verifyComplete()
     }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/InMemorySnapshotStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/InMemorySnapshotStore.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.eventsourcing.snapshot
 
 import me.ahoo.wow.api.modeling.AggregateId
+import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.serialization.toJsonNode
 import me.ahoo.wow.serialization.toObject
 import reactor.core.publisher.Mono
@@ -22,7 +23,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 /**
  * In-memory implementation of SnapshotStore for testing and development.
- * Stores snapshots as JSON strings in a thread-safe map.
+ * Stores snapshots as detached JSON trees in a thread-safe map.
  */
 class InMemorySnapshotStore : SnapshotStore {
     companion object {
@@ -44,7 +45,7 @@ class InMemorySnapshotStore : SnapshotStore {
     private val aggregateIdMapSnapshot = ConcurrentHashMap<AggregateId, ObjectNode>()
 
     /**
-     * Loads a snapshot from the in-memory map by deserializing the JSON string.
+     * Loads a snapshot from the in-memory map by deserializing the JSON tree.
      *
      * @param S the aggregate state type
      * @param aggregateId the ID of the aggregate
@@ -56,7 +57,8 @@ class InMemorySnapshotStore : SnapshotStore {
         }
 
     /**
-     * Saves a snapshot to the in-memory map by serializing it to JSON.
+     * Saves a snapshot to the in-memory map by serializing it to JSON. The atomic map
+     * computation ignores candidates older than the stored snapshot.
      *
      * @param S the aggregate state type
      * @param snapshot the snapshot to save
@@ -64,6 +66,28 @@ class InMemorySnapshotStore : SnapshotStore {
      */
     override fun <S : Any> save(snapshot: Snapshot<S>): Mono<Void> =
         Mono.fromRunnable {
-            aggregateIdMapSnapshot[snapshot.aggregateId] = snapshot.toJsonNode()
+            val snapshotNode: ObjectNode = snapshot.toJsonNode()
+            val snapshotVersion = snapshotNode.snapshotVersion()
+            aggregateIdMapSnapshot.compute(snapshot.aggregateId) { _, storedSnapshotNode ->
+                if (storedSnapshotNode == null) {
+                    return@compute snapshotNode
+                }
+                val storedVersion = storedSnapshotNode.snapshotVersion()
+                if (snapshotVersion >= storedVersion) {
+                    snapshotNode
+                } else {
+                    storedSnapshotNode
+                }
+            }
         }
+
+    private fun ObjectNode.snapshotVersion(): Int {
+        val versionNode = checkNotNull(this[MessageRecords.VERSION]) {
+            "Serialized Wow snapshot has no version."
+        }
+        check(versionNode.isInt) {
+            "Serialized Wow snapshot version must be an integer."
+        }
+        return versionNode.asInt()
+    }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/InMemorySnapshotStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/InMemorySnapshotStore.kt
@@ -67,12 +67,12 @@ class InMemorySnapshotStore : SnapshotStore {
     override fun <S : Any> save(snapshot: Snapshot<S>): Mono<Void> =
         Mono.fromRunnable {
             val snapshotNode: ObjectNode = snapshot.toJsonNode()
-            val snapshotVersion = snapshotNode.snapshotVersion()
+            val snapshotVersion = snapshotNode.requiredSnapshotVersion()
             aggregateIdMapSnapshot.compute(snapshot.aggregateId) { _, storedSnapshotNode ->
                 if (storedSnapshotNode == null) {
                     return@compute snapshotNode
                 }
-                val storedVersion = storedSnapshotNode.snapshotVersion()
+                val storedVersion = storedSnapshotNode.requiredSnapshotVersion()
                 if (snapshotVersion >= storedVersion) {
                     snapshotNode
                 } else {
@@ -80,14 +80,14 @@ class InMemorySnapshotStore : SnapshotStore {
                 }
             }
         }
+}
 
-    private fun ObjectNode.snapshotVersion(): Int {
-        val versionNode = checkNotNull(this[MessageRecords.VERSION]) {
-            "Serialized Wow snapshot has no version."
-        }
-        check(versionNode.isInt) {
-            "Serialized Wow snapshot version must be an integer."
-        }
-        return versionNode.asInt()
+internal fun ObjectNode.requiredSnapshotVersion(): Int {
+    val versionNode = checkNotNull(this[MessageRecords.VERSION]) {
+        "Serialized Wow snapshot has no version."
     }
+    check(versionNode.isInt) {
+        "Serialized Wow snapshot version must be an integer."
+    }
+    return versionNode.asInt()
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt
@@ -57,6 +57,13 @@ interface SnapshotStore :
     /**
      * Saves a snapshot to the store.
      *
+     * Implementations must keep the stored snapshot version monotonically non-decreasing.
+     * The save must atomically compare and write for each aggregate: a candidate whose
+     * version is greater than or equal to the stored version replaces it. A candidate
+     * with a lower version is ignored and the operation completes normally.
+     * The compared candidate version must come from the same materialized snapshot
+     * representation that is written.
+     *
      * @param S the type of the state
      * @param snapshot the snapshot to save
      * @return a Mono that completes when the save operation is done

--- a/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotJsonVersionTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotJsonVersionTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.eventsourcing.snapshot
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.serialization.JsonSerializer
+import me.ahoo.wow.serialization.MessageRecords
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class SnapshotJsonVersionTest {
+
+    @Test
+    fun `should return an integer snapshot version`() {
+        val snapshotNode = JsonSerializer.createObjectNode()
+            .put(MessageRecords.VERSION, 2)
+
+        snapshotNode.requiredSnapshotVersion().assert().isEqualTo(2)
+    }
+
+    @Test
+    fun `should reject a missing snapshot version`() {
+        val snapshotNode = JsonSerializer.createObjectNode()
+
+        val error = assertThrows<IllegalStateException> {
+            snapshotNode.requiredSnapshotVersion()
+        }
+
+        error.message.assert().isEqualTo("Serialized Wow snapshot has no version.")
+    }
+
+    @Test
+    fun `should reject a non-integer snapshot version`() {
+        val snapshotNode = JsonSerializer.createObjectNode()
+            .put(MessageRecords.VERSION, "2")
+
+        val error = assertThrows<IllegalStateException> {
+            snapshotNode.requiredSnapshotVersion()
+        }
+
+        error.message.assert().isEqualTo("Serialized Wow snapshot version must be an integer.")
+    }
+}

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchSnapshotBatchWriter.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchSnapshotBatchWriter.kt
@@ -55,7 +55,7 @@ internal class ElasticsearchSnapshotBatchWriter(
             .values
             .map { sameAggregate ->
                 sameAggregate.reduce { selected, candidate ->
-                    if (candidate.version > selected.version) {
+                    if (candidate.version >= selected.version) {
                         candidate
                     } else {
                         selected

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchSnapshotVersionGuardedWriter.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchSnapshotVersionGuardedWriter.kt
@@ -120,7 +120,7 @@ internal class ElasticsearchSnapshotVersionGuardedWriter(
             "if (!ctx._source.containsKey('version')) { " +
                 "throw new IllegalStateException('Stored Wow snapshot has no version.'); " +
                 "} " +
-                "if (ctx._source.version < params.version) { " +
+                "if (ctx._source.version <= params.version) { " +
                 "ctx._source = params.snapshot; " +
                 "} else { " +
                 "ctx.op = 'noop'; " +

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchSnapshotWrite.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchSnapshotWrite.kt
@@ -15,6 +15,7 @@ package me.ahoo.wow.elasticsearch.eventsourcing
 
 import me.ahoo.wow.elasticsearch.IndexNameConverter.toSnapshotIndexName
 import me.ahoo.wow.eventsourcing.snapshot.Snapshot
+import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.serialization.toLinkedHashMap
 
 internal data class ElasticsearchSnapshotWrite(
@@ -25,10 +26,15 @@ internal data class ElasticsearchSnapshotWrite(
 )
 
 internal fun Snapshot<*>.toElasticsearchSnapshotWrite(): ElasticsearchSnapshotWrite {
+    val document = toLinkedHashMap()
+    val version = document[MessageRecords.VERSION]
+    check(version is Int) {
+        "Serialized Wow snapshot has no integer version."
+    }
     return ElasticsearchSnapshotWrite(
         index = aggregateId.toSnapshotIndexName(),
         id = aggregateId.id,
-        document = toLinkedHashMap(),
+        document = document,
         version = version,
     )
 }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchSnapshotWrite.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchSnapshotWrite.kt
@@ -27,14 +27,18 @@ internal data class ElasticsearchSnapshotWrite(
 
 internal fun Snapshot<*>.toElasticsearchSnapshotWrite(): ElasticsearchSnapshotWrite {
     val document = toLinkedHashMap()
-    val version = document[MessageRecords.VERSION]
-    check(version is Int) {
-        "Serialized Wow snapshot has no integer version."
-    }
     return ElasticsearchSnapshotWrite(
         index = aggregateId.toSnapshotIndexName(),
         id = aggregateId.id,
         document = document,
-        version = version,
+        version = document.requiredSnapshotVersion(),
     )
+}
+
+internal fun Map<String, Any?>.requiredSnapshotVersion(): Int {
+    val version = this[MessageRecords.VERSION]
+    check(version is Int) {
+        "Serialized Wow snapshot has no integer version."
+    }
+    return version
 }

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchSnapshotBatchWriterTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchSnapshotBatchWriterTest.kt
@@ -134,7 +134,7 @@ class ElasticsearchSnapshotBatchWriterTest {
     }
 
     @Test
-    fun `same aggregate and version should preserve the first submitted snapshot`() {
+    fun `same aggregate and version should preserve the last submitted snapshot`() {
         val request = slot<BulkRequest>()
         every { client.bulk(capture(request)) } returns Mono.just(
             bulkResponse(
@@ -161,7 +161,7 @@ class ElasticsearchSnapshotBatchWriterTest {
             .upsert()
             .let(::checkNotNull)["marker"]
             .assert()
-            .isEqualTo("first")
+            .isEqualTo("second")
     }
 
     @Test

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchSnapshotVersionTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchSnapshotVersionTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.elasticsearch.eventsourcing
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.serialization.MessageRecords
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class ElasticsearchSnapshotVersionTest {
+
+    @Test
+    fun `should return an integer snapshot version`() {
+        val snapshotDocument = mapOf<String, Any?>(
+            MessageRecords.VERSION to 2,
+        )
+
+        snapshotDocument.requiredSnapshotVersion().assert().isEqualTo(2)
+    }
+
+    @Test
+    fun `should reject a snapshot without an integer version`() {
+        listOf(
+            emptyMap(),
+            mapOf(MessageRecords.VERSION to "2"),
+        ).forEach { invalidSnapshotDocument ->
+            val error = assertThrows<IllegalStateException> {
+                invalidSnapshotDocument.requiredSnapshotVersion()
+            }
+
+            error.message.assert().isEqualTo("Serialized Wow snapshot has no integer version.")
+        }
+    }
+}

--- a/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/MongoSnapshotStoreTest.kt
+++ b/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/MongoSnapshotStoreTest.kt
@@ -13,10 +13,26 @@
 
 package me.ahoo.wow.mongo
 
+import com.mongodb.client.model.Filters
+import com.mongodb.client.model.Updates
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.event.toDomainEventStream
+import me.ahoo.wow.eventsourcing.snapshot.SimpleSnapshot
 import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
+import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory
+import me.ahoo.wow.mongo.AggregateSchemaInitializer.toSnapshotCollectionName
+import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.tck.container.MongoTestFixture
 import me.ahoo.wow.tck.eventsourcing.snapshot.SnapshotStoreSpec
+import me.ahoo.wow.tck.mock.MockAggregateCreated
+import me.ahoo.wow.tck.mock.MockStateAggregate
+import me.ahoo.wow.test.aggregate.GivenInitializationCommand
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import reactor.kotlin.core.publisher.toMono
+import reactor.kotlin.test.test
 
 class MongoSnapshotStoreTest : SnapshotStoreSpec() {
     @JvmField
@@ -27,5 +43,40 @@ class MongoSnapshotStoreTest : SnapshotStoreSpec() {
         val database = mongo.database()
         SnapshotSchemaInitializer(database).initSchema(aggregateMetadata)
         return MongoSnapshotStore(database)
+    }
+
+    @Test
+    fun saveShouldRepairAStoredSnapshotWithoutAnIntegerVersion() {
+        val snapshotStore = createSnapshotStore()
+        val aggregateId = aggregateMetadata.aggregateId(generateGlobalId())
+        val stateAggregate = ConstructorStateAggregateFactory.create(aggregateMetadata.state, aggregateId)
+        stateAggregate.onSourcing(
+            MockAggregateCreated("repaired").toDomainEventStream(
+                upstream = GivenInitializationCommand(aggregateId),
+                aggregateVersion = stateAggregate.version,
+            )
+        )
+        val snapshot = SimpleSnapshot(stateAggregate, snapshotTime = 1)
+        snapshotStore.save(snapshot).test().verifyComplete()
+        val collection = mongo.database().getCollection(aggregateId.toSnapshotCollectionName())
+        val filter = Filters.eq(Documents.ID_FIELD, aggregateId.id)
+
+        collection.updateOne(filter, Updates.set(MessageRecords.VERSION, "invalid"))
+            .toMono()
+            .then(snapshotStore.save(snapshot))
+            .then(collection.find(filter).first().toMono())
+            .test()
+            .consumeNextWith {
+                it.getInteger(MessageRecords.VERSION).assert().isEqualTo(snapshot.version)
+            }
+            .verifyComplete()
+
+        snapshotStore.load<MockStateAggregate>(aggregateId)
+            .test()
+            .consumeNextWith {
+                it.version.assert().isEqualTo(snapshot.version)
+                it.state.data.assert().isEqualTo(snapshot.state.data)
+            }
+            .verifyComplete()
     }
 }

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoSnapshotStore.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoSnapshotStore.kt
@@ -13,8 +13,11 @@
 
 package me.ahoo.wow.mongo
 
+import com.mongodb.client.model.Aggregates
 import com.mongodb.client.model.Filters
 import com.mongodb.client.model.ReplaceOptions
+import com.mongodb.client.model.UpdateOptions
+import com.mongodb.client.model.mql.MqlValues
 import com.mongodb.reactivestreams.client.MongoDatabase
 import me.ahoo.wow.api.Version.Companion.UNINITIALIZED_VERSION
 import me.ahoo.wow.api.modeling.AggregateId
@@ -23,6 +26,7 @@ import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
 import me.ahoo.wow.mongo.AggregateSchemaInitializer.toSnapshotCollectionName
 import me.ahoo.wow.serialization.MessageRecords
 import org.bson.Document
+import org.bson.conversions.Bson
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
 
@@ -30,6 +34,7 @@ class MongoSnapshotStore(private val database: MongoDatabase) : SnapshotStore {
     companion object {
         const val NAME = "mongo"
         val DEFAULT_REPLACE_OPTIONS: ReplaceOptions = ReplaceOptions().upsert(true)
+        private val VERSION_GUARDED_UPDATE_OPTIONS: UpdateOptions = UpdateOptions().upsert(true)
     }
 
     override val name: String
@@ -75,14 +80,31 @@ class MongoSnapshotStore(private val database: MongoDatabase) : SnapshotStore {
         val snapshotCollectionName = snapshot.aggregateId.toSnapshotCollectionName()
         val document = snapshot.toDocument()
         return database.getCollection(snapshotCollectionName)
-            .replaceOne(
+            .updateOne(
                 Filters.eq(Documents.ID_FIELD, snapshot.aggregateId.id),
-                document,
-                DEFAULT_REPLACE_OPTIONS,
+                versionGuardedSnapshotReplacement(document),
+                VERSION_GUARDED_UPDATE_OPTIONS,
             )
             .toMono()
             .doOnNext {
                 check(it.wasAcknowledged())
             }.then()
     }
+}
+
+internal fun versionGuardedSnapshotReplacement(
+    snapshotDocument: Document,
+): List<Bson> {
+    val snapshotVersion = snapshotDocument[MessageRecords.VERSION]
+    check(snapshotVersion is Int) {
+        "Serialized Wow snapshot has no integer version."
+    }
+    val candidateVersion = MqlValues.of(snapshotVersion)
+    val candidate = MqlValues.of(snapshotDocument)
+    val stored = MqlValues.current()
+    val normalizedStoredVersion = stored.getField(MessageRecords.VERSION)
+        .isIntegerOr(candidateVersion)
+    val replacement = normalizedStoredVersion.lte(candidateVersion)
+        .cond(candidate, stored)
+    return listOf(Aggregates.replaceWith(replacement))
 }

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/MongoSnapshotStoreSaveTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/MongoSnapshotStoreSaveTest.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.mongo
+
+import com.mongodb.MongoClientSettings
+import com.mongodb.client.model.Filters
+import com.mongodb.client.model.UpdateOptions
+import com.mongodb.client.result.UpdateResult
+import com.mongodb.reactivestreams.client.MongoCollection
+import com.mongodb.reactivestreams.client.MongoDatabase
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.event.toDomainEventStream
+import me.ahoo.wow.eventsourcing.snapshot.SimpleSnapshot
+import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
+import me.ahoo.wow.tck.mock.MockAggregateCreated
+import me.ahoo.wow.tck.mock.MockStateAggregate
+import me.ahoo.wow.test.aggregate.GivenInitializationCommand
+import org.bson.BsonDocument
+import org.bson.Document
+import org.bson.conversions.Bson
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.Mono
+import reactor.kotlin.test.test
+
+class MongoSnapshotStoreSaveTest {
+
+    @Test
+    fun `save should issue one version guarded pipeline update`() {
+        val snapshot = snapshot()
+        val database = mockk<MongoDatabase>()
+        val collection = mockk<MongoCollection<Document>>()
+        val filter = slot<Bson>()
+        val updatePipeline = slot<List<Bson>>()
+        val updateOptions = slot<UpdateOptions>()
+        every { database.getCollection(any<String>()) } returns collection
+        every {
+            collection.updateOne(
+                capture(filter),
+                capture(updatePipeline),
+                capture(updateOptions),
+            )
+        } returns Mono.just(UpdateResult.acknowledged(1, 1, null))
+
+        MongoSnapshotStore(database).save(snapshot)
+            .test()
+            .verifyComplete()
+
+        val codecRegistry = MongoClientSettings.getDefaultCodecRegistry()
+        filter.captured.toBsonDocument(BsonDocument::class.java, codecRegistry).assert()
+            .isEqualTo(
+                Filters.eq(Documents.ID_FIELD, snapshot.aggregateId.id)
+                    .toBsonDocument(BsonDocument::class.java, codecRegistry)
+            )
+        updatePipeline.captured.assert().hasSize(1)
+        updateOptions.captured.isUpsert.assert().isTrue()
+        verify(exactly = 1) {
+            collection.updateOne(any<Bson>(), any<List<Bson>>(), any<UpdateOptions>())
+        }
+    }
+
+    @Test
+    fun `save should reject an unacknowledged update`() {
+        val database = mockk<MongoDatabase>()
+        val collection = mockk<MongoCollection<Document>>()
+        every { database.getCollection(any<String>()) } returns collection
+        every {
+            collection.updateOne(
+                any<Bson>(),
+                any<List<Bson>>(),
+                any<UpdateOptions>(),
+            )
+        } returns Mono.just(UpdateResult.unacknowledged())
+
+        MongoSnapshotStore(database).save(snapshot())
+            .test()
+            .expectError(IllegalStateException::class.java)
+            .verify()
+    }
+
+    private fun snapshot(): SimpleSnapshot<MockStateAggregate> {
+        val aggregateId = MOCK_AGGREGATE_METADATA.aggregateId("order-1")
+        val stateAggregate =
+            ConstructorStateAggregateFactory.create(MOCK_AGGREGATE_METADATA.state, aggregateId)
+        stateAggregate.onSourcing(
+            MockAggregateCreated("created").toDomainEventStream(
+                upstream = GivenInitializationCommand(aggregateId),
+                aggregateVersion = stateAggregate.version,
+            )
+        )
+        return SimpleSnapshot(stateAggregate, snapshotTime = 1)
+    }
+}

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/MongoSnapshotVersionGuardTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/MongoSnapshotVersionGuardTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.mongo
+
+import com.mongodb.MongoClientSettings
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.serialization.MessageRecords
+import org.bson.BsonDocument
+import org.bson.Document
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class MongoSnapshotVersionGuardTest {
+
+    @Test
+    fun `should build a serializable replacement pipeline from the candidate document`() {
+        val candidate = Document(Documents.ID_FIELD, "order-1")
+            .append(MessageRecords.VERSION, 2)
+            .append("marker", "\$literal-sensitive")
+        val codecRegistry = MongoClientSettings.getDefaultCodecRegistry()
+        val candidateBson = candidate.toBsonDocument(BsonDocument::class.java, codecRegistry)
+
+        val pipeline = versionGuardedSnapshotReplacement(candidate)
+
+        pipeline.assert().hasSize(1)
+        val renderedStage = pipeline.single()
+            .toBsonDocument(BsonDocument::class.java, codecRegistry)
+        renderedStage.isEmpty().assert().isFalse()
+        renderedStage.toJson().assert().contains(candidateBson.toJson())
+    }
+
+    @Test
+    fun `should reject a candidate document without an integer version`() {
+        listOf(
+            Document(),
+            Document(MessageRecords.VERSION, "2"),
+        ).forEach { invalidCandidate ->
+            val error = assertThrows<IllegalStateException> {
+                versionGuardedSnapshotReplacement(invalidCandidate)
+            }
+            error.message.assert().isEqualTo("Serialized Wow snapshot has no integer version.")
+        }
+    }
+}

--- a/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisSnapshotStore.kt
+++ b/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisSnapshotStore.kt
@@ -16,16 +16,23 @@ package me.ahoo.wow.redis.eventsourcing
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.eventsourcing.snapshot.Snapshot
 import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
+import me.ahoo.wow.redis.RedisScripts
+import me.ahoo.wow.serialization.MessageRecords
+import me.ahoo.wow.serialization.toJsonNode
 import me.ahoo.wow.serialization.toJsonString
 import me.ahoo.wow.serialization.toObject
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate
+import org.springframework.data.redis.core.script.RedisScript
 import reactor.core.publisher.Mono
+import tools.jackson.databind.node.ObjectNode
 
 class RedisSnapshotStore(
     private val redisTemplate: ReactiveStringRedisTemplate
 ) : SnapshotStore {
     companion object {
         const val NAME = "redis"
+        private val SCRIPT_SAVE_SNAPSHOT: RedisScript<String> =
+            RedisScripts.load("snapshot_save.lua", String::class.java)
     }
 
     override val name: String
@@ -40,8 +47,17 @@ class RedisSnapshotStore(
 
     override fun <S : Any> save(snapshot: Snapshot<S>): Mono<Void> {
         val snapshotKey = SnapshotKeyLayout.key(snapshot.aggregateId)
-        return redisTemplate.opsForValue()
-            .set(snapshotKey, snapshot.toJsonString())
-            .then()
+        val snapshotNode: ObjectNode = snapshot.toJsonNode()
+        val versionNode = checkNotNull(snapshotNode[MessageRecords.VERSION]) {
+            "Serialized Wow snapshot has no version."
+        }
+        check(versionNode.isInt) {
+            "Serialized Wow snapshot version must be an integer."
+        }
+        return redisTemplate.execute(
+            SCRIPT_SAVE_SNAPSHOT,
+            listOf(snapshotKey),
+            listOf(versionNode.asInt().toString(), snapshotNode.toJsonString()),
+        ).then()
     }
 }

--- a/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisSnapshotStore.kt
+++ b/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisSnapshotStore.kt
@@ -48,16 +48,21 @@ class RedisSnapshotStore(
     override fun <S : Any> save(snapshot: Snapshot<S>): Mono<Void> {
         val snapshotKey = SnapshotKeyLayout.key(snapshot.aggregateId)
         val snapshotNode: ObjectNode = snapshot.toJsonNode()
-        val versionNode = checkNotNull(snapshotNode[MessageRecords.VERSION]) {
-            "Serialized Wow snapshot has no version."
-        }
-        check(versionNode.isInt) {
-            "Serialized Wow snapshot version must be an integer."
-        }
+        val snapshotVersion = snapshotNode.requiredSnapshotVersion()
         return redisTemplate.execute(
             SCRIPT_SAVE_SNAPSHOT,
             listOf(snapshotKey),
-            listOf(versionNode.asInt().toString(), snapshotNode.toJsonString()),
+            listOf(snapshotVersion.toString(), snapshotNode.toJsonString()),
         ).then()
     }
+}
+
+internal fun ObjectNode.requiredSnapshotVersion(): Int {
+    val versionNode = checkNotNull(this[MessageRecords.VERSION]) {
+        "Serialized Wow snapshot has no version."
+    }
+    check(versionNode.isInt) {
+        "Serialized Wow snapshot version must be an integer."
+    }
+    return versionNode.asInt()
 }

--- a/wow-redis/src/main/resources/snapshot_save.lua
+++ b/wow-redis/src/main/resources/snapshot_save.lua
@@ -1,0 +1,17 @@
+local snapshotKey = KEYS[1];
+local snapshotVersion = tonumber(ARGV[1]);
+local snapshot = ARGV[2];
+
+local storedSnapshot = redis.call("GET", snapshotKey);
+if storedSnapshot then
+    local storedVersion = tonumber(cjson.decode(storedSnapshot)["version"]);
+    if storedVersion == nil then
+        error("Stored Wow snapshot has no numeric version.");
+    end
+    if storedVersion > snapshotVersion then
+        return "Ignored";
+    end
+end
+
+redis.call("SET", snapshotKey, snapshot);
+return "Ok";

--- a/wow-redis/src/test/kotlin/me/ahoo/wow/redis/eventsourcing/RedisSnapshotJsonVersionTest.kt
+++ b/wow-redis/src/test/kotlin/me/ahoo/wow/redis/eventsourcing/RedisSnapshotJsonVersionTest.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.redis.eventsourcing
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.serialization.JsonSerializer
+import me.ahoo.wow.serialization.MessageRecords
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class RedisSnapshotJsonVersionTest {
+
+    @Test
+    fun `should return an integer snapshot version`() {
+        val snapshotNode = JsonSerializer.createObjectNode()
+            .put(MessageRecords.VERSION, 2)
+
+        snapshotNode.requiredSnapshotVersion().assert().isEqualTo(2)
+    }
+
+    @Test
+    fun `should reject a missing snapshot version`() {
+        val snapshotNode = JsonSerializer.createObjectNode()
+
+        val error = assertThrows<IllegalStateException> {
+            snapshotNode.requiredSnapshotVersion()
+        }
+
+        error.message.assert().isEqualTo("Serialized Wow snapshot has no version.")
+    }
+
+    @Test
+    fun `should reject a non-integer snapshot version`() {
+        val snapshotNode = JsonSerializer.createObjectNode()
+            .put(MessageRecords.VERSION, "2")
+
+        val error = assertThrows<IllegalStateException> {
+            snapshotNode.requiredSnapshotVersion()
+        }
+
+        error.message.assert().isEqualTo("Serialized Wow snapshot version must be an integer.")
+    }
+}

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/snapshot/BatchRegenerateSnapshotHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/snapshot/BatchRegenerateSnapshotHandlerFunctionTest.kt
@@ -17,9 +17,12 @@ import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.event.IgnoreSourcing
 import me.ahoo.wow.api.exception.ErrorInfo
 import me.ahoo.wow.api.modeling.AggregateId
+import me.ahoo.wow.event.toDomainEventStream
 import me.ahoo.wow.eventsourcing.AggregateIdScanner.Companion.FIRST_ID
 import me.ahoo.wow.eventsourcing.InMemoryEventStore
+import me.ahoo.wow.eventsourcing.snapshot.InMemorySnapshotStore
 import me.ahoo.wow.eventsourcing.snapshot.NoOpSnapshotStore
+import me.ahoo.wow.eventsourcing.snapshot.SimpleSnapshot
 import me.ahoo.wow.eventsourcing.snapshot.Snapshot
 import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
 import me.ahoo.wow.id.generateGlobalId
@@ -33,6 +36,7 @@ import me.ahoo.wow.tck.mock.MockAggregateCreated
 import me.ahoo.wow.tck.mock.MockCommandAggregate
 import me.ahoo.wow.tck.mock.MockCreateAggregate
 import me.ahoo.wow.tck.mock.MockStateAggregate
+import me.ahoo.wow.test.aggregate.GivenInitializationCommand
 import me.ahoo.wow.test.aggregate.whenCommand
 import me.ahoo.wow.test.aggregateVerifier
 import me.ahoo.wow.webflux.exception.WebFluxRequestExceptionHandler
@@ -123,6 +127,46 @@ class BatchRegenerateSnapshotHandlerFunctionTest {
         val savedSnapshot = snapshotStore.savedSnapshots.single()
         savedSnapshot.aggregateId.id.assert().isEqualTo(aggregateId)
         savedSnapshot.version.assert().isOne()
+    }
+
+    @Test
+    fun `should replace a stored snapshot when regeneration produces the same version`() {
+        val eventStore = InMemoryEventStore()
+        val aggregateIdValue = generateGlobalId()
+        aggregateVerifier<MockCommandAggregate, MockStateAggregate>(eventStore = eventStore)
+            .whenCommand(MockCreateAggregate(id = aggregateIdValue, data = "rebuilt"))
+            .expectNoError()
+            .expectEventType(MockAggregateCreated::class.java)
+            .verify()
+        val aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(aggregateIdValue)
+        val staleStateAggregate =
+            ConstructorStateAggregateFactory.create(MOCK_AGGREGATE_METADATA.state, aggregateId)
+        staleStateAggregate.onSourcing(
+            listOf(MockAggregateCreated("stale")).toDomainEventStream(
+                upstream = GivenInitializationCommand(aggregateId),
+                aggregateVersion = staleStateAggregate.version,
+            )
+        )
+        val snapshotStore = InMemorySnapshotStore()
+        snapshotStore.save(SimpleSnapshot(staleStateAggregate, snapshotTime = 1))
+            .test()
+            .verifyComplete()
+        val handler = RegenerateSnapshotHandler(
+            aggregateMetadata = MOCK_AGGREGATE_METADATA,
+            stateAggregateFactory = ConstructorStateAggregateFactory,
+            eventStore = eventStore,
+            snapshotStore = snapshotStore,
+        )
+
+        handler.handle(aggregateId)
+            .then(Mono.defer { snapshotStore.load<MockStateAggregate>(aggregateId) })
+            .test()
+            .consumeNextWith {
+                it.version.assert().isEqualTo(staleStateAggregate.version)
+                it.state.data.assert().isEqualTo("rebuilt")
+                it.snapshotTime.assert().isNotEqualTo(1)
+            }
+            .verifyComplete()
     }
 
     @Test


### PR DESCRIPTION
## Goal
Prevent out-of-order snapshot writes from regressing stored aggregate state while preserving same-version snapshot regeneration. Completion requires every built-in `SnapshotStore` to atomically accept candidates whose aggregate version is greater than or equal to the stored version and ignore lower versions.

## Changes
- Strengthen the `SnapshotStore.save` contract with atomic compare-and-write semantics and require the guard version to come from the same materialized payload that is persisted.
- Implement the contract with `ConcurrentHashMap.compute`, a MongoDB update pipeline built through the driver MQL API, a Redis Lua script, and Elasticsearch scripted updates for both direct and batch writes.
- Make equal-version writes replace the complete snapshot so regeneration can repair stale payloads; keep lower-version writes as successful no-ops.
- Add shared sequential, equal-version, and concurrent TCK coverage, Mongo unit and integration coverage, Elasticsearch batch coverage, and a snapshot-regeneration regression test.
- Document backend behavior, custom-store requirements, mixed-version rollout constraints, and migration/rollback considerations in English and Chinese.

## Verification
- `./gradlew :wow-core:check :wow-mongo:check :wow-redis:check :wow-elasticsearch:check :wow-webflux:check :wow-tck:check` — passed.
- Cross-backend `SnapshotStoreSpec` contract/integration tests for InMemory, MongoDB, Redis, and Elasticsearch — passed.
- `./gradlew :wow-mock:contractTest --tests '*DelaySnapshotStoreTest*' :wow-opentelemetry:contractTest --tests '*TracingSnapshotStoreTest*'` — passed.
- `./gradlew :wow-mongo:integrationTest --tests '*MongoSnapshotStoreTest*'` — passed.
- `./gradlew :wow-mongo:jacocoTestReport` — passed; the new Mongo save and MQL builder lines and Kotlin branches are covered.
- `pnpm docs:build` in `documentation/` — passed.
- `git diff --check` — passed.

## Risks and Notes
- Equal-version Elasticsearch saves now replace the stored payload instead of becoming no-ops. This is intentional and enables snapshot regeneration.
- MongoDB snapshot writes now use an aggregation update pipeline whose MQL expressions require MongoDB 5.2 or later; the integration suite verifies MongoDB 6.0.6. The driver MQL API is beta but isolated behind an internal pure function and unit tests.
- Custom `SnapshotStore` implementations must provide an equivalent atomic backend primitive. Old and new writers must not run concurrently during rollout because legacy writers can violate the stronger contract.
- Snapshot formats and the JVM method signature are unchanged; no data rewrite is required. Rollback is the commit revert plus coordinated removal of new writers before restoring legacy behavior.
