### PR TITLE
fix(docs): correct Mermaid class diagram syntax

### DIFF
--- a/documentation/docs/zh/articles/traditional-vs-wow-architecture.md
+++ b/documentation/docs/zh/articles/traditional-vs-wow-architecture.md
@@ -88,7 +88,11 @@ classDiagram
     Cart --> CartQuantityChanged : produces
 
     classDef domain fill:#2d333b,stroke:#6d5dfc,color:#e6edf3
-    class Cart,CartState,AddCartItem,CartItemAdded,CartQuantityChanged domain
+    class Cart domain
+    class CartState domain
+    class AddCartItem domain
+    class CartItemAdded domain
+    class CartQuantityChanged domain
 ```
 
 <!-- Sources: example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/Cart.kt:35-77, example/example-domain/src/main/kotlin/me/ahoo/wow/example/domain/cart/CartState.kt:28-67 -->


### PR DESCRIPTION
## 变更
修复中文文档文章 `traditional-vs-wow-architecture` 中 `classDiagram` 的 Mermaid 语法：将逗号分隔的批量 `class` 样式声明改为逐类声明，避免站点运行时解析失败。

## 验证
- `git diff --cached --check`
- `cd documentation && pnpm docs:build`
