### PR TITLE
fix(query): isolate context per subscription

### DIFF
--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/filter/QueryHandler.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/filter/QueryHandler.kt
@@ -51,100 +51,46 @@ abstract class AbstractQueryHandler<R : Any>(
             }
     }
 
-    override fun single(namedAggregate: NamedAggregate, singleQuery: ISingleQuery): Mono<R> {
-        val context = DefaultQueryContext<ISingleQuery, Mono<R>>(
-            namedAggregate = namedAggregate,
-            queryType = QueryType.SINGLE
-        ).setQuery(singleQuery)
-        return handle(context)
-            .then(
-                Mono.defer {
-                    context.getRequiredResult()
-                }
-            )
+    private fun <Q : Any, T : Any> mono(
+        namedAggregate: NamedAggregate,
+        queryType: QueryType,
+        query: Q,
+    ): Mono<T> = Mono.defer {
+        val context = DefaultQueryContext<Q, Mono<T>>(queryType, namedAggregate).setQuery(query)
+        handle(context).then(Mono.defer { context.getRequiredResult() })
     }
 
-    override fun dynamicSingle(namedAggregate: NamedAggregate, singleQuery: ISingleQuery): Mono<DynamicDocument> {
-        val context = DefaultQueryContext<ISingleQuery, Mono<DynamicDocument>>(
-            namedAggregate = namedAggregate,
-            queryType = QueryType.DYNAMIC_SINGLE
-        ).setQuery(singleQuery)
-        return handle(context)
-            .then(
-                Mono.defer {
-                    context.getRequiredResult()
-                }
-            )
+    private fun <Q : Any, T : Any> flux(
+        namedAggregate: NamedAggregate,
+        queryType: QueryType,
+        query: Q,
+    ): Flux<T> = Flux.defer {
+        val context = DefaultQueryContext<Q, Flux<T>>(queryType, namedAggregate).setQuery(query)
+        handle(context).thenMany(Flux.defer { context.getRequiredResult() })
     }
 
-    override fun list(namedAggregate: NamedAggregate, listQuery: IListQuery): Flux<R> {
-        val context = DefaultQueryContext<IListQuery, Flux<R>>(
-            namedAggregate = namedAggregate,
-            queryType = QueryType.LIST
-        ).setQuery(listQuery)
-        return handle(context)
-            .thenMany(
-                Flux.defer {
-                    context.getRequiredResult()
-                }
-            )
-    }
+    override fun single(namedAggregate: NamedAggregate, singleQuery: ISingleQuery): Mono<R> =
+        mono(namedAggregate, QueryType.SINGLE, singleQuery)
 
-    override fun dynamicList(namedAggregate: NamedAggregate, listQuery: IListQuery): Flux<DynamicDocument> {
-        val context = DefaultQueryContext<IListQuery, Flux<DynamicDocument>>(
-            namedAggregate = namedAggregate,
-            queryType = QueryType.DYNAMIC_LIST
-        ).setQuery(listQuery)
-        return handle(context)
-            .thenMany(
-                Flux.defer {
-                    context.getRequiredResult()
-                }
-            )
-    }
+    override fun dynamicSingle(namedAggregate: NamedAggregate, singleQuery: ISingleQuery): Mono<DynamicDocument> =
+        mono(namedAggregate, QueryType.DYNAMIC_SINGLE, singleQuery)
+
+    override fun list(namedAggregate: NamedAggregate, listQuery: IListQuery): Flux<R> =
+        flux(namedAggregate, QueryType.LIST, listQuery)
+
+    override fun dynamicList(namedAggregate: NamedAggregate, listQuery: IListQuery): Flux<DynamicDocument> =
+        flux(namedAggregate, QueryType.DYNAMIC_LIST, listQuery)
 
     override fun paged(
         namedAggregate: NamedAggregate,
         pagedQuery: IPagedQuery
-    ): Mono<PagedList<R>> {
-        val context = DefaultQueryContext<IPagedQuery, Mono<PagedList<R>>>(
-            namedAggregate = namedAggregate,
-            queryType = QueryType.PAGED
-        ).setQuery(pagedQuery)
-        return handle(context)
-            .then(
-                Mono.defer {
-                    context.getRequiredResult()
-                }
-            )
-    }
+    ): Mono<PagedList<R>> = mono(namedAggregate, QueryType.PAGED, pagedQuery)
 
     override fun dynamicPaged(
         namedAggregate: NamedAggregate,
         pagedQuery: IPagedQuery
-    ): Mono<PagedList<DynamicDocument>> {
-        val context = DefaultQueryContext<IPagedQuery, Mono<PagedList<DynamicDocument>>>(
-            namedAggregate = namedAggregate,
-            queryType = QueryType.DYNAMIC_PAGED
-        ).setQuery(pagedQuery)
-        return handle(context)
-            .then(
-                Mono.defer {
-                    context.getRequiredResult()
-                }
-            )
-    }
+    ): Mono<PagedList<DynamicDocument>> = mono(namedAggregate, QueryType.DYNAMIC_PAGED, pagedQuery)
 
-    override fun count(namedAggregate: NamedAggregate, condition: Condition): Mono<Long> {
-        val context = DefaultQueryContext<Condition, Mono<Long>>(
-            namedAggregate = namedAggregate,
-            queryType = QueryType.COUNT
-        ).setQuery(condition)
-        return handle(context)
-            .then(
-                Mono.defer {
-                    context.getRequiredResult()
-                }
-            )
-    }
+    override fun count(namedAggregate: NamedAggregate, condition: Condition): Mono<Long> =
+        mono(namedAggregate, QueryType.COUNT, condition)
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/filter/QueryHandlerSubscriptionTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/filter/QueryHandlerSubscriptionTest.kt
@@ -1,0 +1,202 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.filter
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.ConditionCapable
+import me.ahoo.wow.api.query.DynamicDocument
+import me.ahoo.wow.api.query.PagedList
+import me.ahoo.wow.api.query.SimpleDynamicDocument.Companion.toDynamicDocument
+import me.ahoo.wow.filter.EmptyFilterChain
+import me.ahoo.wow.filter.ErrorHandler
+import me.ahoo.wow.filter.Filter
+import me.ahoo.wow.filter.FilterChain
+import me.ahoo.wow.filter.SimpleFilterChain
+import me.ahoo.wow.query.dsl.listQuery
+import me.ahoo.wow.query.dsl.pagedQuery
+import me.ahoo.wow.query.dsl.singleQuery
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
+import org.junit.jupiter.api.Test
+import org.reactivestreams.Publisher
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
+import reactor.kotlin.test.test
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+
+class QueryHandlerSubscriptionTest {
+    @Test
+    fun `should isolate all query operations when repeated`() {
+        val filter = NonIdempotentTestFilter()
+        val handler = TestQueryHandler(filter.chain())
+        val publishers = operationPublishers(handler)
+        filter.assertNoContexts()
+
+        publishers.forEach { (queryType, publisher) ->
+            Flux.from(publisher)
+                .repeat(1)
+                .test()
+                .expectNextCount(2)
+                .verifyComplete()
+
+            filter.assertIsolated(queryType, 2)
+        }
+    }
+
+    @Test
+    fun `should isolate context when retried`() {
+        val filter = NonIdempotentTestFilter(failures = 1)
+        val handler = TestQueryHandler(filter.chain())
+
+        handler.single(MOCK_AGGREGATE_METADATA, singleQuery { })
+            .retry(1)
+            .test()
+            .expectNext(RESULT)
+            .verifyComplete()
+
+        filter.assertIsolated(QueryType.SINGLE, 2)
+    }
+
+    @Test
+    fun `should isolate concurrent subscriptions`() {
+        val filter = NonIdempotentTestFilter()
+        val handler = TestQueryHandler(filter.chain())
+        val publisher = handler.dynamicList(MOCK_AGGREGATE_METADATA, listQuery { })
+
+        Flux.merge(
+            publisher.subscribeOn(Schedulers.parallel()),
+            publisher.subscribeOn(Schedulers.parallel()),
+        ).test()
+            .expectNextCount(2)
+            .verifyComplete()
+
+        filter.assertIsolated(QueryType.DYNAMIC_LIST, 2)
+    }
+
+    private fun operationPublishers(handler: TestQueryHandler): List<Pair<QueryType, Publisher<*>>> =
+        listOf(
+            QueryType.SINGLE to handler.single(MOCK_AGGREGATE_METADATA, singleQuery { }),
+            QueryType.DYNAMIC_SINGLE to handler.dynamicSingle(MOCK_AGGREGATE_METADATA, singleQuery { }),
+            QueryType.LIST to handler.list(MOCK_AGGREGATE_METADATA, listQuery { }),
+            QueryType.DYNAMIC_LIST to handler.dynamicList(MOCK_AGGREGATE_METADATA, listQuery { }),
+            QueryType.PAGED to handler.paged(MOCK_AGGREGATE_METADATA, pagedQuery { }),
+            QueryType.DYNAMIC_PAGED to handler.dynamicPaged(MOCK_AGGREGATE_METADATA, pagedQuery { }),
+            QueryType.COUNT to handler.count(MOCK_AGGREGATE_METADATA, Condition.ALL),
+        )
+
+    private class TestQueryHandler(chain: FilterChain<QueryContext<*, *>>) :
+        AbstractQueryHandler<String>(
+            chain,
+            ErrorHandler<QueryContext<*, *>> { _, error -> Mono.error(error) }
+        )
+
+    private class NonIdempotentTestFilter(
+        private val failures: AtomicInteger = AtomicInteger(),
+    ) : Filter<QueryContext<*, *>> {
+        constructor(failures: Int) : this(AtomicInteger(failures))
+
+        private val contexts = ConcurrentLinkedQueue<QueryContext<*, *>>()
+
+        fun chain(): FilterChain<QueryContext<*, *>> =
+            SimpleFilterChain(this, SimpleFilterChain(ResultTestFilter, EmptyFilterChain.instance()))
+
+        override fun filter(
+            context: QueryContext<*, *>,
+            next: FilterChain<QueryContext<*, *>>
+        ): Mono<Void> {
+            contexts.add(context)
+            context.asRewritableQuery().rewriteQuery {
+                it.appendCondition(APPENDED_CONDITION)
+            }
+            return next.filter(context).then(
+                Mono.defer {
+                    if (context.queryType == QueryType.COUNT) {
+                        return@defer Mono.empty()
+                    }
+                    val maskCount = (context.getAttribute<Int>(MASK_COUNT_KEY) ?: 0) + 1
+                    check(maskCount == 1) { "Result was masked more than once." }
+                    context.setAttribute(MASK_COUNT_KEY, maskCount)
+                    if (failures.getAndDecrement() > 0) {
+                        Mono.error(IllegalStateException("Retry query."))
+                    } else {
+                        Mono.empty()
+                    }
+                }
+            )
+        }
+
+        fun assertIsolated(queryType: QueryType, expected: Int) {
+            val matchedContexts = contexts.filter { it.queryType == queryType }
+            matchedContexts.assert().hasSize(expected)
+            matchedContexts.toSet().assert().hasSize(expected)
+            matchedContexts.forEach { context ->
+                queryCondition(context).assert().isEqualTo(APPENDED_CONDITION)
+                if (queryType == QueryType.COUNT) {
+                    context.getAttribute<Int>(MASK_COUNT_KEY).assert().isNull()
+                } else {
+                    context.getAttribute<Int>(MASK_COUNT_KEY).assert().isOne()
+                }
+            }
+        }
+
+        fun assertNoContexts() {
+            contexts.assert().isEmpty()
+        }
+    }
+
+    private object ResultTestFilter : Filter<QueryContext<*, *>> {
+        override fun filter(
+            context: QueryContext<*, *>,
+            next: FilterChain<QueryContext<*, *>>
+        ): Mono<Void> {
+            when (context.queryType) {
+                QueryType.SINGLE -> context.asSingleQuery<String>().setResult(Mono.just(RESULT))
+                QueryType.DYNAMIC_SINGLE -> context.asSingleQuery<DynamicDocument>().setResult(
+                    Mono.just(mutableMapOf("result" to RESULT).toDynamicDocument())
+                )
+
+                QueryType.LIST -> context.asListQuery<String>().setResult(Flux.just(RESULT))
+                QueryType.DYNAMIC_LIST -> context.asListQuery<DynamicDocument>().setResult(
+                    Flux.just(mutableMapOf("result" to RESULT).toDynamicDocument())
+                )
+
+                QueryType.PAGED -> context.asPagedQuery<String>().setResult(
+                    Mono.just(PagedList(1, listOf(RESULT)))
+                )
+
+                QueryType.DYNAMIC_PAGED -> context.asPagedQuery<DynamicDocument>().setResult(
+                    Mono.just(PagedList(1, listOf(mutableMapOf("result" to RESULT).toDynamicDocument())))
+                )
+
+                QueryType.COUNT -> context.asCountQuery().setResult(Mono.just(1L))
+            }
+            return next.filter(context)
+        }
+    }
+
+    private companion object {
+        const val RESULT = "result"
+        const val MASK_COUNT_KEY = "maskCount"
+        val APPENDED_CONDITION: Condition = Condition.id("subscription")
+
+        fun queryCondition(context: QueryContext<*, *>): Condition =
+            when (val query = context.getQuery()) {
+                is Condition -> query
+                is ConditionCapable<*> -> query.condition
+                else -> error("Unsupported query type: ${query::class}.")
+            }
+    }
+}


### PR DESCRIPTION
## Summary

- create each mutable query context inside `Mono.defer` or `Flux.defer` for all seven `QueryHandler` operations
- rebuild the filter execution path for every subscription, retry, repeat, and concurrent subscriber
- consolidate the shared Mono/Flux wiring into two private helpers without changing public APIs
- add non-idempotent filter tests that detect repeated condition appends and result masking

## Validation

- `./gradlew :wow-query:check` (253 tests)
- `./gradlew :wow-webflux:test` (246 tests)