### PR TITLE
feat(dashboard): add execution history to failure details

### DIFF
--- a/compensation/dashboard/e2e/dashboard.spec.ts
+++ b/compensation/dashboard/e2e/dashboard.spec.ts
@@ -52,6 +52,34 @@ const execution = {
   isRetryable: true,
 };
 
+const executionHistory = {
+  id: "history-stream-e2e-2",
+  aggregateId: execution.id,
+  aggregateName: "execution_failed",
+  contextName: "compensation",
+  tenantId: "(0)",
+  ownerId: "",
+  spaceId: "",
+  commandId: "history-command-e2e-2",
+  requestId: "history-request-e2e-2",
+  version: 2,
+  createTime: 1_735_000_180_000,
+  header: {},
+  body: [
+    {
+      id: "history-event-e2e-2",
+      name: "execution_failed_applied",
+      bodyType: "compensation.execution_failed.ExecutionFailedApplied",
+      revision: "1.0.0",
+      body: {
+        executeAt: 1_735_000_180_000,
+        recoverable: "RECOVERABLE",
+        error: execution.error,
+      },
+    },
+  ],
+};
+
 async function openDetails(page: Page, projectName: string) {
   if (projectName === "mobile-chromium") {
     await page
@@ -146,6 +174,35 @@ test("copies identifiers when the Clipboard API is unavailable", async ({
       .toBe(value);
   }
   await expect(page.getByText(/^Unable to copy/)).toHaveCount(0);
+});
+
+test("loads lifecycle history through the paged EventStream REST API", async ({
+  page,
+}, testInfo) => {
+  let historyQuery: Record<string, unknown> | undefined;
+  await page.route("**/execution_failed/snapshot/paged/state", (route) =>
+    route.fulfill({ json: { total: 1, list: [execution] } }),
+  );
+  await page.route("**/execution_failed/event/paged", async (route) => {
+    historyQuery = route.request().postDataJSON() as Record<string, unknown>;
+    await route.fulfill({ json: { total: 1, list: [executionHistory] } });
+  });
+
+  await page.goto("/to-retry");
+  await openDetails(page, testInfo.project.name);
+  await page.getByRole("button", { name: "Expand history" }).click();
+
+  await expect(page.getByText("execution_failed_applied")).toBeVisible();
+  await expect(page.getByText("Version 2")).toBeVisible();
+  await page.getByText("Event payload").click();
+  await expect(page.getByText(/"errorCode": "E2E_ERROR"/)).toBeVisible();
+  await expect
+    .poll(() => historyQuery)
+    .toMatchObject({
+      condition: { operator: "AGGREGATE_ID", value: execution.id },
+      sort: [{ field: "version", direction: "DESC" }],
+      pagination: { index: 1, size: 10 },
+    });
 });
 
 test("keeps prepared actions independent of the browser clock", async ({

--- a/compensation/dashboard/e2e/dashboard.spec.ts
+++ b/compensation/dashboard/e2e/dashboard.spec.ts
@@ -115,6 +115,17 @@ test("loads the deterministic queue and responsive execution details", async ({
   await expect(page.getByText("656", { exact: true })).toBeVisible();
   await expect(page.getByText("v656", { exact: true })).toHaveCount(0);
   await expect(page.getByText("3 minutes (180 s)")).toBeVisible();
+  for (const [name, minHeight] of [
+    ["History", 56],
+    ["Execution context", 160],
+    ["Stack trace", 52],
+  ] as const) {
+    const section = page.getByRole("region", { name });
+    await expect(section).toBeVisible();
+    expect((await section.boundingBox())?.height).toBeGreaterThanOrEqual(
+      minHeight,
+    );
+  }
   await expect
     .poll(() => queryBody?.sort)
     .toEqual([{ field: "aggregateId", direction: "DESC" }]);

--- a/compensation/dashboard/src/features/Failed/details/ErrorDetails.tsx
+++ b/compensation/dashboard/src/features/Failed/details/ErrorDetails.tsx
@@ -35,11 +35,20 @@ import { StackTraceEditor } from "./StackTraceEditor.tsx";
 export interface ErrorDetailsProps {
   error: ErrorDetailsModel;
   historical?: boolean;
+  defaultExpanded?: boolean;
 }
 
-export function ErrorDetails({ error, historical = false }: ErrorDetailsProps) {
+export function ErrorDetails({
+  error,
+  historical = false,
+  defaultExpanded,
+}: ErrorDetailsProps) {
   const panelRef = useRef<HTMLDivElement>(null);
-  const [expanded, setExpanded] = useState(!historical);
+  const expandedContentRef = useRef<HTMLDivElement>(null);
+  const [expanded, setExpanded] = useState(
+    defaultExpanded ?? !historical,
+  );
+  const previousExpandedRef = useRef(expanded);
   const [fullscreen, setFullscreen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [wrapLongLines, setWrapLongLines] = useState(true);
@@ -51,6 +60,31 @@ export function ErrorDetails({ error, historical = false }: ErrorDetailsProps) {
     document.addEventListener("fullscreenchange", update);
     return () => document.removeEventListener("fullscreenchange", update);
   }, []);
+
+  useEffect(() => {
+    const shouldRevealContent = expanded && !previousExpandedRef.current;
+    previousExpandedRef.current = expanded;
+    if (shouldRevealContent) {
+      expandedContentRef.current?.scrollIntoView({ block: "nearest" });
+    }
+  }, [expanded]);
+
+  const toggleExpanded = async () => {
+    if (!expanded) {
+      setExpanded(true);
+      return;
+    }
+
+    if (document.fullscreenElement === panelRef.current) {
+      try {
+        await document.exitFullscreen();
+      } catch {
+        toast.error("Unable to change fullscreen mode");
+        return;
+      }
+    }
+    setExpanded(false);
+  };
 
   const toggleFullscreen = async () => {
     try {
@@ -79,6 +113,7 @@ export function ErrorDetails({ error, historical = false }: ErrorDetailsProps) {
         .length
     : 0;
   const title = historical ? "Last failure" : "Stack trace";
+  const collapsible = historical || defaultExpanded !== undefined;
 
   return (
     <section
@@ -92,16 +127,18 @@ export function ErrorDetails({ error, historical = false }: ErrorDetailsProps) {
     >
       <div className="flex min-h-13 items-center justify-between border-b px-4">
         <div className="flex min-w-0 items-center gap-2">
-          {historical ? (
+          {collapsible ? (
             <Button
               type="button"
               variant="ghost"
               size="icon-sm"
               aria-label={
-                expanded ? "Collapse last failure" : "Expand last failure"
+                expanded
+                  ? `Collapse ${title.toLowerCase()}`
+                  : `Expand ${title.toLowerCase()}`
               }
               aria-expanded={expanded}
-              onClick={() => setExpanded((current) => !current)}
+              onClick={() => void toggleExpanded()}
             >
               {expanded ? <ChevronDown /> : <ChevronRight />}
             </Button>
@@ -156,7 +193,10 @@ export function ErrorDetails({ error, historical = false }: ErrorDetailsProps) {
         </div>
       </div>
       {expanded ? (
-        <>
+        <div
+          ref={expandedContentRef}
+          className="flex min-h-0 flex-1 flex-col"
+        >
           <div className="flex flex-wrap items-center gap-2 border-b bg-slate-50 px-3 py-2">
             <div className="min-w-[180px] flex-1">
               <Input
@@ -199,7 +239,7 @@ export function ErrorDetails({ error, historical = false }: ErrorDetailsProps) {
               wrapLongLines={wrapLongLines}
             />
           </div>
-        </>
+        </div>
       ) : null}
     </section>
   );

--- a/compensation/dashboard/src/features/Failed/details/ExecutionContext.tsx
+++ b/compensation/dashboard/src/features/Failed/details/ExecutionContext.tsx
@@ -1,0 +1,150 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Pencil, Workflow } from "lucide-react";
+import type { ReactNode } from "react";
+import type { ExecutionFailedState } from "../../../generated";
+import { CopyButton } from "@/components/CopyButton";
+import { useGlobalDrawer } from "@/components/GlobalDrawer";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { ChangeFunction } from "../ChangeFunction.tsx";
+import type { OnChangedCapable } from "../types.ts";
+
+type ExecutionContextState = Pick<
+  ExecutionFailedState,
+  "eventId" | "function" | "id"
+>;
+
+export interface ExecutionContextProps extends OnChangedCapable {
+  state: ExecutionContextState;
+  mutationsDisabled?: boolean;
+}
+
+interface DetailRowProps {
+  label: string;
+  children: ReactNode;
+  action?: ReactNode;
+  className?: string;
+}
+
+function DetailRow({ label, children, action, className }: DetailRowProps) {
+  return (
+    <div
+      className={cn(
+        "grid min-h-9 grid-cols-[112px_minmax(0,1fr)_auto] items-center gap-3",
+        className,
+      )}
+    >
+      <dt className="text-sm text-slate-500">{label}</dt>
+      <dd className="min-w-0 break-words text-sm text-slate-800">{children}</dd>
+      {action ? <div className="flex items-center">{action}</div> : null}
+    </div>
+  );
+}
+
+export function ExecutionContext({
+  state,
+  onChanged,
+  mutationsDisabled,
+}: ExecutionContextProps) {
+  const { openDrawer } = useGlobalDrawer();
+  const aggregate = state.eventId.aggregateId;
+
+  const editFunction = () =>
+    openDrawer({
+      title: "Change function",
+      description: "Update the handler identity for this failed execution.",
+      width: 500,
+      children: (
+        <ChangeFunction
+          id={state.id}
+          functionInfo={state.function}
+          onChanged={onChanged}
+        />
+      ),
+    });
+
+  return (
+    <section
+      className="overflow-hidden rounded-lg border bg-white shadow-sm"
+      aria-label="Execution context"
+    >
+      <div className="flex min-h-14 items-center gap-3 border-b bg-slate-50/70 px-4 py-3">
+        <Workflow className="size-4 shrink-0 text-slate-500" />
+        <div className="min-w-0">
+          <h2 className="text-sm font-semibold text-slate-900">
+            Execution context
+          </h2>
+          <p className="text-xs text-slate-500">
+            Handler and source event identifiers
+          </p>
+        </div>
+      </div>
+      <dl className="grid grid-cols-1 gap-x-6 p-3 xl:grid-cols-2">
+        <div className="space-y-1 xl:border-r xl:pr-6">
+          <DetailRow
+            label="Processor"
+            action={
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                aria-label="Edit function"
+                disabled={mutationsDisabled}
+                onClick={editFunction}
+              >
+                <Pencil />
+              </Button>
+            }
+          >
+            <span className="block truncate" title={state.function.processorName}>
+              {state.function.processorName}
+            </span>
+          </DetailRow>
+          <DetailRow label="Function kind">
+            {state.function.contextName} / {state.function.functionKind}
+          </DetailRow>
+          <DetailRow label="Aggregate">
+            {aggregate.contextName} / {aggregate.aggregateName}
+          </DetailRow>
+          <DetailRow label="Tenant">
+            <span className="truncate">{aggregate.tenantId}</span>
+          </DetailRow>
+        </div>
+
+        <div className="mt-4 space-y-1 border-t pt-4 xl:mt-0 xl:border-t-0 xl:pl-6 xl:pt-0">
+          <DetailRow label="Event version">{state.eventId.version}</DetailRow>
+          <DetailRow
+            label="Event ID"
+            action={<CopyButton value={state.eventId.id} label="event ID" />}
+          >
+            <span className="block truncate font-mono text-xs">
+              {state.eventId.id}
+            </span>
+          </DetailRow>
+          <DetailRow
+            label="Aggregate ID"
+            action={
+              <CopyButton value={aggregate.aggregateId} label="aggregate ID" />
+            }
+          >
+            <span className="block truncate font-mono text-xs">
+              {aggregate.aggregateId}
+            </span>
+          </DetailRow>
+        </div>
+      </dl>
+    </section>
+  );
+}

--- a/compensation/dashboard/src/features/Failed/details/FailedDetails.tsx
+++ b/compensation/dashboard/src/features/Failed/details/FailedDetails.tsx
@@ -11,49 +11,19 @@
  * limitations under the License.
  */
 
-import { Pencil } from "lucide-react";
-import type { ReactNode } from "react";
 import type { ExecutionFailedState } from "../../../generated";
 import { ExecutionFailedStatus } from "../../../generated";
-import { CopyButton } from "@/components/CopyButton";
-import { useGlobalDrawer } from "@/components/GlobalDrawer";
-import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
-import { formatDate } from "@/utils/dates";
-import { formatSeconds } from "@/utils/durations.ts";
-import { Actions } from "../Actions.tsx";
-import { ApplyRetrySpec } from "../ApplyRetrySpec.tsx";
-import { ChangeFunction } from "../ChangeFunction.tsx";
-import { MarkRecoverable } from "../MarkRecoverable.tsx";
-import { BooleanBadge, StatusBadge } from "../StatusBadge.tsx";
-import { ErrorDetails } from "./ErrorDetails.tsx";
+import { ExecutionHistory } from "../history/ExecutionHistory.tsx";
 import type { OnChangedCapable } from "../types.ts";
+import { ErrorDetails } from "./ErrorDetails.tsx";
+import { ExecutionContext } from "./ExecutionContext.tsx";
+import { FailedDetailsHeader } from "./FailedDetailsHeader.tsx";
+import { FailureSummary } from "./FailureSummary.tsx";
+import { RecoveryStatus } from "./RecoveryStatus.tsx";
 
 export interface FailedDetailsProps extends OnChangedCapable {
   state: ExecutionFailedState;
   mutationsDisabled?: boolean;
-}
-
-interface DetailRowProps {
-  label: string;
-  children: ReactNode;
-  action?: ReactNode;
-  className?: string;
-}
-
-function DetailRow({ label, children, action, className }: DetailRowProps) {
-  return (
-    <div
-      className={cn(
-        "grid min-h-9 grid-cols-[112px_minmax(0,1fr)_auto] items-center gap-3",
-        className,
-      )}
-    >
-      <dt className="text-sm text-slate-500">{label}</dt>
-      <dd className="min-w-0 break-words text-sm text-slate-800">{children}</dd>
-      {action ? <div className="flex items-center">{action}</div> : null}
-    </div>
-  );
 }
 
 export function FailedDetails({
@@ -61,193 +31,39 @@ export function FailedDetails({
   onChanged,
   mutationsDisabled,
 }: FailedDetailsProps) {
-  const { openDrawer } = useGlobalDrawer();
-  const aggregate = state.eventId.aggregateId;
-
-  const editFunction = () =>
-    openDrawer({
-      title: "Change function",
-      description: "Update the handler identity for this failed execution.",
-      width: 500,
-      children: (
-        <ChangeFunction
-          id={state.id}
-          functionInfo={state.function}
-          onChanged={onChanged}
-        />
-      ),
-    });
-
-  const editRetry = () =>
-    openDrawer({
-      title: "Apply retry specification",
-      description: "Tune retry limits and timing for this execution.",
-      width: 440,
-      children: (
-        <ApplyRetrySpec
-          id={state.id}
-          retrySpec={state.retrySpec}
-          onChanged={onChanged}
-        />
-      ),
-    });
+  const historicalFailure = state.status === ExecutionFailedStatus.SUCCEEDED;
 
   return (
     <article className="flex h-full min-h-0 flex-col bg-slate-50/50">
-      <header className="flex flex-col items-stretch gap-4 border-b bg-white py-4 pr-14 pl-5 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:pr-6 sm:pl-6">
-        <div className="flex min-w-0 items-center gap-3">
-          <span
-            className="h-9 w-1 shrink-0 rounded-full bg-red-500"
-            aria-hidden
+      <FailedDetailsHeader
+        state={state}
+        mutationsDisabled={mutationsDisabled}
+        onChanged={onChanged}
+      />
+
+      <div className="grid min-h-0 flex-1 content-start gap-3 overflow-y-auto p-3 sm:p-4">
+        <div className="grid grid-cols-1 gap-3 xl:grid-cols-2">
+          <FailureSummary state={state} />
+          <RecoveryStatus
+            state={state}
+            mutationsDisabled={mutationsDisabled}
+            onChanged={onChanged}
           />
-          <div className="min-w-0">
-            <div className="flex min-w-0 flex-wrap items-center gap-2">
-              <h1 className="min-w-0 truncate text-xl font-semibold tracking-tight text-slate-950">
-                {state.function.name}
-              </h1>
-              <StatusBadge status={state.status} />
-            </div>
-            <div className="mt-1 flex items-center gap-1 text-xs text-slate-500">
-              <span className="truncate">{state.id}</span>
-              <CopyButton value={state.id} label="execution ID" />
-            </div>
-          </div>
         </div>
-        <Actions
+
+        <ExecutionHistory key={state.id} executionId={state.id} />
+
+        <ExecutionContext
           state={state}
-          disabled={mutationsDisabled}
+          mutationsDisabled={mutationsDisabled}
           onChanged={onChanged}
         />
-      </header>
-
-      <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto p-3">
-        <section
-          className="rounded-lg border bg-white p-3 shadow-sm"
-          aria-label="Execution details"
-        >
-          <dl className="grid grid-cols-1 gap-x-6 xl:grid-cols-2">
-            <div className="space-y-1 xl:border-r xl:pr-6">
-              <DetailRow label="Function kind">
-                {state.function.contextName} / {state.function.functionKind}
-              </DetailRow>
-              <DetailRow
-                label="Processor"
-                action={
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-xs"
-                    aria-label="Edit function"
-                    disabled={mutationsDisabled}
-                    onClick={editFunction}
-                  >
-                    <Pencil />
-                  </Button>
-                }
-              >
-                <span
-                  className="block truncate"
-                  title={state.function.processorName}
-                >
-                  {state.function.processorName}
-                </span>
-              </DetailRow>
-              <DetailRow label="Aggregate">
-                {aggregate.contextName} / {aggregate.aggregateName}
-              </DetailRow>
-              <DetailRow label="Event version">
-                {state.eventId.version}
-              </DetailRow>
-              <DetailRow
-                label="Event ID"
-                action={
-                  <CopyButton value={state.eventId.id} label="event ID" />
-                }
-              >
-                <span className="block truncate font-mono text-xs">
-                  {state.eventId.id}
-                </span>
-              </DetailRow>
-              <DetailRow
-                label="Aggregate ID"
-                action={
-                  <CopyButton
-                    value={aggregate.aggregateId}
-                    label="aggregate ID"
-                  />
-                }
-              >
-                <span className="block truncate font-mono text-xs">
-                  {aggregate.aggregateId}
-                </span>
-              </DetailRow>
-              <DetailRow label="Tenant">
-                <span className="truncate">{aggregate.tenantId}</span>
-              </DetailRow>
-            </div>
-
-            <div className="mt-4 space-y-1 border-t pt-4 xl:mt-0 xl:border-t-0 xl:pl-6 xl:pt-0">
-              <DetailRow label="Execute at">
-                {formatDate(state.executeAt)}
-              </DetailRow>
-              <DetailRow
-                label="Retry"
-                action={
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-xs"
-                    aria-label="Edit retry specification"
-                    disabled={mutationsDisabled}
-                    onClick={editRetry}
-                  >
-                    <Pencil />
-                  </Button>
-                }
-              >
-                <span className="flex flex-wrap items-baseline gap-x-2 tabular-nums">
-                  <span>
-                    {state.retryState.retries} of {state.retrySpec.maxRetries}
-                  </span>
-                  <span className="text-xs text-slate-500">
-                    Last: {formatDate(state.retryState.retryAt)}
-                  </span>
-                </span>
-              </DetailRow>
-              <DetailRow label="Next retry at">
-                {formatDate(state.retryState.nextRetryAt)}
-              </DetailRow>
-              <DetailRow label="Recoverable">
-                <MarkRecoverable
-                  id={state.id}
-                  recoverable={state.recoverable}
-                  disabled={mutationsDisabled}
-                  onChanged={onChanged}
-                />
-              </DetailRow>
-              <DetailRow label="Retryable">
-                <BooleanBadge value={state.isRetryable} />
-              </DetailRow>
-              <DetailRow label="Min backoff">
-                <span className="tabular-nums">
-                  {formatSeconds(state.retrySpec.minBackoff)} (
-                  {state.retrySpec.minBackoff.toLocaleString()} s)
-                </span>
-              </DetailRow>
-              <DetailRow label="Timeout">
-                <span className="tabular-nums">
-                  {formatSeconds(state.retrySpec.executionTimeout)} (
-                  {state.retrySpec.executionTimeout.toLocaleString()} s)
-                </span>
-              </DetailRow>
-            </div>
-          </dl>
-        </section>
 
         <ErrorDetails
           key={`${state.id}-${state.status}`}
           error={state.error}
-          historical={state.status === ExecutionFailedStatus.SUCCEEDED}
+          historical={historicalFailure}
+          defaultExpanded={historicalFailure ? undefined : false}
         />
       </div>
     </article>

--- a/compensation/dashboard/src/features/Failed/details/FailedDetails.tsx
+++ b/compensation/dashboard/src/features/Failed/details/FailedDetails.tsx
@@ -13,6 +13,7 @@
 
 import type { ExecutionFailedState } from "../../../generated";
 import { ExecutionFailedStatus } from "../../../generated";
+import { useCallback, useState } from "react";
 import { ExecutionHistory } from "../history/ExecutionHistory.tsx";
 import type { OnChangedCapable } from "../types.ts";
 import { ErrorDetails } from "./ErrorDetails.tsx";
@@ -32,13 +33,18 @@ export function FailedDetails({
   mutationsDisabled,
 }: FailedDetailsProps) {
   const historicalFailure = state.status === ExecutionFailedStatus.SUCCEEDED;
+  const [historyRefreshToken, setHistoryRefreshToken] = useState(0);
+  const handleChanged = useCallback(() => {
+    setHistoryRefreshToken((current) => current + 1);
+    onChanged?.();
+  }, [onChanged]);
 
   return (
     <article className="flex h-full min-h-0 flex-col bg-slate-50/50">
       <FailedDetailsHeader
         state={state}
         mutationsDisabled={mutationsDisabled}
-        onChanged={onChanged}
+        onChanged={handleChanged}
       />
 
       <div className="grid min-h-0 flex-1 auto-rows-max gap-3 overflow-y-auto p-3 sm:p-4">
@@ -47,16 +53,20 @@ export function FailedDetails({
           <RecoveryStatus
             state={state}
             mutationsDisabled={mutationsDisabled}
-            onChanged={onChanged}
+            onChanged={handleChanged}
           />
         </div>
 
-        <ExecutionHistory key={state.id} executionId={state.id} />
+        <ExecutionHistory
+          key={state.id}
+          executionId={state.id}
+          refreshToken={historyRefreshToken}
+        />
 
         <ExecutionContext
           state={state}
           mutationsDisabled={mutationsDisabled}
-          onChanged={onChanged}
+          onChanged={handleChanged}
         />
 
         <ErrorDetails

--- a/compensation/dashboard/src/features/Failed/details/FailedDetails.tsx
+++ b/compensation/dashboard/src/features/Failed/details/FailedDetails.tsx
@@ -41,7 +41,7 @@ export function FailedDetails({
         onChanged={onChanged}
       />
 
-      <div className="grid min-h-0 flex-1 content-start gap-3 overflow-y-auto p-3 sm:p-4">
+      <div className="grid min-h-0 flex-1 auto-rows-max gap-3 overflow-y-auto p-3 sm:p-4">
         <div className="grid grid-cols-1 gap-3 xl:grid-cols-2">
           <FailureSummary state={state} />
           <RecoveryStatus

--- a/compensation/dashboard/src/features/Failed/details/FailedDetailsHeader.tsx
+++ b/compensation/dashboard/src/features/Failed/details/FailedDetailsHeader.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ExecutionFailedState } from "../../../generated";
+import { CopyButton } from "@/components/CopyButton";
+import { Actions } from "../Actions.tsx";
+import { StatusBadge } from "../StatusBadge.tsx";
+import type { OnChangedCapable } from "../types.ts";
+
+export interface FailedDetailsHeaderProps extends OnChangedCapable {
+  state: ExecutionFailedState;
+  mutationsDisabled?: boolean;
+}
+
+export function FailedDetailsHeader({
+  state,
+  onChanged,
+  mutationsDisabled,
+}: FailedDetailsHeaderProps) {
+  return (
+    <header className="flex flex-col items-stretch gap-4 border-b bg-white py-4 pr-14 pl-5 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between sm:pr-6 sm:pl-6">
+      <div className="flex min-w-0 items-center gap-3">
+        <span className="h-9 w-1 shrink-0 rounded-full bg-red-500" aria-hidden />
+        <div className="min-w-0">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            <h1 className="min-w-0 truncate text-xl font-semibold tracking-tight text-slate-950">
+              {state.function.name}
+            </h1>
+            <StatusBadge status={state.status} />
+          </div>
+          <div className="mt-1 flex items-center gap-1 text-xs text-slate-500">
+            <span className="truncate">{state.id}</span>
+            <CopyButton value={state.id} label="execution ID" />
+          </div>
+        </div>
+      </div>
+      <Actions
+        state={state}
+        disabled={mutationsDisabled}
+        onChanged={onChanged}
+      />
+    </header>
+  );
+}

--- a/compensation/dashboard/src/features/Failed/details/FailureSummary.tsx
+++ b/compensation/dashboard/src/features/Failed/details/FailureSummary.tsx
@@ -72,7 +72,9 @@ export function FailureSummary({ state }: FailureSummaryProps) {
         </p>
         <dl className="mt-4 border-t pt-3">
           <div>
-            <dt className="text-xs text-slate-500">Executed</dt>
+            <dt className="text-xs text-slate-500">
+              {historical ? "Succeeded at" : "Failed at"}
+            </dt>
             <dd className="mt-1 text-sm tabular-nums text-slate-800">
               {formatDate(state.executeAt)}
             </dd>

--- a/compensation/dashboard/src/features/Failed/details/FailureSummary.tsx
+++ b/compensation/dashboard/src/features/Failed/details/FailureSummary.tsx
@@ -1,0 +1,84 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AlertTriangle } from "lucide-react";
+import type { ExecutionFailedState } from "../../../generated";
+import { ExecutionFailedStatus } from "../../../generated";
+import { cn } from "@/lib/utils";
+import { formatDate } from "@/utils/dates";
+
+export interface FailureSummaryProps {
+  state: Pick<ExecutionFailedState, "error" | "executeAt" | "status">;
+}
+
+export function FailureSummary({ state }: FailureSummaryProps) {
+  const historical = state.status === ExecutionFailedStatus.SUCCEEDED;
+
+  return (
+    <section
+      className={cn(
+        "overflow-hidden rounded-lg border bg-white shadow-sm",
+        historical ? "border-slate-200" : "border-red-200",
+      )}
+      aria-label={historical ? "Last failure summary" : "Failure summary"}
+    >
+      <div
+        className={cn(
+          "flex min-h-14 items-center justify-between gap-3 border-b px-4 py-3",
+          historical ? "bg-slate-50" : "bg-red-50/70",
+        )}
+      >
+        <div className="flex min-w-0 items-center gap-3">
+          <AlertTriangle
+            className={cn(
+              "size-4 shrink-0",
+              historical ? "text-slate-500" : "text-red-600",
+            )}
+          />
+          <div className="min-w-0">
+            <h2 className="text-sm font-semibold text-slate-900">
+              {historical ? "Last failure" : "Failure summary"}
+            </h2>
+            <p className="text-xs text-slate-500">
+              {historical
+                ? "Most recent recorded failure"
+                : "Current processing failure"}
+            </p>
+          </div>
+        </div>
+        <span
+          className="max-w-44 truncate rounded-md border border-red-200 bg-white px-2 py-1 font-mono text-[11px] font-medium text-red-700"
+          title={state.error.errorCode}
+        >
+          {state.error.errorCode}
+        </span>
+      </div>
+      <div className="p-4">
+        <p
+          className="line-clamp-3 text-sm leading-6 font-medium text-slate-800"
+          title={state.error.errorMsg}
+        >
+          {state.error.errorMsg}
+        </p>
+        <dl className="mt-4 border-t pt-3">
+          <div>
+            <dt className="text-xs text-slate-500">Executed</dt>
+            <dd className="mt-1 text-sm tabular-nums text-slate-800">
+              {formatDate(state.executeAt)}
+            </dd>
+          </div>
+        </dl>
+      </div>
+    </section>
+  );
+}

--- a/compensation/dashboard/src/features/Failed/details/RecoveryStatus.tsx
+++ b/compensation/dashboard/src/features/Failed/details/RecoveryStatus.tsx
@@ -1,0 +1,138 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Pencil, RotateCcw } from "lucide-react";
+import type { ExecutionFailedState } from "../../../generated";
+import { useGlobalDrawer } from "@/components/GlobalDrawer";
+import { Button } from "@/components/ui/button";
+import { formatDate } from "@/utils/dates";
+import { formatSeconds } from "@/utils/durations.ts";
+import { ApplyRetrySpec } from "../ApplyRetrySpec.tsx";
+import { MarkRecoverable } from "../MarkRecoverable.tsx";
+import { BooleanBadge } from "../StatusBadge.tsx";
+import type { OnChangedCapable } from "../types.ts";
+
+type RecoveryState = Pick<
+  ExecutionFailedState,
+  "id" | "isRetryable" | "recoverable" | "retrySpec" | "retryState"
+>;
+
+export interface RecoveryStatusProps extends OnChangedCapable {
+  state: RecoveryState;
+  mutationsDisabled?: boolean;
+}
+
+export function RecoveryStatus({
+  state,
+  onChanged,
+  mutationsDisabled,
+}: RecoveryStatusProps) {
+  const { openDrawer } = useGlobalDrawer();
+
+  const editRetry = () =>
+    openDrawer({
+      title: "Apply retry specification",
+      description: "Tune retry limits and timing for this execution.",
+      width: 440,
+      children: (
+        <ApplyRetrySpec
+          id={state.id}
+          retrySpec={state.retrySpec}
+          onChanged={onChanged}
+        />
+      ),
+    });
+
+  return (
+    <section
+      className="overflow-hidden rounded-lg border border-blue-200 bg-white shadow-sm"
+      aria-label="Recovery status"
+    >
+      <div className="flex min-h-14 items-center justify-between gap-3 border-b bg-blue-50/60 px-4 py-3">
+        <div className="flex min-w-0 items-center gap-3">
+          <RotateCcw className="size-4 shrink-0 text-blue-600" />
+          <div className="min-w-0">
+            <h2 className="text-sm font-semibold text-slate-900">
+              Recovery status
+            </h2>
+            <p className="text-xs text-slate-500">
+              Retry eligibility and timing
+            </p>
+          </div>
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          aria-label="Edit retry specification"
+          disabled={mutationsDisabled}
+          onClick={editRetry}
+        >
+          <Pencil />
+        </Button>
+      </div>
+      <dl className="grid grid-cols-1 gap-x-4 gap-y-4 p-4 sm:grid-cols-2 xl:grid-cols-1 2xl:grid-cols-2">
+        <div>
+          <dt className="text-xs text-slate-500">Retry progress</dt>
+          <dd className="mt-1 text-sm tabular-nums text-slate-800">
+            <span className="font-semibold">
+              {state.retryState.retries} of {state.retrySpec.maxRetries}
+            </span>
+            <span className="mt-0.5 block text-xs text-slate-500">
+              Last: {formatDate(state.retryState.retryAt)}
+            </span>
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs text-slate-500">Next retry at</dt>
+          <dd className="mt-1 text-sm tabular-nums text-slate-800">
+            {formatDate(state.retryState.nextRetryAt)}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs text-slate-500">Recoverable</dt>
+          <dd className="mt-1">
+            <MarkRecoverable
+              id={state.id}
+              recoverable={state.recoverable}
+              disabled={mutationsDisabled}
+              onChanged={onChanged}
+            />
+          </dd>
+        </div>
+        <div>
+          <dt className="text-xs text-slate-500">Retryable</dt>
+          <dd className="mt-1">
+            <BooleanBadge value={state.isRetryable} />
+          </dd>
+        </div>
+      </dl>
+      <dl className="grid grid-cols-2 gap-4 border-t bg-slate-50/70 px-4 py-3">
+        <div>
+          <dt className="text-[11px] text-slate-500">Min backoff</dt>
+          <dd className="mt-0.5 text-xs tabular-nums text-slate-700">
+            {formatSeconds(state.retrySpec.minBackoff)} (
+            {state.retrySpec.minBackoff.toLocaleString()} s)
+          </dd>
+        </div>
+        <div>
+          <dt className="text-[11px] text-slate-500">Timeout</dt>
+          <dd className="mt-0.5 text-xs tabular-nums text-slate-700">
+            {formatSeconds(state.retrySpec.executionTimeout)} (
+            {state.retrySpec.executionTimeout.toLocaleString()} s)
+          </dd>
+        </div>
+      </dl>
+    </section>
+  );
+}

--- a/compensation/dashboard/src/features/Failed/details/__tests__/ErrorDetails.test.tsx
+++ b/compensation/dashboard/src/features/Failed/details/__tests__/ErrorDetails.test.tsx
@@ -35,6 +35,10 @@ function renderErrorDetails() {
 describe("ErrorDetails", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      value: null,
+    });
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: { writeText: mocks.writeText },
@@ -106,6 +110,56 @@ describe("ErrorDetails", () => {
     });
   });
 
+  it("exits fullscreen before collapsing the stack trace", async () => {
+    mocks.exitFullscreen.mockResolvedValue(undefined);
+    render(
+      <TooltipProvider>
+        <ErrorDetails error={error} defaultExpanded />
+      </TooltipProvider>,
+    );
+    const panel = screen.getByRole("region", { name: "Stack trace" });
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      value: panel,
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Collapse stack trace" }),
+    );
+
+    await waitFor(() => expect(mocks.exitFullscreen).toHaveBeenCalledOnce());
+    expect(
+      screen.queryByRole("region", { name: "Stack trace content" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the fullscreen stack trace expanded when exiting fails", async () => {
+    mocks.exitFullscreen.mockRejectedValue(new Error("exit denied"));
+    render(
+      <TooltipProvider>
+        <ErrorDetails error={error} defaultExpanded />
+      </TooltipProvider>,
+    );
+    const panel = screen.getByRole("region", { name: "Stack trace" });
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      value: panel,
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Collapse stack trace" }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        "Unable to change fullscreen mode",
+      ),
+    );
+    expect(
+      screen.getByRole("region", { name: "Stack trace content" }),
+    ).toBeInTheDocument();
+  });
+
   it("collapses a historical failure by default and can reveal it", () => {
     render(
       <TooltipProvider>
@@ -126,6 +180,30 @@ describe("ErrorDetails", () => {
     expect(
       screen.getByRole("region", { name: "Stack trace content" }),
     ).toBeInTheDocument();
+  });
+
+  it("reveals the deferred stack trace in the nearest viewport", () => {
+    const scrollIntoView = vi.mocked(HTMLElement.prototype.scrollIntoView);
+    render(
+      <TooltipProvider>
+        <ErrorDetails error={error} defaultExpanded={false} />
+      </TooltipProvider>,
+    );
+
+    expect(
+      screen.queryByRole("region", { name: "Stack trace content" }),
+    ).not.toBeInTheDocument();
+
+    const expandButton = screen.getByRole("button", {
+      name: "Expand stack trace",
+    });
+    expandButton.focus();
+    fireEvent.click(expandButton);
+    expect(
+      screen.getByRole("region", { name: "Stack trace content" }),
+    ).toBeInTheDocument();
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+    expect(expandButton).toHaveFocus();
   });
 
   it("searches matching stack lines and toggles line wrapping", () => {

--- a/compensation/dashboard/src/features/Failed/details/__tests__/FailedDetails.test.tsx
+++ b/compensation/dashboard/src/features/Failed/details/__tests__/FailedDetails.test.tsx
@@ -17,7 +17,14 @@ vi.mock("@/components/GlobalDrawer", () => ({
 }));
 
 vi.mock("../../Actions.tsx", () => ({
-  Actions: () => <div>Actions</div>,
+  Actions: ({ onChanged }: { onChanged?: () => void }) => (
+    <div>
+      Actions
+      <button type="button" onClick={onChanged}>
+        Complete mutation
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock("../../MarkRecoverable.tsx", () => ({
@@ -45,9 +52,15 @@ vi.mock("../ErrorDetails.tsx", () => ({
 }));
 
 vi.mock("../../history/ExecutionHistory.tsx", () => ({
-  ExecutionHistory: ({ executionId }: { executionId: string }) => (
+  ExecutionHistory: ({
+    executionId,
+    refreshToken,
+  }: {
+    executionId: string;
+    refreshToken?: number;
+  }) => (
     <div role="region" aria-label="Execution history">
-      History: {executionId}
+      History: {executionId}; refresh: {refreshToken}
     </div>
   ),
 }));
@@ -145,7 +158,25 @@ describe("FailedDetails", () => {
   it("renders the selected execution history in the detail flow", () => {
     renderDetails();
 
-    expect(screen.getByText("History: test-id")).toBeInTheDocument();
+    expect(
+      screen.getByRole("region", { name: "Execution history" }),
+    ).toHaveTextContent("History: test-id; refresh: 0");
+  });
+
+  it("invalidates history after a successful execution mutation", () => {
+    const onChanged = vi.fn();
+    render(
+      <TooltipProvider>
+        <FailedDetails state={state} onChanged={onChanged} />
+      </TooltipProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Complete mutation" }));
+
+    expect(onChanged).toHaveBeenCalledOnce();
+    expect(
+      screen.getByRole("region", { name: "Execution history" }),
+    ).toHaveTextContent("History: test-id; refresh: 1");
   });
 
   it("keeps edit flows owned by their corresponding detail sections", () => {
@@ -182,6 +213,8 @@ describe("FailedDetails", () => {
     });
 
     expect(screen.getByText("2026-08-02 20:30:40")).toBeInTheDocument();
+    expect(screen.getByText("Failed at")).toBeInTheDocument();
+    expect(screen.queryByText("Executed")).not.toBeInTheDocument();
     expect(screen.getByText("Last: 2026-08-02 19:20:30")).toBeInTheDocument();
     expect(screen.getByText("2026-08-02 21:40:50")).toBeInTheDocument();
     expect(screen.queryByText(/ UTC$/)).not.toBeInTheDocument();
@@ -241,6 +274,8 @@ describe("FailedDetails", () => {
     );
     expect(screen.getByText("Succeeded")).toBeInTheDocument();
     expect(screen.getByText("Unrecoverable")).toBeInTheDocument();
+    expect(screen.getByText("Succeeded at")).toBeInTheDocument();
+    expect(screen.queryByText("Executed")).not.toBeInTheDocument();
     expect(
       screen.getByText("Error: TEST_ERROR (historical)"),
     ).toBeInTheDocument();

--- a/compensation/dashboard/src/features/Failed/details/__tests__/FailedDetails.test.tsx
+++ b/compensation/dashboard/src/features/Failed/details/__tests__/FailedDetails.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FunctionKind, RecoverableType } from "@ahoo-wang/fetcher-wow";
 import {
   ExecutionFailedStatus,
@@ -8,8 +8,12 @@ import {
 import { FailedDetails } from "../FailedDetails.tsx";
 import { TooltipProvider } from "@/components/ui/tooltip";
 
+const mocks = vi.hoisted(() => ({
+  openDrawer: vi.fn(),
+}));
+
 vi.mock("@/components/GlobalDrawer", () => ({
-  useGlobalDrawer: () => ({ openDrawer: vi.fn() }),
+  useGlobalDrawer: () => ({ openDrawer: mocks.openDrawer }),
 }));
 
 vi.mock("../../Actions.tsx", () => ({
@@ -26,13 +30,24 @@ vi.mock("../ErrorDetails.tsx", () => ({
   ErrorDetails: ({
     error,
     historical,
+    defaultExpanded,
   }: {
     error: { errorCode: string };
     historical?: boolean;
+    defaultExpanded?: boolean;
   }) => (
-    <div>
+    <div role="region" aria-label="Stack trace">
       Error: {error.errorCode}
       {historical ? " (historical)" : ""}
+      {defaultExpanded === false ? " (collapsed)" : ""}
+    </div>
+  ),
+}));
+
+vi.mock("../../history/ExecutionHistory.tsx", () => ({
+  ExecutionHistory: ({ executionId }: { executionId: string }) => (
+    <div role="region" aria-label="Execution history">
+      History: {executionId}
     </div>
   ),
 }));
@@ -85,6 +100,76 @@ function renderDetails(currentState: ExecutionFailedState = state) {
 }
 
 describe("FailedDetails", () => {
+  beforeEach(() => {
+    mocks.openDrawer.mockClear();
+  });
+
+  it("orders content by operational importance", () => {
+    renderDetails();
+
+    const failureSummary = screen.getByRole("region", {
+      name: "Failure summary",
+    });
+    const recoveryStatus = screen.getByRole("region", {
+      name: "Recovery status",
+    });
+    const history = screen.getByRole("region", {
+      name: "Execution history",
+    });
+    const executionContext = screen.getByRole("region", {
+      name: "Execution context",
+    });
+    const stackTrace = screen.getByRole("region", { name: "Stack trace" });
+
+    expect(within(failureSummary).getByText("TEST_ERROR")).toBeInTheDocument();
+    expect(within(failureSummary).getByText("Test error")).toBeInTheDocument();
+    expect(
+      failureSummary.compareDocumentPosition(recoveryStatus) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      recoveryStatus.compareDocumentPosition(history) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      history.compareDocumentPosition(executionContext) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      executionContext.compareDocumentPosition(stackTrace) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(stackTrace).toHaveTextContent("(collapsed)");
+  });
+
+  it("renders the selected execution history in the detail flow", () => {
+    renderDetails();
+
+    expect(screen.getByText("History: test-id")).toBeInTheDocument();
+  });
+
+  it("keeps edit flows owned by their corresponding detail sections", () => {
+    renderDetails();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Edit retry specification" }),
+    );
+    expect(mocks.openDrawer).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        title: "Apply retry specification",
+        width: 440,
+      }),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit function" }));
+    expect(mocks.openDrawer).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        title: "Change function",
+        width: 500,
+      }),
+    );
+  });
+
   it("renders execution timestamps in the browser local time", () => {
     renderDetails({
       ...state,
@@ -117,7 +202,9 @@ describe("FailedDetails", () => {
     expect(screen.queryByText("v1")).not.toBeInTheDocument();
     expect(screen.getByText(/Last:/)).toBeInTheDocument();
     expect(screen.getByText("Yes")).toBeInTheDocument();
-    expect(screen.getByText("Error: TEST_ERROR")).toBeInTheDocument();
+    expect(
+      screen.getByText("Error: TEST_ERROR (collapsed)"),
+    ).toBeInTheDocument();
   });
 
   it("renders tenant as read-only identity information", () => {

--- a/compensation/dashboard/src/features/Failed/history/ExecutionHistory.test.tsx
+++ b/compensation/dashboard/src/features/Failed/history/ExecutionHistory.test.tsx
@@ -1,0 +1,197 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  RecoverableType,
+  type DomainEventStream,
+} from "@ahoo-wang/fetcher-wow";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExecutionFailedDomainEventType } from "../../../generated";
+import { ExecutionHistory } from "./ExecutionHistory.tsx";
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}));
+
+vi.mock("../../../services", () => ({
+  queryExecutionFailedEventStreamPage: mocks.query,
+}));
+
+const stream: DomainEventStream<ExecutionFailedDomainEventType> = {
+  id: "stream-1",
+  aggregateId: "failed-1",
+  aggregateName: "execution_failed",
+  contextName: "compensation",
+  tenantId: "(0)",
+  ownerId: "",
+  spaceId: "",
+  commandId: "command-1",
+  requestId: "request-1",
+  createTime: new Date(2026, 7, 4, 10, 14, 30).getTime(),
+  version: 2,
+  header: { trace_id: "trace-1" },
+  body: [
+    {
+      id: "event-1",
+      name: "execution_failed_applied",
+      bodyType: "compensation.execution_failed.ExecutionFailedApplied",
+      revision: "1.0.0",
+      body: {
+        executeAt: new Date(2026, 7, 4, 10, 14, 30).getTime(),
+        error: {
+          errorCode: "TEST_ERROR",
+          errorMsg: "Test error",
+          stackTrace: "stack trace",
+          bindingErrors: [],
+          succeeded: false,
+        },
+        recoverable: RecoverableType.RECOVERABLE,
+      },
+    },
+  ],
+};
+
+const nextPageStream: DomainEventStream<ExecutionFailedDomainEventType> = {
+  ...stream,
+  id: "stream-2",
+  version: 3,
+  body: stream.body.map((event) => ({
+    ...event,
+    id: "event-2",
+  })),
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((nextResolve, nextReject) => {
+    resolve = nextResolve;
+    reject = nextReject;
+  });
+  return { promise, reject, resolve };
+}
+
+describe("ExecutionHistory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.query.mockReset();
+    mocks.query.mockResolvedValue({ total: 1, list: [stream] });
+  });
+
+  it("queries the selected execution through the paged EventStream REST API", async () => {
+    render(<ExecutionHistory executionId="failed-1" />);
+
+    expect(mocks.query).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Expand history" }));
+
+    expect(
+      screen.getByRole("status", { name: "Loading execution history" }),
+    ).toBeInTheDocument();
+
+    await waitFor(() => expect(mocks.query).toHaveBeenCalled());
+
+    expect(mocks.query.mock.calls[0][0]).toEqual({
+      condition: { operator: "AGGREGATE_ID", value: "failed-1" },
+      projection: undefined,
+      sort: [{ field: "version", direction: "DESC" }],
+      pagination: { index: 1, size: 10 },
+    });
+  });
+
+  it("renders event metadata and reveals the exact payload on demand", async () => {
+    render(<ExecutionHistory executionId="failed-1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Expand history" }));
+
+    expect(
+      await screen.findByText("execution_failed_applied"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Version 2")).toBeInTheDocument();
+    expect(screen.getByText("2026-08-04 10:14:30")).toBeInTheDocument();
+    expect(screen.getByText("1–1 of 1")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Event payload"));
+
+    expect(screen.getByText(/"errorCode": "TEST_ERROR"/)).toBeVisible();
+  });
+
+  it("loads the next page while keeping pagination explicit", async () => {
+    mocks.query.mockResolvedValue({ total: 11, list: [stream] });
+    render(<ExecutionHistory executionId="failed-1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Expand history" }));
+
+    const next = await screen.findByRole("button", { name: "Next history page" });
+    fireEvent.click(next);
+
+    await waitFor(() => expect(mocks.query).toHaveBeenCalledTimes(2));
+    expect(mocks.query.mock.calls[1][0].pagination).toEqual({
+      index: 2,
+      size: 10,
+    });
+  });
+
+  it("keeps the settled page visible and navigable when the next page fails", async () => {
+    const nextPageRequest = deferred<{
+      total: number;
+      list: DomainEventStream<ExecutionFailedDomainEventType>[];
+    }>();
+    mocks.query
+      .mockResolvedValueOnce({ total: 11, list: [stream] })
+      .mockImplementationOnce(() => nextPageRequest.promise)
+      .mockResolvedValueOnce({ total: 11, list: [nextPageStream] });
+
+    render(<ExecutionHistory executionId="failed-1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Expand history" }));
+
+    expect(await screen.findByText("Version 2")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Next history page" }));
+
+    expect(screen.getByText("Version 2")).toBeInTheDocument();
+    expect(screen.getByText("1–1 of 11")).toBeInTheDocument();
+    expect(screen.getByText("1 / 2")).toBeInTheDocument();
+
+    nextPageRequest.reject(new Error("next page unavailable"));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "next page unavailable",
+    );
+    expect(screen.getByText("Version 2")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Next history page" }),
+    ).toBeEnabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Next history page" }));
+
+    expect(await screen.findByText("Version 3")).toBeInTheDocument();
+    expect(screen.queryByText("Version 2")).not.toBeInTheDocument();
+    expect(screen.getByText("11–11 of 11")).toBeInTheDocument();
+    expect(screen.getByText("2 / 2")).toBeInTheDocument();
+  });
+
+  it("shows a recoverable error state", async () => {
+    mocks.query.mockRejectedValueOnce(new Error("history unavailable"));
+    render(<ExecutionHistory executionId="failed-1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Expand history" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "history unavailable",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry history" }));
+
+    await waitFor(() => expect(mocks.query).toHaveBeenCalledTimes(2));
+    expect(
+      await screen.findByText("execution_failed_applied"),
+    ).toBeInTheDocument();
+  });
+});

--- a/compensation/dashboard/src/features/Failed/history/ExecutionHistory.test.tsx
+++ b/compensation/dashboard/src/features/Failed/history/ExecutionHistory.test.tsx
@@ -125,6 +125,57 @@ describe("ExecutionHistory", () => {
     expect(screen.getByText(/"errorCode": "TEST_ERROR"/)).toBeVisible();
   });
 
+  it("surfaces missing query capability instead of claiming an existing execution has no history", async () => {
+    mocks.query.mockResolvedValue({ total: 0, list: [] });
+
+    render(<ExecutionHistory executionId="failed-1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Expand history" }));
+
+    expect(await screen.findByText("History unavailable")).toBeInTheDocument();
+    expect(
+      screen.getByText(/configured event storage.*EventStream queries/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("No history recorded")).not.toBeInTheDocument();
+  });
+
+  it("reloads the first page of expanded history when its refresh token changes", async () => {
+    mocks.query.mockResolvedValue({ total: 11, list: [stream] });
+    const { rerender } = render(
+      <ExecutionHistory executionId="failed-1" refreshToken={0} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Expand history" }));
+
+    await waitFor(() => expect(mocks.query).toHaveBeenCalledTimes(1));
+    fireEvent.click(screen.getByRole("button", { name: "Next history page" }));
+    await waitFor(() => expect(mocks.query).toHaveBeenCalledTimes(2));
+
+    rerender(<ExecutionHistory executionId="failed-1" refreshToken={1} />);
+
+    await waitFor(() => expect(mocks.query).toHaveBeenCalledTimes(3));
+    expect(mocks.query.mock.calls[2][0].pagination).toEqual({
+      index: 1,
+      size: 10,
+    });
+  });
+
+  it("keeps history invalidation lazy while collapsed", async () => {
+    const { rerender } = render(
+      <ExecutionHistory executionId="failed-1" refreshToken={0} />,
+    );
+
+    rerender(<ExecutionHistory executionId="failed-1" refreshToken={1} />);
+
+    expect(mocks.query).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand history" }));
+
+    await waitFor(() => expect(mocks.query).toHaveBeenCalledTimes(1));
+    expect(mocks.query.mock.calls[0][0].pagination).toEqual({
+      index: 1,
+      size: 10,
+    });
+  });
+
   it("loads the next page while keeping pagination explicit", async () => {
     mocks.query.mockResolvedValue({ total: 11, list: [stream] });
     render(<ExecutionHistory executionId="failed-1" />);

--- a/compensation/dashboard/src/features/Failed/history/ExecutionHistory.tsx
+++ b/compensation/dashboard/src/features/Failed/history/ExecutionHistory.tsx
@@ -1,0 +1,372 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DomainEventStream, PagedList } from "@ahoo-wang/fetcher-wow";
+import {
+  aggregateId,
+  desc,
+  DomainEventStreamMetadataFields,
+  pagedList,
+  pagedQuery,
+} from "@ahoo-wang/fetcher-wow";
+import {
+  AlertCircle,
+  Braces,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  History,
+  RefreshCw,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+import type { ExecutionFailedDomainEventType } from "../../../generated";
+import { queryExecutionFailedEventStreamPage } from "../../../services";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { formatDate } from "@/utils/dates";
+
+const PAGE_SIZE = 10;
+
+interface ExecutionHistoryProps {
+  executionId: string;
+}
+
+type ExecutionEventStream = DomainEventStream<ExecutionFailedDomainEventType>;
+
+function isAbortError(error: Error): boolean {
+  return (
+    error.name === "AbortError" ||
+    error.message.toLowerCase().includes("signal is aborted")
+  );
+}
+
+function EventStreamCard({ stream }: { stream: ExecutionEventStream }) {
+  return (
+    <article
+      className="overflow-hidden rounded-lg border border-slate-200 bg-white"
+      aria-label={`Event stream version ${stream.version}`}
+    >
+      <header className="flex flex-wrap items-start justify-between gap-3 border-b bg-slate-50/80 px-4 py-3">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="rounded-md bg-blue-50 px-2 py-1 text-xs font-semibold text-blue-700 ring-1 ring-blue-200 ring-inset">
+              Version {stream.version}
+            </span>
+            <span className="text-xs text-slate-500">
+              {stream.body.length} {stream.body.length === 1 ? "event" : "events"}
+            </span>
+          </div>
+          <p
+            className="mt-2 truncate font-mono text-[11px] text-slate-500"
+            title={stream.id}
+          >
+            Stream {stream.id}
+          </p>
+        </div>
+        <time className="shrink-0 text-xs tabular-nums text-slate-500">
+          {formatDate(stream.createTime)}
+        </time>
+      </header>
+
+      <div className="divide-y divide-slate-100">
+        {stream.body.map((event) => (
+          <div key={event.id} className="px-4 py-3">
+            <div className="flex min-w-0 items-start gap-3">
+              <Braces className="mt-0.5 size-4 shrink-0 text-blue-600" />
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1">
+                  <span className="break-all text-sm font-medium text-slate-900">
+                    {event.name}
+                  </span>
+                  <span className="text-[11px] text-slate-500">
+                    revision {event.revision}
+                  </span>
+                </div>
+                <p
+                  className="mt-1 truncate font-mono text-[11px] text-slate-500"
+                  title={event.bodyType}
+                >
+                  {event.bodyType}
+                </p>
+                <details className="group mt-2 rounded-md border border-slate-200 bg-slate-50/60">
+                  <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-slate-700 outline-none hover:text-blue-700 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-inset">
+                    Event payload
+                  </summary>
+                  <pre className="max-h-72 overflow-auto border-t border-slate-200 bg-slate-950 p-3 text-[11px] leading-relaxed whitespace-pre-wrap text-slate-100">
+                    {JSON.stringify(event.body, null, 2) ?? "null"}
+                  </pre>
+                </details>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </article>
+  );
+}
+
+export function ExecutionHistory({ executionId }: ExecutionHistoryProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [settledPageIndex, setSettledPageIndex] = useState(1);
+  const [requestedPageIndex, setRequestedPageIndex] = useState(1);
+  const [reloadToken, setReloadToken] = useState(0);
+  const [page, setPage] = useState<PagedList<ExecutionEventStream>>(() =>
+    pagedList<ExecutionEventStream>(),
+  );
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error>();
+
+  useEffect(() => {
+    if (!expanded) {
+      return;
+    }
+
+    const abortController = new AbortController();
+    let active = true;
+    queryExecutionFailedEventStreamPage(
+      pagedQuery({
+        condition: aggregateId(executionId),
+        sort: [desc(DomainEventStreamMetadataFields.VERSION)],
+        pagination: { index: requestedPageIndex, size: PAGE_SIZE },
+      }),
+      undefined,
+      abortController,
+    )
+      .then((result) => {
+        if (active) {
+          setPage(result as PagedList<ExecutionEventStream>);
+          setSettledPageIndex(requestedPageIndex);
+          setError(undefined);
+        }
+      })
+      .catch((reason: unknown) => {
+        if (!active) {
+          return;
+        }
+        const nextError =
+          reason instanceof Error ? reason : new Error(String(reason));
+        if (!isAbortError(nextError)) {
+          setError(nextError);
+        }
+      })
+      .finally(() => {
+        if (active) {
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      active = false;
+      abortController.abort();
+    };
+  }, [executionId, expanded, reloadToken, requestedPageIndex]);
+
+  const loadPage = (nextPageIndex: number) => {
+    setLoading(true);
+    setError(undefined);
+    setRequestedPageIndex(nextPageIndex);
+    setReloadToken((current) => current + 1);
+  };
+
+  const firstItem =
+    page.total === 0 ? 0 : (settledPageIndex - 1) * PAGE_SIZE + 1;
+  const lastItem = Math.min(firstItem + page.list.length - 1, page.total);
+  const pageCount = Math.ceil(page.total / PAGE_SIZE);
+
+  return (
+    <section
+      className="flex flex-none flex-col overflow-hidden rounded-lg border bg-white shadow-sm"
+      aria-labelledby="execution-history-title"
+    >
+      <div className="flex min-h-14 flex-wrap items-center justify-between gap-3 px-4 py-2.5">
+        <div className="flex min-w-0 items-center gap-3">
+          <History className="size-4 shrink-0 text-slate-500" />
+          <div className="min-w-0">
+            <h2
+              id="execution-history-title"
+              className="text-sm font-semibold text-slate-900"
+            >
+              History
+            </h2>
+            <p className="truncate text-xs text-slate-500">
+              EventStream lifecycle records, newest first
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          {expanded ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Refresh history"
+              disabled={loading}
+              onClick={() => loadPage(settledPageIndex)}
+            >
+              <RefreshCw className={loading ? "animate-spin" : undefined} />
+            </Button>
+          ) : null}
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            aria-label={expanded ? "Collapse history" : "Expand history"}
+            aria-expanded={expanded}
+            onClick={() => {
+              if (!expanded) {
+                setLoading(true);
+                setError(undefined);
+                setRequestedPageIndex(settledPageIndex);
+              }
+              setExpanded((current) => !current);
+            }}
+          >
+            {expanded ? "Hide" : "View"}
+            {expanded ? <ChevronDown /> : <ChevronRight />}
+          </Button>
+        </div>
+      </div>
+
+      {expanded ? (
+        <div className="border-t bg-slate-50/50 p-3 sm:p-4">
+          {loading && page.list.length === 0 ? (
+            <div
+              role="status"
+              aria-label="Loading execution history"
+              className="space-y-3"
+            >
+              <Skeleton className="h-28 w-full" />
+              <Skeleton className="h-28 w-full" />
+            </div>
+          ) : null}
+
+          {!loading && error && page.list.length === 0 ? (
+            <div
+              role="alert"
+              className="rounded-lg border border-red-200 bg-red-50 p-6 text-center"
+            >
+              <AlertCircle className="mx-auto size-5 text-red-600" />
+              <p className="mt-2 text-sm font-medium text-red-700">
+                Failed to load history
+              </p>
+              <p className="mt-1 text-xs text-red-700/80">{error.message}</p>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="mt-4 bg-white"
+                aria-label="Retry history"
+                onClick={() => loadPage(requestedPageIndex)}
+              >
+                <RefreshCw />
+                Retry
+              </Button>
+            </div>
+          ) : null}
+
+          {!loading && !error && page.list.length === 0 ? (
+            <div className="rounded-lg border border-dashed bg-white p-8 text-center">
+              <History className="mx-auto size-5 text-slate-400" />
+              <p className="mt-2 text-sm font-medium text-slate-700">
+                No history recorded
+              </p>
+              <p className="mt-1 text-xs text-slate-500">
+                No EventStream records were found for this execution.
+              </p>
+            </div>
+          ) : null}
+
+          {!loading && error && page.list.length > 0 ? (
+            <div
+              role="alert"
+              className="mb-3 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3"
+            >
+              <div className="flex min-w-0 items-start gap-2">
+                <AlertCircle className="mt-0.5 size-4 shrink-0 text-amber-700" />
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-amber-900">
+                    Failed to load history page
+                  </p>
+                  <p className="text-xs text-amber-800">
+                    Showing page {settledPageIndex}. {error.message}
+                  </p>
+                </div>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="bg-white"
+                aria-label="Retry history"
+                onClick={() => loadPage(requestedPageIndex)}
+              >
+                <RefreshCw />
+                Retry
+              </Button>
+            </div>
+          ) : null}
+
+          {page.list.length > 0 ? (
+            <div className="space-y-3" aria-busy={loading}>
+              {loading ? (
+                <div
+                  role="status"
+                  aria-label="Loading history page"
+                  className="h-0.5 overflow-hidden bg-blue-100"
+                >
+                  <div className="h-full w-full animate-pulse bg-blue-500 motion-reduce:animate-none" />
+                </div>
+              ) : null}
+              {page.list.map((stream) => (
+                <EventStreamCard key={stream.id} stream={stream} />
+              ))}
+            </div>
+          ) : null}
+
+          {page.total > 0 ? (
+            <div className="mt-4 flex items-center justify-between gap-3 border-t pt-3">
+              <span className="text-xs tabular-nums text-slate-500">
+                {firstItem}–{lastItem} of {page.total}
+              </span>
+              <div className="flex items-center gap-1.5">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon-sm"
+                  aria-label="Previous history page"
+                  disabled={loading || settledPageIndex <= 1}
+                  onClick={() => loadPage(settledPageIndex - 1)}
+                >
+                  <ChevronLeft />
+                </Button>
+                <span className="min-w-14 text-center text-xs tabular-nums text-slate-600">
+                  {settledPageIndex} / {Math.max(1, pageCount)}
+                </span>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon-sm"
+                  aria-label="Next history page"
+                  disabled={loading || settledPageIndex >= pageCount}
+                  onClick={() => loadPage(settledPageIndex + 1)}
+                >
+                  <ChevronRight />
+                </Button>
+              </div>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/compensation/dashboard/src/features/Failed/history/ExecutionHistory.tsx
+++ b/compensation/dashboard/src/features/Failed/history/ExecutionHistory.tsx
@@ -28,7 +28,7 @@ import {
   History,
   RefreshCw,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { ExecutionFailedDomainEventType } from "../../../generated";
 import { queryExecutionFailedEventStreamPage } from "../../../services";
 import { Button } from "@/components/ui/button";
@@ -39,6 +39,7 @@ const PAGE_SIZE = 10;
 
 interface ExecutionHistoryProps {
   executionId: string;
+  refreshToken?: number;
 }
 
 type ExecutionEventStream = DomainEventStream<ExecutionFailedDomainEventType>;
@@ -115,7 +116,10 @@ function EventStreamCard({ stream }: { stream: ExecutionEventStream }) {
   );
 }
 
-export function ExecutionHistory({ executionId }: ExecutionHistoryProps) {
+export function ExecutionHistory({
+  executionId,
+  refreshToken = 0,
+}: ExecutionHistoryProps) {
   const [expanded, setExpanded] = useState(false);
   const [settledPageIndex, setSettledPageIndex] = useState(1);
   const [requestedPageIndex, setRequestedPageIndex] = useState(1);
@@ -125,19 +129,25 @@ export function ExecutionHistory({ executionId }: ExecutionHistoryProps) {
   );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<Error>();
+  const observedRefreshToken = useRef(refreshToken);
+  const activeRequestPageIndex = useRef(requestedPageIndex);
 
   useEffect(() => {
     if (!expanded) {
       return;
     }
 
+    const refreshRequested = observedRefreshToken.current !== refreshToken;
+    const targetPageIndex = refreshRequested ? 1 : requestedPageIndex;
+    observedRefreshToken.current = refreshToken;
+    activeRequestPageIndex.current = targetPageIndex;
     const abortController = new AbortController();
     let active = true;
     queryExecutionFailedEventStreamPage(
       pagedQuery({
         condition: aggregateId(executionId),
         sort: [desc(DomainEventStreamMetadataFields.VERSION)],
-        pagination: { index: requestedPageIndex, size: PAGE_SIZE },
+        pagination: { index: targetPageIndex, size: PAGE_SIZE },
       }),
       undefined,
       abortController,
@@ -145,7 +155,7 @@ export function ExecutionHistory({ executionId }: ExecutionHistoryProps) {
       .then((result) => {
         if (active) {
           setPage(result as PagedList<ExecutionEventStream>);
-          setSettledPageIndex(requestedPageIndex);
+          setSettledPageIndex(targetPageIndex);
           setError(undefined);
         }
       })
@@ -169,7 +179,13 @@ export function ExecutionHistory({ executionId }: ExecutionHistoryProps) {
       active = false;
       abortController.abort();
     };
-  }, [executionId, expanded, reloadToken, requestedPageIndex]);
+  }, [
+    executionId,
+    expanded,
+    refreshToken,
+    reloadToken,
+    requestedPageIndex,
+  ]);
 
   const loadPage = (nextPageIndex: number) => {
     setLoading(true);
@@ -266,7 +282,7 @@ export function ExecutionHistory({ executionId }: ExecutionHistoryProps) {
                 size="sm"
                 className="mt-4 bg-white"
                 aria-label="Retry history"
-                onClick={() => loadPage(requestedPageIndex)}
+                onClick={() => loadPage(activeRequestPageIndex.current)}
               >
                 <RefreshCw />
                 Retry
@@ -275,13 +291,15 @@ export function ExecutionHistory({ executionId }: ExecutionHistoryProps) {
           ) : null}
 
           {!loading && !error && page.list.length === 0 ? (
-            <div className="rounded-lg border border-dashed bg-white p-8 text-center">
-              <History className="mx-auto size-5 text-slate-400" />
-              <p className="mt-2 text-sm font-medium text-slate-700">
-                No history recorded
+            <div className="rounded-lg border border-amber-200 bg-amber-50 p-8 text-center">
+              <AlertCircle className="mx-auto size-5 text-amber-700" />
+              <p className="mt-2 text-sm font-medium text-amber-900">
+                History unavailable
               </p>
-              <p className="mt-1 text-xs text-slate-500">
-                No EventStream records were found for this execution.
+              <p className="mt-1 text-xs text-amber-800">
+                The configured event storage did not expose EventStream records
+                for this existing execution. Verify that it supports EventStream
+                queries.
               </p>
             </div>
           ) : null}
@@ -308,7 +326,7 @@ export function ExecutionHistory({ executionId }: ExecutionHistoryProps) {
                 size="sm"
                 className="bg-white"
                 aria-label="Retry history"
-                onClick={() => loadPage(requestedPageIndex)}
+                onClick={() => loadPage(activeRequestPageIndex.current)}
               >
                 <RefreshCw />
                 Retry

--- a/compensation/dashboard/src/services/executionFailedEventStreamClient.test.ts
+++ b/compensation/dashboard/src/services/executionFailedEventStreamClient.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { aggregateId, pagedQuery } from "@ahoo-wang/fetcher-wow";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { queryExecutionFailedEventStreamPage } from "./executionFailedEventStreamClient.ts";
+
+const mocks = vi.hoisted(() => ({
+  createEventStreamQueryClient: vi.fn(),
+  paged: vi.fn(),
+}));
+
+vi.mock("../generated", () => ({
+  executionFailedQueryClientFactory: {
+    createEventStreamQueryClient:
+      mocks.createEventStreamQueryClient.mockReturnValue({
+        paged: mocks.paged,
+      }),
+  },
+}));
+
+describe("executionFailedEventStreamClient", () => {
+  beforeEach(() => {
+    mocks.paged.mockClear();
+  });
+
+  it("creates the EventStream REST client behind the dashboard service boundary", () => {
+    expect(mocks.createEventStreamQueryClient).toHaveBeenCalledWith({
+      contextAlias: "",
+    });
+  });
+
+  it("delegates paged history queries with request context and cancellation", async () => {
+    const query = pagedQuery({ condition: aggregateId("failed-1") });
+    const attributes = { source: "history" };
+    const abortController = new AbortController();
+
+    await queryExecutionFailedEventStreamPage(
+      query,
+      attributes,
+      abortController,
+    );
+
+    expect(mocks.paged).toHaveBeenCalledWith(
+      query,
+      attributes,
+      abortController,
+    );
+  });
+});

--- a/compensation/dashboard/src/services/executionFailedEventStreamClient.ts
+++ b/compensation/dashboard/src/services/executionFailedEventStreamClient.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { PagedQuery } from "@ahoo-wang/fetcher-wow";
+import { executionFailedQueryClientFactory } from "../generated";
+
+const executionFailedEventStreamQueryClient =
+  executionFailedQueryClientFactory.createEventStreamQueryClient({
+    contextAlias: "",
+  });
+
+export function queryExecutionFailedEventStreamPage(
+  query: PagedQuery,
+  attributes?: Record<string, unknown>,
+  abortController?: AbortController,
+) {
+  return executionFailedEventStreamQueryClient.paged(
+    query,
+    attributes,
+    abortController,
+  );
+}

--- a/compensation/dashboard/src/services/index.ts
+++ b/compensation/dashboard/src/services/index.ts
@@ -1,2 +1,3 @@
 export * from "./executionFailedCommandClient";
+export * from "./executionFailedEventStreamClient";
 export * from "./executionFailedQueryClient";


### PR DESCRIPTION
## Summary

- add a paged execution history panel backed by the EventStream REST API, including payload inspection, refresh, retry, and explicit pagination
- reorganize failure details by operational importance and split header, failure summary, recovery status, and execution context into focused components
- keep stack traces collapsed by default, reveal expanded content in the nearest viewport, and exit fullscreen safely before collapsing
- preserve each detail section's intrinsic height across desktop and mobile layouts
- add component, service, layout, and desktop/mobile browser regression coverage

## Why

Operators need historical lifecycle context alongside the current compensation failure without leaving the detail workflow. The previous monolithic details component also mixed actions, recovery state, execution identity, and error presentation, which made the information hierarchy and interaction boundaries harder to maintain.

## Root cause

The dashboard had no EventStream query boundary or history presentation. During the detail redesign, collapsible stack content also exposed two state-transition issues: expanded content could remain below the mobile viewport, and collapsing while fullscreen could remove the exit control before leaving fullscreen. The constrained details grid initially allowed implicit rows to shrink diagnostic sections into slivers; explicit max-content rows now preserve component height while the parent remains the single scroll container.

## Impact

- execution history is fetched only when expanded and remains isolated behind the dashboard service boundary
- current failure and recovery information is promoted above historical and diagnostic details
- edit flows remain owned by their corresponding detail sections
- generated API clients are unchanged

## Validation

- `pnpm test --run` — 31 files, 137 tests passed
- `pnpm lint`
- `pnpm build`
- `pnpm test:browser` — 10 desktop/mobile Chromium tests passed (run with a temporary writable `PLAYWRIGHT_BROWSERS_PATH`)
- `git diff --check`
