### PR TITLE
docs(metrics): clarify integration guidance

### DIFF
--- a/documentation/docs/en/guide/advanced/metrics.md
+++ b/documentation/docs/en/guide/advanced/metrics.md
@@ -85,12 +85,23 @@ These meters appear only after a batching-enabled store performs the correspondi
 
 ## Non-Spring setup
 
-`wow-core` exposes the Micrometer contract directly. Create one instance and pass it to every
-component that should share the registry:
+`wow-core` exposes the Micrometer contract directly. Create one instance and use it to decorate
+every bus, store, or handler that should record semantic component metrics. A constructor-level
+`metrics` argument instruments only the behavior owned by that component; it does not recursively
+decorate its collaborators:
 
 ```kotlin
 val registry: MeterRegistry = SimpleMeterRegistry()
 val metrics = WowMetrics(registry)
+
+val meteredCommandBus = commandBus.metered(
+    metrics = metrics,
+    source = "command-bus",
+)
+val meteredCommandHandler = commandHandler.metered(
+    metrics = metrics,
+    source = "command-handler",
+)
 
 val eventStore: EventStore = MongoEventStore(
     database = database,
@@ -99,8 +110,8 @@ val eventStore: EventStore = MongoEventStore(
 ).metered(metrics, source = "primary-event-store")
 
 val dispatcher = CommandDispatcher(
-    commandBus = commandBus,
-    commandHandler = commandHandler,
+    commandBus = meteredCommandBus,
+    commandHandler = meteredCommandHandler,
     metrics = metrics,
 )
 ```
@@ -163,7 +174,8 @@ When metrics are missing, verify in order:
 1. `wow.metrics.enabled` is not disabled;
 2. the expected `MeterRegistry` bean exists in the ApplicationContext;
 3. real traffic exercised the relevant component;
-4. `/actuator/metrics/wow.operation` is visible;
+4. the Actuator `metrics` endpoint is temporarily exposed and
+   `/actuator/metrics/wow.operation` is visible;
 5. batching is enabled when checking `wow.batch.*`;
 6. for OTLP, wait one export `step` and confirm that the Collector actually received data.
 

--- a/documentation/docs/en/reference/config/observability.md
+++ b/documentation/docs/en/reference/config/observability.md
@@ -98,10 +98,20 @@ implementation("org.springframework.boot:spring-boot-starter-actuator")
 implementation("io.micrometer:micrometer-registry-prometheus")
 ```
 
-Scrape the `/actuator/prometheus` endpoint from Prometheus. The Wow-specific meters
-(`wow.operation`, `wow.stream.*`, and `wow.batch.*`) appear
-alongside standard JVM/Reactor meters. See [Metrics](/guide/advanced/metrics) for the full
-catalogue.
+Scrape the `/actuator/prometheus` endpoint from Prometheus. The Wow-specific Micrometer meter IDs
+are `wow.operation`, `wow.stream.*`, and `wow.batch.*`; these dotted IDs are used with the Actuator
+`metrics` endpoint. Prometheus applies its naming convention at export time, for example:
+
+| Micrometer meter ID | Prometheus series example |
+|---|---|
+| `wow.operation` (Timer) | `wow_operation_seconds_count`, `wow_operation_seconds_sum` |
+| `wow.stream.messages` (Counter) | `wow_stream_messages_total` |
+
+The Wow series appear alongside standard JVM and other instrumented application meters. Generic
+Reactor Core sequence or scheduler meters appear only when the application explicitly configures
+`reactor-core-micrometer` instrumentation. See [Metrics](/guide/advanced/metrics) for the full Wow
+catalogue and the [Spring Boot metrics documentation](https://docs.spring.io/spring-boot/reference/actuator/metrics.html#actuator.metrics.endpoint)
+for the distinction between logical meter IDs and exported names.
 
 ### Exporting Metrics via OTLP (OpenTelemetry Collector)
 
@@ -151,11 +161,26 @@ classpath. Wow injects that application registry directly, so Wow meters still r
 [Spring Boot OTLP metrics documentation](https://docs.spring.io/spring-boot/reference/actuator/metrics.html#actuator.metrics.export.otlp)
 and [Micrometer OTLP registry documentation](https://docs.micrometer.io/micrometer/reference/implementations/otlp.html).
 
-To verify the integration, temporarily expose the `metrics` actuator endpoint, generate real
-traffic, and inspect `/actuator/metrics/wow.operation`, `/actuator/metrics/wow.batch.write`, or another `wow.*` meter. Then verify that
-the Collector or downstream backend receives it after the configured `step`. An actuator result
-proves collection only; receipt by the Collector proves export. Batch meters appear only after a
-batching-enabled store performs the corresponding operation.
+To verify the integration, temporarily add `metrics` to the existing Actuator exposure list:
+
+```yaml
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - prometheus
+          - threaddump
+          - metrics       # temporary diagnostic endpoint
+```
+
+Generate real traffic, then inspect `/actuator/metrics/wow.operation`,
+`/actuator/metrics/wow.batch.write`, or another `wow.*` meter. Verify that the Collector or
+downstream backend receives it after the configured `step`. An Actuator result proves collection
+only; receipt by the Collector proves export. Batch meters appear only after a batching-enabled
+store performs the corresponding operation. Remove or restrict the diagnostic endpoint after
+verification.
 
 ### Enabling Distributed Tracing (OpenTelemetry)
 

--- a/documentation/docs/zh/guide/advanced/metrics.md
+++ b/documentation/docs/zh/guide/advanced/metrics.md
@@ -85,11 +85,22 @@ MongoDB 和 Elasticsearch 的 batching 路径复用同一个 `WowMetrics` Regist
 
 ## 非 Spring 接入
 
-`wow-core` 直接公开 Micrometer 契约。手动创建一个实例，并把同一实例交给需要插桩的组件：
+`wow-core` 直接公开 Micrometer 契约。手动创建一个实例，并用它分别装饰需要记录语义组件指标的
+总线、存储和处理器。构造函数中的 `metrics` 参数只为该组件自身负责的行为插桩，不会递归装饰
+它依赖的其他组件：
 
 ```kotlin
 val registry: MeterRegistry = SimpleMeterRegistry()
 val metrics = WowMetrics(registry)
+
+val meteredCommandBus = commandBus.metered(
+    metrics = metrics,
+    source = "command-bus",
+)
+val meteredCommandHandler = commandHandler.metered(
+    metrics = metrics,
+    source = "command-handler",
+)
 
 val eventStore: EventStore = MongoEventStore(
     database = database,
@@ -98,8 +109,8 @@ val eventStore: EventStore = MongoEventStore(
 ).metered(metrics, source = "primary-event-store")
 
 val dispatcher = CommandDispatcher(
-    commandBus = commandBus,
-    commandHandler = commandHandler,
+    commandBus = meteredCommandBus,
+    commandHandler = meteredCommandHandler,
     metrics = metrics,
 )
 ```
@@ -159,7 +170,8 @@ Micrometer meter 转换为 span，但 metrics 与 traces 可以发送到同一�
 1. `wow.metrics.enabled` 未被关闭；
 2. ApplicationContext 中存在期望的 `MeterRegistry` Bean；
 3. 产生过对应组件的真实流量；
-4. `/actuator/metrics/wow.operation` 可见；
+4. 已临时暴露 Actuator `metrics` endpoint，且
+   `/actuator/metrics/wow.operation` 可见；
 5. 对于批处理指标，存储已启用 batching；
 6. 对于 OTLP，等待一个 export `step` 后确认 Collector 实际收到数据。
 

--- a/documentation/docs/zh/reference/config/observability.md
+++ b/documentation/docs/zh/reference/config/observability.md
@@ -93,9 +93,19 @@ implementation("org.springframework.boot:spring-boot-starter-actuator")
 implementation("io.micrometer:micrometer-registry-prometheus")
 ```
 
-从 Prometheus 抓取 `/actuator/prometheus` 端点。Wow 特有的 meter
-（`wow.operation`、`wow.stream.*`、`wow.batch.*`）将与标准
-JVM/Reactor meter 一起出现。完整目录参见 [Metrics](/zh/guide/advanced/metrics)。
+从 Prometheus 抓取 `/actuator/prometheus` 端点。Wow 的 Micrometer meter ID 是
+`wow.operation`、`wow.stream.*` 和 `wow.batch.*`；Actuator `metrics` endpoint 使用这些带点号的
+逻辑 ID。Prometheus 在导出时应用自己的命名约定，例如：
+
+| Micrometer meter ID | Prometheus series 示例 |
+|---|---|
+| `wow.operation`（Timer） | `wow_operation_seconds_count`、`wow_operation_seconds_sum` |
+| `wow.stream.messages`（Counter） | `wow_stream_messages_total` |
+
+Wow series 会与标准 JVM 及应用中其他已插桩的 meter 一起出现。通用 Reactor Core sequence 或
+scheduler meter 只有在应用显式配置 `reactor-core-micrometer` 插桩后才会出现。Wow 完整目录参见
+[Metrics](/zh/guide/advanced/metrics)；逻辑 meter ID 与导出名称的区别参见
+[Spring Boot Metrics 文档](https://docs.spring.io/spring-boot/reference/actuator/metrics.html#actuator.metrics.endpoint)。
 
 ### 通过 OTLP 导出指标（OpenTelemetry Collector）
 
@@ -144,10 +154,25 @@ Registry，因此即使设置 `management.metrics.use-global-registry=false`，W
 [Spring Boot OTLP Metrics 文档](https://docs.spring.io/spring-boot/reference/actuator/metrics.html#actuator.metrics.export.otlp)
 和 [Micrometer OTLP Registry 文档](https://docs.micrometer.io/micrometer/reference/implementations/otlp.html)。
 
-验证接入时，可临时暴露 Actuator `metrics` 端点，产生真实流量后检查
-`/actuator/metrics/wow.operation`、`/actuator/metrics/wow.batch.write` 或其他 `wow.*` meter；随后等待一个配置的 `step`，再确认
+验证接入时，先把 `metrics` 临时加入已有的 Actuator endpoint 暴露列表：
+
+```yaml
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - prometheus
+          - threaddump
+          - metrics       # 临时诊断 endpoint
+```
+
+产生真实流量后检查 `/actuator/metrics/wow.operation`、
+`/actuator/metrics/wow.batch.write` 或其他 `wow.*` meter；随后等待一个配置的 `step`，再确认
 Collector 或下游后端已经收到指标。Actuator 中可见只证明指标已采集，Collector 收到数据才证明
-导出链路完整。批处理 meter 仅在存储启用 batching 并执行相应操作后出现。
+导出链路完整。批处理 meter 仅在存储启用 batching 并执行相应操作后出现。验证完成后移除或限制
+该诊断 endpoint。
 
 ### 启用分布式链路追踪（OpenTelemetry）
 


### PR DESCRIPTION
## Summary

- clarify that non-Spring users must explicitly decorate buses, handlers, and stores with the shared `WowMetrics` instance
- distinguish Micrometer logical meter IDs from Prometheus-exported series names
- document that generic Reactor Core meters require explicit `reactor-core-micrometer` instrumentation
- add a copyable temporary Actuator `metrics` endpoint exposure example and cleanup guidance
- keep the English and Chinese metrics documentation aligned

## Why

The previous guidance could produce false negatives during metric troubleshooting, invalid PromQL copied from logical meter IDs, and missing bus or handler metrics in non-Spring setups. It also implied that Reactor Core meters appeared automatically with Actuator.

## Impact

This is documentation-only. It makes Prometheus/OTLP verification reproducible and clarifies the instrumentation boundary without changing runtime behavior or metric contracts.

## Validation

- `pnpm docs:build`
- `./gradlew :wow-spring-boot-starter:test --tests "me.ahoo.wow.spring.boot.starter.metrics.MetricsAutoConfigurationTest"`
- EN/ZH code-block and metric-identifier parity checks
- `git diff --check`