### PR TITLE
fix(test): wait for Elasticsearch authentication readiness

### DIFF
--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/container/WowTestContainers.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/container/WowTestContainers.kt
@@ -16,15 +16,40 @@ package me.ahoo.wow.tck.container
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.KafkaContainer
 import org.testcontainers.containers.MongoDBContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy
 import org.testcontainers.elasticsearch.ElasticsearchContainer
 import org.testcontainers.utility.DockerImageName
 import java.time.Duration
 
+private class AuthenticatedElasticsearchContainer(
+    dockerImageName: DockerImageName,
+    username: String,
+    password: String,
+    httpPort: Int,
+) : ElasticsearchContainer(dockerImageName) {
+    init {
+        waitingFor(
+            WaitAllStrategy()
+                .withStrategy(super.getWaitStrategy())
+                .withStrategy(
+                    Wait.forHttps("/_security/_authenticate")
+                        .forPort(httpPort)
+                        .allowInsecure()
+                        .withBasicCredentials(username, password)
+                        .forStatusCode(200),
+                ),
+        )
+    }
+}
+
 object WowTestContainers {
     const val ELASTIC_USER = "elastic"
 
-    private const val ELASTIC_PASSWORD = "wow"
+    private const val ELASTIC_PASSWORD = "wow-test"
+    private const val ELASTICSEARCH_HTTP_PORT = 9200
     private const val ELASTICSEARCH_JAVA_OPTS = "-Xms512m -Xmx512m"
+    private val ELASTICSEARCH_STARTUP_TIMEOUT = Duration.ofMinutes(5)
 
     val mongo: MongoDBContainer by lazy {
         MongoDBContainer(DockerImageName.parse(ContainerImages.MONGO))
@@ -40,15 +65,18 @@ object WowTestContainers {
     }
 
     val elasticsearch: ElasticsearchContainer by lazy {
-        ElasticsearchContainer(
+        AuthenticatedElasticsearchContainer(
             DockerImageName
                 .parse(ContainerImages.ELASTICSEARCH_REPOSITORY)
                 .withTag(ContainerImages.ELASTICSEARCH_TAG),
+            username = ELASTIC_USER,
+            password = ELASTIC_PASSWORD,
+            httpPort = ELASTICSEARCH_HTTP_PORT,
         )
             .withPassword(ELASTIC_PASSWORD)
             .withEnv("ES_JAVA_OPTS", ELASTICSEARCH_JAVA_OPTS)
             .withNetworkAliases("elasticsearch")
-            .withStartupTimeout(Duration.ofMinutes(5))
+            .withStartupTimeout(ELASTICSEARCH_STARTUP_TIMEOUT)
             .also { it.start() }
     }
 

--- a/test/wow-tck/src/test/kotlin/me/ahoo/wow/tck/container/ElasticsearchTestFixtureTest.kt
+++ b/test/wow-tck/src/test/kotlin/me/ahoo/wow/tck/container/ElasticsearchTestFixtureTest.kt
@@ -25,6 +25,11 @@ class ElasticsearchTestFixtureTest {
     }
 
     @Test
+    fun `should expose a valid Elasticsearch password`() {
+        ElasticsearchTestFixture().password.length.assert().isGreaterThanOrEqualTo(6)
+    }
+
+    @Test
     fun `should reuse and close managed resource`() {
         val fixture = ElasticsearchTestFixture()
         val resource = TestResource("client")


### PR DESCRIPTION
## What changed

- preserve Testcontainers' original Elasticsearch log readiness check
- require authenticated HTTPS readiness before the shared container is exposed to tests
- use one five-minute startup budget for both readiness conditions
- use a password that satisfies Elasticsearch's minimum-length requirement and cover that contract with a test

## Root cause

The Codecov workflow intermittently started the first Elasticsearch integration test after the container emitted its `started` log but before the `elastic` user accepted authenticated requests. The fixture then exhausted its separate two-minute retry window with HTTP 401. Because CI treats passed-after-retry tests as failures, the transient startup race kept the workflow red.

The same failure occurred on an earlier documentation-only change, confirming that it was unrelated to the React dependency update that triggered the latest run.

## Impact

Elasticsearch-backed tests now receive the container only after both node startup and authenticated access are ready. The fixture-level probe remains as a runtime defense.

## Validation

- `CI=GITHUB_ACTIONS ./gradlew :wow-tck:test --tests 'me.ahoo.wow.tck.container.ElasticsearchAuthenticationWaiterTest' --tests 'me.ahoo.wow.tck.container.ElasticsearchTestFixtureTest' :wow-elasticsearch:integrationTest --rerun --stacktrace --no-parallel`
- `./gradlew :wow-tck:check :wow-elasticsearch:check --stacktrace --no-parallel`
- `git diff --check`

The failed Codecov workflow was also rerun successfully: all 3,512 tests passed and 19 were skipped.