### PR TITLE
docs: restore bilingual onboarding guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ pnpm install
 pnpm docs:build
 ```
 
-For more context, see the [architecture guide](https://wow.ahoo.me/guide/advanced/architecture.html), [testing guide](https://wow.ahoo.me/guide/test-suite.html), and [getting-started guide](https://wow.ahoo.me/guide/getting-started.html).
+For an end-to-end repository introduction, start with the [contributor onboarding guide](https://wow.ahoo.me/onboarding/contributor-guide.html). The [architecture guide](https://wow.ahoo.me/guide/advanced/architecture.html), [testing guide](https://wow.ahoo.me/guide/test-suite.html), and [getting-started guide](https://wow.ahoo.me/guide/getting-started.html) remain the canonical topic references.
 
 ## Change Guidelines
 

--- a/documentation/docs/.vitepress/configs/navbar.en.ts
+++ b/documentation/docs/.vitepress/configs/navbar.en.ts
@@ -7,6 +7,11 @@ export const navbarEn: DefaultTheme.NavItem[] = [
         activeMatch: '^/guide/'
     },
     {
+        text: 'Onboarding',
+        link: '/onboarding/',
+        activeMatch: '^/onboarding/'
+    },
+    {
         text: 'Reference',
         activeMatch: '^/reference/',
         items: [

--- a/documentation/docs/.vitepress/configs/navbar.zh.ts
+++ b/documentation/docs/.vitepress/configs/navbar.zh.ts
@@ -12,6 +12,11 @@ export const navbarZh: DefaultTheme.NavItem[] = [
         activeMatch: '^/zh/articles/'
     },
     {
+        text: '入门导航',
+        link: '/zh/onboarding/',
+        activeMatch: '^/zh/onboarding/'
+    },
+    {
         text: '参考',
         activeMatch: '^/zh/reference/',
         items: [

--- a/documentation/docs/.vitepress/configs/sidebar.en.ts
+++ b/documentation/docs/.vitepress/configs/sidebar.en.ts
@@ -14,6 +14,20 @@
 import {DefaultTheme} from "vitepress/types/default-theme";
 
 export const sidebarEn: DefaultTheme.Sidebar = {
+    '/onboarding/': [
+        {
+            base: '/onboarding/',
+            text: 'Onboarding',
+            collapsed: false,
+            items: [
+                {text: 'Choose Your Path', link: ''},
+                {text: 'Contributor Guide', link: 'contributor-guide'},
+                {text: 'Staff Engineer Guide', link: 'staff-engineer-guide'},
+                {text: 'Executive Guide', link: 'executive-guide'},
+                {text: 'Product Manager Guide', link: 'product-manager-guide'},
+            ],
+        },
+    ],
     '/guide/': [
         {
             base: '/guide/',

--- a/documentation/docs/.vitepress/configs/sidebar.en.ts
+++ b/documentation/docs/.vitepress/configs/sidebar.en.ts
@@ -20,7 +20,7 @@ export const sidebarEn: DefaultTheme.Sidebar = {
             text: 'Onboarding',
             collapsed: false,
             items: [
-                {text: 'Choose Your Path', link: ''},
+                {text: 'Choose Your Path', link: '/onboarding/'},
                 {text: 'Contributor Guide', link: 'contributor-guide'},
                 {text: 'Staff Engineer Guide', link: 'staff-engineer-guide'},
                 {text: 'Executive Guide', link: 'executive-guide'},

--- a/documentation/docs/.vitepress/configs/sidebar.zh.ts
+++ b/documentation/docs/.vitepress/configs/sidebar.zh.ts
@@ -25,6 +25,20 @@ export const sidebarZh: DefaultTheme.Sidebar = {
             ],
         },
     ],
+    '/zh/onboarding/': [
+        {
+            base: '/zh/onboarding/',
+            text: '入门导航',
+            collapsed: false,
+            items: [
+                {text: '选择阅读路径', link: ''},
+                {text: '贡献者指南', link: 'contributor-guide'},
+                {text: '资深工程师指南', link: 'staff-engineer-guide'},
+                {text: '管理者指南', link: 'executive-guide'},
+                {text: '产品经理指南', link: 'product-manager-guide'},
+            ],
+        },
+    ],
     '/zh/guide/': [
         {
             base: '/zh/guide/',

--- a/documentation/docs/.vitepress/configs/sidebar.zh.ts
+++ b/documentation/docs/.vitepress/configs/sidebar.zh.ts
@@ -31,7 +31,7 @@ export const sidebarZh: DefaultTheme.Sidebar = {
             text: '入门导航',
             collapsed: false,
             items: [
-                {text: '选择阅读路径', link: ''},
+                {text: '选择阅读路径', link: '/zh/onboarding/'},
                 {text: '贡献者指南', link: 'contributor-guide'},
                 {text: '资深工程师指南', link: 'staff-engineer-guide'},
                 {text: '管理者指南', link: 'executive-guide'},

--- a/documentation/docs/en/onboarding/contributor-guide.md
+++ b/documentation/docs/en/onboarding/contributor-guide.md
@@ -1,0 +1,1987 @@
+# Contributor Guide
+
+This guide takes you from a clean checkout to a small, tested Wow contribution.
+
+It is written for Kotlin contributors who may be arriving from Java, Python, JavaScript, or another reactive stack.
+
+Every repository-specific claim links to the current `main` branch.
+
+If this guide and the source disagree, trust the source and update the guide in the same change.
+
+## What you will be able to do
+
+After completing the guide, you should be able to:
+
+- identify the module that owns a contract or behavior;
+- read a Wow command, event, aggregate, state, and specification as one vertical slice;
+- trace a WebFlux command from HTTP input to event persistence and downstream publication;
+- choose between local, contract, integration, static-analysis, and documentation checks;
+- add a domain behavior without leaking infrastructure into the domain module;
+- diagnose common validation, routing, storage, metadata, and timeout failures;
+- prepare a focused change that is straightforward to review and revert.
+
+## The current baseline
+
+Use the repository wrapper and toolchain rather than installing arbitrary global versions.
+
+| Component | Repository baseline | Source |
+| --- | --- | --- |
+| Wow | `8.9.5` | [`gradle.properties`](https://github.com/Ahoo-Wang/Wow/blob/main/gradle.properties#L18-L23) |
+| Kotlin | `2.4.10` | [version catalog](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L23-L35) |
+| Spring Boot | `4.1.0` | [version catalog](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L1-L5) |
+| Gradle | `9.6.1` | [wrapper properties](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/wrapper/gradle-wrapper.properties#L1-L9) |
+| JVM toolchain | Java `17` | [root build](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L175-L190) |
+| JUnit | `6.1.2` | [version catalog](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L23-L27) |
+| KSP | `2.3.10` | [version catalog](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L31-L35) |
+
+The README also states that Wow 8 targets Spring Boot 4 and Java 17 or later.
+Treat the build files above as the more precise source when versions move.
+[See the compatibility statement.](https://github.com/Ahoo-Wang/Wow/blob/main/README.md#L41-L49)
+
+# Part I — Foundations
+
+## 1. Kotlin for contributors coming from Python or JavaScript
+
+Kotlin is statically typed, null-aware, expression-oriented, and compiled for the JVM in this repository.
+
+The repository enables the official Kotlin code style and the K2-based KSP pipeline in [`gradle.properties`](https://github.com/Ahoo-Wang/Wow/blob/main/gradle.properties#L18-L23).
+
+Use this concrete translation table when arriving from Python or JavaScript:
+
+| Concern | Python | JavaScript / TypeScript | Kotlin in Wow |
+| --- | --- | --- | --- |
+| Immutable binding | Convention only, for example `product_id = "p1"` | `const productId = "p1"` | `val productId = "p1"` |
+| Mutable binding | `quantity = quantity + 1` | `let quantity = 1` | `var quantity = 1` |
+| Value-shaped message | `@dataclass class AddItem: ...` | `type AddItem = { ... }` | `data class AddCartItem(...)` |
+| Nullable value | `str \| None` | `string \| null` | `String?`; `String` excludes `null` |
+| Closed result cases | `match` plus class convention | discriminated union | `sealed interface` plus exhaustive `when` |
+| Read-only collection boundary | `Sequence[T]` by convention | `ReadonlyArray<T>` | `List<T>` is read-only at the interface |
+| One asynchronous value | coroutine / `Awaitable[T]` | `Promise<T>` | Reactor `Mono<T>` |
+| Many asynchronous values | async iterator | async iterator / stream | Reactor `Flux<T>` |
+| Dependency declaration | `pyproject.toml` | `package.json` | `build.gradle.kts` plus centralized `gradle/libs.versions.toml` |
+| Reproducible build entry | project-specific Python tool | package-manager lockfile and scripts | checked-in `./gradlew` wrapper |
+
+The Kotlin examples below expand the rightmost column. The Python and JavaScript cells are migration cues, not source files to add to this repository.
+
+### 1.1 Values, variables, and inferred types
+
+Prefer `val` for immutable references.
+
+Use `var` only when the reference must change.
+
+```kotlin
+val productId = "product-1"
+val initialQuantity: Int = 1
+var remainingQuantity = initialQuantity
+remainingQuantity -= 1
+```
+
+Python and JavaScript infer types dynamically at runtime.
+
+Kotlin usually infers them at compile time.
+
+That distinction means refactoring tools and the compiler can catch many mismatches before a test runs.
+
+### 1.2 Data classes model value-shaped messages
+
+Wow commands and events are commonly Kotlin data classes.
+
+The real cart example declares an `AddCartItem` command and `CartItemAdded` event in the API module, with Jakarta validation attached to command properties.
+[Read the source.](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/AddCartItem.kt#L1-L26)
+
+```kotlin
+data class AddCartItem(
+    val productId: String,
+    val quantity: Int,
+)
+
+data class CartItemAdded(
+    val productId: String,
+    val quantity: Int,
+)
+```
+
+The simplified snippet shows the shape.
+
+The repository source remains authoritative for annotations and validation constraints.
+
+### 1.3 Null is part of the type
+
+`String` does not accept `null`.
+
+`String?` does.
+
+```kotlin
+fun normalizeOwnerId(ownerId: String?): String? = ownerId?.trim()?.takeIf { it.isNotEmpty() }
+```
+
+Use safe calls, Elvis expressions, and explicit branching.
+
+Avoid `!!` unless an invariant is both local and already proven.
+
+### 1.4 Functions can return expressions
+
+```kotlin
+fun nextQuantity(current: Int, delta: Int): Int = current + delta
+```
+
+Aggregate command handlers often return domain events rather than mutating stored infrastructure directly.
+
+The cart aggregate follows that pattern: handlers evaluate state and return `CartItemAdded`, `CartQuantityChanged`, or `CartItemRemoved`.
+[Read the aggregate handlers.](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt#L32-L76)
+
+### 1.5 Classes expose intent through constructors
+
+Constructor injection makes dependencies visible.
+
+The Spring application uses normal component scanning and Spring Boot startup, while framework auto-configuration creates runtime beans conditionally.
+[See `ExampleServer`.](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-server/src/main/kotlin/me/ahoo/wow/example/server/ExampleServer.kt#L16-L35)
+[See command auto-configuration.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandAutoConfiguration.kt#L38-L100)
+
+```kotlin
+class ProductPolicy(
+    private val catalog: ProductCatalog,
+) {
+    fun isKnown(productId: String): Boolean = catalog.contains(productId)
+}
+```
+
+Keep domain dependencies focused.
+
+Do not inject a database client into an aggregate merely because Spring can provide it.
+
+### 1.6 Extension functions keep domain tests readable
+
+Kotlin lets a function appear as though it belongs to a receiver type.
+
+Wow tests use extensions such as the FluentAssert `.assert()` style described by the repository conventions.
+
+```kotlin
+fun Int.requirePositive(): Int {
+    require(this > 0)
+    return this
+}
+```
+
+Extensions do not actually add members to the target class.
+
+Use them to improve a local vocabulary, not to hide surprising control flow.
+
+### 1.7 Sealed types and exhaustive branches
+
+Use sealed hierarchies when a domain result has a closed set of cases.
+
+```kotlin
+sealed interface CartDecision
+
+data class Accepted(val event: Any) : CartDecision
+
+data class Rejected(val reason: String) : CartDecision
+
+fun describe(decision: CartDecision): String = when (decision) {
+    is Accepted -> "accepted"
+    is Rejected -> decision.reason
+}
+```
+
+The compiler verifies that the `when` expression covers every known subtype.
+
+### 1.8 Collections and immutability
+
+Use read-only collection interfaces at boundaries when mutation is not part of the contract.
+
+Write generic types as code, for example `List<CartItem>`.
+
+```kotlin
+fun productIds(items: List<CartItem>): Set<String> = items.mapTo(mutableSetOf()) { it.productId }
+```
+
+The type being read-only does not prove the underlying object is deeply immutable.
+
+Keep ownership clear and avoid exposing a mutable internal collection.
+
+### 1.9 Reactor is the default asynchronous vocabulary
+
+Wow runtime paths use Reactor `Mono` and `Flux`.
+
+Do not insert blocking calls into command dispatch, event persistence, projection, saga, or transport flows.
+
+`Mono<T>` represents zero or one asynchronous value.
+
+`Flux<T>` represents zero to many asynchronous values.
+
+```kotlin
+fun loadCart(cartId: String): Mono<CartView> = repository.load(cartId)
+
+fun streamEvents(cartId: String): Flux<CartEvent> = eventStore.load(cartId)
+```
+
+The types in this conceptual snippet are illustrative.
+
+The real command gateway exposes both `Mono` and `Flux` wait forms and delegates to the command bus.
+[Read the gateway contract.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt#L63-L173)
+
+### 1.10 Think in transformations, not subscriptions
+
+Framework code should usually compose operators and return the pipeline.
+
+The edge of the application owns subscription.
+
+```kotlin
+fun validateThenSend(command: CommandMessage<*>): Mono<Void> =
+    validator.validate(command)
+        .then(commandBus.send(command))
+```
+
+Do not call `block()` in a reactive runtime path.
+
+Do not call `subscribe()` inside reusable domain or infrastructure code unless that code explicitly owns lifecycle and cancellation.
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+flowchart LR
+    A["Kotlin command value"] --> B["Validation"]
+    B --> C["Mono composition"]
+    C --> D["Command gateway"]
+    D --> E["Event stream"]
+    E --> F["Flux publication"]
+    G["Avoid block and hidden subscribe"] -. protects .-> C
+```
+<!-- Sources:
+- [example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/AddCartItem.kt:1-26](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/AddCartItem.kt#L1-L26)
+- [wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt:63-173](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt#L63-L173)
+- [wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt:79-143](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L79-L143)
+-->
+
+## 2. Spring essentials in Wow
+
+Spring is the assembly mechanism around the runtime.
+
+Domain behavior should remain legible without knowing which auto-configuration created a bean.
+
+For contributors coming from FastAPI or Express, map the responsibilities like this:
+
+| Concern | FastAPI | Express | Spring/Wow |
+| --- | --- | --- | --- |
+| Application bootstrap | create a `FastAPI` application | create an `express()` application | `@SpringBootApplication` plus `runApplication` |
+| Route declaration | path-operation decorator | `app.post(...)` or Router | `RouterSpecs` contracts materialized as WebFlux `RouterFunction` |
+| Request pipeline | ASGI middleware and dependencies | middleware chain | WebFlux handler, extractor, policies, then `CommandGateway` |
+| Dependency injection | `Depends(...)` | usually explicit wiring or a third-party container | constructor injection plus conditional Spring beans |
+| Configuration | settings objects and environment | environment/config library | `application.yaml`, typed properties, and auto-configuration conditions |
+| Asynchronous model | coroutine returned by handler | Promise returned by handler | Reactor `Mono`/`Flux`; return the pipeline without blocking |
+
+Unlike a hand-written Express route, a Wow command route is derived from aggregate and command metadata, converted into route contracts, and only then materialized by WebFlux. Keep domain decisions outside that transport pipeline.
+
+### 2.1 Application bootstrap
+
+The sample server uses `@SpringBootApplication` and starts through `runApplication`.
+
+It explicitly scans the example service namespace and Wow namespace.
+[See the complete bootstrap.](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-server/src/main/kotlin/me/ahoo/wow/example/server/ExampleServer.kt#L16-L35)
+
+```kotlin
+@SpringBootApplication
+class ExampleServer
+
+fun main(args: Array<String>) {
+    runApplication<ExampleServer>(*args)
+}
+```
+
+This snippet teaches the Spring shape.
+
+Copy the real annotations and scan configuration from the source when creating a runnable module.
+
+### 2.2 Auto-configuration is capability-based
+
+`wow-spring-boot-starter` exposes feature variants for MongoDB, Redis, mocks, Kafka, WebFlux, Elasticsearch, OpenTelemetry, OpenAPI, and CoSec.
+[See the declared capabilities.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L5-L44)
+
+The starter registers its auto-configurations through Spring Boot's imports file.
+[See the imports.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports#L1-L31)
+
+Choose the smallest feature set that owns the needed integration.
+
+Adding an infrastructure dependency to the domain module is usually a boundary smell.
+
+### 2.3 Conditional beans preserve replaceable boundaries
+
+Auto-configuration creates defaults only when properties and classpath capabilities select them.
+
+The command configuration conditionally assembles local bus variants, builder rewriters, validation, and message creation.
+[Inspect the command conditions and bean factories.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandAutoConfiguration.kt#L38-L100)
+
+The separate gateway configuration assembles idempotency, wait coordination, stage notifiers, and `DefaultCommandGateway`.
+[Inspect gateway assembly.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandGatewayAutoConfiguration.kt#L51-L163)
+
+Before creating another bean:
+
+1. search for the interface;
+2. find existing implementations;
+3. inspect conditional annotations;
+4. check property binding;
+5. check the auto-configuration imports file;
+6. add a replacement only at the owning integration boundary.
+
+### 2.4 Configuration is executable behavior
+
+The example server currently selects MongoDB event and snapshot storage while using in-memory buses.
+[Read the active example configuration.](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-server/src/main/resources/application.yaml#L73-L99)
+
+Do not infer a production topology from that example.
+
+The file is evidence of the sample's local wiring, not a universal deployment recommendation.
+
+### 2.5 WebFlux adapts HTTP to the command model
+
+The WebFlux handler reads the request body, rejects an empty body, delegates to the command handler, and writes the response.
+[Read `CommandHandlerFunction`.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt#L43-L66)
+
+The extractor turns headers, path information, and body content into a `CommandMessage`.
+[Read the extractor.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandMessageExtractor.kt#L23-L46)
+
+The transport handler chooses a wait policy and either an SSE or single-result response.
+[Read the transport handler.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt#L30-L62)
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+flowchart LR
+    R["HTTP request"] --> F["CommandHandlerFunction"]
+    F --> H["CommandHandler"]
+    H --> X["CommandMessageExtractor"]
+    X --> W{"Wait response mode"}
+    W -->|"single"| M["sendAndWait"]
+    W -->|"stream"| S["sendAndWaitStream"]
+    M --> G["CommandGateway"]
+    S --> G
+    G --> O["HTTP response or SSE"]
+```
+<!-- Sources:
+- [wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt:43-66](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt#L43-L66)
+- [wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandMessageExtractor.kt:23-46](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandMessageExtractor.kt#L23-L46)
+- [wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt:30-62](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt#L30-L62)
+-->
+
+# Part II — Understand the codebase
+
+## 3. What Wow is
+
+Wow provides framework contracts and runtime components for domain-driven design, CQRS, and event sourcing.
+
+The project describes itself as a modern reactive framework with command, event, projection, saga, storage, and integration capabilities.
+[Read the project overview and feature list.](https://github.com/Ahoo-Wang/Wow/blob/main/README.md#L51-L84)
+
+The central contributor idea is separation of responsibility:
+
+- API modules define commands, events, and public domain contracts;
+- domain modules implement decisions and event-sourced state transitions;
+- core modules provide runtime behavior;
+- Spring modules assemble runtime components;
+- infrastructure modules adapt storage and transports;
+- test modules provide DSLs, TCKs, and integration support;
+- example modules demonstrate complete vertical slices.
+
+## 4. Repository structure
+
+The authoritative project list lives in [`settings.gradle.kts`](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L23-L85).
+
+There are four useful groups.
+
+### 4.1 Framework and integration modules
+
+| Area | Representative modules | Responsibility |
+| --- | --- | --- |
+| API | `wow-api` | Pure contracts, annotations, command/event types, naming, modeling. |
+| Runtime | `wow-core` | Dispatch, event sourcing, buses, projection, saga, lifecycle. |
+| Compiler | `wow-compiler` | KSP processors and framework metadata generation. |
+| Spring | `wow-spring`, `wow-spring-boot-starter` | Integration primitives and conditional assembly. |
+| Query | `wow-query` | Query model support. |
+| Storage | `wow-mongo`, `wow-redis`, `wow-elasticsearch` | Event and snapshot persistence adapters; Elasticsearch also supplies event-stream and snapshot queries. |
+| Messaging | `wow-kafka` | Distributed command and event bus integration. |
+| Projection and cache | `wow-elasticsearch`, `wow-cocache` | Elasticsearch-backed query/projection support and projection caching. |
+| Transport | `wow-webflux`, `wow-apiclient` | HTTP command endpoints and API client support. |
+| Cross-cutting | `wow-opentelemetry`, `wow-cosec` | Telemetry and authorization. |
+| Schema | `wow-openapi`, `wow-schema` | OpenAPI and JSON Schema support. |
+| BI | `wow-bi` | BI synchronization script generation. |
+| Dependency management | `wow-bom`, `wow-dependencies` | Published version alignment. |
+
+The table summarizes module intent.
+
+Verify exact inclusion and directory mapping in the settings file before editing build logic.
+
+### 4.2 Test modules
+
+The settings file includes test DSLs, test support, storage and bus TCKs, mocks, benchmarks, integration tests, and aggregate coverage reporting.
+[See the test-module declarations.](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L46-L56)
+
+Use a TCK when several implementations must satisfy the same contract.
+
+Use an integration test when the behavior depends on a real external engine or container.
+
+### 4.3 Compensation modules
+
+The compensation area has API, domain, core, server, and dashboard projects.
+[See the compensation declarations.](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L58-L66)
+
+Treat it as a product-shaped subsystem with its own boundaries.
+
+Do not use compensation implementation detail as a default core contract without an explicit architecture decision.
+
+### 4.4 Example modules
+
+The examples include a Kotlin domain/server and a Java transfer domain/server.
+[See the example declarations.](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L68-L85)
+
+The Kotlin cart example is the best first vertical slice because its command, event, aggregate, state, saga, and tests are small and connected.
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+graph TB
+    API["wow-api<br>contracts"] --> CORE["wow-core<br>runtime"]
+    CORE --> SPRING["wow-spring<br>integration"]
+    SPRING --> STARTER["wow-spring-boot-starter<br>assembly"]
+    CORE --> KAFKA["wow-kafka"]
+    CORE --> MONGO["wow-mongo"]
+    CORE --> REDIS["wow-redis"]
+    CORE --> ES["wow-elasticsearch"]
+    CORE --> WEB["wow-webflux"]
+    API --> COMPILER["wow-compiler<br>KSP metadata"]
+    TEST["test modules<br>DSL and TCK"] -. verifies .-> CORE
+    EXAMPLE["example modules"] --> STARTER
+    EXAMPLE --> API
+```
+<!-- Sources:
+- [settings.gradle.kts:23-85](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L23-L85)
+- [wow-spring-boot-starter/build.gradle.kts:5-79](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L5-L79)
+- [example/example-domain/build.gradle.kts:1-20](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/build.gradle.kts#L1-L20)
+-->
+
+## 5. Core concepts
+
+### 5.1 Bounded context and named aggregate
+
+A bounded context gives names a domain boundary.
+
+`NamedBoundedContext` exposes the bounded-context name.
+[Read the contract.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/naming/NamedBoundedContext.kt#L15-L36)
+
+`NamedAggregate` identifies an aggregate name within that context.
+[Read the contract.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/NamedAggregate.kt#L20-L49)
+
+The example declares a service context in its API and a bounded-context marker in its domain.
+[See `ExampleService`.](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/ExampleService.kt#L22-L40)
+[See `ExampleBoundedContext`.](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/ExampleBoundedContext.kt#L19-L21)
+
+### 5.2 Aggregate identity
+
+`AggregateId` combines the named aggregate, the aggregate `id`, and `tenantId`.
+
+Owner and space are related message and aggregate-state context, but they are not fields of the `AggregateId` contract.
+
+The contract states that an aggregate ID is unique across tenants for the same named aggregate.
+[Read the identity contract.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt#L18-L45)
+
+Do not treat `tenantId` as a namespace that permits the same `id` to be reused inside one named aggregate.
+
+### 5.3 Command and command message
+
+A command expresses requested intent.
+
+A `CommandMessage` wraps that intent with identity, routing, headers, aggregate version, and lifecycle flags.
+[Read the message contract.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L24-L61)
+[Read the targeting and version fields.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L70-L125)
+
+The message can indicate creation, expected aggregate version, and void behavior.
+
+Those fields participate in correctness and should not be dropped by adapters.
+
+### 5.4 Domain event and event stream
+
+A domain event records a business fact that has happened.
+
+`DomainEvent` carries sequence, revision, command, aggregate, and metadata context.
+[Read the event contract.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/event/DomainEvent.kt#L21-L50)
+[Read sequence and revision fields.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/event/DomainEvent.kt#L57-L89)
+
+`DomainEventStream` groups events produced by one command.
+
+Its implementation enforces stream-level invariants, including command identity and aggregate context.
+[Read the stream contract and invariants.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L31-L115)
+
+### 5.5 Event store
+
+`EventStore` appends a domain event stream and loads streams for an aggregate.
+[Read the storage contract.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L22-L82)
+
+Optimistic concurrency and duplicate-stream failures belong to this boundary.
+
+Do not convert them into successful writes at an adapter edge.
+
+### 5.6 State sourcing and snapshots
+
+The state aggregate applies domain events to rebuild state.
+
+The contract advances version even when no sourcing handler is present, so absence of a handler is not equivalent to ignoring event position.
+[Read `StateAggregate`.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/state/StateAggregate.kt#L17-L31)
+
+The repository can load a snapshot and replay later events.
+[Read the repository implementation.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventSourcingStateAggregateRepository.kt#L25-L45)
+
+A snapshot captures aggregate state at a version.
+[Read the snapshot contract.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/Snapshot.kt#L20-L41)
+
+### 5.7 State events
+
+A state event is derived after domain event sourcing and can represent the resulting state transition for downstream consumers.
+[Read `StateEvent`.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/StateEvent.kt#L23-L100)
+
+The state-event filter creates and publishes state events after processing the event stream.
+[Read the filter.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/SendStateEventFilter.kt#L29-L76)
+
+### 5.8 Projection, event processor, and saga
+
+An event processor reacts to domain events.
+[Read the `@EventProcessor` annotation.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/EventProcessor.kt#L19-L58)
+
+A projection processor builds read-side views.
+[Read the `@ProjectionProcessor` annotation.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/ProjectionProcessor.kt#L19-L68)
+
+A stateless saga coordinates a reaction without retaining saga state in the annotated type.
+
+The cart example listens for `OrderCreated`. When the order was created from a cart, it emits `RemoveCartItem` for the purchased products and targets the cart through `event.ownerId`.
+
+`@Retry` configures retries around execution of the saga handler. It is not metadata attached to the emitted command.
+[Read `CartSaga`.](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartSaga.kt#L25-L42)
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+erDiagram
+    BOUNDED_CONTEXT ||--o{ NAMED_AGGREGATE : contains
+    NAMED_AGGREGATE ||--o{ AGGREGATE_ID : identifies
+    AGGREGATE_ID ||--o{ COMMAND_MESSAGE : targets
+    COMMAND_MESSAGE ||--o| DOMAIN_EVENT_STREAM : may_produce
+    DOMAIN_EVENT_STREAM ||--|{ DOMAIN_EVENT : contains
+    AGGREGATE_ID ||--o{ SNAPSHOT : checkpoints
+    DOMAIN_EVENT_STREAM ||--o| STATE_EVENT : derives
+    DOMAIN_EVENT ||--o{ PROJECTION : updates
+    DOMAIN_EVENT ||--o{ SAGA : triggers
+```
+<!-- Sources:
+- [wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt:18-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt#L18-L45)
+- [wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt:24-125](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L24-L125)
+- [wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt:31-115](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L31-L115)
+- [wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/Snapshot.kt:20-41](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/Snapshot.kt#L20-L41)
+- [wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/StateEvent.kt:23-100](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/StateEvent.kt#L23-L100)
+- [wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/ProjectionProcessor.kt:19-68](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/ProjectionProcessor.kt#L19-L68)
+- [wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/StatelessSaga.kt:19-62](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/StatelessSaga.kt#L19-L62)
+-->
+
+## 6. The command lifecycle
+
+The following trace is the most useful runtime map for a contributor.
+
+### 6.1 HTTP adaptation
+
+`CommandHandlerFunction` reads and validates the presence of a body.
+
+`CommandMessageExtractor` constructs framework metadata from the request.
+
+`CommandHandler` selects a wait plan and response form.
+
+### 6.2 Gateway validation and idempotency
+
+`DefaultCommandGateway` validates the command and runs idempotency coordination before sending it.
+[Read validation, idempotency, and bus dispatch.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L79-L143)
+
+Duplicate request identity is a correctness condition, not merely a logging concern.
+
+The gateway rejects a duplicate request ID for the same aggregate.
+[Read the duplicate request exception contract.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandExceptions.kt#L25-L35)
+
+### 6.3 Dispatch and aggregate affinity
+
+`CommandDispatcher` receives commands from the bus and selects the named aggregate dispatcher.
+[Read the dispatcher.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/CommandDispatcher.kt#L37-L75)
+
+`AggregateCommandDispatcher` routes work by aggregate ID so commands for the same aggregate preserve worker affinity.
+[Read aggregate dispatch.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/AggregateCommandDispatcher.kt#L25-L86)
+
+Spring assembly creates the processor, filter chain, handler, and dispatcher.
+[Read aggregate auto-configuration.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/modeling/AggregateAutoConfiguration.kt#L70-L145)
+
+### 6.4 Decision, sourcing, and append
+
+The processor filter obtains a command aggregate processor and executes the exchange.
+[Read the processor filter.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/AggregateProcessorFilter.kt#L26-L49)
+
+`RetryableAggregateProcessor` asks the state repository to load the aggregate. `EventSourcingStateAggregateRepository` first tries the snapshot store, then replays the remaining event streams from the event store before a command aggregate is created.
+[Read processor loading.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/RetryableAggregateProcessor.kt#L48-L68)
+[Read snapshot-first reconstruction.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventSourcingStateAggregateRepository.kt#L74-L107)
+
+`SimpleCommandAggregate` resolves the command handler, enforces aggregate conditions, invokes domain behavior, sources the returned events, and appends the event stream.
+[Read the decision path.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L64-L132)
+
+The command aggregate records processing states such as stored, sourced, and expired.
+[Read the aggregate command-state transitions.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/CommandAggregate.kt#L55-L84)
+
+### 6.5 Publication and wait completion
+
+After append, the domain-event filter publishes the stream to the domain event bus.
+[Read the publication filter.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt#L25-L46)
+
+The state-event filter publishes the sourced state transition.
+
+The wait coordinator observes requested stages and completes the transport-facing result.
+
+The stage model declares dependencies between `SENT`, `PROCESSED`, `SNAPSHOT`, `PROJECTED`, `EVENT_HANDLED`, and `SAGA_HANDLED`.
+[Read the stage dependencies.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt#L25-L123)
+
+A wait plan can complete directly at `SENT` or `PROCESSED`. `SNAPSHOT`, `PROJECTED`, `EVENT_HANDLED`, and `SAGA_HANDLED` are sibling targets that share the first two prerequisites; they are not a mandatory sequence traversed by every command.
+
+### 6.6 Deadline and cancellation ownership
+
+Streaming waits use `Flux.using` and single-result waits use `Mono.using` so coordinator resources are released.
+[Read streaming wait ownership.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L201-L223)
+[Read single-result wait ownership.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L238-L266)
+
+The gateway propagates the wait plan, sends the command, and emits `SENT` or an error.
+[Read wait propagation and send.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L282-L301)
+
+Timeout tests verify that wait handles are released and that one absolute deadline bounds the operation.
+[Read the timeout tests.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTimeoutTest.kt#L45-L125)
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+sequenceDiagram
+    autonumber
+    participant Client
+    participant WebFlux
+    participant Gateway
+    participant CommandBus
+    participant Dispatcher
+    participant Processor
+    participant Repository
+    participant SnapshotStore
+    participant Aggregate
+    participant EventStore
+    participant Filters
+    participant EventBus
+    participant WaitCoordinator
+    Client->>WebFlux: HTTP command
+    WebFlux->>WebFlux: extract CommandMessage
+    WebFlux->>Gateway: send and wait
+    Gateway->>Gateway: validate and coordinate idempotency
+    Gateway->>WaitCoordinator: register wait plan
+    Gateway->>CommandBus: send command
+    Gateway-->>WaitCoordinator: SENT
+    CommandBus->>Dispatcher: receive command
+    Dispatcher->>Processor: route by aggregate ID
+    Processor->>Repository: load StateAggregate
+    Repository->>SnapshotStore: load latest snapshot
+    SnapshotStore-->>Repository: snapshot or empty
+    Repository->>EventStore: load tail after snapshot version
+    EventStore-->>Repository: event streams
+    Repository-->>Processor: reconstructed StateAggregate
+    Processor->>Aggregate: create and process command aggregate
+    Aggregate->>Aggregate: enforce conditions and decide
+    Aggregate->>EventStore: append DomainEventStream
+    EventStore-->>Aggregate: stored
+    Aggregate-->>Filters: stored event stream
+    Filters->>EventBus: publish event stream
+    EventBus-->>WaitCoordinator: downstream stages
+    WaitCoordinator-->>Gateway: result or timeout
+    Gateway-->>WebFlux: CommandResult
+    WebFlux-->>Client: response or SSE
+```
+<!-- Sources:
+- [wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt:43-66](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt#L43-L66)
+- [wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt:79-143](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L79-L143)
+- [wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/AggregateCommandDispatcher.kt:25-86](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/AggregateCommandDispatcher.kt#L25-L86)
+- [wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/RetryableAggregateProcessor.kt:48-68](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/RetryableAggregateProcessor.kt#L48-L68)
+- [wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventSourcingStateAggregateRepository.kt:74-107](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventSourcingStateAggregateRepository.kt#L74-L107)
+- [wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt:64-132](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L64-L132)
+- [wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt:25-46](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt#L25-L46)
+-->
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+stateDiagram-v2
+    [*] --> SENT: command bus accepted send
+    SENT --> SENT_COMPLETE: WaitPlan targets SENT
+    SENT --> PROCESSED: aggregate processing completed
+    PROCESSED --> PROCESSED_COMPLETE: WaitPlan targets PROCESSED
+    PROCESSED --> SNAPSHOT: sibling target
+    PROCESSED --> PROJECTED: sibling target
+    PROCESSED --> EVENT_HANDLED: sibling target
+    PROCESSED --> SAGA_HANDLED: sibling target
+    SNAPSHOT --> DOWNSTREAM_COMPLETE: selected target satisfied
+    PROJECTED --> DOWNSTREAM_COMPLETE: selected target satisfied
+    EVENT_HANDLED --> DOWNSTREAM_COMPLETE: selected target satisfied
+    SAGA_HANDLED --> DOWNSTREAM_COMPLETE: selected target satisfied
+    SENT_COMPLETE --> [*]
+    PROCESSED_COMPLETE --> [*]
+    DOWNSTREAM_COMPLETE --> [*]
+```
+<!-- Sources:
+- [wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt:25-123](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt#L25-L123)
+- [wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWait.kt:21-120](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWait.kt#L21-L120)
+- [wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt:282-301](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L282-L301)
+-->
+
+## 7. Key implementation patterns
+
+### 7.1 API → aggregate → state → specification
+
+This is the default domain-feature path.
+
+1. Define command and event contracts in an API module.
+2. Add command handling to the aggregate in the domain module.
+3. Add sourcing behavior to the aggregate state.
+4. Add an `AggregateSpec` covering accepted and rejected behavior.
+5. Run the domain module test and coverage checks.
+
+The cart slice provides all four pieces:
+
+- [example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/AddCartItem.kt:1-26](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/AddCartItem.kt#L1-L26)
+- [example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt:32-76](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt#L32-L76)
+- [example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt:23-46](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt#L23-L46)
+- [example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt:28-87](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt#L28-L87)
+
+### 7.2 Annotations declare discovery boundaries
+
+`@AggregateRoot` identifies an aggregate root. Its `commands` property mounts additional command types, including void or rewritten commands, onto that aggregate.
+[Read the annotation contract.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AggregateRoot.kt#L18-L77)
+
+`@OnCommand` marks an aggregate function as a command handler and can declare the event types it returns. It does not define an HTTP path or method.
+[Read the annotation contract.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/OnCommand.kt#L19-L86)
+
+`@OnSourcing` marks state transitions driven by events.
+[Read the annotation contract.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/OnSourcing.kt#L18-L59)
+
+`@CommandRoute` is the command-class contract for HTTP action, method, prefix, and path dimensions. `@AggregateRoot.commands` controls which extra commands are registered with the aggregate.
+[Read command route options.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/CommandRoute.kt#L18-L72)
+
+The remaining responsibilities are separate layers:
+
+1. KSP writes merged bounded-context and aggregate metadata; it does not register a Spring router.
+2. `CommandRouteContributor` combines registered commands and `@CommandRoute` metadata into `HttpRouteContract` entries in `RouterSpecs`.
+3. WebFlux `RouterFunctionBuilder` materializes those contracts with registered handler factories at runtime.
+
+[See the KSP plugin configuration.](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/build.gradle.kts#L1-L8)
+[See the metadata processor.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/metadata/MetadataSymbolProcessor.kt#L61-L104)
+[See command route contribution.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/aggregate/command/CommandRouteContributor.kt#L52-L91)
+[See runtime route materialization.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/RouterFunctionBuilder.kt#L24-L42)
+
+### 7.3 Filter chains extend processing without collapsing boundaries
+
+Aggregate auto-configuration collects ordered exchange filters and builds a processing chain.
+[Read filter assembly.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/modeling/AggregateAutoConfiguration.kt#L108-L133)
+
+Use a filter for cross-cutting exchange behavior that truly belongs at that stage.
+
+Do not use a filter to hide domain rules that should be visible in the aggregate.
+
+### 7.4 TCKs protect replaceable implementations
+
+Storage and bus integrations have contract-test modules declared in the build.
+[See the TCK modules.](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L46-L56)
+
+When adding an implementation:
+
+1. implement the smallest owning contract;
+2. reuse the relevant TCK;
+3. add adapter-specific integration tests;
+4. register capability and conditional configuration in the starter if needed;
+5. avoid changing the public contract to accommodate one engine unless the model requires it.
+
+### 7.5 Capability and auto-configuration form one extension unit
+
+The starter's feature variants declare optional integrations.
+
+The imports file declares auto-configurations.
+
+The implementation module owns the adapter.
+
+The TCK validates the common contract.
+
+Treat those pieces as one extension surface during review.
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+flowchart TB
+    CONTRACT["Public contract<br>wow-api or wow-core"] --> ADAPTER["Dedicated integration module"]
+    ADAPTER --> TCK["Shared TCK"]
+    ADAPTER --> INTEGRATION["Engine integration test"]
+    ADAPTER --> CAPABILITY["Starter feature capability"]
+    CAPABILITY --> AUTOCONFIG["Conditional auto-configuration"]
+    AUTOCONFIG --> RUNTIME["Selected runtime implementation"]
+    METADATA["KSP metadata"] --> RUNTIME
+    WEBFLUX["WebFlux runtime routing"] --> RUNTIME
+```
+<!-- Sources:
+- [settings.gradle.kts:23-56](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L23-L56)
+- [wow-spring-boot-starter/build.gradle.kts:5-79](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L5-L79)
+- [wow-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports:1-31](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports#L1-L31)
+- [example/example-domain/build.gradle.kts:1-20](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/build.gradle.kts#L1-L20)
+- [wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/metadata/MetadataSymbolProcessor.kt:61-104](https://github.com/Ahoo-Wang/Wow/blob/main/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/metadata/MetadataSymbolProcessor.kt#L61-L104)
+-->
+
+# Part III — Make your first contribution
+
+## 8. Prerequisites
+
+The install commands below are macOS/Homebrew examples. On Linux or Windows, use the equivalent official installer while preserving the required version. Every install command should exit with status `0`; then run the verification command and compare the evidence column.
+
+| Tool | Version | Needed for | Install command | Verify command | Expected evidence |
+| --- | --- | --- | --- | --- | --- |
+| Git | Current supported release | All work | `brew install git` | `git --version` | One line beginning with `git version` |
+| JDK | `17` | JVM tests and Dokka | `brew install --cask temurin@17` | `java -version` | Version output containing `17` |
+| Gradle Wrapper | `9.6.1` | JVM build | No global install; bootstrap with `./gradlew --version` | `./gradlew --version` | `Gradle 9.6.1` and `Launcher JVM: 17...` |
+| Node.js | `24.18.1` in CI | Documentation and dashboard | `brew install node@24` | `node --version` | A `v24...` version; CI uses `v24.18.1` |
+| pnpm | `10.34.5` | Documentation and dashboard | `corepack enable && corepack prepare pnpm@10.34.5 --activate` | `pnpm --version` | Exactly `10.34.5` |
+| Docker-compatible runtime | Engine capable of running Testcontainers | Integration tests only | `brew install --cask docker` | `docker version` | Both `Client` and `Server` sections after the runtime starts |
+
+CI uses Temurin Java 17 for local tests, and the checked-in wrapper downloads Gradle 9.6.1. You do not need a global Gradle installation.
+[See the JVM workflow setup.](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/local-test.yml#L48-L58)
+[See the wrapper version.](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/wrapper/gradle-wrapper.properties#L1-L9)
+
+Documentation and dashboard CI use Node `24.18.1` and pnpm `10.34.5`; their package manifests define separate scripts.
+[See the documentation workflow.](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/documentation-deploy.yml#L44-L86)
+[See documentation scripts.](https://github.com/Ahoo-Wang/Wow/blob/main/documentation/package.json#L6-L32)
+[See dashboard CI.](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/dashboard-test.yml#L35-L63)
+[See dashboard scripts.](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/package.json#L6-L66)
+
+The root build separates local, contract, and container-backed integration source sets and tasks. A passing local test does not prove that an external storage adapter works.
+[Read the test-layer definitions.](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L54-L142)
+
+## 9. Verify the checkout
+
+Run commands from the repository root.
+
+### 9.1 Confirm the wrapper and JVM
+
+```bash
+./gradlew --version
+```
+
+Expected key lines:
+
+```text
+Gradle 9.6.1
+Launcher JVM: 17...
+```
+
+Patch versions and vendor text can differ.
+
+The repository requires the Java 17 toolchain and pins the wrapper version in source.
+
+### 9.2 Inspect your worktree
+
+```bash
+git status --short
+git branch --show-current
+```
+
+Expected result: `git status --short` is empty for a clean checkout, or lists only changes you already own; `git branch --show-current` prints the branch you intend to modify.
+
+Do not discard changes you did not create.
+
+Keep your contribution narrow even when the worktree is already dirty.
+
+### 9.3 Run the cart specification
+
+```bash
+./gradlew :example-domain:test \
+  --tests 'me.ahoo.wow.example.domain.cart.CartSpec' \
+  --stacktrace
+```
+
+Expected result:
+
+```text
+BUILD SUCCESSFUL
+```
+
+The exact duration and task-cache status are machine-dependent.
+
+The specification covers adding and removing items plus deleting and recovering the cart aggregate.
+[Read the scenarios.](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt#L28-L87)
+
+## 10. Read one complete vertical slice
+
+Before editing, open these files in order.
+
+### Step 1 — Command and event
+
+Open [`AddCartItem.kt`](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/AddCartItem.kt#L1-L26).
+
+Observe:
+
+- validation belongs on the public command contract;
+- the command names intent;
+- the event names a completed fact;
+- API types do not import MongoDB, Kafka, or Spring runtime adapters.
+
+### Step 2 — Aggregate decision
+
+Open [`Cart.kt`](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt#L32-L76).
+
+Observe:
+
+- `@AggregateRoot` declares the aggregate;
+- the route identifies how commands target it;
+- each command handler checks current state;
+- handlers return events;
+- the aggregate does not persist itself directly.
+
+### Step 3 — State transition
+
+Open [`CartState.kt`](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt#L23-L46).
+
+Observe:
+
+- sourcing handlers consume events;
+- state changes follow event facts;
+- replay uses the same transition logic as live processing.
+
+### Step 4 — Specification
+
+Open [`CartSpec.kt`](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt#L28-L87).
+
+Observe:
+
+- scenarios use the Wow aggregate test DSL;
+- commands are the input;
+- expected events and state are the primary output;
+- deleted and recovered states are explicit behavior.
+
+### Step 5 — Build boundary
+
+Open [`example-domain/build.gradle.kts`](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/build.gradle.kts#L1-L20).
+
+Observe:
+
+- KSP is applied in the domain module;
+- the domain depends on the API and framework;
+- tests use Wow test support;
+- line coverage has an `0.8` verification rule.
+
+## 11. A safe first task
+
+The walkthrough below is a **teaching proposal**, not behavior currently checked into the repository. It deliberately introduces the new names `SetCartNote` and `CartNoteChanged`; all existing types, DSL calls, module paths, and commands come from the current cart slice.
+
+The proposed feature lets the owner attach a short delivery note to an initialized cart. It is small enough to exercise the complete API → decision → event → sourcing → specification path without changing storage or module boundaries.
+
+### 11.1 Define the contract and affected files
+
+Behavior statement:
+
+> Given an initialized cart, when `SetCartNote` contains a non-blank note of at most 200 characters, emit `CartNoteChanged` and source the new note into `CartState`.
+
+The complete change owns exactly four files:
+
+| File | Proposed change |
+| --- | --- |
+| `example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/SetCartNote.kt` | Add the command and event contracts. |
+| `example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt` | Add the command decision. |
+| `example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt` | Add the sourced state field and handler. |
+| `example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt` | Add red/green behavior coverage. |
+
+Do not add persistence code: the event store persists the new event through the existing runtime path.
+
+### 11.2 Add the API contract
+
+Create `SetCartNote.kt` with the repository's Apache header and this body:
+
+```kotlin
+package me.ahoo.wow.example.api.cart
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import me.ahoo.wow.api.annotation.CommandRoute
+import me.ahoo.wow.api.annotation.Order
+import me.ahoo.wow.api.annotation.Summary
+
+@Order(4)
+@Summary("设置购物车备注")
+@CommandRoute(appendIdPath = CommandRoute.AppendPath.ALWAYS)
+data class SetCartNote(
+    @field:NotBlank
+    @field:Size(max = 200)
+    val note: String,
+)
+
+@Summary("购物车备注已变更")
+data class CartNoteChanged(
+    val note: String,
+)
+```
+
+The command shape follows the existing routed cart commands; validation stays at the API boundary.
+[Compare the real `ChangeQuantity` contract.](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/ChangeQuantity.kt#L1-L21)
+
+### 11.3 Add a failing specification
+
+Import the two proposed types into `CartSpec`. Inside the existing successful `AddCartItem` branch, add this fork so the cart is already initialized:
+
+```kotlin
+fork(name = "Set cart note") {
+    val expectedNote = "Leave at reception"
+    whenCommand(SetCartNote(note = expectedNote)) {
+        expectNoError()
+        expectEventType(CartNoteChanged::class)
+        expectState {
+            note.assert().isEqualTo(expectedNote)
+        }
+    }
+}
+```
+
+[Use the existing initialized-cart forks as the exact DSL model.](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt#L28-L66)
+
+Run only that specification:
+
+```bash
+./gradlew :example-domain:test \
+  --tests 'me.ahoo.wow.example.domain.cart.CartSpec' \
+  --stacktrace
+```
+
+Expected red result: Gradle ends with `BUILD FAILED`, and the first owned cause reports an undefined `SetCartNote` command or the missing `CartState.note` implementation. The HTML report is written under `example/example-domain/build/reports/tests/test/`.
+
+### 11.4 Implement decision and sourcing
+
+Add imports for the proposed types to `Cart.kt`, then add the decision:
+
+```kotlin
+@OnCommand
+fun onCommand(command: SetCartNote): CartNoteChanged {
+    return CartNoteChanged(note = command.note.trim())
+}
+```
+
+Add imports to `CartState.kt`, a state field, and the sourcing handler:
+
+```kotlin
+var note: String? = null
+    private set
+
+@OnSourcing
+fun onCartNoteChanged(event: CartNoteChanged) {
+    note = event.note
+}
+```
+
+The aggregate returns a fact; only the state sourcing function mutates reconstructed state. That is the same separation used by `CartQuantityChanged` today.
+[Compare the current decision.](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt#L69-L76)
+[Compare the current sourcing handler.](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt#L37-L46)
+
+### 11.5 Reach green, inspect scope, and verify coverage
+
+Re-run the narrow test:
+
+```bash
+./gradlew :example-domain:test \
+  --tests 'me.ahoo.wow.example.domain.cart.CartSpec' \
+  --stacktrace
+```
+
+Expected green result: `BUILD SUCCESSFUL`; the test report remains under `example/example-domain/build/reports/tests/test/`.
+
+Then verify the owning module and coverage:
+
+```bash
+./gradlew :example-domain:check :example-domain:jacocoTestCoverageVerification --stacktrace
+```
+
+Expected result: `BUILD SUCCESSFUL`. The module enforces at least `0.8` line coverage.
+[Read the coverage rule.](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/build.gradle.kts#L12-L20)
+
+Finally inspect only the intended vertical slice:
+
+```bash
+git status --short -- \
+  example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/SetCartNote.kt \
+  example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt \
+  example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt \
+  example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt
+git diff -- \
+  example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt \
+  example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt \
+  example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt
+```
+
+Expected result: status lists the new API file plus the three modified tracked files; the diff contains only the three tracked files, with no generated output or unrelated formatting. The following staging step includes and reviews the new file. CI retries remain CI-only; never add local retries to conceal a deterministic failure.
+[Read the retry configuration.](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L175-L229)
+
+## 12. Contributor workflow
+
+The repository requires a focused branch from `main`, conventional commit messages, narrow verification, and a completed pull-request template.
+[Read the maintained contribution rules.](https://github.com/Ahoo-Wang/Wow/blob/main/CONTRIBUTING.md#L50-L86)
+
+### 12.1 Create a focused branch
+
+Start only after preserving or handing off unrelated local changes:
+
+```bash
+git switch main
+git pull --ff-only
+git switch -c feature/cart-note
+```
+
+Expected result: `git pull` reports `Already up to date.` or a fast-forward, and the final command reports `Switched to a new branch 'feature/cart-note'`. Recognized prefixes include `fix/`, `bugfix/`, `feature/`, `feat/`, `perf/`, `breaking/`, `chore/`, `build/`, `ci/`, and `docs/`.
+
+Confirm the branch and initial scope:
+
+```bash
+git branch --show-current
+git status --short
+```
+
+Expected result: the first command prints `feature/cart-note`; the second is empty before editing, or lists only changes you intentionally preserved.
+
+### 12.2 Reproduce, test first, and implement
+
+Read the issue, owning contracts, implementation, tests, build wiring, and completion criteria. Run the narrowest existing test and record the exact behavior before editing.
+
+For behavior changes:
+
+1. add the focused failing test;
+2. confirm the failure is the intended gap rather than an environment problem;
+3. implement the smallest complete model change;
+4. preserve reactive composition and module ownership;
+5. avoid public API breaks unless explicitly approved.
+
+### 12.3 Verify from narrow to broad
+
+Run the narrow test, then the owning module's `check`. Add contract or integration tests when the changed boundary requires them; run Detekt for Kotlin changes and the VitePress build for documentation changes.
+
+Expected result for every green Gradle verification is `BUILD SUCCESSFUL`. For documentation, expect VitePress to finish without dead-link or Mermaid errors and write `documentation/docs/.vitepress/dist/`.
+
+### 12.4 Stage and commit only the intended files
+
+For the teaching feature above:
+
+```bash
+git add \
+  example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/SetCartNote.kt \
+  example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt \
+  example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt \
+  example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt
+git diff --cached --check
+git diff --cached --stat
+```
+
+Expected result: `git diff --cached --check` prints nothing; the stat lists exactly the four intended paths.
+
+Use the repository's conventional style:
+
+```bash
+git commit -m 'feat(example): add cart note'
+```
+
+Expected result: Git prints a commit summary beginning with `[feature/cart-note`, followed by the new commit ID and changed-file counts. Do not commit generated output, credentials, IDE state, `.gradle/`, or `node_modules/`.
+
+### 12.5 Push and open the pull request
+
+```bash
+git push -u origin feature/cart-note
+```
+
+Expected result: Git reports the new remote branch and that the local branch now tracks `origin/feature/cart-note`; GitHub normally also prints a compare or pull-request URL.
+
+Open that URL and complete every section of `.github/PULL_REQUEST_TEMPLATE`: Goal, Changes, Verification, Compatibility and risks, and the checklist. Link the issue when one exists, disclose checks not run, and keep the branch current while addressing review feedback.
+[Read the pull-request template.](https://github.com/Ahoo-Wang/Wow/blob/main/.github/PULL_REQUEST_TEMPLATE#L1-L23)
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+flowchart LR
+    BR["Branch from main<br>focused prefix"] --> O["Orient<br>contracts and owner"]
+    O --> R["Reproduce<br>narrow evidence"]
+    R --> T["Test first<br>when behavior changes"]
+    T --> I["Implement<br>complete vertical slice"]
+    I --> N["Narrow verification"]
+    N --> W["Broader owning-module checks"]
+    W --> D["Inspect and stage<br>exact paths"]
+    D --> C["Conventional commit"]
+    C --> P["Push and open PR<br>template evidence"]
+    P --> V["Review and update branch"]
+    N -->|"failure"| R
+    W -->|"failure"| R
+```
+<!-- Sources:
+- [build.gradle.kts:54-142](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L54-L142)
+- [build.gradle.kts:175-261](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L175-L261)
+- [CONTRIBUTING.md:50-86](https://github.com/Ahoo-Wang/Wow/blob/main/CONTRIBUTING.md#L50-L86)
+- [.github/PULL_REQUEST_TEMPLATE:1-23](https://github.com/Ahoo-Wang/Wow/blob/main/.github/PULL_REQUEST_TEMPLATE#L1-L23)
+-->
+
+## 13. Test and verification layers
+
+### 13.1 Narrow unit or specification test
+
+Use for one class, aggregate, or scenario.
+
+```bash
+./gradlew :wow-core:test \
+  --tests 'me.ahoo.wow.command.DefaultCommandGatewayTimeoutTest'
+```
+
+Or use the cart command shown earlier.
+
+Expected outcome is `BUILD SUCCESSFUL`.
+
+To run one test method rather than the whole class:
+
+```bash
+./gradlew :wow-core:test \
+  --tests 'me.ahoo.wow.command.CommandGatewayApiTest.sendAndWaitShouldUseWaitPlan'
+```
+
+Expected outcome is `BUILD SUCCESSFUL`, with the HTML report containing only the selected method from `CommandGatewayApiTest`.
+[Read the executable test method.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/test/kotlin/me/ahoo/wow/command/CommandGatewayApiTest.kt#L21-L35)
+
+### 13.2 Owning-module check
+
+```bash
+./gradlew :wow-core:check --stacktrace
+```
+
+Expected result: `BUILD SUCCESSFUL`; standard test reports are under `wow-core/build/reports/tests/test/`, and configured contract-test reports are under `wow-core/build/reports/tests/contractTest/`.
+
+The root build wires standard tests and contract tests into module checks where configured.
+[Read source-set and task wiring.](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L94-L142)
+
+### 13.3 All local tests
+
+```bash
+./gradlew allLocalTest --stacktrace
+```
+
+Expected result: `BUILD SUCCESSFUL`; each participating module writes its standard test report under its own `build/reports/tests/test/` directory.
+
+This task aggregates the standard local-safe test layer.
+[Read aggregate task registration.](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L232-L261)
+
+### 13.4 All contract tests
+
+```bash
+./gradlew allContractTest --stacktrace
+```
+
+Expected result: `BUILD SUCCESSFUL`; participating modules write reports under `build/reports/tests/contractTest/`.
+
+Use this layer to validate shared behavior across implementations.
+
+### 13.5 All integration tests
+
+```bash
+./gradlew allIntegrationTest --stacktrace
+```
+
+Expected result with the required engines available: `BUILD SUCCESSFUL`; participating modules write reports under `build/reports/tests/integrationTest/`. Engine connection failures are environment failures, not a passing verification.
+
+Use a Docker-compatible runtime.
+
+Expect external-engine setup to take longer than local tests.
+
+The integration workflow runs the dedicated aggregate task in CI.
+[Read the workflow.](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/integration-test.yml#L14-L77)
+
+### 13.6 Static analysis
+
+```bash
+./gradlew detekt --stacktrace
+```
+
+Expected result: `BUILD SUCCESSFUL` with no remaining Detekt violations. Because auto-correction is enabled, the result also includes any source edits shown by a subsequent `git diff`.
+
+The CI workflow runs Detekt separately.
+[Read the static-analysis workflow.](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/static-analysis.yml#L14-L53)
+
+The root build enables Detekt auto-correction.
+[Read the configuration.](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L144-L158)
+
+Inspect `git diff` after running it because formatting changes may be written.
+
+### 13.7 Coverage reports
+
+Start with the local-only coverage report; it does not schedule container-backed integration tests:
+
+```bash
+./gradlew :code-coverage-report:localCoverageReport
+```
+
+Expected result: `BUILD SUCCESSFUL` and XML at `test/code-coverage-report/build/reports/jacoco/localCoverageReport/localCoverageReport.xml`.
+
+For the complete aggregate report, first start a Docker-compatible runtime. This task depends on local, contract, and container-backed integration tests for the configured modules, so it is broader and slower than `localCoverageReport`:
+
+```bash
+./gradlew codeCoverageReport
+```
+
+Expected result with the required engines available: `BUILD SUCCESSFUL`; the aggregate report is written under `test/code-coverage-report/build/reports/jacoco/codeCoverageReport/`.
+[Read report registration, task dependencies, and output paths.](https://github.com/Ahoo-Wang/Wow/blob/main/test/code-coverage-report/build.gradle.kts#L42-L114)
+
+### 13.8 Benchmark smoke
+
+```bash
+./gradlew :wow-benchmarks:benchmarkSmoke
+```
+
+Expected result: selected JMH smoke benchmarks print result rows and Gradle ends with `BUILD SUCCESSFUL`.
+
+The smoke workflow checks that selected JMH benchmarks execute.
+[Read the workflow.](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/benchmark-smoke.yml#L40-L58)
+
+A smoke result is not a product latency or throughput guarantee.
+
+Use a controlled benchmark design before making performance claims.
+
+### 13.9 Documentation build
+
+```bash
+cd documentation
+pnpm install --shamefully-hoist
+pnpm run docs:build
+```
+
+Expected result: VitePress reports a completed build without dead-link or Mermaid errors, and `documentation/docs/.vitepress/dist/` exists.
+
+The CI workflow runs Dokka first and then builds VitePress.
+[Read the exact workflow.](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/documentation-deploy.yml#L44-L86)
+
+The static site output is `documentation/docs/.vitepress/dist/`.
+
+### 13.10 Dashboard verification
+
+```bash
+cd compensation/dashboard
+pnpm install --frozen-lockfile
+pnpm exec eslint .
+pnpm build
+pnpm coverage
+```
+
+Expected result: ESLint exits without errors, Vite finishes the production build in `compensation/dashboard/dist/`, Vitest reports passing tests, and coverage artifacts appear under `compensation/dashboard/coverage/`.
+
+These commands align with dashboard CI.
+[Read the workflow.](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/dashboard-test.yml#L35-L63)
+
+### 13.11 Final diff checks
+
+```bash
+git diff --check
+git status --short
+git diff --stat
+```
+
+Expected result: `git diff --check` prints nothing; `git status --short` and `git diff --stat` list only the intentional change set.
+
+Read the actual diff before committing.
+
+Do not stage generated build output, local IDE state, credentials, or unrelated user changes.
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+graph TB
+    SPEC["Focused unit or AggregateSpec"] --> CHECK["Owning module check"]
+    CHECK --> CONTRACT["Contract test TCK"]
+    CONTRACT --> INTEGRATION["Container-backed integration test"]
+    CHECK --> STATIC["Detekt"]
+    CHECK --> COVERAGE["JaCoCo verification"]
+    DOCS["VitePress build"] --> REVIEW["Final diff review"]
+    INTEGRATION --> REVIEW
+    STATIC --> REVIEW
+    COVERAGE --> REVIEW
+```
+<!-- Sources:
+- [build.gradle.kts:54-142](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L54-L142)
+- [build.gradle.kts:232-261](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L232-L261)
+- [test/code-coverage-report/build.gradle.kts:42-114](https://github.com/Ahoo-Wang/Wow/blob/main/test/code-coverage-report/build.gradle.kts#L42-L114)
+- [.github/workflows/documentation-deploy.yml:44-86](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/documentation-deploy.yml#L44-L86)
+-->
+
+## 14. Debugging playbook
+
+Use this table to choose the first owned boundary, then follow the detailed evidence and actions below.
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| HTTP command is rejected before aggregate execution | WebFlux body extraction produced no command body. | Verify content type, body, and command route before inspecting storage. |
+| Command stops before bus dispatch | `CommandValidator` or Jakarta validation rejected the command body. | Inspect the exact constraint violation and reproduce it with a narrow gateway or aggregate test. |
+| Duplicate request ID exception | The same aggregate ID and request ID were seen by idempotency coordination. | Preserve the request ID for an intentional retry and inspect prior processing; do not disable idempotency. |
+| Undefined command handler | No compatible command function was resolved from aggregate metadata. | Check the handler signature and annotation, rebuild KSP output, then inspect metadata discovery. |
+| Aggregate lifecycle rejection | The aggregate is uninitialized without create permission, deleted without recovery, or a non-blank owner/space expectation mismatches state. | Inspect lifecycle flags, version, owner, space, and the known event history. |
+| Event append conflict | Stream identity or expected aggregate version conflicts with stored history. | Compare versions and command IDs, then reproduce against the relevant EventStore TCK. |
+| Wait timeout | The requested stage was not signalled before the gateway's absolute deadline. | Record the last observed stage, inspect its owning consumer, and verify wait-handle cleanup. |
+| MongoDB storage bean cannot start | Mongo storage was selected without the required database configuration. | Correct active properties before testing connectivity. |
+| Integration test cannot start an engine | The Docker-compatible runtime is unavailable or an external test engine failed to initialize. | Start the runtime, inspect container logs, and rerun only the owning module's integration task. |
+| VitePress reports a dead link | Locale, rewrite, or repository-relative path resolution is incorrect. | Correct the link against the active locale and rerun the full documentation build. |
+| Detekt leaves source changes | Root Detekt configuration enables auto-correction. | Inspect the diff, keep only intended formatting, and rerun the narrow check. |
+
+### 14.1 Start with the first owned boundary
+
+For an HTTP command failure, inspect in this order:
+
+1. request body and headers;
+2. WebFlux extraction;
+3. command validation;
+4. idempotency coordination;
+5. command-bus send;
+6. aggregate dispatcher selection;
+7. aggregate state reconstruction;
+8. command handler resolution;
+9. event-store append;
+10. downstream stage notification;
+11. wait timeout and cleanup.
+
+This order follows the real processing chain rather than guessing from the final HTTP status.
+
+### 14.2 Empty request body
+
+Symptom: the WebFlux endpoint rejects the request before the aggregate runs.
+
+Evidence: `CommandHandlerFunction` explicitly detects an empty body.
+[Read the branch.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt#L54-L65)
+
+Action:
+
+- confirm the request content type;
+- confirm a body is actually sent;
+- confirm the route points to the expected command endpoint;
+- do not debug event storage yet.
+
+### 14.3 Command validation failure
+
+Symptom: command execution stops before bus dispatch.
+
+Evidence: the gateway validates before sending.
+[Read the validation path.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L79-L118)
+
+Action:
+
+- inspect Jakarta validation annotations on the command;
+- inspect the exact property value;
+- reproduce with a narrow gateway or aggregate test;
+- distinguish input validation from domain-state rejection.
+
+### 14.4 Duplicate request ID
+
+Symptom: a `DuplicateRequestIdException` identifies a request ID previously seen for the same aggregate.
+
+Evidence: the gateway checks `aggregateId` and `requestId` together and rejects a duplicate pair.
+[Read gateway coordination.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L94-L103)
+[Read the exception definition.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandExceptions.kt#L25-L35)
+
+Action:
+
+- compare command ID and request ID;
+- determine whether the client retried intentionally;
+- inspect the prior processing associated with that aggregate and request ID;
+- do not disable idempotency globally to hide incorrect identifiers.
+
+### 14.5 Undefined command handler
+
+Symptom: the aggregate cannot resolve a handler for the command type.
+
+Evidence: `SimpleCommandAggregate` resolves and invokes the command handler in the processing path.
+[Read the handler resolution branch.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L119-L132)
+
+Action:
+
+- confirm the handler annotation and command type;
+- confirm KSP runs in the domain module;
+- rebuild the domain module;
+- inspect metadata discovery before changing WebFlux routes.
+
+### 14.6 Aggregate lifecycle rejection
+
+Symptom: a command is rejected because the aggregate is not initialized, is deleted, or violates ownership or space rules.
+
+Evidence: aggregate preconditions are checked before invoking the handler.
+[Read the conditions.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L91-L121)
+
+Action:
+
+- inspect command create and void flags;
+- inspect aggregate version and identity dimensions;
+- reproduce from a known event history;
+- do not create missing state as a transport workaround.
+
+### 14.7 Event append conflict
+
+Symptom: the event store rejects a stream due to duplicate or version conflict behavior.
+
+Evidence: the event-store contract owns append and load behavior plus storage exceptions.
+[Read the contract.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L22-L82)
+
+Action:
+
+- compare expected and actual aggregate versions;
+- verify stream command identity;
+- verify all events in the stream target the same aggregate;
+- reproduce against the relevant storage TCK;
+- preserve atomic append semantics.
+
+### 14.8 Wait timeout
+
+Symptom: the command was sent but the requested stage was not observed before the deadline.
+
+Evidence: the gateway owns a bounded wait and resource cleanup.
+[Read the resource-scoped waits.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L201-L266)
+[Read timeout coverage.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTimeoutTest.kt#L45-L125)
+
+Action:
+
+- record the requested `CommandStage`;
+- determine the last stage actually emitted;
+- inspect the owning consumer for the missing stage;
+- verify cancellation releases the wait handle;
+- do not replace the bounded deadline with an unbounded wait.
+
+### 14.9 Missing MongoDB database configuration
+
+Symptom: MongoDB event sourcing cannot build its storage bean.
+
+Evidence: Mongo auto-configuration fails explicitly when the required database is absent.
+[Read event-store configuration validation.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfiguration.kt#L134-L143)
+[Read related storage validation.](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfiguration.kt#L201-L230)
+
+Action:
+
+- inspect active profiles;
+- inspect `wow.event-sourcing.store.storage`;
+- inspect the Mongo database property;
+- compare with the example server YAML;
+- verify connectivity only after binding is correct.
+
+### 14.10 Integration test cannot start an engine
+
+Symptom: local tests pass but integration tests fail during container or service startup.
+
+Action:
+
+- verify Docker is running;
+- identify which module's `integrationTest` failed;
+- inspect container logs and mapped ports;
+- run that module's integration task alone;
+- do not relabel it as a unit-test failure.
+
+The build intentionally separates integration tests from local and contract layers.
+[Read the separation.](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L54-L142)
+
+### 14.11 Documentation dead link
+
+Symptom: VitePress build reports an unresolved internal link.
+
+Action:
+
+- check the locale path;
+- check the English rewrite rule;
+- use a repository-relative documentation path;
+- build both locale trees;
+- do not suppress a dead link without proving it is intentionally external.
+
+The VitePress config rewrites English locale paths.
+[Read the rewrite configuration.](https://github.com/Ahoo-Wang/Wow/blob/main/documentation/docs/.vitepress/config.mts#L24-L26)
+
+### 14.12 Detekt changed files
+
+Symptom: static analysis leaves formatting changes in the worktree.
+
+Cause: auto-correction is enabled in the root Detekt configuration.
+[Read the setting.](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L144-L158)
+
+Action:
+
+- inspect `git status --short`;
+- keep intended formatting changes;
+- revert only changes you own and have inspected;
+- rerun the narrow check.
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+flowchart TD
+    START["Command failed"] --> BODY{"Body extracted?"}
+    BODY -->|"no"| WEB["Inspect WebFlux request"]
+    BODY -->|"yes"| VALID{"Validation passed?"}
+    VALID -->|"no"| INPUT["Inspect command constraints"]
+    VALID -->|"yes"| SENT{"Bus send observed?"}
+    SENT -->|"no"| IDEM["Inspect idempotency and bus"]
+    SENT -->|"yes"| HANDLER{"Handler resolved?"}
+    HANDLER -->|"no"| META["Inspect annotation and KSP metadata"]
+    HANDLER -->|"yes"| APPEND{"Event stream appended?"}
+    APPEND -->|"no"| STORE["Inspect version and EventStore"]
+    APPEND -->|"yes"| STAGE{"Requested stage observed?"}
+    STAGE -->|"no"| WAIT["Trace downstream stage and deadline"]
+    STAGE -->|"yes"| TRANSPORT["Inspect response adaptation"]
+```
+<!-- Sources:
+- [wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt:43-66](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt#L43-L66)
+- [wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt:79-143](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L79-L143)
+- [wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt:64-132](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L64-L132)
+- [wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt:25-123](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt#L25-L123)
+-->
+
+## 15. Common pitfalls
+
+### Pitfall 1 — Editing the wrong module
+
+Putting an API contract in an infrastructure module couples users to an adapter.
+
+Start from the dependency direction and choose the lowest stable owning boundary.
+
+### Pitfall 2 — Mutating state in the command handler
+
+Event-sourced state must be reproducible from events.
+
+Return an event from the decision and apply it in `@OnSourcing`.
+
+### Pitfall 3 — Adding a new event without sourcing behavior
+
+The live command might emit the event while replay produces stale state.
+
+Add the sourcing handler and a state assertion in the same change.
+
+### Pitfall 4 — Treating validation and domain rejection as identical
+
+Input-shape validation belongs at the command boundary.
+
+Rules depending on current aggregate state belong in the aggregate.
+
+### Pitfall 5 — Blocking a reactive path
+
+`block()` can consume event-loop capacity and break cancellation semantics.
+
+Return the composed `Mono` or `Flux`.
+
+### Pitfall 6 — Calling `subscribe()` inside a library function
+
+Hidden subscriptions separate work from the caller's cancellation and error handling.
+
+Let the application edge own subscription.
+
+### Pitfall 7 — Confusing KSP metadata with runtime routing
+
+KSP participates in compilation and metadata generation.
+
+WebFlux endpoints are runtime integration behavior.
+
+Debug each boundary separately.
+
+### Pitfall 8 — Running only happy-path tests
+
+Aggregate creation, deletion, recovery, duplication, version mismatch, and timeout paths are part of correctness.
+
+Use existing tests as an edge-case inventory.
+
+### Pitfall 9 — Calling a smoke benchmark a performance guarantee
+
+A JMH smoke task proves that selected benchmarks execute.
+
+It does not establish end-to-end capacity, tail latency, or a production SLA.
+
+### Pitfall 10 — Assuming example configuration is production policy
+
+The example uses a particular mix of MongoDB storage and in-memory buses.
+
+Treat it as executable sample wiring, not a universal deployment design.
+
+### Pitfall 11 — Broadening a public API for one adapter
+
+First determine whether the need is general or engine-specific.
+
+Prefer an adapter option over contract pollution when the concern is local.
+
+### Pitfall 12 — Skipping the TCK
+
+Adapter-specific tests can pass while violating the common contract.
+
+Run the shared TCK and the engine integration test.
+
+### Pitfall 13 — Ignoring generated metadata drift
+
+Change source annotations and processor inputs first.
+
+Do not hand-edit generated output as the primary fix.
+
+### Pitfall 14 — Hiding a deterministic failure with retry
+
+CI retry is a bounded resilience mechanism for CI instability.
+
+It is not permission to leave deterministic tests flaky.
+
+### Pitfall 15 — Reporting unrun checks as passed
+
+List exact commands and outcomes.
+
+State clearly when Docker, Node, credentials, or time prevented a broader check.
+
+# Appendix A — Glossary
+
+The definitions below are contributor-oriented summaries.
+
+Follow the linked contracts for exact semantics.
+
+| Term | Contributor meaning |
+| --- | --- |
+| Wow | The repository's reactive DDD, CQRS, and event-sourcing framework. |
+| DDD | Domain-driven design: model software around domain language and boundaries. |
+| CQRS | Separate command intent from query/read concerns. |
+| Bounded Context | A boundary within which domain names and rules have a consistent meaning. |
+| Named Bounded Context | Wow contract exposing the context name. |
+| Aggregate | A consistency boundary that processes commands and protects invariants. |
+| Aggregate Root | The command-facing root type of an aggregate. |
+| Named Aggregate | Aggregate identity within a bounded context. |
+| Aggregate ID | Named aggregate, aggregate `id`, and tenant context used to target an aggregate; the `id` remains unique across tenants within that named aggregate. |
+| Tenant ID | Routing and isolation context carried by aggregate identity; it does not create a separate aggregate-ID namespace. |
+| Owner ID | Identity dimension representing aggregate ownership. |
+| Space ID | Identity dimension representing a logical space. |
+| Command | A request to perform domain behavior. |
+| Command Message | A command plus routing, identity, headers, version, and lifecycle metadata. |
+| Command ID | Identity of command processing and its resulting stream. |
+| Request ID | Identity used for request-level coordination and idempotency. |
+| Command Gateway | Application-facing facade for sending commands and optionally waiting. |
+| Command Bus | Transport contract that delivers command messages to dispatchers. |
+| Local Command Bus | In-process command transport. |
+| Distributed Command Bus | External transport implementation such as a Kafka-backed bus. |
+| Local First | Preference for local processing when the selected route allows it. |
+| Command Route | Metadata deciding which aggregate and path receive a command. |
+| Command Handler | Aggregate method that evaluates a command and returns event facts. |
+| Command Validator | Boundary component that validates a command before dispatch. |
+| Command Stage | Named lifecycle milestone used by wait plans. |
+| Wait Plan | Requested command stages and deadline behavior. |
+| Wait Signal | A notification that a command reached a stage or failed. |
+| Wait Coordinator | Resource that registers and completes command waits. |
+| SENT | Stage indicating the gateway sent the command. |
+| PROCESSED | Stage indicating aggregate command processing completed. |
+| SNAPSHOT | Stage associated with snapshot completion. |
+| PROJECTED | Stage associated with projection completion. |
+| EVENT_HANDLED | Stage associated with event-processor completion. |
+| SAGA_HANDLED | Stage associated with saga completion. |
+| Domain Event | Immutable business fact emitted by an aggregate decision. |
+| Domain Event Stream | Ordered events emitted for one command and aggregate context. |
+| Event Store | Append/load contract for domain event streams. |
+| Event Sourcing | Reconstruct state by replaying recorded domain events. |
+| State Aggregate | Runtime state plus event-sourcing behavior and version. |
+| State Sourcing | Applying domain events to evolve aggregate state. |
+| `@OnSourcing` | Annotation marking an event-to-state transition handler. |
+| Snapshot | Persisted aggregate state at a known version. |
+| Snapshot Store | Persistence contract for snapshots. |
+| State Event | Downstream message derived from a sourced state transition. |
+| State Event Bus | Transport for state events. |
+| Projection | Read-side model derived from events. |
+| Projection Processor | Event consumer that updates projections. |
+| Event Processor | Event consumer that performs a downstream reaction. |
+| Saga | Cross-aggregate or cross-context reaction coordinated by events and commands. |
+| Stateless Saga | Saga style whose processor type does not retain saga state. |
+| Compensation | Recovery or corrective workflow for a failed distributed process. |
+| Retry | Declared policy for repeating an eligible operation. |
+| Message Bus | Reactive send/receive abstraction for framework messages. |
+| Message Subscription | Lifecycle ownership for receiving a message stream. |
+| Dispatcher | Component that routes received messages to an owning processor. |
+| Command Dispatcher | Dispatcher that selects a named aggregate. |
+| Aggregate Command Dispatcher | Dispatcher that preserves aggregate-ID processing affinity. |
+| Exchange | Runtime envelope carrying a message and processing context. |
+| Filter | One cross-cutting step around exchange processing. |
+| Filter Chain | Ordered composition of filters and a terminal processor. |
+| Reactor | JVM reactive library used for asynchronous composition. |
+| `Mono` | Reactive publisher of zero or one item. |
+| `Flux` | Reactive publisher of zero to many items. |
+| Backpressure | Consumer demand signaling that bounds reactive production. |
+| Cancellation | Signal that downstream no longer needs the operation. |
+| KSP | Kotlin Symbol Processing, used during compilation. |
+| Wow Compiler | Repository module that processes Wow metadata at compile time. |
+| Metadata | Generated or discovered descriptions of commands, aggregates, and handlers. |
+| Spring Auto-configuration | Conditional bean assembly based on classpath and properties. |
+| Feature Variant | Gradle capability selecting an optional starter integration. |
+| Storage Type | Enum selecting MongoDB, Redis, Elasticsearch, in-memory, or delay storage. |
+| TCK | Technology Compatibility Kit: reusable contract tests for implementations. |
+| Aggregate Spec | Wow DSL test for aggregate commands, events, errors, and state. |
+| Saga Spec | DSL test for saga reactions. |
+| Given–When–Expect | Scenario structure describing prior facts, command, and outcome. |
+| Unit Test | Fast test with no external engine requirement. |
+| Contract Test | Shared behavioral test applied to replaceable implementations. |
+| Integration Test | Test that exercises real adapter wiring and external infrastructure. |
+| Testcontainers | Container-based test support for external engines. |
+| JaCoCo | JVM coverage measurement and verification. |
+| Detekt | Kotlin static analysis tool used by the repository. |
+| Dokka | Kotlin API documentation generator used before site build. |
+| VitePress | Static documentation-site generator. |
+| OpenAPI | Machine-readable HTTP API description support. |
+| WebFlux | Spring reactive web integration used for command endpoints. |
+| CoSec | Authorization integration module. |
+| CoCache | Projection caching integration module. |
+| CosId | ID generation dependency used by Wow. |
+| BI | Business-intelligence synchronization support in `wow-bi`. |
+
+Core identity, command, event, and storage definitions are anchored in the following contracts:
+
+- [wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt:18-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt#L18-L45)
+- [wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt:24-125](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L24-L125)
+- [wow-api/src/main/kotlin/me/ahoo/wow/api/event/DomainEvent.kt:21-89](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/event/DomainEvent.kt#L21-L89)
+- [wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt:31-115](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L31-L115)
+- [wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt:22-82](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L22-L82)
+- [wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/StorageType.kt:16-30](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/StorageType.kt#L16-L30)
+
+# Appendix B — Key file reference
+
+## Build and versions
+
+| Path | Purpose | Why It Matters | Source |
+| --- | --- | --- | --- |
+| `settings.gradle.kts` | Declares modules and physical directory mappings. | It is the authoritative project graph for choosing Gradle task paths and ownership. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L23-L85) |
+| `gradle.properties` | Defines project metadata and Kotlin/KSP build flags. | Version bumps and compiler behavior start here. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/gradle.properties#L18-L23) |
+| `gradle/libs.versions.toml` | Centralizes library and plugin versions. | It prevents dependency versions from drifting across modules. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L1-L35) |
+| `gradle/wrapper/gradle-wrapper.properties` | Pins the Gradle distribution. | The wrapper makes local and CI builds use the same Gradle release. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/wrapper/gradle-wrapper.properties#L1-L9) |
+| `build.gradle.kts` | Assembles test layers, Detekt, toolchains, retries, and aggregate tasks. | Most repository-wide verification behavior is defined here. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L54-L261) |
+| `wow-spring-boot-starter/build.gradle.kts` | Declares optional Spring feature capabilities. | Adapter additions can change dependency resolution and must align with these variants. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L5-L79) |
+
+## Domain example
+
+| Path | Purpose | Why It Matters | Source |
+| --- | --- | --- | --- |
+| `example/example-api/src/main/kotlin/me/ahoo/wow/example/api/ExampleService.kt` | Declares API-side service and bounded-context naming. | The name anchors discovery and routing across the example slice. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/ExampleService.kt#L22-L40) |
+| `example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/AddCartItem.kt` | Defines a validated create-capable command and its event. | It is the smallest public-contract model for a new cart behavior. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/AddCartItem.kt#L1-L26) |
+| `example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/ChangeQuantity.kt` | Defines an update command, route, and event. | It demonstrates explicit aggregate-ID routing for existing state. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/ChangeQuantity.kt#L1-L21) |
+| `example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/RemoveCartItem.kt` | Defines item-removal intent and fact. | It shows a compact command/event pair without infrastructure coupling. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/RemoveCartItem.kt#L1-L16) |
+| `example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/CartItem.kt` | Defines the shared cart-item value. | Both command decisions and sourced state depend on this stable API type. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/CartItem.kt#L1-L6) |
+| `example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt` | Implements aggregate command decisions. | It is the owning boundary for invariants and emitted facts. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt#L32-L76) |
+| `example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt` | Applies events to reconstruct cart state. | New cart events are incomplete until their sourcing behavior is represented here. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt#L23-L46) |
+| `example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartSaga.kt` | Maps an order event to a cart command with retry policy. | It demonstrates cross-aggregate reaction without retaining saga state. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartSaga.kt#L25-L42) |
+| `example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt` | Specifies command, event, error, and state scenarios. | It is the primary regression boundary for cart behavior changes. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt#L28-L87) |
+| `example/example-domain/build.gradle.kts` | Configures KSP, test support, and coverage verification. | It defines the build and quality boundary for the domain slice. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/build.gradle.kts#L1-L20) |
+| `example/example-server/src/main/resources/application.yaml` | Selects executable sample storage and bus configuration. | It shows actual sample wiring while remaining distinct from production policy. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-server/src/main/resources/application.yaml#L22-L99) |
+
+## Runtime contracts
+
+| Path | Purpose | Why It Matters | Source |
+| --- | --- | --- | --- |
+| `wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AggregateRoot.kt` | Declares aggregate discovery metadata. | It defines which aggregate type and mounted commands enter the model. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AggregateRoot.kt#L18-L77) |
+| `wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/OnCommand.kt` | Declares command-handler metadata. | Handler discovery and declared return types depend on this contract. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/OnCommand.kt#L19-L86) |
+| `wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/OnSourcing.kt` | Declares event-to-state sourcing metadata. | Replay correctness depends on resolving the intended state transition. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/OnSourcing.kt#L18-L59) |
+| `wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt` | Defines the command envelope and targeting semantics. | Adapters must preserve its routing, identity, version, and lifecycle fields. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L24-L125) |
+| `wow-api/src/main/kotlin/me/ahoo/wow/api/event/DomainEvent.kt` | Defines persisted domain-event metadata. | Sequence, revision, command, and aggregate context are storage invariants. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/event/DomainEvent.kt#L21-L89) |
+| `wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt` | Groups one command's immutable event facts. | The constructor enforces a non-empty body but does not independently verify that every event shares the same context. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L31-L115) |
+| `wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt` | Defines append and aggregate-history loading. | Every storage adapter must preserve this concurrency and replay boundary. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L22-L82) |
+| `wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt` | Exposes application-facing send and wait APIs. | It is the stable entry contract for command callers. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt#L63-L173) |
+| `wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt` | Implements validation, idempotency, waits, deadlines, and bus send. | Request correctness and wait-resource ownership converge here. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L79-L301) |
+| `wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt` | Defines wait stages and their prerequisites. | It prevents downstream stages from being treated as one mandatory sequence. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt#L25-L123) |
+| `wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWait.kt` | Builds stage and chain wait plans. | Callers use these factories to express the exact completion target. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWait.kt#L21-L120) |
+| `wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/CommandDispatcher.kt` | Selects the named-aggregate dispatcher. | It is the first runtime routing boundary after command-bus receipt. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/CommandDispatcher.kt#L37-L75) |
+| `wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/AggregateCommandDispatcher.kt` | Preserves aggregate-ID worker affinity. | Same-aggregate ordering and cross-aggregate concurrency depend on it. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/AggregateCommandDispatcher.kt#L25-L86) |
+| `wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt` | Executes decisions, sources events, and persists the stream. | It is the core aggregate correctness path. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L64-L132) |
+| `wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt` | Publishes stored domain-event streams. | Downstream processing must remain ordered after durable append. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt#L25-L46) |
+| `wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/SendStateEventFilter.kt` | Builds and publishes state events. | Its error boundary determines how downstream state-event lag is exposed. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/SendStateEventFilter.kt#L29-L76) |
+
+## Spring and transport
+
+| Path | Purpose | Why It Matters | Source |
+| --- | --- | --- | --- |
+| `wow-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` | Registers starter auto-configurations. | A configuration class is inactive until it is reachable through this import surface. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports#L1-L31) |
+| `wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandAutoConfiguration.kt` | Assembles command-side builders, validation, and bus defaults. | It shows which beans are conditional and replaceable. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandAutoConfiguration.kt#L38-L100) |
+| `wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandGatewayAutoConfiguration.kt` | Assembles idempotency, wait coordination, notifiers, and the gateway. | Gateway behavior depends on these collaborating beans, not one standalone class. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandGatewayAutoConfiguration.kt#L51-L163) |
+| `wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/modeling/AggregateAutoConfiguration.kt` | Assembles aggregate processors, filters, handlers, and dispatchers. | Filter order and selected implementations define the runtime command chain. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/modeling/AggregateAutoConfiguration.kt#L70-L145) |
+| `wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfiguration.kt` | Creates conditional Mongo event and snapshot storage bindings. | It owns property validation and backend selection for Mongo event sourcing. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfiguration.kt#L54-L143) |
+| `wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt` | Adapts HTTP bodies and command results. | Empty-body handling and response materialization occur at this transport edge. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt#L43-L66) |
+| `wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandMessageExtractor.kt` | Extracts HTTP data into command metadata. | Header and path preservation begins here. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandMessageExtractor.kt#L23-L46) |
+| `wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt` | Chooses wait policy and response mode. | It separates single-result and SSE transport semantics. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt#L30-L62) |
+| `wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/WebFluxErrorStrategy.kt` | Maps runtime failures to transport responses. | Error compatibility and client-visible status behavior converge here. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/WebFluxErrorStrategy.kt#L55-L83) |
+
+## Verification and CI
+
+| Path | Purpose | Why It Matters | Source |
+| --- | --- | --- | --- |
+| `.github/workflows/local-test.yml` | Runs the local-safe JVM test layer in CI. | It is the remote reference for ordinary module-test expectations. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/local-test.yml#L14-L70) |
+| `.github/workflows/contract-test.yml` | Runs shared contract tests in CI. | Adapter compatibility claims should match this layer. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/contract-test.yml#L14-L72) |
+| `.github/workflows/integration-test.yml` | Runs container-backed integration tests in CI. | It defines the external-engine validation boundary. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/integration-test.yml#L14-L77) |
+| `.github/workflows/static-analysis.yml` | Runs Detekt in CI. | Kotlin changes must satisfy the same static-analysis configuration locally and remotely. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/static-analysis.yml#L14-L53) |
+| `.github/workflows/benchmark-smoke.yml` | Runs the PR-safe JMH smoke set. | It verifies benchmark executability without claiming product performance. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/benchmark-smoke.yml#L40-L58) |
+| `.github/workflows/documentation-deploy.yml` | Generates Dokka and builds VitePress. | Documentation changes must match the deployed pipeline, not only a Markdown preview. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/documentation-deploy.yml#L44-L86) |
+| `.github/workflows/dashboard-test.yml` | Runs dashboard lint, build, and coverage. | Frontend verification commands should stay aligned with this workflow. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/dashboard-test.yml#L35-L63) |
+| `.github/PULL_REQUEST_TEMPLATE` | Defines required change, verification, and risk evidence. | Completing it makes review scope and unrun checks explicit. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/.github/PULL_REQUEST_TEMPLATE#L1-L23) |
+
+# Appendix C — Quick reference
+
+## Choose a command by change type
+
+| Change | First command | Broader command | Expected result |
+| --- | --- | --- | --- |
+| Cart behavior | `./gradlew :example-domain:test --tests 'me.ahoo.wow.example.domain.cart.CartSpec'` | `./gradlew :example-domain:check` | `BUILD SUCCESSFUL` |
+| Core command runtime | `./gradlew :wow-core:test --tests 'me.ahoo.wow.command.DefaultCommandGatewayTimeoutTest'` | `./gradlew :wow-core:check` | `BUILD SUCCESSFUL` |
+| Public API contract | `./gradlew :wow-api:check` | `./gradlew allLocalTest` | `BUILD SUCCESSFUL` |
+| MongoDB storage contract | `./gradlew :wow-mongo:integrationTest --tests 'me.ahoo.wow.mongo.MongoEventStoreTest'` | `./gradlew :wow-mongo:check :wow-mongo:integrationTest` | `BUILD SUCCESSFUL` with Docker available |
+| Spring auto-configuration | `./gradlew :wow-spring-boot-starter:test --tests 'me.ahoo.wow.spring.boot.starter.command.CommandAutoConfigurationTest'` | `./gradlew :wow-spring-boot-starter:check` | `BUILD SUCCESSFUL` |
+| WebFlux transport | `./gradlew :wow-webflux:test --tests 'me.ahoo.wow.webflux.route.command.CommandHandlerFunctionTest'` | `./gradlew :wow-webflux:check` | `BUILD SUCCESSFUL` |
+| Kotlin formatting | `./gradlew :wow-core:test --tests 'me.ahoo.wow.command.DefaultCommandGatewayTimeoutTest'` | `./gradlew detekt --stacktrace` | `BUILD SUCCESSFUL`; inspect auto-correct diff |
+| Documentation | `cd documentation && pnpm run docs:build` | `cd documentation && pnpm run docs:build` | VitePress build plus `docs/.vitepress/dist/` |
+| Dashboard | `cd compensation/dashboard && pnpm exec vitest run src/features/Failed/__tests__/ApplyRetrySpec.test.tsx` | `cd compensation/dashboard && pnpm lint && pnpm build && pnpm coverage` | Vitest passes; `dist/` and `coverage/` exist |
+| Benchmark code | `./gradlew :wow-benchmarks:test --tests 'me.ahoo.wow.benchmark.infrastructure.StorageBatchTuningOptionsTest'` | `./gradlew :wow-benchmarks:benchmarkSmoke` | Unit test and JMH smoke end with `BUILD SUCCESSFUL` |
+
+## Fast repository map
+
+```text
+wow-api                    contracts and annotations
+wow-core                   runtime and event sourcing
+wow-compiler               KSP metadata processors
+wow-spring                 Spring integration primitives
+wow-spring-boot-starter    feature capabilities and auto-configuration
+wow-query                  query model
+wow-kafka                  distributed messaging
+wow-mongo                  MongoDB storage
+wow-redis                  Redis storage
+wow-elasticsearch          Elasticsearch event/snapshot storage and queries
+wow-webflux                reactive HTTP command integration
+wow-opentelemetry          tracing and metrics
+wow-cosec                  authorization integration
+wow-cocache                projection caching
+wow-apiclient              REST client support
+wow-openapi                OpenAPI support
+wow-schema                 JSON Schema support
+wow-bi                     BI synchronization scripts
+test                       DSLs, TCKs, mocks, integration, coverage
+compensation               compensation product modules and dashboard
+example                    Kotlin and Java vertical examples
+documentation              VitePress site
+```
+
+## Before opening a pull request
+
+- [ ] The requested outcome is explicit.
+- [ ] The owning module and public boundary are identified.
+- [ ] Behavior changes have focused tests.
+- [ ] Event changes include sourcing and replay coverage.
+- [ ] Reactive paths contain no new blocking calls.
+- [ ] Generated output was not hand-edited as the primary fix.
+- [ ] The narrow test passes.
+- [ ] The owning module check passes.
+- [ ] Required contract or integration tests pass.
+- [ ] Detekt was run when applicable and its edits inspected.
+- [ ] Documentation builds when documentation changed.
+- [ ] `git diff --check` passes.
+- [ ] The final diff contains only intended files.
+- [ ] Unrun checks and environment constraints are disclosed.
+- [ ] No unsupported performance, SLA, retention, or compliance claim was added.
+
+## Final mental model
+
+A command is intent.
+
+The aggregate makes a decision.
+
+The event stream records the decision as facts.
+
+State sourcing makes those facts reproducible.
+
+The event store protects ordered history.
+
+Event processors, projections, and sagas react downstream.
+
+Wait stages connect asynchronous processing back to the caller without erasing the asynchronous boundaries.
+
+Modules and TCKs keep integrations replaceable.
+
+Focused tests make the domain model safe to evolve.
+
+When in doubt, trace the contract, implementation, test, configuration, and CI task as one evidence chain.

--- a/documentation/docs/en/onboarding/contributor-guide.md
+++ b/documentation/docs/en/onboarding/contributor-guide.md
@@ -1047,7 +1047,7 @@ Run only that specification:
   --stacktrace
 ```
 
-Expected red result: Gradle ends with `BUILD FAILED`, and the first owned cause reports an undefined `SetCartNote` command or the missing `CartState.note` implementation. The HTML report is written under `example/example-domain/build/reports/tests/test/`.
+Expected red result: Gradle ends with `BUILD FAILED` because `compileTestKotlin` cannot resolve `CartState.note`. At this red step the test task may not run, so no fresh HTML test report is guaranteed; use the compiler output as the authoritative failure evidence.
 
 ### 11.4 Implement decision and sourcing
 

--- a/documentation/docs/en/onboarding/executive-guide.md
+++ b/documentation/docs/en/onboarding/executive-guide.md
@@ -1,0 +1,594 @@
+---
+title: Executive Guide
+description: Evidence-based executive orientation for adopting and operating Wow
+---
+
+# Executive Guide
+
+## Purpose and evidence baseline
+
+This guide explains what Wow can support, what adopting it requires, and which
+business decisions the repository cannot make for an organization.
+
+It is written for engineering executives, platform leaders, architecture
+groups, security reviewers, and people responsible for delivery risk.
+
+The evidence baseline is the `main` branch of the Wow repository.
+
+Wow identifies itself as a reactive CQRS and Event Sourcing framework for
+modern applications. It is a framework and set of integration modules, not a
+complete business product or a managed service.
+
+The current project version is `8.9.5`, the JVM toolchain is 17, and the build
+uses Kotlin `2.4.10`.
+
+Sources:
+
+- [README.md:7-9](https://github.com/Ahoo-Wang/Wow/blob/main/README.md#L7-L9)
+- [gradle.properties:13-23](https://github.com/Ahoo-Wang/Wow/blob/main/gradle.properties#L13-L23)
+- [gradle/libs.versions.toml:1-35](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L1-L35)
+
+### Reading rules
+
+- “Implemented” means that the repository contains the relevant production
+  code or configuration.
+- “Tested” means that a relevant automated check is present; it does not mean
+  the adopter's production environment has been validated.
+- “Optional” means that the integration is selected through a module or
+  feature capability rather than being universally active.
+- “Example” means that a repository sample demonstrates one deployment choice;
+  it is not a service-level promise or a production standard.
+- “Not declared” means that the repository does not establish an accountable
+  owner, target, policy, or commitment.
+
+## Executive summary
+
+Wow provides a modular foundation for command processing, event persistence,
+state reconstruction, projections, sagas, snapshots, observability hooks, and
+failure-recovery workflows.
+
+The framework is designed around reactive execution and supports selectable
+transport and storage technologies. Adopters still own their domain model,
+service boundaries, data policies, production topology, access controls,
+capacity model, incident process, and service objectives.
+
+The strongest adoption case is an organization that needs auditable domain
+changes, asynchronous workflows, or multiple read models and is prepared to
+operate event-driven infrastructure.
+
+The weakest adoption case is a simple CRUD service whose team does not need
+event history or asynchronous processing and cannot support the operational
+complexity of brokers, stores, projections, and replay.
+
+The repository demonstrates substantial engineering automation: local,
+contract, integration, static-analysis, dashboard, compensation, Java example,
+and benchmark-smoke workflows are present. These checks increase confidence in
+the framework build; they do not establish the adopter's availability,
+latency, recovery, or compliance outcomes.
+
+Sources:
+
+- [settings.gradle.kts:23-85](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L23-L85)
+- [build.gradle.kts:50-166](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L50-L166)
+- [.github/workflows/integration-test.yml:47-75](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/integration-test.yml#L47-L75)
+- [.github/workflows/static-analysis.yml:35-53](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/static-analysis.yml#L35-L53)
+
+## System overview
+
+The following view separates application responsibilities from framework
+capabilities and infrastructure selected by the adopter.
+
+```mermaid
+flowchart LR
+    U["Users and external systems"] --> A["Adopter application"]
+    A --> W["Wow command and event runtime"]
+    W --> B["Selected message bus"]
+    W --> ES["Selected event store"]
+    W --> SS["Selected snapshot store"]
+    B --> H["Domain handlers, projections, and sagas"]
+    H --> RM["Application read models"]
+    H -. failure record .-> C["Compensation service"]
+    C --> D["Compensation dashboard"]
+    W --> O["Metrics and tracing integration"]
+    W --> M["Registered model metadata"]
+    M --> BI["Optional BI SQL generator"]
+    BI --> SQL["SQL response for adopter execution"]
+    SQL -. execute .-> CH["Adopter ClickHouse"]
+    B -. Kafka command and state-event topics .-> CH
+    classDef core fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    classDef external fill:#161b22,stroke:#30363d,color:#e6edf3
+    class U,A,W,H,RM,C,D,O,M,BI,SQL core
+    class B,ES,SS,CH external
+    linkStyle default stroke:#8b949e
+```
+
+<!-- Sources: [settings.gradle.kts:23-66](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L23-L66), [wow-spring-boot-starter/build.gradle.kts:5-44](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L5-L44), [Metrics.kt:138-217](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/metrics/Metrics.kt#L138-L217), [CompensationFilter.kt:58-119](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-core/src/main/kotlin/me/ahoo/wow/compensation/core/CompensationFilter.kt#L58-L119), [GenerateBIScriptHandlerFunction.kt:87-112](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/global/GenerateBIScriptHandlerFunction.kt#L87-L112), [ClickHouseCommandRenderer.kt:108-120](https://github.com/Ahoo-Wang/Wow/blob/main/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseCommandRenderer.kt#L108-L120), [ClickHouseStateEventRenderer.kt:119-132](https://github.com/Ahoo-Wang/Wow/blob/main/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseStateEventRenderer.kt#L119-L132) -->
+
+This diagram describes available integration points. It does not claim that all
+components are enabled in every application or deployed by Wow itself.
+
+## Capability map
+
+| Capability | Status | Maturity | Dependencies | Adoption boundary |
+| --- | --- | --- | --- | --- |
+| Command dispatch | Built | Core implementation | Application domain model; selected bus; WebFlux only for HTTP exposure | Domain authorization and business validation remain application concerns |
+| Event Sourcing | Built | Core implementation | Event store and event-schema governance | Data growth, retention, and deletion policy are not supplied |
+| Snapshots | Built | Configurable core feature | Snapshot store; MongoDB is the default type | Snapshot frequency and store choice need workload validation |
+| Projections | Built | Core plus application-defined stores | Event bus and an application-selected read-model store | Wow does not provide a universal projection writer; schema, freshness, and rebuild are adopter-owned |
+| Sagas | Built | Core implementation | Event dispatch and application-defined saga behavior | Business compensation semantics must be designed by the application |
+| Message buses | Built | Multiple implementations | Kafka by default; Redis, in-memory, or no-op alternatives | Delivery guarantees depend on the selected backend and configuration |
+| Storage routing | Built | Configurable core feature | Named event and snapshot stores | Routing errors and migration procedures need governance |
+| Web API | Built | Optional integration | WebFlux and the selected route capabilities | Universal authentication and rate limiting are not declared |
+| OpenAPI | Built | Optional integration | OpenAPI and WebFlux capabilities | Published contract governance remains adopter-owned |
+| Observability | Built | Optional instrumentation | Metrics or OpenTelemetry backend | Dashboards, alerts, targets, and incident ownership are not declared |
+| Compensation | Built | Separate service and dashboard | Eligible event-handler paths, compensation storage, operator process | It is not command rollback and does not guarantee business consistency |
+| BI script generation | Built | Optional integration | Registered model metadata; Kafka command/state-event topics and ClickHouse only after the adopter executes the generated SQL | Generation returns SQL and uses a no-op deployment inspector by default; execution, data ownership, retention, and analytics governance remain external |
+| Testing DSL | Built | Test support | Application test scenarios | Production behavior still requires integration and load validation |
+| Spring Boot composition | Built | Feature variants | Selected storage, bus, Web, telemetry, and security adapters | Every enabled backend adds upgrade and operating responsibilities |
+
+Sources:
+
+- [BusProperties.kt:21-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/BusProperties.kt#L21-L45)
+- [SnapshotProperties.kt:23-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/snapshot/SnapshotProperties.kt#L23-L45)
+- [StorageRoutingProperties.kt:19-36](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/routing/StorageRoutingProperties.kt#L19-L36)
+- [BuiltInHttpRoutes.kt:18-75](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contract/BuiltInHttpRoutes.kt#L18-L75)
+- [OpenAPIProperties.kt:21-27](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/openapi/OpenAPIProperties.kt#L21-L27)
+- [CompensationFilter.kt:58-119](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-core/src/main/kotlin/me/ahoo/wow/compensation/core/CompensationFilter.kt#L58-L119)
+- [BiScriptProperties.kt:55-66](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/bi/BiScriptProperties.kt#L55-L66)
+- [GenerateBIScriptHandlerFunction.kt:87-112](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/global/GenerateBIScriptHandlerFunction.kt#L87-L112)
+- [ClickHouseStateEventRenderer.kt:119-132](https://github.com/Ahoo-Wang/Wow/blob/main/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseStateEventRenderer.kt#L119-L132)
+
+## Architecture at a glance
+
+Wow follows a layered module direction: API contracts feed the core runtime;
+Spring integration and dedicated infrastructure modules extend the core.
+
+The starter exposes feature capabilities for MongoDB, Redis, mock support,
+Kafka, WebFlux, Elasticsearch, OpenTelemetry, OpenAPI, and CoSec.
+
+This modularity limits mandatory coupling, but the deployed system is still a
+distributed application when durable brokers and stores are selected.
+
+The adoption architecture should therefore document both the Wow module graph
+and the actual runtime topology. They are not interchangeable.
+
+Sources:
+
+- [settings.gradle.kts:23-66](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L23-L66)
+- [wow-spring-boot-starter/build.gradle.kts:5-44](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L5-L44)
+
+## Team topology and collaboration interfaces
+
+The repository does not declare a `CODEOWNERS` file, a team directory, or a
+service ownership map. The following responsibilities are therefore an
+adoption recommendation, not a statement about the Wow maintainers.
+
+| Component | Owner | Criticality | Bus Factor |
+| --- | --- | --- | --- |
+| Application domain model | Suggested: product engineering; repository owner not declared | High — owns business correctness | Not declared |
+| Framework composition and upgrades | Suggested: platform engineering; repository owner not declared | High — affects every adopter service | Not declared |
+| Messaging platform | Suggested: messaging platform or SRE; repository owner not declared | High when an external bus is selected | Not declared |
+| Event and snapshot storage | Suggested: data platform or SRE; repository owner not declared | High — contains recovery state | Not declared |
+| Projections and search | Suggested: product team with data platform; repository owner not declared | Medium to high by customer journey | Not declared |
+| Compensation operations | Suggested: service owner and operations; repository owner not declared | High for eligible recovery flows | Not declared |
+| API exposure and access policy | Suggested: service owner and security; repository owner not declared | High — controls powerful routes | Not declared |
+| Observability and incident response | Suggested: SRE or observability platform; repository owner not declared | High for production operation | Not declared |
+| Data governance | Suggested: data governance and legal; repository owner not declared | High for regulated data | Not declared |
+| Wow framework contribution | Wow maintainers through the contribution process; individuals not declared | Medium to high by change | Not declared |
+
+The contribution guide asks contributors to discuss public API or dependency
+changes before implementation. The security policy directs vulnerability
+reports privately to maintainers. Neither document names an organizational
+production owner for adopter services.
+
+Sources:
+
+- [CONTRIBUTING.md:1-10](https://github.com/Ahoo-Wang/Wow/blob/main/CONTRIBUTING.md#L1-L10)
+- [CONTRIBUTING.md:50-58](https://github.com/Ahoo-Wang/Wow/blob/main/CONTRIBUTING.md#L50-L58)
+- [SECURITY.md:7-21](https://github.com/Ahoo-Wang/Wow/blob/main/SECURITY.md#L7-L21)
+
+## Technology thesis
+
+| Technology or model | Purpose | Alternatives considered in repository | Risk level |
+| --- | --- | --- | --- |
+| CQRS and Event Sourcing | Preserve business changes and separate write behavior from read views | A current-state-only CRUD alternative is not evaluated in a repository decision record | High — event compatibility and lifecycle are long-lived obligations |
+| Reactor-based execution | Compose asynchronous command and event work | Alternatives are not documented | Medium — adopter code and integrations must preserve non-blocking behavior |
+| Spring Boot starter | Compose optional capabilities through configuration | Direct module assembly remains possible; no formal trade study is recorded | Medium — enabled features widen upgrade and operating scope |
+| Kafka, Redis, in-memory, or no-op buses | Transport commands and events | These four bus types are selectable | High for durable production transport; low for local-only options |
+| MongoDB, Redis, Elasticsearch, in-memory, or delay storage | Persist events and snapshots through a selected or routed store; in-memory and delay modes support non-durable/test scenarios | All five `StorageType` values and custom routing are configurable | High for durable stores — data durability and migration depend on the choice |
+| Elasticsearch event/snapshot adapter | Persist and query event streams and snapshots, including search over stored state | MongoDB, Redis, and custom application storage remain alternatives | Medium — index lifecycle and rebuild are adopter-owned; this is not a generic projection writer |
+| OpenTelemetry and metrics wrappers | Export runtime activity | Optional instrumentation; backend choice is external | Medium — cost and privacy depend on sampling and attributes |
+| Compensation service and dashboard | Expose and retry eligible handler failures | Manual business correction remains application-owned | High — unsafe retry can repeat side effects |
+
+### Why the model can create value
+
+An event history can improve auditability and support new projections without
+changing the original write model.
+
+Command handling encourages explicit domain intent rather than generic record
+mutation.
+
+Snapshots provide a performance mechanism for long-lived aggregates without
+discarding the event history.
+
+Failure records and controlled retry actions can make selected asynchronous
+handler failures visible to operators.
+
+### What the model costs
+
+Event schemas become long-lived compatibility contracts.
+
+Projection lag and replay introduce operational states that conventional CRUD
+systems may not have.
+
+Multiple backends require coordinated capacity planning, upgrades, backup,
+restore, and incident response.
+
+The default aggregate deletion path emits a deletion event and marks reconstructed
+state as deleted. The shared `EventStore` contract exposes append and load
+operations but no general erase operation, so an adopter must not treat the
+default delete command as a repository-wide data-erasure mechanism.
+
+Operational recovery requires distinguishing transport retries, handler
+retries, event replay, state reconstruction, and business compensation.
+
+Sources:
+
+- [DomainEventStream.kt:31-56](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L31-L56)
+- [Snapshot.kt:19-40](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/Snapshot.kt#L19-L40)
+- [BusProperties.kt:21-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/BusProperties.kt#L21-L45)
+- [EventStoreProperties.kt:20-25](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/store/EventStoreProperties.kt#L20-L25)
+- [StorageType.kt:16-30](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/StorageType.kt#L16-L30)
+- [DelayEventStore.kt:26-29](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-mock/src/main/kotlin/me/ahoo/wow/eventsourcing/mock/DelayEventStore.kt#L26-L29)
+- [DelaySnapshotStore.kt:24-27](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-mock/src/main/kotlin/me/ahoo/wow/eventsourcing/mock/DelaySnapshotStore.kt#L24-L27)
+- [StorageRoutingProperties.kt:19-36](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/routing/StorageRoutingProperties.kt#L19-L36)
+- [ElasticsearchEventSourcingAutoConfiguration.kt:77-169](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfiguration.kt#L77-L169)
+- [WowOpenTelemetryAutoConfiguration.kt:30-69](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/WowOpenTelemetryAutoConfiguration.kt#L30-L69)
+- [CompensationFilter.kt:58-119](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-core/src/main/kotlin/me/ahoo/wow/compensation/core/CompensationFilter.kt#L58-L119)
+- [DefaultDeleteAggregateFunction.kt:25-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/DefaultDeleteAggregateFunction.kt#L25-L45)
+- [SimpleStateAggregate.kt:151-169](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/state/SimpleStateAggregate.kt#L151-L169)
+- [EventStore.kt:22-122](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L22-L122)
+
+## Dependency map
+
+```mermaid
+flowchart TB
+    APP["Adopter service running Wow"] --> BUS["Selected message service"]
+    APP --> EVENT["Selected event store"]
+    APP --> SNAP["Selected snapshot store"]
+    APP --> TELEMETRY["Optional telemetry backend"]
+    APP --> COMP["Optional compensation service"]
+    COMP --> COMPSTORE["Compensation MongoDB and Redis"]
+    COMP --> DASH["Operator browser"]
+    APP --> META["Registered model metadata"]
+    META --> BI["Optional BI SQL generator"]
+    BI --> SQL["Generated SQL response"]
+    SQL -. adopter executes .-> CLICKHOUSE["Adopter ClickHouse deployment"]
+    BUS -. default .-> KAFKA["Kafka"]
+    KAFKA -. command and state-event topics for deployed BI sync .-> CLICKHOUSE
+    BUS -. alternative .-> REDIS["Redis"]
+    EVENT -. default .-> MONGO["MongoDB"]
+    SNAP -. default .-> MONGO
+    EVENT -. alternative .-> ES["Elasticsearch"]
+    SNAP -. alternative .-> ES
+    EVENT -. alternative .-> REDIS
+    SNAP -. alternative .-> REDIS
+    classDef service fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    classDef optional fill:#161b22,stroke:#30363d,color:#e6edf3
+    class APP,COMP,DASH,META,BI,SQL service
+    class BUS,EVENT,SNAP,TELEMETRY,COMPSTORE,CLICKHOUSE,KAFKA,REDIS,MONGO,ES optional
+    linkStyle default stroke:#8b949e
+```
+
+<!-- Sources: [BusProperties.kt:21-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/BusProperties.kt#L21-L45), [StorageType.kt:16-30](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/StorageType.kt#L16-L30), [EventStoreProperties.kt:20-25](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/store/EventStoreProperties.kt#L20-L25), [SnapshotProperties.kt:23-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/snapshot/SnapshotProperties.kt#L23-L45), [ElasticsearchEventSourcingAutoConfiguration.kt:77-169](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfiguration.kt#L77-L169), [deploy/compensation/config.yaml:38-52](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/compensation/config.yaml#L38-L52), [GenerateBIScriptHandlerFunction.kt:87-112](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/global/GenerateBIScriptHandlerFunction.kt#L87-L112), [ClickHouseCommandRenderer.kt:108-120](https://github.com/Ahoo-Wang/Wow/blob/main/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseCommandRenderer.kt#L108-L120), [ClickHouseStateEventRenderer.kt:119-132](https://github.com/Ahoo-Wang/Wow/blob/main/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseStateEventRenderer.kt#L119-L132) -->
+
+| Dependency | Type | Risk if unavailable |
+| --- | --- | --- |
+| Selected message bus, commonly Kafka or Redis | Service | Command or event delivery through that bus stops or accumulates; exact behavior depends on deployment |
+| Selected event store, MongoDB by default | Data service | New event persistence and state reconstruction that needs stored history are unavailable |
+| Selected snapshot store, MongoDB by default | Data service | Snapshot-assisted loading is unavailable; application behavior depends on fallback and configuration |
+| Elasticsearch | Optional event/snapshot data service | Event/snapshot persistence and queries routed to Elasticsearch are unavailable; it is not a generic application projection writer |
+| OpenTelemetry or metrics backend | Optional platform | Framework work can continue, but production visibility may be reduced or lost |
+| Compensation MongoDB and Redis in the example service | Service and data services | Failure search, scheduling, or retry operations may be unavailable |
+| Kafka command and state-event topics for the BI path | Optional service | Script generation still works, but an executed ClickHouse Kafka Engine cannot ingest synchronized command and state-event data |
+| ClickHouse | Optional analytics data service | With the default no-op inspector, SQL generation can still work; deployed BI synchronization and queries are unavailable |
+
+The table describes runtime consequences only where the repository exposes the
+integration. Exact failover, buffering, recovery time, and business impact are
+not declared and must be validated in the adopter topology.
+
+### Dependency governance questions
+
+1. Which backends are mandatory for the first production use case?
+2. Who owns version compatibility across Spring Boot, Kotlin, brokers, stores,
+   telemetry, and security integrations?
+3. Which module combinations are tested in the adopter's own delivery pipeline?
+4. How will event and snapshot data be migrated when a routed store changes?
+5. Which optional integrations can be removed to reduce attack surface and cost?
+6. What is the rollback path for a framework or schema upgrade?
+
+The centralized catalog records framework dependency versions, and the starter
+declares the integrations it composes. The adopter still needs an upgrade and
+compatibility policy for its chosen subset.
+
+Sources:
+
+- [gradle/libs.versions.toml:1-67](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L1-L67)
+- [wow-dependencies/build.gradle.kts:14-35](https://github.com/Ahoo-Wang/Wow/blob/main/wow-dependencies/build.gradle.kts#L14-L35)
+
+## Risk assessment
+
+| Risk | Likelihood | Impact | Mitigation | Owner |
+| --- | --- | --- | --- | --- |
+| Event-schema evolution | Medium | High — incompatible history can block replay or reconstruction | Fund compatibility tests, versioning rules, and replay rehearsal | Application domain owner; not declared by repository |
+| Privacy and deletion | Medium where regulated data enters events | High — default deletion is not a general erasure mechanism | Minimize event data and approve a backend-specific retention or erasure strategy | Data governance owner; not declared |
+| Access-control gap | High if built-in routes are exposed without local controls | High | Require explicit endpoint, operator authorization, and rate-limit design | Service and security owners; not declared |
+| Operational complexity | High when several external backends are selected | High | Limit initial topology, define failure behavior, and assign owners | Platform or SRE owner; not declared |
+| Recovery misuse | Medium | High — retries can repeat side effects | Approve a runbook with business-side safety checks | Service and business operations owners; not declared |
+| Capacity uncertainty | High before adopter load testing | High at production scale | Benchmark the actual workload and set capacity thresholds | Service and SRE owners; not declared |
+| Documentation and version drift | Confirmed in current repository | Medium | Add release-time consistency checks or an explicit historical label | Release owner; not declared |
+| Secret handling in example configuration | Confirmed in current repository | High if copied into a deployment | Replace inline values with secret injection and scan manifests | Deployment and security owners; not declared |
+| Retry UI unit mismatch | Confirmed in current repository | High for operator decisions | Correct labels and add contract tests before operator use | Compensation product owner; not declared |
+| Incomplete operator history | Confirmed in current repository | Medium to high if auditability is required | Implement or integrate an audit trail before making an audit claim | Compensation service owner; not declared |
+| Ownership ambiguity | Confirmed as not declared | High during incidents | Name service, data, security, and incident owners locally | Adopting executive sponsor |
+| Support-window limit | Medium | Medium | Budget for timely upgrades and dependency validation | Platform owner; not declared |
+
+Sources:
+
+- [AbstractEventStreamJsonSerializer.kt:21-53](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/serialization/event/AbstractEventStreamJsonSerializer.kt#L21-L53)
+- [DefaultDeleteAggregateFunction.kt:25-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/DefaultDeleteAggregateFunction.kt#L25-L45)
+- [SimpleStateAggregate.kt:151-169](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/state/SimpleStateAggregate.kt#L151-L169)
+- [EventStore.kt:22-122](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L22-L122)
+- [wow-spring-boot-starter/build.gradle.kts:40-42](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L40-L42)
+- [EventCompensateSupporter.kt:33-69](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/compensation/EventCompensateSupporter.kt#L33-L69)
+- [ApplyRetrySpec.tsx:77-100](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/features/Failed/ApplyRetrySpec.tsx#L77-L100)
+- [Retry.kt:57-99](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/Retry.kt#L57-L99)
+- [FailedHistory.tsx:14-16](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/features/Failed/FailedHistory.tsx#L14-L16)
+- [deploy/compensation/config.yaml:43-52](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/compensation/config.yaml#L43-L52)
+- [SECURITY.md:3-5](https://github.com/Ahoo-Wang/Wow/blob/main/SECURITY.md#L3-L5)
+
+## Cost and scaling model
+
+The repository does not publish a production cost model, price estimate,
+capacity threshold, or service-level objective.
+
+Executive planning should model the following cost drivers.
+
+| Cost driver | Scaling variable | Control point | Unknown until measured |
+| --- | --- | --- | --- |
+| Application compute | Command and event throughput, handler duration | Pod size, replica count, concurrency | Workload-specific CPU and memory curve |
+| Kafka or Redis bus | Message rate, partitions, retention, replication | Backend topology and bus selection | Broker capacity and recovery time |
+| Event store | Events per command, payload size, aggregate lifetime | MongoDB or routed store sizing | Storage growth and query latency |
+| Snapshot store | Snapshot frequency and state size | Snapshot strategy and backend | Break-even frequency for rehydration |
+| Elasticsearch | Event/snapshot volume, indexing rate, and query pattern | Index lifecycle and shard design | Storage/query cost and rebuild duration |
+| Compensation | Failure rate, retry backoff, retained error detail | Scheduler batch and retry policy | Operator workload and backlog clearance time |
+| Observability | Spans, metric cardinality, log volume | Sampling and backend retention | Telemetry ingestion and storage cost |
+| BI path | Event volume, ClickHouse topology, synchronization design | Script and topology configuration | Analytics ingestion and query cost |
+| Engineering | Schema governance, replay tests, incident drills | Delivery and ownership model | Team learning and support effort |
+
+Batching for the MongoDB event store is disabled by default. Enabling it may
+change throughput, latency, memory pressure, and failure
+behavior, so it requires workload-specific testing.
+
+The example HPA manifests use a minimum of two and maximum of ten replicas with
+an 80% average CPU utilization target. They are examples, not a universal
+production recommendation.
+
+The README includes a two-minute stress-test sample. Its reported numbers must
+not be used as a current version guarantee, an end-to-end SLA, or a sizing
+substitute. The linked performance deployment references version `6.11.3` and
+specific resource settings, while the current project version is `8.9.5`.
+
+Sources:
+
+- [MongoEventStoreBatchProperties.kt:21-42](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventStoreBatchProperties.kt#L21-L42)
+- [README.md:94-109](https://github.com/Ahoo-Wang/Wow/blob/main/README.md#L94-L109)
+- [deploy/example/perf/deployment.yaml:33-80](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/example/perf/deployment.yaml#L33-L80)
+- [deploy/example/hpa.yaml:1-18](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/example/hpa.yaml#L1-L18)
+- [deploy/compensation/hpa.yaml:1-18](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/compensation/hpa.yaml#L1-L18)
+
+## Metrics and observability
+
+Wow can wrap buses, stores, and runtime components with metrics and can create
+OpenTelemetry instrumentation for aggregate, projection, snapshot, saga, and
+event-processing paths.
+
+Metrics are enabled by default when the relevant configuration and classes are
+present. OpenTelemetry integration is also conditionally enabled by default.
+
+The instrumentation includes message and aggregate context attributes. The
+repository does not declare production dashboards, alert thresholds, on-call
+ownership, error budgets, availability targets, or latency targets.
+
+### Suggested measurement contract
+
+| Metric | Current Value | Target | Source |
+| --- | --- | --- | --- |
+| Command send and process count, errors, and latency | Instrumentation points exist; production value not declared | Not declared | [Metrics.kt:138-217](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/metrics/Metrics.kt#L138-L217) |
+| Event append and load latency or failures | Metrics wrappers exist; production value not declared | Not declared | [Metrics.kt:138-217](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/metrics/Metrics.kt#L138-L217) |
+| Projection freshness and backlog | Production value not declared | Not declared | [WowOpenTelemetryAutoConfiguration.kt:30-69](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/WowOpenTelemetryAutoConfiguration.kt#L30-L69) |
+| Saga failures and backlog | Production value not declared | Not declared | [WowOpenTelemetryAutoConfiguration.kt:30-69](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/WowOpenTelemetryAutoConfiguration.kt#L30-L69) |
+| Snapshot load behavior and state size | Production value not declared | Not declared | [Metrics.kt:138-217](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/metrics/Metrics.kt#L138-L217) |
+| Compensation records by dashboard category | Categories exist; production value not declared | Not declared | [routes/constants.tsx:18-25](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/routes/constants.tsx#L18-L25) |
+| Compensation backlog age and recovery time | Production value not declared | Not declared | [routes/constants.tsx:18-25](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/routes/constants.tsx#L18-L25) |
+| Event, snapshot, index, and error-record growth | Production value not declared | Not declared | [EventStore.kt:22-122](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L22-L122) |
+| Broker and store saturation or availability | Backend-specific monitoring is adopter-owned | Not declared | [BusProperties.kt:21-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/BusProperties.kt#L21-L45) |
+
+Sources:
+
+- [ConditionalOnMetricsEnabled.kt:20-28](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/metrics/ConditionalOnMetricsEnabled.kt#L20-L28)
+- [MetricsAutoConfiguration.kt:21-30](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/metrics/MetricsAutoConfiguration.kt#L21-L30)
+- [ConditionalOnOpenTelemetryEnabled.kt:21-30](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/ConditionalOnOpenTelemetryEnabled.kt#L21-L30)
+- [WowOpenTelemetryAutoConfiguration.kt:30-69](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/WowOpenTelemetryAutoConfiguration.kt#L30-L69)
+- [routes/constants.tsx:18-25](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/routes/constants.tsx#L18-L25)
+
+## Roadmap alignment and decision gates
+
+The repository does not declare a product roadmap, delivery dates, customer
+commitments, deprecation calendar, or future service objectives.
+
+Current modules and tests are evidence of present implementation only. Issues,
+examples, and optional capabilities should not be converted into roadmap
+commitments without maintainer confirmation.
+
+```mermaid
+flowchart LR
+    E["Repository evidence"] --> I{"Classification"}
+    I -->|"Implemented and tested"| P["Pilot candidate"]
+    I -->|"Example only"| V["Validate against adopter workload"]
+    I -->|"Not declared"| D["Executive decision required"]
+    P --> G{"Production gates"}
+    V --> G
+    D --> G
+    G --> O["Named owner"]
+    G --> S["Security and data policy"]
+    G --> L["SLO and capacity evidence"]
+    G --> R["Recovery and rollback rehearsal"]
+    O --> GO["Production decision"]
+    S --> GO
+    L --> GO
+    R --> GO
+    classDef evidence fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    classDef gate fill:#161b22,stroke:#30363d,color:#e6edf3
+    class E,I,P,V,D,G,O,S,L,R,GO evidence
+    linkStyle default stroke:#8b949e
+```
+
+<!-- Sources: [CONTRIBUTING.md:1-10](https://github.com/Ahoo-Wang/Wow/blob/main/CONTRIBUTING.md#L1-L10), [.github/workflows/benchmark-smoke.yml:14-58](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/benchmark-smoke.yml#L14-L58), [SECURITY.md:3-25](https://github.com/Ahoo-Wang/Wow/blob/main/SECURITY.md#L3-L25) -->
+
+### Roadmap fact boundary
+
+| Question | Confirmed in repository | Not declared |
+| --- | --- | --- |
+| What exists today? | Modules, code, configuration, tests, examples, and release workflow | Production adoption count and operational outcomes |
+| What is next? | No repository roadmap document was identified | Planned features, dates, and priorities |
+| Who approves priorities? | Contribution discussion is requested for major changes | Product council or named roadmap owner |
+| What is supported? | Current stable receives security fixes; older versions are case-by-case | Commercial support terms or response times |
+| What is the release channel? | GitHub release or manual workflow can publish packages | Release cadence or upgrade deadline |
+| What are the product SLAs? | No production SLA is declared | Availability, latency, recovery, and support targets |
+
+Sources:
+
+- [SECURITY.md:3-5](https://github.com/Ahoo-Wang/Wow/blob/main/SECURITY.md#L3-L5)
+- [.github/workflows/package-deploy.yml:14-67](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/package-deploy.yml#L14-L67)
+
+### Adoption workstreams
+
+These are decision workstreams for an adopter, not claims about the Wow
+maintainers' roadmap.
+
+| Workstream | Business priority | Status | Dependency or blocker |
+| --- | --- | --- | --- |
+| Bounded pilot | Validate that event history or asynchronous views justify the added complexity | Recommended next step | Named product outcome and pilot owner are not declared |
+| Access and data policy | Prevent unauthorized operations and unsupported privacy claims | Required before production | Authentication, authorization, retention, erasure, and compliance policy are not declared |
+| Service objectives and capacity | Convert historical samples into workload-specific operating evidence | Required before production | Current latency, throughput, availability, and capacity targets are not declared |
+| Recovery operations | Make retries, replay, restore, and incident escalation safe | Partial repository capability; adopter process missing | Operator roles, audit history, and recovery objectives are not declared |
+| Release consistency | Reduce deployment and operator error from version or unit drift | Confirmed remediation need | Deployment image drift, retry unit mismatch, and sample credentials remain visible in repository evidence |
+
+## Technical debt and evidence gaps
+
+### Top technical-debt items
+
+| Issue | Business Impact | Effort to Fix | Priority |
+| --- | --- | --- | --- |
+| Retry editor shows milliseconds while the API model uses seconds | Operators may configure recovery with the wrong timing assumptions | Small to medium: UI copy plus contract coverage | P0 before dashboard use |
+| Compensation history view is a stub | A complete operator audit trail cannot be claimed from the dashboard | Medium to large: define audit source, retention, and UI | P1 when auditability is a launch criterion |
+| Example deployment and dashboard versions drift from root `8.9.5` | Adopters may test or deploy artifacts that do not match current source | Small to medium: align or label versions and add release checks | P1 |
+| Example compensation config contains inline credentials | Copying the example can expose reusable secrets | Small: replace with placeholders or secret references and scan manifests | P0 |
+| Compensation deployment requests one replica while its HPA minimum is two | Capacity and cost expectations differ between deployment files | Small: align the example and document intent | P2 |
+
+Sources:
+
+- [gradle.properties:21-23](https://github.com/Ahoo-Wang/Wow/blob/main/gradle.properties#L21-L23)
+- [deploy/example/deployment.yaml:26-31](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/example/deployment.yaml#L26-L31)
+- [deploy/compensation/deployment.yaml:8-26](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/compensation/deployment.yaml#L8-L26)
+- [deploy/example/perf/deployment.yaml:33-40](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/example/perf/deployment.yaml#L33-L40)
+- [compensation/dashboard/package.json:1-16](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/package.json#L1-L16)
+- [ApplyRetrySpec.tsx:77-100](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/features/Failed/ApplyRetrySpec.tsx#L77-L100)
+- [Retry.kt:57-99](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/Retry.kt#L57-L99)
+- [FailedHistory.tsx:14-16](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/features/Failed/FailedHistory.tsx#L14-L16)
+- [deploy/compensation/hpa.yaml:8-18](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/compensation/hpa.yaml#L8-L18)
+- [deploy/compensation/config.yaml:43-52](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/compensation/config.yaml#L43-L52)
+
+### Material unknowns
+
+- Production service owner and escalation path.
+- Maintainer bus factor and succession plan.
+- Availability, latency, throughput, recovery, and support targets.
+- Production capacity envelope for any workload.
+- Data classification, retention, deletion, residency, and backup policy.
+- Encryption requirements and key ownership.
+- Compliance certifications or regulated-use approval.
+- Authentication, authorization, and operator role model for deployed APIs.
+- Alert thresholds, dashboard standards, and incident-response ownership.
+- Roadmap, delivery dates, deprecation calendar, and customer commitments.
+- Production cost model and budget thresholds.
+- Disaster-recovery topology and tested recovery-point or recovery-time target.
+
+These unknowns are not necessarily framework defects. They are decisions that
+must be supplied by the adopting organization or confirmed with maintainers.
+
+## Recommendations
+
+| Priority | Next-quarter recommendation | Expected impact | Completion evidence |
+| --- | --- | --- | --- |
+| 1 | Remove or externalize example credentials, correct retry units, and align or label example versions | Removes the most immediate security and operator-error traps | Manifest scan passes; UI contract test covers seconds; release consistency check is automated |
+| 2 | Select one bounded pilot, the minimum backend set, and named service, data, security, and incident owners | Tests value while containing cost and coordination risk | Signed pilot charter with owner map and exit criteria |
+| 3 | Define endpoint exposure, event-data lifecycle, and application-specific erasure policy | Prevents unsupported access, privacy, and compliance assumptions | Approved route inventory and data-policy review |
+| 4 | Establish service objectives from load, outage, replay, restore, and upgrade tests on the adopter topology | Replaces historical sample numbers with usable capacity and recovery evidence | Approved SLOs, capacity thresholds, dashboards, alerts, and rehearsal records |
+| 5 | Approve compensation runbooks and an operator audit approach before relying on recovery workflows | Reduces repeated-side-effect and untraceable-operation risk | Authorized runbook, audit evidence, escalation path, and recovery drill |
+
+## Executive adoption checklist
+
+### Value
+
+- [ ] The domain benefits from auditable event history or asynchronous flows.
+- [ ] The expected business outcome is measurable.
+- [ ] A simpler CRUD architecture was considered.
+- [ ] The pilot scope is bounded and reversible.
+
+### Ownership
+
+- [ ] A service owner is named.
+- [ ] Messaging and storage owners are named.
+- [ ] Security and data-governance owners are named.
+- [ ] An incident commander and escalation path are defined.
+- [ ] Upgrade and dependency ownership is assigned.
+
+### Reliability
+
+- [ ] Service objectives are written and measurable.
+- [ ] Projection lag and compensation backlog targets are defined.
+- [ ] Backup, restore, replay, and disaster-recovery tests are scheduled.
+- [ ] Capacity evidence uses the adopter's workload.
+- [ ] The README stress sample is not used as an SLA.
+
+### Security and privacy
+
+- [ ] Built-in HTTP routes are inventoried and protected.
+- [ ] Operator actions are authorized and auditable.
+- [ ] Event, header, snapshot, and error data are classified.
+- [ ] Retention and deletion behavior are approved.
+- [ ] Secrets are externalized from manifests.
+- [ ] Compliance claims are supported by organizational evidence.
+
+### Delivery
+
+- [ ] Local, contract, integration, and static checks run in adopter CI.
+- [ ] Schema compatibility and replay tests are present.
+- [ ] Framework and backend upgrades have rollback plans.
+- [ ] Deployment versions are aligned and traceable.
+- [ ] Optional modules are explicitly justified.
+
+## Final decision statement
+
+Wow supplies a substantial event-driven application framework with modular
+storage, transport, Web, observability, testing, and recovery capabilities.
+
+It does not supply the adopter's operating model. A production decision should
+therefore be based on a bounded pilot, workload-specific evidence, named
+ownership, explicit data and security policies, and rehearsed recovery paths.
+
+Where this guide says “not declared,” the correct next action is to obtain a
+decision or evidence, not to infer a promise from an example or an implementation
+detail.

--- a/documentation/docs/en/onboarding/index.md
+++ b/documentation/docs/en/onboarding/index.md
@@ -1,0 +1,49 @@
+# Wow onboarding
+
+Welcome to Wow.
+
+This onboarding hub routes each reader to the guide that matches the decisions they need to make.
+
+Wow is a reactive domain-driven design framework built around CQRS and event sourcing, as summarized by the [project overview](https://github.com/Ahoo-Wang/Wow/blob/main/README.md#L51-L84).
+Its current baseline is Wow `8.9.5`, Kotlin `2.4.10`, Spring Boot `4.1.0`, Gradle `9.6.1`, and Java `17`.
+Those versions are defined by the repository rather than by this page: [project version](https://github.com/Ahoo-Wang/Wow/blob/main/gradle.properties#L18-L23), [dependency versions](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L1-L35), [Gradle wrapper](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/wrapper/gradle-wrapper.properties#L1-L9), and [JVM toolchain](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L175-L190).
+
+## Choose your path
+
+| Audience | Start here | What you will learn | Suggested time |
+| --- | --- | --- | --- |
+| Contributor | [Contributor Guide](./contributor-guide.md) | Set up the repository, understand the runtime, implement a vertical slice, test it, and prepare a reviewable change. | About 30 minutes |
+| Staff engineer | [Staff Engineer Guide](./staff-engineer-guide.md) | Reason about module boundaries, extension contracts, runtime invariants, migrations, and architecture decisions. | About 45 minutes |
+| Executive | [Executive Guide](./executive-guide.md) | Understand the product shape, engineering model, strategic strengths, dependencies, and delivery risks. | About 20 minutes |
+| Product manager | [Product Manager Guide](./product-manager-guide.md) | Translate domain behavior into commands, events, acceptance criteria, observability, and release scope. | About 20 minutes |
+
+## Recommended reading order
+
+New code contributors should begin with the [Contributor Guide](./contributor-guide.md).
+
+Architecture owners can read the contributor guide first, then continue with the [Staff Engineer Guide](./staff-engineer-guide.md).
+
+Product and leadership readers can start directly with their audience guide and return to the contributor guide when they need implementation detail.
+
+## Source-of-truth rule
+
+These guides explain the repository; they do not replace it.
+
+When prose and code differ, follow the checked-in Gradle configuration, public contracts, implementation, tests, and CI workflows.
+The [module list](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L23-L85), [test task wiring](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L54-L142), [local-test workflow](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/local-test.yml#L14-L70), and [integration-test workflow](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/integration-test.yml#L14-L77) are the authoritative starting points.
+
+## What these guides intentionally avoid
+
+They do not promise latency, throughput, availability, retention, or compliance properties that are not enforced by code and operating configuration.
+
+They also do not describe KSP as an HTTP route generator.
+In this repository KSP is part of the compiler and metadata pipeline, while runtime WebFlux routing and OpenAPI support remain explicit modules and auto-configurations: [example KSP configuration](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/build.gradle.kts#L1-L8), [metadata processor output](https://github.com/Ahoo-Wang/Wow/blob/main/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/metadata/MetadataSymbolProcessor.kt#L61-L104), [WebFlux handler](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt#L43-L66), and [starter feature variants](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L5-L44).
+
+## Useful entry points
+
+- [Repository README](https://github.com/Ahoo-Wang/Wow/blob/main/README.md#L41-L84)
+- [Module declarations](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L23-L85)
+- [Cart example API](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/AddCartItem.kt#L1-L26)
+- [Cart aggregate](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt#L32-L76)
+- [Cart specification](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt#L28-L87)
+- [Runtime test guide](../guide/test-runtime.md)

--- a/documentation/docs/en/onboarding/product-manager-guide.md
+++ b/documentation/docs/en/onboarding/product-manager-guide.md
@@ -1,0 +1,730 @@
+---
+title: Product Manager Guide
+description: Product-oriented guide to Wow capabilities, journeys, data, APIs, limitations, and operating decisions
+---
+
+# Product Manager Guide
+
+## Purpose and evidence baseline
+
+This guide explains Wow in product language: what users can do, which product
+flows it can support, what data it handles, and which decisions still belong to
+the application team.
+
+It is for product managers, delivery leads, business analysts, designers,
+support leaders, and engineering partners evaluating a Wow-based product.
+
+The evidence baseline is the `main` branch of the Wow repository.
+
+Wow describes itself as a reactive CQRS and Event Sourcing framework. It is a
+toolkit for building applications. It is not a ready-made customer product,
+hosted platform, or replacement for product discovery.
+
+The current repository version is `8.9.5`.
+
+Sources:
+
+- [README.md:7-9](https://github.com/Ahoo-Wang/Wow/blob/main/README.md#L7-L9)
+- [gradle.properties:21-29](https://github.com/Ahoo-Wang/Wow/blob/main/gradle.properties#L21-L29)
+
+## What problem does Wow help solve?
+
+Many business systems need more than the latest value in a database row.
+
+They may need to know which request changed an order, reconstruct how an
+account reached its current state, update several read views, or recover an
+asynchronous handler after a temporary failure.
+
+Wow gives engineering teams building blocks for those needs:
+
+- A **command** expresses an action a user or system wants to perform.
+- An **aggregate** checks business rules for one consistency boundary.
+- A **domain event** records something that happened.
+- An **event stream** groups ordered events produced by one command.
+- A **snapshot** stores a current state checkpoint for faster loading.
+- A **projection** updates a view optimized for reading or searching.
+- A **saga** reacts to events and coordinates a longer workflow.
+- A **compensation record** makes selected event-handler failures visible and
+  retryable.
+
+These concepts can make behavior and history explicit. They also add product
+and operational states that must be designed: pending work, delayed views,
+failed handlers, retries, replay, and data retention.
+
+Sources:
+
+- [CommandMessage.kt:53-125](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L53-L125)
+- [DomainEventStream.kt:31-56](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L31-L56)
+- [Snapshot.kt:19-40](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/Snapshot.kt#L19-L40)
+
+## Product boundary
+
+Wow can provide framework behavior and technical endpoints.
+
+The adopter still defines:
+
+- The customer and operator experiences.
+- Business commands and validation rules.
+- Event names, meaning, and compatibility.
+- Which read models customers see.
+- What “complete,” “pending,” “failed,” and “recovered” mean to users.
+- Authentication, authorization, rate limits, and operator roles.
+- Service levels, support commitments, and escalation paths.
+- Data classification, retention, deletion, and residency policies.
+- The product roadmap and delivery dates.
+
+The repository does not declare these application-specific choices.
+
+## Primary user journey
+
+The normal journey starts with an application request. The aggregate validates
+the request, accepted changes become events, and downstream handlers update
+other views or workflows.
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "secondaryBorderColor": "#30363d", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+flowchart LR
+    U["User or external system"] --> UI["Product interface"]
+    UI --> C["Submit command"]
+    C --> A{"Business rules accept?"}
+    A -->|"No"| E["Return validation or business error"]
+    A -->|"Yes"| EV["Persist domain event stream"]
+    EV --> ACK["Return command result"]
+    EV --> H["Dispatch to projections and sagas"]
+    H --> R["Update customer or operator read views"]
+    H -. "handler failure" .-> F["Record eligible failure"]
+    classDef journey fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    classDef boundary fill:#161b22,stroke:#30363d,color:#e6edf3
+    class U,UI,C,A,E,EV,ACK,H,R,F journey
+    linkStyle default stroke:#8b949e
+```
+
+<!-- Sources: [CommandMessage.kt:53-125](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L53-L125), [DomainEventStream.kt:31-56](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L31-L56), [CompensationFilter.kt:58-119](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-core/src/main/kotlin/me/ahoo/wow/compensation/core/CompensationFilter.kt#L58-L119) -->
+
+### Product decisions in this journey
+
+1. Does the product wait for processing or acknowledge acceptance first?
+2. Which failures are shown immediately to the user?
+3. Can a read view lag behind the accepted command?
+4. What wording explains a pending update without implying data loss?
+5. Which correlation or request identifier can support staff safely see?
+6. Which operations are safe to retry from the customer interface?
+7. When should a product workflow require human review?
+
+Wow provides a unified command-submission route. Its separate wait route
+receives a `SimpleWaitSignal` notification; it does not submit the command.
+The application still decides which interaction pattern is appropriate.
+
+Sources:
+
+- [BuiltInHttpRoutes.kt:18-25](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contract/BuiltInHttpRoutes.kt#L18-L25)
+- [CommandWaitRouteContributor.kt:31-65](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/global/CommandWaitRouteContributor.kt#L31-L65)
+- [CommandWaitHandlerFunction.kt:32-44](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/wait/CommandWaitHandlerFunction.kt#L32-L44)
+- [CommandFacadeRouteContributor.kt:30-55](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/global/CommandFacadeRouteContributor.kt#L30-L55)
+- [CommandFacadeHandlerFunction.kt:35-52](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandFacadeHandlerFunction.kt#L35-L52)
+
+## Failure-recovery journey
+
+The compensation subsystem records failures from selected event-processing
+paths. Operators can inspect records, adjust retry settings, change a supported
+function reference, mark recoverability, prepare a retry, or force preparation.
+
+It does not undo the original command. It does not automatically or
+unconditionally restore business consistency. A retry repeats eligible event
+handling and may cause external side effects if the application is not designed
+for safe repetition.
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "secondaryBorderColor": "#30363d", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+stateDiagram-v2
+    [*] --> Failed: eligible event handler fails
+    Failed --> Prepared: prepare when retry is allowed
+    Failed --> Prepared: force prepare by authorized operator
+    Prepared --> Succeeded: retry processing succeeds
+    Prepared --> Failed: retry processing fails
+    Failed --> Failed: retry settings or function changed
+    Failed --> Failed: recoverability changed
+    Succeeded --> [*]
+    classDef status fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    class Failed,Prepared,Succeeded status
+```
+
+<!-- Sources: [ExecutionFailedState.kt:65-99](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-domain/src/main/kotlin/me/ahoo/wow/compensation/domain/ExecutionFailedState.kt#L65-L99), [Actions.tsx:32-105](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/features/Failed/Actions.tsx#L32-L105), [ChangeFunction.tsx:28-123](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/features/Failed/ChangeFunction.tsx#L28-L123) -->
+
+### Operator journey
+
+1. Open a failure category such as To Retry, Executing, Next Retry,
+   NonRetryable, Succeeded, or Unrecoverable.
+2. Filter by record, event, aggregate, context, or function information.
+3. Inspect error details, event identity, tenant, aggregate, retry policy, and
+   recoverability.
+4. Decide whether retry is safe for the business side effects involved.
+5. If allowed, prepare the record or force preparation through an authorized
+   process.
+6. Observe whether the retry returns to Failed or reaches Succeeded.
+7. Escalate records that cannot be safely recovered automatically.
+
+The dashboard currently exposes these categories and actions. The repository
+does not declare an operator role model, approval workflow, audit retention, or
+response-time target.
+
+Sources:
+
+- [routes/constants.tsx:18-71](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/routes/constants.tsx#L18-L71)
+- [FailedSearch.tsx:24-95](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/features/Failed/FailedSearch.tsx#L24-L95)
+- [FailedDetails.tsx:29-223](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/features/Failed/details/FailedDetails.tsx#L29-L223)
+
+## Feature capability map
+
+Here, “Live” means the repository contains the implementation. It does not mean
+the feature is enabled, operated, or supported by every adopting application.
+
+| Product need | Wow capability | Status | What users may experience | Limitations |
+| --- | --- | --- | --- | --- |
+| Express intent | Commands | Live | Submit a named business action | Application defines wording, validation, and permission |
+| Preserve history | Domain events and event streams | Live | Support can trace how state changed | Application decides what data may be stored long term |
+| Load current state | State reconstruction and snapshots | Live | Current business state can be loaded | Application defines freshness and error experience |
+| Build query views | Projections | Live | Task-specific lists and searches can be built | Application must explain update delays where relevant |
+| Coordinate workflows | Sagas | Live | Multi-step processes can react to events | Application defines pending, timeout, and cancellation states |
+| Route messaging | Kafka, Redis, in-memory, or no-op bus | Live | Usually invisible infrastructure behavior | Guarantees and outage behavior depend on the selected option |
+| Route storage | Per-model event and snapshot stores | Live | Different domains can use different backends | Migration and support complexity are adopter-owned |
+| Submit over HTTP | Built-in command routes | Live | Product or integration clients can send actions | Endpoints need local protection and client-error design |
+| Inspect metadata | Metadata endpoint | Live | Tools can discover registered models | Exposure decision is adopter-owned |
+| Generate global IDs | ID endpoint | Live | Clients can request identifier text | Trust boundary and availability need are adopter-owned |
+| Operate failures | Compensation service and dashboard | Live | Operators inspect and retry selected failures | History view is incomplete; roles and safe retry policy are not supplied |
+| Describe endpoints | OpenAPI integration | Live | Client tooling can read an API description | Version and generated-client governance are adopter-owned |
+| Observe runtime | Metrics and OpenTelemetry | Live | Support can correlate processing activity | Dashboards, alerts, and support playbooks are not supplied |
+| Generate BI scripts | Optional ClickHouse-oriented SQL generation | Live | Data teams receive SQL generated from registered model metadata; after they execute it, ClickHouse Kafka Engine consumers read command and state-event topics | Generation uses a no-op deployment inspector by default; SQL execution, Kafka, ClickHouse, data movement, and analytics policy are adopter-owned |
+| Test domain rules | Aggregate test DSL | Live | Teams can verify business behavior | Product scenarios and edge cases remain application-owned |
+
+Sources:
+
+- [BuiltInHttpRoutes.kt:18-75](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contract/BuiltInHttpRoutes.kt#L18-L75)
+- [BusProperties.kt:21-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/BusProperties.kt#L21-L45)
+- [StorageRoutingProperties.kt:19-36](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/routing/StorageRoutingProperties.kt#L19-L36)
+- [WowOpenTelemetryAutoConfiguration.kt:30-69](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/WowOpenTelemetryAutoConfiguration.kt#L30-L69)
+- [CompensationFilter.kt:58-119](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-core/src/main/kotlin/me/ahoo/wow/compensation/core/CompensationFilter.kt#L58-L119)
+- [OpenAPIProperties.kt:21-27](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/openapi/OpenAPIProperties.kt#L21-L27)
+- [BiScriptProperties.kt:30-52](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/bi/BiScriptProperties.kt#L30-L52)
+- [BiScriptProperties.kt:55-66](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/bi/BiScriptProperties.kt#L55-L66)
+- [GenerateBIScriptHandlerFunction.kt:87-112](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/global/GenerateBIScriptHandlerFunction.kt#L87-L112)
+- [ClickHouseCommandRenderer.kt:108-120](https://github.com/Ahoo-Wang/Wow/blob/main/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseCommandRenderer.kt#L108-L120)
+- [ClickHouseStateEventRenderer.kt:119-132](https://github.com/Ahoo-Wang/Wow/blob/main/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseStateEventRenderer.kt#L119-L132)
+- [AggregateSpec.kt:69-109](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-test/src/main/kotlin/me/ahoo/wow/test/AggregateSpec.kt#L69-L109)
+
+## Product data model
+
+The diagram shows the framework records that can connect a request to stored
+events, current state, read models, and a failure record.
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "secondaryBorderColor": "#30363d", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+erDiagram
+    COMMAND_MESSAGE ||--o| DOMAIN_EVENT_STREAM : may_produce
+    DOMAIN_EVENT_STREAM ||--|{ DOMAIN_EVENT : contains
+    AGGREGATE ||--o{ DOMAIN_EVENT_STREAM : owns_history
+    AGGREGATE ||--o| SNAPSHOT : may_have
+    DOMAIN_EVENT ||--o{ READ_MODEL : updates
+    DOMAIN_EVENT ||--o{ EXECUTION_FAILED : may_create
+    COMMAND_MESSAGE {
+        string commandId
+        string requestId
+        string aggregateId
+        string tenantId
+        object body
+    }
+    DOMAIN_EVENT {
+        string eventId
+        string eventType
+        int version
+        json body
+    }
+    SNAPSHOT {
+        object state
+        long snapshotTime_epochMillis
+    }
+    EXECUTION_FAILED {
+        string eventId
+        string status
+        string errorDetails
+        int retries
+    }
+```
+
+<!-- Sources: [SimpleCommandMessage.kt:46-60](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/SimpleCommandMessage.kt#L46-L60), [DomainEventStream.kt:31-42](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L31-L42), [DomainEventStream.kt:100-115](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L100-L115), [EventStreamRecord.kt:35-122](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/serialization/event/EventStreamRecord.kt#L35-L122), [Snapshot.kt:19-40](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/Snapshot.kt#L19-L40), [IExecutionFailedState.kt:28-44](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-api/src/main/kotlin/me/ahoo/wow/compensation/api/IExecutionFailedState.kt#L28-L44) -->
+
+A rejected or void command can produce no event stream. When a stream exists,
+its command ID identifies exactly one non-empty stream.
+
+### Data inventory
+
+| Data | Examples of fields in code | Why it exists | Product and privacy question |
+| --- | --- | --- | --- |
+| Command message | Body, aggregate ID, tenant ID, request ID, command ID, headers, create time | Carries user or system intent | Does body or metadata contain personal data? |
+| Domain event | Event body, event ID, type, version, aggregate context, timestamp | Records an accepted business change | How long may immutable history be retained? |
+| Event stream | Command/request identity, tenant, owner, space, ordered events | Connects one command to resulting changes | Who may inspect full history? |
+| Snapshot | Current state and snapshot time | Speeds state loading | Does the snapshot duplicate sensitive event data? |
+| Read model | Application-defined fields | Supports product queries and search | What freshness and deletion behavior apply? |
+| Failure record | Error message, stack trace, binding errors, event identity, retry status | Supports diagnosis and retry | Could technical errors reveal personal or secret data? |
+| Request metadata | User-Agent and remote IP can be appended to headers | Supports correlation and context | Is notice, consent, minimization, or masking required? |
+| Trace and metrics attributes | Message, request, trace, and aggregate metadata | Supports operational visibility | Which identifiers are safe to export? |
+
+Sources:
+
+- [MessageSerializer.kt:26-65](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/serialization/MessageSerializer.kt#L26-L65)
+- [AbstractEventStreamJsonSerializer.kt:21-53](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/serialization/event/AbstractEventStreamJsonSerializer.kt#L21-L53)
+- [IExecutionFailedState.kt:28-44](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-api/src/main/kotlin/me/ahoo/wow/compensation/api/IExecutionFailedState.kt#L28-L44)
+- [WowInstrumenter.kt:26-35](https://github.com/Ahoo-Wang/Wow/blob/main/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/WowInstrumenter.kt#L26-L35)
+
+## Configuration and feature switches
+
+Configuration controls technical behavior. Product managers should understand
+which user-visible states can change when operators change these values.
+
+| Configuration | Repository default | Product effect | Who can change it |
+| --- | --- | --- | --- |
+| `wow.enabled` | `true` | Enables the Wow runtime integration | Deployment operator |
+| Shutdown timeout | 60 seconds | Allows in-flight work time to stop; no recovery target is implied | Deployment operator |
+| Shutdown quiet period | 1 second | Adds a quiet interval during shutdown | Deployment operator |
+| Bus type | Kafka | Selects the default command/event transport | Platform or deployment operator |
+| Local-first bus | `true` | Prefers local handling before external bus where supported | Platform or deployment operator |
+| Event store | MongoDB; alternatives are Redis, Elasticsearch, in-memory, or delay | Selects event persistence; in-memory and delay modes are non-durable/test-oriented | Platform or deployment operator |
+| Snapshots | Enabled | Allows stored state checkpoints | Platform or deployment operator |
+| Snapshot store | MongoDB; alternatives are Redis, Elasticsearch, in-memory, or delay | Selects snapshot persistence; in-memory and delay modes are non-durable/test-oriented | Platform or deployment operator |
+| Prepare support | Enabled | Enables aggregate preparation support | Application or deployment operator |
+| OpenAPI | Enabled | Makes API description support available | Application or deployment operator |
+| WebFlux integration | Enabled | Makes HTTP integration available; universal authentication and rate limits are not supplied | Application or deployment operator |
+| Global WebFlux error handling | Enabled | Uses shared framework error handling | Application or deployment operator |
+| WebFlux batch concurrency | 1 | Processes batch items with configured concurrency | Deployment operator |
+| Compensation | Enabled | Makes compensation integration available; safe retry policy is separate | Application or deployment operator |
+| Compensation max retries | 10 | Limits automatic retry attempts | Compensation service operator |
+| Compensation min backoff | 180 seconds | Delays retries; UI currently labels this as milliseconds | Compensation service operator |
+| Compensation execution timeout | 120 seconds | Bounds an attempt; UI currently labels this as milliseconds | Compensation service operator |
+| Compensation scheduler batch | 100 | Limits records considered in one scheduler batch | Compensation service operator |
+| Compensation scheduler period | 60 seconds | Sets scheduler cadence; no recovery SLA is implied | Compensation service operator |
+| Metrics | Enabled when supported | Produces runtime measurements | Platform or deployment operator |
+| OpenTelemetry | Conditionally enabled | Produces trace instrumentation when dependencies exist | Platform or deployment operator |
+| BI script | Enabled | Generates SQL from registered model metadata and returns it to the caller; it does not execute the SQL | Application or deployment operator |
+| BI deployment inspector | No-op | Does not contact ClickHouse during generation unless changed to the ClickHouse inspector | Data platform or deployment operator |
+| BI topology | Cluster | Selects default ClickHouse topology | Data platform or deployment operator |
+| MongoDB event-store batching | Disabled | Changes the write trade-off if enabled | Platform or deployment operator |
+
+Sources:
+
+- [WowProperties.kt:23-35](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/WowProperties.kt#L23-L35)
+- [BusProperties.kt:21-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/BusProperties.kt#L21-L45)
+- [EventStoreProperties.kt:20-25](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/store/EventStoreProperties.kt#L20-L25)
+- [StorageType.kt:16-30](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/StorageType.kt#L16-L30)
+- [DelayEventStore.kt:26-29](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-mock/src/main/kotlin/me/ahoo/wow/eventsourcing/mock/DelayEventStore.kt#L26-L29)
+- [DelaySnapshotStore.kt:24-27](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-mock/src/main/kotlin/me/ahoo/wow/eventsourcing/mock/DelaySnapshotStore.kt#L24-L27)
+- [ElasticsearchEventSourcingAutoConfiguration.kt:77-169](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfiguration.kt#L77-L169)
+- [SnapshotProperties.kt:23-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/snapshot/SnapshotProperties.kt#L23-L45)
+- [PrepareProperties.kt:21-42](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareProperties.kt#L21-L42)
+- [OpenAPIProperties.kt:21-27](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/openapi/OpenAPIProperties.kt#L21-L27)
+- [WebFluxProperties.kt:22-44](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxProperties.kt#L22-L44)
+- [CompensationProperties.kt:21-27](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/compensation/CompensationProperties.kt#L21-L27)
+- [Retry.kt:57-99](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/Retry.kt#L57-L99)
+- [server CompensationProperties.kt:21-33](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-server/src/main/kotlin/me/ahoo/wow/compensation/server/configuration/CompensationProperties.kt#L21-L33)
+- [SchedulerProperties.kt:22-37](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-server/src/main/kotlin/me/ahoo/wow/compensation/server/scheduler/SchedulerProperties.kt#L22-L37)
+- [BiScriptProperties.kt:30-52](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/bi/BiScriptProperties.kt#L30-L52)
+- [BiScriptProperties.kt:55-66](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/bi/BiScriptProperties.kt#L55-L66)
+- [BiScriptProperties.kt:110-165](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/bi/BiScriptProperties.kt#L110-L165)
+- [GenerateBIScriptHandlerFunction.kt:87-112](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/global/GenerateBIScriptHandlerFunction.kt#L87-L112)
+- [MongoEventStoreBatchProperties.kt:21-42](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventStoreBatchProperties.kt#L21-L42)
+- [ConditionalOnMetricsEnabled.kt:20-28](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/metrics/ConditionalOnMetricsEnabled.kt#L20-L28)
+- [ConditionalOnOpenTelemetryEnabled.kt:21-30](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/ConditionalOnOpenTelemetryEnabled.kt#L21-L30)
+
+## Built-in API surface
+
+The route set provides framework operations. Exact aggregate-specific paths are
+derived from registered models and route contributors.
+
+| Capability | Endpoint/Method | Authentication | Rate Limits |
+| --- | --- | --- | --- |
+| Receive a wait-completion signal; this does not submit a command | `POST /wow/command/wait` | Not declared; CoSec integration is optional | Not declared |
+| Submit a command through the unified facade | `POST /wow/command/send` | Not declared; CoSec integration is optional | Not declared |
+| Read Wow model metadata | `GET /wow/metadata` | Not declared; CoSec integration is optional | Not declared |
+| Generate a global identifier | `GET /wow/id/global` | Not declared; CoSec integration is optional | Not declared |
+| Generate and return BI SQL or a JSON result | `POST /wow/bi/script` | Not declared; CoSec integration is optional | Not declared |
+| Send a typed aggregate command | Aggregate command route | Not declared; application permission is required | Not declared |
+| Query aggregate state | State query route | Not declared; application privacy rules are required | Not declared |
+| Query or regenerate snapshots | Snapshot routes | Not declared; restrict as an operator capability | Not declared |
+| Count, list, page, load, compensate, or resend events | Event routes | Not declared; restrict as an operator capability | Not declared |
+
+The repository does not declare one universal authentication policy, operator
+role model, public exposure policy, rate limit, or API service level. CoSec is
+an optional feature capability that can be active when its classes are present;
+that does not make every deployment protected automatically.
+
+Sources:
+
+- [BuiltInHttpRoutes.kt:18-75](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contract/BuiltInHttpRoutes.kt#L18-L75)
+- [CommandWaitRouteContributor.kt:40-60](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/global/CommandWaitRouteContributor.kt#L40-L60)
+- [CommandWaitHandlerFunction.kt:32-44](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/wait/CommandWaitHandlerFunction.kt#L32-L44)
+- [CommandFacadeRouteContributor.kt:35-52](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/global/CommandFacadeRouteContributor.kt#L35-L52)
+- [CommandFacadeHandlerFunction.kt:35-52](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandFacadeHandlerFunction.kt#L35-L52)
+- [GenerateBIScriptRouteContributor.kt:37-100](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/global/GenerateBIScriptRouteContributor.kt#L37-L100)
+- [GenerateBIScriptHandlerFunction.kt:87-112](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/global/GenerateBIScriptHandlerFunction.kt#L87-L112)
+- [EventRouteContributor.kt:56-207](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/aggregate/event/EventRouteContributor.kt#L56-L207)
+- [wow-spring-boot-starter/build.gradle.kts:40-42](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L40-L42)
+- [CoSecAutoConfiguration.kt:27-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/cosec/CoSecAutoConfiguration.kt#L27-L45)
+
+## Performance and service-level boundary
+
+The repository includes a short README stress-test sample and a benchmark-smoke
+workflow. Neither is a current product SLA.
+
+The README sample ran for two minutes and reports send and processed rates and
+latencies for two example commands. The linked performance deployment uses a
+specific resource profile and image version `6.11.3`, while the current root
+version is `8.9.5`.
+
+Use the sample to discover what to test, not to promise customer outcomes.
+
+| Operation | Expected Latency | Throughput Limit | Current SLA |
+| --- | --- | --- | --- |
+| Command submission | Not declared; historical example numbers are not a promise | Not declared | Not declared |
+| Command processing | Not declared; depends on domain work and selected backends | Not declared | Not declared |
+| Read-view update | Not declared; no freshness target is supplied | Not declared | Not declared |
+| Event persistence and state loading | Not declared; depends on the selected store and workload | Not declared | Not declared |
+| Compensation retry | Scheduler defaults exist, but no recovery-time expectation is declared | Scheduler batch defaults to 100; production limit not declared | Not declared |
+| Dashboard operation | Not declared | Not declared | Not declared |
+| Autoscaling | Not applicable as a fixed latency; example HPA uses an 80% CPU target | Example range is 2–10 replicas; production limit not declared | Not declared |
+
+Sources:
+
+- [README.md:94-109](https://github.com/Ahoo-Wang/Wow/blob/main/README.md#L94-L109)
+- [deploy/example/perf/deployment.yaml:33-80](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/example/perf/deployment.yaml#L33-L80)
+- [.github/workflows/benchmark-smoke.yml:14-58](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/benchmark-smoke.yml#L14-L58)
+- [deploy/example/hpa.yaml:1-18](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/example/hpa.yaml#L1-L18)
+
+### Product performance questions
+
+- How long may a customer wait for command acceptance?
+- How long may a read view lag after acceptance?
+- How should the interface show pending processing?
+- When should an operation time out in the client?
+- What happens when the bus or event store is unavailable?
+- How old may a compensation backlog become before escalation?
+- Which product flows require synchronous confirmation?
+- Which flows can complete asynchronously with notification?
+
+These answers are application requirements, not defaults supplied by Wow.
+
+## Known limitations and cautions
+
+| Limitation | User Impact | Workaround | Planned Fix |
+| --- | --- | --- | --- |
+| Compensation covers eligible event-handler paths, not universal rollback | A retry cannot be presented as undoing the original business action | Require a business safety decision before retry | Not declared |
+| Dashboard history view is a stub | Operators cannot rely on it as a complete audit trail | Use an approved external audit process | Not declared |
+| Retry UI labels seconds-based values as milliseconds | Operators may enter or interpret unsafe timing values | Correct and verify values outside the current form before use | Not declared |
+| Example images and package versions differ from root `8.9.5` | Example behavior may not match current source | Build reviewed artifacts from the selected release | Not declared |
+| Example compensation configuration includes inline credentials | Copying the example can expose reusable secrets | Replace values with the adopter's secret mechanism | Not declared |
+| Default aggregate deletion is not a general event-erasure mechanism | A delete action may not satisfy data-erasure obligations | Minimize regulated event data and design a store-specific lifecycle process | Not declared |
+| No repository-wide SLA, capacity envelope, or data policy | Product commitments cannot be derived from framework defaults | Define and validate them for the adopter service | Not declared |
+
+### Compensation is controlled retry, not universal rollback
+
+The filter records failures for domain event, stateless saga, projection, and
+snapshot dispatch paths. Event compensation support accepts event and state
+event function kinds. This is narrower than every command, workflow, or
+external side effect.
+
+Sources:
+
+- [CompensationFilter.kt:58-119](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-core/src/main/kotlin/me/ahoo/wow/compensation/core/CompensationFilter.kt#L58-L119)
+- [EventCompensateSupporter.kt:33-69](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/compensation/EventCompensateSupporter.kt#L33-L69)
+
+### Operator history is incomplete
+
+The current compensation dashboard history component is a stub. Product and
+operations teams should not assume a complete audit-history experience exists.
+
+Source: [FailedHistory.tsx:14-16](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/features/Failed/FailedHistory.tsx#L14-L16)
+
+### Retry units are presented inconsistently
+
+The dashboard labels minimum backoff and execution timeout as milliseconds.
+The backend API model documents both values in seconds. Correct this mismatch
+before operators rely on the form.
+
+Sources:
+
+- [ApplyRetrySpec.tsx:77-100](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/features/Failed/ApplyRetrySpec.tsx#L77-L100)
+- [Retry.kt:57-99](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/Retry.kt#L57-L99)
+
+### Examples are not production commitments
+
+Deployment images in examples do not match the current root version. A sample
+configuration also contains inline demo credentials. Product launch criteria
+must use reviewed application manifests, not copy examples unchanged.
+
+Sources:
+
+- [gradle.properties:21-23](https://github.com/Ahoo-Wang/Wow/blob/main/gradle.properties#L21-L23)
+- [deploy/example/deployment.yaml:26-31](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/example/deployment.yaml#L26-L31)
+- [deploy/compensation/deployment.yaml:21-26](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/compensation/deployment.yaml#L21-L26)
+- [deploy/compensation/config.yaml:43-52](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/compensation/config.yaml#L43-L52)
+
+### Default aggregate deletion is not a general event-erasure mechanism
+
+The default delete command emits a deletion event, and state reconstruction
+uses that event to toggle a deleted flag. The shared `EventStore` contract
+provides append and load operations but no general erase operation. This does
+not prove that every adopter backend can never support erasure; it means the
+framework's default delete behavior is insufficient evidence for an erasure
+claim. Products with erasure obligations need a separately reviewed,
+store-specific data strategy.
+
+Sources:
+
+- [DefaultDeleteAggregateFunction.kt:25-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/DefaultDeleteAggregateFunction.kt#L25-L45)
+- [SimpleStateAggregate.kt:151-169](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/state/SimpleStateAggregate.kt#L151-L169)
+- [EventStore.kt:22-122](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L22-L122)
+
+## Privacy, security, and data policy
+
+Wow can persist event bodies, event metadata, aggregate identifiers, tenant
+identifiers, command and request identifiers, and headers.
+
+WebFlux integration registers User-Agent and remote IP header appenders by
+default when their enablement properties are absent; each appender can be
+disabled through configuration. Command headers can propagate to event streams,
+and serialized messages include headers.
+
+Failure records can contain error messages, stack traces, and binding errors.
+Those fields may reveal user data, secrets, or internal implementation details
+depending on the application.
+
+The repository does not declare retention periods, data residency, encryption
+policy, compliance certifications, or a general right-to-erasure mechanism.
+
+| Data Type | Storage Location | Retention | Compliance |
+| --- | --- | --- | --- |
+| Command body, identifiers, and headers | In-flight message path and selected bus; exact durable handling is application-specific | Not declared | Not declared |
+| Event body and event-stream metadata | Selected event store; MongoDB is the default store type | Not declared | Not declared |
+| Snapshot state | Selected snapshot store; MongoDB is the default store type | Not declared | Not declared |
+| Read-model data | Application-selected projection store; Wow does not select or write to one universal projection backend | Not declared | Not declared |
+| Compensation error details and retry state | Compensation service stores selected by its deployment; example uses MongoDB and Redis | Not declared | Not declared |
+| User-Agent and remote IP command headers | Command headers and potentially propagated event metadata when default appenders remain enabled | Not declared | Not declared |
+| Trace and metric attributes | Adopter-selected observability backend | Not declared | Not declared |
+| Generated BI SQL | Returned to the HTTP caller as SQL or JSON; the repository does not persist or execute the response | Not declared | Not declared |
+| BI-synchronized command and state-event data | ClickHouse only after the adopter executes the generated SQL; the created Kafka Engine consumers ingest matching topics | Not declared | Not declared |
+
+Sources:
+
+- [CommandRequestRemoteIpHeaderAppender.kt:21-50](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/appender/CommandRequestRemoteIpHeaderAppender.kt#L21-L50)
+- [CommandRequestUserAgentHeaderAppender.kt:21-26](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/appender/CommandRequestUserAgentHeaderAppender.kt#L21-L26)
+- [WebFluxAutoConfiguration.kt:141-158](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfiguration.kt#L141-L158)
+- [CommandRequestHeaderPropagator.kt:19-80](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/CommandRequestHeaderPropagator.kt#L19-L80)
+- [DomainEventStreamFactory.kt:77-119](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStreamFactory.kt#L77-L119)
+- [IExecutionFailedState.kt:28-44](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-api/src/main/kotlin/me/ahoo/wow/compensation/api/IExecutionFailedState.kt#L28-L44)
+- [EventStoreProperties.kt:20-25](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/store/EventStoreProperties.kt#L20-L25)
+- [SnapshotProperties.kt:23-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/snapshot/SnapshotProperties.kt#L23-L45)
+- [deploy/compensation/config.yaml:38-52](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/compensation/config.yaml#L38-L52)
+- [BiScriptProperties.kt:69-165](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/bi/BiScriptProperties.kt#L69-L165)
+- [GenerateBIScriptHandlerFunction.kt:87-112](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/global/GenerateBIScriptHandlerFunction.kt#L87-L112)
+- [ClickHouseCommandRenderer.kt:108-120](https://github.com/Ahoo-Wang/Wow/blob/main/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseCommandRenderer.kt#L108-L120)
+- [ClickHouseStateEventRenderer.kt:119-132](https://github.com/Ahoo-Wang/Wow/blob/main/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseStateEventRenderer.kt#L119-L132)
+- [wow-spring-boot-starter/build.gradle.kts:5-44](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L5-L44)
+
+### Privacy readiness checklist
+
+- [ ] Classify command bodies, event bodies, headers, snapshots, projections,
+  traces, and failure details.
+- [ ] Document why IP and User-Agent collection is needed or disable it where
+  appropriate.
+- [ ] Define event, snapshot, projection, compensation, and telemetry retention.
+- [ ] Define access rules for event query, resend, compensate, and snapshot
+  regeneration operations.
+- [ ] Review tenant context separately from authentication and authorization.
+- [ ] Redact secrets and personal data from exceptions and binding errors.
+- [ ] Design a lawful erasure process before storing regulated personal data in
+  immutable events.
+- [ ] Verify encryption, key ownership, backup, and residency in every selected
+  backend.
+- [ ] Make only evidence-backed compliance claims.
+
+## Product launch checklist
+
+### Experience
+
+- [ ] Every command has success, rejection, pending, timeout, and retry copy.
+- [ ] The UI explains possible read-model delay where users can notice it.
+- [ ] Duplicate submission and refresh behavior are designed.
+- [ ] Support can correlate a customer report without exposing unsafe data.
+- [ ] Operator workflows distinguish safe retry from business correction.
+
+### Data
+
+- [ ] Event names and meanings are reviewed as durable product contracts.
+- [ ] Sensitive fields are minimized.
+- [ ] Retention, deletion, backup, and restore policies are approved.
+- [ ] Projection rebuild behavior is tested.
+- [ ] Analytics data movement is reviewed.
+
+### Operations
+
+- [ ] Availability, latency, freshness, and recovery objectives are defined.
+- [ ] Alerts and escalation paths have named owners.
+- [ ] Load tests use the real product workflow and production-like topology.
+- [ ] Broker/store outages and recovery are rehearsed.
+- [ ] Compensation backlog and operator actions are observable.
+
+### Security
+
+- [ ] Every built-in route has an exposure decision.
+- [ ] Authentication, authorization, and rate limits are implemented where
+  required.
+- [ ] Force retry, resend, compensate, and regeneration operations are tightly
+  controlled.
+- [ ] Sample credentials are not used in deployed environments.
+- [ ] Security review covers all selected optional integrations.
+
+## Glossary
+
+| Term | Plain-language meaning |
+| --- | --- |
+| Aggregate | One business consistency boundary that checks rules and changes state |
+| Aggregate ID | The identifier used to address that boundary |
+| Command | A request to perform a named business action |
+| Command ID | Identifier for one command message |
+| Request ID | Identifier that can connect related processing |
+| Domain event | A record that a meaningful business change happened |
+| Event stream | Ordered events produced by one command for one aggregate |
+| Event Sourcing | Building current state from stored domain events |
+| Snapshot | A saved state checkpoint used to speed loading |
+| Projection | A handler that builds a view for reading or searching |
+| Read model | Data shaped for a customer, operator, or reporting query |
+| Saga | A component that reacts to events across a longer workflow |
+| Compensation | In this project, controlled retry support for selected event handlers |
+| Replay | Processing stored events again to rebuild or repair derived state |
+| Resend | Publishing an event again through a supported operation |
+| Recoverable | A failure marked as eligible for the recovery workflow |
+| Tenant ID | Context used in aggregate and event metadata; not by itself an access-control guarantee |
+| OpenAPI | A machine-readable description of HTTP operations |
+| OpenTelemetry | Instrumentation standard used to export trace information |
+| SLO | A measurable internal service objective; none is supplied universally by Wow |
+| SLA | A service commitment; none is declared by the repository |
+
+## Frequently asked questions
+
+### 1. Is Wow an end-user product?
+
+No. It is a framework and module set used by engineering teams to build
+applications.
+
+### 2. Does every Wow product need Kafka, MongoDB, Redis, and Elasticsearch?
+
+No. The starter exposes optional capabilities and selectable bus/store types.
+Elasticsearch is an event/snapshot storage and query adapter, not a universal
+application projection writer. The right subset depends on the use case.
+
+### 3. Does a successful command mean every screen is already updated?
+
+Not necessarily. Projections and sagas can process events asynchronously. The
+product must define and communicate freshness expectations.
+
+### 4. Can Wow show how a business state changed?
+
+The event stream stores ordered events and related metadata. What is safe and
+useful to show depends on application permissions and data policy.
+
+### 5. Does the compensation dashboard reverse a bad command?
+
+No. It manages selected event-handler failures and retries. It is not universal
+command rollback or guaranteed business reconciliation.
+
+### 6. Can every failure be retried?
+
+No. Recoverability, retry limits, supported function kinds, and business side
+effects constrain safe retry.
+
+### 7. Is there a complete operator audit history in the dashboard?
+
+Do not assume so. The current history component is a stub, and an organizational
+audit policy is not declared.
+
+### 8. What are the default retry values?
+
+The backend defaults are ten retries, a minimum backoff of 180 seconds, and an
+execution timeout of 120 seconds. The current UI labels two values with the
+wrong unit, so operator-facing behavior must be corrected and tested.
+
+### 9. Does Wow guarantee a throughput or latency number?
+
+No. The README contains a historical two-minute sample, not a current SLA or a
+guarantee for another workload.
+
+### 10. Is autoscaling included?
+
+The repository contains example Kubernetes HPA manifests. Production scaling
+and capacity remain deployment decisions.
+
+### 11. Does a tenant ID guarantee tenant isolation?
+
+No. Tenant metadata provides context and routing information. Authentication,
+authorization, storage isolation, and query controls still need explicit design.
+
+### 12. Does deleting an aggregate erase its event history?
+
+Do not assume so. The default delete behavior emits an event and marks rebuilt
+state as deleted, while the shared event-store contract has no general erase
+operation. Any store-specific erasure process needs separate design and proof.
+
+### 13. Does Wow define data retention or residency?
+
+No repository-wide retention period or residency policy is declared.
+
+### 14. Are built-in HTTP endpoints automatically safe for public exposure?
+
+No. The adopter must decide exposure, authentication, authorization, network
+controls, and rate limits. CoSec integration is optional.
+
+### 15. Can product teams generate API descriptions?
+
+OpenAPI support is available and enabled by default in its configuration, but
+contract publication and client compatibility still need governance.
+
+### 16. What should a product team measure first?
+
+Measure command acceptance and processing latency, read-view freshness,
+failure and compensation backlog age, error rates, and event/store growth for
+the actual customer journey.
+
+### 17. Who owns the Wow-based service?
+
+The repository does not name an owner for an adopter's service. The adopting
+organization must assign product, engineering, operations, security, and data
+ownership.
+
+### 18. What is on the Wow roadmap?
+
+No roadmap or delivery-date commitment is declared in the repository. Confirm
+future plans with maintainers before using them in product commitments.
+
+### 19. Does Wow provide a compliance certification?
+
+No repository-wide compliance certification is declared. Compliance depends on
+the application, deployment, policies, and organizational controls.
+
+### 20. When is Wow a poor fit?
+
+It may be a poor fit when the product only needs simple record updates, event
+history has little value, or the organization cannot operate the additional
+messaging, storage, replay, and recovery responsibilities.
+
+## Product decision summary
+
+Wow can make business intent, history, asynchronous views, and selected
+recovery actions explicit. Those capabilities are most valuable when the
+product genuinely needs them.
+
+They also create visible product states and durable data obligations. Product
+plans should include pending and failure experiences, freshness expectations,
+operator safety, data lifecycle, and workload-specific service objectives.
+
+Treat repository examples as starting points. Treat only implemented code,
+tests, and configuration as evidence of current capability. Treat ownership,
+SLA, retention, compliance, and roadmap as unknown until an accountable party
+declares them.

--- a/documentation/docs/en/onboarding/staff-engineer-guide.md
+++ b/documentation/docs/en/onboarding/staff-engineer-guide.md
@@ -1,0 +1,1128 @@
+---
+title: Staff Engineer Guide
+description: Evidence-backed architecture, ownership boundaries, lifecycle, reliability, and evolution guidance for Wow.
+---
+
+# Staff Engineer Guide
+
+This guide is for engineers who must change Wow without weakening its boundaries.
+It describes the repository at `main`, not an aspirational architecture.
+Every concrete claim links to the code that establishes it.
+When the repository does not establish a property, this guide marks it as **unknown**.
+
+## Executive summary
+
+Wow is a reactive CQRS and event-sourcing framework organized around aggregate-scoped command execution.
+The API module defines envelopes and contracts.
+The core module owns command dispatch, event sourcing, message processing, projections, sagas, snapshots, and runtime lifecycle.
+Spring modules adapt those mechanisms to dependency injection and application lifecycle.
+Infrastructure modules implement storage and transport contracts.
+WebFlux and OpenAPI share a runtime route catalog, while KSP produces metadata inputs at compile time.
+The most important consistency boundary is the append of a `DomainEventStream` to `EventStore`.
+Publication and downstream processing happen after that append.
+They are not one distributed transaction.
+Per-aggregate ordering is explicit; global ordering is not promised.
+Retries are selective, acknowledgements are explicit, and compensation is replay, not rollback.
+
+`WowRuntime` is the sole lifecycle owner for registered runtime components.
+
+It starts once, closes admission before draining, and uses a bounded shutdown deadline.
+Security adapters propagate identity-related headers and query tags.
+They do not prove authentication at the service boundary.
+The framework includes local, contract, integration, coverage, and JMH test layers.
+Those layers do not establish a production SLA or a universal throughput ceiling.
+
+## The single core insight
+
+> Wow turns a command into an immutable, versioned event stream inside one aggregate lane, persists that stream, and only then fans it out to independently owned consumers.
+Everything else protects or extends that sequence.
+The command envelope carries aggregate identity, ownership, tenant, request identity, and expected version.
+The aggregate root decides which event payloads to emit.
+The state aggregate sources those events.
+The event store performs the durable append.
+The event and state-event buses drive projections, sagas, and snapshots afterward.
+
+`WowRuntime` controls whether these processors may accept work.
+
+The following Python-like pseudocode is explanatory.
+It deliberately makes the non-transactional fan-out visible.
+
+```python
+async def execute(command):
+    lane = lane_for(command.aggregate_id)
+    async with lane.serialized():
+        state = await snapshots.load(command.aggregate_id) or new_state()
+        async for stream in events.load_from(state.next_version):
+            state.source(stream)
+
+        emitted = await aggregate.decide(command, state)
+        state.source(emitted)
+
+        # The durable command consistency boundary.
+        await events.append(emitted)
+
+        # Downstream effects are separate reactive operations.
+        await domain_event_bus.send(emitted)
+        await state_event_bus.send_best_effort(emitted.with_state(state))
+```
+
+The real implementation sources the in-memory state before appending and marks the command aggregate expired if persistence fails.
+The append contract detects version conflicts and duplicate request IDs.
+The domain-event send is a filter after aggregate processing.
+The state-event send is later still and resumes after logging a send error.
+Sources: [command envelope](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L53-L125), [aggregate execution](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L81-L132), [event-store contract](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L27-L109), [post-append publication](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt#L25-L46), [best-effort state event](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/SendStateEventFilter.kt#L29-L76).
+
+## System architecture
+
+The architecture is layered by responsibility, not by deployment topology.
+Applications may combine modules in one process or place distributed buses and stores between processes.
+The repository does not define one mandatory production topology.
+
+```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#2d333b', 'primaryBorderColor': '#6d5dfc', 'primaryTextColor': '#e6edf3', 'lineColor': '#8b949e', 'clusterBkg': '#161b22', 'clusterBorder': '#30363d'}}}%%
+flowchart TB
+    Client["HTTP or application client"]
+    Web["wow-webflux\nrequest extraction and routes"]
+    Gateway["CommandGateway"]
+    Bus["CommandBus\nlocal-first or distributed"]
+    Dispatcher["CommandDispatcher\naggregate lanes"]
+    Aggregate["CommandAggregate\ndecide and source"]
+    EventStore["EventStore\ndurable append"]
+    DomainBus["DomainEventBus"]
+    StateBus["StateEventBus"]
+    Projection["Projection dispatchers"]
+    Saga["Stateless sagas"]
+    Snapshot["Snapshot dispatcher"]
+    Query["Query stores and handlers"]
+    Runtime["WowRuntime\nadmission and lifecycle"]
+
+    Client --> Web --> Gateway --> Bus --> Dispatcher --> Aggregate --> EventStore
+    EventStore --> DomainBus
+    DomainBus --> Projection
+    DomainBus --> Saga
+    EventStore --> StateBus
+    StateBus --> Projection
+    StateBus --> Snapshot
+    Projection --> Query
+    Runtime -. owns .-> Bus
+    Runtime -. owns .-> Dispatcher
+    Runtime -. owns .-> Projection
+    Runtime -. owns .-> Snapshot
+```
+
+<!-- Sources: [CommandHandler](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt#L35-L63), [CommandDispatcher](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/CommandDispatcher.kt#L37-L83), [event filters](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt#L25-L46), [projection dispatcher](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/projection/ProjectionDispatcher.kt#L23-L55), [runtime ownership](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/RuntimeComponent.kt#L18-L62) -->
+
+### Ownership table
+
+| Area | Owner | Delegates to | Boundary evidence |
+|---|---|---|---|
+| Public command, event, naming, and modeling contracts | `wow-api` | Nothing below core | [minimal API dependencies](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/build.gradle.kts#L1-L5) |
+| Command and event runtime | `wow-core` | Store and bus interfaces | [core dependencies](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/build.gradle.kts#L3-L17) |
+| Spring integration | `wow-spring` | Core services and Spring container | [module dependencies](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring/build.gradle.kts#L1-L5) |
+| Optional Spring Boot composition | `wow-spring-boot-starter` | Feature variants | [capabilities](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L5-L44) |
+| HTTP entry and route materialization | `wow-webflux` | `RouterSpecs` and handlers | [module dependencies](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/build.gradle.kts#L1-L10) |
+| Route contracts and OpenAPI rendering | `wow-openapi` | Metadata, contributors, schema context | [RouterSpecs](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RouterSpecs.kt#L37-L160) |
+| Kafka transport | `wow-kafka` | Reactor Kafka | [module boundary](https://github.com/Ahoo-Wang/Wow/blob/main/wow-kafka/build.gradle.kts#L1-L5) |
+| MongoDB persistence | `wow-mongo` | Mongo driver | [module boundary](https://github.com/Ahoo-Wang/Wow/blob/main/wow-mongo/build.gradle.kts#L1-L5) |
+| Redis persistence | `wow-redis` | Lettuce and Redis scripting | [module boundary](https://github.com/Ahoo-Wang/Wow/blob/main/wow-redis/build.gradle.kts#L1-L5) |
+| Elasticsearch persistence and querying | `wow-elasticsearch` | Elasticsearch client | [module boundary](https://github.com/Ahoo-Wang/Wow/blob/main/wow-elasticsearch/build.gradle.kts#L1-L8) |
+| CoSec integration | `wow-cosec` | WebFlux request context | [adapter dependency](https://github.com/Ahoo-Wang/Wow/blob/main/wow-cosec/build.gradle.kts#L1-L4) |
+| Domain test DSL | `test/wow-test` | Core and JUnit | [test module](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-test/build.gradle.kts#L1-L12) |
+| Backend contracts | `test/wow-tck` | Store and dispatcher interfaces | [TCK module](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-tck/build.gradle.kts#L1-L20) |
+
+### Dependency direction
+
+Infrastructure is replaceable because core depends on interfaces.
+The starter composes optional capabilities without moving persistence or transport behavior into core.
+
+```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#2d333b', 'primaryBorderColor': '#6d5dfc', 'primaryTextColor': '#e6edf3', 'lineColor': '#8b949e', 'clusterBkg': '#161b22', 'clusterBorder': '#30363d'}}}%%
+flowchart LR
+    API["wow-api\ncontracts"]
+    Core["wow-core\nruntime"]
+    Spring["wow-spring\ncontainer bridge"]
+    Starter["wow-spring-boot-starter\ncomposition"]
+    WebFlux["wow-webflux"]
+    OpenAPI["wow-openapi"]
+    Kafka["wow-kafka"]
+    Mongo["wow-mongo"]
+    Redis["wow-redis"]
+    ES["wow-elasticsearch"]
+    Test["wow-test / wow-tck"]
+
+    API --> Core --> Spring --> Starter
+    API --> OpenAPI
+    Core --> WebFlux
+    OpenAPI --> WebFlux
+    Core --> Kafka
+    Core --> Mongo
+    Core --> Redis
+    Core --> ES
+    Core --> Test
+    Starter -. feature variants .-> WebFlux
+    Starter -. feature variants .-> Kafka
+    Starter -. feature variants .-> Mongo
+    Starter -. feature variants .-> Redis
+    Starter -. feature variants .-> ES
+```
+
+<!-- Sources: [settings modules](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L23-L85), [starter capabilities](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L5-L80), [core dependencies](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/build.gradle.kts#L3-L17) -->
+
+## Load-bearing contracts
+
+### `CommandMessage`
+
+`CommandMessage` is the runtime envelope around a business command body.
+
+It carries `aggregateId`, owner and space context, command ID, request ID, and copy semantics.
+It also carries expected version and flags governing aggregate creation, voiding, and creation allowance.
+These fields are framework control data, not domain state.
+Source: [CommandMessage](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L53-L125).
+
+### `DomainEvent`
+
+`DomainEvent` wraps a business event payload with aggregate identity, sequence, revision, and stream position.
+
+The business event can remain a plain Kotlin class or object.
+The example `OrderCreated` is a data class with business fields only.
+Sources: [DomainEvent](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/event/DomainEvent.kt#L47-L89), [OrderCreated](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/CreateOrder.kt#L60-L65).
+
+### `DomainEventStream`
+
+One event stream represents the events produced by one command execution.
+Its contract says the command ID has a one-to-one relation with the stream.
+The concrete stream is non-empty and derives aggregate and version metadata from its first event.
+Source: [DomainEventStream](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L31-L115).
+
+### `EventStore`
+
+`EventStore` owns append, request lookup, version lookup, and stream loading contracts.
+
+The append contract names version conflict, duplicate aggregate ID, and duplicate request ID outcomes.
+It does not define a transaction spanning event publication or projection updates.
+Source: [EventStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L27-L109).
+
+### `SnapshotStore`
+
+`SnapshotStore` loads and saves state checkpoints.
+
+Its save rule is monotonic: a lower version must not replace a higher version atomically.
+The interface has no delete or retention operation.
+Source: [SnapshotStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt#L24-L71).
+
+### `MessageBus`
+
+`MessageBus` separates sending from receiving.
+
+Receiver readiness is part of the contract and lifecycle belongs to `WowRuntime`.
+Local `sendIfSubscribed` is conservative until processing admission succeeds.
+Source: [MessageBus](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/MessageBus.kt#L31-L107).
+
+### `RuntimeComponent`
+
+Construction must be inert.
+
+`prepare`, `start`, `quiesce`, graceful stop, and force stop are distinct phases.
+
+The contract deliberately avoids `AutoCloseable` so arbitrary callers cannot own shutdown.
+Source: [RuntimeComponent](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/RuntimeComponent.kt#L18-L62).
+
+## Domain model and invariants
+
+The framework separates payload classes, framework envelopes, command behavior, and event-sourced state.
+That separation prevents command handlers from directly mutating persisted state.
+
+```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#2d333b', 'primaryBorderColor': '#6d5dfc', 'primaryTextColor': '#e6edf3', 'lineColor': '#8b949e', 'clusterBkg': '#161b22', 'clusterBorder': '#30363d'}}}%%
+classDiagram
+    class CommandMessage {
+      +body
+      +aggregateId
+      +requestId
+      +aggregateVersion
+      +ownerId
+      +spaceId
+    }
+    class CommandAggregate {
+      +state
+      +commandRoot
+      +process(exchange: ServerCommandExchange)
+    }
+    class StateAggregate {
+      +version
+      +onSourcing(stream)
+    }
+    class DomainEventStream {
+      +commandId
+      +version
+      +events
+    }
+    class EventStore {
+      <<interface>>
+      +append(stream)
+      +load(aggregateId, range)
+    }
+    class SnapshotStore {
+      <<interface>>
+      +load(aggregateId)
+      +save(snapshot)
+    }
+
+    CommandMessage --> CommandAggregate : dispatches to
+    CommandAggregate *-- StateAggregate
+    CommandAggregate --> DomainEventStream : emits
+    CommandAggregate --> EventStore : appends
+    SnapshotStore --> StateAggregate : restores checkpoint
+    EventStore --> StateAggregate : replays tail
+```
+
+<!-- Sources: [CommandMessage aggregateVersion](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L83-L96), [AggregateProcessor process](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/AggregateProcessor.kt#L32-L49), [CommandAggregate](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/CommandAggregate.kt#L25-L84), [StateAggregate](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/state/StateAggregate.kt#L25-L31), [repository replay](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventSourcingStateAggregateRepository.kt#L74-L104) -->
+
+### Framework invariants
+
+| Entity | Invariant | Enforced By | Consequence | Source |
+|---|---|---|---|---|
+| `CommandMessage` | Commands are routed by named aggregate and aggregate ID | `CommandMessage.aggregateId` | Identity is part of every command envelope. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L53-L125) |
+| `CommandAggregate` | Expected version must match when supplied | `SimpleCommandAggregate` | A stale writer fails before domain invocation. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L81-L97) |
+| `CommandAggregate` | A supplied owner or space must match initialized aggregate state | `SimpleCommandAggregate` | A non-blank mismatching value is rejected before command handling; blank values skip this comparison. This is a consistency check, not complete authorization. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L98-L105) |
+| `CommandAggregate` | Deleted aggregates reject ordinary commands | `SimpleCommandAggregate` | Deletion is a domain-access guard. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L114-L117) |
+| `StateAggregate` | State is sourced before persistence | `SimpleCommandAggregate` | In-memory state reflects emitted events during processing. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L123-L130) |
+| `CommandAggregate` | Persistence failure expires the aggregate instance | `SimpleCommandAggregate` error hook | A failed in-memory instance is not reused as authoritative state. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L123-L130) |
+| `Snapshot` | Snapshot versions do not move backward | `SnapshotStore` | Concurrent older saves cannot replace newer state. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt#L60-L71) |
+| Aggregate group | One lane processes a group sequentially | `AggregateDispatcher` | Ordering is per group, not global. | [Source](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/AggregateDispatcher.kt#L380-L393) |
+
+### Example order aggregate
+
+The example `Order` demonstrates the intended split.
+
+`Order` receives commands and returns events.
+
+`OrderState` applies events and owns mutable state with private setters.
+
+`CreateOrder` validates input and `OrderCreated` is an immutable event payload.
+
+Payment emits one or two ordered events depending on the amount.
+The state transition rules are explicit: address changes only while created, shipping only while paid, and receipt only while shipped.
+Sources: [Order handlers](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/Order.kt#L105-L197), [OrderState](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/OrderState.kt#L40-L108), [CreateOrder](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/CreateOrder.kt#L31-L65).
+
+```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#2d333b', 'primaryBorderColor': '#6d5dfc', 'primaryTextColor': '#e6edf3', 'lineColor': '#8b949e', 'clusterBkg': '#161b22', 'clusterBorder': '#30363d'}}}%%
+erDiagram
+    ORDER ||--|{ ORDER_ITEM : contains
+    ORDER ||--|| SHIPPING_ADDRESS : ships_to
+    ORDER ||--o{ DOMAIN_EVENT : evolves_by
+    COMMAND ||--o| DOMAIN_EVENT_STREAM : produces
+    DOMAIN_EVENT_STREAM ||--|{ DOMAIN_EVENT : contains
+    ORDER {
+      string id
+      decimal totalAmount
+      decimal paidAmount
+      enum status
+    }
+    ORDER_ITEM {
+      string id
+      string productId
+      decimal price
+      int quantity
+    }
+    SHIPPING_ADDRESS {
+      string country
+      string province
+    }
+    COMMAND {
+      string requestId
+      int expectedVersion
+    }
+    DOMAIN_EVENT_STREAM {
+      string commandId
+      int version
+    }
+    DOMAIN_EVENT {
+      int sequence
+      int revision
+    }
+```
+
+<!-- Sources: [Order state fields](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/OrderState.kt#L40-L67), [create payload and event](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/CreateOrder.kt#L36-L65), [event stream](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L31-L115) -->
+
+## Command lifecycle
+
+### Entry
+
+`CommandHandlerFunction` extracts body, path variables, and headers, then delegates to `CommandHandler`.
+
+`CommandHandler` builds the command message and selects SSE or ordinary wait behavior.
+
+Sources: [HTTP handler function](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt#L43-L66), [command handler](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt#L35-L63).
+
+### Gateway
+
+`DefaultCommandGateway` validates the message and checks request identity before sending.
+
+Waiting uses a handle with an absolute timeout rather than extending the deadline at every stage.
+Sources: [validation and request check](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L79-L143), [wait deadline](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L238-L301).
+
+### Dispatch
+
+`CommandDispatcher` receives local commands and resolves aggregate metadata.
+
+It creates an aggregate-specific dispatcher and scheduler.
+The dispatcher groups work so one aggregate lane remains sequential.
+Sources: [dispatcher creation](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/CommandDispatcher.kt#L37-L83), [aggregate dispatcher](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/AggregateCommandDispatcher.kt#L51-L86).
+
+### Load and decide
+
+The repository loads a snapshot or creates a fresh state aggregate.
+It then replays event streams from the next expected version.
+The command aggregate checks version and deletion state before invoking the handler. For an initialized aggregate, it also compares owner or space when the corresponding message value is non-blank.
+Sources: [snapshot plus replay](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventSourcingStateAggregateRepository.kt#L74-L104), [preconditions](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L81-L117).
+
+### Persist and publish
+
+The aggregate sources emitted events and appends the stream.
+Only after aggregate processing completes does the domain-event filter send the stream.
+The state-event filter follows the domain-event filter.
+Its send failure is logged and resumed.
+Sources: [append](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L123-L130), [domain send](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt#L25-L46), [state send](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/SendStateEventFilter.kt#L29-L76).
+
+```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#2d333b', 'primaryBorderColor': '#6d5dfc', 'primaryTextColor': '#e6edf3', 'lineColor': '#8b949e', 'clusterBkg': '#161b22', 'clusterBorder': '#30363d'}}}%%
+sequenceDiagram
+    autonumber
+    participant C as Client
+    participant W as WebFlux handler
+    participant G as CommandGateway
+    participant B as CommandBus
+    participant D as Command pipeline
+    participant R as State repository
+    participant S as SnapshotStore
+    participant A as CommandAggregate
+    participant E as EventStore
+    participant DE as DomainEventBus
+    participant SE as StateEventBus
+    participant X as Downstream dispatchers
+    participant N as Stage notifier(s)
+
+    C->>W: HTTP command
+    W->>G: send or sendAndWait
+    G->>G: validate and check request ID
+    G->>B: send CommandMessage
+    B-->>G: CommandBus.send completes
+    par caller response timing
+        alt send or SENT-only WaitPlan
+            G-->>W: send completion or SENT result
+            W-->>C: immediate response
+        else WaitPlan for PROCESSED or a later stage
+            Note over G,N: keep the registered wait handle open
+        end
+    and command processing continues for every accepted command
+        B->>D: admitted exchange
+        D->>R: load aggregate state
+        R->>S: load latest snapshot
+        S-->>R: checkpoint or empty
+        R->>E: load event tail after checkpoint
+        E-->>R: event streams
+        R-->>D: sourced state
+        D->>A: process exchange
+        A->>A: validate and source emitted events
+        A->>E: append DomainEventStream
+        E-->>A: append complete
+        D-->>B: finallyAck exchange
+        D->>DE: publish persisted stream
+        D->>SE: publish state event
+        Note over D,SE: state-event send errors are logged and resumed
+        D->>N: PROCESSED after command pipeline completes
+        par state-event consumers
+            SE->>X: SnapshotDispatcher handles state event
+            X->>N: SNAPSHOT
+        and domain-event consumers
+            DE->>X: Projection, event, and saga dispatchers
+            X->>N: PROJECTED, EVENT_HANDLED, or SAGA_HANDLED
+        end
+        opt a later-stage WaitPlan was propagated
+            N-->>G: matching WaitPlan signal
+        end
+    end
+    opt waiting for PROCESSED or a later stage
+        G-->>W: selected wait-stage result
+        W-->>C: response or SSE
+    end
+```
+
+<!-- Sources: [gateway send and SENT path](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L129-L187), [WaitPlan paths](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L201-L266), [repository](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventSourcingStateAggregateRepository.kt#L74-L104), [aggregate](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L81-L132), [ack ordering](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/AggregateProcessorFilter.kt#L26-L49), [stage notifiers](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/NotifierFilters.kt#L49-L118), [domain-event publication](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt#L25-L46), [state-event publication](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/SendStateEventFilter.kt#L29-L76) -->
+
+### Command aggregate state
+
+```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#2d333b', 'primaryBorderColor': '#6d5dfc', 'primaryTextColor': '#e6edf3', 'lineColor': '#8b949e', 'clusterBkg': '#161b22', 'clusterBorder': '#30363d'}}}%%
+stateDiagram-v2
+    [*] --> STORED: aggregate instance created or restored
+    STORED --> SOURCED: command emits and sources events
+    SOURCED --> STORED: EventStore append succeeds
+    SOURCED --> EXPIRED: EventStore append fails
+    STORED --> EXPIRED: instance invalidated
+    EXPIRED --> [*]
+```
+
+<!-- Sources: [CommandAggregate states](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/CommandAggregate.kt#L65-L84), [SimpleCommandAggregate transition](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L123-L132) -->
+
+## Event, projection, saga, and snapshot lifecycles
+
+### Domain-event dispatch
+
+The domain dispatcher owns both domain-event and state-event child dispatchers.
+Function kind selects the relevant child.
+Within one stream, events are handled with `concatMap`.
+Normal event processor return values are discarded after completion.
+Sources: [composite dispatcher](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/dispatcher/CompositeEventDispatcher.kt#L111-L170), [per-stream handling](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/dispatcher/AbstractAggregateEventDispatcher.kt#L83-L110), [function return discarded](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/dispatcher/DomainEventFunctionFilter.kt#L41-L70).
+
+### Projections
+
+`ProjectionDispatcher` subscribes to both domain-event and state-event buses.
+
+It uses the event function filter, so a projection's publisher represents completion, not new domain events.
+Sources: [ProjectionDispatcher](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/projection/ProjectionDispatcher.kt#L23-L55), [ProjectionFunctionFilter](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/projection/ProjectionFunctionFilter.kt#L20-L30).
+
+### Stateless sagas
+
+A stateless saga is the special path that converts handler results into commands.
+Generated request IDs derive from the source event ID and result index.
+Tenant, space, and upstream headers propagate to the new command.
+This is command choreography.
+It is not a distributed transaction and it does not automatically undo prior side effects.
+Source: [StatelessSagaFunction](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt#L42-L105).
+
+### Snapshots
+
+Snapshots are derived checkpoints consumed from state events.
+
+`VersionOffsetSnapshotStrategy` defaults to an offset of five versions.
+
+It compares the stored snapshot version and saves a newer `SimpleSnapshot` when required.
+Snapshot saving is outside the event-store append transaction.
+Sources: [strategy contract](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStrategy.kt#L20-L51), [version-offset strategy](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/VersionOffsetSnapshotStrategy.kt#L24-L63), [snapshot filter](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/dispatcher/SnapshotFunctionFilter.kt#L27-L35).
+
+### Lifecycle comparison
+
+| Artifact | Created by | Durable boundary | Consumer | Failure interpretation |
+|---|---|---|---|---|
+| Command message | Gateway or bus client | Bus-specific | Command dispatcher | Validation or transport failure |
+| Domain event stream | Command aggregate | `EventStore.append` | Domain-event bus | Version, duplicate, or store failure |
+| Domain event delivery | Post-append filter | Bus-specific | Event processor, projection, saga | Retry, handler policy, then acknowledgement |
+| State event | Post-domain-event filter | Bus-specific | Projection and snapshot dispatchers | Immediate send error is logged and resumed |
+| Snapshot | Snapshot strategy | `SnapshotStore.save` | Aggregate repository | Derived checkpoint may lag event store |
+| Saga command | Stateless saga result mapper | Command bus and later event append | Another aggregate | No implicit rollback of the source event |
+
+Sources: [send filters](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt#L25-L46), [retry filter](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/handler/RetryableFilter.kt#L28-L65), [ack semantics](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/handler/ExchangeAck.kt#L20-L60), [saga mapping](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt#L57-L105).
+
+## Runtime lifecycle
+
+`WowRuntime` is a one-shot lifecycle coordinator.
+
+Its states are `NEW`, `STARTING`, `RUNNING`, `STOPPING`, `FORCE_STOPPING`, and `STOPPED`.
+Preparation is a barrier before component start.
+Unexpected component failure closes admission and initiates shutdown.
+Graceful shutdown has one owner and one global deadline.
+The sequence closes global admission, quiesces components, drains work, and stops components in reverse order.
+Timeout or graceful-stop failure escalates to force stop.
+Startup cleanup is a lifecycle rollback only.
+It is not rollback of domain events or external side effects.
+Sources: [states and topology](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt#L93-L145), [start and startup cleanup](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt#L188-L256), [shutdown ownership](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt#L412-L470), [shutdown sequence](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt#L473-L547).
+
+```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#2d333b', 'primaryBorderColor': '#6d5dfc', 'primaryTextColor': '#e6edf3', 'lineColor': '#8b949e', 'clusterBkg': '#161b22', 'clusterBorder': '#30363d'}}}%%
+stateDiagram-v2
+    [*] --> NEW
+    NEW --> STARTING: start()
+    STARTING --> RUNNING: all prepared and started
+    STARTING --> STOPPING: startup failure and cleanup
+    RUNNING --> STOPPING: graceful stop or runtime failure
+    RUNNING --> FORCE_STOPPING: forceStop()
+    STOPPING --> FORCE_STOPPING: deadline or graceful failure
+    STOPPING --> STOPPED: drain and reverse stop complete
+    FORCE_STOPPING --> STOPPED: reverse force stop complete
+    STOPPED --> [*]
+```
+
+<!-- Sources: [WowRuntime state machine](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt#L93-L108), [start](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt#L188-L256), [stop](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt#L328-L409) -->
+
+### Component ordering
+
+Components are registered in ordered, identity-distinct slots.
+Prepare and start run in registration order.
+Graceful and force stop run in reverse order.
+The first failure is retained while later cleanup still runs.
+Source: [RuntimeComponentGroup](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/internal/RuntimeComponentGroup.kt#L25-L121).
+
+### Spring bridge
+
+The Spring lifecycle bridge starts Wow early enough for ingress to see a ready runtime.
+It stops after ingress drains and closes the application context on unexpected runtime termination.
+Default shutdown timeout is 60 seconds and quiet period is one second.
+Sources: [WowRuntimeLifecycle](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring/src/main/kotlin/me/ahoo/wow/spring/WowRuntimeLifecycle.kt#L27-L51), [WowProperties](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/WowProperties.kt#L23-L35).
+
+## Storage architecture
+
+Storage is selected per aggregate through registries and routing decorators.
+The router itself owns lifecycle and delegates each operation to the selected backend.
+An aggregate-specific mapping wins over the default store.
+Sources: [RoutingEventStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/RoutingEventStore.kt#L21-L66), [event registry](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/AggregateEventStoreRegistry.kt#L20-L32), [snapshot router](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/RoutingSnapshotStore.kt#L20-L43), [snapshot registry](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/AggregateSnapshotStoreRegistry.kt#L20-L32).
+
+```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#2d333b', 'primaryBorderColor': '#6d5dfc', 'primaryTextColor': '#e6edf3', 'lineColor': '#8b949e', 'clusterBkg': '#161b22', 'clusterBorder': '#30363d'}}}%%
+flowchart LR
+    Aggregate["NamedAggregate"]
+    EventRegistry["AggregateEventStoreRegistry"]
+    SnapshotRegistry["AggregateSnapshotStoreRegistry"]
+    EventRouter["RoutingEventStore"]
+    SnapshotRouter["RoutingSnapshotStore"]
+    Mongo["MongoDB"]
+    Redis["Redis"]
+    ES["Elasticsearch"]
+    Memory["In-memory"]
+
+    Aggregate --> EventRegistry --> EventRouter
+    Aggregate --> SnapshotRegistry --> SnapshotRouter
+    EventRouter --> Mongo
+    EventRouter --> Redis
+    EventRouter --> ES
+    EventRouter --> Memory
+    SnapshotRouter --> Mongo
+    SnapshotRouter --> Redis
+    SnapshotRouter --> ES
+    SnapshotRouter --> Memory
+```
+
+<!-- Sources: [event routing](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/RoutingEventStore.kt#L21-L66), [snapshot routing](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/RoutingSnapshotStore.kt#L20-L43), [storage types](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/StorageType.kt#L16-L29) -->
+
+### Backend comparison
+
+| Backend | Event store | Snapshot store | Important boundary | Source |
+|---|---|---|---|---|
+| In-memory | Yes | Yes | Development and test semantics; durability is process-local | [InMemoryEventStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/InMemoryEventStore.kt#L31-L75), [InMemorySnapshotStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/InMemorySnapshotStore.kt#L28-L80) |
+| MongoDB | Yes | Yes | Sorted event loading; direct or optional batched append | [MongoEventStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoEventStore.kt#L36-L97), [MongoSnapshotStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoSnapshotStore.kt#L32-L80) |
+| Redis | Yes | Yes | Lua append checks conflicts; event-time loading is unsupported | [RedisEventStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStore.kt#L41-L106), [RedisSnapshotStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisSnapshotStore.kt#L29-L57) |
+| Elasticsearch | Yes | Yes | Refresh and optional batching affect visibility and latency | [ElasticsearchEventStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchEventStore.kt#L37-L81), [ElasticsearchSnapshotStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchSnapshotStore.kt#L25-L80) |
+
+### Batching
+
+MongoDB and Elasticsearch batching is opt-in.
+The default options disable batching because partial batches add up to `maxDelay` latency.
+Default option values include a maximum batch size of 128, pending capacity of 4096, one lane, and one millisecond delay.
+These are configuration defaults, not measured optimal values for every workload.
+Sources: [Mongo event options](https://github.com/Ahoo-Wang/Wow/blob/main/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoEventStoreBatchOptions.kt#L18-L50), [Elasticsearch event options](https://github.com/Ahoo-Wang/Wow/blob/main/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchEventStoreBatchOptions.kt#L18-L50).
+Pending queues are bounded and can reject admission with a typed overload error.
+That is intentional backpressure, not silent buffering.
+Source: [Mongo batch appender](https://github.com/Ahoo-Wang/Wow/blob/main/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/BatchMongoEventStreamAppender.kt#L58-L94).
+
+## Messaging architecture
+
+### Per-aggregate ordering
+
+`AggregateDispatcher` maps a message to a group key.
+
+Each group uses `publishOn` followed by `concatMap` for sequential handling.
+Different groups can run in parallel.
+The default lane count is `64 * available processors`, with a system-property override.
+This is not a global ordering guarantee.
+Sources: [group processing](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/AggregateDispatcher.kt#L380-L393), [parallelism](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/MessageParallelism.kt#L25-L43).
+
+### Local-first behavior
+
+Local-first sends a local delivery copy and a distributed copy.
+The distributed copy is marked locally handled only after local admission succeeds.
+If local delivery errors, the distributed path remains eligible.
+Filtered distributed copies are acknowledged.
+This is an admission-aware optimization.
+It is not proof of cluster-wide exactly-once processing.
+Source: [LocalFirstMessageBus](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/LocalFirstMessageBus.kt#L142-L199).
+
+### Kafka
+
+Kafka send completes from the sender result.
+Receive uses a consumer group, retries the receive stream, and decodes records sequentially.
+The Kafka key is the aggregate ID string.
+The topic converter supplies aggregate and function routing context.
+Sources: [send and receive](https://github.com/Ahoo-Wang/Wow/blob/main/wow-kafka/src/main/kotlin/me/ahoo/wow/kafka/AbstractKafkaBus.kt#L92-L113), [subscription](https://github.com/Ahoo-Wang/Wow/blob/main/wow-kafka/src/main/kotlin/me/ahoo/wow/kafka/AbstractKafkaBus.kt#L188-L211), [key and serialization](https://github.com/Ahoo-Wang/Wow/blob/main/wow-kafka/src/main/kotlin/me/ahoo/wow/kafka/AbstractKafkaBus.kt#L295-L309).
+Default Kafka receiver policy uses prefetch one, maximum deferred acknowledgement one, three retry attempts, and a ten-second retry delay.
+These values are configuration defaults, not throughput guarantees.
+Source: [KafkaReceiverPolicy](https://github.com/Ahoo-Wang/Wow/blob/main/wow-kafka/src/main/kotlin/me/ahoo/wow/kafka/KafkaReceiverPolicy.kt#L18-L36).
+
+### Acknowledgement semantics
+
+`finallyAck` acknowledges after success.
+
+On error it acknowledges first and then rethrows the error.
+Therefore exhausted handler failure does not by itself imply broker redelivery.
+Retry and compensation policy must be understood before relying on replay behavior.
+Source: [ExchangeAck](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/handler/ExchangeAck.kt#L20-L60).
+
+## Failure handling
+
+The default retry filter retries at most three times with two-second backoff.
+It retries only exceptions classified as recoverable.
+It is ordered before aggregate, event-function, and snapshot processing filters.
+The default event-processor error handler logs and resumes after the chain policy completes.
+Sources: [RetryableFilter](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/handler/RetryableFilter.kt#L28-L65), [event auto-configuration](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/event/EventDispatcherAutoConfiguration.kt#L60-L85).
+Compensation reloads persisted events, marks them with a compensation target, and resends them.
+State-event compensation reconstructs state through event sourcing before resending.
+Neither path reverses the original event-store append.
+Sources: [domain compensation](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/compensation/DomainEventCompensator.kt#L43-L100), [state compensation](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/compensation/StateEventCompensator.kt#L50-L130).
+
+```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#2d333b', 'primaryBorderColor': '#6d5dfc', 'primaryTextColor': '#e6edf3', 'lineColor': '#8b949e', 'clusterBkg': '#161b22', 'clusterBorder': '#30363d'}}}%%
+flowchart TD
+    Start["Handle command or event"]
+    Error{"Error?"}
+    Recoverable{"Classified recoverable?"}
+    Retry{"Retry budget remains?"}
+    Again["Backoff and retry chain"]
+    Ack["Acknowledge exchange"]
+    Rethrow["Propagate or log-resume by handler policy"]
+    Persisted{"Persisted event available?"}
+    Compensate["Explicit compensation request"]
+    Reload["Reload event stream"]
+    Resend["Attach target and resend"]
+    Done["Complete"]
+
+    Start --> Error
+    Error -- no --> Ack --> Done
+    Error -- yes --> Recoverable
+    Recoverable -- yes --> Retry
+    Retry -- yes --> Again --> Start
+    Retry -- no --> Ack --> Rethrow
+    Recoverable -- no --> Ack --> Rethrow
+    Rethrow --> Persisted
+    Persisted -- yes, operator chooses --> Compensate --> Reload --> Resend --> Done
+    Persisted -- no or no request --> Done
+```
+
+<!-- Sources: [retry classification](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/handler/RetryableFilter.kt#L28-L65), [ack on error](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/handler/ExchangeAck.kt#L32-L60), [compensation replay](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/compensation/DomainEventCompensator.kt#L61-L100) -->
+
+### Failure-mode table
+
+| Failure | Immediate behavior | Durable truth | Staff-engineer action |
+|---|---|---|---|
+| Expected-version mismatch | Reject before handler invocation | Existing event stream | Treat as optimistic concurrency conflict |
+| Duplicate request ID | Event-store contract rejects duplicate | First accepted stream | Keep request IDs stable across client retry |
+| Event-store append failure | Aggregate becomes expired | Backend decides whether append committed | Reload before reusing state; inspect backend result |
+| Domain-event send failure | Command stream may already be durable | Event store remains source of truth | Use retry or explicit compensation based on classification |
+| State-event send failure | Error is logged and resumed | Event stream remains durable | Monitor lag and use state-event compensation when required |
+| Projection handler failure | Retry selective, then ack/error policy | Projection may lag | Make handler idempotent and define replay runbook |
+| Saga command failure | Source event remains committed | No automatic rollback | Model compensating business commands explicitly |
+| Runtime startup failure | Started components are cleaned up | No domain rollback implied | Inspect first failure and cleanup failure |
+| Graceful shutdown timeout | Escalate to force stop | In-flight outcome may be uncertain | Reconcile by request ID and event-store state |
+
+Sources: [append errors](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L27-L54), [aggregate expiration](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L123-L132), [runtime shutdown](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt#L412-L547).
+
+## Metadata, generated code, routes, and OpenAPI
+
+These are related pipelines, not one generation step.
+
+### Compile-time KSP metadata
+
+`MetadataSymbolProcessor` scans bounded contexts and aggregate roots.
+
+It merges the result and writes the metadata resource as JSON.
+
+`AggregatesMetadataResolver` separately generates Kotlin accessors that call `aggregateMetadata<Command, State>()`, which invokes the runtime aggregate metadata parser.
+
+These are two runtime inputs, not one discovery chain: `MetadataSearcher` loads the JSON resource, while generated accessors invoke `AggregateMetadataParser` through `aggregateMetadata()`.
+Sources: [metadata resource generation](https://github.com/Ahoo-Wang/Wow/blob/main/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/metadata/MetadataSymbolProcessor.kt#L39-L106), [aggregate accessor generation](https://github.com/Ahoo-Wang/Wow/blob/main/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/aggregate/metadata/AggregatesMetadataResolver.kt#L38-L61), [resource search](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/configuration/MetadataSearcher.kt#L33-L58), [runtime parser](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/annotation/AggregateMetadataParser.kt#L49-L59).
+
+### Runtime route catalog
+
+`RouterSpecs` orders route contributors.
+
+It reads runtime `MetadataSearcher` entries, filters disabled aggregate routes, and builds a validated `RouteCatalog`.
+The catalog rejects duplicate route keys and path-variable mismatches.
+Sources: [route collection](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RouterSpecs.kt#L137-L160), [catalog validation](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/catalog/RouteCatalog.kt#L20-L79).
+
+### Runtime WebFlux materialization
+
+`RouterFunctionBuilder` iterates the route catalog.
+
+It materializes each contract into a predicate and handler function.
+Spring Boot creates this router from `RouterSpecs` and the handler registrar.
+Sources: [RouterFunctionBuilder](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/RouterFunctionBuilder.kt#L25-L41), [WebFlux auto-configuration](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfiguration.kt#L300-L325).
+
+### Runtime OpenAPI rendering
+
+The same catalog is rendered into OpenAPI 3.1 paths and components.
+Springdoc customization merges that generated catalog into the application `OpenAPI` object.
+Sources: [OpenAPI rendering](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RouterSpecs.kt#L80-L121), [OpenAPI auto-configuration](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/openapi/OpenAPIAutoConfiguration.kt#L39-L75).
+
+```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#2d333b', 'primaryBorderColor': '#6d5dfc', 'primaryTextColor': '#e6edf3', 'lineColor': '#8b949e', 'clusterBkg': '#161b22', 'clusterBorder': '#30363d'}}}%%
+flowchart LR
+    Source["Annotated domain source"]
+    KSP["wow-compiler KSP"]
+    JSON["wow-metadata.json"]
+    Accessor["Generated aggregate metadata accessors"]
+    Searcher["MetadataSearcher at runtime"]
+    Parser["AggregateMetadataParser at runtime"]
+    Contributors["Route contributors"]
+    Specs["RouterSpecs"]
+    Catalog["Validated RouteCatalog"]
+    Web["WebFlux RouterFunction"]
+    OA["OpenAPI 3.1 document"]
+
+    Source --> KSP
+    KSP --> JSON --> Searcher
+    KSP --> Accessor --> Parser
+    Searcher --> Specs
+    Contributors --> Specs
+    Specs --> Catalog
+    Catalog --> Web
+    Catalog --> OA
+```
+
+<!-- Sources: [KSP resource processor](https://github.com/Ahoo-Wang/Wow/blob/main/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/metadata/MetadataSymbolProcessor.kt#L61-L106), [generated accessors](https://github.com/Ahoo-Wang/Wow/blob/main/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/aggregate/metadata/AggregatesMetadataResolver.kt#L38-L61), [resource searcher](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/configuration/MetadataSearcher.kt#L33-L58), [runtime parser](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/annotation/AggregateMetadataParser.kt#L49-L59), [RouterSpecs collection](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RouterSpecs.kt#L124-L160) -->
+
+### Reflection boundary
+
+Do not describe Wow as a zero-reflection framework.
+Core declares Kotlin reflection as an API dependency.
+Metadata parser documentation explicitly includes reflective analysis.
+The test DSL also reflects generic type arguments.
+KSP removes some discovery and registration boilerplate, but it does not prove zero runtime reflection.
+Sources: [core reflection dependency](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/build.gradle.kts#L3-L17), [metadata parser contract](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/metadata/Metadata.kt#L23-L26), [AggregateSpec reflection](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-test/src/main/kotlin/me/ahoo/wow/test/AggregateSpec.kt#L69-L86).
+
+## Security and trust boundaries
+
+### Request context
+
+WebFlux extracts tenant, owner, space, aggregate ID, and local-first hints from paths and headers.
+Extraction is not authentication.
+The deployment must decide which headers are accepted from an untrusted client and which are overwritten by a trusted edge.
+Source: [AggregateRequest](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/AggregateRequest.kt#L34-L96).
+
+### CoSec adapter
+
+The CoSec extractor copies request ID and space ID headers into the command builder.
+Other CoSec adapters propagate app and device IDs.
+The module boundary depends on WebFlux and does not itself establish an authenticator.
+Sources: [builder extractor](https://github.com/Ahoo-Wang/Wow/blob/main/wow-cosec/src/main/kotlin/me/ahoo/wow/cosec/extractor/CoSecCommandBuilderExtractor.kt#L23-L40), [message propagation](https://github.com/Ahoo-Wang/Wow/blob/main/wow-cosec/src/main/kotlin/me/ahoo/wow/cosec/propagation/CoSecMessagePropagator.kt#L20-L46), [module dependency](https://github.com/Ahoo-Wang/Wow/blob/main/wow-cosec/build.gradle.kts#L1-L4).
+
+### Aggregate authorization preconditions
+
+For initialized aggregates, command processing checks owner and space equality only when the corresponding message value is non-blank.
+Read-side owner preconditions can reject access to an owner aggregate.
+Route metadata controls whether owner paths are never, always, or aggregate-ID based.
+Sources: [command checks](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L91-L105), [owner precondition](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/OwnerAggregatePrecondition.kt#L22-L34), [route ownership](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AggregateRoute.kt#L57-L90).
+
+These conditional checks protect aggregate context when it is supplied; they do not authenticate the caller or replace endpoint authorization.
+
+### Query ABAC
+
+`AbacQueryFilter` converts principal tags into query conditions.
+
+Principal tag resolution is abstract and must be supplied by an integration.
+An empty tag set resolves to `Condition.all()`.
+Therefore the presence of this filter alone does not prove an authenticated or restricted query.
+Source: [AbacQueryFilter](https://github.com/Ahoo-Wang/Wow/blob/main/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/AbacQueryFilter.kt#L33-L130).
+
+### Security checklist
+
+- Terminate external authentication before trusting Wow identity headers.
+- Strip client-supplied internal headers at the edge.
+- Bind tenant, owner, and space to the authenticated principal.
+- Provide a concrete principal-tag resolver for ABAC.
+- Test the empty-tag behavior explicitly.
+- Treat the local-first header as an internal routing hint.
+- Verify compensation endpoints have operator authorization.
+- Verify metadata and BI-script endpoints match exposure policy.
+- Audit generated OpenAPI before publishing it externally.
+- Keep store credentials and signing material outside the repository.
+
+The code establishes the extraction and filtering points above.
+The concrete production identity provider, edge policy, and secret store are **unknown** from this repository.
+
+## Performance model
+
+### Structural hot path
+
+The write path includes request decoding, validation, request-ID checks, bus admission, lane scheduling, snapshot load, tail replay, domain invocation, event serialization, store append, publication, and optional wait coordination.
+The dominant cost depends on workload and deployment.
+The repository does not prove one universal bottleneck.
+
+### Explicit bounds and knobs
+
+| Knob | Code default | What it bounds | What it does not prove |
+|---|---:|---|---|
+| Dispatcher lanes | `64 * processors` | In-process grouping parallelism | Optimal CPU or store concurrency |
+| Kafka prefetch | `1` | Receiver demand | End-to-end throughput |
+| Kafka deferred ack | `1` | Outstanding deferred acknowledgement | Delivery guarantee |
+| Kafka retries | `3`, `10s` delay | Receive-stream retry policy | Handler replay after final ack |
+| Batch max size | `128` | One optional storage batch | Best batch size for a workload |
+| Batch max pending | `4096` | Pending queue capacity | Safe memory or latency at saturation |
+| Batch lanes | `1` | Coordinator lane count | Universal optimal ordering strategy |
+| Batch max delay | `1ms` | Partial-batch wait | End-to-end latency |
+| Runtime timeout | `60s` | Default shutdown deadline | Business-operation deadline |
+
+Sources: [message parallelism](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/MessageParallelism.kt#L25-L43), [Kafka receiver policy](https://github.com/Ahoo-Wang/Wow/blob/main/wow-kafka/src/main/kotlin/me/ahoo/wow/kafka/KafkaReceiverPolicy.kt#L18-L36), [Mongo batch options](https://github.com/Ahoo-Wang/Wow/blob/main/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoEventStoreBatchOptions.kt#L18-L50), [runtime defaults](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/WowProperties.kt#L23-L35).
+
+### Benchmark evidence
+
+The benchmark module includes component, end-to-end, WebFlux, MongoDB, Redis, and Elasticsearch fixtures.
+It uses JMH and depends on example, test, mock, and infrastructure modules.
+Sources: [benchmark dependencies](https://github.com/Ahoo-Wang/Wow/blob/main/wow-benchmarks/build.gradle.kts#L1-L21), [JMH version](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L3-L33).
+The simulated-I/O benchmark studies I/O latency and scheduler handoff.
+The batch E2E benchmark normalizes measurements per command.
+The concurrency benchmark says repeated-key ordering belongs to functional tests rather than its throughput measurement.
+Sources: [simulated I/O benchmark](https://github.com/Ahoo-Wang/Wow/blob/main/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/e2e/SimulatedIoCommandWriteBenchmark.kt#L36-L43), [batch E2E benchmark](https://github.com/Ahoo-Wang/Wow/blob/main/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/e2e/BatchCommandWriteE2EBenchmark.kt#L34-L35), [coordinator benchmark scope](https://github.com/Ahoo-Wang/Wow/blob/main/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/infrastructure/mongo/MongoBatchCoordinatorConcurrencyBenchmark.kt#L44-L44).
+
+### README stress sample
+
+The README reports one two-minute stress test of the example application.
+It lists measured average and peak TPS for particular operations and wait plans.
+Those numbers are a historical sample under the linked deployment setup.
+They are not an SLA, a capacity plan, or a component performance ceiling.
+Source: [README sample](https://github.com/Ahoo-Wang/Wow/blob/main/README.md#L94-L109).
+
+### Performance decision rule
+
+Use a reproducible workload.
+Pin the code revision and environment.
+Measure store, broker, CPU, allocation, and scheduler behavior together.
+Separate component screening from end-to-end confirmation.
+Retest ordering and overload behavior when changing concurrency.
+Do not change a default from one quick benchmark.
+Do not transfer EventStore results to SnapshotStore without measurement.
+Production capacity and tail-latency targets are **unknown** until a deployment-specific experiment supplies them.
+
+## Testing strategy
+
+### Layers
+
+| Layer | Purpose | Evidence |
+|---|---|---|
+| Domain spec | Given/when/expect behavior | [AggregateSpec](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-test/src/main/kotlin/me/ahoo/wow/test/AggregateSpec.kt#L24-L39) |
+| Saga spec | Isolated emitted-command expectations | [SagaSpec](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-test/src/main/kotlin/me/ahoo/wow/test/SagaSpec.kt#L24-L33) |
+| Event-store TCK | Append, load, conflict, duplicate, concurrency | [EventStoreSpec](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/eventsourcing/EventStoreSpec.kt#L41-L176) |
+| Snapshot-store TCK | Load, monotonic save, concurrency | [SnapshotStoreSpec](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/eventsourcing/snapshot/SnapshotStoreSpec.kt#L39-L212) |
+| Backend contract implementations | Run TCK against real adapters | [Mongo event test](https://github.com/Ahoo-Wang/Wow/blob/main/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/MongoEventStoreTest.kt#L38-L38), [Redis event test](https://github.com/Ahoo-Wang/Wow/blob/main/wow-redis/src/integrationTest/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStoreTest.kt#L32-L32), [Elasticsearch event test](https://github.com/Ahoo-Wang/Wow/blob/main/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchEventStoreTest.kt#L34-L34) |
+| Integration CI | Services plus aggregate integration tasks | [workflow](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/integration-test.yml#L47-L77) |
+| Static analysis | Detekt | [workflow](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/static-analysis.yml#L35-L53) |
+| Coverage | Jacoco is enabled for library projects; thresholds are configured by individual modules where required | [root Jacoco wiring](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L175-L198), [example 80% rule](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/build.gradle.kts#L12-L20) |
+| Benchmark | JMH regression and diagnosis | [benchmark module](https://github.com/Ahoo-Wang/Wow/blob/main/wow-benchmarks/build.gradle.kts#L1-L21) |
+
+### Domain test style
+
+The DSL exposes dynamic JUnit tests around Given, When, and Expect phases.
+Generic command aggregate type discovery in `AggregateSpec` uses reflection.
+Example domain modules can enforce an 80 percent Jacoco floor.
+Sources: [AggregateSpec factory](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-test/src/main/kotlin/me/ahoo/wow/test/AggregateSpec.kt#L69-L107), [example coverage](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/build.gradle.kts#L12-L20).
+
+### Change-to-test map
+
+| Change | Minimum focused verification | Broader gate |
+|---|---|---|
+| Command validation or handler | Aggregate spec for success and rejection | Domain module `check` |
+| Event sourcing rule | Replay from full history and snapshot tail | Store TCK plus integration test |
+| Event-store adapter | Conflict, duplicate request, ordering, concurrency | Adapter module `check` and integration workflow |
+| Snapshot adapter | Monotonic concurrent save | Snapshot TCK and adapter `check` |
+| Dispatcher concurrency | Same-key order, cross-key parallelism, quiesce | Core tests and benchmark diagnosis |
+| Runtime lifecycle | Prepare barrier, reverse cleanup, timeout, cancellation | `:wow-core:test` |
+| Route contributor | Catalog validation and route snapshot | OpenAPI and WebFlux tests |
+| Metadata KSP | Generated resource and accessor golden output | Compiler module `check` |
+| Security filter | Authenticated, unauthenticated, empty-tag, forged-header cases | WebFlux integration test |
+| Performance default | Multiple-fork component and E2E comparison | Deployment-representative load test |
+
+Green tests establish only their fixtures and assertions.
+They do not prove real-provider cancellation, production authorization, migration safety, or a deployment SLA unless those conditions are in the test.
+
+## Architecture decisions
+
+The repository does not contain a cited ADR that records the historical alternatives or original motivation for these mechanisms.
+`Not declared` is therefore deliberate: each rationale below is a present-day architectural interpretation of the cited behavior, not proof of historical design intent.
+
+| Decision | Alternatives Considered | Rationale | Source |
+|---|---|---|---|
+| Separate business payloads from framework envelopes | Not declared | Current envelopes keep routing, identity, ownership, and version controls outside the business payload; this is an interpretation of the present contract. | [CommandMessage](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L53-L125) |
+| Persist before publishing domain events | Not declared | Current filter order makes the event-store append complete before downstream publication, leaving consumers able to lag or replay. | [send filter order](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt#L25-L46) |
+| Treat snapshots as derived checkpoints | Not declared | The current strategy saves sourced state after event processing and does not replace event history. | [snapshot strategy](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/VersionOffsetSnapshotStrategy.kt#L49-L63) |
+| Serialize work by aggregate-derived group | Not declared | Current grouped `concatMap` processing protects same-group order while allowing different groups to progress independently. | [AggregateDispatcher](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/AggregateDispatcher.kt#L380-L393) |
+| Use admission-aware local-first delivery | Not declared | The implementation attempts local delivery while retaining a marked distributed copy, trading broker avoidance for more complex copy and acknowledgement semantics. | [LocalFirstMessageBus](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/LocalFirstMessageBus.kt#L142-L199) |
+| Give one runtime exclusive lifecycle ownership | Not declared | The current contract separates prepare, start, quiesce, graceful stop, and force stop so readiness and cleanup have one coordinator. | [RuntimeComponent](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/RuntimeComponent.kt#L18-L62) |
+| Route stores per aggregate | Not declared | Current registries allow aggregate-specific storage selection while preserving a default backend. | [store registries](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/AggregateEventStoreRegistry.kt#L20-L32) |
+| Compose adapters through starter capabilities | Not declared | Feature variants keep infrastructure modules selectable, while variant resolution becomes part of release compatibility. | [starter capabilities](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L5-L44) |
+| Share one validated route catalog | Not declared | The current catalog is consumed by both route and OpenAPI materialization, reducing contract drift between those outputs. | [RouterSpecs](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RouterSpecs.kt#L115-L160) |
+| Make compensation an explicit replay operation | Not declared | The current compensator reloads persisted events and resends them toward a target; it does not reverse the original append. | [DomainEventCompensator](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/compensation/DomainEventCompensator.kt#L61-L100) |
+
+## Dependency rationale
+
+The catalog pins Kotlin 2.4.10, KSP 2.3.10, Spring Boot 4.1.0, JUnit 6.1.2, Testcontainers 2.0.5, and JMH 1.37.
+Source: [version catalog](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L3-L33).
+
+No cited ADR or migration record identifies what these dependencies replaced.
+The `What It Replaced` column therefore remains `Not declared` instead of inventing history.
+
+| Dependency | Purpose | What It Replaced | Source |
+|---|---|---|---|
+| Kotlin and KSP | Kotlin implements the framework and KSP generates metadata resources and typed accessors at compile time. | Not declared | [version catalog](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L3-L33), [compiler dependencies](https://github.com/Ahoo-Wang/Wow/blob/main/wow-compiler/build.gradle.kts#L1-L17) |
+| Spring Boot | Supplies auto-configuration, lifecycle integration, WebFlux composition, and feature variants. | Not declared | [starter features](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L1-L44) |
+| Reactor | Provides the non-blocking publisher model used by command, event, retry, ordering, and drain paths. | Not declared | [core dependencies](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/build.gradle.kts#L3-L17) |
+| Jackson | Serializes command, event, state, and metadata representations. | Not declared | [core dependencies](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/build.gradle.kts#L3-L17), [message serializer](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/serialization/MessageSerializer.kt#L26-L65) |
+| Reactor Kafka | Implements the distributed Kafka message-bus adapter. | Not declared | [Kafka module](https://github.com/Ahoo-Wang/Wow/blob/main/wow-kafka/build.gradle.kts#L1-L6) |
+| MongoDB reactive driver | Implements MongoDB event, snapshot, and query persistence. | Not declared | [MongoDB module](https://github.com/Ahoo-Wang/Wow/blob/main/wow-mongo/build.gradle.kts#L1-L6) |
+| Spring Data Redis and Lettuce | Implement Redis event and snapshot persistence plus Redis transport integration. | Not declared | [Redis module](https://github.com/Ahoo-Wang/Wow/blob/main/wow-redis/build.gradle.kts#L1-L6) |
+| Spring Data Elasticsearch | Implements Elasticsearch event, snapshot, and query adapters. | Not declared | [Elasticsearch module](https://github.com/Ahoo-Wang/Wow/blob/main/wow-elasticsearch/build.gradle.kts#L1-L8) |
+| Swagger/OpenAPI libraries | Model and render the runtime route catalog as an OpenAPI contract. | Not declared | [OpenAPI module](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/build.gradle.kts#L1-L14) |
+| JUnit and Testcontainers | Provide dynamic domain tests, backend TCK fixtures, and external-service integration tests. | Not declared | [TCK dependencies](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-tck/build.gradle.kts#L1-L21) |
+
+## Known technical debt
+
+The repository does not label these gaps as debt in a cited ADR or issue.
+The qualitative risk levels are review priorities derived from current impact, not maintainer commitments.
+
+| Issue | Risk Level | Affected Files | Source |
+|---|---|---|---|
+| Redis cannot implement the public event-time loading capability, so time-range replay is unavailable on that backend. | Medium | `EventStore.kt`, `RedisEventStore.kt` | [contract](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L84-L97), [Redis implementation](https://github.com/Ahoo-Wang/Wow/blob/main/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStore.kt#L101-L106) |
+| Snapshot deletion and retention are absent from the public store contract, leaving lifecycle policy to backend operations or an additional application contract. | Medium | `SnapshotStore.kt`, selected snapshot backend and deployment policy | [SnapshotStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt#L24-L71) |
+
+### Explicit framework boundaries and intentional constraints
+
+These behaviors are code-confirmed boundaries.
+They should not be called technical debt without an ADR, issue, or maintainer decision that establishes remediation intent.
+
+| Constraint | Engineering implication | Source |
+|---|---|---|
+| State-event send errors are logged and resumed at the immediate filter boundary. | Snapshot and state-event consumers may lag; concrete bus durability and replay policy must close the operational gap. | [SendStateEventFilter](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/SendStateEventFilter.kt#L54-L76) |
+| Authentication and principal-tag resolution are integration-owned. | Header extraction and ABAC hooks alone do not establish authenticated or restricted access. | [CoSec extraction](https://github.com/Ahoo-Wang/Wow/blob/main/wow-cosec/src/main/kotlin/me/ahoo/wow/cosec/extractor/CoSecCommandBuilderExtractor.kt#L23-L40), [ABAC empty tags](https://github.com/Ahoo-Wang/Wow/blob/main/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/AbacQueryFilter.kt#L91-L130) |
+| Ordinary event-processor return values have no publication semantics. | Use stateless saga mapping when event results must become commands. | [event function filter](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/dispatcher/DomainEventFunctionFilter.kt#L41-L70), [saga mapper](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt#L57-L105) |
+| `WowRuntime` and its Spring bridge are one-shot. | Embedding code must replace the runtime rather than restart a stopped instance. | [one-shot start](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt#L188-L217), [Spring lifecycle states](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring/src/main/kotlin/me/ahoo/wow/spring/WowRuntimeLifecycle.kt#L45-L51) |
+| KSP does not remove runtime aggregate reflection. | AOT, startup, or reflection-reduction work must measure the actual parser and invocation path. | [generated accessor](https://github.com/Ahoo-Wang/Wow/blob/main/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/aggregate/metadata/AggregatesMetadataResolver.kt#L48-L59), [runtime parser](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/annotation/AggregateMetadataParser.kt#L54-L102) |
+
+## Unknowns that require deployment evidence
+
+- The production authentication provider is unknown.
+- The trusted proxy and header sanitation policy are unknown.
+- The production event-store and snapshot-store selection per aggregate are unknown.
+- The broker replication and retention policy are unknown.
+- The disaster-recovery RPO and RTO are unknown.
+- The projection replay runbook is unknown.
+- The compensation endpoint authorization policy is unknown.
+- The acceptable state-event lag is unknown.
+- The production command latency SLO is unknown.
+- The safe maximum concurrency for any deployment is unknown.
+- The capacity ceiling of each storage backend is unknown.
+- The migration policy for event payload schema changes is not established by the cited contracts.
+- The retention policy for event streams and snapshots is unknown.
+- The operational response to a partially completed force stop is unknown.
+- Whether clients preserve request IDs across network retries is unknown.
+
+These are not framework defects by themselves.
+They are inputs a production design must supply.
+
+## Staff engineer change protocol
+
+### Before design
+
+1. Name the aggregate, bounded context, and module that owns the behavior.
+2. Identify the durable truth: event store, snapshot, projection, or external system.
+3. Trace the envelope fields and metadata used for routing.
+4. Identify the runtime component that owns admission and shutdown.
+5. State whether the change affects one aggregate lane or cross-aggregate coordination.
+6. List the exact retry, acknowledgement, and compensation behavior.
+7. Identify trusted and untrusted headers.
+8. Decide whether KSP output, runtime route catalog, or both change.
+9. Define backward compatibility for persisted events and public routes.
+10. Write the failure-mode test before implementation when behavior changes.
+
+### During implementation
+
+1. Keep public contracts in `wow-api`.
+2. Keep runtime behavior in `wow-core`.
+3. Keep Spring wiring in `wow-spring*`.
+4. Keep transport and storage details in adapter modules.
+5. Preserve non-blocking Reactor paths.
+6. Preserve per-aggregate ordering.
+7. Do not widen acknowledgement semantics accidentally.
+8. Do not hide send failures without an explicit replay path.
+9. Do not hand-edit generated outputs as the primary fix.
+10. Keep route and OpenAPI materialization driven by the same catalog.
+
+### Before merge
+
+1. Run the narrowest module test first.
+2. Run the relevant store or dispatcher TCK.
+3. Run static analysis for touched Kotlin.
+4. Render and compare generated OpenAPI when routes change.
+5. Inspect generated metadata when annotations change.
+6. Test startup, graceful stop, and force stop when lifecycle changes.
+7. Test same-key ordering and cross-key parallelism when concurrency changes.
+8. Test recoverable and unrecoverable errors separately.
+9. Verify compensation is idempotent for affected processors.
+10. Record remaining unknown deployment assumptions.
+
+## Recommended reading order
+
+1. Start with [`CommandMessage`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L53-L125) to understand the control envelope.
+2. Read [`DomainEvent`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/event/DomainEvent.kt#L47-L89) and separate payload from metadata.
+3. Read [`DomainEventStream`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L31-L115) for the command-to-stream relation.
+4. Read [`SimpleCommandAggregate`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L81-L132) for the consistency boundary.
+5. Read [`EventStore`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L27-L109) for persistence contracts.
+6. Read [`EventSourcingStateAggregateRepository`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventSourcingStateAggregateRepository.kt#L74-L104) for snapshot-plus-tail replay.
+7. Read the two [publication filters](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/SendStateEventFilter.kt#L29-L76) for post-append boundaries.
+8. Read [`AggregateDispatcher`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/AggregateDispatcher.kt#L380-L393) for ordering.
+9. Read [`LocalFirstMessageBus`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/LocalFirstMessageBus.kt#L142-L199) for admission-aware delivery.
+10. Read [`ExchangeAck`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/handler/ExchangeAck.kt#L20-L60) before changing failure policy.
+11. Read [`RetryableFilter`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/handler/RetryableFilter.kt#L28-L65) for retry classification.
+12. Read [`DomainEventCompensator`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/compensation/DomainEventCompensator.kt#L43-L100) for replay semantics.
+13. Read [`StatelessSagaFunction`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt#L42-L105) for cross-aggregate choreography.
+14. Read [`VersionOffsetSnapshotStrategy`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/VersionOffsetSnapshotStrategy.kt#L24-L63) for snapshot timing.
+15. Read [`RuntimeComponent`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/RuntimeComponent.kt#L18-L62) before lifecycle code.
+16. Read [`WowRuntime`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt#L188-L256) for startup ownership.
+17. Continue through [shutdown ownership](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt#L412-L547).
+18. Read [`RuntimeComponentGroup`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/internal/RuntimeComponentGroup.kt#L25-L121) for ordering and cleanup.
+19. Read [`MetadataSymbolProcessor`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/metadata/MetadataSymbolProcessor.kt#L39-L106) for compile-time metadata.
+20. Read [`RouterSpecs`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RouterSpecs.kt#L37-L160) for runtime route and OpenAPI assembly.
+21. Read [`RouterFunctionBuilder`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/RouterFunctionBuilder.kt#L25-L41) for HTTP materialization.
+22. Read the [order example](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/Order.kt#L55-L197) only after the framework boundaries are clear.
+
+## Review heuristics
+
+Reject a change that treats a snapshot as the source of truth.
+Reject a change that publishes before the event-store append without a new, explicit consistency model.
+Reject a change that introduces blocking I/O in command, event, projection, saga, or store reactive paths.
+Reject a claim of exactly-once processing without broker, acknowledgement, handler idempotency, and replay evidence.
+Reject a claim of automatic rollback when the code only provides retry or compensation replay.
+Reject a claim of zero reflection while reflective dependencies and parsers remain.
+Reject a performance default change backed only by the README sample or one quick JMH run.
+Reject an authorization claim based only on header extraction.
+Require an explicit migration path for persisted event schema changes.
+Require lifecycle tests for new runtime components.
+Require overload tests for new queues or batch coordinators.
+Require route-catalog and OpenAPI checks for route metadata changes.
+
+## Glossary
+
+**Aggregate lane** — the sequential processing group derived from an aggregate identifier.
+**Command envelope** — `CommandMessage` plus routing, identity, ownership, and version control data.
+**Domain event payload** — the application-defined immutable object describing a fact.
+**Domain event stream** — the non-empty ordered events emitted by one command execution.
+**Event sourcing** — rebuilding state by applying persisted event streams after an optional snapshot.
+**State event** — a domain event stream decorated with the sourced aggregate state.
+**Snapshot** — a derived state checkpoint used to reduce replay work.
+**Projection** — an event consumer that updates a read-oriented model.
+**Stateless saga** — an event function whose results are converted into new commands.
+**Compensation** — explicit replay of persisted domain or reconstructed state events toward a target function.
+**Local-first** — attempt local admission while retaining a distributed delivery path.
+**Quiesce** — stop accepting new work while allowing admitted work to drain.
+**Force stop** — best-effort shutdown after graceful completion is no longer possible.
+**Route catalog** — validated runtime contracts shared by WebFlux route and OpenAPI materialization.
+**Generated metadata** — KSP produces a JSON resource loaded by `MetadataSearcher` and separate accessors that invoke the runtime aggregate metadata parser.
+
+## Final mental model
+
+Start with one aggregate and one command.
+Follow its envelope to one serialized lane.
+Rebuild state from snapshot plus event tail.
+Let the aggregate emit events rather than mutate storage.
+Append one event stream as the durable command result.
+Treat every later bus, projection, saga, and snapshot effect as a separately owned asynchronous boundary.
+Let `WowRuntime` decide when those owners can accept and finish work.
+Use retries for classified transient failures.
+Use explicit compensation replay for persisted events that require downstream reprocessing.
+Use evidence, not labels, for security, delivery, and performance guarantees.

--- a/documentation/docs/en/onboarding/staff-engineer-guide.md
+++ b/documentation/docs/en/onboarding/staff-engineer-guide.md
@@ -230,7 +230,9 @@ Source: [RuntimeComponent](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/s
 ## Domain model and invariants
 
 The framework separates payload classes, framework envelopes, command behavior, and event-sourced state.
-That separation prevents command handlers from directly mutating persisted state.
+That separation supports event-sourced design, but the framework does not prevent a command handler from mutating the state object directly.
+Enforce the convention in the domain model: keep state setters private and have command handlers return events that sourcing handlers apply.
+Source: [command-root construction](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregateFactory.kt#L42-L55), [encapsulated cart state](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt#L24-L46).
 
 ```mermaid
 %%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#2d333b', 'primaryBorderColor': '#6d5dfc', 'primaryTextColor': '#e6edf3', 'lineColor': '#8b949e', 'clusterBkg': '#161b22', 'clusterBorder': '#30363d'}}}%%

--- a/documentation/docs/zh/onboarding/contributor-guide.md
+++ b/documentation/docs/zh/onboarding/contributor-guide.md
@@ -1050,7 +1050,7 @@ fork(name = "Set cart note") {
   --stacktrace
 ```
 
-预期 Red 结果：Gradle 以 `BUILD FAILED` 结束，第一条所属原因报告未定义 `SetCartNote` Command 或缺少 `CartState.note` 实现；HTML Report 写入 `example/example-domain/build/reports/tests/test/`。
+预期 Red 结果：Gradle 以 `BUILD FAILED` 结束，因为 `compileTestKotlin` 无法解析 `CartState.note`。此 Red 阶段可能尚未运行 Test Task，因此不保证生成新的 HTML Test Report；应以编译器输出作为权威失败证据。
 
 ### 11.4 实现决策与 Sourcing
 

--- a/documentation/docs/zh/onboarding/contributor-guide.md
+++ b/documentation/docs/zh/onboarding/contributor-guide.md
@@ -1,0 +1,1990 @@
+# 贡献者指南
+
+本指南带你从一个干净的检出开始，完成一次范围清晰、经过验证的 Wow 代码贡献。
+
+内容面向 Kotlin 贡献者，也照顾从 Java、Python、JavaScript 或其他响应式技术栈转入的读者。
+
+所有仓库事实都链接到当前 `main` 分支。
+
+如果指南与源码不一致，请以源码为准，并在同一个变更中修正文档。
+
+## 学习目标
+
+完成本指南后，你应该能够：
+
+- 判断一个契约或行为属于哪个模块；
+- 把 Wow 的命令、事件、聚合、状态与规格测试作为一个垂直切片阅读；
+- 从 HTTP 输入开始，追踪命令到事件持久化和下游发布的全过程；
+- 正确选择本地测试、契约测试、集成测试、静态分析与文档构建；
+- 在不把基础设施泄漏进领域模块的前提下增加领域行为；
+- 定位常见的校验、路由、存储、元数据与超时问题；
+- 准备一份容易评审、容易回滚的聚焦变更。
+
+## 当前技术基线
+
+请使用仓库内的 Wrapper 与 Toolchain，不要依赖随意安装的全局版本。
+
+| 组件 | 仓库基线 | 事实来源 |
+| --- | --- | --- |
+| Wow | `8.9.5` | [`gradle.properties`](https://github.com/Ahoo-Wang/Wow/blob/main/gradle.properties#L18-L23) |
+| Kotlin | `2.4.10` | [版本目录](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L23-L35) |
+| Spring Boot | `4.1.0` | [版本目录](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L1-L5) |
+| Gradle | `9.6.1` | [Wrapper 配置](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/wrapper/gradle-wrapper.properties#L1-L9) |
+| JVM Toolchain | Java `17` | [根构建脚本](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L175-L190) |
+| JUnit | `6.1.2` | [版本目录](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L23-L27) |
+| KSP | `2.3.10` | [版本目录](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L31-L35) |
+
+README 也说明 Wow 8 面向 Spring Boot 4 与 Java 17 及以上版本。
+
+版本变化时，应优先相信上表中的构建文件。
+[查看兼容性说明。](https://github.com/Ahoo-Wang/Wow/blob/main/README.md#L41-L49)
+
+# 第一部分：必要基础
+
+## 1. 面向 Python 或 JavaScript 开发者的 Kotlin
+
+Kotlin 是静态类型、空安全、偏表达式风格的语言。
+
+本仓库把它编译到 JVM。
+
+仓库在 [`gradle.properties`](https://github.com/Ahoo-Wang/Wow/blob/main/gradle.properties#L18-L23) 中启用官方 Kotlin 代码风格和基于 K2 的 KSP 流水线。
+
+从 Python 或 JavaScript 转入时，可以按下表做具体映射：
+
+| 关注点 | Python | JavaScript / TypeScript | Wow 中的 Kotlin |
+| --- | --- | --- | --- |
+| 不可重新赋值的绑定 | 只有约定，例如 `product_id = "p1"` | `const productId = "p1"` | `val productId = "p1"` |
+| 可变绑定 | `quantity = quantity + 1` | `let quantity = 1` | `var quantity = 1` |
+| 值形消息 | `@dataclass class AddItem: ...` | `type AddItem = { ... }` | `data class AddCartItem(...)` |
+| 可空值 | `str \| None` | `string \| null` | `String?`；`String` 不接受 `null` |
+| 封闭结果类型 | `match` 加类约定 | Discriminated Union | `sealed interface` 加穷尽 `when` |
+| 只读集合边界 | 约定使用 `Sequence[T]` | `ReadonlyArray<T>` | `List<T>` 在接口层只读 |
+| 一个异步结果 | Coroutine / `Awaitable[T]` | `Promise<T>` | Reactor `Mono<T>` |
+| 多个异步结果 | Async Iterator | Async Iterator / Stream | Reactor `Flux<T>` |
+| 依赖声明 | `pyproject.toml` | `package.json` | `build.gradle.kts` 加集中式 `gradle/libs.versions.toml` |
+| 可复现构建入口 | 项目选择的 Python 工具 | Lockfile 与 Package Script | 仓库提交的 `./gradlew` Wrapper |
+
+后文 Kotlin 示例会展开最右列；Python 与 JavaScript 单元格只是迁移提示，不是要加入本仓库的源码。
+
+### 1.1 值、变量与类型推断
+
+默认使用 `val` 表示不可重新赋值的引用。
+
+只有引用确实需要变化时才使用 `var`。
+
+```kotlin
+val productId = "product-1"
+val initialQuantity: Int = 1
+var remainingQuantity = initialQuantity
+remainingQuantity -= 1
+```
+
+Python 与 JavaScript 通常在运行期动态确定类型。
+
+Kotlin 通常在编译期完成类型推断。
+
+因此编译器与重构工具可以在测试运行前发现大量不匹配。
+
+### 1.2 用 data class 表达值形消息
+
+Wow 的命令与事件经常使用 Kotlin data class。
+
+真实购物车示例在 API 模块中声明 `AddCartItem` 命令和 `CartItemAdded` 事件，并在命令属性上使用 Jakarta Validation。
+[阅读源码。](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/AddCartItem.kt#L1-L26)
+
+```kotlin
+data class AddCartItem(
+    val productId: String,
+    val quantity: Int,
+)
+
+data class CartItemAdded(
+    val productId: String,
+    val quantity: Int,
+)
+```
+
+这个简化片段只展示结构。
+
+复制代码时，注解和校验约束应以仓库源码为准。
+
+### 1.3 可空性属于类型系统
+
+`String` 不接受 `null`。
+
+`String?` 接受 `null`。
+
+```kotlin
+fun normalizeOwnerId(ownerId: String?): String? = ownerId?.trim()?.takeIf { it.isNotEmpty() }
+```
+
+优先使用安全调用、Elvis 表达式与显式分支。
+
+除非不变量已经在局部得到证明，否则避免使用 `!!`。
+
+### 1.4 函数可以直接返回表达式
+
+```kotlin
+fun nextQuantity(current: Int, delta: Int): Int = current + delta
+```
+
+聚合命令处理器通常返回领域事件，而不是直接修改基础设施中的持久化状态。
+
+购物车聚合正是这样做的：处理器检查状态，再返回 `CartItemAdded`、`CartQuantityChanged` 或 `CartItemRemoved`。
+[阅读聚合处理器。](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt#L32-L76)
+
+### 1.5 构造函数应暴露依赖意图
+
+构造函数注入让依赖一目了然。
+
+示例服务使用常规 Spring Boot 启动与组件扫描，框架自动配置则按条件创建运行时 Bean。
+[查看 `ExampleServer`。](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-server/src/main/kotlin/me/ahoo/wow/example/server/ExampleServer.kt#L16-L35)
+[查看命令自动配置。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandAutoConfiguration.kt#L38-L100)
+
+```kotlin
+class ProductPolicy(
+    private val catalog: ProductCatalog,
+) {
+    fun isKnown(productId: String): Boolean = catalog.contains(productId)
+}
+```
+
+领域依赖应保持聚焦。
+
+不要仅仅因为 Spring 能提供数据库客户端，就把它注入聚合。
+
+### 1.6 扩展函数让测试语言更自然
+
+Kotlin 扩展函数让一个函数看起来像接收者类型的成员。
+
+Wow 测试按仓库约定使用 FluentAssert 的 `.assert()` 风格。
+
+```kotlin
+fun Int.requirePositive(): Int {
+    require(this > 0)
+    return this
+}
+```
+
+扩展函数不会真的给目标类增加成员。
+
+可以用它改善局部语言，但不要用它隐藏令人意外的控制流。
+
+### 1.7 密封类型与穷尽分支
+
+当领域结果只有封闭的几种情况时，可以使用密封层次。
+
+```kotlin
+sealed interface CartDecision
+
+data class Accepted(val event: Any) : CartDecision
+
+data class Rejected(val reason: String) : CartDecision
+
+fun describe(decision: CartDecision): String = when (decision) {
+    is Accepted -> "accepted"
+    is Rejected -> decision.reason
+}
+```
+
+编译器会验证 `when` 表达式覆盖所有已知子类型。
+
+### 1.8 集合与不可变边界
+
+当修改不属于契约时，在边界上使用只读集合接口。
+
+泛型类型应写成代码，例如 `List<CartItem>`。
+
+```kotlin
+fun productIds(items: List<CartItem>): Set<String> = items.mapTo(mutableSetOf()) { it.productId }
+```
+
+只读接口并不代表底层对象深度不可变。
+
+请明确所有权，不要暴露内部可变集合。
+
+### 1.9 Reactor 是默认异步词汇
+
+Wow 的运行时路径使用 Reactor `Mono` 与 `Flux`。
+
+不要在命令分发、事件持久化、投影、Saga 或传输路径中加入阻塞调用。
+
+`Mono<T>` 表示异步的零个或一个值。
+
+`Flux<T>` 表示异步的零到多个值。
+
+```kotlin
+fun loadCart(cartId: String): Mono<CartView> = repository.load(cartId)
+
+fun streamEvents(cartId: String): Flux<CartEvent> = eventStore.load(cartId)
+```
+
+这个概念片段中的类型仅用于说明。
+
+真实 `CommandGateway` 契约同时提供基于 `Mono` 与 `Flux` 的等待形式，并委托命令总线发送。
+[阅读网关契约。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt#L63-L173)
+
+### 1.10 组合变换，而不是偷偷订阅
+
+框架代码通常应组合操作符并返回流水线。
+
+应用边缘负责订阅。
+
+```kotlin
+fun validateThenSend(command: CommandMessage<*>): Mono<Void> =
+    validator.validate(command)
+        .then(commandBus.send(command))
+```
+
+不要在响应式运行时路径调用 `block()`。
+
+不要在可复用领域或基础设施代码中调用 `subscribe()`，除非该代码明确拥有生命周期与取消职责。
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+flowchart LR
+    A["Kotlin 命令值"] --> B["输入校验"]
+    B --> C["Mono 组合"]
+    C --> D["CommandGateway"]
+    D --> E["事件流"]
+    E --> F["Flux 发布"]
+    G["避免 block 与隐藏 subscribe"] -. 保护 .-> C
+```
+<!-- Sources:
+- [example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/AddCartItem.kt:1-26](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/AddCartItem.kt#L1-L26)
+- [wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt:63-173](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt#L63-L173)
+- [wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt:79-143](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L79-L143)
+-->
+
+## 2. Wow 中的 Spring 基础
+
+Spring 是运行时外围的装配机制。
+
+领域行为本身应该无需了解某个 Bean 由哪段自动配置创建，也能被读懂。
+
+熟悉 FastAPI 或 Express 的贡献者，可以按下表理解职责：
+
+| 关注点 | FastAPI | Express | Spring/Wow |
+| --- | --- | --- | --- |
+| 应用启动 | 创建 `FastAPI` 应用 | 创建 `express()` 应用 | `@SpringBootApplication` 加 `runApplication` |
+| 路由声明 | Path Operation Decorator | `app.post(...)` 或 Router | `RouterSpecs` 契约被物化为 WebFlux `RouterFunction` |
+| 请求流水线 | ASGI Middleware 与 Dependency | Middleware Chain | WebFlux Handler、Extractor、Policy，再进入 `CommandGateway` |
+| 依赖注入 | `Depends(...)` | 通常显式装配或使用第三方容器 | 构造函数注入加条件 Spring Bean |
+| 配置 | Settings 对象与环境变量 | 环境变量/配置库 | `application.yaml`、类型化 Properties 与自动配置条件 |
+| 异步模型 | Handler 返回 Coroutine | Handler 返回 Promise | Reactor `Mono`/`Flux`；返回组合后的 Pipeline，不阻塞 |
+
+与手写 Express Route 不同，Wow Command Route 先由聚合与命令元数据派生，再转换成 Route Contract，最后由 WebFlux 物化。领域决策应留在该传输流水线之外。
+
+### 2.1 应用启动
+
+示例服务使用 `@SpringBootApplication`，并通过 `runApplication` 启动。
+
+它显式扫描示例服务与 Wow 命名空间。
+[查看完整启动代码。](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-server/src/main/kotlin/me/ahoo/wow/example/server/ExampleServer.kt#L16-L35)
+
+```kotlin
+@SpringBootApplication
+class ExampleServer
+
+fun main(args: Array<String>) {
+    runApplication<ExampleServer>(*args)
+}
+```
+
+该片段只用于说明 Spring 形态。
+
+创建可运行模块时，应从真实源码复制完整注解与扫描配置。
+
+### 2.2 自动配置按能力拆分
+
+`wow-spring-boot-starter` 为 MongoDB、Redis、Mock、Kafka、WebFlux、Elasticsearch、OpenTelemetry、OpenAPI 与 CoSec 声明 Feature Variants。
+[查看能力声明。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L5-L44)
+
+Starter 通过 Spring Boot imports 文件注册自动配置。
+[查看自动配置清单。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports#L1-L31)
+
+只选择拥有目标集成的最小能力集。
+
+把基础设施依赖加到领域模块，通常说明边界放错了位置。
+
+### 2.3 条件 Bean 保持边界可替换
+
+自动配置只在属性与类路径能力满足条件时创建默认实现。
+
+命令自动配置通过条件 Bean 组装本地 Bus 变体、Builder Rewriter、校验器与消息工厂。
+[查看命令侧条件与 Bean 工厂。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandAutoConfiguration.kt#L38-L100)
+
+独立的 Gateway 自动配置负责组装幂等、等待协调、阶段通知器与 `DefaultCommandGateway`。
+[查看 Gateway 装配。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandGatewayAutoConfiguration.kt#L51-L163)
+
+创建新 Bean 前：
+
+1. 搜索接口；
+2. 查找现有实现；
+3. 阅读条件注解；
+4. 检查属性绑定；
+5. 检查自动配置 imports；
+6. 只在所属集成边界提供替换实现。
+
+### 2.4 配置也是可执行行为
+
+示例服务当前选择 MongoDB 作为事件与快照存储，同时使用内存总线。
+[阅读示例配置。](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-server/src/main/resources/application.yaml#L73-L99)
+
+不要从该示例推导生产拓扑。
+
+它只证明示例当前的本地装配，不代表通用部署建议。
+
+### 2.5 WebFlux 把 HTTP 适配为命令模型
+
+WebFlux Handler 读取请求体、拒绝空请求体、委托命令处理器并写回响应。
+[阅读 `CommandHandlerFunction`。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt#L43-L66)
+
+Extractor 把请求头、路径信息与请求体构造成 `CommandMessage`。
+[阅读 Extractor。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandMessageExtractor.kt#L23-L46)
+
+传输处理器选择等待策略，并返回 SSE 或单结果响应。
+[阅读传输处理器。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt#L30-L62)
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+flowchart LR
+    R["HTTP 请求"] --> F["CommandHandlerFunction"]
+    F --> H["CommandHandler"]
+    H --> X["CommandMessageExtractor"]
+    X --> W{"等待响应模式"}
+    W -->|"单结果"| M["sendAndWait"]
+    W -->|"流式"| S["sendAndWaitStream"]
+    M --> G["CommandGateway"]
+    S --> G
+    G --> O["HTTP 响应或 SSE"]
+```
+<!-- Sources:
+- [wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt:43-66](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt#L43-L66)
+- [wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandMessageExtractor.kt:23-46](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandMessageExtractor.kt#L23-L46)
+- [wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt:30-62](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt#L30-L62)
+-->
+
+# 第二部分：理解代码库
+
+## 3. Wow 是什么
+
+Wow 为领域驱动设计、CQRS 与事件溯源提供框架契约和运行时组件。
+
+项目自身把它描述为具备命令、事件、投影、Saga、存储与集成能力的现代响应式框架。
+[阅读项目概览与能力列表。](https://github.com/Ahoo-Wang/Wow/blob/main/README.md#L51-L84)
+
+贡献者最需要掌握的是职责分离：
+
+- API 模块定义命令、事件与公开领域契约；
+- Domain 模块实现决策和事件溯源状态迁移；
+- Core 模块提供运行时行为；
+- Spring 模块装配运行时组件；
+- 基础设施模块适配存储与传输；
+- Test 模块提供 DSL、TCK 与集成测试支持；
+- Example 模块展示完整垂直切片。
+
+## 4. 仓库结构
+
+权威项目清单位于 [`settings.gradle.kts`](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L23-L85)。
+
+可以先按四组理解。
+
+### 4.1 框架与集成模块
+
+| 区域 | 代表模块 | 职责 |
+| --- | --- | --- |
+| API | `wow-api` | 纯契约、注解、命令/事件类型、命名与建模。 |
+| Runtime | `wow-core` | 分发、事件溯源、总线、投影、Saga 与生命周期。 |
+| Compiler | `wow-compiler` | KSP Processor 与框架元数据生成。 |
+| Spring | `wow-spring`、`wow-spring-boot-starter` | 集成原语与条件装配。 |
+| Query | `wow-query` | 查询模型支持。 |
+| Storage | `wow-mongo`、`wow-redis`、`wow-elasticsearch` | 事件与快照持久化适配器；Elasticsearch 还提供事件流与快照查询。 |
+| Messaging | `wow-kafka` | 分布式命令/事件总线集成。 |
+| Projection 与 Cache | `wow-elasticsearch`、`wow-cocache` | Elasticsearch 查询/投影支持与投影缓存。 |
+| Transport | `wow-webflux`、`wow-apiclient` | HTTP 命令端点与 API Client。 |
+| Cross-cutting | `wow-opentelemetry`、`wow-cosec` | 遥测与授权。 |
+| Schema | `wow-openapi`、`wow-schema` | OpenAPI 与 JSON Schema 支持。 |
+| BI | `wow-bi` | BI 同步脚本生成。 |
+| Dependency management | `wow-bom`、`wow-dependencies` | 发布版本对齐。 |
+
+该表用于快速理解职责。
+
+修改构建逻辑前，应回到 settings 文件核对精确的项目包含关系与目录映射。
+
+### 4.2 测试模块
+
+Settings 文件包含测试 DSL、测试支持、存储与总线 TCK、Mock、Benchmark、集成测试与聚合覆盖率报告。
+[查看测试模块声明。](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L46-L56)
+
+多个实现必须满足同一契约时，应复用 TCK。
+
+行为依赖真实外部引擎或容器时，应写集成测试。
+
+### 4.3 补偿模块
+
+补偿区域包含 API、Domain、Core、Server 与 Dashboard 项目。
+[查看补偿模块声明。](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L58-L66)
+
+它是一个具有自身边界的产品形子系统。
+
+未经显式架构决策，不应把补偿实现细节提升为 Core 默认契约。
+
+### 4.4 示例模块
+
+示例包含 Kotlin Domain/Server 与 Java Transfer Domain/Server。
+[查看示例声明。](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L68-L85)
+
+Kotlin Cart 示例是最合适的第一个垂直切片，因为其命令、事件、聚合、状态、Saga 与测试都很小且彼此连通。
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+graph TB
+    API["wow-api<br>契约"] --> CORE["wow-core<br>运行时"]
+    CORE --> SPRING["wow-spring<br>集成原语"]
+    SPRING --> STARTER["wow-spring-boot-starter<br>条件装配"]
+    CORE --> KAFKA["wow-kafka"]
+    CORE --> MONGO["wow-mongo"]
+    CORE --> REDIS["wow-redis"]
+    CORE --> ES["wow-elasticsearch"]
+    CORE --> WEB["wow-webflux"]
+    API --> COMPILER["wow-compiler<br>KSP 元数据"]
+    TEST["test 模块<br>DSL 与 TCK"] -. 验证 .-> CORE
+    EXAMPLE["example 模块"] --> STARTER
+    EXAMPLE --> API
+```
+<!-- Sources:
+- [settings.gradle.kts:23-85](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L23-L85)
+- [wow-spring-boot-starter/build.gradle.kts:5-79](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L5-L79)
+- [example/example-domain/build.gradle.kts:1-20](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/build.gradle.kts#L1-L20)
+-->
+
+## 5. 核心概念
+
+### 5.1 限界上下文与命名聚合
+
+限界上下文为领域名称提供边界。
+
+`NamedBoundedContext` 暴露限界上下文名称。
+[阅读契约。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/naming/NamedBoundedContext.kt#L15-L36)
+
+`NamedAggregate` 标识该上下文中的聚合名称。
+[阅读契约。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/NamedAggregate.kt#L20-L49)
+
+示例分别在 API 与 Domain 中声明服务上下文和限界上下文标记。
+[查看 `ExampleService`。](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/ExampleService.kt#L22-L40)
+[查看 `ExampleBoundedContext`。](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/ExampleBoundedContext.kt#L19-L21)
+
+### 5.2 聚合标识
+
+`AggregateId` 由命名聚合、聚合 `id` 和 `tenantId` 组成。
+
+Owner 与 Space 是相关的消息和聚合状态上下文，但不是 `AggregateId` 契约的字段。
+
+契约说明：同一个命名聚合内，Aggregate ID 跨租户唯一。
+[阅读标识契约。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt#L18-L45)
+
+不要把 `tenantId` 当成同一命名聚合内可重复使用相同 `id` 的命名空间。
+
+### 5.3 命令与命令消息
+
+命令表达请求执行的意图。
+
+`CommandMessage` 在意图之外承载标识、路由、Header、聚合版本与生命周期标志。
+[阅读消息契约。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L24-L61)
+[阅读目标与版本字段。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L70-L125)
+
+消息可以表达创建、预期聚合版本与 Void 行为。
+
+这些字段参与正确性，适配器不能随意丢弃。
+
+### 5.4 领域事件与事件流
+
+领域事件记录已经发生的业务事实。
+
+`DomainEvent` 携带序列、修订号、命令、聚合与元数据上下文。
+[阅读事件契约。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/event/DomainEvent.kt#L21-L50)
+[阅读序列与修订字段。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/event/DomainEvent.kt#L57-L89)
+
+`DomainEventStream` 把一个命令产生的事件组合起来。
+
+实现会约束命令标识与聚合上下文等流级不变量。
+[阅读事件流契约与不变量。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L31-L115)
+
+### 5.5 事件存储
+
+`EventStore` 负责追加领域事件流并按聚合加载事件流。
+[阅读存储契约。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L22-L82)
+
+乐观并发与重复事件流失败属于这个边界。
+
+适配器不能把它们转换成“成功写入”。
+
+### 5.6 状态溯源与快照
+
+状态聚合通过应用领域事件重建状态。
+
+即使缺少 sourcing handler，契约仍推进版本，因此“没有处理器”不等于“可以忽略事件位置”。
+[阅读 `StateAggregate`。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/state/StateAggregate.kt#L17-L31)
+
+Repository 可以加载快照并重放后续事件。
+[阅读 Repository 实现。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventSourcingStateAggregateRepository.kt#L25-L45)
+
+快照保存某一版本的聚合状态。
+[阅读快照契约。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/Snapshot.kt#L20-L41)
+
+### 5.7 状态事件
+
+状态事件在领域事件完成 sourcing 后派生，可向下游表达结果状态迁移。
+[阅读 `StateEvent`。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/StateEvent.kt#L23-L100)
+
+状态事件 Filter 在事件流处理后创建并发布 State Event。
+[阅读 Filter。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/SendStateEventFilter.kt#L29-L76)
+
+### 5.8 投影、事件处理器与 Saga
+
+Event Processor 响应领域事件。
+[阅读 `@EventProcessor`。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/EventProcessor.kt#L19-L58)
+
+Projection Processor 构建读模型。
+[阅读 `@ProjectionProcessor`。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/ProjectionProcessor.kt#L19-L68)
+
+Stateless Saga 协调事件反应，但不在被注解类型中保存 Saga 状态。
+
+购物车示例监听 `OrderCreated`。当订单来自购物车时，它针对 `event.ownerId` 对应的购物车发出 `RemoveCartItem`，移除已购买商品。
+
+`@Retry` 配置的是 Saga Handler 的执行重试，不是附加到所发命令上的元数据。
+[阅读 `CartSaga`。](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartSaga.kt#L25-L42)
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+erDiagram
+    BOUNDED_CONTEXT ||--o{ NAMED_AGGREGATE : 包含
+    NAMED_AGGREGATE ||--o{ AGGREGATE_ID : 标识
+    AGGREGATE_ID ||--o{ COMMAND_MESSAGE : 定位
+    COMMAND_MESSAGE ||--o| DOMAIN_EVENT_STREAM : 可能产生
+    DOMAIN_EVENT_STREAM ||--|{ DOMAIN_EVENT : 包含
+    AGGREGATE_ID ||--o{ SNAPSHOT : 检查点
+    DOMAIN_EVENT_STREAM ||--o| STATE_EVENT : 派生
+    DOMAIN_EVENT ||--o{ PROJECTION : 更新
+    DOMAIN_EVENT ||--o{ SAGA : 触发
+```
+<!-- Sources:
+- [wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt:18-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt#L18-L45)
+- [wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt:24-125](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L24-L125)
+- [wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt:31-115](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L31-L115)
+- [wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/Snapshot.kt:20-41](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/Snapshot.kt#L20-L41)
+- [wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/StateEvent.kt:23-100](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/StateEvent.kt#L23-L100)
+- [wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/ProjectionProcessor.kt:19-68](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/ProjectionProcessor.kt#L19-L68)
+- [wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/StatelessSaga.kt:19-62](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/StatelessSaga.kt#L19-L62)
+-->
+
+## 6. 命令生命周期
+
+下面这条链路是贡献者最有用的运行时地图。
+
+### 6.1 HTTP 适配
+
+`CommandHandlerFunction` 读取请求体并检查是否为空。
+
+`CommandMessageExtractor` 从请求构造框架元数据。
+
+`CommandHandler` 选择 WaitPlan 与响应形式。
+
+### 6.2 网关校验与幂等
+
+`DefaultCommandGateway` 先校验命令并协调幂等，再发送命令。
+[阅读校验、幂等与总线分发。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L79-L143)
+
+重复请求标识是正确性问题，不只是日志问题。
+
+网关会拒绝同一聚合上重复的 Request ID。
+[阅读重复请求异常契约。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandExceptions.kt#L25-L35)
+
+### 6.3 分发与聚合亲和性
+
+`CommandDispatcher` 从总线接收命令，并选择命名聚合 Dispatcher。
+[阅读 Dispatcher。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/CommandDispatcher.kt#L37-L75)
+
+`AggregateCommandDispatcher` 按 Aggregate ID 路由工作，使同一聚合的命令保持 Worker 亲和性。
+[阅读聚合分发。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/AggregateCommandDispatcher.kt#L25-L86)
+
+Spring 装配创建 Processor、Filter Chain、Handler 与 Dispatcher。
+[阅读聚合自动配置。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/modeling/AggregateAutoConfiguration.kt#L70-L145)
+
+### 6.4 决策、Sourcing 与追加
+
+Processor Filter 获取命令聚合处理器并执行 Exchange。
+[阅读 Processor Filter。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/AggregateProcessorFilter.kt#L26-L49)
+
+`RetryableAggregateProcessor` 先请求状态仓储加载聚合。`EventSourcingStateAggregateRepository` 会先尝试加载快照，再从 EventStore 重放快照版本之后的事件流，最后才创建 Command Aggregate。
+[阅读 Processor 加载过程。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/RetryableAggregateProcessor.kt#L48-L68)
+[阅读快照优先的状态重建。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventSourcingStateAggregateRepository.kt#L74-L107)
+
+`SimpleCommandAggregate` 解析命令处理器、校验聚合条件、调用领域行为、对返回事件执行 sourcing，并追加事件流。
+[阅读决策路径。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L64-L132)
+
+命令聚合记录 stored、sourced、expired 等处理状态。
+[阅读命令状态迁移。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/CommandAggregate.kt#L55-L84)
+
+### 6.5 发布与等待完成
+
+追加完成后，领域事件 Filter 把事件流发布到 Domain Event Bus。
+[阅读发布 Filter。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt#L25-L46)
+
+State Event Filter 发布完成 sourcing 的状态迁移。
+
+WaitCoordinator 观察请求的阶段，并完成面向传输层的结果。
+
+阶段模型声明 `SENT`、`PROCESSED`、`SNAPSHOT`、`PROJECTED`、`EVENT_HANDLED` 与 `SAGA_HANDLED` 之间的依赖。
+[阅读阶段依赖。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt#L25-L123)
+
+WaitPlan 可以直接在 `SENT` 或 `PROCESSED` 完成。`SNAPSHOT`、`PROJECTED`、`EVENT_HANDLED` 与 `SAGA_HANDLED` 是共享前两个前置条件的并列目标，不是每条命令都必须依次经过的序列。
+
+### 6.6 Deadline 与取消所有权
+
+流式等待使用 `Flux.using`，单结果等待使用 `Mono.using`，以释放协调器资源。
+[阅读流式等待所有权。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L201-L223)
+[阅读单结果等待所有权。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L238-L266)
+
+网关传播 WaitPlan、发送命令，并发出 `SENT` 或错误信号。
+[阅读等待传播与发送。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L282-L301)
+
+超时测试验证等待 Handle 得到释放，并由一个绝对 Deadline 约束整个操作。
+[阅读超时测试。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTimeoutTest.kt#L45-L125)
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+sequenceDiagram
+    autonumber
+    participant Client as 客户端
+    participant WebFlux
+    participant Gateway
+    participant CommandBus
+    participant Dispatcher
+    participant Processor
+    participant Repository
+    participant SnapshotStore
+    participant Aggregate as 聚合
+    participant EventStore
+    participant Filters as Filter 链
+    participant EventBus
+    participant WaitCoordinator
+    Client->>WebFlux: HTTP 命令
+    WebFlux->>WebFlux: 提取 CommandMessage
+    WebFlux->>Gateway: 发送并等待
+    Gateway->>Gateway: 校验并协调幂等
+    Gateway->>WaitCoordinator: 注册 WaitPlan
+    Gateway->>CommandBus: 发送命令
+    Gateway-->>WaitCoordinator: SENT
+    CommandBus->>Dispatcher: 接收命令
+    Dispatcher->>Processor: 按 Aggregate ID 路由
+    Processor->>Repository: 加载 StateAggregate
+    Repository->>SnapshotStore: 加载最新快照
+    SnapshotStore-->>Repository: 快照或 Empty
+    Repository->>EventStore: 加载快照版本之后的事件
+    EventStore-->>Repository: 事件流
+    Repository-->>Processor: 已重建的 StateAggregate
+    Processor->>Aggregate: 创建并处理 Command Aggregate
+    Aggregate->>Aggregate: 校验聚合条件并决策
+    Aggregate->>EventStore: 追加 DomainEventStream
+    EventStore-->>Aggregate: stored
+    Aggregate-->>Filters: 已存储的事件流
+    Filters->>EventBus: 发布事件流
+    EventBus-->>WaitCoordinator: 下游阶段信号
+    WaitCoordinator-->>Gateway: 结果或超时
+    Gateway-->>WebFlux: CommandResult
+    WebFlux-->>Client: 响应或 SSE
+```
+<!-- Sources:
+- [wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt:43-66](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt#L43-L66)
+- [wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt:79-143](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L79-L143)
+- [wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/AggregateCommandDispatcher.kt:25-86](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/AggregateCommandDispatcher.kt#L25-L86)
+- [wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/RetryableAggregateProcessor.kt:48-68](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/RetryableAggregateProcessor.kt#L48-L68)
+- [wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventSourcingStateAggregateRepository.kt:74-107](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventSourcingStateAggregateRepository.kt#L74-L107)
+- [wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt:64-132](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L64-L132)
+- [wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt:25-46](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt#L25-L46)
+-->
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+stateDiagram-v2
+    [*] --> SENT: 命令总线接受发送
+    SENT --> SENT_COMPLETE: WaitPlan 目标为 SENT
+    SENT --> PROCESSED: 聚合处理完成
+    PROCESSED --> PROCESSED_COMPLETE: WaitPlan 目标为 PROCESSED
+    PROCESSED --> SNAPSHOT: 并列目标
+    PROCESSED --> PROJECTED: 并列目标
+    PROCESSED --> EVENT_HANDLED: 并列目标
+    PROCESSED --> SAGA_HANDLED: 并列目标
+    SNAPSHOT --> DOWNSTREAM_COMPLETE: 所选目标已满足
+    PROJECTED --> DOWNSTREAM_COMPLETE: 所选目标已满足
+    EVENT_HANDLED --> DOWNSTREAM_COMPLETE: 所选目标已满足
+    SAGA_HANDLED --> DOWNSTREAM_COMPLETE: 所选目标已满足
+    SENT_COMPLETE --> [*]
+    PROCESSED_COMPLETE --> [*]
+    DOWNSTREAM_COMPLETE --> [*]
+```
+<!-- Sources:
+- [wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt:25-123](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt#L25-L123)
+- [wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWait.kt:21-120](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWait.kt#L21-L120)
+- [wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt:282-301](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L282-L301)
+-->
+
+## 7. 关键实现模式
+
+### 7.1 API → Aggregate → State → Spec
+
+这是默认的领域功能路径。
+
+1. 在 API 模块定义命令与事件契约。
+2. 在 Domain 模块为聚合增加命令处理。
+3. 在聚合状态中增加 sourcing 行为。
+4. 编写 `AggregateSpec`，覆盖接受与拒绝分支。
+5. 运行领域模块测试与覆盖率校验。
+
+Cart 切片包含全部四部分：
+
+- [example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/AddCartItem.kt:1-26](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/AddCartItem.kt#L1-L26)
+- [example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt:32-76](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt#L32-L76)
+- [example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt:23-46](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt#L23-L46)
+- [example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt:28-87](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt#L28-L87)
+
+### 7.2 注解声明发现边界
+
+`@AggregateRoot` 标识聚合根；其 `commands` 属性把额外命令类型（包括 Void 或重写命令）挂载到该聚合。
+[阅读注解契约。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AggregateRoot.kt#L18-L77)
+
+`@OnCommand` 标识聚合中的命令处理函数，并可声明其返回的事件类型；它不定义 HTTP 路径或方法。
+[阅读注解契约。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/OnCommand.kt#L19-L86)
+
+`@OnSourcing` 标识事件驱动的状态迁移处理器。
+[阅读注解契约。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/OnSourcing.kt#L18-L59)
+
+`@CommandRoute` 是命令类上的 HTTP Action、Method、Prefix 与路径维度契约；`@AggregateRoot.commands` 决定向聚合注册哪些额外命令。
+[阅读 Command Route 选项。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/CommandRoute.kt#L18-L72)
+
+后续职责分为独立层次：
+
+1. KSP 写出合并后的限界上下文与聚合元数据，但不注册 Spring Router；
+2. `CommandRouteContributor` 将已注册命令和 `@CommandRoute` 元数据组合成 `RouterSpecs` 中的 `HttpRouteContract`；
+3. WebFlux `RouterFunctionBuilder` 在运行期用已注册 Handler Factory 物化这些契约。
+
+[查看 KSP Plugin 配置。](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/build.gradle.kts#L1-L8)
+[查看 Metadata Processor。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/metadata/MetadataSymbolProcessor.kt#L61-L104)
+[查看 Command Route 贡献。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/aggregate/command/CommandRouteContributor.kt#L52-L91)
+[查看运行时 Route 物化。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/RouterFunctionBuilder.kt#L24-L42)
+
+### 7.3 Filter Chain 扩展处理但不混淆边界
+
+聚合自动配置收集有序 Exchange Filter，并构建处理链。
+[阅读 Filter 装配。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/modeling/AggregateAutoConfiguration.kt#L108-L133)
+
+只有真正属于该阶段的横切 Exchange 行为才适合放入 Filter。
+
+不要用 Filter 隐藏本应出现在聚合中的领域规则。
+
+### 7.4 TCK 保护可替换实现
+
+构建中声明了存储与总线的契约测试模块。
+[查看 TCK 模块。](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L46-L56)
+
+新增实现时：
+
+1. 实现最小所属契约；
+2. 复用相关 TCK；
+3. 增加适配器专属集成测试；
+4. 需要时在 Starter 注册 Capability 与条件配置；
+5. 除非模型确实需要，不要为了一个引擎修改公共契约。
+
+### 7.5 Capability 与 Auto-configuration 是一个扩展单元
+
+Starter 的 Feature Variants 声明可选集成。
+
+Imports 文件声明自动配置。
+
+实现模块拥有适配器。
+
+TCK 验证共同契约。
+
+评审扩展时应把这些部分作为一个完整表面检查。
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+flowchart TB
+    CONTRACT["公共契约<br>wow-api 或 wow-core"] --> ADAPTER["专属集成模块"]
+    ADAPTER --> TCK["共享 TCK"]
+    ADAPTER --> INTEGRATION["引擎集成测试"]
+    ADAPTER --> CAPABILITY["Starter Feature Capability"]
+    CAPABILITY --> AUTOCONFIG["条件自动配置"]
+    AUTOCONFIG --> RUNTIME["选中的运行时实现"]
+    METADATA["KSP 元数据"] --> RUNTIME
+    WEBFLUX["WebFlux 运行时路由"] --> RUNTIME
+```
+<!-- Sources:
+- [settings.gradle.kts:23-56](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L23-L56)
+- [wow-spring-boot-starter/build.gradle.kts:5-79](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L5-L79)
+- [wow-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports:1-31](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports#L1-L31)
+- [example/example-domain/build.gradle.kts:1-20](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/build.gradle.kts#L1-L20)
+- [wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/metadata/MetadataSymbolProcessor.kt:61-104](https://github.com/Ahoo-Wang/Wow/blob/main/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/metadata/MetadataSymbolProcessor.kt#L61-L104)
+-->
+
+# 第三部分：完成第一次贡献
+
+## 8. 环境要求
+
+下列安装命令以 macOS/Homebrew 为例；Linux 或 Windows 请使用等价的官方安装方式，并保持所需版本。每条安装命令都应以状态码 `0` 结束，然后运行验证命令并核对“预期证据”列。
+
+| Tool | Version | 用途 | 安装命令 | 验证命令 | 预期证据 |
+| --- | --- | --- | --- | --- | --- |
+| Git | 当前受支持版本 | 所有工作 | `brew install git` | `git --version` | 一行以 `git version` 开头的输出 |
+| JDK | `17` | JVM 测试与 Dokka | `brew install --cask temurin@17` | `java -version` | 版本输出包含 `17` |
+| Gradle Wrapper | `9.6.1` | JVM 构建 | 无需全局安装；用 `./gradlew --version` 启动 | `./gradlew --version` | `Gradle 9.6.1` 与 `Launcher JVM: 17...` |
+| Node.js | CI 使用 `24.18.1` | 文档与 Dashboard | `brew install node@24` | `node --version` | `v24...`；CI 精确使用 `v24.18.1` |
+| pnpm | `10.34.5` | 文档与 Dashboard | `corepack enable && corepack prepare pnpm@10.34.5 --activate` | `pnpm --version` | 精确输出 `10.34.5` |
+| Docker 兼容运行时 | 能运行 Testcontainers 的 Engine | 仅 Integration Test | `brew install --cask docker` | `docker version` | 启动运行时后同时输出 `Client` 与 `Server` 部分 |
+
+本地测试 CI 使用 Temurin Java 17，仓库中的 Wrapper 会下载 Gradle 9.6.1，无需安装全局 Gradle。
+[查看 JVM 工作流配置。](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/local-test.yml#L48-L58)
+[查看 Wrapper 版本。](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/wrapper/gradle-wrapper.properties#L1-L9)
+
+文档与 Dashboard CI 使用 Node `24.18.1` 和 pnpm `10.34.5`；两者由各自 Package Manifest 声明脚本。
+[查看文档工作流。](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/documentation-deploy.yml#L44-L86)
+[查看文档脚本。](https://github.com/Ahoo-Wang/Wow/blob/main/documentation/package.json#L6-L32)
+[查看 Dashboard CI。](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/dashboard-test.yml#L35-L63)
+[查看 Dashboard 脚本。](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/package.json#L6-L66)
+
+根构建把 Local、Contract 与容器支持的 Integration Source Set 和任务分开；本地测试通过不能证明外部存储适配器工作正常。
+[阅读测试分层定义。](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L54-L142)
+
+## 9. 验证检出
+
+以下命令从仓库根目录执行。
+
+### 9.1 确认 Wrapper 与 JVM
+
+```bash
+./gradlew --version
+```
+
+预期关键行：
+
+```text
+Gradle 9.6.1
+Launcher JVM: 17...
+```
+
+补丁版本与 Vendor 文本可能不同。
+
+仓库源码要求 Java 17 Toolchain，并固定 Wrapper 版本。
+
+### 9.2 检查 Worktree
+
+```bash
+git status --short
+git branch --show-current
+```
+
+预期结果：干净检出时 `git status --short` 没有输出，否则只列出你已经拥有的改动；`git branch --show-current` 输出准备修改的分支。
+
+不要丢弃你未创建的变更。
+
+即使工作树已有其他修改，也要保持自己的贡献范围狭窄。
+
+### 9.3 运行 Cart 规格测试
+
+```bash
+./gradlew :example-domain:test \
+  --tests 'me.ahoo.wow.example.domain.cart.CartSpec' \
+  --stacktrace
+```
+
+预期结果：
+
+```text
+BUILD SUCCESSFUL
+```
+
+耗时与任务缓存状态因机器而异。
+
+该规格覆盖添加和移除商品，以及删除与恢复 Cart 聚合。
+[阅读测试场景。](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt#L28-L87)
+
+## 10. 阅读一个完整垂直切片
+
+修改前，按以下顺序打开文件。
+
+### 第 1 步：命令与事件
+
+打开 [`AddCartItem.kt`](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/AddCartItem.kt#L1-L26)。
+
+观察：
+
+- 校验位于公开命令契约；
+- 命令名称表达意图；
+- 事件名称表达已完成事实；
+- API 类型不导入 MongoDB、Kafka 或 Spring Runtime Adapter。
+
+### 第 2 步：聚合决策
+
+打开 [`Cart.kt`](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt#L32-L76)。
+
+观察：
+
+- `@AggregateRoot` 声明聚合；
+- Route 说明命令如何定位；
+- 每个命令处理器检查当前状态；
+- 处理器返回事件；
+- 聚合不直接持久化自己。
+
+### 第 3 步：状态迁移
+
+打开 [`CartState.kt`](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt#L23-L46)。
+
+观察：
+
+- Sourcing Handler 消费事件；
+- 状态变化跟随事件事实；
+- 重放与实时处理使用同一套迁移逻辑。
+
+### 第 4 步：规格测试
+
+打开 [`CartSpec.kt`](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt#L28-L87)。
+
+观察：
+
+- 场景使用 Wow Aggregate Test DSL；
+- 命令是输入；
+- 预期事件与状态是主要输出；
+- 删除与恢复是显式行为。
+
+### 第 5 步：构建边界
+
+打开 [`example-domain/build.gradle.kts`](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/build.gradle.kts#L1-L20)。
+
+观察：
+
+- KSP 应用于 Domain 模块；
+- Domain 依赖 API 与 Framework；
+- 测试使用 Wow Test Support；
+- 行覆盖率设置 `0.8` 校验规则。
+
+## 11. 适合作为第一次贡献的任务
+
+下面是一个**教学提案**，不是仓库当前已经提交的行为。它会有意引入 `SetCartNote` 和 `CartNoteChanged` 两个新名称；其余现有类型、DSL、模块路径和命令都来自当前 Cart 垂直切片。
+
+提议的功能允许 Owner 为已初始化的购物车添加简短配送备注。它足够小，但能走完 API → 决策 → 事件 → Sourcing → Specification 全路径，不需要修改存储或模块边界。
+
+### 11.1 定义契约与影响文件
+
+行为陈述：
+
+> 给定已初始化的购物车，当 `SetCartNote` 包含非空且不超过 200 个字符的备注时，发出 `CartNoteChanged`，并把新备注 sourcing 到 `CartState`。
+
+完整变更只涉及四个文件：
+
+| 文件 | 提议的修改 |
+| --- | --- |
+| `example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/SetCartNote.kt` | 增加 Command 与 Event 契约。 |
+| `example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt` | 增加命令决策。 |
+| `example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt` | 增加状态字段与 Sourcing Handler。 |
+| `example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt` | 增加 Red/Green 行为覆盖。 |
+
+不要增加持久化代码；Event Store 会通过现有运行时路径保存新事件。
+
+### 11.2 增加 API 契约
+
+创建 `SetCartNote.kt`，保留仓库 Apache Header，并使用以下正文：
+
+```kotlin
+package me.ahoo.wow.example.api.cart
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import me.ahoo.wow.api.annotation.CommandRoute
+import me.ahoo.wow.api.annotation.Order
+import me.ahoo.wow.api.annotation.Summary
+
+@Order(4)
+@Summary("设置购物车备注")
+@CommandRoute(appendIdPath = CommandRoute.AppendPath.ALWAYS)
+data class SetCartNote(
+    @field:NotBlank
+    @field:Size(max = 200)
+    val note: String,
+)
+
+@Summary("购物车备注已变更")
+data class CartNoteChanged(
+    val note: String,
+)
+```
+
+该命令形状沿用现有带路由的 Cart Command，输入校验保持在 API 边界。
+[对照真实 `ChangeQuantity` 契约。](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/ChangeQuantity.kt#L1-L21)
+
+### 11.3 增加失败的 Specification
+
+在 `CartSpec` 中导入两个提议类型，并把以下 Fork 放入现有成功 `AddCartItem` 分支，确保购物车已经初始化：
+
+```kotlin
+fork(name = "Set cart note") {
+    val expectedNote = "Leave at reception"
+    whenCommand(SetCartNote(note = expectedNote)) {
+        expectNoError()
+        expectEventType(CartNoteChanged::class)
+        expectState {
+            note.assert().isEqualTo(expectedNote)
+        }
+    }
+}
+```
+
+[以现有已初始化 Cart 的 Fork 为准确 DSL 模型。](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt#L28-L66)
+
+只运行这个 Specification：
+
+```bash
+./gradlew :example-domain:test \
+  --tests 'me.ahoo.wow.example.domain.cart.CartSpec' \
+  --stacktrace
+```
+
+预期 Red 结果：Gradle 以 `BUILD FAILED` 结束，第一条所属原因报告未定义 `SetCartNote` Command 或缺少 `CartState.note` 实现；HTML Report 写入 `example/example-domain/build/reports/tests/test/`。
+
+### 11.4 实现决策与 Sourcing
+
+在 `Cart.kt` 导入提议类型，并加入决策：
+
+```kotlin
+@OnCommand
+fun onCommand(command: SetCartNote): CartNoteChanged {
+    return CartNoteChanged(note = command.note.trim())
+}
+```
+
+在 `CartState.kt` 增加 Import、状态字段与 Sourcing Handler：
+
+```kotlin
+var note: String? = null
+    private set
+
+@OnSourcing
+fun onCartNoteChanged(event: CartNoteChanged) {
+    note = event.note
+}
+```
+
+Aggregate 返回事实；只有 State Sourcing Function 修改重建后的状态。这与当前 `CartQuantityChanged` 的职责分离一致。
+[对照当前决策。](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt#L69-L76)
+[对照当前 Sourcing Handler。](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt#L37-L46)
+
+### 11.5 达到 Green、检查范围并验证覆盖率
+
+重新运行窄测试：
+
+```bash
+./gradlew :example-domain:test \
+  --tests 'me.ahoo.wow.example.domain.cart.CartSpec' \
+  --stacktrace
+```
+
+预期 Green 结果：`BUILD SUCCESSFUL`；测试报告仍位于 `example/example-domain/build/reports/tests/test/`。
+
+然后验证所属模块与覆盖率：
+
+```bash
+./gradlew :example-domain:check :example-domain:jacocoTestCoverageVerification --stacktrace
+```
+
+预期结果：`BUILD SUCCESSFUL`。该模块至少要求 `0.8` 行覆盖率。
+[阅读 Coverage 规则。](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/build.gradle.kts#L12-L20)
+
+最后只检查预期垂直切片：
+
+```bash
+git status --short -- \
+  example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/SetCartNote.kt \
+  example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt \
+  example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt \
+  example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt
+git diff -- \
+  example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt \
+  example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt \
+  example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt
+```
+
+预期结果：Status 列出一个新增 API 文件与三个已修改跟踪文件；Diff 只包含三个跟踪文件，没有生成输出或无关格式化。下一步 Staging 会纳入并复核新文件。CI Retry 仍只在 CI 启用；不要用本地 Retry 隐藏确定性失败。
+[阅读 Retry 配置。](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L175-L229)
+
+## 12. 贡献工作流
+
+仓库要求从 `main` 创建聚焦分支、使用 Conventional Commit、执行窄范围验证，并完整填写 Pull Request 模板。
+[阅读维护中的贡献规则。](https://github.com/Ahoo-Wang/Wow/blob/main/CONTRIBUTING.md#L50-L86)
+
+### 12.1 创建聚焦分支
+
+先妥善保存或移交无关本地改动，再执行：
+
+```bash
+git switch main
+git pull --ff-only
+git switch -c feature/cart-note
+```
+
+预期结果：`git pull` 输出 `Already up to date.` 或 Fast-forward；最后一条命令输出 `Switched to a new branch 'feature/cart-note'`。可识别前缀包括 `fix/`、`bugfix/`、`feature/`、`feat/`、`perf/`、`breaking/`、`chore/`、`build/`、`ci/` 与 `docs/`。
+
+确认分支与初始范围：
+
+```bash
+git branch --show-current
+git status --short
+```
+
+预期结果：第一条命令输出 `feature/cart-note`；编辑前第二条命令为空，或只列出你明确保留的改动。
+
+### 12.2 复现、测试先行与实现
+
+阅读 Issue、所属契约、实现、测试、构建装配与完成标准。修改前运行最窄现有测试并记录精确行为。
+
+行为变更应遵循：
+
+1. 增加聚焦的失败测试；
+2. 确认失败来自预期行为缺口，而不是环境问题；
+3. 完成最小但完整的模型变更；
+4. 保持响应式组合与模块所有权；
+5. 未明确批准时不要破坏公共 API。
+
+### 12.3 从窄到宽验证
+
+先运行窄测试，再运行所属模块 `check`。边界需要时增加 Contract 或 Integration Test；Kotlin 变更运行 Detekt，文档变更运行 VitePress Build。
+
+所有通过的 Gradle 验证都应以 `BUILD SUCCESSFUL` 结束。文档构建应无 Dead Link 或 Mermaid 错误，并写入 `documentation/docs/.vitepress/dist/`。
+
+### 12.4 只暂存并提交目标文件
+
+对于前述教学功能：
+
+```bash
+git add \
+  example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/SetCartNote.kt \
+  example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt \
+  example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt \
+  example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt
+git diff --cached --check
+git diff --cached --stat
+```
+
+预期结果：`git diff --cached --check` 没有输出；Stat 只列出四个目标路径。
+
+使用仓库 Conventional Commit 风格：
+
+```bash
+git commit -m 'feat(example): add cart note'
+```
+
+预期结果：Git 输出以 `[feature/cart-note` 开头的提交摘要，随后是新 Commit ID 与文件统计。不要提交生成输出、凭据、IDE 状态、`.gradle/` 或 `node_modules/`。
+
+### 12.5 Push 并创建 Pull Request
+
+```bash
+git push -u origin feature/cart-note
+```
+
+预期结果：Git 报告新建远程分支，并说明本地分支开始跟踪 `origin/feature/cart-note`；GitHub 通常还会输出 Compare 或 Pull Request URL。
+
+打开该 URL，完整填写 `.github/PULL_REQUEST_TEMPLATE` 的 Goal、Changes、Verification、Compatibility and risks 与 Checklist。有对应 Issue 时建立关联，披露未运行的检查，并在处理 Review Feedback 时保持分支最新。
+[阅读 Pull Request 模板。](https://github.com/Ahoo-Wang/Wow/blob/main/.github/PULL_REQUEST_TEMPLATE#L1-L23)
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+flowchart LR
+    BR["从 main 建分支<br>聚焦前缀"] --> O["定位<br>契约与所属模块"]
+    O --> R["复现<br>窄范围证据"]
+    R --> T["测试先行<br>行为变化时"]
+    T --> I["实现<br>完整垂直切片"]
+    I --> N["窄范围验证"]
+    N --> W["所属模块广验证"]
+    W --> D["检查并暂存<br>精确路径"]
+    D --> C["Conventional Commit"]
+    C --> P["Push 并创建 PR<br>模板证据"]
+    P --> V["Review 并更新分支"]
+    N -->|"失败"| R
+    W -->|"失败"| R
+```
+<!-- Sources:
+- [build.gradle.kts:54-142](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L54-L142)
+- [build.gradle.kts:175-261](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L175-L261)
+- [CONTRIBUTING.md:50-86](https://github.com/Ahoo-Wang/Wow/blob/main/CONTRIBUTING.md#L50-L86)
+- [.github/PULL_REQUEST_TEMPLATE:1-23](https://github.com/Ahoo-Wang/Wow/blob/main/.github/PULL_REQUEST_TEMPLATE#L1-L23)
+-->
+
+## 13. 测试与验证分层
+
+### 13.1 窄范围单元或规格测试
+
+用于一个类、聚合或场景。
+
+```bash
+./gradlew :wow-core:test \
+  --tests 'me.ahoo.wow.command.DefaultCommandGatewayTimeoutTest'
+```
+
+也可以运行前文的 Cart 命令。
+
+预期结果为 `BUILD SUCCESSFUL`。
+
+如果只运行一个测试方法，而不是整个测试类：
+
+```bash
+./gradlew :wow-core:test \
+  --tests 'me.ahoo.wow.command.CommandGatewayApiTest.sendAndWaitShouldUseWaitPlan'
+```
+
+预期结果为 `BUILD SUCCESSFUL`，HTML Report 中只包含 `CommandGatewayApiTest` 的选定方法。
+[阅读这个可执行测试方法。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/test/kotlin/me/ahoo/wow/command/CommandGatewayApiTest.kt#L21-L35)
+
+### 13.2 所属模块 Check
+
+```bash
+./gradlew :wow-core:check --stacktrace
+```
+
+预期结果：`BUILD SUCCESSFUL`；标准测试报告位于 `wow-core/build/reports/tests/test/`，已配置的 Contract Test 报告位于 `wow-core/build/reports/tests/contractTest/`。
+
+根构建按配置把标准测试与契约测试接入模块 Check。
+[阅读 Source Set 与任务编排。](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L94-L142)
+
+### 13.3 全部本地测试
+
+```bash
+./gradlew allLocalTest --stacktrace
+```
+
+预期结果：`BUILD SUCCESSFUL`；每个参与模块把标准测试报告写入自己的 `build/reports/tests/test/` 目录。
+
+该任务聚合标准的本地安全测试层。
+[阅读聚合任务注册。](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L232-L261)
+
+### 13.4 全部契约测试
+
+```bash
+./gradlew allContractTest --stacktrace
+```
+
+预期结果：`BUILD SUCCESSFUL`；参与模块把报告写入 `build/reports/tests/contractTest/`。
+
+用该层验证多个实现共享的行为。
+
+### 13.5 全部集成测试
+
+```bash
+./gradlew allIntegrationTest --stacktrace
+```
+
+所需引擎可用时，预期结果为 `BUILD SUCCESSFUL`；参与模块把报告写入 `build/reports/tests/integrationTest/`。引擎连接失败属于环境失败，不能算验证通过。
+
+需要 Docker 兼容运行时。
+
+外部引擎初始化通常比本地测试更慢。
+
+Integration 工作流在 CI 运行专用聚合任务。
+[阅读工作流。](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/integration-test.yml#L14-L77)
+
+### 13.6 静态分析
+
+```bash
+./gradlew detekt --stacktrace
+```
+
+预期结果：`BUILD SUCCESSFUL`，且没有剩余 Detekt Violation。由于启用了 Auto-correction，后续 `git diff` 还会显示它实际修改的源码。
+
+CI 单独运行 Detekt 工作流。
+[阅读静态分析工作流。](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/static-analysis.yml#L14-L53)
+
+根构建启用了 Detekt Auto-correction。
+[阅读配置。](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L144-L158)
+
+运行后检查 `git diff`，因为格式修改可能会写入工作树。
+
+### 13.7 覆盖率报告
+
+先运行仅本地测试的覆盖率报告；它不会调度容器支持的 Integration Test：
+
+```bash
+./gradlew :code-coverage-report:localCoverageReport
+```
+
+预期结果：`BUILD SUCCESSFUL`，并生成 `test/code-coverage-report/build/reports/jacoco/localCoverageReport/localCoverageReport.xml`。
+
+如果需要完整聚合报告，应先启动 Docker 兼容运行时。该任务依赖配置模块的 Local、Contract 与容器支持的 Integration Test，因此范围和耗时都大于 `localCoverageReport`：
+
+```bash
+./gradlew codeCoverageReport
+```
+
+所需引擎可用时，预期结果为 `BUILD SUCCESSFUL`；聚合报告写入 `test/code-coverage-report/build/reports/jacoco/codeCoverageReport/`。
+[阅读报告注册、任务依赖与输出路径。](https://github.com/Ahoo-Wang/Wow/blob/main/test/code-coverage-report/build.gradle.kts#L42-L114)
+
+### 13.8 Benchmark Smoke
+
+```bash
+./gradlew :wow-benchmarks:benchmarkSmoke
+```
+
+预期结果：选定 JMH Smoke Benchmark 打印结果行，Gradle 以 `BUILD SUCCESSFUL` 结束。
+
+Smoke 工作流检查选定 JMH Benchmark 能否执行。
+[阅读工作流。](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/benchmark-smoke.yml#L40-L58)
+
+Smoke 结果不是产品延迟或吞吐保证。
+
+提出性能结论前，必须使用受控 Benchmark 设计。
+
+### 13.9 文档构建
+
+```bash
+cd documentation
+pnpm install --shamefully-hoist
+pnpm run docs:build
+```
+
+预期结果：VitePress 完成构建，没有 Dead Link 或 Mermaid 错误，并生成 `documentation/docs/.vitepress/dist/`。
+
+CI 先运行 Dokka，再构建 VitePress。
+[阅读准确工作流。](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/documentation-deploy.yml#L44-L86)
+
+静态站点输出位于 `documentation/docs/.vitepress/dist/`。
+
+### 13.10 Dashboard 验证
+
+```bash
+cd compensation/dashboard
+pnpm install --frozen-lockfile
+pnpm exec eslint .
+pnpm build
+pnpm coverage
+```
+
+预期结果：ESLint 无错误退出，Vite 在 `compensation/dashboard/dist/` 完成生产构建，Vitest 报告测试通过，并在 `compensation/dashboard/coverage/` 生成 Coverage Artifact。
+
+这些命令与 Dashboard CI 对齐。
+[阅读工作流。](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/dashboard-test.yml#L35-L63)
+
+### 13.11 最终 Diff 检查
+
+```bash
+git diff --check
+git status --short
+git diff --stat
+```
+
+预期结果：`git diff --check` 没有输出；`git status --short` 与 `git diff --stat` 只列出预期变更集。
+
+提交前阅读真实 Diff。
+
+不要暂存生成的构建输出、本地 IDE 状态、凭据或他人的无关变更。
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+graph TB
+    SPEC["聚焦 Unit 或 AggregateSpec"] --> CHECK["所属模块 Check"]
+    CHECK --> CONTRACT["Contract Test TCK"]
+    CONTRACT --> INTEGRATION["容器 Integration Test"]
+    CHECK --> STATIC["Detekt"]
+    CHECK --> COVERAGE["JaCoCo 校验"]
+    DOCS["VitePress Build"] --> REVIEW["最终 Diff Review"]
+    INTEGRATION --> REVIEW
+    STATIC --> REVIEW
+    COVERAGE --> REVIEW
+```
+<!-- Sources:
+- [build.gradle.kts:54-142](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L54-L142)
+- [build.gradle.kts:232-261](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L232-L261)
+- [test/code-coverage-report/build.gradle.kts:42-114](https://github.com/Ahoo-Wang/Wow/blob/main/test/code-coverage-report/build.gradle.kts#L42-L114)
+- [.github/workflows/documentation-deploy.yml:44-86](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/documentation-deploy.yml#L44-L86)
+-->
+
+## 14. 调试手册
+
+先用下表选择第一个所属边界，再继续阅读后面的详细证据与操作。
+
+| 现象 | 原因 | 修复方式 |
+| --- | --- | --- |
+| HTTP 命令在聚合执行前被拒绝 | WebFlux Body 提取没有产生命令体。 | 检查 Content-Type、Body 与 Command Route，再开始排查存储。 |
+| 命令在 Bus Dispatch 前停止 | `CommandValidator` 或 Jakarta Validation 拒绝了命令体。 | 检查准确的约束违规，并用窄范围 Gateway 或 Aggregate Test 复现。 |
+| 出现重复 Request ID 异常 | 幂等协调已见过同一 Aggregate ID 与 Request ID。 | 有意重试时保留 Request ID 并检查此前处理结果；不要关闭幂等。 |
+| 找不到 Command Handler | 聚合元数据没有解析出兼容的 Command Function。 | 检查 Handler 签名和注解，重新构建 KSP 产物，再检查元数据发现。 |
+| 聚合生命周期拒绝 | 聚合未初始化且不允许创建、已删除且不是恢复命令，或非空 Owner/Space 期望与状态不一致。 | 检查生命周期标志、版本、Owner、Space 与已知事件历史。 |
+| 事件追加冲突 | 事件流标识或预期聚合版本与已存储历史冲突。 | 对比版本与 Command ID，再用对应 EventStore TCK 复现。 |
+| 等待超时 | 请求阶段没有在 Gateway 的绝对 Deadline 前发出信号。 | 记录最后观察到的阶段，检查所属 Consumer，并验证 Wait Handle 清理。 |
+| MongoDB Storage Bean 无法启动 | 已选择 Mongo Storage，但缺少必需 Database 配置。 | 先修正 Active Properties，再检查连通性。 |
+| Integration Test 无法启动引擎 | Docker 兼容运行时不可用，或外部测试引擎初始化失败。 | 启动运行时、检查容器日志，并只重跑所属模块的 Integration Task。 |
+| VitePress 报告死链接 | Locale、Rewrite 或仓库相对路径解析不正确。 | 按当前 Locale 修正链接，再运行完整文档构建。 |
+| Detekt 留下源码修改 | 根 Detekt 配置启用了 Auto-correction。 | 检查 Diff，只保留预期格式化，再运行窄范围检查。 |
+
+### 14.1 从第一个所属边界开始
+
+HTTP 命令失败时，按以下顺序检查：
+
+1. 请求体与 Header；
+2. WebFlux 提取；
+3. 命令校验；
+4. 幂等协调；
+5. Command Bus 发送；
+6. Aggregate Dispatcher 选择；
+7. 聚合状态重建；
+8. Command Handler 解析；
+9. EventStore 追加；
+10. 下游阶段通知；
+11. 等待超时与清理。
+
+这个顺序沿真实处理链定位，而不是从最终 HTTP 状态猜测。
+
+### 14.2 请求体为空
+
+现象：WebFlux 端点在聚合运行前拒绝请求。
+
+证据：`CommandHandlerFunction` 显式检测空 Body。
+[阅读该分支。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt#L54-L65)
+
+操作：
+
+- 确认请求 Content-Type；
+- 确认真正发送了 Body；
+- 确认 Route 指向预期命令端点；
+- 此时不要先调试事件存储。
+
+### 14.3 命令校验失败
+
+现象：命令在 Bus Dispatch 前停止。
+
+证据：网关在发送前校验。
+[阅读校验路径。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L79-L118)
+
+操作：
+
+- 检查命令上的 Jakarta Validation 注解；
+- 检查准确属性值；
+- 用窄范围网关或聚合测试复现；
+- 区分输入校验与领域状态拒绝。
+
+### 14.4 重复 Request ID
+
+现象：`DuplicateRequestIdException` 指出同一聚合上的 Request ID 已经出现。
+
+证据：网关组合检查 `aggregateId` 与 `requestId`，并拒绝重复组合。
+[阅读网关协调。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L94-L103)
+[阅读异常定义。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandExceptions.kt#L25-L35)
+
+操作：
+
+- 对比 Command ID 与 Request ID；
+- 判断客户端是否有意重试；
+- 检查该 Aggregate ID 与 Request ID 对应的此前处理；
+- 不要全局关闭幂等来隐藏错误标识。
+
+### 14.5 找不到 Command Handler
+
+现象：聚合无法为命令类型解析 Handler。
+
+证据：`SimpleCommandAggregate` 在处理路径中解析并调用 Handler。
+[阅读 Handler 解析分支。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L119-L132)
+
+操作：
+
+- 确认 Handler 注解与命令类型；
+- 确认 Domain 模块运行 KSP；
+- 重新构建 Domain 模块；
+- 修改 WebFlux Route 前先检查元数据发现。
+
+### 14.6 聚合生命周期拒绝
+
+现象：命令因聚合未初始化、已删除、所有者或空间规则而被拒绝。
+
+证据：调用 Handler 前会检查聚合前置条件。
+[阅读这些条件。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L91-L121)
+
+操作：
+
+- 检查 Command Create 与 Void 标志；
+- 检查聚合版本和标识维度；
+- 从已知事件历史复现；
+- 不要在传输层变通创建缺失状态。
+
+### 14.7 事件追加冲突
+
+现象：EventStore 因重复或版本冲突拒绝事件流。
+
+证据：EventStore 契约拥有 Append、Load 与 Storage Exception 行为。
+[阅读契约。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L22-L82)
+
+操作：
+
+- 对比预期与实际聚合版本；
+- 校验事件流 Command Identity；
+- 校验流中所有事件属于同一聚合；
+- 用相关 Storage TCK 复现；
+- 保持原子追加语义。
+
+### 14.8 等待超时
+
+现象：命令已发送，但 Deadline 前未观察到请求阶段。
+
+证据：网关拥有有界等待与资源清理。
+[阅读资源作用域等待。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L201-L266)
+[阅读超时覆盖。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTimeoutTest.kt#L45-L125)
+
+操作：
+
+- 记录请求的 `CommandStage`；
+- 判断最后实际发出的 Stage；
+- 检查缺失阶段所属 Consumer；
+- 验证取消会释放 Wait Handle；
+- 不要把有界 Deadline 改成无限等待。
+
+### 14.9 缺少 MongoDB Database 配置
+
+现象：MongoDB Event Sourcing 无法创建 Storage Bean。
+
+证据：缺少必需 Database 时，Mongo Auto-configuration 会显式失败。
+[阅读 EventStore 配置校验。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfiguration.kt#L134-L143)
+[阅读相关 Storage 校验。](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfiguration.kt#L201-L230)
+
+操作：
+
+- 检查 Active Profile；
+- 检查 `wow.event-sourcing.store.storage`；
+- 检查 Mongo Database 属性；
+- 与 Example Server YAML 对比；
+- 属性绑定正确后再验证连接。
+
+### 14.10 集成测试无法启动引擎
+
+现象：本地测试通过，但 Integration Test 在容器或服务启动时失败。
+
+操作：
+
+- 确认 Docker 正在运行；
+- 确认哪个模块的 `integrationTest` 失败；
+- 阅读容器日志与映射端口；
+- 单独运行该模块 Integration Task；
+- 不要把它误判为单元测试失败。
+
+构建刻意分离 Integration、Local 与 Contract 测试层。
+[阅读分层。](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L54-L142)
+
+### 14.11 文档死链接
+
+现象：VitePress Build 报告内部链接无法解析。
+
+操作：
+
+- 检查 Locale Path；
+- 检查英文 Rewrite Rule；
+- 使用仓库内的文档相对路径；
+- 构建两个语言树；
+- 未证明链接故意指向外部前，不要抑制 Dead Link。
+
+VitePress 配置会重写英文 Locale 路径。
+[阅读 Rewrite 配置。](https://github.com/Ahoo-Wang/Wow/blob/main/documentation/docs/.vitepress/config.mts#L24-L26)
+
+### 14.12 Detekt 修改了文件
+
+现象：静态分析后工作树出现格式修改。
+
+原因：根 Detekt 配置启用了 Auto-correction。
+[阅读配置。](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L144-L158)
+
+操作：
+
+- 检查 `git status --short`；
+- 保留符合预期的格式修改；
+- 只还原你拥有且已经检查的变更；
+- 重新运行窄范围检查。
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+flowchart TD
+    START["命令失败"] --> BODY{"已提取 Body?"}
+    BODY -->|"否"| WEB["检查 WebFlux 请求"]
+    BODY -->|"是"| VALID{"校验通过?"}
+    VALID -->|"否"| INPUT["检查命令约束"]
+    VALID -->|"是"| SENT{"观察到 Bus Send?"}
+    SENT -->|"否"| IDEM["检查幂等与 Bus"]
+    SENT -->|"是"| HANDLER{"已解析 Handler?"}
+    HANDLER -->|"否"| META["检查注解与 KSP 元数据"]
+    HANDLER -->|"是"| APPEND{"事件流已追加?"}
+    APPEND -->|"否"| STORE["检查版本与 EventStore"]
+    APPEND -->|"是"| STAGE{"观察到请求阶段?"}
+    STAGE -->|"否"| WAIT["追踪下游阶段与 Deadline"]
+    STAGE -->|"是"| TRANSPORT["检查响应适配"]
+```
+<!-- Sources:
+- [wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt:43-66](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt#L43-L66)
+- [wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt:79-143](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L79-L143)
+- [wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt:64-132](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L64-L132)
+- [wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt:25-123](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt#L25-L123)
+-->
+
+## 15. 常见陷阱
+
+### 陷阱 1：修改了错误模块
+
+把 API 契约放进基础设施模块，会让使用方耦合到 Adapter。
+
+从依赖方向出发，选择最低且稳定的所属边界。
+
+### 陷阱 2：在 Command Handler 中直接修改持久化状态
+
+事件溯源状态必须能从事件重现。
+
+在决策中返回事件，在 `@OnSourcing` 中应用事件。
+
+### 陷阱 3：增加事件却没有 Sourcing 行为
+
+实时命令可能发出事件，但重放会产生过期状态。
+
+同一个变更应包含 Sourcing Handler 与状态断言。
+
+### 陷阱 4：把输入校验与领域拒绝混为一谈
+
+输入形状校验属于命令边界。
+
+依赖当前聚合状态的规则属于聚合。
+
+### 陷阱 5：阻塞响应式路径
+
+`block()` 会占用事件循环能力并破坏取消语义。
+
+返回组合后的 `Mono` 或 `Flux`。
+
+### 陷阱 6：在库函数中调用 `subscribe()`
+
+隐藏订阅会让工作脱离调用方的取消与错误处理。
+
+让应用边缘拥有订阅。
+
+### 陷阱 7：混淆 KSP 元数据与运行时路由
+
+KSP 参与编译和元数据生成。
+
+WebFlux Endpoint 属于运行时集成行为。
+
+分别调试这两个边界。
+
+### 陷阱 8：只运行 Happy Path
+
+聚合创建、删除、恢复、重复、版本不匹配与超时路径都属于正确性。
+
+把现有测试作为边界清单。
+
+### 陷阱 9：把 Smoke Benchmark 当作性能保证
+
+JMH Smoke Task 证明选定 Benchmark 能执行。
+
+它不能建立端到端容量、尾延迟或生产 SLA。
+
+### 陷阱 10：把示例配置当作生产策略
+
+示例使用 MongoDB 存储与内存总线的特定组合。
+
+它是可执行示例装配，不是通用部署设计。
+
+### 陷阱 11：为了一个 Adapter 扩大公共 API
+
+先判断需求是通用还是引擎专属。
+
+如果关注点是局部的，优先使用 Adapter Option，避免污染契约。
+
+### 陷阱 12：跳过 TCK
+
+Adapter 专属测试可能通过，但仍违反共同契约。
+
+同时运行共享 TCK 与引擎 Integration Test。
+
+### 陷阱 13：忽略生成元数据漂移
+
+先修改源注解和 Processor Input。
+
+不要把手工编辑生成输出作为主要修复。
+
+### 陷阱 14：用 Retry 隐藏确定性失败
+
+CI Retry 是针对 CI 不稳定性的有界机制。
+
+它不允许保留确定性 Flaky Test。
+
+### 陷阱 15：把未运行的检查报告为通过
+
+列出准确命令与结果。
+
+如果 Docker、Node、凭据或时间阻止了广范围检查，应明确说明。
+
+# 附录 A：术语表
+
+以下定义面向贡献者，用于快速理解。
+
+精确语义请继续阅读链接中的契约。
+
+| 术语 | 贡献者视角的含义 |
+| --- | --- |
+| Wow | 本仓库的响应式 DDD、CQRS 与事件溯源框架。 |
+| DDD | Domain-driven Design，围绕领域语言与边界建模软件。 |
+| CQRS | 把命令意图与查询/读取关注点分开。 |
+| Bounded Context | 领域名称与规则保持一致含义的边界。 |
+| Named Bounded Context | 暴露上下文名称的 Wow 契约。 |
+| Aggregate | 处理命令并保护不变量的一致性边界。 |
+| Aggregate Root | 聚合面向命令的根类型。 |
+| Named Aggregate | 限界上下文中的聚合身份。 |
+| Aggregate ID | 用于定位聚合的命名聚合、聚合 `id` 和租户上下文；同一命名聚合内的 `id` 仍必须跨租户唯一。 |
+| Tenant ID | 聚合标识携带的路由与隔离上下文；它不会创建独立的 Aggregate ID 命名空间。 |
+| Owner ID | 表达聚合所有者的标识维度。 |
+| Space ID | 表达逻辑空间的标识维度。 |
+| Command | 请求执行领域行为的意图。 |
+| Command Message | 命令以及路由、标识、Header、版本与生命周期元数据。 |
+| Command ID | 命令处理及其结果事件流的标识。 |
+| Request ID | 请求级协调与幂等使用的标识。 |
+| Command Gateway | 发送命令并可等待结果的应用侧门面。 |
+| Command Bus | 把命令消息传递给 Dispatcher 的传输契约。 |
+| Local Command Bus | 进程内命令传输。 |
+| Distributed Command Bus | Kafka 等外部传输实现。 |
+| Local First | Route 允许时优先本地处理。 |
+| Command Route | 决定命令目标聚合与路径的元数据。 |
+| Command Handler | 评估命令并返回事件事实的聚合方法。 |
+| Command Validator | Dispatch 前校验命令的边界组件。 |
+| Command Stage | WaitPlan 使用的生命周期里程碑。 |
+| Wait Plan | 请求的命令阶段与 Deadline 行为。 |
+| Wait Signal | 命令到达阶段或失败的通知。 |
+| Wait Coordinator | 注册并完成命令等待的资源。 |
+| SENT | 网关已发送命令的阶段。 |
+| PROCESSED | 聚合命令处理完成的阶段。 |
+| SNAPSHOT | 与快照完成相关的阶段。 |
+| PROJECTED | 与投影完成相关的阶段。 |
+| EVENT_HANDLED | 与 Event Processor 完成相关的阶段。 |
+| SAGA_HANDLED | 与 Saga 完成相关的阶段。 |
+| Domain Event | 聚合决策发出的不可变业务事实。 |
+| Domain Event Stream | 一个命令在一个聚合上下文中发出的有序事件。 |
+| Event Store | 追加与加载领域事件流的契约。 |
+| Event Sourcing | 通过重放领域事件重建状态。 |
+| State Aggregate | 运行时状态、事件溯源行为与版本。 |
+| State Sourcing | 应用领域事件以推进聚合状态。 |
+| `@OnSourcing` | 标记事件到状态迁移处理器的注解。 |
+| Snapshot | 已知版本上的持久化聚合状态。 |
+| Snapshot Store | 快照持久化契约。 |
+| State Event | 从完成 sourcing 的状态迁移派生的下游消息。 |
+| State Event Bus | State Event 传输。 |
+| Projection | 从事件派生的读模型。 |
+| Projection Processor | 更新 Projection 的事件消费者。 |
+| Event Processor | 执行下游反应的事件消费者。 |
+| Saga | 由事件与命令协调的跨聚合或跨上下文反应。 |
+| Stateless Saga | Processor 类型自身不保存 Saga 状态的 Saga 风格。 |
+| Compensation | 分布式流程失败后的恢复或纠正工作流。 |
+| Retry | 对合格操作进行重复尝试的声明策略。 |
+| Message Bus | 框架消息的响应式 Send/Receive 抽象。 |
+| Message Subscription | 接收消息流的生命周期所有权。 |
+| Dispatcher | 把接收消息路由到所属 Processor 的组件。 |
+| Command Dispatcher | 选择 Named Aggregate 的 Dispatcher。 |
+| Aggregate Command Dispatcher | 保持 Aggregate ID 处理亲和性的 Dispatcher。 |
+| Exchange | 承载消息与处理上下文的运行时信封。 |
+| Filter | 围绕 Exchange Processing 的一个横切步骤。 |
+| Filter Chain | Filter 与终端 Processor 的有序组合。 |
+| Reactor | 本仓库用于异步组合的 JVM 响应式库。 |
+| `Mono` | 发布零个或一个 Item 的 Reactive Publisher。 |
+| `Flux` | 发布零到多个 Item 的 Reactive Publisher。 |
+| Backpressure | 由消费者需求信号约束生产。 |
+| Cancellation | 下游不再需要该操作的信号。 |
+| KSP | Kotlin Symbol Processing，运行于编译期。 |
+| Wow Compiler | 编译期处理 Wow 元数据的仓库模块。 |
+| Metadata | 对命令、聚合与 Handler 的生成或发现描述。 |
+| Spring Auto-configuration | 基于类路径与属性进行的条件 Bean 装配。 |
+| Feature Variant | 选择可选 Starter 集成的 Gradle Capability。 |
+| Storage Type | 选择 MongoDB、Redis、Elasticsearch、In-memory 或 Delay Storage 的枚举。 |
+| TCK | Technology Compatibility Kit，可复用的实现契约测试。 |
+| Aggregate Spec | 测试聚合命令、事件、错误与状态的 Wow DSL。 |
+| Saga Spec | 测试 Saga 反应的 DSL。 |
+| Given–When–Expect | 描述既有事实、命令与结果的场景结构。 |
+| Unit Test | 不依赖外部引擎的快速测试。 |
+| Contract Test | 应用于可替换实现的共享行为测试。 |
+| Integration Test | 使用真实 Adapter Wiring 与外部基础设施的测试。 |
+| Testcontainers | 为外部引擎提供容器化测试支持。 |
+| JaCoCo | JVM 覆盖率度量与校验工具。 |
+| Detekt | 仓库使用的 Kotlin 静态分析工具。 |
+| Dokka | 站点构建前使用的 Kotlin API 文档生成器。 |
+| VitePress | 静态文档站点生成器。 |
+| OpenAPI | 机器可读 HTTP API 描述支持。 |
+| WebFlux | 命令端点使用的 Spring 响应式 Web 集成。 |
+| CoSec | 授权集成模块。 |
+| CoCache | 投影缓存集成模块。 |
+| CosId | Wow 使用的 ID 生成依赖。 |
+| BI | `wow-bi` 中的商业智能同步支持。 |
+
+核心标识、命令、事件与存储定义位于以下契约：
+
+- [wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt:18-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/modeling/AggregateId.kt#L18-L45)
+- [wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt:24-125](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L24-L125)
+- [wow-api/src/main/kotlin/me/ahoo/wow/api/event/DomainEvent.kt:21-89](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/event/DomainEvent.kt#L21-L89)
+- [wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt:31-115](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L31-L115)
+- [wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt:22-82](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L22-L82)
+- [wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/StorageType.kt:16-30](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/StorageType.kt#L16-L30)
+
+# 附录 B：关键文件索引
+
+## 构建与版本
+
+| 路径 | 用途 | 为什么重要 | 来源 |
+| --- | --- | --- | --- |
+| `settings.gradle.kts` | 声明模块及其物理目录映射。 | 它是选择 Gradle Task Path 与模块归属的权威项目图。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L23-L85) |
+| `gradle.properties` | 定义项目元数据及 Kotlin/KSP 构建标志。 | 版本升级与编译器行为从这里开始。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/gradle.properties#L18-L23) |
+| `gradle/libs.versions.toml` | 集中管理库与 Plugin 版本。 | 它防止各模块的依赖版本漂移。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L1-L35) |
+| `gradle/wrapper/gradle-wrapper.properties` | 固定 Gradle Distribution。 | Wrapper 让本地与 CI 使用同一 Gradle 版本。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/wrapper/gradle-wrapper.properties#L1-L9) |
+| `build.gradle.kts` | 编排测试层、Detekt、Toolchain、Retry 与聚合任务。 | 大多数仓库级验证行为都在这里定义。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L54-L261) |
+| `wow-spring-boot-starter/build.gradle.kts` | 声明可选 Spring Feature Capability。 | 增加 Adapter 可能改变依赖解析，必须与这些 Variant 对齐。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L5-L79) |
+
+## 领域示例
+
+| 路径 | 用途 | 为什么重要 | 来源 |
+| --- | --- | --- | --- |
+| `example/example-api/src/main/kotlin/me/ahoo/wow/example/api/ExampleService.kt` | 声明 API 侧服务与限界上下文名称。 | 该名称串联示例切片的发现与路由。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/ExampleService.kt#L22-L40) |
+| `example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/AddCartItem.kt` | 定义带校验、允许创建的命令及其事件。 | 它是新增 Cart 行为时最小的公共契约范例。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/AddCartItem.kt#L1-L26) |
+| `example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/ChangeQuantity.kt` | 定义更新命令、Route 与事件。 | 它展示已有状态的显式 Aggregate ID 路由。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/ChangeQuantity.kt#L1-L21) |
+| `example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/RemoveCartItem.kt` | 定义移除商品的意图与事实。 | 它展示不耦合基础设施的紧凑 Command/Event 对。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/RemoveCartItem.kt#L1-L16) |
+| `example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/CartItem.kt` | 定义共享的 Cart Item 值。 | 命令决策与 Sourced State 都依赖这个稳定 API 类型。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/CartItem.kt#L1-L6) |
+| `example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt` | 实现聚合命令决策。 | 它是业务不变量与所发事实的所属边界。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt#L32-L76) |
+| `example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt` | 应用事件以重建 Cart State。 | 新 Cart 事件必须在这里具备 Sourcing 行为才算完整。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt#L23-L46) |
+| `example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartSaga.kt` | 用 Retry Policy 把订单事件映射为 Cart 命令。 | 它展示不保存 Saga 状态的跨聚合反应。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartSaga.kt#L25-L42) |
+| `example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt` | 规定命令、事件、错误与状态场景。 | 它是 Cart 行为变更的主要回归边界。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt#L28-L87) |
+| `example/example-domain/build.gradle.kts` | 配置 KSP、测试支持与覆盖率校验。 | 它定义该领域切片的构建与质量边界。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/build.gradle.kts#L1-L20) |
+| `example/example-server/src/main/resources/application.yaml` | 选择可执行示例的存储与 Bus 配置。 | 它展示真实示例装配，同时不代表生产政策。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-server/src/main/resources/application.yaml#L22-L99) |
+
+## 运行时契约
+
+| 路径 | 用途 | 为什么重要 | 来源 |
+| --- | --- | --- | --- |
+| `wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AggregateRoot.kt` | 声明聚合发现元数据。 | 它定义哪些聚合类型与挂载命令进入模型。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AggregateRoot.kt#L18-L77) |
+| `wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/OnCommand.kt` | 声明 Command Handler 元数据。 | Handler 发现与声明的返回类型依赖该契约。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/OnCommand.kt#L19-L86) |
+| `wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/OnSourcing.kt` | 声明事件到状态的 Sourcing 元数据。 | 重放正确性依赖解析出预期状态迁移。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/OnSourcing.kt#L18-L59) |
+| `wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt` | 定义命令信封与目标语义。 | Adapter 必须保留其路由、标识、版本与生命周期字段。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L24-L125) |
+| `wow-api/src/main/kotlin/me/ahoo/wow/api/event/DomainEvent.kt` | 定义持久化领域事件元数据。 | Sequence、Revision、Command 与 Aggregate Context 是存储不变量。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/event/DomainEvent.kt#L21-L89) |
+| `wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt` | 组合一个命令产生的不可变事件事实。 | 构造函数会校验 Body 非空，但不会独立验证每个事件是否共享同一上下文。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L31-L115) |
+| `wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt` | 定义 Append 与 Aggregate History Load。 | 所有 Storage Adapter 都必须保持该并发与重放边界。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L22-L82) |
+| `wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt` | 暴露应用侧 Send 与 Wait API。 | 它是命令调用方依赖的稳定入口契约。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt#L63-L173) |
+| `wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt` | 实现校验、幂等、等待、Deadline 与 Bus Send。 | 请求正确性和 Wait Resource 所有权在这里汇合。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L79-L301) |
+| `wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt` | 定义 Wait Stage 及其前置条件。 | 它避免把下游阶段误解成一条强制顺序链。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt#L25-L123) |
+| `wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWait.kt` | 构建 Stage 与 Chain WaitPlan。 | 调用方通过这些 Factory 表达精确完成目标。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandWait.kt#L21-L120) |
+| `wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/CommandDispatcher.kt` | 选择 Named Aggregate Dispatcher。 | 它是 Command Bus 接收后的第一层运行时路由边界。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/CommandDispatcher.kt#L37-L75) |
+| `wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/AggregateCommandDispatcher.kt` | 保持 Aggregate ID Worker 亲和性。 | 同聚合顺序与跨聚合并发都依赖它。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/AggregateCommandDispatcher.kt#L25-L86) |
+| `wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt` | 执行决策、Sourcing 并持久化事件流。 | 它是聚合正确性的核心路径。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L64-L132) |
+| `wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt` | 发布已存储的 DomainEventStream。 | 下游处理必须保持在持久追加之后。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt#L25-L46) |
+| `wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/SendStateEventFilter.kt` | 创建并发布 State Event。 | 它的错误边界决定如何暴露下游 State Event 延迟。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/SendStateEventFilter.kt#L29-L76) |
+
+## Spring 与传输
+
+| 路径 | 用途 | 为什么重要 | 来源 |
+| --- | --- | --- | --- |
+| `wow-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` | 注册 Starter Auto-configuration。 | Configuration Class 必须进入该导入面才能生效。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports#L1-L31) |
+| `wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandAutoConfiguration.kt` | 装配命令侧 Builder、Validation 与 Bus 默认实现。 | 它说明哪些 Bean 是条件式且可替换的。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandAutoConfiguration.kt#L38-L100) |
+| `wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandGatewayAutoConfiguration.kt` | 装配 Idempotency、Wait Coordination、Notifier 与 Gateway。 | Gateway 行为依赖这些协作 Bean，而不是一个孤立类。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandGatewayAutoConfiguration.kt#L51-L163) |
+| `wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/modeling/AggregateAutoConfiguration.kt` | 装配 Aggregate Processor、Filter、Handler 与 Dispatcher。 | Filter 顺序和所选实现共同定义运行时命令链。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/modeling/AggregateAutoConfiguration.kt#L70-L145) |
+| `wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfiguration.kt` | 创建条件式 Mongo Event/Snapshot Storage Binding。 | 它拥有 Mongo Event Sourcing 的属性校验与后端选择。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfiguration.kt#L54-L143) |
+| `wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt` | 适配 HTTP Body 与 Command Result。 | Empty Body 处理和响应物化发生在这个 Transport Edge。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt#L43-L66) |
+| `wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandMessageExtractor.kt` | 把 HTTP 数据提取为 Command Metadata。 | Header 与 Path 的保留从这里开始。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/extractor/CommandMessageExtractor.kt#L23-L46) |
+| `wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt` | 选择 Wait Policy 与响应模式。 | 它分离单结果与 SSE Transport 语义。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt#L30-L62) |
+| `wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/WebFluxErrorStrategy.kt` | 把运行时失败映射为 Transport Response。 | Error Compatibility 与客户端可见状态在这里汇合。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/WebFluxErrorStrategy.kt#L55-L83) |
+
+## 验证与 CI
+
+| 路径 | 用途 | 为什么重要 | 来源 |
+| --- | --- | --- | --- |
+| `.github/workflows/local-test.yml` | 在 CI 运行本地安全 JVM 测试层。 | 它是普通模块测试预期的远程参照。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/local-test.yml#L14-L70) |
+| `.github/workflows/contract-test.yml` | 在 CI 运行共享 Contract Test。 | Adapter Compatibility 结论应与该层一致。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/contract-test.yml#L14-L72) |
+| `.github/workflows/integration-test.yml` | 在 CI 运行容器支持的 Integration Test。 | 它定义外部引擎验证边界。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/integration-test.yml#L14-L77) |
+| `.github/workflows/static-analysis.yml` | 在 CI 运行 Detekt。 | Kotlin 变更在本地和远程必须满足同一静态分析配置。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/static-analysis.yml#L14-L53) |
+| `.github/workflows/benchmark-smoke.yml` | 运行适合 PR 的 JMH Smoke 集。 | 它验证 Benchmark 可执行性，但不证明产品性能。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/benchmark-smoke.yml#L40-L58) |
+| `.github/workflows/documentation-deploy.yml` | 生成 Dokka 并构建 VitePress。 | 文档变更必须对齐部署流水线，而不只是 Markdown 预览。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/documentation-deploy.yml#L44-L86) |
+| `.github/workflows/dashboard-test.yml` | 运行 Dashboard Lint、Build 与 Coverage。 | 前端验证命令应始终与该 Workflow 对齐。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/dashboard-test.yml#L35-L63) |
+| `.github/PULL_REQUEST_TEMPLATE` | 规定变更、验证与风险证据。 | 完整填写可让 Review Scope 与未运行检查保持显式。 | [源码](https://github.com/Ahoo-Wang/Wow/blob/main/.github/PULL_REQUEST_TEMPLATE#L1-L23) |
+
+# 附录 C：快速参考
+
+## 按变更类型选择命令
+
+| 变更 | 第一条命令 | 更广验证 | 预期结果 |
+| --- | --- | --- | --- |
+| Cart 行为 | `./gradlew :example-domain:test --tests 'me.ahoo.wow.example.domain.cart.CartSpec'` | `./gradlew :example-domain:check` | `BUILD SUCCESSFUL` |
+| Core Command Runtime | `./gradlew :wow-core:test --tests 'me.ahoo.wow.command.DefaultCommandGatewayTimeoutTest'` | `./gradlew :wow-core:check` | `BUILD SUCCESSFUL` |
+| Public API Contract | `./gradlew :wow-api:check` | `./gradlew allLocalTest` | `BUILD SUCCESSFUL` |
+| MongoDB Storage Contract | `./gradlew :wow-mongo:integrationTest --tests 'me.ahoo.wow.mongo.MongoEventStoreTest'` | `./gradlew :wow-mongo:check :wow-mongo:integrationTest` | Docker 可用时 `BUILD SUCCESSFUL` |
+| Spring Auto-configuration | `./gradlew :wow-spring-boot-starter:test --tests 'me.ahoo.wow.spring.boot.starter.command.CommandAutoConfigurationTest'` | `./gradlew :wow-spring-boot-starter:check` | `BUILD SUCCESSFUL` |
+| WebFlux Transport | `./gradlew :wow-webflux:test --tests 'me.ahoo.wow.webflux.route.command.CommandHandlerFunctionTest'` | `./gradlew :wow-webflux:check` | `BUILD SUCCESSFUL` |
+| Kotlin Formatting | `./gradlew :wow-core:test --tests 'me.ahoo.wow.command.DefaultCommandGatewayTimeoutTest'` | `./gradlew detekt --stacktrace` | `BUILD SUCCESSFUL`；检查 Auto-correct Diff |
+| Documentation | `cd documentation && pnpm run docs:build` | `cd documentation && pnpm run docs:build` | VitePress Build 并生成 `docs/.vitepress/dist/` |
+| Dashboard | `cd compensation/dashboard && pnpm exec vitest run src/features/Failed/__tests__/ApplyRetrySpec.test.tsx` | `cd compensation/dashboard && pnpm lint && pnpm build && pnpm coverage` | Vitest 通过；生成 `dist/` 与 `coverage/` |
+| Benchmark Code | `./gradlew :wow-benchmarks:test --tests 'me.ahoo.wow.benchmark.infrastructure.StorageBatchTuningOptionsTest'` | `./gradlew :wow-benchmarks:benchmarkSmoke` | Unit Test 与 JMH Smoke 均以 `BUILD SUCCESSFUL` 结束 |
+
+## 快速仓库地图
+
+```text
+wow-api                    契约与注解
+wow-core                   运行时与事件溯源
+wow-compiler               KSP 元数据处理器
+wow-spring                 Spring 集成原语
+wow-spring-boot-starter    Feature Capability 与自动配置
+wow-query                  查询模型
+wow-kafka                  分布式消息
+wow-mongo                  MongoDB 存储
+wow-redis                  Redis 存储
+wow-elasticsearch          Elasticsearch 事件/快照存储与查询
+wow-webflux                响应式 HTTP 命令集成
+wow-opentelemetry          Tracing 与 Metrics
+wow-cosec                  授权集成
+wow-cocache                投影缓存
+wow-apiclient              REST Client 支持
+wow-openapi                OpenAPI 支持
+wow-schema                 JSON Schema 支持
+wow-bi                     BI 同步脚本
+test                       DSL、TCK、Mock、Integration、Coverage
+compensation               补偿产品模块与 Dashboard
+example                    Kotlin 与 Java 垂直示例
+documentation              VitePress 站点
+```
+
+## 发起 Pull Request 前
+
+- [ ] 请求结果已经明确。
+- [ ] 所属模块与公共边界已经识别。
+- [ ] 行为变更有聚焦测试。
+- [ ] 事件变更包含 Sourcing 与 Replay 覆盖。
+- [ ] 响应式路径没有新增阻塞调用。
+- [ ] 没有把手工编辑生成输出作为主要修复。
+- [ ] 窄范围测试通过。
+- [ ] 所属模块 Check 通过。
+- [ ] 必要 Contract 或 Integration Test 通过。
+- [ ] 适用时运行 Detekt，并检查其修改。
+- [ ] 文档变化时完成文档构建。
+- [ ] `git diff --check` 通过。
+- [ ] 最终 Diff 只有预期文件。
+- [ ] 未运行检查与环境限制已披露。
+- [ ] 没有新增无证据的性能、SLA、数据保留或合规承诺。
+
+## 最终心智模型
+
+命令是意图。
+
+聚合做出决策。
+
+事件流把决策记录为事实。
+
+状态溯源让这些事实可以重现。
+
+事件存储保护有序历史。
+
+Event Processor、Projection 与 Saga 在下游响应。
+
+Wait Stage 把异步处理连接回调用方，但不会抹掉异步边界。
+
+模块与 TCK 让集成保持可替换。
+
+聚焦测试让领域模型可以安全演进。
+
+不确定时，把契约、实现、测试、配置与 CI Task 串成一条证据链追踪。

--- a/documentation/docs/zh/onboarding/executive-guide.md
+++ b/documentation/docs/zh/onboarding/executive-guide.md
@@ -1,0 +1,552 @@
+---
+title: 高管指南
+description: 面向 Wow 采用与运营决策的循证高管指南
+---
+
+# 高管指南
+
+## 目的与证据基线
+
+本指南说明 Wow 能支持什么、采用它需要承担什么，以及哪些业务决策
+无法由仓库替组织作出。
+
+目标读者包括工程负责人、平台负责人、架构委员会、安全评审者以及
+对交付风险负责的管理者。
+
+证据基线为 Wow 仓库的 `main` 分支。
+
+Wow 将自身定位为面向现代应用的响应式 CQRS 与 Event Sourcing 框架。
+它是框架和集成模块集合，不是完整业务产品，也不是托管服务。
+
+当前项目版本为 `8.9.5`，JVM 工具链为 17，构建使用 Kotlin `2.4.10`。
+
+来源：
+
+- [README.md:7-9](https://github.com/Ahoo-Wang/Wow/blob/main/README.md#L7-L9)
+- [gradle.properties:13-23](https://github.com/Ahoo-Wang/Wow/blob/main/gradle.properties#L13-L23)
+- [gradle/libs.versions.toml:1-35](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L1-L35)
+
+### 阅读约定
+
+- “已实现”表示仓库中存在对应生产代码或配置。
+- “已测试”表示存在相关自动化检查，不代表采用方的生产环境已验证。
+- “可选”表示该集成通过模块或 feature capability 选择，不是全局必然启用。
+- “示例”表示仓库展示了一种部署选择，不代表服务等级承诺或生产标准。
+- “未声明”表示仓库没有建立可问责的负责人、目标、政策或承诺。
+
+## 高管摘要
+
+Wow 提供命令处理、事件持久化、状态重建、投影、Saga、快照、可观测性
+接入和失败恢复工作流的模块化基础。
+
+框架围绕响应式执行设计，支持选择传输和存储技术。采用方仍需负责领域
+模型、服务边界、数据政策、生产拓扑、访问控制、容量模型、事件响应流程
+和服务目标。
+
+最适合采用的情形，是组织确实需要可审计的领域变更、异步工作流或多个
+读模型，并且有能力运营事件驱动基础设施。
+
+最不适合采用的情形，是简单 CRUD 服务既不需要事件历史和异步处理，团队
+也无法承担消息代理、存储、投影和重放带来的运营复杂度。
+
+仓库提供了较完整的工程自动化：本地、契约、集成、静态分析、Dashboard、
+补偿、Java 示例和 benchmark smoke 工作流。这些检查提高框架构建置信度，
+但不能证明采用方的可用性、延迟、恢复或合规结果。
+
+来源：
+
+- [settings.gradle.kts:23-85](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L23-L85)
+- [build.gradle.kts:50-166](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L50-L166)
+- [.github/workflows/integration-test.yml:47-75](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/integration-test.yml#L47-L75)
+- [.github/workflows/static-analysis.yml:35-53](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/static-analysis.yml#L35-L53)
+
+## 系统概览
+
+下图将采用方应用责任、框架能力和采用方选择的基础设施分开表示。
+
+```mermaid
+flowchart LR
+    U["用户与外部系统"] --> A["采用方应用"]
+    A --> W["Wow 命令与事件运行时"]
+    W --> B["选定的消息总线"]
+    W --> ES["选定的事件存储"]
+    W --> SS["选定的快照存储"]
+    B --> H["领域处理器、投影与 Saga"]
+    H --> RM["应用读模型"]
+    H -. "记录失败" .-> C["补偿服务"]
+    C --> D["补偿 Dashboard"]
+    W --> O["指标与链路追踪集成"]
+    W --> M["已注册模型元数据"]
+    M --> BI["可选 BI SQL 生成器"]
+    BI --> SQL["返回采用方执行的 SQL"]
+    SQL -. "执行" .-> CH["采用方 ClickHouse"]
+    B -. "Kafka 命令与状态事件 Topic" .-> CH
+    classDef core fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    classDef external fill:#161b22,stroke:#30363d,color:#e6edf3
+    class U,A,W,H,RM,C,D,O,M,BI,SQL core
+    class B,ES,SS,CH external
+    linkStyle default stroke:#8b949e
+```
+
+<!-- Sources: [settings.gradle.kts:23-66](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L23-L66), [wow-spring-boot-starter/build.gradle.kts:5-44](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L5-L44), [Metrics.kt:138-217](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/metrics/Metrics.kt#L138-L217), [CompensationFilter.kt:58-119](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-core/src/main/kotlin/me/ahoo/wow/compensation/core/CompensationFilter.kt#L58-L119), [GenerateBIScriptHandlerFunction.kt:87-112](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/global/GenerateBIScriptHandlerFunction.kt#L87-L112), [ClickHouseCommandRenderer.kt:108-120](https://github.com/Ahoo-Wang/Wow/blob/main/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseCommandRenderer.kt#L108-L120), [ClickHouseStateEventRenderer.kt:119-132](https://github.com/Ahoo-Wang/Wow/blob/main/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseStateEventRenderer.kt#L119-L132) -->
+
+该图描述可用集成点，不表示所有组件都在每个应用中启用，也不表示这些组件
+都由 Wow 自动部署。
+
+## 能力地图
+
+| 能力 | 状态 | 成熟度 | 依赖 | 采用边界 |
+| --- | --- | --- | --- | --- |
+| 命令分发 | 已构建 | 核心实现 | 应用领域模型、选定总线；仅 HTTP 暴露需要 WebFlux | 领域授权和业务校验仍由应用负责 |
+| Event Sourcing | 已构建 | 核心实现 | 事件存储与事件 Schema 治理 | 未提供数据增长、保留和删除政策 |
+| 快照 | 已构建 | 可配置核心能力 | 快照存储；默认类型为 MongoDB | 快照频率和存储选择需要负载验证 |
+| 投影 | 已构建 | 核心加应用定义存储 | 事件总线与应用选择的读模型存储 | Wow 不提供通用投影写入器；Schema、新鲜度和重建由采用方负责 |
+| Saga | 已构建 | 核心实现 | 事件分发和应用定义的 Saga 行为 | 业务补偿语义必须由应用设计 |
+| 消息总线 | 已构建 | 多种实现 | 默认 Kafka；可选 Redis、内存或 No-op | 交付保证取决于后端及其配置 |
+| 存储路由 | 已构建 | 可配置核心能力 | 具名事件存储和快照存储 | 路由错误和迁移流程需要治理 |
+| Web API | 已构建 | 可选集成 | WebFlux 与所选路由能力 | 未声明通用认证和限流 |
+| OpenAPI | 已构建 | 可选集成 | OpenAPI 与 WebFlux capability | 发布契约治理仍由采用方负责 |
+| 可观测性 | 已构建 | 可选插桩 | Metrics 或 OpenTelemetry 后端 | 未声明 Dashboard、告警、目标和事件负责人 |
+| 补偿 | 已构建 | 独立服务与 Dashboard | 符合条件的事件处理路径、补偿存储和运营流程 | 不是命令回滚，也不保证业务一致性 |
+| BI 脚本生成 | 已构建 | 可选集成 | 已注册模型元数据；仅在采用方执行生成 SQL 后才依赖 Kafka 命令/状态事件 Topic 与 ClickHouse | 生成过程返回 SQL，且默认使用 No-op 部署检查器；执行、数据所有权、保留和分析治理仍在框架外 |
+| 测试 DSL | 已构建 | 测试支持 | 应用测试场景 | 生产行为仍需集成与负载验证 |
+| Spring Boot 组合 | 已构建 | Feature variants | 所选存储、总线、Web、遥测和安全适配器 | 每个启用后端都会增加升级和运营责任 |
+
+来源：
+
+- [BusProperties.kt:21-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/BusProperties.kt#L21-L45)
+- [SnapshotProperties.kt:23-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/snapshot/SnapshotProperties.kt#L23-L45)
+- [StorageRoutingProperties.kt:19-36](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/routing/StorageRoutingProperties.kt#L19-L36)
+- [BuiltInHttpRoutes.kt:18-75](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contract/BuiltInHttpRoutes.kt#L18-L75)
+- [OpenAPIProperties.kt:21-27](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/openapi/OpenAPIProperties.kt#L21-L27)
+- [CompensationFilter.kt:58-119](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-core/src/main/kotlin/me/ahoo/wow/compensation/core/CompensationFilter.kt#L58-L119)
+- [BiScriptProperties.kt:55-66](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/bi/BiScriptProperties.kt#L55-L66)
+- [GenerateBIScriptHandlerFunction.kt:87-112](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/global/GenerateBIScriptHandlerFunction.kt#L87-L112)
+- [ClickHouseStateEventRenderer.kt:119-132](https://github.com/Ahoo-Wang/Wow/blob/main/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseStateEventRenderer.kt#L119-L132)
+
+## 架构概览
+
+Wow 遵循分层模块方向：API 契约进入核心运行时，Spring 集成和专用基础设施
+模块在核心之上扩展。
+
+Starter 为 MongoDB、Redis、Mock、Kafka、WebFlux、Elasticsearch、
+OpenTelemetry、OpenAPI 和 CoSec 暴露 feature capabilities。
+
+这种模块化降低强制耦合，但选择持久消息代理和存储后，部署系统仍是分布式
+应用。
+
+采用架构因此应同时记录 Wow 模块图和实际运行拓扑，两者不能互相替代。
+
+来源：
+
+- [settings.gradle.kts:23-66](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L23-L66)
+- [wow-spring-boot-starter/build.gradle.kts:5-44](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L5-L44)
+
+## 团队拓扑与协作接口
+
+仓库没有声明 `CODEOWNERS`、团队目录或服务所有权地图。下表因此是采用建议，
+不是对 Wow 维护者组织结构的陈述。
+
+| 组件 | 负责人 | 关键性 | Bus Factor |
+| --- | --- | --- | --- |
+| 应用领域模型 | 建议由产品研发负责；仓库未声明 | 高——决定业务正确性 | 未声明 |
+| 框架组合与升级 | 建议由平台工程负责；仓库未声明 | 高——影响每个采用服务 | 未声明 |
+| 消息平台 | 建议由消息平台或 SRE 负责；仓库未声明 | 选择外部总线时为高 | 未声明 |
+| 事件与快照存储 | 建议由数据平台或 SRE 负责；仓库未声明 | 高——保存恢复所需状态 | 未声明 |
+| 投影与搜索 | 建议由产品团队和数据平台负责；仓库未声明 | 按客户旅程为中到高 | 未声明 |
+| 补偿运营 | 建议由服务负责人和运维负责；仓库未声明 | 对符合条件的恢复流程为高 | 未声明 |
+| API 暴露与访问政策 | 建议由服务负责人和安全团队负责；仓库未声明 | 高——控制强操作路由 | 未声明 |
+| 可观测与事件响应 | 建议由 SRE 或可观测平台负责；仓库未声明 | 生产运营为高 | 未声明 |
+| 数据治理 | 建议由数据治理和法务负责；仓库未声明 | 受监管数据为高 | 未声明 |
+| Wow 框架贡献 | 通过贡献流程与 Wow 维护者协作；未声明个人 | 按变更为中到高 | 未声明 |
+
+贡献指南要求在实现公共 API 或依赖变更前先讨论；安全政策要求向维护者私下
+报告漏洞。两份文件都没有指定采用方生产服务的组织负责人。
+
+来源：
+
+- [CONTRIBUTING.md:1-10](https://github.com/Ahoo-Wang/Wow/blob/main/CONTRIBUTING.md#L1-L10)
+- [CONTRIBUTING.md:50-58](https://github.com/Ahoo-Wang/Wow/blob/main/CONTRIBUTING.md#L50-L58)
+- [SECURITY.md:7-21](https://github.com/Ahoo-Wang/Wow/blob/main/SECURITY.md#L7-L21)
+
+## 技术投资逻辑
+
+| 技术或模型 | 用途 | 仓库中考虑的替代方案 | 风险等级 |
+| --- | --- | --- | --- |
+| CQRS 与 Event Sourcing | 保留业务变化，并分离写行为和读视图 | 仓库决策记录未评估只保存当前状态的 CRUD 方案 | 高——事件兼容与生命周期是长期义务 |
+| 基于 Reactor 的执行 | 组合异步命令与事件工作 | 未记录替代方案 | 中——采用方代码与集成必须保持非阻塞 |
+| Spring Boot Starter | 通过配置组合可选能力 | 可直接组合模块；仓库未记录正式权衡 | 中——启用功能会扩大升级与运营范围 |
+| Kafka、Redis、内存或 No-op 总线 | 传输命令与事件 | 可选择这四类总线 | 持久生产传输为高，本地选项为低 |
+| MongoDB、Redis、Elasticsearch、内存或 Delay 存储 | 通过选定或路由存储持久化事件与快照；内存和 Delay 模式用于非持久化/测试场景 | 五种 `StorageType` 和自定义路由均可配置 | 持久存储为高——持久性和迁移取决于选择 |
+| Elasticsearch 事件/快照适配器 | 持久化并查询事件流和快照，包括搜索已存储状态 | MongoDB、Redis 和应用自定义存储仍是替代方案 | 中——索引生命周期与重建由采用方负责；它不是通用投影写入器 |
+| OpenTelemetry 与 Metrics 包装 | 导出运行时活动 | 插桩可选，后端由采用方选择 | 中——成本与隐私取决于采样和属性 |
+| 补偿服务与 Dashboard | 展示并重试符合条件的处理器失败 | 业务人工纠正仍由应用负责 | 高——不安全重试可能重复副作用 |
+
+### 为什么该模型可能创造价值
+
+事件历史可以提高可审计性，并支持在不改变原始写模型的情况下新增投影。
+
+命令处理鼓励表达明确的领域意图，而不是通用记录修改。
+
+快照在不丢弃事件历史的前提下，为长生命周期聚合提供性能机制。
+
+失败记录与受控重试能让选定异步处理器的失败对运营人员可见。
+
+### 该模型带来的成本
+
+事件 Schema 会成为长期兼容契约。
+
+投影延迟和重放会引入传统 CRUD 系统可能没有的运营状态。
+
+多个后端需要协调容量规划、升级、备份、恢复和事件响应。
+
+默认聚合删除路径会产生删除事件，并把重建状态标为 deleted。公共
+`EventStore` 契约提供 append 与 load 等操作，但没有通用擦除操作，因此采用方
+不能把默认删除命令视为仓库级数据擦除机制。
+
+运营恢复必须区分传输重试、处理器重试、事件重放、状态重建和业务补偿。
+
+来源：
+
+- [DomainEventStream.kt:31-56](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L31-L56)
+- [Snapshot.kt:19-40](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/Snapshot.kt#L19-L40)
+- [BusProperties.kt:21-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/BusProperties.kt#L21-L45)
+- [EventStoreProperties.kt:20-25](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/store/EventStoreProperties.kt#L20-L25)
+- [StorageType.kt:16-30](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/StorageType.kt#L16-L30)
+- [DelayEventStore.kt:26-29](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-mock/src/main/kotlin/me/ahoo/wow/eventsourcing/mock/DelayEventStore.kt#L26-L29)
+- [DelaySnapshotStore.kt:24-27](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-mock/src/main/kotlin/me/ahoo/wow/eventsourcing/mock/DelaySnapshotStore.kt#L24-L27)
+- [StorageRoutingProperties.kt:19-36](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/routing/StorageRoutingProperties.kt#L19-L36)
+- [ElasticsearchEventSourcingAutoConfiguration.kt:77-169](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfiguration.kt#L77-L169)
+- [WowOpenTelemetryAutoConfiguration.kt:30-69](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/WowOpenTelemetryAutoConfiguration.kt#L30-L69)
+- [CompensationFilter.kt:58-119](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-core/src/main/kotlin/me/ahoo/wow/compensation/core/CompensationFilter.kt#L58-L119)
+- [DefaultDeleteAggregateFunction.kt:25-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/DefaultDeleteAggregateFunction.kt#L25-L45)
+- [SimpleStateAggregate.kt:151-169](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/state/SimpleStateAggregate.kt#L151-L169)
+- [EventStore.kt:22-122](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L22-L122)
+
+## 依赖地图
+
+```mermaid
+flowchart TB
+    APP["运行 Wow 的采用方服务"] --> BUS["选定的消息服务"]
+    APP --> EVENT["选定的事件存储"]
+    APP --> SNAP["选定的快照存储"]
+    APP --> TELEMETRY["可选遥测后端"]
+    APP --> COMP["可选补偿服务"]
+    COMP --> COMPSTORE["补偿 MongoDB 与 Redis"]
+    COMP --> DASH["运营人员浏览器"]
+    APP --> META["已注册模型元数据"]
+    META --> BI["可选 BI SQL 生成器"]
+    BI --> SQL["生成的 SQL 响应"]
+    SQL -. "采用方执行" .-> CLICKHOUSE["采用方 ClickHouse 部署"]
+    BUS -. "默认" .-> KAFKA["Kafka"]
+    KAFKA -. "部署 BI 同步后的命令与状态事件 Topic" .-> CLICKHOUSE
+    BUS -. "替代" .-> REDIS["Redis"]
+    EVENT -. "默认" .-> MONGO["MongoDB"]
+    SNAP -. "默认" .-> MONGO
+    EVENT -. "替代" .-> ES["Elasticsearch"]
+    SNAP -. "替代" .-> ES
+    EVENT -. "替代" .-> REDIS
+    SNAP -. "替代" .-> REDIS
+    classDef service fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    classDef optional fill:#161b22,stroke:#30363d,color:#e6edf3
+    class APP,COMP,DASH,META,BI,SQL service
+    class BUS,EVENT,SNAP,TELEMETRY,COMPSTORE,CLICKHOUSE,KAFKA,REDIS,MONGO,ES optional
+    linkStyle default stroke:#8b949e
+```
+
+<!-- Sources: [BusProperties.kt:21-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/BusProperties.kt#L21-L45), [StorageType.kt:16-30](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/StorageType.kt#L16-L30), [EventStoreProperties.kt:20-25](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/store/EventStoreProperties.kt#L20-L25), [SnapshotProperties.kt:23-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/snapshot/SnapshotProperties.kt#L23-L45), [ElasticsearchEventSourcingAutoConfiguration.kt:77-169](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfiguration.kt#L77-L169), [deploy/compensation/config.yaml:38-52](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/compensation/config.yaml#L38-L52), [GenerateBIScriptHandlerFunction.kt:87-112](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/global/GenerateBIScriptHandlerFunction.kt#L87-L112), [ClickHouseCommandRenderer.kt:108-120](https://github.com/Ahoo-Wang/Wow/blob/main/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseCommandRenderer.kt#L108-L120), [ClickHouseStateEventRenderer.kt:119-132](https://github.com/Ahoo-Wang/Wow/blob/main/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseStateEventRenderer.kt#L119-L132) -->
+
+| 依赖 | 类型 | 不可用风险 |
+| --- | --- | --- |
+| 选定的消息总线，通常为 Kafka 或 Redis | 服务 | 经该总线的命令或事件交付停止或积压；具体行为取决于部署 |
+| 选定的事件存储，默认为 MongoDB | 数据服务 | 新事件持久化和需要历史的状态重建不可用 |
+| 选定的快照存储，默认为 MongoDB | 数据服务 | 快照辅助加载不可用；应用行为取决于回退和配置 |
+| Elasticsearch | 可选事件/快照数据服务 | 路由到 Elasticsearch 的事件/快照持久化和查询不可用；它不是通用应用投影写入器 |
+| OpenTelemetry 或 Metrics 后端 | 可选平台 | 框架工作可继续，但生产可见性可能降低或丢失 |
+| 示例补偿服务的 MongoDB 与 Redis | 服务与数据服务 | 失败搜索、调度或重试操作可能不可用 |
+| BI 路径使用的 Kafka 命令与状态事件 Topic | 可选服务 | 脚本生成仍可工作，但已执行的 ClickHouse Kafka Engine 无法摄入同步命令与状态事件数据 |
+| ClickHouse | 可选分析数据服务 | 默认 No-op 检查器下 SQL 生成仍可工作；已部署 BI 同步和查询不可用 |
+
+上表只描述仓库暴露的集成及其运行影响。精确故障转移、缓冲、恢复时间和业务
+影响均未声明，必须在采用方拓扑中验证。
+
+### 依赖治理问题
+
+1. 首个生产用例必须使用哪些后端？
+2. 谁负责 Spring Boot、Kotlin、消息代理、存储、遥测和安全集成的版本兼容？
+3. 采用方自己的交付流水线覆盖哪些模块组合？
+4. 路由存储变化时，事件和快照数据如何迁移？
+5. 哪些可选集成可以删除，以降低攻击面和成本？
+6. 框架或 Schema 升级的回滚路径是什么？
+
+集中版本目录记录框架依赖版本，Starter 声明其组合的集成。采用方仍需为
+选定子集建立升级和兼容政策。
+
+来源：
+
+- [gradle/libs.versions.toml:1-67](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L1-L67)
+- [wow-dependencies/build.gradle.kts:14-35](https://github.com/Ahoo-Wang/Wow/blob/main/wow-dependencies/build.gradle.kts#L14-L35)
+
+## 风险评估
+
+| 风险 | 可能性 | 影响 | 缓解措施 | 负责人 |
+| --- | --- | --- | --- | --- |
+| 事件 Schema 演进 | 中 | 高——不兼容历史可能阻断重放或重建 | 投资兼容测试、版本规则和重放演练 | 应用领域负责人；仓库未声明 |
+| 隐私与删除 | 受监管数据进入事件时为中 | 高——默认删除不是通用擦除机制 | 最小化事件数据，并审批后端特定保留或擦除策略 | 数据治理负责人；未声明 |
+| 访问控制缺口 | 未加本地控制即暴露内置路由时为高 | 高 | 明确端点、运营授权与限流设计 | 服务与安全负责人；未声明 |
+| 运营复杂度 | 选择多个外部后端时为高 | 高 | 缩小初始拓扑、定义故障行为并指定负责人 | 平台或 SRE 负责人；未声明 |
+| 恢复误用 | 中 | 高——重试可能重复副作用 | 审批包含业务安全检查的操作手册 | 服务与业务运营负责人；未声明 |
+| 容量不确定 | 采用方压测前为高 | 生产规模下为高 | 使用真实负载压测并定义容量阈值 | 服务与 SRE 负责人；未声明 |
+| 文档与版本漂移 | 当前仓库已确认 | 中 | 增加发布一致性检查或明确历史标签 | 发布负责人；未声明 |
+| 示例配置 Secret 管理 | 当前仓库已确认 | 复制到部署时为高 | 改用 Secret 注入并扫描清单 | 部署与安全负责人；未声明 |
+| 重试 UI 单位不一致 | 当前仓库已确认 | 对运营决策为高 | 运营使用前修复标签并增加契约测试 | 补偿产品负责人；未声明 |
+| 运营历史不完整 | 当前仓库已确认 | 审计为必需时为中到高 | 作出审计声明前实现或接入审计轨迹 | 补偿服务负责人；未声明 |
+| 所有权模糊 | 已确认为未声明 | 事件期间为高 | 在组织内指定服务、数据、安全和事件负责人 | 采用方高管 Sponsor |
+| 支持窗口有限 | 中 | 中 | 为及时升级和依赖验证安排预算 | 平台负责人；未声明 |
+
+来源：
+
+- [AbstractEventStreamJsonSerializer.kt:21-53](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/serialization/event/AbstractEventStreamJsonSerializer.kt#L21-L53)
+- [DefaultDeleteAggregateFunction.kt:25-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/DefaultDeleteAggregateFunction.kt#L25-L45)
+- [SimpleStateAggregate.kt:151-169](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/state/SimpleStateAggregate.kt#L151-L169)
+- [EventStore.kt:22-122](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L22-L122)
+- [wow-spring-boot-starter/build.gradle.kts:40-42](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L40-L42)
+- [EventCompensateSupporter.kt:33-69](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/compensation/EventCompensateSupporter.kt#L33-L69)
+- [ApplyRetrySpec.tsx:77-100](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/features/Failed/ApplyRetrySpec.tsx#L77-L100)
+- [IExecutionFailedState.kt:68-107](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-api/src/main/kotlin/me/ahoo/wow/compensation/api/IExecutionFailedState.kt#L68-L107)
+- [FailedHistory.tsx:14-16](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/features/Failed/FailedHistory.tsx#L14-L16)
+- [deploy/compensation/config.yaml:43-52](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/compensation/config.yaml#L43-L52)
+- [SECURITY.md:3-5](https://github.com/Ahoo-Wang/Wow/blob/main/SECURITY.md#L3-L5)
+
+## 成本与扩展模型
+
+仓库没有发布生产成本模型、价格估算、容量阈值或服务等级目标。
+
+高管规划应覆盖以下成本驱动因素。
+
+| 成本驱动 | 扩展变量 | 控制点 | 测量前未知 |
+| --- | --- | --- | --- |
+| 应用计算 | 命令与事件吞吐、处理时长 | Pod 大小、副本数、并发 | 特定负载 CPU 与内存曲线 |
+| Kafka 或 Redis 总线 | 消息速率、分区、保留、复制 | 后端拓扑和总线选择 | 消息代理容量与恢复时间 |
+| 事件存储 | 每命令事件数、负载大小、聚合寿命 | MongoDB 或路由存储容量 | 存储增长与查询延迟 |
+| 快照存储 | 快照频率和状态大小 | 快照策略与后端 | 状态重建的收益平衡点 |
+| Elasticsearch | 事件/快照数量、索引速率和查询模式 | 索引生命周期和分片设计 | 存储/查询成本与重建耗时 |
+| 补偿 | 失败率、退避、错误详情保留 | Scheduler 批量和重试政策 | 运营工作量与积压清理时间 |
+| 可观测性 | Span、指标基数、日志量 | 采样和后端保留 | 遥测摄入和存储成本 |
+| BI 路径 | 事件量、ClickHouse 拓扑、同步设计 | 脚本和拓扑配置 | 分析摄入和查询成本 |
+| 工程投入 | Schema 治理、重放测试、事件演练 | 交付与所有权模型 | 学习和支持投入 |
+
+MongoDB 事件存储的 batching 默认关闭。启用可能改变吞吐、延迟、内存压力和
+失败行为，因此必须使用真实负载验证。
+
+示例 HPA 使用最小 2、最大 10 个副本，平均 CPU 利用率目标为 80%。这是示例，
+不是通用生产建议。
+
+README 包含两分钟压测样例。其结果不能作为当前版本保证、端到端 SLA 或容量
+评估替代品。关联性能部署引用版本 `6.11.3` 和特定资源配置，而当前项目版本
+为 `8.9.5`。
+
+来源：
+
+- [MongoEventStoreBatchProperties.kt:21-42](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventStoreBatchProperties.kt#L21-L42)
+- [README.md:94-109](https://github.com/Ahoo-Wang/Wow/blob/main/README.md#L94-L109)
+- [deploy/example/perf/deployment.yaml:33-80](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/example/perf/deployment.yaml#L33-L80)
+- [deploy/example/hpa.yaml:1-18](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/example/hpa.yaml#L1-L18)
+- [deploy/compensation/hpa.yaml:1-18](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/compensation/hpa.yaml#L1-L18)
+
+## 指标与可观测性
+
+Wow 可以为总线、存储和运行时组件增加 Metrics 包装，并为聚合、投影、快照、
+Saga 和事件处理路径创建 OpenTelemetry 插桩。
+
+相关配置和类存在时，Metrics 默认启用；OpenTelemetry 集成也条件性默认启用。
+
+插桩包含消息和聚合上下文属性。仓库未声明生产 Dashboard、告警阈值、值班
+所有权、错误预算、可用性目标或延迟目标。
+
+### 建议的度量契约
+
+| 指标 | 当前值 | 目标 | 来源 |
+| --- | --- | --- | --- |
+| 命令发送/处理数量、错误与延迟 | 有插桩点；未声明生产值 | 未声明 | [Metrics.kt:138-217](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/metrics/Metrics.kt#L138-L217) |
+| 事件追加/加载延迟与失败 | 有 Metrics 包装；未声明生产值 | 未声明 | [Metrics.kt:138-217](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/metrics/Metrics.kt#L138-L217) |
+| 投影新鲜度与积压 | 未声明生产值 | 未声明 | [WowOpenTelemetryAutoConfiguration.kt:30-69](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/WowOpenTelemetryAutoConfiguration.kt#L30-L69) |
+| Saga 失败与积压 | 未声明生产值 | 未声明 | [WowOpenTelemetryAutoConfiguration.kt:30-69](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/WowOpenTelemetryAutoConfiguration.kt#L30-L69) |
+| 快照加载行为与状态大小 | 未声明生产值 | 未声明 | [Metrics.kt:138-217](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/metrics/Metrics.kt#L138-L217) |
+| 按 Dashboard 分类的补偿记录数 | 分类存在；未声明生产值 | 未声明 | [routes/constants.tsx:18-25](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/routes/constants.tsx#L18-L25) |
+| 补偿积压年龄与恢复时间 | 未声明生产值 | 未声明 | [routes/constants.tsx:18-25](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/routes/constants.tsx#L18-L25) |
+| 事件、快照、索引和错误记录增长 | 未声明生产值 | 未声明 | [EventStore.kt:22-122](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L22-L122) |
+| 消息代理与存储饱和度或可用性 | 后端监控由采用方负责 | 未声明 | [BusProperties.kt:21-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/BusProperties.kt#L21-L45) |
+
+来源：
+
+- [ConditionalOnMetricsEnabled.kt:20-28](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/metrics/ConditionalOnMetricsEnabled.kt#L20-L28)
+- [MetricsAutoConfiguration.kt:21-30](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/metrics/MetricsAutoConfiguration.kt#L21-L30)
+- [ConditionalOnOpenTelemetryEnabled.kt:21-30](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/ConditionalOnOpenTelemetryEnabled.kt#L21-L30)
+- [WowOpenTelemetryAutoConfiguration.kt:30-69](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/WowOpenTelemetryAutoConfiguration.kt#L30-L69)
+- [routes/constants.tsx:18-25](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/routes/constants.tsx#L18-L25)
+
+## 路线图边界与决策门禁
+
+仓库没有声明产品路线图、交付日期、客户承诺、弃用日历或未来服务目标。
+
+当前模块和测试只是当前实现证据。未经维护者确认，不应把 Issue、示例和可选
+能力转换成路线图承诺。
+
+```mermaid
+flowchart LR
+    E["仓库证据"] --> I{"分类"}
+    I -->|"已实现并测试"| P["可进入试点"]
+    I -->|"仅示例"| V["用采用方负载验证"]
+    I -->|"未声明"| D["需要高管决策"]
+    P --> G{"生产门禁"}
+    V --> G
+    D --> G
+    G --> O["指定负责人"]
+    G --> S["安全与数据政策"]
+    G --> L["SLO 与容量证据"]
+    G --> R["恢复与回滚演练"]
+    O --> GO["生产决策"]
+    S --> GO
+    L --> GO
+    R --> GO
+    classDef evidence fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    classDef gate fill:#161b22,stroke:#30363d,color:#e6edf3
+    class E,I,P,V,D,G,O,S,L,R,GO evidence
+    linkStyle default stroke:#8b949e
+```
+
+<!-- Sources: [CONTRIBUTING.md:1-10](https://github.com/Ahoo-Wang/Wow/blob/main/CONTRIBUTING.md#L1-L10), [.github/workflows/benchmark-smoke.yml:14-58](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/benchmark-smoke.yml#L14-L58), [SECURITY.md:3-25](https://github.com/Ahoo-Wang/Wow/blob/main/SECURITY.md#L3-L25) -->
+
+### 路线图事实边界
+
+| 问题 | 仓库已确认 | 未声明 |
+| --- | --- | --- |
+| 当前存在什么？ | 模块、代码、配置、测试、示例和发布工作流 | 生产采用量和运营结果 |
+| 下一步是什么？ | 未识别到仓库路线图文档 | 计划特性、日期和优先级 |
+| 谁批准优先级？ | 重大变更要求先讨论 | 产品委员会或具名路线图负责人 |
+| 支持什么版本？ | 当前稳定版获安全修复，旧版按情况处理 | 商业支持条款或响应时间 |
+| 发布通道是什么？ | GitHub Release 或手动工作流可发布包 | 发布节奏或升级截止日期 |
+| 产品 SLA 是什么？ | 未声明生产 SLA | 可用性、延迟、恢复和支持目标 |
+
+来源：
+
+- [SECURITY.md:3-5](https://github.com/Ahoo-Wang/Wow/blob/main/SECURITY.md#L3-L5)
+- [.github/workflows/package-deploy.yml:14-67](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/package-deploy.yml#L14-L67)
+
+### 采用工作流
+
+以下是采用方的决策工作流，不是 Wow 维护者路线图声明。
+
+| 工作流 | 业务优先级 | 状态 | 依赖或阻塞项 |
+| --- | --- | --- | --- |
+| 有界试点 | 验证事件历史或异步视图是否值得额外复杂度 | 建议下一步 | 未声明具名产品结果和试点负责人 |
+| 访问与数据政策 | 防止未授权操作和无依据隐私声明 | 生产前必需 | 未声明认证、授权、保留、擦除和合规政策 |
+| 服务目标与容量 | 把历史样例转为负载特定运营证据 | 生产前必需 | 未声明当前延迟、吞吐、可用性和容量目标 |
+| 恢复运营 | 安全执行重试、重放、恢复和事件升级 | 仓库能力部分存在；采用方流程缺失 | 未声明运营角色、审计历史和恢复目标 |
+| 发布一致性 | 减少版本或单位漂移导致的部署与运营错误 | 已确认修复需求 | 仓库证据中仍有镜像漂移、重试单位不一致和示例凭据 |
+
+## 技术债与证据缺口
+
+### 主要技术债
+
+| 问题 | 业务影响 | 修复工作量 | 优先级 |
+| --- | --- | --- | --- |
+| 重试编辑器显示毫秒，而 API 模型使用秒 | 运营人员可能按错误时间假设配置恢复 | 小到中：UI 文案加契约覆盖 | P0，Dashboard 使用前 |
+| 补偿历史视图为 stub | 不能依赖 Dashboard 宣称完整运营审计轨迹 | 中到大：定义审计源、保留和 UI | 审计为上线标准时 P1 |
+| 示例部署和 Dashboard 版本与根版本 `8.9.5` 漂移 | 采用方可能测试或部署不匹配当前源码的制品 | 小到中：对齐或标记版本并增加发布检查 | P1 |
+| 补偿示例配置含内联凭据 | 复制示例可能暴露可复用 Secret | 小：替换为占位或 Secret 引用，并扫描清单 | P0 |
+| 补偿部署声明一个副本，而 HPA 最小副本为两个 | 部署文件之间的容量和成本预期不一致 | 小：对齐示例并记录意图 | P2 |
+
+来源：
+
+- [gradle.properties:21-23](https://github.com/Ahoo-Wang/Wow/blob/main/gradle.properties#L21-L23)
+- [deploy/example/deployment.yaml:26-31](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/example/deployment.yaml#L26-L31)
+- [deploy/compensation/deployment.yaml:8-26](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/compensation/deployment.yaml#L8-L26)
+- [deploy/example/perf/deployment.yaml:33-40](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/example/perf/deployment.yaml#L33-L40)
+- [compensation/dashboard/package.json:1-16](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/package.json#L1-L16)
+- [ApplyRetrySpec.tsx:77-100](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/features/Failed/ApplyRetrySpec.tsx#L77-L100)
+- [IExecutionFailedState.kt:68-107](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-api/src/main/kotlin/me/ahoo/wow/compensation/api/IExecutionFailedState.kt#L68-L107)
+- [FailedHistory.tsx:14-16](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/features/Failed/FailedHistory.tsx#L14-L16)
+- [deploy/compensation/hpa.yaml:8-18](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/compensation/hpa.yaml#L8-L18)
+- [deploy/compensation/config.yaml:43-52](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/compensation/config.yaml#L43-L52)
+
+### 重要未知项
+
+- 生产服务负责人和升级路径。
+- 维护者 bus factor 与继任计划。
+- 可用性、延迟、吞吐、恢复和支持目标。
+- 任一负载的生产容量边界。
+- 数据分类、保留、删除、驻留和备份政策。
+- 加密要求和密钥所有权。
+- 合规认证或受监管场景批准。
+- 部署 API 的认证、授权和运营角色模型。
+- 告警阈值、Dashboard 标准和事件响应责任。
+- 路线图、交付日期、弃用日历和客户承诺。
+- 生产成本模型和预算阈值。
+- 灾备拓扑以及已验证的 RPO/RTO 目标。
+
+这些未知项不一定是框架缺陷，而是必须由采用组织补充或与维护者确认的决策。
+
+## 建议
+
+| 优先级 | 下季度建议 | 预期影响 | 完成证据 |
+| --- | --- | --- | --- |
+| 1 | 移除或外置示例凭据，修复重试单位，并对齐或标记示例版本 | 消除最直接的安全与运营误用风险 | 清单扫描通过；UI 契约测试覆盖秒；发布一致性检查自动化 |
+| 2 | 选择一个有界试点、最小后端集合，并指定服务、数据、安全和事件负责人 | 在控制成本与协作风险的同时验证价值 | 已签署的试点章程、负责人地图和退出标准 |
+| 3 | 定义端点暴露、事件数据生命周期和应用级擦除政策 | 防止无支持的访问、隐私和合规假设 | 已审批的路由清单和数据政策评审 |
+| 4 | 基于采用方拓扑执行负载、故障、重放、恢复和升级测试并建立服务目标 | 用可用的容量与恢复证据替代历史样例 | 已审批的 SLO、容量阈值、Dashboard、告警和演练记录 |
+| 5 | 依赖恢复工作流前，审批补偿操作手册与运营审计方案 | 降低重复副作用和操作不可追踪风险 | 已授权手册、审计证据、升级路径和恢复演练 |
+
+## 高管采用检查表
+
+### 价值
+
+- [ ] 领域确实需要可审计事件历史或异步流程。
+- [ ] 预期业务结果可度量。
+- [ ] 已评估更简单的 CRUD 架构。
+- [ ] 试点范围有界且可回滚。
+
+### 所有权
+
+- [ ] 已指定服务负责人。
+- [ ] 已指定消息和存储负责人。
+- [ ] 已指定安全和数据治理负责人。
+- [ ] 已定义事件指挥和升级路径。
+- [ ] 已分配升级和依赖所有权。
+
+### 可靠性
+
+- [ ] 服务目标书面化且可测量。
+- [ ] 已定义投影延迟和补偿积压目标。
+- [ ] 已安排备份、恢复、重放和灾备测试。
+- [ ] 容量证据来自采用方实际负载。
+- [ ] 没有把 README 压测样例当作 SLA。
+
+### 安全与隐私
+
+- [ ] 已清点并保护内置 HTTP 路由。
+- [ ] 运营操作已授权且可审计。
+- [ ] 已分类事件、Header、快照和错误数据。
+- [ ] 已批准保留和删除行为。
+- [ ] Secret 已从清单外部注入。
+- [ ] 合规声明由组织证据支持。
+
+### 交付
+
+- [ ] 采用方 CI 运行本地、契约、集成和静态检查。
+- [ ] 存在 Schema 兼容性和重放测试。
+- [ ] 框架与后端升级有回滚方案。
+- [ ] 部署版本一致且可追踪。
+- [ ] 每个可选模块都有明确理由。
+
+## 最终决策结论
+
+Wow 提供了较完整的事件驱动应用框架，包含模块化存储、传输、Web、
+可观测性、测试和恢复能力。
+
+它不提供采用方的运营模型。因此，生产决策应建立在有界试点、真实负载证据、
+明确所有权、显式数据与安全政策，以及经过演练的恢复路径之上。
+
+当本指南标记“未声明”时，正确的下一步是取得决策或证据，而不是从示例或
+实现细节中推断承诺。

--- a/documentation/docs/zh/onboarding/index.md
+++ b/documentation/docs/zh/onboarding/index.md
@@ -1,0 +1,49 @@
+# Wow 入门中心
+
+欢迎来到 Wow。
+
+本页按读者需要做出的决策，将你分流到最合适的入门指南。
+
+Wow 是围绕 CQRS 与事件溯源构建的响应式领域驱动设计框架，项目的[能力概览](https://github.com/Ahoo-Wang/Wow/blob/main/README.md#L51-L84)对此进行了说明。
+当前仓库基线为 Wow `8.9.5`、Kotlin `2.4.10`、Spring Boot `4.1.0`、Gradle `9.6.1` 与 Java `17`。
+这些版本以仓库配置为准，而不是以本文为准：[项目版本](https://github.com/Ahoo-Wang/Wow/blob/main/gradle.properties#L18-L23)、[依赖版本](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L1-L35)、[Gradle Wrapper](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/wrapper/gradle-wrapper.properties#L1-L9) 与 [JVM Toolchain](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L175-L190)。
+
+## 选择阅读路径
+
+| 读者 | 从这里开始 | 你将学到什么 | 建议时间 |
+| --- | --- | --- | --- |
+| 贡献者 | [贡献者指南](./contributor-guide.md) | 配置仓库、理解运行时、实现垂直切片、验证并准备可评审变更。 | 约 30 分钟 |
+| Staff Engineer | [Staff Engineer 指南](./staff-engineer-guide.md) | 判断模块边界、扩展契约、运行时不变量、迁移与架构决策。 | 约 45 分钟 |
+| 管理者 | [管理者指南](./executive-guide.md) | 理解产品形态、工程模型、战略优势、依赖与交付风险。 | 约 20 分钟 |
+| 产品经理 | [产品经理指南](./product-manager-guide.md) | 将领域行为转换为命令、事件、验收标准、可观测性与发布范围。 | 约 20 分钟 |
+
+## 推荐阅读顺序
+
+第一次参与代码贡献，请从[贡献者指南](./contributor-guide.md)开始。
+
+架构负责人可以先读贡献者指南，再继续阅读 [Staff Engineer 指南](./staff-engineer-guide.md)。
+
+产品与管理读者可以直接进入对应指南，在需要实现细节时再回到贡献者指南。
+
+## 事实来源原则
+
+这些指南解释仓库，但不能替代仓库。
+
+当文字与代码不一致时，应以已提交的 Gradle 配置、公开契约、实现、测试与 CI 工作流为准。
+[模块清单](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L23-L85)、[测试任务编排](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L54-L142)、[本地测试工作流](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/local-test.yml#L14-L70) 与 [集成测试工作流](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/integration-test.yml#L14-L77) 是首要事实来源。
+
+## 这些指南刻意不做的事
+
+指南不会承诺代码与运行配置没有保障的延迟、吞吐量、可用性、数据保留或合规指标。
+
+指南也不会把 KSP 描述成 HTTP 路由生成器。
+在本仓库中，KSP 属于编译器与元数据流水线；运行期 WebFlux 路由与 OpenAPI 支持仍由显式模块和自动配置承担：[示例 KSP 配置](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/build.gradle.kts#L1-L8)、[元数据 Processor 输出](https://github.com/Ahoo-Wang/Wow/blob/main/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/metadata/MetadataSymbolProcessor.kt#L61-L104)、[WebFlux 处理器](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt#L43-L66) 与 [Starter Feature Variants](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L5-L44)。
+
+## 常用入口
+
+- [仓库 README](https://github.com/Ahoo-Wang/Wow/blob/main/README.md#L41-L84)
+- [模块声明](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L23-L85)
+- [Cart 示例 API](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/cart/AddCartItem.kt#L1-L26)
+- [Cart 聚合](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt#L32-L76)
+- [Cart 规格测试](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt#L28-L87)
+- [运行时测试指南](../guide/test-runtime.md)

--- a/documentation/docs/zh/onboarding/product-manager-guide.md
+++ b/documentation/docs/zh/onboarding/product-manager-guide.md
@@ -1,0 +1,678 @@
+---
+title: 产品经理指南
+description: 面向产品能力、用户旅程、数据、API、限制与运营决策的 Wow 指南
+---
+
+# 产品经理指南
+
+## 目的与证据基线
+
+本指南用产品语言解释 Wow：用户可以做什么、它可以支持哪些产品流程、会处理
+哪些数据，以及哪些决策仍然属于应用团队。
+
+目标读者包括产品经理、交付负责人、业务分析师、设计师、客户支持负责人以及
+评估 Wow 应用的工程合作伙伴。
+
+证据基线为 Wow 仓库的 `main` 分支。
+
+Wow 将自身定义为响应式 CQRS 与 Event Sourcing 框架。它是用于构建应用的
+工具箱，不是现成的客户产品、托管平台或产品发现的替代品。
+
+当前仓库版本为 `8.9.5`。
+
+来源：
+
+- [README.md:7-9](https://github.com/Ahoo-Wang/Wow/blob/main/README.md#L7-L9)
+- [gradle.properties:21-29](https://github.com/Ahoo-Wang/Wow/blob/main/gradle.properties#L21-L29)
+
+## Wow 帮助解决什么问题？
+
+很多业务系统需要的不只是数据库中最新的一行数据。
+
+它们可能需要知道哪个请求改变了订单、重建账户如何到达当前状态、更新多个
+读视图，或在临时故障后恢复异步处理器。
+
+Wow 为这些需求提供工程构件：
+
+- **命令（Command）** 表达用户或系统希望执行的动作。
+- **聚合（Aggregate）** 在一个一致性边界内检查业务规则。
+- **领域事件（Domain Event）** 记录已经发生的事情。
+- **事件流（Event Stream）** 按顺序组合一个命令产生的事件。
+- **快照（Snapshot）** 保存当前状态检查点，以加快加载。
+- **投影（Projection）** 更新为读取或搜索优化的视图。
+- **Saga** 响应事件并协调较长的工作流。
+- **补偿记录** 让选定事件处理器的失败可见并可重试。
+
+这些概念能让行为和历史更明确，也会增加必须设计的产品与运营状态：待处理、
+读视图延迟、处理失败、重试、重放和数据保留。
+
+来源：
+
+- [CommandMessage.kt:53-125](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L53-L125)
+- [DomainEventStream.kt:31-56](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L31-L56)
+- [Snapshot.kt:19-40](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/Snapshot.kt#L19-L40)
+
+## 产品边界
+
+Wow 可以提供框架行为和技术端点。
+
+采用方仍需定义：
+
+- 客户体验和运营体验。
+- 业务命令及其校验规则。
+- 事件名称、含义和兼容性。
+- 客户可以看到哪些读模型。
+- 对用户而言，“完成”“处理中”“失败”和“已恢复”分别意味着什么。
+- 认证、授权、限流和运营角色。
+- 服务等级、支持承诺和升级路径。
+- 数据分类、保留、删除和驻留政策。
+- 产品路线图和交付日期。
+
+仓库没有声明这些应用特定选择。
+
+## 主要用户旅程
+
+正常旅程从应用请求开始。聚合校验请求，接受的变化成为事件，下游处理器据此
+更新其他视图或工作流。
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "secondaryBorderColor": "#30363d", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+flowchart LR
+    U["用户或外部系统"] --> UI["产品界面"]
+    UI --> C["提交命令"]
+    C --> A{"业务规则接受？"}
+    A -->|"否"| E["返回校验或业务错误"]
+    A -->|"是"| EV["持久化领域事件流"]
+    EV --> ACK["返回命令结果"]
+    EV --> H["分发给投影和 Saga"]
+    H --> R["更新客户或运营读视图"]
+    H -. "处理器失败" .-> F["记录符合条件的失败"]
+    classDef journey fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    classDef boundary fill:#161b22,stroke:#30363d,color:#e6edf3
+    class U,UI,C,A,E,EV,ACK,H,R,F journey
+    linkStyle default stroke:#8b949e
+```
+
+<!-- Sources: [CommandMessage.kt:53-125](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L53-L125), [DomainEventStream.kt:31-56](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L31-L56), [CompensationFilter.kt:58-119](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-core/src/main/kotlin/me/ahoo/wow/compensation/core/CompensationFilter.kt#L58-L119) -->
+
+### 这段旅程中的产品决策
+
+1. 产品是等待处理结果，还是先确认已接收？
+2. 哪些失败需要立即向用户展示？
+3. 命令接受后，读视图是否允许暂时落后？
+4. 什么文案可以解释“处理中”，又不会让用户以为数据丢失？
+5. 支持人员可以安全查看哪个关联标识或请求标识？
+6. 哪些操作允许客户在界面上安全重试？
+7. 哪些流程必须进入人工审核？
+
+Wow 提供统一命令提交路由；单独的 wait 路由只接收 `SimpleWaitSignal` 通知，
+不负责提交命令。应用仍需决定合适的交互模式。
+
+来源：
+
+- [BuiltInHttpRoutes.kt:18-25](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contract/BuiltInHttpRoutes.kt#L18-L25)
+- [CommandWaitRouteContributor.kt:31-65](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/global/CommandWaitRouteContributor.kt#L31-L65)
+- [CommandWaitHandlerFunction.kt:32-44](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/wait/CommandWaitHandlerFunction.kt#L32-L44)
+- [CommandFacadeRouteContributor.kt:30-55](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/global/CommandFacadeRouteContributor.kt#L30-L55)
+- [CommandFacadeHandlerFunction.kt:35-52](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandFacadeHandlerFunction.kt#L35-L52)
+
+## 失败恢复旅程
+
+补偿子系统记录选定事件处理路径中的失败。运营人员可以查看记录、调整重试
+参数、修改受支持的函数引用、标记可恢复性、准备重试或强制准备。
+
+它不会撤销原命令，也不会自动或无条件恢复业务一致性。重试会再次执行符合条件
+的事件处理；如果应用没有实现安全重复，外部副作用可能再次发生。
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "secondaryBorderColor": "#30363d", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+stateDiagram-v2
+    [*] --> Failed: 符合条件的事件处理器失败
+    Failed --> Prepared: 允许重试时准备
+    Failed --> Prepared: 经授权运营人员强制准备
+    Prepared --> Succeeded: 重试处理成功
+    Prepared --> Failed: 重试处理失败
+    Failed --> Failed: 修改重试参数或函数
+    Failed --> Failed: 修改可恢复性
+    Succeeded --> [*]
+    classDef status fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    class Failed,Prepared,Succeeded status
+```
+
+<!-- Sources: [ExecutionFailedState.kt:65-99](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-domain/src/main/kotlin/me/ahoo/wow/compensation/domain/ExecutionFailedState.kt#L65-L99), [Actions.tsx:32-105](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/features/Failed/Actions.tsx#L32-L105), [ChangeFunction.tsx:28-123](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/features/Failed/ChangeFunction.tsx#L28-L123) -->
+
+### 运营人员旅程
+
+1. 打开 To Retry、Executing、Next Retry、NonRetryable、Succeeded 或
+   Unrecoverable 等失败分类。
+2. 按记录、事件、聚合、上下文或函数信息筛选。
+3. 检查错误详情、事件标识、租户、聚合、重试政策和可恢复性。
+4. 根据涉及的业务副作用判断重试是否安全。
+5. 在允许时，通过授权流程准备记录或强制准备。
+6. 观察重试是回到 Failed，还是到达 Succeeded。
+7. 升级处理无法安全自动恢复的记录。
+
+Dashboard 当前提供这些分类和操作。仓库没有声明运营角色模型、审批工作流、
+审计保留期或响应时间目标。
+
+来源：
+
+- [routes/constants.tsx:18-71](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/routes/constants.tsx#L18-L71)
+- [FailedSearch.tsx:24-95](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/features/Failed/FailedSearch.tsx#L24-L95)
+- [FailedDetails.tsx:29-223](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/features/Failed/details/FailedDetails.tsx#L29-L223)
+
+## 产品能力地图
+
+这里的“已上线”仅表示仓库存在实现，不表示每个采用方应用都已启用、运营或
+承诺支持该能力。
+
+| 产品需求 | Wow 能力 | 状态 | 用户可能感知的结果 | 限制 |
+| --- | --- | --- | --- | --- |
+| 表达意图 | 命令 | 已上线 | 提交具名业务动作 | 应用定义文案、校验和权限 |
+| 保留历史 | 领域事件和事件流 | 已上线 | 支持人员可追踪状态如何变化 | 应用决定哪些数据可长期保存 |
+| 加载当前状态 | 状态重建和快照 | 已上线 | 可加载当前业务状态 | 应用定义新鲜度和错误体验 |
+| 构建查询视图 | 投影 | 已上线 | 可构建面向任务的列表和搜索 | 必要时由应用解释更新延迟 |
+| 协调工作流 | Saga | 已上线 | 多步骤流程可以响应事件 | 应用定义等待、超时和取消状态 |
+| 路由消息 | Kafka、Redis、内存或 No-op 总线 | 已上线 | 通常对用户不可见 | 保证与故障行为取决于选项 |
+| 路由存储 | 按模型选择事件与快照存储 | 已上线 | 不同领域可使用不同后端 | 迁移与支持复杂度由采用方负责 |
+| 通过 HTTP 提交 | 内置命令路由 | 已上线 | 产品或集成客户端可发送动作 | 端点需要本地保护和客户端错误设计 |
+| 查看元数据 | 元数据端点 | 已上线 | 工具可发现已注册模型 | 暴露决策由采用方负责 |
+| 生成全局 ID | ID 端点 | 已上线 | 客户端可请求文本标识 | 信任边界和可用性要求由采用方负责 |
+| 运营失败 | 补偿服务和 Dashboard | 已上线 | 运营人员查看并重试选定失败 | 历史视图不完整；未提供角色与安全重试政策 |
+| 描述端点 | OpenAPI 集成 | 已上线 | 客户端工具可读取 API 描述 | 版本与生成客户端治理由采用方负责 |
+| 观察运行时 | Metrics 与 OpenTelemetry | 已上线 | 支持人员可关联处理活动 | 未提供 Dashboard、告警与支持手册 |
+| 生成 BI 脚本 | 可选 ClickHouse 向 SQL 生成 | 已上线 | 数据团队获得基于已注册模型元数据生成的 SQL；执行后由 ClickHouse Kafka Engine 消费命令与状态事件 Topic | 默认使用 No-op 部署检查器；SQL 执行、Kafka、ClickHouse、数据流动和分析政策由采用方负责 |
+| 测试领域规则 | 聚合测试 DSL | 已上线 | 团队可验证业务行为 | 产品场景和边界条件由应用维护 |
+
+来源：
+
+- [BuiltInHttpRoutes.kt:18-75](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contract/BuiltInHttpRoutes.kt#L18-L75)
+- [BusProperties.kt:21-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/BusProperties.kt#L21-L45)
+- [StorageRoutingProperties.kt:19-36](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/routing/StorageRoutingProperties.kt#L19-L36)
+- [WowOpenTelemetryAutoConfiguration.kt:30-69](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/WowOpenTelemetryAutoConfiguration.kt#L30-L69)
+- [CompensationFilter.kt:58-119](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-core/src/main/kotlin/me/ahoo/wow/compensation/core/CompensationFilter.kt#L58-L119)
+- [OpenAPIProperties.kt:21-27](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/openapi/OpenAPIProperties.kt#L21-L27)
+- [BiScriptProperties.kt:30-52](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/bi/BiScriptProperties.kt#L30-L52)
+- [BiScriptProperties.kt:55-66](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/bi/BiScriptProperties.kt#L55-L66)
+- [GenerateBIScriptHandlerFunction.kt:87-112](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/global/GenerateBIScriptHandlerFunction.kt#L87-L112)
+- [ClickHouseCommandRenderer.kt:108-120](https://github.com/Ahoo-Wang/Wow/blob/main/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseCommandRenderer.kt#L108-L120)
+- [ClickHouseStateEventRenderer.kt:119-132](https://github.com/Ahoo-Wang/Wow/blob/main/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseStateEventRenderer.kt#L119-L132)
+- [AggregateSpec.kt:69-109](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-test/src/main/kotlin/me/ahoo/wow/test/AggregateSpec.kt#L69-L109)
+
+## 产品数据模型
+
+下图展示框架记录如何把一个请求连接到持久事件、当前状态、读模型和失败记录。
+
+```mermaid
+%%{init: {"theme": "dark", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "secondaryBorderColor": "#30363d", "tertiaryColor": "#161b22", "clusterBkg": "#161b22", "clusterBorder": "#30363d"}}}%%
+erDiagram
+    COMMAND_MESSAGE ||--o| DOMAIN_EVENT_STREAM : 可能产生
+    DOMAIN_EVENT_STREAM ||--|{ DOMAIN_EVENT : 包含
+    AGGREGATE ||--o{ DOMAIN_EVENT_STREAM : 拥有历史
+    AGGREGATE ||--o| SNAPSHOT : 可能拥有
+    DOMAIN_EVENT ||--o{ READ_MODEL : 更新
+    DOMAIN_EVENT ||--o{ EXECUTION_FAILED : 可能产生
+    COMMAND_MESSAGE {
+        string commandId
+        string requestId
+        string aggregateId
+        string tenantId
+        object body
+    }
+    DOMAIN_EVENT {
+        string eventId
+        string eventType
+        int version
+        json body
+    }
+    SNAPSHOT {
+        object state
+        long snapshotTime_epochMillis
+    }
+    EXECUTION_FAILED {
+        string eventId
+        string status
+        string errorDetails
+        int retries
+    }
+```
+
+<!-- Sources: [SimpleCommandMessage.kt:46-60](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/SimpleCommandMessage.kt#L46-L60), [DomainEventStream.kt:31-42](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L31-L42), [DomainEventStream.kt:100-115](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L100-L115), [EventStreamRecord.kt:35-122](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/serialization/event/EventStreamRecord.kt#L35-L122), [Snapshot.kt:19-40](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/Snapshot.kt#L19-L40), [IExecutionFailedState.kt:28-44](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-api/src/main/kotlin/me/ahoo/wow/compensation/api/IExecutionFailedState.kt#L28-L44) -->
+
+被拒绝或 Void 命令可以不产生事件流。当事件流存在时，其 Command ID 唯一对应
+一个非空事件流。
+
+### 数据清单
+
+| 数据 | 代码中的字段示例 | 存在目的 | 产品与隐私问题 |
+| --- | --- | --- | --- |
+| 命令消息 | Body、聚合 ID、租户 ID、请求 ID、命令 ID、Header、创建时间 | 承载用户或系统意图 | Body 或元数据是否含个人数据？ |
+| 领域事件 | 事件 Body、事件 ID、类型、版本、聚合上下文、时间戳 | 记录已接受的业务变化 | 不可变历史可以保留多久？ |
+| 事件流 | 命令/请求标识、租户、Owner、Space、有序事件 | 连接一个命令及其变化 | 谁可查看完整历史？ |
+| 快照 | 当前状态与快照时间 | 加快状态加载 | 是否复制了事件中的敏感数据？ |
+| 读模型 | 应用定义字段 | 支持产品查询与搜索 | 新鲜度和删除行为是什么？ |
+| 失败记录 | 错误消息、Stack Trace、绑定错误、事件标识、重试状态 | 支持诊断和重试 | 技术错误是否泄漏个人数据或 Secret？ |
+| 请求元数据 | User-Agent 和远程 IP 可加入 Header | 支持关联与上下文 | 是否需要告知、最小化或脱敏？ |
+| Trace 与 Metrics 属性 | 消息、请求、Trace、聚合元数据 | 支持运营可见性 | 哪些标识可安全导出？ |
+
+来源：
+
+- [MessageSerializer.kt:26-65](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/serialization/MessageSerializer.kt#L26-L65)
+- [AbstractEventStreamJsonSerializer.kt:21-53](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/serialization/event/AbstractEventStreamJsonSerializer.kt#L21-L53)
+- [IExecutionFailedState.kt:28-44](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-api/src/main/kotlin/me/ahoo/wow/compensation/api/IExecutionFailedState.kt#L28-L44)
+- [WowInstrumenter.kt:26-35](https://github.com/Ahoo-Wang/Wow/blob/main/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/WowInstrumenter.kt#L26-L35)
+
+## 配置与功能开关
+
+配置控制技术行为。产品经理需要理解，当运营人员修改这些值时，哪些用户可见
+状态可能发生变化。
+
+| 配置 | 仓库默认值 | 产品影响 | 谁可以修改 |
+| --- | --- | --- | --- |
+| `wow.enabled` | `true` | 启用 Wow 运行时集成 | 部署运营人员 |
+| 关闭超时 | 60 秒 | 为进行中任务提供停止时间；不代表恢复目标 | 部署运营人员 |
+| 关闭静默期 | 1 秒 | 关闭时增加静默间隔 | 部署运营人员 |
+| 总线类型 | Kafka | 选择默认命令/事件传输 | 平台或部署运营人员 |
+| Local-first 总线 | `true` | 支持时优先本地处理 | 平台或部署运营人员 |
+| 事件存储 | MongoDB；可选 Redis、Elasticsearch、内存或 Delay | 选择事件持久化；内存和 Delay 模式面向非持久化/测试场景 | 平台或部署运营人员 |
+| 快照 | 启用 | 允许保存状态检查点 | 平台或部署运营人员 |
+| 快照存储 | MongoDB；可选 Redis、Elasticsearch、内存或 Delay | 选择快照持久化；内存和 Delay 模式面向非持久化/测试场景 | 平台或部署运营人员 |
+| Prepare 支持 | 启用 | 启用聚合准备能力 | 应用或部署运营人员 |
+| OpenAPI | 启用 | 提供 API 描述支持 | 应用或部署运营人员 |
+| WebFlux 集成 | 启用 | 提供 HTTP 集成；不通用提供认证和限流 | 应用或部署运营人员 |
+| 全局 WebFlux 错误处理 | 启用 | 使用框架公共错误处理 | 应用或部署运营人员 |
+| WebFlux 批量并发 | 1 | 按配置并发处理批量项 | 部署运营人员 |
+| 补偿 | 启用 | 提供补偿集成；安全重试政策另行定义 | 应用或部署运营人员 |
+| 补偿最大重试 | 10 | 限制自动重试次数 | 补偿服务运营人员 |
+| 补偿最小退避 | 180 秒 | 延迟重试；UI 当前错误标为毫秒 | 补偿服务运营人员 |
+| 补偿执行超时 | 120 秒 | 限制一次执行；UI 当前错误标为毫秒 | 补偿服务运营人员 |
+| 补偿 Scheduler 批量 | 100 | 限制单批处理记录数 | 补偿服务运营人员 |
+| 补偿 Scheduler 周期 | 60 秒 | 设置调度周期；不构成恢复 SLA | 补偿服务运营人员 |
+| Metrics | 支持时启用 | 产生运行时度量 | 平台或部署运营人员 |
+| OpenTelemetry | 条件性启用 | 依赖存在时产生 Trace | 平台或部署运营人员 |
+| BI 脚本 | 启用 | 从已注册模型元数据生成 SQL 并返回调用方；不执行 SQL | 应用或部署运营人员 |
+| BI 部署检查器 | No-op | 生成期间不联系 ClickHouse；切换到 ClickHouse 检查器后才会检查 | 数据平台或部署运营人员 |
+| BI 拓扑 | Cluster | 选择默认 ClickHouse 拓扑 | 数据平台或部署运营人员 |
+| MongoDB 事件存储 batching | 关闭 | 启用后改变写入权衡 | 平台或部署运营人员 |
+
+来源：
+
+- [WowProperties.kt:23-35](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/WowProperties.kt#L23-L35)
+- [BusProperties.kt:21-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/BusProperties.kt#L21-L45)
+- [EventStoreProperties.kt:20-25](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/store/EventStoreProperties.kt#L20-L25)
+- [StorageType.kt:16-30](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/StorageType.kt#L16-L30)
+- [DelayEventStore.kt:26-29](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-mock/src/main/kotlin/me/ahoo/wow/eventsourcing/mock/DelayEventStore.kt#L26-L29)
+- [DelaySnapshotStore.kt:24-27](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-mock/src/main/kotlin/me/ahoo/wow/eventsourcing/mock/DelaySnapshotStore.kt#L24-L27)
+- [ElasticsearchEventSourcingAutoConfiguration.kt:77-169](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfiguration.kt#L77-L169)
+- [SnapshotProperties.kt:23-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/snapshot/SnapshotProperties.kt#L23-L45)
+- [PrepareProperties.kt:21-42](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/prepare/PrepareProperties.kt#L21-L42)
+- [OpenAPIProperties.kt:21-27](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/openapi/OpenAPIProperties.kt#L21-L27)
+- [WebFluxProperties.kt:22-44](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxProperties.kt#L22-L44)
+- [CompensationProperties.kt:21-27](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/compensation/CompensationProperties.kt#L21-L27)
+- [Retry.kt:57-99](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/Retry.kt#L57-L99)
+- [server CompensationProperties.kt:21-33](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-server/src/main/kotlin/me/ahoo/wow/compensation/server/configuration/CompensationProperties.kt#L21-L33)
+- [SchedulerProperties.kt:22-37](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-server/src/main/kotlin/me/ahoo/wow/compensation/server/scheduler/SchedulerProperties.kt#L22-L37)
+- [BiScriptProperties.kt:30-52](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/bi/BiScriptProperties.kt#L30-L52)
+- [BiScriptProperties.kt:55-66](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/bi/BiScriptProperties.kt#L55-L66)
+- [BiScriptProperties.kt:110-165](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/bi/BiScriptProperties.kt#L110-L165)
+- [GenerateBIScriptHandlerFunction.kt:87-112](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/global/GenerateBIScriptHandlerFunction.kt#L87-L112)
+- [MongoEventStoreBatchProperties.kt:21-42](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventStoreBatchProperties.kt#L21-L42)
+- [ConditionalOnMetricsEnabled.kt:20-28](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/metrics/ConditionalOnMetricsEnabled.kt#L20-L28)
+- [ConditionalOnOpenTelemetryEnabled.kt:21-30](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/opentelemetry/ConditionalOnOpenTelemetryEnabled.kt#L21-L30)
+
+## 内置 API 范围
+
+路由集提供框架操作。精确的聚合专属路径由注册模型和路由贡献者派生。
+
+| 能力 | 端点/方法 | 认证 | 限流 |
+| --- | --- | --- | --- |
+| 接收等待完成信号；不提交命令 | `POST /wow/command/wait` | 未声明；CoSec 集成为可选 | 未声明 |
+| 通过统一入口提交命令 | `POST /wow/command/send` | 未声明；CoSec 集成为可选 | 未声明 |
+| 读取 Wow 模型元数据 | `GET /wow/metadata` | 未声明；CoSec 集成为可选 | 未声明 |
+| 生成全局标识 | `GET /wow/id/global` | 未声明；CoSec 集成为可选 | 未声明 |
+| 生成并返回 BI SQL 或 JSON 结果 | `POST /wow/bi/script` | 未声明；CoSec 集成为可选 | 未声明 |
+| 发送类型化聚合命令 | 聚合命令路由 | 未声明；需要应用权限政策 | 未声明 |
+| 查询聚合状态 | 状态查询路由 | 未声明；需要应用隐私政策 | 未声明 |
+| 查询或重新生成快照 | 快照路由 | 未声明；应限制为运营能力 | 未声明 |
+| 计数、列表、分页、加载、补偿或重发事件 | 事件路由 | 未声明；应限制为运营能力 | 未声明 |
+
+仓库没有声明统一认证政策、运营角色模型、公开暴露政策、限流或 API 服务等级。
+CoSec 是类存在时可激活的可选 feature capability，这不意味着每次部署都会
+自动受到保护。
+
+来源：
+
+- [BuiltInHttpRoutes.kt:18-75](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contract/BuiltInHttpRoutes.kt#L18-L75)
+- [CommandWaitRouteContributor.kt:40-60](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/global/CommandWaitRouteContributor.kt#L40-L60)
+- [CommandWaitHandlerFunction.kt:32-44](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/wait/CommandWaitHandlerFunction.kt#L32-L44)
+- [CommandFacadeRouteContributor.kt:35-52](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/global/CommandFacadeRouteContributor.kt#L35-L52)
+- [CommandFacadeHandlerFunction.kt:35-52](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandFacadeHandlerFunction.kt#L35-L52)
+- [GenerateBIScriptRouteContributor.kt:37-100](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/global/GenerateBIScriptRouteContributor.kt#L37-L100)
+- [GenerateBIScriptHandlerFunction.kt:87-112](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/global/GenerateBIScriptHandlerFunction.kt#L87-L112)
+- [EventRouteContributor.kt:56-207](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/aggregate/event/EventRouteContributor.kt#L56-L207)
+- [wow-spring-boot-starter/build.gradle.kts:40-42](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L40-L42)
+- [CoSecAutoConfiguration.kt:27-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/cosec/CoSecAutoConfiguration.kt#L27-L45)
+
+## 性能与服务等级边界
+
+仓库包含 README 短时压测样例和 benchmark smoke 工作流，两者都不是当前
+产品 SLA。
+
+README 样例运行两分钟，报告两个示例命令的发送/处理速率和延迟。关联性能
+部署使用特定资源配置和镜像版本 `6.11.3`，而当前根版本为 `8.9.5`。
+
+该样例只能帮助发现需要测试的内容，不能直接承诺客户结果。
+
+| 操作 | 预期延迟 | 吞吐限制 | 当前 SLA |
+| --- | --- | --- | --- |
+| 命令提交 | 未声明；历史样例数字不是承诺 | 未声明 | 未声明 |
+| 命令处理 | 未声明；取决于领域工作和所选后端 | 未声明 | 未声明 |
+| 读视图更新 | 未声明；没有新鲜度目标 | 未声明 | 未声明 |
+| 事件持久化与状态加载 | 未声明；取决于所选存储和负载 | 未声明 | 未声明 |
+| 补偿重试 | 存在 Scheduler 默认值，但未声明恢复时间预期 | Scheduler 批量默认 100；生产限制未声明 | 未声明 |
+| Dashboard 操作 | 未声明 | 未声明 | 未声明 |
+| 自动扩缩容 | 不适用固定延迟；示例 HPA 使用 80% CPU 目标 | 示例范围为 2–10 副本；生产限制未声明 | 未声明 |
+
+来源：
+
+- [README.md:94-109](https://github.com/Ahoo-Wang/Wow/blob/main/README.md#L94-L109)
+- [deploy/example/perf/deployment.yaml:33-80](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/example/perf/deployment.yaml#L33-L80)
+- [.github/workflows/benchmark-smoke.yml:14-58](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/benchmark-smoke.yml#L14-L58)
+- [deploy/example/hpa.yaml:1-18](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/example/hpa.yaml#L1-L18)
+
+### 产品性能问题
+
+- 客户可等待命令受理多长时间？
+- 受理后读视图可落后多久？
+- 界面如何展示处理中状态？
+- 客户端何时应超时？
+- 总线或事件存储不可用时发生什么？
+- 补偿积压达到多大年龄时必须升级？
+- 哪些产品流程需要同步确认？
+- 哪些流程可以异步完成后再通知？
+
+这些答案是应用需求，不是 Wow 提供的默认承诺。
+
+## 已知限制与注意事项
+
+| 限制 | 用户影响 | 变通方案 | 计划修复 |
+| --- | --- | --- | --- |
+| 补偿只覆盖符合条件的事件处理路径，不是通用回滚 | 不能把重试描述为撤销原业务动作 | 重试前要求业务安全判断 | 未声明 |
+| Dashboard 历史视图为 stub | 运营人员不能依赖它作为完整审计轨迹 | 使用已审批的外部审计流程 | 未声明 |
+| 重试 UI 把以秒为单位的值标为毫秒 | 运营人员可能输入或解释不安全的时间值 | 使用前在当前表单外校正并验证参数 | 未声明 |
+| 示例镜像和 package 版本与根版本 `8.9.5` 不一致 | 示例行为可能与当前源码不匹配 | 从选定发布构建经过评审的制品 | 未声明 |
+| 补偿示例配置含内联凭据 | 复制示例可能暴露可复用 Secret | 替换为采用方 Secret 机制 | 未声明 |
+| 默认聚合删除不是通用事件擦除机制 | 删除操作可能不满足数据擦除义务 | 最小化受监管事件数据，并设计存储特定生命周期流程 | 未声明 |
+| 仓库未提供通用 SLA、容量边界或数据政策 | 不能从框架默认值推导产品承诺 | 为采用方服务定义并验证 | 未声明 |
+
+### 补偿是受控重试，不是通用回滚
+
+过滤器记录 Domain Event、Stateless Saga、Projection 和 Snapshot 分发路径的
+失败。事件补偿支持 EVENT 和 STATE_EVENT function kind。该范围小于所有命令、
+工作流或外部副作用。
+
+来源：
+
+- [CompensationFilter.kt:58-119](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-core/src/main/kotlin/me/ahoo/wow/compensation/core/CompensationFilter.kt#L58-L119)
+- [EventCompensateSupporter.kt:33-69](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/compensation/EventCompensateSupporter.kt#L33-L69)
+
+### 运营历史尚不完整
+
+当前补偿 Dashboard 的历史组件只是 stub。产品和运营团队不能假定完整审计历史
+体验已经存在。
+
+来源：[FailedHistory.tsx:14-16](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/features/Failed/FailedHistory.tsx#L14-L16)
+
+### 重试单位展示不一致
+
+Dashboard 把 minimum backoff 和 execution timeout 标为毫秒，而后端 API 模型
+明确两者单位为秒。运营人员依赖该表单前应修复并测试。
+
+来源：
+
+- [ApplyRetrySpec.tsx:77-100](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/dashboard/src/features/Failed/ApplyRetrySpec.tsx#L77-L100)
+- [IExecutionFailedState.kt:68-107](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-api/src/main/kotlin/me/ahoo/wow/compensation/api/IExecutionFailedState.kt#L68-L107)
+
+### 示例不是生产承诺
+
+示例中的部署镜像与当前根版本不一致，一份示例配置还包含内联演示凭据。产品
+上线标准必须使用经过评审的应用清单，不能原样复制示例。
+
+来源：
+
+- [gradle.properties:21-23](https://github.com/Ahoo-Wang/Wow/blob/main/gradle.properties#L21-L23)
+- [deploy/example/deployment.yaml:26-31](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/example/deployment.yaml#L26-L31)
+- [deploy/compensation/deployment.yaml:21-26](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/compensation/deployment.yaml#L21-L26)
+- [deploy/compensation/config.yaml:43-52](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/compensation/config.yaml#L43-L52)
+
+### 默认聚合删除不是通用事件擦除机制
+
+默认删除命令会产生删除事件，状态重建再根据该事件切换 deleted 标记。公共
+`EventStore` 契约提供 append 与 load 等操作，但没有通用 erase 操作。这并不
+证明所有采用方后端永远不能擦除，而是说明框架默认删除行为不足以支持擦除声明。
+有擦除义务的产品需要单独评审、存储特定的数据策略。
+
+来源：
+
+- [DefaultDeleteAggregateFunction.kt:25-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/DefaultDeleteAggregateFunction.kt#L25-L45)
+- [SimpleStateAggregate.kt:151-169](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/state/SimpleStateAggregate.kt#L151-L169)
+- [EventStore.kt:22-122](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L22-L122)
+
+## 隐私、安全与数据政策
+
+Wow 可以持久化事件 Body、事件元数据、聚合标识、租户标识、命令和请求标识
+以及 Header。
+
+当对应启用配置缺失时，WebFlux 集成会默认注册 User-Agent 和远程 IP Header
+追加器；两者都可通过配置关闭。命令 Header 可以传播到事件流，序列化消息也
+包含 Header。
+
+失败记录可能包含错误消息、Stack Trace 和绑定错误。取决于应用，这些字段可能
+泄漏用户数据、Secret 或内部实现细节。
+
+仓库没有声明保留期、数据驻留、加密政策、合规认证或通用数据擦除机制。
+
+| 数据类型 | 存储位置 | 保留期 | 合规状态 |
+| --- | --- | --- | --- |
+| 命令 Body、标识和 Header | 传输中的消息路径及所选总线；具体持久化由应用决定 | 未声明 | 未声明 |
+| 事件 Body 与事件流元数据 | 所选事件存储；默认存储类型为 MongoDB | 未声明 | 未声明 |
+| 快照状态 | 所选快照存储；默认存储类型为 MongoDB | 未声明 | 未声明 |
+| 读模型数据 | 应用选择的投影存储；Wow 不选择也不写入一个通用投影后端 | 未声明 | 未声明 |
+| 补偿错误详情和重试状态 | 补偿服务部署选择的存储；示例使用 MongoDB 与 Redis | 未声明 | 未声明 |
+| User-Agent 与远程 IP 命令 Header | 默认追加器保持启用时，位于命令 Header 并可能传播到事件元数据 | 未声明 | 未声明 |
+| Trace 与 Metrics 属性 | 采用方选择的可观测后端 | 未声明 | 未声明 |
+| 生成的 BI SQL | 以 SQL 或 JSON 通过 HTTP 返回调用方；仓库不持久化也不执行该响应 | 未声明 | 未声明 |
+| BI 同步的命令与状态事件数据 | 仅在采用方执行生成 SQL 后进入 ClickHouse；生成的 Kafka Engine 消费者从匹配 Topic 摄入 | 未声明 | 未声明 |
+
+来源：
+
+- [CommandRequestRemoteIpHeaderAppender.kt:21-50](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/appender/CommandRequestRemoteIpHeaderAppender.kt#L21-L50)
+- [CommandRequestUserAgentHeaderAppender.kt:21-26](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/appender/CommandRequestUserAgentHeaderAppender.kt#L21-L26)
+- [WebFluxAutoConfiguration.kt:141-158](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfiguration.kt#L141-L158)
+- [CommandRequestHeaderPropagator.kt:19-80](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/propagation/CommandRequestHeaderPropagator.kt#L19-L80)
+- [DomainEventStreamFactory.kt:77-119](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStreamFactory.kt#L77-L119)
+- [IExecutionFailedState.kt:28-44](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-api/src/main/kotlin/me/ahoo/wow/compensation/api/IExecutionFailedState.kt#L28-L44)
+- [EventStoreProperties.kt:20-25](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/store/EventStoreProperties.kt#L20-L25)
+- [SnapshotProperties.kt:23-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/snapshot/SnapshotProperties.kt#L23-L45)
+- [deploy/compensation/config.yaml:38-52](https://github.com/Ahoo-Wang/Wow/blob/main/deploy/compensation/config.yaml#L38-L52)
+- [BiScriptProperties.kt:69-165](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/bi/BiScriptProperties.kt#L69-L165)
+- [GenerateBIScriptHandlerFunction.kt:87-112](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/global/GenerateBIScriptHandlerFunction.kt#L87-L112)
+- [ClickHouseCommandRenderer.kt:108-120](https://github.com/Ahoo-Wang/Wow/blob/main/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseCommandRenderer.kt#L108-L120)
+- [ClickHouseStateEventRenderer.kt:119-132](https://github.com/Ahoo-Wang/Wow/blob/main/wow-bi/src/main/kotlin/me/ahoo/wow/bi/renderer/ClickHouseStateEventRenderer.kt#L119-L132)
+- [wow-spring-boot-starter/build.gradle.kts:5-44](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L5-L44)
+
+### 隐私准备检查表
+
+- [ ] 分类命令 Body、事件 Body、Header、快照、投影、Trace 和失败详情。
+- [ ] 记录收集 IP 与 User-Agent 的目的，或在适当场景关闭。
+- [ ] 定义事件、快照、投影、补偿和遥测的保留期。
+- [ ] 定义事件查询、重发、补偿和快照重新生成操作的访问规则。
+- [ ] 将租户上下文与认证、授权分开评审。
+- [ ] 从异常和绑定错误中脱敏 Secret 与个人数据。
+- [ ] 在不可变事件中存储受监管个人数据前，设计合法擦除流程。
+- [ ] 在每个选定后端验证加密、密钥所有权、备份和驻留。
+- [ ] 只作有证据支持的合规声明。
+
+## 产品上线检查表
+
+### 体验
+
+- [ ] 每个命令都有成功、拒绝、处理中、超时和重试文案。
+- [ ] 用户可以感知读模型延迟时，UI 会明确解释。
+- [ ] 已设计重复提交和刷新行为。
+- [ ] 支持人员可关联客户报告，且不会暴露不安全数据。
+- [ ] 运营流程能区分安全重试与业务纠正。
+
+### 数据
+
+- [ ] 事件名称和含义按长期产品契约评审。
+- [ ] 已最小化敏感字段。
+- [ ] 已批准保留、删除、备份和恢复政策。
+- [ ] 已测试投影重建行为。
+- [ ] 已评审分析数据流动。
+
+### 运营
+
+- [ ] 已定义可用性、延迟、新鲜度和恢复目标。
+- [ ] 告警和升级路径有具名负责人。
+- [ ] 负载测试使用真实产品旅程和类生产拓扑。
+- [ ] 已演练消息代理/存储故障和恢复。
+- [ ] 补偿积压和运营操作可观测。
+
+### 安全
+
+- [ ] 每个内置路由都有暴露决策。
+- [ ] 按需实现认证、授权和限流。
+- [ ] 严格控制强制重试、重发、补偿和重新生成操作。
+- [ ] 部署环境不使用示例凭据。
+- [ ] 安全评审覆盖所有选定可选集成。
+
+## 术语表
+
+| 术语 | 通俗含义 |
+| --- | --- |
+| Aggregate | 检查规则和改变状态的一个业务一致性边界 |
+| Aggregate ID | 用于定位该一致性边界的标识 |
+| Command | 请求执行具名业务动作的消息 |
+| Command ID | 一条命令消息的标识 |
+| Request ID | 可关联相关处理过程的标识 |
+| Domain Event | 记录有意义业务变化已经发生 |
+| Event Stream | 一个命令为一个聚合产生的有序事件 |
+| Event Sourcing | 从已存领域事件构建当前状态 |
+| Snapshot | 加快加载的状态检查点 |
+| Projection | 构建读取或搜索视图的处理器 |
+| Read Model | 按客户、运营或报表查询形态组织的数据 |
+| Saga | 在较长工作流中响应事件的组件 |
+| Compensation | 本项目中，选定事件处理器的受控重试支持 |
+| Replay | 再次处理已存事件，以重建或修复派生状态 |
+| Resend | 通过受支持操作再次发布事件 |
+| Recoverable | 被标记为可进入恢复流程的失败 |
+| Tenant ID | 聚合和事件元数据中的上下文，本身不保证访问控制 |
+| OpenAPI | 对 HTTP 操作的机器可读描述 |
+| OpenTelemetry | 用于导出 Trace 信息的插桩标准 |
+| SLO | 可测量的内部服务目标；Wow 不提供通用目标 |
+| SLA | 服务承诺；仓库未声明通用 SLA |
+
+## 常见问题
+
+### 1. Wow 是最终用户产品吗？
+
+不是。它是工程团队用于构建应用的框架和模块集合。
+
+### 2. 每个 Wow 产品都需要 Kafka、MongoDB、Redis 和 Elasticsearch 吗？
+
+不需要。Starter 提供可选 capability 和可选总线/存储类型，具体子集取决于
+用例。Elasticsearch 是事件/快照存储与查询适配器，不是通用应用投影写入器。
+
+### 3. 命令成功是否表示所有页面已经更新？
+
+不一定。投影和 Saga 可能异步处理事件，产品必须定义并表达新鲜度预期。
+
+### 4. Wow 能展示业务状态如何变化吗？
+
+事件流会存储有序事件和相关元数据。哪些内容可以安全、有效地展示，取决于
+应用权限和数据政策。
+
+### 5. 补偿 Dashboard 会撤销错误命令吗？
+
+不会。它管理选定事件处理器的失败和重试，不是通用命令回滚，也不保证业务
+一致性恢复。
+
+### 6. 所有失败都能重试吗？
+
+不能。可恢复性、重试限制、支持的 function kind 和业务副作用都会限制安全
+重试。
+
+### 7. Dashboard 中是否已有完整运营审计历史？
+
+不要这样假设。当前历史组件只是 stub，仓库也未声明组织审计政策。
+
+### 8. 默认重试值是什么？
+
+后端默认最多重试 10 次、最小退避 180 秒、执行超时 120 秒。当前 UI 对两个值
+标错单位，因此必须先修复并测试运营体验。
+
+### 9. Wow 是否保证吞吐或延迟数字？
+
+不保证。README 是历史两分钟样例，不是当前 SLA，也不保证其他负载结果。
+
+### 10. 是否包含自动扩缩容？
+
+仓库含 Kubernetes HPA 示例。生产扩缩容和容量仍是部署决策。
+
+### 11. Tenant ID 是否保证租户隔离？
+
+不保证。租户元数据提供上下文和路由信息，认证、授权、存储隔离和查询控制仍需
+显式设计。
+
+### 12. 删除聚合是否擦除其事件历史？
+
+不能这样假设。默认删除行为产生事件并把重建状态标为 deleted，而公共事件
+存储契约没有通用擦除操作。任何存储特定擦除流程都需要单独设计和证明。
+
+### 13. Wow 是否定义数据保留期或驻留地域？
+
+仓库没有声明全局保留期或驻留政策。
+
+### 14. 内置 HTTP 端点是否自动适合公开暴露？
+
+不适合直接假设。采用方必须决定暴露范围、认证、授权、网络控制和限流；CoSec
+集成是可选的。
+
+### 15. 产品团队可以生成 API 描述吗？
+
+OpenAPI 支持可用，其配置默认启用，但契约发布和客户端兼容仍需治理。
+
+### 16. 产品团队应首先测量什么？
+
+针对真实客户旅程，先测量命令受理与处理延迟、读视图新鲜度、失败与补偿积压
+年龄、错误率和事件/存储增长。
+
+### 17. 谁负责基于 Wow 的服务？
+
+仓库不会替采用方指定服务负责人。采用组织必须分配产品、工程、运营、安全和
+数据所有权。
+
+### 18. Wow 的路线图是什么？
+
+仓库未声明路线图或交付日期承诺。把未来特性写入产品承诺前，应先与维护者确认。
+
+### 19. Wow 是否提供合规认证？
+
+仓库未声明全局合规认证。合规取决于应用、部署、政策和组织控制。
+
+### 20. 哪些场景不适合 Wow？
+
+如果产品只需要简单记录更新、事件历史价值有限，或组织无法运营新增的消息、
+存储、重放和恢复职责，Wow 可能并不合适。
+
+## 产品决策总结
+
+Wow 可以让业务意图、历史、异步视图和选定恢复操作更明确。只有产品确实需要
+这些能力时，它们的价值才最大。
+
+这些能力也会产生可见产品状态和长期数据义务。产品计划应覆盖处理中和失败体验、
+新鲜度预期、运营安全、数据生命周期和基于真实负载的服务目标。
+
+把仓库示例视为起点；只把已实现代码、测试和配置当作当前能力证据。对所有权、
+SLA、保留、合规和路线图，在可问责主体明确声明前一律视为未知。

--- a/documentation/docs/zh/onboarding/staff-engineer-guide.md
+++ b/documentation/docs/zh/onboarding/staff-engineer-guide.md
@@ -233,7 +233,9 @@ flowchart LR
 ## 领域模型与不变量
 
 框架分离业务载荷、框架信封、命令行为与事件溯源状态。
-这种分离防止命令处理器直接修改持久状态。
+这种分离支持事件溯源设计，但框架不会阻止命令处理器直接修改状态对象。
+应在领域模型中落实该约定：保持 State Setter 私有，让 Command Handler 返回事件，再由 Sourcing Handler 应用事件。
+来源：[Command Root 构造](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregateFactory.kt#L42-L55)、[封装状态的 Cart 示例](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt#L24-L46)。
 
 ```mermaid
 %%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#2d333b', 'primaryBorderColor': '#6d5dfc', 'primaryTextColor': '#e6edf3', 'lineColor': '#8b949e', 'clusterBkg': '#161b22', 'clusterBorder': '#30363d'}}}%%

--- a/documentation/docs/zh/onboarding/staff-engineer-guide.md
+++ b/documentation/docs/zh/onboarding/staff-engineer-guide.md
@@ -1,0 +1,1133 @@
+---
+title: Staff Engineer 指南
+description: 基于代码证据说明 Wow 的架构、所有权边界、生命周期、可靠性与演进约束。
+---
+
+# Staff Engineer 指南
+
+本指南面向需要在不破坏边界的前提下演进 Wow 的工程师。
+它描述的是 `main` 分支中的真实架构，而不是愿景架构。
+每个具体事实都链接到建立该事实的代码。
+仓库无法证明的属性会明确标记为 **未知**。
+
+## 执行摘要
+
+Wow 是围绕聚合级命令执行组织的响应式 CQRS 与事件溯源框架。
+
+`wow-api` 定义消息信封与公共契约。
+
+`wow-core` 拥有命令调度、事件溯源、消息处理、投影、Saga、快照与运行时生命周期。
+
+Spring 模块把这些机制适配到依赖注入和应用生命周期。
+基础设施模块实现存储与传输契约。
+WebFlux 与 OpenAPI 共享运行时路由目录；KSP 则在编译期生成它们依赖的元数据输入。
+最重要的一致性边界是把 `DomainEventStream` 追加到 `EventStore`。
+事件发布和下游处理发生在追加成功之后。
+它们并不处在同一个分布式事务中。
+框架明确保证聚合级顺序，但没有承诺全局顺序。
+重试是选择性的，ack 是显式的，补偿表示重放而不是回滚。
+
+`WowRuntime` 是已注册运行时组件的唯一生命周期所有者。
+
+它只能启动一次，先关闭准入再排空，并使用有界关闭期限。
+安全适配器传播身份相关 Header 和查询标签。
+它们本身不能证明服务边界已经完成认证。
+仓库具有本地、契约、集成、覆盖率与 JMH 测试层。
+这些测试层不能建立生产 SLA 或通用吞吐上限。
+
+## 唯一核心洞见
+
+> Wow 在一个聚合串行通道内把命令转换为不可变、带版本的事件流，先持久化该事件流，再把它扇出给职责独立的消费者。
+其余机制都在保护或扩展这条主线。
+命令信封携带聚合标识、所有权、租户、请求标识和期望版本。
+聚合根决定产生哪些事件载荷。
+状态聚合溯源这些事件。
+事件存储完成持久追加。
+领域事件总线和状态事件总线随后驱动投影、Saga 与快照。
+
+`WowRuntime` 控制这些处理器何时能够接收工作。
+
+下面的 Python-like 伪代码用于解释边界。
+它特意把非事务性的扇出展示出来。
+
+```python
+async def execute(command):
+    lane = lane_for(command.aggregate_id)
+    async with lane.serialized():
+        state = await snapshots.load(command.aggregate_id) or new_state()
+        async for stream in events.load_from(state.next_version):
+            state.source(stream)
+
+        emitted = await aggregate.decide(command, state)
+        state.source(emitted)
+
+        # 命令侧的持久一致性边界。
+        await events.append(emitted)
+
+        # 下游效果属于独立的响应式操作。
+        await domain_event_bus.send(emitted)
+        await state_event_bus.send_best_effort(emitted.with_state(state))
+```
+
+真实实现会先溯源内存状态再追加，持久化失败时把命令聚合标为过期。
+追加契约检测版本冲突和重复请求 ID。
+领域事件发送位于聚合处理之后的过滤器中。
+状态事件发送更晚，发送错误会被记录后恢复。
+来源：[命令信封](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L53-L125)、[聚合执行](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L81-L132)、[事件存储契约](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L27-L109)、[追加后发布](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt#L25-L46)、[尽力发送状态事件](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/SendStateEventFilter.kt#L29-L76)。
+
+## 系统架构
+
+架构按职责分层，而不是按部署拓扑分层。
+应用可以在一个进程组合模块，也可以用分布式总线和存储连接多个进程。
+仓库没有规定唯一的生产部署拓扑。
+
+```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#2d333b', 'primaryBorderColor': '#6d5dfc', 'primaryTextColor': '#e6edf3', 'lineColor': '#8b949e', 'clusterBkg': '#161b22', 'clusterBorder': '#30363d'}}}%%
+flowchart TB
+    Client["HTTP 或应用客户端"]
+    Web["wow-webflux\n请求提取与路由"]
+    Gateway["CommandGateway"]
+    Bus["CommandBus\n本地优先或分布式"]
+    Dispatcher["CommandDispatcher\n聚合通道"]
+    Aggregate["CommandAggregate\n决策与溯源"]
+    EventStore["EventStore\n持久追加"]
+    DomainBus["DomainEventBus"]
+    StateBus["StateEventBus"]
+    Projection["投影调度器"]
+    Saga["无状态 Saga"]
+    Snapshot["快照调度器"]
+    Query["查询存储与处理器"]
+    Runtime["WowRuntime\n准入与生命周期"]
+
+    Client --> Web --> Gateway --> Bus --> Dispatcher --> Aggregate --> EventStore
+    EventStore --> DomainBus
+    DomainBus --> Projection
+    DomainBus --> Saga
+    EventStore --> StateBus
+    StateBus --> Projection
+    StateBus --> Snapshot
+    Projection --> Query
+    Runtime -. 拥有 .-> Bus
+    Runtime -. 拥有 .-> Dispatcher
+    Runtime -. 拥有 .-> Projection
+    Runtime -. 拥有 .-> Snapshot
+```
+
+<!-- Sources: [CommandHandler](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt#L35-L63), [CommandDispatcher](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/CommandDispatcher.kt#L37-L83), [event filters](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt#L25-L46), [projection dispatcher](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/projection/ProjectionDispatcher.kt#L23-L55), [runtime ownership](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/RuntimeComponent.kt#L18-L62) -->
+
+### 所有权表
+
+| 领域 | 所有者 | 委托对象 | 边界证据 |
+|---|---|---|---|
+| 命令、事件、命名与建模公共契约 | `wow-api` | 不依赖 core 下层 | [API 最小依赖](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/build.gradle.kts#L1-L5) |
+| 命令与事件运行时 | `wow-core` | 存储和总线接口 | [core 依赖](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/build.gradle.kts#L3-L17) |
+| Spring 集成 | `wow-spring` | core 服务和 Spring 容器 | [模块依赖](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring/build.gradle.kts#L1-L5) |
+| 可选 Spring Boot 组合 | `wow-spring-boot-starter` | feature variants | [capabilities](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L5-L44) |
+| HTTP 入口与路由物化 | `wow-webflux` | `RouterSpecs` 与处理器 | [模块依赖](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/build.gradle.kts#L1-L10) |
+| 路由契约与 OpenAPI 渲染 | `wow-openapi` | 元数据、贡献者、Schema 上下文 | [RouterSpecs](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RouterSpecs.kt#L37-L160) |
+| Kafka 传输 | `wow-kafka` | Reactor Kafka | [模块边界](https://github.com/Ahoo-Wang/Wow/blob/main/wow-kafka/build.gradle.kts#L1-L5) |
+| MongoDB 持久化 | `wow-mongo` | Mongo 驱动 | [模块边界](https://github.com/Ahoo-Wang/Wow/blob/main/wow-mongo/build.gradle.kts#L1-L5) |
+| Redis 持久化 | `wow-redis` | Lettuce 与 Redis 脚本 | [模块边界](https://github.com/Ahoo-Wang/Wow/blob/main/wow-redis/build.gradle.kts#L1-L5) |
+| Elasticsearch 持久化与查询 | `wow-elasticsearch` | Elasticsearch 客户端 | [模块边界](https://github.com/Ahoo-Wang/Wow/blob/main/wow-elasticsearch/build.gradle.kts#L1-L8) |
+| CoSec 集成 | `wow-cosec` | WebFlux 请求上下文 | [适配器依赖](https://github.com/Ahoo-Wang/Wow/blob/main/wow-cosec/build.gradle.kts#L1-L4) |
+| 领域测试 DSL | `test/wow-test` | core 与 JUnit | [测试模块](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-test/build.gradle.kts#L1-L12) |
+| 后端契约 | `test/wow-tck` | 存储与调度接口 | [TCK 模块](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-tck/build.gradle.kts#L1-L20) |
+
+### 依赖方向
+
+core 依赖接口，因此基础设施可以替换。
+starter 通过可选 capability 组合组件，不把持久化或传输行为搬进 core。
+
+```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#2d333b', 'primaryBorderColor': '#6d5dfc', 'primaryTextColor': '#e6edf3', 'lineColor': '#8b949e', 'clusterBkg': '#161b22', 'clusterBorder': '#30363d'}}}%%
+flowchart LR
+    API["wow-api\n契约"]
+    Core["wow-core\n运行时"]
+    Spring["wow-spring\n容器桥接"]
+    Starter["wow-spring-boot-starter\n组合"]
+    WebFlux["wow-webflux"]
+    OpenAPI["wow-openapi"]
+    Kafka["wow-kafka"]
+    Mongo["wow-mongo"]
+    Redis["wow-redis"]
+    ES["wow-elasticsearch"]
+    Test["wow-test / wow-tck"]
+
+    API --> Core --> Spring --> Starter
+    API --> OpenAPI
+    Core --> WebFlux
+    OpenAPI --> WebFlux
+    Core --> Kafka
+    Core --> Mongo
+    Core --> Redis
+    Core --> ES
+    Core --> Test
+    Starter -. feature variants .-> WebFlux
+    Starter -. feature variants .-> Kafka
+    Starter -. feature variants .-> Mongo
+    Starter -. feature variants .-> Redis
+    Starter -. feature variants .-> ES
+```
+
+<!-- Sources: [settings modules](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L23-L85), [starter capabilities](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L5-L80), [core dependencies](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/build.gradle.kts#L3-L17) -->
+
+## 承重契约
+
+### `CommandMessage`
+
+`CommandMessage` 是业务命令载荷的运行时信封。
+
+它携带 `aggregateId`、owner、space、command ID、request ID 与复制语义。
+它还携带期望版本以及创建、允许创建、作废等控制标记。
+这些字段是框架控制数据，不是领域状态。
+来源：[CommandMessage](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L53-L125)。
+
+### `DomainEvent`
+
+`DomainEvent` 用聚合标识、序号、修订号和事件流位置包装业务事件载荷。
+
+业务事件仍可保持为普通 Kotlin class 或 object。
+示例 `OrderCreated` 只包含业务字段。
+来源：[DomainEvent](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/event/DomainEvent.kt#L47-L89)、[OrderCreated](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/CreateOrder.kt#L60-L65)。
+
+### `DomainEventStream`
+
+一个事件流代表一次命令执行产生的事件。
+契约规定 command ID 与事件流是一对一关系。
+具体事件流非空，并从第一个事件导出聚合与版本元数据。
+来源：[DomainEventStream](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L31-L115)。
+
+### `EventStore`
+
+`EventStore` 拥有追加、请求查询、版本查询和事件流加载契约。
+
+追加契约明确了版本冲突、重复聚合 ID 与重复请求 ID。
+它没有定义跨事件发布或投影更新的事务。
+来源：[EventStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L27-L109)。
+
+### `SnapshotStore`
+
+`SnapshotStore` 加载和保存状态检查点。
+
+保存规则单调递增：低版本不能原子地覆盖高版本。
+接口没有删除或保留期操作。
+来源：[SnapshotStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt#L24-L71)。
+
+### `MessageBus`
+
+`MessageBus` 分离发送和接收。
+
+接收器就绪是契约的一部分，生命周期归 `WowRuntime` 所有。
+本地 `sendIfSubscribed` 在处理准入成功前保守返回 false。
+来源：[MessageBus](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/MessageBus.kt#L31-L107)。
+
+### `RuntimeComponent`
+
+组件构造必须无副作用。
+
+`prepare`、`start`、`quiesce`、优雅停止和强制停止是独立阶段。
+
+契约刻意不使用 `AutoCloseable`，避免任意调用者拥有关闭权。
+来源：[RuntimeComponent](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/RuntimeComponent.kt#L18-L62)。
+
+## 领域模型与不变量
+
+框架分离业务载荷、框架信封、命令行为与事件溯源状态。
+这种分离防止命令处理器直接修改持久状态。
+
+```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#2d333b', 'primaryBorderColor': '#6d5dfc', 'primaryTextColor': '#e6edf3', 'lineColor': '#8b949e', 'clusterBkg': '#161b22', 'clusterBorder': '#30363d'}}}%%
+classDiagram
+    class CommandMessage {
+      +body
+      +aggregateId
+      +requestId
+      +aggregateVersion
+      +ownerId
+      +spaceId
+    }
+    class CommandAggregate {
+      +state
+      +commandRoot
+      +process(exchange: ServerCommandExchange)
+    }
+    class StateAggregate {
+      +version
+      +onSourcing(stream)
+    }
+    class DomainEventStream {
+      +commandId
+      +version
+      +events
+    }
+    class EventStore {
+      <<interface>>
+      +append(stream)
+      +load(aggregateId, range)
+    }
+    class SnapshotStore {
+      <<interface>>
+      +load(aggregateId)
+      +save(snapshot)
+    }
+
+    CommandMessage --> CommandAggregate : 调度到
+    CommandAggregate *-- StateAggregate
+    CommandAggregate --> DomainEventStream : 产生
+    CommandAggregate --> EventStore : 追加
+    SnapshotStore --> StateAggregate : 恢复检查点
+    EventStore --> StateAggregate : 重放尾部
+```
+
+<!-- Sources: [CommandMessage aggregateVersion](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L83-L96), [AggregateProcessor process](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/AggregateProcessor.kt#L32-L49), [CommandAggregate](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/CommandAggregate.kt#L25-L84), [StateAggregate](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/state/StateAggregate.kt#L25-L31), [repository replay](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventSourcingStateAggregateRepository.kt#L74-L104) -->
+
+### 框架不变量
+
+| Entity | Invariant | Enforced By | Consequence | Source |
+|---|---|---|---|---|
+| `CommandMessage` | 命令按 named aggregate 与 aggregate ID 路由 | `CommandMessage.aggregateId` | 每个命令信封包含身份。 | [来源](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L53-L125) |
+| `CommandAggregate` | 提供期望版本时必须匹配 | `SimpleCommandAggregate` | 过期写入者在领域调用前失败。 | [来源](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L81-L97) |
+| `CommandAggregate` | 已提供的 owner 或 space 必须匹配已初始化聚合状态 | `SimpleCommandAggregate` | 非空值不匹配时在处理前拒绝；空值会跳过该比较。这是一致性检查，不是完整授权机制。 | [来源](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L98-L105) |
+| `CommandAggregate` | 已删除聚合拒绝普通命令 | `SimpleCommandAggregate` | 删除状态成为访问保护。 | [来源](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L114-L117) |
+| `StateAggregate` | 持久化前先溯源内存状态 | `SimpleCommandAggregate` | 处理期间状态反映已产生事件。 | [来源](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L123-L130) |
+| `CommandAggregate` | 持久化失败使聚合实例过期 | `SimpleCommandAggregate` 错误钩子 | 失败实例不能继续充当权威状态。 | [来源](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L123-L130) |
+| `Snapshot` | 快照版本不能后退 | `SnapshotStore` | 并发旧保存不能覆盖新状态。 | [来源](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt#L60-L71) |
+| 聚合分组 | 一个通道内顺序处理 | `AggregateDispatcher` | 顺序是分组级而非全局。 | [来源](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/AggregateDispatcher.kt#L380-L393) |
+
+### 示例订单聚合
+
+示例 `Order` 展示了推荐分层。
+
+`Order` 接收命令并返回事件。
+
+`OrderState` 应用事件并通过 private setter 拥有可变状态。
+
+`CreateOrder` 校验输入，`OrderCreated` 是不可变事件载荷。
+
+支付根据金额产生一个或两个有序事件。
+状态规则明确：仅 CREATED 可改地址，仅 PAID 可发货，仅 SHIPPED 可收货。
+来源：[Order 处理器](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/Order.kt#L105-L197)、[OrderState](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/OrderState.kt#L40-L108)、[CreateOrder](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/CreateOrder.kt#L31-L65)。
+
+```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#2d333b', 'primaryBorderColor': '#6d5dfc', 'primaryTextColor': '#e6edf3', 'lineColor': '#8b949e', 'clusterBkg': '#161b22', 'clusterBorder': '#30363d'}}}%%
+erDiagram
+    ORDER ||--|{ ORDER_ITEM : 包含
+    ORDER ||--|| SHIPPING_ADDRESS : 配送到
+    ORDER ||--o{ DOMAIN_EVENT : 由事件演化
+    COMMAND ||--o| DOMAIN_EVENT_STREAM : 产生
+    DOMAIN_EVENT_STREAM ||--|{ DOMAIN_EVENT : 包含
+    ORDER {
+      string id
+      decimal totalAmount
+      decimal paidAmount
+      enum status
+    }
+    ORDER_ITEM {
+      string id
+      string productId
+      decimal price
+      int quantity
+    }
+    SHIPPING_ADDRESS {
+      string country
+      string province
+    }
+    COMMAND {
+      string requestId
+      int expectedVersion
+    }
+    DOMAIN_EVENT_STREAM {
+      string commandId
+      int version
+    }
+    DOMAIN_EVENT {
+      int sequence
+      int revision
+    }
+```
+
+<!-- Sources: [Order state fields](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/OrderState.kt#L40-L67), [create payload and event](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-api/src/main/kotlin/me/ahoo/wow/example/api/order/CreateOrder.kt#L36-L65), [event stream](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L31-L115) -->
+
+## 命令生命周期
+
+### 入口
+
+`CommandHandlerFunction` 提取 body、路径变量和 Header，再委托给 `CommandHandler`。
+
+`CommandHandler` 构建命令消息，并选择 SSE 或普通等待行为。
+
+来源：[HTTP handler function](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandlerFunction.kt#L43-L66)、[command handler](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/CommandHandler.kt#L35-L63)。
+
+### Gateway
+
+`DefaultCommandGateway` 在发送前校验消息并检查 request ID。
+
+等待使用绝对超时，不会在每个阶段重新延长期限。
+来源：[校验与请求检查](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L79-L143)、[等待期限](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L238-L301)。
+
+### 调度
+
+`CommandDispatcher` 接收本地命令并解析聚合元数据。
+
+它创建聚合专属调度器和 scheduler。
+调度器按组处理，使一个聚合通道保持串行。
+来源：[调度器创建](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/CommandDispatcher.kt#L37-L83)、[聚合调度器](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/AggregateCommandDispatcher.kt#L51-L86)。
+
+### 加载与决策
+
+仓储加载快照或创建新状态聚合。
+随后从下一个期望版本重放事件流。
+命令聚合在调用 handler 前检查版本与删除状态。对已初始化聚合，它还会在对应消息值非空时比较 owner 或 space。
+来源：[快照加尾部重放](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventSourcingStateAggregateRepository.kt#L74-L104)、[前置条件](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L81-L117)。
+
+### 持久化与发布
+
+聚合先溯源产生的事件并追加事件流。
+聚合处理完成后，领域事件过滤器才发送事件流。
+状态事件过滤器排在领域事件过滤器之后。
+它会记录发送失败并恢复。
+来源：[追加](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L123-L130)、[领域事件发送](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt#L25-L46)、[状态事件发送](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/SendStateEventFilter.kt#L29-L76)。
+
+```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#2d333b', 'primaryBorderColor': '#6d5dfc', 'primaryTextColor': '#e6edf3', 'lineColor': '#8b949e', 'clusterBkg': '#161b22', 'clusterBorder': '#30363d'}}}%%
+sequenceDiagram
+    autonumber
+    participant C as 客户端
+    participant W as WebFlux handler
+    participant G as CommandGateway
+    participant B as CommandBus
+    participant D as 命令流水线
+    participant R as 状态仓储
+    participant S as SnapshotStore
+    participant A as CommandAggregate
+    participant E as EventStore
+    participant DE as DomainEventBus
+    participant SE as StateEventBus
+    participant X as 下游调度器
+    participant N as 阶段通知器
+
+    C->>W: HTTP 命令
+    W->>G: send 或 sendAndWait
+    G->>G: 校验并检查 request ID
+    G->>B: 发送 CommandMessage
+    B-->>G: CommandBus.send 完成
+    par 调用方响应时机
+        alt send 或仅等待 SENT 的 WaitPlan
+            G-->>W: send 完成或 SENT 结果
+            W-->>C: 立即响应
+        else 等待 PROCESSED 或后续阶段的 WaitPlan
+            Note over G,N: 保持已注册的 Wait Handle 开启
+        end
+    and 每个已接收命令都继续处理
+        B->>D: 已准入 exchange
+        D->>R: 加载聚合状态
+        R->>S: 加载最新快照
+        S-->>R: 检查点或空结果
+        R->>E: 加载检查点之后的事件尾部
+        E-->>R: 事件流
+        R-->>D: 已溯源状态
+        D->>A: 处理 exchange
+        A->>A: 校验并溯源新事件
+        A->>E: 追加 DomainEventStream
+        E-->>A: 追加完成
+        D-->>B: finallyAck exchange
+        D->>DE: 发布已持久化事件流
+        D->>SE: 发布状态事件
+        Note over D,SE: 状态事件发送错误会记录并恢复
+        D->>N: 命令流水线完成后通知 PROCESSED
+        par 状态事件 Consumer
+            SE->>X: SnapshotDispatcher 处理状态事件
+            X->>N: SNAPSHOT
+        and 领域事件 Consumer
+            DE->>X: Projection、Event 与 Saga Dispatcher
+            X->>N: PROJECTED、EVENT_HANDLED 或 SAGA_HANDLED
+        end
+        opt 已传播后续阶段 WaitPlan
+            N-->>G: 匹配 WaitPlan 的信号
+        end
+    end
+    opt 等待 PROCESSED 或后续阶段
+        G-->>W: 所选等待阶段结果
+        W-->>C: 响应或 SSE
+    end
+```
+
+<!-- Sources: [gateway send and SENT path](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L129-L187), [WaitPlan paths](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L201-L266), [repository](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventSourcingStateAggregateRepository.kt#L74-L104), [aggregate](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L81-L132), [ack ordering](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/AggregateProcessorFilter.kt#L26-L49), [stage notifiers](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/NotifierFilters.kt#L49-L118), [domain-event publication](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt#L25-L46), [state-event publication](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/SendStateEventFilter.kt#L29-L76) -->
+
+### 命令聚合状态
+
+```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#2d333b', 'primaryBorderColor': '#6d5dfc', 'primaryTextColor': '#e6edf3', 'lineColor': '#8b949e', 'clusterBkg': '#161b22', 'clusterBorder': '#30363d'}}}%%
+stateDiagram-v2
+    [*] --> STORED: 创建或恢复聚合实例
+    STORED --> SOURCED: 命令产生并溯源事件
+    SOURCED --> STORED: EventStore 追加成功
+    SOURCED --> EXPIRED: EventStore 追加失败
+    STORED --> EXPIRED: 实例失效
+    EXPIRED --> [*]
+```
+
+<!-- Sources: [CommandAggregate states](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/CommandAggregate.kt#L65-L84), [SimpleCommandAggregate transition](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L123-L132) -->
+
+## 事件、投影、Saga 与快照生命周期
+
+### 领域事件调度
+
+领域调度器拥有领域事件和状态事件两个子调度器。
+Function kind 选择对应子调度器。
+同一事件流内通过 `concatMap` 顺序处理事件。
+普通事件处理器的返回值在完成后被丢弃。
+来源：[组合调度器](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/dispatcher/CompositeEventDispatcher.kt#L111-L170)、[事件流内处理](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/dispatcher/AbstractAggregateEventDispatcher.kt#L83-L110)、[返回值丢弃](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/dispatcher/DomainEventFunctionFilter.kt#L41-L70)。
+
+### 投影
+
+`ProjectionDispatcher` 同时订阅领域事件与状态事件总线。
+
+它使用事件函数过滤器，因此投影 Publisher 表示完成，不表示新领域事件。
+来源：[ProjectionDispatcher](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/projection/ProjectionDispatcher.kt#L23-L55)、[ProjectionFunctionFilter](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/projection/ProjectionFunctionFilter.kt#L20-L30)。
+
+### 无状态 Saga
+
+无状态 Saga 是把 handler 结果转换为命令的特殊路径。
+新 request ID 从源事件 ID 和结果序号派生。
+tenant、space 与 upstream Header 传播到新命令。
+这是命令编舞。
+它不是分布式事务，也不会自动撤销之前的副作用。
+来源：[StatelessSagaFunction](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt#L42-L105)。
+
+### 快照
+
+快照是从状态事件派生的检查点。
+
+`VersionOffsetSnapshotStrategy` 的默认偏移是五个版本。
+
+它比较已保存版本，并在需要时保存更新的 `SimpleSnapshot`。
+快照保存不属于事件存储追加事务。
+来源：[策略契约](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStrategy.kt#L20-L51)、[版本偏移策略](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/VersionOffsetSnapshotStrategy.kt#L24-L63)、[快照过滤器](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/dispatcher/SnapshotFunctionFilter.kt#L27-L35)。
+
+### 生命周期对比
+
+| 产物 | 创建者 | 持久边界 | 消费者 | 失败含义 |
+|---|---|---|---|---|
+| 命令消息 | Gateway 或总线客户端 | 取决于总线 | 命令调度器 | 校验或传输失败 |
+| 领域事件流 | 命令聚合 | `EventStore.append` | 领域事件总线 | 版本、重复或存储失败 |
+| 领域事件投递 | 追加后过滤器 | 取决于总线 | 事件处理器、投影、Saga | 重试、处理策略、随后 ack |
+| 状态事件 | 领域事件之后的过滤器 | 取决于总线 | 投影和快照调度器 | 即时发送错误被记录并恢复 |
+| 快照 | 快照策略 | `SnapshotStore.save` | 聚合仓储 | 派生检查点可能落后于事件存储 |
+| Saga 命令 | 无状态 Saga 结果映射器 | 命令总线及后续事件追加 | 另一个聚合 | 不会隐式回滚源事件 |
+
+来源：[发送过滤器](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt#L25-L46)、[重试过滤器](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/handler/RetryableFilter.kt#L28-L65)、[ack 语义](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/handler/ExchangeAck.kt#L20-L60)、[Saga 映射](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt#L57-L105)。
+
+## 运行时生命周期
+
+`WowRuntime` 是一次性的生命周期协调器。
+
+状态包括 `NEW`、`STARTING`、`RUNNING`、`STOPPING`、`FORCE_STOPPING` 和 `STOPPED`。
+所有组件 prepare 完成后才能进入 start 阶段。
+组件意外失败会关闭准入并启动关闭流程。
+优雅关闭只有一个所有者和一个全局期限。
+顺序是关闭全局准入、quiesce 组件、排空工作、反向停止组件。
+超时或优雅停止失败会升级为强制停止。
+启动清理只是生命周期回滚。
+它不是领域事件或外部副作用回滚。
+来源：[状态与拓扑](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt#L93-L145)、[启动与启动清理](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt#L188-L256)、[关闭所有权](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt#L412-L470)、[关闭顺序](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt#L473-L547)。
+
+```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#2d333b', 'primaryBorderColor': '#6d5dfc', 'primaryTextColor': '#e6edf3', 'lineColor': '#8b949e', 'clusterBkg': '#161b22', 'clusterBorder': '#30363d'}}}%%
+stateDiagram-v2
+    [*] --> NEW
+    NEW --> STARTING: start()
+    STARTING --> RUNNING: 全部 prepare 并 start
+    STARTING --> STOPPING: 启动失败并清理
+    RUNNING --> STOPPING: 优雅停止或运行时失败
+    RUNNING --> FORCE_STOPPING: forceStop()
+    STOPPING --> FORCE_STOPPING: 超时或优雅停止失败
+    STOPPING --> STOPPED: 排空与反向停止完成
+    FORCE_STOPPING --> STOPPED: 反向强制停止完成
+    STOPPED --> [*]
+```
+
+<!-- Sources: [WowRuntime state machine](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt#L93-L108), [start](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt#L188-L256), [stop](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt#L328-L409) -->
+
+### 组件顺序
+
+组件注册到有序且身份去重的 slot。
+prepare 与 start 按注册顺序执行。
+优雅停止与强制停止按反向顺序执行。
+系统保留第一个失败，同时继续后续清理。
+来源：[RuntimeComponentGroup](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/internal/RuntimeComponentGroup.kt#L25-L121)。
+
+### Spring 桥接
+
+Spring 生命周期桥接保证入口看到已经就绪的 Wow 运行时。
+它在入口排空后停止，运行时意外终止时关闭应用上下文。
+默认关闭超时为 60 秒，quiet period 为 1 秒。
+来源：[WowRuntimeLifecycle](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring/src/main/kotlin/me/ahoo/wow/spring/WowRuntimeLifecycle.kt#L27-L51)、[WowProperties](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/WowProperties.kt#L23-L35)。
+
+## 存储架构
+
+存储通过注册表和路由装饰器按聚合选择。
+路由器拥有生命周期，并把每个操作委托给选中的后端。
+聚合专属映射优先于默认存储。
+来源：[RoutingEventStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/RoutingEventStore.kt#L21-L66)、[事件注册表](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/AggregateEventStoreRegistry.kt#L20-L32)、[快照路由](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/RoutingSnapshotStore.kt#L20-L43)、[快照注册表](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/AggregateSnapshotStoreRegistry.kt#L20-L32)。
+
+```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#2d333b', 'primaryBorderColor': '#6d5dfc', 'primaryTextColor': '#e6edf3', 'lineColor': '#8b949e', 'clusterBkg': '#161b22', 'clusterBorder': '#30363d'}}}%%
+flowchart LR
+    Aggregate["NamedAggregate"]
+    EventRegistry["AggregateEventStoreRegistry"]
+    SnapshotRegistry["AggregateSnapshotStoreRegistry"]
+    EventRouter["RoutingEventStore"]
+    SnapshotRouter["RoutingSnapshotStore"]
+    Mongo["MongoDB"]
+    Redis["Redis"]
+    ES["Elasticsearch"]
+    Memory["In-memory"]
+
+    Aggregate --> EventRegistry --> EventRouter
+    Aggregate --> SnapshotRegistry --> SnapshotRouter
+    EventRouter --> Mongo
+    EventRouter --> Redis
+    EventRouter --> ES
+    EventRouter --> Memory
+    SnapshotRouter --> Mongo
+    SnapshotRouter --> Redis
+    SnapshotRouter --> ES
+    SnapshotRouter --> Memory
+```
+
+<!-- Sources: [event routing](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/RoutingEventStore.kt#L21-L66), [snapshot routing](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/RoutingSnapshotStore.kt#L20-L43), [storage types](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/StorageType.kt#L16-L29) -->
+
+### 后端对比
+
+| 后端 | EventStore | SnapshotStore | 重要边界 | 来源 |
+|---|---|---|---|---|
+| In-memory | 是 | 是 | 用于开发和测试；持久性仅限进程 | [InMemoryEventStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/InMemoryEventStore.kt#L31-L75)、[InMemorySnapshotStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/InMemorySnapshotStore.kt#L28-L80) |
+| MongoDB | 是 | 是 | 有序加载；直接写或可选批量追加 | [MongoEventStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoEventStore.kt#L36-L97)、[MongoSnapshotStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoSnapshotStore.kt#L32-L80) |
+| Redis | 是 | 是 | Lua 追加检查冲突；不支持按事件时间加载 | [RedisEventStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStore.kt#L41-L106)、[RedisSnapshotStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisSnapshotStore.kt#L29-L57) |
+| Elasticsearch | 是 | 是 | refresh 与可选批处理影响可见性和延迟 | [ElasticsearchEventStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchEventStore.kt#L37-L81)、[ElasticsearchSnapshotStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchSnapshotStore.kt#L25-L80) |
+
+### 批处理
+
+MongoDB 和 Elasticsearch 批处理默认选择性启用。
+默认关闭，因为不满批次会增加最多 `maxDelay` 的延迟。
+默认参数包括批次 128、pending 4096、lane 1、延迟 1ms。
+这些是配置默认值，不是所有工作负载的最优测量值。
+来源：[Mongo 事件选项](https://github.com/Ahoo-Wang/Wow/blob/main/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoEventStoreBatchOptions.kt#L18-L50)、[Elasticsearch 事件选项](https://github.com/Ahoo-Wang/Wow/blob/main/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchEventStoreBatchOptions.kt#L18-L50)。
+pending 队列有界，耗尽时可用类型化过载错误拒绝准入。
+这是显式背压，而不是无界静默缓存。
+来源：[Mongo 批量追加器](https://github.com/Ahoo-Wang/Wow/blob/main/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/BatchMongoEventStreamAppender.kt#L58-L94)。
+
+## 消息架构
+
+### 聚合级顺序
+
+`AggregateDispatcher` 把消息映射为 group key。
+
+每个组使用 `publishOn` 加 `concatMap` 顺序处理。
+不同组可以并行。
+默认 lane 数为 `64 * available processors`，可用系统属性覆盖。
+这不是全局顺序保证。
+来源：[分组处理](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/AggregateDispatcher.kt#L380-L393)、[并行度](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/MessageParallelism.kt#L25-L43)。
+
+### Local-first 行为
+
+Local-first 同时准备本地投递副本与分布式副本。
+只有本地准入成功后，分布式副本才标为已在本地处理。
+本地投递出错时，分布式路径仍可用。
+被过滤的分布式副本会 ack。
+这是准入感知优化。
+它不能证明集群级 exactly-once。
+来源：[LocalFirstMessageBus](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/LocalFirstMessageBus.kt#L142-L199)。
+
+### Kafka
+
+Kafka 发送在 sender result 返回时完成。
+接收使用 consumer group，重试 receive stream，并顺序解码记录。
+Kafka key 是 aggregate ID 字符串。
+topic converter 提供聚合与函数路由上下文。
+来源：[发送与接收](https://github.com/Ahoo-Wang/Wow/blob/main/wow-kafka/src/main/kotlin/me/ahoo/wow/kafka/AbstractKafkaBus.kt#L92-L113)、[订阅](https://github.com/Ahoo-Wang/Wow/blob/main/wow-kafka/src/main/kotlin/me/ahoo/wow/kafka/AbstractKafkaBus.kt#L188-L211)、[key 与序列化](https://github.com/Ahoo-Wang/Wow/blob/main/wow-kafka/src/main/kotlin/me/ahoo/wow/kafka/AbstractKafkaBus.kt#L295-L309)。
+默认 Kafka receiver policy 使用 prefetch 1、maximum deferred ack 1、重试 3 次、延迟 10 秒。
+这些是配置默认值，不是吞吐保证。
+来源：[KafkaReceiverPolicy](https://github.com/Ahoo-Wang/Wow/blob/main/wow-kafka/src/main/kotlin/me/ahoo/wow/kafka/KafkaReceiverPolicy.kt#L18-L36)。
+
+### Ack 语义
+
+`finallyAck` 在成功后 ack。
+
+发生错误时，它先 ack 再重新抛出错误。
+因此 handler 最终失败本身不意味着 broker 会重新投递。
+依赖重放前必须理解重试与补偿策略。
+来源：[ExchangeAck](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/handler/ExchangeAck.kt#L20-L60)。
+
+## 失败处理
+
+默认重试过滤器最多重试三次，backoff 为两秒。
+只有标记为 recoverable 的异常才会重试。
+它排在聚合、事件函数与快照处理过滤器之前。
+默认事件处理错误策略在过滤器策略结束后记录并恢复。
+来源：[RetryableFilter](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/handler/RetryableFilter.kt#L28-L65)、[事件自动配置](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/event/EventDispatcherAutoConfiguration.kt#L60-L85)。
+补偿会重新加载已持久化事件、添加 compensation target 并重发。
+状态事件补偿在重发前通过事件溯源重建状态。
+两条路径都不会撤销原始事件存储追加。
+来源：[领域事件补偿](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/compensation/DomainEventCompensator.kt#L43-L100)、[状态事件补偿](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/compensation/StateEventCompensator.kt#L50-L130)。
+
+```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#2d333b', 'primaryBorderColor': '#6d5dfc', 'primaryTextColor': '#e6edf3', 'lineColor': '#8b949e', 'clusterBkg': '#161b22', 'clusterBorder': '#30363d'}}}%%
+flowchart TD
+    Start["处理命令或事件"]
+    Error{"发生错误？"}
+    Recoverable{"被分类为 recoverable？"}
+    Retry{"仍有重试预算？"}
+    Again["backoff 并重试过滤器链"]
+    Ack["ack exchange"]
+    Rethrow["传播，或由策略 log-resume"]
+    Persisted{"存在持久事件？"}
+    Compensate["显式补偿请求"]
+    Reload["重新加载事件流"]
+    Resend["附加 target 并重发"]
+    Done["完成"]
+
+    Start --> Error
+    Error -- 否 --> Ack --> Done
+    Error -- 是 --> Recoverable
+    Recoverable -- 是 --> Retry
+    Retry -- 是 --> Again --> Start
+    Retry -- 否 --> Ack --> Rethrow
+    Recoverable -- 否 --> Ack --> Rethrow
+    Rethrow --> Persisted
+    Persisted -- 是，操作者选择 --> Compensate --> Reload --> Resend --> Done
+    Persisted -- 否或未请求 --> Done
+```
+
+<!-- Sources: [retry classification](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/handler/RetryableFilter.kt#L28-L65), [ack on error](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/handler/ExchangeAck.kt#L32-L60), [compensation replay](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/compensation/DomainEventCompensator.kt#L61-L100) -->
+
+### 失败模式表
+
+| 失败 | 即时行为 | 持久事实 | Staff Engineer 动作 |
+|---|---|---|---|
+| 期望版本不匹配 | handler 调用前拒绝 | 现有事件流 | 按乐观并发冲突处理 |
+| 重复 request ID | EventStore 契约拒绝重复 | 第一次接受的事件流 | 客户端重试必须保留 request ID |
+| EventStore 追加失败 | 聚合实例过期 | 是否提交由后端结果决定 | 重用状态前重新加载并核对后端 |
+| 领域事件发送失败 | 命令事件流可能已经持久化 | EventStore 仍是事实来源 | 按异常分类使用重试或显式补偿 |
+| 状态事件发送失败 | 记录错误并恢复 | 事件流仍持久 | 监控延迟，必要时执行状态事件补偿 |
+| 投影 handler 失败 | 选择性重试，随后执行 ack/error 策略 | 投影可能落后 | handler 幂等并定义重放 runbook |
+| Saga 命令失败 | 源事件已提交 | 无自动回滚 | 显式建模业务补偿命令 |
+| 运行时启动失败 | 清理已启动组件 | 不意味着领域回滚 | 同时检查首个失败与清理失败 |
+| 优雅关闭超时 | 升级为强制停止 | 在途结果可能未知 | 用 request ID 与事件存储对账 |
+
+来源：[追加错误](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L27-L54)、[聚合过期](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L123-L132)、[运行时关闭](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt#L412-L547)。
+
+## 元数据、生成代码、路由与 OpenAPI
+
+这些是相关但不同的流水线，不是一个生成步骤。
+
+### 编译期 KSP 元数据
+
+`MetadataSymbolProcessor` 扫描 bounded context 与 aggregate root。
+
+它合并结果并把元数据资源写成 JSON。
+
+`AggregatesMetadataResolver` 另行生成调用 `aggregateMetadata<Command, State>()` 的 Kotlin 访问器，该函数会调用运行时聚合元数据 parser。
+
+这是两条不同的运行时输入，不是一条发现链：`MetadataSearcher` 加载 JSON 资源，生成访问器则通过 `aggregateMetadata()` 调用 `AggregateMetadataParser`。
+来源：[元数据资源生成](https://github.com/Ahoo-Wang/Wow/blob/main/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/metadata/MetadataSymbolProcessor.kt#L39-L106)、[聚合访问器生成](https://github.com/Ahoo-Wang/Wow/blob/main/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/aggregate/metadata/AggregatesMetadataResolver.kt#L38-L61)、[资源搜索](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/configuration/MetadataSearcher.kt#L33-L58)、[运行时 parser](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/annotation/AggregateMetadataParser.kt#L49-L59)。
+
+### 运行时路由目录
+
+`RouterSpecs` 对 route contributor 排序。
+
+它读取运行时 `MetadataSearcher`、过滤禁用的聚合路由并构建经校验的 `RouteCatalog`。
+目录会拒绝重复 route key 和路径变量不匹配。
+来源：[路由收集](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RouterSpecs.kt#L137-L160)、[目录校验](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/catalog/RouteCatalog.kt#L20-L79)。
+
+### 运行时 WebFlux 物化
+
+`RouterFunctionBuilder` 遍历路由目录。
+
+它把每个契约物化为 predicate 与 handler function。
+Spring Boot 用 `RouterSpecs` 和 handler registrar 创建该 router。
+来源：[RouterFunctionBuilder](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/RouterFunctionBuilder.kt#L25-L41)、[WebFlux 自动配置](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfiguration.kt#L300-L325)。
+
+### 运行时 OpenAPI 渲染
+
+同一目录被渲染为 OpenAPI 3.1 path 与 component。
+Springdoc customizer 把生成目录合并进应用 `OpenAPI` 对象。
+来源：[OpenAPI 渲染](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RouterSpecs.kt#L80-L121)、[OpenAPI 自动配置](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/openapi/OpenAPIAutoConfiguration.kt#L39-L75)。
+
+```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': {'primaryColor': '#2d333b', 'primaryBorderColor': '#6d5dfc', 'primaryTextColor': '#e6edf3', 'lineColor': '#8b949e', 'clusterBkg': '#161b22', 'clusterBorder': '#30363d'}}}%%
+flowchart LR
+    Source["带注解的领域源码"]
+    KSP["wow-compiler KSP"]
+    JSON["wow-metadata.json"]
+    Accessor["生成的聚合元数据访问器"]
+    Searcher["运行时 MetadataSearcher"]
+    Parser["运行时 AggregateMetadataParser"]
+    Contributors["Route contributors"]
+    Specs["RouterSpecs"]
+    Catalog["经校验的 RouteCatalog"]
+    Web["WebFlux RouterFunction"]
+    OA["OpenAPI 3.1 文档"]
+
+    Source --> KSP
+    KSP --> JSON --> Searcher
+    KSP --> Accessor --> Parser
+    Searcher --> Specs
+    Contributors --> Specs
+    Specs --> Catalog
+    Catalog --> Web
+    Catalog --> OA
+```
+
+<!-- Sources: [KSP resource processor](https://github.com/Ahoo-Wang/Wow/blob/main/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/metadata/MetadataSymbolProcessor.kt#L61-L106), [generated accessors](https://github.com/Ahoo-Wang/Wow/blob/main/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/aggregate/metadata/AggregatesMetadataResolver.kt#L38-L61), [resource searcher](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/configuration/MetadataSearcher.kt#L33-L58), [runtime parser](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/annotation/AggregateMetadataParser.kt#L49-L59), [RouterSpecs collection](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RouterSpecs.kt#L124-L160) -->
+
+### 反射边界
+
+不要把 Wow 描述成零反射框架。
+core 把 Kotlin reflection 声明为 API 依赖。
+元数据 parser 文档明确包含反射分析。
+测试 DSL 也反射泛型参数。
+KSP 减少部分发现与注册样板，但不能证明运行时零反射。
+来源：[core reflection 依赖](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/build.gradle.kts#L3-L17)、[元数据 parser 契约](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/metadata/Metadata.kt#L23-L26)、[AggregateSpec 反射](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-test/src/main/kotlin/me/ahoo/wow/test/AggregateSpec.kt#L69-L86)。
+
+## 安全与信任边界
+
+### 请求上下文
+
+WebFlux 从 path 和 Header 提取 tenant、owner、space、aggregate ID 与 local-first 提示。
+提取不等于认证。
+部署必须决定哪些 Header 可来自不受信客户端，哪些必须由可信边缘覆盖。
+来源：[AggregateRequest](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/command/AggregateRequest.kt#L34-L96)。
+
+### CoSec 适配器
+
+CoSec extractor 把 request ID 和 space ID Header 写入命令 builder。
+其他 CoSec 适配器传播 app 与 device ID。
+该模块仅依赖 WebFlux，本身没有建立 authenticator。
+来源：[builder extractor](https://github.com/Ahoo-Wang/Wow/blob/main/wow-cosec/src/main/kotlin/me/ahoo/wow/cosec/extractor/CoSecCommandBuilderExtractor.kt#L23-L40)、[消息传播](https://github.com/Ahoo-Wang/Wow/blob/main/wow-cosec/src/main/kotlin/me/ahoo/wow/cosec/propagation/CoSecMessagePropagator.kt#L20-L46)、[模块依赖](https://github.com/Ahoo-Wang/Wow/blob/main/wow-cosec/build.gradle.kts#L1-L4)。
+
+### 聚合授权前置条件
+
+对已初始化聚合，命令处理仅在对应消息值非空时比较 owner 或 space 与已加载聚合状态。
+读侧 owner precondition 可以拒绝 owner aggregate 访问。
+路由元数据控制 owner path 是 NEVER、ALWAYS 或由 AGGREGATE_ID 决定。
+来源：[命令检查](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L91-L105)、[owner precondition](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/state/OwnerAggregatePrecondition.kt#L22-L34)、[路由所有权](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/annotation/AggregateRoute.kt#L57-L90)。
+
+这些条件检查会在上下文已提供时保护聚合一致性；它们不负责认证调用方，也不能替代端点授权。
+
+### 查询 ABAC
+
+`AbacQueryFilter` 把 principal tag 转换为查询条件。
+
+principal tag 解析是抽象方法，必须由集成实现。
+空 tag 集解析为 `Condition.all()`。
+因此仅存在该过滤器不能证明查询已认证或受限。
+来源：[AbacQueryFilter](https://github.com/Ahoo-Wang/Wow/blob/main/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/AbacQueryFilter.kt#L33-L130)。
+
+### 安全检查清单
+
+- 信任 Wow 身份 Header 前先终止外部认证。
+- 在边缘剥离客户端提供的内部 Header。
+- 把 tenant、owner、space 绑定到已认证 principal。
+- 为 ABAC 提供具体 principal-tag resolver。
+- 显式测试空 tag 行为。
+- 把 local-first Header 当作内部路由提示。
+- 验证补偿端点具有运维授权。
+- 验证 metadata 与 BI script 端点符合暴露策略。
+- 对外发布前审计生成的 OpenAPI。
+- 存储凭证和签名材料不得进入仓库。
+
+代码建立了以上提取与过滤点。
+具体生产身份提供方、边缘策略与 secret store 在仓库中 **未知**。
+
+## 性能模型
+
+### 结构性热路径
+
+写路径包括请求解码、校验、request ID 检查、总线准入、lane 调度、快照加载、尾部重放、领域调用、事件序列化、存储追加、发布与可选等待协调。
+主导成本取决于工作负载和部署。
+仓库不能证明唯一的通用瓶颈。
+
+### 显式边界与调节项
+
+| 调节项 | 代码默认值 | 限制内容 | 不能证明 |
+|---|---:|---|---|
+| Dispatcher lanes | `64 * processors` | 进程内分组并行度 | 最优 CPU 或存储并发 |
+| Kafka prefetch | `1` | Receiver demand | 端到端吞吐 |
+| Kafka deferred ack | `1` | 未完成 deferred ack | 投递保证 |
+| Kafka retry | `3`，延迟 `10s` | receive-stream 重试 | 最终 ack 后 handler 重放 |
+| Batch max size | `128` | 一次可选存储批次 | 工作负载最优批次 |
+| Batch max pending | `4096` | pending 队列容量 | 饱和时安全内存或延迟 |
+| Batch lanes | `1` | coordinator lane 数 | 通用最优顺序策略 |
+| Batch max delay | `1ms` | 不满批次等待 | 端到端延迟 |
+| Runtime timeout | `60s` | 默认关闭期限 | 业务操作期限 |
+
+来源：[消息并行度](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/MessageParallelism.kt#L25-L43)、[Kafka receiver policy](https://github.com/Ahoo-Wang/Wow/blob/main/wow-kafka/src/main/kotlin/me/ahoo/wow/kafka/KafkaReceiverPolicy.kt#L18-L36)、[Mongo batch 选项](https://github.com/Ahoo-Wang/Wow/blob/main/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoEventStoreBatchOptions.kt#L18-L50)、[运行时默认值](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/WowProperties.kt#L23-L35)。
+
+### Benchmark 证据
+
+benchmark 模块包含组件、端到端、WebFlux、MongoDB、Redis 与 Elasticsearch fixture。
+它使用 JMH，并依赖 example、test、mock 与基础设施模块。
+来源：[benchmark 依赖](https://github.com/Ahoo-Wang/Wow/blob/main/wow-benchmarks/build.gradle.kts#L1-L21)、[JMH 版本](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L3-L33)。
+模拟 I/O benchmark 研究 I/O 延迟与 scheduler handoff。
+批量 E2E benchmark 按命令归一化结果。
+并发 benchmark 明确说重复 key 顺序由功能测试覆盖，而非吞吐 benchmark。
+来源：[模拟 I/O benchmark](https://github.com/Ahoo-Wang/Wow/blob/main/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/e2e/SimulatedIoCommandWriteBenchmark.kt#L36-L43)、[批量 E2E benchmark](https://github.com/Ahoo-Wang/Wow/blob/main/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/e2e/BatchCommandWriteE2EBenchmark.kt#L34-L35)、[coordinator benchmark 范围](https://github.com/Ahoo-Wang/Wow/blob/main/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/infrastructure/mongo/MongoBatchCoordinatorConcurrencyBenchmark.kt#L44-L44)。
+
+### README 压测样例
+
+README 报告了一次示例应用的两分钟压力测试。
+它列出特定操作与等待计划的平均和峰值 TPS。
+这些数字是链接部署条件下的历史样例。
+它们不是 SLA、容量计划或组件性能上限。
+来源：[README 样例](https://github.com/Ahoo-Wang/Wow/blob/main/README.zh-CN.md#L96-L110)。
+
+### 性能决策规则
+
+使用可复现工作负载。
+固定代码修订和环境。
+同时测量存储、broker、CPU、分配与 scheduler 行为。
+分离组件筛选与端到端确认。
+改变并发时重新验证顺序与过载行为。
+不要根据一次 quick benchmark 修改默认值。
+没有测量就不要把 EventStore 结果迁移到 SnapshotStore。
+在部署专属实验给出结果前，生产容量与尾延迟目标均为 **未知**。
+
+## 测试策略
+
+### 测试层
+
+| 测试层 | 目的 | 证据 |
+|---|---|---|
+| Domain spec | Given/when/expect 行为 | [AggregateSpec](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-test/src/main/kotlin/me/ahoo/wow/test/AggregateSpec.kt#L24-L39) |
+| Saga spec | 隔离验证产生的命令 | [SagaSpec](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-test/src/main/kotlin/me/ahoo/wow/test/SagaSpec.kt#L24-L33) |
+| EventStore TCK | 追加、加载、冲突、重复、并发 | [EventStoreSpec](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/eventsourcing/EventStoreSpec.kt#L41-L176) |
+| SnapshotStore TCK | 加载、单调保存、并发 | [SnapshotStoreSpec](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/eventsourcing/snapshot/SnapshotStoreSpec.kt#L39-L212) |
+| 后端契约实现 | 在真实适配器运行 TCK | [Mongo](https://github.com/Ahoo-Wang/Wow/blob/main/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/MongoEventStoreTest.kt#L38-L38)、[Redis](https://github.com/Ahoo-Wang/Wow/blob/main/wow-redis/src/integrationTest/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStoreTest.kt#L32-L32)、[Elasticsearch](https://github.com/Ahoo-Wang/Wow/blob/main/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchEventStoreTest.kt#L34-L34) |
+| Integration CI | 服务与聚合集成任务 | [workflow](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/integration-test.yml#L47-L77) |
+| Static analysis | Detekt | [workflow](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/static-analysis.yml#L35-L53) |
+| Coverage | 库模块启用 Jacoco；要求阈值时由具体模块配置 | [根 Jacoco 配置](https://github.com/Ahoo-Wang/Wow/blob/main/build.gradle.kts#L175-L198)、[示例 80% 规则](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/build.gradle.kts#L12-L20) |
+| Benchmark | JMH 回归与诊断 | [benchmark 模块](https://github.com/Ahoo-Wang/Wow/blob/main/wow-benchmarks/build.gradle.kts#L1-L21) |
+
+### Domain test 风格
+
+DSL 通过 JUnit dynamic test 暴露 Given、When、Expect 阶段。
+
+`AggregateSpec` 的泛型命令聚合类型发现使用反射。
+
+示例领域模块可执行 80% Jacoco 下限。
+来源：[AggregateSpec factory](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-test/src/main/kotlin/me/ahoo/wow/test/AggregateSpec.kt#L69-L107)、[示例覆盖率](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/build.gradle.kts#L12-L20)。
+
+### 变更到测试映射
+
+| 变更 | 最小聚焦验证 | 更宽门禁 |
+|---|---|---|
+| 命令校验或 handler | 成功与拒绝的 Aggregate spec | 领域模块 `check` |
+| 事件溯源规则 | 完整历史与快照尾部重放 | 存储 TCK 与集成测试 |
+| EventStore 适配器 | 冲突、重复请求、顺序、并发 | 适配器 `check` 与集成 workflow |
+| SnapshotStore 适配器 | 并发单调保存 | Snapshot TCK 与适配器 `check` |
+| 调度并发 | 同 key 顺序、跨 key 并行、quiesce | core test 与 benchmark 诊断 |
+| 运行时生命周期 | prepare barrier、反向清理、超时、取消 | `:wow-core:test` |
+| Route contributor | 目录校验与路由快照 | OpenAPI 与 WebFlux test |
+| 元数据 KSP | 生成资源与访问器 golden output | compiler `check` |
+| 安全过滤器 | 已认证、未认证、空 tag、伪造 Header | WebFlux 集成测试 |
+| 性能默认值 | 多 fork 组件与 E2E 对比 | 部署代表性压测 |
+
+绿灯测试只证明 fixture 与 assertion 覆盖的内容。
+除非条件进入测试，否则不能证明真实 provider 取消、生产授权、迁移安全或部署 SLA。
+
+## 架构决策
+
+仓库中没有可引用的 ADR 记录这些机制的历史替代方案或原始动机。
+因此下表有意将替代方案写为“未声明”；“理由”是对当前代码行为的架构解释，不是历史设计意图的证据。
+
+| 决策 | 考虑过的替代方案 | 理由 | 来源 |
+|---|---|---|---|
+| 分离业务载荷与框架信封 | 未声明 | 当前信封把路由、身份、所有权和版本控制放在业务载荷之外；这是对现有契约的解释。 | [CommandMessage](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L53-L125) |
+| 先持久化再发布领域事件 | 未声明 | 当前过滤器顺序保证 EventStore 追加先完成，下游因此允许延迟或重放。 | [过滤器顺序](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt#L25-L46) |
+| 把快照视为派生检查点 | 未声明 | 当前策略在事件处理后保存已溯源状态，不替代事件历史。 | [快照策略](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/VersionOffsetSnapshotStrategy.kt#L49-L63) |
+| 按聚合派生分组串行处理 | 未声明 | 当前分组 `concatMap` 保持同组顺序，同时允许不同分组独立推进。 | [AggregateDispatcher](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/AggregateDispatcher.kt#L380-L393) |
+| 使用准入感知 local-first 投递 | 未声明 | 实现会尝试本地投递并保留带标记的分布式副本，以更复杂的 copy 与 ack 语义换取减少 broker 往返。 | [LocalFirstMessageBus](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/LocalFirstMessageBus.kt#L142-L199) |
+| 由唯一运行时独占生命周期所有权 | 未声明 | 当前契约分离 prepare、start、quiesce、graceful stop 和 force stop，使就绪与清理由一个协调者拥有。 | [RuntimeComponent](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/RuntimeComponent.kt#L18-L62) |
+| 按聚合路由存储 | 未声明 | 当前注册表允许聚合专属存储，同时保留默认后端。 | [存储注册表](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/AggregateEventStoreRegistry.kt#L20-L32) |
+| 通过 starter capability 组合适配器 | 未声明 | Feature variant 使基础设施模块可选，同时让 variant resolution 成为发布兼容面。 | [starter capabilities](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L5-L44) |
+| 共享一个经校验的路由目录 | 未声明 | 当前目录同时供路由与 OpenAPI 物化使用，降低两类输出之间的契约漂移。 | [RouterSpecs](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RouterSpecs.kt#L115-L160) |
+| 把补偿建模为显式重放操作 | 未声明 | 当前 compensator 重新加载持久事件并向目标重发，不撤销原始追加。 | [DomainEventCompensator](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/compensation/DomainEventCompensator.kt#L61-L100) |
+
+## 依赖理由
+
+版本目录固定 Kotlin 2.4.10、KSP 2.3.10、Spring Boot 4.1.0、JUnit 6.1.2、Testcontainers 2.0.5 与 JMH 1.37。
+来源：[version catalog](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L3-L33)。
+
+引用证据中没有 ADR 或迁移记录说明这些依赖替换过什么。
+因此 `替代了什么` 一列统一写“未声明”，不虚构历史。
+
+| 依赖 | 用途 | 替代了什么 | 来源 |
+|---|---|---|---|
+| Kotlin 与 KSP | Kotlin 实现框架，KSP 在编译期生成元数据资源与类型化访问器。 | 未声明 | [版本目录](https://github.com/Ahoo-Wang/Wow/blob/main/gradle/libs.versions.toml#L3-L33)、[编译器依赖](https://github.com/Ahoo-Wang/Wow/blob/main/wow-compiler/build.gradle.kts#L1-L17) |
+| Spring Boot | 提供自动配置、生命周期集成、WebFlux 组合与 feature variant。 | 未声明 | [starter features](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/build.gradle.kts#L1-L44) |
+| Reactor | 提供命令、事件、重试、顺序与排空路径使用的非阻塞 Publisher 模型。 | 未声明 | [core 依赖](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/build.gradle.kts#L3-L17) |
+| Jackson | 序列化命令、事件、状态与元数据表示。 | 未声明 | [core 依赖](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/build.gradle.kts#L3-L17)、[消息序列化器](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/serialization/MessageSerializer.kt#L26-L65) |
+| Reactor Kafka | 实现分布式 Kafka 消息总线适配器。 | 未声明 | [Kafka 模块](https://github.com/Ahoo-Wang/Wow/blob/main/wow-kafka/build.gradle.kts#L1-L6) |
+| MongoDB reactive driver | 实现 MongoDB 事件、快照与查询持久化。 | 未声明 | [MongoDB 模块](https://github.com/Ahoo-Wang/Wow/blob/main/wow-mongo/build.gradle.kts#L1-L6) |
+| Spring Data Redis 与 Lettuce | 实现 Redis 事件与快照持久化及 Redis 传输集成。 | 未声明 | [Redis 模块](https://github.com/Ahoo-Wang/Wow/blob/main/wow-redis/build.gradle.kts#L1-L6) |
+| Spring Data Elasticsearch | 实现 Elasticsearch 事件、快照与查询适配器。 | 未声明 | [Elasticsearch 模块](https://github.com/Ahoo-Wang/Wow/blob/main/wow-elasticsearch/build.gradle.kts#L1-L8) |
+| Swagger/OpenAPI libraries | 把运行时路由目录建模并渲染为 OpenAPI 契约。 | 未声明 | [OpenAPI 模块](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/build.gradle.kts#L1-L14) |
+| JUnit 与 Testcontainers | 提供动态领域测试、后端 TCK fixture 与外部服务集成测试。 | 未声明 | [TCK 依赖](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-tck/build.gradle.kts#L1-L21) |
+
+## 已知技术债
+
+仓库没有在可引用的 ADR 或 Issue 中把以下缺口标记为技术债。
+定性风险等级是根据当前影响给出的评审优先级，不是维护者承诺。
+
+| 问题 | 风险等级 | 受影响文件 | 来源 |
+|---|---|---|---|
+| Redis 无法实现公共的按事件时间加载能力，因此该后端不支持时间范围重放。 | 中 | `EventStore.kt`、`RedisEventStore.kt` | [契约](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L84-L97)、[Redis 实现](https://github.com/Ahoo-Wang/Wow/blob/main/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStore.kt#L101-L106) |
+| 公共 SnapshotStore 契约缺少删除和保留能力，生命周期政策只能由后端运维或额外应用契约补充。 | 中 | `SnapshotStore.kt`、选定快照后端与部署政策 | [SnapshotStore](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotStore.kt#L24-L71) |
+
+### 显式框架边界与有意约束
+
+以下行为是代码确认的边界。
+没有 ADR、Issue 或维护者决策声明改造意图时，不应直接称其为技术债。
+
+| 约束 | 工程影响 | 来源 |
+|---|---|---|
+| 状态事件发送错误会在即时过滤器边界记录并恢复。 | 快照和状态事件消费者可能落后；具体总线持久性和重放政策必须补齐运营闭环。 | [SendStateEventFilter](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/SendStateEventFilter.kt#L54-L76) |
+| 认证和 principal-tag 解析由集成负责。 | 只有 Header 提取与 ABAC hook 不能证明访问已经认证或受限。 | [CoSec 提取](https://github.com/Ahoo-Wang/Wow/blob/main/wow-cosec/src/main/kotlin/me/ahoo/wow/cosec/extractor/CoSecCommandBuilderExtractor.kt#L23-L40)、[ABAC 空 tag](https://github.com/Ahoo-Wang/Wow/blob/main/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/AbacQueryFilter.kt#L91-L130) |
+| 普通事件处理器返回值没有发布语义。 | 事件结果需要转成命令时，应使用 stateless saga 映射。 | [事件函数过滤器](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/dispatcher/DomainEventFunctionFilter.kt#L41-L70)、[Saga 映射器](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt#L57-L105) |
+| `WowRuntime` 与 Spring bridge 都是一次性的。 | 嵌入代码必须替换运行时，而不是重启已停止实例。 | [一次性启动](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt#L188-L217)、[Spring 生命周期状态](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring/src/main/kotlin/me/ahoo/wow/spring/WowRuntimeLifecycle.kt#L45-L51) |
+| KSP 不会消除聚合运行时反射。 | AOT、启动时间或反射削减工作必须测量真实 parser 和 invocation 路径。 | [生成访问器](https://github.com/Ahoo-Wang/Wow/blob/main/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/aggregate/metadata/AggregatesMetadataResolver.kt#L48-L59)、[运行时 parser](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/annotation/AggregateMetadataParser.kt#L54-L102) |
+
+## 需要部署证据的未知项
+
+- 生产认证提供方未知。
+- 可信代理与 Header 清洗策略未知。
+- 每个聚合的生产 EventStore 与 SnapshotStore 选择未知。
+- broker 复制与保留策略未知。
+- 灾难恢复 RPO 与 RTO 未知。
+- 投影重放 runbook 未知。
+- 补偿端点授权策略未知。
+- 可接受状态事件延迟未知。
+- 生产命令延迟 SLO 未知。
+- 任一部署的安全最大并发未知。
+- 各存储后端的容量上限未知。
+- 引用契约没有建立事件载荷 Schema 迁移策略。
+- 事件流与快照保留策略未知。
+- 强制停止部分完成后的运维响应未知。
+- 客户端网络重试是否保持 request ID 未知。
+
+这些不一定是框架缺陷。
+它们是生产设计必须补充的输入。
+
+## Staff Engineer 变更协议
+
+### 设计前
+
+1. 明确拥有行为的 aggregate、bounded context 与模块。
+2. 明确持久事实是 EventStore、snapshot、projection 还是外部系统。
+3. 追踪路由使用的信封字段和元数据。
+4. 找到拥有准入和关闭权的 RuntimeComponent。
+5. 说明变更影响单聚合通道还是跨聚合协调。
+6. 列出精确的 retry、ack 与 compensation 行为。
+7. 区分可信与不可信 Header。
+8. 判断 KSP 产物、运行时路由目录是否变化。
+9. 定义持久事件和公共路由的向后兼容性。
+10. 行为变化时优先先写失败模式测试。
+
+### 实现期间
+
+1. 公共契约留在 `wow-api`。
+2. 运行时行为留在 `wow-core`。
+3. Spring wiring 留在 `wow-spring*`。
+4. 传输与存储细节留在适配器模块。
+5. 保持 Reactor 路径非阻塞。
+6. 保持聚合级顺序。
+7. 不要意外扩大 ack 语义。
+8. 不要在没有重放路径时隐藏发送失败。
+9. 不要把手改生成文件作为主要修复。
+10. 让路由和 OpenAPI 继续由同一个目录驱动。
+
+### 合并前
+
+1. 先运行最窄模块测试。
+2. 运行相关存储或调度器 TCK。
+3. 对修改的 Kotlin 运行 static analysis。
+4. 路由变化时渲染并比较 OpenAPI。
+5. 注解变化时检查生成元数据。
+6. 生命周期变化时测试启动、优雅停止、强制停止。
+7. 并发变化时测试同 key 顺序和跨 key 并行。
+8. 分别测试 recoverable 与 unrecoverable 错误。
+9. 验证受影响处理器的补偿幂等性。
+10. 记录仍然存在的部署假设。
+
+## 推荐阅读顺序
+
+1. 从 [`CommandMessage`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L53-L125) 理解控制信封。
+2. 阅读 [`DomainEvent`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/event/DomainEvent.kt#L47-L89)，分离载荷与元数据。
+3. 阅读 [`DomainEventStream`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/DomainEventStream.kt#L31-L115)，理解命令到事件流关系。
+4. 阅读 [`SimpleCommandAggregate`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/SimpleCommandAggregate.kt#L81-L132)，定位一致性边界。
+5. 阅读 [`EventStore`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L27-L109)，理解持久化契约。
+6. 阅读 [`EventSourcingStateAggregateRepository`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventSourcingStateAggregateRepository.kt#L74-L104)，理解快照加尾部重放。
+7. 阅读两个[发布过滤器](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/SendStateEventFilter.kt#L29-L76)，理解追加后边界。
+8. 阅读 [`AggregateDispatcher`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/dispatcher/AggregateDispatcher.kt#L380-L393)，理解顺序。
+9. 阅读 [`LocalFirstMessageBus`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/LocalFirstMessageBus.kt#L142-L199)，理解准入感知投递。
+10. 修改失败策略前阅读 [`ExchangeAck`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/handler/ExchangeAck.kt#L20-L60)。
+11. 阅读 [`RetryableFilter`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/handler/RetryableFilter.kt#L28-L65)，理解重试分类。
+12. 阅读 [`DomainEventCompensator`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/event/compensation/DomainEventCompensator.kt#L43-L100)，理解重放语义。
+13. 阅读 [`StatelessSagaFunction`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt#L42-L105)，理解跨聚合编舞。
+14. 阅读 [`VersionOffsetSnapshotStrategy`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/VersionOffsetSnapshotStrategy.kt#L24-L63)，理解快照时机。
+15. 修改生命周期前阅读 [`RuntimeComponent`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/RuntimeComponent.kt#L18-L62)。
+16. 阅读 [`WowRuntime`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt#L188-L256)，理解启动所有权。
+17. 继续阅读[关闭所有权](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/WowRuntime.kt#L412-L547)。
+18. 阅读 [`RuntimeComponentGroup`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/runtime/internal/RuntimeComponentGroup.kt#L25-L121)，理解顺序与清理。
+19. 阅读 [`MetadataSymbolProcessor`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-compiler/src/main/kotlin/me/ahoo/wow/compiler/metadata/MetadataSymbolProcessor.kt#L39-L106)，理解编译期元数据。
+20. 阅读 [`RouterSpecs`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RouterSpecs.kt#L37-L160)，理解运行时路由与 OpenAPI 组装。
+21. 阅读 [`RouterFunctionBuilder`](https://github.com/Ahoo-Wang/Wow/blob/main/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/RouterFunctionBuilder.kt#L25-L41)，理解 HTTP 物化。
+22. 框架边界明确后再阅读[订单示例](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/order/Order.kt#L55-L197)。
+
+## 评审启发式规则
+
+拒绝把 snapshot 当成事实来源的变更。
+没有显式新一致性模型时，拒绝在 EventStore 追加前发布。
+拒绝在命令、事件、投影、Saga 或存储响应式路径引入阻塞 I/O。
+没有 broker、ack、handler 幂等与重放证据时，拒绝 exactly-once 结论。
+代码只提供 retry 或 compensation replay 时，拒绝自动回滚结论。
+仍存在反射依赖和 parser 时，拒绝零反射结论。
+拒绝仅根据 README 样例或一次 quick JMH 修改性能默认值。
+拒绝仅根据 Header 提取作出授权结论。
+持久事件 Schema 变化必须提供显式迁移路径。
+新增 RuntimeComponent 必须有生命周期测试。
+新增队列或 batch coordinator 必须有过载测试。
+路由元数据变化必须检查路由目录与 OpenAPI。
+
+## 术语表
+
+**Aggregate lane**：从 aggregate ID 派生的串行处理组。
+**Command envelope**：`CommandMessage` 加路由、身份、所有权与版本控制数据。
+**Domain event payload**：描述事实的应用级不可变对象。
+**Domain event stream**：一次命令执行产生的非空有序事件集合。
+**Event sourcing**：在可选快照之后应用持久事件流重建状态。
+**State event**：用已溯源聚合状态装饰的领域事件流。
+**Snapshot**：用于减少重放工作的派生状态检查点。
+**Projection**：更新读模型的事件消费者。
+**Stateless saga**：其结果被转换为新命令的事件函数。
+**Compensation**：针对目标函数显式重放持久领域事件或重建状态事件。
+**Local-first**：保留分布式投递路径，同时尝试本地准入。
+**Quiesce**：停止接收新工作，但允许已准入工作排空。
+**Force stop**：优雅完成不再可行后的尽力关闭。
+**Route catalog**：由 WebFlux 路由与 OpenAPI 物化共享的已校验运行时契约。
+**Generated metadata**：KSP 生成由 `MetadataSearcher` 加载的 JSON 资源，以及调用运行时聚合元数据 parser 的独立访问器。
+
+## 最终心智模型
+
+从一个聚合和一个命令开始。
+沿命令信封进入一个串行通道。
+从快照加事件尾部重建状态。
+让聚合产生事件，而不是直接修改存储。
+把一个事件流追加为命令的持久结果。
+把之后的总线、投影、Saga 与快照效果视为职责独立的异步边界。
+让 `WowRuntime` 决定这些所有者何时可以接收和完成工作。
+对分类为临时的失败使用 retry。
+需要下游重新处理时，对持久事件执行显式 compensation replay。
+对安全、投递与性能保证只采用证据，不采用标签。


### PR DESCRIPTION
## What changed

- Restore bilingual onboarding entry pages and four audience-specific guides for contributors, staff engineers, executives, and product managers.
- Align architectural, command lifecycle, storage, extension, testing, and product descriptions with current source, tests, configuration, and runtime contracts.
- Add English and Chinese VitePress navigation/sidebar entries.
- Link the contributor onboarding guide from `CONTRIBUTING.md`.

## Why

The previous documentation cleanup removed the onboarding tree. The repository still needs a role-oriented entry point that complements the canonical topic guides without duplicating stale contracts.

## Impact

Readers can now choose an onboarding path appropriate to their role. The guides explicitly distinguish verified framework behavior from product or operational properties that are not defined by the repository.

## Validation

- Cross-review completed with no remaining findings.
- Source citation validation: `citation_errors=0`.
- Structure, length, Mermaid source/color validation: `structure_errors=0`.
- Whitespace validation and `git diff --check`: passed.
- VitePress production build: passed.
- Rendered onboarding pages: `10/10`.

The build retains the existing non-failing Rollup chunk-size warning.