### PR TITLE
perf(compensation): optimize failed snapshot searches

### DIFF
--- a/compensation/dashboard/src/features/Failed/FindCategory.ts
+++ b/compensation/dashboard/src/features/Failed/FindCategory.ts
@@ -17,8 +17,8 @@ import {
   type Condition,
   eq,
   gt,
+  isIn,
   lte,
-  ne,
   or,
   RecoverableType,
 } from "@ahoo-wang/fetcher-wow";
@@ -37,12 +37,22 @@ export enum FindCategory {
   Unrecoverable = "Unrecoverable",
 }
 
+const RETRYABLE_RECOVERABILITY = [
+  RecoverableType.RECOVERABLE,
+  RecoverableType.UNKNOWN,
+];
+
+const ACTIVE_STATUSES = [
+  ExecutionFailedStatus.FAILED,
+  ExecutionFailedStatus.PREPARED,
+];
+
 export class RetryConditions {
   static toRetryCondition(): Condition {
     return and(
-      ne(
+      isIn(
         ExecutionFailedAggregatedFields.STATE_RECOVERABLE,
-        RecoverableType.UNRECOVERABLE,
+        ...RETRYABLE_RECOVERABILITY,
       ),
       eq(ExecutionFailedAggregatedFields.STATE_IS_RETRYABLE, true),
       or(
@@ -80,9 +90,9 @@ export class RetryConditions {
   static nextRetryCondition(): Condition {
     const currentTime = new Date().getTime();
     return and(
-      ne(
+      isIn(
         ExecutionFailedAggregatedFields.STATE_RECOVERABLE,
-        RecoverableType.UNRECOVERABLE,
+        ...RETRYABLE_RECOVERABILITY,
       ),
       eq(ExecutionFailedAggregatedFields.STATE_IS_RETRYABLE, true),
       lte(
@@ -109,13 +119,13 @@ export class RetryConditions {
   }
 
   static nonRetryableCondition = and(
-    ne(
+    isIn(
       ExecutionFailedAggregatedFields.STATE_RECOVERABLE,
-      RecoverableType.UNRECOVERABLE,
+      ...RETRYABLE_RECOVERABILITY,
     ),
-    ne(
+    isIn(
       ExecutionFailedAggregatedFields.STATE_STATUS,
-      ExecutionFailedStatus.SUCCEEDED,
+      ...ACTIVE_STATUSES,
     ),
     eq(ExecutionFailedAggregatedFields.STATE_IS_BELOW_RETRY_THRESHOLD, false),
   );
@@ -129,9 +139,9 @@ export class RetryConditions {
       ExecutionFailedAggregatedFields.STATE_RECOVERABLE,
       RecoverableType.UNRECOVERABLE,
     ),
-    ne(
+    isIn(
       ExecutionFailedAggregatedFields.STATE_STATUS,
-      ExecutionFailedStatus.SUCCEEDED,
+      ...ACTIVE_STATUSES,
     ),
   );
 

--- a/compensation/dashboard/src/features/Failed/__tests__/FindCategory.test.ts
+++ b/compensation/dashboard/src/features/Failed/__tests__/FindCategory.test.ts
@@ -1,4 +1,17 @@
-import { describe, it, expect } from "vitest";
+import {
+  and,
+  eq,
+  gt,
+  isIn,
+  lte,
+  or,
+  RecoverableType,
+} from "@ahoo-wang/fetcher-wow";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ExecutionFailedAggregatedFields,
+  ExecutionFailedStatus,
+} from "../../../generated";
 import { RetryConditions, FindCategory } from "../FindCategory.ts";
 
 describe("FindCategory", () => {
@@ -15,33 +28,136 @@ describe("FindCategory", () => {
   });
 
   describe("RetryConditions", () => {
-    it("toRetryCondition returns correct condition", () => {
-      const condition = RetryConditions.toRetryCondition();
-      expect(condition).toBeDefined();
-      // We can't easily test the exact structure without mocking the fetcher-wow functions
-      // But we can verify it returns a condition object
+    const currentTime = 1785501209222;
+    const retryableRecoverability = [
+      RecoverableType.RECOVERABLE,
+      RecoverableType.UNKNOWN,
+    ];
+    const activeStatuses = [
+      ExecutionFailedStatus.FAILED,
+      ExecutionFailedStatus.PREPARED,
+    ];
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(currentTime);
     });
 
-    it("executingCondition returns correct condition", () => {
-      const condition = RetryConditions.executingCondition();
-      expect(condition).toBeDefined();
+    afterEach(() => {
+      vi.useRealTimers();
     });
 
-    it("nextRetryCondition returns correct condition", () => {
-      const condition = RetryConditions.nextRetryCondition();
-      expect(condition).toBeDefined();
+    it("uses index-friendly recoverability values for to-retry", () => {
+      expect(RetryConditions.toRetryCondition()).toEqual(
+        and(
+          isIn(
+            ExecutionFailedAggregatedFields.STATE_RECOVERABLE,
+            ...retryableRecoverability,
+          ),
+          eq(ExecutionFailedAggregatedFields.STATE_IS_RETRYABLE, true),
+          or(
+            eq(
+              ExecutionFailedAggregatedFields.STATE_STATUS,
+              ExecutionFailedStatus.FAILED,
+            ),
+            and(
+              eq(
+                ExecutionFailedAggregatedFields.STATE_STATUS,
+                ExecutionFailedStatus.PREPARED,
+              ),
+              lte(
+                ExecutionFailedAggregatedFields.STATE_RETRY_STATE_TIMEOUT_AT,
+                currentTime,
+              ),
+            ),
+          ),
+        ),
+      );
     });
 
-    it("nonRetryableCondition is defined", () => {
-      expect(RetryConditions.nonRetryableCondition).toBeDefined();
+    it("keeps the executing range condition", () => {
+      expect(RetryConditions.executingCondition()).toEqual(
+        and(
+          eq(
+            ExecutionFailedAggregatedFields.STATE_STATUS,
+            ExecutionFailedStatus.PREPARED,
+          ),
+          gt(
+            ExecutionFailedAggregatedFields.STATE_RETRY_STATE_TIMEOUT_AT,
+            currentTime,
+          ),
+        ),
+      );
+    });
+
+    it("uses index-friendly recoverability values for next-retry", () => {
+      expect(RetryConditions.nextRetryCondition()).toEqual(
+        and(
+          isIn(
+            ExecutionFailedAggregatedFields.STATE_RECOVERABLE,
+            ...retryableRecoverability,
+          ),
+          eq(ExecutionFailedAggregatedFields.STATE_IS_RETRYABLE, true),
+          lte(
+            ExecutionFailedAggregatedFields.STATE_RETRY_STATE_NEXT_RETRY_AT,
+            currentTime,
+          ),
+          or(
+            eq(
+              ExecutionFailedAggregatedFields.STATE_STATUS,
+              ExecutionFailedStatus.FAILED,
+            ),
+            and(
+              eq(
+                ExecutionFailedAggregatedFields.STATE_STATUS,
+                ExecutionFailedStatus.PREPARED,
+              ),
+              lte(
+                ExecutionFailedAggregatedFields.STATE_RETRY_STATE_TIMEOUT_AT,
+                currentTime,
+              ),
+            ),
+          ),
+        ),
+      );
+    });
+
+    it("uses closed enum values for non-retryable", () => {
+      expect(RetryConditions.nonRetryableCondition).toEqual(
+        and(
+          isIn(
+            ExecutionFailedAggregatedFields.STATE_RECOVERABLE,
+            ...retryableRecoverability,
+          ),
+          isIn(
+            ExecutionFailedAggregatedFields.STATE_STATUS,
+            ...activeStatuses,
+          ),
+          eq(
+            ExecutionFailedAggregatedFields.STATE_IS_BELOW_RETRY_THRESHOLD,
+            false,
+          ),
+        ),
+      );
     });
 
     it("successCondition is defined", () => {
       expect(RetryConditions.successCondition).toBeDefined();
     });
 
-    it("unrecoverableCondition is defined", () => {
-      expect(RetryConditions.unrecoverableCondition).toBeDefined();
+    it("uses active status values for unrecoverable", () => {
+      expect(RetryConditions.unrecoverableCondition).toEqual(
+        and(
+          eq(
+            ExecutionFailedAggregatedFields.STATE_RECOVERABLE,
+            RecoverableType.UNRECOVERABLE,
+          ),
+          isIn(
+            ExecutionFailedAggregatedFields.STATE_STATUS,
+            ...activeStatuses,
+          ),
+        ),
+      );
     });
   });
 });

--- a/compensation/wow-compensation-server/src/main/kotlin/me/ahoo/wow/compensation/server/failed/SnapshotFindNextRetry.kt
+++ b/compensation/wow-compensation-server/src/main/kotlin/me/ahoo/wow/compensation/server/failed/SnapshotFindNextRetry.kt
@@ -45,7 +45,10 @@ class SnapshotFindNextRetry(
             limit(limit)
             condition {
                 nestedState()
-                RECOVERABLE ne RecoverableType.UNRECOVERABLE.name
+                RECOVERABLE isIn listOf(
+                    RecoverableType.RECOVERABLE.name,
+                    RecoverableType.UNKNOWN.name,
+                )
                 IS_RETRYABLE eq true
                 RETRY_STATE__NEXT_RETRY_AT lte currentTime
                 or {

--- a/compensation/wow-compensation-server/src/test/kotlin/me/ahoo/wow/compensation/server/failed/SnapshotFindNextRetryTest.kt
+++ b/compensation/wow-compensation-server/src/test/kotlin/me/ahoo/wow/compensation/server/failed/SnapshotFindNextRetryTest.kt
@@ -1,12 +1,17 @@
 package me.ahoo.wow.compensation.server.failed
 
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.exception.RecoverableType
+import me.ahoo.wow.api.query.IListQuery
 import me.ahoo.wow.compensation.api.ExecutionFailedStatus
-import me.ahoo.wow.compensation.domain.ExecutionFailedStateProperties
+import me.ahoo.wow.compensation.domain.ExecutionFailedState
 import me.ahoo.wow.query.dsl.condition
-import me.ahoo.wow.query.snapshot.nestedState
+import me.ahoo.wow.query.snapshot.SnapshotQueryService
 import org.junit.jupiter.api.Test
+import reactor.core.publisher.Flux
 
 class SnapshotFindNextRetryTest {
     companion object {
@@ -22,9 +27,23 @@ class SnapshotFindNextRetryTest {
 
     @Test
     fun `should build correct find next retry condition`() {
-        val currentTime = System.currentTimeMillis()
+        val querySlot = slot<IListQuery>()
+        val queryService = mockk<SnapshotQueryService<ExecutionFailedState>> {
+            every { list(capture(querySlot)) } returns Flux.empty()
+        }
+        val before = System.currentTimeMillis()
+        SnapshotFindNextRetry(queryService).findNextRetry(10).collectList().block()
+        val after = System.currentTimeMillis()
+        val nextQuery = querySlot.captured
+        val currentTime = nextQuery.condition.children
+            .first { it.field == NEXT_RETRY_AT_FIELD }
+            .value as Long
+
         val originalCondition = condition {
-            RECOVERABLE_FIELD ne RecoverableType.UNRECOVERABLE.name
+            RECOVERABLE_FIELD isIn listOf(
+                RecoverableType.RECOVERABLE.name,
+                RecoverableType.UNKNOWN.name,
+            )
             IS_RETRYABLE_FIELD eq true
             NEXT_RETRY_AT_FIELD lte currentTime
             or {
@@ -36,19 +55,9 @@ class SnapshotFindNextRetryTest {
             }
         }
 
-        val nextCondition = condition {
-            nestedState()
-            ExecutionFailedStateProperties.RECOVERABLE ne RecoverableType.UNRECOVERABLE.name
-            ExecutionFailedStateProperties.IS_RETRYABLE eq true
-            ExecutionFailedStateProperties.RETRY_STATE__NEXT_RETRY_AT lte currentTime
-            or {
-                ExecutionFailedStateProperties.STATUS eq ExecutionFailedStatus.FAILED.name
-                and {
-                    ExecutionFailedStateProperties.STATUS eq ExecutionFailedStatus.PREPARED.name
-                    ExecutionFailedStateProperties.RETRY_STATE__TIMEOUT_AT lte currentTime
-                }
-            }
-        }
-        nextCondition.assert().isEqualTo(originalCondition)
+        currentTime.assert().isGreaterThanOrEqualTo(before)
+        currentTime.assert().isLessThanOrEqualTo(after)
+        nextQuery.limit.assert().isEqualTo(10)
+        nextQuery.condition.assert().isEqualTo(originalCondition)
     }
 }

--- a/deploy/compensation/init-schema.js
+++ b/deploy/compensation/init-schema.js
@@ -5,6 +5,10 @@ db.execution_failed_snapshot.createIndex({ "state.isRetryable" : "hashed" })
 db.execution_failed_snapshot.createIndex({ "state.status" : "hashed" })
 db.execution_failed_snapshot.createIndex({ "state.retryState.timeoutAt" : 1 })
 db.execution_failed_snapshot.createIndex({ "state.retryState.nextRetryAt" : 1 })
+db.execution_failed_snapshot.createIndex(
+    { "tenantId" : 1, "state.status" : 1, "state.recoverable" : 1, "deleted" : 1, "_id" : "hashed" },
+    { name : "tenantId_1_state.status_1_state.recoverable_1_deleted_1__id_hashed" }
+)
 
 sh.enableSharding("compensation_db");
 sh.shardCollection("compensation_db.execution_failed_snapshot", { "_id" : "hashed" });

--- a/wow-mongo/src/init-schema/init-schema.js
+++ b/wow-mongo/src/init-schema/init-schema.js
@@ -19,5 +19,9 @@ sh.shardCollection("wow_db.event_stream", { "aggregateId" : "hashed" });
 
 
 sh.enableSharding("compensation_db");
+db.getSiblingDB("compensation_db").execution_failed_snapshot.createIndex(
+    { "tenantId" : 1, "state.status" : 1, "state.recoverable" : 1, "deleted" : 1, "_id" : "hashed" },
+    { name : "tenantId_1_state.status_1_state.recoverable_1_deleted_1__id_hashed" }
+)
 sh.shardCollection("compensation_db.execution_failed_snapshot", { "_id" : "hashed" });
 sh.shardCollection("compensation_db.execution_failed_event_stream", { "aggregateId" : "hashed" });


### PR DESCRIPTION
## What changed

- Replace broad `NE` predicates with closed-enum `IN` predicates in the compensation dashboard retry categories.
- Apply the same recoverability rewrite to the server-side next-retry scheduler query.
- Add exact condition-structure tests for dashboard and scheduler queries.
- Persist a tenant-aware compound MongoDB index for the failed snapshot collection:
  `tenantId -> state.status -> state.recoverable -> deleted -> _id hashed`.

## Why

The dashboard pagination path runs both `countDocuments` and the first-page `find`. Broad `$ne` predicates caused large scans. Production diagnosis also showed that the query service automatically adds `tenantId`; omitting it from the compound index forced the sharded exact-count aggregation to fetch roughly 302k documents per shard.

## Impact

Production read-only validation with the tenant-aware index produced:

- Q1: 32 ms
- Q2: 15 ms
- Q3: 24 ms
- Q4: 28 ms
- Q5: 23 ms
- Q6: 574 ms (previously about 4.6 s)

The corrected index was used on all three shards, and MongoDB CPU remained below 100m during final validation.

## Verification

- `./gradlew :wow-compensation-server:check --no-daemon`
- `pnpm test` — 16 files, 53 tests passed
- `pnpm lint`
- `pnpm build`
- `git diff --check`
