### PR TITLE
fix(ci): disable provenance attestation in docker deploy workflows

### DIFF
--- a/.github/workflows/compensation-deploy.yml
+++ b/.github/workflows/compensation-deploy.yml
@@ -131,5 +131,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           context: compensation/wow-compensation-server
           push: true
+          # AliyunCR 不支持 OCI 1.1 artifact manifest（provenance 证明），推送会被拒绝
+          provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/example-deploy.yml
+++ b/.github/workflows/example-deploy.yml
@@ -106,5 +106,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           context: example/example-server
           push: true
+          # AliyunCR 不支持 OCI 1.1 artifact manifest（provenance 证明），推送会被拒绝
+          provenance: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary

修复 main 上 `Example Docker Image Deploy` / `Compensation Docker Image Deploy` 自 2026-08-13 起的持续失败：

```
ERROR: failed to push registry.cn-shanghai.aliyuncs.com/ahoo/wow-example-server:main:
denied: unknown manifest class for application/vnd.oci.empty.v1+json
```

## Root cause

`docker/build-push-action@v7` 默认生成 OCI 1.1 provenance 证明（attestation manifest 使用 `application/vnd.oci.empty.v1+json` 空配置）。DockerHub 与 GHCR 支持该类 artifact，**Aliyun ACR 不支持**，推送被拒。

时间线佐证（同为 scheduled、同一 main 代码）：08-12 最后一次成功 → 08-13 首次失败，纯 runner/buildx 版本滚动导致，与仓库改动无关（早于 BOM 4.3.0 升级三天）。

## Changes

- 两个 deploy workflow 的 build-push 步骤增加 `provenance: false`（附中文注释说明约束）。

## Testing

- [x] 从本分支 `workflow_dispatch` 实际运行两个部署 workflow，均成功：
  - [Example run 31939148356](https://github.com/Ahoo-Wang/Wow/actions/runs/31939148356)
  - [Compensation run 31939149960](https://github.com/Ahoo-Wang/Wow/actions/runs/31939149960)
  - 日志确认 `registry.cn-shanghai.aliyuncs.com` manifest 推送成功
- 注：验证运行向三个仓库推送了以分支名命名的临时 tag（`fix-docker-deploy-disable-provenance`），合并后可手动删除。
