### PR TITLE
chore(skills): version Wow plugin 0.0.4

### DIFF
--- a/skills/plugins.json
+++ b/skills/plugins.json
@@ -3,6 +3,7 @@
   "plugins": [
     {
       "name": "ahoo-wow-skills",
+      "version": "0.0.4",
       "description": "Intent-focused Agent Skills for developing, reviewing, debugging, and migrating Wow reactive DDD, Event Sourcing, and CQRS services.",
       "skills": {
         "include": [


### PR DESCRIPTION
## Summary

- assign version 0.0.4 specifically to the ahoo-wow-skills distribution plugin
- let Ahoo-Wang/skills invalidate the installed 0.0.3 cache without bumping unrelated plugins

## Why

The rewritten four-Skill package replaces the former Wow Skill set. A plugin-level version ensures existing marketplace users receive the new package while preserving upstream ownership of plugin metadata.

## Validation

- python3 -S scripts/validate_wow_skills.py
- python3 -S -m unittest -v scripts/test_validate_wow_skills.py
- JSON assertion for ahoo-wow-skills 0.0.4
- git diff --check
