### PR TITLE
fix(test): tolerate one-second ttl drift in query api cache source ttl assertion

### DIFF
--- a/wow-cocache/src/test/kotlin/me/ahoo/wow/cache/source/QueryApiCacheSourceTest.kt
+++ b/wow-cocache/src/test/kotlin/me/ahoo/wow/cache/source/QueryApiCacheSourceTest.kt
@@ -19,6 +19,7 @@ import io.mockk.spyk
 import me.ahoo.cache.DefaultCacheValue
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.query.MaterializedSnapshot
+import org.assertj.core.data.Offset
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
@@ -50,8 +51,9 @@ class QueryApiCacheSourceTest {
         queryApiCacheSource.loadCacheSourceConfiguration.assert().isEqualTo(
             LoadCacheSourceConfiguration(ttl = 1000, ttlAmplitude = 0)
         )
-        val cacheValue = queryApiCacheSource.loadCacheValue("test")
-        cacheValue.assert().isEqualTo(DefaultCacheValue.ttlAt("test", 1000))
+        val cacheValue = requireNotNull(queryApiCacheSource.loadCacheValue("test"))
+        cacheValue.value.assert().isEqualTo("test")
+        cacheValue.ttlAt.assert().isCloseTo(DefaultCacheValue.ttlAt("test", 1000).ttlAt, Offset.offset(1))
     }
 
     @Test


### PR DESCRIPTION
## Summary

修复 `b2f74ab57`（BOM 4.3.0 升级）CI 中 `wow-cocache:test` 的失败：

```
QueryApiCacheSourceTest > should load cache value with custom TTL() FAILED
expected: DefaultCacheValue(value=test, ttlAt=1786870489)
 but was: DefaultCacheValue(value=test, ttlAt=1786870488)
```

## Root cause

测试对两次独立计算的 `now + ttl` 时间戳做精确相等断言：

- actual：`StateCacheSource.loadCacheValue` 内部 `DefaultCacheValue.ttlAt(state, 1000, 0)` → `ComputedTtlAt.at()` = `CacheSecondClock.currentTime() + ttl`
- expected：测试体内再次求值 `DefaultCacheValue.ttlAt("test", 1000)`

两次秒级时钟读取跨越一秒边界时 `ttlAt` 相差 1 秒，断言失败。单次运行概率低，CI 恰好命中。**BOM 升级本身无责**：`DefaultCacheValue` / `ComputedTtlAt` / `cocache-api` 在 cocache 4.2.0 与 4.3.0 之间零改动（`git diff v4.2.0..HEAD` 为空），属于测试固有的时间敏感 flaky。

与 Ahoo-Wang/CoCache#523 同类漂移，采用相同修法。

## Changes

- 拆分为 `value` 相等断言 + `ttlAt` `isCloseTo(expected, Offset.offset(1))` 容忍 ±1 秒。

## Testing

- [x] `./gradlew :wow-cocache:test` 本地全部通过（含 QueryApiCacheSourceTest 3 个用例）
