### PR TITLE
fix compensation Elasticsearch Boot 4 compatibility

### DIFF
--- a/compensation/wow-compensation-server/build.gradle.kts
+++ b/compensation/wow-compensation-server/build.gradle.kts
@@ -85,7 +85,7 @@ dependencies {
     implementation("me.ahoo.coapi:coapi-spring-boot-starter")
     implementation("org.springframework.boot:spring-boot-starter-data-mongodb-reactive")
     implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
-    implementation("org.springframework.boot:spring-boot-starter-elasticsearch")
+    implementation("org.springframework.boot:spring-boot-starter-data-elasticsearch")
     api("io.projectreactor.kotlin:reactor-kotlin-extensions")
     implementation("org.springdoc:springdoc-openapi-starter-webflux-ui")
     implementation("org.springframework.boot:spring-boot-starter-validation")

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfiguration.kt
@@ -15,6 +15,8 @@ package me.ahoo.wow.spring.boot.starter.elasticsearch
 
 import co.elastic.clients.json.JsonpMapper
 import co.elastic.clients.json.jackson.Jackson3JsonpMapper
+import co.elastic.clients.transport.rest5_client.Rest5ClientOptions
+import co.elastic.clients.transport.rest5_client.low_level.RequestOptions
 import me.ahoo.wow.elasticsearch.IndexTemplateInitializer
 import me.ahoo.wow.elasticsearch.WowJsonpMapper
 import me.ahoo.wow.elasticsearch.eventsourcing.ElasticsearchEventStore
@@ -39,6 +41,7 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.elasticsearch.autoconfigure.ElasticsearchClientAutoConfiguration
 import org.springframework.boot.elasticsearch.autoconfigure.ElasticsearchRestClientAutoConfiguration
@@ -69,6 +72,20 @@ class ElasticsearchEventSourcingAutoConfiguration @Autowired constructor(
         eventStoreBatchProperties = ElasticsearchEventStoreBatchProperties(),
         snapshotStoreBatchProperties = ElasticsearchSnapshotStoreBatchProperties(),
     )
+
+    @Bean
+    @ConditionalOnProperty(ElasticsearchProperties.COMPATIBILITY_VERSION_KEY)
+    @ConditionalOnMissingBean(Rest5ClientOptions::class)
+    fun rest5ClientOptions(): Rest5ClientOptions {
+        val compatibilityVersion = requireNotNull(elasticsearchProperties.compatibilityVersion) {
+            "${ElasticsearchProperties.COMPATIBILITY_VERSION_KEY} must be configured when the compatibility option is enabled"
+        }
+        val mediaType = "application/vnd.elasticsearch+json; compatible-with=$compatibilityVersion"
+        val builder = Rest5ClientOptions.Builder(RequestOptions.DEFAULT.toBuilder())
+        builder.setHeader("Accept", mediaType)
+        builder.setHeader("Content-Type", mediaType)
+        return builder.build()
+    }
 
     @Bean
     @ConditionalOnMissingBean(JsonpMapper::class)

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfiguration.kt
@@ -16,7 +16,7 @@ package me.ahoo.wow.spring.boot.starter.elasticsearch
 import co.elastic.clients.json.JsonpMapper
 import co.elastic.clients.json.jackson.Jackson3JsonpMapper
 import co.elastic.clients.transport.rest5_client.Rest5ClientOptions
-import co.elastic.clients.transport.rest5_client.low_level.RequestOptions
+import co.elastic.clients.transport.rest5_client.SafeResponseConsumer
 import me.ahoo.wow.elasticsearch.IndexTemplateInitializer
 import me.ahoo.wow.elasticsearch.WowJsonpMapper
 import me.ahoo.wow.elasticsearch.eventsourcing.ElasticsearchEventStore
@@ -81,7 +81,7 @@ class ElasticsearchEventSourcingAutoConfiguration @Autowired constructor(
             "${ElasticsearchProperties.COMPATIBILITY_VERSION_KEY} must be configured when the compatibility option is enabled"
         }
         val mediaType = "application/vnd.elasticsearch+json; compatible-with=$compatibilityVersion"
-        val builder = Rest5ClientOptions.Builder(RequestOptions.DEFAULT.toBuilder())
+        val builder = Rest5ClientOptions.Builder(SafeResponseConsumer.DEFAULT_REQUEST_OPTIONS.toBuilder())
         builder.setHeader("Accept", mediaType)
         builder.setHeader("Content-Type", mediaType)
         return builder.build()

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchProperties.kt
@@ -24,6 +24,8 @@ class ElasticsearchProperties(
     @DefaultValue("true") var autoInitTemplate: Boolean = true,
     var compatibilityVersion: Int? = null,
 ) : EnabledCapable {
+    constructor(enabled: Boolean, autoInitTemplate: Boolean) : this(enabled, autoInitTemplate, null)
+
     companion object {
         const val PREFIX = "${Wow.WOW_PREFIX}elasticsearch"
         const val COMPATIBILITY_VERSION_KEY = "$PREFIX.compatibility-version"

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchProperties.kt
@@ -22,8 +22,10 @@ import org.springframework.boot.context.properties.bind.DefaultValue
 class ElasticsearchProperties(
     @DefaultValue("true") override val enabled: Boolean = true,
     @DefaultValue("true") var autoInitTemplate: Boolean = true,
+    var compatibilityVersion: Int? = null,
 ) : EnabledCapable {
     companion object {
         const val PREFIX = "${Wow.WOW_PREFIX}elasticsearch"
+        const val COMPATIBILITY_VERSION_KEY = "$PREFIX.compatibility-version"
     }
 }

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfigurationTest.kt
@@ -61,6 +61,17 @@ internal class ElasticsearchEventSourcingAutoConfigurationTest {
     ).getBeanProvider(WowMetrics::class.java)
 
     @Test
+    fun `should preserve binary compatible constructor`() {
+        val properties = ElasticsearchProperties::class.java
+            .getConstructor(java.lang.Boolean.TYPE, java.lang.Boolean.TYPE)
+            .newInstance(false, false)
+
+        properties.enabled.assert().isFalse()
+        properties.autoInitTemplate.assert().isFalse()
+        properties.compatibilityVersion.assert().isNull()
+    }
+
+    @Test
     fun `secondary constructor should use default batch properties`() {
         val autoConfiguration = ElasticsearchEventSourcingAutoConfiguration(
             ElasticsearchProperties(autoInitTemplate = false)
@@ -143,7 +154,7 @@ internal class ElasticsearchEventSourcingAutoConfigurationTest {
     @Test
     fun `should fail fast when compatibility version is not bound`() {
         val autoConfiguration = ElasticsearchEventSourcingAutoConfiguration(
-            ElasticsearchProperties(compatibilityVersion = null),
+            ElasticsearchProperties(),
         )
 
         assertThrownBy<IllegalArgumentException> {

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfigurationTest.kt
@@ -20,6 +20,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import me.ahoo.test.asserts.assert
+import me.ahoo.test.asserts.assertThrownBy
 import me.ahoo.wow.elasticsearch.IndexTemplateInitializer
 import me.ahoo.wow.elasticsearch.WowJsonpMapper
 import me.ahoo.wow.elasticsearch.eventsourcing.ElasticsearchEventStore
@@ -131,6 +132,19 @@ internal class ElasticsearchEventSourcingAutoConfigurationTest {
                 headers.first { it.key == "Accept" }.value.assert().isEqualTo(mediaType)
                 headers.first { it.key == "Content-Type" }.value.assert().isEqualTo(mediaType)
             }
+    }
+
+    @Test
+    fun `should fail fast when compatibility version is not bound`() {
+        val autoConfiguration = ElasticsearchEventSourcingAutoConfiguration(
+            ElasticsearchProperties(compatibilityVersion = null),
+        )
+
+        assertThrownBy<IllegalArgumentException> {
+            autoConfiguration.rest5ClientOptions()
+        }.hasMessage(
+            "${ElasticsearchProperties.COMPATIBILITY_VERSION_KEY} must be configured when the compatibility option is enabled",
+        )
     }
 
     @Test

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfigurationTest.kt
@@ -15,6 +15,7 @@ package me.ahoo.wow.spring.boot.starter.elasticsearch
 
 import co.elastic.clients.json.JsonpMapper
 import co.elastic.clients.json.jackson.Jackson3JsonpMapper
+import co.elastic.clients.transport.rest5_client.Rest5ClientOptions
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -103,6 +104,32 @@ internal class ElasticsearchEventSourcingAutoConfigurationTest {
                     .hasSingleBean(ElasticsearchEventStore::class.java)
                     .hasSingleBean(JsonpMapper::class.java)
                 context.getBean(JsonpMapper::class.java).assert().isSameAs(WowJsonpMapper)
+            }
+    }
+
+    @Test
+    fun `should configure Elasticsearch compatibility media type`() {
+        ApplicationContextRunner()
+            .enableWow()
+            .withConfiguration(
+                AutoConfigurations.of(
+                    ElasticsearchRestClientAutoConfiguration::class.java,
+                    ElasticsearchClientAutoConfiguration::class.java,
+                    DataElasticsearchAutoConfiguration::class.java,
+                    ElasticsearchEventSourcingAutoConfiguration::class.java,
+                ),
+            )
+            .withPropertyValues(
+                "${EventStoreProperties.STORAGE}=${StorageType.ELASTICSEARCH_NAME}",
+                "${SnapshotProperties.STORAGE}=${StorageType.MONGO_NAME}",
+                "${ElasticsearchProperties.PREFIX}.auto-init-template=false",
+                "${ElasticsearchProperties.COMPATIBILITY_VERSION_KEY}=8",
+            )
+            .run { context ->
+                val mediaType = "application/vnd.elasticsearch+json; compatible-with=8"
+                val headers = context.getBean(Rest5ClientOptions::class.java).headers().toList()
+                headers.first { it.key == "Accept" }.value.assert().isEqualTo(mediaType)
+                headers.first { it.key == "Content-Type" }.value.assert().isEqualTo(mediaType)
             }
     }
 

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfigurationTest.kt
@@ -16,6 +16,7 @@ package me.ahoo.wow.spring.boot.starter.elasticsearch
 import co.elastic.clients.json.JsonpMapper
 import co.elastic.clients.json.jackson.Jackson3JsonpMapper
 import co.elastic.clients.transport.rest5_client.Rest5ClientOptions
+import co.elastic.clients.transport.rest5_client.SafeResponseConsumer
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -131,6 +132,11 @@ internal class ElasticsearchEventSourcingAutoConfigurationTest {
                 val headers = context.getBean(Rest5ClientOptions::class.java).headers().toList()
                 headers.first { it.key == "Accept" }.value.assert().isEqualTo(mediaType)
                 headers.first { it.key == "Content-Type" }.value.assert().isEqualTo(mediaType)
+                context.getBean(Rest5ClientOptions::class.java)
+                    .restClientRequestOptions()
+                    .httpAsyncResponseConsumerFactory
+                    .assert()
+                    .isSameAs(SafeResponseConsumer.DEFAULT_FACTORY)
             }
     }
 


### PR DESCRIPTION
## 变更

- 将 `compensation/wow-compensation-server` 的 `spring-boot-starter-elasticsearch` 替换为 `spring-boot-starter-data-elasticsearch`，补齐 `ReactiveElasticsearchClient` 自动配置。
- 增加可选的 `wow.elasticsearch.compatibility-version` 配置，用于为 Elasticsearch Java client 设置兼容的 `Accept` 和 `Content-Type` media type。
- 增加自动配置测试，覆盖成功配置及版本未绑定时的 fail-fast 分支。

## 根因

- Wow `8.10.3` 使用 Spring Boot 4.1 / `elasticsearch-java 9.4.2`；与 Elasticsearch 8 服务端交互时，默认 ES 9 media type 会被拒绝。
- compensation server 原先仅引入基础 Elasticsearch starter，缺少 Data Elasticsearch starter，导致 `ReactiveElasticsearchClient` bean 无法自动配置。

## 验证

- `./gradlew :wow-spring-boot-starter:test --tests 'me.ahoo.wow.spring.boot.starter.elasticsearch.ElasticsearchEventSourcingAutoConfigurationTest' --no-daemon -Pkotlin.compiler.execution.strategy=in-process`
- `./gradlew :wow-spring-boot-starter:check :wow-spring-boot-starter:jacocoTestCoverageVerification :wow-compensation-server:test :wow-compensation-server:check :wow-compensation-server:installDist --no-daemon -Pkotlin.compiler.execution.strategy=in-process`
- `git diff --check`
- Elasticsearch 自动配置类 JaCoCo 指令、分支、行覆盖率均为 `100%`。

使用 Elasticsearch 8 时配置 `wow.elasticsearch.compatibility-version: 8`。