### PR TITLE
docs(metrics): fix MongoDB example

### DIFF
--- a/documentation/docs/en/guide/advanced/metrics.md
+++ b/documentation/docs/en/guide/advanced/metrics.md
@@ -105,9 +105,12 @@ val meteredCommandHandler = commandHandler.metered(
 
 val eventStore: EventStore = MongoEventStore(
     database = database,
-    batchOptions = batchOptions,
-    metrics = metrics,
-).metered(metrics, source = "primary-event-store")
+    batchOptions = MongoEventStoreBatchOptions(enabled = true),
+    metrics = metrics, // Batch lifecycle metrics.
+).metered(
+    metrics = metrics, // EventStore operation metrics.
+    source = "primary-event-store",
+)
 
 val dispatcher = CommandDispatcher(
     commandBus = meteredCommandBus,
@@ -115,6 +118,10 @@ val dispatcher = CommandDispatcher(
     metrics = metrics,
 )
 ```
+
+The `MongoEventStore` constructor receives `WowMetrics` for its internal batch lifecycle. The
+`metered` decorator records the `EventStore` operations listed above. Passing the same instance to
+both layers keeps all meters in one registry without double-counting an operation.
 
 Finite operations and long-lived streams can use the unified model directly:
 

--- a/documentation/docs/zh/guide/advanced/metrics.md
+++ b/documentation/docs/zh/guide/advanced/metrics.md
@@ -104,9 +104,12 @@ val meteredCommandHandler = commandHandler.metered(
 
 val eventStore: EventStore = MongoEventStore(
     database = database,
-    batchOptions = batchOptions,
-    metrics = metrics,
-).metered(metrics, source = "primary-event-store")
+    batchOptions = MongoEventStoreBatchOptions(enabled = true),
+    metrics = metrics, // 批处理生命周期指标。
+).metered(
+    metrics = metrics, // EventStore 操作指标。
+    source = "primary-event-store",
+)
 
 val dispatcher = CommandDispatcher(
     commandBus = meteredCommandBus,
@@ -114,6 +117,10 @@ val dispatcher = CommandDispatcher(
     metrics = metrics,
 )
 ```
+
+`MongoEventStore` 构造函数接收的 `WowMetrics` 用于内部批处理生命周期；`metered` 装饰器记录
+上文列出的 `EventStore` 操作。两层传入同一个实例，可以让所有 meter 写入同一 Registry，
+同时不会重复计算同一次操作。
 
 有限操作和长生命周期流也可以直接复用统一模型：
 


### PR DESCRIPTION
## Summary

- replace the undefined `batchOptions` placeholder with an explicit `MongoEventStoreBatchOptions`
- clarify the separate responsibilities of constructor-level batch metrics and the `metered` EventStore decorator
- keep the English and Chinese metrics guides synchronized

## Root cause

The non-Spring example referenced an undeclared, untyped `batchOptions` value, so it was not directly copyable and did not make batching enablement explicit.

## Validation

- `./gradlew :wow-mongo:test --tests 'me.ahoo.wow.mongo.MongoEventStoreBatchCloseTest' --no-daemon`
- `cd documentation && pnpm docs:build`
- `git diff --check`