### PR TITLE
fix(dashboard): support clipboard fallback

### DIFF
--- a/compensation/dashboard/e2e/dashboard.spec.ts
+++ b/compensation/dashboard/e2e/dashboard.spec.ts
@@ -92,6 +92,62 @@ test("loads the deterministic queue and responsive execution details", async ({
     .toEqual([{ field: "aggregateId", direction: "DESC" }]);
 });
 
+test("copies identifiers when the Clipboard API is unavailable", async ({
+  page,
+}, testInfo) => {
+  await page.route("**/execution_failed/snapshot/paged/state", (route) =>
+    route.fulfill({ json: { total: 1, list: [execution] } }),
+  );
+
+  await page.goto("/to-retry");
+  await openDetails(page, testInfo.project.name);
+  await page.evaluate(() => {
+    const execCommand = document.execCommand.bind(document);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: (commandId: string, showUI?: boolean, valueArgument?: string) => {
+        const textarea = [...document.querySelectorAll("textarea")].find(
+          ({ selectionStart, selectionEnd }) => selectionEnd > selectionStart,
+        );
+        if (commandId === "copy" && textarea) {
+          const { selectionStart, selectionEnd, value } = textarea;
+          Object.defineProperty(window, "__copiedText", {
+            configurable: true,
+            value: value.slice(selectionStart, selectionEnd),
+          });
+        }
+        return execCommand(commandId, showUI, valueArgument);
+      },
+    });
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+  expect(await page.evaluate(() => navigator.clipboard)).toBeUndefined();
+  expect(
+    await page.evaluate(() => Object.hasOwn(document, "execCommand")),
+  ).toBe(true);
+
+  for (const [label, value] of [
+    ["Copy execution ID", execution.id],
+    ["Copy event ID", execution.eventId.id],
+    ["Copy aggregate ID", execution.eventId.aggregateId.aggregateId],
+  ]) {
+    const copyButton = page.getByRole("button", { name: label });
+    await copyButton.click();
+    await expect(copyButton.locator("svg")).toHaveClass(/lucide-check/);
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => (window as Window & { __copiedText?: string }).__copiedText,
+        ),
+      )
+      .toBe(value);
+  }
+  await expect(page.getByText(/^Unable to copy/)).toHaveCount(0);
+});
+
 test("keeps prepared actions independent of the browser clock", async ({
   page,
 }, testInfo) => {

--- a/compensation/dashboard/src/utils/clipboard.test.ts
+++ b/compensation/dashboard/src/utils/clipboard.test.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { copyTextToClipboard } from "./clipboard.ts";
+
+const originalClipboard = Object.getOwnPropertyDescriptor(
+  navigator,
+  "clipboard",
+);
+const originalExecCommand = Object.getOwnPropertyDescriptor(
+  document,
+  "execCommand",
+);
+
+function defineClipboard(value: Clipboard | undefined) {
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value,
+  });
+}
+
+function defineExecCommand(value: (command: string) => boolean) {
+  Object.defineProperty(document, "execCommand", {
+    configurable: true,
+    value,
+  });
+}
+
+describe("copyTextToClipboard", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (originalClipboard) {
+      Object.defineProperty(navigator, "clipboard", originalClipboard);
+    } else {
+      Reflect.deleteProperty(navigator, "clipboard");
+    }
+    if (originalExecCommand) {
+      Object.defineProperty(document, "execCommand", originalExecCommand);
+    } else {
+      Reflect.deleteProperty(document, "execCommand");
+    }
+  });
+
+  it("uses the Clipboard API when it is available", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const execCommand = vi.fn(() => true);
+    defineClipboard({ writeText } as unknown as Clipboard);
+    defineExecCommand(execCommand);
+
+    await expect(copyTextToClipboard("execution-1")).resolves.toBe(true);
+
+    expect(writeText).toHaveBeenCalledWith("execution-1");
+    expect(execCommand).not.toHaveBeenCalled();
+  });
+
+  it("falls back when the Clipboard API is unavailable", async () => {
+    const execCommand = vi.fn(() => {
+      const textarea = document.activeElement as HTMLTextAreaElement;
+      expect(textarea).toBeInstanceOf(HTMLTextAreaElement);
+      expect(textarea.value).toBe("event-1");
+      expect(textarea.selectionStart).toBe(0);
+      expect(textarea.selectionEnd).toBe("event-1".length);
+      return true;
+    });
+    defineClipboard(undefined);
+    defineExecCommand(execCommand);
+
+    await expect(copyTextToClipboard("event-1")).resolves.toBe(true);
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(document.querySelector("textarea")).not.toBeInTheDocument();
+  });
+
+  it("falls back when the Clipboard API rejects the write", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("permission denied"));
+    const execCommand = vi.fn(() => true);
+    defineClipboard({ writeText } as unknown as Clipboard);
+    defineExecCommand(execCommand);
+
+    await expect(copyTextToClipboard("aggregate-1")).resolves.toBe(true);
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("restores focus and removes the temporary textarea", async () => {
+    defineClipboard(undefined);
+    defineExecCommand(() => true);
+    const button = document.createElement("button");
+    document.body.append(button);
+    button.focus();
+
+    await copyTextToClipboard("stack trace");
+
+    expect(document.activeElement).toBe(button);
+    expect(document.querySelector("textarea")).not.toBeInTheDocument();
+  });
+
+  it("returns false when both copy mechanisms fail", async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error("permission denied"));
+    defineClipboard({ writeText } as unknown as Clipboard);
+    defineExecCommand(() => false);
+
+    await expect(copyTextToClipboard("execution-1")).resolves.toBe(false);
+
+    expect(document.querySelector("textarea")).not.toBeInTheDocument();
+  });
+});

--- a/compensation/dashboard/src/utils/clipboard.ts
+++ b/compensation/dashboard/src/utils/clipboard.ts
@@ -11,14 +11,50 @@
  * limitations under the License.
  */
 
-export async function copyTextToClipboard(value: string): Promise<boolean> {
-  try {
-    if (!navigator.clipboard?.writeText) {
-      return false;
-    }
-    await navigator.clipboard.writeText(value);
-    return true;
-  } catch {
+function copyTextUsingLegacyCommand(value: string): boolean {
+  if (
+    typeof document === "undefined" ||
+    !document.body ||
+    typeof document.execCommand !== "function"
+  ) {
     return false;
   }
+
+  const activeElement =
+    document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : undefined;
+  const textarea = document.createElement("textarea");
+  textarea.value = value;
+  textarea.readOnly = true;
+  textarea.tabIndex = -1;
+  textarea.style.position = "fixed";
+  textarea.style.top = "0";
+  textarea.style.left = "-9999px";
+  textarea.style.opacity = "0";
+  document.body.append(textarea);
+
+  try {
+    textarea.focus({ preventScroll: true });
+    textarea.select();
+    textarea.setSelectionRange(0, value.length);
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    textarea.remove();
+    activeElement?.focus({ preventScroll: true });
+  }
+}
+
+export async function copyTextToClipboard(value: string): Promise<boolean> {
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(value);
+      return true;
+    }
+  } catch {
+    // Fall back for denied permissions and non-secure deployment contexts.
+  }
+  return copyTextUsingLegacyCommand(value);
 }


### PR DESCRIPTION
## Summary

- fall back to a temporary textarea copy command when the Clipboard API is unavailable or rejects a write
- remove the temporary element and restore focus after every fallback attempt
- add focused unit coverage and desktop/mobile Playwright regression coverage for identifier copying without the Clipboard API

## Root cause

The compensation dashboard can be served from an ordinary HTTP origin. In a non-secure context, browsers may not expose `navigator.clipboard`, so the shared clipboard helper returned `false` and every execution ID, event ID, aggregate ID, and stack trace copy action reported a failure.

## Impact

Copy actions continue to prefer `navigator.clipboard.writeText` on secure origins and now work on supported non-secure deployments through the fallback. If both browser mechanisms fail, the existing error feedback is preserved.

## Verification

- `pnpm lint`
- `pnpm build`
- `pnpm coverage` — 29 test files and 124 tests passed; all configured coverage thresholds passed
- `pnpm test:browser` — 8 desktop/mobile Chromium tests passed
- `git diff --check`