### PR TITLE
docs(benchmarks): refresh current quick benchmark reports

### DIFF
--- a/wow-benchmarks/results/reports/quick-batch-command-write-e2e.md
+++ b/wow-benchmarks/results/reports/quick-batch-command-write-e2e.md
@@ -12,28 +12,35 @@ Quick Batch CommandWrite E2E compares 32 individual blocking boundaries with one
 - Throughput uses decimal prefixes: `k` = 1,000, `M` = 1,000,000, `G` = 1,000,000,000.
 - Allocation uses binary prefixes: `KiB` = 1,024 bytes, `MiB` = 1,048,576 bytes.
 - Every displayed score and error keeps its scaled unit attached, for example `1.57 k ops/s`.
-- Average latency is automatically scaled to `ns/op`, `µs/op`, `ms/op`, or `s/op`.
+- Average-time results are automatically scaled to `ns/op`, `µs/op`, `ms/op`, or `s/op`.
 - `±` is the JMH-reported error. Scaling changes presentation only; calculations keep raw precision.
 
 ## Benchmark Run Provenance
-- **Source Commit**: `cf5809a61fe32f3ee86aa2357a3b5572683de0a4`
+- **Source Commit**: `a43b45acb730bf2f8922bcb0348ac336cf59f520`
 - **Source Dirty**: `false`
-- **Project Version**: `8.9.0`
-- **JMH Jar SHA-256**: `264e446f22fa0ae471fed066ff1a0ea82311dff859823be9d8b76883c028dd8b`
+- **Project Version**: `8.10.4`
+- **JMH Jar SHA-256**: `85ddc559cd882343e027133cb2c9e3db27632711420132bf97860168d7aad93a`
 - **Runtime JVM**: OpenJDK 64-Bit Server VM 17.0.7+7-LTS / Java 17.0.7
 - **Runtime OS**: Mac OS X 26.5.2 aarch64
 - **CPU Cores**: 14
 - **Physical Memory**: 24.0 GiB
 
+### Manifest-bound Run-Time Infrastructure
+
+- **Captured At**: 2026-08-05T06:42:38.429070Z to 2026-08-05T06:45:27.442970Z
+- **Benchmark Client**: host JVM
+- **Docker Server**: not required by these suites
+- **Local Docker Containers**: none required; service endpoints remain bound in each run manifest.
+
 | Suite | Profile | Threads | Run ID | Started | Completed | Profilers | Rows | Result SHA-256 |
 |-------|---------|---------|--------|---------|-----------|-----------|------|----------------|
-| batch-command-write-e2e | quick | 1 | `27dd4e6a-2e9a-4dd7-a6d5-e676be2aa698` | 2026-07-22T13:23:59.419383Z | 2026-07-22T13:25:17.887813Z | `-prof gc` | 9 | `a83deef22746d5d7b24c15a2fe187e81b993b44b747f7d46acf52729abfb7054` |
+| batch-command-write-e2e | quick | 1 | `aaf7309a-a5d8-45f7-beec-12df71f6e025` | 2026-08-05T06:42:38.429093Z | 2026-08-05T06:45:27.443667Z | `-prof gc` | 9 | `30aa2ec98396eb81fefc22baa46fa88eaedef39f80722292a3006fcb2346b5e5` |
 
 ## Report Generation Environment
-- **Version**: 8.9.0
+- **Version**: 8.10.4
 - **JVM**: OpenJDK 64-Bit Server VM 17.0.7+7-LTS
 - **OS**: Mac OS X 26.5.2 aarch64
-- **Generated At**: 2026-07-22T21:37:19+08:00
+- **Generated At**: 2026-08-05T14:45:27+08:00
 - **CPU Cores**: 14
 - **Physical Memory**: 24.0 GiB
 - **Benchmark JVM Args**: `-Xmx1g -Xms1g -XX:+UseG1GC`
@@ -54,9 +61,9 @@ The same 32-command workload is normalized per command. Sequential c1 isolates b
 
 | Scenario | Control | Primary c1 | vs Control | Scaling c4 | vs Control | c4 / c1 |
 |----------|------------------------|---------------|---------------|---------------|---------------|---------|
-| `ceiling` | 94.75 k ops/s | 129.13 k ops/s | +36.3% | 268.2 k ops/s | +183.1% | 2.08× |
-| `noop-store` | 92.16 k ops/s | 114.81 k ops/s | +24.6% | 230.21 k ops/s | +149.8% | 2.01× |
-| `in-memory-new-aggregate` | 86.43 k ops/s | 105.79 k ops/s | +22.4% | 194.87 k ops/s | +125.5% | 1.84× |
+| `ceiling` | 29.95 k ops/s | 86.84 k ops/s | +190.0% | 168.02 k ops/s | +461.1% | 1.93× |
+| `noop-store` | 62.51 k ops/s | 88.3 k ops/s | +41.3% | 147.38 k ops/s | +135.8% | 1.67× |
+| `in-memory-new-aggregate` | 44.79 k ops/s | 83.41 k ops/s | +86.2% | 140.68 k ops/s | +214.1% | 1.69× |
 
 Higher throughput is better. Changes use unrounded JMH scores.
 
@@ -64,9 +71,9 @@ Higher throughput is better. Changes use unrounded JMH scores.
 
 | Scenario | Control | Primary c1 | Reduction vs Control | Scaling c4 | Reduction vs Control | c4 / c1 |
 |----------|------------------------|---------------|-----------|---------------|-----------|---------|
-| `ceiling` | 3.86 KiB/op | 142.75 B/op | 96.4% | 657.39 B/op | 83.4% | 4.61× |
-| `noop-store` | 4.8 KiB/op | 255.59 B/op | 94.8% | 2.36 KiB/op | 50.7% | 9.47× |
-| `in-memory-new-aggregate` | 4.57 KiB/op | 255.69 B/op | 94.5% | 1.94 KiB/op | 57.6% | 7.77× |
+| `ceiling` | 4.72 KiB/op | 199.57 B/op | 95.9% | 4.66 KiB/op | 1.4% | 23.90× |
+| `noop-store` | 5.65 KiB/op | 338.69 B/op | 94.1% | 5.6 KiB/op | 0.9% | 16.93× |
+| `in-memory-new-aggregate` | 5.51 KiB/op | 338.31 B/op | 94.0% | 5.43 KiB/op | 1.5% | 16.42× |
 
 Lower allocation is better. Reduction is relative to the Control; c4 / c1 makes the concurrency trade-off explicit.
 
@@ -74,12 +81,12 @@ Lower allocation is better. Reduction is relative to the Control; c4 / c1 makes 
 
 | Suite | Benchmark | Threads | Mode | Score | Error | gc.alloc.rate.norm |
 |-------|-----------|---------|------|-------|-------|-------------------|
-| Batch CommandWrite E2E | BatchCommandWriteE2EBenchmark.sendBatchConcurrentAndWaitProcessed (scenario=ceiling) | 1 | thrpt | 268.2 k ops/s | - | 657.39 B/op |
-| Batch CommandWrite E2E | BatchCommandWriteE2EBenchmark.sendBatchConcurrentAndWaitProcessed (scenario=in-memory-new-aggregate) | 1 | thrpt | 194.87 k ops/s | - | 1.94 KiB/op |
-| Batch CommandWrite E2E | BatchCommandWriteE2EBenchmark.sendBatchConcurrentAndWaitProcessed (scenario=noop-store) | 1 | thrpt | 230.21 k ops/s | - | 2.36 KiB/op |
-| Batch CommandWrite E2E | BatchCommandWriteE2EBenchmark.sendBatchSequentialAndWaitProcessed (scenario=ceiling) | 1 | thrpt | 129.13 k ops/s | - | 142.75 B/op |
-| Batch CommandWrite E2E | BatchCommandWriteE2EBenchmark.sendBatchSequentialAndWaitProcessed (scenario=in-memory-new-aggregate) | 1 | thrpt | 105.79 k ops/s | - | 255.69 B/op |
-| Batch CommandWrite E2E | BatchCommandWriteE2EBenchmark.sendBatchSequentialAndWaitProcessed (scenario=noop-store) | 1 | thrpt | 114.81 k ops/s | - | 255.59 B/op |
-| Batch CommandWrite E2E | BatchCommandWriteE2EBenchmark.sendIndividuallyAndWaitProcessed (scenario=ceiling) | 1 | thrpt | 94.75 k ops/s | - | 3.86 KiB/op |
-| Batch CommandWrite E2E | BatchCommandWriteE2EBenchmark.sendIndividuallyAndWaitProcessed (scenario=in-memory-new-aggregate) | 1 | thrpt | 86.43 k ops/s | - | 4.57 KiB/op |
-| Batch CommandWrite E2E | BatchCommandWriteE2EBenchmark.sendIndividuallyAndWaitProcessed (scenario=noop-store) | 1 | thrpt | 92.16 k ops/s | - | 4.8 KiB/op |
+| Batch CommandWrite E2E | BatchCommandWriteE2EBenchmark.sendBatchConcurrentAndWaitProcessed (scenario=ceiling) | 1 | thrpt | 168.02 k ops/s | - | 4.66 KiB/op |
+| Batch CommandWrite E2E | BatchCommandWriteE2EBenchmark.sendBatchConcurrentAndWaitProcessed (scenario=in-memory-new-aggregate) | 1 | thrpt | 140.68 k ops/s | - | 5.43 KiB/op |
+| Batch CommandWrite E2E | BatchCommandWriteE2EBenchmark.sendBatchConcurrentAndWaitProcessed (scenario=noop-store) | 1 | thrpt | 147.38 k ops/s | - | 5.6 KiB/op |
+| Batch CommandWrite E2E | BatchCommandWriteE2EBenchmark.sendBatchSequentialAndWaitProcessed (scenario=ceiling) | 1 | thrpt | 86.84 k ops/s | - | 199.57 B/op |
+| Batch CommandWrite E2E | BatchCommandWriteE2EBenchmark.sendBatchSequentialAndWaitProcessed (scenario=in-memory-new-aggregate) | 1 | thrpt | 83.41 k ops/s | - | 338.31 B/op |
+| Batch CommandWrite E2E | BatchCommandWriteE2EBenchmark.sendBatchSequentialAndWaitProcessed (scenario=noop-store) | 1 | thrpt | 88.3 k ops/s | - | 338.69 B/op |
+| Batch CommandWrite E2E | BatchCommandWriteE2EBenchmark.sendIndividuallyAndWaitProcessed (scenario=ceiling) | 1 | thrpt | 29.95 k ops/s | - | 4.72 KiB/op |
+| Batch CommandWrite E2E | BatchCommandWriteE2EBenchmark.sendIndividuallyAndWaitProcessed (scenario=in-memory-new-aggregate) | 1 | thrpt | 44.79 k ops/s | - | 5.51 KiB/op |
+| Batch CommandWrite E2E | BatchCommandWriteE2EBenchmark.sendIndividuallyAndWaitProcessed (scenario=noop-store) | 1 | thrpt | 62.51 k ops/s | - | 5.65 KiB/op |

--- a/wow-benchmarks/results/reports/quick-framework-e2e.md
+++ b/wow-benchmarks/results/reports/quick-framework-e2e.md
@@ -16,10 +16,10 @@ Quick Framework E2E results are directional local feedback. Use Baseline E2E run
 - `±` is the JMH-reported error. Scaling changes presentation only; calculations keep raw precision.
 
 ## Benchmark Run Provenance
-- **Source Commit**: `9c06e97daffadd574a969046fb9916b61cc1b282`
+- **Source Commit**: `adcf1080df0d2bac2a8cca2e9f63ec0302da3d2a`
 - **Source Dirty**: `false`
-- **Project Version**: `8.10.3`
-- **JMH Jar SHA-256**: `593a6b572a29efc13c780a4e329caaba617633cb6e5351410fe9a2785ceefad1`
+- **Project Version**: `8.10.4`
+- **JMH Jar SHA-256**: `85ddc559cd882343e027133cb2c9e3db27632711420132bf97860168d7aad93a`
 - **Runtime JVM**: OpenJDK 64-Bit Server VM 17.0.7+7-LTS / Java 17.0.7
 - **Runtime OS**: Mac OS X 26.5.2 aarch64
 - **CPU Cores**: 14
@@ -27,21 +27,21 @@ Quick Framework E2E results are directional local feedback. Use Baseline E2E run
 
 ### Manifest-bound Run-Time Infrastructure
 
-- **Captured At**: 2026-08-04T15:53:05.162184Z to 2026-08-04T15:56:24.650673Z
+- **Captured At**: 2026-08-05T06:29:30.130866Z to 2026-08-05T06:32:49.372659Z
 - **Benchmark Client**: host JVM
 - **Docker Server**: not required by these suites
 - **Local Docker Containers**: none required; service endpoints remain bound in each run manifest.
 
 | Suite | Profile | Threads | Run ID | Started | Completed | Profilers | Rows | Result SHA-256 |
 |-------|---------|---------|--------|---------|-----------|-----------|------|----------------|
-| framework-e2e | quick | 1 | `dd78dbf8-0acf-4980-8828-f702250b8ebe` | 2026-08-04T15:53:05.162262Z | 2026-08-04T15:54:44.840838Z | `-prof gc` | 8 | `bbab5cc0951be2254906cc130da40132fd37ea01c397eda4b8fb6813cd03a512` |
-| framework-e2e | quick | 4 | `dd78dbf8-0acf-4980-8828-f702250b8ebe` | 2026-08-04T15:54:44.898647Z | 2026-08-04T15:56:24.650813Z | `-prof gc` | 8 | `f22a6e2e5d6a7c669e0ca32e6611bd152f58d52aa3b0a232526962fa7a4133b5` |
+| framework-e2e | quick | 1 | `793e57c4-3374-44ea-a1c5-0d57f312c8d8` | 2026-08-05T06:29:30.130920Z | 2026-08-05T06:31:09.599744Z | `-prof gc` | 8 | `d22310aac5de5aa348b71d943dd7a30291a6ba68706580558bddedf0ebea23cd` |
+| framework-e2e | quick | 4 | `793e57c4-3374-44ea-a1c5-0d57f312c8d8` | 2026-08-05T06:31:09.663049Z | 2026-08-05T06:32:49.372824Z | `-prof gc` | 8 | `7669834e4af0f8a467af1b751fa2d188cb3244369bacb3f80fd51eb4d7bd2eec` |
 
 ## Report Generation Environment
-- **Version**: 8.10.3
+- **Version**: 8.10.4
 - **JVM**: OpenJDK 64-Bit Server VM 17.0.7+7-LTS
 - **OS**: Mac OS X 26.5.2 aarch64
-- **Generated At**: 2026-08-04T23:56:24+08:00
+- **Generated At**: 2026-08-05T14:42:12+08:00
 - **CPU Cores**: 14
 - **Physical Memory**: 24.0 GiB
 - **Benchmark JVM Args**: `-Xmx1g -Xms1g -XX:+UseG1GC`
@@ -51,19 +51,19 @@ Quick Framework E2E results are directional local feedback. Use Baseline E2E run
 
 | Suite | Benchmark | Threads | Mode | Score | Error | gc.alloc.rate.norm |
 |-------|-----------|---------|------|-------|-------|-------------------|
-| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=ceiling) | 1 | thrpt | 257.47 k ops/s | - | 3.95 KiB/op |
-| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=ceiling) | 4 | thrpt | 347.41 k ops/s | - | 3.93 KiB/op |
-| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=validated) | 1 | thrpt | 254.48 k ops/s | - | 4.35 KiB/op |
-| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=validated) | 4 | thrpt | 349.07 k ops/s | - | 4.38 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 139.42 k ops/s | - | 12.96 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 143.79 k ops/s | - | 13.02 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 1 | thrpt | 52.77 k ops/s | - | 4.69 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 4 | thrpt | 128.79 k ops/s | - | 4.68 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 124.98 k ops/s | - | 14.09 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 131.67 k ops/s | - | 14.23 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 1 | thrpt | 62.28 k ops/s | - | 5.41 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 4 | thrpt | 117.77 k ops/s | - | 5.38 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 132.65 k ops/s | - | 13.99 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 140.87 k ops/s | - | 14.01 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 1 | thrpt | 60.28 k ops/s | - | 5.68 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 4 | thrpt | 125.18 k ops/s | - | 5.59 KiB/op |
+| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=ceiling) | 1 | thrpt | 293.48 k ops/s | - | 3.95 KiB/op |
+| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=ceiling) | 4 | thrpt | 338.75 k ops/s | - | 3.94 KiB/op |
+| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=validated) | 1 | thrpt | 274.78 k ops/s | - | 4.3 KiB/op |
+| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=validated) | 4 | thrpt | 334.66 k ops/s | - | 4.43 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 175.77 k ops/s | - | 12.96 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 148.32 k ops/s | - | 13.04 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 1 | thrpt | 66.42 k ops/s | - | 4.69 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 4 | thrpt | 130.75 k ops/s | - | 4.71 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 125.29 k ops/s | - | 14.12 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 130.33 k ops/s | - | 14.25 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 1 | thrpt | 61.79 k ops/s | - | 5.47 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 4 | thrpt | 119.43 k ops/s | - | 5.36 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 141.99 k ops/s | - | 13.97 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 142 k ops/s | - | 13.97 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 1 | thrpt | 66.79 k ops/s | - | 5.69 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 4 | thrpt | 125.13 k ops/s | - | 5.56 KiB/op |

--- a/wow-benchmarks/results/reports/quick-grouped.md
+++ b/wow-benchmarks/results/reports/quick-grouped.md
@@ -14,32 +14,39 @@
 - Throughput uses decimal prefixes: `k` = 1,000, `M` = 1,000,000, `G` = 1,000,000,000.
 - Allocation uses binary prefixes: `KiB` = 1,024 bytes, `MiB` = 1,048,576 bytes.
 - Every displayed score and error keeps its scaled unit attached, for example `1.57 k ops/s`.
-- Average latency is automatically scaled to `ns/op`, `µs/op`, `ms/op`, or `s/op`.
+- Average-time results are automatically scaled to `ns/op`, `µs/op`, `ms/op`, or `s/op`.
 - `±` is the JMH-reported error. Scaling changes presentation only; calculations keep raw precision.
 
 ## Benchmark Run Provenance
-- **Source Commit**: `07fcba8b412f7250b547425289ad0ef218ba8bde`
+- **Source Commit**: `adcf1080df0d2bac2a8cca2e9f63ec0302da3d2a`
 - **Source Dirty**: `false`
-- **Project Version**: `8.9.0`
-- **JMH Jar SHA-256**: `1d5902b9f334f5f771736a2933ad577f157440513808ff2bd5a15179acf3332e`
+- **Project Version**: `8.10.4`
+- **JMH Jar SHA-256**: `85ddc559cd882343e027133cb2c9e3db27632711420132bf97860168d7aad93a`
 - **Runtime JVM**: OpenJDK 64-Bit Server VM 17.0.7+7-LTS / Java 17.0.7
 - **Runtime OS**: Mac OS X 26.5.2 aarch64
 - **CPU Cores**: 14
 - **Physical Memory**: 24.0 GiB
 
+### Manifest-bound Run-Time Infrastructure
+
+- **Captured At**: 2026-08-05T06:29:30.130866Z to 2026-08-05T06:38:12.090971Z
+- **Benchmark Client**: host JVM
+- **Docker Server**: not required by these suites
+- **Local Docker Containers**: none required; service endpoints remain bound in each run manifest.
+
 | Suite | Profile | Threads | Run ID | Started | Completed | Profilers | Rows | Result SHA-256 |
 |-------|---------|---------|--------|---------|-----------|-----------|------|----------------|
-| component | quick | 1 | `b1bd4033-0cc9-4f9c-9d2a-404d7f7596c9` | 2026-07-22T10:16:20.146641Z | 2026-07-22T10:20:12.158117Z | `-prof gc` | 27 | `db6973eb1d06dde28b75f4a39358661076912f31a60b9cdc7489fa591e2f7da6` |
-| framework-e2e | quick | 1 | `b1bd4033-0cc9-4f9c-9d2a-404d7f7596c9` | 2026-07-22T10:14:00.699165Z | 2026-07-22T10:15:10.471937Z | `-prof gc` | 8 | `fc45780e80d034f074c8d48f2f0cd9128631f8dabe252cc1e616545066348c54` |
-| framework-e2e | quick | 4 | `b1bd4033-0cc9-4f9c-9d2a-404d7f7596c9` | 2026-07-22T10:15:10.513408Z | 2026-07-22T10:16:20.101418Z | `-prof gc` | 8 | `eb1d170249cfa308d4b4ad780ccb4b68402ef70e9f95be8571cee1e610a1753f` |
-| webflux | quick | 1 | `b1bd4033-0cc9-4f9c-9d2a-404d7f7596c9` | 2026-07-22T10:20:12.211184Z | 2026-07-22T10:20:53.094047Z | `-prof gc` | 15 | `ecac86721ed4c2b6661b826f7873d7389df29798ec6f283de23c687117a99ef4` |
-| webflux | quick | 4 | `b1bd4033-0cc9-4f9c-9d2a-404d7f7596c9` | 2026-07-22T10:20:53.135051Z | 2026-07-22T10:21:34.267333Z | `-prof gc` | 15 | `3524838dc170d0e096898884580397abb16fb8e825839bb842b705993804d91c` |
+| component | quick | 1 | `793e57c4-3374-44ea-a1c5-0d57f312c8d8` | 2026-08-05T06:32:49.432560Z | 2026-08-05T06:36:50.609731Z | `-prof gc` | 27 | `724e0e0d4a0fbb379396d5e30e78ce6325465fe31ad0098816504581400fcca6` |
+| framework-e2e | quick | 1 | `793e57c4-3374-44ea-a1c5-0d57f312c8d8` | 2026-08-05T06:29:30.130920Z | 2026-08-05T06:31:09.599744Z | `-prof gc` | 8 | `d22310aac5de5aa348b71d943dd7a30291a6ba68706580558bddedf0ebea23cd` |
+| framework-e2e | quick | 4 | `793e57c4-3374-44ea-a1c5-0d57f312c8d8` | 2026-08-05T06:31:09.663049Z | 2026-08-05T06:32:49.372824Z | `-prof gc` | 8 | `7669834e4af0f8a467af1b751fa2d188cb3244369bacb3f80fd51eb4d7bd2eec` |
+| webflux | quick | 1 | `793e57c4-3374-44ea-a1c5-0d57f312c8d8` | 2026-08-05T06:36:50.676489Z | 2026-08-05T06:37:31.243716Z | `-prof gc` | 15 | `e92c518426eaf6efab022b518de28edbe6c3526259f051a97b018d818fb021e4` |
+| webflux | quick | 4 | `793e57c4-3374-44ea-a1c5-0d57f312c8d8` | 2026-08-05T06:37:31.288159Z | 2026-08-05T06:38:12.091083Z | `-prof gc` | 15 | `0fcef87d5ef1dfa8568f00c70690c4397a4ebb8491b053861a4213c6c3e60187` |
 
 ## Report Generation Environment
-- **Version**: 8.9.0
+- **Version**: 8.10.4
 - **JVM**: OpenJDK 64-Bit Server VM 17.0.7+7-LTS
 - **OS**: Mac OS X 26.5.2 aarch64
-- **Generated At**: 2026-07-22T21:36:47+08:00
+- **Generated At**: 2026-08-05T14:38:12+08:00
 - **CPU Cores**: 14
 - **Physical Memory**: 24.0 GiB
 - **Benchmark JVM Args**: see per-suite Run Profiles below
@@ -57,31 +64,31 @@
 
 | Suite | Threads | Benchmark | Score | Error |
 |-------|---------|-----------|-------|-------|
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 81.13 k ops/s | - |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 91.3 k ops/s | - |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 91.97 k ops/s | - |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 133.95 k ops/s | - |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 143 k ops/s | - |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 147.17 k ops/s | - |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 158.98 k ops/s | - |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 167.47 k ops/s | - |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 208.21 k ops/s | - |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 224.32 k ops/s | - |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 61.79 k ops/s | - |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 66.42 k ops/s | - |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 66.79 k ops/s | - |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 119.43 k ops/s | - |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 125.13 k ops/s | - |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 125.29 k ops/s | - |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 130.33 k ops/s | - |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 130.75 k ops/s | - |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 141.99 k ops/s | - |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 142 k ops/s | - |
 
 ### Highest Allocation
 
 | Suite | Threads | Benchmark | Mode | Allocation | Allocation Error | Score |
 |-------|---------|-----------|------|------------|------------------|-------|
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 13.22 KiB/op | - | 143 k ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 13.18 KiB/op | - | 208.21 k ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 13.03 KiB/op | - | 167.47 k ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 13 KiB/op | - | 249.84 k ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 12.09 KiB/op | - | 224.32 k ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 12.08 KiB/op | - | 302.78 k ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 4.8 KiB/op | - | 91.97 k ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 4.79 KiB/op | - | 147.17 k ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 4.58 KiB/op | - | 81.13 k ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 4.51 KiB/op | - | 133.95 k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 14.25 KiB/op | - | 130.33 k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 14.12 KiB/op | - | 125.29 k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 13.97 KiB/op | - | 141.99 k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 13.97 KiB/op | - | 142 k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 13.04 KiB/op | - | 148.32 k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 12.96 KiB/op | - | 175.77 k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 5.69 KiB/op | - | 66.79 k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 5.56 KiB/op | - | 125.13 k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 5.47 KiB/op | - | 61.79 k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 5.36 KiB/op | - | 119.43 k ops/s |
 
 ## Component Bottlenecks
 
@@ -89,30 +96,30 @@
 
 | Suite | Threads | Benchmark | Score | Error |
 |-------|---------|-----------|-------|-------|
-| Component | 1 | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=500) | 74.47 k ops/s | - |
-| Component | 1 | CommandDispatcherChainComponentBenchmark.dispatchSingleHotAggregateThroughChain (handlerCost=NOOP, schedulerStrategy=PARALLEL) | 120.04 k ops/s | - |
-| Component | 1 | SerializationComponentBenchmark.eventStreamSerializeDeserialize | 450.57 k ops/s | - |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithLocalWait | 455.68 k ops/s | - |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainStateEvents | 564.96 k ops/s | - |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithoutWait | 574.93 k ops/s | - |
-| Component | 1 | SerializationComponentBenchmark.commandSerializeDeserialize | 607.53 k ops/s | - |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainEvent | 684.28 k ops/s | - |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateOnly | 769.14 k ops/s | - |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateWithoutRetry | 859.76 k ops/s | - |
+| Component | 1 | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=500) | 65.81 k ops/s | - |
+| Component | 1 | CommandDispatcherChainComponentBenchmark.dispatchSingleHotAggregateThroughChain (handlerCost=NOOP, schedulerStrategy=PARALLEL) | 178.33 k ops/s | - |
+| Component | 1 | SerializationComponentBenchmark.eventStreamSerializeDeserialize | 468.13 k ops/s | - |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithLocalWait | 469.23 k ops/s | - |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithoutWait | 568.9 k ops/s | - |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainStateEvents | 582.13 k ops/s | - |
+| Component | 1 | SerializationComponentBenchmark.commandSerializeDeserialize | 655.09 k ops/s | - |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainEvent | 691.01 k ops/s | - |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateOnly | 791.8 k ops/s | - |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateWithoutRetry | 901.83 k ops/s | - |
 
 ### Highest Allocation
 
 | Suite | Threads | Benchmark | Mode | Allocation | Allocation Error | Score |
 |-------|---------|-----------|------|------------|------------------|-------|
-| Component | 1 | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=500) | thrpt | 55.3 KiB/op | - | 74.47 k ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithLocalWait | thrpt | 10.27 KiB/op | - | 455.68 k ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithoutWait | thrpt | 8.66 KiB/op | - | 574.93 k ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainStateEvents | thrpt | 8.63 KiB/op | - | 564.96 k ops/s |
-| Component | 1 | SerializationComponentBenchmark.eventStreamSerializeDeserialize | thrpt | 7.73 KiB/op | - | 450.57 k ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainEvent | thrpt | 7.34 KiB/op | - | 684.28 k ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateOnly | thrpt | 6.98 KiB/op | - | 769.14 k ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateWithoutRetry | thrpt | 5.89 KiB/op | - | 859.76 k ops/s |
-| Component | 1 | SerializationComponentBenchmark.commandSerializeDeserialize | thrpt | 5.52 KiB/op | - | 607.53 k ops/s |
+| Component | 1 | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=500) | thrpt | 70.93 KiB/op | - | 65.81 k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithLocalWait | thrpt | 10.29 KiB/op | - | 469.23 k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainStateEvents | thrpt | 8.58 KiB/op | - | 582.13 k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithoutWait | thrpt | 8.52 KiB/op | - | 568.9 k ops/s |
+| Component | 1 | SerializationComponentBenchmark.eventStreamSerializeDeserialize | thrpt | 7.77 KiB/op | - | 468.13 k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainEvent | thrpt | 7.31 KiB/op | - | 691.01 k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateOnly | thrpt | 6.95 KiB/op | - | 791.8 k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateWithoutRetry | thrpt | 5.9 KiB/op | - | 901.83 k ops/s |
+| Component | 1 | SerializationComponentBenchmark.commandSerializeDeserialize | thrpt | 5.55 KiB/op | - | 655.09 k ops/s |
 | Component | 1 | AggregateRepositoryLoadComponentBenchmark.loadSnapshot | thrpt | 5.14 KiB/op | - | 1.05 M ops/s |
 
 ## WebFlux Adapter Bottlenecks
@@ -121,31 +128,31 @@
 
 | Suite | Threads | Benchmark | Score | Error |
 |-------|---------|-----------|-------|-------|
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 1.57 k ops/s | - |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 5.26 k ops/s | - |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 5.58 k ops/s | - |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 8.96 k ops/s | - |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 18.11 k ops/s | - |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 19.65 k ops/s | - |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 28.55 k ops/s | - |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 34.35 k ops/s | - |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 47.37 k ops/s | - |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 64.51 k ops/s | - |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 1.58 k ops/s | - |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 5.18 k ops/s | - |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 5.54 k ops/s | - |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 8.76 k ops/s | - |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 20.06 k ops/s | - |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 20.08 k ops/s | - |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 26.11 k ops/s | - |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 32.98 k ops/s | - |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 50.47 k ops/s | - |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=10, traceWindowSize=10) | 59.69 k ops/s | - |
 
 ### Highest Allocation
 
 | Suite | Threads | Benchmark | Mode | Allocation | Allocation Error | Score |
 |-------|---------|-----------|------|------------|------------------|-------|
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2.84 MiB/op | - | 1.57 k ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2.82 MiB/op | - | 5.26 k ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 742.58 KiB/op | - | 5.58 k ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 737.23 KiB/op | - | 19.65 k ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 435.8 KiB/op | - | 8.96 k ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 434 KiB/op | - | 34.35 k ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 165.09 KiB/op | - | 18.11 k ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 162.48 KiB/op | - | 47.37 k ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 79.81 KiB/op | - | 28.55 k ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 78.07 KiB/op | - | 110.84 k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2.85 MiB/op | - | 1.58 k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2.83 MiB/op | - | 5.18 k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 746.02 KiB/op | - | 5.54 k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 738.42 KiB/op | - | 20.08 k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 439.38 KiB/op | - | 8.76 k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 435.86 KiB/op | - | 26.11 k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 165.36 KiB/op | - | 20.06 k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 162.88 KiB/op | - | 50.47 k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 79.46 KiB/op | - | 32.98 k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 78.1 KiB/op | - | 107.75 k ops/s |
 
 ## Group Details
 
@@ -153,91 +160,91 @@
 
 | Suite | Threads | Benchmark | Score | Error |
 |-------|---------|-----------|-------|-------|
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 81.13 k ops/s | - |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 91.3 k ops/s | - |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 91.97 k ops/s | - |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 133.95 k ops/s | - |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 143 k ops/s | - |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 147.17 k ops/s | - |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 158.98 k ops/s | - |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 167.47 k ops/s | - |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 208.21 k ops/s | - |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 224.32 k ops/s | - |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 61.79 k ops/s | - |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 66.42 k ops/s | - |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 66.79 k ops/s | - |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 119.43 k ops/s | - |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 125.13 k ops/s | - |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 125.29 k ops/s | - |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 130.33 k ops/s | - |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 130.75 k ops/s | - |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 141.99 k ops/s | - |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 142 k ops/s | - |
 
 ### Primary Framework E2E Highest Allocation
 
 | Suite | Threads | Benchmark | Mode | Allocation | Allocation Error | Score |
 |-------|---------|-----------|------|------------|------------------|-------|
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 13.22 KiB/op | - | 143 k ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 13.18 KiB/op | - | 208.21 k ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 13.03 KiB/op | - | 167.47 k ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 13 KiB/op | - | 249.84 k ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 12.09 KiB/op | - | 224.32 k ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 12.08 KiB/op | - | 302.78 k ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 4.8 KiB/op | - | 91.97 k ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 4.79 KiB/op | - | 147.17 k ops/s |
-| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 4.58 KiB/op | - | 81.13 k ops/s |
-| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 4.51 KiB/op | - | 133.95 k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 14.25 KiB/op | - | 130.33 k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | thrpt | 14.12 KiB/op | - | 125.29 k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 13.97 KiB/op | - | 141.99 k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | thrpt | 13.97 KiB/op | - | 142 k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 13.04 KiB/op | - | 148.32 k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | thrpt | 12.96 KiB/op | - | 175.77 k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 5.69 KiB/op | - | 66.79 k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | thrpt | 5.56 KiB/op | - | 125.13 k ops/s |
+| Primary Framework E2E | 1 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 5.47 KiB/op | - | 61.79 k ops/s |
+| Primary Framework E2E | 4 | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | thrpt | 5.36 KiB/op | - | 119.43 k ops/s |
 
 ### Component Lowest Throughput
 
 | Suite | Threads | Benchmark | Score | Error |
 |-------|---------|-----------|-------|-------|
-| Component | 1 | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=500) | 74.47 k ops/s | - |
-| Component | 1 | CommandDispatcherChainComponentBenchmark.dispatchSingleHotAggregateThroughChain (handlerCost=NOOP, schedulerStrategy=PARALLEL) | 120.04 k ops/s | - |
-| Component | 1 | SerializationComponentBenchmark.eventStreamSerializeDeserialize | 450.57 k ops/s | - |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithLocalWait | 455.68 k ops/s | - |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainStateEvents | 564.96 k ops/s | - |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithoutWait | 574.93 k ops/s | - |
-| Component | 1 | SerializationComponentBenchmark.commandSerializeDeserialize | 607.53 k ops/s | - |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainEvent | 684.28 k ops/s | - |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateOnly | 769.14 k ops/s | - |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateWithoutRetry | 859.76 k ops/s | - |
+| Component | 1 | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=500) | 65.81 k ops/s | - |
+| Component | 1 | CommandDispatcherChainComponentBenchmark.dispatchSingleHotAggregateThroughChain (handlerCost=NOOP, schedulerStrategy=PARALLEL) | 178.33 k ops/s | - |
+| Component | 1 | SerializationComponentBenchmark.eventStreamSerializeDeserialize | 468.13 k ops/s | - |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithLocalWait | 469.23 k ops/s | - |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithoutWait | 568.9 k ops/s | - |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainStateEvents | 582.13 k ops/s | - |
+| Component | 1 | SerializationComponentBenchmark.commandSerializeDeserialize | 655.09 k ops/s | - |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainEvent | 691.01 k ops/s | - |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateOnly | 791.8 k ops/s | - |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateWithoutRetry | 901.83 k ops/s | - |
 
 ### Component Highest Allocation
 
 | Suite | Threads | Benchmark | Mode | Allocation | Allocation Error | Score |
 |-------|---------|-----------|------|------------|------------------|-------|
-| Component | 1 | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=500) | thrpt | 55.3 KiB/op | - | 74.47 k ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithLocalWait | thrpt | 10.27 KiB/op | - | 455.68 k ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithoutWait | thrpt | 8.66 KiB/op | - | 574.93 k ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainStateEvents | thrpt | 8.63 KiB/op | - | 564.96 k ops/s |
-| Component | 1 | SerializationComponentBenchmark.eventStreamSerializeDeserialize | thrpt | 7.73 KiB/op | - | 450.57 k ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainEvent | thrpt | 7.34 KiB/op | - | 684.28 k ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateOnly | thrpt | 6.98 KiB/op | - | 769.14 k ops/s |
-| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateWithoutRetry | thrpt | 5.89 KiB/op | - | 859.76 k ops/s |
-| Component | 1 | SerializationComponentBenchmark.commandSerializeDeserialize | thrpt | 5.52 KiB/op | - | 607.53 k ops/s |
+| Component | 1 | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=500) | thrpt | 70.93 KiB/op | - | 65.81 k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithLocalWait | thrpt | 10.29 KiB/op | - | 469.23 k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainStateEvents | thrpt | 8.58 KiB/op | - | 582.13 k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithoutWait | thrpt | 8.52 KiB/op | - | 568.9 k ops/s |
+| Component | 1 | SerializationComponentBenchmark.eventStreamSerializeDeserialize | thrpt | 7.77 KiB/op | - | 468.13 k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainEvent | thrpt | 7.31 KiB/op | - | 691.01 k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateOnly | thrpt | 6.95 KiB/op | - | 791.8 k ops/s |
+| Component | 1 | CommandPipelineComponentBenchmark.handleAggregateWithoutRetry | thrpt | 5.9 KiB/op | - | 901.83 k ops/s |
+| Component | 1 | SerializationComponentBenchmark.commandSerializeDeserialize | thrpt | 5.55 KiB/op | - | 655.09 k ops/s |
 | Component | 1 | AggregateRepositoryLoadComponentBenchmark.loadSnapshot | thrpt | 5.14 KiB/op | - | 1.05 M ops/s |
 
 ### WebFlux Adapter Lowest Throughput
 
 | Suite | Threads | Benchmark | Score | Error |
 |-------|---------|-----------|-------|-------|
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 1.57 k ops/s | - |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 5.26 k ops/s | - |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 5.58 k ops/s | - |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 8.96 k ops/s | - |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 18.11 k ops/s | - |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 19.65 k ops/s | - |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 28.55 k ops/s | - |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 34.35 k ops/s | - |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 47.37 k ops/s | - |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 64.51 k ops/s | - |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 1.58 k ops/s | - |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 5.18 k ops/s | - |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 5.54 k ops/s | - |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 8.76 k ops/s | - |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 20.06 k ops/s | - |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 20.08 k ops/s | - |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 26.11 k ops/s | - |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 32.98 k ops/s | - |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 50.47 k ops/s | - |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=10, traceWindowSize=10) | 59.69 k ops/s | - |
 
 ### WebFlux Adapter Highest Allocation
 
 | Suite | Threads | Benchmark | Mode | Allocation | Allocation Error | Score |
 |-------|---------|-----------|------|------------|------------------|-------|
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2.84 MiB/op | - | 1.57 k ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2.82 MiB/op | - | 5.26 k ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 742.58 KiB/op | - | 5.58 k ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 737.23 KiB/op | - | 19.65 k ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 435.8 KiB/op | - | 8.96 k ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 434 KiB/op | - | 34.35 k ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 165.09 KiB/op | - | 18.11 k ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 162.48 KiB/op | - | 47.37 k ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 79.81 KiB/op | - | 28.55 k ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 78.07 KiB/op | - | 110.84 k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2.85 MiB/op | - | 1.58 k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2.83 MiB/op | - | 5.18 k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 746.02 KiB/op | - | 5.54 k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 738.42 KiB/op | - | 20.08 k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 439.38 KiB/op | - | 8.76 k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 435.86 KiB/op | - | 26.11 k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 165.36 KiB/op | - | 20.06 k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 162.88 KiB/op | - | 50.47 k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 79.46 KiB/op | - | 32.98 k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 78.1 KiB/op | - | 107.75 k ops/s |
 
 ## Primary Framework E2E Results
 
@@ -247,29 +254,29 @@
 - **Source Row Count**: 16
 - **Parsed Row Count**: 16
 
-- **threads=1 Result File**: `wow-benchmarks/results/jmh/quick/framework-e2e/threads-1-framework-e2e.json`
-  - Last Modified: 2026-07-22T10:15:10.454Z
-- **threads=4 Result File**: `wow-benchmarks/results/jmh/quick/framework-e2e/threads-4-framework-e2e.json`
-  - Last Modified: 2026-07-22T10:16:20.083Z
+- **threads=1 Result File**: ` wow-benchmarks/results/jmh/quick/framework-e2e/threads-1-framework-e2e.json `
+  - Last Modified: 2026-08-05T06:31:09.568Z
+- **threads=4 Result File**: ` wow-benchmarks/results/jmh/quick/framework-e2e/threads-4-framework-e2e.json `
+  - Last Modified: 2026-08-05T06:32:49.353Z
 
 | Suite | Benchmark | Threads | Mode | Score | Error | gc.alloc.rate.norm |
 |-------|-----------|---------|------|-------|-------|-------------------|
-| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=ceiling) | 1 | thrpt | 686.87 k ops/s | - | 2.21 KiB/op |
-| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=ceiling) | 4 | thrpt | 675.93 k ops/s | - | 2.21 KiB/op |
-| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=validated) | 1 | thrpt | 663.67 k ops/s | - | 2.61 KiB/op |
-| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=validated) | 4 | thrpt | 679.13 k ops/s | - | 2.65 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 302.78 k ops/s | - | 12.08 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 224.32 k ops/s | - | 12.09 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 1 | thrpt | 91.3 k ops/s | - | 3.86 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 4 | thrpt | 158.98 k ops/s | - | 3.86 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 208.21 k ops/s | - | 13.18 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 143 k ops/s | - | 13.22 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 1 | thrpt | 81.13 k ops/s | - | 4.58 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 4 | thrpt | 133.95 k ops/s | - | 4.51 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 249.84 k ops/s | - | 13 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 167.47 k ops/s | - | 13.03 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 1 | thrpt | 91.97 k ops/s | - | 4.8 KiB/op |
-| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 4 | thrpt | 147.17 k ops/s | - | 4.79 KiB/op |
+| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=ceiling) | 1 | thrpt | 293.48 k ops/s | - | 3.95 KiB/op |
+| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=ceiling) | 4 | thrpt | 338.75 k ops/s | - | 3.94 KiB/op |
+| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=validated) | 1 | thrpt | 274.78 k ops/s | - | 4.3 KiB/op |
+| Primary Framework E2E | CommandSendE2EBenchmark.sendAndWaitSent (gatewayScenario=validated) | 4 | thrpt | 334.66 k ops/s | - | 4.43 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 175.77 k ops/s | - | 12.96 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 148.32 k ops/s | - | 13.04 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 1 | thrpt | 66.42 k ops/s | - | 4.69 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=ceiling, schedulerStrategy=PARALLEL) | 4 | thrpt | 130.75 k ops/s | - | 4.71 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 125.29 k ops/s | - | 14.12 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 130.33 k ops/s | - | 14.25 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 1 | thrpt | 61.79 k ops/s | - | 5.47 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=in-memory-new-aggregate, schedulerStrategy=PARALLEL) | 4 | thrpt | 119.43 k ops/s | - | 5.36 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 141.99 k ops/s | - | 13.97 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=IMMEDIATE) | 4 | thrpt | 142 k ops/s | - | 13.97 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 1 | thrpt | 66.79 k ops/s | - | 5.69 KiB/op |
+| Primary Framework E2E | CommandWriteE2EBenchmark.sendAndWaitProcessed (scenario=noop-store, schedulerStrategy=PARALLEL) | 4 | thrpt | 125.13 k ops/s | - | 5.56 KiB/op |
 
 ## Infrastructure E2E Results
 
@@ -279,8 +286,8 @@
 - **Source Row Count**: 0
 - **Parsed Row Count**: 0
 
-- **threads=1 Result File**: `wow-benchmarks/results/jmh/quick/infrastructure-e2e/threads-1-infrastructure-e2e.json`
-- **threads=4 Result File**: `wow-benchmarks/results/jmh/quick/infrastructure-e2e/threads-4-infrastructure-e2e.json`
+- **threads=1 Result File**: ` wow-benchmarks/results/jmh/quick/infrastructure-e2e/threads-1-infrastructure-e2e.json `
+- **threads=4 Result File**: ` wow-benchmarks/results/jmh/quick/infrastructure-e2e/threads-4-infrastructure-e2e.json `
 
 Status: unavailable. Result files were not present. Run benchmarkQuickInfrastructureE2E to include this optional group.
 
@@ -292,38 +299,38 @@ Status: unavailable. Result files were not present. Run benchmarkQuickInfrastruc
 - **Source Row Count**: 27
 - **Parsed Row Count**: 27
 
-- **threads=1 Result File**: `wow-benchmarks/results/jmh/quick/component/threads-1-component.json`
-  - Last Modified: 2026-07-22T10:20:12.139Z
+- **threads=1 Result File**: ` wow-benchmarks/results/jmh/quick/component/threads-1-component.json `
+  - Last Modified: 2026-08-05T06:36:50.598Z
 
 | Suite | Benchmark | Threads | Mode | Score | Error | gc.alloc.rate.norm |
 |-------|-----------|---------|------|-------|-------|-------------------|
-| Component | AggregateHandleComponentBenchmark.processCommandAggregate | 1 | thrpt | 1.18 M ops/s | - | 5.05 KiB/op |
-| Component | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=10) | 1 | thrpt | 3.32 M ops/s | - | 1.71 KiB/op |
-| Component | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=500) | 1 | thrpt | 74.47 k ops/s | - | 55.3 KiB/op |
-| Component | AggregateRepositoryLoadComponentBenchmark.loadEmptyStateAggregate | 1 | thrpt | 6 M ops/s | - | 1.3 KiB/op |
+| Component | AggregateHandleComponentBenchmark.processCommandAggregate | 1 | thrpt | 1.18 M ops/s | - | 5.02 KiB/op |
+| Component | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=10) | 1 | thrpt | 3.12 M ops/s | - | 2.02 KiB/op |
+| Component | AggregateLoadComponentBenchmark.recoverConstantSizeStateFromEvents (eventCount=500) | 1 | thrpt | 65.81 k ops/s | - | 70.93 KiB/op |
+| Component | AggregateRepositoryLoadComponentBenchmark.loadEmptyStateAggregate | 1 | thrpt | 6.05 M ops/s | - | 1.3 KiB/op |
 | Component | AggregateRepositoryLoadComponentBenchmark.loadSnapshot | 1 | thrpt | 1.05 M ops/s | - | 5.14 KiB/op |
-| Component | CommandDispatcherChainComponentBenchmark.dispatchSingleHotAggregateThroughChain (handlerCost=NOOP, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 5.94 M ops/s | - | 624 B/op |
-| Component | CommandDispatcherChainComponentBenchmark.dispatchSingleHotAggregateThroughChain (handlerCost=NOOP, schedulerStrategy=PARALLEL) | 1 | thrpt | 120.04 k ops/s | - | 710.21 B/op |
-| Component | CommandIdComponentBenchmark.generateGlobalIdAndCreateAggregateId | 1 | thrpt | 16.58 M ops/s | - | 272 B/op |
-| Component | CommandMessageComponentBenchmark.createCommandMessage | 1 | thrpt | 5.04 M ops/s | - | 1.05 KiB/op |
-| Component | CommandMessageComponentBenchmark.readCommandMessageProperties | 1 | thrpt | 668.85 M ops/s | - | 2.7e-07 B/op |
-| Component | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithLocalWait | 1 | thrpt | 455.68 k ops/s | - | 10.27 KiB/op |
-| Component | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithoutWait | 1 | thrpt | 574.93 k ops/s | - | 8.66 KiB/op |
-| Component | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainEvent | 1 | thrpt | 684.28 k ops/s | - | 7.34 KiB/op |
-| Component | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainStateEvents | 1 | thrpt | 564.96 k ops/s | - | 8.63 KiB/op |
-| Component | CommandPipelineComponentBenchmark.handleAggregateOnly | 1 | thrpt | 769.14 k ops/s | - | 6.98 KiB/op |
-| Component | CommandPipelineComponentBenchmark.handleAggregateWithoutRetry | 1 | thrpt | 859.76 k ops/s | - | 5.89 KiB/op |
-| Component | CommandValidationComponentBenchmark.validateCommandBody | 1 | thrpt | 7.81 M ops/s | - | 360.04 B/op |
-| Component | EventPublishComponentBenchmark.publishDomainEventStream | 1 | thrpt | 20.46 M ops/s | - | 168 B/op |
-| Component | EventStoreComponentBenchmark.appendInMemoryNewAggregateEventStream | 1 | thrpt | 14.29 M ops/s | - | 467.89 B/op |
-| Component | EventStoreComponentBenchmark.appendNoopEventStream | 1 | thrpt | 2.73 G ops/s | - | 6.7e-08 B/op |
-| Component | IdempotencyComponentBenchmark.checkKnownRequestId | 1 | thrpt | 20.67 M ops/s | - | 192.48 B/op |
+| Component | CommandDispatcherChainComponentBenchmark.dispatchSingleHotAggregateThroughChain (handlerCost=NOOP, schedulerStrategy=IMMEDIATE) | 1 | thrpt | 4.64 M ops/s | - | 672.05 B/op |
+| Component | CommandDispatcherChainComponentBenchmark.dispatchSingleHotAggregateThroughChain (handlerCost=NOOP, schedulerStrategy=PARALLEL) | 1 | thrpt | 178.33 k ops/s | - | 807.19 B/op |
+| Component | CommandIdComponentBenchmark.generateGlobalIdAndCreateAggregateId | 1 | thrpt | 16.82 M ops/s | - | 272 B/op |
+| Component | CommandMessageComponentBenchmark.createCommandMessage | 1 | thrpt | 5.08 M ops/s | - | 1.05 KiB/op |
+| Component | CommandMessageComponentBenchmark.readCommandMessageProperties | 1 | thrpt | 679.39 M ops/s | - | 2.7e-07 B/op |
+| Component | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithLocalWait | 1 | thrpt | 469.23 k ops/s | - | 10.29 KiB/op |
+| Component | CommandPipelineComponentBenchmark.handleAggregateAndNotifyProcessedWithoutWait | 1 | thrpt | 568.9 k ops/s | - | 8.52 KiB/op |
+| Component | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainEvent | 1 | thrpt | 691.01 k ops/s | - | 7.31 KiB/op |
+| Component | CommandPipelineComponentBenchmark.handleAggregateAndSendDomainStateEvents | 1 | thrpt | 582.13 k ops/s | - | 8.58 KiB/op |
+| Component | CommandPipelineComponentBenchmark.handleAggregateOnly | 1 | thrpt | 791.8 k ops/s | - | 6.95 KiB/op |
+| Component | CommandPipelineComponentBenchmark.handleAggregateWithoutRetry | 1 | thrpt | 901.83 k ops/s | - | 5.9 KiB/op |
+| Component | CommandValidationComponentBenchmark.validateCommandBody | 1 | thrpt | 9.51 M ops/s | - | 408.04 B/op |
+| Component | EventPublishComponentBenchmark.publishDomainEventStream | 1 | thrpt | 24.95 M ops/s | - | 112 B/op |
+| Component | EventStoreComponentBenchmark.appendInMemoryNewAggregateEventStream | 1 | thrpt | 15.05 M ops/s | - | 465.8 B/op |
+| Component | EventStoreComponentBenchmark.appendNoopEventStream | 1 | thrpt | 2.91 G ops/s | - | 6.3e-08 B/op |
+| Component | IdempotencyComponentBenchmark.checkKnownRequestId | 1 | thrpt | 20.7 M ops/s | - | 192.45 B/op |
 | Component | MongoDocumentComponentBenchmark.eventStreamToDocument | 1 | thrpt | 1.27 M ops/s | - | 4.23 KiB/op |
-| Component | SerializationComponentBenchmark.commandSerializeDeserialize | 1 | thrpt | 607.53 k ops/s | - | 5.52 KiB/op |
-| Component | SerializationComponentBenchmark.eventStreamSerializeDeserialize | 1 | thrpt | 450.57 k ops/s | - | 7.73 KiB/op |
-| Component | WaitNotifyComponentBenchmark.notifyProcessed | 1 | thrpt | 3.31 M ops/s | - | 1.46 KiB/op |
-| Component | WaitNotifyComponentBenchmark.registerWaitRegistration | 1 | thrpt | 31.03 M ops/s | - | 320 B/op |
-| Component | WaitNotifyComponentBenchmark.waitForProcessed | 1 | thrpt | 3.01 M ops/s | - | 1.72 KiB/op |
+| Component | SerializationComponentBenchmark.commandSerializeDeserialize | 1 | thrpt | 655.09 k ops/s | - | 5.55 KiB/op |
+| Component | SerializationComponentBenchmark.eventStreamSerializeDeserialize | 1 | thrpt | 468.13 k ops/s | - | 7.77 KiB/op |
+| Component | WaitNotifyComponentBenchmark.notifyProcessed | 1 | thrpt | 3.7 M ops/s | - | 1.41 KiB/op |
+| Component | WaitNotifyComponentBenchmark.registerWaitRegistration | 1 | thrpt | 32.06 M ops/s | - | 320 B/op |
+| Component | WaitNotifyComponentBenchmark.waitForProcessed | 1 | thrpt | 3.04 M ops/s | - | 1.72 KiB/op |
 
 ## WebFlux Adapter Results
 
@@ -333,40 +340,40 @@ Status: unavailable. Result files were not present. Run benchmarkQuickInfrastruc
 - **Source Row Count**: 30
 - **Parsed Row Count**: 30
 
-- **threads=1 Result File**: `wow-benchmarks/results/jmh/quick/webflux/threads-1-webflux.json`
-  - Last Modified: 2026-07-22T10:20:53.075Z
-- **threads=4 Result File**: `wow-benchmarks/results/jmh/quick/webflux/threads-4-webflux.json`
-  - Last Modified: 2026-07-22T10:21:34.251Z
+- **threads=1 Result File**: ` wow-benchmarks/results/jmh/quick/webflux/threads-1-webflux.json `
+  - Last Modified: 2026-08-05T06:37:31.224Z
+- **threads=4 Result File**: ` wow-benchmarks/results/jmh/quick/webflux/threads-4-webflux.json `
+  - Last Modified: 2026-08-05T06:38:12.071Z
 
 | Suite | Benchmark | Threads | Mode | Score | Error | gc.alloc.rate.norm |
 |-------|-----------|---------|------|-------|-------|-------------------|
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 1 | thrpt | 28.55 k ops/s | - | 79.81 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 4 | thrpt | 110.84 k ops/s | - | 78.07 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 1 | thrpt | 18.11 k ops/s | - | 165.09 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 4 | thrpt | 47.37 k ops/s | - | 162.48 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 1 | thrpt | 5.58 k ops/s | - | 742.58 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 4 | thrpt | 19.65 k ops/s | - | 737.23 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=1, traceWindowSize=10) | 1 | thrpt | 803.6 k ops/s | - | 3.23 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=1, traceWindowSize=10) | 4 | thrpt | 2.34 M ops/s | - | 3.19 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 1 | thrpt | 64.51 k ops/s | - | 36.45 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 4 | thrpt | 260.45 k ops/s | - | 35.85 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 1 | thrpt | 1.57 k ops/s | - | 2.84 MiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 4 | thrpt | 5.26 k ops/s | - | 2.82 MiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=1, traceWindowSize=10) | 1 | thrpt | 747.65 k ops/s | - | 3.76 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=1, traceWindowSize=10) | 4 | thrpt | 1.91 M ops/s | - | 3.72 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=10, traceWindowSize=10) | 1 | thrpt | 68.1 k ops/s | - | 36.89 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=10, traceWindowSize=10) | 4 | thrpt | 216.52 k ops/s | - | 36.38 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 1 | thrpt | 8.96 k ops/s | - | 435.8 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 4 | thrpt | 34.35 k ops/s | - | 434 KiB/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.commandResultJsonServerResponseOnly | 1 | thrpt | 831.41 k ops/s | - | 4.39 KiB/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.commandResultJsonServerResponseOnly | 4 | thrpt | 2.26 M ops/s | - | 4.36 KiB/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.extractPreparedCommandMessage | 1 | thrpt | 3.57 M ops/s | - | 1.35 KiB/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.extractPreparedCommandMessage | 4 | thrpt | 6.74 M ops/s | - | 1.33 KiB/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.handlePreparedAddCartItemRequestWaitSent | 1 | thrpt | 118.69 k ops/s | - | 11.08 KiB/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.handlePreparedAddCartItemRequestWaitSent | 4 | thrpt | 234.42 k ops/s | - | 10.96 KiB/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.sendWaitSentCoreFromExtractedMessage | 1 | thrpt | 1.05 M ops/s | - | 3.45 KiB/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.sendWaitSentCoreFromExtractedMessage | 4 | thrpt | 1.01 M ops/s | - | 3.46 KiB/op |
-| WebFlux Adapter | WebFluxResponseBenchmark.commandResultSseServerResponseOnly | 1 | thrpt | 1.84 M ops/s | - | 3.33 KiB/op |
-| WebFlux Adapter | WebFluxResponseBenchmark.commandResultSseServerResponseOnly | 4 | thrpt | 7.13 M ops/s | - | 3.21 KiB/op |
-| WebFlux Adapter | WebFluxResponseBenchmark.fluxJsonStreamingArrayServerResponseOnly | 1 | thrpt | 5.2 M ops/s | - | 1.05 KiB/op |
-| WebFlux Adapter | WebFluxResponseBenchmark.fluxJsonStreamingArrayServerResponseOnly | 4 | thrpt | 19.6 M ops/s | - | 1.04 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 1 | thrpt | 32.98 k ops/s | - | 79.46 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 4 | thrpt | 107.75 k ops/s | - | 78.1 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 1 | thrpt | 20.06 k ops/s | - | 165.36 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 4 | thrpt | 50.47 k ops/s | - | 162.88 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 1 | thrpt | 5.54 k ops/s | - | 746.02 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 4 | thrpt | 20.08 k ops/s | - | 738.42 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=1, traceWindowSize=10) | 1 | thrpt | 803.16 k ops/s | - | 3.29 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=1, traceWindowSize=10) | 4 | thrpt | 2.33 M ops/s | - | 3.25 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 1 | thrpt | 62.4 k ops/s | - | 37.12 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 4 | thrpt | 211.96 k ops/s | - | 36.55 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 1 | thrpt | 1.58 k ops/s | - | 2.85 MiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 4 | thrpt | 5.18 k ops/s | - | 2.83 MiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=1, traceWindowSize=10) | 1 | thrpt | 724.09 k ops/s | - | 3.82 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=1, traceWindowSize=10) | 4 | thrpt | 2.1 M ops/s | - | 3.78 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=10, traceWindowSize=10) | 1 | thrpt | 59.69 k ops/s | - | 37.64 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=10, traceWindowSize=10) | 4 | thrpt | 194.13 k ops/s | - | 37.06 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 1 | thrpt | 8.76 k ops/s | - | 439.38 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 4 | thrpt | 26.11 k ops/s | - | 435.86 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.commandResultJsonServerResponseOnly | 1 | thrpt | 802.38 k ops/s | - | 4.4 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.commandResultJsonServerResponseOnly | 4 | thrpt | 2.28 M ops/s | - | 4.35 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.extractPreparedCommandMessage | 1 | thrpt | 3.62 M ops/s | - | 1.35 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.extractPreparedCommandMessage | 4 | thrpt | 6.83 M ops/s | - | 1.33 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.handlePreparedAddCartItemRequestWaitSent | 1 | thrpt | 111.01 k ops/s | - | 11.12 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.handlePreparedAddCartItemRequestWaitSent | 4 | thrpt | 204.08 k ops/s | - | 10.88 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.sendWaitSentCoreFromExtractedMessage | 1 | thrpt | 283.68 k ops/s | - | 4.66 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.sendWaitSentCoreFromExtractedMessage | 4 | thrpt | 310.38 k ops/s | - | 4.63 KiB/op |
+| WebFlux Adapter | WebFluxResponseBenchmark.commandResultSseServerResponseOnly | 1 | thrpt | 1.79 M ops/s | - | 3.28 KiB/op |
+| WebFlux Adapter | WebFluxResponseBenchmark.commandResultSseServerResponseOnly | 4 | thrpt | 6.47 M ops/s | - | 3.28 KiB/op |
+| WebFlux Adapter | WebFluxResponseBenchmark.fluxJsonStreamingArrayServerResponseOnly | 1 | thrpt | 5.05 M ops/s | - | 1.04 KiB/op |
+| WebFlux Adapter | WebFluxResponseBenchmark.fluxJsonStreamingArrayServerResponseOnly | 4 | thrpt | 20.2 M ops/s | - | 1.03 KiB/op |

--- a/wow-benchmarks/results/reports/quick-webflux.md
+++ b/wow-benchmarks/results/reports/quick-webflux.md
@@ -12,29 +12,36 @@ Quick WebFlux results are short-loop local feedback for command dispatch, respon
 - Throughput uses decimal prefixes: `k` = 1,000, `M` = 1,000,000, `G` = 1,000,000,000.
 - Allocation uses binary prefixes: `KiB` = 1,024 bytes, `MiB` = 1,048,576 bytes.
 - Every displayed score and error keeps its scaled unit attached, for example `1.57 k ops/s`.
-- Average latency is automatically scaled to `ns/op`, `µs/op`, `ms/op`, or `s/op`.
+- Average-time results are automatically scaled to `ns/op`, `µs/op`, `ms/op`, or `s/op`.
 - `±` is the JMH-reported error. Scaling changes presentation only; calculations keep raw precision.
 
 ## Benchmark Run Provenance
-- **Source Commit**: `07fcba8b412f7250b547425289ad0ef218ba8bde`
+- **Source Commit**: `adcf1080df0d2bac2a8cca2e9f63ec0302da3d2a`
 - **Source Dirty**: `false`
-- **Project Version**: `8.9.0`
-- **JMH Jar SHA-256**: `1d5902b9f334f5f771736a2933ad577f157440513808ff2bd5a15179acf3332e`
+- **Project Version**: `8.10.4`
+- **JMH Jar SHA-256**: `85ddc559cd882343e027133cb2c9e3db27632711420132bf97860168d7aad93a`
 - **Runtime JVM**: OpenJDK 64-Bit Server VM 17.0.7+7-LTS / Java 17.0.7
 - **Runtime OS**: Mac OS X 26.5.2 aarch64
 - **CPU Cores**: 14
 - **Physical Memory**: 24.0 GiB
 
+### Manifest-bound Run-Time Infrastructure
+
+- **Captured At**: 2026-08-05T06:36:50.676466Z to 2026-08-05T06:38:12.090971Z
+- **Benchmark Client**: host JVM
+- **Docker Server**: not required by these suites
+- **Local Docker Containers**: none required; service endpoints remain bound in each run manifest.
+
 | Suite | Profile | Threads | Run ID | Started | Completed | Profilers | Rows | Result SHA-256 |
 |-------|---------|---------|--------|---------|-----------|-----------|------|----------------|
-| webflux | quick | 1 | `b1bd4033-0cc9-4f9c-9d2a-404d7f7596c9` | 2026-07-22T10:20:12.211184Z | 2026-07-22T10:20:53.094047Z | `-prof gc` | 15 | `ecac86721ed4c2b6661b826f7873d7389df29798ec6f283de23c687117a99ef4` |
-| webflux | quick | 4 | `b1bd4033-0cc9-4f9c-9d2a-404d7f7596c9` | 2026-07-22T10:20:53.135051Z | 2026-07-22T10:21:34.267333Z | `-prof gc` | 15 | `3524838dc170d0e096898884580397abb16fb8e825839bb842b705993804d91c` |
+| webflux | quick | 1 | `793e57c4-3374-44ea-a1c5-0d57f312c8d8` | 2026-08-05T06:36:50.676489Z | 2026-08-05T06:37:31.243716Z | `-prof gc` | 15 | `e92c518426eaf6efab022b518de28edbe6c3526259f051a97b018d818fb021e4` |
+| webflux | quick | 4 | `793e57c4-3374-44ea-a1c5-0d57f312c8d8` | 2026-08-05T06:37:31.288159Z | 2026-08-05T06:38:12.091083Z | `-prof gc` | 15 | `0fcef87d5ef1dfa8568f00c70690c4397a4ebb8491b053861a4213c6c3e60187` |
 
 ## Report Generation Environment
-- **Version**: 8.9.0
+- **Version**: 8.10.4
 - **JVM**: OpenJDK 64-Bit Server VM 17.0.7+7-LTS
 - **OS**: Mac OS X 26.5.2 aarch64
-- **Generated At**: 2026-07-22T20:44:31+08:00
+- **Generated At**: 2026-08-05T14:42:12+08:00
 - **CPU Cores**: 14
 - **Physical Memory**: 24.0 GiB
 - **Benchmark JVM Args**: `-Xmx1g -Xms1g -XX:+UseG1GC`
@@ -42,10 +49,10 @@ Quick WebFlux results are short-loop local feedback for command dispatch, respon
 
 ## Source Files
 
-- **threads=1 Result File**: `wow-benchmarks/results/jmh/quick/webflux/threads-1-webflux.json`
-  - Last Modified: 2026-07-22T10:20:53.075Z
-- **threads=4 Result File**: `wow-benchmarks/results/jmh/quick/webflux/threads-4-webflux.json`
-  - Last Modified: 2026-07-22T10:21:34.251Z
+- **threads=1 Result File**: ` wow-benchmarks/results/jmh/quick/webflux/threads-1-webflux.json `
+  - Last Modified: 2026-08-05T06:37:31.224Z
+- **threads=4 Result File**: ` wow-benchmarks/results/jmh/quick/webflux/threads-4-webflux.json `
+  - Last Modified: 2026-08-05T06:38:12.071Z
 
 ## Bottlenecks
 
@@ -53,63 +60,63 @@ Quick WebFlux results are short-loop local feedback for command dispatch, respon
 
 | Suite | Threads | Benchmark | Score | Error |
 |-------|---------|-----------|-------|-------|
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 1.57 k ops/s | - |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 5.26 k ops/s | - |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 5.58 k ops/s | - |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 8.96 k ops/s | - |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 18.11 k ops/s | - |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 19.65 k ops/s | - |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 28.55 k ops/s | - |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 34.35 k ops/s | - |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 47.37 k ops/s | - |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 64.51 k ops/s | - |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 1.58 k ops/s | - |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 5.18 k ops/s | - |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 5.54 k ops/s | - |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 8.76 k ops/s | - |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 20.06 k ops/s | - |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 20.08 k ops/s | - |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 26.11 k ops/s | - |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 32.98 k ops/s | - |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 50.47 k ops/s | - |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=10, traceWindowSize=10) | 59.69 k ops/s | - |
 
 ### Highest Allocation
 
 | Suite | Threads | Benchmark | Mode | Allocation | Allocation Error | Score |
 |-------|---------|-----------|------|------------|------------------|-------|
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2.84 MiB/op | - | 1.57 k ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2.82 MiB/op | - | 5.26 k ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 742.58 KiB/op | - | 5.58 k ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 737.23 KiB/op | - | 19.65 k ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 435.8 KiB/op | - | 8.96 k ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 434 KiB/op | - | 34.35 k ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 165.09 KiB/op | - | 18.11 k ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 162.48 KiB/op | - | 47.37 k ops/s |
-| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 79.81 KiB/op | - | 28.55 k ops/s |
-| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 78.07 KiB/op | - | 110.84 k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2.85 MiB/op | - | 1.58 k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | thrpt | 2.83 MiB/op | - | 5.18 k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 746.02 KiB/op | - | 5.54 k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 738.42 KiB/op | - | 20.08 k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 439.38 KiB/op | - | 8.76 k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | thrpt | 435.86 KiB/op | - | 26.11 k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 165.36 KiB/op | - | 20.06 k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | thrpt | 162.88 KiB/op | - | 50.47 k ops/s |
+| WebFlux Adapter | 1 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 79.46 KiB/op | - | 32.98 k ops/s |
+| WebFlux Adapter | 4 | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | thrpt | 78.1 KiB/op | - | 107.75 k ops/s |
 
 ## Results
 
 | Suite | Benchmark | Threads | Mode | Score | Error | gc.alloc.rate.norm |
 |-------|-----------|---------|------|-------|-------|-------------------|
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 1 | thrpt | 28.55 k ops/s | - | 79.81 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 4 | thrpt | 110.84 k ops/s | - | 78.07 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 1 | thrpt | 18.11 k ops/s | - | 165.09 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 4 | thrpt | 47.37 k ops/s | - | 162.48 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 1 | thrpt | 5.58 k ops/s | - | 742.58 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 4 | thrpt | 19.65 k ops/s | - | 737.23 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=1, traceWindowSize=10) | 1 | thrpt | 803.6 k ops/s | - | 3.23 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=1, traceWindowSize=10) | 4 | thrpt | 2.34 M ops/s | - | 3.19 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 1 | thrpt | 64.51 k ops/s | - | 36.45 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 4 | thrpt | 260.45 k ops/s | - | 35.85 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 1 | thrpt | 1.57 k ops/s | - | 2.84 MiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 4 | thrpt | 5.26 k ops/s | - | 2.82 MiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=1, traceWindowSize=10) | 1 | thrpt | 747.65 k ops/s | - | 3.76 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=1, traceWindowSize=10) | 4 | thrpt | 1.91 M ops/s | - | 3.72 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=10, traceWindowSize=10) | 1 | thrpt | 68.1 k ops/s | - | 36.89 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=10, traceWindowSize=10) | 4 | thrpt | 216.52 k ops/s | - | 36.38 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 1 | thrpt | 8.96 k ops/s | - | 435.8 KiB/op |
-| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 4 | thrpt | 34.35 k ops/s | - | 434 KiB/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.commandResultJsonServerResponseOnly | 1 | thrpt | 831.41 k ops/s | - | 4.39 KiB/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.commandResultJsonServerResponseOnly | 4 | thrpt | 2.26 M ops/s | - | 4.36 KiB/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.extractPreparedCommandMessage | 1 | thrpt | 3.57 M ops/s | - | 1.35 KiB/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.extractPreparedCommandMessage | 4 | thrpt | 6.74 M ops/s | - | 1.33 KiB/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.handlePreparedAddCartItemRequestWaitSent | 1 | thrpt | 118.69 k ops/s | - | 11.08 KiB/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.handlePreparedAddCartItemRequestWaitSent | 4 | thrpt | 234.42 k ops/s | - | 10.96 KiB/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.sendWaitSentCoreFromExtractedMessage | 1 | thrpt | 1.05 M ops/s | - | 3.45 KiB/op |
-| WebFlux Adapter | CommandHandlerFunctionBenchmark.sendWaitSentCoreFromExtractedMessage | 4 | thrpt | 1.01 M ops/s | - | 3.46 KiB/op |
-| WebFlux Adapter | WebFluxResponseBenchmark.commandResultSseServerResponseOnly | 1 | thrpt | 1.84 M ops/s | - | 3.33 KiB/op |
-| WebFlux Adapter | WebFluxResponseBenchmark.commandResultSseServerResponseOnly | 4 | thrpt | 7.13 M ops/s | - | 3.21 KiB/op |
-| WebFlux Adapter | WebFluxResponseBenchmark.fluxJsonStreamingArrayServerResponseOnly | 1 | thrpt | 5.2 M ops/s | - | 1.05 KiB/op |
-| WebFlux Adapter | WebFluxResponseBenchmark.fluxJsonStreamingArrayServerResponseOnly | 4 | thrpt | 19.6 M ops/s | - | 1.04 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 1 | thrpt | 32.98 k ops/s | - | 79.46 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=1, traceWindowSize=10) | 4 | thrpt | 107.75 k ops/s | - | 78.1 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 1 | thrpt | 20.06 k ops/s | - | 165.36 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=10, traceWindowSize=10) | 4 | thrpt | 50.47 k ops/s | - | 162.88 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 1 | thrpt | 5.54 k ops/s | - | 746.02 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.handleTailLimitRequestAndSerialize (eventCount=100, traceWindowSize=10) | 4 | thrpt | 20.08 k ops/s | - | 738.42 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=1, traceWindowSize=10) | 1 | thrpt | 803.16 k ops/s | - | 3.29 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=1, traceWindowSize=10) | 4 | thrpt | 2.33 M ops/s | - | 3.25 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 1 | thrpt | 62.4 k ops/s | - | 37.12 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=10, traceWindowSize=10) | 4 | thrpt | 211.96 k ops/s | - | 36.55 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 1 | thrpt | 1.58 k ops/s | - | 2.85 MiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceAndSerializeCartHistory (eventCount=100, traceWindowSize=10) | 4 | thrpt | 5.18 k ops/s | - | 2.83 MiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=1, traceWindowSize=10) | 1 | thrpt | 724.09 k ops/s | - | 3.82 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=1, traceWindowSize=10) | 4 | thrpt | 2.1 M ops/s | - | 3.78 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=10, traceWindowSize=10) | 1 | thrpt | 59.69 k ops/s | - | 37.64 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=10, traceWindowSize=10) | 4 | thrpt | 194.13 k ops/s | - | 37.06 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 1 | thrpt | 8.76 k ops/s | - | 439.38 KiB/op |
+| WebFlux Adapter | AggregateTracingBenchmark.traceWindowWithPrefixReplayAndSerialize (eventCount=100, traceWindowSize=10) | 4 | thrpt | 26.11 k ops/s | - | 435.86 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.commandResultJsonServerResponseOnly | 1 | thrpt | 802.38 k ops/s | - | 4.4 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.commandResultJsonServerResponseOnly | 4 | thrpt | 2.28 M ops/s | - | 4.35 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.extractPreparedCommandMessage | 1 | thrpt | 3.62 M ops/s | - | 1.35 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.extractPreparedCommandMessage | 4 | thrpt | 6.83 M ops/s | - | 1.33 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.handlePreparedAddCartItemRequestWaitSent | 1 | thrpt | 111.01 k ops/s | - | 11.12 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.handlePreparedAddCartItemRequestWaitSent | 4 | thrpt | 204.08 k ops/s | - | 10.88 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.sendWaitSentCoreFromExtractedMessage | 1 | thrpt | 283.68 k ops/s | - | 4.66 KiB/op |
+| WebFlux Adapter | CommandHandlerFunctionBenchmark.sendWaitSentCoreFromExtractedMessage | 4 | thrpt | 310.38 k ops/s | - | 4.63 KiB/op |
+| WebFlux Adapter | WebFluxResponseBenchmark.commandResultSseServerResponseOnly | 1 | thrpt | 1.79 M ops/s | - | 3.28 KiB/op |
+| WebFlux Adapter | WebFluxResponseBenchmark.commandResultSseServerResponseOnly | 4 | thrpt | 6.47 M ops/s | - | 3.28 KiB/op |
+| WebFlux Adapter | WebFluxResponseBenchmark.fluxJsonStreamingArrayServerResponseOnly | 1 | thrpt | 5.05 M ops/s | - | 1.04 KiB/op |
+| WebFlux Adapter | WebFluxResponseBenchmark.fluxJsonStreamingArrayServerResponseOnly | 4 | thrpt | 20.2 M ops/s | - | 1.03 KiB/op |


### PR DESCRIPTION
## Summary

- Refresh the generated Framework E2E, grouped, WebFlux, and Batch CommandWrite Quick benchmark reports for project version 8.10.4.
- Re-run the Quick Framework/Component/WebFlux and Batch suites with manifest-bound provenance; all four reports record `Source Dirty: false`.
- Keep the formal baseline and historical Mongo tuning reports unchanged because their protocols and scope are different.

## Validation

- `./gradlew :wow-benchmarks:benchmarkQuickE2E :wow-benchmarks:benchmarkQuickComponent :wow-benchmarks:benchmarkQuickWebFlux :wow-benchmarks:generateQuickBenchmarkReport :wow-benchmarks:benchmarkQuickBatchE2E :wow-benchmarks:generateBatchBenchmarkReport -PbenchmarkQuickThreads=1,4 -PbenchmarkQuickComponentThreads=1 -PbenchmarkQuickWebFluxThreads=1,4 --no-parallel`
- `./gradlew :wow-benchmarks:generateBenchmarkReport :wow-benchmarks:generateQuickWebFluxBenchmarkReport --no-parallel`
- `./gradlew :wow-benchmarks:benchmarkSmoke :wow-benchmarks:check --no-parallel`

Quick results are directional local feedback and do not replace the accepted formal baseline.