### PR TITLE
docs: simplify OpenTelemetry integration

### DIFF
--- a/documentation/docs/en/guide/advanced/architecture.md
+++ b/documentation/docs/en/guide/advanced/architecture.md
@@ -21,7 +21,7 @@ Wow's architecture is built around a single core principle: **"Domain Model as a
 | **wow-test** | Unit testing DSL: `AggregateSpec` / `SagaSpec` with Given-When-Expect pattern | `test/wow-test` | [settings.gradle.kts:44-45](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L44-L45) |
 | **wow-kafka** | Command/event bus implementation via Apache Kafka | `wow-kafka` module | [settings.gradle.kts:27](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L27) |
 | **wow-elasticsearch** | Projection (read model) storage via Elasticsearch | `wow-elasticsearch` module | [settings.gradle.kts:31](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L31) |
-| **wow-opentelemetry** | End-to-end tracing and observability | `wow-opentelemetry` module | [settings.gradle.kts:35](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L35) |
+| **wow-opentelemetry** | Distributed tracing for Wow operations | `wow-opentelemetry` module | [settings.gradle.kts:35](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L35) |
 | **wow-cosec** | Authorization and access control | `wow-cosec` module | [settings.gradle.kts:40](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L40) |
 | **wow-webflux** | Spring WebFlux integration: auto-registers command route handler functions | `wow-webflux` module | [settings.gradle.kts:33](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L33) |
 
@@ -50,7 +50,7 @@ flowchart TB
         E5["wow-elasticsearch<br>Elasticsearch projection"]
         E6["wow-webflux<br>WebFlux command endpoint"]
         E7["wow-cosec<br>Authorization"]
-        E8["wow-opentelemetry<br>Tracing & metrics"]
+        E8["wow-opentelemetry<br>Distributed tracing"]
     end
 
     subgraph SPRING["Spring Integration"]
@@ -101,7 +101,7 @@ The module hierarchy is defined in [settings.gradle.kts:19-80](https://github.co
 | **Core Engine** | `wow-core` | Aggregate processing, command bus, event store abstraction, saga processing, projection dispatch, serialization. All reactive (Project Reactor). | [wow-core](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt) |
 | **Compile-Time** | `wow-compiler` | KSP processor. Generates command routing tables, event handler metadata, and OpenAPI specs from annotations at compile time. | [settings.gradle.kts:26](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L26) |
 | **Spring Integration** | `wow-spring`, `wow-spring-boot-starter` | Bridges the core engine into Spring's `ApplicationContext`. The starter provides auto-configuration with Gradle feature variants for optional capabilities. | [WowAutoConfiguration.kt](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/WowAutoConfiguration.kt) |
-| **Observability** | `wow-opentelemetry` | End-to-end tracing, metrics, and logging integration via OpenTelemetry. | [settings.gradle.kts:35](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L35) |
+| **Observability** | `wow-opentelemetry` | End-to-end tracing integration via OpenTelemetry. Metrics are provided separately through Micrometer. | [settings.gradle.kts:35](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L35) |
 | **Security** | `wow-cosec` | Command/query authorization with policy-based access control. | [settings.gradle.kts:40](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L40) |
 | **Testing** | `wow-test`, `wow-tck`, `wow-mock` | Aggregate and saga testing DSL; Technology Compatibility Kit for integration tests; in-memory mock implementations. | [settings.gradle.kts:44-49](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L44-L49) |
 | **Compensation** | `wow-compensation-api`, `wow-compensation-core`, `wow-compensation-domain`, `wow-compensation-server` | Event compensation subsystem with dashboard for monitoring and retrying failed events. | [settings.gradle.kts:56-63](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L56-L63) |
@@ -437,4 +437,4 @@ The architectural choices of the Wow Framework directly enable its performance p
 | [Testing](../test-suite) | AggregateSpec and SagaSpec testing DSL |
 | [Spring Boot Integration](../extensions/spring-boot-starter) | Auto-configuration details and property reference |
 | [CoCache](../extensions/cocache) | Projection caching for query performance |
-| [Observability](../../reference/config/observability) | OpenTelemetry tracing and metrics |
+| [Observability](../../reference/config/observability) | OpenTelemetry tracing and Micrometer metrics |

--- a/documentation/docs/en/guide/advanced/metrics.md
+++ b/documentation/docs/en/guide/advanced/metrics.md
@@ -19,11 +19,9 @@ implementation("org.springframework.boot:spring-boot-starter-actuator")
 runtimeOnly("io.micrometer:micrometer-registry-prometheus") // or micrometer-registry-otlp
 ```
 
-```yaml
-wow:
-  metrics:
-    enabled: true # default
-```
+No Wow configuration is required to enable metrics; `wow.metrics.enabled` defaults to `true`.
+When using the OTLP registry, `OTEL_SERVICE_NAME` and `OTEL_EXPORTER_OTLP_ENDPOINT` are sufficient
+for the default exporter path.
 
 If `wow.metrics.enabled=false`, or no `MeterRegistry` exists in the context, Wow uses
 `WowMetrics.NONE` and keeps the compact, uninstrumented reactive path.
@@ -167,9 +165,11 @@ flowchart LR
     Tracing["wow-opentelemetry spans"] --> Collector
 ```
 
-For OTLP, add `micrometer-registry-otlp` and configure
-`management.otlp.metrics.export.url`. `wow-opentelemetry` instruments tracing; it does not turn
-Micrometer meters into spans, although metrics and traces can target the same Collector.
+For OTLP, add `micrometer-registry-otlp`, then set `OTEL_SERVICE_NAME` and the shared
+`OTEL_EXPORTER_OTLP_ENDPOINT`, normally an OTLP/HTTP Collector endpoint on port `4318`. Spring Boot
+maps the endpoint to its `OtlpMeterRegistry`; no manual registry bean or metrics YAML is required.
+`wow-opentelemetry` instruments tracing and does not turn Micrometer meters into spans, although
+metrics and traces can use the same environment and Collector.
 
 See [Observability Configuration](/reference/config/observability) for complete setup and
 verification steps.

--- a/documentation/docs/en/guide/advanced/module-dependencies.md
+++ b/documentation/docs/en/guide/advanced/module-dependencies.md
@@ -20,7 +20,7 @@ The Wow framework is composed of over 20 Gradle modules, each with a single, wel
 | `wow-redis` | Infra | `EventStore` and `SnapshotStore` via Redis / Lettuce. |
 | `wow-elasticsearch` | Infra | Projection indexing via Elasticsearch. |
 | `wow-webflux` | Infra | Spring WebFlux command endpoint integration. |
-| `wow-opentelemetry` | Infra | Distributed tracing and metrics via OpenTelemetry. |
+| `wow-opentelemetry` | Infra | Distributed tracing for Wow operations via OpenTelemetry. |
 | `wow-cosec` | Infra | ABAC authorization via CoSec. |
 | `wow-compiler` | Tooling | KSP processor — generates command routing, event handling metadata, OpenAPI specs at compile time. |
 | `wow-test` | Testing | Unit testing DSL: `AggregateSpec`, `SagaSpec`, Given-When-Expect pattern. |
@@ -312,7 +312,7 @@ graph TB
 | `wow-redis` | `EventStore`, `SnapshotStore` | `spring-data-redis`, `lettuce-core` |
 | `wow-elasticsearch` | Projection storage | `spring-data-elasticsearch` |
 | `wow-webflux` | Command endpoints | `spring-webflux` |
-| `wow-opentelemetry` | Tracing &amp; metrics | `opentelemetry-instrumentation-api` |
+| `wow-opentelemetry` | Distributed tracing | `opentelemetry-instrumentation-api` |
 | `wow-cosec` | Authorization | (depends on wow-webflux) |
 
 ### Tooling Modules

--- a/documentation/docs/en/guide/extensions/opentelemetry.md
+++ b/documentation/docs/en/guide/extensions/opentelemetry.md
@@ -11,12 +11,15 @@ Supported by the Cloud Native Computing Foundation (CNCF) and the OpenTelemetry 
 Its main goal is to provide developers with consistent tracing solutions to help them collect, generate, and export tracing data for distributed systems to better understand application performance, behavior, and exceptions.
 OpenTelemetry supports multiple programming languages and frameworks such as Java, Python, Go, Node.js, making it easy for developers to integrate tracing functionality.
 
-OpenTelemetry provides the following core features:
+The OpenTelemetry project provides the following core features:
 - Distributed Tracing: Captures the passage of requests between different services and components, forming call chains to track the path and execution time of entire distributed requests.
 - Metrics Collection: Collects and exports performance metrics such as request rate, response time, error rate, etc., helping developers monitor and optimize performance.
 - Logging: Collects application log data, associates it with tracing and metrics data, providing deep insights into application behavior and issues.
 
-The _OpenTelemetry_ module of the Wow framework provides a series of instrumenters to record operations of the framework's core components, helping developers better understand application performance, behavior, and exceptions.
+The Wow `wow-opentelemetry` module deliberately covers **distributed tracing only**. It provides
+instrumenters for the framework's core operations, while Wow metrics remain Micrometer meters and
+are exported by a Micrometer registry. The module does not initialize an OpenTelemetry SDK or
+exporter by itself.
 
 - `AggregateInstrumenter`: Aggregate root instrumenter, used to record aggregate root operations.
 - `EventProcessorInstrumenter`: Event processor instrumenter, used to record event processor operations.
@@ -44,14 +47,28 @@ Supports the following attribute tags:
 
 ## Installation
 
+For a Gradle-based Spring Boot application, request the starter's `opentelemetry-support` capability.
+This is the recommended single dependency entry point: it brings in `wow-opentelemetry` and enables
+the corresponding Wow auto-configuration.
+
 ::: code-group
 ```kotlin [Gradle(Kotlin)]
-implementation("me.ahoo.wow:wow-opentelemetry")
+implementation("me.ahoo.wow:wow-spring-boot-starter") {
+    capabilities {
+        requireCapability("me.ahoo.wow:opentelemetry-support")
+    }
+}
 ```
 ```groovy [Gradle(Groovy)]
-implementation 'me.ahoo.wow:wow-opentelemetry'
+implementation('me.ahoo.wow:wow-spring-boot-starter') {
+    capabilities {
+        requireCapability('me.ahoo.wow:opentelemetry-support')
+    }
+}
 ```
 ```xml [Maven]
+<!-- Maven does not resolve Gradle feature capabilities. Keep wow-spring-boot-starter
+     in the application and add the tracing module explicitly. -->
 <dependency>
     <groupId>me.ahoo.wow</groupId>
     <artifactId>wow-opentelemetry</artifactId>
@@ -60,9 +77,34 @@ implementation 'me.ahoo.wow:wow-opentelemetry'
 ```
 :::
 
+When not using Spring Boot auto-configuration, depend on `wow-opentelemetry` directly and register
+the tracing filters/decorators yourself.
+
+## Quick Start with OTLP
+
+The recommended runtime is the OpenTelemetry Java Agent. It initializes `GlobalOpenTelemetry`
+before Wow creates its tracing instrumenters:
+
+```bash
+export JAVA_TOOL_OPTIONS="-javaagent:/opt/otel/opentelemetry-javaagent.jar"
+export OTEL_SERVICE_NAME=order-service
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+java -jar your-app.jar
+```
+
+The general endpoint uses OTLP/HTTP: the Agent appends `/v1/traces`. If the application also has
+Spring Boot Actuator and `micrometer-registry-otlp`, Micrometer reuses the same service name and
+endpoint and appends `/v1/metrics`. No Wow-specific exporter configuration is required.
+
+Do not enable the Java Agent's Micrometer bridge when `micrometer-registry-otlp` is present; both
+paths would export the same application meters. See
+[Observability Configuration](/reference/config/observability) for dependencies, authentication,
+verification, and signal-specific endpoint overrides.
+
 ## Configuration
 
-When `wow-opentelemetry` is on the classpath, Wow tracing auto-configuration is enabled by default. It can be disabled without removing the dependency:
+When the starter auto-configuration is active and `wow-opentelemetry` is on the classpath, Wow
+tracing is enabled by default. It can be disabled without removing the dependency:
 
 ```yaml
 wow:
@@ -70,7 +112,9 @@ wow:
     enabled: false
 ```
 
-Initialize `GlobalOpenTelemetry` before the Wow application context creates tracing filters and decorators. Use the OpenTelemetry Java agent or register an SDK during application bootstrap; registering the SDK after Wow tracing instrumenters have initialized is too late.
+If you use an SDK instead of the Agent, initialize `GlobalOpenTelemetry` before the Wow application
+context creates tracing filters and decorators. Registering the SDK after Wow tracing instrumenters
+have initialized is too late.
 
 ## How Tracing Is Wired
 

--- a/documentation/docs/en/onboarding/contributor-guide.md
+++ b/documentation/docs/en/onboarding/contributor-guide.md
@@ -1938,7 +1938,7 @@ wow-mongo                  MongoDB storage
 wow-redis                  Redis storage
 wow-elasticsearch          Elasticsearch event/snapshot storage and queries
 wow-webflux                reactive HTTP command integration
-wow-opentelemetry          tracing and metrics
+wow-opentelemetry          distributed tracing
 wow-cosec                  authorization integration
 wow-cocache                projection caching
 wow-apiclient              REST client support

--- a/documentation/docs/en/reference/config/observability.md
+++ b/documentation/docs/en/reference/config/observability.md
@@ -35,9 +35,10 @@ wow:
     enabled: true
 ```
 
-Enabled by default (`matchIfMissing = true`) when the `wow-opentelemetry` module and the
-`WowInstrumenter` class are on the classpath. Set to `false` to disable distributed tracing
-spans across the command bus, event store, projections, and sagas.
+With `wow-spring-boot-starter` auto-configuration active, tracing is enabled by default
+(`matchIfMissing = true`) when the `wow-opentelemetry` module and its `WowInstrumenter` class are
+on the classpath. Set it to `false` to disable distributed tracing spans across the command bus,
+event store, projections, and sagas.
 
 ## Metrics
 
@@ -124,42 +125,43 @@ implementation("org.springframework.boot:spring-boot-starter-actuator")
 runtimeOnly("io.micrometer:micrometer-registry-otlp")
 ```
 
-Configure the OTLP/HTTP metrics endpoint. Wow directly uses Spring Boot's `OtlpMeterRegistry` bean;
-Micrometer's global-registry bridge is not required:
+Use the standard OpenTelemetry environment variables for the shortest setup. Both Micrometer's
+OTLP registry and the Java Agent understand the general endpoint and service name:
 
-```yaml
-wow:
-  metrics:
-    enabled: true
-
-management:
-  otlp:
-    metrics:
-      export:
-        enabled: ${OTEL_METRICS_ENABLED:true}
-        url: ${OTEL_EXPORTER_OTLP_METRICS_ENDPOINT:http://otel-collector:4318/v1/metrics}
-        step: 30s
-  opentelemetry:
-    resource-attributes:
-      service.name: ${spring.application.name}
+```bash
+export OTEL_SERVICE_NAME=order-service
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+export OTEL_EXPORTER_OTLP_HEADERS="authorization=Bearer token" # Optional.
 ```
+
+No `wow.metrics` or `management.otlp.metrics` YAML is required for the default path. Metrics are
+enabled by default; Spring Boot maps the general endpoint to the metrics exporter and appends
+`/v1/metrics`. Use `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` only when metrics must target a different
+OTLP/HTTP endpoint.
 
 ```mermaid
 flowchart LR
-    Wow["WowMetrics"] --> Otlp["Application OtlpMeterRegistry"]
+    Env["OTEL_* environment"] --> Otlp["Application OtlpMeterRegistry"]
+    Env --> Agent["OpenTelemetry Java Agent"]
+    Wow["WowMetrics"] --> Otlp
     Otlp -->|"OTLP/HTTP"| Collector["OpenTelemetry Collector"]
-    Tracing["wow-opentelemetry tracing"] --> Collector
+    Agent --> Global["GlobalOpenTelemetry"]
+    Tracing["wow-opentelemetry tracing"] --> Global
+    Global -->|"OTLP/HTTP"| Collector
 
     classDef telemetry fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
-    class Wow,Otlp,Collector,Tracing telemetry
+    class Env,Otlp,Agent,Wow,Collector,Global,Tracing telemetry
 ```
-<!-- Sources: wow-core/src/main/kotlin/me/ahoo/wow/metrics/WowMetrics.kt, wow-core/src/main/kotlin/me/ahoo/wow/infra/batch/BatchMetrics.kt, wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/metrics/MetricsAutoConfiguration.kt -->
+<!-- Sources: wow-core/src/main/kotlin/me/ahoo/wow/metrics/WowMetrics.kt, wow-core/src/main/kotlin/me/ahoo/wow/infra/batch/BatchMetrics.kt, wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/aggregate/AggregateInstrumenter.kt, wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/metrics/MetricsAutoConfiguration.kt -->
 
 Spring Boot auto-configures `OtlpMeterRegistry` when the registry implementation is on the runtime
 classpath. Wow injects that application registry directly, so Wow meters still reach OTLP when
 `management.metrics.use-global-registry=false`. See the
 [Spring Boot OTLP metrics documentation](https://docs.spring.io/spring-boot/reference/actuator/metrics.html#actuator.metrics.export.otlp)
 and [Micrometer OTLP registry documentation](https://docs.micrometer.io/micrometer/reference/implementations/otlp.html).
+Do not also enable the Java Agent's Micrometer bridge: `OtlpMeterRegistry` already exports these
+meters, and a second bridge can duplicate them. The bridge is disabled by default for this reason;
+see the [OpenTelemetry Java supported libraries](https://opentelemetry.io/docs/zero-code/java/agent/supported-libraries/).
 
 To verify the integration, temporarily add `metrics` to the existing Actuator exposure list:
 
@@ -170,8 +172,6 @@ management:
       exposure:
         include:
           - health
-          - prometheus
-          - threaddump
           - metrics       # temporary diagnostic endpoint
 ```
 
@@ -184,25 +184,33 @@ verification.
 
 ### Enabling Distributed Tracing (OpenTelemetry)
 
-The recommended way to enable tracing is the OpenTelemetry Java Agent, which bootstraps
-`GlobalOpenTelemetry` before the Spring context starts:
-
-```bash
-java -javaagent:opentelemetry-javaagent.jar \
-     -Dotel.service.name=${spring.application.name} \
-     -Dotel.exporter.otlp.endpoint=http://otel-collector:4317 \
-     -jar your-app.jar
-```
-
-Add `wow-opentelemetry` to your dependencies. You also need `wow-spring-boot-starter` (with the
-`opentelemetry-support` capability) — `WowOpenTelemetryAutoConfiguration` lives in the starter,
-not the module. The auto-configuration detects the agent's initialized `GlobalOpenTelemetry` and
-registers the Wow tracing filters and decorators automatically. Set `wow.opentelemetry.enabled=false` only to disable Wow's spans while
-keeping the agent's other instrumentation.
+For a Gradle-based Spring Boot application, request the starter's `opentelemetry-support` capability.
+It brings in `wow-opentelemetry`; `WowOpenTelemetryAutoConfiguration` itself lives in the starter:
 
 ```kotlin
-implementation("me.ahoo.wow:wow-opentelemetry")
+implementation("me.ahoo.wow:wow-spring-boot-starter") {
+    capabilities {
+        requireCapability("me.ahoo.wow:opentelemetry-support")
+    }
+}
 ```
+
+The recommended tracing runtime is the OpenTelemetry Java Agent. It initializes
+`GlobalOpenTelemetry` before the Spring context starts. Reuse the same OTLP/HTTP endpoint and
+service name as metrics:
+
+```bash
+export JAVA_TOOL_OPTIONS="-javaagent:/opt/otel/opentelemetry-javaagent.jar"
+export OTEL_SERVICE_NAME=order-service
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+java -jar your-app.jar
+```
+
+The Agent appends `/v1/traces`; Micrometer appends `/v1/metrics`. This shared endpoint assumes the
+Collector exposes OTLP/HTTP on port `4318`. If tracing must use OTLP/gRPC on `4317`, configure its
+protocol and signal-specific endpoint separately. The auto-configuration registers Wow tracing
+filters and decorators automatically. Set `wow.opentelemetry.enabled=false` only to disable Wow's
+spans while keeping the Agent's other instrumentation.
 
 See [Observability](/guide/advanced/observability) for the instrumentation coverage and
 [OpenTelemetry Extension](/guide/extensions/opentelemetry) for the instrumenter list.

--- a/documentation/docs/zh/guide/advanced/architecture.md
+++ b/documentation/docs/zh/guide/advanced/architecture.md
@@ -21,7 +21,7 @@ Wow 的架构围绕一个核心原则构建：**"领域模型即服务"**。编�
 | **wow-test** | 单元测试 DSL：`AggregateSpec` / `SagaSpec` 配合 Given-When-Expect 模式 | `test/wow-test` | [settings.gradle.kts:44-45](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L44-L45) |
 | **wow-kafka** | 通过 Apache Kafka 实现的命令/事件总线 | `wow-kafka` 模块 | [settings.gradle.kts:27](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L27) |
 | **wow-elasticsearch** | 通过 Elasticsearch 进行投影（读模型）存储 | `wow-elasticsearch` 模块 | [settings.gradle.kts:31](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L31) |
-| **wow-opentelemetry** | 端到端追踪和可观测性 | `wow-opentelemetry` 模块 | [settings.gradle.kts:35](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L35) |
+| **wow-opentelemetry** | Wow 操作的分布式链路追踪 | `wow-opentelemetry` 模块 | [settings.gradle.kts:35](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L35) |
 | **wow-cosec** | 授权和访问控制 | `wow-cosec` 模块 | [settings.gradle.kts:40](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L40) |
 | **wow-webflux** | Spring WebFlux 集成：自动注册命令路由处理函数 | `wow-webflux` 模块 | [settings.gradle.kts:33](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L33) |
 
@@ -50,7 +50,7 @@ flowchart TB
         E5["wow-elasticsearch<br>Elasticsearch 投影"]
         E6["wow-webflux<br>WebFlux 命令端点"]
         E7["wow-cosec<br>授权"]
-        E8["wow-opentelemetry<br>追踪与指标"]
+        E8["wow-opentelemetry<br>分布式链路追踪"]
     end
 
     subgraph SPRING["Spring 集成"]
@@ -101,7 +101,7 @@ flowchart TB
 | **核心引擎** | `wow-core` | 聚合处理、命令总线、事件存储抽象、Saga 处理、投影分发、序列化。全部响应式（Project Reactor）。 | [wow-core](https://github.com/Ahoo-Wang/Wow/blob/main/wow-core/src/main/kotlin/me/ahoo/wow/command/CommandGateway.kt) |
 | **编译时** | `wow-compiler` | KSP 处理器。在编译时从注解生成命令路由表、事件处理器元数据和 OpenAPI 规范。 | [settings.gradle.kts:26](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L26) |
 | **Spring 集成** | `wow-spring`、`wow-spring-boot-starter` | 将核心引擎桥接到 Spring 的 `ApplicationContext`。starter 通过 Gradle 功能变体提供自动配置和可选能力。 | [WowAutoConfiguration.kt](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/WowAutoConfiguration.kt) |
-| **可观测性** | `wow-opentelemetry` | 通过 OpenTelemetry 进行端到端追踪、指标和日志集成。 | [settings.gradle.kts:35](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L35) |
+| **可观测性** | `wow-opentelemetry` | 通过 OpenTelemetry 提供端到端链路追踪；指标由 Micrometer 独立提供。 | [settings.gradle.kts:35](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L35) |
 | **安全** | `wow-cosec` | 基于策略的访问控制的命令/查询授权。 | [settings.gradle.kts:40](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L40) |
 | **测试** | `wow-test`、`wow-tck`、`wow-mock` | 聚合和 Saga 测试 DSL；集成测试技术兼容性工具包；内存模拟实现。 | [settings.gradle.kts:44-49](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L44-L49) |
 | **补偿** | `wow-compensation-api`、`wow-compensation-core`、`wow-compensation-domain`、`wow-compensation-server` | 事件补偿子系统，带有用于监控和重试失败事件的仪表板。 | [settings.gradle.kts:56-63](https://github.com/Ahoo-Wang/Wow/blob/main/settings.gradle.kts#L56-L63) |
@@ -437,4 +437,4 @@ Wow 框架的架构选择直接支撑了其性能表现。影响性能的关键�
 | [测试](../test-suite) | AggregateSpec 和 SagaSpec 测试 DSL |
 | [Spring Boot 集成](../extensions/spring-boot-starter) | 自动配置详情和属性参考 |
 | [CoCache](../extensions/cocache) | 用于查询性能的投影缓存 |
-| [可观测性](../../reference/config/observability) | OpenTelemetry 追踪和指标 |
+| [可观测性](../../reference/config/observability) | OpenTelemetry 链路追踪与 Micrometer 指标 |

--- a/documentation/docs/zh/guide/advanced/metrics.md
+++ b/documentation/docs/zh/guide/advanced/metrics.md
@@ -19,11 +19,8 @@ implementation("org.springframework.boot:spring-boot-starter-actuator")
 runtimeOnly("io.micrometer:micrometer-registry-prometheus") // 或 micrometer-registry-otlp
 ```
 
-```yaml
-wow:
-  metrics:
-    enabled: true # 默认值
-```
+指标默认启用，不需要额外配置 Wow；`wow.metrics.enabled` 的默认值是 `true`。使用 OTLP Registry
+时，默认导出路径只需设置 `OTEL_SERVICE_NAME` 和 `OTEL_EXPORTER_OTLP_ENDPOINT`。
 
 如果 `wow.metrics.enabled=false`，或者上下文中没有 `MeterRegistry`，Wow 使用
 `WowMetrics.NONE`，响应式链保持无指标的紧凑路径。
@@ -164,9 +161,11 @@ flowchart LR
     Tracing["wow-opentelemetry spans"] --> Collector
 ```
 
-通过 OTLP 导出时加入 `micrometer-registry-otlp` 并配置
-`management.otlp.metrics.export.url`。`wow-opentelemetry` 负责 tracing；它不会自动把
-Micrometer meter 转换为 span，但 metrics 与 traces 可以发送到同一个 Collector。
+通过 OTLP 导出时加入 `micrometer-registry-otlp`，再设置 `OTEL_SERVICE_NAME` 和统一的
+`OTEL_EXPORTER_OTLP_ENDPOINT`；通常指向 Collector 的 OTLP/HTTP `4318` 端口。Spring Boot 会把
+该端点映射到 `OtlpMeterRegistry`，无需手动创建 Registry Bean 或配置 Metrics YAML。
+`wow-opentelemetry` 负责 tracing，不会把 Micrometer meter 转换为 span，但 metrics 与 traces
+可以复用相同的环境变量和 Collector。
 
 完整配置和验证步骤参见[可观测性配置](/zh/reference/config/observability)。
 

--- a/documentation/docs/zh/guide/advanced/module-dependencies.md
+++ b/documentation/docs/zh/guide/advanced/module-dependencies.md
@@ -20,7 +20,7 @@ Wow 框架由 20 多个 Gradle 模块组成，每个模块都有单一且定义�
 | `wow-redis` | Infra | 通过 Redis / Lettuce 实现 `EventStore` 和 `SnapshotStore`。 |
 | `wow-elasticsearch` | Infra | 通过 Elasticsearch 实现投影索引。 |
 | `wow-webflux` | Infra | Spring WebFlux 命令端点集成。 |
-| `wow-opentelemetry` | Infra | 通过 OpenTelemetry 实现分布式链路追踪和指标。 |
+| `wow-opentelemetry` | Infra | 通过 OpenTelemetry 为 Wow 操作提供分布式链路追踪。 |
 | `wow-cosec` | Infra | 通过 CoSec 实现 ABAC 授权。 |
 | `wow-compiler` | Tooling | KSP 处理器 — 在编译时生成命令路由、事件处理元数据和 OpenAPI 规范。 |
 | `wow-test` | Testing | 单元测试 DSL：`AggregateSpec`、`SagaSpec`，Given-When-Expect 模式。 |
@@ -312,7 +312,7 @@ graph TB
 | `wow-redis` | `EventStore`、`SnapshotStore` | `spring-data-redis`、`lettuce-core` |
 | `wow-elasticsearch` | 投影存储 | `spring-data-elasticsearch` |
 | `wow-webflux` | 命令端点 | `spring-webflux` |
-| `wow-opentelemetry` | 链路追踪与指标 | `opentelemetry-instrumentation-api` |
+| `wow-opentelemetry` | 分布式链路追踪 | `opentelemetry-instrumentation-api` |
 | `wow-cosec` | 授权 | （依赖 wow-webflux） |
 
 ### 工具模块

--- a/documentation/docs/zh/guide/extensions/opentelemetry.md
+++ b/documentation/docs/zh/guide/extensions/opentelemetry.md
@@ -11,12 +11,14 @@ OpenTelemetry 是一个厂商中立的开源项目，旨在为跟踪和监控分
 其主要目标是为开发人员提供一致的跟踪解决方案，帮助他们收集、生成和导出分布式系统的跟踪数据，以更好地理解应用程序的性能、行为和异常。
 OpenTelemetry 支持多种编程语言和框架，如 Java、Python、Go、Node.js，使得开发人员可以轻松集成跟踪功能。
 
-OpenTelemetry 提供以下核心功能：
+OpenTelemetry 项目提供以下核心功能：
 - 分布式追踪：捕获请求在不同服务和组件之间的传递，形成调用链，以追踪整个分布式请求的路径和执行时间。
 - 指标收集：收集和导出性能指标，如请求速率、响应时间、错误率等，助力开发人员监控和优化性能。
 - 日志记录：收集应用程序的日志数据，与跟踪和指标数据相关联，提供深入了解应用程序行为和问题的视角。
 
-Wow 框架的 _OpenTelemetry_ 模块通过提供一系列仪表器（_Instrumenter_）来记录框架的核心组件的操作，以帮助开发人员更好地理解应用程序的性能、行为和异常。
+Wow 的 `wow-opentelemetry` 模块刻意只负责**分布式链路追踪**：它为框架核心操作提供
+instrumenter；Wow 指标仍是 Micrometer meter，由 Micrometer Registry 负责导出。该模块本身
+不会初始化 OpenTelemetry SDK 或 exporter。
 
 - `AggregateInstrumenter`: 聚合根仪表器，用于记录聚合根的操作。
 - `EventProcessorInstrumenter`: 事件处理器仪表器，用于记录事件处理器的操作。
@@ -44,14 +46,27 @@ Wow 框架的 _OpenTelemetry_ 模块通过提供一系列仪表器（_Instrument
 
 ## 安装
 
+Gradle 构建的 Spring Boot 应用推荐请求 starter 的 `opentelemetry-support` capability。这是单一的
+依赖入口：它会引入 `wow-opentelemetry`，并启用对应的 Wow 自动配置。
+
 ::: code-group
 ```kotlin [Gradle(Kotlin)]
-implementation("me.ahoo.wow:wow-opentelemetry")
+implementation("me.ahoo.wow:wow-spring-boot-starter") {
+    capabilities {
+        requireCapability("me.ahoo.wow:opentelemetry-support")
+    }
+}
 ```
 ```groovy [Gradle(Groovy)]
-implementation 'me.ahoo.wow:wow-opentelemetry'
+implementation('me.ahoo.wow:wow-spring-boot-starter') {
+    capabilities {
+        requireCapability('me.ahoo.wow:opentelemetry-support')
+    }
+}
 ```
 ```xml [Maven]
+<!-- Maven 不解析 Gradle feature capability。应用保留 wow-spring-boot-starter，
+     并显式加入链路追踪模块。 -->
 <dependency>
     <groupId>me.ahoo.wow</groupId>
     <artifactId>wow-opentelemetry</artifactId>
@@ -60,9 +75,33 @@ implementation 'me.ahoo.wow:wow-opentelemetry'
 ```
 :::
 
+不使用 Spring Boot 自动配置时，可以直接依赖 `wow-opentelemetry`，并自行注册 tracing filters
+和 decorators。
+
+## OTLP 快速接入
+
+推荐使用 OpenTelemetry Java Agent 作为运行时。它会在 Wow 创建 tracing instrumenters 前初始化
+`GlobalOpenTelemetry`：
+
+```bash
+export JAVA_TOOL_OPTIONS="-javaagent:/opt/otel/opentelemetry-javaagent.jar"
+export OTEL_SERVICE_NAME=order-service
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+java -jar your-app.jar
+```
+
+统一端点使用 OTLP/HTTP，Agent 自动追加 `/v1/traces`。如果应用同时引入 Spring Boot Actuator
+和 `micrometer-registry-otlp`，Micrometer 会复用相同的服务名与端点，并自动追加 `/v1/metrics`；
+不需要配置 Wow 专用 exporter。
+
+存在 `micrometer-registry-otlp` 时，不要再开启 Java Agent 的 Micrometer bridge，否则两条路径会
+重复导出应用指标。依赖、鉴权、验证方法和 signal-specific endpoint 覆盖方式参见
+[可观测性配置](/zh/reference/config/observability)。
+
 ## 配置
 
-当 `wow-opentelemetry` 位于 classpath 时，Wow 默认开启链路追踪自动配置。无需移除依赖即可关闭：
+当 starter 自动配置生效且 `wow-opentelemetry` 位于 classpath 时，Wow 默认开启链路追踪。无需
+移除依赖即可关闭：
 
 ```yaml
 wow:
@@ -70,7 +109,8 @@ wow:
     enabled: false
 ```
 
-请在 Wow 应用上下文创建 tracing filters 和 decorators 前初始化 `GlobalOpenTelemetry`。可以使用 OpenTelemetry Java Agent，或在应用启动阶段注册 SDK；若在 Wow tracing instrumenters 初始化后才注册 SDK，则时机过晚。
+如果不使用 Agent 而是自行创建 SDK，请在 Wow 应用上下文创建 tracing filters 和 decorators 前
+初始化 `GlobalOpenTelemetry`；若在 Wow tracing instrumenters 初始化后才注册 SDK，则时机过晚。
 
 ## 链路追踪如何装配
 

--- a/documentation/docs/zh/onboarding/contributor-guide.md
+++ b/documentation/docs/zh/onboarding/contributor-guide.md
@@ -1941,7 +1941,7 @@ wow-mongo                  MongoDB 存储
 wow-redis                  Redis 存储
 wow-elasticsearch          Elasticsearch 事件/快照存储与查询
 wow-webflux                响应式 HTTP 命令集成
-wow-opentelemetry          Tracing 与 Metrics
+wow-opentelemetry          分布式链路追踪
 wow-cosec                  授权集成
 wow-cocache                投影缓存
 wow-apiclient              REST Client 支持

--- a/documentation/docs/zh/reference/config/observability.md
+++ b/documentation/docs/zh/reference/config/observability.md
@@ -33,8 +33,9 @@ wow:
     enabled: true
 ```
 
-当 `wow-opentelemetry` 模块和 `WowInstrumenter` 类位于类路径上时，默认启用
-（`matchIfMissing = true`）。设为 `false` 可禁用横跨命令总线、事件存储、投影和 Saga 的分布式追踪链路。
+当 `wow-spring-boot-starter` 自动配置生效，且 `wow-opentelemetry` 模块及其 `WowInstrumenter`
+类位于 classpath 上时，链路追踪默认启用（`matchIfMissing = true`）。设为 `false` 可禁用横跨命令
+总线、事件存储、投影和 Saga 的分布式追踪链路。
 
 ## 指标
 
@@ -118,41 +119,41 @@ implementation("org.springframework.boot:spring-boot-starter-actuator")
 runtimeOnly("io.micrometer:micrometer-registry-otlp")
 ```
 
-配置 OTLP/HTTP Metrics 端点。Wow 会直接使用 Spring Boot 创建的 `OtlpMeterRegistry` Bean，
-不需要 Micrometer global-registry bridge：
+最简接入只需使用标准 OpenTelemetry 环境变量。Micrometer OTLP Registry 与 Java Agent 都能
+识别统一端点和服务名：
 
-```yaml
-wow:
-  metrics:
-    enabled: true
-
-management:
-  otlp:
-    metrics:
-      export:
-        enabled: ${OTEL_METRICS_ENABLED:true}
-        url: ${OTEL_EXPORTER_OTLP_METRICS_ENDPOINT:http://otel-collector:4318/v1/metrics}
-        step: 30s
-  opentelemetry:
-    resource-attributes:
-      service.name: ${spring.application.name}
+```bash
+export OTEL_SERVICE_NAME=order-service
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+export OTEL_EXPORTER_OTLP_HEADERS="authorization=Bearer token" # 可选。
 ```
+
+默认路径不需要配置 `wow.metrics` 或 `management.otlp.metrics` YAML。指标默认启用；Spring Boot
+会把统一端点映射到 Metrics exporter，并自动追加 `/v1/metrics`。只有 Metrics 需要发送到不同的
+OTLP/HTTP 端点时，才配置 `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`。
 
 ```mermaid
 flowchart LR
-    Wow["WowMetrics"] --> Otlp["Application OtlpMeterRegistry"]
+    Env["OTEL_* 环境变量"] --> Otlp["Application OtlpMeterRegistry"]
+    Env --> Agent["OpenTelemetry Java Agent"]
+    Wow["WowMetrics"] --> Otlp
     Otlp -->|"OTLP/HTTP"| Collector["OpenTelemetry Collector"]
-    Tracing["wow-opentelemetry 链路追踪"] --> Collector
+    Agent --> Global["GlobalOpenTelemetry"]
+    Tracing["wow-opentelemetry 链路追踪"] --> Global
+    Global -->|"OTLP/HTTP"| Collector
 
     classDef telemetry fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
-    class Wow,Otlp,Collector,Tracing telemetry
+    class Env,Otlp,Agent,Wow,Collector,Global,Tracing telemetry
 ```
-<!-- Sources: wow-core/src/main/kotlin/me/ahoo/wow/metrics/WowMetrics.kt, wow-core/src/main/kotlin/me/ahoo/wow/infra/batch/BatchMetrics.kt, wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/metrics/MetricsAutoConfiguration.kt -->
+<!-- Sources: wow-core/src/main/kotlin/me/ahoo/wow/metrics/WowMetrics.kt, wow-core/src/main/kotlin/me/ahoo/wow/infra/batch/BatchMetrics.kt, wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/aggregate/AggregateInstrumenter.kt, wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/metrics/MetricsAutoConfiguration.kt -->
 
 Registry 实现位于运行时类路径时，Spring Boot 会自动配置 `OtlpMeterRegistry`。Wow 注入这个应用
 Registry，因此即使设置 `management.metrics.use-global-registry=false`，Wow meter 仍能进入 OTLP Registry。参见
 [Spring Boot OTLP Metrics 文档](https://docs.spring.io/spring-boot/reference/actuator/metrics.html#actuator.metrics.export.otlp)
 和 [Micrometer OTLP Registry 文档](https://docs.micrometer.io/micrometer/reference/implementations/otlp.html)。
+不要同时启用 Java Agent 的 Micrometer bridge：`OtlpMeterRegistry` 已负责导出这些 meter，第二条
+bridge 可能造成重复导出。该 Agent 插桩默认关闭，参见
+[OpenTelemetry Java 支持列表](https://opentelemetry.io/docs/zero-code/java/agent/supported-libraries/)。
 
 验证接入时，先把 `metrics` 临时加入已有的 Actuator endpoint 暴露列表：
 
@@ -163,8 +164,6 @@ management:
       exposure:
         include:
           - health
-          - prometheus
-          - threaddump
           - metrics       # 临时诊断 endpoint
 ```
 
@@ -176,23 +175,31 @@ Collector 或下游后端已经收到指标。Actuator 中可见只证明指标�
 
 ### 启用分布式链路追踪（OpenTelemetry）
 
-启用链路追踪的推荐方式是使用 OpenTelemetry Java Agent，它会在 Spring 上下文启动前引导初始化
-`GlobalOpenTelemetry`：
-
-```bash
-java -javaagent:opentelemetry-javaagent.jar \
-     -Dotel.service.name=${spring.application.name} \
-     -Dotel.exporter.otlp.endpoint=http://otel-collector:4317 \
-     -jar your-app.jar
-```
-
-在依赖中添加 `wow-opentelemetry`。自动配置会检测 Agent 已初始化的 `GlobalOpenTelemetry`，
-并自动注册 Wow 追踪过滤器与装饰器。仅当需要禁用 Wow 的 span 但保留 Agent 的其他仪表时，
-才设置 `wow.opentelemetry.enabled=false`。
+Gradle 构建的 Spring Boot 应用应请求 starter 的 `opentelemetry-support` capability。它会引入
+`wow-opentelemetry`；`WowOpenTelemetryAutoConfiguration` 本身位于 starter 中：
 
 ```kotlin
-implementation("me.ahoo.wow:wow-opentelemetry")
+implementation("me.ahoo.wow:wow-spring-boot-starter") {
+    capabilities {
+        requireCapability("me.ahoo.wow:opentelemetry-support")
+    }
+}
 ```
+
+链路追踪推荐使用 OpenTelemetry Java Agent，它会在 Spring 上下文启动前初始化
+`GlobalOpenTelemetry`。Tracing 与 Metrics 复用同一个 OTLP/HTTP 端点和服务名：
+
+```bash
+export JAVA_TOOL_OPTIONS="-javaagent:/opt/otel/opentelemetry-javaagent.jar"
+export OTEL_SERVICE_NAME=order-service
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
+java -jar your-app.jar
+```
+
+Agent 自动追加 `/v1/traces`，Micrometer 自动追加 `/v1/metrics`。统一端点要求 Collector 在
+`4318` 端口提供 OTLP/HTTP；如果 tracing 必须使用 `4317` 的 OTLP/gRPC，需要单独配置 protocol
+和 signal-specific endpoint。自动配置会注册 Wow tracing filters 和 decorators。只有需要禁用
+Wow span、同时保留 Agent 其他插桩时，才设置 `wow.opentelemetry.enabled=false`。
 
 仪表覆盖范围参见 [可观测性](/zh/guide/advanced/observability)，
 仪表器列表参见 [OpenTelemetry 扩展](/zh/guide/extensions/opentelemetry)。


### PR DESCRIPTION
## What changed

- document `wow-spring-boot-starter`'s `opentelemetry-support` capability as the recommended tracing entry point
- standardize the minimal OTLP/HTTP setup on `OTEL_SERVICE_NAME` and `OTEL_EXPORTER_OTLP_ENDPOINT` using port `4318`
- clarify that `wow-opentelemetry` provides Wow tracing instrumentation while Micrometer owns metrics collection and export
- warn against enabling the Java Agent Micrometer bridge together with `micrometer-registry-otlp`
- synchronize the English and Chinese observability, metrics, architecture, module, and contributor documentation

## Why

The previous examples mixed OpenTelemetry project capabilities with the narrower responsibility of the `wow-opentelemetry` module, used a less convenient configuration path, and included an invalid shell substitution in the Java Agent example. The new documentation presents one consistent dependency boundary and one shared OTLP/HTTP endpoint for traces and metrics.

## Validation

- `git diff --check`
- `cd documentation && pnpm docs:build`
- scanned the bilingual documentation for the removed `4317` example, invalid `${spring.application.name}` shell substitution, and stale `management.otlp.metrics.export.url` guidance