### PR TITLE
fix(core): bound command wait lifetime

### DIFF
--- a/documentation/docs/en/guide/command-gateway.md
+++ b/documentation/docs/en/guide/command-gateway.md
@@ -54,6 +54,20 @@ commandGateway.sendAndWaitStream(command, waitPlan)
     .subscribe()
 ```
 
+#### Wait Timeout
+
+`sendAndWait` and `sendAndWaitStream` have a default maximum duration of 30 seconds. The deadline starts on subscription and covers command checks, sending, and target-stage waiting. A timeout cancels the wait and releases its registered `WaitHandle`. Override the default for one call with `withTimeout`:
+
+```kotlin
+val waitPlan = CommandWait.processed(command.commandId)
+    .withTimeout(Duration.ofMinutes(2))
+
+commandGateway.sendAndWait(command, waitPlan)
+```
+
+`withTimeout` controls caller-side resource lifetime only; it is not propagated in remote message headers.
+The `sendAndWaitForSent` fast path has no `WaitPlan` parameter and always uses the 30-second default.
+
 ### Convenience Methods
 
 The `CommandGateway` provides convenience methods that pre-configure common wait plans:

--- a/documentation/docs/zh/guide/command-gateway.md
+++ b/documentation/docs/zh/guide/command-gateway.md
@@ -54,6 +54,20 @@ commandGateway.sendAndWaitStream(command, waitPlan)
     .subscribe()
 ```
 
+#### 等待超时
+
+`sendAndWait` 和 `sendAndWaitStream` 默认最多等待 30 秒。该期限从订阅开始计算，覆盖命令检查、发送以及目标阶段等待；超时会取消等待并释放已注册的 `WaitHandle`。可通过 `withTimeout` 为单次调用覆盖默认值：
+
+```kotlin
+val waitPlan = CommandWait.processed(command.commandId)
+    .withTimeout(Duration.ofMinutes(2))
+
+commandGateway.sendAndWait(command, waitPlan)
+```
+
+`withTimeout` 只控制调用方本地资源生命周期，不会传播到远端消息头。
+`sendAndWaitForSent` 快路径没有 `WaitPlan` 参数，因此始终使用 30 秒默认期限。
+
 ### 便捷方法
 
 `CommandGateway` 提供了预配置常用等待计划的便捷方法：

--- a/skills/wow/references/command-gateway.md
+++ b/skills/wow/references/command-gateway.md
@@ -42,6 +42,11 @@ val waitPlan = CommandWait.snapshot(command.commandId)
 commandGateway.sendAndWait(command, waitPlan)
     .doOnSuccess { result -> ... }
 
+// The default wait timeout is 30 seconds; override it per call when needed
+val longRunningPlan = CommandWait.snapshot(command.commandId)
+    .withTimeout(Duration.ofMinutes(2))
+commandGateway.sendAndWait(command, longRunningPlan)
+
 // Streaming updates as command progresses through stages
 commandGateway.sendAndWaitStream(command, CommandWait.processed(command.commandId))
     .doOnNext { result ->

--- a/wow-core/README.md
+++ b/wow-core/README.md
@@ -63,8 +63,10 @@ gateway.send(command)
     .doOnSuccess { println("Command sent successfully") }
     .subscribe()
 
-// Send and wait for completion with different plans
-gateway.sendAndWait(command, CommandWait.processed(command.commandId))
+// Send and wait for completion. The 30-second default can be overridden per call
+val waitPlan = CommandWait.processed(command.commandId)
+    .withTimeout(Duration.ofMinutes(2))
+gateway.sendAndWait(command, waitPlan)
     .doOnNext { result ->
         if (result.succeeded) {
             println("Cart item added: ${result.commandId}")

--- a/wow-core/README_CN.md
+++ b/wow-core/README_CN.md
@@ -63,8 +63,10 @@ gateway.send(command)
     .doOnSuccess { println("命令发送成功") }
     .subscribe()
 
-// 发送并等待完成，使用不同的等待计划
-gateway.sendAndWait(command, CommandWait.processed(command.commandId))
+// 发送并等待完成。默认期限为 30 秒，可按调用覆盖
+val waitPlan = CommandWait.processed(command.commandId)
+    .withTimeout(Duration.ofMinutes(2))
+gateway.sendAndWait(command, waitPlan)
     .doOnNext { result ->
         if (result.succeeded) {
             println("购物车商品添加成功: ${result.commandId}")

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt
@@ -66,6 +66,8 @@ fun CommandMessage<*>.commandSentSignal(
  * The Command Gateway provides a high-level API for sending commands to aggregates
  * and optionally waiting for their processing results. It supports various waiting
  * plans to control how long to wait and what stage of processing to wait for.
+ * Implementations that report [enforcesCommandWaitTimeout] must enforce `WaitPlan.timeout`
+ * as an end-to-end deadline for [sendAndWait] and [sendAndWaitStream].
  *
  * @author ahoo wang
  * @see CommandBus
@@ -74,10 +76,20 @@ fun CommandMessage<*>.commandSentSignal(
  */
 interface CommandGateway : CommandBus {
     /**
+     * Whether this gateway enforces `WaitPlan.timeout` itself.
+     *
+     * The default remains false so existing third-party implementations retain the
+     * WebFlux boundary timeout used before gateway-level deadlines were introduced.
+     */
+    val enforcesCommandWaitTimeout: Boolean
+        get() = false
+
+    /**
      * Sends a command and returns a stream of command results as processing progresses.
      *
      * This method provides real-time updates on the command's processing status,
-     * emitting CommandResult objects at various stages of the command lifecycle.
+     * emitting CommandResult objects at various stages of the command lifecycle. The wait
+     * uses the default timeout unless [waitPlan] is decorated with `WaitPlan.withTimeout`.
      *
      * @param C the type of the command
      * @param command the command message to send
@@ -96,6 +108,7 @@ interface CommandGateway : CommandBus {
      *
      * This method blocks until the command processing is complete or fails.
      * If the command fails, it throws a CommandResultException containing the error details.
+     * The wait uses the default timeout unless [waitPlan] is decorated with `WaitPlan.withTimeout`.
      *
      * @param C the type of the command
      * @param command the command message to send
@@ -116,7 +129,8 @@ interface CommandGateway : CommandBus {
      * Sends a command and waits until it is successfully sent to the command bus.
      *
      * This convenience method waits for the command to be accepted by the command bus
-     * but does not wait for actual processing by the aggregate.
+     * but does not wait for actual processing by the aggregate. It is bounded by the
+     * default command wait timeout.
      *
      * @param C the type of the command
      * @param command the command message to send

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
@@ -20,12 +20,14 @@ import me.ahoo.wow.command.validation.validateCommand
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.CommandWaitEndpoint
 import me.ahoo.wow.command.wait.CommandWaitNotifier
+import me.ahoo.wow.command.wait.DEFAULT_WAIT_TIMEOUT
 import me.ahoo.wow.command.wait.SkipsSuccessfulSentSignal
 import me.ahoo.wow.command.wait.WaitCoordinator
 import me.ahoo.wow.command.wait.WaitHandle
 import me.ahoo.wow.command.wait.WaitPlan
 import me.ahoo.wow.command.wait.extractWaitPlan
 import me.ahoo.wow.command.wait.notifyAndForget
+import me.ahoo.wow.command.wait.timeout
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.messaging.MessageReceiver
 import me.ahoo.wow.messaging.MessageSubscription
@@ -33,6 +35,10 @@ import me.ahoo.wow.reactor.thenDefer
 import me.ahoo.wow.reactor.thenRunnable
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import reactor.core.scheduler.Scheduler
+import reactor.core.scheduler.Schedulers
+import java.time.Duration
+import java.util.concurrent.TimeUnit
 
 /**
  * Default implementation of the CommandGateway interface.
@@ -55,6 +61,8 @@ class DefaultCommandGateway(
     private val commandWaitNotifier: CommandWaitNotifier,
 ) : CommandGateway,
     CommandBus by commandBus {
+    override val enforcesCommandWaitTimeout: Boolean = true
+
     override fun receiver(
         subscription: MessageSubscription,
     ): MessageReceiver<ServerCommandExchange<*>> =
@@ -146,6 +154,7 @@ class DefaultCommandGateway(
      * @param command The command message to send.
      * @return A Mono emitting the SENT stage CommandResult.
      * @throws CommandResultException if the pre-send checks fail or the command bus rejects the command.
+     * @throws java.util.concurrent.TimeoutException if the default command wait deadline expires.
      */
     override fun <C : Any> sendAndWaitForSent(command: CommandMessage<C>): Mono<CommandResult> =
         check(command)
@@ -175,7 +184,7 @@ class DefaultCommandGateway(
                     ),
                     it,
                 )
-            }
+            }.withDeadline(DEFAULT_WAIT_TIMEOUT)
 
     /**
      * Sends a command and returns a stream of command results as they become available.
@@ -198,19 +207,20 @@ class DefaultCommandGateway(
             check(command)
                 .mapToCommandResultException(command, waitPlan)
                 .thenMany(
-                    Flux.defer {
-                        val handle = waitCoordinator.createStream(waitPlan)
-                        sendWithRegisteredWaitHandle(command, waitPlan, handle)
-                            .thenMany(
-                                handle.stream().map { waitSignal ->
-                                    waitSignal.toResult(command)
-                                }
-                            ).doOnCancel {
-                                handle.cancel()
-                            }
-                    }
+                    Flux.using(
+                        { waitCoordinator.createStream(waitPlan) },
+                        { handle ->
+                            sendWithRegisteredWaitHandle(command, waitPlan, handle)
+                                .thenMany(
+                                    handle.stream().map { waitSignal ->
+                                        waitSignal.toResult(command)
+                                    }
+                                )
+                        },
+                        { handle -> handle.cancel() },
+                    )
                 )
-        }
+        }.withDeadline(waitPlan.timeout)
 
     /**
      * Sends a command and waits for the final result.
@@ -234,25 +244,26 @@ class DefaultCommandGateway(
             check(command)
                 .mapToCommandResultException(command, waitPlan)
                 .then(
-                    Mono.defer {
-                        val handle = waitCoordinator.createLast(waitPlan)
-                        sendWithRegisteredWaitHandle(command, waitPlan, handle)
-                            .then(
-                                handle.await()
-                                    .map { waitSignal ->
-                                        waitSignal.toResult(command)
-                                            .apply {
-                                                if (!succeeded) {
-                                                    throw CommandResultException(this)
+                    Mono.using(
+                        { waitCoordinator.createLast(waitPlan) },
+                        { handle ->
+                            sendWithRegisteredWaitHandle(command, waitPlan, handle)
+                                .then(
+                                    handle.await()
+                                        .map { waitSignal ->
+                                            waitSignal.toResult(command)
+                                                .apply {
+                                                    if (!succeeded) {
+                                                        throw CommandResultException(this)
+                                                    }
                                                 }
-                                            }
-                                    }
-                            ).doOnCancel {
-                                handle.cancel()
-                            }
-                    }
+                                        }
+                                )
+                        },
+                        { handle -> handle.cancel() },
+                    )
                 )
-        }
+        }.withDeadline(waitPlan.timeout)
 
     /**
      * Sends a command with a specific wait plan.
@@ -287,8 +298,6 @@ class DefaultCommandGateway(
             val waitSignal = command.commandSentSignal(waitPlan.waitCommandId, it)
             waitHandle.next(waitSignal)
             waitHandle.error(it)
-        }.doOnCancel {
-            waitHandle.cancel()
         }.mapToCommandResultException(command, waitPlan)
     }
 
@@ -319,3 +328,28 @@ class DefaultCommandGateway(
             )
         }
 }
+
+private fun <T : Any> Mono<T>.withDeadline(timeout: Duration): Mono<T> =
+    timeout(timeout)
+
+private fun <T : Any> Flux<T>.withDeadline(timeout: Duration): Flux<T> =
+    Flux.defer {
+        val scheduler = Schedulers.parallel()
+        val startedAt = scheduler.now(TimeUnit.NANOSECONDS)
+        this.timeout(
+            deadlineSignal(timeout, startedAt, scheduler),
+            { deadlineSignal(timeout, startedAt, scheduler) },
+        )
+    }
+
+private fun deadlineSignal(
+    timeout: Duration,
+    startedAt: Long,
+    scheduler: Scheduler,
+): Mono<Long> =
+    Mono.delay(
+        timeout
+            .minusNanos(scheduler.now(TimeUnit.NANOSECONDS) - startedAt)
+            .coerceAtLeast(Duration.ZERO),
+        scheduler,
+    )

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitCoordinator.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitCoordinator.kt
@@ -16,8 +16,14 @@ package me.ahoo.wow.command.wait
 import java.util.concurrent.ConcurrentHashMap
 
 interface WaitCoordinator {
+    /**
+     * Creates and registers a low-level handle whose lifetime is owned by the caller.
+     */
     fun createLast(plan: WaitPlan): WaitLastHandle
 
+    /**
+     * Creates and registers a low-level handle whose lifetime is owned by the caller.
+     */
     fun createStream(plan: WaitPlan): WaitStreamHandle
 
     fun signal(signal: WaitSignal): Boolean

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitHandle.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitHandle.kt
@@ -19,6 +19,13 @@ import reactor.core.publisher.SignalType
 import reactor.core.publisher.Sinks
 import reactor.util.concurrent.Queues
 
+/**
+ * A low-level, single-subscriber command wait resource.
+ *
+ * Callers that create a handle through [WaitCoordinator] own its lifetime and must eventually
+ * terminate it through a final signal, [error], or [cancel]. [cancel] must be idempotent and safe
+ * to invoke after another terminal signal.
+ */
 interface WaitHandle : WaitCommandIdCapable {
     val plan: WaitPlan
     fun next(signal: WaitSignal): Boolean
@@ -31,7 +38,8 @@ interface WaitLastHandle : WaitHandle {
      * Awaits the final wait signal.
      *
      * A wait handle is designed for a single subscriber. Signals may arrive
-     * before subscription, and the final result is retained for awaiting.
+     * before subscription, and the final result is retained for awaiting. This low-level
+     * publisher does not apply `WaitPlan.timeout`; gateway APIs own end-to-end deadlines.
      */
     fun await(): Mono<WaitSignal>
 }
@@ -41,7 +49,8 @@ interface WaitStreamHandle : WaitHandle {
      * Streams accepted wait signals.
      *
      * A wait handle is single-subscriber. Signals may arrive before subscription
-     * and are buffered for the first subscriber only.
+     * and are buffered for the first subscriber only. This low-level publisher does not
+     * apply `WaitPlan.timeout`; gateway APIs own end-to-end deadlines.
      */
     fun stream(): Flux<WaitSignal>
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitTimeout.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitTimeout.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.command.wait
+
+import java.time.Duration
+
+/**
+ * Default maximum duration for command wait operations.
+ */
+val DEFAULT_WAIT_TIMEOUT: Duration = Duration.ofSeconds(30)
+
+/**
+ * A local execution decorator that bounds how long a gateway may execute a [WaitPlan].
+ *
+ * The timeout is intentionally not propagated with command headers. It owns caller-side
+ * resource lifetime, while the delegated plan continues to own distributed stage matching.
+ */
+private data class TimeoutWaitPlan(
+    val delegate: WaitPlan,
+    val timeout: Duration,
+) : WaitPlan by delegate {
+    init {
+        require(!timeout.isZero && !timeout.isNegative) {
+            "Wait timeout must be greater than zero."
+        }
+    }
+}
+
+/**
+ * Returns the local execution timeout for this plan.
+ */
+val WaitPlan.timeout: Duration
+    get() = (this as? TimeoutWaitPlan)?.timeout ?: DEFAULT_WAIT_TIMEOUT
+
+/**
+ * Returns a plan with a caller-side execution timeout.
+ */
+fun WaitPlan.withTimeout(timeout: Duration): WaitPlan =
+    if (this is TimeoutWaitPlan) {
+        copy(timeout = timeout)
+    } else {
+        TimeoutWaitPlan(delegate = this, timeout = timeout)
+    }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTimeoutTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTimeoutTest.kt
@@ -1,0 +1,198 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.command
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.command.CommandMessage
+import me.ahoo.wow.command.validation.NoOpValidator
+import me.ahoo.wow.command.wait.CommandStage
+import me.ahoo.wow.command.wait.CommandWait
+import me.ahoo.wow.command.wait.DEFAULT_WAIT_TIMEOUT
+import me.ahoo.wow.command.wait.DefaultWaitCoordinator
+import me.ahoo.wow.command.wait.RecordingCommandWaitNotifier
+import me.ahoo.wow.command.wait.SimpleCommandWaitEndpoint
+import me.ahoo.wow.command.wait.TestCommandMessage
+import me.ahoo.wow.command.wait.WaitCoordinator
+import me.ahoo.wow.command.wait.WaitLastHandle
+import me.ahoo.wow.command.wait.WaitPlan
+import me.ahoo.wow.command.wait.WaitSignal
+import me.ahoo.wow.command.wait.WaitStreamHandle
+import me.ahoo.wow.command.wait.testSignal
+import me.ahoo.wow.command.wait.withTimeout
+import me.ahoo.wow.messaging.MessageSubscription
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+import java.time.Duration
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+
+class DefaultCommandGatewayTimeoutTest {
+    @Test
+    fun `send and wait for sent default timeout bounds pending command bus`() {
+        val gateway = commandGateway(
+            commandBus = TimeoutTestCommandBus(Mono.never()),
+            waitCoordinator = DefaultWaitCoordinator(),
+        )
+
+        StepVerifier.withVirtualTime {
+            gateway.sendAndWaitForSent(TestCommandMessage(id = "command-id"))
+        }
+            .thenAwait(DEFAULT_WAIT_TIMEOUT)
+            .expectError(TimeoutException::class.java)
+            .verify(Duration.ofSeconds(1))
+    }
+
+    @Test
+    fun `send and wait default timeout releases handle and allows wait id reuse`() {
+        val waitCoordinator = DefaultWaitCoordinator()
+        val gateway = commandGateway(waitCoordinator = waitCoordinator)
+        val waitPlan = CommandWait.processed("wait-command-id")
+
+        StepVerifier.withVirtualTime {
+            gateway.sendAndWait(TestCommandMessage(id = "command-id"), waitPlan)
+        }
+            .then { waitCoordinator.contains("wait-command-id").assert().isTrue() }
+            .thenAwait(DEFAULT_WAIT_TIMEOUT)
+            .expectError(TimeoutException::class.java)
+            .verify()
+
+        waitCoordinator.contains("wait-command-id").assert().isFalse()
+        waitCoordinator.createLast(CommandWait.processed("wait-command-id")).cancel()
+    }
+
+    @Test
+    fun `send and wait timeout releases handle while command bus is pending`() {
+        val commandBus = TimeoutTestCommandBus(Mono.never())
+        val waitCoordinator = DefaultWaitCoordinator()
+        val gateway = commandGateway(commandBus = commandBus, waitCoordinator = waitCoordinator)
+        val waitPlan = CommandWait.processed("wait-command-id")
+            .withTimeout(Duration.ofSeconds(1))
+
+        StepVerifier.withVirtualTime {
+            gateway.sendAndWait(TestCommandMessage(id = "command-id"), waitPlan)
+        }
+            .then { waitCoordinator.contains("wait-command-id").assert().isTrue() }
+            .thenAwait(Duration.ofSeconds(1))
+            .expectError(TimeoutException::class.java)
+            .verify()
+
+        waitCoordinator.contains("wait-command-id").assert().isFalse()
+    }
+
+    @Test
+    fun `send and wait timeout cancels custom handle once while command bus is pending`() {
+        val waitCoordinator = CountingWaitCoordinator()
+        val gateway = commandGateway(
+            commandBus = TimeoutTestCommandBus(Mono.never()),
+            waitCoordinator = waitCoordinator,
+        )
+        val waitPlan = CommandWait.processed("wait-command-id")
+            .withTimeout(Duration.ofSeconds(1))
+
+        StepVerifier.withVirtualTime {
+            gateway.sendAndWait(TestCommandMessage(id = "command-id"), waitPlan)
+        }
+            .thenAwait(Duration.ofSeconds(1))
+            .expectError(TimeoutException::class.java)
+            .verify()
+
+        waitCoordinator.lastHandle.cancelCalls.get().assert().isEqualTo(1)
+    }
+
+    @Test
+    fun `send and wait stream timeout is an absolute deadline and releases handle`() {
+        val waitCoordinator = DefaultWaitCoordinator()
+        val gateway = commandGateway(waitCoordinator = waitCoordinator)
+        val waitPlan = CommandWait.snapshot("wait-command-id")
+            .withTimeout(Duration.ofSeconds(1))
+
+        StepVerifier.withVirtualTime {
+            gateway.sendAndWaitStream(TestCommandMessage(id = "command-id"), waitPlan)
+        }
+            .assertNext { it.stage.assert().isEqualTo(CommandStage.SENT) }
+            .thenAwait(Duration.ofMillis(900))
+            .then {
+                waitCoordinator.signal(
+                    testSignal(
+                        stage = CommandStage.PROCESSED,
+                        waitCommandId = "wait-command-id",
+                        commandId = "command-id",
+                    )
+                ).assert().isTrue()
+            }
+            .assertNext { it.stage.assert().isEqualTo(CommandStage.PROCESSED) }
+            .thenAwait(Duration.ofMillis(100))
+            .expectError(TimeoutException::class.java)
+            .verify()
+
+        waitCoordinator.contains("wait-command-id").assert().isFalse()
+    }
+
+    private fun commandGateway(
+        commandBus: CommandBus = TimeoutTestCommandBus(),
+        waitCoordinator: WaitCoordinator,
+    ): DefaultCommandGateway =
+        DefaultCommandGateway(
+            commandWaitEndpoint = SimpleCommandWaitEndpoint("test-command-wait-endpoint"),
+            commandBus = commandBus,
+            validator = NoOpValidator,
+            requestIdChecker = RequestIdChecker { _, _ -> Mono.just(true) },
+            waitCoordinator = waitCoordinator,
+            commandWaitNotifier = RecordingCommandWaitNotifier(),
+        )
+}
+
+private class CountingWaitCoordinator : WaitCoordinator {
+    lateinit var lastHandle: CountingWaitLastHandle
+        private set
+
+    override fun createLast(plan: WaitPlan): WaitLastHandle =
+        CountingWaitLastHandle(plan).also {
+            lastHandle = it
+        }
+
+    override fun createStream(plan: WaitPlan): WaitStreamHandle =
+        error("Stream handle is not used by this test.")
+
+    override fun signal(signal: WaitSignal): Boolean = false
+
+    override fun contains(waitCommandId: String): Boolean = false
+}
+
+private class CountingWaitLastHandle(
+    override val plan: WaitPlan,
+) : WaitLastHandle {
+    override val waitCommandId: String = plan.waitCommandId
+    val cancelCalls = AtomicInteger()
+
+    override fun await(): Mono<WaitSignal> = Mono.never()
+
+    override fun next(signal: WaitSignal): Boolean = false
+
+    override fun error(throwable: Throwable) = Unit
+
+    override fun cancel() {
+        cancelCalls.incrementAndGet()
+    }
+}
+
+private class TimeoutTestCommandBus(
+    private val sendResult: Mono<Void> = Mono.empty(),
+) : CommandBus {
+    override fun send(message: CommandMessage<*>): Mono<Void> = sendResult
+
+    override fun receive(subscription: MessageSubscription): Flux<ServerCommandExchange<*>> = Flux.empty()
+}

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitPlanTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/wait/WaitPlanTest.kt
@@ -19,6 +19,8 @@ import me.ahoo.wow.command.wait.chain.WaitingChainTail.Companion.toWaitingChainT
 import me.ahoo.wow.command.wait.stage.StageWaitState
 import me.ahoo.wow.messaging.DefaultHeader
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.Duration
 
 class WaitPlanTest {
     @Test
@@ -89,6 +91,43 @@ class WaitPlanTest {
         header[COMMAND_WAIT_ENDPOINT].assert().isEqualTo(TEST_ENDPOINT)
         header[COMMAND_WAIT_STAGE].assert().isEqualTo(CommandStage.PROJECTED.name)
         header.extractWaitFunction().assert().isEqualTo(testNamedFunction())
+    }
+
+    @Test
+    fun waitPlanShouldHaveDefaultAndCustomTimeouts() {
+        val plan = CommandWait.processed("wait-id")
+
+        plan.timeout.assert().isEqualTo(DEFAULT_WAIT_TIMEOUT)
+
+        val timedPlan = plan.withTimeout(Duration.ofMinutes(2))
+        timedPlan.timeout.assert().isEqualTo(Duration.ofMinutes(2))
+        timedPlan.waitCommandId.assert().isEqualTo(plan.waitCommandId)
+        timedPlan.target.assert().isEqualTo(plan.target)
+        timedPlan.supportVoidCommand.assert().isEqualTo(plan.supportVoidCommand)
+    }
+
+    @Test
+    fun waitPlanTimeoutShouldRemainLocalWhenHeadersArePropagated() {
+        val header = DefaultHeader.empty()
+        val endpoint = SimpleCommandWaitEndpoint(TEST_ENDPOINT)
+        val timedPlan = CommandWait.processed("wait-id")
+            .withTimeout(Duration.ofMinutes(2))
+
+        timedPlan.propagate(endpoint, header)
+
+        header.extractWaitPlan()!!.plan.timeout.assert().isEqualTo(DEFAULT_WAIT_TIMEOUT)
+    }
+
+    @Test
+    fun waitPlanTimeoutShouldBePositive() {
+        val plan = CommandWait.processed("wait-id")
+
+        assertThrows<IllegalArgumentException> {
+            plan.withTimeout(Duration.ZERO)
+        }
+        assertThrows<IllegalArgumentException> {
+            plan.withTimeout(Duration.ofMillis(-1))
+        }
     }
 
     @Test

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/wait/TracingCommandGateway.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/wait/TracingCommandGateway.kt
@@ -29,6 +29,9 @@ import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 class TracingCommandGateway(override val delegate: CommandGateway) : Traced, CommandGateway, Decorator<CommandGateway> {
+    override val enforcesCommandWaitTimeout: Boolean
+        get() = delegate.enforcesCommandWaitTimeout
+
     override fun <C : Any> sendAndWaitStream(
         command: CommandMessage<C>,
         waitPlan: WaitPlan

--- a/wow-opentelemetry/src/test/kotlin/me/ahoo/wow/opentelemetry/wait/TracingCommandGatewayWaitTest.kt
+++ b/wow-opentelemetry/src/test/kotlin/me/ahoo/wow/opentelemetry/wait/TracingCommandGatewayWaitTest.kt
@@ -97,6 +97,7 @@ class TracingCommandGatewayWaitTest {
             waitCoordinator = waitCoordinator,
             commandWaitNotifier = LocalCommandWaitNotifier(waitCoordinator),
         ).tracing()
+        commandGateway.enforcesCommandWaitTimeout.assert().isTrue()
         val command = MockCreateAggregate(
             id = generateGlobalId(),
             data = generateGlobalId(),

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt
@@ -16,12 +16,16 @@ package me.ahoo.wow.webflux.route.command
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.command.CommandGateway
 import me.ahoo.wow.command.CommandResult
+import me.ahoo.wow.command.wait.timeout
+import me.ahoo.wow.command.wait.withTimeout
 import me.ahoo.wow.openapi.metadata.AggregateRouteMetadata
 import me.ahoo.wow.webflux.route.command.extractor.CommandMessageExtractor
 import me.ahoo.wow.webflux.route.policy.CommandWaitPolicy
 import org.reactivestreams.Publisher
 import org.springframework.web.reactive.function.server.ServerRequest
 import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.time.Duration
 
 class CommandHandler(
     private val commandGateway: CommandGateway,
@@ -44,16 +48,31 @@ class CommandHandler(
 
     private fun sendCommand(commandMessage: CommandMessage<Any>, request: ServerRequest): Publisher<CommandResult> {
         val waitPlan = commandWaitPolicy.waitPlan(request, commandMessage)
-        val commandWaitTimeout = commandWaitPolicy.timeout(request)
-        if (request.isSse()) {
-            return commandGateway.sendAndWaitStream(
+            .withTimeout(commandWaitPolicy.timeout(request))
+        return if (request.isSse()) {
+            commandGateway.sendAndWaitStream(
                 command = commandMessage,
                 waitPlan = waitPlan
-            ).timeout(commandWaitTimeout)
+            ).ensureWaitTimeout(commandWaitTimeout = waitPlan.timeout)
+        } else {
+            commandGateway.sendAndWait(
+                command = commandMessage,
+                waitPlan = waitPlan
+            ).ensureWaitTimeout(commandWaitTimeout = waitPlan.timeout)
         }
-        return commandGateway.sendAndWait(
-            command = commandMessage,
-            waitPlan = waitPlan
-        ).timeout(commandWaitTimeout)
     }
+
+    private fun Flux<CommandResult>.ensureWaitTimeout(commandWaitTimeout: Duration): Flux<CommandResult> =
+        if (commandGateway.enforcesCommandWaitTimeout) {
+            this
+        } else {
+            timeout(commandWaitTimeout)
+        }
+
+    private fun Mono<CommandResult>.ensureWaitTimeout(commandWaitTimeout: Duration): Mono<CommandResult> =
+        if (commandGateway.enforcesCommandWaitTimeout) {
+            this
+        } else {
+            timeout(commandWaitTimeout)
+        }
 }

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.webflux.route.command
 
 import me.ahoo.wow.command.CommandGateway
+import me.ahoo.wow.command.wait.DEFAULT_WAIT_TIMEOUT
 import me.ahoo.wow.openapi.contract.BuiltInHttpRouteHandlerKeys
 import me.ahoo.wow.openapi.contract.HttpRouteContract
 import me.ahoo.wow.openapi.contract.HttpRouteHandlerMetadata
@@ -32,7 +33,7 @@ import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.switchIfEmpty
 import java.time.Duration
 
-val DEFAULT_TIME_OUT: Duration = Duration.ofSeconds(30)
+val DEFAULT_TIME_OUT: Duration = DEFAULT_WAIT_TIMEOUT
 
 /**
  * [org.springframework.web.reactive.result.method.annotation.RequestMappingHandlerMapping]

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerTest.kt
@@ -16,6 +16,7 @@ package me.ahoo.wow.webflux.route.command
 import com.sun.security.auth.UserPrincipal
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.command.CommandGateway
@@ -24,6 +25,7 @@ import me.ahoo.wow.command.factory.SimpleCommandMessageFactory
 import me.ahoo.wow.command.validation.NoOpValidator
 import me.ahoo.wow.command.wait.CommandStage
 import me.ahoo.wow.command.wait.WaitPlan
+import me.ahoo.wow.command.wait.timeout
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.openapi.aggregate.command.CommandComponent
 import me.ahoo.wow.openapi.metadata.aggregateRouteMetadata
@@ -41,6 +43,7 @@ import org.springframework.http.MediaType
 import org.springframework.mock.web.reactive.function.server.MockServerRequest
 import reactor.core.publisher.Mono
 import reactor.kotlin.test.test
+import reactor.test.StepVerifier
 import java.time.Duration
 import java.util.concurrent.TimeoutException
 
@@ -114,15 +117,17 @@ class CommandHandlerTest {
     }
 
     @Test
-    fun `should use command wait policy timeout`() {
+    fun `should pass command wait policy timeout to gateway without adding a handler timer`() {
         val request = MockServerRequest.builder().build()
+        val waitPlanSlot = slot<WaitPlan>()
         val commandMessage = mockk<CommandMessage<Any>> {
             every { commandId } returns generateGlobalId()
             every { contextName } returns "contextName"
         }
         val commandGateway = mockk<CommandGateway> {
+            every { enforcesCommandWaitTimeout } returns true
             every {
-                sendAndWait(commandMessage, any<WaitPlan>())
+                sendAndWait(commandMessage, capture(waitPlanSlot))
             } returns Mono.never()
         }
         val commandMessageExtractor = mockk<CommandMessageExtractor> {
@@ -136,13 +141,30 @@ class CommandHandlerTest {
             commandWaitPolicy = CommandWaitPolicy(Duration.ofMillis(20))
         )
 
-        commandHandler.handle(
-            request,
-            MockCreateAggregate(generateGlobalId(), generateGlobalId()),
-            MOCK_AGGREGATE_METADATA.command.aggregateType.aggregateRouteMetadata()
-        ).test()
+        StepVerifier.withVirtualTime {
+            commandHandler.handle(
+                request,
+                MockCreateAggregate(generateGlobalId(), generateGlobalId()),
+                MOCK_AGGREGATE_METADATA.command.aggregateType.aggregateRouteMetadata()
+            )
+        }
+            .thenAwait(Duration.ofMillis(20))
+            .thenCancel()
+            .verify()
+
+        waitPlanSlot.captured.timeout.assert().isEqualTo(Duration.ofMillis(20))
+
+        every { commandGateway.enforcesCommandWaitTimeout } returns false
+        StepVerifier.withVirtualTime {
+            commandHandler.handle(
+                request,
+                MockCreateAggregate(generateGlobalId(), generateGlobalId()),
+                MOCK_AGGREGATE_METADATA.command.aggregateType.aggregateRouteMetadata()
+            )
+        }
+            .thenAwait(Duration.ofMillis(20))
             .expectError(TimeoutException::class.java)
-            .verify(Duration.ofMillis(500))
+            .verify()
     }
 
     @Test


### PR DESCRIPTION
## Summary

- add a 30-second default end-to-end deadline for `sendAndWait`, `sendAndWaitStream`, and the SENT fast path
- support per-call overrides through the local-only `WaitPlan.withTimeout(Duration)` decorator
- make `using` the single owner of `WaitHandle` cleanup and preserve an absolute deadline for streaming waits
- avoid duplicate WebFlux timers for built-in gateways while retaining the previous boundary timeout for legacy custom `CommandGateway` implementations
- document the low-level `WaitHandle` lifecycle contract and update English/Chinese command gateway guidance

## Root cause

A registered wait handle was removed only after a terminal wait signal, an error, or subscriber cancellation. If command dispatch succeeded but a later processed/snapshot/projection/saga signal was lost, the returned publisher never terminated and the handle remained in `DefaultWaitCoordinator.handles`, preventing wait ID reuse and accumulating retained handles.

## Impact

Command waits now fail with `TimeoutException` when their deadline expires and release the registered handle. Existing callers receive the 30-second default; longer operations can opt in to another duration with `WaitPlan.withTimeout`. The timeout remains caller-local and is not propagated through command headers.

Existing third-party `CommandGateway` implementations remain compatible: `enforcesCommandWaitTimeout` defaults to `false`, so WebFlux retains its previous boundary timeout until an implementation explicitly reports gateway-level enforcement.

## Validation

- `./gradlew :wow-core:check :wow-webflux:check :wow-opentelemetry:check :wow-spring-boot-starter:test --tests 'me.ahoo.wow.spring.boot.starter.webflux.WebFluxAutoConfigurationTest' :wow-benchmarks:compileJmhKotlin`
- `./gradlew :wow-benchmarks:benchmarkSmoke`
- `cd documentation && pnpm docs:build`
- `git diff --check`
