### PR TITLE
refactor(query): add semantic kernel

### DIFF
--- a/document/design/2026-08-06-query-service-architecture-upgrade.md
+++ b/document/design/2026-08-06-query-service-architecture-upgrade.md
@@ -633,7 +633,7 @@ mapping `_meta` 保存 mapping version、document kind 和 capability digest。�
 | Phase | 当前证据 | 状态 |
 |---|---|---|
 | 0 | `QueryHandler` 已形成单一 defer/fail-closed 边界；EventStream factory 已使用 materialized key 与并发缓存；对应同步、异步、partial Flux、cancel、direct handle 和多订阅测试已存在 | 已实现，待 PR #2908 合并 |
-| 1 | 仓库中不存在 `QueryInvocation`、`NormalizedCondition`、`QueryPlan`、Normalizer、Planner 或 analytics model | 未开始 |
+| 1 | P1-A 已在 stacked 分支引入 internal `QueryInvocation`、`NormalizedCondition`、`QueryPlan` 与最小 analytics model；尚无 Normalizer、Planner 或运行时接线 | P1-A 已实现，P1-B/P1-C 未开始 |
 | 2 | Spring Registrar 仍从 storage `QueryServiceFactory` 直接创建 Bean；WebFlux 仍直接调用 legacy `QueryHandler` | 未开始 |
 | 3 | MongoDB 查询仍由 `AbstractMongoQueryService` 直接执行 `find/countDocuments`，没有 planned compiler、Backend、单操作 page 或 aggregation pipeline | 未开始 |
 | 4 | Elasticsearch 查询仍使用 `from/size` 和 hits/count，没有 field binding、readiness、完整性 validator、PIT 或 composite aggregation | 未开始 |
@@ -697,12 +697,19 @@ Phase 0 提交，不涉及配置、索引或数据。
   `QueryInvocation`、operation/result shape、
   execution/validation mode、无 `Any` 的 `NormalizedValue/NormalizedCondition`、record/analytics plan skeleton；
 - analytics grouping 建模为 `Global | By(NonEmptyList<Dimension>)`，支持合法的无 `GROUP BY` 全局统计；
-- 所有 collection/map/bytes 在边界防御复制，不能用 Kotlin read-only interface 冒充深度不可变；
+- `QueryInvocation` 是每订阅创建、不得比较或缓存的临时 envelope；其中 legacy wire DTO 保持原样，深度不可变
+  从 admitted snapshot/normalized query 边界开始；
+- normalized condition/value、analytics model 与 Plan 的所有 collection/map/bytes 在边界防御复制，不能用
+  Kotlin read-only interface 冒充深度不可变；
+- Kotlin `internal` 类型在 JVM 字节码中仍可能表现为 public class；它们位于 internal package 且不进入受支持
+  API，兼容性声明不得表述为“JAR 严格零 ABI diff”；
 - 不加 Jackson/Swagger 注解，不修改 `wow-api`、`QueryService` 或 `QueryType`，不发布 cursor codec。
 
 #### P1-B：Admission 与 Normalizer
 
 - 实现内部具体 `RawAdmissionGuard` 与 `QueryNormalizer`，不先开放 SPI；
+- admission 必须在一次有界遍历中完成校验与防御性物化，产出 immutable admitted snapshot；Normalizer
+  只能读取该 snapshot，禁止校验后再次读取调用方的动态 getter、`Any`、List、Map 或 ByteArray；
 - 固化深度/节点/字段/value/options 大小，递归 `AND/OR/NOR`、`ELEM_MATCH` 相对字段、system field、
   projection、sort、limit 和 page 规则；
 - 每次 normalization 只读取一次 `Clock.instant()`；时间范围使用半开区间；

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/analytics/AnalyticsModel.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/analytics/AnalyticsModel.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.internal.analytics
+
+import me.ahoo.wow.query.internal.normalization.LogicalField
+import me.ahoo.wow.query.internal.normalization.NormalizedCondition
+import me.ahoo.wow.query.internal.value.NonEmptyList
+
+@JvmInline
+internal value class AnalyticsAlias(val value: String) {
+    init {
+        require(value.isNotBlank()) {
+            "Analytics alias must not be blank."
+        }
+    }
+}
+
+internal data class AnalyticsDimension(
+    val alias: AnalyticsAlias,
+    val field: LogicalField,
+)
+
+internal sealed interface AnalyticsGrouping {
+    data object Global : AnalyticsGrouping
+
+    data class By(val dimensions: NonEmptyList<AnalyticsDimension>) : AnalyticsGrouping
+}
+
+internal sealed interface AnalyticsMetric {
+    val alias: AnalyticsAlias
+
+    data class DocumentCount(
+        override val alias: AnalyticsAlias,
+    ) : AnalyticsMetric
+
+    data class Min(
+        override val alias: AnalyticsAlias,
+        val field: LogicalField,
+    ) : AnalyticsMetric
+
+    data class Max(
+        override val alias: AnalyticsAlias,
+        val field: LogicalField,
+    ) : AnalyticsMetric
+
+    data class Sum(
+        override val alias: AnalyticsAlias,
+        val field: LogicalField,
+    ) : AnalyticsMetric
+
+    data class Average(
+        override val alias: AnalyticsAlias,
+        val field: LogicalField,
+    ) : AnalyticsMetric
+}
+
+/**
+ * Backend-independent analytics input after its future wire adapter has normalized field and value semantics.
+ * It remains internal until the public analytics contract is introduced in a later phase.
+ */
+internal data class AnalyticsQuery(
+    val userCondition: NormalizedCondition,
+    val grouping: AnalyticsGrouping,
+    val metrics: NonEmptyList<AnalyticsMetric>,
+)

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/model/QueryInvocation.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/model/QueryInvocation.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.internal.model
+
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.IListQuery
+import me.ahoo.wow.api.query.IPagedQuery
+import me.ahoo.wow.api.query.ISingleQuery
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.modeling.materialize
+import me.ahoo.wow.query.internal.analytics.AnalyticsQuery
+
+internal enum class QueryDocumentKind {
+    SNAPSHOT,
+    EVENT_STREAM,
+}
+
+internal class QueryTarget(
+    namedAggregate: NamedAggregate,
+    val documentKind: QueryDocumentKind,
+) {
+    val namedAggregate: MaterializedNamedAggregate = namedAggregate.materialize()
+
+    override fun equals(other: Any?): Boolean =
+        this === other ||
+            other is QueryTarget &&
+            namedAggregate == other.namedAggregate &&
+            documentKind == other.documentKind
+
+    override fun hashCode(): Int = 31 * namedAggregate.hashCode() + documentKind.hashCode()
+
+    override fun toString(): String =
+        "QueryTarget(namedAggregate=$namedAggregate, documentKind=$documentKind)"
+}
+
+internal enum class QueryOperation {
+    SINGLE,
+    STREAM,
+    PAGE,
+    COUNT,
+    ANALYZE,
+}
+
+internal enum class QueryResultShape {
+    TYPED,
+    DYNAMIC,
+    COUNT,
+    ANALYTICS,
+}
+
+internal enum class RecordResultShape {
+    TYPED,
+    DYNAMIC,
+}
+
+internal enum class QueryExecutionMode {
+    LEGACY,
+    SHADOW,
+    PLANNED,
+}
+
+internal enum class QueryValidationMode {
+    COMPATIBLE,
+    STRICT,
+}
+
+/**
+ * Invocation input at the application boundary.
+ *
+ * Record variants deliberately retain the existing wire DTO so the compatibility adapter can admit and normalize it.
+ * They are ephemeral references rather than value objects and must never be cached or used as map keys. The gateway
+ * creates them per subscription and P1-B synchronously materializes an immutable admitted snapshot before normalization.
+ * Analytics has no legacy wire DTO, so its internal input is already backend-independent and immutable.
+ */
+internal sealed interface QueryInput {
+    class Single(val query: ISingleQuery) : QueryInput
+
+    class Stream(val query: IListQuery) : QueryInput
+
+    class Page(val query: IPagedQuery) : QueryInput
+
+    class Count(val condition: Condition) : QueryInput
+
+    data class Analytics(val query: AnalyticsQuery) : QueryInput
+}
+
+/**
+ * Per-subscription envelope describing one query operation.
+ *
+ * This is intentionally not a value object because legacy record inputs are not deeply immutable. Stable equality,
+ * fingerprints and cache keys start at the admitted snapshot, normalized query and plan boundaries.
+ */
+internal class QueryInvocation(
+    val target: QueryTarget,
+    val operation: QueryOperation,
+    val resultShape: QueryResultShape,
+    val input: QueryInput,
+) {
+    init {
+        require(operation.accepts(input)) {
+            "Query input does not match operation $operation."
+        }
+        require(operation.accepts(resultShape)) {
+            "Query result shape $resultShape does not match operation $operation."
+        }
+    }
+
+    private fun QueryOperation.accepts(input: QueryInput): Boolean =
+        when (this) {
+            QueryOperation.SINGLE -> input is QueryInput.Single
+            QueryOperation.STREAM -> input is QueryInput.Stream
+            QueryOperation.PAGE -> input is QueryInput.Page
+            QueryOperation.COUNT -> input is QueryInput.Count
+            QueryOperation.ANALYZE -> input is QueryInput.Analytics
+        }
+
+    private fun QueryOperation.accepts(resultShape: QueryResultShape): Boolean =
+        when (this) {
+            QueryOperation.SINGLE,
+            QueryOperation.STREAM,
+            QueryOperation.PAGE,
+            -> resultShape == QueryResultShape.TYPED || resultShape == QueryResultShape.DYNAMIC
+
+            QueryOperation.COUNT -> resultShape == QueryResultShape.COUNT
+            QueryOperation.ANALYZE -> resultShape == QueryResultShape.ANALYTICS
+        }
+}

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/normalization/NormalizedCondition.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/normalization/NormalizedCondition.kt
@@ -1,0 +1,178 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.internal.normalization
+
+import java.util.Collections
+
+internal enum class PathBasis {
+    ROOT,
+    CURRENT_ELEMENT,
+}
+
+internal enum class SystemFieldKind {
+    IDENTITY,
+    AGGREGATE_ID,
+    TENANT_ID,
+    OWNER_ID,
+    SPACE_ID,
+    DELETED,
+}
+
+internal sealed interface LogicalField {
+    data class System(val kind: SystemFieldKind) : LogicalField
+
+    class Path(
+        segments: Iterable<String>,
+        val basis: PathBasis,
+    ) : LogicalField {
+        val segments: List<String> = Collections.unmodifiableList(segments.toList())
+
+        init {
+            require(this.segments.isNotEmpty()) {
+                "Logical field path must not be empty."
+            }
+            require(this.segments.none { it.isBlank() }) {
+                "Logical field path segments must not be blank."
+            }
+        }
+
+        override fun equals(other: Any?): Boolean =
+            this === other || other is Path && segments == other.segments && basis == other.basis
+
+        override fun hashCode(): Int = 31 * segments.hashCode() + basis.hashCode()
+
+        override fun toString(): String = "Path(segments=$segments, basis=$basis)"
+    }
+}
+
+internal enum class JunctionOperator {
+    AND,
+    OR,
+    NOR,
+}
+
+internal enum class PredicateOperator(val requiresValue: Boolean) {
+    EQ(true),
+    NE(true),
+    GT(true),
+    LT(true),
+    GTE(true),
+    LTE(true),
+    CONTAINS(true),
+    IN(true),
+    NOT_IN(true),
+    BETWEEN(true),
+    ALL_IN(true),
+    STARTS_WITH(true),
+    ENDS_WITH(true),
+    IS_NULL(false),
+    NOT_NULL(false),
+    IS_TRUE(false),
+    IS_FALSE(false),
+    EXISTS(true),
+}
+
+internal enum class CaseSensitivity {
+    SENSITIVE,
+    INSENSITIVE,
+}
+
+internal data class NormalizedPredicateOptions(
+    val caseSensitivity: CaseSensitivity = CaseSensitivity.SENSITIVE,
+)
+
+@JvmInline
+internal value class SearchScope(val value: String) {
+    init {
+        require(value.isNotBlank()) {
+            "Search scope must not be blank."
+        }
+    }
+}
+
+@JvmInline
+internal value class BackendId(val value: String) {
+    init {
+        require(value.isNotBlank()) {
+            "Backend id must not be blank."
+        }
+    }
+}
+
+@JvmInline
+internal value class Utf8Json(val value: String) {
+    init {
+        require(value.isNotBlank()) {
+            "Native JSON must not be blank."
+        }
+    }
+}
+
+internal sealed interface NormalizedCondition {
+    data object All : NormalizedCondition
+
+    class Junction(
+        val operator: JunctionOperator,
+        children: Iterable<NormalizedCondition>,
+    ) : NormalizedCondition {
+        val children: List<NormalizedCondition> = Collections.unmodifiableList(children.toList())
+
+        init {
+            require(this.children.isNotEmpty()) {
+                "Junction children must not be empty."
+            }
+        }
+
+        override fun equals(other: Any?): Boolean =
+            this === other || other is Junction && operator == other.operator && children == other.children
+
+        override fun hashCode(): Int = 31 * operator.hashCode() + children.hashCode()
+
+        override fun toString(): String = "Junction(operator=$operator, children=$children)"
+    }
+
+    data class Predicate(
+        val field: LogicalField,
+        val operator: PredicateOperator,
+        val value: NormalizedValue? = null,
+        val options: NormalizedPredicateOptions = NormalizedPredicateOptions(),
+    ) : NormalizedCondition {
+        init {
+            require(operator.requiresValue == (value != null)) {
+                "Predicate value does not match operator $operator."
+            }
+        }
+    }
+
+    data class ElementMatch(
+        val field: LogicalField.Path,
+        val condition: NormalizedCondition,
+    ) : NormalizedCondition
+
+    data class Search(
+        val scope: SearchScope,
+        val text: String,
+    ) : NormalizedCondition {
+        init {
+            require(text.isNotBlank()) {
+                "Search text must not be blank."
+            }
+        }
+    }
+
+    data class Native(
+        val backendId: BackendId,
+        val payload: Utf8Json,
+    ) : NormalizedCondition
+}

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/normalization/NormalizedValue.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/normalization/NormalizedValue.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.internal.normalization
+
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.Collections
+import java.util.LinkedHashMap
+
+internal sealed interface NormalizedValue {
+    data object Null : NormalizedValue
+
+    data class BooleanValue(val value: Boolean) : NormalizedValue
+
+    data class Text(val value: String) : NormalizedValue
+
+    data class Int64(val value: Long) : NormalizedValue
+
+    data class Decimal(val value: BigDecimal) : NormalizedValue
+
+    data class InstantValue(val value: Instant) : NormalizedValue
+
+    class Bytes(value: ByteArray) : NormalizedValue {
+        private val value: ByteArray = value.copyOf()
+
+        fun toByteArray(): ByteArray = value.copyOf()
+
+        override fun equals(other: Any?): Boolean =
+            this === other || other is Bytes && value.contentEquals(other.value)
+
+        override fun hashCode(): Int = value.contentHashCode()
+
+        override fun toString(): String = "Bytes(size=${value.size})"
+    }
+
+    class ListValue(values: Iterable<NormalizedValue>) : NormalizedValue {
+        val values: List<NormalizedValue> = Collections.unmodifiableList(values.toList())
+
+        override fun equals(other: Any?): Boolean =
+            this === other || other is ListValue && values == other.values
+
+        override fun hashCode(): Int = values.hashCode()
+
+        override fun toString(): String = values.toString()
+    }
+
+    class ObjectValue(values: Map<String, NormalizedValue>) : NormalizedValue {
+        val values: Map<String, NormalizedValue> =
+            Collections.unmodifiableMap(LinkedHashMap(values))
+
+        override fun equals(other: Any?): Boolean =
+            this === other || other is ObjectValue && values == other.values
+
+        override fun hashCode(): Int = values.hashCode()
+
+        override fun toString(): String = values.toString()
+    }
+}

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/plan/QueryPlan.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/plan/QueryPlan.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.internal.plan
+
+import me.ahoo.wow.query.internal.analytics.AnalyticsGrouping
+import me.ahoo.wow.query.internal.analytics.AnalyticsMetric
+import me.ahoo.wow.query.internal.model.QueryOperation
+import me.ahoo.wow.query.internal.model.QueryTarget
+import me.ahoo.wow.query.internal.model.RecordResultShape
+import me.ahoo.wow.query.internal.normalization.NormalizedCondition
+import me.ahoo.wow.query.internal.value.NonEmptyList
+
+internal sealed interface QueryPlan {
+    val target: QueryTarget
+    val operation: QueryOperation
+}
+
+internal sealed interface FilteredQueryPlan : QueryPlan {
+    val condition: NormalizedCondition
+}
+
+internal sealed interface RecordQueryPlan : FilteredQueryPlan {
+    val resultShape: RecordResultShape
+}
+
+internal data class SingleQueryPlan(
+    override val target: QueryTarget,
+    override val condition: NormalizedCondition,
+    override val resultShape: RecordResultShape,
+) : RecordQueryPlan {
+    override val operation: QueryOperation = QueryOperation.SINGLE
+}
+
+internal sealed interface StreamLimit {
+    data object Unbounded : StreamLimit
+
+    data class Bounded(val value: Int) : StreamLimit {
+        init {
+            require(value > 0) {
+                "Bounded stream limit must be positive."
+            }
+        }
+    }
+}
+
+internal data class StreamQueryPlan(
+    override val target: QueryTarget,
+    override val condition: NormalizedCondition,
+    override val resultShape: RecordResultShape,
+    val limit: StreamLimit,
+) : RecordQueryPlan {
+    override val operation: QueryOperation = QueryOperation.STREAM
+}
+
+internal data class PageWindow(
+    val offset: Long,
+    val size: Int,
+) {
+    init {
+        require(offset >= 0) {
+            "Page offset must not be negative."
+        }
+        require(size > 0) {
+            "Page size must be positive."
+        }
+    }
+}
+
+internal data class PageQueryPlan(
+    override val target: QueryTarget,
+    override val condition: NormalizedCondition,
+    override val resultShape: RecordResultShape,
+    val page: PageWindow,
+) : RecordQueryPlan {
+    override val operation: QueryOperation = QueryOperation.PAGE
+}
+
+internal data class CountQueryPlan(
+    override val target: QueryTarget,
+    override val condition: NormalizedCondition,
+) : FilteredQueryPlan {
+    override val operation: QueryOperation = QueryOperation.COUNT
+}
+
+internal data class AnalyticsQueryPlan(
+    override val target: QueryTarget,
+    val preFilter: NormalizedCondition,
+    val grouping: AnalyticsGrouping,
+    val metrics: NonEmptyList<AnalyticsMetric>,
+) : QueryPlan {
+    override val operation: QueryOperation = QueryOperation.ANALYZE
+
+    init {
+        val dimensionAliases =
+            when (grouping) {
+                AnalyticsGrouping.Global -> emptyList()
+                is AnalyticsGrouping.By -> grouping.dimensions.values.map { it.alias }
+            }
+        val aliases = dimensionAliases + metrics.values.map { it.alias }
+        require(aliases.size == aliases.toSet().size) {
+            "Analytics aliases must be unique."
+        }
+    }
+}

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/value/NonEmptyList.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/value/NonEmptyList.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.internal.value
+
+import java.util.Collections
+
+internal class NonEmptyList<T> private constructor(values: List<T>) {
+    val values: List<T> = Collections.unmodifiableList(values)
+
+    val first: T
+        get() = values.first()
+
+    override fun equals(other: Any?): Boolean =
+        this === other || other is NonEmptyList<*> && values == other.values
+
+    override fun hashCode(): Int = values.hashCode()
+
+    override fun toString(): String = values.toString()
+
+    companion object {
+        fun <T> of(
+            first: T,
+            vararg rest: T,
+        ): NonEmptyList<T> = NonEmptyList(listOf(first, *rest))
+
+        fun <T> from(values: Iterable<T>): NonEmptyList<T>? {
+            val materialized = values.toList()
+            if (materialized.isEmpty()) {
+                return null
+            }
+            return NonEmptyList(materialized)
+        }
+    }
+}

--- a/wow-query/src/test/java/me/ahoo/wow/query/JavaQueryServiceCompatibilityTest.java
+++ b/wow-query/src/test/java/me/ahoo/wow/query/JavaQueryServiceCompatibilityTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query;
+
+import me.ahoo.wow.api.modeling.NamedAggregate;
+import me.ahoo.wow.api.query.Condition;
+import me.ahoo.wow.api.query.DynamicDocument;
+import me.ahoo.wow.api.query.IListQuery;
+import me.ahoo.wow.api.query.IPagedQuery;
+import me.ahoo.wow.api.query.ISingleQuery;
+import me.ahoo.wow.api.query.PagedList;
+import me.ahoo.wow.modeling.MaterializedNamedAggregate;
+import me.ahoo.wow.query.filter.QueryType;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class JavaQueryServiceCompatibilityTest {
+
+    @Test
+    void shouldCompileAndCallThePublicJavaContract() {
+        QueryService<String> service = new JavaQueryService();
+
+        assertFalse(QueryType.COUNT.isDynamic());
+        assertFalse(service.getAggregateName().isBlank());
+    }
+
+    private static final class JavaQueryService implements QueryService<String> {
+        private final NamedAggregate namedAggregate = new MaterializedNamedAggregate("sales", "order");
+
+        @Override
+        public NamedAggregate getNamedAggregate() {
+            return namedAggregate;
+        }
+
+        @Override
+        public Mono<String> single(ISingleQuery singleQuery) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<DynamicDocument> dynamicSingle(ISingleQuery singleQuery) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Flux<String> list(IListQuery listQuery) {
+            return Flux.empty();
+        }
+
+        @Override
+        public Flux<DynamicDocument> dynamicList(IListQuery listQuery) {
+            return Flux.empty();
+        }
+
+        @Override
+        public Mono<PagedList<String>> paged(IPagedQuery pagedQuery) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<PagedList<DynamicDocument>> dynamicPaged(IPagedQuery pagedQuery) {
+            return Mono.empty();
+        }
+
+        @Override
+        public Mono<Long> count(Condition condition) {
+            return Mono.empty();
+        }
+    }
+}

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/PublicQueryContractCompatibilityTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/PublicQueryContractCompatibilityTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.query.filter.QueryType
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Modifier
+
+class PublicQueryContractCompatibilityTest {
+
+    @Test
+    fun `query service should retain seven public generic signatures`() {
+        QueryService::class.java.declaredMethods
+            .filter { Modifier.isPublic(it.modifiers) && !it.isSynthetic }
+            .map { method ->
+                val parameters = method.genericParameterTypes.joinToString(",") { it.typeName }
+                "${method.name}($parameters):${method.genericReturnType.typeName}"
+            }
+            .sorted()
+            .assert()
+            .containsExactly(
+                "count(me.ahoo.wow.api.query.Condition):reactor.core.publisher.Mono<java.lang.Long>",
+                "dynamicList(me.ahoo.wow.api.query.IListQuery):reactor.core.publisher.Flux<me.ahoo.wow.api.query.DynamicDocument>",
+                "dynamicPaged(me.ahoo.wow.api.query.IPagedQuery):reactor.core.publisher.Mono<me.ahoo.wow.api.query.PagedList<me.ahoo.wow.api.query.DynamicDocument>>",
+                "dynamicSingle(me.ahoo.wow.api.query.ISingleQuery):reactor.core.publisher.Mono<me.ahoo.wow.api.query.DynamicDocument>",
+                "list(me.ahoo.wow.api.query.IListQuery):reactor.core.publisher.Flux<R>",
+                "paged(me.ahoo.wow.api.query.IPagedQuery):reactor.core.publisher.Mono<me.ahoo.wow.api.query.PagedList<R>>",
+                "single(me.ahoo.wow.api.query.ISingleQuery):reactor.core.publisher.Mono<R>",
+            )
+
+        QueryService::class.java.genericInterfaces.map { it.typeName }.assert().containsExactly(
+            "me.ahoo.wow.api.modeling.NamedAggregateDecorator",
+        )
+    }
+
+    @Test
+    fun `query type should retain seven values`() {
+        QueryType.entries.map { it.name }.assert().containsExactly(
+            "SINGLE",
+            "DYNAMIC_SINGLE",
+            "LIST",
+            "DYNAMIC_LIST",
+            "PAGED",
+            "DYNAMIC_PAGED",
+            "COUNT",
+        )
+    }
+}

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/internal/model/QueryInvocationTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/internal/model/QueryInvocationTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.internal.model
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.test.asserts.assertThrownBy
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.modeling.NamedAggregateDecorator
+import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.ListQuery
+import me.ahoo.wow.api.query.PagedQuery
+import me.ahoo.wow.api.query.SingleQuery
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.query.internal.analytics.AnalyticsAlias
+import me.ahoo.wow.query.internal.analytics.AnalyticsGrouping
+import me.ahoo.wow.query.internal.analytics.AnalyticsMetric
+import me.ahoo.wow.query.internal.analytics.AnalyticsQuery
+import me.ahoo.wow.query.internal.normalization.NormalizedCondition
+import me.ahoo.wow.query.internal.value.NonEmptyList
+import org.junit.jupiter.api.Test
+
+class QueryInvocationTest {
+
+    private val namedAggregate = MaterializedNamedAggregate("sales", "order")
+    private val target = QueryTarget(namedAggregate, QueryDocumentKind.SNAPSHOT)
+    private val analytics = AnalyticsQuery(
+        userCondition = NormalizedCondition.All,
+        grouping = AnalyticsGrouping.Global,
+        metrics = NonEmptyList.of(AnalyticsMetric.DocumentCount(AnalyticsAlias("count"))),
+    )
+
+    @Test
+    fun `target should materialize aggregate decorators`() {
+        val decorator = object : NamedAggregateDecorator {
+            override val namedAggregate: NamedAggregate = this@QueryInvocationTest.namedAggregate
+        }
+
+        val actual = QueryTarget(decorator, QueryDocumentKind.EVENT_STREAM)
+
+        actual.namedAggregate.assert().isSameAs(namedAggregate)
+        actual.documentKind.assert().isEqualTo(QueryDocumentKind.EVENT_STREAM)
+    }
+
+    @Test
+    fun `should accept the complete operation result and input matrix`() {
+        val invocations = listOf(
+            QueryInvocation(
+                target = target,
+                operation = QueryOperation.SINGLE,
+                resultShape = QueryResultShape.TYPED,
+                input = QueryInput.Single(SingleQuery(Condition.ALL)),
+            ),
+            QueryInvocation(
+                target = target,
+                operation = QueryOperation.SINGLE,
+                resultShape = QueryResultShape.DYNAMIC,
+                input = QueryInput.Single(SingleQuery(Condition.ALL)),
+            ),
+            QueryInvocation(
+                target = target,
+                operation = QueryOperation.STREAM,
+                resultShape = QueryResultShape.TYPED,
+                input = QueryInput.Stream(ListQuery(Condition.ALL)),
+            ),
+            QueryInvocation(
+                target = target,
+                operation = QueryOperation.STREAM,
+                resultShape = QueryResultShape.DYNAMIC,
+                input = QueryInput.Stream(ListQuery(Condition.ALL)),
+            ),
+            QueryInvocation(
+                target = target,
+                operation = QueryOperation.PAGE,
+                resultShape = QueryResultShape.TYPED,
+                input = QueryInput.Page(PagedQuery(Condition.ALL)),
+            ),
+            QueryInvocation(
+                target = target,
+                operation = QueryOperation.PAGE,
+                resultShape = QueryResultShape.DYNAMIC,
+                input = QueryInput.Page(PagedQuery(Condition.ALL)),
+            ),
+            QueryInvocation(
+                target = target,
+                operation = QueryOperation.COUNT,
+                resultShape = QueryResultShape.COUNT,
+                input = QueryInput.Count(Condition.ALL),
+            ),
+            QueryInvocation(
+                target = target,
+                operation = QueryOperation.ANALYZE,
+                resultShape = QueryResultShape.ANALYTICS,
+                input = QueryInput.Analytics(analytics),
+            ),
+        )
+
+        invocations.assert().hasSize(8)
+    }
+
+    @Test
+    fun `analytics invocation should carry the semantic request`() {
+        val invocation = QueryInvocation(
+            target = target,
+            operation = QueryOperation.ANALYZE,
+            resultShape = QueryResultShape.ANALYTICS,
+            input = QueryInput.Analytics(analytics),
+        )
+
+        (invocation.input as QueryInput.Analytics).query.assert().isSameAs(analytics)
+    }
+
+    @Test
+    fun `should reject an input that does not match the operation`() {
+        assertThrownBy<IllegalArgumentException> {
+            QueryInvocation(
+                target = target,
+                operation = QueryOperation.SINGLE,
+                resultShape = QueryResultShape.TYPED,
+                input = QueryInput.Stream(ListQuery(Condition.ALL)),
+            )
+        }
+    }
+
+    @Test
+    fun `should reject a result shape that does not match the operation`() {
+        assertThrownBy<IllegalArgumentException> {
+            QueryInvocation(
+                target = target,
+                operation = QueryOperation.COUNT,
+                resultShape = QueryResultShape.DYNAMIC,
+                input = QueryInput.Count(Condition.ALL),
+            )
+        }
+    }
+
+    @Test
+    fun `execution and validation modes should remain independent`() {
+        val combinations = QueryExecutionMode.entries.flatMap { executionMode ->
+            QueryValidationMode.entries.map { validationMode -> executionMode to validationMode }
+        }
+
+        combinations.assert().hasSize(6)
+        combinations.assert().contains(QueryExecutionMode.SHADOW to QueryValidationMode.STRICT)
+    }
+}

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/internal/normalization/NormalizedConditionTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/internal/normalization/NormalizedConditionTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.internal.normalization
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.test.asserts.assertThrownBy
+import org.junit.jupiter.api.Test
+
+class NormalizedConditionTest {
+
+    @Test
+    fun `logical path should isolate and expose immutable segments`() {
+        val source = mutableListOf("state", "name")
+        val path = LogicalField.Path(source, PathBasis.ROOT)
+
+        source.add("late")
+
+        path.segments.assert().containsExactly("state", "name")
+        assertThrownBy<UnsupportedOperationException> {
+            @Suppress("UNCHECKED_CAST")
+            (path.segments as MutableList<String>).add("other")
+        }
+    }
+
+    @Test
+    fun `junction should isolate mutable children`() {
+        val source = mutableListOf<NormalizedCondition>(NormalizedCondition.All)
+        val junction = NormalizedCondition.Junction(JunctionOperator.AND, source)
+
+        source.add(NormalizedCondition.All)
+
+        junction.children.assert().containsExactly(NormalizedCondition.All)
+    }
+
+    @Test
+    fun `predicate should enforce value arity`() {
+        val field = LogicalField.Path(listOf("state", "status"), PathBasis.ROOT)
+
+        assertThrownBy<IllegalArgumentException> {
+            NormalizedCondition.Predicate(field, PredicateOperator.EQ)
+        }
+        assertThrownBy<IllegalArgumentException> {
+            NormalizedCondition.Predicate(field, PredicateOperator.IS_NULL, NormalizedValue.Null)
+        }
+    }
+
+    @Test
+    fun `search scope and text should not be blank`() {
+        assertThrownBy<IllegalArgumentException> {
+            SearchScope(" ")
+        }
+        assertThrownBy<IllegalArgumentException> {
+            NormalizedCondition.Search(SearchScope("default"), " ")
+        }
+    }
+
+    @Test
+    fun `native condition should retain immutable backend json`() {
+        val condition = NormalizedCondition.Native(
+            backendId = BackendId("elasticsearch"),
+            payload = Utf8Json("{\"term\":{\"state\":\"PAID\"}}"),
+        )
+
+        condition.backendId.value.assert().isEqualTo("elasticsearch")
+        condition.payload.value.assert().isEqualTo("{\"term\":{\"state\":\"PAID\"}}")
+    }
+}

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/internal/normalization/NormalizedValueTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/internal/normalization/NormalizedValueTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.internal.normalization
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.test.asserts.assertThrownBy
+import org.junit.jupiter.api.Test
+
+class NormalizedValueTest {
+
+    @Test
+    fun `bytes should have content equality and defensive access`() {
+        val source = byteArrayOf(1, 2, 3)
+        val value = NormalizedValue.Bytes(source)
+        val expected = NormalizedValue.Bytes(byteArrayOf(1, 2, 3))
+        val initialHashCode = value.hashCode()
+
+        source[0] = 9
+        val exposed = value.toByteArray()
+        exposed[1] = 9
+
+        value.assert().isEqualTo(expected)
+        value.hashCode().assert().isEqualTo(initialHashCode)
+        value.toByteArray().assert().isEqualTo(byteArrayOf(1, 2, 3))
+    }
+
+    @Test
+    fun `list and object should deeply isolate mutable inputs`() {
+        val sourceBytes = byteArrayOf(1, 2)
+        val sourceList = mutableListOf<NormalizedValue>(NormalizedValue.Bytes(sourceBytes))
+        val sourceMap = linkedMapOf<String, NormalizedValue>("items" to NormalizedValue.ListValue(sourceList))
+        val value = NormalizedValue.ObjectValue(sourceMap)
+        val initialHashCode = value.hashCode()
+
+        sourceBytes[0] = 9
+        sourceList.add(NormalizedValue.Text("late"))
+        sourceMap.clear()
+
+        value.assert().isEqualTo(
+            NormalizedValue.ObjectValue(
+                mapOf("items" to NormalizedValue.ListValue(listOf(NormalizedValue.Bytes(byteArrayOf(1, 2))))),
+            ),
+        )
+        value.hashCode().assert().isEqualTo(initialHashCode)
+    }
+
+    @Test
+    fun `immutable collections should not be mutable through a cast`() {
+        val list = NormalizedValue.ListValue(listOf(NormalizedValue.Text("value")))
+        val map = NormalizedValue.ObjectValue(mapOf("key" to NormalizedValue.Text("value")))
+
+        assertThrownBy<UnsupportedOperationException> {
+            @Suppress("UNCHECKED_CAST")
+            (list.values as MutableList<NormalizedValue>).add(NormalizedValue.Null)
+        }
+        assertThrownBy<UnsupportedOperationException> {
+            @Suppress("UNCHECKED_CAST")
+            (map.values as MutableMap<String, NormalizedValue>)["other"] = NormalizedValue.Null
+        }
+    }
+
+    @Test
+    fun `list should materialize a one-shot iterable exactly once`() {
+        var iteratorCalls = 0
+        val oneShot = Iterable {
+            iteratorCalls++
+            check(iteratorCalls == 1)
+            listOf(NormalizedValue.Text("value")).iterator()
+        }
+
+        val value = NormalizedValue.ListValue(oneShot)
+
+        value.values.assert().containsExactly(NormalizedValue.Text("value"))
+        iteratorCalls.assert().isEqualTo(1)
+    }
+}

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/internal/plan/QueryPlanTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/internal/plan/QueryPlanTest.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.internal.plan
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.test.asserts.assertThrownBy
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.query.internal.analytics.AnalyticsAlias
+import me.ahoo.wow.query.internal.analytics.AnalyticsDimension
+import me.ahoo.wow.query.internal.analytics.AnalyticsGrouping
+import me.ahoo.wow.query.internal.analytics.AnalyticsMetric
+import me.ahoo.wow.query.internal.model.QueryDocumentKind
+import me.ahoo.wow.query.internal.model.QueryOperation
+import me.ahoo.wow.query.internal.model.QueryTarget
+import me.ahoo.wow.query.internal.model.RecordResultShape
+import me.ahoo.wow.query.internal.normalization.LogicalField
+import me.ahoo.wow.query.internal.normalization.NormalizedCondition
+import me.ahoo.wow.query.internal.normalization.PathBasis
+import me.ahoo.wow.query.internal.value.NonEmptyList
+import org.junit.jupiter.api.Test
+
+class QueryPlanTest {
+
+    private val target = QueryTarget(
+        MaterializedNamedAggregate("sales", "order"),
+        QueryDocumentKind.SNAPSHOT,
+    )
+    private val field = LogicalField.Path(listOf("state", "amount"), PathBasis.ROOT)
+
+    @Test
+    fun `record plans should expose their operation without backend state`() {
+        val plans = listOf(
+            SingleQueryPlan(target, NormalizedCondition.All, RecordResultShape.TYPED),
+            StreamQueryPlan(target, NormalizedCondition.All, RecordResultShape.DYNAMIC, StreamLimit.Unbounded),
+            PageQueryPlan(
+                target,
+                NormalizedCondition.All,
+                RecordResultShape.TYPED,
+                PageWindow(offset = 0, size = 20),
+            ),
+            CountQueryPlan(target, NormalizedCondition.All),
+        )
+
+        plans.map { it.operation }.assert().containsExactly(
+            QueryOperation.SINGLE,
+            QueryOperation.STREAM,
+            QueryOperation.PAGE,
+            QueryOperation.COUNT,
+        )
+        plans.filterIsInstance<RecordQueryPlan>().map { it.resultShape }.assert().containsExactly(
+            RecordResultShape.TYPED,
+            RecordResultShape.DYNAMIC,
+            RecordResultShape.TYPED,
+        )
+    }
+
+    @Test
+    fun `bounded stream and page window should reject invalid values`() {
+        assertThrownBy<IllegalArgumentException> {
+            StreamLimit.Bounded(0)
+        }
+        assertThrownBy<IllegalArgumentException> {
+            PageWindow(offset = -1, size = 10)
+        }
+        assertThrownBy<IllegalArgumentException> {
+            PageWindow(offset = 0, size = 0)
+        }
+    }
+
+    @Test
+    fun `global analytics should be valid without a dimension`() {
+        val plan = AnalyticsQueryPlan(
+            target = target,
+            preFilter = NormalizedCondition.All,
+            grouping = AnalyticsGrouping.Global,
+            metrics = NonEmptyList.of(AnalyticsMetric.DocumentCount(AnalyticsAlias("count"))),
+        )
+
+        plan.operation.assert().isEqualTo(QueryOperation.ANALYZE)
+        plan.grouping.assert().isEqualTo(AnalyticsGrouping.Global)
+    }
+
+    @Test
+    fun `grouped analytics should require at least one dimension`() {
+        NonEmptyList.from<AnalyticsDimension>(emptyList()).assert().isNull()
+
+        val grouping = AnalyticsGrouping.By(
+            NonEmptyList.of(AnalyticsDimension(AnalyticsAlias("amount"), field)),
+        )
+
+        grouping.dimensions.values.assert().hasSize(1)
+    }
+
+    @Test
+    fun `analytics aliases should be unique across dimensions and metrics`() {
+        val alias = AnalyticsAlias("amount")
+        val grouping = AnalyticsGrouping.By(NonEmptyList.of(AnalyticsDimension(alias, field)))
+
+        assertThrownBy<IllegalArgumentException> {
+            AnalyticsQueryPlan(
+                target = target,
+                preFilter = NormalizedCondition.All,
+                grouping = grouping,
+                metrics = NonEmptyList.of(AnalyticsMetric.Sum(alias, field)),
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add the internal P1-A query semantic kernel: `QueryTarget`, per-subscription `QueryInvocation`, operation/result shapes, execution/validation modes
- add backend-independent, deeply immutable `NormalizedValue` and `NormalizedCondition` models
- add record and analytics plan skeletons, including `Global | By(NonEmptyList<Dimension>)` grouping
- add exact Kotlin reflection and real Java compile/runtime guards for the existing seven-method `QueryService` and `QueryType`
- update the architecture plan with the P1-A status and the one-pass admission/materialization boundary required by P1-B

## Why

This is the first additive slice of the query-service architecture upgrade. It establishes a deterministic semantic boundary before admission, normalization, planning, policy, or backend compilers are wired into production traffic.

The branch is stacked on #2908. Review this PR against `agent/query-service-architecture-upgrade`; it does not include or replace the Phase 0 changes.

## Boundary decisions

- legacy record DTOs inside `QueryInvocation` are explicitly ephemeral raw references, not value objects or cache keys
- P1-B must validate and defensively materialize those DTOs in one bounded pass before normalization to avoid TOCTOU
- analytics input is internal and backend-independent; no public analytics wire API is introduced
- no Jackson/Swagger annotations, backend driver types, physical field names, Spring wiring, or runtime traffic changes are included
- Kotlin `internal` types still compile to JVM-visible classes, so they are treated as unsupported implementation details rather than described as a strict zero-ABI JAR diff

## Validation

- `./gradlew :wow-query:test --tests 'me.ahoo.wow.query.internal.*' --tests 'me.ahoo.wow.query.PublicQueryContractCompatibilityTest'`
- `./gradlew :wow-query:test --tests 'me.ahoo.wow.query.JavaQueryServiceCompatibilityTest' --tests 'me.ahoo.wow.query.PublicQueryContractCompatibilityTest'`
- `./gradlew :wow-query:check`
- `./gradlew :wow-openapi:test --tests 'me.ahoo.wow.openapi.snapshot.OpenApiCompatibilitySnapshotTest'`
- `git diff --cached --check`