### PR TITLE
docs: split migration guides

### DIFF
--- a/documentation/docs/.vitepress/configs/sidebar.en.ts
+++ b/documentation/docs/.vitepress/configs/sidebar.en.ts
@@ -85,8 +85,16 @@ export const sidebarEn: DefaultTheme.Sidebar = {
                 {text: 'Best Practices', link: 'best-practices'},
                 {text: 'Performance Testing', link: 'perf-test'},
                 {text: 'Troubleshooting', link: 'troubleshooting'},
-                {text: 'Migration Guide', link: 'migration'},
-                {text: 'Runtime Orchestration Migration', link: 'migration/runtime-orchestration'},
+                {
+                    text: 'Migration Guide',
+                    link: 'migration',
+                    collapsed: false,
+                    items: [
+                        {text: 'Traditional Architecture', link: 'migration/traditional-architecture'},
+                        {text: 'Migrate Wow v6 to v8', link: 'migration/v6-to-v8'},
+                        {text: 'Runtime Orchestration', link: 'migration/runtime-orchestration'},
+                    ],
+                },
             ],
         },
         {

--- a/documentation/docs/.vitepress/configs/sidebar.zh.ts
+++ b/documentation/docs/.vitepress/configs/sidebar.zh.ts
@@ -85,8 +85,16 @@ export const sidebarZh: DefaultTheme.Sidebar = {
                 {text: '最佳实践', link: 'best-practices'},
                 {text: '性能评测', link: 'perf-test'},
                 {text: '故障排查', link: 'troubleshooting'},
-                {text: '迁移指南', link: 'migration'},
-                {text: '运行时编排迁移', link: 'migration/runtime-orchestration'},
+                {
+                    text: '迁移指南',
+                    link: 'migration',
+                    collapsed: false,
+                    items: [
+                        {text: '传统架构迁移', link: 'migration/traditional-architecture'},
+                        {text: 'Wow v6 迁移到 v8', link: 'migration/v6-to-v8'},
+                        {text: '运行时编排迁移', link: 'migration/runtime-orchestration'},
+                    ],
+                },
             ],
         },
         {

--- a/documentation/docs/en/guide/bi-operations.md
+++ b/documentation/docs/en/guide/bi-operations.md
@@ -114,5 +114,5 @@ and must not be introduced while the scope is in `PENDING_UPDATE` or `RESETTING`
 4. Emergency isolation may set `wow.bi.script.enabled=false`, but that only removes the HTTP route, OpenAPI
    operation, and inspector; it does not roll back ClickHouse data.
 
-See the [Migration Guide](./migration) for the cross-module upgrade order and
+See [Migrate Wow v6 to v8](./migration/v6-to-v8) for the cross-module upgrade order and
 [BI Script Configuration](./configuration#bi-script-configuration) for properties.

--- a/documentation/docs/en/guide/extensions/redis.md
+++ b/documentation/docs/en/guide/extensions/redis.md
@@ -236,7 +236,8 @@ index keys for local aggregates resolved to the auto-configured `RedisEventStore
 aggregate and Redis key. The check fails closed when Redis is unavailable and cannot be disabled. Direct-library,
 independently constructed custom-store, retired-aggregate, and snapshot-only Redis usages require an offline audit.
 
-Do not perform a mixed-version rolling deployment. See the [migration guide](../migration.md#redis-eventstore-canonical-v2-layout)
+Do not perform a mixed-version rolling deployment. See
+[Migrate Wow v6 to v8](../migration/v6-to-v8.md#redis-eventstore-canonical-v2-layout-introduced-in-v8-9-0)
 for the required offline cutover and rollback boundary.
 
 ## Prepare Key

--- a/documentation/docs/en/guide/migration.md
+++ b/documentation/docs/en/guide/migration.md
@@ -1,445 +1,200 @@
 ---
 title: Migration Guide
-description: Guide for migrating from traditional architecture to the Wow framework and upgrading between versions.
+description: Choose between traditional-architecture adoption and the Wow v6-to-v8 upgrade path.
 ---
 
 # Migration Guide
 
-This guide helps you migrate from traditional architecture to the Wow framework, as well as upgrade between different versions.
+There are two primary migration paths. **First-time Wow adoption** is about domain boundaries,
+data modeling, and traffic cutover. **Wow v6 → v8** is about Spring Boot 4, source compatibility,
+and storage-format cutovers. A system already on Wow v8 with custom runtime lifecycle ownership
+also needs the **runtime-orchestration migration track** inside the v8 path; it is not a third
+business or data migration. Choose the primary path first; do not combine both into one release.
 
-## Version Upgrade Guide
+## Choose a Migration Path
 
-### Upgrade Steps
-
-1. **Backup Data**: Backup event store and snapshot data before upgrading
-2. **Read Changelog**: Check [Release Notes](https://github.com/Ahoo-Wang/Wow/releases)
-3. **Update Dependency Version**: Modify build.gradle.kts or pom.xml
-4. **Run Tests**: Ensure all tests pass
-5. **Gradual Rollout**: Gradually upgrade production environment
-
-### Dependency Version Update
-
-::: code-group
-```kotlin [Gradle(Kotlin)]
-// Update wow version
-implementation("me.ahoo.wow:wow-spring-boot-starter:new-version")
-```
-```xml [Maven]
-<dependency>
-    <groupId>me.ahoo.wow</groupId>
-    <artifactId>wow-spring-boot-starter</artifactId>
-    <version>new-version</version>
-</dependency>
-```
-:::
-
-### Breaking Changes Check
-
-Before upgrading, check the following:
-
-1. **API Changes**: Check for interface signature changes
-2. **Configuration Changes**: Check for configuration property changes
-3. **Metadata Changes**: Regenerate metadata files
-
-## Unified Runtime Orchestration
-
-The runtime lifecycle migration is now documented separately so this page can
-remain an upgrade index:
-
-- [Runtime Orchestration Migration](./migration/runtime-orchestration.md) covers
-  source-breaking changes, custom components and message buses, Spring ownership,
-  verification, and rollback.
-- [Runtime Lifecycle](./advanced/runtime-lifecycle.md) describes the stable
-  post-migration architecture and shutdown semantics.
-
-This migration changes lifecycle extension contracts but does not change event,
-snapshot, or message formats. No data migration is required.
-
-## Versioned Snapshot Checkpoint Removal
-
-The versioned snapshot checkpoint capability introduced in v8.9.0 has been removed without a compatibility layer.
-`VersionedSnapshotStore`, `VersionIntervalCheckpointStrategy`, `CompositeSnapshotStrategy`, their metrics and tracing
-decorators, and `SnapshotCheckpointProperties` no longer exist. The `wow.eventsourcing.snapshot.checkpoint.*`
-properties are ignored, and the `wow.snapshot.checkpoint.*` metrics and checkpoint spans are no longer emitted.
-There is no replacement API; applications should use `SnapshotStore`, which stores and loads only the latest snapshot.
-
-MongoDB `*_snapshot_checkpoint` collections are no longer read, written, scanned, or automatically deleted. Back up
-event and snapshot data before upgrading, stop all old-version writers, and remove those collections only after
-confirming they are no longer needed. Rollback requires restoring the old runtime and retaining its checkpoint data;
-mixed-version deployment is unsupported.
-
-## Atomic SnapshotStore Saves
-
-`SnapshotStore.save()` keeps the same JVM signature and snapshot formats, but its
-storage contract is stronger: each aggregate must use one atomic compare-and-write
-operation. A candidate whose aggregate version is greater than or equal to the
-stored version replaces the complete snapshot; a lower candidate completes
-successfully without writing. Equal-version replacement is intentional so the
-snapshot-regeneration routes can repair a stale payload.
-
-Custom `SnapshotStore` implementations must use a backend CAS, conditional update,
-transaction, or equivalent atomic primitive. A client-side `load()` followed by an
-unconditional write is not conformant. Materialize the candidate once and derive the
-comparison version from that same payload. Stop and drain all old writers before
-relying on this guarantee: old MongoDB or Redis writers can still regress a newer
-snapshot, and an old Elasticsearch writer does not perform equal-version replacement.
-No data rewrite is required. Rollback restores the old save behavior, so do not run
-old and new writers concurrently.
-
-For `wow-mongo`, the guarded update uses MongoDB MQL expressions that require
-MongoDB 5.2 or later; the integration suite verifies MongoDB 6.0.6. Upgrade the
-MongoDB server before deploying this runtime when the existing server is older.
-
-## Redis EventStore Canonical v2 Layout (introduced in v8.9.0)
-
-When upgrading from v8.6.x or v8.8.x to v8.9.0, treat Redis persistence as a hard storage-format cutover. Redis
-EventStore, Redis SnapshotStore, and Redis PrepareKey read and write canonical v2 keys only. There is no legacy
-fallback, dual write, or built-in migrator, and old runtimes cannot read new v2 writes. The new EventStore also
-enforces that `AggregateId.id` is unique within a named aggregate across all tenants.
-
-The Spring Boot starter checks the exact sentinel keys created by successful writes in the published v8.6 and v8.8
-EventStore layouts. It checks local aggregates resolved to the auto-configured `RedisEventStore`, supports Redis
-Cluster without runtime `SCAN`, and blocks startup when incompatible data is found. It does not cover direct-library
-usage, independently constructed custom stores, retired aggregate metadata, or snapshot-only Redis routes. A legacy
-snapshot has no aggregate-independent exact sentinel. Canonical v2 ignores legacy snapshot keys. A missing v2
-snapshot causes aggregate loading to replay events, but normal loading does not persist a rebuilt snapshot
-automatically.
-
-The exact-key guard is not a substitute for an offline data audit. A historical alias change, key eviction, or a
-manually deleted or corrupted legacy index can hide the sentinel while orphaned streams remain. The resolved context
-alias (the configured alias, or `contextName` when no alias is configured) and aggregate name form the persistent v2
-key scope. The migration manifest must pin every historical source alias to the target resolved alias. Changing the
-resolved alias or aggregate name after a write requires a separate offline key migration.
-
-Use an offline cutover:
-
-1. Stop traffic and every old-version writer, drain in-flight appends to zero, and create a consistent Redis backup
-   together with event-count and version baselines. Do not use a mixed-version rolling deployment.
-2. Inventory all legacy event ZSETs, v8.6 shared request SETs, v8.8 per-stream request SETs, v8.8 bucketed ID ZSETs,
-   and legacy snapshot and PrepareKey hashes in every logical database on every Cluster primary. Record source key,
-   Redis type, cardinality, checksum, and target mapping. Use identity embedded in event or snapshot JSON as the
-   authority; an ambiguous historical key is only a locator.
-3. Audit each named aggregate for duplicate `AggregateId.id` values across tenants. Resolve every collision before
-   migration; canonical v2 intentionally cannot represent two owners of one ID.
-4. Use an empty v2 target scope on the first run. For disposable data, remove only the inventoried legacy keys from
-   the target or use an empty dedicated database. Never use `FLUSHDB` on a database shared with message-bus or
-   application data. Keep the complete source dataset immutable for rollback.
-5. Run a separately reviewed offline migrator. Its durable manifest must record source key, target keys, source and
-   target checksums, status, and last completed batch. Resume may reuse a target only when manifest and checksum
-   match; otherwise fail without overwriting. Copy operations must be idempotent, and partial target data must not be
-   accepted without manifest-backed re-verification.
-6. Preserve every event ZSET member and score, and verify identity consistency plus contiguous score/version order.
-   Treat committed event JSON as authoritative for v2 request-ID SETs. For v8.6, compare the shared SET with
-   `union(event.requestId)` in both directions and report shared-only and event-only differences separately; never fan
-   it out to streams. For v8.8, compute the symmetric difference between each source per-stream SET and that stream's
-   event request IDs. A non-empty difference fails migration unless an explicit reviewed disposition is recorded.
-7. Rebuild every non-empty aggregate-ID index in the 128-bucket space. The bucket is
-   `aggregateId.id.hashCode().mod(128)` using Java/Kotlin UTF-16 `String.hashCode`; keys and members must use the exact
-   canonical v2 codec. The runtime does not perform this conversion.
-8. Verify ordered member-and-score checksums, first/last versions, request-ID equality, the complete ID index,
-   aggregate-ID scan results, and representative state replay. A failed run must retain its manifest and last verified
-   cursor, then either clean the partial target or resume from that cursor; the application must not start meanwhile.
-9. After full verification, an in-place migration must remove or move every legacy key in the recorded inventory.
-   Delete sentinel keys last, rerun inventory, and require zero legacy keys. With a separate target database, keep the
-   complete source dataset read-only through the rollback window.
-10. Start one new instance against the target and run isolated-ID read/write smoke tests. Explicitly regenerate
-    snapshots, then verify snapshot counts and versions before switching traffic and scaling out. Use the single-ID
-    regenerate route from the complete inventory. The batch route may be treated as exhaustive only when the audited
-    ID domain is strictly above `AggregateIdScanner.FIRST_ID`; otherwise it can omit lower IDs.
-
-Rollback is a coordinated application-and-data operation. Before production v2 writes, reconnect the untouched
-legacy dataset and old runtime. After any production v2 write, first stop traffic and v2 writers, then reverse-migrate
-or replay those writes before restarting the old runtime; restoring only the cutover backup loses every later v2
-write. Prefer a separate target database or namespace.
-
-The mandatory exact-key check is an internal startup invariant. It is intentionally neither optional nor exposed as
-a compatibility or migration setting.
-
-Source, JVM binary, and behavioral compatibility are intentionally broken for Redis layout internals. Removed APIs
-include `AggregateKeyConverter`, `RedisWrappedKey`, `RedisSnapshotRepository`, `EventStreamKeyConverter`,
-`DefaultSnapshotKeyConverter`, `PrepareKeyConverter`, and `RedisEventStore.SCRIPT_EVENT_STEAM_APPEND`; the
-`redisSnapshotRepository` bean alias and custom snapshot-key converter constructor are also removed. The new
-`SCRIPT_EVENT_STREAM_APPEND` is internal, with no public replacement. Canonical converter outputs changed, PrepareKey
-now includes its `name`, and v2 rejects empty aggregate/prepare IDs and unpaired UTF-16 surrogates. Application code
-should use `EventStore`, `SnapshotStore`, and `PrepareKey`; reviewed offline tooling must independently implement and
-verify the documented v2 codec.
-
-## Mongo Ownership Guard
-
-This upgrade keeps aggregate-name-only Mongo collection names, but adds a durable
-`wow_database_metadata` ownership marker. The supported deployment layout is one bounded context per MongoDB
-database.
-
-Before rollout:
-
-1. Inspect every configured event-stream, snapshot, and prepare database. Check all `*_event_stream`, `*_snapshot`,
-   and `prepare_*` collections.
-2. Confirm that each database belongs to only one `wow.context-name`; a mixed database must be split before upgrade.
-3. Upgrade the database's real owner first. The first upgraded instance scans legacy aggregate collections before
-   atomically claiming the marker. Legacy `prepare_*` records contain no context metadata, so a prepare-only database
-   is claimed by the first upgraded context and must be audited before rollout.
-4. Audit existing managed indexes. Missing indexes are created, but incompatible key order, uniqueness, TTL,
-   partial-filter, collation, sparse, or hidden options block startup and require a controlled migration.
-
-Do not edit the marker to bypass a context mismatch. Move or remove the old data, then remove the marker only when
-the database is intentionally reassigned.
-
-## Migrating from Traditional Architecture
-
-### Migration Strategy
-
-#### Gradual Migration
-
-We recommend a gradual migration strategy, progressively migrating functional modules to event sourcing architecture:
+| Current state | Goal | Read | Keep out of scope |
+|---|---|---|---|
+| Traditional CRUD, transaction scripts, or direct database writes | Adopt Wow CQRS and event sourcing incrementally | [Migrating from Traditional Architecture](./migration/traditional-architecture.md) | Wow v6 version-compatibility assumptions |
+| Wow v6 and Spring Boot 3 | Wow v8 and Spring Boot 4 | [Migrate Wow v6 to v8](./migration/v6-to-v8.md) | Redesigning every business boundary |
+| Wow v8 with custom Dispatcher, MessageBus, or Spring lifecycle integration | Current unified `WowRuntime` | [Runtime Orchestration Migration](./migration/runtime-orchestration.md) | Rewriting business data |
 
 ```mermaid
-flowchart LR
-    subgraph Legacy["Traditional Architecture"]
-        LDB[(Relational Database)]
-        LS[Legacy Service]
-    end
-    
-    subgraph Wow["Wow Framework"]
-        ES[(Event Store)]
-        WS[Wow Service]
-    end
-    
-    LS -->|Publish Events| WS
-    WS -->|Sync Data| LDB
-
+%%{init: {"theme": "dark"}}%%
+flowchart TD
+    Start{"Does the system already use Wow?"}
+    Start -->|"No"| Traditional["Traditional architecture migration"]
+    Start -->|"Yes, Wow v6"| V6["Migrate Wow v6 to v8"]
+    Start -->|"Yes, Wow v8"| Custom{"Custom runtime lifecycle?"}
+    Custom -->|"Yes"| Runtime["Runtime orchestration migration"]
+    Custom -->|"No"| Release["Follow Release Notes<br>for the current minor"]
+    classDef route fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    class Start,Traditional,V6,Custom,Runtime,Release route
 ```
 
-#### Migration Steps
+<!-- Sources:
+- README.md:47-49
+- documentation/docs/en/guide/migration/traditional-architecture.md
+- documentation/docs/en/guide/migration/v6-to-v8.md
+- documentation/docs/en/guide/migration/runtime-orchestration.md
+-->
 
-1. **Identify Bounded Contexts**: Determine business modules to migrate
-2. **Design Domain Model**: Define aggregate roots, commands, and events
-3. **Implement Dual Writing**: Write to both old and new systems
-4. **Verify Consistency**: Ensure data consistency
-5. **Switch Read/Write**: Gradually switch to new system
+## Documentation Boundaries
+
+```mermaid
+%%{init: {"theme": "dark"}}%%
+graph TD
+    Index["Migration guide<br>path selection only"]
+    Traditional["Traditional architecture<br>domain and traffic cutover"]
+    V6["v6 → v8<br>platform and data cutover"]
+    Runtime["Runtime orchestration<br>lifecycle source migration"]
+    Lifecycle["Runtime lifecycle<br>stable post-migration model"]
+    Index --> Traditional
+    Index --> V6
+    V6 --> Runtime
+    Runtime --> Lifecycle
+    classDef doc fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    class Index,Traditional,V6,Runtime,Lifecycle doc
+```
+
+<!-- Sources:
+- documentation/docs/en/guide/migration/traditional-architecture.md
+- documentation/docs/en/guide/migration/v6-to-v8.md
+- documentation/docs/en/guide/migration/runtime-orchestration.md
+- documentation/docs/en/guide/advanced/runtime-lifecycle.md
+-->
+
+| Page | Answers | Primary source |
+|---|---|---|
+| Traditional architecture | How do we establish commands, aggregates, events, and state from CRUD, then move traffic safely? | [CreateOrder.kt:31-64](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/CreateOrder.kt#L31-L64), [Order.kt:55-137](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/Order.kt#L55-L137) |
+| v6 → v8 | How do we cross Spring Boot 3 → 4 and handle v8 storage and API breaks? | [v8.0.0 Release](https://github.com/Ahoo-Wang/Wow/releases/tag/v8.0.0), [gradle/libs.versions.toml:3-18](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L3-L18) |
+| Runtime orchestration | How do we converge multiple lifecycle owners on one `WowRuntime`? | [WowAutoConfiguration.kt:118-152](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/WowAutoConfiguration.kt#L118-L152) |
+
+## Shared Completion Gates
+
+Both primary paths and the runtime-orchestration track must advance on evidence. A process that
+merely starts is not yet migrated.
+
+```mermaid
+%%{init: {"theme": "dark"}}%%
+stateDiagram-v2
+    [*] --> Baseline: Fix scope and baseline
+    Baseline --> Rehearsal: Rehearse in isolation
+    Rehearsal --> Verify: Test, reconcile, replay
+    Verify --> Rehearsal: Gate fails
+    Verify --> Canary: Gate passes
+    Canary --> Rollback: Production check fails
+    Rollback --> Baseline
+    Canary --> Complete: Observation window passes
+    Complete --> [*]
+```
+
+<!-- Sources:
+- wow-core/src/main/kotlin/me/ahoo/wow/command/CommandFactory.kt:60-103
+- wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt:75-159
+- wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt:57-71
+- wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/WowAutoConfiguration.kt:118-152
+-->
+
+- **Scope**: Fix the bounded context, dataset, source version, target version, and explicit exclusions.
+- **Baseline**: Record tests, event/snapshot counts, critical business metrics, and a restorable backup.
+- **Verification**: Run unit and integration tests, per-aggregate reconciliation, representative replay, and real startup/shutdown.
+- **Rollout**: Validate one instance or a small traffic slice first, including rollback after new writes.
+- **Closure**: Remove old data, writers, compatibility code, and temporary synchronization only after the observation window.
+
+## Legacy Link Navigation
+
+The topics formerly on this page moved to
+[Migrating from Traditional Architecture](./migration/traditional-architecture.md),
+[Migrate Wow v6 to v8](./migration/v6-to-v8.md), and
+[Runtime Orchestration Migration](./migration/runtime-orchestration.md). The headings and aliases
+below retain every deep link from the original page; continue to the linked page after arrival.
+
+### Version Upgrade Guide
+
+<span id="upgrade-steps"></span>
+<span id="dependency-version-update"></span>
+<span id="breaking-changes-check"></span>
+
+See [v6 → v8: General Upgrade Steps](./migration/v6-to-v8.md#general-upgrade-steps).
+
+### Migrating from Traditional Architecture
+
+<span id="migration-strategy"></span>
+<span id="gradual-migration"></span>
+<span id="migration-steps"></span>
+
+See [Traditional Architecture: Migration Overview](./migration/traditional-architecture.md#migration-overview).
 
 ### Data Migration
 
-#### Historical Data Import
+<span id="historical-data-import"></span>
 
-For scenarios requiring historical data preservation, it is recommended to define migration commands:
-
-```kotlin
-// 1. Define Migration Command
-@CreateAggregate
-data class MigrateOrder(
-    val orderId: String,
-    val customerId: String,
-    val items: List<OrderItem>,
-    val createdAt: Long
-)
-
-// 2. Handle Migration Command in Aggregate
-@AggregateRoot
-class Order(private val state: OrderState) {
-    @OnCommand
-    fun onMigrate(command: MigrateOrder): OrderCreated {
-        return OrderCreated(
-            orderId = command.orderId,
-            customerId = command.customerId,
-            items = command.items,
-            createdAt = command.createdAt
-        )
-    }
-}
-
-// 3. Send Migration Command
-fun migrateHistoricalData(legacyOrders: List<LegacyOrder>) {
-    legacyOrders.forEach { order ->
-        val command = MigrateOrder(
-            orderId = order.id,
-            customerId = order.customerId,
-            items = order.items.map { /* convert */ },
-            createdAt = order.createdAt
-        )
-        commandGateway.send(command).block()
-    }
-}
-```
+See [Traditional Architecture: Import and Catch Up with One Writer](./migration/traditional-architecture.md#_2-import-and-catch-up-with-one-writer).
 
 ### Code Migration
 
-#### From CRUD to Command Pattern
+<span id="from-crud-to-command-pattern"></span>
+<span id="from-direct-queries-to-query-snapshots"></span>
 
-**Traditional CRUD Code**:
+See [Traditional Architecture: Migrate the Boundary Before the Tables](./migration/traditional-architecture.md#_1-migrate-the-boundary-before-the-tables)
+and [Reconcile, Then Move Reads and Writes Separately](./migration/traditional-architecture.md#_3-reconcile-then-move-reads-and-writes-separately).
 
-```kotlin
-// Traditional service
-@Service
-class OrderService(private val orderRepository: OrderRepository) {
-    
-    fun createOrder(request: CreateOrderRequest): Order {
-        val order = Order(
-            id = UUID.randomUUID().toString(),
-            customerId = request.customerId,
-            items = request.items,
-            status = OrderStatus.CREATED
-        )
-        return orderRepository.save(order)
-    }
-    
-    fun updateOrderStatus(orderId: String, status: OrderStatus) {
-        val order = orderRepository.findById(orderId)
-        order.status = status
-        orderRepository.save(order)
-    }
-}
-```
+### Compatibility Notes
 
-**Migrated Wow Code**:
+<span id="data-format-compatibility"></span>
+<span id="event-upgrades"></span>
+<span id="message-format-compatibility"></span>
 
-```kotlin
-// Command definitions
-@CreateAggregate
-data class CreateOrder(
-    val customerId: String,
-    val items: List<OrderItem>
-)
+See [Traditional Architecture: Continue Evolving the Domain Model](./migration/traditional-architecture.md#_4-continue-evolving-the-domain-model)
+and [v6 → v8: Breaking Changes Check](./migration/v6-to-v8.md#breaking-changes-check).
 
-@CommandRoute
-data class UpdateOrderStatus(
-    @AggregateId val id: String,
-    val status: OrderStatus
-)
+### Known Issues
 
-// Aggregate root
-@AggregateRoot
-class Order(private val state: OrderState) {
-    
-    @OnCommand
-    fun onCreate(command: CreateOrder): OrderCreated {
-        return OrderCreated(
-            customerId = command.customerId,
-            items = command.items
-        )
-    }
-    
-    @OnCommand
-    fun onUpdateStatus(command: UpdateOrderStatus): OrderStatusUpdated {
-        return OrderStatusUpdated(command.status)
-    }
-}
+<span id="version-specific-issues"></span>
+<span id="common-migration-issues"></span>
 
-// State aggregate root
-class OrderState : Identifier {
-    lateinit var id: String
-    lateinit var customerId: String
-    var items: List<OrderItem> = emptyList()
-    var status: OrderStatus = OrderStatus.CREATED
-    
-    fun onSourcing(event: OrderCreated) {
-        this.customerId = event.customerId
-        this.items = event.items
-    }
-    
-    fun onSourcing(event: OrderStatusUpdated) {
-        this.status = event.status
-    }
-}
-```
+See the [Release Notes](https://github.com/Ahoo-Wang/Wow/releases) and
+[Troubleshooting](./troubleshooting.md).
 
-#### From Direct Queries to Query Snapshots
+### Migration Checklist
 
-**Traditional Query Code**:
+See the [Traditional Architecture Completion Checklist](./migration/traditional-architecture.md#completion-checklist)
+or the [v6 → v8 Verification Checklist](./migration/v6-to-v8.md#verification-checklist).
 
-```kotlin
-@Repository
-interface OrderRepository : JpaRepository<Order, String> {
-    fun findByCustomerId(customerId: String): List<Order>
-    fun findByStatus(status: OrderStatus): List<Order>
-}
-```
+### Rollback Plan
 
-**Migrated Query Code**:
+See the [Shared Completion Gates](#shared-completion-gates) on this page and the cutover and
+rollback steps on the selected migration page.
 
-Refer to [Query Service](query.md)
+### Unified Runtime Orchestration
 
-```kotlin
-class OrderService(
-    private val queryService: SnapshotQueryService<OrderState>
-) {
-    fun getById(id: String): Mono<OrderState> {
-        return singleQuery {
-            condition {
-                id(id)
-            }
-        }.query(queryService).toState().throwNotFoundIfEmpty()
-    }
-}
-```
+See [Runtime Orchestration Migration](./migration/runtime-orchestration.md).
 
-## Compatibility Notes
+<span id="versioned-snapshot-checkpoint-removal"></span>
 
-### Data Format Compatibility
+### Removal of Versioned Snapshot Checkpoints
 
-The Wow framework uses JSON serialization for events and snapshot data, ensuring good forward compatibility:
+See [v6 → v8: Versioned Snapshot Checkpoint Removal](./migration/v6-to-v8.md#versioned-snapshot-checkpoint-removal).
 
-- **Adding Fields**: New fields will be ignored (backward compatible)
-- **Removing Fields**: Uses default values (needs handling)
-- **Changing Field Types**: Requires event upgrader
+### Atomic SnapshotStore Saves
 
-### Event Upgrades
+See [v6 → v8: Atomic SnapshotStore Saves](./migration/v6-to-v8.md#atomic-snapshotstore-saves).
 
-Use the `revision` attribute of the `@Event` annotation for event version control:
+### Redis EventStore Canonical v2 Layout (introduced in v8.9.0)
 
-```kotlin
-@Event(revision = "1.0")
-data class OrderCreatedV1(
-    val orderId: String,
-    val items: List<OrderItem>
-)
+See [v6 → v8: Redis EventStore Canonical v2 Layout](./migration/v6-to-v8.md#redis-eventstore-canonical-v2-layout-introduced-in-v8-9-0).
 
-@Event(revision = "2.0")
-data class OrderCreated(
-    val orderId: String,
-    val items: List<OrderItem>,
-    val customerId: String // New field
-)
-```
+### Mongo Ownership Guard
 
-### Message Format Compatibility
+See [v6 → v8: Mongo Ownership Guard](./migration/v6-to-v8.md#mongo-ownership-guard).
 
-Ensure message format compatibility:
+## Related Pages
 
-1. **Adding Fields**: Safe, uses default values
-2. **Removing Fields**: Need to ensure consumers can handle
-3. **Renaming Fields**: Not compatible, requires version control
-
-## Known Issues
-
-### Version-Specific Issues
-
-Please check [GitHub Issues](https://github.com/Ahoo-Wang/Wow/issues) for the latest known issues list.
-
-### Common Migration Issues
-
-1. **Event Replay Order**: Ensure events are appended in version order
-2. **Timestamp Handling**: Preserve original timestamps
-3. **ID Generation**: Maintain consistent ID format
-
-## Migration Checklist
-
-- [ ] Backup existing data
-- [ ] Update dependency version
-- [ ] Check breaking changes
-- [ ] Update configuration files
-- [ ] Regenerate metadata
-- [ ] Run unit tests
-- [ ] Run integration tests
-- [ ] Gradual rollout verification
-- [ ] Full rollout
-- [ ] Monitoring verification
-
-## Rollback Plan
-
-If migration fails, follow these rollback steps:
-
-1. Stop new service
-2. Restore old service
-3. Verify data consistency
-4. Analyze failure cause
-5. Fix issues and retry
+| Page | Relationship |
+|---|---|
+| [Migrating from Traditional Architecture](./migration/traditional-architecture.md) | First-time Wow adoption |
+| [Migrate Wow v6 to v8](./migration/v6-to-v8.md) | Platform upgrade for existing Wow systems |
+| [Runtime Orchestration Migration](./migration/runtime-orchestration.md) | v8 lifecycle extension migration |
+| [Best Practices](./best-practices.md) | Engineering constraints after migration |
+| [Troubleshooting](./troubleshooting.md) | Investigation entry point when verification fails |

--- a/documentation/docs/en/guide/migration/traditional-architecture.md
+++ b/documentation/docs/en/guide/migration/traditional-architecture.md
@@ -1,0 +1,235 @@
+---
+title: Migrating from Traditional Architecture
+description: Incrementally move a CRUD system to Wow CQRS and event sourcing with one writer, replayable synchronization, and reconciliation gates.
+---
+
+# Migrating from Traditional Architecture
+
+This guide is for traditional CRUD systems that do not yet use Wow. The goal is not a
+big-bang rewrite. Migrate one bounded context at a time, import history, catch up live changes,
+move reads, and finally move writes while retaining **exactly one authoritative business writer**.
+
+If the system already runs Wow v6, use [Migrate Wow v6 to v8](./v6-to-v8.md).
+
+## Migration Overview
+
+| Stage | Authoritative writer | Work | Exit gate | Source |
+|---|---|---|---|---|
+| 0. Select a boundary | Legacy system | Choose a low-coupling bounded context; fix ID, tenant, and invariant mappings | Business owners approve the language, aggregate boundary, and acceptance cases | [Modeling](../modeling.md) |
+| 1. Build the Wow model | Legacy system | Define commands, aggregates, domain events, and state sourcing | `AggregateSpec` covers success, rejection, and idempotency paths | [CreateOrder.kt:31-64](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/CreateOrder.kt#L31-L64), [OrderSpec.kt:44-113](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/order/OrderSpec.kt#L44-L113) |
+| 2. Shadow synchronization | Legacy system | Send replayable synchronization commands through outbox/CDC; Wow takes no production writes | Lag, failure queue, and per-aggregate reconciliation meet their thresholds | [CommandFactory.kt:60-103](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandFactory.kt#L60-L103) |
+| 3. Move reads | Legacy system | Route queries to Wow snapshots/projections while retaining fast rollback | New and old query results agree throughout the observation window | [OrderQueryController.kt:34-45](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-server/src/main/kotlin/me/ahoo/wow/example/server/order/OrderQueryController.kt#L34-L45) |
+| 4. Move writes | Wow | Stop traffic, catch up, reconcile, then route command ingress to Wow | The old writer is closed; Wow writes and monitoring are verified | [CommandGateway.kt:75-159](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt#L75-L159) |
+| 5. Retire the legacy model | Wow | Keep old data read-only through the rollback window, then remove the old write path | No rollback dependency or unresolved difference remains | [Event Store](../eventstore.md) |
+
+```mermaid
+%%{init: {"theme": "dark"}}%%
+flowchart LR
+    Scope["Select bounded context"] --> Model["Command / Aggregate<br>Event / State"]
+    Model --> Shadow["Historical import + live sync"]
+    Shadow --> Read["Shadow queries and move reads"]
+    Read --> Gate{"Final reconciliation passes?"}
+    Gate -->|"No"| Shadow
+    Gate -->|"Yes"| Write["Stop old writer<br>move command ingress"]
+    Write --> Observe["Observation and rollback window"]
+    classDef step fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    class Scope,Model,Shadow,Read,Gate,Write,Observe step
+```
+
+<!-- Sources:
+- documentation/docs/en/guide/modeling.md
+- example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/CreateOrder.kt:31-64
+- example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/Order.kt:55-137
+- example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/OrderState.kt:39-99
+-->
+
+## 1. Migrate the Boundary Before the Tables
+
+A table often carries several business concepts and does not map directly to an aggregate.
+Derive commands from use cases, then define the invariants that must remain atomic inside one
+aggregate. Coordinate across aggregates with domain events, sagas, or projections. The current
+example models `CreateOrder` as a creation command, keeps rules in `Order`, and rebuilds state
+through `OrderState.onSourcing` instead of mutating state from command handlers.
+
+- [`CreateOrder.kt:31-64`](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/CreateOrder.kt#L31-L64)
+- [`Order.kt:55-137`](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/Order.kt#L55-L137)
+- [`OrderState.kt:39-99`](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/OrderState.kt#L39-L99)
+
+Fix these mappings before migration:
+
+| Legacy model | Wow model | Constraint |
+|---|---|---|
+| Primary key | `AggregateId.id` | It must be unique across tenants within one `NamedAggregate`; preserve a globally unique key, but audit collisions and define a deterministic mapping for tenant-local keys |
+| Tenant column | `tenantId` | Use the same mapping for import, synchronization, and online commands |
+| Optimistic-lock/update version | Command `requestId` plus source version | Use both for idempotency and ordering; a consumer offset alone is insufficient |
+| Current row state | Domain-event sequence | Express business facts; do not mechanically invent an event history from a row |
+| Join-heavy query | Snapshot/projection | Design a separate read model instead of making the aggregate query across boundaries |
+
+The uniqueness scope of `AggregateId.id` is the `NamedAggregate`, not `(tenantId, id)`.
+Redis explicitly rejects the same ID across tenants within a named aggregate; the MongoDB
+event-stream unique index and Elasticsearch document ID also omit the tenant. If a legacy key
+is unique only inside a tenant, derive a compound ID with a versioned, unambiguous deterministic
+encoding or UUID v5 and persist the mapping manifest. Historical import, CDC, online commands,
+queries, and rollback must all reuse the same mapping rather than generating a fresh ID per run.
+[`AggregateId.kt:23-26`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt#L23-L26)
+[`EventStreamSchemaInitializer.kt:65-70`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/EventStreamSchemaInitializer.kt#L65-L70)
+[`ElasticsearchEventStreamAppender.kt:38-43`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchEventStreamAppender.kt#L38-L43)
+
+## 2. Import and Catch Up with One Writer
+
+Do not make an HTTP request write the legacy database and then the EventStore. If the second
+write fails, the two states cannot be atomically rolled back. Keep the legacy database as the
+single writer, publish changes from a transactional outbox or recoverable CDC stream, and let
+the migration adapter send idempotent commands.
+
+```mermaid
+%%{init: {"theme": "dark"}}%%
+sequenceDiagram
+    autonumber
+    participant Client
+    participant Legacy as Legacy service
+    participant DB as Legacy database + outbox
+    participant Adapter as Migration adapter
+    participant Gateway as CommandGateway
+    participant Wow as Wow aggregate
+
+    Client->>Legacy: Business request
+    Legacy->>DB: One transaction writes row and outbox
+    DB-->>Adapter: Replayable change
+    Adapter->>Gateway: requestId = source + id + version
+    Gateway->>Wow: sendAndWaitForProcessed
+    Wow-->>Adapter: processed / duplicate / error
+    Adapter->>DB: Verify target, then record cursor and outcome
+```
+
+<!-- Sources:
+- wow-core/src/main/kotlin/me/ahoo/wow/command/CommandFactory.kt:60-103
+- wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt:75-159
+- example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/Order.kt:105-137
+-->
+
+Historical import also uses the command boundary. Reuse the deterministic business-ID mapping
+and derive a stable `requestId` to prevent duplicate writes. A duplicate `requestId` does not
+return the previous success result: `sendAndWaitForProcessed` reports `DuplicateRequestId`
+through `CommandResultException`. Treat it as already applied only after reconciling the target
+event/state and source version, then advance the cursor. Keep the batch reactive. Only the
+outermost entry point of a standalone offline process may wait for completion; never call
+`block()` in the server request chain or Wow core path.
+
+```kotlin
+fun importOrders(rows: Iterable<LegacyOrder>): Mono<Void> =
+    Flux.fromIterable(rows)
+        .concatMap(::importOrder)
+        .then()
+
+private fun importOrder(row: LegacyOrder): Mono<Void> {
+    val aggregateId = legacyOrderIdMapping.requireTargetId(row.tenantId, row.id)
+    val command = ImportLegacyOrder.from(row).toCommandMessage(
+        aggregateId = aggregateId,
+        tenantId = row.tenantId,
+        requestId = legacyOrderRequestId(row),
+    )
+    return commandGateway.sendAndWaitForProcessed(command)
+        .then()
+        .onErrorResume(CommandResultException::class.java) { error ->
+            if (error.commandResult.errorCode != ErrorCodes.DUPLICATE_REQUEST_ID) {
+                return@onErrorResume Mono.error(error)
+            }
+            verifyImportedOrder(
+                tenantId = row.tenantId,
+                aggregateId = aggregateId,
+                sourceVersion = row.version,
+            )
+        }
+}
+```
+
+`toCommandMessage` accepts explicit `aggregateId`, `tenantId`, `requestId`, and expected
+version values. `sendAndWaitForProcessed` completes after the aggregate has processed the
+command. The example's `verifyImportedOrder` must load the target event/state and compare the
+source version; never swallow `DuplicateRequestId` without that verification.
+`legacyOrderRequestId` must use a versioned, unambiguous encoding rather than directly joining
+raw fields that may contain the delimiter.
+`legacyOrderIdMapping`, `legacyOrderRequestId`, and `verifyImportedOrder` are illustrative
+functions that the migration adapter must implement; they are not Wow framework APIs.
+[`CommandFactory.kt:60-103`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandFactory.kt#L60-L103)
+[`CommandGateway.kt:127-143`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt#L127-L143)
+[`DefaultCommandGateway.kt:86-95`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L86-L95)
+[`DefaultCommandGateway.kt:228-255`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L228-L255)
+
+::: warning Do not fabricate history
+Reconstruct historical domain events only when trustworthy business facts and ordering exist.
+When only the current row is available, emit an explicit `LegacyOrderImported` or
+`OrderBaselineEstablished` event containing the source, source version, and import time. Do
+not invent a sequence of business events that never happened.
+:::
+
+## 3. Reconcile, Then Move Reads and Writes Separately
+
+At minimum, reconcile existence, critical business fields, status, monetary or quantity
+values, source version, and last synchronization time per `(tenantId, aggregateId)`. Equal
+totals do not prove per-aggregate equality. Classify every difference as retryable, accepted,
+or cutover-blocking.
+
+```mermaid
+%%{init: {"theme": "dark"}}%%
+stateDiagram-v2
+    [*] --> LegacyWriter: Legacy system writes
+    LegacyWriter --> Shadowing: Historical import and live sync
+    Shadowing --> ReadCanary: Per-aggregate reconciliation passes
+    ReadCanary --> Shadowing: Difference found
+    ReadCanary --> Freeze: Read observation window passes
+    Freeze --> WowWriter: Stop traffic and catch up
+    WowWriter --> LegacyRollback: Failure during rollback window
+    LegacyRollback --> LegacyWriter: Reverse-sync new Wow writes
+    WowWriter --> LegacyRetired: Rollback window ends
+```
+
+<!-- Sources:
+- example/example-server/src/main/kotlin/me/ahoo/wow/example/server/order/OrderQueryController.kt:34-45
+- wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt:75-159
+- wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt:35-71
+-->
+
+Moving reads first is usually easier to reverse. Route selected tenants, users, or request
+percentages to `SnapshotQueryService` or a projection while continuing to compare legacy
+results in the background. Moving writes requires a short freeze:
+
+1. Close ingress and drain legacy transactions, outbox/CDC, and the migration adapter.
+2. Freeze the source cursor and run final per-aggregate reconciliation.
+3. Disable the legacy writer, then open Wow command ingress.
+4. Verify creation, update, rejection, query visibility, monitoring, and alerting.
+5. Keep legacy data read-only during the rollback window. If Wow has accepted new writes,
+   reverse-sync those writes before rolling back.
+
+## 4. Continue Evolving the Domain Model
+
+After migration, new optional fields still need safe defaults. Deleting, renaming, or changing
+types cannot rely on permissive JSON parsing alone. Before materializing a domain event, Wow
+applies ordered `EventUpgrader` instances to the `DomainEventRecord`, allowing older records
+to be transformed to the current shape.
+[`DomainEventRecord.kt:71-89`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/serialization/event/DomainEventRecord.kt#L71-L89)
+[`EventUpgraderFactory.kt:37-73`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/upgrader/EventUpgraderFactory.kt#L37-L73)
+[`EventUpgraderFactory.kt:89-115`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/upgrader/EventUpgraderFactory.kt#L89-L115)
+
+## Completion Checklist
+
+- [ ] Bounded context, aggregate, cross-tenant-unique ID, tenant, and ownership mappings are fixed
+- [ ] Command handlers, state sourcing, and domain tests cover major invariants and failures
+- [ ] Historical import and live sync have stable request IDs, duplicate reconciliation, retries, dead letters, and cursors
+- [ ] Exactly one business writer exists throughout migration
+- [ ] Per-aggregate reconciliation passes and every difference has an explicit disposition
+- [ ] Reads and writes are canaried separately; cutover and rollback are rehearsed
+- [ ] Legacy data remains read-only in the rollback window, with a plan for reverse-syncing Wow writes
+- [ ] Monitoring covers synchronization lag, failures, reconciliation differences, and command outcomes
+
+## Related Pages
+
+| Page | Relationship |
+|---|---|
+| [Migration Guide](../migration.md) | Choose the correct migration path |
+| [Migrate Wow v6 to v8](./v6-to-v8.md) | Version upgrade after Wow adoption |
+| [Modeling](../modeling.md) | Aggregate, command, event, and state design |
+| [Test Suite](../test-suite.md) | Lock domain behavior with `AggregateSpec` |
+| [Query Service](../query.md) | Snapshot/projection read models and query cutover |
+| [Event Store](../eventstore.md) | Event-stream persistence and replay |

--- a/documentation/docs/en/guide/migration/v6-to-v8.md
+++ b/documentation/docs/en/guide/migration/v6-to-v8.md
@@ -1,0 +1,326 @@
+---
+title: Migrate Wow v6 to v8
+description: A staged guide for moving from Spring Boot 3 and Wow v6 to Spring Boot 4 and Wow v8, including data cutover and rollback.
+---
+
+# Migrate Wow v6 to v8
+
+This page is only for systems already running Wow v6 and moving to Wow v8. For a first
+adoption from CRUD, use [Migrating from Traditional Architecture](./traditional-architecture.md).
+
+Wow v6 and v8 both require Java 17+, but v6 targets Spring Boot 3.x while v8 targets
+Spring Boot 4.x. This is a platform migration, not a one-line dependency bump. The current
+v8 baseline also includes Spring Boot 4.1, Kotlin 2.4, CosId 3.2, CoAPI 2.1, and CoCache 4.2.
+[`README.md:47-49`](https://github.com/Ahoo-Wang/Wow/blob/main/README.md#L47-L49)
+[`gradle/libs.versions.toml:3-18`](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L3-L18)
+[`gradle/libs.versions.toml:32-33`](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L32-L33)
+
+## Migration Overview
+
+| Stage | Goal | Exit gate | Main risk | Source |
+|---|---|---|---|---|
+| 0. Stabilize v6 | Move to the latest v6 and remove deprecated API use | Full v6 test suite passes; event, snapshot, and message counts are baselined | Carrying old failures across the platform boundary | [v6.21.5 Release](https://github.com/Ahoo-Wang/Wow/releases/tag/v6.21.5) |
+| 1. Adapt the platform | Upgrade Spring Boot 4, Jackson 3, and related major dependencies together | Compilation, unit tests, and integration tests pass | Boot modularization, `tools.jackson`, and incompatible third-party starters | [v8.0.0 Release](https://github.com/Ahoo-Wang/Wow/releases/tag/v8.0.0), [SerializationAutoConfiguration.kt:14-30](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/serialization/SerializationAutoConfiguration.kt#L14-L30) |
+| 2. Adapt Wow APIs | Resolve source breaks accumulated across v8 minors | Domain, messaging, query, and test DSL code all recompiles | `CommandGateway`, lifecycle extensions, and storage internals changed | [CommandGateway.kt:75-159](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt#L75-L159) |
+| 3. Prepare data | Audit and convert Redis/Mongo data while traffic is stopped | Checksums, versions, ID indexes, and representative replay match | v8.9 Redis canonical v2 is incompatible with legacy layouts | [RedisEventSourcingAutoConfiguration.kt:200-243](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/redis/RedisEventSourcingAutoConfiguration.kt#L200-L243) |
+| 4. Isolated cutover | Validate one v8 instance before scaling | Read/write, replay, snapshot, query, and shutdown checks pass | Mixed old/new writers break snapshot and Redis rollback guarantees | [SnapshotStore.kt:57-71](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt#L57-L71) |
+
+```mermaid
+%%{init: {"theme": "dark"}}%%
+flowchart LR
+    V6["Latest Wow v6<br>green baseline"] --> Platform["Spring Boot 4<br>Jackson 3"]
+    Platform --> Compile["Fix source and tests<br>regenerate metadata"]
+    Compile --> Data["Offline data audit<br>and hard cutover"]
+    Data --> Canary["Single-instance validation"]
+    Canary --> V8["Wow v8<br>gradual scale-out"]
+    classDef step fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    class V6,Platform,Compile,Data,Canary,V8 step
+```
+
+<!-- Sources:
+- https://github.com/Ahoo-Wang/Wow/releases/tag/v8.0.0
+- README.md:47-49
+- gradle/libs.versions.toml:3-18
+- gradle/libs.versions.toml:32-33
+-->
+
+Do not run this as a mixed-version rolling upgrade. Prove the platform and data procedure
+in an isolated environment, then stop ingress, drain every old writer, cut over the data,
+and start exactly one v8 instance for validation.
+
+```mermaid
+%%{init: {"theme": "dark"}}%%
+sequenceDiagram
+    autonumber
+    participant Traffic as Ingress
+    participant V6 as Wow v6 cluster
+    participant Migrator as Offline migrator
+    participant Store as Target store
+    participant V8 as Single Wow v8 instance
+
+    Traffic->>V6: Stop new writes
+    V6->>V6: Drain in-flight work
+    V6-->>Migrator: Stop every writer
+    Migrator->>Store: Inventory, convert, checksum
+    Migrator-->>V8: Data gate passes
+    V8->>Store: Isolated-ID write and replay
+    V8-->>Traffic: Shift canary traffic after smoke test
+```
+
+<!-- Sources:
+- wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/redis/RedisEventSourcingAutoConfiguration.kt:200-243
+- wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt:57-71
+- wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoDatabaseContextGuard.kt:30-65
+-->
+
+```mermaid
+%%{init: {"theme": "dark"}}%%
+stateDiagram-v2
+    [*] --> V6Running: Stable v6
+    V6Running --> Offline: Stop traffic and back up
+    Offline --> V8Canary: Data gate passes
+    V8Canary --> V8Running: Smoke test passes
+    V8Canary --> V6Rollback: No v8 production writes
+    V8Running --> ReverseMigration: v8 production writes exist
+    ReverseMigration --> V6Rollback: Reverse migration or replay completes
+    V6Rollback --> V6Running
+```
+
+<!-- Sources:
+- wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStore.kt
+- wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/redis/RedisEventSourcingAutoConfiguration.kt:236-243
+- wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt:57-71
+-->
+
+## Spring Boot 4 and Jackson 3
+
+The defining v8.0.0 change is Spring Boot 4 support, accompanied by migration of Wow's
+serialization implementation to Jackson 3 under the `tools.jackson` namespace. Applications
+that directly reference Jackson `ObjectMapper` or `JsonNode`, Spring Boot auto-configuration
+types, or custom starters need an explicit source migration. Do not force Spring Boot 3 or
+Jackson 2 back under Wow v8. Spring Boot's official guidance permits classic starters as a
+temporary compilation bridge, followed by convergence on focused starters.
+
+- [Wow v8.0.0 Release](https://github.com/Ahoo-Wang/Wow/releases/tag/v8.0.0)
+- [Spring Boot 4.0 Migration Guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide)
+- [`JsonSerializer.kt:14-51`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/serialization/JsonSerializer.kt#L14-L51)
+- [`SerializationAutoConfiguration.kt:14-30`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/serialization/SerializationAutoConfiguration.kt#L14-L30)
+
+## General Upgrade Steps
+
+### Upgrade Steps
+
+1. **Backup Data**: Backup event store and snapshot data before upgrading
+2. **Read Changelog**: Check [Release Notes](https://github.com/Ahoo-Wang/Wow/releases)
+3. **Update Dependency Version**: Modify build.gradle.kts or pom.xml
+4. **Run Tests**: Ensure all tests pass
+5. **Canary after hard cutover**: Stop traffic and finish the data cutover, validate one v8 instance, then shift canary traffic and scale only v8 instances
+
+### Dependency Version Update
+
+::: code-group
+```kotlin [Gradle(Kotlin)]
+// Update wow version
+implementation("me.ahoo.wow:wow-spring-boot-starter:8.9.3")
+```
+```xml [Maven]
+<dependency>
+    <groupId>me.ahoo.wow</groupId>
+    <artifactId>wow-spring-boot-starter</artifactId>
+    <version>8.9.3</version>
+</dependency>
+```
+:::
+
+### Breaking Changes Check
+
+Before upgrading, check the following:
+
+1. **API Changes**: Check for interface signature changes
+2. **Configuration Changes**: Check for configuration property changes
+3. **Metadata Changes**: Regenerate metadata files
+
+## Unified Runtime Orchestration
+
+The runtime lifecycle migration is now documented separately so this page can
+remain an upgrade index:
+
+- [Runtime Orchestration Migration](./runtime-orchestration.md) covers
+  source-breaking changes, custom components and message buses, Spring ownership,
+  verification, and rollback.
+- [Runtime Lifecycle](../advanced/runtime-lifecycle.md) describes the stable
+  post-migration architecture and shutdown semantics.
+
+This migration changes lifecycle extension contracts but does not change event,
+snapshot, or message formats. No data migration is required.
+
+## Versioned Snapshot Checkpoint Removal
+
+The versioned snapshot checkpoint capability introduced in v8.9.0 has been removed without a compatibility layer.
+`VersionedSnapshotStore`, `VersionIntervalCheckpointStrategy`, `CompositeSnapshotStrategy`, their metrics and tracing
+decorators, and `SnapshotCheckpointProperties` no longer exist. The `wow.eventsourcing.snapshot.checkpoint.*`
+properties are ignored, and the `wow.snapshot.checkpoint.*` metrics and checkpoint spans are no longer emitted.
+There is no replacement API; applications should use `SnapshotStore`, which stores and loads only the latest snapshot.
+
+MongoDB `*_snapshot_checkpoint` collections are no longer read, written, scanned, or automatically deleted. Back up
+event and snapshot data before upgrading, stop all old-version writers, and remove those collections only after
+confirming they are no longer needed. Rollback requires restoring the old runtime and retaining its checkpoint data;
+mixed-version deployment is unsupported.
+
+Sources: [`refactor(snapshot): remove versioned checkpoint support (#2831)`](https://github.com/Ahoo-Wang/Wow/pull/2831),
+[`SnapshotStore.kt:24-71`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt#L24-L71).
+
+## Atomic SnapshotStore Saves
+
+`SnapshotStore.save()` keeps the same JVM signature and snapshot formats, but its
+storage contract is stronger: each aggregate must use one atomic compare-and-write
+operation. A candidate whose aggregate version is greater than or equal to the
+stored version replaces the complete snapshot; a lower candidate completes
+successfully without writing. Equal-version replacement is intentional so the
+snapshot-regeneration routes can repair a stale payload.
+
+Custom `SnapshotStore` implementations must use a backend CAS, conditional update,
+transaction, or equivalent atomic primitive. A client-side `load()` followed by an
+unconditional write is not conformant. Materialize the candidate once and derive the
+comparison version from that same payload. Stop and drain all old writers before
+relying on this guarantee: old MongoDB or Redis writers can still regress a newer
+snapshot, and an old Elasticsearch writer does not perform equal-version replacement.
+No data rewrite is required. Rollback restores the old save behavior, so do not run
+old and new writers concurrently.
+
+For `wow-mongo`, the guarded update uses MongoDB MQL expressions that require
+MongoDB 5.2 or later; the integration suite verifies MongoDB 6.0.6. Upgrade the
+MongoDB server before deploying this runtime when the existing server is older.
+
+Sources: [`SnapshotStore.kt:57-71`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt#L57-L71),
+[`MongoSnapshotStore.kt`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoSnapshotStore.kt),
+[`RedisSnapshotStore.kt`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisSnapshotStore.kt),
+and [`ElasticsearchSnapshotStore.kt`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchSnapshotStore.kt).
+
+## Redis EventStore Canonical v2 Layout (introduced in v8.9.0)
+
+When upgrading from v6.x, v8.6.x, or v8.8.x to v8.9.0+, treat Redis persistence as a hard
+storage-format cutover. v6.21.5 and v8.6.x use legacy event keys and a shared request-ID SET;
+v8.8.x uses per-stream request SETs and bucketed ID indexes. Redis EventStore, Redis
+SnapshotStore, and Redis PrepareKey read and write canonical v2 keys only. There is no legacy
+fallback, dual write, or built-in migrator, and old runtimes cannot read new v2 writes. The new
+EventStore also enforces that `AggregateId.id` is unique within a named aggregate across all
+tenants.
+
+The Spring Boot starter checks the exact sentinel keys created by successful writes in the
+published v6/v8.6 shared layout and v8.8 bucketed layout. It checks local aggregates resolved to
+the auto-configured `RedisEventStore`, supports Redis Cluster without runtime `SCAN`, and blocks
+startup when incompatible data is found. It does not cover direct-library usage, independently
+constructed custom stores, retired aggregate metadata, or snapshot-only Redis routes. A legacy
+snapshot has no aggregate-independent exact sentinel. Canonical v2 ignores legacy snapshot keys.
+A missing v2 snapshot causes aggregate loading to replay events, but normal loading does not
+persist a rebuilt snapshot automatically.
+
+The exact-key guard is not a substitute for an offline data audit. A historical alias change, key eviction, or a
+manually deleted or corrupted legacy index can hide the sentinel while orphaned streams remain. The resolved context
+alias (the configured alias, or `contextName` when no alias is configured) and aggregate name form the persistent v2
+key scope. The migration manifest must pin every historical source alias to the target resolved alias. Changing the
+resolved alias or aggregate name after a write requires a separate offline key migration.
+
+Use an offline cutover:
+
+1. Stop traffic and every old-version writer, drain in-flight appends to zero, and create a consistent Redis backup
+   together with event-count and version baselines. Do not use a mixed-version rolling deployment.
+2. Inventory all legacy event ZSETs, v6/v8.6 shared request SETs, v8.8 per-stream request SETs, v8.8 bucketed ID ZSETs,
+   and legacy snapshot and PrepareKey hashes in every logical database on every Cluster primary. Record source key,
+   Redis type, cardinality, checksum, and target mapping. Use identity embedded in event or snapshot JSON as the
+   authority; an ambiguous historical key is only a locator.
+3. Audit each named aggregate for duplicate `AggregateId.id` values across tenants. Resolve every collision before
+   migration; canonical v2 intentionally cannot represent two owners of one ID.
+4. Use an empty v2 target scope on the first run. For disposable data, remove only the inventoried legacy keys from
+   the target or use an empty dedicated database. Never use `FLUSHDB` on a database shared with message-bus or
+   application data. Keep the complete source dataset immutable for rollback.
+5. Run a separately reviewed offline migrator. Its durable manifest must record source key, target keys, source and
+   target checksums, status, and last completed batch. Resume may reuse a target only when manifest and checksum
+   match; otherwise fail without overwriting. Copy operations must be idempotent, and partial target data must not be
+   accepted without manifest-backed re-verification.
+6. Preserve every event ZSET member and score, and verify identity consistency plus contiguous score/version order.
+   Treat committed event JSON as authoritative for v2 request-ID SETs. For v6/v8.6, compare the shared SET with
+   `union(event.requestId)` in both directions and report shared-only and event-only differences separately; never
+   fan it out to streams. For v8.8, compute the symmetric difference between each source per-stream SET and that
+   stream's event request IDs. A non-empty difference fails migration unless an explicit reviewed disposition is
+   recorded.
+7. Rebuild every non-empty aggregate-ID index in the 128-bucket space. The bucket is
+   `aggregateId.id.hashCode().mod(128)` using Java/Kotlin UTF-16 `String.hashCode`; keys and members must use the exact
+   canonical v2 codec. The runtime does not perform this conversion.
+8. Verify ordered member-and-score checksums, first/last versions, request-ID equality, the complete ID index,
+   aggregate-ID scan results, and representative state replay. A failed run must retain its manifest and last verified
+   cursor, then either clean the partial target or resume from that cursor; the application must not start meanwhile.
+9. After full verification, an in-place migration must remove or move every legacy key in the recorded inventory.
+   Delete sentinel keys last, rerun inventory, and require zero legacy keys. With a separate target database, keep the
+   complete source dataset read-only through the rollback window.
+10. Start one new instance against the target and run isolated-ID read/write smoke tests. Explicitly regenerate
+    snapshots, then verify snapshot counts and versions before switching traffic and scaling out. Use the single-ID
+    regenerate route from the complete inventory. The batch route may be treated as exhaustive only when the audited
+    ID domain is strictly above `AggregateIdScanner.FIRST_ID`; otherwise it can omit lower IDs.
+
+Rollback is a coordinated application-and-data operation. Before production v2 writes, reconnect the untouched
+legacy dataset and old runtime. After any production v2 write, first stop traffic and v2 writers, then reverse-migrate
+or replay those writes before restarting the old runtime; restoring only the cutover backup loses every later v2
+write. Prefer a separate target database or namespace.
+
+The mandatory exact-key check is an internal startup invariant. It is intentionally neither optional nor exposed as
+a compatibility or migration setting.
+
+Source, JVM binary, and behavioral compatibility are intentionally broken for Redis layout internals. Removed APIs
+include `AggregateKeyConverter`, `RedisWrappedKey`, `RedisSnapshotRepository`, `EventStreamKeyConverter`,
+`DefaultSnapshotKeyConverter`, `PrepareKeyConverter`, and `RedisEventStore.SCRIPT_EVENT_STEAM_APPEND`; the
+`redisSnapshotRepository` bean alias and custom snapshot-key converter constructor are also removed. The new
+`SCRIPT_EVENT_STREAM_APPEND` is internal, with no public replacement. Canonical converter outputs changed, PrepareKey
+now includes its `name`, and v2 rejects empty aggregate/prepare IDs and unpaired UTF-16 surrogates. Application code
+should use `EventStore`, `SnapshotStore`, and `PrepareKey`; reviewed offline tooling must independently implement and
+verify the documented v2 codec.
+
+Sources: [`RedisEventStore.kt`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStore.kt),
+[`RedisKeyComponentCodec.kt:22-69`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-redis/src/main/kotlin/me/ahoo/wow/redis/RedisKeyComponentCodec.kt#L22-L69),
+[`RedisEventSourcingAutoConfiguration.kt:166-185`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/redis/RedisEventSourcingAutoConfiguration.kt#L166-L185),
+[`v6.21.5 EventStreamKeyConverter.kt:21-33`](https://github.com/Ahoo-Wang/Wow/blob/v6.21.5/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/EventStreamKeyConverter.kt#L21-L33),
+and [`v6.21.5 event_steam_append.lua:12-27`](https://github.com/Ahoo-Wang/Wow/blob/v6.21.5/wow-redis/src/main/resources/event_steam_append.lua#L12-L27).
+
+## Mongo Ownership Guard
+
+This upgrade keeps aggregate-name-only Mongo collection names, but adds a durable
+`wow_database_metadata` ownership marker. The supported deployment layout is one bounded context per MongoDB
+database.
+
+Before rollout:
+
+1. Inspect every configured event-stream, snapshot, and prepare database. Check all `*_event_stream`, `*_snapshot`,
+   and `prepare_*` collections.
+2. Confirm that each database belongs to only one `wow.context-name`; a mixed database must be split before upgrade.
+3. Upgrade the database's real owner first. The first upgraded instance scans legacy aggregate collections before
+   atomically claiming the marker. Legacy `prepare_*` records contain no context metadata, so a prepare-only database
+   is claimed by the first upgraded context and must be audited before rollout.
+4. Audit existing managed indexes. Missing indexes are created, but incompatible key order, uniqueness, TTL,
+   partial-filter, collation, sparse, or hidden options block startup and require a controlled migration.
+
+Do not edit the marker to bypass a context mismatch. Move or remove the old data, then remove the marker only when
+the database is intentionally reassigned.
+
+Source: [`MongoDatabaseContextGuard.kt:30-132`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoDatabaseContextGuard.kt#L30-L132).
+
+## Verification Checklist
+
+- [ ] v6 is on its latest maintenance release and deprecated API use is gone
+- [ ] Spring Boot 4, Jackson 3, and every third-party starter have passed compatibility review
+- [ ] All domain, server, integration-test, and KSP metadata code has been recompiled
+- [ ] Event, snapshot, PrepareKey, Redis key, and Mongo database inventories are complete
+- [ ] Migration manifests, checksums, ID indexes, and representative event replay agree
+- [ ] One v8 instance passes read/write, query, snapshot regeneration, monitoring, and graceful shutdown tests
+- [ ] The rollback window, legacy read-only retention, and reverse migration of v8 writes have been rehearsed
+
+## Related Pages
+
+| Page | Relationship |
+|---|---|
+| [Migration Guide](../migration.md) | Choose the correct migration path |
+| [Migrating from Traditional Architecture](./traditional-architecture.md) | First-time Wow adoption |
+| [Runtime Orchestration Migration](./runtime-orchestration.md) | Current v8 lifecycle source breaks and extension migration |
+| [Runtime Lifecycle](../advanced/runtime-lifecycle.md) | Stable post-migration runtime model |
+| [Redis Extension](../extensions/redis.md) | Redis configuration and the canonical-v2 startup guard |
+| [Mongo Extension](../extensions/mongo.md) | Mongo storage and database ownership constraints |

--- a/documentation/docs/zh/guide/bi-operations.md
+++ b/documentation/docs/zh/guide/bi-operations.md
@@ -105,4 +105,5 @@ BI 没有原地向后兼容回滚。旧版本可能无法识别当前 registry �
 4. 紧急隔离可设置 `wow.bi.script.enabled=false`，但这只移除 HTTP 路由、OpenAPI operation 和
    inspector，不会回滚 ClickHouse 数据。
 
-版本升级的跨模块顺序参见[迁移指南](./migration)，配置项参见[BI 脚本配置](./configuration#bi-脚本配置)。
+版本升级的跨模块顺序参见 [Wow v6 迁移到 v8](./migration/v6-to-v8)，配置项参见
+[BI 脚本配置](./configuration#bi-脚本配置)。

--- a/documentation/docs/zh/guide/extensions/redis.md
+++ b/documentation/docs/zh/guide/extensions/redis.md
@@ -231,7 +231,8 @@ Value: {snapshotJson}
 同样失败关闭，且不能禁用。直接使用库、独立构造的自定义 store、已退役聚合以及仅使用 Redis snapshot
 的场景必须离线审计。
 
-禁止新旧版本混合滚动发布。离线切换步骤与回滚边界见[迁移指南](../migration.md#redis-eventstore-canonical-v2-布局)。
+禁止新旧版本混合滚动发布。离线切换步骤与回滚边界见
+[Wow v6 迁移到 v8](../migration/v6-to-v8.md#redis-eventstore-canonical-v2-布局-v8-9-0-引入)。
 
 ## 预分配 Key
 

--- a/documentation/docs/zh/guide/migration.md
+++ b/documentation/docs/zh/guide/migration.md
@@ -1,427 +1,194 @@
 ---
 title: 迁移指南
-description: 从传统架构迁移到 Wow 框架以及版本间升级的指南。
+description: 根据系统现状选择传统架构迁移或 Wow v6 到 v8 升级路径。
 ---
 
 # 迁移指南
 
-本指南帮助您从传统架构迁移到 Wow 框架，以及在不同版本之间升级。
+迁移有两条主路径：**首次采用 Wow** 解决的是领域边界、数据建模和流量切换；
+**Wow v6 → v8** 解决的是 Spring Boot 4、源码兼容和存储格式切换。已经使用 Wow v8
+且自定义运行时生命周期的系统，还需执行其中的**运行时编排专项迁移**；它不是第三种
+业务或数据迁移。请先选择主路径，不要把两套步骤混在同一次发布中。
 
-## 版本升级指南
+## 选择迁移路径
 
-### 升级步骤
-
-1. **备份数据**：在升级前备份事件存储和快照数据
-2. **阅读更新日志**：查看 [Release Notes](https://github.com/Ahoo-Wang/Wow/releases)
-3. **更新依赖版本**：修改 build.gradle.kts 或 pom.xml
-4. **运行测试**：确保所有测试通过
-5. **灰度发布**：逐步升级生产环境
-
-### 依赖版本更新
-
-::: code-group
-```kotlin [Gradle(Kotlin)]
-// 更新 wow 版本
-implementation("me.ahoo.wow:wow-spring-boot-starter:新版本号")
-```
-```xml [Maven]
-<dependency>
-    <groupId>me.ahoo.wow</groupId>
-    <artifactId>wow-spring-boot-starter</artifactId>
-    <version>新版本号</version>
-</dependency>
-```
-:::
-
-### 破坏性变更检查
-
-升级前请检查以下内容：
-
-1. **API 变更**：检查是否有接口签名变更
-2. **配置变更**：检查配置属性是否有变更
-3. **元数据变更**：重新生成元数据文件
-
-## 统一运行时编排
-
-运行时生命周期迁移已经拆分为独立专题，使本页保持升级索引职责：
-
-- [运行时编排迁移](./migration/runtime-orchestration.md) 说明源码破坏性变更、
-  自定义组件与消息总线、Spring 所有权、验证和回滚；
-- [运行时生命周期](./advanced/runtime-lifecycle.md) 说明迁移后的稳定架构与停机语义。
-
-该迁移会改变生命周期扩展契约，但不改变 event、snapshot 与 message 格式，无需迁移
-数据。
-
-## 移除版本化快照检查点
-
-v8.9.0 引入的版本化快照检查点能力已被移除，且不提供兼容层。`VersionedSnapshotStore`、
-`VersionIntervalCheckpointStrategy`、`CompositeSnapshotStrategy`、对应的 metrics/tracing 装饰器及
-`SnapshotCheckpointProperties` 均不再存在。`wow.eventsourcing.snapshot.checkpoint.*` 配置将被忽略，
-不再产生 `wow.snapshot.checkpoint.*` 指标与 checkpoint span。该能力没有替代接口；应用应使用仅保存和
-加载最新快照的 `SnapshotStore`。
-
-MongoDB 中既有的 `*_snapshot_checkpoint` collection 不再被读取、写入、扫描或自动删除。升级前应备份
-event 与 snapshot 数据、停止全部旧版本 writer，并仅在确认不再需要后清理这些 collection。回滚必须
-恢复旧运行时并保留其 checkpoint 数据；不支持新旧版本混合部署。
-
-## SnapshotStore 原子保存
-
-`SnapshotStore.save()` 的 JVM 签名与快照格式保持不变，但存储契约得到加强：
-每个聚合必须使用一次原子 compare-and-write。候选聚合版本大于或等于已存版本时
-完整替换快照；版本较低时正常完成且不写入。同版本覆盖是有意行为，使快照重建
-路由可以修复陈旧 payload。
-
-自定义 `SnapshotStore` 必须使用后端 CAS、条件更新、事务或等价的原子原语；
-客户端先 `load()` 再无条件写入不符合契约。候选快照应只物化一次，比较版本必须
-取自同一个待写 payload。在依赖此保证前，应停止全部旧 writer 并排空在途写入：
-旧 MongoDB 或 Redis writer 仍可能使新快照版本倒退，旧 Elasticsearch writer
-也不会执行同版本覆盖。无需重写数据。回滚会恢复旧保存行为，因此新旧 writer
-不得并行运行。
-
-`wow-mongo` 的条件更新使用了要求 MongoDB 5.2 或更高版本的 MQL 表达式；
-集成测试验证的版本为 MongoDB 6.0.6。现有服务端版本较低时，必须先升级
-MongoDB，再部署此版本运行时。
-
-## Redis EventStore Canonical v2 布局（v8.9.0 引入）
-
-从 v8.6.x 或 v8.8.x 升级到 v8.9.0 时，必须把 Redis 持久化视为存储格式硬切换。Redis EventStore、
-Redis SnapshotStore 与 Redis PrepareKey 只读写 canonical v2 Key，不提供旧布局回退、双写或内置迁移器；
-旧运行时也无法读取新的 v2 写入。新 EventStore 还会强制同一个 named aggregate 下的 `AggregateId.id`
-在所有租户之间唯一。
-
-Spring Boot starter 会精确检查已发布 v8.6 与 v8.8 EventStore 成功写入时必然创建的哨兵 Key。检查范围
-仅包括解析到自动配置 `RedisEventStore` 的本地聚合，不在运行时使用 `SCAN`，因此支持 Redis Cluster；
-发现不兼容数据会阻止启动。该守卫不覆盖直接使用库、独立构造的自定义 store、已从元数据移除的聚合或
-仅将 snapshot 路由到 Redis 的场景。旧 snapshot 没有与 aggregate 无关的精确哨兵。canonical v2 会
-忽略旧 snapshot Key；缺少 v2 snapshot 时，聚合加载会回放事件，但普通加载不会自动持久化重建后的
-snapshot。
-
-精确 Key 守卫不能替代离线数据审计。历史 alias 变更、Key eviction、手工删除或破坏旧索引，都可能让
-哨兵消失但留下孤立事件流。解析后的 context alias（已配置 alias 时使用 alias，否则使用 `contextName`）
-与 aggregate name 共同构成 v2 持久化 Key scope。迁移 manifest 必须固定每个历史 source alias 到目标
-resolved alias 的映射；写入后变更 resolved alias 或 aggregate name 必须另做离线 Key 迁移。
-
-必须采用离线切换：
-
-1. 停止入口流量和全部旧版本 writer，将 in-flight append 排空为零，再创建一致的 Redis 备份并记录
-   事件数量与版本基线。禁止新旧版本混合滚动发布。
-2. 在每个 Cluster primary 的每个 logical database 中盘点全部旧 event ZSET、v8.6 shared request SET、
-   v8.8 per-stream request SET、v8.8 bucket ids ZSET、旧 snapshot 与 PrepareKey Hash；记录 source Key、
-   Redis type、cardinality、checksum 与 target mapping。历史 Key 中的 identity 只用于定位，最终身份以
-   event/snapshot JSON 为准。
-3. 按 named aggregate 审计不同租户之间是否存在重复 `AggregateId.id`。迁移前必须解决所有冲突；
-   canonical v2 有意不允许同一个 ID 存在两个所有者。
-4. 首次运行必须要求 v2 目标 scope 为空。可丢弃数据只能清除 inventory 中的旧 Key，或使用空的专用
-   database；与 message bus 或应用数据共库时禁止 `FLUSHDB`。完整源数据集保持不可变以供回滚。
-5. 使用单独评审的离线迁移器。持久化 manifest 必须记录 source Key、target Keys、源/目标 checksum、
-   状态和最后完成批次。恢复执行时只有 manifest 与 checksum 一致才能复用 target，否则失败且不得覆盖。
-   复制必须幂等；缺少 manifest 复核的半成品 target 不得被接受。
-6. 保持每个 event ZSET member 与 score，校验 identity 一致且 score/version 连续。v2 request-ID SET 以
-   已提交事件 JSON 为唯一权威来源。对 v8.6，必须双向比较 shared SET 与 `union(event.requestId)`，分别
-   报告 shared-only 与 event-only 差异，禁止 fan-out。对 v8.8，逐流计算 source SET 与该流事件 requestId
-   的 symmetric difference。差集非空时必须失败，除非记录了明确且已评审的处置策略。
-7. 在 128 个 bucket 空间中重建所有非空聚合 ID 索引。bucket 公式是
-   `aggregateId.id.hashCode().mod(128)`，使用 Java/Kotlin UTF-16 `String.hashCode`；Key 与 member 必须
-   严格使用 canonical v2 codec。运行时不会执行该转换。
-8. 校验有序 member+score checksum、首尾版本、request-ID 集合、完整 ID 索引、aggregate-ID scan 结果
-   和代表性状态回放。失败时必须保留 manifest 和最后验证 cursor，随后清理半成品或从该 cursor 恢复；
-   此期间不得启动应用。
-9. 全部验证通过后，原地迁移必须移除或迁出 inventory 中的每个旧 Key；哨兵 Key 最后删除，随后重新
-   inventory 并要求旧 Key 为零。使用独立 target database 时，完整源数据集在回滚观察期内保持只读。
-10. 先让一个新实例连接 target 并完成隔离 ID 的读写 smoke test。显式执行 snapshot regeneration，校验
-    snapshot 数量与版本后再切流量和扩容。应依据完整 inventory 调用单 ID regenerate 路由；只有审计
-    证明全部 ID 严格大于 `AggregateIdScanner.FIRST_ID` 时，batch 路由才能视为不会漏项。
-
-回滚必须同时切换应用与数据。尚无生产 v2 写入时，可以重新连接未改动的旧数据集并启动旧运行时；一旦
-已有生产 v2 写入，必须先停止流量和全部 v2 writer，再反向迁移或重放这些写入，之后才能启动旧运行时。
-仅恢复切换时备份会丢失此后的所有 v2 写入。推荐使用独立 target database/namespace。
-
-强制精确 Key 检查属于启动期内部不变量，不提供关闭开关，也不作为兼容或迁移配置暴露。
-
-Redis 布局内部 API 有意不保持源码、JVM 二进制与行为兼容。已移除 `AggregateKeyConverter`、
-`RedisWrappedKey`、`RedisSnapshotRepository`、`EventStreamKeyConverter`、`DefaultSnapshotKeyConverter`、
-`PrepareKeyConverter` 与 `RedisEventStore.SCRIPT_EVENT_STEAM_APPEND`；同时移除
-`redisSnapshotRepository` Bean alias 和自定义 snapshot-key converter 构造参数。新的
-`SCRIPT_EVENT_STREAM_APPEND` 为 internal，不提供公开替代。canonical converter 输出已改变，PrepareKey
-现在包含 `name`，v2 会拒绝空 aggregate/prepare ID 与 unpaired UTF-16 surrogate。应用代码应使用
-`EventStore`、`SnapshotStore` 与 `PrepareKey`；单独评审的离线工具应独立实现并校验 v2 codec。
-
-## Mongo 所有权保护
-
-本次升级保留仅含 aggregate name 的 Mongo collection 命名，但新增持久化
-`wow_database_metadata` 所有权标记。支持的部署布局是一个 MongoDB database 只属于一个 bounded
-context。
-
-上线前：
-
-1. 检查所有已配置的 event-stream、snapshot 与 prepare database，以及其中的 `*_event_stream`、
-   `*_snapshot` 和 `prepare_*` collection。
-2. 确认每个 database 只属于一个 `wow.context-name`；历史混写数据库必须先拆分。
-3. 先升级数据库的真实所有者。第一个新版本实例会扫描存量 aggregate collection，再原子认领标记。
-   存量 `prepare_*` 文档没有 context 元数据，因此 prepare-only database 会由首个升级 context 认领，
-   上线前必须先审计其映射关系。
-4. 审计现有受管索引。缺失索引会创建；key 顺序、unique、TTL、partial filter、collation、sparse 或
-   hidden 选项不兼容时会阻止启动，必须执行受控迁移。
-
-不要通过修改所有权标记绕过 context 冲突。应先迁移或删除旧数据；只有明确重新分配空数据库时才删除
-标记。
-
-## 从传统架构迁移
-
-### 迁移策略
-
-#### 渐进式迁移
-
-推荐使用渐进式迁移策略，逐步将功能模块迁移到事件溯源架构：
+| 当前状态 | 目标 | 应阅读 | 不应混入 |
+|---|---|---|---|
+| 传统 CRUD / 事务脚本 / 直接操作数据库 | 渐进采用 Wow CQRS + Event Sourcing | [传统架构迁移](./migration/traditional-architecture.md) | Wow v6 的版本兼容假设 |
+| Wow v6 + Spring Boot 3 | Wow v8 + Spring Boot 4 | [Wow v6 迁移到 v8](./migration/v6-to-v8.md) | 重新设计全部业务边界 |
+| 已在 Wow v8 上自定义 Dispatcher、MessageBus 或 Spring 生命周期 | 当前统一 `WowRuntime` | [运行时编排迁移](./migration/runtime-orchestration.md) | 业务数据重写 |
 
 ```mermaid
-flowchart LR
-    subgraph Legacy["传统架构"]
-        LDB[(关系数据库)]
-        LS[传统服务]
-    end
-    
-    subgraph Wow["Wow 框架"]
-        ES[(事件存储)]
-        WS[Wow 服务]
-    end
-    
-    LS -->|发布事件| WS
-    WS -->|同步数据| LDB
-
+%%{init: {"theme": "dark"}}%%
+flowchart TD
+    Start{"当前系统是否已经使用 Wow？"}
+    Start -->|"否"| Traditional["传统架构迁移"]
+    Start -->|"是，Wow v6"| V6["Wow v6 迁移到 v8"]
+    Start -->|"是，Wow v8"| Custom{"是否有自定义运行时生命周期？"}
+    Custom -->|"是"| Runtime["运行时编排迁移"]
+    Custom -->|"否"| Release["按 Release Notes<br>处理当前小版本升级"]
+    classDef route fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    class Start,Traditional,V6,Custom,Runtime,Release route
 ```
 
-#### 迁移步骤
+<!-- Sources:
+- README.zh-CN.md:47-49
+- documentation/docs/zh/guide/migration/traditional-architecture.md
+- documentation/docs/zh/guide/migration/v6-to-v8.md
+- documentation/docs/zh/guide/migration/runtime-orchestration.md
+-->
 
-1. **识别边界上下文**：确定要迁移的业务模块
-2. **设计领域模型**：定义聚合根、命令和事件
-3. **实现双写**：同时写入旧系统和新系统
-4. **验证一致性**：确保数据一致性
-5. **切换读写**：逐步切换到新系统
+## 文档边界
+
+```mermaid
+%%{init: {"theme": "dark"}}%%
+graph TD
+    Index["迁移指南<br>只负责路径选择"]
+    Traditional["传统架构迁移<br>领域与流量切换"]
+    V6["v6 → v8<br>平台与数据切换"]
+    Runtime["运行时编排迁移<br>生命周期源码适配"]
+    Lifecycle["运行时生命周期<br>迁移后稳定模型"]
+    Index --> Traditional
+    Index --> V6
+    V6 --> Runtime
+    Runtime --> Lifecycle
+    classDef doc fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    class Index,Traditional,V6,Runtime,Lifecycle doc
+```
+
+<!-- Sources:
+- documentation/docs/zh/guide/migration/traditional-architecture.md
+- documentation/docs/zh/guide/migration/v6-to-v8.md
+- documentation/docs/zh/guide/migration/runtime-orchestration.md
+- documentation/docs/zh/guide/advanced/runtime-lifecycle.md
+-->
+
+| 文档 | 负责回答 | 核心源码依据 |
+|---|---|---|
+| 传统架构迁移 | 如何从 CRUD 建立 command、aggregate、event、state，并安全切流？ | [CreateOrder.kt:31-64](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/CreateOrder.kt#L31-L64)、[Order.kt:55-137](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/Order.kt#L55-L137) |
+| v6 → v8 | 如何跨越 Spring Boot 3 → 4，并处理 v8 的存储与 API 破坏？ | [v8.0.0 Release](https://github.com/Ahoo-Wang/Wow/releases/tag/v8.0.0)、[gradle/libs.versions.toml:3-18](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L3-L18) |
+| 运行时编排迁移 | 如何把多个生命周期 owner 收敛到一个 `WowRuntime`？ | [WowAutoConfiguration.kt:118-152](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/WowAutoConfiguration.kt#L118-L152) |
+
+## 共同完成门禁
+
+无论选择主路径还是运行时编排专项，都应按证据推进，而不是以“应用能启动”作为完成标准。
+
+```mermaid
+%%{init: {"theme": "dark"}}%%
+stateDiagram-v2
+    [*] --> Baseline: 固化基线与范围
+    Baseline --> Rehearsal: 隔离环境迁移演练
+    Rehearsal --> Verify: 测试、对账、回放
+    Verify --> Rehearsal: 门禁失败
+    Verify --> Canary: 门禁通过
+    Canary --> Rollback: 线上验证失败
+    Rollback --> Baseline
+    Canary --> Complete: 观察窗通过
+    Complete --> [*]
+```
+
+<!-- Sources:
+- wow-core/src/main/kotlin/me/ahoo/wow/command/CommandFactory.kt:60-103
+- wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt:75-159
+- wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt:57-71
+- wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/WowAutoConfiguration.kt:118-152
+-->
+
+- **范围**：固定 bounded context、数据集、版本起点、目标版本与明确不迁移的内容。
+- **基线**：记录测试结果、事件/快照数量、关键业务指标和可回滚备份。
+- **验证**：执行单元测试、集成测试、逐聚合对账、代表性事件回放和真实启动/停机。
+- **发布**：先单实例或小流量验证，明确新写入出现后的回滚数据处理方式。
+- **关闭**：观察窗结束后再清理旧数据、旧 writer、兼容代码和临时同步链路。
+
+## 旧链接导航
+
+原迁移页中的主题已分别移动到 [传统架构迁移](./migration/traditional-architecture.md)、
+[Wow v6 迁移到 v8](./migration/v6-to-v8.md) 和
+[运行时编排迁移](./migration/runtime-orchestration.md)。以下标题和别名完整保留原页面
+的深链接；到达后请继续进入对应的新页面。
+
+### 版本升级指南
+
+<span id="升级步骤"></span>
+<span id="依赖版本更新"></span>
+<span id="破坏性变更检查"></span>
+
+参见 [v6 → v8：通用升级步骤](./migration/v6-to-v8.md#通用升级步骤)。
+
+### 从传统架构迁移
+
+<span id="迁移策略"></span>
+<span id="渐进式迁移"></span>
+<span id="迁移步骤"></span>
+
+参见 [传统架构迁移：迁移总览](./migration/traditional-architecture.md#迁移总览)。
 
 ### 数据迁移
 
-#### 历史数据导入
+<span id="历史数据导入"></span>
 
-对于需要保留历史数据的场景，建议定义迁移命令：
-
-```kotlin
-// 1. 定义迁移命令
-@CreateAggregate
-data class MigrateOrder(
-    val orderId: String,
-    val customerId: String,
-    val items: List<OrderItem>,
-    val createdAt: Long
-)
-
-// 2. 在聚合根中处理迁移命令
-@AggregateRoot
-class Order(private val state: OrderState) {
-    @OnCommand
-    fun onMigrate(command: MigrateOrder): OrderCreated {
-        return OrderCreated(
-            orderId = command.orderId,
-            customerId = command.customerId,
-            items = command.items,
-            createdAt = command.createdAt
-        )
-    }
-}
-
-// 3. 发送迁移命令
-fun migrateHistoricalData(legacyOrders: List<LegacyOrder>) {
-    legacyOrders.forEach { order ->
-        val command = MigrateOrder(
-            orderId = order.id,
-            customerId = order.customerId,
-            items = order.items.map { /* 转换 */ },
-            createdAt = order.createdAt
-        )
-        commandGateway.send(command).block()
-    }
-}
-```
+参见 [传统架构迁移：用单写者完成历史导入与增量追平](./migration/traditional-architecture.md#_2-用单写者完成历史导入与增量追平)。
 
 ### 代码迁移
 
-#### 从 CRUD 到命令模式
+<span id="从-crud-到命令模式"></span>
+<span id="从直接查询到查询快照"></span>
 
-**传统 CRUD 代码**：
+参见 [传统架构迁移：先迁移边界，不先迁移表](./migration/traditional-architecture.md#_1-先迁移边界-不先迁移表)
+和 [对账后分别切换读与写](./migration/traditional-architecture.md#_3-对账后分别切换读与写)。
 
-```kotlin
-// 传统服务
-@Service
-class OrderService(private val orderRepository: OrderRepository) {
-    
-    fun createOrder(request: CreateOrderRequest): Order {
-        val order = Order(
-            id = UUID.randomUUID().toString(),
-            customerId = request.customerId,
-            items = request.items,
-            status = OrderStatus.CREATED
-        )
-        return orderRepository.save(order)
-    }
-    
-    fun updateOrderStatus(orderId: String, status: OrderStatus) {
-        val order = orderRepository.findById(orderId)
-        order.status = status
-        orderRepository.save(order)
-    }
-}
-```
+### 兼容性说明
 
-**迁移后的 Wow 代码**：
+<span id="数据格式兼容性"></span>
+<span id="事件升级"></span>
+<span id="消息格式兼容性"></span>
 
-```kotlin
-// 命令定义
-@CreateAggregate
-data class CreateOrder(
-    val customerId: String,
-    val items: List<OrderItem>
-)
+参见 [传统架构迁移：领域模型继续演进](./migration/traditional-architecture.md#_4-领域模型继续演进)
+和 [v6 → v8：破坏性变更检查](./migration/v6-to-v8.md#破坏性变更检查)。
 
-@CommandRoute
-data class UpdateOrderStatus(
-    @AggregateId val id: String,
-    val status: OrderStatus
-)
+### 已知问题
 
-// 聚合根
-@AggregateRoot
-class Order(private val state: OrderState) {
-    
-    @OnCommand
-    fun onCreate(command: CreateOrder): OrderCreated {
-        return OrderCreated(
-            customerId = command.customerId,
-            items = command.items
-        )
-    }
-    
-    @OnCommand
-    fun onUpdateStatus(command: UpdateOrderStatus): OrderStatusUpdated {
-        return OrderStatusUpdated(command.status)
-    }
-}
+<span id="版本特定问题"></span>
+<span id="常见迁移问题"></span>
 
-// 状态聚合根
-class OrderState : Identifier {
-    lateinit var id: String
-    lateinit var customerId: String
-    var items: List<OrderItem> = emptyList()
-    var status: OrderStatus = OrderStatus.CREATED
-    
-    fun onSourcing(event: OrderCreated) {
-        this.customerId = event.customerId
-        this.items = event.items
-    }
-    
-    fun onSourcing(event: OrderStatusUpdated) {
-        this.status = event.status
-    }
-}
-```
+参见 [Release Notes](https://github.com/Ahoo-Wang/Wow/releases) 和
+[故障排查](./troubleshooting.md)。
 
-#### 从直接查询到查询快照
+### 迁移检查清单
 
-**传统查询代码**：
+参见 [传统架构迁移检查清单](./migration/traditional-architecture.md#完成检查清单)
+或 [v6 → v8 验证清单](./migration/v6-to-v8.md#验证清单)。
 
-```kotlin
-@Repository
-interface OrderRepository : JpaRepository<Order, String> {
-    fun findByCustomerId(customerId: String): List<Order>
-    fun findByStatus(status: OrderStatus): List<Order>
-}
-```
+### 回滚计划
 
-**迁移后的查询代码**：
+参见本页[共同完成门禁](#共同完成门禁)，以及所选迁移页面的切换和回滚步骤。
 
-参考 [查询服务](query.md)
+### 统一运行时编排
 
-```kotlin
-class OrderService(
-    private val queryService: SnapshotQueryService<OrderState>
-) {
-    fun getById(id: String): Mono<OrderState> {
-        return singleQuery {
-            condition {
-                id(id)
-            }
-        }.query(queryService).toState().throwNotFoundIfEmpty()
-    }
-}
-```
+参见 [运行时编排迁移](./migration/runtime-orchestration.md)。
 
-## 兼容性说明
+### 移除版本化快照检查点
 
-### 数据格式兼容性
+参见 [v6 → v8：移除版本化快照检查点](./migration/v6-to-v8.md#移除版本化快照检查点)。
 
-Wow 框架使用 JSON 序列化事件和快照数据，确保了良好的前向兼容性：
+### SnapshotStore 原子保存
 
-- **新增字段**：新字段会被忽略（向后兼容）
-- **删除字段**：使用默认值（需要处理）
-- **修改字段类型**：需要事件升级器
+参见 [v6 → v8：SnapshotStore 原子保存](./migration/v6-to-v8.md#snapshotstore-原子保存)。
 
-### 事件升级
+### Redis EventStore Canonical v2 布局（v8.9.0 引入）
 
-使用 `@Event` 注解的 `revision` 属性进行事件版本控制：
+参见 [v6 → v8：Redis EventStore Canonical v2 布局](./migration/v6-to-v8.md#redis-eventstore-canonical-v2-布局-v8-9-0-引入)。
 
-```kotlin
-@Event(revision = "1.0")
-data class OrderCreatedV1(
-    val orderId: String,
-    val items: List<OrderItem>
-)
+### Mongo 所有权保护
 
-@Event(revision = "2.0")
-data class OrderCreated(
-    val orderId: String,
-    val items: List<OrderItem>,
-    val customerId: String // 新增字段
-)
-```
+参见 [v6 → v8：Mongo 所有权保护](./migration/v6-to-v8.md#mongo-所有权保护)。
 
-### 消息格式兼容性
+## 相关页面
 
-确保消息格式的兼容性：
-
-1. **添加字段**：安全，使用默认值
-2. **删除字段**：需要确保消费者可以处理
-3. **修改字段名**：不兼容，需要版本控制
-
-## 已知问题
-
-### 版本特定问题
-
-请查阅 [GitHub Issues](https://github.com/Ahoo-Wang/Wow/issues) 获取最新的已知问题列表。
-
-### 常见迁移问题
-
-1. **事件重放顺序**：确保事件按版本顺序追加
-2. **时间戳处理**：保留原始时间戳
-3. **ID 生成**：保持 ID 格式一致
-
-## 迁移检查清单
-
-- [ ] 备份现有数据
-- [ ] 更新依赖版本
-- [ ] 检查破坏性变更
-- [ ] 更新配置文件
-- [ ] 重新生成元数据
-- [ ] 运行单元测试
-- [ ] 运行集成测试
-- [ ] 灰度发布验证
-- [ ] 全量发布
-- [ ] 监控验证
-
-## 回滚计划
-
-如果迁移失败，请按照以下步骤回滚：
-
-1. 停止新服务
-2. 恢复旧服务
-3. 验证数据一致性
-4. 分析失败原因
-5. 修复问题后重试
+| 页面 | 关系 |
+|---|---|
+| [传统架构迁移](./migration/traditional-architecture.md) | 首次采用 Wow |
+| [Wow v6 迁移到 v8](./migration/v6-to-v8.md) | 已使用 Wow 的平台升级 |
+| [运行时编排迁移](./migration/runtime-orchestration.md) | v8 生命周期扩展迁移 |
+| [最佳实践](./best-practices.md) | 迁移后的工程约束 |
+| [故障排查](./troubleshooting.md) | 验证失败时的定位入口 |

--- a/documentation/docs/zh/guide/migration/traditional-architecture.md
+++ b/documentation/docs/zh/guide/migration/traditional-architecture.md
@@ -1,0 +1,222 @@
+---
+title: 传统架构迁移
+description: 以单写者、可重放同步和对账门禁，将传统 CRUD 系统渐进迁移到 Wow 的 CQRS 与事件溯源架构。
+---
+
+# 传统架构迁移
+
+本指南面向尚未使用 Wow 的传统 CRUD 系统。目标不是一次性重写全部服务，而是以一个
+bounded context 为单位建立 Wow 领域模型，在**始终只有一个业务写入权威**的前提下完成
+历史导入、增量追平、读路径切换和最终写路径切换。
+
+如果系统已经运行 Wow v6，请改读 [Wow v6 迁移到 v8](./v6-to-v8.md)。
+
+## 迁移总览
+
+| 阶段 | 写入权威 | 主要工作 | 完成门禁 | 来源 |
+|---|---|---|---|---|
+| 0. 选定边界 | 传统系统 | 选择低耦合 bounded context，固定 ID、租户和不变量 | 领域术语、聚合边界与验收用例得到业务确认 | [建模指南](../modeling.md) |
+| 1. 建立 Wow 模型 | 传统系统 | 定义 command、aggregate、domain event 与 state sourcing | `AggregateSpec` 覆盖正常、拒绝和幂等路径 | [CreateOrder.kt:31-64](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/CreateOrder.kt#L31-L64)、[OrderSpec.kt:44-113](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/order/OrderSpec.kt#L44-L113) |
+| 2. 影子同步 | 传统系统 | 通过 outbox/CDC 发送可重放同步命令；Wow 不承接生产写入 | 延迟、失败队列与逐聚合对账达到阈值 | [CommandFactory.kt:60-103](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandFactory.kt#L60-L103) |
+| 3. 切换读路径 | 传统系统 | 查询转向 Wow snapshot/projection，保留快速回退 | 新旧查询结果在观察窗内一致 | [OrderQueryController.kt:34-45](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-server/src/main/kotlin/me/ahoo/wow/example/server/order/OrderQueryController.kt#L34-L45) |
+| 4. 切换写路径 | Wow | 停流、追平、最终对账后把 command ingress 切到 Wow | 旧 writer 已关闭，Wow 写入与监控验证通过 | [CommandGateway.kt:75-159](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt#L75-L159) |
+| 5. 下线旧模型 | Wow | 只读保留旧数据至回滚窗口结束，再移除旧写路径 | 无回滚依赖、无未处置差异、审计记录完整 | [事件存储](../eventstore.md) |
+
+```mermaid
+%%{init: {"theme": "dark"}}%%
+flowchart LR
+    Scope["选择 bounded context"] --> Model["Command / Aggregate<br>Event / State"]
+    Model --> Shadow["历史导入 + 增量同步"]
+    Shadow --> Read["查询影子与读切换"]
+    Read --> Gate{"最终对账通过？"}
+    Gate -->|"否"| Shadow
+    Gate -->|"是"| Write["停旧 writer<br>切换 command ingress"]
+    Write --> Observe["观察与回滚窗口"]
+    classDef step fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    class Scope,Model,Shadow,Read,Gate,Write,Observe step
+```
+
+<!-- Sources:
+- documentation/docs/zh/guide/modeling.md
+- example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/CreateOrder.kt:31-64
+- example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/Order.kt:55-137
+- example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/OrderState.kt:39-99
+-->
+
+## 1. 先迁移边界，不先迁移表
+
+表结构通常同时承载多个业务概念，不能直接等价为 aggregate。先从业务用例反推 command，
+再确定单个 aggregate 内必须原子保持的不变量；跨 aggregate 协作使用 domain event、Saga 或
+projection。当前示例把 `CreateOrder` 建模为创建命令，把规则放在 `Order`，并由
+`OrderState.onSourcing` 重建状态，而不是在 handler 内直接修改状态。
+
+- [`CreateOrder.kt:31-64`](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/CreateOrder.kt#L31-L64)
+- [`Order.kt:55-137`](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/Order.kt#L55-L137)
+- [`OrderState.kt:39-99`](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/OrderState.kt#L39-L99)
+
+开始迁移前必须固定以下映射：
+
+| 传统模型 | Wow 模型 | 迁移约束 |
+|---|---|---|
+| 主键 | `AggregateId.id` | 同一 `NamedAggregate` 内必须跨 tenant 唯一；全局唯一主键可原样保留，tenant-local 主键必须先完成碰撞审计和确定性映射 |
+| 租户字段 | `tenantId` | 导入、同步与在线 command 使用同一映射 |
+| 乐观锁/更新时间 | command `requestId` 与源版本 | 用于幂等和乱序检测，不能只依赖消费 offset |
+| 行状态 | domain event 序列 | 用业务事实表达变化，不把当前行机械拆成伪事件历史 |
+| 联表查询 | snapshot/projection | 独立设计读模型，不让聚合承担跨边界查询 |
+
+`AggregateId.id` 的唯一性范围是 `NamedAggregate`，不是 `(tenantId, id)`。Redis 会显式拒绝同一
+named aggregate 下跨 tenant 的重复 ID；MongoDB 的 event-stream 唯一索引和 Elasticsearch 的文档
+ID 也不包含 tenant。若旧系统主键只在 tenant 内唯一，应使用经过版本控制、无歧义的确定性编码
+或 UUID v5 等方式生成复合 ID，并保存映射 manifest；历史导入、CDC、在线 command、查询和回滚
+必须复用同一映射，不能在每次导入时重新生成。
+[`AggregateId.kt:23-26`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt#L23-L26)
+[`EventStreamSchemaInitializer.kt:65-70`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/EventStreamSchemaInitializer.kt#L65-L70)
+[`ElasticsearchEventStreamAppender.kt:38-43`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchEventStreamAppender.kt#L38-L43)
+
+## 2. 用单写者完成历史导入与增量追平
+
+迁移期间不要让一个 HTTP 请求依次写传统数据库和 EventStore。第二次写入失败时，两套状态
+无法自动原子回滚。推荐保留传统数据库为唯一 writer，通过同一事务中的 outbox 或可恢复 CDC
+发布变更，再由迁移适配器发送幂等 command。
+
+```mermaid
+%%{init: {"theme": "dark"}}%%
+sequenceDiagram
+    autonumber
+    participant Client
+    participant Legacy as 传统服务
+    participant DB as 传统数据库 + Outbox
+    participant Adapter as 迁移适配器
+    participant Gateway as CommandGateway
+    participant Wow as Wow Aggregate
+
+    Client->>Legacy: 业务请求
+    Legacy->>DB: 一个事务写业务行与 outbox
+    DB-->>Adapter: 可重放变更
+    Adapter->>Gateway: requestId = source + id + version
+    Gateway->>Wow: sendAndWaitForProcessed
+    Wow-->>Adapter: processed / duplicate / error
+    Adapter->>DB: 核对目标后记录游标与结果
+```
+
+<!-- Sources:
+- wow-core/src/main/kotlin/me/ahoo/wow/command/CommandFactory.kt:60-103
+- wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt:75-159
+- example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/Order.kt:105-137
+-->
+
+历史导入也走 command 边界，显式复用已确定的业务 ID 映射，并使用稳定 `requestId` 阻止重复
+写入。重复 `requestId` 不会自动返回上一次成功结果；`sendAndWaitForProcessed` 会以
+`CommandResultException` 报告 `DuplicateRequestId`。迁移器只能在核对目标 event/state 与源版本
+一致后把该结果视为 already-applied，再推进游标。批处理保持响应式；只有独立离线进程的最外层
+入口可以等待完成，服务请求链和 Wow 核心路径中不要调用 `block()`。
+
+```kotlin
+fun importOrders(rows: Iterable<LegacyOrder>): Mono<Void> =
+    Flux.fromIterable(rows)
+        .concatMap(::importOrder)
+        .then()
+
+private fun importOrder(row: LegacyOrder): Mono<Void> {
+    val aggregateId = legacyOrderIdMapping.requireTargetId(row.tenantId, row.id)
+    val command = ImportLegacyOrder.from(row).toCommandMessage(
+        aggregateId = aggregateId,
+        tenantId = row.tenantId,
+        requestId = legacyOrderRequestId(row),
+    )
+    return commandGateway.sendAndWaitForProcessed(command)
+        .then()
+        .onErrorResume(CommandResultException::class.java) { error ->
+            if (error.commandResult.errorCode != ErrorCodes.DUPLICATE_REQUEST_ID) {
+                return@onErrorResume Mono.error(error)
+            }
+            verifyImportedOrder(
+                tenantId = row.tenantId,
+                aggregateId = aggregateId,
+                sourceVersion = row.version,
+            )
+        }
+}
+```
+
+`toCommandMessage` 允许显式传入 `aggregateId`、`tenantId`、`requestId` 与期望版本；
+`sendAndWaitForProcessed` 在 aggregate 已处理 command 后完成。示例中的 `verifyImportedOrder` 必须读取
+目标 event/state 并核对源版本；不得仅捕获 `DuplicateRequestId` 后无条件吞掉错误。
+`legacyOrderRequestId` 应使用带版本、无歧义的编码，不能直接拼接可能包含分隔符的原始字段。
+`legacyOrderIdMapping`、`legacyOrderRequestId` 与 `verifyImportedOrder` 均为迁移适配器需要实现的
+示意函数，不是 Wow 框架 API。
+[`CommandFactory.kt:60-103`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandFactory.kt#L60-L103)
+[`CommandGateway.kt:127-143`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt#L127-L143)
+[`DefaultCommandGateway.kt:86-95`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L86-L95)
+[`DefaultCommandGateway.kt:228-255`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L228-L255)
+
+::: warning 不伪造历史
+只有确有可信业务事实和顺序时才重建历史 domain event。只有当前行快照时，应发出明确的
+`LegacyOrderImported`/`OrderBaselineEstablished` 事件，保留来源、源版本和导入时间；不要把当前状态
+臆造成一串从未发生过的业务事件。
+:::
+
+## 3. 对账后分别切换读与写
+
+对账至少按 `(tenantId, aggregateId)` 比较存在性、关键业务字段、状态、金额/数量、源版本与
+最后同步时间。总数相同不代表逐聚合一致。所有差异必须分类为可重试、已接受或阻断切换。
+
+```mermaid
+%%{init: {"theme": "dark"}}%%
+stateDiagram-v2
+    [*] --> LegacyWriter: 传统系统单写
+    LegacyWriter --> Shadowing: 历史导入与增量同步
+    Shadowing --> ReadCanary: 逐聚合对账通过
+    ReadCanary --> Shadowing: 发现差异
+    ReadCanary --> Freeze: 读路径观察窗通过
+    Freeze --> WowWriter: 停流并最终追平
+    WowWriter --> LegacyRollback: 回滚窗口内失败
+    LegacyRollback --> LegacyWriter: 反向同步 Wow 新写入
+    WowWriter --> LegacyRetired: 回滚窗口结束
+```
+
+<!-- Sources:
+- example/example-server/src/main/kotlin/me/ahoo/wow/example/server/order/OrderQueryController.kt:34-45
+- wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt:75-159
+- wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt:35-71
+-->
+
+先切读路径通常更容易回退：按租户、用户或请求比例把查询指向
+`SnapshotQueryService`/projection，并在后台继续比对旧查询。写切换必须安排短暂停流：
+
+1. 关闭入口并等待传统事务、outbox/CDC 与迁移适配器全部排空。
+2. 固化源端游标，执行最后一次逐聚合对账。
+3. 禁用传统 writer，再开放 Wow command ingress。
+4. 验证创建、更新、拒绝路径、查询可见性、监控与告警。
+5. 回滚窗口内保留旧数据只读；若 Wow 已产生新写入，回滚前必须先反向同步这些写入。
+
+## 4. 领域模型继续演进
+
+迁移完成后，新增可选字段仍要有安全默认值；删除、改名或改类型不能只依赖 JSON 宽松解析。
+Wow 在 `DomainEventRecord` 物化领域事件前调用按顺序注册的 `EventUpgrader`，可把旧事件记录转换为
+当前形状。
+[`DomainEventRecord.kt:71-89`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/serialization/event/DomainEventRecord.kt#L71-L89)
+[`EventUpgraderFactory.kt:37-73`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/upgrader/EventUpgraderFactory.kt#L37-L73)
+[`EventUpgraderFactory.kt:89-115`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/upgrader/EventUpgraderFactory.kt#L89-L115)
+
+## 完成检查清单
+
+- [ ] bounded context、aggregate、跨 tenant 唯一 ID、tenant 与所有权映射已固定
+- [ ] command handler、state sourcing 与领域测试覆盖主要不变量和失败路径
+- [ ] 历史导入和增量同步具有稳定 `requestId`、duplicate 核对、重试、死信和游标
+- [ ] 迁移期间始终只有一个业务 writer
+- [ ] 逐聚合对账通过，差异均有明确处置
+- [ ] 读路径和写路径分别灰度，切换与回滚演练通过
+- [ ] 回滚窗口内旧数据保持只读，Wow 新写入具备反向同步方案
+- [ ] 监控覆盖同步延迟、失败量、对账差异和 command 处理结果
+
+## 相关页面
+
+| 页面 | 关系 |
+|---|---|
+| [迁移指南](../migration.md) | 选择迁移路径 |
+| [Wow v6 迁移到 v8](./v6-to-v8.md) | 已采用 Wow 的版本升级 |
+| [建模](../modeling.md) | 聚合、command、event 与 state 设计 |
+| [测试套件](../test-suite.md) | 用 `AggregateSpec` 固化领域行为 |
+| [查询服务](../query.md) | snapshot/projection 读模型与查询切换 |
+| [事件存储](../eventstore.md) | 事件流持久化与回放 |

--- a/documentation/docs/zh/guide/migration/v6-to-v8.md
+++ b/documentation/docs/zh/guide/migration/v6-to-v8.md
@@ -1,0 +1,303 @@
+---
+title: Wow v6 迁移到 v8
+description: 从 Spring Boot 3 / Wow v6 迁移到 Spring Boot 4 / Wow v8 的分阶段升级、数据切换与回滚指南。
+---
+
+# Wow v6 迁移到 v8
+
+本文只处理已经使用 Wow v6 的系统升级到 Wow v8。传统 CRUD 系统首次采用 Wow，请改读
+[传统架构迁移](./traditional-architecture.md)。
+
+Wow v6 与 v8 都要求 Java 17+，但 v6 对应 Spring Boot 3.x，v8 对应 Spring Boot 4.x；
+这是一轮平台迁移，不是只修改一个依赖版本。当前 v8 依赖基线还包括 Spring Boot 4.1、
+Kotlin 2.4、CosId 3.2、CoAPI 2.1 与 CoCache 4.2。
+[`README.zh-CN.md:47-49`](https://github.com/Ahoo-Wang/Wow/blob/main/README.zh-CN.md#L47-L49)
+[`gradle/libs.versions.toml:3-18`](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L3-L18)
+[`gradle/libs.versions.toml:32-33`](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L32-L33)
+
+## 迁移总览
+
+| 阶段 | 目标 | 完成门禁 | 主要风险 | 来源 |
+|---|---|---|---|---|
+| 0. 固化 v6 基线 | 先升级到最新 v6，清除弃用 API | v6 全量测试通过，事件/快照/消息数量有基线 | 带着旧缺陷跨平台定位困难 | [v6.21.5 Release](https://github.com/Ahoo-Wang/Wow/releases/tag/v6.21.5) |
+| 1. 平台适配 | Spring Boot 4、Jackson 3、依赖主版本同步升级 | 编译、单测、集成测试通过 | Boot 模块化、`tools.jackson` 包名与第三方 starter 不兼容 | [v8.0.0 Release](https://github.com/Ahoo-Wang/Wow/releases/tag/v8.0.0)、[SerializationAutoConfiguration.kt:14-30](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/serialization/SerializationAutoConfiguration.kt#L14-L30) |
+| 2. Wow API 适配 | 修复 v8 各小版本的源码破坏 | 领域、消息、查询、测试 DSL 全部重新编译 | `CommandGateway`、生命周期扩展与内部存储 API 已变化 | [CommandGateway.kt:75-159](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt#L75-L159) |
+| 3. 数据预迁移 | 在停流条件下完成 Redis/Mongo 审计与转换 | checksum、版本、ID 索引、回放一致 | v8.9 Redis canonical v2 不兼容旧布局 | [RedisEventSourcingAutoConfiguration.kt:200-243](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/redis/RedisEventSourcingAutoConfiguration.kt#L200-L243) |
+| 4. 隔离验证与切流 | 单实例 smoke test 后再灰度扩容 | 读写、回放、快照、查询与停机验证通过 | 新旧 writer 混跑会破坏快照和 Redis 回滚边界 | [SnapshotStore.kt:57-71](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt#L57-L71) |
+
+```mermaid
+%%{init: {"theme": "dark"}}%%
+flowchart LR
+    V6["最新 Wow v6<br>基线绿色"] --> Platform["Spring Boot 4<br>Jackson 3"]
+    Platform --> Compile["修复源码与测试<br>重新生成元数据"]
+    Compile --> Data["离线数据审计<br>与硬切换"]
+    Data --> Canary["单实例验证"]
+    Canary --> V8["Wow v8<br>灰度扩容"]
+    classDef step fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    class V6,Platform,Compile,Data,Canary,V8 step
+```
+
+<!-- Sources:
+- https://github.com/Ahoo-Wang/Wow/releases/tag/v8.0.0
+- README.zh-CN.md:47-49
+- gradle/libs.versions.toml:3-18
+- gradle/libs.versions.toml:32-33
+-->
+
+禁止把旧集群直接做混合版本滚动升级。先在隔离环境完成平台编译与数据演练，再停入口、
+排空全部旧 writer、完成数据切换，最后只启动一个 v8 实例验证。
+
+```mermaid
+%%{init: {"theme": "dark"}}%%
+sequenceDiagram
+    autonumber
+    participant Traffic as 入口流量
+    participant V6 as Wow v6 集群
+    participant Migrator as 离线迁移器
+    participant Store as 目标存储
+    participant V8 as Wow v8 单实例
+
+    Traffic->>V6: 关闭新写入
+    V6->>V6: 排空 in-flight 工作
+    V6-->>Migrator: 停止全部 writer
+    Migrator->>Store: inventory、转换、checksum
+    Migrator-->>V8: 数据门禁通过
+    V8->>Store: 隔离 ID 读写与回放
+    V8-->>Traffic: smoke test 通过后灰度切流
+```
+
+<!-- Sources:
+- wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/redis/RedisEventSourcingAutoConfiguration.kt:200-243
+- wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt:57-71
+- wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoDatabaseContextGuard.kt:30-65
+-->
+
+```mermaid
+%%{init: {"theme": "dark"}}%%
+stateDiagram-v2
+    [*] --> V6Running: v6 稳定运行
+    V6Running --> Offline: 停流并备份
+    Offline --> V8Canary: 数据门禁通过
+    V8Canary --> V8Running: smoke test 通过
+    V8Canary --> V6Rollback: 尚无 v8 生产写入
+    V8Running --> ReverseMigration: 已产生 v8 生产写入
+    ReverseMigration --> V6Rollback: 反向迁移或重放完成
+    V6Rollback --> V6Running
+```
+
+<!-- Sources:
+- wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStore.kt
+- wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/redis/RedisEventSourcingAutoConfiguration.kt:236-243
+- wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt:57-71
+-->
+
+## Spring Boot 4 与 Jackson 3
+
+v8.0.0 的核心变化是支持 Spring Boot 4，同时把框架序列化实现迁移到 Jackson 3 的
+`tools.jackson` 命名空间。应用若直接引用 Jackson `ObjectMapper`、`JsonNode`、Spring Boot
+auto-configuration 类或自建 starter，必须单独完成源码迁移；不要通过强制回退 Spring Boot 3
+或 Jackson 2 来维持旧组合。Spring Boot 官方建议先使用 classic starter 作为短期编译过渡，
+再收敛到按功能拆分的 starter。
+
+- [Wow v8.0.0 Release](https://github.com/Ahoo-Wang/Wow/releases/tag/v8.0.0)
+- [Spring Boot 4.0 Migration Guide](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide)
+- [`JsonSerializer.kt:14-51`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/serialization/JsonSerializer.kt#L14-L51)
+- [`SerializationAutoConfiguration.kt:14-30`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/serialization/SerializationAutoConfiguration.kt#L14-L30)
+
+## 通用升级步骤
+
+### 升级步骤
+
+1. **备份数据**：在升级前备份事件存储和快照数据
+2. **阅读更新日志**：查看 [Release Notes](https://github.com/Ahoo-Wang/Wow/releases)
+3. **更新依赖版本**：修改 build.gradle.kts 或 pom.xml
+4. **运行测试**：确保所有测试通过
+5. **硬切后灰度**：停流完成数据切换，只启动一个 v8 实例验证，再灰度切流并仅扩容 v8 实例
+
+### 依赖版本更新
+
+::: code-group
+```kotlin [Gradle(Kotlin)]
+// 更新 wow 版本
+implementation("me.ahoo.wow:wow-spring-boot-starter:8.9.3")
+```
+```xml [Maven]
+<dependency>
+    <groupId>me.ahoo.wow</groupId>
+    <artifactId>wow-spring-boot-starter</artifactId>
+    <version>8.9.3</version>
+</dependency>
+```
+:::
+
+### 破坏性变更检查
+
+升级前请检查以下内容：
+
+1. **API 变更**：检查是否有接口签名变更
+2. **配置变更**：检查配置属性是否有变更
+3. **元数据变更**：重新生成元数据文件
+
+## 统一运行时编排
+
+运行时生命周期迁移已经拆分为独立专题，使本页保持升级索引职责：
+
+- [运行时编排迁移](./runtime-orchestration.md) 说明源码破坏性变更、
+  自定义组件与消息总线、Spring 所有权、验证和回滚；
+- [运行时生命周期](../advanced/runtime-lifecycle.md) 说明迁移后的稳定架构与停机语义。
+
+该迁移会改变生命周期扩展契约，但不改变 event、snapshot 与 message 格式，无需迁移
+数据。
+
+## 移除版本化快照检查点
+
+v8.9.0 引入的版本化快照检查点能力已被移除，且不提供兼容层。`VersionedSnapshotStore`、
+`VersionIntervalCheckpointStrategy`、`CompositeSnapshotStrategy`、对应的 metrics/tracing 装饰器及
+`SnapshotCheckpointProperties` 均不再存在。`wow.eventsourcing.snapshot.checkpoint.*` 配置将被忽略，
+不再产生 `wow.snapshot.checkpoint.*` 指标与 checkpoint span。该能力没有替代接口；应用应使用仅保存和
+加载最新快照的 `SnapshotStore`。
+
+MongoDB 中既有的 `*_snapshot_checkpoint` collection 不再被读取、写入、扫描或自动删除。升级前应备份
+event 与 snapshot 数据、停止全部旧版本 writer，并仅在确认不再需要后清理这些 collection。回滚必须
+恢复旧运行时并保留其 checkpoint 数据；不支持新旧版本混合部署。
+
+来源：[`refactor(snapshot): remove versioned checkpoint support (#2831)`](https://github.com/Ahoo-Wang/Wow/pull/2831)、
+[`SnapshotStore.kt:24-71`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt#L24-L71)。
+
+## SnapshotStore 原子保存
+
+`SnapshotStore.save()` 的 JVM 签名与快照格式保持不变，但存储契约得到加强：
+每个聚合必须使用一次原子 compare-and-write。候选聚合版本大于或等于已存版本时
+完整替换快照；版本较低时正常完成且不写入。同版本覆盖是有意行为，使快照重建
+路由可以修复陈旧 payload。
+
+自定义 `SnapshotStore` 必须使用后端 CAS、条件更新、事务或等价的原子原语；
+客户端先 `load()` 再无条件写入不符合契约。候选快照应只物化一次，比较版本必须
+取自同一个待写 payload。在依赖此保证前，应停止全部旧 writer 并排空在途写入：
+旧 MongoDB 或 Redis writer 仍可能使新快照版本倒退，旧 Elasticsearch writer
+也不会执行同版本覆盖。无需重写数据。回滚会恢复旧保存行为，因此新旧 writer
+不得并行运行。
+
+`wow-mongo` 的条件更新使用了要求 MongoDB 5.2 或更高版本的 MQL 表达式；
+集成测试验证的版本为 MongoDB 6.0.6。现有服务端版本较低时，必须先升级
+MongoDB，再部署此版本运行时。
+
+来源：[`SnapshotStore.kt:57-71`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt#L57-L71)、
+[`MongoSnapshotStore.kt`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoSnapshotStore.kt)、
+[`RedisSnapshotStore.kt`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisSnapshotStore.kt)、
+[`ElasticsearchSnapshotStore.kt`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchSnapshotStore.kt)。
+
+## Redis EventStore Canonical v2 布局（v8.9.0 引入）
+
+从 v6.x、v8.6.x 或 v8.8.x 升级到 v8.9.0+ 时，必须把 Redis 持久化视为存储格式硬切换。
+v6.21.5 与 v8.6.x 使用 legacy event Key 和 shared request-ID SET；v8.8.x 使用 per-stream request SET
+与 bucketed ID 索引。Redis EventStore、Redis SnapshotStore 与 Redis PrepareKey 只读写 canonical v2
+Key，不提供旧布局回退、双写或内置迁移器；旧运行时也无法读取新的 v2 写入。新 EventStore 还会
+强制同一个 named aggregate 下的 `AggregateId.id` 在所有租户之间唯一。
+
+Spring Boot starter 会精确检查已发布 v6/v8.6 shared layout 与 v8.8 bucketed layout 成功写入时
+必然创建的哨兵 Key。检查范围仅包括解析到自动配置 `RedisEventStore` 的本地聚合，不在运行时使用
+`SCAN`，因此支持 Redis Cluster；发现不兼容数据会阻止启动。该守卫不覆盖直接使用库、独立构造的
+自定义 store、已从元数据移除的聚合或仅将 snapshot 路由到 Redis 的场景。旧 snapshot 没有与
+aggregate 无关的精确哨兵。canonical v2 会忽略旧 snapshot Key；缺少 v2 snapshot 时，聚合加载会
+回放事件，但普通加载不会自动持久化重建后的 snapshot。
+
+精确 Key 守卫不能替代离线数据审计。历史 alias 变更、Key eviction、手工删除或破坏旧索引，都可能让
+哨兵消失但留下孤立事件流。解析后的 context alias（已配置 alias 时使用 alias，否则使用 `contextName`）
+与 aggregate name 共同构成 v2 持久化 Key scope。迁移 manifest 必须固定每个历史 source alias 到目标
+resolved alias 的映射；写入后变更 resolved alias 或 aggregate name 必须另做离线 Key 迁移。
+
+必须采用离线切换：
+
+1. 停止入口流量和全部旧版本 writer，将 in-flight append 排空为零，再创建一致的 Redis 备份并记录
+   事件数量与版本基线。禁止新旧版本混合滚动发布。
+2. 在每个 Cluster primary 的每个 logical database 中盘点全部旧 event ZSET、v6/v8.6 shared request SET、
+   v8.8 per-stream request SET、v8.8 bucket ids ZSET、旧 snapshot 与 PrepareKey Hash；记录 source Key、
+   Redis type、cardinality、checksum 与 target mapping。历史 Key 中的 identity 只用于定位，最终身份以
+   event/snapshot JSON 为准。
+3. 按 named aggregate 审计不同租户之间是否存在重复 `AggregateId.id`。迁移前必须解决所有冲突；
+   canonical v2 有意不允许同一个 ID 存在两个所有者。
+4. 首次运行必须要求 v2 目标 scope 为空。可丢弃数据只能清除 inventory 中的旧 Key，或使用空的专用
+   database；与 message bus 或应用数据共库时禁止 `FLUSHDB`。完整源数据集保持不可变以供回滚。
+5. 使用单独评审的离线迁移器。持久化 manifest 必须记录 source Key、target Keys、源/目标 checksum、
+   状态和最后完成批次。恢复执行时只有 manifest 与 checksum 一致才能复用 target，否则失败且不得覆盖。
+   复制必须幂等；缺少 manifest 复核的半成品 target 不得被接受。
+6. 保持每个 event ZSET member 与 score，校验 identity 一致且 score/version 连续。v2 request-ID SET 以
+   已提交事件 JSON 为唯一权威来源。对 v6/v8.6，必须双向比较 shared SET 与
+   `union(event.requestId)`，分别报告 shared-only 与 event-only 差异，禁止 fan-out。对 v8.8，逐流计算
+   source SET 与该流事件 requestId 的 symmetric difference。差集非空时必须失败，除非记录了明确且
+   已评审的处置策略。
+7. 在 128 个 bucket 空间中重建所有非空聚合 ID 索引。bucket 公式是
+   `aggregateId.id.hashCode().mod(128)`，使用 Java/Kotlin UTF-16 `String.hashCode`；Key 与 member 必须
+   严格使用 canonical v2 codec。运行时不会执行该转换。
+8. 校验有序 member+score checksum、首尾版本、request-ID 集合、完整 ID 索引、aggregate-ID scan 结果
+   和代表性状态回放。失败时必须保留 manifest 和最后验证 cursor，随后清理半成品或从该 cursor 恢复；
+   此期间不得启动应用。
+9. 全部验证通过后，原地迁移必须移除或迁出 inventory 中的每个旧 Key；哨兵 Key 最后删除，随后重新
+   inventory 并要求旧 Key 为零。使用独立 target database 时，完整源数据集在回滚观察期内保持只读。
+10. 先让一个新实例连接 target 并完成隔离 ID 的读写 smoke test。显式执行 snapshot regeneration，校验
+    snapshot 数量与版本后再切流量和扩容。应依据完整 inventory 调用单 ID regenerate 路由；只有审计
+    证明全部 ID 严格大于 `AggregateIdScanner.FIRST_ID` 时，batch 路由才能视为不会漏项。
+
+回滚必须同时切换应用与数据。尚无生产 v2 写入时，可以重新连接未改动的旧数据集并启动旧运行时；一旦
+已有生产 v2 写入，必须先停止流量和全部 v2 writer，再反向迁移或重放这些写入，之后才能启动旧运行时。
+仅恢复切换时备份会丢失此后的所有 v2 写入。推荐使用独立 target database/namespace。
+
+强制精确 Key 检查属于启动期内部不变量，不提供关闭开关，也不作为兼容或迁移配置暴露。
+
+Redis 布局内部 API 有意不保持源码、JVM 二进制与行为兼容。已移除 `AggregateKeyConverter`、
+`RedisWrappedKey`、`RedisSnapshotRepository`、`EventStreamKeyConverter`、`DefaultSnapshotKeyConverter`、
+`PrepareKeyConverter` 与 `RedisEventStore.SCRIPT_EVENT_STEAM_APPEND`；同时移除
+`redisSnapshotRepository` Bean alias 和自定义 snapshot-key converter 构造参数。新的
+`SCRIPT_EVENT_STREAM_APPEND` 为 internal，不提供公开替代。canonical converter 输出已改变，PrepareKey
+现在包含 `name`，v2 会拒绝空 aggregate/prepare ID 与 unpaired UTF-16 surrogate。应用代码应使用
+`EventStore`、`SnapshotStore` 与 `PrepareKey`；单独评审的离线工具应独立实现并校验 v2 codec。
+
+来源：[`RedisEventStore.kt`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStore.kt)、
+[`RedisKeyComponentCodec.kt:22-69`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-redis/src/main/kotlin/me/ahoo/wow/redis/RedisKeyComponentCodec.kt#L22-L69)、
+[`RedisEventSourcingAutoConfiguration.kt:166-185`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/redis/RedisEventSourcingAutoConfiguration.kt#L166-L185)、
+[`v6.21.5 EventStreamKeyConverter.kt:21-33`](https://github.com/Ahoo-Wang/Wow/blob/v6.21.5/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/EventStreamKeyConverter.kt#L21-L33)、
+[`v6.21.5 event_steam_append.lua:12-27`](https://github.com/Ahoo-Wang/Wow/blob/v6.21.5/wow-redis/src/main/resources/event_steam_append.lua#L12-L27)。
+
+## Mongo 所有权保护
+
+本次升级保留仅含 aggregate name 的 Mongo collection 命名，但新增持久化
+`wow_database_metadata` 所有权标记。支持的部署布局是一个 MongoDB database 只属于一个 bounded
+context。
+
+上线前：
+
+1. 检查所有已配置的 event-stream、snapshot 与 prepare database，以及其中的 `*_event_stream`、
+   `*_snapshot` 和 `prepare_*` collection。
+2. 确认每个 database 只属于一个 `wow.context-name`；历史混写数据库必须先拆分。
+3. 先升级数据库的真实所有者。第一个新版本实例会扫描存量 aggregate collection，再原子认领标记。
+   存量 `prepare_*` 文档没有 context 元数据，因此 prepare-only database 会由首个升级 context 认领，
+   上线前必须先审计其映射关系。
+4. 审计现有受管索引。缺失索引会创建；key 顺序、unique、TTL、partial filter、collation、sparse 或
+   hidden 选项不兼容时会阻止启动，必须执行受控迁移。
+
+不要通过修改所有权标记绕过 context 冲突。应先迁移或删除旧数据；只有明确重新分配空数据库时才删除
+标记。
+
+来源：[`MongoDatabaseContextGuard.kt:30-132`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoDatabaseContextGuard.kt#L30-L132)。
+
+## 验证清单
+
+- [ ] v6 已升级到最新维护版本，弃用 API 已清除
+- [ ] Spring Boot 4、Jackson 3 与所有第三方 starter 已完成兼容性检查
+- [ ] 所有 domain、server、integration test 与 KSP 元数据已重新编译
+- [ ] event、snapshot、PrepareKey、Redis Key 与 Mongo database 已完成 inventory
+- [ ] 数据迁移 manifest、checksum、ID 索引与代表性事件回放一致
+- [ ] 单个 v8 实例的读写、查询、快照重建、监控和优雅停机通过
+- [ ] 回滚窗口、旧数据只读保留期与 v8 新写入反向迁移方案已经演练
+
+## 相关页面
+
+| 页面 | 关系 |
+|---|---|
+| [迁移指南](../migration.md) | 选择迁移路径 |
+| [传统架构迁移](./traditional-architecture.md) | 面向首次采用 Wow 的系统改造 |
+| [运行时编排迁移](./runtime-orchestration.md) | v8 当前生命周期源码破坏与扩展迁移 |
+| [运行时生命周期](../advanced/runtime-lifecycle.md) | 迁移后的稳定运行模型 |
+| [Redis 扩展](../extensions/redis.md) | Redis 配置与 canonical v2 启动守卫 |
+| [Mongo 扩展](../extensions/mongo.md) | Mongo 存储与 database 所有权约束 |


### PR DESCRIPTION
## Summary

- split the migration guide into dedicated traditional-architecture and Wow v6-to-v8 paths
- add nested bilingual sidebar navigation and update related Redis/BI links
- document single-writer cutover, cross-tenant aggregate ID uniqueness, replay-safe import handling, and v6 Redis canonical-v2 migration requirements
- preserve all 56 legacy English and Chinese deep-link anchors

## Why

The previous page mixed first-time Wow adoption with platform, runtime, and storage upgrades. That made the intended migration path difficult to select and left operationally unsafe ambiguity around mixed-version rollout, retry handling, and tenant-local IDs.

## Impact

Documentation only. Runtime code, public APIs, persistence formats, and build configuration are unchanged.

## Validation

- `pnpm docs:build`
- `SITE_BASE=/wow/ pnpm docs:build`
- `git diff --check`
- verified all local Markdown targets, 30 fragment links, and 56 legacy anchors
- verified three Mermaid diagrams on each new or refactored migration page