### PR TITLE
docs: add Agent Skills guide

### DIFF
--- a/documentation/docs/.vitepress/configs/navbar.en.ts
+++ b/documentation/docs/.vitepress/configs/navbar.en.ts
@@ -53,6 +53,10 @@ export const navbarEn: DefaultTheme.NavItem[] = [
         text: "Resources",
         items: [
             {
+                text: 'Agent Skills',
+                link: '/guide/skills'
+            },
+            {
                 text: 'Project template for quickly building DDD projects based on Wow framework',
                 link: 'https://github.com/Ahoo-Wang/wow-project-template'
             },

--- a/documentation/docs/.vitepress/configs/navbar.zh.ts
+++ b/documentation/docs/.vitepress/configs/navbar.zh.ts
@@ -53,6 +53,10 @@ export const navbarZh: DefaultTheme.NavItem[] = [
         text: "资源",
         items: [
             {
+                text: 'Agent Skills',
+                link: '/zh/guide/skills'
+            },
+            {
                 text: '用于快速构建基于 Wow 框架的 DDD 项目模板',
                 link: 'https://github.com/Ahoo-Wang/wow-project-template'
             },

--- a/documentation/docs/.vitepress/configs/sidebar.en.ts
+++ b/documentation/docs/.vitepress/configs/sidebar.en.ts
@@ -75,6 +75,7 @@ export const sidebarEn: DefaultTheme.Sidebar = {
                 {text: 'Open API', link: 'open-api'},
                 {text: 'Test Suite', link: 'test-suite'},
                 {text: 'Test Runtime', link: 'test-runtime'},
+                {text: 'Agent Skills', link: 'skills'},
                 {text: 'Business Intelligence', link: 'bi'},
                 {text: 'BI Deployment and Recovery', link: 'bi-operations'},
                 {text: 'Event Compensation', link: 'event-compensation'},

--- a/documentation/docs/.vitepress/configs/sidebar.zh.ts
+++ b/documentation/docs/.vitepress/configs/sidebar.zh.ts
@@ -75,6 +75,7 @@ export const sidebarZh: DefaultTheme.Sidebar = {
                 {text: 'Open API', link: 'open-api'},
                 {text: '测试套件', link: 'test-suite'},
                 {text: '测试运行体系', link: 'test-runtime'},
+                {text: 'Agent Skills', link: 'skills'},
                 {text: '商业智能', link: 'bi'},
                 {text: 'BI 部署与恢复', link: 'bi-operations'},
                 {text: '事件补偿', link: 'event-compensation'},

--- a/documentation/docs/en/guide/skills.md
+++ b/documentation/docs/en/guide/skills.md
@@ -1,0 +1,185 @@
+---
+title: "Agent Skills"
+description: "Install and use Wow Agent Skills so Codex, Claude Code, and other agents follow Wow source, tests, and workflows for development, review, debugging, and migration."
+---
+
+# Agent Skills
+
+Wow Agent Skills package the framework's development method, review rules, debugging paths, and migration gates as reusable agent workflows. They do not replace source code, tests, or this documentation. Instead, they help compatible clients select the right workflow, inspect the current checkout, and leave reproducible verification evidence when handling Wow tasks. [`skills/README.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/README.md#L1-L13)
+
+| Entry point | Purpose | Source |
+|---|---|---|
+| This repository's `skills/` | Source files and maintenance rules for Wow Skills | [`skills/README.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/README.md#L1-L15) |
+| `ahoo-wow-skills` | Distribution plugin containing all non-workspace skills from this repository | [`skills/plugins.json`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/plugins.json#L1-L13) |
+| [Ahoo Skills site](https://skills.ahoo.me/) | Plugin catalogue, installation commands, and distribution model | [skills.ahoo.me](https://skills.ahoo.me/) |
+| [Ahoo-Wang/skills](https://github.com/Ahoo-Wang/skills) | Plugin marketplace and aggregation repository for Codex and Claude Code | [GitHub repository](https://github.com/Ahoo-Wang/skills) |
+
+## Architecture and distribution
+
+| Layer | Responsibility | Source |
+|---|---|---|
+| Source | The Wow repository owns skill content, references, scripts, and source plugin metadata | [`skills/README.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/README.md#L7-L15) |
+| Distribution | Ahoo Skills periodically synchronizes source repositories and generates one focused plugin per project | [Ahoo Skills](https://skills.ahoo.me/) |
+| Client | Codex, Claude Code, or another compatible client installs the plugin and loads the matching skill | [`skills/README.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/README.md#L1-L5) |
+| Evidence | The skill sends the agent back to source, tests, configuration, and executable verification in the current checkout | [`wow/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow/SKILL.md#L21-L34) |
+
+```mermaid
+flowchart LR
+    subgraph Source["Wow source repository"]
+        Metadata["skills/plugins.json"]
+        Skills["skills/*/SKILL.md"]
+        References["references and scripts"]
+    end
+    subgraph Hub["Ahoo Skills distribution"]
+        Sync["Periodic sync and validation"]
+        Plugin["ahoo-wow-skills"]
+    end
+    subgraph Client["Agent client"]
+        Install["Install plugin"]
+        Route["Load skill by task"]
+        Verify["Inspect current source and verify"]
+    end
+    Metadata --> Sync
+    Skills --> Sync
+    References --> Sync
+    Sync --> Plugin
+    Plugin --> Install
+    Install --> Route
+    Route --> Verify
+
+    classDef default fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    style Source fill:#161b22,stroke:#30363d,color:#e6edf3
+    style Hub fill:#161b22,stroke:#30363d,color:#e6edf3
+    style Client fill:#161b22,stroke:#30363d,color:#e6edf3
+    linkStyle default stroke:#8b949e
+```
+<!-- Sources: skills/README.md:1-15, skills/plugins.json:1-13, skills/wow/SKILL.md:21-34, https://skills.ahoo.me/ -->
+
+Two boundaries matter here: the **Wow repository is the content source**, while `Ahoo-Wang/skills` is the **distribution entry point**. The aggregation repository synchronizes upstream content and generates the marketplace manifests required by Codex and Claude Code. Update `skills/` in Wow first instead of editing a generated plugin copy. [`skills/README.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/README.md#L114-L120) [Ahoo Skills distribution](https://skills.ahoo.me/)
+
+## Skill components
+
+The current `ahoo-wow-skills` plugin uses `include: ["*"]` to package the repository's non-workspace skills. [`skills/plugins.json`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/plugins.json#L5-L13)
+
+| Skill | Use it when | Core boundary | Source |
+|---|---|---|---|
+| `wow` | The task is mixed, asks a focused framework question, or implements Gateway, Query DSL, configuration, Projection, or similar behavior | Acts as a router to a specialist or an on-demand reference; always checks current source before editing | [`wow/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow/SKILL.md#L15-L55) |
+| `wow-development-workflow` | Adding, completing, or restructuring Aggregate or Saga behavior | Aligns, discovers, models, proves, implements, reviews, and verifies; Projection work is outside this workflow | [`wow-development-workflow/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-development-workflow/SKILL.md#L6-L38) |
+| `wow-code-review` | Reviewing a PR, diff, pre-merge change, or Wow semantics | Read-only by default; prioritizes Event Sourcing, CQRS, routing, concurrency, and test contracts | [`wow-code-review/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-code-review/SKILL.md#L6-L33) |
+| `wow-debugging` | A command is unhandled, state is wrong, a Saga does not trigger, a wait hangs, or a query or configuration behaves incorrectly | Read-only by default; reproduces and locates the failing stage before testing one hypothesis | [`wow-debugging/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-debugging/SKILL.md#L6-L16) |
+| `wow-v6-to-v8-migration` | Auditing, planning, implementing, or verifying an existing Wow v6 application's move to a pinned Wow v8 release | Covers platform, source, data, runtime, release, and rollback gates; not for first-time adoption or routine upgrades that already start on v8 | [`wow-v6-to-v8-migration/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-v6-to-v8-migration/SKILL.md#L1-L31) |
+
+`wow/references/` supplies focused, on-demand material for modeling, annotations, testing, Command Gateway, Query DSL, configuration, and PrepareKey. Detailed facts stay in references so the router remains small. [`skills/README.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/README.md#L67-L88) [`wow/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow/SKILL.md#L85-L95)
+
+## Task routing
+
+| Example task | Preferred skill | Source |
+|---|---|---|
+| "Add order cancellation behavior and tests" | `wow-development-workflow` | [`skills/README.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/README.md#L96-L108) |
+| "Review the Wow changes on this branch" | `wow-code-review` | [`wow-code-review/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-code-review/SKILL.md#L27-L43) |
+| "Why does this command not reach its handler?" | `wow-debugging` | [`wow-debugging/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-debugging/SKILL.md#L29-L49) |
+| "Migrate this existing application from Wow v6 to v8" | `wow-v6-to-v8-migration` | [`wow-v6-to-v8-migration/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-v6-to-v8-migration/SKILL.md#L21-L31) |
+| "Look up `@CommandRoute` and change WebFlux routing" | `wow` | [`wow/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow/SKILL.md#L36-L55) |
+
+```mermaid
+flowchart TD
+    Task["Wow task"] --> Intent{"Primary intent"}
+    Intent -->|Review| Review["wow-code-review"]
+    Intent -->|Diagnosis| Debug["wow-debugging"]
+    Intent -->|v6 to v8| Migration["wow-v6-to-v8-migration"]
+    Intent -->|End-to-end Aggregate or Saga development| Workflow["wow-development-workflow"]
+    Intent -->|Mixed, lookup, or another focused change| Router["wow Router"]
+    Router --> Reference{"Responsibility boundary"}
+    Reference --> Workflow
+    Reference --> Review
+    Reference --> Debug
+    Reference --> Focused["On-demand references and current source"]
+
+    classDef default fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    style Intent fill:#161b22,stroke:#30363d,color:#e6edf3
+    style Reference fill:#161b22,stroke:#30363d,color:#e6edf3
+    linkStyle default stroke:#8b949e
+```
+<!-- Sources: skills/README.md:16-45, skills/README.md:96-112, skills/wow/SKILL.md:36-55, skills/wow-code-review/SKILL.md:27-43, skills/wow-debugging/SKILL.md:14-27, skills/wow-v6-to-v8-migration/SKILL.md:21-35 -->
+
+Routing protects responsibility boundaries rather than adding ceremony. For example, reviews and diagnoses remain read-only until the user explicitly authorizes a fix or another state-changing action. [`wow-code-review/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-code-review/SKILL.md#L10-L25) [`wow-debugging/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-debugging/SKILL.md#L10-L12)
+
+## Installation
+
+The marketplace distributes Wow Skills as the focused `ahoo-wow-skills` plugin, so you do not need to install skill packages for unrelated projects. [`skills/plugins.json`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/plugins.json#L3-L39)
+
+### Codex
+
+```bash
+codex plugin marketplace add Ahoo-Wang/skills --ref main
+codex plugin add ahoo-wow-skills@ahoo-skills
+```
+
+### Claude Code
+
+```text
+/plugin marketplace add https://github.com/Ahoo-Wang/skills
+/plugin install ahoo-wow-skills
+```
+
+Treat the [Ahoo Skills site](https://skills.ahoo.me/) and [Ahoo-Wang/skills](https://github.com/Ahoo-Wang/skills) as the current source for installation commands and distributable plugins. Client versions can differ in plugin discovery and refresh behavior; after installation, use the client's plugin list or a new task to confirm that `ahoo-wow-skills` is available.
+
+## Usage flow
+
+After installation, describe the objective, scope, and success criteria. You can explicitly name a skill if the client does not match one automatically. Either way, the skill instructs the agent to re-read relevant source and tests in the current checkout instead of treating examples inside the skill as the framework API truth. [`wow/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow/SKILL.md#L21-L34)
+
+```mermaid
+%%{init: {"theme": "base", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "tertiaryColor": "#161b22"}}}%%
+sequenceDiagram
+    autonumber
+    participant User
+    participant Client as Agent client
+    participant Skill as Wow Skill
+    participant Repo as Current checkout
+    participant Gate as Tests and verification
+
+    User->>Client: Describe objective, scope, and success criteria
+    Client->>Skill: Load the matching specialist or router
+    Skill->>Repo: Inspect source, tests, configuration, and current diff
+    Repo-->>Skill: Return actual API and behavior evidence
+    Skill->>Gate: Run the narrowest test, check, or lint
+    Gate-->>Skill: Return commands, results, and residual risks
+    Skill-->>User: Deliver the change or evidence-backed conclusion
+```
+<!-- Sources: skills/wow/SKILL.md:21-55, skills/wow-development-workflow/SKILL.md:26-38, skills/wow-development-workflow/SKILL.md:217-229, skills/wow-code-review/SKILL.md:27-33, skills/wow-debugging/SKILL.md:29-74 -->
+
+Include at least the following information in a request:
+
+| Information | Example | Why it matters | Source |
+|---|---|---|---|
+| Objective | "Add cancellation to `Order`" | Defines the business result and deliverable | [`wow-development-workflow/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-development-workflow/SKILL.md#L83-L97) |
+| Scope | "Only change `example-domain`; preserve public API compatibility" | Prevents cross-module or breaking expansion | [`wow-development-workflow/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-development-workflow/SKILL.md#L89-L97) |
+| Mode | "Review only; do not edit" or "Diagnose and fix" | Separates read-only evidence gathering from authorized implementation | [`wow-code-review/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-code-review/SKILL.md#L10-L25) |
+| Verification | "Run `:example-domain:test`" | Makes the completion criterion reproducible | [`wow-development-workflow/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-development-workflow/SKILL.md#L217-L229) |
+
+## Constraints and maintenance
+
+| Principle | Meaning | Source |
+|---|---|---|
+| Source first | A skill is navigation and workflow, not a substitute for the current API | [`wow/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow/SKILL.md#L21-L34) |
+| Test-backed | Aggregate and Saga behavior use their matching Spec or Verifier; behavior changes follow RED→GREEN→REFACTOR | [`wow-development-workflow/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-development-workflow/SKILL.md#L14-L24) |
+| Read-only by default | Review and diagnosis do not authorize edits, replies, approvals, merges, or fixes | [`wow-code-review/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-code-review/SKILL.md#L10-L18), [`wow-debugging/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-debugging/SKILL.md#L10-L12) |
+| Migration is a system change | A v6→v8 migration cannot treat dependency resolution, compilation, or startup as proof of data, runtime, release, and rollback safety | [`wow-v6-to-v8-migration/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-v6-to-v8-migration/SKILL.md#L6-L31) |
+| Upstream ownership | Maintain and validate Wow Skills in this repository, then let the aggregation repository synchronize them | [`skills/README.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/README.md#L114-L150) |
+
+## References
+
+- [Ahoo Skills site](https://skills.ahoo.me/)
+- [Ahoo-Wang/skills aggregation repository](https://github.com/Ahoo-Wang/skills)
+- [Wow `skills/` source directory](https://github.com/Ahoo-Wang/Wow/tree/main/skills)
+- [Agent Skills specification](https://agentskills.io/)
+
+## Related pages
+
+| Page | Relationship |
+|---|---|
+| [Getting Started](./getting-started.md) | Build a runnable Wow application before using skills to guide iteration |
+| [Aggregate Modeling](./modeling.md) | Core model used by `wow` and the development workflow |
+| [Test Suite](./test-suite.md) | Test DSL used to prove Aggregate and Saga behavior |
+| [Troubleshooting](./troubleshooting.md) | Runtime and configuration diagnosis used with `wow-debugging` |
+| [Migrate Wow v6 to v8](./migration/v6-to-v8.md) | Framework migration detail used by `wow-v6-to-v8-migration` |

--- a/documentation/docs/zh/guide/skills.md
+++ b/documentation/docs/zh/guide/skills.md
@@ -1,0 +1,185 @@
+---
+title: "Agent Skills"
+description: "安装并使用 Wow Agent Skills，让 Codex、Claude Code 等 Agent 按 Wow 的源码、测试和工作流完成开发、评审、排障与迁移。"
+---
+
+# Agent Skills
+
+Wow Agent Skills 把框架的开发方法、评审规则、排障路径和迁移门禁组织成可复用的 Agent 工作流。它们不替代源码、测试或本文档；它们解决的是另一个问题：让支持 Agent Skills 的客户端在处理 Wow 任务时，先选择正确的工作流，再读取当前代码并留下可复核的验证证据。[`skills/README.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/README.md#L1-L13)
+
+| 入口 | 用途 | Source |
+|---|---|---|
+| 本仓库 `skills/` | Wow Skills 的源文件与维护规则 | [`skills/README.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/README.md#L1-L15) |
+| `ahoo-wow-skills` | 包含本仓库全部非 workspace skills 的分发插件 | [`skills/plugins.json`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/plugins.json#L1-L13) |
+| [Ahoo Skills 站点](https://skills.ahoo.me/zh-CN/) | 查看插件、安装命令与分发模型 | [skills.ahoo.me](https://skills.ahoo.me/zh-CN/) |
+| [Ahoo-Wang/skills](https://github.com/Ahoo-Wang/skills) | Codex 与 Claude Code 的插件市场和聚合仓库 | [GitHub repository](https://github.com/Ahoo-Wang/skills) |
+
+## 架构与分发
+
+| 层次 | 职责 | Source |
+|---|---|---|
+| Source | Wow 仓库维护 skill 内容、references、脚本和插件源元数据 | [`skills/README.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/README.md#L7-L15) |
+| Distribution | Ahoo Skills 定期同步源仓库，并按项目生成独立插件 | [Ahoo Skills](https://skills.ahoo.me/zh-CN/) |
+| Client | Codex、Claude Code 或其他兼容客户端安装插件并加载匹配的 skill | [`skills/README.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/README.md#L1-L5) |
+| Evidence | Skill 要求 Agent 回到当前 checkout 的源码、测试、配置和实际命令验证结论 | [`wow/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow/SKILL.md#L21-L34) |
+
+```mermaid
+flowchart LR
+    subgraph Source["Wow 源仓库"]
+        Metadata["skills/plugins.json"]
+        Skills["skills/*/SKILL.md"]
+        References["references 与 scripts"]
+    end
+    subgraph Hub["Ahoo Skills 分发层"]
+        Sync["定期同步与校验"]
+        Plugin["ahoo-wow-skills"]
+    end
+    subgraph Client["Agent 客户端"]
+        Install["安装插件"]
+        Route["按任务加载 Skill"]
+        Verify["读取当前源码并验证"]
+    end
+    Metadata --> Sync
+    Skills --> Sync
+    References --> Sync
+    Sync --> Plugin
+    Plugin --> Install
+    Install --> Route
+    Route --> Verify
+
+    classDef default fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    style Source fill:#161b22,stroke:#30363d,color:#e6edf3
+    style Hub fill:#161b22,stroke:#30363d,color:#e6edf3
+    style Client fill:#161b22,stroke:#30363d,color:#e6edf3
+    linkStyle default stroke:#8b949e
+```
+<!-- Sources: skills/README.md:1-15, skills/plugins.json:1-13, skills/wow/SKILL.md:21-34, https://skills.ahoo.me/zh-CN/ -->
+
+这里有两个需要刻意区分的边界：**Wow 仓库是内容源**，`Ahoo-Wang/skills` 是**分发入口**。聚合仓库会同步上游内容并生成 Codex、Claude Code 所需的市场清单，因此技能定义有更新时，应先修改 Wow 仓库中的 `skills/`，而不是修改生成后的插件副本。[`skills/README.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/README.md#L114-L120) [Ahoo Skills distribution](https://skills.ahoo.me/zh-CN/)
+
+## Skills 组件
+
+当前 `ahoo-wow-skills` 通过 `include: ["*"]` 收录本仓库的非 workspace skills。[`skills/plugins.json`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/plugins.json#L5-L13)
+
+| Skill | 何时使用 | 核心边界 | Source |
+|---|---|---|---|
+| `wow` | 混合任务、单点框架问题，以及 Gateway、Query DSL、配置、Projection 等聚焦实现 | 作为 Router 选择 specialist 或按需 reference；修改前必须核对当前源码 | [`wow/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow/SKILL.md#L15-L55) |
+| `wow-development-workflow` | 新增、完善或重构 Aggregate/Saga 行为 | 依次完成对齐、发现、建模、测试证明、实现、评审和验证；Projection 不在该 workflow 内 | [`wow-development-workflow/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-development-workflow/SKILL.md#L6-L38) |
+| `wow-code-review` | PR、diff、预合并变更或 Wow 语义审查 | 默认只读；优先检查 Event Sourcing、CQRS、路由、并发和测试契约 | [`wow-code-review/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-code-review/SKILL.md#L6-L33) |
+| `wow-debugging` | 命令未处理、状态错误、Saga 未触发、等待卡住、查询或配置异常 | 默认只读；先复现和定位失败阶段，再验证单一假设 | [`wow-debugging/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-debugging/SKILL.md#L6-L16) |
+| `wow-v6-to-v8-migration` | 评估、规划、实施或验证已有 Wow v6 应用迁移到固定的 Wow v8 版本 | 同时覆盖平台、源码、数据、runtime、发布和回滚门禁；不用于首次采用 Wow 或 v8 内常规升级 | [`wow-v6-to-v8-migration/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-v6-to-v8-migration/SKILL.md#L1-L31) |
+
+`wow/references/` 还按需提供建模、注解、测试、Command Gateway、Query DSL、配置和 PrepareKey 的聚焦参考；长篇事实材料放在 reference 中，Router 保持轻量。[`skills/README.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/README.md#L67-L88) [`wow/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow/SKILL.md#L85-L95)
+
+## 任务路由
+
+| 任务示例 | 首选 Skill | Source |
+|---|---|---|
+| “为 Order 聚合增加取消能力并补测试” | `wow-development-workflow` | [`skills/README.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/README.md#L96-L108) |
+| “Review 当前分支的 Wow 变更” | `wow-code-review` | [`wow-code-review/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-code-review/SKILL.md#L27-L43) |
+| “为什么命令没有命中 handler？” | `wow-debugging` | [`wow-debugging/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-debugging/SKILL.md#L29-L49) |
+| “把已有应用从 Wow v6 迁到 v8” | `wow-v6-to-v8-migration` | [`wow-v6-to-v8-migration/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-v6-to-v8-migration/SKILL.md#L21-L31) |
+| “查询 `@CommandRoute` 并修改 WebFlux 路由” | `wow` | [`wow/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow/SKILL.md#L36-L55) |
+
+```mermaid
+flowchart TD
+    Task["Wow 任务"] --> Intent{"主要意图"}
+    Intent -->|评审| Review["wow-code-review"]
+    Intent -->|排障| Debug["wow-debugging"]
+    Intent -->|v6 到 v8| Migration["wow-v6-to-v8-migration"]
+    Intent -->|Aggregate 或 Saga 端到端开发| Workflow["wow-development-workflow"]
+    Intent -->|混合、查询或其他聚焦实现| Router["wow Router"]
+    Router --> Reference{"职责边界"}
+    Reference --> Workflow
+    Reference --> Review
+    Reference --> Debug
+    Reference --> Focused["按需 references 与当前源码"]
+
+    classDef default fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
+    style Intent fill:#161b22,stroke:#30363d,color:#e6edf3
+    style Reference fill:#161b22,stroke:#30363d,color:#e6edf3
+    linkStyle default stroke:#8b949e
+```
+<!-- Sources: skills/README.md:16-45, skills/README.md:96-112, skills/wow/SKILL.md:36-55, skills/wow-code-review/SKILL.md:27-43, skills/wow-debugging/SKILL.md:14-27, skills/wow-v6-to-v8-migration/SKILL.md:21-35 -->
+
+路由的目的不是增加流程，而是保护职责边界。例如，代码审查和故障诊断默认保持只读；只有用户明确要求修复时，才进入获得授权的实现流程。[`wow-code-review/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-code-review/SKILL.md#L10-L25) [`wow-debugging/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-debugging/SKILL.md#L10-L12)
+
+## 安装
+
+插件市场会把 Wow Skills 作为独立的 `ahoo-wow-skills` 分发，不需要安装其他项目的 skill 包。[`skills/plugins.json`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/plugins.json#L3-L39)
+
+### Codex
+
+```bash
+codex plugin marketplace add Ahoo-Wang/skills --ref main
+codex plugin add ahoo-wow-skills@ahoo-skills
+```
+
+### Claude Code
+
+```text
+/plugin marketplace add https://github.com/Ahoo-Wang/skills
+/plugin install ahoo-wow-skills
+```
+
+安装命令与当前可分发插件以 [Ahoo Skills 中文站点](https://skills.ahoo.me/zh-CN/) 和 [Ahoo-Wang/skills](https://github.com/Ahoo-Wang/skills) 为准。客户端版本可能影响插件发现和刷新方式；安装后请使用该客户端提供的插件列表或新任务确认 `ahoo-wow-skills` 已可用。
+
+## 使用流程
+
+安装后，直接描述目标、范围和成功标准即可；如果客户端没有自动匹配，也可以明确点名所需 skill。无论采用哪种触发方式，skill 都要求 Agent 在当前 checkout 中重新读取相关源码和测试，而不是把 skill 内的示例当成框架 API 真相。[`wow/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow/SKILL.md#L21-L34)
+
+```mermaid
+%%{init: {"theme": "base", "themeVariables": {"primaryColor": "#2d333b", "primaryBorderColor": "#6d5dfc", "primaryTextColor": "#e6edf3", "lineColor": "#8b949e", "secondaryColor": "#161b22", "tertiaryColor": "#161b22"}}}%%
+sequenceDiagram
+    autonumber
+    participant User as 用户
+    participant Client as Agent 客户端
+    participant Skill as Wow Skill
+    participant Repo as 当前 checkout
+    participant Gate as 测试与验证
+
+    User->>Client: 描述目标、范围和完成标准
+    Client->>Skill: 加载匹配的 specialist 或 Router
+    Skill->>Repo: 读取源码、测试、配置和当前 diff
+    Repo-->>Skill: 返回实际 API 与行为证据
+    Skill->>Gate: 执行最窄的 test、check 或 lint
+    Gate-->>Skill: 返回命令、结果和剩余风险
+    Skill-->>User: 交付变更或证据化结论
+```
+<!-- Sources: skills/wow/SKILL.md:21-55, skills/wow-development-workflow/SKILL.md:26-38, skills/wow-development-workflow/SKILL.md:217-229, skills/wow-code-review/SKILL.md:27-33, skills/wow-debugging/SKILL.md:29-74 -->
+
+建议在请求中至少写清楚：
+
+| 信息 | 示例 | 为什么重要 | Source |
+|---|---|---|---|
+| 目标 | “为 `Order` 增加取消能力” | 决定业务结果与交付物 | [`wow-development-workflow/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-development-workflow/SKILL.md#L83-L97) |
+| 范围 | “只修改 `example-domain`，保持公开 API 兼容” | 防止跨模块或破坏性扩张 | [`wow-development-workflow/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-development-workflow/SKILL.md#L89-L97) |
+| 模式 | “只 review，不修改”或“定位并修复” | 区分只读取证与授权实现 | [`wow-code-review/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-code-review/SKILL.md#L10-L25) |
+| 验证 | “运行 `:example-domain:test`” | 让完成标准可以复核 | [`wow-development-workflow/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-development-workflow/SKILL.md#L217-L229) |
+
+## 约束与维护
+
+| 原则 | 含义 | Source |
+|---|---|---|
+| Source first | Skill 是导航与工作流，不是当前 API 的替代品 | [`wow/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow/SKILL.md#L21-L34) |
+| Test-backed | Aggregate/Saga 行为分别由对应 Spec 或 Verifier 证明，行为变更遵循 RED→GREEN→REFACTOR | [`wow-development-workflow/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-development-workflow/SKILL.md#L14-L24) |
+| Read-only by default | Review 和 diagnosis 不自动授权修改、回复、批准、合并或修复 | [`wow-code-review/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-code-review/SKILL.md#L10-L18), [`wow-debugging/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-debugging/SKILL.md#L10-L12) |
+| Migration is a system change | v6→v8 不能以依赖解析、编译或启动成功代替数据、runtime、发布和回滚验证 | [`wow-v6-to-v8-migration/SKILL.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/wow-v6-to-v8-migration/SKILL.md#L6-L31) |
+| Upstream ownership | 修改 Wow Skills 时在本仓库维护并验证，再由聚合仓库同步分发 | [`skills/README.md`](https://github.com/Ahoo-Wang/Wow/blob/main/skills/README.md#L114-L150) |
+
+## 参考资料
+
+- [Ahoo Skills 中文站点](https://skills.ahoo.me/zh-CN/)
+- [Ahoo-Wang/skills 聚合仓库](https://github.com/Ahoo-Wang/skills)
+- [Wow `skills/` 源目录](https://github.com/Ahoo-Wang/Wow/tree/main/skills)
+- [Agent Skills 规范](https://agentskills.io/)
+
+## 相关页面
+
+| 页面 | 关系 |
+|---|---|
+| [快速上手](./getting-started.md) | 建立一个可运行的 Wow 应用，再让 skills 辅助迭代 |
+| [聚合建模](./modeling.md) | `wow` 和 development workflow 所依据的核心模型 |
+| [测试套件](./test-suite.md) | Aggregate/Saga 行为验证使用的测试 DSL |
+| [故障排查](./troubleshooting.md) | 与 `wow-debugging` 配合定位运行与配置问题 |
+| [Wow v6 迁移到 v8](./migration/v6-to-v8.md) | `wow-v6-to-v8-migration` 的框架迁移专题 |


### PR DESCRIPTION
## Summary

- add bilingual Agent Skills guides for the five Wow skills, task routing, responsibility boundaries, and usage guidance
- document Codex and Claude Code installation through the Ahoo Skills marketplace
- add source-linked Mermaid diagrams for distribution, routing, and verification flow
- expose the guide from both the Resources navbar and Tooling sidebar

## Impact

Developers can now discover, install, and select the appropriate Wow skill directly from the documentation site. The guide distinguishes the Wow repository as the content source from `Ahoo-Wang/skills` as the distribution entry point.

## Validation

- `cd documentation && pnpm docs:build`
- `git diff --check`
- browser rendering for `/guide/skills` and `/zh/guide/skills`: 3 Mermaid SVGs and 7 tables per page, no console errors, and no horizontal overflow