### PR TITLE
fix(deps): exempt lockFileMaintenance from minimumReleaseAge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": [
+    "config:recommended"
+  ],
   "timezone": "Asia/Shanghai",
-  "labels": ["dependencies"],
+  "labels": [
+    "dependencies"
+  ],
   "dependencyDashboard": true,
   "commitMessagePrefix": "fix(deps)",
   "commitMessageTopic": "{{depName}}",
@@ -12,24 +16,33 @@
   "prConcurrentLimit": 20,
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 3pm on monday"],
-    "commitMessageTopic": "lock files"
+    "schedule": [
+      "before 3pm on monday"
+    ],
+    "commitMessageTopic": "lock files",
+    "minimumReleaseAge": null
   },
   "packageRules": [
     {
       "description": "Require manual approval for major version updates.",
-      "matchUpdateTypes": ["major"],
+      "matchUpdateTypes": [
+        "major"
+      ],
       "dependencyDashboardApproval": true
     },
     {
       "description": "Group GitHub Actions updates.",
-      "matchManagers": ["github-actions"],
+      "matchManagers": [
+        "github-actions"
+      ],
       "groupName": "github-actions",
       "commitMessageTopic": "GitHub Actions"
     },
     {
       "description": "Group Spring Boot, Spring Framework, and Springdoc updates.",
-      "matchDatasources": ["maven"],
+      "matchDatasources": [
+        "maven"
+      ],
       "matchPackageNames": [
         "/^org\\.springframework[.:]/",
         "/^org\\.springdoc:/"
@@ -49,7 +62,9 @@
     },
     {
       "description": "Group OpenTelemetry core and instrumentation BOMs so API/SDK and instrumentation stay aligned.",
-      "matchDatasources": ["maven"],
+      "matchDatasources": [
+        "maven"
+      ],
       "matchPackageNames": [
         "io.opentelemetry:opentelemetry-bom",
         "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom"
@@ -59,13 +74,19 @@
     },
     {
       "description": "Keep OpenTelemetry semantic conventions visible because this artifact is alpha-versioned independently.",
-      "matchDatasources": ["maven"],
-      "matchPackageNames": ["io.opentelemetry:opentelemetry-semconv"],
+      "matchDatasources": [
+        "maven"
+      ],
+      "matchPackageNames": [
+        "io.opentelemetry:opentelemetry-semconv"
+      ],
       "commitMessageTopic": "OpenTelemetry semantic conventions"
     },
     {
       "description": "Group Ahoo platform BOM updates used by wow-dependencies.",
-      "matchDatasources": ["maven"],
+      "matchDatasources": [
+        "maven"
+      ],
       "matchPackageNames": [
         "me.ahoo.cosid:cosid-bom",
         "me.ahoo.simba:simba-bom",
@@ -77,14 +98,20 @@
     },
     {
       "description": "Group Ahoo Fetcher packages because the dashboard uses the generated client stack as one version family.",
-      "matchDatasources": ["npm"],
-      "matchPackageNames": ["/^@ahoo-wang\\/fetcher/"],
+      "matchDatasources": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "/^@ahoo-wang\\/fetcher/"
+      ],
       "groupName": "fetcher",
       "commitMessageTopic": "Fetcher packages"
     },
     {
       "description": "Group React runtime packages used by the compensation dashboard.",
-      "matchDatasources": ["npm"],
+      "matchDatasources": [
+        "npm"
+      ],
       "matchPackageNames": [
         "react",
         "react-dom",
@@ -97,7 +124,9 @@
     },
     {
       "description": "Group Vite and Vitest tooling used by the compensation dashboard.",
-      "matchDatasources": ["npm"],
+      "matchDatasources": [
+        "npm"
+      ],
       "matchPackageNames": [
         "vite",
         "@vitejs/plugin-react",
@@ -112,7 +141,9 @@
     },
     {
       "description": "Group VitePress documentation tooling.",
-      "matchDatasources": ["npm"],
+      "matchDatasources": [
+        "npm"
+      ],
       "matchPackageNames": [
         "vitepress",
         "vitepress-plugin-llms",


### PR DESCRIPTION
## 背景

锁文件维护 PR（如 #2830）因继承顶层 `minimumReleaseAge: "12 hours"`，导致 `renovate/stability-days` 检查持续 `pending`，PR 状态变为 `UNSTABLE`，被分支保护门禁拦截，长期无法自动合并。

## 根因

`renovate.json` 顶层设置了 `"minimumReleaseAge": "12 hours"`，而 `lockFileMaintenance` 块未显式覆盖，于是继承该门禁。锁文件维护刷新的是传递依赖（lockfile 内的版本漂移），这些版本往往刚发布不久，不满足 12 小时稳定期，因此 stability-days 始终 pending。

## 修改

给 `lockFileMaintenance` 显式设置 `"minimumReleaseAge": null`，豁免其最小发布年龄门禁。锁文件维护不引入新的 manifest 版本声明，只是把 lock 刷新到当前已声明范围内的最新可解析版本，风险可控，无需额外稳定期门禁。

```diff
  "lockFileMaintenance": {
    "enabled": true,
    "schedule": ["before 3pm on monday"],
-   "commitMessageTopic": "lock files"
+   "commitMessageTopic": "lock files",
+   "minimumReleaseAge": null
  },
```

其余配置零改动。

## 验证

合并后，后续周一的锁文件维护 PR 将不再因 stability-days 卡住。