### PR TITLE
fix(query): fail when backend is unavailable

### DIFF
--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/routing/StorageRouteResolver.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/routing/StorageRouteResolver.kt
@@ -18,8 +18,6 @@ import me.ahoo.wow.eventsourcing.EventStore
 import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
 import me.ahoo.wow.modeling.MaterializedNamedAggregate
 import me.ahoo.wow.query.event.EventStreamQueryServiceFactory
-import me.ahoo.wow.query.event.NoOpEventStreamQueryServiceFactory
-import me.ahoo.wow.query.snapshot.NoOpSnapshotQueryServiceFactory
 import me.ahoo.wow.query.snapshot.SnapshotQueryServiceFactory
 import me.ahoo.wow.spring.boot.starter.eventsourcing.StorageType
 
@@ -111,7 +109,11 @@ class StorageRouteResolver(
                 namedAggregate to resolveEventStreamQueryServiceFactory(routeKey, channel)
             }.toMap()
         return ResolvedEventStreamQueryServiceFactoryRoutes(
-            defaultEventStreamQueryServiceFactory = eventStreamQueryServiceFactory(defaultEventStorage),
+            defaultEventStreamQueryServiceFactory = requiredEventStreamQueryServiceFactory(
+                defaultEventStorage,
+                "<default>",
+                EVENT_CHANNEL,
+            ),
             eventStreamQueryServiceFactoryRoutes = routes,
         )
     }
@@ -126,7 +128,11 @@ class StorageRouteResolver(
                 namedAggregate to resolveSnapshotQueryServiceFactory(routeKey, channel)
             }.toMap()
         return ResolvedSnapshotQueryServiceFactoryRoutes(
-            defaultSnapshotQueryServiceFactory = snapshotQueryServiceFactory(defaultSnapshotStorage),
+            defaultSnapshotQueryServiceFactory = requiredSnapshotQueryServiceFactory(
+                defaultSnapshotStorage,
+                "<default>",
+                SNAPSHOT_CHANNEL,
+            ),
             snapshotQueryServiceFactoryRoutes = routes,
         )
     }
@@ -184,11 +190,14 @@ class StorageRouteResolver(
     ): EventStreamQueryServiceFactory {
         validateChannel(routeKey, EVENT_CHANNEL, channel)
         channel.storage?.let { storage ->
-            return eventStreamQueryServiceFactory(storage)
+            return requiredEventStreamQueryServiceFactory(storage, routeKey, EVENT_CHANNEL)
         }
         val binding = channel.binding!!.trim()
-        return eventStreamQueryServiceFactoryBindingsByName[binding]?.eventStreamQueryServiceFactory
-            ?: NoOpEventStreamQueryServiceFactory
+        return requireNotNull(
+            eventStreamQueryServiceFactoryBindingsByName[binding]?.eventStreamQueryServiceFactory
+        ) {
+            "Storage route[$routeKey] channel[$EVENT_CHANNEL] query service factory binding[$binding] was not found."
+        }
     }
 
     private fun resolveSnapshotQueryServiceFactory(
@@ -197,11 +206,12 @@ class StorageRouteResolver(
     ): SnapshotQueryServiceFactory {
         validateChannel(routeKey, SNAPSHOT_CHANNEL, channel)
         channel.storage?.let { storage ->
-            return snapshotQueryServiceFactory(storage)
+            return requiredSnapshotQueryServiceFactory(storage, routeKey, SNAPSHOT_CHANNEL)
         }
         val binding = channel.binding!!.trim()
-        return snapshotQueryServiceFactoryBindingsByName[binding]?.snapshotQueryServiceFactory
-            ?: NoOpSnapshotQueryServiceFactory
+        return requireNotNull(snapshotQueryServiceFactoryBindingsByName[binding]?.snapshotQueryServiceFactory) {
+            "Storage route[$routeKey] channel[$SNAPSHOT_CHANNEL] query service factory binding[$binding] was not found."
+        }
     }
 
     private fun validateChannel(
@@ -237,13 +247,23 @@ class StorageRouteResolver(
             "Storage route[$routeKey] channel[$channelName] storage[${storage.name}] was not found."
         }
 
-    private fun eventStreamQueryServiceFactory(storage: StorageType): EventStreamQueryServiceFactory =
-        eventStreamQueryServiceFactoryBindingsByStorage[storage]?.eventStreamQueryServiceFactory
-            ?: NoOpEventStreamQueryServiceFactory
+    private fun requiredEventStreamQueryServiceFactory(
+        storage: StorageType,
+        routeKey: String,
+        channelName: String,
+    ): EventStreamQueryServiceFactory =
+        requireNotNull(eventStreamQueryServiceFactoryBindingsByStorage[storage]?.eventStreamQueryServiceFactory) {
+            "Storage route[$routeKey] channel[$channelName] query service factory storage[${storage.name}] was not found."
+        }
 
-    private fun snapshotQueryServiceFactory(storage: StorageType): SnapshotQueryServiceFactory =
-        snapshotQueryServiceFactoryBindingsByStorage[storage]?.snapshotQueryServiceFactory
-            ?: NoOpSnapshotQueryServiceFactory
+    private fun requiredSnapshotQueryServiceFactory(
+        storage: StorageType,
+        routeKey: String,
+        channelName: String,
+    ): SnapshotQueryServiceFactory =
+        requireNotNull(snapshotQueryServiceFactoryBindingsByStorage[storage]?.snapshotQueryServiceFactory) {
+            "Storage route[$routeKey] channel[$channelName] query service factory storage[${storage.name}] was not found."
+        }
 
     companion object {
         private const val EVENT_CHANNEL = "event"

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/query/QueryAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/query/QueryAutoConfiguration.kt
@@ -150,13 +150,13 @@ class QueryAutoConfiguration {
         return DefaultEventStreamQueryHandler(chain, queryErrorHandler)
     }
 
-    @Bean
+    @Bean("noOpSnapshotQueryServiceFactory")
     @ConditionalOnMissingBean(SnapshotQueryServiceFactory::class)
     fun unavailableSnapshotQueryServiceFactory(): SnapshotQueryServiceFactory {
         return UnavailableSnapshotQueryServiceFactory
     }
 
-    @Bean
+    @Bean("noOpEventStreamQueryServiceFactory")
     @ConditionalOnMissingBean(EventStreamQueryServiceFactory::class)
     fun unavailableEventStreamQueryServiceFactory(): EventStreamQueryServiceFactory {
         return UnavailableEventStreamQueryServiceFactory

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/query/QueryAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/query/QueryAutoConfiguration.kt
@@ -39,7 +39,6 @@ import me.ahoo.wow.query.snapshot.filter.TailSnapshotQueryFilter
 import me.ahoo.wow.spring.boot.starter.ConditionalOnWowEnabled
 import me.ahoo.wow.spring.query.EventStreamQueryServiceRegistrar
 import me.ahoo.wow.spring.query.SnapshotQueryServiceRegistrar
-import me.ahoo.wow.spring.query.getOrNoOp
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.autoconfigure.AutoConfiguration
@@ -93,14 +92,14 @@ class QueryAutoConfiguration {
     fun tailSnapshotQueryFilter(
         snapshotQueryServiceFactory: ObjectProvider<SnapshotQueryServiceFactory>,
     ): TailSnapshotQueryFilter<Any> {
-        return TailSnapshotQueryFilter(snapshotQueryServiceFactory.getOrNoOp())
+        return TailSnapshotQueryFilter(snapshotQueryServiceFactory.getObject())
     }
 
     @Bean
     fun tailEventStreamQueryFilter(
         eventStreamQueryServiceFactory: ObjectProvider<EventStreamQueryServiceFactory>,
     ): TailEventStreamQueryFilter {
-        return TailEventStreamQueryFilter(eventStreamQueryServiceFactory.getOrNoOp())
+        return TailEventStreamQueryFilter(eventStreamQueryServiceFactory.getObject())
     }
 
     @Bean
@@ -153,13 +152,19 @@ class QueryAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean(SnapshotQueryServiceFactory::class)
-    fun noOpSnapshotQueryServiceFactory(): SnapshotQueryServiceFactory {
-        return NoOpSnapshotQueryServiceFactory
+    fun unavailableSnapshotQueryServiceFactory(): SnapshotQueryServiceFactory {
+        return UnavailableSnapshotQueryServiceFactory
     }
 
     @Bean
     @ConditionalOnMissingBean(EventStreamQueryServiceFactory::class)
-    fun noOpEventStreamQueryServiceFactory(): EventStreamQueryServiceFactory {
-        return NoOpEventStreamQueryServiceFactory
+    fun unavailableEventStreamQueryServiceFactory(): EventStreamQueryServiceFactory {
+        return UnavailableEventStreamQueryServiceFactory
     }
+
+    @Deprecated("NoOp query services must be configured explicitly.")
+    fun noOpSnapshotQueryServiceFactory(): SnapshotQueryServiceFactory = NoOpSnapshotQueryServiceFactory
+
+    @Deprecated("NoOp query services must be configured explicitly.")
+    fun noOpEventStreamQueryServiceFactory(): EventStreamQueryServiceFactory = NoOpEventStreamQueryServiceFactory
 }

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/query/UnavailableQueryService.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/query/UnavailableQueryService.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.spring.boot.starter.query
+
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.DynamicDocument
+import me.ahoo.wow.api.query.IListQuery
+import me.ahoo.wow.api.query.IPagedQuery
+import me.ahoo.wow.api.query.ISingleQuery
+import me.ahoo.wow.api.query.MaterializedSnapshot
+import me.ahoo.wow.api.query.PagedList
+import me.ahoo.wow.event.DomainEventStream
+import me.ahoo.wow.exception.ErrorCodes
+import me.ahoo.wow.exception.WowException
+import me.ahoo.wow.modeling.materialize
+import me.ahoo.wow.query.QueryService
+import me.ahoo.wow.query.event.EventStreamQueryService
+import me.ahoo.wow.query.event.EventStreamQueryServiceFactory
+import me.ahoo.wow.query.snapshot.SnapshotQueryService
+import me.ahoo.wow.query.snapshot.SnapshotQueryServiceFactory
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+internal object UnavailableSnapshotQueryServiceFactory : SnapshotQueryServiceFactory {
+    override fun <S : Any> create(namedAggregate: NamedAggregate): SnapshotQueryService<S> =
+        UnavailableSnapshotQueryService(namedAggregate.materialize())
+}
+
+internal object UnavailableEventStreamQueryServiceFactory : EventStreamQueryServiceFactory {
+    override fun create(namedAggregate: NamedAggregate): EventStreamQueryService =
+        UnavailableEventStreamQueryService(namedAggregate.materialize())
+}
+
+private class UnavailableSnapshotQueryService<S : Any>(namedAggregate: NamedAggregate) :
+    UnavailableQueryService<MaterializedSnapshot<S>>(namedAggregate),
+    SnapshotQueryService<S> {
+    override val name: String = "unavailable"
+}
+
+private class UnavailableEventStreamQueryService(namedAggregate: NamedAggregate) :
+    UnavailableQueryService<DomainEventStream>(namedAggregate),
+    EventStreamQueryService
+
+private abstract class UnavailableQueryService<R : Any>(
+    final override val namedAggregate: NamedAggregate,
+) : QueryService<R> {
+    override fun single(singleQuery: ISingleQuery): Mono<R> = unavailableMono()
+
+    override fun dynamicSingle(singleQuery: ISingleQuery): Mono<DynamicDocument> = unavailableMono()
+
+    override fun list(listQuery: IListQuery): Flux<R> = unavailableFlux()
+
+    override fun dynamicList(listQuery: IListQuery): Flux<DynamicDocument> = unavailableFlux()
+
+    override fun paged(pagedQuery: IPagedQuery): Mono<PagedList<R>> = unavailableMono()
+
+    override fun dynamicPaged(pagedQuery: IPagedQuery): Mono<PagedList<DynamicDocument>> = unavailableMono()
+
+    override fun count(condition: Condition): Mono<Long> = unavailableMono()
+
+    private fun <T : Any> unavailableMono(): Mono<T> = Mono.error(unavailable())
+
+    private fun <T : Any> unavailableFlux(): Flux<T> = Flux.error(unavailable())
+
+    private fun unavailable(): WowException = WowException(
+        ErrorCodes.INTERNAL_SERVER_ERROR,
+        "No query backend is configured for aggregate[$namedAggregate].",
+    )
+}

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/routing/StorageRouteResolverTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/routing/StorageRouteResolverTest.kt
@@ -331,33 +331,77 @@ class StorageRouteResolverTest {
     }
 
     @Test
-    fun `missing query service factory bindings fall back to noop factories`() {
+    fun `missing named event query service factory binding fails`() {
         val properties = StorageRoutingProperties(
             aggregates = mapOf(
                 "audit" to AggregateStorageRouteProperties(
                     event = StorageChannelRouteProperties(binding = "archive-event-store"),
+                ),
+            ),
+        )
+        val resolver = resolver(includeQueryServiceFactoryBindings = false)
+
+        val exception = assertThrows<IllegalArgumentException> {
+            resolver.resolveEventStreamQueryServiceFactoryRoutes(properties)
+        }
+        exception.message.assert().contains("audit")
+        exception.message.assert().contains("archive-event-store")
+        exception.message.assert().contains("query service factory")
+    }
+
+    @Test
+    fun `missing named snapshot query service factory binding fails`() {
+        val properties = StorageRoutingProperties(
+            aggregates = mapOf(
+                "audit" to AggregateStorageRouteProperties(
                     snapshot = StorageChannelRouteProperties(binding = "archive-snapshot-store"),
                 ),
             ),
         )
         val resolver = resolver(includeQueryServiceFactoryBindings = false)
 
-        resolver.resolveEventStreamQueryServiceFactoryRoutes(properties)
-            .eventStreamQueryServiceFactoryRoutes.values.single()
-            .assert().isSameAs(NoOpEventStreamQueryServiceFactory)
-        resolver.resolveSnapshotQueryServiceFactoryRoutes(properties)
-            .snapshotQueryServiceFactoryRoutes.values.single()
-            .assert().isSameAs(NoOpSnapshotQueryServiceFactory)
+        val exception = assertThrows<IllegalArgumentException> {
+            resolver.resolveSnapshotQueryServiceFactoryRoutes(properties)
+        }
+        exception.message.assert().contains("audit")
+        exception.message.assert().contains("archive-snapshot-store")
+        exception.message.assert().contains("query service factory")
     }
 
     @Test
-    fun `missing default query service factory bindings fall back to noop factories`() {
+    fun `missing storage query service factory binding fails`() {
+        val properties = StorageRoutingProperties(
+            aggregates = mapOf(
+                "order" to AggregateStorageRouteProperties(
+                    event = StorageChannelRouteProperties(storage = StorageType.REDIS),
+                ),
+            ),
+        )
         val resolver = resolver(includeQueryServiceFactoryBindings = false)
 
-        resolver.resolveEventStreamQueryServiceFactoryRoutes(StorageRoutingProperties())
-            .defaultEventStreamQueryServiceFactory.assert().isSameAs(NoOpEventStreamQueryServiceFactory)
-        resolver.resolveSnapshotQueryServiceFactoryRoutes(StorageRoutingProperties())
-            .defaultSnapshotQueryServiceFactory.assert().isSameAs(NoOpSnapshotQueryServiceFactory)
+        val exception = assertThrows<IllegalArgumentException> {
+            resolver.resolveEventStreamQueryServiceFactoryRoutes(properties)
+        }
+        exception.message.assert().contains("order")
+        exception.message.assert().contains(StorageType.REDIS.name)
+        exception.message.assert().contains("query service factory")
+    }
+
+    @Test
+    fun `missing default query service factory binding fails`() {
+        val resolver = resolver(includeQueryServiceFactoryBindings = false)
+
+        val eventException = assertThrows<IllegalArgumentException> {
+            resolver.resolveEventStreamQueryServiceFactoryRoutes(StorageRoutingProperties())
+        }
+        eventException.message.assert().contains("<default>")
+        eventException.message.assert().contains("query service factory")
+
+        val snapshotException = assertThrows<IllegalArgumentException> {
+            resolver.resolveSnapshotQueryServiceFactoryRoutes(StorageRoutingProperties())
+        }
+        snapshotException.message.assert().contains("<default>")
+        snapshotException.message.assert().contains("query service factory")
     }
 
     private fun resolver(

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/routing/StorageRoutingAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/eventsourcing/routing/StorageRoutingAutoConfigurationTest.kt
@@ -337,6 +337,20 @@ class StorageRoutingAutoConfigurationTest {
     }
 
     @Test
+    fun `named storage binding without query factory binding should fail startup`() {
+        routingContextRunner
+            .withPropertyValues(
+                "${StorageRoutingProperties.AGGREGATES}.audit.event.binding=store-only-event-store",
+            )
+            .run { context: AssertableApplicationContext ->
+                val failure = context.startupFailure
+                failure.assert().isInstanceOf(BeanCreationException::class.java)
+                failure!!.message.assert().contains("query service factory")
+                failure.message.assert().contains("store-only-event-store")
+            }
+    }
+
+    @Test
     fun `full aggregate key should not prepend current context`() {
         routingContextRunner
             .withPropertyValues(
@@ -428,6 +442,14 @@ class StorageRoutingAutoConfigurationTest {
             )
 
         @Bean
+        fun storeOnlyEventStoreBinding(stores: RecordingStores): EventStoreBinding =
+            EventStoreBinding(
+                name = "store-only-event-store",
+                storage = null,
+                eventStore = stores.archiveEventStore,
+            )
+
+        @Bean
         fun mongoSnapshotStoreBinding(stores: RecordingStores): SnapshotStoreBinding =
             SnapshotStoreBinding.storage(StorageType.MONGO, stores.mongoSnapshotStore)
 
@@ -466,6 +488,16 @@ class StorageRoutingAutoConfigurationTest {
             )
 
         @Bean
+        fun archiveEventStreamQueryServiceFactoryBinding(
+            stores: RecordingStores
+        ): EventStreamQueryServiceFactoryBinding =
+            EventStreamQueryServiceFactoryBinding(
+                name = "archive-event-store",
+                storage = null,
+                eventStreamQueryServiceFactory = stores.archiveEventStreamQueryServiceFactory,
+            )
+
+        @Bean
         fun mongoSnapshotQueryServiceFactory(stores: RecordingStores): SnapshotQueryServiceFactory =
             stores.mongoSnapshotQueryServiceFactory
 
@@ -486,6 +518,14 @@ class StorageRoutingAutoConfigurationTest {
                 StorageType.REDIS,
                 stores.redisSnapshotQueryServiceFactory
             )
+
+        @Bean
+        fun archiveSnapshotQueryServiceFactoryBinding(stores: RecordingStores): SnapshotQueryServiceFactoryBinding =
+            SnapshotQueryServiceFactoryBinding(
+                name = "archive-snapshot-store",
+                storage = null,
+                snapshotQueryServiceFactory = stores.archiveSnapshotQueryServiceFactory,
+            )
     }
 
     internal class RecordingStores {
@@ -497,8 +537,10 @@ class StorageRoutingAutoConfigurationTest {
         val archiveSnapshotStore = RecordingSnapshotStore("archive-snapshot")
         val mongoEventStreamQueryServiceFactory = RecordingEventStreamQueryServiceFactory()
         val redisEventStreamQueryServiceFactory = RecordingEventStreamQueryServiceFactory()
+        val archiveEventStreamQueryServiceFactory = RecordingEventStreamQueryServiceFactory()
         val mongoSnapshotQueryServiceFactory = RecordingSnapshotQueryServiceFactory()
         val redisSnapshotQueryServiceFactory = RecordingSnapshotQueryServiceFactory()
+        val archiveSnapshotQueryServiceFactory = RecordingSnapshotQueryServiceFactory()
     }
 
     internal class CloseDelegate(

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/query/QueryAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/query/QueryAutoConfigurationTest.kt
@@ -47,6 +47,8 @@ class QueryAutoConfigurationTest {
                 context.assert()
                     .hasBean(ExistsBeanName.SNAPSHOT_QUERY_SERVICE)
                     .hasBean(ExistsBeanName.EVENT_STREAM_QUERY_SERVICE)
+                    .hasBean("noOpSnapshotQueryServiceFactory")
+                    .hasBean("noOpEventStreamQueryServiceFactory")
                     .hasSingleBean(MaskingSnapshotQueryFilter::class.java)
                     .hasSingleBean(TailSnapshotQueryFilter::class.java)
                     .hasBean("snapshotQueryFilterChain")

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/query/QueryAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/query/QueryAutoConfigurationTest.kt
@@ -3,9 +3,18 @@ package me.ahoo.wow.spring.boot.starter.query
 import io.mockk.every
 import io.mockk.spyk
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.exception.ErrorCodes
+import me.ahoo.wow.exception.WowException
+import me.ahoo.wow.query.event.EventStreamQueryService
+import me.ahoo.wow.query.event.EventStreamQueryServiceFactory
+import me.ahoo.wow.query.event.NoOpEventStreamQueryServiceFactory
 import me.ahoo.wow.query.event.filter.EventStreamQueryHandler
 import me.ahoo.wow.query.mask.EventStreamDynamicDocumentMasker
 import me.ahoo.wow.query.mask.StateDynamicDocumentMasker
+import me.ahoo.wow.query.snapshot.NoOpSnapshotQueryServiceFactory
+import me.ahoo.wow.query.snapshot.SnapshotQueryService
+import me.ahoo.wow.query.snapshot.SnapshotQueryServiceFactory
 import me.ahoo.wow.query.snapshot.filter.MaskingSnapshotQueryFilter
 import me.ahoo.wow.query.snapshot.filter.SnapshotQueryHandler
 import me.ahoo.wow.query.snapshot.filter.TailSnapshotQueryFilter
@@ -14,6 +23,7 @@ import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import reactor.kotlin.test.test
 
 class QueryAutoConfigurationTest {
     private val contextRunner = ApplicationContextRunner()
@@ -36,6 +46,7 @@ class QueryAutoConfigurationTest {
             .run { context: AssertableApplicationContext ->
                 context.assert()
                     .hasBean(ExistsBeanName.SNAPSHOT_QUERY_SERVICE)
+                    .hasBean(ExistsBeanName.EVENT_STREAM_QUERY_SERVICE)
                     .hasSingleBean(MaskingSnapshotQueryFilter::class.java)
                     .hasSingleBean(TailSnapshotQueryFilter::class.java)
                     .hasBean("snapshotQueryFilterChain")
@@ -44,6 +55,21 @@ class QueryAutoConfigurationTest {
                     .hasBean("eventStreamQueryErrorHandler")
                     .hasSingleBean(SnapshotQueryHandler::class.java)
                     .hasSingleBean(EventStreamQueryHandler::class.java)
+
+                context.getBean(
+                    ExistsBeanName.SNAPSHOT_QUERY_SERVICE,
+                    SnapshotQueryService::class.java,
+                ).count(Condition.ALL)
+                    .test()
+                    .expectErrorSatisfies(::assertUnavailable)
+                    .verify()
+                context.getBean(
+                    ExistsBeanName.EVENT_STREAM_QUERY_SERVICE,
+                    EventStreamQueryService::class.java,
+                ).count(Condition.ALL)
+                    .test()
+                    .expectErrorSatisfies(::assertUnavailable)
+                    .verify()
             }
     }
 
@@ -59,11 +85,43 @@ class QueryAutoConfigurationTest {
                     .hasSingleBean(ExistsBeanName::class.java)
             }
     }
+
+    @Test
+    fun `should preserve explicitly configured no op query services`() {
+        contextRunner
+            .enableWow()
+            .withUserConfiguration(QueryAutoConfiguration::class.java)
+            .withBean(SnapshotQueryServiceFactory::class.java, { NoOpSnapshotQueryServiceFactory })
+            .withBean(EventStreamQueryServiceFactory::class.java, { NoOpEventStreamQueryServiceFactory })
+            .run { context: AssertableApplicationContext ->
+                context.getBean(
+                    ExistsBeanName.SNAPSHOT_QUERY_SERVICE,
+                    SnapshotQueryService::class.java,
+                ).count(Condition.ALL)
+                    .test()
+                    .expectNext(0L)
+                    .verifyComplete()
+                context.getBean(
+                    ExistsBeanName.EVENT_STREAM_QUERY_SERVICE,
+                    EventStreamQueryService::class.java,
+                ).count(Condition.ALL)
+                    .test()
+                    .expectNext(0L)
+                    .verifyComplete()
+            }
+    }
+
+    private fun assertUnavailable(error: Throwable) {
+        error.assert().isInstanceOf(WowException::class.java)
+        (error as WowException).errorCode.assert().isEqualTo(ErrorCodes.INTERNAL_SERVER_ERROR)
+        error.message.assert().contains("No query backend is configured")
+    }
 }
 
 @Suppress("UtilityClassWithPublicConstructor")
 class ExistsBeanName {
     companion object {
         const val SNAPSHOT_QUERY_SERVICE = "example.order.SnapshotQueryService"
+        const val EVENT_STREAM_QUERY_SERVICE = "example.order.EventStreamQueryService"
     }
 }

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/EventStreamQueryServiceRegistrar.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/EventStreamQueryServiceRegistrar.kt
@@ -44,8 +44,7 @@ class EventStreamQueryServiceRegistrar : QueryServiceRegistrar() {
             return
         }
         val beanDefinitionBuilder = BeanDefinitionBuilder.rootBeanDefinition(EventStreamQueryService::class.java) {
-            val queryServiceFactory: EventStreamQueryServiceFactory =
-                appContext.getBeanProvider(EventStreamQueryServiceFactory::class.java).getOrNoOp()
+            val queryServiceFactory = appContext.getBean(EventStreamQueryServiceFactory::class.java)
             queryServiceFactory.create(namedAggregate)
         }
 

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/SnapshotQueryServiceRegistrar.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/SnapshotQueryServiceRegistrar.kt
@@ -52,8 +52,7 @@ class SnapshotQueryServiceRegistrar : QueryServiceRegistrar() {
         )
 
         val beanDefinitionBuilder = BeanDefinitionBuilder.rootBeanDefinition(snapshotQueryServiceType) {
-            val queryServiceFactory: SnapshotQueryServiceFactory =
-                appContext.getBeanProvider(SnapshotQueryServiceFactory::class.java).getOrNoOp()
+            val queryServiceFactory = appContext.getBean(SnapshotQueryServiceFactory::class.java)
             queryServiceFactory.create<Any>(namedAggregate)
         }
 


### PR DESCRIPTION
## Summary

- fail storage route resolution when an explicit query factory storage or named binding is missing
- replace automatic NoOp fallback with internal unavailable services that return `WowException(InternalServerError)` on query calls
- make Spring query service registrars require the configured factory instead of selecting NoOp
- preserve explicit `NoOp*QueryServiceFactory` behavior and existing public compatibility methods
- cover invalid bindings, backend-free startup/query failure, and explicit NoOp configuration

## Validation

- `./gradlew :wow-spring-boot-starter:test :wow-query:test :wow-spring:test`
- `./gradlew :wow-spring-boot-starter:check :wow-spring:check :wow-query:check`
- 207 starter tests, 253 query tests, and 17 spring tests passed