### PR TITLE
fix(runtime): close admission on startup failure

### DIFF
--- a/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt
@@ -244,6 +244,9 @@ class WowRuntime private constructor(
     private fun rollbackAfterStartFailure(startFailure: Throwable): Mono<Void> {
         val cleanup = claimStartFailureCleanup(startFailure)
             ?: return Mono.error(resolveStartFailureAfterConcurrentShutdown(startFailure))
+        if (startFailure !is StartupCancelledException) {
+            runtimeContext.closeAdmissionAndDrain()
+        }
         scheduleShutdownDeadline(cleanup.owner)
         subscribeShutdown(cleanup.owner)
         return rawTerminationSignal

--- a/wow-core/src/test/kotlin/me/ahoo/wow/runtime/WowRuntimeTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/runtime/WowRuntimeTest.kt
@@ -884,6 +884,40 @@ class WowRuntimeTest {
     }
 
     @Test
+    fun `startup failure closes intake before rollback`() {
+        val calls = CopyOnWriteArrayList<String>()
+        val quiesced = CountDownLatch(1)
+        val startFailure = IllegalStateException("start")
+        val first = RecordingLifecycle(
+            name = "first",
+            calls = calls,
+            onQuiesce = quiesced::countDown,
+        )
+        val failing = RecordingLifecycle(
+            name = "failing",
+            calls = calls,
+            startFailure = startFailure,
+        )
+        val runtime = WowRuntime(
+            components = listOf(first, failing),
+            shutdownTimeout = Duration.ofSeconds(60),
+            shutdownQuietPeriod = Duration.ofSeconds(30),
+        )
+        val executor = Executors.newSingleThreadExecutor()
+
+        try {
+            val startup = runtime.startAsync(executor)
+
+            quiesced.await(1, TimeUnit.SECONDS).assert().isTrue()
+            first.runtimeContext!!.tryAcquire().assert().isNull()
+            startup.get(1, TimeUnit.SECONDS).assert().isSameAs(startFailure)
+        } finally {
+            runtime.forceStop()
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
     fun `startup rollback does not block its Reactor worker`() {
         val startFailure = IllegalStateException("start")
         val forceInvocations = AtomicInteger()


### PR DESCRIPTION
## Summary

- close runtime admission immediately when component preparation or startup fails
- preserve quiet-period semantics for an explicit `StartupCancelledException`
- add a regression test covering a non-zero shutdown quiet period

## Root cause

Startup rollback reused the ordinary graceful-shutdown pipeline. A synchronous
component startup failure was recorded, but admission remained open until the
quiet period completed, allowing new work to enter a runtime that could no
longer become ready.

## Impact

Fatal startup failures now stop accepting new work before rollback while
already admitted work still drains normally. Public APIs and the normal
graceful-shutdown path are unchanged.

## Verification

- `./gradlew :wow-core:test --tests 'me.ahoo.wow.runtime.WowRuntimeTest.startup failure closes intake before rollback'`
- `./gradlew :wow-core:test --tests 'me.ahoo.wow.runtime.WowRuntimeTest'`
- `./gradlew :wow-core:check`
- `git diff --check`

## Related

This isolates the remaining actionable startup-admission finding from #2840
without reintroducing that PR's obsolete alternative runtime implementation.
