### PR TITLE
chore(skills): add Wow v6 to v8 migration

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -20,6 +20,7 @@ graph TD
     A[用户任务] --> C{任务意图}
     C -->|明确审查| E[wow-code-review]
     C -->|明确诊断| F[wow-debugging]
+    C -->|Wow v6 到 v8 迁移| H[wow-v6-to-v8-migration]
     C -->|Aggregate/Saga 端到端实现| D[wow-development-workflow]
     C -->|混合、单点查询或其他聚焦实现| B[wow Router]
     B --> D
@@ -51,6 +52,7 @@ graph TD
 | `wow-development-workflow` | 端到端开发工作流。覆盖需求确认、源码发现、领域建模、Aggregate Flow、Saga Flow、测试、增强、审查和验证。 |
 | `wow-code-review` | Wow 语义优先的代码审查。重点检查事件溯源、聚合边界、Saga 编排、测试覆盖和 API metadata。 |
 | `wow-debugging` | Wow 管线问题定位。按命令、事件、溯源、Saga、等待计划、Query DSL、配置和测试阶段定位根因。 |
+| `wow-v6-to-v8-migration` | 将已有 Wow v6 应用按平台、源码、数据、运行时与发布门禁迁移到固定的 Wow v8 版本。 |
 
 ## 工作流哲学
 
@@ -103,6 +105,7 @@ graph TD
 | 审查 PR 或 diff | `wow-code-review` |
 | 审查并修复 PR 或 diff | `wow-code-review` ->（Aggregate/Saga：`wow-development-workflow`；其他：`wow`）-> `wow-code-review` post-fix review；仅对新发现且已授权的问题重复 |
 | 定位失败或异常行为 | `wow-debugging` |
+| 审计、规划、实施或验证 Wow v6 到 v8 迁移 | `wow-v6-to-v8-migration` |
 | 混合任务 | `wow` -> 对应 specialist |
 | 查询单点 API 或注解规则 | `wow` -> `wow/references/*` |
 | 实现 Projection 或 EventProcessor | `wow` -> `annotations.md`、`testing.md` |
@@ -130,6 +133,7 @@ graph TD
 | Configuration | `wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/**/*Properties.kt` |
 | Saga retry policy | `wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/Retry.kt` |
 | PrepareKey | `wow-core/src/main/kotlin/me/ahoo/wow/infra/prepare/PrepareKey.kt`, `PreparedValue.kt`; `wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareKeyAutoRegistrar.kt` |
+| v6 到 v8 迁移 | `documentation/docs/zh/guide/migration/v6-to-v8.md`, `documentation/docs/zh/guide/migration/runtime-orchestration.md` |
 
 ## 验证
 

--- a/skills/plugins.json
+++ b/skills/plugins.json
@@ -3,7 +3,7 @@
   "plugins": [
     {
       "name": "ahoo-wow-skills",
-      "description": "Agent skills for building, testing, reviewing, and debugging Wow reactive DDD, Event Sourcing, and CQRS microservices.",
+      "description": "Agent skills for building, testing, reviewing, debugging, and migrating Wow reactive DDD, Event Sourcing, and CQRS microservices.",
       "skills": {
         "include": [
           "*"
@@ -22,7 +22,8 @@
         "kotlin",
         "spring-boot",
         "reactor",
-        "microservices"
+        "microservices",
+        "migration"
       ],
       "category": "development",
       "interface": {
@@ -30,7 +31,7 @@
         "capabilities": [
           "Skills"
         ],
-        "defaultPrompt": "Help me design, test, review, and debug Wow DDD, Event Sourcing, and CQRS services."
+        "defaultPrompt": "Help me design, test, review, debug, and migrate Wow DDD, Event Sourcing, and CQRS services."
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/skills/wow-v6-to-v8-migration/SKILL.md
+++ b/skills/wow-v6-to-v8-migration/SKILL.md
@@ -99,7 +99,7 @@ flowchart LR
 1. 根据精确目标版本判断 [迁移契约](references/migration-contracts.md) 中的 Snapshot、Redis 和 Mongo 条目是否生效。
 2. 对每个 store 输出 source→target 映射、数据类型、cardinality、版本范围、checksum、owner 和处置方式。
 3. 对自定义 `SnapshotStore` 验证原子 compare-and-write；禁止客户端 `load()` 后无条件保存。
-4. 目标为 v8.9.0+ 且使用 Redis EventStore 时，设计并单独评审离线 canonical v2 迁移器；运行时没有内置迁移器、双读或双写兜底。
+4. 目标为 v8.9.0+ 且使用 Redis EventStore、Redis SnapshotStore 或 Redis PrepareKey 时，分别设计并单独评审 canonical v2 离线迁移或受控重建方案；运行时没有内置迁移器、双读或双写兜底。
 5. 使用 Mongo 时，验证 database 与 bounded context 一对一、存量 collection、PrepareKey 归属、服务端版本和索引兼容性。
 6. 用 manifest、checksum、cursor 和幂等批次保存迁移证据。任何差集、重复 aggregate ID、孤立 Key 或所有权冲突都必须先处置。
 

--- a/skills/wow-v6-to-v8-migration/SKILL.md
+++ b/skills/wow-v6-to-v8-migration/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: wow-v6-to-v8-migration
+description: Audit, plan, implement, and verify migrations of existing Wow framework applications from v6 and Spring Boot 3 to a pinned Wow v8 and Spring Boot 4 release. Use for v6-to-v8 dependency upgrades, compilation or configuration migration, removed Wow APIs, Jackson 3 source changes, generated metadata refreshes, custom runtime lifecycle adaptation, SnapshotStore contract changes, Redis or Mongo data cutovers, canary rollout, rollback planning, or review of an in-progress Wow v6-to-v8 migration. Do not use for first-time Wow adoption or routine upgrades that start on v8.
+---
+
+# Wow v6 到 v8 迁移
+
+把升级视为平台、源码、数据与发布流程的联合迁移。先固定证据和目标版本，再按门禁推进；不要把依赖解析成功、单个模块编译通过或启动成功当成迁移完成。
+
+## 证据优先级
+
+按以下顺序建立结论：
+
+1. 目标应用当前 checkout 的依赖、源码、测试、生成物、配置与部署清单。
+2. 精确目标 v8 tag/release 的 Wow 源码、测试、BOM 与 Release Notes。
+3. 当前 Wow 仓库中的 `documentation/docs/zh/guide/migration/v6-to-v8.md` 和相关专题页。
+4. 本 skill 的 [迁移契约](references/migration-contracts.md)，仅作为发现风险的起点。
+
+若当前 checkout 不是 Wow 框架仓库，不要假定能读取第 3 项；使用精确 tag 的官方源码和本 skill reference。版本、属性名或 API 有冲突时，以目标 tag 为准，并记录差异。
+
+## 开始前锁定契约
+
+先确认并记录：
+
+- 当前 Wow、Spring Boot、Kotlin/KSP、Java 与相关 BOM 的**解析后版本**；
+- 精确目标 v8 版本，不接受只有“v8”而没有最终 pin 的实施或上线；
+- 任务模式是只读评估、迁移计划、代码实施、数据演练还是生产切换；
+- 涉及的 module、bounded context、aggregate、store、message bus 和部署环境；
+- Redis/Mongo/Elasticsearch/自定义 store 的真实 topology、database/namespace、数据量与所有者；
+- 可接受停机窗口、RPO/RTO、回滚窗口和完成证据；
+- 当前 worktree 的本地改动与可修改范围。
+
+若缺少生产数据权限或切换授权，继续完成代码审计、迁移矩阵和可执行命令，但把数据与上线门禁标为 `MISSING EVIDENCE`；不要伪造通过。
+
+## 工作流
+
+```mermaid
+flowchart LR
+    A[固定 v6 基线] --> B[锁定目标 v8]
+    B --> C[平台与源码适配]
+    C --> D[数据预迁移演练]
+    D --> E[隔离单实例验证]
+    E --> F[硬切后灰度扩容]
+    F --> G[观察与回滚窗口]
+```
+
+### 1. 固化 v6 基线
+
+1. 检查 `git status --short --branch`，保护用户已有改动。
+2. 定位 Gradle/Maven 入口、version catalog、BOM、KSP、生成代码和 CI 命令。
+3. 解析实际依赖，不只读取声明值。Gradle 项目优先使用 `dependencyInsight` 或对应 configuration 的 `dependencies`。
+4. 在 skill 目录可用时运行只读扫描：
+
+   ```bash
+   bash <skill-dir>/scripts/audit-v6-usage.sh <target-repository>
+   ```
+
+   把命中项当作待审查线索，不把“未命中”解释为兼容性证明。
+5. 运行现有 v6 的窄测试、模块 `check` 与必要集成测试，保存失败基线。
+6. 记录 event、snapshot、request ID、PrepareKey、aggregate ID、消息 backlog 与关键查询结果的可复核基线。
+7. 若项目未在最新维护版 v6，先评估升级到维护线末版并清除弃用 API；不要直接跨越已知的 v6 基线失败。
+
+### 2. 建立迁移矩阵
+
+至少按以下 track 分栏，逐项标注 `NOT_APPLICABLE`、`TODO`、`PROVED` 或 `BLOCKED`：
+
+| Track | 必查内容 | 最低完成证据 |
+|---|---|---|
+| Platform | Boot 4、Jackson 3、Kotlin/KSP、第三方 starter/BOM | 解析后依赖 + compile/test |
+| Source/API | removed/changed Wow API、配置、测试 DSL、生成元数据 | producer/consumer 重新编译 |
+| Runtime | 自定义 Dispatcher、MessageBus、Spring lifecycle owner | 启停、fatal、drain、deadline 测试 |
+| Storage | EventStore、SnapshotStore、已移除的 wow-r2dbc、Redis、Mongo、自定义实现 | inventory + 契约测试 + 回放 |
+| Contracts | OpenAPI/JSON Schema/KSP/序列化输出 | 重新生成后的 golden diff |
+| Release | 停流、排空、单实例、灰度、监控、回滚 | 演练记录与 go/no-go 门禁 |
+
+再把每个发现分类为 `AUTO_REWRITE`、`SOURCE_ADAPT`、`DESIGN_REQUIRED/BLOCKED`、`DATA_CUTOVER` 或 `VERIFY_ONLY`。只有确定、局部且有目标 API 证据的改写才属于 `AUTO_REWRITE`；store、sharding、runtime owner 和自定义 transport/route 扩展默认要求设计判断。
+
+读取 [迁移契约](references/migration-contracts.md)，只加载适用于目标版本和实际 store 的章节。若应用自定义运行时，再读取 Wow 仓库的 `documentation/docs/zh/guide/migration/runtime-orchestration.md` 或对应目标 tag 的官方页面。
+
+### 3. 适配平台与源码
+
+按可独立验证的批次实施：
+
+1. 对齐 Wow v8 的平台 BOM；不要把 Spring Boot 3 或 Jackson 2 强压回 v8 依赖图。
+2. 处理 Boot 4 模块化、`tools.jackson` 迁移与第三方 starter 兼容性。应用的 Spring 边界可能仍出现 `com.fasterxml` 类型，必须依据目标依赖和调用边界判断，不要机械全局替换包名。
+3. 用编译器驱动 Wow API 迁移；逐个定位定义、实现、调用者和测试，禁止仅根据同名猜测替换。
+4. 若命中 `wow-r2dbc`、`r2dbc-support` 或 `me.ahoo.wow.sharding.*`，把它列为迁移 blocker；v8 没有机械替代，先让用户选择新 store、数据迁移和回滚方案。
+5. 对行为变化优先写失败测试再修复。纯签名迁移可用编译失败作 RED 证据，但仍需补运行时或契约验证。
+6. 重新运行 KSP/OpenAPI/JSON Schema/client 生成链路，并审查 golden diff；不要手改生成物掩盖 producer 问题。
+7. 若命中自定义 Dispatcher、MessageBus 或 Spring 生命周期扩展，单独执行 runtime track，确保只有一个 owner。
+8. 每个批次运行最窄的 `test/check/lint/typecheck`，通过后再扩大验证面。
+
+不要顺手重写领域边界。v6→v8 是平台和兼容性迁移；领域重构应单独立项，避免让数据与行为差异无法归因。
+
+### 4. 准备数据切换
+
+仅在用户明确授权对应环境后执行写操作。修改数据前必须验证备份可恢复、目标 scope、inventory 和停止条件。
+
+1. 根据精确目标版本判断 [迁移契约](references/migration-contracts.md) 中的 Snapshot、Redis 和 Mongo 条目是否生效。
+2. 对每个 store 输出 source→target 映射、数据类型、cardinality、版本范围、checksum、owner 和处置方式。
+3. 对自定义 `SnapshotStore` 验证原子 compare-and-write；禁止客户端 `load()` 后无条件保存。
+4. 目标为 v8.9.0+ 且使用 Redis EventStore 时，设计并单独评审离线 canonical v2 迁移器；运行时没有内置迁移器、双读或双写兜底。
+5. 使用 Mongo 时，验证 database 与 bounded context 一对一、存量 collection、PrepareKey 归属、服务端版本和索引兼容性。
+6. 用 manifest、checksum、cursor 和幂等批次保存迁移证据。任何差集、重复 aggregate ID、孤立 Key 或所有权冲突都必须先处置。
+
+禁止新旧 writer 混跑，禁止用 `FLUSHDB` 或宽泛删除代替精确 inventory，禁止修改 ownership marker 绕过真实冲突。
+
+### 5. 验证、切流与回滚
+
+按顺序执行：
+
+1. 停入口并排空全部 v6 writer；确认 in-flight 与 backlog 达到约定门禁。
+2. 创建并验证一致备份，执行离线迁移与全量 reconciliation。
+3. 只启动一个 v8 实例，使用隔离 ID 验证写入、幂等、读取、事件回放、查询、snapshot regeneration、监控与优雅停机。
+4. 通过后硬切流量，再仅扩容 v8 实例。不要做混合版本滚动升级。
+5. 观察错误率、延迟、积压、版本连续性、重复请求和数据对账。
+6. 演练两条回滚路径：尚无 v8 生产写入时切回只读保留的 v6 数据；已有 v8 写入时先停流，再反向迁移或重放新增写入。
+
+仅有代码测试时，不得声称数据迁移或生产切换完成。仅有 smoke test 时，不得声称回放、并发、停机或回滚已验证。
+
+## 变更边界
+
+- 只读评估或 review 请求只输出证据与建议，不修改代码、数据、CI、PR 或部署状态。
+- 代码实施不自动授权数据迁移、生产发布、依赖新增、module 调整或公开 API 破坏。
+- 数据脚本必须先在副本/隔离 namespace 演练，并具备 dry-run、resume、checksum 和失败关闭行为。
+- 发现目标版本与 current `main` 不同时，始终使用目标 tag 的 API 和存储契约。
+- 不信任仅凭本地 tag 名得出的版本结论；同时核对 tag 内容中的 `gradle.properties`、BOM 与发布记录。
+
+## 完成审计
+
+结束前逐项列出：
+
+- 基线与目标版本证据；
+- 迁移矩阵每一项的状态及文件、命令、日志或数据报告；
+- 实际修改文件和行为边界；
+- 重新生成的契约差异及消费者验证；
+- 数据 inventory、manifest、checksum、回放和 reconciliation 结果；
+- 单实例、灰度、停机与回滚演练结果；
+- 尚未覆盖的 store、环境、流量或第三方集成。
+
+最终输出依次给出：目标对齐、基线与风险、变更摘要、验证结果、切流与回滚状态、未决事项。把未验证项明确标为 `MISSING EVIDENCE`，不要用“应当可行”替代证据。
+
+## 资源
+
+- [迁移契约](references/migration-contracts.md)：按目标版本选择平台、API、runtime 与 storage 硬约束。
+- `scripts/audit-v6-usage.sh`：只读扫描目标仓库中的依赖、旧 API、生命周期、存储与配置线索。

--- a/skills/wow-v6-to-v8-migration/SKILL.md
+++ b/skills/wow-v6-to-v8-migration/SKILL.md
@@ -55,7 +55,7 @@ flowchart LR
    bash <skill-dir>/scripts/audit-v6-usage.sh <target-repository>
    ```
 
-   默认排除可能包含凭据的 `.env*` 与 `*.env`。仅在用户明确要求、确认输出渠道安全且必须审计仅由环境变量声明的存储配置时，把 `--include-dotenv` 放在目标仓库参数前；输出仍会脱敏，但不能把该过滤器当作完整的 secret scanner。把命中项当作待审查线索，不把“未命中”解释为兼容性证明。
+   默认仅输出 `path:line:matched-token`，并排除可能包含凭据的 `.env*` 与 `*.env`。仅在用户明确要求、确认输出渠道安全且必须审计仅由环境变量声明的存储配置时，把 `--include-dotenv` 放在目标仓库参数前；敏感关键词仍会脱敏，但不能把该过滤器当作完整的 secret scanner。把命中项当作待审查线索，不把“未命中”解释为兼容性证明。
 5. 运行现有 v6 的窄测试、模块 `check` 与必要集成测试，保存失败基线。
 6. 记录 event、snapshot、request ID、PrepareKey、aggregate ID、消息 backlog 与关键查询结果的可复核基线。
 7. 若项目未在最新维护版 v6，先评估升级到维护线末版并清除弃用 API；不要直接跨越已知的 v6 基线失败。

--- a/skills/wow-v6-to-v8-migration/SKILL.md
+++ b/skills/wow-v6-to-v8-migration/SKILL.md
@@ -55,7 +55,7 @@ flowchart LR
    bash <skill-dir>/scripts/audit-v6-usage.sh <target-repository>
    ```
 
-   把命中项当作待审查线索，不把“未命中”解释为兼容性证明。
+   默认排除可能包含凭据的 `.env*` 与 `*.env`。仅在用户明确要求、确认输出渠道安全且必须审计仅由环境变量声明的存储配置时，把 `--include-dotenv` 放在目标仓库参数前；输出仍会脱敏，但不能把该过滤器当作完整的 secret scanner。把命中项当作待审查线索，不把“未命中”解释为兼容性证明。
 5. 运行现有 v6 的窄测试、模块 `check` 与必要集成测试，保存失败基线。
 6. 记录 event、snapshot、request ID、PrepareKey、aggregate ID、消息 backlog 与关键查询结果的可复核基线。
 7. 若项目未在最新维护版 v6，先评估升级到维护线末版并清除弃用 API；不要直接跨越已知的 v6 基线失败。

--- a/skills/wow-v6-to-v8-migration/SKILL.md
+++ b/skills/wow-v6-to-v8-migration/SKILL.md
@@ -55,7 +55,7 @@ flowchart LR
    bash <skill-dir>/scripts/audit-v6-usage.sh <target-repository>
    ```
 
-   默认仅输出 `path:line:matched-token`，并排除可能包含凭据的 `.env*` 与 `*.env`。仅在用户明确要求、确认输出渠道安全且必须审计仅由环境变量声明的存储配置时，把 `--include-dotenv` 放在目标仓库参数前；敏感关键词仍会脱敏，但不能把该过滤器当作完整的 secret scanner。把命中项当作待审查线索，不把“未命中”解释为兼容性证明。
+   默认输出标题、审计根目录、分节与完成提示，其中每条命中采用 `path:line:matched-token` 格式；同时排除可能包含凭据的 `.env*` 与 `*.env`。仅在用户明确要求、确认输出渠道安全且必须审计仅由环境变量声明的存储配置时，把 `--include-dotenv` 放在目标仓库参数前；敏感关键词仍会脱敏，但不能把该过滤器当作完整的 secret scanner。把命中项当作待审查线索，不把“未命中”解释为兼容性证明。
 5. 运行现有 v6 的窄测试、模块 `check` 与必要集成测试，保存失败基线。
 6. 记录 event、snapshot、request ID、PrepareKey、aggregate ID、消息 backlog 与关键查询结果的可复核基线。
 7. 若项目未在最新维护版 v6，先评估升级到维护线末版并清除弃用 API；不要直接跨越已知的 v6 基线失败。

--- a/skills/wow-v6-to-v8-migration/agents/openai.yaml
+++ b/skills/wow-v6-to-v8-migration/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Wow v6 to v8 Migration"
+  short_description: "Plan and execute evidence-gated Wow v6 to v8 upgrades"
+  default_prompt: "Use $wow-v6-to-v8-migration to audit this Wow v6 service and produce an evidence-gated migration to Wow v8."

--- a/skills/wow-v6-to-v8-migration/references/migration-contracts.md
+++ b/skills/wow-v6-to-v8-migration/references/migration-contracts.md
@@ -96,8 +96,7 @@
 - resolved context alias 与 aggregate name 构成持久化 scope；alias 或 aggregate rename 需要显式 Key 迁移。
 - canonical v2 request-ID SET 必须从已提交 event JSON 重建；禁止把 legacy shared SET 直接 fan-out 到所有 stream。
 - 128 bucket 公式使用 `aggregateId.id.hashCode().mod(128)` 与 Java/Kotlin UTF-16 `String.hashCode`；迁移器必须独立校验 codec。
-- 旧 snapshot 不会自动转成 v2 snapshot。迁移后显式执行 snapshot regeneration 并验证数量与版本。
-- snapshot regeneration 默认从完整 inventory 使用单 ID 路由。只有审计证明全部 ID 严格大于 `AggregateIdScanner.FIRST_ID`（`"(0)"`）时，batch 路由才可视为穷尽；否则它会漏掉小于或等于该 sentinel 的 ID。
+- 旧 snapshot 不会自动转成 v2 snapshot。迁移后显式执行 snapshot regeneration 并验证数量与版本，默认从完整 inventory 使用单 ID 路由。只有审计证明全部 ID 严格大于 `AggregateIdScanner.FIRST_ID`（`"(0)"`）时，batch 路由才可视为穷尽；否则它会漏掉小于或等于该 sentinel 的 ID。
 
 迁移 manifest 至少记录 source Key、type、cardinality、target Key、source/target checksum、批次、cursor、状态与处置策略。第一次写入前要求 target scope 为空；恢复执行时 checksum 不一致必须失败关闭。
 

--- a/skills/wow-v6-to-v8-migration/references/migration-contracts.md
+++ b/skills/wow-v6-to-v8-migration/references/migration-contracts.md
@@ -34,7 +34,7 @@
 
 1. **公开 Wow API**：定位旧符号的目标定义、调用者、实现与测试；使用 compiler error 驱动迁移。
 2. **内部 API**：Redis key converter、Lua script 常量、repository bean alias 等不承诺源码/JVM/行为兼容；迁回应使用 `EventStore`、`SnapshotStore` 与 `PrepareKey` 公开边界。
-3. **测试 DSL**：只迁移实际旧调用，不要全量重写 DSL。Aggregate 使用 `whenCommand`，Saga 使用 `whenEvent`，`inject(service)` 使用 `inject { register(service) }`，query `deleted(true|false)` 迁到目标 tag 的 `DeletionState`。
+3. **测试 DSL**：只迁移实际旧调用，不要全量重写 DSL。Aggregate 使用 `whenCommand`，Saga 使用 `whenEvent`，`inject(service)` 使用 `inject { register(service) }`。当前 v8.9.5 仍支持 query `deleted(Boolean)`；除非精确目标 tag 已移除该重载，否则不要改写有效调用。
 4. **Command wait**：检查旧 `ClientCommandExchange`、`WaitStrategy`、`WaitingFor*`、自定义 notifier/registrar 与 `sendAndWait` 调用；对照目标 tag 的 `WaitPlan`、`CommandWait` 和 HTTP wait header 行为。当前 v8 gateway 还拥有绝对等待 deadline，不能只做类型替换。
 5. **Message subscription**：检查旧 `MessageBus.receive(Set<NamedAggregate>)`、dispatcher launcher、Reactor Context receiver-group helpers 和自定义 bus；迁到目标版本显式 `MessageSubscription` 后，重新验证 aggregate scope 与 consumer group 隔离。
 6. **OpenAPI/WebFlux 扩展**：检查自定义 `RouteSpec`、`RouteSpecFactory`、`GlobalRouteSpecFactory`、`AggregateRouteSpecFactory` 与 `RouteHandlerFunctionFactory`；当前 v8 使用 `RouteContributor`、`HttpRouteContract` 与 `HttpRouteHandlerFunctionFactory`，必须重新生成和 golden-diff 路由契约。

--- a/skills/wow-v6-to-v8-migration/references/migration-contracts.md
+++ b/skills/wow-v6-to-v8-migration/references/migration-contracts.md
@@ -1,0 +1,149 @@
+# Wow v6 → v8 迁移契约
+
+本 reference 是风险发现索引，不替代精确目标 tag 的源码、Release Notes 或目标应用证据。先固定目标版本，再应用对应条目。
+
+## 目录
+
+- [版本与平台](#版本与平台)
+- [源码与生成契约](#源码与生成契约)
+- [R2DBC 与 sharding 移除](#r2dbc-与-sharding-移除)
+- [统一运行时](#统一运行时)
+- [SnapshotStore](#snapshotstore)
+- [Redis](#redis)
+- [MongoDB](#mongodb)
+- [切换与回滚](#切换与回滚)
+- [验证矩阵](#验证矩阵)
+
+## 版本与平台
+
+| 条目 | v6 基线 | v8 目标 | 迁移动作 |
+|---|---|---|---|
+| Java | 17+ | 17+ | 核对 toolchain 与运行镜像，不需要为大版本本身升级 Java |
+| Spring Boot | 3.x | 4.x | 同步迁移 Boot 模块、auto-configuration 与第三方 starter |
+| Jackson | 2.x 生态 | 框架内部 Jackson 3 `tools.jackson` | 审计直接使用的 `ObjectMapper`、`JsonNode`、module、serializer 与 Spring 边界 |
+| Kotlin/KSP | 取自应用实际解析结果 | 取自目标 Wow BOM/源码 | 对齐 Kotlin metadata 与 KSP 后再解释编译错误 |
+| 相关平台 | v6 的 CosId/CoAPI/CoCache 等 | 取自目标 v8 BOM | 不单独强压旧主版本；检查公开类型和 starter 兼容性 |
+
+当前仓库 v8.9.5 的基线位于 `gradle/libs.versions.toml`；迁移到其他 v8 小版本时读取对应 tag，禁止拿 current `main` 代替。
+
+不要全局替换 Jackson import。当前 v8 框架的 core/databind/module 使用 `tools.jackson`，但注解仍使用 `com.fasterxml.jackson.annotation`；应用还可能在 Spring 或第三方库边界保留 `com.fasterxml` 类型。逐个核对目标 API、wire format 与 module 注册点。
+
+## 源码与生成契约
+
+对目标应用执行以下分类，而不是尝试维护一份静态的全部 API diff：
+
+1. **公开 Wow API**：定位旧符号的目标定义、调用者、实现与测试；使用 compiler error 驱动迁移。
+2. **内部 API**：Redis key converter、Lua script 常量、repository bean alias 等不承诺源码/JVM/行为兼容；迁回应使用 `EventStore`、`SnapshotStore` 与 `PrepareKey` 公开边界。
+3. **测试 DSL**：只迁移实际旧调用，不要全量重写 DSL。Aggregate 使用 `whenCommand`，Saga 使用 `whenEvent`，`inject(service)` 使用 `inject { register(service) }`，query `deleted(true|false)` 迁到目标 tag 的 `DeletionState`。
+4. **Command wait**：检查旧 `ClientCommandExchange`、`WaitStrategy`、`WaitingFor*`、自定义 notifier/registrar 与 `sendAndWait` 调用；对照目标 tag 的 `WaitPlan`、`CommandWait` 和 HTTP wait header 行为。当前 v8 gateway 还拥有绝对等待 deadline，不能只做类型替换。
+5. **Message subscription**：检查旧 `MessageBus.receive(Set<NamedAggregate>)`、dispatcher launcher、Reactor Context receiver-group helpers 和自定义 bus；迁到目标版本显式 `MessageSubscription` 后，重新验证 aggregate scope 与 consumer group 隔离。
+6. **OpenAPI/WebFlux 扩展**：检查自定义 `RouteSpec`、`RouteSpecFactory`、`GlobalRouteSpecFactory`、`AggregateRouteSpecFactory` 与 `RouteHandlerFunctionFactory`；当前 v8 使用 `RouteContributor`、`HttpRouteContract` 与 `HttpRouteHandlerFunctionFactory`，必须重新生成和 golden-diff 路由契约。
+7. **生成契约**：重新生成 KSP metadata、OpenAPI、JSON Schema 和 client；对 nullable、枚举、包名、title/description 与路由做 golden diff。
+
+同时检查 Boot 4 的配置命名和 auto-configuration 包结构。特别审计 MongoDB、Elasticsearch、Jackson 配置以及 `spring.autoconfigure.exclude` 中写死的类名；YAML 层级配置不能只靠字符串替换，应与目标 Boot configuration metadata 对照。
+
+静态扫描只能发现名称命中，无法证明调用语义、安全默认值、序列化 wire format 或消费者兼容。
+
+## R2DBC 与 sharding 移除
+
+当前 v8 已删除 v6 的 `wow-r2dbc` module、`r2dbc-support` feature、`wow.r2dbc.*` 配置、`me.ahoo.wow.r2dbc.*` 类型，以及 core `me.ahoo.wow.sharding.*`。这不是改包名即可完成的源码迁移。
+
+若目标应用命中任一项：
+
+1. 标记为迁移 blocker，不替用户猜测新 store。
+2. 盘点 event stream、snapshot、shard mapping、transaction boundary、query/read model 与恢复流程。
+3. 让用户选择受支持的目标 store 或维护独立 adapter，并明确数据转换、双写禁令、停机、验证与回滚方案。
+4. 用目标 store TCK/集成测试和真实数据 rehearsal 证明迁移；仅让代码编译不能关闭该 blocker。
+
+## 统一运行时
+
+仅在目标版本包含统一 `WowRuntime` 且应用存在自定义生命周期时启用本 track。
+
+- 让一个 `WowRuntime` 拥有全部 `RuntimeComponent`；不要保留每个 Dispatcher 的独立 launcher/owner。
+- 在 Spring 中只保留一个 canonical `WowRuntimeLifecycle`。自定义 `WowRuntime` Bean 必须避免 Spring 根据 `AutoCloseable.close()` 推断第二个 destroy owner。
+- 验证 prepare 全部完成后才 start、全局 admission、tail work、stable quiet period、共享 deadline、fatal failure 与 reverse-order cleanup。
+- 把生命周期源码适配与数据迁移分开：它不改变 event、snapshot、message 格式。
+- 使用目标 tag 的 runtime 文档和源码，因为该能力在 v8 小版本间仍可能演进。
+
+当前仓库证据入口：
+
+- `documentation/docs/zh/guide/migration/runtime-orchestration.md`
+- `documentation/docs/zh/guide/advanced/runtime-lifecycle.md`
+- `wow-core/src/main/kotlin/me/ahoo/wow/runtime/`
+- `wow-spring/src/main/kotlin/me/ahoo/wow/spring/WowRuntimeLifecycle.kt`
+
+## SnapshotStore
+
+目标为当前 v8.9.5 时应用以下原子保存约束，并在其他目标 tag 上重新确认引入版本。版本化 checkpoint 是 v8.9.0 引入后又移除的能力；直接从纯 v6 升级通常不会命中，只有应用或中间迁移分支曾试用该能力时才执行对应清理：
+
+- 版本化 snapshot checkpoint 已移除，且没有兼容层。仅在实际命中时删除 `VersionedSnapshotStore`、`VersionIntervalCheckpointStrategy`、`CompositeSnapshotStrategy`、相关 metrics/tracing decorator 与 `SnapshotCheckpointProperties` 的应用侧依赖。
+- `wow.eventsourcing.snapshot.checkpoint.*` 不再生效；中间环境既有的 `*_snapshot_checkpoint` collection 不会被读取、写入、扫描或自动删除。
+- `SnapshotStore.save()` 要求一次原子 compare-and-write：candidate version 大于或等于 stored version 时完整替换，较低时正常完成但不写入。同版本覆盖是 snapshot regeneration 的修复语义。
+- 当前 `SnapshotRepository` 只是 Kotlin `typealias SnapshotStore`。它可以帮助 Kotlin 源码迁移，但不证明 Java 调用者或已编译扩展的 JVM 二进制兼容；这些消费者必须重新编译。
+- 自定义 store 必须使用 CAS、条件更新、事务或等价原子原语。客户端先 `load()` 再无条件写入不满足契约。
+- 当前 Mongo 实现依赖 MongoDB 5.2+ 的 MQL 表达式；部署前验证真实服务端版本。
+
+快照格式不因原子保存契约而要求重写，但新旧 writer 并行仍可能破坏单调性。
+
+## Redis
+
+目标为 v8.9.0+ 时，把 Redis EventStore/SnapshotStore/PrepareKey 当成存储格式硬切换：
+
+- v6/v8.6 legacy layout、v8.8 bucketed layout 与 canonical v2 不兼容。
+- v8.9.0+ runtime 只读写 canonical v2；没有旧布局回退、双读、双写或内置迁移器。
+- 同一 named aggregate 下的 `AggregateId.id` 必须跨 tenant 唯一。
+- starter 启动守卫只检查可精确识别的旧哨兵，不替代离线全量 inventory；自定义 store、已移除 aggregate、snapshot-only route 和孤立 Key 可能不在守卫覆盖范围。
+- resolved context alias 与 aggregate name 构成持久化 scope；alias 或 aggregate rename 需要显式 Key 迁移。
+- canonical v2 request-ID SET 必须从已提交 event JSON 重建；禁止把 legacy shared SET 直接 fan-out 到所有 stream。
+- 128 bucket 公式使用 `aggregateId.id.hashCode().mod(128)` 与 Java/Kotlin UTF-16 `String.hashCode`；迁移器必须独立校验 codec。
+- 旧 snapshot 不会自动转成 v2 snapshot。迁移后显式执行 snapshot regeneration 并验证数量与版本。
+
+迁移 manifest 至少记录 source Key、type、cardinality、target Key、source/target checksum、批次、cursor、状态与处置策略。第一次写入前要求 target scope 为空；恢复执行时 checksum 不一致必须失败关闭。
+
+当前仓库证据入口：
+
+- `documentation/docs/zh/guide/migration/v6-to-v8.md`
+- `documentation/docs/zh/guide/extensions/redis.md`
+- `wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStore.kt`
+- `wow-redis/src/main/kotlin/me/ahoo/wow/redis/RedisKeyComponentCodec.kt`
+- `wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/redis/RedisEventSourcingAutoConfiguration.kt`
+
+## MongoDB
+
+目标为当前 v8.9.5 时应用以下约束，并在其他目标 tag 上确认：
+
+- collection 名仍以 aggregate name 为核心，但 database 新增 `wow_database_metadata` bounded-context ownership marker。
+- 支持的布局是一个 Mongo database 只属于一个 bounded context。历史混写 database 必须先拆分，不能改 marker 绕过冲突。
+- inventory 必须覆盖 event-stream、snapshot、PrepareKey database，以及 `*_event_stream`、`*_snapshot`、`*_snapshot_checkpoint`、`prepare_*` collection。
+- prepare-only database 的旧文档没有 context metadata；必须在首个 v8 context 认领前人工确认归属。
+- 受管索引缺失时会创建；key 顺序、unique、TTL、partial filter、collation、sparse 或 hidden 不兼容时应阻止启动并受控迁移。
+- 自定义 `SnapshotStore` 或当前 Mongo snapshot 实现还需满足上一节的原子保存与服务端版本要求。
+
+当前仓库证据入口：
+
+- `documentation/docs/zh/guide/extensions/mongo.md`
+- `wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoDatabaseContextGuard.kt`
+- `wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoSnapshotStore.kt`
+
+## 切换与回滚
+
+- 禁止新旧 writer 混跑；使用停流、排空、离线迁移、单 v8 实例、硬切、仅扩容 v8 的顺序。
+- 尚无 v8 生产写入时，回滚可重新连接完整保留的旧数据集并启动 v6。
+- 已有 v8 生产写入时，先停止流量和全部 v8 writer，再反向迁移或重放新增写入；仅恢复切换点备份会丢数据。
+- 优先使用独立 target database/namespace，让旧源在观察期只读保留。
+- 不把应用启动、健康检查或单条读写当成全量数据门禁。
+
+## 验证矩阵
+
+| 层级 | 必要证据 |
+|---|---|
+| Dependency | resolution、冲突与第三方 starter 兼容报告 |
+| Compile | 全部 domain、server、adapter、test fixtures 与 KSP processor consumers 编译 |
+| Behavior | aggregate/saga/projection/query/command wait 的相关单元与集成测试 |
+| Contract | metadata、OpenAPI、JSON Schema、SDK 的 regenerated golden diff |
+| Storage | inventory、checksum、版本连续性、request-ID 集、ID index、代表性 replay |
+| Runtime | startup、readiness、fatal、drain、quiet period、deadline、graceful shutdown |
+| Cutover | 停流/排空证据、单实例 smoke、灰度监控与只扩容 v8 |
+| Rollback | 无新写入与已有新写入两条路径的演练记录 |
+
+任何一行缺少与其范围匹配的当前证据，都保持未完成状态。

--- a/skills/wow-v6-to-v8-migration/references/migration-contracts.md
+++ b/skills/wow-v6-to-v8-migration/references/migration-contracts.md
@@ -97,6 +97,7 @@
 - canonical v2 request-ID SET 必须从已提交 event JSON 重建；禁止把 legacy shared SET 直接 fan-out 到所有 stream。
 - 128 bucket 公式使用 `aggregateId.id.hashCode().mod(128)` 与 Java/Kotlin UTF-16 `String.hashCode`；迁移器必须独立校验 codec。
 - 旧 snapshot 不会自动转成 v2 snapshot。迁移后显式执行 snapshot regeneration 并验证数量与版本。
+- snapshot regeneration 默认从完整 inventory 使用单 ID 路由。只有审计证明全部 ID 严格大于 `AggregateIdScanner.FIRST_ID`（`"(0)"`）时，batch 路由才可视为穷尽；否则它会漏掉小于或等于该 sentinel 的 ID。
 
 迁移 manifest 至少记录 source Key、type、cardinality、target Key、source/target checksum、批次、cursor、状态与处置策略。第一次写入前要求 target scope 为空；恢复执行时 checksum 不一致必须失败关闭。
 

--- a/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
+++ b/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
@@ -66,9 +66,11 @@ match_section \
   '\bClientCommandExchange\b|\bWaitStrategy\b|\bWaitStrategyRegistrar\b|\bExtractedWaitStrategy\b|\bWaitingFors\b|\bWaitingFor[A-Za-z]*\b|sendAndWait|CommandWaitNotifier' \
   --glob '*.kt' --glob '*.java'
 
+# The backticks below are literal ripgrep tokens, not shell command substitutions.
+# shellcheck disable=SC2016
 match_section \
   'Legacy test DSL usage' \
-  '\.\s*`when`\s*\(|\.when\s*\{|inject\s*\([^\{]|deleted\s*\(\s*(true|false)\s*\)' \
+  '\.\s*`when`\s*\(|\.when\s*\{|inject\s*\([^\{]' \
   --glob '*Test.kt' --glob '*Spec.kt' --glob '*Test.java'
 
 match_section \
@@ -99,7 +101,7 @@ match_section \
 
 match_section \
   'Redis and Mongo configuration' \
-  'wow\..*(event-store|snapshot-store|prepare|redis|mongo)|spring\.(data\.)?(redis|mongodb)|Redis(EventStore|SnapshotStore|PrepareKey)|Mongo(EventStore|SnapshotStore)|MongoDatabaseContext' \
+  'wow\..*(event-store|snapshot-store|prepare|redis|mongo)|spring\.(data\.)?(redis|mongodb)|^[[:space:]]*storage:[[:space:]]*(redis|mongo)\b|^[[:space:]]*(redis|mongodb):[[:space:]]*(#.*)?$|Redis(EventStore|SnapshotStore|PrepareKey)|Mongo(EventStore|SnapshotStore)|MongoDatabaseContext' \
   --glob '*.yml' --glob '*.yaml' --glob '*.properties' --glob '*.kt' --glob '*.java'
 
 match_section \

--- a/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
+++ b/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
@@ -179,7 +179,7 @@ fi
 
 match_section \
   'Redis and Mongo configuration' \
-  'wow\.[[:alnum:]_.-]*(event-store|snapshot-store|prepare|redis|mongo)[[:alnum:]_.-]*|spring\.(data\.)?(redis|mongodb)|WOW_[A-Z0-9_]*(STORAGE|REDIS|MONGO)[A-Z0-9_]*|SPRING_(DATA_)?(REDIS|MONGODB)(_[A-Z0-9_]+)?|[=:][[:space:]]*(REDIS|MONGO(DB)?)([[:space:]#]|$)|^[[:space:]]*storage:[[:space:]]*(redis|mongo)\b|^[[:space:]]*(redis|mongodb):|Redis(EventStore|SnapshotStore|PrepareKey)|Mongo(EventStore|SnapshotStore)|MongoDatabaseContext' \
+  'wow\.[[:alnum:]_.-]*(event-store|snapshot-store|prepare|redis|mongo)[[:alnum:]_.-]*|spring\.(data\.)?(redis|mongodb)|WOW_[A-Z0-9_]*(STORAGE|REDIS|MONGO)[A-Z0-9_]*|SPRING_(DATA_)?(REDIS|MONGODB)(_[A-Z0-9_]+)?|^[[:space:]]*storage[[:space:]]*[=:][[:space:]]*([Rr][Ee][Dd][Ii][Ss]|[Mm][Oo][Nn][Gg][Oo]([Dd][Bb])?)\b|^[[:space:]]*(redis|mongodb):|Redis(EventStore|SnapshotStore|PrepareKey)|Mongo(EventStore|SnapshotStore)|MongoDatabaseContext' \
   "${storage_globs[@]}"
 
 match_section \

--- a/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
+++ b/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
@@ -57,7 +57,7 @@ printf 'note: matches are review leads, not proof of incompatibility or complete
 
 match_section \
   'Declared platform and Wow versions' \
-  '^[[:space:]]*(wow|kotlin|ksp|spring-boot)[[:space:]]*=|me\.ahoo\.wow|wow-(bom|dependencies|spring-boot-starter)|wow[._-]?version|org\.springframework\.boot|springBoot|spring-boot|kotlin\("jvm"\)|\bksp\b|<java\.version>|jvmToolchain|distributionUrl' \
+  '^[[:space:]]*(wow|kotlin|ksp|spring-boot)[[:space:]]*=|me\.ahoo\.wow|wow-(bom|dependencies|spring-boot-starter)|wow[._-]?version|org\.springframework\.boot|springBoot|spring-boot|kotlin\("jvm"\)|org\.jetbrains\.kotlin\.jvm|\bksp\b|<java\.version>|<kotlin\.version>|jvmToolchain|distributionUrl' \
   --glob '*.gradle' --glob '*.gradle.kts' --glob 'libs.versions.toml' \
   --glob 'gradle.properties' --glob 'gradle-wrapper.properties' --glob 'pom.xml'
 
@@ -81,11 +81,12 @@ match_section \
 match_section \
   'Legacy test DSL usage' \
   '\.\s*`when`\s*\(|\.when\s*[({]|inject\s*\(\s*[^[:space:]{]' \
-  --glob '*Test.kt' --glob '*Spec.kt' --glob '*Test.java'
+  --glob '*Test.kt' --glob '*Tests.kt' --glob '*Spec.kt' --glob '*IT.kt' \
+  --glob '*Test.java' --glob '*Tests.java' --glob '*Spec.java' --glob '*IT.java'
 
 match_section \
   'Custom messaging or lifecycle ownership' \
-  '\b[A-Za-z]*DispatcherLauncher\b|MessageSubscription|MessageBus<|override\s+fun\s+receive\s*\([^)]*(Set<NamedAggregate>|namedAggregates)|getReceiverGroup|setReceiverGroup|writeReceiverGroup|SmartLifecycle|DisposableBean|GracefullyStoppable|WowRuntime|WowRuntimeLifecycle|RuntimeComponent|me\.ahoo\.wow\.infra\.lifecycle\.Lifecycle|@PostConstruct|@PreDestroy|destroyMethod' \
+  '\b[A-Za-z]*DispatcherLauncher\b|MessageSubscription|MessageBus<|override\s+fun\s+receive\s*\([^)]*(Set<NamedAggregate>|namedAggregates)|\.receive\s*\(\s*(setOf(?:\s*<[^>]+>)?\s*\(|Set\.of\s*\(|namedAggregates\b)|getReceiverGroup|setReceiverGroup|writeReceiverGroup|SmartLifecycle|DisposableBean|GracefullyStoppable|WowRuntime|WowRuntimeLifecycle|RuntimeComponent|me\.ahoo\.wow\.infra\.lifecycle\.Lifecycle|@PostConstruct|@PreDestroy|destroyMethod' \
   --glob '*.kt' --glob '*.java'
 
 match_section \

--- a/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
+++ b/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
@@ -90,7 +90,7 @@ match_section() {
 
   local output
   local rg_status
-  if output="$(rg -n --color never "$@" "${common_globs[@]}" -- "$pattern" "$scan_root")"; then
+  if output="$(rg -n --only-matching --color never "$@" "${common_globs[@]}" -- "$pattern" "$scan_root")"; then
     :
   else
     rg_status=$?
@@ -112,7 +112,7 @@ printf 'note: matches are review leads, not proof of incompatibility or complete
 
 match_section \
   'Declared platform and Wow versions' \
-  '^[[:space:]]*(wow|kotlin|ksp|spring-boot)[[:space:]]*=|me\.ahoo\.wow|wow-(bom|dependencies|spring-boot-starter)|wow[._-]?version|org\.springframework\.boot|springBoot|spring-boot|kotlin\("jvm"\)|org\.jetbrains\.kotlin\.jvm|\bksp\b|<java\.version>|<kotlin\.version>|jvmToolchain|distributionUrl' \
+  '^[[:space:]]*(wow|kotlin|ksp|spring-boot)[[:space:]]*=[[:space:]]*"?[0-9][[:alnum:].+_-]*"?|me\.ahoo\.wow:[[:alnum:]_.-]+:[0-9][[:alnum:].+_-]*|wow[._-]?[Vv]ersion[[:space:]]*[=:][[:space:]]*"?[0-9][[:alnum:].+_-]*"?|<(java|kotlin)\.version>[0-9][[:alnum:].+_-]*</(java|kotlin)\.version>|(?:org\.springframework\.boot|org\.jetbrains\.kotlin\.jvm)[" )]*version[[:space:]]*"?[0-9][[:alnum:].+_-]*"?|kotlin\("jvm"\)[[:space:]]*version[[:space:]]*"?[0-9][[:alnum:].+_-]*"?|me\.ahoo\.wow|wow-(bom|dependencies|spring-boot-starter)|wow[._-]?[Vv]ersion|org\.springframework\.boot|springBoot|spring-boot|kotlin\("jvm"\)|org\.jetbrains\.kotlin\.jvm|\bksp\b|<java\.version>|<kotlin\.version>|jvmToolchain|distributionUrl' \
   --glob '*.gradle' --glob '*.gradle.kts' --glob '*.versions.toml' \
   --glob 'gradle.properties' --glob 'gradle-wrapper.properties' --glob 'pom.xml'
 
@@ -168,7 +168,7 @@ match_section \
 
 match_section \
   'Redis and Mongo configuration' \
-  'wow\..*(?:event-store|snapshot-store|prepare|redis|mongo)|spring\.(?:data\.)?(?:redis|mongodb)|WOW_[A-Z0-9_]*(?:STORAGE|REDIS|MONGO)[A-Z0-9_]*|SPRING_(?:DATA_)?(?:REDIS|MONGODB)(?:_[A-Z0-9_]+)?|[=:][[:space:]]*(?:REDIS|MONGO(?:DB)?)(?:[[:space:]#]|$)|^[[:space:]]*storage:[[:space:]]*(?:redis|mongo)\b|^[[:space:]]*(?:redis|mongodb):[[:space:]]*(?:#.*)?$|Redis(?:EventStore|SnapshotStore|PrepareKey)|Mongo(?:EventStore|SnapshotStore)|MongoDatabaseContext' \
+  'wow\.[[:alnum:]_.-]*(?:event-store|snapshot-store|prepare|redis|mongo)[[:alnum:]_.-]*|spring\.(?:data\.)?(?:redis|mongodb)|WOW_[A-Z0-9_]*(?:STORAGE|REDIS|MONGO)[A-Z0-9_]*|SPRING_(?:DATA_)?(?:REDIS|MONGODB)(?:_[A-Z0-9_]+)?|[=:][[:space:]]*(?:REDIS|MONGO(?:DB)?)(?:[[:space:]#]|$)|^[[:space:]]*storage:[[:space:]]*(?:redis|mongo)\b|^[[:space:]]*(?:redis|mongodb):[[:space:]]*(?:#.*)?$|Redis(?:EventStore|SnapshotStore|PrepareKey)|Mongo(?:EventStore|SnapshotStore)|MongoDatabaseContext' \
   --glob '*.yml' --glob '*.yaml' --glob '*.properties' --glob '.env*' --glob '*.env' \
   --glob '*.kt' --glob '*.java'
 

--- a/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
+++ b/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
@@ -2,6 +2,33 @@
 
 set -euo pipefail
 
+usage() {
+  printf 'Usage: %s [--include-dotenv] [target-repository]\n' "${0##*/}"
+}
+
+include_dotenv=false
+case "${1:-}" in
+  --include-dotenv)
+    include_dotenv=true
+    shift
+    ;;
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  -*)
+    printf 'ERROR: unknown option: %s\n' "$1" >&2
+    usage >&2
+    exit 2
+    ;;
+esac
+
+if [[ "$#" -gt 1 ]]; then
+  printf 'ERROR: expected at most one target repository.\n' >&2
+  usage >&2
+  exit 2
+fi
+
 scan_root="${1:-.}"
 
 if ! command -v rg >/dev/null 2>&1; then
@@ -27,6 +54,10 @@ common_globs=(
   --glob '!**/npm-shrinkwrap.json'
   --glob '!**/pnpm-lock.yaml'
 )
+
+if [[ "$include_dotenv" == false ]]; then
+  common_globs+=(--glob '!**/.env*' --glob '!**/*.env')
+fi
 
 redact_sensitive_values() {
   awk '
@@ -138,7 +169,7 @@ match_section \
 match_section \
   'Redis and Mongo configuration' \
   'wow\..*(?:event-store|snapshot-store|prepare|redis|mongo)|spring\.(?:data\.)?(?:redis|mongodb)|WOW_[A-Z0-9_]*(?:STORAGE|REDIS|MONGO)[A-Z0-9_]*|SPRING_(?:DATA_)?(?:REDIS|MONGODB)(?:_[A-Z0-9_]+)?|[=:][[:space:]]*(?:REDIS|MONGO(?:DB)?)(?:[[:space:]#]|$)|^[[:space:]]*storage:[[:space:]]*(?:redis|mongo)\b|^[[:space:]]*(?:redis|mongodb):[[:space:]]*(?:#.*)?$|Redis(?:EventStore|SnapshotStore|PrepareKey)|Mongo(?:EventStore|SnapshotStore)|MongoDatabaseContext' \
-  --glob '*.yml' --glob '*.yaml' --glob '*.properties' --glob '*.env' --glob '.env*' \
+  --glob '*.yml' --glob '*.yaml' --glob '*.properties' --glob '.env*' --glob '*.env' \
   --glob '*.kt' --glob '*.java'
 
 match_section \

--- a/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
+++ b/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
@@ -141,7 +141,7 @@ match_section \
 
 match_section \
   'Custom messaging or lifecycle ownership' \
-  '\b([A-Za-z]*DispatcherLauncher|MainDispatcher|AggregateDispatcher|AggregateSchedulerSupplier|AUTO_REGISTRAR_PHASE)\b|MessageSubscription|MessageBus<|override\s+fun\s+receive\s*\([^)]*(Set<NamedAggregate>|namedAggregates)|\.receive\s*\(\s*(setOf(\s*<[^>]+>)?\s*\(|Set\.of\s*\(|namedAggregates\b)|getReceiverGroup|setReceiverGroup|writeReceiverGroup|\bLifecycle\b|SmartLifecycle|DisposableBean|GracefullyStoppable|WowRuntime|WowRuntimeLifecycle|RuntimeComponent|me\.ahoo\.wow\.infra\.lifecycle\.Lifecycle|@PostConstruct|@PreDestroy|destroyMethod' \
+  '\b([A-Za-z]*DispatcherLauncher|MainDispatcher|AggregateDispatcher|AggregateSchedulerSupplier|AUTO_REGISTRAR_PHASE)\b|MessageSubscription|MessageBus<|override\s+fun\s+receive\s*\([^)]*(Set<NamedAggregate>|namedAggregates)|\.receive\s*\(\s*(setOf(\s*<[^>]+>)?\s*\(|Set\.of\s*\(|namedAggregates\b)|\b([A-Za-z_][A-Za-z0-9_]*)?[Bb]us\.receive\s*\(\s*[A-Za-z_][A-Za-z0-9_]*\s*\)|getReceiverGroup|setReceiverGroup|writeReceiverGroup|\bLifecycle\b|SmartLifecycle|DisposableBean|GracefullyStoppable|WowRuntime|WowRuntimeLifecycle|RuntimeComponent|me\.ahoo\.wow\.infra\.lifecycle\.Lifecycle|@PostConstruct|@PreDestroy|destroyMethod' \
   --glob '*.kt' --glob '*.java'
 
 match_section \

--- a/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
+++ b/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
@@ -112,7 +112,7 @@ printf 'note: matches are review leads, not proof of incompatibility or complete
 
 match_section \
   'Declared platform and Wow versions' \
-  '^[[:space:]]*(wow|kotlin|ksp|spring-boot)[[:space:]]*=[[:space:]]*"?[0-9][[:alnum:].+_-]*"?|me\.ahoo\.wow:[[:alnum:]_.-]+:[0-9][[:alnum:].+_-]*|wow[._-]?[Vv]ersion[[:space:]]*[=:][[:space:]]*"?[0-9][[:alnum:].+_-]*"?|<(java|kotlin)\.version>[0-9][[:alnum:].+_-]*</(java|kotlin)\.version>|(?:org\.springframework\.boot|org\.jetbrains\.kotlin\.jvm)[" )]*version[[:space:]]*"?[0-9][[:alnum:].+_-]*"?|kotlin\("jvm"\)[[:space:]]*version[[:space:]]*"?[0-9][[:alnum:].+_-]*"?|me\.ahoo\.wow|wow-(bom|dependencies|spring-boot-starter)|wow[._-]?[Vv]ersion|org\.springframework\.boot|springBoot|spring-boot|kotlin\("jvm"\)|org\.jetbrains\.kotlin\.jvm|\bksp\b|<java\.version>|<kotlin\.version>|jvmToolchain|distributionUrl' \
+  '^[[:space:]]*(wow|kotlin|ksp|spring-boot)[[:space:]]*=[[:space:]]*"?[0-9][[:alnum:].+_-]*"?|me\.ahoo\.wow:[[:alnum:]_.-]+:[0-9][[:alnum:].+_-]*|wow[._-]?[Vv]ersion[[:space:]]*[=:][[:space:]]*"?[0-9][[:alnum:].+_-]*"?|<(java|kotlin)\.version>[0-9][[:alnum:].+_-]*</(java|kotlin)\.version>|(org\.springframework\.boot|org\.jetbrains\.kotlin\.jvm)[" )]*version[[:space:]]*"?[0-9][[:alnum:].+_-]*"?|kotlin\("jvm"\)[[:space:]]*version[[:space:]]*"?[0-9][[:alnum:].+_-]*"?|me\.ahoo\.wow|wow-(bom|dependencies|spring-boot-starter)|wow[._-]?[Vv]ersion|org\.springframework\.boot|springBoot|spring-boot|kotlin\("jvm"\)|org\.jetbrains\.kotlin\.jvm|\bksp\b|<java\.version>|<kotlin\.version>|jvmToolchain|distributionUrl' \
   --glob '*.gradle' --glob '*.gradle.kts' --glob '*.versions.toml' \
   --glob 'gradle.properties' --glob 'gradle-wrapper.properties' --glob 'pom.xml'
 
@@ -123,7 +123,7 @@ match_section \
 
 match_section \
   'Spring Boot configuration and auto-configuration exposure' \
-  '^[[:space:]]*(wow|spring|r2dbc):[[:space:]]*(#.*)?$|spring\.(jackson|data\.mongodb|mongodb|data\.elasticsearch|elasticsearch|autoconfigure\.exclude)|org\.springframework\.boot\.autoconfigure\.|JacksonAutoConfiguration|Mongo[A-Za-z]*AutoConfiguration|Elasticsearch[A-Za-z]*AutoConfiguration' \
+  '^[[:space:]]*(wow|spring|r2dbc):|spring\.(jackson|data\.mongodb|mongodb|data\.elasticsearch|elasticsearch|autoconfigure\.exclude)|org\.springframework\.boot\.autoconfigure\.|JacksonAutoConfiguration|Mongo[A-Za-z]*AutoConfiguration|Elasticsearch[A-Za-z]*AutoConfiguration' \
   --glob '*.kt' --glob '*.java' --glob '*.yml' --glob '*.yaml' --glob '*.properties'
 
 match_section \
@@ -141,7 +141,7 @@ match_section \
 
 match_section \
   'Custom messaging or lifecycle ownership' \
-  '\b([A-Za-z]*DispatcherLauncher|MainDispatcher|AggregateDispatcher|AggregateSchedulerSupplier|AUTO_REGISTRAR_PHASE)\b|MessageSubscription|MessageBus<|override\s+fun\s+receive\s*\([^)]*(Set<NamedAggregate>|namedAggregates)|\.receive\s*\(\s*(setOf(?:\s*<[^>]+>)?\s*\(|Set\.of\s*\(|namedAggregates\b)|getReceiverGroup|setReceiverGroup|writeReceiverGroup|\bLifecycle\b|SmartLifecycle|DisposableBean|GracefullyStoppable|WowRuntime|WowRuntimeLifecycle|RuntimeComponent|me\.ahoo\.wow\.infra\.lifecycle\.Lifecycle|@PostConstruct|@PreDestroy|destroyMethod' \
+  '\b([A-Za-z]*DispatcherLauncher|MainDispatcher|AggregateDispatcher|AggregateSchedulerSupplier|AUTO_REGISTRAR_PHASE)\b|MessageSubscription|MessageBus<|override\s+fun\s+receive\s*\([^)]*(Set<NamedAggregate>|namedAggregates)|\.receive\s*\(\s*(setOf(\s*<[^>]+>)?\s*\(|Set\.of\s*\(|namedAggregates\b)|getReceiverGroup|setReceiverGroup|writeReceiverGroup|\bLifecycle\b|SmartLifecycle|DisposableBean|GracefullyStoppable|WowRuntime|WowRuntimeLifecycle|RuntimeComponent|me\.ahoo\.wow\.infra\.lifecycle\.Lifecycle|@PostConstruct|@PreDestroy|destroyMethod' \
   --glob '*.kt' --glob '*.java'
 
 match_section \
@@ -168,7 +168,7 @@ match_section \
 
 match_section \
   'Redis and Mongo configuration' \
-  'wow\.[[:alnum:]_.-]*(?:event-store|snapshot-store|prepare|redis|mongo)[[:alnum:]_.-]*|spring\.(?:data\.)?(?:redis|mongodb)|WOW_[A-Z0-9_]*(?:STORAGE|REDIS|MONGO)[A-Z0-9_]*|SPRING_(?:DATA_)?(?:REDIS|MONGODB)(?:_[A-Z0-9_]+)?|[=:][[:space:]]*(?:REDIS|MONGO(?:DB)?)(?:[[:space:]#]|$)|^[[:space:]]*storage:[[:space:]]*(?:redis|mongo)\b|^[[:space:]]*(?:redis|mongodb):[[:space:]]*(?:#.*)?$|Redis(?:EventStore|SnapshotStore|PrepareKey)|Mongo(?:EventStore|SnapshotStore)|MongoDatabaseContext' \
+  'wow\.[[:alnum:]_.-]*(event-store|snapshot-store|prepare|redis|mongo)[[:alnum:]_.-]*|spring\.(data\.)?(redis|mongodb)|WOW_[A-Z0-9_]*(STORAGE|REDIS|MONGO)[A-Z0-9_]*|SPRING_(DATA_)?(REDIS|MONGODB)(_[A-Z0-9_]+)?|[=:][[:space:]]*(REDIS|MONGO(DB)?)([[:space:]#]|$)|^[[:space:]]*storage:[[:space:]]*(redis|mongo)\b|^[[:space:]]*(redis|mongodb):|Redis(EventStore|SnapshotStore|PrepareKey)|Mongo(EventStore|SnapshotStore)|MongoDatabaseContext' \
   --glob '*.yml' --glob '*.yaml' --glob '*.properties' --glob '.env*' --glob '*.env' \
   --glob '*.kt' --glob '*.java'
 

--- a/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
+++ b/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
@@ -16,7 +16,7 @@ fi
 
 common_globs=(
   --hidden
-  --glob '!.git/**'
+  --glob '!**/.git/**'
   --glob '!**/.idea/**'
   --glob '!**/.vscode/**'
   --glob '!**/build/**'
@@ -35,7 +35,17 @@ match_section() {
   shift 2
 
   local output
-  output="$(rg -n --color never "$@" "${common_globs[@]}" -- "$pattern" "$scan_root" 2>/dev/null || true)"
+  local rg_status
+  if output="$(rg -n --color never "$@" "${common_globs[@]}" -- "$pattern" "$scan_root")"; then
+    :
+  else
+    rg_status=$?
+    if [[ "$rg_status" -eq 1 ]]; then
+      return 0
+    fi
+    printf 'ERROR: ripgrep failed while scanning section [%s] (exit %s).\n' "$title" "$rg_status" >&2
+    return "$rg_status"
+  fi
   if [[ -n "$output" ]]; then
     printf '\n## %s\n%s\n' "$title" "$output"
   fi
@@ -70,7 +80,7 @@ match_section \
 # shellcheck disable=SC2016
 match_section \
   'Legacy test DSL usage' \
-  '\.\s*`when`\s*\(|\.when\s*\{|inject\s*\([^\{]' \
+  '\.\s*`when`\s*\(|\.when\s*[({]|inject\s*\(\s*[^[:space:]{]' \
   --glob '*Test.kt' --glob '*Spec.kt' --glob '*Test.java'
 
 match_section \

--- a/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
+++ b/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
@@ -22,7 +22,6 @@ common_globs=(
   --glob '!**/build/**'
   --glob '!**/.gradle/**'
   --glob '!**/node_modules/**'
-  --glob '!**/dist/**'
   --glob '!**/target/**'
   --glob '!**/*lock*.json'
   --glob '!**/*lock*.yaml'
@@ -68,7 +67,7 @@ match_section \
 
 match_section \
   'Spring Boot configuration and auto-configuration exposure' \
-  '^[[:space:]]*(wow|spring|r2dbc):[[:space:]]*(#.*)?$|spring\.(jackson|data\.mongodb|mongodb|data\.elasticsearch|elasticsearch|autoconfigure\.exclude)|org\.springframework\.boot\.autoconfigure\.(mongo|data\.mongo|elasticsearch|jackson)|JacksonAutoConfiguration|Mongo[A-Za-z]*AutoConfiguration|Elasticsearch[A-Za-z]*AutoConfiguration' \
+  '^[[:space:]]*(wow|spring|r2dbc):[[:space:]]*(#.*)?$|spring\.(jackson|data\.mongodb|mongodb|data\.elasticsearch|elasticsearch|autoconfigure\.exclude)|org\.springframework\.boot\.autoconfigure\.|JacksonAutoConfiguration|Mongo[A-Za-z]*AutoConfiguration|Elasticsearch[A-Za-z]*AutoConfiguration' \
   --glob '*.kt' --glob '*.java' --glob '*.yml' --glob '*.yaml' --glob '*.properties'
 
 match_section \
@@ -86,7 +85,7 @@ match_section \
 
 match_section \
   'Custom messaging or lifecycle ownership' \
-  '\b[A-Za-z]*DispatcherLauncher\b|MessageSubscription|MessageBus<|override\s+fun\s+receive\s*\([^)]*(Set<NamedAggregate>|namedAggregates)|\.receive\s*\(\s*(setOf(?:\s*<[^>]+>)?\s*\(|Set\.of\s*\(|namedAggregates\b)|getReceiverGroup|setReceiverGroup|writeReceiverGroup|SmartLifecycle|DisposableBean|GracefullyStoppable|WowRuntime|WowRuntimeLifecycle|RuntimeComponent|me\.ahoo\.wow\.infra\.lifecycle\.Lifecycle|@PostConstruct|@PreDestroy|destroyMethod' \
+  '\b([A-Za-z]*DispatcherLauncher|MainDispatcher|AggregateDispatcher|AggregateSchedulerSupplier|AUTO_REGISTRAR_PHASE)\b|MessageSubscription|MessageBus<|override\s+fun\s+receive\s*\([^)]*(Set<NamedAggregate>|namedAggregates)|\.receive\s*\(\s*(setOf(?:\s*<[^>]+>)?\s*\(|Set\.of\s*\(|namedAggregates\b)|getReceiverGroup|setReceiverGroup|writeReceiverGroup|SmartLifecycle|DisposableBean|GracefullyStoppable|WowRuntime|WowRuntimeLifecycle|RuntimeComponent|me\.ahoo\.wow\.infra\.lifecycle\.Lifecycle|@PostConstruct|@PreDestroy|destroyMethod' \
   --glob '*.kt' --glob '*.java'
 
 match_section \
@@ -113,8 +112,9 @@ match_section \
 
 match_section \
   'Redis and Mongo configuration' \
-  'wow\..*(event-store|snapshot-store|prepare|redis|mongo)|spring\.(data\.)?(redis|mongodb)|^[[:space:]]*storage:[[:space:]]*(redis|mongo)\b|^[[:space:]]*(redis|mongodb):[[:space:]]*(#.*)?$|Redis(EventStore|SnapshotStore|PrepareKey)|Mongo(EventStore|SnapshotStore)|MongoDatabaseContext' \
-  --glob '*.yml' --glob '*.yaml' --glob '*.properties' --glob '*.kt' --glob '*.java'
+  'wow\..*(event-store|snapshot-store|prepare|redis|mongo)|spring\.(data\.)?(redis|mongodb)|WOW_[A-Z0-9_]*(STORAGE|REDIS|MONGO)[A-Z0-9_]*|SPRING_(DATA_)?(REDIS|MONGODB)(_[A-Z0-9_]+)?|[=:][[:space:]]*(REDIS|MONGO(DB)?)([[:space:]#]|$)|^[[:space:]]*storage:[[:space:]]*(redis|mongo)\b|^[[:space:]]*(redis|mongodb):[[:space:]]*(#.*)?$|Redis(EventStore|SnapshotStore|PrepareKey)|Mongo(EventStore|SnapshotStore)|MongoDatabaseContext' \
+  --glob '*.yml' --glob '*.yaml' --glob '*.properties' --glob '*.env' --glob '.env*' \
+  --glob '*.kt' --glob '*.java'
 
 match_section \
   'Generated metadata and API contracts' \

--- a/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
+++ b/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
@@ -137,7 +137,7 @@ match_section \
 
 match_section \
   'Redis and Mongo configuration' \
-  'wow\..*(event-store|snapshot-store|prepare|redis|mongo)|spring\.(data\.)?(redis|mongodb)|WOW_[A-Z0-9_]*(STORAGE|REDIS|MONGO)[A-Z0-9_]*|SPRING_(DATA_)?(REDIS|MONGODB)(_[A-Z0-9_]+)?|[=:][[:space:]]*(REDIS|MONGO(DB)?)([[:space:]#]|$)|^[[:space:]]*storage:[[:space:]]*(redis|mongo)\b|^[[:space:]]*(redis|mongodb):[[:space:]]*(#.*)?$|Redis(EventStore|SnapshotStore|PrepareKey)|Mongo(EventStore|SnapshotStore)|MongoDatabaseContext' \
+  'wow\..*(?:event-store|snapshot-store|prepare|redis|mongo)|spring\.(?:data\.)?(?:redis|mongodb)|WOW_[A-Z0-9_]*(?:STORAGE|REDIS|MONGO)[A-Z0-9_]*|SPRING_(?:DATA_)?(?:REDIS|MONGODB)(?:_[A-Z0-9_]+)?|[=:][[:space:]]*(?:REDIS|MONGO(?:DB)?)(?:[[:space:]#]|$)|^[[:space:]]*storage:[[:space:]]*(?:redis|mongo)\b|^[[:space:]]*(?:redis|mongodb):[[:space:]]*(?:#.*)?$|Redis(?:EventStore|SnapshotStore|PrepareKey)|Mongo(?:EventStore|SnapshotStore)|MongoDatabaseContext' \
   --glob '*.yml' --glob '*.yaml' --glob '*.properties' --glob '*.env' --glob '.env*' \
   --glob '*.kt' --glob '*.java'
 

--- a/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
+++ b/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
@@ -166,11 +166,21 @@ match_section \
   'AggregateKeyConverter|RedisWrappedKey|RedisSnapshotRepository|EventStreamKeyConverter|DefaultSnapshotKeyConverter|PrepareKeyConverter|SCRIPT_EVENT_STEAM_APPEND|SCRIPT_EVENT_STREAM_APPEND|redisSnapshotRepository' \
   --glob '*.kt' --glob '*.java' --glob '*.yml' --glob '*.yaml' --glob '*.properties'
 
+storage_globs=(
+  --glob '*.yml'
+  --glob '*.yaml'
+  --glob '*.properties'
+  --glob '*.kt'
+  --glob '*.java'
+)
+if [[ "$include_dotenv" == true ]]; then
+  storage_globs+=(--glob '.env*' --glob '*.env')
+fi
+
 match_section \
   'Redis and Mongo configuration' \
   'wow\.[[:alnum:]_.-]*(event-store|snapshot-store|prepare|redis|mongo)[[:alnum:]_.-]*|spring\.(data\.)?(redis|mongodb)|WOW_[A-Z0-9_]*(STORAGE|REDIS|MONGO)[A-Z0-9_]*|SPRING_(DATA_)?(REDIS|MONGODB)(_[A-Z0-9_]+)?|[=:][[:space:]]*(REDIS|MONGO(DB)?)([[:space:]#]|$)|^[[:space:]]*storage:[[:space:]]*(redis|mongo)\b|^[[:space:]]*(redis|mongodb):|Redis(EventStore|SnapshotStore|PrepareKey)|Mongo(EventStore|SnapshotStore)|MongoDatabaseContext' \
-  --glob '*.yml' --glob '*.yaml' --glob '*.properties' --glob '.env*' --glob '*.env' \
-  --glob '*.kt' --glob '*.java'
+  "${storage_globs[@]}"
 
 match_section \
   'Generated metadata and API contracts' \

--- a/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
+++ b/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+scan_root="${1:-.}"
+
+if ! command -v rg >/dev/null 2>&1; then
+  echo "ERROR: rg is required" >&2
+  exit 127
+fi
+
+if [[ ! -d "$scan_root" ]]; then
+  echo "ERROR: target is not a directory: $scan_root" >&2
+  exit 2
+fi
+
+common_globs=(
+  --hidden
+  --glob '!.git/**'
+  --glob '!**/.idea/**'
+  --glob '!**/.vscode/**'
+  --glob '!**/build/**'
+  --glob '!**/.gradle/**'
+  --glob '!**/node_modules/**'
+  --glob '!**/dist/**'
+  --glob '!**/target/**'
+  --glob '!**/*lock*.json'
+  --glob '!**/*lock*.yaml'
+  --glob '!**/*lock*.yml'
+)
+
+match_section() {
+  local title="$1"
+  local pattern="$2"
+  shift 2
+
+  local output
+  output="$(rg -n --color never "$@" "${common_globs[@]}" -- "$pattern" "$scan_root" 2>/dev/null || true)"
+  if [[ -n "$output" ]]; then
+    printf '\n## %s\n%s\n' "$title" "$output"
+  fi
+}
+
+printf '# Wow v6 to v8 static exposure audit\n'
+printf 'root: %s\n' "$(cd "$scan_root" && pwd)"
+printf 'note: matches are review leads, not proof of incompatibility or completeness.\n'
+
+match_section \
+  'Declared platform and Wow versions' \
+  '^[[:space:]]*(wow|kotlin|ksp|spring-boot)[[:space:]]*=|me\.ahoo\.wow|wow-(bom|dependencies|spring-boot-starter)|wow[._-]?version|org\.springframework\.boot|springBoot|spring-boot|kotlin\("jvm"\)|\bksp\b|<java\.version>|jvmToolchain|distributionUrl' \
+  --glob '*.gradle' --glob '*.gradle.kts' --glob 'libs.versions.toml' \
+  --glob 'gradle.properties' --glob 'gradle-wrapper.properties' --glob 'pom.xml'
+
+match_section \
+  'Jackson 2 or Jackson 3 direct usage' \
+  'com\.fasterxml\.jackson\.(core|databind|module|datatype)|tools\.jackson|ObjectMapper|JsonNode|JsonSerializer|JsonDeserializer|JacksonAutoConfiguration' \
+  --glob '*.kt' --glob '*.java' --glob '*.gradle' --glob '*.gradle.kts' --glob 'pom.xml'
+
+match_section \
+  'Spring Boot configuration and auto-configuration exposure' \
+  '^[[:space:]]*(wow|spring|r2dbc):[[:space:]]*(#.*)?$|spring\.(jackson|data\.mongodb|mongodb|data\.elasticsearch|elasticsearch|autoconfigure\.exclude)|org\.springframework\.boot\.autoconfigure\.(mongo|data\.mongo|elasticsearch|jackson)|JacksonAutoConfiguration|Mongo[A-Za-z]*AutoConfiguration|Elasticsearch[A-Za-z]*AutoConfiguration' \
+  --glob '*.kt' --glob '*.java' --glob '*.yml' --glob '*.yaml' --glob '*.properties'
+
+match_section \
+  'Removed or changed command wait APIs' \
+  '\bClientCommandExchange\b|\bWaitStrategy\b|\bWaitStrategyRegistrar\b|\bExtractedWaitStrategy\b|\bWaitingFors\b|\bWaitingFor[A-Za-z]*\b|sendAndWait|CommandWaitNotifier' \
+  --glob '*.kt' --glob '*.java'
+
+match_section \
+  'Legacy test DSL usage' \
+  '\.\s*`when`\s*\(|\.when\s*\{|inject\s*\([^\{]|deleted\s*\(\s*(true|false)\s*\)' \
+  --glob '*Test.kt' --glob '*Spec.kt' --glob '*Test.java'
+
+match_section \
+  'Custom messaging or lifecycle ownership' \
+  '\b[A-Za-z]*DispatcherLauncher\b|MessageSubscription|MessageBus<|override\s+fun\s+receive\s*\([^)]*(Set<NamedAggregate>|namedAggregates)|getReceiverGroup|setReceiverGroup|writeReceiverGroup|SmartLifecycle|DisposableBean|GracefullyStoppable|WowRuntime|WowRuntimeLifecycle|RuntimeComponent|me\.ahoo\.wow\.infra\.lifecycle\.Lifecycle|@PostConstruct|@PreDestroy|destroyMethod' \
+  --glob '*.kt' --glob '*.java'
+
+match_section \
+  'Removed R2DBC and sharding support' \
+  'wow-r2dbc|r2dbc-support|wow\.r2dbc|me\.ahoo\.wow\.r2dbc|me\.ahoo\.wow\.sharding' \
+  --glob '*.kt' --glob '*.java' --glob '*.gradle' --glob '*.gradle.kts' \
+  --glob 'libs.versions.toml' --glob 'pom.xml' --glob '*.yml' --glob '*.yaml' --glob '*.properties'
+
+match_section \
+  'Changed OpenAPI and WebFlux extension APIs' \
+  '\bRouteSpec\b|\bRouteSpecFactory\b|\bGlobalRouteSpecFactory\b|\bAggregateRouteSpecFactory\b|\bRouteHandlerFunctionFactory\b' \
+  --glob '*.kt' --glob '*.java'
+
+match_section \
+  'Snapshot checkpoint or custom store exposure' \
+  'VersionedSnapshotStore|VersionIntervalCheckpointStrategy|CompositeSnapshotStrategy|SnapshotCheckpointProperties|wow\.eventsourcing\.snapshot\.checkpoint|SnapshotStore|SnapshotRepository|EventStore' \
+  --glob '*.kt' --glob '*.java' --glob '*.yml' --glob '*.yaml' --glob '*.properties'
+
+match_section \
+  'Removed Redis persistence internals' \
+  'AggregateKeyConverter|RedisWrappedKey|RedisSnapshotRepository|EventStreamKeyConverter|DefaultSnapshotKeyConverter|PrepareKeyConverter|SCRIPT_EVENT_STEAM_APPEND|SCRIPT_EVENT_STREAM_APPEND|redisSnapshotRepository' \
+  --glob '*.kt' --glob '*.java' --glob '*.yml' --glob '*.yaml' --glob '*.properties'
+
+match_section \
+  'Redis and Mongo configuration' \
+  'wow\..*(event-store|snapshot-store|prepare|redis|mongo)|spring\.(data\.)?(redis|mongodb)|Redis(EventStore|SnapshotStore|PrepareKey)|Mongo(EventStore|SnapshotStore)|MongoDatabaseContext' \
+  --glob '*.yml' --glob '*.yaml' --glob '*.properties' --glob '*.kt' --glob '*.java'
+
+match_section \
+  'Generated metadata and API contracts' \
+  'wow-metadata\.json|openapi|json-schema|\bksp\b' \
+  --glob '*.gradle' --glob '*.gradle.kts' --glob 'pom.xml' \
+  --glob '*.json' --glob '*.yaml' --glob '*.yml' --glob '*.kt' --glob '*.java'
+
+printf '\nAudit complete. Confirm resolved dependencies, runtime behavior, storage inventory, and target-tag contracts separately.\n'

--- a/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
+++ b/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
@@ -38,7 +38,7 @@ redact_sensitive_values() {
         content = substr($0, RLENGTH + 1)
       }
       lower = tolower(content)
-      if (match(lower, /(^|[^[:alnum:]])(password|passphrase|secret|token|credential|private[_-]?key|access[_-]?key|username|uri|url)/)) {
+      if (match(lower, /(^|[^[:alnum:]])(password|passphrase|secret|client[_-]?secret|token|credential|api[_-]?key|private[_-]?key|access[_-]?key|authorization|bearer|username|uri|url)/)) {
         sensitive_end = RSTART + RLENGTH
         suffix = substr(content, sensitive_end)
         if (match(suffix, /[=:]/)) {

--- a/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
+++ b/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
@@ -23,10 +23,34 @@ common_globs=(
   --glob '!**/.gradle/**'
   --glob '!**/node_modules/**'
   --glob '!**/target/**'
-  --glob '!**/*lock*.json'
-  --glob '!**/*lock*.yaml'
-  --glob '!**/*lock*.yml'
+  --glob '!**/package-lock.json'
+  --glob '!**/npm-shrinkwrap.json'
+  --glob '!**/pnpm-lock.yaml'
 )
+
+redact_sensitive_values() {
+  awk '
+    {
+      prefix = ""
+      content = $0
+      if (match($0, /^[^:]+:[0-9]+:/)) {
+        prefix = substr($0, 1, RLENGTH)
+        content = substr($0, RLENGTH + 1)
+      }
+      lower = tolower(content)
+      if (match(lower, /(^|[^[:alnum:]])(password|passphrase|secret|token|credential|private[_-]?key|access[_-]?key|username|uri|url)/)) {
+        sensitive_end = RSTART + RLENGTH
+        suffix = substr(content, sensitive_end)
+        if (match(suffix, /[=:]/)) {
+          delimiter_end = sensitive_end + RSTART - 1
+          print prefix substr(content, 1, delimiter_end) "<redacted>"
+          next
+        }
+      }
+      print $0
+    }
+  '
+}
 
 match_section() {
   local title="$1"
@@ -46,6 +70,7 @@ match_section() {
     return "$rg_status"
   fi
   if [[ -n "$output" ]]; then
+    output="$(printf '%s\n' "$output" | redact_sensitive_values)"
     printf '\n## %s\n%s\n' "$title" "$output"
   fi
 }
@@ -57,12 +82,12 @@ printf 'note: matches are review leads, not proof of incompatibility or complete
 match_section \
   'Declared platform and Wow versions' \
   '^[[:space:]]*(wow|kotlin|ksp|spring-boot)[[:space:]]*=|me\.ahoo\.wow|wow-(bom|dependencies|spring-boot-starter)|wow[._-]?version|org\.springframework\.boot|springBoot|spring-boot|kotlin\("jvm"\)|org\.jetbrains\.kotlin\.jvm|\bksp\b|<java\.version>|<kotlin\.version>|jvmToolchain|distributionUrl' \
-  --glob '*.gradle' --glob '*.gradle.kts' --glob 'libs.versions.toml' \
+  --glob '*.gradle' --glob '*.gradle.kts' --glob '*.versions.toml' \
   --glob 'gradle.properties' --glob 'gradle-wrapper.properties' --glob 'pom.xml'
 
 match_section \
   'Jackson 2 or Jackson 3 direct usage' \
-  'com\.fasterxml\.jackson\.(core|databind|module|datatype)|tools\.jackson|ObjectMapper|JsonNode|JsonSerializer|JsonDeserializer|JacksonAutoConfiguration' \
+  'com\.fasterxml\.jackson\.(core|databind|module|datatype|dataformat)|tools\.jackson|ObjectMapper|JsonNode|JsonSerializer|JsonDeserializer|JacksonAutoConfiguration' \
   --glob '*.kt' --glob '*.java' --glob '*.gradle' --glob '*.gradle.kts' --glob 'pom.xml'
 
 match_section \
@@ -85,14 +110,14 @@ match_section \
 
 match_section \
   'Custom messaging or lifecycle ownership' \
-  '\b([A-Za-z]*DispatcherLauncher|MainDispatcher|AggregateDispatcher|AggregateSchedulerSupplier|AUTO_REGISTRAR_PHASE)\b|MessageSubscription|MessageBus<|override\s+fun\s+receive\s*\([^)]*(Set<NamedAggregate>|namedAggregates)|\.receive\s*\(\s*(setOf(?:\s*<[^>]+>)?\s*\(|Set\.of\s*\(|namedAggregates\b)|getReceiverGroup|setReceiverGroup|writeReceiverGroup|SmartLifecycle|DisposableBean|GracefullyStoppable|WowRuntime|WowRuntimeLifecycle|RuntimeComponent|me\.ahoo\.wow\.infra\.lifecycle\.Lifecycle|@PostConstruct|@PreDestroy|destroyMethod' \
+  '\b([A-Za-z]*DispatcherLauncher|MainDispatcher|AggregateDispatcher|AggregateSchedulerSupplier|AUTO_REGISTRAR_PHASE)\b|MessageSubscription|MessageBus<|override\s+fun\s+receive\s*\([^)]*(Set<NamedAggregate>|namedAggregates)|\.receive\s*\(\s*(setOf(?:\s*<[^>]+>)?\s*\(|Set\.of\s*\(|namedAggregates\b)|getReceiverGroup|setReceiverGroup|writeReceiverGroup|\bLifecycle\b|SmartLifecycle|DisposableBean|GracefullyStoppable|WowRuntime|WowRuntimeLifecycle|RuntimeComponent|me\.ahoo\.wow\.infra\.lifecycle\.Lifecycle|@PostConstruct|@PreDestroy|destroyMethod' \
   --glob '*.kt' --glob '*.java'
 
 match_section \
   'Removed R2DBC and sharding support' \
   'wow-r2dbc|r2dbc-support|wow\.r2dbc|me\.ahoo\.wow\.r2dbc|me\.ahoo\.wow\.sharding' \
   --glob '*.kt' --glob '*.java' --glob '*.gradle' --glob '*.gradle.kts' \
-  --glob 'libs.versions.toml' --glob 'pom.xml' --glob '*.yml' --glob '*.yaml' --glob '*.properties'
+  --glob '*.versions.toml' --glob 'pom.xml' --glob '*.yml' --glob '*.yaml' --glob '*.properties'
 
 match_section \
   'Changed OpenAPI and WebFlux extension APIs' \

--- a/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
+++ b/skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh
@@ -105,6 +105,7 @@ match_section \
   'VersionedSnapshotStore|VersionIntervalCheckpointStrategy|CompositeSnapshotStrategy|SnapshotCheckpointProperties|wow\.eventsourcing\.snapshot\.checkpoint|SnapshotStore|SnapshotRepository|EventStore' \
   --glob '*.kt' --glob '*.java' --glob '*.yml' --glob '*.yaml' --glob '*.properties'
 
+# v6 exposed the misspelled public STEAM constant; v8 replaced it with internal STREAM.
 match_section \
   'Removed Redis persistence internals' \
   'AggregateKeyConverter|RedisWrappedKey|RedisSnapshotRepository|EventStreamKeyConverter|DefaultSnapshotKeyConverter|PrepareKeyConverter|SCRIPT_EVENT_STEAM_APPEND|SCRIPT_EVENT_STREAM_APPEND|redisSnapshotRepository' \

--- a/skills/wow/SKILL.md
+++ b/skills/wow/SKILL.md
@@ -7,6 +7,8 @@ description: |
 
   Use wow-development-workflow directly for clearly scoped end-to-end aggregate or saga implementation. Use wow-code-review or wow-debugging directly for review or diagnosis.
 
+  Use wow-v6-to-v8-migration directly for auditing, planning, implementing, or verifying an existing Wow v6 application's upgrade to Wow v8.
+
   Do not trigger for unrelated Kotlin, Gradle, frontend, or documentation tasks unless Wow framework behavior or APIs are directly relevant.
 ---
 
@@ -48,6 +50,7 @@ rg -n "@ConfigurationProperties|class .*Properties" wow-spring-boot-starter -g "
 | Implement or change Query DSL, pagination, projection, sort, query service calls | `references/dsl.md` |
 | Implement or change Spring Boot starter, storage, buses, feature switches | `references/configuration.md` |
 | Implement or change uniqueness or reservation with PrepareKey | `references/prepare-key.md` |
+| Audit, plan, implement, or verify an existing application's Wow v6 to v8 upgrade | `../wow-v6-to-v8-migration/SKILL.md` |
 | Review Wow code, PR diffs, framework semantics, or test coverage | `../wow-code-review/SKILL.md` |
 | Debug failing commands, events, sourcing, sagas, projections, waits, queries, config, or tests | `../wow-debugging/SKILL.md` |
 


### PR DESCRIPTION
## Summary

- add an evidence-gated `wow-v6-to-v8-migration` specialist skill
- bundle a migration contract covering platform, source/API, runtime, storage, cutover, and rollback concerns
- add a read-only v6 exposure scanner and route migration requests through the Wow skill catalog

## Why

Wow v6 to v8 is a platform and data migration rather than a dependency-only upgrade. This skill turns the migration guidance into an executable workflow with version pinning, evidence gates, storage cutover controls, and explicit rollback validation.

## Validation

- all five Wow skills pass `quick_validate.py`
- `bash -n skills/wow-v6-to-v8-migration/scripts/audit-v6-usage.sh`
- scanner forward-tested against a real Wow v6 consumer
- invalid scanner target returns exit code 2
- `python3 -m json.tool skills/plugins.json`
- `git diff origin/main...HEAD --check`