### PR TITLE
docs: add production best practices

### DIFF
--- a/documentation/docs/.vitepress/configs/sidebar.en.ts
+++ b/documentation/docs/.vitepress/configs/sidebar.en.ts
@@ -85,6 +85,7 @@ export const sidebarEn: DefaultTheme.Sidebar = {
             text: 'Best Practices',
             collapsed: false,
             items: [
+                {text: 'Production Best Practices', link: 'best-practices'},
                 {text: 'Troubleshooting', link: 'troubleshooting'},
                 {
                     text: 'Migration Guide',

--- a/documentation/docs/.vitepress/configs/sidebar.zh.ts
+++ b/documentation/docs/.vitepress/configs/sidebar.zh.ts
@@ -85,6 +85,7 @@ export const sidebarZh: DefaultTheme.Sidebar = {
             text: '最佳实践',
             collapsed: false,
             items: [
+                {text: '生产最佳实践', link: 'best-practices'},
                 {text: '故障排查', link: 'troubleshooting'},
                 {
                     text: '迁移指南',

--- a/documentation/docs/en/guide/best-practices.md
+++ b/documentation/docs/en/guide/best-practices.md
@@ -1,0 +1,227 @@
+---
+title: "Production Best Practices"
+description: "Evidence-based practices for modeling, command delivery, consistency, snapshots, compensation, testing, and operating Wow services."
+outline: deep
+---
+
+# Production Best Practices
+
+Wow removes much of the infrastructure plumbing around CQRS and event sourcing, but it does not remove the need to choose explicit domain boundaries, consistency targets, and failure policies. This guide turns the framework's current contracts into a production checklist.
+
+## Practice Map
+
+| Concern | Recommended default | Avoid | Source |
+|---|---|---|---|
+| Domain logic | Validate invariants in command handlers; mutate state only from events | CRUD-style public state mutation | [Cart.kt:38-76](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt#L38-L76), [CartState.kt:23-46](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt#L23-L46) |
+| Reactive execution | Keep the full handler and storage path non-blocking | `block()`, blocking I/O, or hidden thread waits in runtime paths | [AggregateProcessorFilter.kt:31-49](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/AggregateProcessorFilter.kt#L31-L49) |
+| Command results | Wait for the smallest stage that proves the caller's business outcome | Treating `SENT` as successful domain processing | [CommandStage.kt:25-102](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt#L25-L102) |
+| Duplicate requests | Reuse a stable `requestId` for the same logical operation | Generating a new request ID for every transport retry | [DefaultCommandGateway.kt:86-118](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L86-L118) |
+| Concurrency | Send `aggregateVersion` when the caller must reject stale writes | Assuming all concurrent business commands are interchangeable | [CommandMessage.kt:85-95](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L85-L95) |
+| Snapshots | Use `strategy: all` so the latest aggregate state is the default query store | Using `version_offset` while expecting every query to see the latest state | [SnapshotProperties.kt:23-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/snapshot/SnapshotProperties.kt#L23-L45) |
+| Cross-aggregate work | Use Saga for orchestration and compensation for recoverable failures | Calling Saga completion a distributed transaction commit | [StatelessSagaFunction.kt:57-69](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt#L57-L69) |
+
+## Model Business Decisions, Not Data Updates
+
+| Element | Responsibility | Rule of thumb | Source |
+|---|---|---|---|
+| Command | Express intent | Name it after a business action, such as `AddCartItem` | [Cart.kt:40-63](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt#L40-L63) |
+| Command aggregate | Enforce invariants and decide facts | Return domain events; do not directly expose mutable state | [Cart.kt:44-60](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt#L44-L60) |
+| Domain event | Record an accepted business fact | Use past-tense names such as `CartItemAdded` | [Cart.kt:50-60](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt#L50-L60) |
+| State aggregate | Rebuild state deterministically | Apply changes only in `@OnSourcing` functions | [CartState.kt:27-45](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt#L27-L45) |
+
+```mermaid
+flowchart LR
+    Intent[Business intent] --> Command[Command]
+    Command --> Decision[Aggregate invariant and decision]
+    Decision -->|accepted| Event[Domain event]
+    Decision -->|rejected| Error[Domain error]
+    Event --> State[State rebuilt by OnSourcing]
+    Event --> Consumers[Projection, processor, or Saga]
+
+    classDef primary fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    classDef secondary fill:#161b22,stroke:#30363d,color:#e6edf3
+    class Intent,Command,Decision,Event primary
+    class Error,State,Consumers secondary
+```
+
+<!-- Sources: example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt:38-76, example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt:23-46 -->
+
+Keep an aggregate as small as the invariant allows. If two concepts do not need one atomic decision, connect them with an event and a Saga instead of growing a shared aggregate. The framework routes each command by `AggregateId`, and the dispatcher creates aggregate-specific processing through the configured scheduler ([CommandDispatcher.kt:37-75](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/CommandDispatcher.kt#L37-L75)).
+
+## Preserve the Reactive Boundary
+
+| Layer | Framework contract | Application responsibility | Source |
+|---|---|---|---|
+| Gateway and bus | `Mono`/`Flux` based dispatch | Compose, do not synchronously wait | [DefaultCommandGateway.kt:129-143](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L129-L143) |
+| Dispatcher | Receives a `Flux` and routes by aggregate | Keep filters non-blocking | [CommandDispatcher.kt:46-75](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/CommandDispatcher.kt#L46-L75) |
+| Aggregate processing | Chains processing and acknowledgement as `Mono` | Return reactive work instead of hiding I/O | [AggregateProcessorFilter.kt:31-49](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/AggregateProcessorFilter.kt#L31-L49) |
+| Event store | Appends and loads through `Mono`/`Flux` | Use the provided reactive storage adapters | [EventStore.kt:41-54](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L41-L54) |
+
+```mermaid
+%%{init: {"theme":"base","themeVariables":{"primaryColor":"#2d333b","primaryBorderColor":"#6d5dfc","primaryTextColor":"#e6edf3","lineColor":"#8b949e","secondaryColor":"#161b22","tertiaryColor":"#161b22"}}}%%
+sequenceDiagram
+    autonumber
+    actor Caller
+    participant Gateway as CommandGateway
+    participant Bus as CommandBus
+    participant Dispatcher as CommandDispatcher
+    participant Handler as Command filter chain
+    participant Aggregate as AggregateProcessor
+    participant Store as EventStore
+    participant EventBus as DomainEventBus
+
+    Caller->>Gateway: send CommandMessage
+    Gateway->>Bus: send after validation and idempotency check
+    Bus->>Dispatcher: deliver exchange
+    Dispatcher->>Handler: handle exchange reactively
+    Handler->>Aggregate: process command
+    Aggregate->>Store: append DomainEventStream
+    Store-->>Aggregate: append completed
+    Aggregate-->>Handler: stored DomainEventStream
+    Handler->>EventBus: publish stored event stream
+```
+
+<!-- Sources: wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt:114-143, wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/CommandDispatcher.kt:37-75, wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/CommandAggregate.kt:65-82, wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt:25-46 -->
+
+When a legacy SDK or database driver blocks, isolate it behind a bounded adapter and scheduler outside the core command, event-store, projection, and Saga paths. Treat that boundary as a measured exception, not the default programming model.
+
+## Wait for the Business Outcome You Need
+
+| Stage | What it proves | What it does not prove | Typical caller | Source |
+|---|---|---|---|---|
+| `SENT` | The command bus accepted the command | Aggregate processing | Fire-and-observe workflows | [CommandStage.kt:26-34](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt#L26-L34) |
+| `PROCESSED` | The aggregate processed the command | Projection or external handler completion | Write APIs returning domain results | [CommandStage.kt:36-44](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt#L36-L44) |
+| `SNAPSHOT` | Snapshot processing completed; with `strategy: all`, the current state was saved | Other projections or external read models; `version_offset` may have skipped the write | Read-after-write snapshot queries using `all` and the same query-capable backend | [CommandStage.kt:46-54](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt#L46-L54) |
+| `PROJECTED` | A `PROJECTED` signal matching the optional function target | Every projection in the system | Read-after-write UI/API | [CommandStage.kt:56-65](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt#L56-L65) |
+| `EVENT_HANDLED` | An `EVENT_HANDLED` signal matching the optional function target | Saga-generated command processing | A caller depending on one side effect | [CommandStage.kt:67-75](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt#L67-L75) |
+| `SAGA_HANDLED` | A matching Saga handled the source event and any generated commands were accepted/sent | Downstream aggregate completion or a distributed transaction commit | Observing orchestration acceptance | [CommandStage.kt:77-86](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt#L77-L86), [StatelessSagaFunction.kt:57-69](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt#L57-L69) |
+
+For `PROJECTED`, `EVENT_HANDLED`, and `SAGA_HANDLED`, provide a function target when one specific processor must complete. Without one, the wait target accepts a signal at the requested stage without function matching ([WaitPlan.kt:32-57](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitPlan.kt#L32-L57)).
+
+```mermaid
+flowchart TD
+    Start{What must the response prove?}
+    Start -->|Bus acceptance only| Sent[SENT]
+    Start -->|Aggregate decision| Processed[PROCESSED]
+    Start -->|Target read model updated| Projected[PROJECTED]
+    Start -->|Target external handler done| Handled[EVENT_HANDLED]
+    Start -->|Target Saga accepted its output| Saga[SAGA_HANDLED]
+    Start -->|Snapshot processing completed| Snapshot[SNAPSHOT]
+
+    classDef primary fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    classDef secondary fill:#161b22,stroke:#30363d,color:#e6edf3
+    class Start primary
+    class Sent,Processed,Projected,Handled,Saga,Snapshot secondary
+```
+
+<!-- Sources: wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt:25-102, wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt:57-69 -->
+
+Prefer the narrowest sufficient stage: wider waits couple API latency and availability to more asynchronous consumers. The default wait deadline is 30 seconds, and `WaitPlan.withTimeout` changes a caller-side execution deadline rather than a propagated message header ([WaitTimeout.kt:18-53](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitTimeout.kt#L18-L53)). Set an explicit timeout from the caller's latency budget and handle timeouts as an unknown observation result, not proof that the command was never processed.
+
+## Make Retry, Concurrency, and LocalFirst Semantics Explicit
+
+| Mechanism | Use it for | Boundary | Source |
+|---|---|---|---|
+| `requestId` | Deduplicating the same logical command | The gateway checks the target aggregate and request ID before send | [DefaultCommandGateway.kt:86-118](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L86-L118) |
+| `aggregateVersion` | Rejecting stale commands with optimistic concurrency | Optional; omit only when stale writes are acceptable to domain rules | [CommandMessage.kt:85-95](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L85-L95) |
+| LocalFirst | Avoiding broker latency after local runtime admission | It does not provide end-to-end exactly-once delivery | [LocalFirstMessageBus.kt:141-199](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/LocalFirstMessageBus.kt#L141-L199) |
+| Aggregate retry | Retrying framework-classified recoverable processing failures | Limited to three backoff retries in the current processor | [RetryableAggregateProcessor.kt:30-70](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/RetryableAggregateProcessor.kt#L30-L70) |
+
+For a client retry of the same business request, preserve `requestId`; otherwise the duplicate check sees a new command. Use `aggregateVersion` when the command was prepared from a specific state version—for example, approving an order only if it has not changed since review.
+
+For an eligible local, non-void command, LocalFirst first attempts local runtime admission and sends a distributed copy. The copy is marked locally handled only when every targeted local receiver confirms admission; otherwise it stays eligible for distributed processing. Void commands explicitly disable LocalFirst, and a later Handler failure after successful admission does not retroactively reactivate the distributed copy ([LocalFirstCommandBus.kt:29-46](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/LocalFirstCommandBus.kt#L29-L46), [LocalFirstMessageBus.kt:141-199](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/LocalFirstMessageBus.kt#L141-L199)). Design Handler retry and adapter acknowledgement policy separately.
+
+## Use Snapshots as the Default Query Store
+
+`strategy: all` is the recommended strategy. It saves the state produced by every state event, so after the `SNAPSHOT` stage completes, the snapshot collection is both an aggregate-loading checkpoint and a real-time current-state query store. For standard queries over one aggregate type, applications do not need to write a projection processor that copies the same state elsewhere.
+
+| Choice | Query semantics | Recommendation | Source |
+|---|---|---|---|
+| `strategy: all` | Every processed state event updates the latest snapshot | Recommended default for current-state queries | [SnapshotAutoConfiguration.kt:67-92](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/snapshot/SnapshotAutoConfiguration.kt#L67-L92), [SimpleSnapshotStrategy.kt:19-38](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SimpleSnapshotStrategy.kt#L19-L38) |
+| `strategy: version_offset` | The stored snapshot may trail the aggregate by as many events as the configured threshold allows | Use only when stale snapshot queries are acceptable or another read model serves current queries | [VersionOffsetSnapshotStrategy.kt:24-63](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/VersionOffsetSnapshotStrategy.kt#L24-L63) |
+| Custom projection | Maintains a purpose-built read schema | Reserve for cross-aggregate joins, denormalized views, analytics, or external systems | [ProjectionHandler.kt:23-43](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/projection/ProjectionHandler.kt#L23-L43) |
+
+```mermaid
+flowchart LR
+    Command[Command] --> Aggregate[Aggregate]
+    Aggregate --> StateEvent[State event]
+    StateEvent --> All[SimpleSnapshotStrategy all]
+    All --> Store[Query-capable SnapshotStore]
+    Store --> Service[SnapshotQueryService]
+    Service --> Routes[Built-in WebFlux query routes]
+    Routes --> Client[Client]
+    StateEvent -. cross-aggregate or custom view .-> Projection[Projection]
+
+    classDef primary fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    classDef secondary fill:#161b22,stroke:#30363d,color:#e6edf3
+    class Command,Aggregate,StateEvent,All primary
+    class Store,Service,Routes,Client,Projection secondary
+```
+
+<!-- Sources: wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SimpleSnapshotStrategy.kt:19-38, wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/SnapshotQueryService.kt:30-61, wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/aggregate/snapshot/SnapshotRouteContributor.kt:59-281, wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/route/QueryRouteModule.kt:34-79 -->
+
+With WebFlux support enabled, Wow contributes single, list, paged, count, and state-only snapshot endpoints, so applications do not need to hand-write controllers for these standard query shapes ([SnapshotRouteContributor.kt:59-281](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/aggregate/snapshot/SnapshotRouteContributor.kt#L59-L281), [QueryRouteModule.kt:34-79](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/route/QueryRouteModule.kt#L34-L79)). The same service is registered per aggregate as `<aggregate>.SnapshotQueryService` for in-process queries ([SnapshotQueryServiceRegistrar.kt:28-61](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/SnapshotQueryServiceRegistrar.kt#L28-L61)).
+
+This read path requires a query-capable snapshot backend: MongoDB and Elasticsearch provide `SnapshotQueryServiceFactory`; a custom backend must provide the matching factory binding. Redis and in-memory snapshot stores persist/load snapshots but do not by themselves implement dynamic snapshot queries. Keep authorization, tenant/owner filtering, and database indexes explicit. With `strategy: all` and the query service bound to the same backend, read-after-write callers should wait for `SNAPSHOT`; snapshot processing consumes state events asynchronously. The stage only proves processing completed—`version_offset` may complete without writing when its threshold is not met. The event stream remains the source of truth.
+
+## Orchestrate and Compensate Deliberately
+
+| Situation | Mechanism | Required decision | Source |
+|---|---|---|---|
+| One event triggers commands for another aggregate | Stateless Saga | Define command idempotency and downstream observation | [StatelessSagaFunction.kt:57-69](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt#L57-L69) |
+| A recoverable asynchronous execution fails | Compensation | Define retry threshold, backoff, timeout, and operator path | [CompensationProperties.kt:21-33](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-server/src/main/kotlin/me/ahoo/wow/compensation/server/configuration/CompensationProperties.kt#L21-L33) |
+| Recovery reaches a terminal result | Compensation state | Distinguish `FAILED`, `PREPARED`, and `SUCCEEDED` | [ExecutionFailedState.kt:44-85](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-domain/src/main/kotlin/me/ahoo/wow/compensation/domain/ExecutionFailedState.kt#L44-L85) |
+
+```mermaid
+%%{init: {"theme":"base","themeVariables":{"primaryColor":"#2d333b","primaryBorderColor":"#6d5dfc","primaryTextColor":"#e6edf3","lineColor":"#8b949e","secondaryColor":"#161b22","tertiaryColor":"#161b22"}}}%%
+stateDiagram-v2
+    [*] --> FAILED: failure recorded
+    FAILED --> PREPARED: retry prepared
+    PREPARED --> FAILED: retry failed
+    PREPARED --> SUCCEEDED: retry succeeded
+    PREPARED --> PREPARED: timed-out attempt reclaimed
+    SUCCEEDED --> [*]
+```
+
+<!-- Sources: compensation/wow-compensation-domain/src/main/kotlin/me/ahoo/wow/compensation/domain/ExecutionFailed.kt:59-106, compensation/wow-compensation-domain/src/main/kotlin/me/ahoo/wow/compensation/domain/ExecutionFailedState.kt:44-85, compensation/wow-compensation-api/src/main/kotlin/me/ahoo/wow/compensation/api/IExecutionFailedState.kt:138-164 -->
+
+Do not describe a Saga as an ACID transaction. Saga completion observes the source-event handler and command-send boundary; downstream aggregate execution may be concurrent or later. For compensation, set finite retry and execution limits, expose exhausted or unrecoverable work to operators, and make the retried side effect idempotent.
+
+## Test Behavior at the Narrowest Useful Layer
+
+| Test layer | What to assert | Framework support | Source |
+|---|---|---|---|
+| Aggregate specification | Error, emitted event type/body, and resulting state | `AggregateSpec` | [AggregateSpec.kt:32-70](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-test/src/main/kotlin/me/ahoo/wow/test/AggregateSpec.kt#L32-L70) |
+| Saga specification | Commands emitted for a source event | `SagaSpec` | [SagaSpec.kt:28-70](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-test/src/main/kotlin/me/ahoo/wow/test/SagaSpec.kt#L28-L70) |
+| Adapter contract | Message bus, event store, snapshot store, projection, and query behavior | `wow-tck` specifications | [EventStoreSpec.kt:47-80](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/eventsourcing/EventStoreSpec.kt#L47-L80) |
+| Integration path | Serialization, generated contracts, storage, broker, and Spring wiring | TCK-backed integration tests with real adapters | [KafkaMongoCommandDispatcher.kt:31-72](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-it/src/integrationTest/kotlin/me/ahoo/wow/it/KafkaMongoCommandDispatcher.kt#L31-L72) |
+
+Every aggregate rule should have a success case, a rejection case, and relevant state-transition forks. The Cart specification demonstrates event and state assertions plus delete/recover branches ([CartSpec.kt:28-86](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt#L28-L86)). Add broader integration tests only where infrastructure behavior matters; this keeps failures local and diagnostics precise.
+
+## Production Readiness Checklist
+
+| Gate | Ready when | Evidence to keep | Source |
+|---|---|---|---|
+| Domain | Invariants and event/state transitions have focused specs | Aggregate and Saga test reports | [CartSpec.kt:28-86](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt#L28-L86) |
+| Consistency | Every endpoint documents its wait stage and timeout | API contract and latency budget | [WaitTimeout.kt:18-53](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitTimeout.kt#L18-L53) |
+| Delivery | Retry, idempotency, concurrency, and LocalFirst boundaries are explicit | Failure-path tests and adapter settings | [DefaultCommandGateway.kt:86-143](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L86-L143) |
+| Snapshot query | `all` is enabled on a query-capable backend; filters, indexes, routes, and `SNAPSHOT` read-after-write behavior are verified | API tests and query plans with production-like data | [SnapshotQueryService.kt:30-61](https://github.com/Ahoo-Wang/Wow/blob/main/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/SnapshotQueryService.kt#L30-L61) |
+| Recovery | Retry exhaustion and unrecoverable failures have an operator workflow | Compensation dashboard/runbook | [IExecutionFailedState.kt:138-164](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-api/src/main/kotlin/me/ahoo/wow/compensation/api/IExecutionFailedState.kt#L138-L164) |
+| Observability | Command waits, bus sends, and storage calls are traceable | Trace and metric screenshots from staging | [TracingCommandGateway.kt:31-66](https://github.com/Ahoo-Wang/Wow/blob/main/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/wait/TracingCommandGateway.kt#L31-L66), [TracingEventStore.kt:28-66](https://github.com/Ahoo-Wang/Wow/blob/main/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/eventsourcing/TracingEventStore.kt#L28-L66) |
+| Lifecycle | Shutdown drains accepted work within an explicit deadline | Deployment termination test | [CommandDispatcher.kt:78-83](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/CommandDispatcher.kt#L78-L83) |
+
+Promote only after validating the actual storage adapter, broker, deployment topology, and data distribution. Green unit tests establish domain behavior; they do not by themselves prove capacity, recovery, or shutdown behavior in production.
+
+## Related Pages
+
+| Page | Relationship |
+|---|---|
+| [Core Concepts](./core-concepts.md) | Defines commands, events, aggregates, and CQRS |
+| [Aggregate Modeling](./modeling.md) | Shows how to model command and state aggregates |
+| [Command Gateway](./command-gateway.md) | Documents wait plans and command delivery |
+| [Snapshot](./snapshot.md) | Explains snapshot stores and strategies |
+| [Query Service](./query.md) | Documents snapshot query DSL and built-in endpoints |
+| [Distributed Transactions (Saga)](./saga.md) | Covers cross-aggregate orchestration |
+| [Event Compensation](./event-compensation.md) | Covers failure recovery and operator workflows |
+| [Test Suite](./test-suite.md) | Describes the aggregate and Saga testing DSL |
+| [Observability](./advanced/observability.md) | Covers traces and runtime observability |

--- a/documentation/docs/en/guide/configuration.md
+++ b/documentation/docs/en/guide/configuration.md
@@ -43,9 +43,8 @@ wow:
       storage: mongo               # Event store type: mongo, redis, elasticsearch, in_memory, delay
     snapshot:
       enabled: true
-      strategy: all                # all, version_offset
+      strategy: all                # recommended for current-state queries
       storage: mongo
-      version-offset: 10
 
   # Infrastructure-specific configurations
   kafka:
@@ -196,8 +195,7 @@ wow:
   eventsourcing:
     snapshot:
       enabled: true
-      strategy: version_offset      # all, version_offset
-      version-offset: 10
+      strategy: all                 # recommended for current-state queries
       storage: mongo
 ```
 
@@ -623,8 +621,7 @@ wow:
       storage: mongo
     snapshot:
       enabled: true
-      strategy: version_offset
-      version-offset: 10
+      strategy: all
       storage: mongo
   kafka:
     bootstrap-servers:
@@ -701,8 +698,7 @@ wow:
       storage: mongo
     snapshot:
       enabled: true
-      strategy: version_offset
-      version-offset: 10
+      strategy: all
       storage: mongo
   kafka:
     bootstrap-servers:

--- a/documentation/docs/en/guide/eventstore.md
+++ b/documentation/docs/en/guide/eventstore.md
@@ -235,8 +235,7 @@ wow:
       storage: mongo
     snapshot:
       enabled: true
-      strategy: version_offset  # all, version_offset
-      version-offset: 10
+      strategy: all  # Recommended: persist the state produced by every state event
       storage: mongo
 ```
 
@@ -250,7 +249,7 @@ wow:
 
 ## Best Practices
 
-1. **Enable snapshots for long-lived aggregates**: Set `strategy` to `version_offset` with offset 5-20 to avoid linear degradation for aggregates with many events.
+1. **Use snapshots as the default current-state query store**: Keep the recommended `strategy: all` so every processed state event updates the latest snapshot. With a query-capable backend and WebFlux support, `SnapshotQueryService` and the built-in single/list/paged/count routes replace duplicate projection code and hand-written query endpoints for standard single-aggregate queries. Use `version_offset` only when stale snapshot queries are acceptable or another read model serves current queries.
 
 2. **Monitor version conflicts**: Occasional `EventVersionConflictException`s are normal. High frequency indicates contention — consider redesigning aggregate boundaries.
 
@@ -262,7 +261,8 @@ wow:
 
 ## Related Topics
 
-- [Snapshot](./snapshot) — Optimize aggregate loading with snapshots
+- [Snapshot](./snapshot) — Use snapshots for aggregate loading and current-state queries
+- [Query Service](./query) — Query snapshots through the DSL and built-in endpoints
 - [Command Gateway](./command-gateway) — How commands are routed to aggregates
 - [Saga](./saga) — Distributed transactions across aggregates
 - [Projection](./projection) — How projections consume event streams

--- a/documentation/docs/en/guide/snapshot.md
+++ b/documentation/docs/en/guide/snapshot.md
@@ -1,11 +1,11 @@
 ---
 title: Snapshot
-description: Snapshot is an important optimization mechanism in event sourcing architecture that improves performance by saving checkpoints of aggregate root state.
+description: Use snapshots as aggregate loading checkpoints and the default current-state query store with Wow's built-in query service and routes.
 ---
 
 # Snapshot
 
-Snapshot is an important optimization mechanism in event sourcing architecture that improves performance by saving checkpoints of aggregate root state to reduce the number of event replays.
+Snapshots save aggregate-state checkpoints to reduce event replay. With the recommended `all` strategy, the same data also serves as the default materialized current-state query store through `SnapshotQueryService` and Wow's built-in query routes.
 
 ## Snapshot Mechanism
 
@@ -111,7 +111,7 @@ stateDiagram-v2
     Stale --> Create: Interval Reached
 ```
 
-<!-- Sources: wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotMaterializer.kt, dispatcher/SnapshotHandler.kt -->
+<!-- Sources: wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotMaterializer.kt, wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/dispatcher/SnapshotHandler.kt -->
 
 ## Snapshot Store
 
@@ -169,12 +169,12 @@ class InMemorySnapshotStore : SnapshotStore {
 
 ### Supported Backends
 
-| Backend | Module | Status |
-|---------|--------|--------|
-| In-memory | `wow-core` | Development/testing |
-| MongoDB | `wow-mongo` | Production-ready |
-| Redis | `wow-redis` | Production-ready |
-| Elasticsearch | `wow-elasticsearch` | Production-ready |
+| Backend | Module | Snapshot storage | Dynamic snapshot query |
+|---------|--------|------------------|------------------------|
+| In-memory | `wow-core` | Development/testing | No built-in query factory |
+| MongoDB | `wow-mongo` | Production-ready | Yes |
+| Redis | `wow-redis` | Production-ready | No built-in query factory |
+| Elasticsearch | `wow-elasticsearch` | Production-ready | Yes |
 
 ## Snapshot Processing Flow
 
@@ -191,7 +191,6 @@ wow:
     snapshot:
       enabled: true  # Whether to enable snapshots
       strategy: all  # Snapshot strategy (all, version_offset)
-      version-offset: 5  # Version offset (only valid for version_offset strategy)
       storage: mongo  # Snapshot storage backend (mongo, redis, elasticsearch, in_memory)
 ```
 
@@ -202,6 +201,50 @@ wow:
 | `wow.eventsourcing.snapshot.version-offset` | `5` | Version offset threshold (only used by `version_offset`) |
 | `wow.eventsourcing.snapshot.storage` | `mongo` | Snapshot storage backend (shared `StorageType` enum) |
 
+## Snapshots as the Default Read Model
+
+Use `strategy: all` by default. `SimpleSnapshotStrategy` materializes the state produced by every state event, making the snapshot store a real-time current-state query store after the `SNAPSHOT` stage completes, as well as an aggregate-loading checkpoint. For standard queries over one aggregate type, this removes the need to write a projection that duplicates aggregate state.
+
+| Strategy | Stored state | Query consequence | Recommendation |
+|---|---|---|---|
+| `all` | Every processed state event updates the latest snapshot | Queries read the latest materialized aggregate state after snapshot processing completes | Recommended |
+| `version_offset` | A snapshot is written only after the version gap reaches `version-offset` | Snapshot queries can lag behind the aggregate | Use only when staleness is accepted or another read model serves current queries |
+
+```mermaid
+flowchart LR
+    Command[Command] --> Aggregate[Aggregate]
+    Aggregate --> Event[State event]
+    Event --> Strategy[SimpleSnapshotStrategy all]
+    Strategy --> Store[Query-capable snapshot store]
+    Store --> Service[SnapshotQueryService]
+    Service --> Routes[Built-in WebFlux routes]
+    Routes --> Client[Client]
+    Event -. cross-aggregate or custom view .-> Projection[Projection]
+
+    classDef primary fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    classDef secondary fill:#161b22,stroke:#30363d,color:#e6edf3
+    class Command,Aggregate,Event,Strategy primary
+    class Store,Service,Routes,Client,Projection secondary
+```
+
+<!-- Sources: wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SimpleSnapshotStrategy.kt:19-38, wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/SnapshotQueryService.kt:30-61, wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/aggregate/snapshot/SnapshotRouteContributor.kt:59-281, wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/route/QueryRouteModule.kt:34-79 -->
+
+When WebFlux support is enabled, Wow generates standard snapshot query endpoints for each aggregate:
+
+| Query shape | Route suffix | Result |
+|---|---|---|
+| Count | `/snapshot/count` | Number of matching snapshots |
+| List | `/snapshot/list` and `/snapshot/list/state` | Bounded snapshot or state list |
+| Paged | `/snapshot/paged` and `/snapshot/paged/state` | Paged snapshots or states |
+| Single | `/snapshot/single` and `/snapshot/single/state` | One snapshot or state |
+
+These routes are backed by the same `SnapshotQueryService` contract used by the Query DSL, and Spring registers a typed `<aggregate>.SnapshotQueryService` bean for each aggregate. Applications therefore do not need to hand-write query API endpoints for these standard shapes ([SnapshotQueryService.kt:30-61](https://github.com/Ahoo-Wang/Wow/blob/main/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/SnapshotQueryService.kt#L30-L61), [SnapshotQueryServiceRegistrar.kt:28-61](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/SnapshotQueryServiceRegistrar.kt#L28-L61), [SnapshotRouteContributor.kt:59-281](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/aggregate/snapshot/SnapshotRouteContributor.kt#L59-L281)).
+
+:::warning Query capability and consistency boundaries
+A query-capable backend is required. MongoDB and Elasticsearch provide `SnapshotQueryServiceFactory`; a custom backend must provide the matching binding. Redis and in-memory snapshot stores support persistence and loading but do not by themselves provide dynamic snapshot queries. Keep tenant/owner filtering, authorization, and indexes explicit. Snapshot processing consumes state events asynchronously. With `strategy: all` and the query service bound to the same backend, a caller that requires read-after-write visibility must wait for the `SNAPSHOT` command stage. The stage only proves snapshot processing completed; `version_offset` can complete without writing when its threshold is not met. The event stream remains the source of truth.
+:::
+
+Continue to use a projection when the read model joins multiple aggregates, needs a denormalized schema that differs from aggregate state, feeds analytics, or synchronizes an external system.
 
 ## Aggregate Loading Optimization
 
@@ -221,17 +264,27 @@ do not use the latest snapshot.
 
 ## Performance Impact
 
-- **Snapshots Enabled**: Aggregate loading time is proportional to snapshot interval, not total event count
+- **`all` Strategy**: Once snapshot processing completes, the latest snapshot already contains the state produced by the latest state event
+- **`version_offset` Strategy**: Aggregate loading replays only events after the last snapshot, bounded by the configured offset
 - **Snapshots Disabled**: Every load requires replaying all historical events
 - **Storage Cost**: Requires additional storage space to save snapshot data
 
-With a snapshot interval of 50, an aggregate with 1000 events replays at most 49 events instead of all 1000 -- a ~95% reduction.
+For example, explicitly choosing `strategy: version_offset` with `version-offset: 50` limits aggregate loading to at most 49 replayed events, but the same lag also applies to direct snapshot queries. The recommended `all` strategy favors a current query store over reducing snapshot writes.
 
 ## Best Practices
 
-1. **Choose Appropriate Snapshot Strategy**: Select appropriate snapshot frequency based on business scenarios
-2. **Monitor Snapshot Effectiveness**: Regularly check if snapshots significantly improve loading performance
-3. **Snapshot Consistency**: Ensure snapshot version consistency with event streams
+1. **Prefer `all`**: Use the latest snapshot as the default current-state read model.
+2. **Reuse the query service and routes**: Do not duplicate aggregate state in a projection or write a controller for standard single/list/paged/count queries.
+3. **Select a query-capable backend**: Use MongoDB, Elasticsearch, or a custom `SnapshotQueryServiceFactory` when dynamic queries are required.
+4. **Design query safety and performance**: Verify authorization, tenant/owner filters, indexes, and query plans with production-like data.
+5. **Define read-after-write behavior**: With `all` and the same query-capable backend, wait for `SNAPSHOT` when the response must be visible through snapshot queries.
+6. **Treat `version_offset` as an explicit trade-off**: Use it only after accepting query staleness or providing another current-state read model.
 
 `SnapshotStore` currently has no generic deletion API. Physical cleanup, when required, must be
 designed and verified for the selected backend rather than treated as a Wow lifecycle capability.
+
+## Related Topics
+
+- [Production Best Practices](./best-practices.md) — Apply snapshots as the default query store in a complete production checklist
+- [Query Service](./query.md) — Build filters and use the generated snapshot query endpoints
+- [Projection](./projection.md) — Build cross-aggregate or purpose-specific read models

--- a/documentation/docs/en/guide/troubleshooting.md
+++ b/documentation/docs/en/guide/troubleshooting.md
@@ -152,8 +152,7 @@ wow:
   eventsourcing:
     snapshot:
       enabled: true
-      strategy: VERSION_OFFSET
-      version-offset: 10
+      strategy: all
 ```
 
 #### Q: Snapshot Inconsistency
@@ -303,8 +302,7 @@ wow:
 wow:
   eventsourcing:
     snapshot:
-      strategy: VERSION_OFFSET
-      version-offset: 10
+      strategy: all
 ```
 
 3. **Adjust Connection Pool**

--- a/documentation/docs/en/reference/config/core.md
+++ b/documentation/docs/en/reference/config/core.md
@@ -196,8 +196,7 @@ wow:
   eventsourcing:
     snapshot:
       enabled: true
-      strategy: version_offset
-      version-offset: 10
+      strategy: all
       storage: mongo
 ```
 
@@ -335,8 +334,7 @@ wow:
       storage: mongo
     snapshot:
       enabled: true
-      strategy: version_offset
-      version-offset: 10
+      strategy: all
       storage: mongo
 ```
 
@@ -370,8 +368,7 @@ wow:
       storage: mongo
     snapshot:
       enabled: true
-      strategy: version_offset
-      version-offset: 10
+      strategy: all
       storage: mongo
     state:
       bus:

--- a/documentation/docs/zh/guide/best-practices.md
+++ b/documentation/docs/zh/guide/best-practices.md
@@ -1,0 +1,227 @@
+---
+title: "生产最佳实践"
+description: "基于当前实现的 Wow 领域建模、命令投递、一致性、快照、补偿、测试与生产运行最佳实践。"
+outline: deep
+---
+
+# 生产最佳实践
+
+Wow 消除了 CQRS 与事件溯源的大量基础设施样板代码，但不会替你决定领域边界、一致性目标和失败策略。本指南将框架当前契约整理为一份可执行的生产检查清单。
+
+## 实践地图
+
+| 关注点 | 推荐默认做法 | 避免 | 来源 |
+|---|---|---|---|
+| 领域逻辑 | 在命令处理器中校验不变量，只通过事件变更状态 | CRUD 式公开状态修改 | [Cart.kt:38-76](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt#L38-L76)、[CartState.kt:23-46](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt#L23-L46) |
+| 响应式执行 | 保持 Handler 与存储全链路非阻塞 | 在运行时路径中使用 `block()`、阻塞 I/O 或隐藏的线程等待 | [AggregateProcessorFilter.kt:31-49](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/AggregateProcessorFilter.kt#L31-L49) |
+| 命令结果 | 等待能够证明调用方业务目标的最小阶段 | 把 `SENT` 当成领域处理成功 | [CommandStage.kt:25-102](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt#L25-L102) |
+| 重复请求 | 同一逻辑操作复用稳定的 `requestId` | 每次传输重试都生成新的请求 ID | [DefaultCommandGateway.kt:86-118](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L86-L118) |
+| 并发 | 调用方必须拒绝陈旧写入时传递 `aggregateVersion` | 假设所有并发业务命令都可以互换 | [CommandMessage.kt:85-95](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L85-L95) |
+| 快照 | 使用 `strategy: all`，让最新聚合状态直接作为默认查询存储 | 使用 `version_offset` 却要求每次查询都读到最新状态 | [SnapshotProperties.kt:23-45](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/snapshot/SnapshotProperties.kt#L23-L45) |
+| 跨聚合流程 | 用 Saga 编排，用补偿处理可恢复失败 | 把 Saga 完成称为分布式事务提交 | [StatelessSagaFunction.kt:57-69](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt#L57-L69) |
+
+## 建模业务决策，而不是数据更新
+
+| 元素 | 职责 | 经验规则 | 来源 |
+|---|---|---|---|
+| 命令 | 表达意图 | 使用业务动作命名，例如 `AddCartItem` | [Cart.kt:40-63](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt#L40-L63) |
+| 命令聚合 | 执行不变量并决定事实 | 返回领域事件，不直接暴露可变状态 | [Cart.kt:44-60](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt#L44-L60) |
+| 领域事件 | 记录已接受的业务事实 | 使用过去式名称，例如 `CartItemAdded` | [Cart.kt:50-60](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt#L50-L60) |
+| 状态聚合 | 确定性地重建状态 | 只在 `@OnSourcing` 函数中应用变更 | [CartState.kt:27-45](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt#L27-L45) |
+
+```mermaid
+flowchart LR
+    Intent[业务意图] --> Command[命令]
+    Command --> Decision[聚合不变量与决策]
+    Decision -->|接受| Event[领域事件]
+    Decision -->|拒绝| Error[领域错误]
+    Event --> State[通过 OnSourcing 重建状态]
+    Event --> Consumers[投影、处理器或 Saga]
+
+    classDef primary fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    classDef secondary fill:#161b22,stroke:#30363d,color:#e6edf3
+    class Intent,Command,Decision,Event primary
+    class Error,State,Consumers secondary
+```
+
+<!-- Sources: example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt:38-76, example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt:23-46 -->
+
+聚合应当小到刚好能够保护不变量。如果两个概念不需要在一次原子决策中同时改变，就用事件和 Saga 连接它们，而不是扩大共享聚合。框架按 `AggregateId` 路由命令，Dispatcher 通过配置的 Scheduler 创建聚合专属处理流程（[CommandDispatcher.kt:37-75](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/CommandDispatcher.kt#L37-L75)）。
+
+## 保持响应式边界
+
+| 层 | 框架契约 | 应用职责 | 来源 |
+|---|---|---|---|
+| Gateway 与 Bus | 基于 `Mono`/`Flux` 调度 | 组合异步步骤，不同步等待 | [DefaultCommandGateway.kt:129-143](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L129-L143) |
+| Dispatcher | 接收 `Flux` 并按聚合路由 | 保持 Filter 非阻塞 | [CommandDispatcher.kt:46-75](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/CommandDispatcher.kt#L46-L75) |
+| 聚合处理 | 以 `Mono` 串联处理与确认 | 返回响应式工作，不在内部隐藏 I/O | [AggregateProcessorFilter.kt:31-49](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/AggregateProcessorFilter.kt#L31-L49) |
+| 事件存储 | 通过 `Mono`/`Flux` 追加和加载 | 使用框架提供的响应式存储 Adapter | [EventStore.kt:41-54](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt#L41-L54) |
+
+```mermaid
+%%{init: {"theme":"base","themeVariables":{"primaryColor":"#2d333b","primaryBorderColor":"#6d5dfc","primaryTextColor":"#e6edf3","lineColor":"#8b949e","secondaryColor":"#161b22","tertiaryColor":"#161b22"}}}%%
+sequenceDiagram
+    autonumber
+    actor Caller as 调用方
+    participant Gateway as CommandGateway
+    participant Bus as CommandBus
+    participant Dispatcher as CommandDispatcher
+    participant Handler as 命令 Filter 链
+    participant Aggregate as AggregateProcessor
+    participant Store as EventStore
+    participant EventBus as DomainEventBus
+
+    Caller->>Gateway: 发送 CommandMessage
+    Gateway->>Bus: 校验和幂等检查后发送
+    Bus->>Dispatcher: 投递 Exchange
+    Dispatcher->>Handler: 响应式处理 Exchange
+    Handler->>Aggregate: 处理命令
+    Aggregate->>Store: 追加 DomainEventStream
+    Store-->>Aggregate: 追加完成
+    Aggregate-->>Handler: 已存储的 DomainEventStream
+    Handler->>EventBus: 发布已存储事件流
+```
+
+<!-- Sources: wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt:114-143, wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/CommandDispatcher.kt:37-75, wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/CommandAggregate.kt:65-82, wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/SendDomainEventStreamFilter.kt:25-46 -->
+
+当遗留 SDK 或数据库驱动只能阻塞调用时，将它隔离到有容量上限的 Adapter 和 Scheduler 中，并放在核心命令、事件存储、投影与 Saga 路径之外。这个边界应当是经过测量的例外，而不是默认编程模型。
+
+## 等待真正需要的业务结果
+
+| 阶段 | 能证明什么 | 不能证明什么 | 典型调用方 | 来源 |
+|---|---|---|---|---|
+| `SENT` | 命令总线接受了命令 | 聚合已处理 | 发送后另行观测的流程 | [CommandStage.kt:26-34](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt#L26-L34) |
+| `PROCESSED` | 聚合处理了命令 | 投影或外部 Handler 完成 | 返回领域结果的写 API | [CommandStage.kt:36-44](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt#L36-L44) |
+| `SNAPSHOT` | 快照处理完成；使用 `strategy: all` 时当前状态已保存 | 其他投影或外部读模型已更新；`version_offset` 可能跳过本次写入 | 使用 `all` 且查询同一可查询后端的写后读操作 | [CommandStage.kt:46-54](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt#L46-L54) |
+| `PROJECTED` | 与可选函数目标匹配的 `PROJECTED` 信号 | 系统中所有投影都完成 | 需要写后读的 UI/API | [CommandStage.kt:56-65](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt#L56-L65) |
+| `EVENT_HANDLED` | 与可选函数目标匹配的 `EVENT_HANDLED` 信号 | Saga 派生命令处理完成 | 依赖某一副作用的调用方 | [CommandStage.kt:67-75](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt#L67-L75) |
+| `SAGA_HANDLED` | 匹配的 Saga 已处理源事件，若生成了命令则已被接受/发送 | 下游聚合完成或分布式事务提交 | 观测编排接受边界 | [CommandStage.kt:77-86](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt#L77-L86)、[StatelessSagaFunction.kt:57-69](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt#L57-L69) |
+
+对于 `PROJECTED`、`EVENT_HANDLED` 和 `SAGA_HANDLED`，当必须等待某个特定 Processor 时应提供函数目标。未提供时，等待目标会接受所请求阶段的信号，不执行函数匹配（[WaitPlan.kt:32-57](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitPlan.kt#L32-L57)）。
+
+```mermaid
+flowchart TD
+    Start{响应需要证明什么?}
+    Start -->|仅总线接受| Sent[SENT]
+    Start -->|聚合决策| Processed[PROCESSED]
+    Start -->|目标读模型更新| Projected[PROJECTED]
+    Start -->|目标外部 Handler 完成| Handled[EVENT_HANDLED]
+    Start -->|目标 Saga 已接受输出| Saga[SAGA_HANDLED]
+    Start -->|快照处理完成| Snapshot[SNAPSHOT]
+
+    classDef primary fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    classDef secondary fill:#161b22,stroke:#30363d,color:#e6edf3
+    class Start primary
+    class Sent,Processed,Projected,Handled,Saga,Snapshot secondary
+```
+
+<!-- Sources: wow-core/src/main/kotlin/me/ahoo/wow/command/wait/CommandStage.kt:25-102, wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt:57-69 -->
+
+优先选择足够但最窄的阶段：等待范围越宽，API 延迟和可用性与更多异步消费者耦合。默认等待截止时间是 30 秒，`WaitPlan.withTimeout` 修改的是调用方本地执行截止时间，不是传播到消息 Header 的超时（[WaitTimeout.kt:18-53](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitTimeout.kt#L18-L53)）。根据调用方延迟预算设置明确超时；超时表示观测结果未知，不能证明命令从未被处理。
+
+## 明确重试、并发与 LocalFirst 语义
+
+| 机制 | 用途 | 边界 | 来源 |
+|---|---|---|---|
+| `requestId` | 对同一逻辑命令去重 | Gateway 在发送前按目标聚合与请求 ID 检查 | [DefaultCommandGateway.kt:86-118](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L86-L118) |
+| `aggregateVersion` | 通过乐观并发拒绝陈旧命令 | 可为空；仅当领域允许陈旧写入时才省略 | [CommandMessage.kt:85-95](https://github.com/Ahoo-Wang/Wow/blob/main/wow-api/src/main/kotlin/me/ahoo/wow/api/command/CommandMessage.kt#L85-L95) |
+| LocalFirst | 本地运行时准入后避免 Broker 延迟 | 不提供端到端 exactly-once 投递保证 | [LocalFirstMessageBus.kt:141-199](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/LocalFirstMessageBus.kt#L141-L199) |
+| 聚合重试 | 重试框架分类为可恢复的处理失败 | 当前 Processor 最多执行三次退避重试 | [RetryableAggregateProcessor.kt:30-70](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/RetryableAggregateProcessor.kt#L30-L70) |
+
+客户端重试同一业务请求时应保留 `requestId`，否则重复检查会看到一个新命令。当命令基于某个确定状态版本生成时，应使用 `aggregateVersion`——例如仅在订单自审核后未发生变化时批准订单。
+
+对于符合条件的本地非空命令，LocalFirst 先尝试本地运行时准入，同时发送分布式副本。只有所有目标本地 Receiver 都确认准入后，副本才会标记为已在本地处理；否则仍可由分布式消费者处理。空命令会显式禁用 LocalFirst；本地准入成功后的 Handler 失败也不会追溯性地重新启用分布式副本（[LocalFirstCommandBus.kt:29-46](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/LocalFirstCommandBus.kt#L29-L46)、[LocalFirstMessageBus.kt:141-199](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/messaging/LocalFirstMessageBus.kt#L141-L199)）。Handler 重试与 Adapter 确认策略必须单独设计。
+
+## 将快照作为默认查询存储
+
+推荐使用 `strategy: all`。它会保存每个状态事件产生的状态，因此在 `SNAPSHOT` 阶段完成后，快照集合既是聚合加载检查点，也是当前状态的实时查询存储。对于单一聚合类型的标准查询，应用无需再编写投影处理器，把同一份状态复制到其他存储。
+
+| 选择 | 查询语义 | 建议 | 来源 |
+|---|---|---|---|
+| `strategy: all` | 每个已处理状态事件都会更新最新快照 | 当前状态查询的推荐默认值 | [SnapshotAutoConfiguration.kt:67-92](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/snapshot/SnapshotAutoConfiguration.kt#L67-L92)、[SimpleSnapshotStrategy.kt:19-38](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SimpleSnapshotStrategy.kt#L19-L38) |
+| `strategy: version_offset` | 已存快照最多可落后配置阈值允许的事件数 | 仅在允许快照查询陈旧，或另有读模型承载实时查询时使用 | [VersionOffsetSnapshotStrategy.kt:24-63](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/VersionOffsetSnapshotStrategy.kt#L24-L63) |
+| 自定义投影 | 维护面向特定查询的读模型 | 仅用于跨聚合关联、反范式视图、分析或外部系统 | [ProjectionHandler.kt:23-43](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/projection/ProjectionHandler.kt#L23-L43) |
+
+```mermaid
+flowchart LR
+    Command[命令] --> Aggregate[聚合]
+    Aggregate --> StateEvent[状态事件]
+    StateEvent --> All[SimpleSnapshotStrategy all]
+    All --> Store[支持查询的 SnapshotStore]
+    Store --> Service[SnapshotQueryService]
+    Service --> Routes[内置 WebFlux 查询路由]
+    Routes --> Client[客户端]
+    StateEvent -. 跨聚合或自定义视图 .-> Projection[投影]
+
+    classDef primary fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    classDef secondary fill:#161b22,stroke:#30363d,color:#e6edf3
+    class Command,Aggregate,StateEvent,All primary
+    class Store,Service,Routes,Client,Projection secondary
+```
+
+<!-- Sources: wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SimpleSnapshotStrategy.kt:19-38, wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/SnapshotQueryService.kt:30-61, wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/aggregate/snapshot/SnapshotRouteContributor.kt:59-281, wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/route/QueryRouteModule.kt:34-79 -->
+
+启用 WebFlux 支持后，Wow 会提供 single、list、paged、count 以及只返回 state 的快照端点，应用无需再为这些标准查询形态手写 Controller（[SnapshotRouteContributor.kt:59-281](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/aggregate/snapshot/SnapshotRouteContributor.kt#L59-L281)、[QueryRouteModule.kt:34-79](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/route/QueryRouteModule.kt#L34-L79)）。同一个服务还会按聚合注册为 `<aggregate>.SnapshotQueryService`，供进程内查询使用（[SnapshotQueryServiceRegistrar.kt:28-61](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/SnapshotQueryServiceRegistrar.kt#L28-L61)）。
+
+这条读链路需要支持查询的快照后端：MongoDB 与 Elasticsearch 提供 `SnapshotQueryServiceFactory`；自定义后端必须提供对应的 factory binding。Redis 与内存快照存储能够保存/加载快照，但自身不实现动态快照查询。授权、租户/所有者过滤和数据库索引仍需显式设计。使用 `strategy: all` 且查询服务绑定同一后端时，需要写后读一致性的调用方应等待 `SNAPSHOT`，因为快照通过状态事件异步处理。该阶段本身只证明处理完成；`version_offset` 未达到阈值时可能完成但不写入。事件流仍是真相来源。
+
+## 有意识地编排与补偿
+
+| 场景 | 机制 | 必须做出的决策 | 来源 |
+|---|---|---|---|
+| 一个事件触发其他聚合命令 | 无状态 Saga | 定义命令幂等与下游观测边界 | [StatelessSagaFunction.kt:57-69](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt#L57-L69) |
+| 可恢复的异步执行失败 | 补偿 | 定义重试阈值、退避、超时和运维入口 | [CompensationProperties.kt:21-33](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-server/src/main/kotlin/me/ahoo/wow/compensation/server/configuration/CompensationProperties.kt#L21-L33) |
+| 恢复到达终态 | 补偿状态 | 区分 `FAILED`、`PREPARED` 与 `SUCCEEDED` | [ExecutionFailedState.kt:44-85](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-domain/src/main/kotlin/me/ahoo/wow/compensation/domain/ExecutionFailedState.kt#L44-L85) |
+
+```mermaid
+%%{init: {"theme":"base","themeVariables":{"primaryColor":"#2d333b","primaryBorderColor":"#6d5dfc","primaryTextColor":"#e6edf3","lineColor":"#8b949e","secondaryColor":"#161b22","tertiaryColor":"#161b22"}}}%%
+stateDiagram-v2
+    [*] --> FAILED: 记录失败
+    FAILED --> PREPARED: 准备重试
+    PREPARED --> FAILED: 重试失败
+    PREPARED --> SUCCEEDED: 重试成功
+    PREPARED --> PREPARED: 回收超时尝试
+    SUCCEEDED --> [*]
+```
+
+<!-- Sources: compensation/wow-compensation-domain/src/main/kotlin/me/ahoo/wow/compensation/domain/ExecutionFailed.kt:59-106, compensation/wow-compensation-domain/src/main/kotlin/me/ahoo/wow/compensation/domain/ExecutionFailedState.kt:44-85, compensation/wow-compensation-api/src/main/kotlin/me/ahoo/wow/compensation/api/IExecutionFailedState.kt:138-164 -->
+
+不要把 Saga 描述成 ACID 事务。Saga 完成观测的是源事件 Handler 与命令发送边界；下游聚合执行可能并发或稍后发生。对于补偿，应设置有限的重试次数与执行时间，把耗尽重试或不可恢复的任务暴露给运维人员，并保证被重试的副作用具备幂等性。
+
+## 在足够窄的层次测试行为
+
+| 测试层 | 断言内容 | 框架支持 | 来源 |
+|---|---|---|---|
+| 聚合规格 | 错误、事件类型/内容与最终状态 | `AggregateSpec` | [AggregateSpec.kt:32-70](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-test/src/main/kotlin/me/ahoo/wow/test/AggregateSpec.kt#L32-L70) |
+| Saga 规格 | 源事件产生的命令 | `SagaSpec` | [SagaSpec.kt:28-70](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-test/src/main/kotlin/me/ahoo/wow/test/SagaSpec.kt#L28-L70) |
+| Adapter 契约 | 消息总线、事件存储、快照、投影与查询行为 | `wow-tck` 规格 | [EventStoreSpec.kt:47-80](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/eventsourcing/EventStoreSpec.kt#L47-L80) |
+| 集成链路 | 序列化、生成契约、存储、Broker 与 Spring 装配 | 使用真实 Adapter 的 TCK 集成测试 | [KafkaMongoCommandDispatcher.kt:31-72](https://github.com/Ahoo-Wang/Wow/blob/main/test/wow-it/src/integrationTest/kotlin/me/ahoo/wow/it/KafkaMongoCommandDispatcher.kt#L31-L72) |
+
+每条聚合规则都应有成功用例、拒绝用例和必要的状态迁移分支。Cart 规格展示了事件与状态断言，以及删除/恢复分支（[CartSpec.kt:28-86](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt#L28-L86)）。只有基础设施行为相关时才增加更宽的集成测试，从而让失败保持局部、诊断保持精确。
+
+## 生产就绪检查清单
+
+| 门禁 | 就绪标准 | 应保留的证据 | 来源 |
+|---|---|---|---|
+| 领域 | 不变量和事件/状态迁移都有聚焦规格 | Aggregate 与 Saga 测试报告 | [CartSpec.kt:28-86](https://github.com/Ahoo-Wang/Wow/blob/main/example/example-domain/src/test/kotlin/me/ahoo/wow/example/domain/cart/CartSpec.kt#L28-L86) |
+| 一致性 | 每个端点都记录等待阶段和超时 | API 契约与延迟预算 | [WaitTimeout.kt:18-53](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/wait/WaitTimeout.kt#L18-L53) |
+| 投递 | 重试、幂等、并发和 LocalFirst 边界明确 | 失败路径测试与 Adapter 设置 | [DefaultCommandGateway.kt:86-143](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt#L86-L143) |
+| 快照查询 | 在支持查询的后端启用 `all`，并验证过滤、索引、路由与 `SNAPSHOT` 写后读行为 | 使用类生产数据的 API 测试与查询计划 | [SnapshotQueryService.kt:30-61](https://github.com/Ahoo-Wang/Wow/blob/main/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/SnapshotQueryService.kt#L30-L61) |
+| 恢复 | 重试耗尽与不可恢复失败有运维流程 | 补偿看板/Runbook | [IExecutionFailedState.kt:138-164](https://github.com/Ahoo-Wang/Wow/blob/main/compensation/wow-compensation-api/src/main/kotlin/me/ahoo/wow/compensation/api/IExecutionFailedState.kt#L138-L164) |
+| 可观测性 | 命令等待、总线发送和存储调用可追踪 | 预发环境 Trace 与指标截图 | [TracingCommandGateway.kt:31-66](https://github.com/Ahoo-Wang/Wow/blob/main/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/wait/TracingCommandGateway.kt#L31-L66)、[TracingEventStore.kt:28-66](https://github.com/Ahoo-Wang/Wow/blob/main/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/eventsourcing/TracingEventStore.kt#L28-L66) |
+| 生命周期 | 停机能在明确截止时间内排空已接受工作 | 部署终止测试 | [CommandDispatcher.kt:78-83](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/dispatcher/CommandDispatcher.kt#L78-L83) |
+
+只有在真实存储 Adapter、Broker、部署拓扑和数据分布上验证后才能发布。单元测试通过能够证明领域行为，但不能单独证明生产容量、恢复和停机行为。
+
+## 相关页面
+
+| 页面 | 关系 |
+|---|---|
+| [核心概念](./core-concepts.md) | 定义命令、事件、聚合与 CQRS |
+| [聚合建模](./modeling.md) | 展示命令聚合与状态聚合的建模方法 |
+| [命令网关](./command-gateway.md) | 说明等待计划与命令投递 |
+| [快照](./snapshot.md) | 说明快照存储与策略 |
+| [查询服务](./query.md) | 说明快照查询 DSL 与内置端点 |
+| [分布式事务（Saga）](./saga.md) | 说明跨聚合编排 |
+| [事件补偿](./event-compensation.md) | 说明失败恢复与运维流程 |
+| [测试套件](./test-suite.md) | 说明 Aggregate 与 Saga 测试 DSL |
+| [可观测性](./advanced/observability.md) | 说明 Trace 与运行时可观测性 |

--- a/documentation/docs/zh/guide/configuration.md
+++ b/documentation/docs/zh/guide/configuration.md
@@ -43,9 +43,8 @@ wow:
       storage: mongo               # 事件存储类型: mongo, redis, elasticsearch, in_memory, delay
     snapshot:
       enabled: true
-      strategy: all                # all, version_offset
+      strategy: all                # 推荐用于当前状态查询
       storage: mongo
-      version-offset: 10
 
   # 基础设施特定配置
   kafka:
@@ -194,8 +193,7 @@ wow:
   eventsourcing:
     snapshot:
       enabled: true
-      strategy: version_offset      # all, version_offset
-      version-offset: 10
+      strategy: all                 # 推荐用于当前状态查询
       storage: mongo
 ```
 
@@ -620,8 +618,7 @@ wow:
       storage: mongo
     snapshot:
       enabled: true
-      strategy: version_offset
-      version-offset: 10
+      strategy: all
       storage: mongo
   kafka:
     bootstrap-servers:
@@ -698,8 +695,7 @@ wow:
       storage: mongo
     snapshot:
       enabled: true
-      strategy: version_offset
-      version-offset: 10
+      strategy: all
       storage: mongo
   kafka:
     bootstrap-servers:

--- a/documentation/docs/zh/guide/eventstore.md
+++ b/documentation/docs/zh/guide/eventstore.md
@@ -233,8 +233,7 @@ wow:
       storage: mongo
     snapshot:
       enabled: true
-      strategy: version_offset  # all, version_offset
-      version-offset: 10
+      strategy: all  # 推荐：保存每个状态事件产生的状态
       storage: mongo
 ```
 
@@ -248,7 +247,7 @@ wow:
 
 ## 最佳实践
 
-1. **为长期聚合启用快照**：将 `strategy` 设置为 `version_offset`，偏移量设为 5-20，以避免拥有大量事件的聚合出现线性性能下降。
+1. **将快照作为默认当前状态查询存储**：保持推荐的 `strategy: all`，让每个已处理状态事件都更新最新快照。在支持查询的后端并启用 WebFlux 后，`SnapshotQueryService` 与内置 single/list/paged/count 路由可以替代单聚合标准查询中重复的投影代码和手写查询端点。仅在允许快照查询陈旧，或另有读模型承载实时查询时使用 `version_offset`。
 
 2. **监控版本冲突**：偶尔出现 `EventVersionConflictException` 是正常的。高频出现则表明存在竞争 -- 考虑重新设计聚合边界。
 
@@ -260,7 +259,8 @@ wow:
 
 ## 相关主题
 
-- [快照](./snapshot) -- 通过快照优化聚合加载
+- [快照](./snapshot) -- 使用快照优化聚合加载并支持当前状态查询
+- [查询服务](./query) -- 通过 DSL 与内置端点查询快照
 - [命令网关](./command-gateway) -- 命令如何路由到聚合
 - [Saga](./saga) -- 跨聚合的分布式事务
 - [投影](./projection) -- 投影如何消费事件流

--- a/documentation/docs/zh/guide/snapshot.md
+++ b/documentation/docs/zh/guide/snapshot.md
@@ -1,11 +1,11 @@
 ---
 title: 快照
-description: 快照是事件溯源架构中的重要优化机制，通过保存聚合根状态检查点来提升性能，减少事件重放次数。
+description: 将快照作为聚合加载检查点与默认当前状态查询存储，并使用 Wow 内置查询服务和路由。
 ---
 
 # 快照
 
-快照是事件溯源架构中的重要优化机制，通过保存聚合根状态检查点来提升性能，减少事件重放次数。
+快照通过保存聚合状态检查点来减少事件重放。采用推荐的 `all` 策略后，同一份数据还可通过 `SnapshotQueryService` 与 Wow 内置查询路由，直接作为默认的当前状态物化查询存储。
 
 ## 快照机制
 
@@ -109,7 +109,7 @@ stateDiagram-v2
     Stale --> Create: 达到间隔
 ```
 
-<!-- Sources: wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotMaterializer.kt, dispatcher/SnapshotHandler.kt -->
+<!-- Sources: wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotMaterializer.kt, wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/dispatcher/SnapshotHandler.kt -->
 
 ## 快照存储
 
@@ -163,12 +163,12 @@ class InMemorySnapshotStore : SnapshotStore {
 
 ### 支持的后端
 
-| 后端 | 模块 | 状态 |
-|---------|--------|--------|
-| 内存 | `wow-core` | 开发/测试 |
-| MongoDB | `wow-mongo` | 生产就绪 |
-| Redis | `wow-redis` | 生产就绪 |
-| Elasticsearch | `wow-elasticsearch` | 生产就绪 |
+| 后端 | 模块 | 快照存储 | 动态快照查询 |
+|---------|--------|----------|--------------|
+| 内存 | `wow-core` | 开发/测试 | 无内置查询工厂 |
+| MongoDB | `wow-mongo` | 生产就绪 | 支持 |
+| Redis | `wow-redis` | 生产就绪 | 无内置查询工厂 |
+| Elasticsearch | `wow-elasticsearch` | 生产就绪 | 支持 |
 
 ## 快照处理流程
 
@@ -185,7 +185,6 @@ wow:
     snapshot:
       enabled: true  # 是否启用快照
       strategy: all  # 快照策略 (all, version_offset)
-      version-offset: 5  # 版本偏移（仅对 version_offset 策略有效）
       storage: mongo  # 快照存储后端 (mongo、redis、elasticsearch、in_memory)
 ```
 
@@ -196,6 +195,50 @@ wow:
 | `wow.eventsourcing.snapshot.version-offset` | `5` | 版本偏移阈值（仅 `version_offset` 使用） |
 | `wow.eventsourcing.snapshot.storage` | `mongo` | 快照存储后端（共享 `StorageType` 枚举） |
 
+## 将快照作为默认读模型
+
+默认使用 `strategy: all`。`SimpleSnapshotStrategy` 会物化每个状态事件产生的状态，使快照存储在 `SNAPSHOT` 阶段完成后直接成为当前状态的实时查询存储，同时也作为聚合加载检查点。对于单一聚合类型的标准查询，这意味着无需再编写投影来复制聚合状态。
+
+| 策略 | 存储状态 | 查询影响 | 建议 |
+|---|---|---|---|
+| `all` | 每个已处理状态事件都会更新最新快照 | 快照处理完成后，查询可读取最新物化聚合状态 | 推荐 |
+| `version_offset` | 仅当版本差达到 `version-offset` 时写入快照 | 快照查询可能落后于聚合 | 仅在允许陈旧数据，或另有读模型承载实时查询时使用 |
+
+```mermaid
+flowchart LR
+    Command[命令] --> Aggregate[聚合]
+    Aggregate --> Event[状态事件]
+    Event --> Strategy[SimpleSnapshotStrategy all]
+    Strategy --> Store[支持查询的快照存储]
+    Store --> Service[SnapshotQueryService]
+    Service --> Routes[内置 WebFlux 路由]
+    Routes --> Client[客户端]
+    Event -. 跨聚合或自定义视图 .-> Projection[投影]
+
+    classDef primary fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    classDef secondary fill:#161b22,stroke:#30363d,color:#e6edf3
+    class Command,Aggregate,Event,Strategy primary
+    class Store,Service,Routes,Client,Projection secondary
+```
+
+<!-- Sources: wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SimpleSnapshotStrategy.kt:19-38, wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/SnapshotQueryService.kt:30-61, wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/aggregate/snapshot/SnapshotRouteContributor.kt:59-281, wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/route/QueryRouteModule.kt:34-79 -->
+
+启用 WebFlux 支持后，Wow 会为每个聚合生成标准快照查询端点：
+
+| 查询形态 | 路由后缀 | 结果 |
+|---|---|---|
+| 计数 | `/snapshot/count` | 匹配的快照数量 |
+| 列表 | `/snapshot/list` 与 `/snapshot/list/state` | 有上限的快照或状态列表 |
+| 分页 | `/snapshot/paged` 与 `/snapshot/paged/state` | 分页快照或状态 |
+| 单条 | `/snapshot/single` 与 `/snapshot/single/state` | 单个快照或状态 |
+
+这些路由由 Query DSL 使用的同一个 `SnapshotQueryService` 契约提供能力；Spring 还会为每个聚合注册类型化的 `<aggregate>.SnapshotQueryService` Bean。因此，应用无需再为这些标准形态手写查询 API 端点（[SnapshotQueryService.kt:30-61](https://github.com/Ahoo-Wang/Wow/blob/main/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/SnapshotQueryService.kt#L30-L61)、[SnapshotQueryServiceRegistrar.kt:28-61](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/SnapshotQueryServiceRegistrar.kt#L28-L61)、[SnapshotRouteContributor.kt:59-281](https://github.com/Ahoo-Wang/Wow/blob/main/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/aggregate/snapshot/SnapshotRouteContributor.kt#L59-L281)）。
+
+:::warning 查询能力与一致性边界
+这条路径需要支持查询的后端。MongoDB 与 Elasticsearch 提供 `SnapshotQueryServiceFactory`；自定义后端必须提供对应的 binding。Redis 与内存快照存储支持持久化和加载，但自身不提供动态快照查询。租户/所有者过滤、授权与索引仍需显式设计。快照通过状态事件异步处理。使用 `strategy: all` 且查询服务绑定同一后端时，要求写后读可见性的调用方必须等待 `SNAPSHOT` 命令阶段。该阶段本身只证明快照处理完成；`version_offset` 未达到阈值时可能完成但不写入。事件流仍是真相来源。
+:::
+
+当读模型需要关联多个聚合、采用不同于聚合状态的反范式结构、服务分析场景或同步外部系统时，仍应使用投影。
 
 ## 聚合加载优化
 
@@ -214,17 +257,27 @@ val aggregate: Mono<StateAggregate<OrderState>> =
 
 ## 性能影响
 
-- **启用快照**：聚合加载时间与快照间隔成正比，而非总事件数
+- **`all` 策略**：快照处理完成后，最新快照已包含最新状态事件产生的状态
+- **`version_offset` 策略**：聚合加载只需重放上次快照之后的事件，数量受配置偏移量限制
 - **禁用快照**：每次加载都需要重放所有历史事件
 - **存储成本**：需要额外的存储空间来保存快照数据
 
-当快照间隔为 50 时，拥有 1000 个事件的聚合最多重放 49 个事件，而非全部 1000 个 -- 减少约 95%。
+例如，显式选择 `strategy: version_offset` 并设置 `version-offset: 50`，可把聚合加载限制为最多重放 49 个事件，但直接快照查询也会承受同样的状态滞后。推荐的 `all` 策略优先保证当前状态查询存储，而不是减少快照写入。
 
 ## 最佳实践
 
-1. **选择合适的快照策略**：根据业务场景选择合适的快照频率
-2. **监控快照效果**：定期检查快照是否显著改善了加载性能
-3. **快照一致性**：确保快照版本与事件流的一致性
+1. **优先使用 `all`**：将最新快照作为默认当前状态读模型。
+2. **复用查询服务与路由**：单聚合的标准 single/list/paged/count 查询无需复制状态到投影，也无需手写 Controller。
+3. **选择支持查询的后端**：动态查询使用 MongoDB、Elasticsearch 或自定义 `SnapshotQueryServiceFactory`。
+4. **设计查询安全与性能**：使用类生产数据验证授权、租户/所有者过滤、索引与查询计划。
+5. **定义写后读行为**：使用 `all` 且查询同一可查询后端时，结果必须通过快照查询可见则等待 `SNAPSHOT`。
+6. **把 `version_offset` 视为显式权衡**：仅在接受查询陈旧或已有其他当前状态读模型时使用。
 
 `SnapshotStore` 当前没有通用删除 API；如需物理清理，必须按具体存储后端设计并验证，
 不能把它当作 Wow 的框架级生命周期能力。
+
+## 相关主题
+
+- [生产最佳实践](./best-practices.md) -- 在完整生产检查清单中应用快照查询模式
+- [查询服务](./query.md) -- 构建过滤条件并使用生成的快照查询端点
+- [投影](./projection.md) -- 构建跨聚合或特定用途读模型

--- a/documentation/docs/zh/guide/troubleshooting.md
+++ b/documentation/docs/zh/guide/troubleshooting.md
@@ -152,8 +152,7 @@ wow:
   eventsourcing:
     snapshot:
       enabled: true
-      strategy: VERSION_OFFSET
-      version-offset: 10
+      strategy: all
 ```
 
 #### Q: 快照不一致
@@ -303,8 +302,7 @@ wow:
 wow:
   eventsourcing:
     snapshot:
-      strategy: VERSION_OFFSET
-      version-offset: 10
+      strategy: all
 ```
 
 3. **调整连接池**

--- a/documentation/docs/zh/reference/config/core.md
+++ b/documentation/docs/zh/reference/config/core.md
@@ -195,8 +195,7 @@ wow:
   eventsourcing:
     snapshot:
       enabled: true
-      strategy: version_offset
-      version-offset: 10
+      strategy: all
       storage: mongo
 ```
 
@@ -330,8 +329,7 @@ wow:
       storage: mongo
     snapshot:
       enabled: true
-      strategy: version_offset
-      version-offset: 10
+      strategy: all
       storage: mongo
 ```
 
@@ -365,8 +363,7 @@ wow:
       storage: mongo
     snapshot:
       enabled: true
-      strategy: version_offset
-      version-offset: 10
+      strategy: all
       storage: mongo
     state:
       bus:


### PR DESCRIPTION
## Summary

- add bilingual production best-practices guides and expose them in both sidebars
- recommend `strategy: all` so snapshots serve as the single-aggregate current-state query store
- document built-in `SnapshotQueryService` and WebFlux query routes, including backend, projection, and `SNAPSHOT` consistency boundaries
- align configuration, event-store, snapshot, troubleshooting, and core-reference examples with the recommended strategy

## Validation

- `cd documentation && pnpm docs:build`
- `git diff --check`
- verified changed local links, EN/ZH structure, and GitHub source paths/line ranges
- independent accuracy, information-architecture, and documentation-quality reviews: no blocking findings
