### PR TITLE
refactor(query): add admission and normalizer

### DIFF
--- a/document/design/2026-08-06-query-service-architecture-upgrade.md
+++ b/document/design/2026-08-06-query-service-architecture-upgrade.md
@@ -109,7 +109,7 @@ Policy 不直接接收未经验证的 `Any` DTO。Admission 先执行低成本�
 
 - 条件深度、节点数、children 形态；
 - 字段、projection、sort 数量和字符串长度；
-- value、options、RAW payload 的大小上限；
+- value、options，以及未来已绑定 immutable JSON `RAW` payload 的大小上限；
 - 非法分页、负 limit 和明显溢出。
 
 Admission 只防止畸形输入消耗过多资源，不决定业务授权或 Backend 语义。
@@ -628,12 +628,13 @@ mapping `_meta` 保存 mapping version、document kind 和 capability digest。�
 
 ### 10.1 当前基线与完成度
 
-以下状态以提交 `9ddeba24f` 为审计基线。状态只根据当前源码和测试判断，不根据设计意图推断：
+以下状态以 stacked Phase 1 分支的当前源码和测试为审计基线。状态只根据可执行代码与验证结果判断，
+不根据设计意图推断：
 
 | Phase | 当前证据 | 状态 |
 |---|---|---|
 | 0 | `QueryHandler` 已形成单一 defer/fail-closed 边界；EventStream factory 已使用 materialized key 与并发缓存；对应同步、异步、partial Flux、cancel、direct handle 和多订阅测试已存在 | 已实现，待 PR #2908 合并 |
-| 1 | P1-A 已在 stacked 分支引入 internal `QueryInvocation`、`NormalizedCondition`、`QueryPlan` 与最小 analytics model；尚无 Normalizer、Planner 或运行时接线 | P1-A 已实现，P1-B/P1-C 未开始 |
+| 1 | P1-A 已引入 internal `QueryInvocation`、语义代数、`QueryPlan` 与最小 analytics model；P1-B 已引入单遍 admission snapshot、全局 value/payload budget、typed rejection 与 43 operator Normalizer；尚无 Planner、Backend compiler 或运行时接线 | P1-A/P1-B 已实现，P1-C 未开始 |
 | 2 | Spring Registrar 仍从 storage `QueryServiceFactory` 直接创建 Bean；WebFlux 仍直接调用 legacy `QueryHandler` | 未开始 |
 | 3 | MongoDB 查询仍由 `AbstractMongoQueryService` 直接执行 `find/countDocuments`，没有 planned compiler、Backend、单操作 page 或 aggregation pipeline | 未开始 |
 | 4 | Elasticsearch 查询仍使用 `from/size` 和 hits/count，没有 field binding、readiness、完整性 validator、PIT 或 composite aggregation | 未开始 |
@@ -715,6 +716,27 @@ Phase 0 提交，不涉及配置、索引或数据。
 - 每次 normalization 只读取一次 `Clock.instant()`；时间范围使用半开区间；
 - 从 PR #2903 搬运有效 operator fixtures/validator cases，但不复用其 Backend-specific converter 修改；
 - 返回稳定 category/path/code 的 typed rejection，测试不绑定异常文案。
+
+P1-B 当前实现约束：
+
+- `QueryAdmissionLimits` 同时限制局部容器和整次 admission 的 condition/value node、UTF-8 payload、数字精度；
+  默认值仍是 internal safety baseline，P2-A 接入运行时时再通过配置与真实流量证据校准；
+- legacy `RAW` 不携带 Backend id，admission 不读取、不预算并丢弃原 driver object，只产出 `NativeUnbound` marker，
+  Normalizer 稳定返回 `UNSUPPORTED_FEATURE/NATIVE_BACKEND_UNBOUND`；未来已绑定 immutable JSON Native contract
+  才进入 payload budget，留 P1-C/P5-A；
+- mixed include/exclude 在 Normalizer 保留为 `NormalizedProjection.Mixed`，不在缺失 validation mode 时提前决定
+  compatible/strict policy；P1-C Planner 根据 result shape、validation mode 和 compatibility issue 决策；
+- `RawAdmissionGuard`、`RawValueSnapshotter`、`AdmissionBudget` 与 `QueryNormalizer` 均保持 internal，生产调用链、
+  Spring Bean、现有 wire DTO 和 OpenAPI 不接线。
+
+P1-B 验证证据：
+
+- admission tests 覆盖动态 getter 单读、one-shot iterable、List/Map/ByteArray 防御复制、condition/value cycle、
+  hostile duplicate-key Map、局部与累计预算、稳定 key path、分页 Long offset 和 typed rejection；
+- Normalizer golden tests 覆盖全部 43 个 wire operator、Mongo 空集合常量、数字 canonicalization、system field、
+  多层 `ELEM_MATCH` 相对 scope、literal pattern、projection/sort、一次 Clock、DST-safe 半开时间范围和 RAW 拒绝；
+- `./gradlew :wow-query:check` 与 OpenAPI snapshot test 是该切片的退出验证；P1-C 完成前不宣称 Phase 1 exit gate
+  整体满足。
 
 #### P1-C：Logical Schema 与 Planner
 

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/admission/AdmissionBudget.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/admission/AdmissionBudget.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.internal.admission
+
+import me.ahoo.wow.query.internal.rejection.QueryRejectionCategory
+import me.ahoo.wow.query.internal.rejection.QueryRejectionCode
+import me.ahoo.wow.query.internal.rejection.QueryRejectionPath
+import me.ahoo.wow.query.internal.rejection.rejectQuery
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.nio.charset.StandardCharsets
+
+/** Per-admission cumulative budget shared by every condition value, field and option. */
+internal class AdmissionBudget(
+    private val limits: QueryAdmissionLimits,
+) {
+    private var valueNodes: Int = 0
+    private var payloadBytes: Long = 0
+
+    fun enterValue(path: QueryRejectionPath) {
+        if (valueNodes == limits.maxValueNodes) {
+            rejectBudget(path, QueryRejectionCode.VALUE_NODE_LIMIT_EXCEEDED)
+        }
+        valueNodes++
+    }
+
+    fun consumeString(value: String, path: QueryRejectionPath) {
+        if (value.length > limits.maxStringLength) {
+            rejectBudget(path, QueryRejectionCode.STRING_LIMIT_EXCEEDED)
+        }
+        consumeUtf8(value, path)
+    }
+
+    fun consumeUtf8(value: String, path: QueryRejectionPath) {
+        consumePayload(value.toByteArray(StandardCharsets.UTF_8).size.toLong(), path)
+    }
+
+    fun consumeBytes(size: Int, path: QueryRejectionPath) {
+        if (size > limits.maxByteArrayLength) {
+            rejectBudget(path, QueryRejectionCode.BYTE_ARRAY_LIMIT_EXCEEDED)
+        }
+        consumePayload(size.toLong(), path)
+    }
+
+    fun consumeNumber(number: Number, path: QueryRejectionPath): String {
+        when (number) {
+            is BigDecimal -> if (number.precision() > limits.maxNumericPrecision) {
+                rejectBudget(path, QueryRejectionCode.NUMERIC_PRECISION_LIMIT_EXCEEDED)
+            }
+            is BigInteger -> {
+                val maxBits = limits.maxNumericPrecision.toLong() * 4 + 1
+                if (number.abs().bitLength().toLong() > maxBits) {
+                    rejectBudget(path, QueryRejectionCode.NUMERIC_PRECISION_LIMIT_EXCEEDED)
+                }
+            }
+        }
+        val text = number.toString()
+        val precision = text.trimStart('-').count(Char::isDigit)
+        if (precision > limits.maxNumericPrecision) {
+            rejectBudget(path, QueryRejectionCode.NUMERIC_PRECISION_LIMIT_EXCEEDED)
+        }
+        consumeString(text, path)
+        return text
+    }
+
+    private fun consumePayload(size: Long, path: QueryRejectionPath) {
+        if (size > limits.maxValuePayloadBytes - payloadBytes) {
+            rejectBudget(path, QueryRejectionCode.PAYLOAD_LIMIT_EXCEEDED)
+        }
+        payloadBytes += size
+    }
+
+    private fun rejectBudget(path: QueryRejectionPath, code: QueryRejectionCode): Nothing =
+        rejectQuery(QueryRejectionCategory.BUDGET_EXCEEDED, path, code)
+}

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/admission/AdmittedQuery.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/admission/AdmittedQuery.kt
@@ -1,0 +1,212 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.internal.admission
+
+import me.ahoo.wow.api.query.DeletionState
+import me.ahoo.wow.api.query.Operator
+import me.ahoo.wow.api.query.Sort
+import me.ahoo.wow.query.internal.analytics.AnalyticsQuery
+import me.ahoo.wow.query.internal.model.QueryOperation
+import me.ahoo.wow.query.internal.model.QueryResultShape
+import me.ahoo.wow.query.internal.model.QueryTarget
+import me.ahoo.wow.query.internal.normalization.CaseSensitivity
+import me.ahoo.wow.query.internal.normalization.NormalizedValue
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Collections
+
+internal data class QueryAdmissionLimits(
+    val maxConditionDepth: Int = 32,
+    val maxConditionNodes: Int = 1024,
+    val maxChildrenPerNode: Int = 128,
+    val maxFieldLength: Int = 512,
+    val maxStringLength: Int = 65_536,
+    val maxCollectionSize: Int = 1024,
+    val maxObjectFields: Int = 256,
+    val maxValueDepth: Int = 16,
+    val maxValueNodes: Int = 16_384,
+    val maxNumericPrecision: Int = 1024,
+    val maxByteArrayLength: Int = 65_536,
+    val maxValuePayloadBytes: Long = 4L * 1024 * 1024,
+    val maxProjectionFields: Int = 128,
+    val maxSortFields: Int = 32,
+    val maxOptions: Int = 8,
+) {
+    init {
+        require(
+            listOf(
+                maxConditionDepth,
+                maxConditionNodes,
+                maxChildrenPerNode,
+                maxFieldLength,
+                maxStringLength,
+                maxCollectionSize,
+                maxObjectFields,
+                maxValueDepth,
+                maxValueNodes,
+                maxNumericPrecision,
+                maxByteArrayLength,
+                maxProjectionFields,
+                maxSortFields,
+                maxOptions,
+            ).all { it > 0 },
+        ) {
+            "Query admission limits must be positive."
+        }
+        require(maxValuePayloadBytes > 0) {
+            "Query value payload limit must be positive."
+        }
+    }
+
+    companion object {
+        val DEFAULT: QueryAdmissionLimits = QueryAdmissionLimits()
+    }
+}
+
+internal data class AdmittedQueryInvocation(
+    val target: QueryTarget,
+    val operation: QueryOperation,
+    val resultShape: QueryResultShape,
+    val input: AdmittedQueryInput,
+)
+
+internal sealed interface AdmittedQueryInput {
+    data class Single(val query: AdmittedRecordQuery) : AdmittedQueryInput
+
+    data class Stream(
+        val query: AdmittedRecordQuery,
+        val limit: Int,
+    ) : AdmittedQueryInput
+
+    data class Page(
+        val query: AdmittedRecordQuery,
+        val page: AdmittedPage,
+    ) : AdmittedQueryInput
+
+    data class Count(val condition: AdmittedCondition) : AdmittedQueryInput
+
+    data class Analytics(val query: AnalyticsQuery) : AdmittedQueryInput
+}
+
+internal class AdmittedRecordQuery(
+    val condition: AdmittedCondition,
+    val projection: AdmittedProjection,
+    sort: Iterable<AdmittedSort>,
+) {
+    val sort: List<AdmittedSort> = Collections.unmodifiableList(sort.toList())
+
+    override fun equals(other: Any?): Boolean =
+        this === other ||
+            other is AdmittedRecordQuery &&
+            condition == other.condition &&
+            projection == other.projection &&
+            sort == other.sort
+
+    override fun hashCode(): Int = 31 * (31 * condition.hashCode() + projection.hashCode()) + sort.hashCode()
+}
+
+internal class AdmittedProjection(
+    include: Iterable<String>,
+    exclude: Iterable<String>,
+) {
+    val include: List<String> = Collections.unmodifiableList(include.toList())
+    val exclude: List<String> = Collections.unmodifiableList(exclude.toList())
+
+    override fun equals(other: Any?): Boolean =
+        this === other ||
+            other is AdmittedProjection &&
+            include == other.include &&
+            exclude == other.exclude
+
+    override fun hashCode(): Int = 31 * include.hashCode() + exclude.hashCode()
+}
+
+internal data class AdmittedSort(
+    val field: String,
+    val direction: Sort.Direction,
+)
+
+internal data class AdmittedPage(
+    val index: Int,
+    val size: Int,
+    val offset: Long,
+)
+
+internal sealed interface AdmittedConditionValue {
+    data object Absent : AdmittedConditionValue
+
+    /** Legacy RAW marker; no driver object crosses the admission boundary. */
+    data object NativeUnbound : AdmittedConditionValue
+
+    data class QueryValue(val value: NormalizedValue) : AdmittedConditionValue
+
+    data class TimeOfDay(val value: LocalTime) : AdmittedConditionValue
+
+    data class Deletion(val value: DeletionState) : AdmittedConditionValue
+}
+
+internal data class AdmittedConditionOptions(
+    val caseSensitivity: CaseSensitivity = CaseSensitivity.SENSITIVE,
+    val zoneId: ZoneId? = null,
+    val datePattern: AdmittedDatePattern? = null,
+)
+
+internal class AdmittedDatePattern(
+    val formatter: DateTimeFormatter,
+    descriptor: String,
+) {
+    private val signature: List<Any?> = listOf(
+        descriptor,
+        formatter.locale,
+        formatter.decimalStyle,
+        formatter.resolverStyle,
+        formatter.chronology,
+        formatter.zone,
+        formatter.resolverFields,
+    )
+
+    override fun equals(other: Any?): Boolean =
+        this === other || other is AdmittedDatePattern && signature == other.signature
+
+    override fun hashCode(): Int = signature.hashCode()
+}
+
+internal class AdmittedCondition(
+    val field: String,
+    val operator: Operator,
+    val value: AdmittedConditionValue,
+    children: Iterable<AdmittedCondition>,
+    val options: AdmittedConditionOptions,
+) {
+    val children: List<AdmittedCondition> = Collections.unmodifiableList(children.toList())
+
+    override fun equals(other: Any?): Boolean =
+        this === other ||
+            other is AdmittedCondition &&
+            field == other.field &&
+            operator == other.operator &&
+            value == other.value &&
+            children == other.children &&
+            options == other.options
+
+    override fun hashCode(): Int {
+        var result = field.hashCode()
+        result = 31 * result + operator.hashCode()
+        result = 31 * result + value.hashCode()
+        result = 31 * result + children.hashCode()
+        result = 31 * result + options.hashCode()
+        return result
+    }
+}

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/admission/RawAdmissionGuard.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/admission/RawAdmissionGuard.kt
@@ -1,0 +1,712 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.internal.admission
+
+import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.DeletionState
+import me.ahoo.wow.api.query.IListQuery
+import me.ahoo.wow.api.query.IPagedQuery
+import me.ahoo.wow.api.query.ISingleQuery
+import me.ahoo.wow.api.query.Operator
+import me.ahoo.wow.api.query.Pagination
+import me.ahoo.wow.api.query.Projection
+import me.ahoo.wow.api.query.Sort
+import me.ahoo.wow.query.internal.model.QueryInput
+import me.ahoo.wow.query.internal.model.QueryInvocation
+import me.ahoo.wow.query.internal.normalization.CaseSensitivity
+import me.ahoo.wow.query.internal.normalization.NormalizedValue
+import me.ahoo.wow.query.internal.rejection.QueryRejectionCategory
+import me.ahoo.wow.query.internal.rejection.QueryRejectionCode
+import me.ahoo.wow.query.internal.rejection.QueryRejectionPath
+import me.ahoo.wow.query.internal.rejection.rejectQuery
+import java.time.DateTimeException
+import java.time.LocalTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.util.Collections
+import java.util.IdentityHashMap
+
+internal class RawAdmissionGuard(
+    private val limits: QueryAdmissionLimits,
+) {
+    private val valueSnapshotter = RawValueSnapshotter(limits)
+
+    fun admit(invocation: QueryInvocation): AdmittedQueryInvocation {
+        val session = AdmissionSession(limits)
+        val inputPath = QueryRejectionPath.ROOT.property("input")
+        val admittedInput =
+            when (val input = invocation.input) {
+                is QueryInput.Single -> AdmittedQueryInput.Single(
+                    admitRecordQuery(input.query, inputPath.property("query"), session),
+                )
+
+                is QueryInput.Stream -> admitStream(input.query, inputPath.property("query"), session)
+                is QueryInput.Page -> admitPage(input.query, inputPath.property("query"), session)
+                is QueryInput.Count -> AdmittedQueryInput.Count(
+                    admitCondition(input.condition, inputPath.property("condition"), 1, session),
+                )
+
+                is QueryInput.Analytics -> AdmittedQueryInput.Analytics(input.query)
+            }
+        return AdmittedQueryInvocation(
+            target = invocation.target,
+            operation = invocation.operation,
+            resultShape = invocation.resultShape,
+            input = admittedInput,
+        )
+    }
+
+    private fun admitStream(
+        query: IListQuery,
+        path: QueryRejectionPath,
+        session: AdmissionSession,
+    ): AdmittedQueryInput.Stream {
+        val condition: Condition? = query.condition
+        val projection: Projection? = query.projection
+        val sort: List<Sort>? = query.sort
+        val limit = query.limit
+        requireRecordQuery(condition, projection, sort, path)
+        if (limit < 0) {
+            rejectInvalid(path.property("limit"), QueryRejectionCode.INVALID_LIMIT)
+        }
+        return AdmittedQueryInput.Stream(
+            query = admitRecordQuery(
+                checkNotNull(condition),
+                checkNotNull(projection),
+                checkNotNull(sort),
+                path,
+                session,
+            ),
+            limit = limit,
+        )
+    }
+
+    private fun admitPage(
+        query: IPagedQuery,
+        path: QueryRejectionPath,
+        session: AdmissionSession,
+    ): AdmittedQueryInput.Page {
+        val condition: Condition? = query.condition
+        val projection: Projection? = query.projection
+        val sort: List<Sort>? = query.sort
+        val pagination: Pagination? = query.pagination
+        requireRecordQuery(condition, projection, sort, path)
+        if (pagination == null) {
+            rejectInvalid(path.property("pagination"), QueryRejectionCode.INVALID_PAGE)
+        }
+        val index = pagination.index
+        val size = pagination.size
+        if (index < 1 || size <= 0) {
+            rejectInvalid(path.property("pagination"), QueryRejectionCode.INVALID_PAGE)
+        }
+        val offset = Math.multiplyExact(index.toLong() - 1, size.toLong())
+        return AdmittedQueryInput.Page(
+            query = admitRecordQuery(
+                checkNotNull(condition),
+                checkNotNull(projection),
+                checkNotNull(sort),
+                path,
+                session,
+            ),
+            page = AdmittedPage(index, size, offset),
+        )
+    }
+
+    private fun admitRecordQuery(
+        query: ISingleQuery,
+        path: QueryRejectionPath,
+        session: AdmissionSession,
+    ): AdmittedRecordQuery {
+        val condition: Condition? = query.condition
+        val projection: Projection? = query.projection
+        val sort: List<Sort>? = query.sort
+        requireRecordQuery(condition, projection, sort, path)
+        return admitRecordQuery(
+            checkNotNull(condition),
+            checkNotNull(projection),
+            checkNotNull(sort),
+            path,
+            session,
+        )
+    }
+
+    private fun requireRecordQuery(
+        condition: Condition?,
+        projection: Projection?,
+        sort: List<Sort>?,
+        path: QueryRejectionPath,
+    ) {
+        if (condition == null) {
+            rejectInvalid(path.property("condition"), QueryRejectionCode.INVALID_VALUE_TYPE)
+        }
+        if (projection == null) {
+            rejectInvalid(path.property("projection"), QueryRejectionCode.INVALID_PROJECTION)
+        }
+        if (sort == null) {
+            rejectInvalid(path.property("sort"), QueryRejectionCode.INVALID_SORT)
+        }
+    }
+
+    private fun admitRecordQuery(
+        condition: Condition,
+        projection: Projection,
+        sort: List<Sort>,
+        path: QueryRejectionPath,
+        session: AdmissionSession,
+    ): AdmittedRecordQuery =
+        AdmittedRecordQuery(
+            condition = admitCondition(condition, path.property("condition"), 1, session),
+            projection = admitProjection(projection, path.property("projection"), session),
+            sort = admitSort(sort, path.property("sort"), session),
+        )
+
+    private fun admitProjection(
+        projection: Projection,
+        path: QueryRejectionPath,
+        session: AdmissionSession,
+    ): AdmittedProjection {
+        val include = projection.include
+        val exclude = projection.exclude
+        val admittedInclude = admitFieldList(
+            include,
+            path.property("include"),
+            limits.maxProjectionFields,
+            session,
+        )
+        return AdmittedProjection(
+            include = admittedInclude,
+            exclude = admitFieldList(
+                exclude,
+                path.property("exclude"),
+                limits.maxProjectionFields - admittedInclude.size,
+                session,
+            ),
+        )
+    }
+
+    private fun admitSort(
+        sort: Iterable<*>,
+        path: QueryRejectionPath,
+        session: AdmissionSession,
+    ): List<AdmittedSort> {
+        val result = ArrayList<AdmittedSort>()
+        val iterator = sort.iterator()
+        while (iterator.hasNext()) {
+            if (result.size == limits.maxSortFields) {
+                rejectBudget(path, QueryRejectionCode.SORT_LIMIT_EXCEEDED)
+            }
+            val index = result.size
+            val item = iterator.next()
+            if (item !is Sort) {
+                rejectInvalid(path.index(index), QueryRejectionCode.INVALID_SORT)
+            }
+            val fieldPath = path.index(index).property("field")
+            validateField(item.field, fieldPath)
+            session.budget.consumeUtf8(item.field, fieldPath)
+            result += AdmittedSort(item.field, item.direction)
+        }
+        return Collections.unmodifiableList(result)
+    }
+
+    private fun admitFieldList(
+        fields: Iterable<*>,
+        path: QueryRejectionPath,
+        limit: Int,
+        session: AdmissionSession,
+    ): List<String> {
+        val result = ArrayList<String>()
+        val iterator = fields.iterator()
+        while (iterator.hasNext()) {
+            if (result.size == limit) {
+                rejectBudget(path, QueryRejectionCode.PROJECTION_LIMIT_EXCEEDED)
+            }
+            val index = result.size
+            val field = iterator.next()
+            if (field !is String) {
+                rejectInvalid(path.index(index), QueryRejectionCode.INVALID_PROJECTION)
+            }
+            validateField(field, path.index(index))
+            session.budget.consumeUtf8(field, path.index(index))
+            result += field
+        }
+        return Collections.unmodifiableList(result)
+    }
+
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
+    private fun admitCondition(
+        condition: Condition,
+        path: QueryRejectionPath,
+        depth: Int,
+        session: AdmissionSession,
+    ): AdmittedCondition {
+        if (depth > limits.maxConditionDepth) {
+            rejectBudget(path, QueryRejectionCode.CONDITION_DEPTH_LIMIT_EXCEEDED)
+        }
+        if (session.conditionNodes == limits.maxConditionNodes) {
+            rejectBudget(path, QueryRejectionCode.CONDITION_NODE_LIMIT_EXCEEDED)
+        }
+        session.conditionNodes++
+        if (session.conditionActive.put(condition, Unit) != null) {
+            rejectInvalid(path, QueryRejectionCode.CYCLIC_INPUT)
+        }
+        try {
+            val field = condition.field
+            val operator = condition.operator
+            val rawValue = condition.value
+            val rawChildren = condition.children
+            val rawOptions = condition.options
+            val fieldPath = path.property("field")
+            validateConditionField(field, operator, fieldPath)
+            session.budget.consumeUtf8(field, fieldPath)
+            val children = materializeChildren(rawChildren, path.property("children"))
+            validateChildren(operator, children, path.property("children"))
+            val options = admitOptions(operator, rawOptions, path.property("options"), session)
+            val value = admitConditionValue(operator, rawValue, path.property("value"), session)
+            val admittedChildren = children.mapIndexed { index, child ->
+                admitCondition(child, path.property("children").index(index), depth + 1, session)
+            }
+            return AdmittedCondition(field, operator, value, admittedChildren, options)
+        } finally {
+            session.conditionActive.remove(condition)
+        }
+    }
+
+    private fun materializeChildren(
+        children: List<*>,
+        path: QueryRejectionPath,
+    ): List<Condition> {
+        val result = ArrayList<Condition>()
+        val iterator = children.iterator()
+        while (iterator.hasNext()) {
+            if (result.size == limits.maxChildrenPerNode) {
+                rejectBudget(path, QueryRejectionCode.CHILDREN_LIMIT_EXCEEDED)
+            }
+            val index = result.size
+            val child = iterator.next()
+            if (child !is Condition) {
+                rejectInvalid(path.index(index), QueryRejectionCode.INVALID_CHILDREN)
+            }
+            result += child
+        }
+        return result
+    }
+
+    private fun validateChildren(
+        operator: Operator,
+        children: List<Condition>,
+        path: QueryRejectionPath,
+    ) {
+        when (operator) {
+            Operator.AND,
+            Operator.OR,
+            Operator.NOR,
+            -> if (children.isEmpty()) {
+                rejectInvalid(path, QueryRejectionCode.INVALID_CHILDREN)
+            }
+
+            Operator.ELEM_MATCH -> if (children.size != 1) {
+                rejectInvalid(path, QueryRejectionCode.INVALID_CHILDREN)
+            }
+
+            else -> if (children.isNotEmpty()) {
+                rejectInvalid(path, QueryRejectionCode.INVALID_CHILDREN)
+            }
+        }
+    }
+
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
+    private fun admitConditionValue(
+        operator: Operator,
+        rawValue: Any?,
+        path: QueryRejectionPath,
+        session: AdmissionSession,
+    ): AdmittedConditionValue =
+        when (operator) {
+            Operator.AND,
+            Operator.OR,
+            Operator.NOR,
+            Operator.ALL,
+            Operator.ELEM_MATCH,
+            Operator.NULL,
+            Operator.NOT_NULL,
+            Operator.TRUE,
+            Operator.FALSE,
+            Operator.TODAY,
+            Operator.TOMORROW,
+            Operator.THIS_WEEK,
+            Operator.NEXT_WEEK,
+            Operator.LAST_WEEK,
+            Operator.THIS_MONTH,
+            Operator.LAST_MONTH,
+            -> AdmittedConditionValue.Absent
+
+            Operator.ID,
+            Operator.AGGREGATE_ID,
+            Operator.TENANT_ID,
+            Operator.OWNER_ID,
+            Operator.SPACE_ID,
+            Operator.CONTAINS,
+            Operator.STARTS_WITH,
+            Operator.ENDS_WITH,
+            Operator.MATCH,
+            -> AdmittedConditionValue.QueryValue(
+                normalizeRequiredString(rawValue, path, session, requireNonBlank = operator == Operator.MATCH),
+            )
+
+            Operator.IDS,
+            Operator.AGGREGATE_IDS,
+            -> AdmittedConditionValue.QueryValue(
+                valueSnapshotter.snapshotRequiredStringIterable(rawValue, path, session.budget),
+            )
+
+            Operator.IN,
+            Operator.NOT_IN,
+            Operator.ALL_IN,
+            -> AdmittedConditionValue.QueryValue(
+                valueSnapshotter.snapshotRequiredIterable(rawValue, path, session.budget),
+            )
+
+            Operator.BETWEEN -> {
+                val value = valueSnapshotter.snapshotRequiredIterable(rawValue, path, session.budget)
+                if (value.values.size != 2) {
+                    rejectInvalid(path, QueryRejectionCode.INVALID_VALUE_ARITY)
+                }
+                AdmittedConditionValue.QueryValue(value)
+            }
+
+            Operator.EXISTS -> {
+                session.budget.enterValue(path)
+                if (rawValue !is Boolean) {
+                    rejectInvalid(path, QueryRejectionCode.INVALID_VALUE_TYPE)
+                }
+                AdmittedConditionValue.QueryValue(NormalizedValue.BooleanValue(rawValue))
+            }
+
+            Operator.DELETED -> AdmittedConditionValue.Deletion(normalizeDeletionState(rawValue, path, session))
+            Operator.BEFORE_TODAY -> AdmittedConditionValue.TimeOfDay(normalizeTimeOfDay(rawValue, path, session))
+            Operator.RECENT_DAYS,
+            Operator.EARLIER_DAYS,
+            -> AdmittedConditionValue.QueryValue(
+                NormalizedValue.Int64(normalizePositiveWholeNumber(rawValue, path, session)),
+            )
+
+            Operator.EQ,
+            Operator.NE,
+            Operator.GT,
+            Operator.LT,
+            Operator.GTE,
+            Operator.LTE,
+            -> AdmittedConditionValue.QueryValue(valueSnapshotter.snapshot(rawValue, path, session.budget))
+
+            Operator.RAW -> AdmittedConditionValue.NativeUnbound
+        }
+
+    private fun normalizeRequiredString(
+        rawValue: Any?,
+        path: QueryRejectionPath,
+        session: AdmissionSession,
+        requireNonBlank: Boolean,
+    ): NormalizedValue.Text {
+        session.budget.enterValue(path)
+        if (rawValue !is String) {
+            rejectInvalid(path, QueryRejectionCode.INVALID_VALUE_TYPE)
+        }
+        session.budget.consumeString(rawValue, path)
+        if (requireNonBlank && rawValue.isBlank()) {
+            rejectInvalid(path, QueryRejectionCode.INVALID_VALUE_TYPE)
+        }
+        return NormalizedValue.Text(rawValue)
+    }
+
+    private fun normalizeDeletionState(
+        rawValue: Any?,
+        path: QueryRejectionPath,
+        session: AdmissionSession,
+    ): DeletionState {
+        session.budget.enterValue(path)
+        return when (rawValue) {
+            is DeletionState -> rawValue
+            is Boolean -> if (rawValue) DeletionState.DELETED else DeletionState.ACTIVE
+            is String -> {
+                session.budget.consumeString(rawValue, path)
+                try {
+                    DeletionState.valueOf(rawValue.uppercase())
+                } catch (error: IllegalArgumentException) {
+                    rejectInvalid(path, QueryRejectionCode.INVALID_VALUE_TYPE, error)
+                }
+            }
+            else -> rejectInvalid(path, QueryRejectionCode.INVALID_VALUE_TYPE)
+        }
+    }
+
+    private fun normalizeTimeOfDay(
+        rawValue: Any?,
+        path: QueryRejectionPath,
+        session: AdmissionSession,
+    ): LocalTime {
+        session.budget.enterValue(path)
+        return when (rawValue) {
+            is LocalTime -> rawValue
+            is String -> {
+                session.budget.consumeString(rawValue, path)
+                try {
+                    LocalTime.parse(rawValue)
+                } catch (error: DateTimeParseException) {
+                    rejectInvalid(path, QueryRejectionCode.INVALID_TIME_VALUE, error)
+                }
+            }
+            is Number -> {
+                val seconds = exactLong(rawValue, path, QueryRejectionCode.INVALID_TIME_VALUE, session)
+                if (seconds !in 0..86_399) {
+                    rejectInvalid(path, QueryRejectionCode.INVALID_TIME_VALUE)
+                }
+                LocalTime.ofSecondOfDay(seconds)
+            }
+            else -> rejectInvalid(path, QueryRejectionCode.INVALID_TIME_VALUE)
+        }
+    }
+
+    private fun normalizePositiveWholeNumber(
+        rawValue: Any?,
+        path: QueryRejectionPath,
+        session: AdmissionSession,
+    ): Long {
+        session.budget.enterValue(path)
+        if (rawValue !is Number) {
+            rejectInvalid(path, QueryRejectionCode.INVALID_TIME_VALUE)
+        }
+        val value = exactLong(rawValue, path, QueryRejectionCode.INVALID_TIME_VALUE, session)
+        if (value <= 0) {
+            rejectInvalid(path, QueryRejectionCode.INVALID_TIME_VALUE)
+        }
+        return value
+    }
+
+    private fun exactLong(
+        number: Number,
+        path: QueryRejectionPath,
+        code: QueryRejectionCode,
+        session: AdmissionSession,
+    ): Long {
+        if (!number.isSupported()) {
+            rejectInvalid(path, code)
+        }
+        val numberText = session.budget.consumeNumber(number, path)
+        return try {
+            numberText.toBigDecimal().longValueExact()
+        } catch (error: NumberFormatException) {
+            rejectInvalid(path, code, error)
+        } catch (error: ArithmeticException) {
+            rejectInvalid(path, code, error)
+        }
+    }
+
+    private fun Number.isSupported(): Boolean =
+        when (this) {
+            is Byte,
+            is Short,
+            is Int,
+            is Long,
+            is Float,
+            is Double,
+            is java.math.BigDecimal,
+            is java.math.BigInteger,
+            -> true
+            else -> false
+        }
+
+    private fun admitOptions(
+        operator: Operator,
+        options: Map<*, *>,
+        path: QueryRejectionPath,
+        session: AdmissionSession,
+    ): AdmittedConditionOptions {
+        var caseSensitivity = CaseSensitivity.SENSITIVE
+        var zoneId: ZoneId? = null
+        var datePattern: AdmittedDatePattern? = null
+        var count = 0
+        val seenKeys = HashSet<String>()
+        val iterator = options.entries.iterator()
+        while (iterator.hasNext()) {
+            if (count == limits.maxOptions) {
+                rejectBudget(path, QueryRejectionCode.OPTIONS_LIMIT_EXCEEDED)
+            }
+            val entry = iterator.next()
+            count++
+            val key = entry.key
+            if (key !is String) {
+                rejectInvalid(path, QueryRejectionCode.INVALID_OPTION_TYPE)
+            }
+            val optionPath = path.key(key)
+            session.budget.consumeString(key, optionPath)
+            if (!seenKeys.add(key)) {
+                rejectInvalid(optionPath, QueryRejectionCode.DUPLICATE_OBJECT_KEY)
+            }
+            val value = entry.value
+            session.budget.enterValue(optionPath)
+            when (key) {
+                Condition.IGNORE_CASE_OPTION_KEY -> {
+                    ensureOptionAllowed(operator, STRING_OPTION_OPERATORS, optionPath)
+                    if (value !is Boolean) {
+                        rejectInvalid(optionPath, QueryRejectionCode.INVALID_OPTION_TYPE)
+                    }
+                    caseSensitivity = if (value) CaseSensitivity.INSENSITIVE else CaseSensitivity.SENSITIVE
+                }
+
+                Condition.ZONE_ID_OPTION_KEY -> {
+                    ensureOptionAllowed(operator, TIME_OPERATORS, optionPath)
+                    zoneId = normalizeZoneId(value, optionPath, session)
+                }
+
+                Condition.DATE_PATTERN_OPTION_KEY -> {
+                    ensureOptionAllowed(operator, TIME_OPERATORS, optionPath)
+                    datePattern = normalizeDatePattern(value, optionPath, session)
+                }
+
+                else -> rejectInvalid(optionPath, QueryRejectionCode.UNKNOWN_OPTION)
+            }
+        }
+        return AdmittedConditionOptions(caseSensitivity, zoneId, datePattern)
+    }
+
+    private fun ensureOptionAllowed(
+        operator: Operator,
+        allowed: Set<Operator>,
+        path: QueryRejectionPath,
+    ) {
+        if (operator !in allowed) {
+            rejectInvalid(path, QueryRejectionCode.OPTION_NOT_ALLOWED)
+        }
+    }
+
+    private fun normalizeZoneId(
+        value: Any?,
+        path: QueryRejectionPath,
+        session: AdmissionSession,
+    ): ZoneId =
+        when (value) {
+            is ZoneId -> value
+            is String -> {
+                session.budget.consumeString(value, path)
+                try {
+                    ZoneId.of(value)
+                } catch (error: DateTimeException) {
+                    rejectInvalid(path, QueryRejectionCode.INVALID_OPTION_VALUE, error)
+                }
+            }
+            else -> rejectInvalid(path, QueryRejectionCode.INVALID_OPTION_TYPE)
+        }
+
+    private fun normalizeDatePattern(
+        value: Any?,
+        path: QueryRejectionPath,
+        session: AdmissionSession,
+    ): AdmittedDatePattern =
+        when (value) {
+            is DateTimeFormatter -> admitDateTimeFormatter(value, path, session)
+            is String -> {
+                session.budget.consumeString(value, path)
+                try {
+                    val formatter = DateTimeFormatter.ofPattern(value)
+                    AdmittedDatePattern(formatter, formatter.toString())
+                } catch (error: IllegalArgumentException) {
+                    rejectInvalid(path, QueryRejectionCode.INVALID_OPTION_VALUE, error)
+                }
+            }
+            else -> rejectInvalid(path, QueryRejectionCode.INVALID_OPTION_TYPE)
+        }
+
+    private fun admitDateTimeFormatter(
+        formatter: DateTimeFormatter,
+        path: QueryRejectionPath,
+        session: AdmissionSession,
+    ): AdmittedDatePattern {
+        val descriptor = formatter.toString()
+        session.budget.consumeString(descriptor, path)
+        return AdmittedDatePattern(formatter, descriptor)
+    }
+
+    private fun validateConditionField(field: String, operator: Operator, path: QueryRejectionPath) {
+        if (operator in FIELDLESS_OPERATORS) {
+            if (field.isNotEmpty()) {
+                rejectInvalid(path, QueryRejectionCode.INVALID_FIELD)
+            }
+            return
+        }
+        validateField(field, path)
+    }
+
+    private fun validateField(field: String, path: QueryRejectionPath) {
+        if (field.isBlank()) {
+            rejectInvalid(path, QueryRejectionCode.FIELD_REQUIRED)
+        }
+        if (field.length > limits.maxFieldLength) {
+            rejectBudget(path, QueryRejectionCode.STRING_LIMIT_EXCEEDED)
+        }
+        if (field.split('.').any { it.isBlank() || it.any(Char::isISOControl) }) {
+            rejectInvalid(path, QueryRejectionCode.INVALID_FIELD)
+        }
+    }
+
+    private fun rejectInvalid(
+        path: QueryRejectionPath,
+        code: QueryRejectionCode,
+        cause: Throwable? = null,
+    ): Nothing = rejectQuery(QueryRejectionCategory.INVALID_QUERY, path, code, cause)
+
+    private fun rejectBudget(path: QueryRejectionPath, code: QueryRejectionCode): Nothing =
+        rejectQuery(QueryRejectionCategory.BUDGET_EXCEEDED, path, code)
+
+    private class AdmissionSession(limits: QueryAdmissionLimits) {
+        var conditionNodes: Int = 0
+        val conditionActive: IdentityHashMap<Condition, Unit> = IdentityHashMap()
+        val budget: AdmissionBudget = AdmissionBudget(limits)
+    }
+
+    companion object {
+        private val FIELDLESS_OPERATORS = setOf(
+            Operator.AND,
+            Operator.OR,
+            Operator.NOR,
+            Operator.ID,
+            Operator.IDS,
+            Operator.AGGREGATE_ID,
+            Operator.AGGREGATE_IDS,
+            Operator.TENANT_ID,
+            Operator.OWNER_ID,
+            Operator.SPACE_ID,
+            Operator.DELETED,
+            Operator.ALL,
+            Operator.RAW,
+        )
+        private val STRING_OPTION_OPERATORS = setOf(
+            Operator.CONTAINS,
+            Operator.STARTS_WITH,
+            Operator.ENDS_WITH,
+        )
+        private val TIME_OPERATORS = setOf(
+            Operator.TODAY,
+            Operator.BEFORE_TODAY,
+            Operator.TOMORROW,
+            Operator.THIS_WEEK,
+            Operator.NEXT_WEEK,
+            Operator.LAST_WEEK,
+            Operator.THIS_MONTH,
+            Operator.LAST_MONTH,
+            Operator.RECENT_DAYS,
+            Operator.EARLIER_DAYS,
+        )
+    }
+}

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/admission/RawValueSnapshotter.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/admission/RawValueSnapshotter.kt
@@ -1,0 +1,309 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.internal.admission
+
+import me.ahoo.wow.query.internal.normalization.NormalizedValue
+import me.ahoo.wow.query.internal.rejection.QueryRejectionCategory
+import me.ahoo.wow.query.internal.rejection.QueryRejectionCode
+import me.ahoo.wow.query.internal.rejection.QueryRejectionPath
+import me.ahoo.wow.query.internal.rejection.rejectQuery
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZonedDateTime
+import java.util.Date
+import java.util.IdentityHashMap
+import java.util.LinkedHashMap
+import java.util.UUID
+
+/**
+ * Converts legacy `Any` values into the closed, deeply immutable normalized value algebra.
+ *
+ * Each public operation owns its identity session, so this stateless component is safe to reuse concurrently.
+ */
+internal class RawValueSnapshotter(
+    private val limits: QueryAdmissionLimits,
+) {
+    fun snapshot(
+        rawValue: Any?,
+        path: QueryRejectionPath,
+        budget: AdmissionBudget,
+    ): NormalizedValue = snapshotValue(rawValue, path, depth = 1, ValueSession(), budget)
+
+    fun snapshotRequiredIterable(
+        rawValue: Any?,
+        path: QueryRejectionPath,
+        budget: AdmissionBudget,
+    ): NormalizedValue.ListValue {
+        if (rawValue !is Iterable<*>) {
+            rejectInvalid(path, QueryRejectionCode.INVALID_VALUE_TYPE)
+        }
+        budget.enterValue(path)
+        return snapshotIterable(rawValue, path, depth = 1, ValueSession(), budget)
+    }
+
+    fun snapshotRequiredStringIterable(
+        rawValue: Any?,
+        path: QueryRejectionPath,
+        budget: AdmissionBudget,
+    ): NormalizedValue.ListValue {
+        if (rawValue !is Iterable<*>) {
+            rejectInvalid(path, QueryRejectionCode.INVALID_VALUE_TYPE)
+        }
+        budget.enterValue(path)
+        val session = ValueSession()
+        enterValue(rawValue, path, session)
+        try {
+            val result = ArrayList<NormalizedValue>()
+            val iterator = rawValue.iterator()
+            while (iterator.hasNext()) {
+                if (result.size == limits.maxCollectionSize) {
+                    rejectBudget(path, QueryRejectionCode.COLLECTION_LIMIT_EXCEEDED)
+                }
+                val itemPath = path.index(result.size)
+                val item = iterator.next()
+                budget.enterValue(itemPath)
+                if (item !is String) {
+                    rejectInvalid(itemPath, QueryRejectionCode.INVALID_VALUE_TYPE)
+                }
+                budget.consumeString(item, itemPath)
+                result += NormalizedValue.Text(item)
+            }
+            return NormalizedValue.ListValue(result)
+        } finally {
+            session.active.remove(rawValue)
+        }
+    }
+
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
+    private fun snapshotValue(
+        rawValue: Any?,
+        path: QueryRejectionPath,
+        depth: Int,
+        session: ValueSession,
+        budget: AdmissionBudget,
+    ): NormalizedValue {
+        if (depth > limits.maxValueDepth) {
+            rejectBudget(path, QueryRejectionCode.VALUE_DEPTH_LIMIT_EXCEEDED)
+        }
+        budget.enterValue(path)
+        return when (rawValue) {
+            null -> NormalizedValue.Null
+            is NormalizedValue -> rejectInvalid(path, QueryRejectionCode.INVALID_VALUE_TYPE)
+            is Boolean -> NormalizedValue.BooleanValue(rawValue)
+            is String -> {
+                budget.consumeString(rawValue, path)
+                NormalizedValue.Text(rawValue)
+            }
+            is Char -> normalizedText(rawValue.toString(), path, budget)
+            is UUID -> normalizedText(rawValue.toString(), path, budget)
+            is Enum<*> -> normalizedText(rawValue.name, path, budget)
+            is Number -> normalizeNumber(rawValue, path, budget)
+            is Instant -> NormalizedValue.InstantValue(rawValue)
+            is Date -> {
+                val instant = try {
+                    rawValue.toInstant()
+                } catch (error: UnsupportedOperationException) {
+                    rejectInvalid(path, QueryRejectionCode.INVALID_VALUE_TYPE, error)
+                }
+                NormalizedValue.InstantValue(instant)
+            }
+            is OffsetDateTime -> NormalizedValue.InstantValue(rawValue.toInstant())
+            is ZonedDateTime -> NormalizedValue.InstantValue(rawValue.toInstant())
+            is ByteArray -> {
+                budget.consumeBytes(rawValue.size, path)
+                NormalizedValue.Bytes(rawValue)
+            }
+            is Map<*, *> -> snapshotMap(rawValue, path, depth, session, budget)
+            is Iterable<*> -> snapshotIterable(rawValue, path, depth, session, budget)
+            is Array<*> -> snapshotArray(rawValue, path, depth, session, budget)
+            else -> rejectInvalid(path, QueryRejectionCode.INVALID_VALUE_TYPE)
+        }
+    }
+
+    private fun normalizedText(
+        value: String,
+        path: QueryRejectionPath,
+        budget: AdmissionBudget,
+    ): NormalizedValue.Text {
+        budget.consumeString(value, path)
+        return NormalizedValue.Text(value)
+    }
+
+    @Suppress("CyclomaticComplexMethod")
+    private fun normalizeNumber(
+        number: Number,
+        path: QueryRejectionPath,
+        budget: AdmissionBudget,
+    ): NormalizedValue {
+        if (!number.isSupported()) {
+            rejectInvalid(path, QueryRejectionCode.INVALID_VALUE_TYPE)
+        }
+        budget.consumeNumber(number, path)
+        val decimal = try {
+            when (number) {
+                is BigDecimal -> number
+                is BigInteger -> number.toBigDecimal()
+                is Byte,
+                is Short,
+                is Int,
+                is Long,
+                -> BigDecimal.valueOf(number.toLong())
+                is Float -> {
+                    if (!number.isFinite()) {
+                        rejectInvalid(path, QueryRejectionCode.INVALID_VALUE_TYPE)
+                    }
+                    BigDecimal.valueOf(number.toDouble())
+                }
+                is Double -> {
+                    if (!number.isFinite()) {
+                        rejectInvalid(path, QueryRejectionCode.INVALID_VALUE_TYPE)
+                    }
+                    BigDecimal.valueOf(number)
+                }
+                else -> error("Supported numeric types are exhaustive.")
+            }
+        } catch (error: NumberFormatException) {
+            rejectInvalid(path, QueryRejectionCode.INVALID_VALUE_TYPE, error)
+        }
+        val exactLong = try {
+            decimal.longValueExact()
+        } catch (_: ArithmeticException) {
+            null
+        }
+        if (exactLong != null) {
+            return NormalizedValue.Int64(exactLong)
+        }
+        return try {
+            NormalizedValue.Decimal(decimal)
+        } catch (error: ArithmeticException) {
+            rejectInvalid(path, QueryRejectionCode.INVALID_VALUE_TYPE, error)
+        }
+    }
+
+    private fun Number.isSupported(): Boolean =
+        when (this) {
+            is BigDecimal,
+            is BigInteger,
+            is Byte,
+            is Short,
+            is Int,
+            is Long,
+            is Float,
+            is Double,
+            -> true
+            else -> false
+        }
+
+    private fun snapshotIterable(
+        values: Iterable<*>,
+        path: QueryRejectionPath,
+        depth: Int,
+        session: ValueSession,
+        budget: AdmissionBudget,
+    ): NormalizedValue.ListValue {
+        enterValue(values, path, session)
+        try {
+            val result = ArrayList<NormalizedValue>()
+            val iterator = values.iterator()
+            while (iterator.hasNext()) {
+                if (result.size == limits.maxCollectionSize) {
+                    rejectBudget(path, QueryRejectionCode.COLLECTION_LIMIT_EXCEEDED)
+                }
+                val index = result.size
+                result += snapshotValue(iterator.next(), path.index(index), depth + 1, session, budget)
+            }
+            return NormalizedValue.ListValue(result)
+        } finally {
+            session.active.remove(values)
+        }
+    }
+
+    private fun snapshotArray(
+        values: Array<*>,
+        path: QueryRejectionPath,
+        depth: Int,
+        session: ValueSession,
+        budget: AdmissionBudget,
+    ): NormalizedValue.ListValue {
+        if (values.size > limits.maxCollectionSize) {
+            rejectBudget(path, QueryRejectionCode.COLLECTION_LIMIT_EXCEEDED)
+        }
+        enterValue(values, path, session)
+        try {
+            return NormalizedValue.ListValue(
+                values.mapIndexed { index, value ->
+                    snapshotValue(value, path.index(index), depth + 1, session, budget)
+                },
+            )
+        } finally {
+            session.active.remove(values)
+        }
+    }
+
+    private fun snapshotMap(
+        values: Map<*, *>,
+        path: QueryRejectionPath,
+        depth: Int,
+        session: ValueSession,
+        budget: AdmissionBudget,
+    ): NormalizedValue.ObjectValue {
+        enterValue(values, path, session)
+        try {
+            val result = LinkedHashMap<String, NormalizedValue>()
+            val iterator = values.entries.iterator()
+            var entryCount = 0
+            while (iterator.hasNext()) {
+                if (entryCount == limits.maxObjectFields) {
+                    rejectBudget(path, QueryRejectionCode.OBJECT_LIMIT_EXCEEDED)
+                }
+                val entry = iterator.next()
+                entryCount++
+                val key = entry.key
+                if (key !is String) {
+                    rejectInvalid(path, QueryRejectionCode.INVALID_VALUE_TYPE)
+                }
+                val keyPath = path.key(key)
+                budget.consumeString(key, keyPath)
+                if (result.containsKey(key)) {
+                    rejectInvalid(keyPath, QueryRejectionCode.DUPLICATE_OBJECT_KEY)
+                }
+                result[key] = snapshotValue(entry.value, keyPath, depth + 1, session, budget)
+            }
+            return NormalizedValue.ObjectValue(result)
+        } finally {
+            session.active.remove(values)
+        }
+    }
+
+    private fun enterValue(value: Any, path: QueryRejectionPath, session: ValueSession) {
+        if (session.active.put(value, Unit) != null) {
+            rejectInvalid(path, QueryRejectionCode.CYCLIC_INPUT)
+        }
+    }
+
+    private fun rejectInvalid(
+        path: QueryRejectionPath,
+        code: QueryRejectionCode,
+        cause: Throwable? = null,
+    ): Nothing = rejectQuery(QueryRejectionCategory.INVALID_QUERY, path, code, cause)
+
+    private fun rejectBudget(path: QueryRejectionPath, code: QueryRejectionCode): Nothing =
+        rejectQuery(QueryRejectionCategory.BUDGET_EXCEEDED, path, code)
+
+    private class ValueSession {
+        val active: IdentityHashMap<Any, Unit> = IdentityHashMap()
+    }
+}

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/normalization/NormalizedCondition.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/normalization/NormalizedCondition.kt
@@ -122,6 +122,8 @@ internal value class Utf8Json(val value: String) {
 internal sealed interface NormalizedCondition {
     data object All : NormalizedCondition
 
+    data object None : NormalizedCondition
+
     class Junction(
         val operator: JunctionOperator,
         children: Iterable<NormalizedCondition>,

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/normalization/NormalizedQuery.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/normalization/NormalizedQuery.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.internal.normalization
+
+import me.ahoo.wow.query.internal.analytics.AnalyticsQuery
+import me.ahoo.wow.query.internal.model.QueryOperation
+import me.ahoo.wow.query.internal.model.QueryResultShape
+import me.ahoo.wow.query.internal.model.QueryTarget
+import me.ahoo.wow.query.internal.value.NonEmptyList
+import java.util.Collections
+
+internal data class NormalizedQueryInvocation(
+    val target: QueryTarget,
+    val operation: QueryOperation,
+    val resultShape: QueryResultShape,
+    val input: NormalizedQueryInput,
+)
+
+internal sealed interface NormalizedQueryInput {
+    data class Single(val query: NormalizedRecordQuery) : NormalizedQueryInput
+
+    data class Stream(
+        val query: NormalizedRecordQuery,
+        val limit: Int,
+    ) : NormalizedQueryInput
+
+    data class Page(
+        val query: NormalizedRecordQuery,
+        val page: NormalizedPage,
+    ) : NormalizedQueryInput
+
+    data class Count(val userCondition: NormalizedCondition) : NormalizedQueryInput
+
+    data class Analytics(val query: AnalyticsQuery) : NormalizedQueryInput
+}
+
+internal class NormalizedRecordQuery(
+    val userCondition: NormalizedCondition,
+    val projection: NormalizedProjection,
+    sort: Iterable<NormalizedSort>,
+) {
+    val sort: List<NormalizedSort> = Collections.unmodifiableList(sort.toList())
+
+    override fun equals(other: Any?): Boolean =
+        this === other ||
+            other is NormalizedRecordQuery &&
+            userCondition == other.userCondition &&
+            projection == other.projection &&
+            sort == other.sort
+
+    override fun hashCode(): Int = 31 * (31 * userCondition.hashCode() + projection.hashCode()) + sort.hashCode()
+}
+
+internal sealed interface NormalizedProjection {
+    data object All : NormalizedProjection
+
+    data class Include(val fields: NonEmptyList<LogicalField.Path>) : NormalizedProjection
+
+    data class Exclude(val fields: NonEmptyList<LogicalField.Path>) : NormalizedProjection
+
+    /** Preserved until P1-C applies result-shape and validation-mode policy. */
+    data class Mixed(
+        val include: NonEmptyList<LogicalField.Path>,
+        val exclude: NonEmptyList<LogicalField.Path>,
+    ) : NormalizedProjection
+}
+
+internal enum class NormalizedSortDirection {
+    ASC,
+    DESC,
+}
+
+internal data class NormalizedSort(
+    val field: LogicalField.Path,
+    val direction: NormalizedSortDirection,
+)
+
+internal data class NormalizedPage(
+    val index: Int,
+    val size: Int,
+    val offset: Long,
+)

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/normalization/NormalizedValue.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/normalization/NormalizedValue.kt
@@ -27,7 +27,16 @@ internal sealed interface NormalizedValue {
 
     data class Int64(val value: Long) : NormalizedValue
 
-    data class Decimal(val value: BigDecimal) : NormalizedValue
+    class Decimal(value: BigDecimal) : NormalizedValue {
+        val value: BigDecimal = value.stripTrailingZeros()
+
+        override fun equals(other: Any?): Boolean =
+            this === other || other is Decimal && value == other.value
+
+        override fun hashCode(): Int = value.hashCode()
+
+        override fun toString(): String = "Decimal(value=$value)"
+    }
 
     data class InstantValue(val value: Instant) : NormalizedValue
 
@@ -58,11 +67,13 @@ internal sealed interface NormalizedValue {
     class ObjectValue(values: Map<String, NormalizedValue>) : NormalizedValue {
         val values: Map<String, NormalizedValue> =
             Collections.unmodifiableMap(LinkedHashMap(values))
+        private val orderedEntries: List<Pair<String, NormalizedValue>> =
+            this.values.map { entry -> entry.key to entry.value }
 
         override fun equals(other: Any?): Boolean =
-            this === other || other is ObjectValue && values == other.values
+            this === other || other is ObjectValue && orderedEntries == other.orderedEntries
 
-        override fun hashCode(): Int = values.hashCode()
+        override fun hashCode(): Int = orderedEntries.hashCode()
 
         override fun toString(): String = values.toString()
     }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/normalization/QueryNormalizer.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/normalization/QueryNormalizer.kt
@@ -1,0 +1,656 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.internal.normalization
+
+import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.DeletionState
+import me.ahoo.wow.api.query.Operator
+import me.ahoo.wow.api.query.Sort
+import me.ahoo.wow.query.internal.admission.AdmittedCondition
+import me.ahoo.wow.query.internal.admission.AdmittedConditionValue
+import me.ahoo.wow.query.internal.admission.AdmittedPage
+import me.ahoo.wow.query.internal.admission.AdmittedProjection
+import me.ahoo.wow.query.internal.admission.AdmittedQueryInput
+import me.ahoo.wow.query.internal.admission.AdmittedQueryInvocation
+import me.ahoo.wow.query.internal.admission.AdmittedRecordQuery
+import me.ahoo.wow.query.internal.rejection.QueryRejectionCategory
+import me.ahoo.wow.query.internal.rejection.QueryRejectionCode
+import me.ahoo.wow.query.internal.rejection.QueryRejectionPath
+import me.ahoo.wow.query.internal.rejection.rejectQuery
+import me.ahoo.wow.query.internal.value.NonEmptyList
+import java.time.Clock
+import java.time.DateTimeException
+import java.time.DayOfWeek
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.temporal.TemporalAdjusters
+import java.util.LinkedHashSet
+
+internal class QueryNormalizer(
+    private val clock: Clock,
+) {
+    fun normalize(invocation: AdmittedQueryInvocation): NormalizedQueryInvocation {
+        val session = NormalizationSession(clock.instant())
+        val inputPath = QueryRejectionPath.ROOT.property("input")
+        val normalizedInput =
+            when (val input = invocation.input) {
+                is AdmittedQueryInput.Single -> NormalizedQueryInput.Single(
+                    normalizeRecordQuery(input.query, inputPath.property("query"), session),
+                )
+
+                is AdmittedQueryInput.Stream -> NormalizedQueryInput.Stream(
+                    query = normalizeRecordQuery(input.query, inputPath.property("query"), session),
+                    limit = input.limit,
+                )
+
+                is AdmittedQueryInput.Page -> NormalizedQueryInput.Page(
+                    query = normalizeRecordQuery(input.query, inputPath.property("query"), session),
+                    page = input.page.normalize(),
+                )
+
+                is AdmittedQueryInput.Count -> NormalizedQueryInput.Count(
+                    normalizeCondition(
+                        input.condition,
+                        inputPath.property("condition"),
+                        elementScope = null,
+                        session,
+                    ),
+                )
+
+                is AdmittedQueryInput.Analytics -> NormalizedQueryInput.Analytics(input.query)
+            }
+        return NormalizedQueryInvocation(
+            target = invocation.target,
+            operation = invocation.operation,
+            resultShape = invocation.resultShape,
+            input = normalizedInput,
+        )
+    }
+
+    private fun normalizeRecordQuery(
+        query: AdmittedRecordQuery,
+        path: QueryRejectionPath,
+        session: NormalizationSession,
+    ): NormalizedRecordQuery =
+        NormalizedRecordQuery(
+            userCondition = normalizeCondition(
+                query.condition,
+                path.property("condition"),
+                elementScope = null,
+                session,
+            ),
+            projection = normalizeProjection(query.projection),
+            sort = query.sort.map { admittedSort ->
+                NormalizedSort(
+                    field = normalizeField(admittedSort.field, elementScope = null),
+                    direction =
+                    when (admittedSort.direction) {
+                        Sort.Direction.ASC -> NormalizedSortDirection.ASC
+                        Sort.Direction.DESC -> NormalizedSortDirection.DESC
+                    },
+                )
+            },
+        )
+
+    private fun normalizeProjection(projection: AdmittedProjection): NormalizedProjection {
+        if (projection.include.isNotEmpty() && projection.exclude.isNotEmpty()) {
+            return NormalizedProjection.Mixed(
+                include = checkNotNull(NonEmptyList.from(projection.include.map { normalizeField(it, null) })),
+                exclude = checkNotNull(NonEmptyList.from(projection.exclude.map { normalizeField(it, null) })),
+            )
+        }
+        if (projection.include.isNotEmpty()) {
+            return NormalizedProjection.Include(
+                checkNotNull(NonEmptyList.from(projection.include.map { normalizeField(it, null) })),
+            )
+        }
+        if (projection.exclude.isNotEmpty()) {
+            return NormalizedProjection.Exclude(
+                checkNotNull(NonEmptyList.from(projection.exclude.map { normalizeField(it, null) })),
+            )
+        }
+        return NormalizedProjection.All
+    }
+
+    @Suppress("CyclomaticComplexMethod", "LongMethod")
+    private fun normalizeCondition(
+        condition: AdmittedCondition,
+        path: QueryRejectionPath,
+        elementScope: ElementScope?,
+        session: NormalizationSession,
+    ): NormalizedCondition {
+        validateElementScopedField(condition, path, elementScope)
+        return when (condition.operator) {
+            Operator.AND -> normalizeJunction(
+                JunctionOperator.AND,
+                normalizeChildren(condition, path, elementScope, session),
+            )
+
+            Operator.OR -> normalizeJunction(
+                JunctionOperator.OR,
+                normalizeChildren(condition, path, elementScope, session),
+            )
+
+            Operator.NOR -> normalizeJunction(
+                JunctionOperator.NOR,
+                normalizeChildren(condition, path, elementScope, session),
+            )
+
+            Operator.ID -> systemPredicate(
+                SystemFieldKind.IDENTITY,
+                PredicateOperator.EQ,
+                condition.queryValue(),
+                condition,
+                path,
+                elementScope,
+            )
+
+            Operator.IDS -> systemCollectionPredicate(
+                SystemFieldKind.IDENTITY,
+                PredicateOperator.IN,
+                condition,
+                path,
+                elementScope,
+            )
+
+            Operator.AGGREGATE_ID -> systemPredicate(
+                SystemFieldKind.AGGREGATE_ID,
+                PredicateOperator.EQ,
+                condition.queryValue(),
+                condition,
+                path,
+                elementScope,
+            )
+
+            Operator.AGGREGATE_IDS -> systemCollectionPredicate(
+                SystemFieldKind.AGGREGATE_ID,
+                PredicateOperator.IN,
+                condition,
+                path,
+                elementScope,
+            )
+
+            Operator.TENANT_ID -> systemPredicate(
+                SystemFieldKind.TENANT_ID,
+                PredicateOperator.EQ,
+                condition.queryValue(),
+                condition,
+                path,
+                elementScope,
+            )
+
+            Operator.OWNER_ID -> systemPredicate(
+                SystemFieldKind.OWNER_ID,
+                PredicateOperator.EQ,
+                condition.queryValue(),
+                condition,
+                path,
+                elementScope,
+            )
+
+            Operator.SPACE_ID -> systemPredicate(
+                SystemFieldKind.SPACE_ID,
+                PredicateOperator.EQ,
+                condition.queryValue(),
+                condition,
+                path,
+                elementScope,
+            )
+
+            Operator.DELETED -> normalizeDeleted(condition, path, elementScope)
+            Operator.ALL -> NormalizedCondition.All
+            Operator.EQ -> fieldPredicate(condition, PredicateOperator.EQ, elementScope)
+            Operator.NE -> fieldPredicate(condition, PredicateOperator.NE, elementScope)
+            Operator.GT -> fieldPredicate(condition, PredicateOperator.GT, elementScope)
+            Operator.LT -> fieldPredicate(condition, PredicateOperator.LT, elementScope)
+            Operator.GTE -> fieldPredicate(condition, PredicateOperator.GTE, elementScope)
+            Operator.LTE -> fieldPredicate(condition, PredicateOperator.LTE, elementScope)
+            Operator.CONTAINS -> fieldPredicate(condition, PredicateOperator.CONTAINS, elementScope)
+            Operator.IN -> collectionPredicate(condition, PredicateOperator.IN, elementScope)
+            Operator.NOT_IN -> collectionPredicate(condition, PredicateOperator.NOT_IN, elementScope)
+            Operator.BETWEEN -> fieldPredicate(condition, PredicateOperator.BETWEEN, elementScope)
+            Operator.ALL_IN -> collectionPredicate(condition, PredicateOperator.ALL_IN, elementScope)
+            Operator.STARTS_WITH -> fieldPredicate(condition, PredicateOperator.STARTS_WITH, elementScope)
+            Operator.ENDS_WITH -> fieldPredicate(condition, PredicateOperator.ENDS_WITH, elementScope)
+            Operator.ELEM_MATCH -> normalizeElementMatch(condition, path, elementScope, session)
+            Operator.NULL -> fieldPredicate(condition, PredicateOperator.IS_NULL, elementScope, value = null)
+            Operator.NOT_NULL -> fieldPredicate(condition, PredicateOperator.NOT_NULL, elementScope, value = null)
+            Operator.TRUE -> fieldPredicate(condition, PredicateOperator.IS_TRUE, elementScope, value = null)
+            Operator.FALSE -> fieldPredicate(condition, PredicateOperator.IS_FALSE, elementScope, value = null)
+            Operator.EXISTS -> fieldPredicate(condition, PredicateOperator.EXISTS, elementScope)
+            Operator.TODAY -> normalizeTimeRange(condition, path, TimeRangeKind.TODAY, elementScope, session)
+            Operator.BEFORE_TODAY -> normalizeBeforeToday(condition, path, elementScope, session)
+            Operator.TOMORROW -> normalizeTimeRange(condition, path, TimeRangeKind.TOMORROW, elementScope, session)
+            Operator.THIS_WEEK -> normalizeTimeRange(condition, path, TimeRangeKind.THIS_WEEK, elementScope, session)
+            Operator.NEXT_WEEK -> normalizeTimeRange(condition, path, TimeRangeKind.NEXT_WEEK, elementScope, session)
+            Operator.LAST_WEEK -> normalizeTimeRange(condition, path, TimeRangeKind.LAST_WEEK, elementScope, session)
+            Operator.THIS_MONTH -> normalizeTimeRange(condition, path, TimeRangeKind.THIS_MONTH, elementScope, session)
+            Operator.LAST_MONTH -> normalizeTimeRange(condition, path, TimeRangeKind.LAST_MONTH, elementScope, session)
+            Operator.RECENT_DAYS -> normalizeRecentDays(condition, path, elementScope, session)
+            Operator.EARLIER_DAYS -> normalizeEarlierDays(condition, path, elementScope, session)
+            Operator.MATCH -> NormalizedCondition.Search(
+                scope = SearchScope(normalizeSearchScope(condition.field, elementScope)),
+                text = (condition.queryValue() as NormalizedValue.Text).value,
+            )
+
+            Operator.RAW -> rejectQuery(
+                QueryRejectionCategory.UNSUPPORTED_FEATURE,
+                path,
+                QueryRejectionCode.NATIVE_BACKEND_UNBOUND,
+            )
+        }
+    }
+
+    private fun validateElementScopedField(
+        condition: AdmittedCondition,
+        path: QueryRejectionPath,
+        elementScope: ElementScope?,
+    ) {
+        if (elementScope == null || condition.field.isEmpty()) {
+            return
+        }
+        val segments = condition.field.split('.')
+        if (elementScope.qualifiedPrefixes.any { segments == it }) {
+            rejectInvalid(path.property("field"), QueryRejectionCode.INVALID_FIELD)
+        }
+    }
+
+    private fun normalizeChildren(
+        condition: AdmittedCondition,
+        path: QueryRejectionPath,
+        elementScope: ElementScope?,
+        session: NormalizationSession,
+    ): List<NormalizedCondition> =
+        condition.children.mapIndexed { index, child ->
+            normalizeCondition(child, path.property("children").index(index), elementScope, session)
+        }
+
+    private fun normalizeJunction(
+        operator: JunctionOperator,
+        children: List<NormalizedCondition>,
+    ): NormalizedCondition =
+        when (operator) {
+            JunctionOperator.AND -> {
+                if (children.any { it == NormalizedCondition.None }) {
+                    NormalizedCondition.None
+                } else {
+                    val effective = children.filterNot { it == NormalizedCondition.All }
+                    when (effective.size) {
+                        0 -> NormalizedCondition.All
+                        1 -> effective.single()
+                        else -> NormalizedCondition.Junction(operator, effective)
+                    }
+                }
+            }
+
+            JunctionOperator.OR -> {
+                if (children.any { it == NormalizedCondition.All }) {
+                    NormalizedCondition.All
+                } else {
+                    val effective = children.filterNot { it == NormalizedCondition.None }
+                    when (effective.size) {
+                        0 -> NormalizedCondition.None
+                        1 -> effective.single()
+                        else -> NormalizedCondition.Junction(operator, effective)
+                    }
+                }
+            }
+
+            JunctionOperator.NOR -> {
+                if (children.any { it == NormalizedCondition.All }) {
+                    NormalizedCondition.None
+                } else {
+                    val effective = children.filterNot { it == NormalizedCondition.None }
+                    if (effective.isEmpty()) {
+                        NormalizedCondition.All
+                    } else {
+                        NormalizedCondition.Junction(operator, effective)
+                    }
+                }
+            }
+        }
+
+    private fun normalizeElementMatch(
+        condition: AdmittedCondition,
+        path: QueryRejectionPath,
+        elementScope: ElementScope?,
+        session: NormalizationSession,
+    ): NormalizedCondition.ElementMatch {
+        val normalizedField = normalizeField(condition.field, elementScope)
+        val nestedScope = elementScope.nest(normalizedField.segments)
+        return NormalizedCondition.ElementMatch(
+            field = normalizedField,
+            condition = normalizeCondition(
+                condition.children.single(),
+                path.property("children").index(0),
+                nestedScope,
+                session,
+            ),
+        )
+    }
+
+    private fun fieldPredicate(
+        condition: AdmittedCondition,
+        operator: PredicateOperator,
+        elementScope: ElementScope?,
+        value: NormalizedValue? = condition.queryValue(),
+    ): NormalizedCondition =
+        NormalizedCondition.Predicate(
+            field = normalizeField(condition.field, elementScope),
+            operator = operator,
+            value = value,
+            options = NormalizedPredicateOptions(condition.options.caseSensitivity),
+        )
+
+    private fun collectionPredicate(
+        condition: AdmittedCondition,
+        operator: PredicateOperator,
+        elementScope: ElementScope?,
+    ): NormalizedCondition {
+        val values = condition.queryValue() as NormalizedValue.ListValue
+        val uniqueValues = LinkedHashSet(values.values).toList()
+        if (uniqueValues.isEmpty()) {
+            return if (operator == PredicateOperator.NOT_IN) {
+                NormalizedCondition.All
+            } else {
+                NormalizedCondition.None
+            }
+        }
+        return fieldPredicate(
+            condition,
+            operator,
+            elementScope,
+            NormalizedValue.ListValue(uniqueValues),
+        )
+    }
+
+    private fun systemPredicate(
+        fieldKind: SystemFieldKind,
+        operator: PredicateOperator,
+        value: NormalizedValue?,
+        condition: AdmittedCondition,
+        path: QueryRejectionPath,
+        elementScope: ElementScope?,
+    ): NormalizedCondition {
+        ensureRootSystemField(path, elementScope)
+        return NormalizedCondition.Predicate(
+            LogicalField.System(fieldKind),
+            operator,
+            value,
+            NormalizedPredicateOptions(condition.options.caseSensitivity),
+        )
+    }
+
+    private fun systemCollectionPredicate(
+        fieldKind: SystemFieldKind,
+        operator: PredicateOperator,
+        condition: AdmittedCondition,
+        path: QueryRejectionPath,
+        elementScope: ElementScope?,
+    ): NormalizedCondition {
+        ensureRootSystemField(path, elementScope)
+        val values = (condition.queryValue() as NormalizedValue.ListValue).values
+        val uniqueValues = LinkedHashSet(values).toList()
+        if (uniqueValues.isEmpty()) {
+            return NormalizedCondition.None
+        }
+        return systemPredicate(
+            fieldKind,
+            operator,
+            NormalizedValue.ListValue(uniqueValues),
+            condition,
+            path,
+            elementScope,
+        )
+    }
+
+    private fun normalizeDeleted(
+        condition: AdmittedCondition,
+        path: QueryRejectionPath,
+        elementScope: ElementScope?,
+    ): NormalizedCondition {
+        ensureRootSystemField(path, elementScope)
+        return when ((condition.value as AdmittedConditionValue.Deletion).value) {
+            DeletionState.ACTIVE -> systemPredicate(
+                SystemFieldKind.DELETED,
+                PredicateOperator.IS_FALSE,
+                null,
+                condition,
+                path,
+                elementScope,
+            )
+
+            DeletionState.DELETED -> systemPredicate(
+                SystemFieldKind.DELETED,
+                PredicateOperator.IS_TRUE,
+                null,
+                condition,
+                path,
+                elementScope,
+            )
+
+            DeletionState.ALL -> NormalizedCondition.All
+        }
+    }
+
+    private fun ensureRootSystemField(path: QueryRejectionPath, elementScope: ElementScope?) {
+        if (elementScope != null) {
+            rejectInvalid(path, QueryRejectionCode.SYSTEM_FIELD_IN_ELEMENT_SCOPE)
+        }
+    }
+
+    private fun normalizeTimeRange(
+        condition: AdmittedCondition,
+        path: QueryRejectionPath,
+        kind: TimeRangeKind,
+        elementScope: ElementScope?,
+        session: NormalizationSession,
+    ): NormalizedCondition {
+        val zone = condition.options.zoneId ?: clock.zone
+        val today = session.instant.atZone(zone).toLocalDate()
+        val (fromDate, toDate) =
+            when (kind) {
+                TimeRangeKind.TODAY -> today to today.plusDays(1)
+                TimeRangeKind.TOMORROW -> today.plusDays(1) to today.plusDays(2)
+                TimeRangeKind.THIS_WEEK -> weekStart(today) to weekStart(today).plusWeeks(1)
+                TimeRangeKind.NEXT_WEEK -> weekStart(today).plusWeeks(1) to weekStart(today).plusWeeks(2)
+                TimeRangeKind.LAST_WEEK -> weekStart(today).minusWeeks(1) to weekStart(today)
+                TimeRangeKind.THIS_MONTH -> monthStart(today) to monthStart(today).plusMonths(1)
+                TimeRangeKind.LAST_MONTH -> monthStart(today).minusMonths(1) to monthStart(today)
+            }
+        return halfOpenRange(
+            condition,
+            elementScope,
+            fromDate.atStartOfDay(zone).toInstant(),
+            toDate.atStartOfDay(zone).toInstant(),
+            zone,
+            path,
+        )
+    }
+
+    private fun normalizeRecentDays(
+        condition: AdmittedCondition,
+        path: QueryRejectionPath,
+        elementScope: ElementScope?,
+        session: NormalizationSession,
+    ): NormalizedCondition {
+        val zone = condition.options.zoneId ?: clock.zone
+        val today = session.instant.atZone(zone).toLocalDate()
+        val days = (condition.queryValue() as NormalizedValue.Int64).value
+        val from = subtractDays(today, days - 1, path).atStartOfDay(zone).toInstant()
+        val to = today.plusDays(1).atStartOfDay(zone).toInstant()
+        return halfOpenRange(condition, elementScope, from, to, zone, path)
+    }
+
+    private fun normalizeEarlierDays(
+        condition: AdmittedCondition,
+        path: QueryRejectionPath,
+        elementScope: ElementScope?,
+        session: NormalizationSession,
+    ): NormalizedCondition {
+        val zone = condition.options.zoneId ?: clock.zone
+        val today = session.instant.atZone(zone).toLocalDate()
+        val days = (condition.queryValue() as NormalizedValue.Int64).value
+        val cutoff = subtractDays(today, days - 1, path).atStartOfDay(zone).toInstant()
+        return NormalizedCondition.Predicate(
+            field = normalizeField(condition.field, elementScope),
+            operator = PredicateOperator.LT,
+            value = timeValue(cutoff, condition.options.datePattern?.formatter, zone, path),
+        )
+    }
+
+    private fun normalizeBeforeToday(
+        condition: AdmittedCondition,
+        path: QueryRejectionPath,
+        elementScope: ElementScope?,
+        session: NormalizationSession,
+    ): NormalizedCondition {
+        val zone = condition.options.zoneId ?: clock.zone
+        val today = session.instant.atZone(zone).toLocalDate()
+        val time = (condition.value as AdmittedConditionValue.TimeOfDay).value
+        val cutoff = today.atTime(time).atZone(zone).toInstant()
+        return NormalizedCondition.Predicate(
+            field = normalizeField(condition.field, elementScope),
+            operator = PredicateOperator.LT,
+            value = timeValue(cutoff, condition.options.datePattern?.formatter, zone, path),
+        )
+    }
+
+    private fun halfOpenRange(
+        condition: AdmittedCondition,
+        elementScope: ElementScope?,
+        from: Instant,
+        to: Instant,
+        zone: ZoneId,
+        path: QueryRejectionPath,
+    ): NormalizedCondition =
+        NormalizedCondition.Junction(
+            JunctionOperator.AND,
+            listOf(
+                NormalizedCondition.Predicate(
+                    normalizeField(condition.field, elementScope),
+                    PredicateOperator.GTE,
+                    timeValue(from, condition.options.datePattern?.formatter, zone, path),
+                ),
+                NormalizedCondition.Predicate(
+                    normalizeField(condition.field, elementScope),
+                    PredicateOperator.LT,
+                    timeValue(to, condition.options.datePattern?.formatter, zone, path),
+                ),
+            ),
+        )
+
+    private fun timeValue(
+        instant: Instant,
+        datePattern: DateTimeFormatter?,
+        zone: ZoneId,
+        path: QueryRejectionPath,
+    ): NormalizedValue {
+        if (datePattern == null) {
+            return NormalizedValue.InstantValue(instant)
+        }
+        val formatted = try {
+            datePattern.format(instant.atZone(zone))
+        } catch (error: DateTimeException) {
+            rejectInvalid(
+                path.property("options").key(Condition.DATE_PATTERN_OPTION_KEY),
+                QueryRejectionCode.INVALID_OPTION_VALUE,
+                error,
+            )
+        }
+        return NormalizedValue.Text(formatted)
+    }
+
+    private fun normalizeField(field: String, elementScope: ElementScope?): LogicalField.Path {
+        val segments = field.split('.')
+        if (elementScope == null) {
+            return LogicalField.Path(segments, PathBasis.ROOT)
+        }
+        val matchedPrefix = elementScope.qualifiedPrefixes
+            .filter { prefix -> segments.startsWithPrefix(prefix) }
+            .maxByOrNull(List<String>::size)
+        val relative = matchedPrefix?.let { segments.drop(it.size) } ?: segments
+        return LogicalField.Path(relative, PathBasis.CURRENT_ELEMENT)
+    }
+
+    private fun normalizeSearchScope(field: String, elementScope: ElementScope?): String =
+        normalizeField(field, elementScope).segments.joinToString(".")
+
+    private fun ElementScope?.nest(relativeField: List<String>): ElementScope {
+        if (this == null) {
+            return ElementScope(relativeField, listOf(relativeField))
+        }
+        val newAbsolute = absoluteSegments + relativeField
+        val newPrefixes = buildList {
+            add(newAbsolute)
+            qualifiedPrefixes.forEach { prefix -> add(prefix + relativeField) }
+            add(relativeField)
+        }.distinct()
+        return ElementScope(newAbsolute, newPrefixes)
+    }
+
+    private fun AdmittedCondition.queryValue(): NormalizedValue =
+        (value as AdmittedConditionValue.QueryValue).value
+
+    private fun AdmittedPage.normalize(): NormalizedPage = NormalizedPage(index, size, offset)
+
+    private fun weekStart(date: LocalDate): LocalDate =
+        date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+
+    private fun monthStart(date: LocalDate): LocalDate = date.withDayOfMonth(1)
+
+    private fun subtractDays(
+        date: LocalDate,
+        days: Long,
+        path: QueryRejectionPath,
+    ): LocalDate =
+        try {
+            date.minusDays(days)
+        } catch (error: DateTimeException) {
+            rejectQuery(
+                QueryRejectionCategory.INVALID_QUERY,
+                path.property("value"),
+                QueryRejectionCode.INVALID_TIME_VALUE,
+                error,
+            )
+        }
+
+    private fun <T> List<T>.startsWithPrefix(prefix: List<T>): Boolean =
+        size >= prefix.size && subList(0, prefix.size) == prefix
+
+    private fun rejectInvalid(
+        path: QueryRejectionPath,
+        code: QueryRejectionCode,
+        cause: Throwable? = null,
+    ): Nothing = rejectQuery(QueryRejectionCategory.INVALID_QUERY, path, code, cause)
+
+    private data class NormalizationSession(val instant: Instant)
+
+    private data class ElementScope(
+        val absoluteSegments: List<String>,
+        val qualifiedPrefixes: List<List<String>>,
+    )
+
+    private enum class TimeRangeKind {
+        TODAY,
+        TOMORROW,
+        THIS_WEEK,
+        NEXT_WEEK,
+        LAST_WEEK,
+        THIS_MONTH,
+        LAST_MONTH,
+    }
+}

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/rejection/QueryRejection.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/internal/rejection/QueryRejection.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.internal.rejection
+
+internal enum class QueryRejectionCategory {
+    INVALID_QUERY,
+    BUDGET_EXCEEDED,
+    UNSUPPORTED_FEATURE,
+}
+
+internal enum class QueryRejectionCode {
+    CONDITION_DEPTH_LIMIT_EXCEEDED,
+    CONDITION_NODE_LIMIT_EXCEEDED,
+    CHILDREN_LIMIT_EXCEEDED,
+    COLLECTION_LIMIT_EXCEEDED,
+    OBJECT_LIMIT_EXCEEDED,
+    VALUE_DEPTH_LIMIT_EXCEEDED,
+    VALUE_NODE_LIMIT_EXCEEDED,
+    NUMERIC_PRECISION_LIMIT_EXCEEDED,
+    BYTE_ARRAY_LIMIT_EXCEEDED,
+    PAYLOAD_LIMIT_EXCEEDED,
+    PROJECTION_LIMIT_EXCEEDED,
+    SORT_LIMIT_EXCEEDED,
+    OPTIONS_LIMIT_EXCEEDED,
+    STRING_LIMIT_EXCEEDED,
+    CYCLIC_INPUT,
+    INVALID_CHILDREN,
+    FIELD_REQUIRED,
+    INVALID_FIELD,
+    INVALID_VALUE_TYPE,
+    INVALID_VALUE_ARITY,
+    DUPLICATE_OBJECT_KEY,
+    INVALID_OPTION_TYPE,
+    INVALID_OPTION_VALUE,
+    UNKNOWN_OPTION,
+    OPTION_NOT_ALLOWED,
+    INVALID_TIME_VALUE,
+    INVALID_LIMIT,
+    INVALID_PAGE,
+    INVALID_PROJECTION,
+    INVALID_SORT,
+    SYSTEM_FIELD_IN_ELEMENT_SCOPE,
+    NATIVE_BACKEND_UNBOUND,
+}
+
+internal class QueryRejectionPath private constructor(
+    private val segments: List<Segment>,
+) {
+    fun property(name: String): QueryRejectionPath = QueryRejectionPath(segments + Segment.Property(name))
+
+    fun index(index: Int): QueryRejectionPath = QueryRejectionPath(segments + Segment.Index(index))
+
+    fun key(key: String): QueryRejectionPath = QueryRejectionPath(segments + Segment.Key(key))
+
+    override fun equals(other: Any?): Boolean =
+        this === other || other is QueryRejectionPath && segments == other.segments
+
+    override fun hashCode(): Int = segments.hashCode()
+
+    override fun toString(): String = buildString {
+        append('$')
+        segments.forEach { segment ->
+            when (segment) {
+                is Segment.Property -> append('.').append(segment.name)
+                is Segment.Index -> append('[').append(segment.value).append(']')
+                is Segment.Key -> append("['").append(segment.value.escapeKey()).append("']")
+            }
+        }
+    }
+
+    private sealed interface Segment {
+        data class Property(val name: String) : Segment
+
+        data class Index(val value: Int) : Segment
+
+        data class Key(val value: String) : Segment
+    }
+
+    private fun String.escapeKey(): String = buildString {
+        this@escapeKey.forEach { character ->
+            when (character) {
+                '\\' -> append("\\\\")
+                '\'' -> append("\\'")
+                '\n' -> append("\\n")
+                '\r' -> append("\\r")
+                '\t' -> append("\\t")
+                else -> if (character.isISOControl()) {
+                    append("\\u").append(character.code.toString(16).padStart(4, '0'))
+                } else {
+                    append(character)
+                }
+            }
+        }
+    }
+
+    companion object {
+        val ROOT: QueryRejectionPath = QueryRejectionPath(emptyList())
+    }
+}
+
+internal data class QueryRejection(
+    val category: QueryRejectionCategory,
+    val path: QueryRejectionPath,
+    val code: QueryRejectionCode,
+)
+
+internal class QueryRejectedException(
+    val rejection: QueryRejection,
+    cause: Throwable? = null,
+) : IllegalArgumentException(
+    "${rejection.category}/${rejection.code} at ${rejection.path}",
+    cause,
+)
+
+internal fun rejectQuery(
+    category: QueryRejectionCategory,
+    path: QueryRejectionPath,
+    code: QueryRejectionCode,
+    cause: Throwable? = null,
+): Nothing = throw QueryRejectedException(QueryRejection(category, path, code), cause)

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/internal/admission/RawAdmissionGuardBoundaryTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/internal/admission/RawAdmissionGuardBoundaryTest.kt
@@ -1,0 +1,544 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.internal.admission
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.test.asserts.assertThrownBy
+import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.Operator
+import me.ahoo.wow.api.query.Projection
+import me.ahoo.wow.api.query.SingleQuery
+import me.ahoo.wow.api.query.Sort
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.query.internal.model.QueryDocumentKind
+import me.ahoo.wow.query.internal.model.QueryInput
+import me.ahoo.wow.query.internal.model.QueryInvocation
+import me.ahoo.wow.query.internal.model.QueryOperation
+import me.ahoo.wow.query.internal.model.QueryResultShape
+import me.ahoo.wow.query.internal.model.QueryTarget
+import me.ahoo.wow.query.internal.normalization.NormalizedValue
+import me.ahoo.wow.query.internal.rejection.QueryRejectedException
+import me.ahoo.wow.query.internal.rejection.QueryRejectionCategory
+import me.ahoo.wow.query.internal.rejection.QueryRejectionCode
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.math.BigInteger
+import java.time.format.DateTimeFormatterBuilder
+import java.util.AbstractMap.SimpleImmutableEntry
+import java.util.UUID
+import java.util.function.Consumer
+
+class RawAdmissionGuardBoundaryTest {
+
+    private val target = QueryTarget(
+        MaterializedNamedAggregate("sales", "order"),
+        QueryDocumentKind.SNAPSHOT,
+    )
+    private val baseLimits = QueryAdmissionLimits(
+        maxConditionDepth = 8,
+        maxConditionNodes = 32,
+        maxChildrenPerNode = 8,
+        maxFieldLength = 24,
+        maxStringLength = 16,
+        maxCollectionSize = 4,
+        maxObjectFields = 4,
+        maxValueDepth = 4,
+        maxValueNodes = 32,
+        maxByteArrayLength = 4,
+        maxValuePayloadBytes = 128,
+        maxProjectionFields = 4,
+        maxSortFields = 4,
+        maxOptions = 4,
+    )
+
+    @Test
+    fun `should enforce cumulative value node budget across sibling conditions`() {
+        val guard = RawAdmissionGuard(baseLimits.copy(maxValueNodes = 4))
+        guard.admit(
+            countInvocation(
+                Condition.and(
+                    Condition.eq("first", listOf(1, 2)),
+                    Condition.eq("second", 3),
+                ),
+            ),
+        )
+
+        assertRejected(
+            guard,
+            Condition.and(
+                Condition.eq("first", listOf(1, 2)),
+                Condition.eq("second", 3),
+                Condition.eq("third", 4),
+            ),
+            QueryRejectionCategory.BUDGET_EXCEEDED,
+            QueryRejectionCode.VALUE_NODE_LIMIT_EXCEEDED,
+            "$.input.condition.children[2].value",
+        )
+    }
+
+    @Test
+    fun `should enforce cumulative UTF-8 payload budget without rejecting the exact boundary`() {
+        val guard = RawAdmissionGuard(baseLimits.copy(maxValuePayloadBytes = 19))
+        guard.admit(
+            countInvocation(
+                Condition.and(
+                    Condition.eq("first", "éé"),
+                    Condition.eq("second", "éé"),
+                ),
+            ),
+        )
+
+        assertRejected(
+            guard,
+            Condition.and(
+                Condition.eq("first", "éé"),
+                Condition.eq("second", "ééa"),
+            ),
+            QueryRejectionCategory.BUDGET_EXCEEDED,
+            QueryRejectionCode.PAYLOAD_LIMIT_EXCEEDED,
+            "$.input.condition.children[1].value",
+        )
+    }
+
+    @Test
+    fun `should include condition projection and sort fields in the cumulative payload budget`() {
+        val exactGuard = RawAdmissionGuard(baseLimits.copy(maxValuePayloadBytes = 8))
+        exactGuard.admit(
+            singleInvocation(
+                SingleQuery(
+                    condition = Condition("abc", Operator.NULL),
+                    projection = Projection(include = listOf("de")),
+                    sort = listOf(Sort("fgh", Sort.Direction.ASC)),
+                ),
+            ),
+        )
+
+        assertInvocationRejected(
+            QueryRejectionCategory.BUDGET_EXCEEDED,
+            QueryRejectionCode.PAYLOAD_LIMIT_EXCEEDED,
+            "$.input.query.sort[0].field",
+        ) {
+            exactGuard.admit(
+                singleInvocation(
+                    SingleQuery(
+                        condition = Condition("abc", Operator.NULL),
+                        projection = Projection(include = listOf("de")),
+                        sort = listOf(Sort("fghi", Sort.Direction.ASC)),
+                    ),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `should reject excessive numeric precision before materialization`() {
+        assertRejected(
+            RawAdmissionGuard(baseLimits.copy(maxNumericPrecision = 4)),
+            Condition.eq("field", BigInteger("12345")),
+            QueryRejectionCategory.BUDGET_EXCEEDED,
+            QueryRejectionCode.NUMERIC_PRECISION_LIMIT_EXCEEDED,
+            "$.input.condition.value",
+        )
+    }
+
+    @Test
+    fun `should reject decimal canonicalization overflow with a typed rejection`() {
+        assertRejected(
+            RawAdmissionGuard(baseLimits),
+            Condition.eq("field", BigDecimal(BigInteger.TEN, Int.MIN_VALUE)),
+            QueryRejectionCategory.INVALID_QUERY,
+            QueryRejectionCode.INVALID_VALUE_TYPE,
+            "$.input.condition.value",
+        )
+    }
+
+    @Test
+    fun `should accept exact local value boundaries and reject the next item`() {
+        val guard = RawAdmissionGuard(baseLimits)
+        guard.admit(countInvocation(Condition.eq("field", byteArrayOf(1, 2, 3, 4))))
+        guard.admit(countInvocation(Condition.eq("field", listOf(1, 2, 3, 4))))
+        guard.admit(
+            countInvocation(
+                Condition.eq("field", linkedMapOf("a" to 1, "b" to 2, "c" to 3, "d" to 4)),
+            ),
+        )
+        guard.admit(countInvocation(Condition.eq("field", listOf(listOf(listOf(1))))))
+
+        val cases = listOf(
+            Condition.eq("field", byteArrayOf(1, 2, 3, 4, 5)) to
+                QueryRejectionCode.BYTE_ARRAY_LIMIT_EXCEEDED,
+            Condition.eq("field", listOf(1, 2, 3, 4, 5)) to
+                QueryRejectionCode.COLLECTION_LIMIT_EXCEEDED,
+            Condition.eq("field", linkedMapOf("a" to 1, "b" to 2, "c" to 3, "d" to 4, "e" to 5)) to
+                QueryRejectionCode.OBJECT_LIMIT_EXCEEDED,
+            Condition.eq("field", listOf(listOf(listOf(listOf(1))))) to
+                QueryRejectionCode.VALUE_DEPTH_LIMIT_EXCEEDED,
+        )
+        cases.forEach { (condition, code) ->
+            assertThrownBy<QueryRejectedException> {
+                guard.admit(countInvocation(condition))
+            }.satisfies(
+                Consumer { error ->
+                    error.rejection.category.assert().isEqualTo(QueryRejectionCategory.BUDGET_EXCEEDED)
+                    error.rejection.code.assert().isEqualTo(code)
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `should enforce condition node child and field boundaries`() {
+        RawAdmissionGuard(baseLimits.copy(maxConditionNodes = 3)).admit(
+            countInvocation(Condition.and(Condition.eq("a", 1), Condition.eq("b", 2))),
+        )
+        assertRejected(
+            RawAdmissionGuard(baseLimits.copy(maxConditionNodes = 3)),
+            Condition.and(Condition.eq("a", 1), Condition.eq("b", 2), Condition.eq("c", 3)),
+            QueryRejectionCategory.BUDGET_EXCEEDED,
+            QueryRejectionCode.CONDITION_NODE_LIMIT_EXCEEDED,
+            "$.input.condition.children[2]",
+        )
+
+        RawAdmissionGuard(baseLimits.copy(maxChildrenPerNode = 2)).admit(
+            countInvocation(Condition.and(Condition.eq("a", 1), Condition.eq("b", 2))),
+        )
+        assertRejected(
+            RawAdmissionGuard(baseLimits.copy(maxChildrenPerNode = 2)),
+            Condition.and(Condition.eq("a", 1), Condition.eq("b", 2), Condition.eq("c", 3)),
+            QueryRejectionCategory.BUDGET_EXCEEDED,
+            QueryRejectionCode.CHILDREN_LIMIT_EXCEEDED,
+            "$.input.condition.children",
+        )
+
+        RawAdmissionGuard(baseLimits).admit(
+            countInvocation(Condition.eq("f".repeat(baseLimits.maxFieldLength), "x")),
+        )
+        assertRejected(
+            RawAdmissionGuard(baseLimits),
+            Condition.eq("f".repeat(baseLimits.maxFieldLength + 1), "x"),
+            QueryRejectionCategory.BUDGET_EXCEEDED,
+            QueryRejectionCode.STRING_LIMIT_EXCEEDED,
+            "$.input.condition.field",
+        )
+    }
+
+    @Test
+    fun `should enforce projection and sort boundaries`() {
+        val fields = listOf("a", "b")
+        val sorts = listOf(
+            Sort("a", Sort.Direction.ASC),
+            Sort("b", Sort.Direction.DESC),
+        )
+        val exactGuard = RawAdmissionGuard(baseLimits.copy(maxProjectionFields = 2, maxSortFields = 2))
+        exactGuard.admit(singleInvocation(SingleQuery(Condition.ALL, Projection(include = fields), sorts)))
+        exactGuard.admit(
+            singleInvocation(
+                SingleQuery(Condition.ALL, Projection(include = listOf("a"), exclude = listOf("b")), sorts),
+            ),
+        )
+
+        assertInvocationRejected(
+            QueryRejectionCategory.BUDGET_EXCEEDED,
+            QueryRejectionCode.PROJECTION_LIMIT_EXCEEDED,
+            "$.input.query.projection.include",
+        ) {
+            exactGuard.admit(
+                singleInvocation(
+                    SingleQuery(Condition.ALL, Projection(include = fields + "c"), sorts),
+                ),
+            )
+        }
+        assertInvocationRejected(
+            QueryRejectionCategory.BUDGET_EXCEEDED,
+            QueryRejectionCode.SORT_LIMIT_EXCEEDED,
+            "$.input.query.sort",
+        ) {
+            exactGuard.admit(
+                singleInvocation(
+                    SingleQuery(
+                        Condition.ALL,
+                        Projection(include = fields),
+                        sorts + Sort("c", Sort.Direction.ASC),
+                    ),
+                ),
+            )
+        }
+        assertInvocationRejected(
+            QueryRejectionCategory.BUDGET_EXCEEDED,
+            QueryRejectionCode.PROJECTION_LIMIT_EXCEEDED,
+            "$.input.query.projection.exclude",
+        ) {
+            exactGuard.admit(
+                singleInvocation(
+                    SingleQuery(
+                        Condition.ALL,
+                        Projection(include = fields, exclude = listOf("c")),
+                        sorts,
+                    ),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `should enforce option count boundary`() {
+        val optionGuard = RawAdmissionGuard(baseLimits.copy(maxOptions = 1))
+        optionGuard.admit(
+            countInvocation(
+                Condition("field", Operator.TODAY, options = mapOf(Condition.ZONE_ID_OPTION_KEY to "UTC")),
+            ),
+        )
+        assertRejected(
+            optionGuard,
+            Condition(
+                "field",
+                Operator.TODAY,
+                options = linkedMapOf(
+                    Condition.ZONE_ID_OPTION_KEY to "UTC",
+                    Condition.DATE_PATTERN_OPTION_KEY to "yyyy-MM-dd",
+                ),
+            ),
+            QueryRejectionCategory.BUDGET_EXCEEDED,
+            QueryRejectionCode.OPTIONS_LIMIT_EXCEEDED,
+            "$.input.condition.options",
+        )
+    }
+
+    @Test
+    fun `should reject pre-normalized values at the raw boundary`() {
+        val values = listOf(
+            NormalizedValue.Text("text"),
+            NormalizedValue.Bytes(byteArrayOf(1)),
+            NormalizedValue.ListValue(listOf(NormalizedValue.Int64(1))),
+            NormalizedValue.ObjectValue(mapOf("key" to NormalizedValue.Int64(1))),
+        )
+
+        values.forEach { value ->
+            assertRejected(
+                RawAdmissionGuard(baseLimits),
+                Condition.eq("field", value),
+                QueryRejectionCategory.INVALID_QUERY,
+                QueryRejectionCode.INVALID_VALUE_TYPE,
+                "$.input.condition.value",
+            )
+        }
+    }
+
+    @Test
+    fun `should validate original IDS element types before canonicalization`() {
+        listOf(UUID.randomUUID(), 'x', TestValue.VALUE).forEach { invalidId ->
+            assertRejected(
+                RawAdmissionGuard(baseLimits),
+                Condition(operator = Operator.IDS, value = listOf(invalidId)),
+                QueryRejectionCategory.INVALID_QUERY,
+                QueryRejectionCode.INVALID_VALUE_TYPE,
+                "$.input.condition.value[0]",
+            )
+        }
+    }
+
+    @Test
+    fun `should type reject null collection members injected through Java compatible lists`() {
+        assertRejected(
+            RawAdmissionGuard(baseLimits),
+            Condition(operator = Operator.AND, children = unsafeList(null)),
+            QueryRejectionCategory.INVALID_QUERY,
+            QueryRejectionCode.INVALID_CHILDREN,
+            "$.input.condition.children[0]",
+        )
+        assertInvocationRejected(
+            QueryRejectionCategory.INVALID_QUERY,
+            QueryRejectionCode.INVALID_PROJECTION,
+            "$.input.query.projection.include[0]",
+        ) {
+            RawAdmissionGuard(baseLimits).admit(
+                singleInvocation(
+                    SingleQuery(Condition.ALL, Projection(include = unsafeList(null))),
+                ),
+            )
+        }
+        assertInvocationRejected(
+            QueryRejectionCategory.INVALID_QUERY,
+            QueryRejectionCode.INVALID_SORT,
+            "$.input.query.sort[0]",
+        ) {
+            RawAdmissionGuard(baseLimits).admit(
+                singleInvocation(SingleQuery(Condition.ALL, sort = unsafeList(null))),
+            )
+        }
+    }
+
+    @Test
+    fun `should apply string budget before parsing time deletion and options`() {
+        val overLimit = "x".repeat(baseLimits.maxStringLength + 1)
+        val oversizedFormatter = DateTimeFormatterBuilder().appendLiteral(overLimit).toFormatter()
+        val cases = listOf(
+            Condition(operator = Operator.DELETED, value = overLimit) to "$.input.condition.value",
+            Condition("field", Operator.BEFORE_TODAY, overLimit) to "$.input.condition.value",
+            Condition("field", Operator.TODAY, options = mapOf(Condition.ZONE_ID_OPTION_KEY to overLimit)) to
+                "$.input.condition.options['zoneId']",
+            Condition("field", Operator.TODAY, options = mapOf(Condition.DATE_PATTERN_OPTION_KEY to overLimit)) to
+                "$.input.condition.options['datePattern']",
+            Condition("field", Operator.TODAY, options = mapOf(Condition.DATE_PATTERN_OPTION_KEY to oversizedFormatter)) to
+                "$.input.condition.options['datePattern']",
+        )
+
+        cases.forEach { (condition, path) ->
+            assertRejected(
+                RawAdmissionGuard(baseLimits),
+                condition,
+                QueryRejectionCategory.BUDGET_EXCEEDED,
+                QueryRejectionCode.STRING_LIMIT_EXCEEDED,
+                path,
+            )
+        }
+    }
+
+    @Test
+    fun `should count a string date pattern exactly once`() {
+        val exactPayloadSize = "field".length + Condition.DATE_PATTERN_OPTION_KEY.length + "yyyy".length
+        RawAdmissionGuard(baseLimits.copy(maxValuePayloadBytes = exactPayloadSize.toLong())).admit(
+            countInvocation(
+                Condition(
+                    "field",
+                    Operator.TODAY,
+                    options = mapOf(Condition.DATE_PATTERN_OPTION_KEY to "yyyy"),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `should reject unsupported sql date values with a typed rejection`() {
+        listOf(
+            java.sql.Date.valueOf("2024-03-10"),
+            java.sql.Time.valueOf("12:30:00"),
+        ).forEach { value ->
+            assertRejected(
+                RawAdmissionGuard(baseLimits),
+                Condition.eq("field", value),
+                QueryRejectionCategory.INVALID_QUERY,
+                QueryRejectionCode.INVALID_VALUE_TYPE,
+                "$.input.condition.value",
+            )
+        }
+    }
+
+    @Test
+    fun `should reject hostile duplicate map entries after a bounded number of reads`() {
+        val duplicateMap = DuplicateKeyMap()
+
+        assertRejected(
+            RawAdmissionGuard(baseLimits),
+            Condition.eq("field", duplicateMap),
+            QueryRejectionCategory.INVALID_QUERY,
+            QueryRejectionCode.DUPLICATE_OBJECT_KEY,
+            "$.input.condition.value['same']",
+        )
+        duplicateMap.nextReads.assert().isEqualTo(2)
+    }
+
+    @Test
+    fun `should keep option rejection path stable across map iteration order`() {
+        val optionsA = linkedMapOf<String, Any>(Condition.ZONE_ID_OPTION_KEY to "UTC", "unexpected" to true)
+        val optionsB = linkedMapOf<String, Any>("unexpected" to true, Condition.ZONE_ID_OPTION_KEY to "UTC")
+
+        listOf(optionsA, optionsB).forEach { options ->
+            assertRejected(
+                RawAdmissionGuard(baseLimits),
+                Condition("field", Operator.TODAY, options = options),
+                QueryRejectionCategory.INVALID_QUERY,
+                QueryRejectionCode.UNKNOWN_OPTION,
+                "$.input.condition.options['unexpected']",
+            )
+        }
+    }
+
+    private fun countInvocation(condition: Condition): QueryInvocation =
+        QueryInvocation(
+            target = target,
+            operation = QueryOperation.COUNT,
+            resultShape = QueryResultShape.COUNT,
+            input = QueryInput.Count(condition),
+        )
+
+    @Suppress("UNCHECKED_CAST")
+    private fun <T> unsafeList(value: Any?): List<T> = listOf(value) as List<T>
+
+    private fun singleInvocation(query: SingleQuery): QueryInvocation =
+        QueryInvocation(
+            target = target,
+            operation = QueryOperation.SINGLE,
+            resultShape = QueryResultShape.TYPED,
+            input = QueryInput.Single(query),
+        )
+
+    private fun assertInvocationRejected(
+        category: QueryRejectionCategory,
+        code: QueryRejectionCode,
+        path: String,
+        action: () -> Unit,
+    ) {
+        assertThrownBy<QueryRejectedException>(action).satisfies(
+            Consumer { error ->
+                error.rejection.category.assert().isEqualTo(category)
+                error.rejection.code.assert().isEqualTo(code)
+                error.rejection.path.toString().assert().isEqualTo(path)
+            },
+        )
+    }
+
+    private fun assertRejected(
+        guard: RawAdmissionGuard,
+        condition: Condition,
+        category: QueryRejectionCategory,
+        code: QueryRejectionCode,
+        path: String,
+    ) {
+        assertThrownBy<QueryRejectedException> {
+            guard.admit(countInvocation(condition))
+        }.satisfies(
+            Consumer { error ->
+                error.rejection.category.assert().isEqualTo(category)
+                error.rejection.code.assert().isEqualTo(code)
+                error.rejection.path.toString().assert().isEqualTo(path)
+            },
+        )
+    }
+
+    private enum class TestValue {
+        VALUE,
+    }
+
+    private class DuplicateKeyMap : AbstractMap<String, Any?>() {
+        var nextReads: Int = 0
+            private set
+
+        override val entries: Set<Map.Entry<String, Any?>> = object : AbstractSet<Map.Entry<String, Any?>>() {
+            override val size: Int = Int.MAX_VALUE
+
+            override fun iterator(): Iterator<Map.Entry<String, Any?>> = object : Iterator<Map.Entry<String, Any?>> {
+                override fun hasNext(): Boolean = true
+
+                override fun next(): Map.Entry<String, Any?> {
+                    if (!hasNext()) {
+                        throw NoSuchElementException()
+                    }
+                    nextReads++
+                    return SimpleImmutableEntry("same", nextReads)
+                }
+            }
+        }
+    }
+}

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/internal/admission/RawAdmissionGuardTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/internal/admission/RawAdmissionGuardTest.kt
@@ -1,0 +1,322 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.internal.admission
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.test.asserts.assertThrownBy
+import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.ISingleQuery
+import me.ahoo.wow.api.query.Operator
+import me.ahoo.wow.api.query.Projection
+import me.ahoo.wow.api.query.Sort
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.query.internal.model.QueryDocumentKind
+import me.ahoo.wow.query.internal.model.QueryInput
+import me.ahoo.wow.query.internal.model.QueryInvocation
+import me.ahoo.wow.query.internal.model.QueryOperation
+import me.ahoo.wow.query.internal.model.QueryResultShape
+import me.ahoo.wow.query.internal.model.QueryTarget
+import me.ahoo.wow.query.internal.normalization.NormalizedValue
+import me.ahoo.wow.query.internal.rejection.QueryRejectedException
+import me.ahoo.wow.query.internal.rejection.QueryRejectionCategory
+import me.ahoo.wow.query.internal.rejection.QueryRejectionCode
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.util.function.Consumer
+
+class RawAdmissionGuardTest {
+
+    private val target = QueryTarget(
+        MaterializedNamedAggregate("sales", "order"),
+        QueryDocumentKind.SNAPSHOT,
+    )
+    private val limits = QueryAdmissionLimits(
+        maxConditionDepth = 4,
+        maxConditionNodes = 12,
+        maxChildrenPerNode = 4,
+        maxFieldLength = 24,
+        maxStringLength = 16,
+        maxCollectionSize = 4,
+        maxObjectFields = 4,
+        maxValueDepth = 4,
+        maxByteArrayLength = 4,
+        maxProjectionFields = 4,
+        maxSortFields = 3,
+        maxOptions = 3,
+    )
+    private val guard = RawAdmissionGuard(limits)
+
+    @Test
+    fun `should read each query getter once and freeze every mutable boundary`() {
+        val bytes = byteArrayOf(1, 2)
+        val objectValue = linkedMapOf<String, Any?>("bytes" to bytes)
+        val oneShot = OneShotIterable(listOf(objectValue))
+        val projectionFields = mutableListOf("state.name")
+        val sorts = mutableListOf(Sort("state.name", Sort.Direction.ASC))
+        val query = SingleReadQuery(
+            conditionValue = Condition("state.items", Operator.IN, oneShot),
+            projectionValue = Projection(include = projectionFields),
+            sortValue = sorts,
+        )
+
+        val admitted = guard.admit(singleInvocation(query))
+        projectionFields += "late"
+        sorts.clear()
+        objectValue.clear()
+        bytes[0] = 9
+
+        query.conditionReads.assert().isEqualTo(1)
+        query.projectionReads.assert().isEqualTo(1)
+        query.sortReads.assert().isEqualTo(1)
+        oneShot.iteratorReads.assert().isEqualTo(1)
+
+        val admittedQuery = (admitted.input as AdmittedQueryInput.Single).query
+        admittedQuery.projection.include.assert().containsExactly("state.name")
+        admittedQuery.sort.map { it.field }.assert().containsExactly("state.name")
+        admittedQuery.condition.queryValue().assert().isEqualTo(
+            NormalizedValue.ListValue(
+                listOf(
+                    NormalizedValue.ObjectValue(
+                        mapOf("bytes" to NormalizedValue.Bytes(byteArrayOf(1, 2))),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `should canonicalize equivalent numeric values during admission`() {
+        val condition = Condition(
+            "state.numbers",
+            Operator.ALL_IN,
+            OneShotIterable(listOf(1, 1L, 1.0, BigDecimal("1.00"))),
+        )
+
+        val admitted = guard.admit(singleInvocation(SingleReadQuery(condition)))
+        val admittedCondition = (admitted.input as AdmittedQueryInput.Single).query.condition
+        val values = admittedCondition.queryValue() as NormalizedValue.ListValue
+
+        values.values.assert().containsExactly(
+            NormalizedValue.Int64(1),
+            NormalizedValue.Int64(1),
+            NormalizedValue.Int64(1),
+            NormalizedValue.Int64(1),
+        )
+    }
+
+    @Test
+    fun `should reject budgets at the exact offending path`() {
+        val tooDeep = Condition.and(
+            Condition.and(
+                Condition.and(
+                    Condition.and(Condition.eq("field", "value")),
+                ),
+            ),
+        )
+        assertRejected(
+            QueryRejectionCategory.BUDGET_EXCEEDED,
+            QueryRejectionCode.CONDITION_DEPTH_LIMIT_EXCEEDED,
+            "$.input.query.condition.children[0].children[0].children[0].children[0]",
+        ) {
+            guard.admit(singleInvocation(SingleReadQuery(tooDeep)))
+        }
+
+        assertRejected(
+            QueryRejectionCategory.BUDGET_EXCEEDED,
+            QueryRejectionCode.STRING_LIMIT_EXCEEDED,
+            "$.input.query.condition.value",
+        ) {
+            guard.admit(
+                singleInvocation(
+                    SingleReadQuery(Condition.eq("field", "x".repeat(limits.maxStringLength + 1))),
+                ),
+            )
+        }
+
+        assertRejected(
+            QueryRejectionCategory.BUDGET_EXCEEDED,
+            QueryRejectionCode.COLLECTION_LIMIT_EXCEEDED,
+            "$.input.query.condition.value",
+        ) {
+            guard.admit(
+                singleInvocation(
+                    SingleReadQuery(
+                        Condition("field", Operator.IN, OneShotIterable((0..limits.maxCollectionSize).toList())),
+                    ),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `should reject condition and value cycles without overflowing the stack`() {
+        val children = mutableListOf<Condition>()
+        val cyclicCondition = Condition(operator = Operator.AND, children = children)
+        children += cyclicCondition
+
+        assertRejected(
+            QueryRejectionCategory.INVALID_QUERY,
+            QueryRejectionCode.CYCLIC_INPUT,
+            "$.input.query.condition.children[0]",
+        ) {
+            guard.admit(singleInvocation(SingleReadQuery(cyclicCondition)))
+        }
+
+        val values = mutableListOf<Any?>()
+        values.add(values)
+        assertRejected(
+            QueryRejectionCategory.INVALID_QUERY,
+            QueryRejectionCode.CYCLIC_INPUT,
+            "$.input.query.condition.value[0]",
+        ) {
+            guard.admit(singleInvocation(SingleReadQuery(Condition.eq("field", values))))
+        }
+    }
+
+    @Test
+    fun `should reject malformed operator values with typed errors`() {
+        val cases = listOf(
+            Condition(operator = Operator.AND) to QueryRejectionCode.INVALID_CHILDREN,
+            Condition("field", Operator.BETWEEN, listOf(1)) to QueryRejectionCode.INVALID_VALUE_ARITY,
+            Condition("field", Operator.ELEM_MATCH) to QueryRejectionCode.INVALID_CHILDREN,
+            Condition(operator = Operator.ID, value = 1) to QueryRejectionCode.INVALID_VALUE_TYPE,
+            Condition(operator = Operator.IDS, value = listOf("id", 1)) to QueryRejectionCode.INVALID_VALUE_TYPE,
+            Condition("field", Operator.IN, "value") to QueryRejectionCode.INVALID_VALUE_TYPE,
+            Condition("field", Operator.EXISTS, "true") to QueryRejectionCode.INVALID_VALUE_TYPE,
+            Condition("field", Operator.RECENT_DAYS, 0) to QueryRejectionCode.INVALID_TIME_VALUE,
+            Condition("field", Operator.BEFORE_TODAY, 86_400) to QueryRejectionCode.INVALID_TIME_VALUE,
+        )
+
+        cases.forEach { (condition, code) ->
+            assertThrownBy<QueryRejectedException> {
+                guard.admit(singleInvocation(SingleReadQuery(condition)))
+            }.satisfies(
+                Consumer { error ->
+                    error.rejection.category.assert().isEqualTo(QueryRejectionCategory.INVALID_QUERY)
+                    error.rejection.code.assert().isEqualTo(code)
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `should reject unknown or mistyped options and unbound native input`() {
+        val cases = listOf(
+            Condition(
+                "field",
+                Operator.CONTAINS,
+                "value",
+                options = mapOf(Condition.IGNORE_CASE_OPTION_KEY to "true"),
+            ) to QueryRejectionCode.INVALID_OPTION_TYPE,
+            Condition(
+                "field",
+                Operator.TODAY,
+                options = mapOf("unknown" to true),
+            ) to QueryRejectionCode.UNKNOWN_OPTION,
+            Condition.eq("field", "value").copy(
+                options = mapOf(Condition.IGNORE_CASE_OPTION_KEY to true),
+            ) to QueryRejectionCode.OPTION_NOT_ALLOWED,
+        )
+
+        cases.forEach { (condition, code) ->
+            assertThrownBy<QueryRejectedException> {
+                guard.admit(singleInvocation(SingleReadQuery(condition)))
+            }.satisfies(
+                Consumer { error ->
+                    error.rejection.code.assert().isEqualTo(code)
+                }
+            )
+        }
+
+        val raw = guard.admit(singleInvocation(SingleReadQuery(Condition.raw(HostileRawValue()))))
+        val rawCondition = (raw.input as AdmittedQueryInput.Single).query.condition
+        rawCondition.value.assert().isEqualTo(AdmittedConditionValue.NativeUnbound)
+    }
+
+    private fun singleInvocation(query: ISingleQuery): QueryInvocation =
+        QueryInvocation(
+            target = target,
+            operation = QueryOperation.SINGLE,
+            resultShape = QueryResultShape.TYPED,
+            input = QueryInput.Single(query),
+        )
+
+    private fun assertRejected(
+        category: QueryRejectionCategory,
+        code: QueryRejectionCode,
+        path: String,
+        action: () -> Unit,
+    ) {
+        assertThrownBy<QueryRejectedException>(action).satisfies(
+            Consumer { error ->
+                error.rejection.category.assert().isEqualTo(category)
+                error.rejection.code.assert().isEqualTo(code)
+                error.rejection.path.toString().assert().isEqualTo(path)
+            }
+        )
+    }
+
+    private class OneShotIterable<T>(private val values: List<T>) : Iterable<T> {
+        var iteratorReads: Int = 0
+            private set
+
+        override fun iterator(): Iterator<T> {
+            iteratorReads++
+            check(iteratorReads == 1) {
+                "Iterable can only be consumed once."
+            }
+            return values.iterator()
+        }
+    }
+
+    private class HostileRawValue {
+        override fun toString(): String = error("RAW driver objects must not be inspected during admission.")
+    }
+
+    private class SingleReadQuery(
+        private val conditionValue: Condition,
+        private val projectionValue: Projection = Projection.ALL,
+        private val sortValue: List<Sort> = emptyList(),
+    ) : ISingleQuery {
+        var conditionReads: Int = 0
+            private set
+        var projectionReads: Int = 0
+            private set
+        var sortReads: Int = 0
+            private set
+
+        override val condition: Condition
+            get() = conditionValue.also {
+                conditionReads++
+                check(conditionReads == 1)
+            }
+        override val projection: Projection
+            get() = projectionValue.also {
+                projectionReads++
+                check(projectionReads == 1)
+            }
+        override val sort: List<Sort>
+            get() = sortValue.also {
+                sortReads++
+                check(sortReads == 1)
+            }
+
+        override fun withCondition(newCondition: Condition): ISingleQuery = this
+
+        override fun withProjection(newProjection: Projection): ISingleQuery = this
+    }
+}
+
+private fun AdmittedCondition.queryValue(): NormalizedValue =
+    (value as AdmittedConditionValue.QueryValue).value

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/internal/admission/RawQueryGetterSnapshotTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/internal/admission/RawQueryGetterSnapshotTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.internal.admission
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.IListQuery
+import me.ahoo.wow.api.query.IPagedQuery
+import me.ahoo.wow.api.query.Pagination
+import me.ahoo.wow.api.query.Projection
+import me.ahoo.wow.api.query.Sort
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.query.internal.model.QueryDocumentKind
+import me.ahoo.wow.query.internal.model.QueryInput
+import me.ahoo.wow.query.internal.model.QueryInvocation
+import me.ahoo.wow.query.internal.model.QueryOperation
+import me.ahoo.wow.query.internal.model.QueryResultShape
+import me.ahoo.wow.query.internal.model.QueryTarget
+import org.junit.jupiter.api.Test
+
+class RawQueryGetterSnapshotTest {
+
+    private val target = QueryTarget(
+        MaterializedNamedAggregate("sales", "order"),
+        QueryDocumentKind.SNAPSHOT,
+    )
+    private val guard = RawAdmissionGuard(QueryAdmissionLimits.DEFAULT)
+
+    @Test
+    fun `should read every stream query getter exactly once`() {
+        val query = SingleReadListQuery()
+
+        val admitted = guard.admit(
+            QueryInvocation(
+                target,
+                QueryOperation.STREAM,
+                QueryResultShape.TYPED,
+                QueryInput.Stream(query),
+            ),
+        )
+
+        query.reads.assert().containsExactlyInAnyOrderEntriesOf(
+            mapOf("condition" to 1, "projection" to 1, "sort" to 1, "limit" to 1),
+        )
+        (admitted.input as AdmittedQueryInput.Stream).limit.assert().isEqualTo(10)
+    }
+
+    @Test
+    fun `should read every page query getter exactly once`() {
+        val query = SingleReadPagedQuery()
+
+        val admitted = guard.admit(
+            QueryInvocation(
+                target,
+                QueryOperation.PAGE,
+                QueryResultShape.DYNAMIC,
+                QueryInput.Page(query),
+            ),
+        )
+
+        query.reads.assert().containsExactlyInAnyOrderEntriesOf(
+            mapOf("condition" to 1, "projection" to 1, "sort" to 1, "pagination" to 1),
+        )
+        (admitted.input as AdmittedQueryInput.Page).page.assert().isEqualTo(AdmittedPage(2, 25, 25))
+    }
+
+    private abstract class SingleReadQueryable {
+        val reads: MutableMap<String, Int> = linkedMapOf()
+
+        protected fun <T> readOnce(name: String, value: T): T {
+            val count = reads.getOrDefault(name, 0) + 1
+            reads[name] = count
+            check(count == 1) {
+                "$name can only be read once."
+            }
+            return value
+        }
+    }
+
+    private class SingleReadListQuery : SingleReadQueryable(), IListQuery {
+        override val condition: Condition
+            get() = readOnce("condition", Condition.ALL)
+        override val projection: Projection
+            get() = readOnce("projection", Projection.ALL)
+        override val sort: List<Sort>
+            get() = readOnce("sort", emptyList())
+        override val limit: Int
+            get() = readOnce("limit", 10)
+
+        override fun withCondition(newCondition: Condition): IListQuery = this
+
+        override fun withProjection(newProjection: Projection): IListQuery = this
+    }
+
+    private class SingleReadPagedQuery : SingleReadQueryable(), IPagedQuery {
+        override val condition: Condition
+            get() = readOnce("condition", Condition.ALL)
+        override val projection: Projection
+            get() = readOnce("projection", Projection.ALL)
+        override val sort: List<Sort>
+            get() = readOnce("sort", emptyList())
+        override val pagination: Pagination
+            get() = readOnce("pagination", Pagination(2, 25))
+
+        override fun withCondition(newCondition: Condition): IPagedQuery = this
+
+        override fun withProjection(newProjection: Projection): IPagedQuery = this
+    }
+}

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/internal/normalization/NormalizedValueTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/internal/normalization/NormalizedValueTest.kt
@@ -71,6 +71,19 @@ class NormalizedValueTest {
     }
 
     @Test
+    fun `object equality should preserve Mongo document field order`() {
+        val first = NormalizedValue.ObjectValue(
+            linkedMapOf("a" to NormalizedValue.Int64(1), "b" to NormalizedValue.Int64(2)),
+        )
+        val reversed = NormalizedValue.ObjectValue(
+            linkedMapOf("b" to NormalizedValue.Int64(2), "a" to NormalizedValue.Int64(1)),
+        )
+
+        first.assert().isNotEqualTo(reversed)
+        first.hashCode().assert().isNotEqualTo(reversed.hashCode())
+    }
+
+    @Test
     fun `list should materialize a one-shot iterable exactly once`() {
         var iteratorCalls = 0
         val oneShot = Iterable {

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/internal/normalization/QueryNormalizerTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/internal/normalization/QueryNormalizerTest.kt
@@ -1,0 +1,641 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.internal.normalization
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.test.asserts.assertThrownBy
+import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.DeletionState
+import me.ahoo.wow.api.query.ListQuery
+import me.ahoo.wow.api.query.Operator
+import me.ahoo.wow.api.query.PagedQuery
+import me.ahoo.wow.api.query.Pagination
+import me.ahoo.wow.api.query.Projection
+import me.ahoo.wow.api.query.SingleQuery
+import me.ahoo.wow.api.query.Sort
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.query.internal.admission.QueryAdmissionLimits
+import me.ahoo.wow.query.internal.admission.RawAdmissionGuard
+import me.ahoo.wow.query.internal.model.QueryDocumentKind
+import me.ahoo.wow.query.internal.model.QueryInput
+import me.ahoo.wow.query.internal.model.QueryInvocation
+import me.ahoo.wow.query.internal.model.QueryOperation
+import me.ahoo.wow.query.internal.model.QueryResultShape
+import me.ahoo.wow.query.internal.model.QueryTarget
+import me.ahoo.wow.query.internal.rejection.QueryRejectedException
+import me.ahoo.wow.query.internal.rejection.QueryRejectionCategory
+import me.ahoo.wow.query.internal.rejection.QueryRejectionCode
+import org.junit.jupiter.api.Test
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatterBuilder
+import java.time.temporal.ChronoField
+import java.util.function.Consumer
+
+class QueryNormalizerTest {
+
+    private val target = QueryTarget(
+        MaterializedNamedAggregate("sales", "order"),
+        QueryDocumentKind.SNAPSHOT,
+    )
+    private val guard = RawAdmissionGuard(QueryAdmissionLimits.DEFAULT)
+    private val fixedInstant = Instant.parse("2024-03-10T06:30:00Z")
+    private val zoneId = ZoneId.of("America/New_York")
+
+    @Test
+    fun `should normalize all wire operators or reject native explicitly`() {
+        Operator.entries.forEach { operator ->
+            val invocation = countInvocation(validCondition(operator))
+            if (operator == Operator.RAW) {
+                assertThrownBy<QueryRejectedException> {
+                    QueryNormalizer(Clock.fixed(fixedInstant, zoneId)).normalize(guard.admit(invocation))
+                }.satisfies(
+                    Consumer { error ->
+                        error.rejection.category.assert().isEqualTo(QueryRejectionCategory.UNSUPPORTED_FEATURE)
+                        error.rejection.code.assert().isEqualTo(QueryRejectionCode.NATIVE_BACKEND_UNBOUND)
+                    }
+                )
+            } else {
+                QueryNormalizer(Clock.fixed(fixedInstant, zoneId)).normalize(guard.admit(invocation))
+            }
+        }
+    }
+
+    @Test
+    fun `should normalize system fields without guessing ordinary id paths`() {
+        val condition = Condition.and(
+            Condition.id("identity"),
+            Condition.ids("identity-1", "identity-2"),
+            Condition.aggregateId("aggregate"),
+            Condition.aggregateIds("aggregate-1", "aggregate-2"),
+            Condition.tenantId("tenant"),
+            Condition.ownerId("owner"),
+            Condition.spaceId("space"),
+            Condition.deleted(DeletionState.ACTIVE),
+            Condition.eq("id", "element-or-state-id"),
+        )
+
+        val normalized = normalizeCount(condition)
+        val children = (normalized as NormalizedCondition.Junction).children
+
+        (children[0] as NormalizedCondition.Predicate).field.assert().isEqualTo(
+            LogicalField.System(SystemFieldKind.IDENTITY),
+        )
+        (children[2] as NormalizedCondition.Predicate).field.assert().isEqualTo(
+            LogicalField.System(SystemFieldKind.AGGREGATE_ID),
+        )
+        (children[4] as NormalizedCondition.Predicate).field.assert().isEqualTo(
+            LogicalField.System(SystemFieldKind.TENANT_ID),
+        )
+        (children[7] as NormalizedCondition.Predicate).operator.assert().isEqualTo(PredicateOperator.IS_FALSE)
+        (children[8] as NormalizedCondition.Predicate).field.assert().isEqualTo(
+            LogicalField.Path(listOf("id"), PathBasis.ROOT),
+        )
+    }
+
+    @Test
+    fun `should normalize element match fields relative to each element scope`() {
+        val condition = Condition.elemMatch(
+            "items",
+            Condition.and(
+                Condition.eq("items.sku", "sku-a"),
+                Condition.eq("id", "line-id"),
+                Condition.elemMatch(
+                    "attributes",
+                    Condition.and(
+                        Condition.eq("name", "size"),
+                        Condition.eq("attributes.code", "size-code"),
+                        Condition.eq("items.attributes.label", "size-label"),
+                    ),
+                ),
+            ),
+        )
+
+        val normalized = normalizeCount(condition) as NormalizedCondition.ElementMatch
+        normalized.field.assert().isEqualTo(LogicalField.Path(listOf("items"), PathBasis.ROOT))
+        val children = (normalized.condition as NormalizedCondition.Junction).children
+        (children[0] as NormalizedCondition.Predicate).field.assert().isEqualTo(
+            LogicalField.Path(listOf("sku"), PathBasis.CURRENT_ELEMENT),
+        )
+        (children[1] as NormalizedCondition.Predicate).field.assert().isEqualTo(
+            LogicalField.Path(listOf("id"), PathBasis.CURRENT_ELEMENT),
+        )
+        val nested = children[2] as NormalizedCondition.ElementMatch
+        nested.field.assert().isEqualTo(
+            LogicalField.Path(listOf("attributes"), PathBasis.CURRENT_ELEMENT),
+        )
+        val nestedChildren = (nested.condition as NormalizedCondition.Junction).children
+        (nestedChildren[0] as NormalizedCondition.Predicate).field.assert().isEqualTo(
+            LogicalField.Path(listOf("name"), PathBasis.CURRENT_ELEMENT),
+        )
+        (nestedChildren[1] as NormalizedCondition.Predicate).field.assert().isEqualTo(
+            LogicalField.Path(listOf("code"), PathBasis.CURRENT_ELEMENT),
+        )
+        (nestedChildren[2] as NormalizedCondition.Predicate).field.assert().isEqualTo(
+            LogicalField.Path(listOf("label"), PathBasis.CURRENT_ELEMENT),
+        )
+    }
+
+    @Test
+    fun `should resolve absolute and qualified prefixes through three element levels`() {
+        val condition = Condition.elemMatch(
+            "items",
+            Condition.elemMatch(
+                "attributes",
+                Condition.elemMatch(
+                    "attributes.values",
+                    Condition.and(
+                        Condition.eq("value", "large"),
+                        Condition.eq("values.code", "large-code"),
+                        Condition.eq("attributes.values.label", "large-label"),
+                        Condition.eq("items.attributes.values.kind", "size-kind"),
+                    ),
+                ),
+            ),
+        )
+
+        val firstLevel = normalizeCount(condition) as NormalizedCondition.ElementMatch
+        val secondLevel = firstLevel.condition as NormalizedCondition.ElementMatch
+        val thirdLevel = secondLevel.condition as NormalizedCondition.ElementMatch
+        thirdLevel.field.assert().isEqualTo(LogicalField.Path(listOf("values"), PathBasis.CURRENT_ELEMENT))
+        val fields = (thirdLevel.condition as NormalizedCondition.Junction).children.map { child ->
+            (child as NormalizedCondition.Predicate).field
+        }
+        fields.assert().containsExactly(
+            LogicalField.Path(listOf("value"), PathBasis.CURRENT_ELEMENT),
+            LogicalField.Path(listOf("code"), PathBasis.CURRENT_ELEMENT),
+            LogicalField.Path(listOf("label"), PathBasis.CURRENT_ELEMENT),
+            LogicalField.Path(listOf("kind"), PathBasis.CURRENT_ELEMENT),
+        )
+    }
+
+    @Test
+    fun `should reject system operators inside element scope`() {
+        val condition = Condition.elemMatch("items", Condition.id("line-id"))
+
+        assertThrownBy<QueryRejectedException> {
+            normalizeCount(condition)
+        }.satisfies(
+            Consumer { error ->
+                error.rejection.category.assert().isEqualTo(QueryRejectionCategory.INVALID_QUERY)
+                error.rejection.code.assert().isEqualTo(QueryRejectionCode.SYSTEM_FIELD_IN_ELEMENT_SCOPE)
+                error.rejection.path.toString().assert().isEqualTo("$.input.condition.children[0]")
+            }
+        )
+    }
+
+    @Test
+    fun `should freeze clock once and expand time macros as DST safe half open ranges`() {
+        val clock = CountingClock(fixedInstant, zoneId)
+        val condition = Condition.and(
+            Condition.today("createdAt"),
+            Condition.tomorrow("updatedAt"),
+        )
+        val admitted = guard.admit(countInvocation(condition))
+
+        val normalized = QueryNormalizer(clock).normalize(admitted)
+        val children = ((normalized.input as NormalizedQueryInput.Count).userCondition as NormalizedCondition.Junction)
+            .children
+
+        clock.instantReads.assert().isEqualTo(1)
+        children[0].assert().isEqualTo(
+            halfOpenRange(
+                "createdAt",
+                Instant.parse("2024-03-10T05:00:00Z"),
+                Instant.parse("2024-03-11T04:00:00Z"),
+            ),
+        )
+        children[1].assert().isEqualTo(
+            halfOpenRange(
+                "updatedAt",
+                Instant.parse("2024-03-11T04:00:00Z"),
+                Instant.parse("2024-03-12T04:00:00Z"),
+            ),
+        )
+    }
+
+    @Test
+    fun `should normalize search and Mongo baseline empty collection constants`() {
+        normalizeCount(Condition.match("description", "distributed systems")).assert().isEqualTo(
+            NormalizedCondition.Search(SearchScope("description"), "distributed systems"),
+        )
+        normalizeCount(Condition("field", Operator.IN, emptyList<Any>())).assert()
+            .isEqualTo(NormalizedCondition.None)
+        normalizeCount(Condition("field", Operator.NOT_IN, emptyList<Any>())).assert()
+            .isEqualTo(NormalizedCondition.All)
+        normalizeCount(Condition("field", Operator.ALL_IN, emptyList<Any>())).assert()
+            .isEqualTo(NormalizedCondition.None)
+
+        val allIn = normalizeCount(
+            Condition("field", Operator.ALL_IN, listOf(1, 1L, 1.0)),
+        ) as NormalizedCondition.Predicate
+        (allIn.value as NormalizedValue.ListValue).values.assert().containsExactly(NormalizedValue.Int64(1))
+
+        val orderedDocument = linkedMapOf<String, Any>("a" to 1, "b" to 2)
+        val reversedDocument = linkedMapOf<String, Any>("b" to 2, "a" to 1)
+        val documentIn = normalizeCount(
+            Condition("field", Operator.IN, listOf(orderedDocument, reversedDocument)),
+        ) as NormalizedCondition.Predicate
+        (documentIn.value as NormalizedValue.ListValue).values.assert().containsExactly(
+            NormalizedValue.ObjectValue(
+                linkedMapOf("a" to NormalizedValue.Int64(1), "b" to NormalizedValue.Int64(2)),
+            ),
+            NormalizedValue.ObjectValue(
+                linkedMapOf("b" to NormalizedValue.Int64(2), "a" to NormalizedValue.Int64(1)),
+            ),
+        )
+    }
+
+    @Test
+    fun `should map field predicate operators without backend escaping`() {
+        val comparisonOperators = mapOf(
+            Operator.EQ to PredicateOperator.EQ,
+            Operator.NE to PredicateOperator.NE,
+            Operator.GT to PredicateOperator.GT,
+            Operator.LT to PredicateOperator.LT,
+            Operator.GTE to PredicateOperator.GTE,
+            Operator.LTE to PredicateOperator.LTE,
+            Operator.IN to PredicateOperator.IN,
+            Operator.NOT_IN to PredicateOperator.NOT_IN,
+            Operator.ALL_IN to PredicateOperator.ALL_IN,
+            Operator.BETWEEN to PredicateOperator.BETWEEN,
+        )
+        comparisonOperators.forEach { (wire, expected) ->
+            val rawValue = if (wire in COLLECTION_OPERATORS) listOf(1, 2) else 1
+            val predicate = normalizeCount(Condition("field", wire, rawValue)) as NormalizedCondition.Predicate
+            predicate.operator.assert().isEqualTo(expected)
+        }
+
+        val literal = normalizeCount(Condition.contains("field", "*?\\", ignoreCase = true))
+            as NormalizedCondition.Predicate
+        literal.value.assert().isEqualTo(NormalizedValue.Text("*?\\"))
+        literal.operator.assert().isEqualTo(PredicateOperator.CONTAINS)
+        literal.options.caseSensitivity.assert().isEqualTo(CaseSensitivity.INSENSITIVE)
+    }
+
+    @Test
+    fun `should normalize constant boolean deletion and junction truth tables`() {
+        val fieldless = mapOf(
+            Operator.NULL to PredicateOperator.IS_NULL,
+            Operator.NOT_NULL to PredicateOperator.NOT_NULL,
+            Operator.TRUE to PredicateOperator.IS_TRUE,
+            Operator.FALSE to PredicateOperator.IS_FALSE,
+        )
+        fieldless.forEach { (wire, expected) ->
+            val predicate = normalizeCount(Condition("field", wire)) as NormalizedCondition.Predicate
+            predicate.operator.assert().isEqualTo(expected)
+            predicate.value.assert().isNull()
+        }
+        (normalizeCount(Condition.exists("field", false)) as NormalizedCondition.Predicate).value.assert()
+            .isEqualTo(NormalizedValue.BooleanValue(false))
+        (normalizeCount(Condition.deleted(true)) as NormalizedCondition.Predicate).operator.assert()
+            .isEqualTo(PredicateOperator.IS_TRUE)
+        (normalizeCount(Condition.deleted(false)) as NormalizedCondition.Predicate).operator.assert()
+            .isEqualTo(PredicateOperator.IS_FALSE)
+        normalizeCount(Condition.deleted(DeletionState.ALL)).assert().isEqualTo(NormalizedCondition.All)
+        normalizeCount(Condition.nor(Condition.ALL)).assert().isEqualTo(NormalizedCondition.None)
+        normalizeCount(Condition.nor(Condition("field", Operator.IN, emptyList<Any>()))).assert()
+            .isEqualTo(NormalizedCondition.All)
+        normalizeCount(Condition(operator = Operator.IDS, value = emptyList<String>())).assert()
+            .isEqualTo(NormalizedCondition.None)
+        normalizeCount(Condition(operator = Operator.AGGREGATE_IDS, value = emptyList<String>())).assert()
+            .isEqualTo(NormalizedCondition.None)
+    }
+
+    @Test
+    fun `should expand week month and relative time operators from the frozen instant`() {
+        normalizeCount(Condition.thisWeek("field")).assert().isEqualTo(
+            halfOpenRange("field", Instant.parse("2024-03-04T05:00:00Z"), Instant.parse("2024-03-11T04:00:00Z")),
+        )
+        normalizeCount(Condition.nextWeek("field")).assert().isEqualTo(
+            halfOpenRange("field", Instant.parse("2024-03-11T04:00:00Z"), Instant.parse("2024-03-18T04:00:00Z")),
+        )
+        normalizeCount(Condition.lastWeek("field")).assert().isEqualTo(
+            halfOpenRange("field", Instant.parse("2024-02-26T05:00:00Z"), Instant.parse("2024-03-04T05:00:00Z")),
+        )
+        normalizeCount(Condition.thisMonth("field")).assert().isEqualTo(
+            halfOpenRange("field", Instant.parse("2024-03-01T05:00:00Z"), Instant.parse("2024-04-01T04:00:00Z")),
+        )
+        normalizeCount(Condition.lastMonth("field")).assert().isEqualTo(
+            halfOpenRange("field", Instant.parse("2024-02-01T05:00:00Z"), Instant.parse("2024-03-01T05:00:00Z")),
+        )
+        normalizeCount(Condition.recentDays("field", 2)).assert().isEqualTo(
+            halfOpenRange("field", Instant.parse("2024-03-09T05:00:00Z"), Instant.parse("2024-03-11T04:00:00Z")),
+        )
+        normalizeCount(Condition.earlierDays("field", 2)).assert().isEqualTo(
+            NormalizedCondition.Predicate(
+                LogicalField.Path(listOf("field"), PathBasis.ROOT),
+                PredicateOperator.LT,
+                NormalizedValue.InstantValue(Instant.parse("2024-03-09T05:00:00Z")),
+            ),
+        )
+        normalizeCount(Condition.beforeToday("field", "12:30:00")).assert().isEqualTo(
+            NormalizedCondition.Predicate(
+                LogicalField.Path(listOf("field"), PathBasis.ROOT),
+                PredicateOperator.LT,
+                NormalizedValue.InstantValue(Instant.parse("2024-03-10T16:30:00Z")),
+            ),
+        )
+    }
+
+    @Test
+    fun `should apply explicit time zone and date pattern without backend types`() {
+        val condition = Condition(
+            field = "field",
+            operator = Operator.TODAY,
+            options = mapOf(
+                Condition.ZONE_ID_OPTION_KEY to "UTC",
+                Condition.DATE_PATTERN_OPTION_KEY to "yyyy-MM-dd HH:mm",
+            ),
+        )
+
+        normalizeCount(condition).assert().isEqualTo(
+            NormalizedCondition.Junction(
+                JunctionOperator.AND,
+                listOf(
+                    NormalizedCondition.Predicate(
+                        LogicalField.Path(listOf("field"), PathBasis.ROOT),
+                        PredicateOperator.GTE,
+                        NormalizedValue.Text("2024-03-10 00:00"),
+                    ),
+                    NormalizedCondition.Predicate(
+                        LogicalField.Path(listOf("field"), PathBasis.ROOT),
+                        PredicateOperator.LT,
+                        NormalizedValue.Text("2024-03-11 00:00"),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `should reject an admitted formatter that cannot format the frozen instant`() {
+        val formatter = DateTimeFormatterBuilder()
+            .appendValue(ChronoField.YEAR, 1)
+            .toFormatter()
+        val condition = Condition(
+            field = "field",
+            operator = Operator.TODAY,
+            options = mapOf(Condition.DATE_PATTERN_OPTION_KEY to formatter),
+        )
+
+        assertRejected(QueryRejectionCode.INVALID_OPTION_VALUE, "$.input.condition.options['datePattern']") {
+            normalizeCount(condition)
+        }
+    }
+
+    @Test
+    fun `should return typed rejections for malformed search element scope and temporal overflow`() {
+        listOf("", "   ").forEach { text ->
+            assertRejected(QueryRejectionCode.INVALID_VALUE_TYPE, "$.input.condition.value") {
+                normalizeCount(Condition.match("field", text))
+            }
+        }
+        assertRejected(QueryRejectionCode.INVALID_FIELD, "$.input.condition.children[0].field") {
+            normalizeCount(Condition.elemMatch("items", Condition.eq("items", "value")))
+        }
+        listOf(Operator.RECENT_DAYS, Operator.EARLIER_DAYS).forEach { operator ->
+            assertRejected(QueryRejectionCode.INVALID_TIME_VALUE, "$.input.condition.value") {
+                normalizeCount(Condition("field", operator, Long.MAX_VALUE))
+            }
+        }
+        assertRejected(
+            QueryRejectionCode.NATIVE_BACKEND_UNBOUND,
+            "$.input.condition",
+            QueryRejectionCategory.UNSUPPORTED_FEATURE,
+        ) {
+            normalizeCount(Condition.raw("{}"))
+        }
+    }
+
+    @Test
+    fun `should normalize projection sort list limit and long page offset`() {
+        val pageInvocation = QueryInvocation(
+            target = target,
+            operation = QueryOperation.PAGE,
+            resultShape = QueryResultShape.DYNAMIC,
+            input = QueryInput.Page(
+                PagedQuery(
+                    condition = Condition.ALL,
+                    projection = Projection(include = listOf("state.name", "state.amount")),
+                    sort = listOf(
+                        Sort("state.amount", Sort.Direction.DESC),
+                        Sort("id", Sort.Direction.ASC),
+                    ),
+                    pagination = Pagination(Int.MAX_VALUE, Int.MAX_VALUE),
+                ),
+            ),
+        )
+
+        val normalized = normalize(pageInvocation)
+        val page = normalized.input as NormalizedQueryInput.Page
+        val projection = page.query.projection as NormalizedProjection.Include
+
+        projection.fields.values.assert().containsExactly(
+            LogicalField.Path(listOf("state", "name"), PathBasis.ROOT),
+            LogicalField.Path(listOf("state", "amount"), PathBasis.ROOT),
+        )
+        page.query.sort.map { it.direction }.assert().containsExactly(
+            NormalizedSortDirection.DESC,
+            NormalizedSortDirection.ASC,
+        )
+        page.page.offset.assert().isEqualTo(
+            (Int.MAX_VALUE.toLong() - 1) * Int.MAX_VALUE.toLong(),
+        )
+
+        val listInvocation = QueryInvocation(
+            target = target,
+            operation = QueryOperation.STREAM,
+            resultShape = QueryResultShape.TYPED,
+            input = QueryInput.Stream(ListQuery(Condition.ALL, limit = 0)),
+        )
+        (normalize(listInvocation).input as NormalizedQueryInput.Stream).limit.assert().isEqualTo(0)
+    }
+
+    @Test
+    fun `should preserve mixed projection for planner policy and reject invalid limit or page`() {
+        val mixed = SingleQuery(
+            condition = Condition.ALL,
+            projection = Projection(include = listOf("state.name"), exclude = listOf("state.secret")),
+        )
+        val normalizedMixed = normalize(
+            QueryInvocation(
+                target,
+                QueryOperation.SINGLE,
+                QueryResultShape.TYPED,
+                QueryInput.Single(mixed),
+            ),
+        )
+        val projection = (normalizedMixed.input as NormalizedQueryInput.Single).query.projection
+        projection.assert().isInstanceOf(NormalizedProjection.Mixed::class.java)
+
+        assertAdmissionRejected(QueryRejectionCode.INVALID_LIMIT) {
+            guard.admit(
+                QueryInvocation(
+                    target,
+                    QueryOperation.STREAM,
+                    QueryResultShape.TYPED,
+                    QueryInput.Stream(ListQuery(Condition.ALL, limit = -1)),
+                ),
+            )
+        }
+        listOf(Pagination(index = 0, size = 10), Pagination(index = 1, size = 0)).forEach { page ->
+            assertAdmissionRejected(QueryRejectionCode.INVALID_PAGE) {
+                guard.admit(
+                    QueryInvocation(
+                        target,
+                        QueryOperation.PAGE,
+                        QueryResultShape.TYPED,
+                        QueryInput.Page(PagedQuery(Condition.ALL, pagination = page)),
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun normalize(invocation: QueryInvocation): NormalizedQueryInvocation =
+        QueryNormalizer(Clock.fixed(fixedInstant, zoneId)).normalize(guard.admit(invocation))
+
+    private fun normalizeCount(condition: Condition): NormalizedCondition =
+        (normalize(countInvocation(condition)).input as NormalizedQueryInput.Count).userCondition
+
+    private fun countInvocation(condition: Condition): QueryInvocation =
+        QueryInvocation(
+            target = target,
+            operation = QueryOperation.COUNT,
+            resultShape = QueryResultShape.COUNT,
+            input = QueryInput.Count(condition),
+        )
+
+    private fun assertAdmissionRejected(code: QueryRejectionCode, action: () -> Any?) {
+        assertThrownBy<QueryRejectedException> {
+            action()
+        }.satisfies(
+            Consumer { error ->
+                error.rejection.category.assert().isEqualTo(QueryRejectionCategory.INVALID_QUERY)
+                error.rejection.code.assert().isEqualTo(code)
+            }
+        )
+    }
+
+    private fun assertRejected(
+        code: QueryRejectionCode,
+        path: String,
+        category: QueryRejectionCategory = QueryRejectionCategory.INVALID_QUERY,
+        action: () -> Unit,
+    ) {
+        assertThrownBy<QueryRejectedException>(action).satisfies(
+            Consumer { error ->
+                error.rejection.category.assert().isEqualTo(category)
+                error.rejection.code.assert().isEqualTo(code)
+                error.rejection.path.toString().assert().isEqualTo(path)
+            },
+        )
+    }
+
+    private fun halfOpenRange(field: String, from: Instant, to: Instant): NormalizedCondition =
+        NormalizedCondition.Junction(
+            JunctionOperator.AND,
+            listOf(
+                NormalizedCondition.Predicate(
+                    LogicalField.Path(field.split('.'), PathBasis.ROOT),
+                    PredicateOperator.GTE,
+                    NormalizedValue.InstantValue(from),
+                ),
+                NormalizedCondition.Predicate(
+                    LogicalField.Path(field.split('.'), PathBasis.ROOT),
+                    PredicateOperator.LT,
+                    NormalizedValue.InstantValue(to),
+                ),
+            ),
+        )
+
+    @Suppress("CyclomaticComplexMethod")
+    private fun validCondition(operator: Operator): Condition =
+        when (operator) {
+            Operator.AND -> Condition.and(Condition.ALL)
+            Operator.OR -> Condition.or(Condition.ALL)
+            Operator.NOR -> Condition.nor(Condition.eq("field", "value"))
+            Operator.ID -> Condition.id("id")
+            Operator.IDS -> Condition.ids("id")
+            Operator.AGGREGATE_ID -> Condition.aggregateId("id")
+            Operator.AGGREGATE_IDS -> Condition.aggregateIds("id")
+            Operator.TENANT_ID -> Condition.tenantId("tenant")
+            Operator.OWNER_ID -> Condition.ownerId("owner")
+            Operator.SPACE_ID -> Condition.spaceId("space")
+            Operator.DELETED -> Condition.deleted(false)
+            Operator.ALL -> Condition.ALL
+            Operator.EQ,
+            Operator.NE,
+            Operator.GT,
+            Operator.LT,
+            Operator.GTE,
+            Operator.LTE,
+            -> Condition("field", operator, 1)
+            Operator.CONTAINS,
+            Operator.STARTS_WITH,
+            Operator.ENDS_WITH,
+            Operator.MATCH,
+            -> Condition("field", operator, "value")
+            Operator.IN,
+            Operator.NOT_IN,
+            Operator.ALL_IN,
+            -> Condition("field", operator, listOf(1, 2))
+            Operator.BETWEEN -> Condition.between("field", 1, 2)
+            Operator.ELEM_MATCH -> Condition.elemMatch("items", Condition.eq("name", "value"))
+            Operator.NULL,
+            Operator.NOT_NULL,
+            Operator.TRUE,
+            Operator.FALSE,
+            -> Condition("field", operator)
+            Operator.EXISTS -> Condition.exists("field")
+            Operator.TODAY,
+            Operator.TOMORROW,
+            Operator.THIS_WEEK,
+            Operator.NEXT_WEEK,
+            Operator.LAST_WEEK,
+            Operator.THIS_MONTH,
+            Operator.LAST_MONTH,
+            -> Condition("field", operator)
+            Operator.BEFORE_TODAY -> Condition.beforeToday("field", "12:30:00")
+            Operator.RECENT_DAYS,
+            Operator.EARLIER_DAYS,
+            -> Condition("field", operator, 2)
+            Operator.RAW -> Condition.raw("{}")
+        }
+
+    private class CountingClock(
+        private val fixedInstant: Instant,
+        private val fixedZone: ZoneId,
+    ) : Clock() {
+        var instantReads: Int = 0
+            private set
+
+        override fun getZone(): ZoneId = fixedZone
+
+        override fun withZone(zone: ZoneId): Clock = CountingClock(fixedInstant, zone)
+
+        override fun instant(): Instant = fixedInstant.also { instantReads++ }
+    }
+
+    companion object {
+        private val COLLECTION_OPERATORS = setOf(
+            Operator.IN,
+            Operator.NOT_IN,
+            Operator.ALL_IN,
+            Operator.BETWEEN,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add a one-pass, bounded raw admission boundary that snapshots legacy query DTOs into deeply immutable internal values
- add stable typed rejections for malformed shapes, budget exhaustion, temporal errors, and unsupported native queries
- normalize all wire operators into a backend-neutral query model using MongoDB baseline semantics, including empty collections, numeric canonicalization, ordered embedded documents, element scopes, and frozen-clock time ranges
- preserve mixed projections for the P1-C planner instead of choosing compatibility policy prematurely
- update the architecture plan with the implemented P1-B boundaries

## Why

The query architecture upgrade needs a deterministic semantic boundary before policy, planning, routing, and backend compilation. Legacy DTOs can expose dynamic getters and mutable `Any` graphs, so validation alone is vulnerable to TOCTOU and resource amplification.

This PR establishes the immutable admitted snapshot and normalizer without wiring them into production execution.

## Compatibility / impact

- stacked on #2909
- no changes to supported public query APIs, wire DTOs, Spring beans, backend drivers, or OpenAPI schemas
- all new runtime types remain under `me.ahoo.wow.query.internal`
- legacy unbound `RAW` driver objects are discarded and rejected on the planned path
- Kotlin `internal` classes remain JVM-visible implementation details; this is not claimed as a zero JAR ABI diff

## Verification

- `./gradlew :wow-query:check --rerun-tasks`
- `./gradlew :wow-query:test --tests 'me.ahoo.wow.query.PublicQueryContractCompatibilityTest' :wow-openapi:test --tests 'me.ahoo.wow.openapi.snapshot.OpenApiCompatibilitySnapshotTest'`
- `git diff --cached --check`
- final staged diff reviewed independently for DTO/admission, operator semantics, and rejection/test coverage; no actionable P0/P1/P2 findings remain
