### PR TITLE
Verify OTLP metrics export

### DIFF
--- a/documentation/docs/en/guide/advanced/metrics.md
+++ b/documentation/docs/en/guide/advanced/metrics.md
@@ -16,12 +16,14 @@ typical setup adds Actuator and one registry implementation:
 
 ```kotlin
 implementation("org.springframework.boot:spring-boot-starter-actuator")
-runtimeOnly("io.micrometer:micrometer-registry-prometheus") // or micrometer-registry-otlp
+runtimeOnly("io.micrometer:micrometer-registry-prometheus")
 ```
 
 No Wow configuration is required to enable metrics; `wow.metrics.enabled` defaults to `true`.
-When using the OTLP registry, `OTEL_SERVICE_NAME` and `OTEL_EXPORTER_OTLP_ENDPOINT` are sufficient
-for the default exporter path.
+For OTLP with the current Spring Boot 4.1.0 baseline, replace the Prometheus registry with
+`spring-boot-opentelemetry` and `micrometer-registry-otlp`; then `OTEL_SERVICE_NAME` and
+`OTEL_EXPORTER_OTLP_ENDPOINT` are sufficient for the default exporter path. See the complete
+[Observability Configuration](/reference/config/observability#exporting-metrics-via-otlp-opentelemetry-collector).
 
 If `wow.metrics.enabled=false`, or no `MeterRegistry` exists in the context, Wow uses
 `WowMetrics.NONE` and keeps the compact, uninstrumented reactive path.
@@ -165,7 +167,9 @@ flowchart LR
     Tracing["wow-opentelemetry spans"] --> Collector
 ```
 
-For OTLP, add `micrometer-registry-otlp`, then set `OTEL_SERVICE_NAME` and the shared
+For OTLP with the current Spring Boot 4.1.0 baseline, add `spring-boot-opentelemetry` and
+`micrometer-registry-otlp`, then set
+`OTEL_SERVICE_NAME` and the shared
 `OTEL_EXPORTER_OTLP_ENDPOINT`, normally an OTLP/HTTP Collector endpoint on port `4318`. Spring Boot
 maps the endpoint to its `OtlpMeterRegistry`; no manual registry bean or metrics YAML is required.
 `wow-opentelemetry` instruments tracing and does not turn Micrometer meters into spans, although

--- a/documentation/docs/en/guide/extensions/opentelemetry.md
+++ b/documentation/docs/en/guide/extensions/opentelemetry.md
@@ -93,8 +93,9 @@ java -jar your-app.jar
 ```
 
 The general endpoint uses OTLP/HTTP: the Agent appends `/v1/traces`. If the application also has
-Spring Boot Actuator and `micrometer-registry-otlp`, Micrometer reuses the same service name and
-endpoint and appends `/v1/metrics`. No Wow-specific exporter configuration is required.
+Spring Boot Actuator, `spring-boot-opentelemetry`, and `micrometer-registry-otlp`, Micrometer reuses
+the same service name and endpoint and appends `/v1/metrics`. No Wow-specific exporter
+configuration is required.
 
 Do not enable the Java Agent's Micrometer bridge when `micrometer-registry-otlp` is present; both
 paths would export the same application meters. See

--- a/documentation/docs/en/reference/config/observability.md
+++ b/documentation/docs/en/reference/config/observability.md
@@ -118,12 +118,19 @@ for the distinction between logical meter IDs and exported names.
 
 Wow records metrics with Micrometer; `wow-opentelemetry` instruments tracing and does not export
 Micrometer meters. To send Wow and standard application metrics to an OpenTelemetry Collector,
-add Spring Boot Actuator and Micrometer's OTLP registry to the application:
+add Spring Boot Actuator, Boot's OpenTelemetry support module, and Micrometer's OTLP registry:
 
 ```kotlin
 implementation("org.springframework.boot:spring-boot-starter-actuator")
+runtimeOnly("org.springframework.boot:spring-boot-opentelemetry")
 runtimeOnly("io.micrometer:micrometer-registry-otlp")
 ```
+
+With the project's current Spring Boot 4.1.0 baseline, `spring-boot-opentelemetry` supplies the
+shared OpenTelemetry environment and resource configuration used by the OTLP metrics
+auto-configuration. The starter's
+`opentelemetry-support` capability supplies Wow tracing instrumentation, but does not replace this
+Spring Boot runtime module.
 
 Use the standard OpenTelemetry environment variables for the shortest setup. Both Micrometer's
 OTLP registry and the Java Agent understand the general endpoint and service name:

--- a/documentation/docs/zh/guide/advanced/metrics.md
+++ b/documentation/docs/zh/guide/advanced/metrics.md
@@ -16,11 +16,14 @@ Actuator 和一个 Registry 实现：
 
 ```kotlin
 implementation("org.springframework.boot:spring-boot-starter-actuator")
-runtimeOnly("io.micrometer:micrometer-registry-prometheus") // 或 micrometer-registry-otlp
+runtimeOnly("io.micrometer:micrometer-registry-prometheus")
 ```
 
-指标默认启用，不需要额外配置 Wow；`wow.metrics.enabled` 的默认值是 `true`。使用 OTLP Registry
-时，默认导出路径只需设置 `OTEL_SERVICE_NAME` 和 `OTEL_EXPORTER_OTLP_ENDPOINT`。
+指标默认启用，不需要额外配置 Wow；`wow.metrics.enabled` 的默认值是 `true`。项目当前使用的
+Spring Boot 4.1.0 通过 OTLP 导出时，把 Prometheus Registry 替换为 `spring-boot-opentelemetry` 和
+`micrometer-registry-otlp`；默认导出路径只需设置 `OTEL_SERVICE_NAME` 和
+`OTEL_EXPORTER_OTLP_ENDPOINT`。完整依赖参见
+[可观测性配置](/zh/reference/config/observability#通过-otlp-导出指标-opentelemetry-collector)。
 
 如果 `wow.metrics.enabled=false`，或者上下文中没有 `MeterRegistry`，Wow 使用
 `WowMetrics.NONE`，响应式链保持无指标的紧凑路径。
@@ -161,9 +164,10 @@ flowchart LR
     Tracing["wow-opentelemetry spans"] --> Collector
 ```
 
-通过 OTLP 导出时加入 `micrometer-registry-otlp`，再设置 `OTEL_SERVICE_NAME` 和统一的
-`OTEL_EXPORTER_OTLP_ENDPOINT`；通常指向 Collector 的 OTLP/HTTP `4318` 端口。Spring Boot 会把
-该端点映射到 `OtlpMeterRegistry`，无需手动创建 Registry Bean 或配置 Metrics YAML。
+项目当前使用的 Spring Boot 4.1.0 通过 OTLP 导出时需要加入 `spring-boot-opentelemetry` 和
+`micrometer-registry-otlp`，再设置 `OTEL_SERVICE_NAME` 和统一的 `OTEL_EXPORTER_OTLP_ENDPOINT`；
+通常指向 Collector 的 OTLP/HTTP `4318` 端口。Spring Boot 会把该端点映射到
+`OtlpMeterRegistry`，无需手动创建 Registry Bean 或配置 Metrics YAML。
 `wow-opentelemetry` 负责 tracing，不会把 Micrometer meter 转换为 span，但 metrics 与 traces
 可以复用相同的环境变量和 Collector。
 

--- a/documentation/docs/zh/guide/extensions/opentelemetry.md
+++ b/documentation/docs/zh/guide/extensions/opentelemetry.md
@@ -90,9 +90,9 @@ export OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318
 java -jar your-app.jar
 ```
 
-统一端点使用 OTLP/HTTP，Agent 自动追加 `/v1/traces`。如果应用同时引入 Spring Boot Actuator
-和 `micrometer-registry-otlp`，Micrometer 会复用相同的服务名与端点，并自动追加 `/v1/metrics`；
-不需要配置 Wow 专用 exporter。
+统一端点使用 OTLP/HTTP，Agent 自动追加 `/v1/traces`。如果应用同时引入 Spring Boot Actuator、
+`spring-boot-opentelemetry` 和 `micrometer-registry-otlp`，Micrometer 会复用相同的服务名与端点，
+并自动追加 `/v1/metrics`；不需要配置 Wow 专用 exporter。
 
 存在 `micrometer-registry-otlp` 时，不要再开启 Java Agent 的 Micrometer bridge，否则两条路径会
 重复导出应用指标。依赖、鉴权、验证方法和 signal-specific endpoint 覆盖方式参见

--- a/documentation/docs/zh/reference/config/observability.md
+++ b/documentation/docs/zh/reference/config/observability.md
@@ -112,12 +112,18 @@ scheduler meter 只有在应用显式配置 `reactor-core-micrometer` 插桩后�
 
 Wow 使用 Micrometer 记录指标；`wow-opentelemetry` 负责链路追踪埋点，并不导出 Micrometer
 meter。要把 Wow 指标和应用标准指标发送到 OpenTelemetry Collector，请在应用中加入
-Spring Boot Actuator 和 Micrometer OTLP Registry：
+Spring Boot Actuator、Boot OpenTelemetry 支持模块和 Micrometer OTLP Registry：
 
 ```kotlin
 implementation("org.springframework.boot:spring-boot-starter-actuator")
+runtimeOnly("org.springframework.boot:spring-boot-opentelemetry")
 runtimeOnly("io.micrometer:micrometer-registry-otlp")
 ```
+
+在项目当前使用的 Spring Boot 4.1.0 中，`spring-boot-opentelemetry` 提供 OTLP Metrics
+自动配置所依赖的统一 OpenTelemetry 环境变量与 Resource 配置。Starter 的
+`opentelemetry-support` capability 提供 Wow 链路追踪埋点，但不能替代这个 Spring Boot
+运行时模块。
 
 最简接入只需使用标准 OpenTelemetry 环境变量。Micrometer OTLP Registry 与 Java Agent 都能
 识别统一端点和服务名：

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ cocache = "4.2.0"
 testcontainers = "2.0.5"
 opentelemetry = "1.64.0"
 opentelemetry-instrumentation = "2.30.0"
+opentelemetry-proto = "1.10.0-alpha"
 opentelemetry-semconv = "1.30.1-alpha"
 guava = "33.6.0-jre"
 kotlin-logging = "8.0.4"
@@ -46,6 +47,7 @@ json-schema-validator = { module = "com.networknt:json-schema-validator", versio
 kotlinx-coroutines-bom = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-bom", version.ref = "kotlinx-coroutines" }
 opentelemetry-bom = { module = "io.opentelemetry:opentelemetry-bom", version.ref = "opentelemetry" }
 opentelemetry-instrumentation-bom = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom", version.ref = "opentelemetry-instrumentation" }
+opentelemetry-proto = { module = "io.opentelemetry.proto:opentelemetry-proto", version.ref = "opentelemetry-proto" }
 opentelemetry-semconv = { module = "io.opentelemetry:opentelemetry-semconv", version.ref = "opentelemetry-semconv" }
 testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version.ref = "testcontainers" }
 ksp-symbol-processing-api = { module = "com.google.devtools.ksp:symbol-processing-api", version.ref = "ksp" }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/event/dispatcher/CompositeEventDispatcherLifecycleTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/event/dispatcher/CompositeEventDispatcherLifecycleTest.kt
@@ -175,8 +175,8 @@ class CompositeEventDispatcherLifecycleTest {
     }
 
     @Test
-    fun `runtime graceful stop closes every intake before scheduler cleanup`() {
-        val gracefulCalls = mutableListOf<String>()
+    fun `runtime graceful stop closes every logical intake before scheduler cleanup`() {
+        val gracefulCalls = CopyOnWriteArrayList<String>()
         val gracefulDispatcher = newRecordingDispatcher(gracefulCalls)
         val runtime = runtime(gracefulDispatcher)
         runtime.start().block()
@@ -184,11 +184,13 @@ class CompositeEventDispatcherLifecycleTest {
 
         StepVerifier.create(runtime.stopGracefully()).verifyComplete()
 
-        gracefulCalls.assert().containsExactly(
-            "stop:domain",
-            "stop:state",
-            "stop:scheduler",
-        )
+        gracefulCalls
+            .filter { it.startsWith("close:") || it == "stop:scheduler" }
+            .assert().containsExactly(
+                "close:domain",
+                "close:state",
+                "stop:scheduler",
+            )
     }
 
     @Test
@@ -233,8 +235,14 @@ class CompositeEventDispatcherLifecycleTest {
 
     private fun newRecordingDispatcher(calls: MutableList<String>): RecordingCompositeEventDispatcher =
         RecordingCompositeEventDispatcher(
-            domainEventBus = RecordingDomainEventBus(calls),
-            stateEventBus = RecordingStateEventBus(calls),
+            domainEventBus = RecordingDomainEventBus(
+                calls = calls,
+                onCloseProcessing = { calls += "close:domain" },
+            ),
+            stateEventBus = RecordingStateEventBus(
+                calls = calls,
+                onCloseProcessing = { calls += "close:state" },
+            ),
             functionRegistrar = registrar(
                 RecordingFunction(FunctionKind.EVENT),
                 RecordingFunction(FunctionKind.STATE_EVENT),
@@ -292,6 +300,7 @@ class CompositeEventDispatcherLifecycleTest {
 
     private class RecordingDomainEventBus(
         private val calls: MutableList<String>,
+        private val onCloseProcessing: () -> Unit = {},
         private val onCancel: () -> Unit = {},
     ) : DomainEventBus {
         val subscriptionCount = AtomicInteger()
@@ -313,6 +322,12 @@ class CompositeEventDispatcherLifecycleTest {
                     cancellationEntered.countDown()
                     onCancel()
                 }
+
+        override fun runtimeReceiver(subscription: MessageSubscription): MessageReceiver<EventStreamExchange> =
+            MessageReceiver(
+                messages = receive(subscription),
+                processingQuiescence = onCloseProcessing,
+            )
 
         fun awaitCancellation() {
             cancellationEntered.await(1, TimeUnit.SECONDS).assert().isTrue()
@@ -352,6 +367,7 @@ class CompositeEventDispatcherLifecycleTest {
 
     private class RecordingStateEventBus(
         private val calls: MutableList<String>,
+        private val onCloseProcessing: () -> Unit = {},
         private val onCancel: () -> Unit = {},
     ) : StateEventBus {
         private val cancellationEntered = CountDownLatch(1)
@@ -369,6 +385,12 @@ class CompositeEventDispatcherLifecycleTest {
                     cancellationEntered.countDown()
                     onCancel()
                 }
+
+        override fun runtimeReceiver(subscription: MessageSubscription): MessageReceiver<StateEventExchange<*>> =
+            MessageReceiver(
+                messages = receive(subscription),
+                processingQuiescence = onCloseProcessing,
+            )
 
         fun awaitCancellation() {
             cancellationEntered.await(1, TimeUnit.SECONDS).assert().isTrue()

--- a/wow-spring-boot-starter/build.gradle.kts
+++ b/wow-spring-boot-starter/build.gradle.kts
@@ -79,7 +79,7 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-starter-webflux")
     testImplementation("org.springdoc:springdoc-openapi-starter-webflux-ui")
-    testCompileOnly("io.opentelemetry.proto:opentelemetry-proto:1.10.0-alpha")
+    testCompileOnly(libs.opentelemetry.proto)
     testRuntimeOnly("org.springframework.boot:spring-boot-opentelemetry")
 }
 

--- a/wow-spring-boot-starter/build.gradle.kts
+++ b/wow-spring-boot-starter/build.gradle.kts
@@ -74,9 +74,13 @@ dependencies {
     testImplementation(project(":example-domain"))
     testImplementation(project(":example-transfer-domain"))
     testImplementation(project(":wow-compensation-domain"))
+    testImplementation("io.micrometer:micrometer-registry-otlp")
+    testImplementation("org.springframework.boot:spring-boot-starter-actuator")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.boot:spring-boot-starter-webflux")
     testImplementation("org.springdoc:springdoc-openapi-starter-webflux-ui")
+    testCompileOnly("io.opentelemetry.proto:opentelemetry-proto:1.10.0-alpha")
+    testRuntimeOnly("org.springframework.boot:spring-boot-opentelemetry")
 }
 
 configurations.named("testImplementation") {

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/metrics/OtlpMetricsExportSmokeTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/metrics/OtlpMetricsExportSmokeTest.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.spring.boot.starter.metrics
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import io.micrometer.registry.otlp.OtlpMeterRegistry
+import io.opentelemetry.proto.collector.metrics.v1.ExportMetricsServiceRequest
+import io.opentelemetry.proto.metrics.v1.Metric
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.metrics.MetricDescriptor
+import me.ahoo.wow.metrics.WowMetrics
+import me.ahoo.wow.spring.boot.starter.enableWowProperties
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.micrometer.metrics.autoconfigure.export.otlp.OtlpMetricsExportAutoConfiguration
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import reactor.core.publisher.Mono
+import java.io.Closeable
+import java.net.InetSocketAddress
+import java.time.Duration
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration as BootMetricsAutoConfiguration
+
+class OtlpMetricsExportSmokeTest {
+    private val contextRunner = ApplicationContextRunner()
+        .withConfiguration(
+            AutoConfigurations.of(
+                BootMetricsAutoConfiguration::class.java,
+                OtlpMetricsExportAutoConfiguration::class.java,
+            ),
+        )
+        .enableWowProperties()
+
+    @Test
+    fun `should export Wow metrics through the application OTLP registry`() {
+        OtlpHttpReceiver().use { receiver ->
+            contextRunner
+                .withPropertyValues(
+                    "management.metrics.use-global-registry=false",
+                    "management.otlp.metrics.export.url=${receiver.endpoint}",
+                    "management.otlp.metrics.export.step=1h",
+                )
+                .withUserConfiguration(MetricsAutoConfiguration::class.java)
+                .run { context ->
+                    context.assert()
+                        .hasSingleBean(OtlpMeterRegistry::class.java)
+                        .hasSingleBean(WowMetrics::class.java)
+
+                    val metrics = context.getBean(WowMetrics::class.java)
+                    metrics.enabled.assert().isTrue()
+                    metrics.operation(
+                        Mono.just("ok"),
+                        MetricDescriptor(component = "test", operation = "otlp"),
+                    ).block()
+
+                    publish(context.getBean(OtlpMeterRegistry::class.java))
+
+                    val capturedRequest = receiver.awaitRequest(Duration.ofSeconds(5))
+                    capturedRequest.method.assert().isEqualTo("POST")
+                    capturedRequest.path.assert().isEqualTo("/v1/metrics")
+                    capturedRequest.body.size.assert().isGreaterThan(0)
+
+                    val exportRequest = ExportMetricsServiceRequest.parseFrom(capturedRequest.body)
+                    val operationMetric = exportRequest.metrics()
+                        .single { it.name == "wow.operation" }
+                    operationMetric.hasHistogram().assert().isTrue()
+                    operationMetric.histogram.dataPointsCount.assert().isGreaterThanOrEqualTo(1)
+
+                    val attributes = operationMetric.histogram.dataPointsList
+                        .flatMap { it.attributesList }
+                        .associate { it.key to it.value.stringValue }
+                    attributes["component"].assert().isEqualTo("test")
+                    attributes["operation"].assert().isEqualTo("otlp")
+                    attributes["outcome"].assert().isEqualTo("success")
+                    attributes["exception"].assert().isEqualTo("none")
+                }
+        }
+    }
+
+    private fun publish(registry: OtlpMeterRegistry) {
+        PUBLISH_METHOD.invoke(registry)
+    }
+
+    private companion object {
+        val PUBLISH_METHOD = OtlpMeterRegistry::class.java.getDeclaredMethod("publish").apply {
+            check(trySetAccessible()) { "Could not access OtlpMeterRegistry.publish()." }
+        }
+    }
+}
+
+private data class CapturedRequest(
+    val method: String,
+    val path: String,
+    val body: ByteArray,
+)
+
+private class OtlpHttpReceiver : Closeable {
+    private val requests = LinkedBlockingQueue<CapturedRequest>()
+    private val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0).apply {
+        createContext("/v1/metrics", ::capture)
+        start()
+    }
+
+    val endpoint: String = "http://127.0.0.1:${server.address.port}/v1/metrics"
+
+    fun awaitRequest(timeout: Duration): CapturedRequest = requireNotNull(
+        requests.poll(timeout.toMillis(), TimeUnit.MILLISECONDS),
+    ) {
+        "Timed out waiting for an OTLP metrics request."
+    }
+
+    override fun close() {
+        server.stop(0)
+    }
+
+    private fun capture(exchange: HttpExchange) {
+        try {
+            requests.offer(
+                CapturedRequest(
+                    method = exchange.requestMethod,
+                    path = exchange.requestURI.path,
+                    body = exchange.requestBody.use { it.readAllBytes() },
+                ),
+            )
+            exchange.sendResponseHeaders(200, -1)
+        } finally {
+            exchange.close()
+        }
+    }
+}
+
+private fun ExportMetricsServiceRequest.metrics(): List<Metric> = resourceMetricsList.flatMap { resourceMetrics ->
+    resourceMetrics.scopeMetricsList.flatMap { it.metricsList }
+}

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/metrics/OtlpMetricsExportSmokeTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/metrics/OtlpMetricsExportSmokeTest.kt
@@ -21,83 +21,113 @@ import io.opentelemetry.proto.metrics.v1.Metric
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.metrics.MetricDescriptor
 import me.ahoo.wow.metrics.WowMetrics
-import me.ahoo.wow.spring.boot.starter.enableWowProperties
 import org.junit.jupiter.api.Test
-import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.SpringApplication
+import org.springframework.boot.SpringBootConfiguration
+import org.springframework.boot.WebApplicationType
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration
 import org.springframework.boot.micrometer.metrics.autoconfigure.export.otlp.OtlpMetricsExportAutoConfiguration
-import org.springframework.boot.test.context.runner.ApplicationContextRunner
 import reactor.core.publisher.Mono
 import java.io.Closeable
 import java.net.InetSocketAddress
+import java.nio.file.Path
 import java.time.Duration
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import org.springframework.boot.micrometer.metrics.autoconfigure.MetricsAutoConfiguration as BootMetricsAutoConfiguration
 
 class OtlpMetricsExportSmokeTest {
-    private val contextRunner = ApplicationContextRunner()
-        .withConfiguration(
-            AutoConfigurations.of(
-                BootMetricsAutoConfiguration::class.java,
-                OtlpMetricsExportAutoConfiguration::class.java,
-            ),
-        )
-        .enableWowProperties()
-
     @Test
-    fun `should export Wow metrics through the application OTLP registry`() {
+    fun `should export Wow metrics through the documented OTEL environment path`() {
         OtlpHttpReceiver().use { receiver ->
-            contextRunner
-                .withPropertyValues(
-                    "management.metrics.use-global-registry=false",
-                    "management.otlp.metrics.export.url=${receiver.endpoint}",
-                    "management.otlp.metrics.export.step=1h",
-                )
-                .withUserConfiguration(MetricsAutoConfiguration::class.java)
-                .run { context ->
-                    context.assert()
-                        .hasSingleBean(OtlpMeterRegistry::class.java)
-                        .hasSingleBean(WowMetrics::class.java)
+            runExportProcess(receiver.baseEndpoint)
 
-                    val metrics = context.getBean(WowMetrics::class.java)
-                    metrics.enabled.assert().isTrue()
-                    metrics.operation(
-                        Mono.just("ok"),
-                        MetricDescriptor(component = "test", operation = "otlp"),
-                    ).block()
+            val capturedRequest = receiver.awaitRequest(Duration.ofSeconds(5))
+            capturedRequest.method.assert().isEqualTo("POST")
+            capturedRequest.path.assert().isEqualTo("/v1/metrics")
+            capturedRequest.body.size.assert().isGreaterThan(0)
 
-                    publish(context.getBean(OtlpMeterRegistry::class.java))
+            val exportRequest = ExportMetricsServiceRequest.parseFrom(capturedRequest.body)
+            exportRequest.resourceAttributes()["service.name"].assert().isEqualTo(SERVICE_NAME)
 
-                    val capturedRequest = receiver.awaitRequest(Duration.ofSeconds(5))
-                    capturedRequest.method.assert().isEqualTo("POST")
-                    capturedRequest.path.assert().isEqualTo("/v1/metrics")
-                    capturedRequest.body.size.assert().isGreaterThan(0)
+            val operationMetric = exportRequest.metrics()
+                .single { it.name == "wow.operation" }
+            operationMetric.hasHistogram().assert().isTrue()
+            operationMetric.histogram.dataPointsCount.assert().isGreaterThanOrEqualTo(1)
 
-                    val exportRequest = ExportMetricsServiceRequest.parseFrom(capturedRequest.body)
-                    val operationMetric = exportRequest.metrics()
-                        .single { it.name == "wow.operation" }
-                    operationMetric.hasHistogram().assert().isTrue()
-                    operationMetric.histogram.dataPointsCount.assert().isGreaterThanOrEqualTo(1)
-
-                    val attributes = operationMetric.histogram.dataPointsList
-                        .flatMap { it.attributesList }
-                        .associate { it.key to it.value.stringValue }
-                    attributes["component"].assert().isEqualTo("test")
-                    attributes["operation"].assert().isEqualTo("otlp")
-                    attributes["outcome"].assert().isEqualTo("success")
-                    attributes["exception"].assert().isEqualTo("none")
-                }
+            val attributes = operationMetric.histogram.dataPointsList
+                .flatMap { it.attributesList }
+                .associate { it.key to it.value.stringValue }
+            attributes["component"].assert().isEqualTo("test")
+            attributes["operation"].assert().isEqualTo("otlp")
+            attributes["outcome"].assert().isEqualTo("success")
+            attributes["exception"].assert().isEqualTo("none")
         }
     }
 
-    private fun publish(registry: OtlpMeterRegistry) {
-        PUBLISH_METHOD.invoke(registry)
+    private fun runExportProcess(endpoint: String) {
+        val process = ProcessBuilder(
+            Path.of(System.getProperty("java.home"), "bin", "java").toString(),
+            "-cp",
+            testRuntimeClasspath(),
+            OtlpMetricsExportApplication::class.java.name,
+        ).apply {
+            environment()["OTEL_EXPORTER_OTLP_ENDPOINT"] = endpoint
+            environment()["OTEL_SERVICE_NAME"] = SERVICE_NAME
+            inheritIO()
+        }.start()
+        try {
+            process.waitFor(30, TimeUnit.SECONDS).assert().isTrue()
+            process.exitValue().assert().isZero()
+        } finally {
+            if (process.isAlive) {
+                process.destroyForcibly()
+            }
+        }
     }
+
+    private fun testRuntimeClasspath(): String = System.getProperty("java.class.path")
+        .also { check(it.isNotBlank()) { "Could not determine the test runtime classpath." } }
 
     private companion object {
-        val PUBLISH_METHOD = OtlpMeterRegistry::class.java.getDeclaredMethod("publish").apply {
-            check(trySetAccessible()) { "Could not access OtlpMeterRegistry.publish()." }
+        const val SERVICE_NAME = "wow-otlp-smoke-test"
+    }
+}
+
+@SpringBootConfiguration(proxyBeanMethods = false)
+@ImportAutoConfiguration(
+    BootMetricsAutoConfiguration::class,
+    OtlpMetricsExportAutoConfiguration::class,
+    MetricsAutoConfiguration::class,
+)
+private class OtlpMetricsExportConfiguration
+
+internal object OtlpMetricsExportApplication {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        SpringApplication(OtlpMetricsExportConfiguration::class.java).apply {
+            setWebApplicationType(WebApplicationType.NONE)
+            setDefaultProperties(
+                mapOf(
+                    "management.metrics.use-global-registry" to "false",
+                    "management.otlp.metrics.export.step" to "1h",
+                    "spring.main.banner-mode" to "off",
+                ),
+            )
+        }.run(*args).use { context ->
+            val metrics = context.getBean(WowMetrics::class.java)
+            check(metrics.enabled) { "Wow metrics are not enabled." }
+            metrics.operation(
+                Mono.just("ok"),
+                MetricDescriptor(component = "test", operation = "otlp"),
+            ).block()
+
+            PUBLISH_METHOD.invoke(context.getBean(OtlpMeterRegistry::class.java))
         }
+    }
+
+    private val PUBLISH_METHOD = OtlpMeterRegistry::class.java.getDeclaredMethod("publish").apply {
+        check(trySetAccessible()) { "Could not access OtlpMeterRegistry.publish()." }
     }
 }
 
@@ -114,7 +144,7 @@ private class OtlpHttpReceiver : Closeable {
         start()
     }
 
-    val endpoint: String = "http://127.0.0.1:${server.address.port}/v1/metrics"
+    val baseEndpoint: String = "http://127.0.0.1:${server.address.port}"
 
     fun awaitRequest(timeout: Duration): CapturedRequest = requireNotNull(
         requests.poll(timeout.toMillis(), TimeUnit.MILLISECONDS),
@@ -145,3 +175,7 @@ private class OtlpHttpReceiver : Closeable {
 private fun ExportMetricsServiceRequest.metrics(): List<Metric> = resourceMetricsList.flatMap { resourceMetrics ->
     resourceMetrics.scopeMetricsList.flatMap { it.metricsList }
 }
+
+private fun ExportMetricsServiceRequest.resourceAttributes(): Map<String, String> = resourceMetricsList
+    .flatMap { it.resource.attributesList }
+    .associate { it.key to it.value.stringValue }


### PR DESCRIPTION
## Summary

- add a Spring Boot starter smoke test that starts an isolated application with the documented `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_SERVICE_NAME`, then validates the `/v1/metrics` request, resource `service.name`, protobuf payload, and Wow metric tags
- document the complete Spring Boot 4.1.0 OTLP runtime dependency set and environment-variable setup in English and Chinese
- centralize the `opentelemetry-proto` test dependency version
- stabilize the composite dispatcher shutdown test by asserting logical quiescence instead of detached physical cancellation order

## Why

The previous tests stopped at `SimpleMeterRegistry` or injected `management.otlp.metrics.export.url` directly, so they did not verify the documented OTEL environment-variable path. Exercising the real path also showed that Spring Boot 4.1.0 OTLP auto-configuration needs `spring-boot-opentelemetry` at runtime; the documentation previously listed only Actuator and `micrometer-registry-otlp`.

The dispatcher assertion change removes a timing-sensitive assumption while preserving the lifecycle contract being tested.

## Impact

Production module dependencies and runtime behavior are unchanged. All code additions are test-only; published artifacts only receive documentation and version-catalog alignment. Applications using Spring Boot's OTLP metrics auto-configuration now have a verified dependency and configuration recipe.

## Validation

- `./gradlew :wow-spring-boot-starter:test --tests "me.ahoo.wow.spring.boot.starter.metrics.OtlpMetricsExportSmokeTest" --no-daemon`
- `./gradlew :wow-spring-boot-starter:check --no-daemon --stacktrace`
- `cd documentation && pnpm docs:build`
- `git diff --check`
