### PR TITLE
refactor(dashboard): reuse EventStream query client

### DIFF
--- a/compensation/dashboard/src/features/Failed/history/ExecutionHistory.test.tsx
+++ b/compensation/dashboard/src/features/Failed/history/ExecutionHistory.test.tsx
@@ -11,7 +11,13 @@
  * limitations under the License.
  */
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import {
   RecoverableType,
   type DomainEventStream,
@@ -25,7 +31,9 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../../../services", () => ({
-  queryExecutionFailedEventStreamPage: mocks.query,
+  executionFailedEventStreamQueryClient: {
+    paged: mocks.query,
+  },
 }));
 
 const stream: DomainEventStream<ExecutionFailedDomainEventType> = {
@@ -158,6 +166,78 @@ describe("ExecutionHistory", () => {
     });
   });
 
+  it("cancels the stale EventStream query when a refresh starts", async () => {
+    const staleRequest = deferred<{
+      total: number;
+      list: DomainEventStream<ExecutionFailedDomainEventType>[];
+    }>();
+    let staleAbortController: AbortController | undefined;
+    mocks.query
+      .mockImplementationOnce(
+        (
+          _query: unknown,
+          _attributes: unknown,
+          abortController: AbortController,
+        ) => {
+          staleAbortController = abortController;
+          return staleRequest.promise;
+        },
+      )
+      .mockResolvedValueOnce({ total: 1, list: [nextPageStream] });
+
+    const { rerender } = render(
+      <ExecutionHistory executionId="failed-1" refreshToken={0} />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Expand history" }));
+    await waitFor(() => expect(mocks.query).toHaveBeenCalledTimes(1));
+
+    rerender(<ExecutionHistory executionId="failed-1" refreshToken={1} />);
+
+    expect(await screen.findByText("Version 3")).toBeInTheDocument();
+    expect(staleAbortController?.signal.aborted).toBe(true);
+
+    await act(async () => {
+      staleRequest.resolve({ total: 1, list: [stream] });
+      await staleRequest.promise;
+    });
+    expect(screen.getByText("Version 3")).toBeInTheDocument();
+    expect(screen.queryByText("Version 2")).not.toBeInTheDocument();
+  });
+
+  it("cancels the in-flight EventStream query when history is collapsed", async () => {
+    const pendingRequest = deferred<{
+      total: number;
+      list: DomainEventStream<ExecutionFailedDomainEventType>[];
+    }>();
+    const observedRejection = pendingRequest.promise.catch(() => undefined);
+    let abortController: AbortController | undefined;
+    mocks.query.mockImplementationOnce(
+      (
+        _query: unknown,
+        _attributes: unknown,
+        nextAbortController: AbortController,
+      ) => {
+        abortController = nextAbortController;
+        return pendingRequest.promise;
+      },
+    );
+
+    render(<ExecutionHistory executionId="failed-1" />);
+    fireEvent.click(screen.getByRole("button", { name: "Expand history" }));
+    await waitFor(() => expect(mocks.query).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse history" }));
+    const wasAborted = abortController?.signal.aborted;
+
+    await act(async () => {
+      const abortError = new Error("The operation was aborted");
+      abortError.name = "AbortError";
+      pendingRequest.reject(abortError);
+      await observedRejection;
+    });
+    expect(wasAborted).toBe(true);
+  });
+
   it("keeps history invalidation lazy while collapsed", async () => {
     const { rerender } = render(
       <ExecutionHistory executionId="failed-1" refreshToken={0} />,
@@ -181,7 +261,9 @@ describe("ExecutionHistory", () => {
     render(<ExecutionHistory executionId="failed-1" />);
     fireEvent.click(screen.getByRole("button", { name: "Expand history" }));
 
-    const next = await screen.findByRole("button", { name: "Next history page" });
+    const next = await screen.findByRole("button", {
+      name: "Next history page",
+    });
     fireEvent.click(next);
 
     await waitFor(() => expect(mocks.query).toHaveBeenCalledTimes(2));

--- a/compensation/dashboard/src/features/Failed/history/ExecutionHistory.tsx
+++ b/compensation/dashboard/src/features/Failed/history/ExecutionHistory.tsx
@@ -11,14 +11,6 @@
  * limitations under the License.
  */
 
-import type { DomainEventStream, PagedList } from "@ahoo-wang/fetcher-wow";
-import {
-  aggregateId,
-  desc,
-  DomainEventStreamMetadataFields,
-  pagedList,
-  pagedQuery,
-} from "@ahoo-wang/fetcher-wow";
 import {
   AlertCircle,
   Braces,
@@ -28,27 +20,19 @@ import {
   History,
   RefreshCw,
 } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
-import type { ExecutionFailedDomainEventType } from "../../../generated";
-import { queryExecutionFailedEventStreamPage } from "../../../services";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { formatDate } from "@/utils/dates";
-
-const PAGE_SIZE = 10;
+import {
+  EXECUTION_HISTORY_PAGE_SIZE,
+  type ExecutionEventStream,
+  useExecutionHistory,
+} from "./useExecutionHistory.ts";
 
 interface ExecutionHistoryProps {
   executionId: string;
   refreshToken?: number;
-}
-
-type ExecutionEventStream = DomainEventStream<ExecutionFailedDomainEventType>;
-
-function isAbortError(error: Error): boolean {
-  return (
-    error.name === "AbortError" ||
-    error.message.toLowerCase().includes("signal is aborted")
-  );
 }
 
 function EventStreamCard({ stream }: { stream: ExecutionEventStream }) {
@@ -64,7 +48,8 @@ function EventStreamCard({ stream }: { stream: ExecutionEventStream }) {
               Version {stream.version}
             </span>
             <span className="text-xs text-slate-500">
-              {stream.body.length} {stream.body.length === 1 ? "event" : "events"}
+              {stream.body.length}{" "}
+              {stream.body.length === 1 ? "event" : "events"}
             </span>
           </div>
           <p
@@ -121,83 +106,19 @@ export function ExecutionHistory({
   refreshToken = 0,
 }: ExecutionHistoryProps) {
   const [expanded, setExpanded] = useState(false);
-  const [settledPageIndex, setSettledPageIndex] = useState(1);
-  const [requestedPageIndex, setRequestedPageIndex] = useState(1);
-  const [reloadToken, setReloadToken] = useState(0);
-  const [page, setPage] = useState<PagedList<ExecutionEventStream>>(() =>
-    pagedList<ExecutionEventStream>(),
-  );
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<Error>();
-  const observedRefreshToken = useRef(refreshToken);
-  const activeRequestPageIndex = useRef(requestedPageIndex);
-
-  useEffect(() => {
-    if (!expanded) {
-      return;
-    }
-
-    const refreshRequested = observedRefreshToken.current !== refreshToken;
-    const targetPageIndex = refreshRequested ? 1 : requestedPageIndex;
-    observedRefreshToken.current = refreshToken;
-    activeRequestPageIndex.current = targetPageIndex;
-    const abortController = new AbortController();
-    let active = true;
-    queryExecutionFailedEventStreamPage(
-      pagedQuery({
-        condition: aggregateId(executionId),
-        sort: [desc(DomainEventStreamMetadataFields.VERSION)],
-        pagination: { index: targetPageIndex, size: PAGE_SIZE },
-      }),
-      undefined,
-      abortController,
-    )
-      .then((result) => {
-        if (active) {
-          setPage(result as PagedList<ExecutionEventStream>);
-          setSettledPageIndex(targetPageIndex);
-          setError(undefined);
-        }
-      })
-      .catch((reason: unknown) => {
-        if (!active) {
-          return;
-        }
-        const nextError =
-          reason instanceof Error ? reason : new Error(String(reason));
-        if (!isAbortError(nextError)) {
-          setError(nextError);
-        }
-      })
-      .finally(() => {
-        if (active) {
-          setLoading(false);
-        }
-      });
-
-    return () => {
-      active = false;
-      abortController.abort();
-    };
-  }, [
-    executionId,
-    expanded,
-    refreshToken,
-    reloadToken,
-    requestedPageIndex,
-  ]);
-
-  const loadPage = (nextPageIndex: number) => {
-    setLoading(true);
-    setError(undefined);
-    setRequestedPageIndex(nextPageIndex);
-    setReloadToken((current) => current + 1);
-  };
+  const { error, loadPage, loading, page, retry, settledPageIndex } =
+    useExecutionHistory({
+      enabled: expanded,
+      executionId,
+      refreshToken,
+    });
 
   const firstItem =
-    page.total === 0 ? 0 : (settledPageIndex - 1) * PAGE_SIZE + 1;
+    page.total === 0
+      ? 0
+      : (settledPageIndex - 1) * EXECUTION_HISTORY_PAGE_SIZE + 1;
   const lastItem = Math.min(firstItem + page.list.length - 1, page.total);
-  const pageCount = Math.ceil(page.total / PAGE_SIZE);
+  const pageCount = Math.ceil(page.total / EXECUTION_HISTORY_PAGE_SIZE);
 
   return (
     <section
@@ -238,14 +159,7 @@ export function ExecutionHistory({
             size="sm"
             aria-label={expanded ? "Collapse history" : "Expand history"}
             aria-expanded={expanded}
-            onClick={() => {
-              if (!expanded) {
-                setLoading(true);
-                setError(undefined);
-                setRequestedPageIndex(settledPageIndex);
-              }
-              setExpanded((current) => !current);
-            }}
+            onClick={() => setExpanded((current) => !current)}
           >
             {expanded ? "Hide" : "View"}
             {expanded ? <ChevronDown /> : <ChevronRight />}
@@ -282,7 +196,7 @@ export function ExecutionHistory({
                 size="sm"
                 className="mt-4 bg-white"
                 aria-label="Retry history"
-                onClick={() => loadPage(activeRequestPageIndex.current)}
+                onClick={retry}
               >
                 <RefreshCw />
                 Retry
@@ -326,7 +240,7 @@ export function ExecutionHistory({
                 size="sm"
                 className="bg-white"
                 aria-label="Retry history"
-                onClick={() => loadPage(activeRequestPageIndex.current)}
+                onClick={retry}
               >
                 <RefreshCw />
                 Retry

--- a/compensation/dashboard/src/features/Failed/history/useExecutionHistory.ts
+++ b/compensation/dashboard/src/features/Failed/history/useExecutionHistory.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { usePagedQuery } from "@ahoo-wang/fetcher-react";
+import type { DomainEventStream, PagedList } from "@ahoo-wang/fetcher-wow";
+import {
+  aggregateId,
+  desc,
+  DomainEventStreamMetadataFields,
+  pagedList,
+  pagedQuery,
+} from "@ahoo-wang/fetcher-wow";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ExecutionFailedDomainEventType } from "../../../generated";
+import { executionFailedEventStreamQueryClient } from "../../../services";
+
+export const EXECUTION_HISTORY_PAGE_SIZE = 10;
+
+export type ExecutionEventStream =
+  DomainEventStream<ExecutionFailedDomainEventType>;
+
+interface UseExecutionHistoryOptions {
+  enabled: boolean;
+  executionId: string;
+  refreshToken: number;
+}
+
+function createExecutionHistoryQuery(executionId: string, pageIndex: number) {
+  return pagedQuery({
+    condition: aggregateId(executionId),
+    sort: [desc(DomainEventStreamMetadataFields.VERSION)],
+    pagination: { index: pageIndex, size: EXECUTION_HISTORY_PAGE_SIZE },
+  });
+}
+
+function isAbortError(error: Error): boolean {
+  return (
+    error.name === "AbortError" ||
+    error.message.toLowerCase().includes("signal is aborted")
+  );
+}
+
+export function useExecutionHistory({
+  enabled,
+  executionId,
+  refreshToken,
+}: UseExecutionHistoryOptions) {
+  const [page, setPage] = useState<PagedList<ExecutionEventStream>>(() =>
+    pagedList<ExecutionEventStream>(),
+  );
+  const [settledPageIndex, setSettledPageIndex] = useState(1);
+  const requestedPageIndex = useRef(1);
+  const observedExecutionId = useRef(executionId);
+  const observedRefreshToken = useRef(refreshToken);
+  const wasEnabled = useRef(false);
+
+  const { abort, loading, error, execute, setQuery } = usePagedQuery<
+    ExecutionEventStream,
+    string,
+    Error
+  >({
+    autoExecute: false,
+    initialQuery: createExecutionHistoryQuery(executionId, 1),
+    execute: (query, attributes, abortController) =>
+      executionFailedEventStreamQueryClient.paged<ExecutionEventStream>(
+        query,
+        attributes,
+        abortController,
+      ),
+    onSuccess: (nextPage) => {
+      setPage(nextPage);
+      setSettledPageIndex(requestedPageIndex.current);
+    },
+  });
+
+  const loadPage = useCallback(
+    (pageIndex: number) => {
+      requestedPageIndex.current = pageIndex;
+      setQuery(createExecutionHistoryQuery(executionId, pageIndex));
+      void execute();
+    },
+    [execute, executionId, setQuery],
+  );
+
+  const retry = useCallback(() => {
+    void execute();
+  }, [execute]);
+
+  useEffect(() => {
+    if (!enabled) {
+      if (wasEnabled.current) {
+        abort();
+      }
+      wasEnabled.current = false;
+      return;
+    }
+
+    const executionChanged = observedExecutionId.current !== executionId;
+    const refreshRequested = observedRefreshToken.current !== refreshToken;
+    const expanding = !wasEnabled.current;
+    wasEnabled.current = true;
+    observedExecutionId.current = executionId;
+    observedRefreshToken.current = refreshToken;
+
+    if (!expanding && !executionChanged && !refreshRequested) {
+      return;
+    }
+
+    if (executionChanged) {
+      setPage(pagedList<ExecutionEventStream>());
+      setSettledPageIndex(1);
+    }
+    loadPage(executionChanged || refreshRequested ? 1 : settledPageIndex);
+  }, [abort, enabled, executionId, loadPage, refreshToken, settledPageIndex]);
+
+  return {
+    error: error && !isAbortError(error) ? error : undefined,
+    loadPage,
+    loading,
+    page,
+    retry,
+    settledPageIndex,
+  };
+}

--- a/compensation/dashboard/src/services/executionFailedEventStreamClient.test.ts
+++ b/compensation/dashboard/src/services/executionFailedEventStreamClient.test.ts
@@ -11,50 +11,31 @@
  * limitations under the License.
  */
 
-import { aggregateId, pagedQuery } from "@ahoo-wang/fetcher-wow";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { queryExecutionFailedEventStreamPage } from "./executionFailedEventStreamClient.ts";
+import { describe, expect, it, vi } from "vitest";
+import { executionFailedEventStreamQueryClient } from "./executionFailedEventStreamClient.ts";
 
 const mocks = vi.hoisted(() => ({
+  client: {
+    count: vi.fn(),
+    list: vi.fn(),
+    listStream: vi.fn(),
+    paged: vi.fn(),
+  },
   createEventStreamQueryClient: vi.fn(),
-  paged: vi.fn(),
 }));
 
 vi.mock("../generated", () => ({
   executionFailedQueryClientFactory: {
     createEventStreamQueryClient:
-      mocks.createEventStreamQueryClient.mockReturnValue({
-        paged: mocks.paged,
-      }),
+      mocks.createEventStreamQueryClient.mockReturnValue(mocks.client),
   },
 }));
 
 describe("executionFailedEventStreamClient", () => {
-  beforeEach(() => {
-    mocks.paged.mockClear();
-  });
-
-  it("creates the EventStream REST client behind the dashboard service boundary", () => {
+  it("exposes the configured EventStreamQueryClient without narrowing its API", () => {
     expect(mocks.createEventStreamQueryClient).toHaveBeenCalledWith({
       contextAlias: "",
     });
-  });
-
-  it("delegates paged history queries with request context and cancellation", async () => {
-    const query = pagedQuery({ condition: aggregateId("failed-1") });
-    const attributes = { source: "history" };
-    const abortController = new AbortController();
-
-    await queryExecutionFailedEventStreamPage(
-      query,
-      attributes,
-      abortController,
-    );
-
-    expect(mocks.paged).toHaveBeenCalledWith(
-      query,
-      attributes,
-      abortController,
-    );
+    expect(executionFailedEventStreamQueryClient).toBe(mocks.client);
   });
 });

--- a/compensation/dashboard/src/services/executionFailedEventStreamClient.ts
+++ b/compensation/dashboard/src/services/executionFailedEventStreamClient.ts
@@ -11,22 +11,9 @@
  * limitations under the License.
  */
 
-import type { PagedQuery } from "@ahoo-wang/fetcher-wow";
 import { executionFailedQueryClientFactory } from "../generated";
 
-const executionFailedEventStreamQueryClient =
+export const executionFailedEventStreamQueryClient =
   executionFailedQueryClientFactory.createEventStreamQueryClient({
     contextAlias: "",
   });
-
-export function queryExecutionFailedEventStreamPage(
-  query: PagedQuery,
-  attributes?: Record<string, unknown>,
-  abortController?: AbortController,
-) {
-  return executionFailedEventStreamQueryClient.paged(
-    query,
-    attributes,
-    abortController,
-  );
-}


### PR DESCRIPTION
## Summary

- expose the configured `EventStreamQueryClient` instead of narrowing it to a one-off paged wrapper
- extract execution-history query state into a focused `useExecutionHistory` hook powered by `usePagedQuery`
- preserve lazy loading, pagination, retries, and last-successful-page rendering while delegating request state and stale-result protection to Fetcher
- cancel in-flight EventStream requests when history is collapsed and cover refresh/collapse cancellation with regression tests

## Why

The history component manually owned `AbortController`, Promise lifecycle, loading/error state, and race guards even though `fetcher-react` already provides those guarantees. The service layer also hid the reusable EventStream client behind a single-method pass-through. This change moves query lifecycle concerns into a cohesive hook and exposes the typed client for reuse.

## Validation

- `pnpm test --run` — 31 files, 142 tests passed
- `pnpm lint`
- `pnpm build`
- `pnpm test:browser` — 10 desktop/mobile Playwright tests passed
- Prettier check for all changed Dashboard files
- `git diff --check`