### PR TITLE
fix(elasticsearch): unify literal string queries

### DIFF
--- a/documentation/docs/en/guide/query.md
+++ b/documentation/docs/en/guide/query.md
@@ -57,6 +57,10 @@ Currently the `wow-mongo` module and `wow-elasticsearch` module support query se
 | RECENT_DAYS   | Matches all documents where the field is within the specified number of recent days range. For example: `today`: `2024-06-06`, recent 3 days, matches range: `2024-06-04 00:00:00.000` ~ `2024-06-06 23:59:59.999`. That is: today, yesterday, the day before yesterday |
 | EARLIER_DAYS  | Matches all documents where the field is within the specified number of days before the specified value. For example: `today`: `2024-06-06`, 3 days ago, matches range: less than `2024-06-04 00:00:00.000`                                                             |
 
+:::info Elasticsearch string fields
+`CONTAINS`, `STARTS_WITH`, and `ENDS_WITH` are literal operations. In Elasticsearch, use them with term-level fields such as `keyword` and `wildcard`; `*`, `?`, and `\` are matched as ordinary characters, and all three support `ignoreCase`. Use `MATCH` for full-text search.
+:::
+
 ## Query DSL
 
 The `Query DSL` aims to provide a concise and flexible way to build query conditions.

--- a/documentation/docs/zh/guide/query.md
+++ b/documentation/docs/zh/guide/query.md
@@ -57,6 +57,10 @@ description: 通过 wow-mongo 和 wow-elasticsearch 模块提供的查询服务�
 | RECENT_DAYS   | 匹配字段在指定值最近天数范围区间的所有文档。比如：`today` : `2024-06-06`，近三天，匹配范围 : `2024-06-04 00:00:00.000` ~ `2024-06-06 23:59:59.999` 的所有文档。即 : 今天、昨天、前天 |
 | EARLIER_DAYS  | 匹配字段在指定值之前天数范围的所有文档。比如：`today` : `2024-06-06`，前三天，匹配范围 : 小于`2024-06-04 00:00:00.000`的所有文档                                           |
 
+:::info Elasticsearch 字符串字段
+`CONTAINS`、`STARTS_WITH` 和 `ENDS_WITH` 是字面量操作，在 Elasticsearch 中应作用于 `keyword`、`wildcard` 等 term-level 字段；`*`、`?` 和 `\` 按普通字符匹配，三者均支持 `ignoreCase`。全文检索请使用 `MATCH`。
+:::
+
 ## Query DSL
 
 `Query DSL` 旨在提供一种简洁而灵活的方式来构建查询条件。

--- a/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/event/ElasticsearchEventStreamQueryServiceTest.kt
+++ b/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/event/ElasticsearchEventStreamQueryServiceTest.kt
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
+import reactor.core.publisher.Flux
 import reactor.kotlin.test.test
 
 class ElasticsearchEventStreamQueryServiceTest : EventStreamQueryServiceSpec() {
@@ -87,6 +88,27 @@ class ElasticsearchEventStreamQueryServiceTest : EventStreamQueryServiceSpec() {
             .count(eventStreamQueryService)
             .test()
             .expectNext(0L)
+            .verifyComplete()
+    }
+
+    @Test
+    fun `should query keyword field with literal string operators`() {
+        val target = generateEventStream(
+            namedAggregate.aggregateId(id = generateGlobalId(), tenantId = """Tenant*?Literal\Tail""")
+        )
+        val wildcardCandidate = generateEventStream(
+            namedAggregate.aggregateId(id = generateGlobalId(), tenantId = "TenantXYLiteralZTail")
+        )
+        eventStore.append(target)
+            .then(eventStore.append(wildcardCandidate))
+            .block()
+
+        Flux.concat(
+            condition { "tenantId".contains("*?literal", ignoreCase = true) }.count(eventStreamQueryService),
+            condition { "tenantId".startsWith("tenant*?", ignoreCase = true) }.count(eventStreamQueryService),
+            condition { "tenantId".endsWith("""\tail""", ignoreCase = true) }.count(eventStreamQueryService),
+        ).test()
+            .expectNext(1L, 1L, 1L)
             .verifyComplete()
     }
 }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchConditionConverter.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchConditionConverter.kt
@@ -20,7 +20,6 @@ import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.exists
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.ids
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.match
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.matchAll
-import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.matchPhrase
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.nested
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.prefix
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.range
@@ -144,9 +143,10 @@ abstract class AbstractElasticsearchConditionConverter : AbstractConditionConver
     }
 
     override fun contains(condition: Condition): Query {
-        return matchPhrase {
+        return wildcard {
             it.field(condition.field)
-                .query(condition.valueAs<String>())
+                .value("*${condition.valueAs<String>().escapeWildcard()}*")
+                .caseInsensitive(condition.ignoreCase())
         }
     }
 
@@ -209,13 +209,15 @@ abstract class AbstractElasticsearchConditionConverter : AbstractConditionConver
         return prefix {
             it.field(condition.field)
                 .value(condition.valueAs<String>())
+                .caseInsensitive(condition.ignoreCase())
         }
     }
 
     override fun endsWith(condition: Condition): Query {
         return wildcard {
             it.field(condition.field)
-                .value("*${condition.valueAs<String>()}")
+                .value("*${condition.valueAs<String>().escapeWildcard()}")
+                .caseInsensitive(condition.ignoreCase())
         }
     }
 
@@ -317,3 +319,8 @@ abstract class AbstractElasticsearchConditionConverter : AbstractConditionConver
         return Query.Builder().withJson(StringReader(this)).build()
     }
 }
+
+private fun String.escapeWildcard(): String =
+    replace("\\", "\\\\")
+        .replace("*", "\\*")
+        .replace("?", "\\?")

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchConditionConverterTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchConditionConverterTest.kt
@@ -20,7 +20,6 @@ import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.exists
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.ids
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.match
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.matchAll
-import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.matchPhrase
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.nested
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.prefix
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.range
@@ -304,15 +303,16 @@ class ElasticsearchConditionConverterTest {
     @Test
     fun `contains condition to Query`() {
         val query = condition {
-            "field" contains "value"
+            "field".contains("""Value*?\Tail""", ignoreCase = true)
         }.let {
             SnapshotConditionConverter.convert(it)
         }
         assertConvert(
             query,
-            matchPhrase {
+            wildcard {
                 it.field("field")
-                    .query("value")
+                    .value("""*Value\*\?\\Tail*""")
+                    .caseInsensitive(true)
             }
         )
     }
@@ -406,7 +406,7 @@ class ElasticsearchConditionConverterTest {
     @Test
     fun `startsWith condition to Query`() {
         val query = condition {
-            "field" startsWith "value"
+            "field".startsWith("""Value*?\Tail""", ignoreCase = true)
         }.let {
             SnapshotConditionConverter.convert(it)
         }
@@ -414,7 +414,8 @@ class ElasticsearchConditionConverterTest {
             query,
             prefix {
                 it.field("field")
-                    .value("value")
+                    .value("""Value*?\Tail""")
+                    .caseInsensitive(true)
             }
         )
     }
@@ -422,7 +423,7 @@ class ElasticsearchConditionConverterTest {
     @Test
     fun `endsWith condition to Query`() {
         val query = condition {
-            "field" endsWith "value"
+            "field".endsWith("""Value*?\Tail""", ignoreCase = true)
         }.let {
             SnapshotConditionConverter.convert(it)
         }
@@ -430,7 +431,8 @@ class ElasticsearchConditionConverterTest {
             query,
             wildcard {
                 it.field("field")
-                    .value("*value")
+                    .value("""*Value\*\?\\Tail""")
+                    .caseInsensitive(true)
             }
         )
     }


### PR DESCRIPTION
## Summary

- translate `CONTAINS` to an escaped double-sided wildcard query
- propagate `ignoreCase` through `CONTAINS`, `STARTS_WITH`, and `ENDS_WITH` while treating `*`, `?`, and `\` literally
- keep `MATCH` as full-text search and document the Elasticsearch term-level field requirement
- cover conversion and real Elasticsearch behavior with special-character and case-insensitive queries

## Validation

- `./gradlew :wow-elasticsearch:test :wow-elasticsearch:integrationTest` (99 unit tests, 64 integration tests)
- `cd documentation && pnpm docs:build`