### PR TITLE
fix(mongo): convert fields in logical conditions

### DIFF
--- a/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/query/event/MongoEventStreamQueryServiceTest.kt
+++ b/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/query/event/MongoEventStreamQueryServiceTest.kt
@@ -2,12 +2,20 @@ package me.ahoo.wow.mongo.query.event
 
 import com.mongodb.reactivestreams.client.MongoDatabase
 import me.ahoo.wow.eventsourcing.EventStore
+import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.modeling.aggregateId
 import me.ahoo.wow.mongo.MongoEventStore
+import me.ahoo.wow.query.dsl.singleQuery
 import me.ahoo.wow.query.event.EventStreamQueryServiceFactory
+import me.ahoo.wow.query.event.query
 import me.ahoo.wow.tck.container.MongoTestFixture
+import me.ahoo.wow.tck.event.MockDomainEventStreams.generateEventStream
 import me.ahoo.wow.tck.query.EventStreamQueryServiceSpec
+import me.ahoo.wow.serialization.MessageRecords
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import reactor.kotlin.test.test
 
 class MongoEventStreamQueryServiceTest : EventStreamQueryServiceSpec() {
     @JvmField
@@ -28,5 +36,21 @@ class MongoEventStreamQueryServiceTest : EventStreamQueryServiceSpec() {
 
     override fun createEventStreamQueryServiceFactory(): EventStreamQueryServiceFactory {
         return MongoEventStreamQueryServiceFactory(database)
+    }
+
+    @Test
+    fun `should query event stream by id in logical condition`() {
+        val eventStream = generateEventStream(namedAggregate.aggregateId(tenantId = generateGlobalId()))
+        eventStore.append(eventStream).block()
+
+        singleQuery {
+            condition {
+                MessageRecords.ID eq eventStream.id
+                tenantId(eventStream.aggregateId.tenantId)
+            }
+        }.query(eventStreamQueryService)
+            .test()
+            .expectNext(eventStream)
+            .verifyComplete()
     }
 }

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoConditionConverter.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoConditionConverter.kt
@@ -16,6 +16,7 @@ package me.ahoo.wow.mongo.query
 import com.mongodb.client.model.Filters
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.DeletionState
+import me.ahoo.wow.api.query.Operator
 import me.ahoo.wow.mongo.Documents
 import me.ahoo.wow.query.converter.AbstractConditionConverter
 import me.ahoo.wow.query.converter.FieldConverter
@@ -34,10 +35,14 @@ abstract class AbstractMongoConditionConverter : AbstractConditionConverter<Bson
 
     protected open fun convertCondition(condition: Condition): Condition {
         val convertedField = fieldConverter.convert(condition.field)
-        if (convertedField == condition.field) {
+        val convertedChildren = when (condition.operator) {
+            Operator.AND, Operator.OR, Operator.NOR -> condition.children.map(::convertCondition)
+            else -> condition.children
+        }
+        if (convertedField == condition.field && convertedChildren == condition.children) {
             return condition
         }
-        return condition.copy(field = convertedField)
+        return condition.copy(field = convertedField, children = convertedChildren)
     }
 
     override fun convert(condition: Condition): Bson {

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/SnapshotConditionConverterTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/SnapshotConditionConverterTest.kt
@@ -363,6 +363,24 @@ class SnapshotConditionConverterTest {
         assertConvert(actual, expected)
     }
 
+    @Test
+    fun `should convert aggregate id in logical conditions`() {
+        val condition = Condition.and(
+            Condition.eq(MessageRecords.AGGREGATE_ID, "and"),
+            Condition.or(Condition.eq(MessageRecords.AGGREGATE_ID, "or")),
+            Condition.nor(Condition.eq(MessageRecords.AGGREGATE_ID, "nor")),
+        )
+
+        val actual = SnapshotConditionConverter.convert(condition)
+        val expected = Filters.and(
+            Filters.eq(Documents.ID_FIELD, "and"),
+            Filters.or(Filters.eq(Documents.ID_FIELD, "or")),
+            Filters.nor(Filters.eq(Documents.ID_FIELD, "nor")),
+        )
+
+        assertConvert(actual, expected)
+    }
+
     @ParameterizedTest
     @MethodSource("toMongoFilterParameters")
     fun `should convert condition to mongo filter`(condition: Condition, expected: Bson) {

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/event/EventStreamConditionConverterTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/event/EventStreamConditionConverterTest.kt
@@ -15,6 +15,7 @@ package me.ahoo.wow.mongo.query.event
 
 import com.mongodb.client.model.Filters
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.mongo.Documents
 import me.ahoo.wow.query.dsl.condition
 import me.ahoo.wow.serialization.MessageRecords
@@ -42,6 +43,44 @@ class EventStreamConditionConverterTest {
         val condition = condition { aggregateIds("aggregateIds") }
         val actual = EventStreamConditionConverter.convert(condition)
         val expected = Filters.`in`(MessageRecords.AGGREGATE_ID, condition.valueAs<Iterable<String>>())
+        actual.assert().isEqualTo(expected)
+    }
+
+    @Test
+    fun `should convert id in logical conditions`() {
+        val condition = Condition.and(
+            Condition.eq(MessageRecords.ID, "and"),
+            Condition.or(Condition.eq(MessageRecords.ID, "or")),
+            Condition.nor(Condition.eq(MessageRecords.ID, "nor")),
+        )
+
+        val actual = EventStreamConditionConverter.convert(condition).toBsonDocument()
+        val expected = Filters.and(
+            Filters.eq(Documents.ID_FIELD, "and"),
+            Filters.or(Filters.eq(Documents.ID_FIELD, "or")),
+            Filters.nor(Filters.eq(Documents.ID_FIELD, "nor")),
+        ).toBsonDocument()
+
+        actual.assert().isEqualTo(expected)
+    }
+
+    @Test
+    fun `should keep element relative id unchanged`() {
+        val condition = Condition.and(
+            Condition.elemMatch(
+                "body",
+                Condition.and(Condition.eq(MessageRecords.ID, "event-body-id")),
+            )
+        )
+
+        val actual = EventStreamConditionConverter.convert(condition).toBsonDocument()
+        val expected = Filters.and(
+            Filters.elemMatch(
+                "body",
+                Filters.and(Filters.eq(MessageRecords.ID, "event-body-id")),
+            )
+        ).toBsonDocument()
+
         actual.assert().isEqualTo(expected)
     }
 }


### PR DESCRIPTION
## Summary

- recursively convert mapped Mongo fields inside `AND`, `OR`, and `NOR` conditions
- keep `ELEM_MATCH` child fields relative to their array element
- cover event stream and snapshot mappings with unit and Mongo integration tests

## Testing

- `./gradlew :wow-mongo:check --stacktrace`
- `./gradlew :wow-mongo:test :wow-mongo:integrationTest --stacktrace`