### PR TITLE
docs(benchmarks): refresh Mongo batch E2E report

### DIFF
--- a/wow-benchmarks/results/reports/quick-mongo-batch-append-candidate-e2e.md
+++ b/wow-benchmarks/results/reports/quick-mongo-batch-append-candidate-e2e.md
@@ -16,10 +16,10 @@ This bounded engineering experiment compares EventStore insertOne, native unorde
 - `±` is the JMH-reported error. Scaling changes presentation only; calculations keep raw precision.
 
 ## Benchmark Run Provenance
-- **Source Commit**: `587604827df58276ea4232aa7e79bd8c9faf9be3`
+- **Source Commit**: `204754948d315cbf220cb515592b44934621230c`
 - **Source Dirty**: `false`
-- **Project Version**: `8.9.1`
-- **JMH Jar SHA-256**: `4d3fc4661c2e8a53c85c72124514e3ed0ff322d15bc9687df3f8b0c48b32febf`
+- **Project Version**: `8.10.4`
+- **JMH Jar SHA-256**: `85ddc559cd882343e027133cb2c9e3db27632711420132bf97860168d7aad93a`
 - **Runtime JVM**: OpenJDK 64-Bit Server VM 17.0.7+7-LTS / Java 17.0.7
 - **Runtime OS**: Mac OS X 26.5.2 aarch64
 - **CPU Cores**: 14
@@ -28,13 +28,13 @@ This bounded engineering experiment compares EventStore insertOne, native unorde
 
 ### Manifest-bound Run-Time Infrastructure
 
-- **Captured At**: 2026-07-27T08:30:00.022841Z to 2026-07-27T08:31:29.572711Z
+- **Captured At**: 2026-08-05T07:28:54.816944Z to 2026-08-05T07:30:24.641779Z
 - **Benchmark Client**: host JVM
 - **Docker Server**: Server=29.6.2 CPUs=4 Memory=5.8 GiB Kernel=6.12.76-linuxkit
 - **Mongo Container**: ` wow-benchmark-mongo `
   - Running: `true`
   - Container ID: ` 39316b50739e6e6e41b3c12f543bf6de3a35de90794cf467b08b992d01970612 `
-  - Started At: ` 2026-07-26T16:23:47.551143055Z `
+  - Started At: ` 2026-08-05T07:28:32.511412888Z `
   - Image: ` mongo:8.3.4 `
   - Image ID: ` sha256:6818b4556f741c6d220e7edf3d51730719d965f51d5c4e80ac9e0eeafcaac94d `
   - Repo Digests: ` mongo@sha256:48a009d2d8007e92d6d7e8baa31713cd11c48c06e827e856240e5a1d319b49d9 `
@@ -45,14 +45,14 @@ This bounded engineering experiment compares EventStore insertOne, native unorde
 
 | Suite | Profile | Threads | Run ID | Started | Completed | Profilers | Rows | Result SHA-256 |
 |-------|---------|---------|--------|---------|-----------|-----------|------|----------------|
-| mongo-batch-append-quick-engineering | quick-mongo-candidate-e2e | 1 | `064986b8-7918-457e-9385-eb128a96638c` | 2026-07-27T08:30:00.022869Z | 2026-07-27T08:30:40.639173Z | `-prof gc` | 6 | `12eab7d63ff89d1cca4a0866efbd333ccf759c080260fa7a26e4358eef6ff5a1` |
-| mongo-batch-append-quick-engineering | quick-mongo-candidate-e2e | 4 | `064986b8-7918-457e-9385-eb128a96638c` | 2026-07-27T08:30:40.831933Z | 2026-07-27T08:31:29.573282Z | `-prof gc` | 6 | `5cb7f47159efc3a988caec6b726af22fd435fbaad6930017603dc2094d329d0c` |
+| mongo-batch-append-quick-engineering | quick-mongo-candidate-e2e | 1 | `b1e4ae16-9c4d-4c02-ba9e-4d21af4d0816` | 2026-08-05T07:28:54.817769Z | 2026-08-05T07:29:35.614533Z | `-prof gc` | 6 | `c8f29960dd97c0ca19313151401950f8038d9739e775c4b7d405b8a5367d7c97` |
+| mongo-batch-append-quick-engineering | quick-mongo-candidate-e2e | 4 | `b1e4ae16-9c4d-4c02-ba9e-4d21af4d0816` | 2026-08-05T07:29:35.823021Z | 2026-08-05T07:30:24.642170Z | `-prof gc` | 6 | `8702335f46d39ffcd8a13c9d4862cbbe45bdad795e22eb03e4a37759eb09eefd` |
 
 ## Report Generation Environment
-- **Version**: 8.9.1
+- **Version**: 8.10.4
 - **JVM**: OpenJDK 64-Bit Server VM 17.0.7+7-LTS
 - **OS**: Mac OS X 26.5.2 aarch64
-- **Generated At**: 2026-07-27T16:32:47+08:00
+- **Generated At**: 2026-08-05T15:30:24+08:00
 - **CPU Cores**: 14
 - **Physical Memory**: 24.0 GiB
 - **Benchmark JVM Args**: `-Xmx1g -Xms1g -XX:+UseG1GC`
@@ -73,14 +73,14 @@ This section is live diagnostic context only. Manifest-bound run-time container 
 
 ## Three-Layer JMH Comparison
 
-Each invocation writes 128 independent event streams and JMH normalizes scores per event stream. The three layers distinguish single-request protocol cost, native storage bulk capability, and the end-to-end coordinator path. The coordinated path includes batch formation and may flush a partial batch on `maxDelay`, so its delta from native Bulk is not a pure coordinator CPU-cost estimate.
+Each invocation writes 128 independent event streams and JMH normalizes scores per event. The three layers distinguish single-request protocol cost, native storage bulk capability, and the end-to-end coordinator path. The coordinated path includes batch formation and may flush a partial batch on `maxDelay`, so its delta from native Bulk is not a pure coordinator CPU-cost estimate.
 
 ### Throughput
 
 | JMH Threads | Parameters | EventStore insertOne | Native insertMany | Coordinated batch | Native vs single | Coordinated vs single | Coordinated vs native |
 |-------------|------------|--------|--------|--------|------------------|-----------------------|-----------------------|
-| 1 | `batchOptions=192x250us` | 28.02 k ops/s | 53.69 k ops/s | 47.45 k ops/s | +91.6% | +69.3% | -11.6% |
-| 4 | `batchOptions=192x250us` | 36.99 k ops/s | 119.03 k ops/s | 48.91 k ops/s | +221.8% | +32.2% | -58.9% |
+| 1 | `batchOptions=192x250us` | 18.48 k ops/s | 56.94 k ops/s | 38.64 k ops/s | +208.1% | +109.1% | -32.1% |
+| 4 | `batchOptions=192x250us` | 24.99 k ops/s | 105.98 k ops/s | 55.66 k ops/s | +324.0% | +122.7% | -47.5% |
 
 Higher throughput is better; positive changes are gains.
 
@@ -88,8 +88,8 @@ Higher throughput is better; positive changes are gains.
 
 | JMH Threads | Parameters | EventStore insertOne | Native insertMany | Coordinated batch | Native vs single | Coordinated vs single | Coordinated vs native |
 |-------------|------------|--------|--------|--------|------------------|-----------------------|-----------------------|
-| 1 | `batchOptions=192x250us` | 33.74 µs/op | 17.33 µs/op | 20.06 µs/op | +48.6% | +40.5% | -15.8% |
-| 4 | `batchOptions=192x250us` | 93.28 µs/op | 31.58 µs/op | 73.49 µs/op | +66.1% | +21.2% | -132.7% |
+| 1 | `batchOptions=192x250us` | 41.72 µs/op | 17.43 µs/op | 20.75 µs/op | +58.2% | +50.3% | -19.0% |
+| 4 | `batchOptions=192x250us` | 126.57 µs/op | 33.99 µs/op | 79.66 µs/op | +73.1% | +37.1% | -134.4% |
 
 Lower amortized time is better. JMH divides each 128-event invocation's wall time by 128; this is not an independent single-request response latency. The two `vs single` columns and `Coordinated vs native` all report time reduction, so positive changes are gains.
 
@@ -97,15 +97,15 @@ Lower amortized time is better. JMH divides each 128-event invocation's wall tim
 
 | Suite | Benchmark | Threads | Mode | Score | Error | gc.alloc.rate.norm |
 |-------|-----------|---------|------|-------|-------|-------------------|
-| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithInsertManyBatch (batchOptions=192x250us) | 1 | avgt | 20.06 µs/op | - | 8.59 KiB/op |
-| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithInsertManyBatch (batchOptions=192x250us) | 1 | thrpt | 47.45 k ops/s | - | 8.58 KiB/op |
-| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithInsertManyBatch (batchOptions=192x250us) | 4 | avgt | 73.49 µs/op | - | 8.74 KiB/op |
-| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithInsertManyBatch (batchOptions=192x250us) | 4 | thrpt | 48.91 k ops/s | - | 9.08 KiB/op |
-| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithInsertOne (batchOptions=192x250us) | 1 | avgt | 33.74 µs/op | - | 18.98 KiB/op |
-| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithInsertOne (batchOptions=192x250us) | 1 | thrpt | 28.02 k ops/s | - | 19.21 KiB/op |
-| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithInsertOne (batchOptions=192x250us) | 4 | avgt | 93.28 µs/op | - | 19.31 KiB/op |
-| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithInsertOne (batchOptions=192x250us) | 4 | thrpt | 36.99 k ops/s | - | 19.28 KiB/op |
-| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithNativeInsertMany (batchOptions=192x250us) | 1 | avgt | 17.33 µs/op | - | 7.49 KiB/op |
-| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithNativeInsertMany (batchOptions=192x250us) | 1 | thrpt | 53.69 k ops/s | - | 7.49 KiB/op |
-| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithNativeInsertMany (batchOptions=192x250us) | 4 | avgt | 31.58 µs/op | - | 7.54 KiB/op |
-| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithNativeInsertMany (batchOptions=192x250us) | 4 | thrpt | 119.03 k ops/s | - | 7.51 KiB/op |
+| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithInsertManyBatch (batchOptions=192x250us) | 1 | avgt | 20.75 µs/op | - | 8.58 KiB/op |
+| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithInsertManyBatch (batchOptions=192x250us) | 1 | thrpt | 38.64 k ops/s | - | 8.62 KiB/op |
+| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithInsertManyBatch (batchOptions=192x250us) | 4 | avgt | 79.66 µs/op | - | 8.72 KiB/op |
+| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithInsertManyBatch (batchOptions=192x250us) | 4 | thrpt | 55.66 k ops/s | - | 8.71 KiB/op |
+| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithInsertOne (batchOptions=192x250us) | 1 | avgt | 41.72 µs/op | - | 19.27 KiB/op |
+| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithInsertOne (batchOptions=192x250us) | 1 | thrpt | 18.48 k ops/s | - | 19.53 KiB/op |
+| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithInsertOne (batchOptions=192x250us) | 4 | avgt | 126.57 µs/op | - | 19.31 KiB/op |
+| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithInsertOne (batchOptions=192x250us) | 4 | thrpt | 24.99 k ops/s | - | 19.34 KiB/op |
+| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithNativeInsertMany (batchOptions=192x250us) | 1 | avgt | 17.43 µs/op | - | 7.52 KiB/op |
+| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithNativeInsertMany (batchOptions=192x250us) | 1 | thrpt | 56.94 k ops/s | - | 7.49 KiB/op |
+| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithNativeInsertMany (batchOptions=192x250us) | 4 | avgt | 33.99 µs/op | - | 7.54 KiB/op |
+| Quick Mongo Batch Candidate E2E | MongoEventStoreAppendBenchmark.appendWithNativeInsertMany (batchOptions=192x250us) | 4 | thrpt | 105.98 k ops/s | - | 7.54 KiB/op |


### PR DESCRIPTION
## Summary

- Refresh the generated Mongo Batch Candidate E2E report with a clean-source run on MongoDB.
- Record current EventStore `insertOne`, native unordered `insertMany`, and coordinated `BatchCoordinator` results for JMH threads 1 and 4.
- Keep the production `batchOptions` default unchanged; this remains directional engineering evidence.

## Validation

- `./gradlew :wow-benchmarks:benchmarkQuickMongoBatchAppendCandidateE2E :wow-benchmarks:generateQuickMongoBatchAppendCandidateE2EReport --no-parallel --no-daemon`
- `./gradlew :wow-benchmarks:benchmarkSmoke :wow-benchmarks:check --no-parallel`
- `git diff --check`

The report is bound to the successful thread-level manifests and real local MongoDB `mongo:8.3.4` infrastructure. Quick results are not a production-capacity claim.