### PR TITLE
feat(elasticsearch): resolve query fields from mappings

### DIFF
--- a/documentation/docs/en/guide/extensions/elasticsearch.md
+++ b/documentation/docs/en/guide/extensions/elasticsearch.md
@@ -164,9 +164,13 @@ Field selection follows these rules:
 |---|---|
 | `EQ`, `NE`, `IN`, `NOT_IN`, `ALL_IN`, `TRUE`, `FALSE` | Term-query compatible, including supported doc-value-only fields |
 | `CONTAINS`, `STARTS_WITH`, `ENDS_WITH` | `keyword` or `wildcard` |
-| Range operations | numeric, date, ip, or keyword, including applicable `doc_values=true,index=false` fields |
-| `MATCH` | `text`, `match_only_text`, or `search_as_you_type` |
-| Sort | Sortable field with `doc_values`, or a sortable runtime field; `index=true` is not required |
+| Range operations | numeric, date, ip, keyword, or `*_range`, including applicable `doc_values=true,index=false` fields |
+| `MATCH` | `text`, `match_only_text`, `search_as_you_type`, or `semantic_text` |
+| Sort | Sortable field with `doc_values`, indexed `text` with `fielddata`, or a sortable runtime field |
+
+`_score`, `_doc`, and `_shard_doc` are Elasticsearch metadata sort fields. They bypass mapping field resolution and are
+passed through unchanged. Because `text.fielddata=true` uses significant heap memory, a `keyword` multi-field is still
+preferred in most cases. Sorting on doc-values and runtime fields does not require `index=true`.
 
 Dynamic keys under a flattened field do not have individual mapping entries. For a concrete path such as
 `state.labels.release`, the resolver walks up to the nearest flattened parent and preserves the original path for exact

--- a/documentation/docs/en/guide/extensions/elasticsearch.md
+++ b/documentation/docs/en/guide/extensions/elasticsearch.md
@@ -162,11 +162,11 @@ Field selection follows these rules:
 
 | Query operation | Mapping requirement |
 |---|---|
-| `EQ`, `NE`, `IN`, `NOT_IN`, `ALL_IN`, `TRUE`, `FALSE` | Term-query compatible |
+| `EQ`, `NE`, `IN`, `NOT_IN`, `ALL_IN`, `TRUE`, `FALSE` | Term-query compatible, including supported doc-value-only fields |
 | `CONTAINS`, `STARTS_WITH`, `ENDS_WITH` | `keyword` or `wildcard` |
-| Range operations | numeric, date, or keyword |
+| Range operations | numeric, date, or keyword, including `doc_values=true,index=false` |
 | `MATCH` | `text`, `match_only_text`, or `search_as_you_type` |
-| Sort | Indexed field sortable with `doc_values`, or a sortable runtime field |
+| Sort | Sortable field with `doc_values`, or a sortable runtime field; `index=true` is not required |
 
 For example, one logical field can support both full-text and exact operations:
 

--- a/documentation/docs/en/guide/extensions/elasticsearch.md
+++ b/documentation/docs/en/guide/extensions/elasticsearch.md
@@ -147,6 +147,69 @@ version-metadata migration is required.
 | Event Stream | `wow.{contextName}.{aggregateName}.es` | `wow.order-service.order.es` |
 | Snapshot | `wow.{contextName}.{aggregateName}.snapshot` | `wow.order-service.order.snapshot` |
 
+## Snapshot Query Field Resolution
+
+On the first snapshot query for an aggregate index, Wow asynchronously loads the current Elasticsearch mapping and
+compiles conditions and sorts from its physical field capabilities. The mapping is the only capability source; no
+separate `QuerySchema` is maintained. The cache is isolated by index and has no TTL. A missing or incompatible cached
+field triggers one automatic refresh. A successful refresh atomically replaces the cache; a failed refresh preserves
+the previous cache and fails the current query closed.
+
+Field selection follows these rules:
+
+| Query operation | Mapping requirement |
+|---|---|
+| `EQ`, `NE`, `IN`, `NOT_IN`, `ALL_IN`, `TRUE`, `FALSE` | Term-query compatible |
+| `CONTAINS`, `STARTS_WITH`, `ENDS_WITH` | `keyword` or `wildcard` |
+| Range operations | numeric, date, or keyword |
+| `MATCH` | `text`, `match_only_text`, or `search_as_you_type` |
+| Sort | Indexed field sortable with `doc_values`, or a sortable runtime field |
+
+For a multi-field, Wow tries the current field, `.keyword`/`.text`, `.exact`, and finally a single compatible child.
+Multiple compatible children fail as ambiguous rather than silently changing semantics. `EXISTS`, `NULL`, `NOT_NULL`,
+projection, and `RAW` remain logical fields; the parent of `ELEM_MATCH` must be mapped as `nested`. A custom
+`ConditionConverter` retains ownership of its physical fields and bypasses this rewriting.
+
+A field alias inherits the query and sort capabilities of its target while queries continue to use the alias name.
+Runtime fields declared in the mapping also participate according to their type. They are evaluated at query time and
+may be rejected by the cluster when `search.allow_expensive_queries=false`.
+
+Each aggregate must resolve to one physical snapshot index. An alias or data stream that resolves to multiple indices
+fails closed. Such a topology must be reduced to one physical index or handled by an application-specific `_field_caps`
+query implementation.
+
+## Actively Refresh a Mapping
+
+Adding `org.springframework.boot:spring-boot-starter-actuator` registers an optional maintenance endpoint. It has no
+access by default. Configure both access and Web exposure, and restrict it to a maintenance role in management endpoint
+security:
+
+```yaml
+management:
+  endpoint:
+    wowElasticsearchMapping:
+      access: unrestricted
+  endpoints:
+    web:
+      exposure:
+        include: health,wowElasticsearchMapping
+```
+
+Refresh the mapping for a registered aggregate on the current application instance:
+
+```http request
+POST /actuator/wowElasticsearchMapping/{contextName}/{aggregateName}
+```
+
+The endpoint does not accept arbitrary index expressions; it derives the index name from aggregate metadata. Its
+response contains only `scope=LOCAL_INSTANCE`, `indexName`, `fieldCount`, `changed`, and `refreshedAt`, never the full
+mapping. Elasticsearch credentials need `view_index_metadata` on the target index. Missing privileges, a missing index,
+or an unparseable mapping fails the request without damaging a previously successful cache entry.
+
+Refresh is local to the instance that receives the request. In a replicated deployment, operations must call each Pod;
+there is no broadcast, scheduled refresh, or refresh-all operation. New queries use the refreshed mapping, while
+in-flight queries continue with the mapping obtained when their compilation began.
+
 ## Configure Event Stream Index Template
 
 ```http request

--- a/documentation/docs/en/guide/extensions/elasticsearch.md
+++ b/documentation/docs/en/guide/extensions/elasticsearch.md
@@ -164,9 +164,14 @@ Field selection follows these rules:
 |---|---|
 | `EQ`, `NE`, `IN`, `NOT_IN`, `ALL_IN`, `TRUE`, `FALSE` | Term-query compatible, including supported doc-value-only fields |
 | `CONTAINS`, `STARTS_WITH`, `ENDS_WITH` | `keyword` or `wildcard` |
-| Range operations | numeric, date, or keyword, including `doc_values=true,index=false` |
+| Range operations | numeric, date, ip, or keyword, including applicable `doc_values=true,index=false` fields |
 | `MATCH` | `text`, `match_only_text`, or `search_as_you_type` |
 | Sort | Sortable field with `doc_values`, or a sortable runtime field; `index=true` is not required |
+
+Dynamic keys under a flattened field do not have individual mapping entries. For a concrete path such as
+`state.labels.release`, the resolver walks up to the nearest flattened parent and preserves the original path for exact
+and sort operations. Flattened values use keyword semantics, so sorting is lexicographic. Dynamic keys do not
+automatically enable range operations; explicitly mapped typed sub-fields continue to use their own type capabilities.
 
 For example, one logical field can support both full-text and exact operations:
 

--- a/documentation/docs/en/guide/extensions/elasticsearch.md
+++ b/documentation/docs/en/guide/extensions/elasticsearch.md
@@ -86,6 +86,7 @@ wow:
 ```
 
 - Configuration class: [ElasticsearchProperties](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchProperties.kt)
+- Query configuration class: [ElasticsearchQueryProperties](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchQueryProperties.kt)
 - Prefix: `wow.elasticsearch.`
 
 | Name | Data Type | Default Value | Description |
@@ -102,6 +103,8 @@ wow:
 | `snapshot-store-batch.max-delay` | `Duration` | `1ms` | Maximum wait used to collect a partial snapshot batch |
 | `snapshot-store-batch.max-pending-saves` | `Int` | `4096` | Maximum accepted saves waiting or being written; must be at least `max-size` |
 | `snapshot-store-batch.lane-count` | `Int` | `1` | Number of serial write lanes; saves for the same aggregate stay on one lane |
+| `query.batch-size` | `Int` | `10000` | Internal PIT + `search_after` list-query batch size, in the range `1..10000` |
+| `query.keep-alive` | `Duration` | `1m` | PIT keep-alive, which must be greater than `0` |
 
 Required index templates are installed before application startup completes. A failed or unacknowledged request fails
 startup. Set `wow.elasticsearch.auto-init-template=false` only when templates are managed externally. The built-in
@@ -165,6 +168,33 @@ Field selection follows these rules:
 | `MATCH` | `text`, `match_only_text`, or `search_as_you_type` |
 | Sort | Indexed field sortable with `doc_values`, or a sortable runtime field |
 
+For example, one logical field can support both full-text and exact operations:
+
+```json
+{
+  "properties": {
+    "state": {
+      "properties": {
+        "customerName": {
+          "type": "text",
+          "fields": {
+            "keyword": { "type": "keyword" }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+| Query operation | Client field | Resolved field |
+|---|---|---|
+| `MATCH` | `state.customerName` | `state.customerName` |
+| `EQ`, `IN`, sort | `state.customerName` | `state.customerName.keyword` |
+| projection | `state.customerName` | `state.customerName` (unchanged) |
+
+Clients always use the logical field and do not need to hard-code `.keyword` or `.text`.
+
 For a multi-field, Wow tries the current field, `.keyword`/`.text`, `.exact`, and finally a single compatible child.
 Multiple compatible children fail as ambiguous rather than silently changing semantics. `EXISTS`, `NULL`, `NOT_NULL`,
 projection, and `RAW` remain logical fields; the parent of `ELEM_MATCH` must be mapped as `nested`. A custom
@@ -172,7 +202,8 @@ projection, and `RAW` remain logical fields; the parent of `ELEM_MATCH` must be 
 
 A field alias inherits the query and sort capabilities of its target while queries continue to use the alias name.
 Runtime fields declared in the mapping also participate according to their type. They are evaluated at query time and
-may be rejected by the cluster when `search.allow_expensive_queries=false`.
+may be rejected by the cluster when `search.allow_expensive_queries=false`. Projection still applies its logical path
+to `_source`; it does not rewrite a field alias or runtime field to its target.
 
 Each aggregate must resolve to one physical snapshot index. An alias or data stream that resolves to multiple indices
 fails closed. Such a topology must be reduced to one physical index or handled by an application-specific `_field_caps`
@@ -183,6 +214,18 @@ query implementation.
 Adding `org.springframework.boot:spring-boot-starter-actuator` registers an optional maintenance endpoint. It has no
 access by default. Configure both access and Web exposure, and restrict it to a maintenance role in management endpoint
 security:
+
+::: code-group
+```kotlin [Gradle(Kotlin)]
+implementation("org.springframework.boot:spring-boot-starter-actuator")
+```
+```xml [Maven]
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-actuator</artifactId>
+</dependency>
+```
+:::
 
 ```yaml
 management:
@@ -197,14 +240,30 @@ management:
 
 Refresh the mapping for a registered aggregate on the current application instance:
 
-```http request
-POST /actuator/wowElasticsearchMapping/{contextName}/{aggregateName}
+```bash
+curl -X POST \
+  http://localhost:8080/actuator/wowElasticsearchMapping/order-service/order
 ```
 
-The endpoint does not accept arbitrary index expressions; it derives the index name from aggregate metadata. Its
-response contains only `scope=LOCAL_INSTANCE`, `indexName`, `fieldCount`, `changed`, and `refreshedAt`, never the full
-mapping. Elasticsearch credentials need `view_index_metadata` on the target index. Missing privileges, a missing index,
-or an unparseable mapping fails the request without damaging a previously successful cache entry.
+Example response:
+
+```json
+{
+  "scope": "LOCAL_INSTANCE",
+  "indexName": "wow.order-service.order.snapshot",
+  "fieldCount": 24,
+  "changed": true,
+  "refreshedAt": "2026-08-21T09:00:00Z"
+}
+```
+
+The endpoint does not accept arbitrary index expressions; it derives the index name from aggregate metadata.
+`fieldCount` is the number of parsed field paths, and `changed` reports whether the new capability model differs from
+the previous one. The response never contains the full mapping. An unregistered aggregate returns `400 Bad Request`.
+
+Elasticsearch credentials need `view_index_metadata` on the target index. Missing privileges, a missing index, or an
+unparseable mapping fails the request without damaging a previously successful cache entry. Refresh only reloads the
+query capability cache; it does not modify the Elasticsearch mapping, rebuild the index, or backfill old snapshots.
 
 Refresh is local to the instance that receives the request. In a replicated deployment, operations must call each Pod;
 there is no broadcast, scheduled refresh, or refresh-all operation. New queries use the refreshed mapping, while
@@ -419,12 +478,16 @@ compose both baseline and custom mappings from component templates.
 
 ```kotlin
 // Use QueryService for full-text search
-val condition = Condition.all()
-    .match("state.description", "phone")
-    .range("state.totalAmount", 100, 500)
-    .limit(10)
-
-snapshotQueryService.dynamicQuery(condition)
+listQuery {
+    condition {
+        "state.description" match "phone"
+        "state.totalAmount" between 100 to 500
+    }
+    sort {
+        "state.customerName".asc()
+    }
+    limit(10)
+}.dynamicQuery(snapshotQueryService)
 ```
 
 ## Aggregation Queries
@@ -545,24 +608,32 @@ Set `wow.elasticsearch.query.batch-size` no higher than the target index's `inde
 
 ### Common Issues
 
-#### 1. Index Mapping Conflict
+#### 1. Query reports an unmapped, incompatible, or ambiguous multi-field
 
-**Solutions**:
-- Check dynamic template configuration
-- Use strict mapping mode
+Inspect the current physical mapping with `GET /{indexName}/_mapping`, then call the active refresh endpoint. When
+multiple compatible children are ambiguous, use the conventional `.keyword`, `.text`, or `.exact` child name.
 
-#### 2. Cluster Status Yellow or Red
+#### 2. Refresh endpoint is unavailable or refresh fails
 
-**Solutions**:
-- Check node status
-- Add replicas or reallocate shards
+A `404` means the Actuator dependency, endpoint access, or Web exposure should be checked. A `400` means the
+`contextName` or `aggregateName` is not registered. For an Elasticsearch error, verify the index and
+`view_index_metadata` privilege. A failed refresh does not delete the previous cache entry.
 
-#### 3. Slow Query Performance
+#### 3. An alias or data stream cannot be resolved
 
-**Solutions**:
-- Optimize query statements
-- Increase index shards
-- Use caching
+Ensure the snapshot alias resolves to exactly one physical index. The resolver does not merge mappings from multiple
+indices; applications that require that topology must implement a `_field_caps`-based query strategy.
+
+#### 4. Old data is still unqueryable after updating a template and refreshing
+
+An index template affects only indices created afterward, and mapping refresh only updates Wow's capability cache.
+Depending on the mapping change, use `PUT /{indexName}/_mapping`, reindex, or rebuild snapshots, then reconcile result
+counts, ordering, and snapshot versions.
+
+#### 5. A runtime-field query is rejected
+
+Check the cluster's `search.allow_expensive_queries` setting. If the restriction must remain, materialize frequently
+queried fields in the physical mapping instead of relying on runtime fields.
 
 ## Complete Configuration Example
 
@@ -579,6 +650,10 @@ spring:
     socket-timeout: 30s
 
 wow:
+  elasticsearch:
+    query:
+      batch-size: 10000
+      keep-alive: 1m
   eventsourcing:
     store:
       storage: elasticsearch
@@ -590,8 +665,8 @@ wow:
 
 ## Best Practices
 
-1. **Pre-define Mappings**: Create index templates in production to avoid dynamic mapping issues
+1. **Pre-define Mappings**: Install a higher-priority aggregate template before the first snapshot write so dynamic mapping cannot lock in the wrong type
 2. **Appropriate Sharding**: Set appropriate shard count based on data volume, avoid too many small shards
-3. **Use Aliases**: Use index aliases for zero-downtime migration
-4. **Enable ILM**: Use index lifecycle management to automatically manage indexes
-5. **Monitor Cluster**: Monitor cluster health status and performance metrics
+3. **Limit Alias Topology**: An alias or data stream used by Wow snapshot queries must resolve to one physical index
+4. **Reconcile After Rebuilds**: When a mapping change requires reindexing or snapshot rebuilding, verify result counts, ordering, and snapshot versions
+5. **Monitor the Cluster**: Monitor cluster health, open PIT contexts, and query latency

--- a/documentation/docs/zh/guide/extensions/elasticsearch.md
+++ b/documentation/docs/zh/guide/extensions/elasticsearch.md
@@ -143,6 +143,62 @@ SnapshotStore 使用带 scripted upsert 的 Bulk `update`，direct 路径使用�
 | 事件流 | `wow.{contextName}.{aggregateName}.es` | `wow.order-service.order.es` |
 | 快照 | `wow.{contextName}.{aggregateName}.snapshot` | `wow.order-service.order.snapshot` |
 
+## 快照查询字段解析
+
+快照查询第一次访问聚合索引时会异步加载当前 Elasticsearch Mapping，并按物理字段能力编译条件和排序；Mapping
+是字段能力的唯一来源，不需要维护额外的 `QuerySchema`。缓存按索引隔离且没有 TTL。当缓存中的字段缺失或能力不匹配时，
+查询会自动刷新一次 Mapping；刷新成功后替换缓存，刷新失败时保留旧缓存并使当前查询失败关闭。
+
+字段选择规则如下：
+
+| Query 操作 | Mapping 要求 |
+|---|---|
+| `EQ`、`NE`、`IN`、`NOT_IN`、`ALL_IN`、`TRUE`、`FALSE` | 可执行 term 查询 |
+| `CONTAINS`、`STARTS_WITH`、`ENDS_WITH` | `keyword` 或 `wildcard` |
+| 范围操作 | numeric、date 或 keyword |
+| `MATCH` | `text`、`match_only_text` 或 `search_as_you_type` |
+| 排序 | 索引字段可排序且启用 `doc_values`，或 runtime field 支持排序 |
+
+对于 multi-field，依次选择当前字段、`.keyword`/`.text`、`.exact`，最后才选择唯一的兼容子字段；存在多个兼容候选时
+查询失败，避免静默改变语义。`EXISTS`、`NULL`、`NOT_NULL`、projection 和 `RAW` 不重写，`ELEM_MATCH` 的父路径
+必须映射为 `nested`。自定义 `ConditionConverter` 继续负责解释自己的物理字段，不经过上述重写。
+
+Field alias 继承其目标字段的查询与排序能力，并继续使用 alias 名称生成查询。Mapping 中声明的 runtime field 也会按
+其类型参与能力解析；runtime 查询会在查询时计算，且当 Elasticsearch 设置 `search.allow_expensive_queries=false` 时
+可能被集群拒绝。
+
+每个聚合必须解析到一个物理快照索引。alias 或 data stream 如果解析出多个索引，查询会失败；这种拓扑需要先收敛为
+单个物理索引，或由应用自行实现基于 `_field_caps` 的查询方案。
+
+## 主动刷新 Mapping
+
+应用引入 `org.springframework.boot:spring-boot-starter-actuator` 后会注册可选维护端点。端点默认不可访问，必须同时配置
+access 和 Web exposure，并由管理端安全策略限制为维护角色：
+
+```yaml
+management:
+  endpoint:
+    wowElasticsearchMapping:
+      access: unrestricted
+  endpoints:
+    web:
+      exposure:
+        include: health,wowElasticsearchMapping
+```
+
+按已注册聚合刷新当前实例的 Mapping：
+
+```http request
+POST /actuator/wowElasticsearchMapping/{contextName}/{aggregateName}
+```
+
+端点不接受任意索引表达式，索引名由聚合元数据计算。响应只包含 `scope=LOCAL_INSTANCE`、`indexName`、
+`fieldCount`、`changed` 和 `refreshedAt`，不会返回完整 Mapping。Elasticsearch 凭据需要目标索引的
+`view_index_metadata` 权限；权限不足、索引不存在或 Mapping 无法解析时请求失败，已有成功缓存不受影响。
+
+刷新只作用于收到请求的应用实例。多副本部署需要运维逐 Pod 调用；当前不提供广播、定时刷新或“刷新全部聚合”。
+刷新完成后的新查询使用新 Mapping，已经在途的查询继续使用其开始编译时取得的旧 Mapping。
+
 ## 配置事件流索引模板
 
 ```http request

--- a/documentation/docs/zh/guide/extensions/elasticsearch.md
+++ b/documentation/docs/zh/guide/extensions/elasticsearch.md
@@ -86,6 +86,7 @@ wow:
 ```
 
 - 配置类：[ElasticsearchProperties](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchProperties.kt)
+- 查询配置类：[ElasticsearchQueryProperties](https://github.com/Ahoo-Wang/Wow/blob/main/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchQueryProperties.kt)
 - 前缀：`wow.elasticsearch.`
 
 | 名称 | 数据类型 | 默认值 | 描述 |
@@ -102,6 +103,8 @@ wow:
 | `snapshot-store-batch.max-delay` | `Duration` | `1ms` | 收集部分快照批次的等待时长上限 |
 | `snapshot-store-batch.max-pending-saves` | `Int` | `4096` | 等待或正在写入的保存请求上限；必须不小于 `max-size` |
 | `snapshot-store-batch.lane-count` | `Int` | `1` | 串行写入通道数；同一聚合的保存保持在同一通道 |
+| `query.batch-size` | `Int` | `10000` | PIT + `search_after` 列表查询的内部批大小，取值范围 `1..10000` |
+| `query.keep-alive` | `Duration` | `1m` | PIT 的保持时间，必须大于 `0` |
 
 应用启动完成前会安装所需索引模板；请求失败或未确认会导致启动失败。仅当索引模板由外部系统管理时，才应设置
 `wow.elasticsearch.auto-init-template=false`。内置模板不会固定分片数和副本数，这些拓扑参数应由集群或更高优先级的
@@ -159,13 +162,40 @@ SnapshotStore 使用带 scripted upsert 的 Bulk `update`，direct 路径使用�
 | `MATCH` | `text`、`match_only_text` 或 `search_as_you_type` |
 | 排序 | 索引字段可排序且启用 `doc_values`，或 runtime field 支持排序 |
 
+例如，同一逻辑字段可同时支持全文搜索和精确查询：
+
+```json
+{
+  "properties": {
+    "state": {
+      "properties": {
+        "customerName": {
+          "type": "text",
+          "fields": {
+            "keyword": { "type": "keyword" }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+| Query 操作 | 客户端字段 | 实际字段 |
+|---|---|---|
+| `MATCH` | `state.customerName` | `state.customerName` |
+| `EQ`、`IN`、排序 | `state.customerName` | `state.customerName.keyword` |
+| projection | `state.customerName` | `state.customerName`（不重写） |
+
+客户端始终使用逻辑字段，不需要固定写入 `.keyword` 或 `.text`。
+
 对于 multi-field，依次选择当前字段、`.keyword`/`.text`、`.exact`，最后才选择唯一的兼容子字段；存在多个兼容候选时
 查询失败，避免静默改变语义。`EXISTS`、`NULL`、`NOT_NULL`、projection 和 `RAW` 不重写，`ELEM_MATCH` 的父路径
 必须映射为 `nested`。自定义 `ConditionConverter` 继续负责解释自己的物理字段，不经过上述重写。
 
 Field alias 继承其目标字段的查询与排序能力，并继续使用 alias 名称生成查询。Mapping 中声明的 runtime field 也会按
 其类型参与能力解析；runtime 查询会在查询时计算，且当 Elasticsearch 设置 `search.allow_expensive_queries=false` 时
-可能被集群拒绝。
+可能被集群拒绝。projection 仍按逻辑路径作用于 `_source`，不会把 field alias 或 runtime field 改写为其目标字段。
 
 每个聚合必须解析到一个物理快照索引。alias 或 data stream 如果解析出多个索引，查询会失败；这种拓扑需要先收敛为
 单个物理索引，或由应用自行实现基于 `_field_caps` 的查询方案。
@@ -174,6 +204,18 @@ Field alias 继承其目标字段的查询与排序能力，并继续使用 alia
 
 应用引入 `org.springframework.boot:spring-boot-starter-actuator` 后会注册可选维护端点。端点默认不可访问，必须同时配置
 access 和 Web exposure，并由管理端安全策略限制为维护角色：
+
+::: code-group
+```kotlin [Gradle(Kotlin)]
+implementation("org.springframework.boot:spring-boot-starter-actuator")
+```
+```xml [Maven]
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-actuator</artifactId>
+</dependency>
+```
+:::
 
 ```yaml
 management:
@@ -188,13 +230,29 @@ management:
 
 按已注册聚合刷新当前实例的 Mapping：
 
-```http request
-POST /actuator/wowElasticsearchMapping/{contextName}/{aggregateName}
+```bash
+curl -X POST \
+  http://localhost:8080/actuator/wowElasticsearchMapping/order-service/order
 ```
 
-端点不接受任意索引表达式，索引名由聚合元数据计算。响应只包含 `scope=LOCAL_INSTANCE`、`indexName`、
-`fieldCount`、`changed` 和 `refreshedAt`，不会返回完整 Mapping。Elasticsearch 凭据需要目标索引的
-`view_index_metadata` 权限；权限不足、索引不存在或 Mapping 无法解析时请求失败，已有成功缓存不受影响。
+响应示例：
+
+```json
+{
+  "scope": "LOCAL_INSTANCE",
+  "indexName": "wow.order-service.order.snapshot",
+  "fieldCount": 24,
+  "changed": true,
+  "refreshedAt": "2026-08-21T09:00:00Z"
+}
+```
+
+端点不接受任意索引表达式，索引名由聚合元数据计算。`fieldCount` 是解析到的字段路径数，`changed`
+表示新能力模型是否与刷新前不同；响应不会返回完整 Mapping。未注册的聚合返回 `400 Bad Request`。
+
+Elasticsearch 凭据需要目标索引的 `view_index_metadata` 权限；权限不足、索引不存在或 Mapping 无法解析时
+请求失败，已有成功缓存不受影响。刷新只重新加载查询能力缓存，不修改 Elasticsearch Mapping、
+不重建索引，也不回填历史快照。
 
 刷新只作用于收到请求的应用实例。多副本部署需要运维逐 Pod 调用；当前不提供广播、定时刷新或“刷新全部聚合”。
 刷新完成后的新查询使用新 Mapping，已经在途的查询继续使用其开始编译时取得的旧 Mapping。
@@ -411,12 +469,16 @@ POST _index_template/wow-order-snapshot-template
 
 ```kotlin
 // 使用 QueryService 进行全文搜索
-val condition = Condition.all()
-    .match("state.description", "搜索关键词")
-    .range("state.totalAmount", 100, 500)
-    .limit(10)
-
-snapshotQueryService.dynamicQuery(condition)
+listQuery {
+    condition {
+        "state.description" match "搜索关键词"
+        "state.totalAmount" between 100 to 500
+    }
+    sort {
+        "state.customerName".asc()
+    }
+    limit(10)
+}.dynamicQuery(snapshotQueryService)
 ```
 
 ## 聚合查询
@@ -537,24 +599,29 @@ spring:
 
 ### 常见问题
 
-#### 1. 索引映射冲突
+#### 1. 查询报字段未映射、能力不兼容或 multi-field 存在歧义
 
-**解决方案**：
-- 检查动态模板配置
-- 使用严格映射模式
+使用 `GET /{indexName}/_mapping` 检查当前物理 Mapping，再调用主动刷新端点。多个兼容子字段时，使用
+`.keyword`、`.text` 或 `.exact` 的约定名称消除歧义。
 
-#### 2. 集群状态为黄色或红色
+#### 2. 刷新端点不可用或刷新失败
 
-**解决方案**：
-- 检查节点状态
-- 增加副本或重新分配分片
+`404` 时检查 Actuator 依赖、endpoint access 和 Web exposure；`400` 时检查 `contextName` 和 `aggregateName`
+是否已注册。Elasticsearch 错误时检查索引是否存在以及 `view_index_metadata` 权限。刷新失败不会删除旧缓存。
 
-#### 3. 查询性能慢
+#### 3. alias 或 data stream 无法解析
 
-**解决方案**：
-- 优化查询语句
-- 增加索引分片
-- 使用缓存
+确认快照别名只指向一个物理索引。当前 Resolver 不合并多索引 Mapping，需要多索引查询时由应用基于
+`_field_caps` 实现。
+
+#### 4. 更新索引模板并刷新后，历史数据仍无法查询
+
+索引模板只影响之后创建的索引，Mapping 刷新也只更新 Wow 的能力缓存。根据 Mapping 变更类型执行
+`PUT /{indexName}/_mapping`、reindex 或快照重建，并核对结果数、排序和快照版本。
+
+#### 5. runtime field 查询被拒绝
+
+检查集群的 `search.allow_expensive_queries`。保持该限制时，将高频查询字段落到物理 Mapping，不要依赖 runtime field。
 
 ## 完整配置示例
 
@@ -571,6 +638,10 @@ spring:
     socket-timeout: 30s
 
 wow:
+  elasticsearch:
+    query:
+      batch-size: 10000
+      keep-alive: 1m
   eventsourcing:
     store:
       storage: elasticsearch
@@ -582,8 +653,8 @@ wow:
 
 ## 最佳实践
 
-1. **预定义映射**：在生产环境中预先创建索引模板，避免动态映射问题
+1. **预定义映射**：在首个快照写入前安装高优先级的聚合索引模板，避免动态映射锁定错误类型
 2. **合理分片**：根据数据量设置合适的分片数，避免过多小分片
-3. **使用别名**：使用索引别名便于零停机迁移
-4. **启用 ILM**：使用索引生命周期管理自动管理索引
-5. **监控集群**：监控集群健康状态和性能指标
+3. **限制别名拓扑**：Wow 快照查询使用的 alias 或 data stream 必须只解析到一个物理索引
+4. **重建后核对**：Mapping 变更需要 reindex 或快照重建时，核对结果数、排序和快照版本
+5. **监控集群**：监控集群健康状态、PIT 数量和查询延迟

--- a/documentation/docs/zh/guide/extensions/elasticsearch.md
+++ b/documentation/docs/zh/guide/extensions/elasticsearch.md
@@ -158,9 +158,13 @@ SnapshotStore 使用带 scripted upsert 的 Bulk `update`，direct 路径使用�
 |---|---|
 | `EQ`、`NE`、`IN`、`NOT_IN`、`ALL_IN`、`TRUE`、`FALSE` | 可执行 term 查询，包括受支持的 doc-value-only 字段 |
 | `CONTAINS`、`STARTS_WITH`、`ENDS_WITH` | `keyword` 或 `wildcard` |
-| 范围操作 | numeric、date、ip 或 keyword，支持适用的 `doc_values=true,index=false` 字段 |
-| `MATCH` | `text`、`match_only_text` 或 `search_as_you_type` |
-| 排序 | 启用 `doc_values` 的可排序字段，或 runtime field 支持排序；不要求 `index=true` |
+| 范围操作 | numeric、date、ip、keyword 或 `*_range`，支持适用的 `doc_values=true,index=false` 字段 |
+| `MATCH` | `text`、`match_only_text`、`search_as_you_type` 或 `semantic_text` |
+| 排序 | 启用 `doc_values` 的可排序字段、启用 `fielddata` 的已索引 `text` 字段，或可排序 runtime field |
+
+`_score`、`_doc` 和 `_shard_doc` 是 Elasticsearch 元数据排序字段，不参与 Mapping 字段解析并保持原样传递。
+`text.fielddata=true` 会占用较多堆内存，通常仍应优先使用 `keyword` multi-field；doc-values 字段和 runtime field
+排序不要求 `index=true`。
 
 flattened 字段的动态键不会单独出现在 Mapping 中。Resolver 会从 `state.labels.release` 这类具体路径向上查找最近的
 flattened 父字段，并保留原路径执行精确和排序操作。flattened 值均按 keyword 处理，排序是字典序；

--- a/documentation/docs/zh/guide/extensions/elasticsearch.md
+++ b/documentation/docs/zh/guide/extensions/elasticsearch.md
@@ -156,11 +156,11 @@ SnapshotStore 使用带 scripted upsert 的 Bulk `update`，direct 路径使用�
 
 | Query 操作 | Mapping 要求 |
 |---|---|
-| `EQ`、`NE`、`IN`、`NOT_IN`、`ALL_IN`、`TRUE`、`FALSE` | 可执行 term 查询 |
+| `EQ`、`NE`、`IN`、`NOT_IN`、`ALL_IN`、`TRUE`、`FALSE` | 可执行 term 查询，包括受支持的 doc-value-only 字段 |
 | `CONTAINS`、`STARTS_WITH`、`ENDS_WITH` | `keyword` 或 `wildcard` |
-| 范围操作 | numeric、date 或 keyword |
+| 范围操作 | numeric、date 或 keyword，支持 `doc_values=true,index=false` |
 | `MATCH` | `text`、`match_only_text` 或 `search_as_you_type` |
-| 排序 | 索引字段可排序且启用 `doc_values`，或 runtime field 支持排序 |
+| 排序 | 启用 `doc_values` 的可排序字段，或 runtime field 支持排序；不要求 `index=true` |
 
 例如，同一逻辑字段可同时支持全文搜索和精确查询：
 

--- a/documentation/docs/zh/guide/extensions/elasticsearch.md
+++ b/documentation/docs/zh/guide/extensions/elasticsearch.md
@@ -158,9 +158,13 @@ SnapshotStore 使用带 scripted upsert 的 Bulk `update`，direct 路径使用�
 |---|---|
 | `EQ`、`NE`、`IN`、`NOT_IN`、`ALL_IN`、`TRUE`、`FALSE` | 可执行 term 查询，包括受支持的 doc-value-only 字段 |
 | `CONTAINS`、`STARTS_WITH`、`ENDS_WITH` | `keyword` 或 `wildcard` |
-| 范围操作 | numeric、date 或 keyword，支持 `doc_values=true,index=false` |
+| 范围操作 | numeric、date、ip 或 keyword，支持适用的 `doc_values=true,index=false` 字段 |
 | `MATCH` | `text`、`match_only_text` 或 `search_as_you_type` |
 | 排序 | 启用 `doc_values` 的可排序字段，或 runtime field 支持排序；不要求 `index=true` |
+
+flattened 字段的动态键不会单独出现在 Mapping 中。Resolver 会从 `state.labels.release` 这类具体路径向上查找最近的
+flattened 父字段，并保留原路径执行精确和排序操作。flattened 值均按 keyword 处理，排序是字典序；
+动态键不自动启用范围操作，显式声明的 typed sub-field 仍使用自身类型能力。
 
 例如，同一逻辑字段可同时支持全文搜索和精确查询：
 

--- a/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryServiceTest.kt
+++ b/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryServiceTest.kt
@@ -13,7 +13,9 @@
 
 package me.ahoo.wow.elasticsearch.query.snapshot
 
+import co.elastic.clients.elasticsearch._types.Refresh
 import co.elastic.clients.elasticsearch._types.mapping.RuntimeFieldType
+import co.elastic.clients.elasticsearch.core.UpdateRequest
 import co.elastic.clients.elasticsearch.indices.PutMappingRequest
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.query.Condition
@@ -128,6 +130,65 @@ class ElasticsearchSnapshotQueryServiceTest : SnapshotQueryServiceSpec() {
                 limit = 10,
             ),
         ).test()
+            .expectNextCount(1)
+            .verifyComplete()
+    }
+
+    @Test
+    fun `doc value only fields should support exact range and sort queries`() {
+        val indexName = MOCK_AGGREGATE_METADATA.toSnapshotIndexName()
+        elasticsearchClient.indices().putMapping(
+            PutMappingRequest.of { request ->
+                request.index(indexName)
+                    .properties("docValueOnlyKeyword") { field ->
+                        field.keyword { keyword -> keyword.index(false) }
+                    }.properties("docValueOnlyLong") { field ->
+                        field.long_ { number -> number.index(false) }
+                    }
+            },
+        ).block()
+
+        @Suppress("UNCHECKED_CAST")
+        val documentClass = Map::class.java as Class<Map<String, Any?>>
+        elasticsearchClient.update(
+            UpdateRequest.of<Map<String, Any?>, Map<String, Any?>> { request ->
+                request.index(indexName)
+                    .id(snapshot.aggregateId.id)
+                    .doc(
+                        mapOf(
+                            "docValueOnlyKeyword" to "exact",
+                            "docValueOnlyLong" to 42,
+                        ),
+                    ).refresh(Refresh.True)
+            },
+            documentClass,
+        ).block()
+
+        val mappingResolver = ElasticsearchIndexMappingResolver(elasticsearchClient)
+        val mapping = mappingResolver.currentOrLoad(indexName).block()!!
+        mapping.resolve("docValueOnlyKeyword", ElasticsearchFieldUsage.EXACT)
+            .assert().isEqualTo("docValueOnlyKeyword")
+        mapping.resolve("docValueOnlyLong", ElasticsearchFieldUsage.RANGE)
+            .assert().isEqualTo("docValueOnlyLong")
+        mapping.resolve("docValueOnlyLong", ElasticsearchFieldUsage.SORT)
+            .assert().isEqualTo("docValueOnlyLong")
+
+        ElasticsearchSnapshotQueryServiceFactory(
+            elasticsearchClient,
+            DEFAULT_SEARCH_BATCH_SIZE,
+            DEFAULT_PIT_KEEP_ALIVE,
+            mappingResolver,
+        ).create<MockStateAggregate>(MOCK_AGGREGATE_METADATA)
+            .dynamicList(
+                ListQuery(
+                    condition = Condition.and(
+                        Condition.eq("docValueOnlyKeyword", "exact"),
+                        Condition.gt("docValueOnlyLong", 1),
+                    ),
+                    sort = listOf(Sort("docValueOnlyLong", Sort.Direction.ASC)),
+                    limit = 10,
+                ),
+            ).test()
             .expectNextCount(1)
             .verifyComplete()
     }

--- a/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryServiceTest.kt
+++ b/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryServiceTest.kt
@@ -135,7 +135,7 @@ class ElasticsearchSnapshotQueryServiceTest : SnapshotQueryServiceSpec() {
     }
 
     @Test
-    fun `doc value only fields should support exact range and sort queries`() {
+    fun `mapping capabilities should support doc values ip ranges and flattened paths`() {
         val indexName = MOCK_AGGREGATE_METADATA.toSnapshotIndexName()
         elasticsearchClient.indices().putMapping(
             PutMappingRequest.of { request ->
@@ -144,6 +144,10 @@ class ElasticsearchSnapshotQueryServiceTest : SnapshotQueryServiceSpec() {
                         field.keyword { keyword -> keyword.index(false) }
                     }.properties("docValueOnlyLong") { field ->
                         field.long_ { number -> number.index(false) }
+                    }.properties("ipAddress") { field ->
+                        field.ip { ip -> ip.index(false) }
+                    }.properties("labels") { field ->
+                        field.flattened { flattened -> flattened }
                     }
             },
         ).block()
@@ -158,6 +162,8 @@ class ElasticsearchSnapshotQueryServiceTest : SnapshotQueryServiceSpec() {
                         mapOf(
                             "docValueOnlyKeyword" to "exact",
                             "docValueOnlyLong" to 42,
+                            "ipAddress" to "192.168.1.1",
+                            "labels" to mapOf("release" to "v1.2.3"),
                         ),
                     ).refresh(Refresh.True)
             },
@@ -172,6 +178,12 @@ class ElasticsearchSnapshotQueryServiceTest : SnapshotQueryServiceSpec() {
             .assert().isEqualTo("docValueOnlyLong")
         mapping.resolve("docValueOnlyLong", ElasticsearchFieldUsage.SORT)
             .assert().isEqualTo("docValueOnlyLong")
+        mapping.resolve("ipAddress", ElasticsearchFieldUsage.RANGE)
+            .assert().isEqualTo("ipAddress")
+        mapping.resolve("labels.release", ElasticsearchFieldUsage.EXACT)
+            .assert().isEqualTo("labels.release")
+        mapping.resolve("labels.release", ElasticsearchFieldUsage.SORT)
+            .assert().isEqualTo("labels.release")
 
         ElasticsearchSnapshotQueryServiceFactory(
             elasticsearchClient,
@@ -184,8 +196,13 @@ class ElasticsearchSnapshotQueryServiceTest : SnapshotQueryServiceSpec() {
                     condition = Condition.and(
                         Condition.eq("docValueOnlyKeyword", "exact"),
                         Condition.gt("docValueOnlyLong", 1),
+                        Condition.gt("ipAddress", "192.168.0.1"),
+                        Condition.eq("labels.release", "v1.2.3"),
                     ),
-                    sort = listOf(Sort("docValueOnlyLong", Sort.Direction.ASC)),
+                    sort = listOf(
+                        Sort("docValueOnlyLong", Sort.Direction.ASC),
+                        Sort("labels.release", Sort.Direction.ASC),
+                    ),
                     limit = 10,
                 ),
             ).test()

--- a/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryServiceTest.kt
+++ b/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryServiceTest.kt
@@ -135,7 +135,7 @@ class ElasticsearchSnapshotQueryServiceTest : SnapshotQueryServiceSpec() {
     }
 
     @Test
-    fun `mapping capabilities should support doc values ip ranges and flattened paths`() {
+    fun `mapping capabilities should support special field types and metadata sorts`() {
         val indexName = MOCK_AGGREGATE_METADATA.toSnapshotIndexName()
         elasticsearchClient.indices().putMapping(
             PutMappingRequest.of { request ->
@@ -146,6 +146,12 @@ class ElasticsearchSnapshotQueryServiceTest : SnapshotQueryServiceSpec() {
                         field.long_ { number -> number.index(false) }
                     }.properties("ipAddress") { field ->
                         field.ip { ip -> ip.index(false) }
+                    }.properties("integerRange") { field ->
+                        field.integerRange { range -> range }
+                    }.properties("ipRange") { field ->
+                        field.ipRange { range -> range }
+                    }.properties("sortableText") { field ->
+                        field.text { text -> text.fielddata(true) }
                     }.properties("labels") { field ->
                         field.flattened { flattened -> flattened }
                     }
@@ -163,6 +169,9 @@ class ElasticsearchSnapshotQueryServiceTest : SnapshotQueryServiceSpec() {
                             "docValueOnlyKeyword" to "exact",
                             "docValueOnlyLong" to 42,
                             "ipAddress" to "192.168.1.1",
+                            "integerRange" to mapOf("gte" to 10, "lte" to 20),
+                            "ipRange" to "192.168.0.0/24",
+                            "sortableText" to "single",
                             "labels" to mapOf("release" to "v1.2.3"),
                         ),
                     ).refresh(Refresh.True)
@@ -180,6 +189,12 @@ class ElasticsearchSnapshotQueryServiceTest : SnapshotQueryServiceSpec() {
             .assert().isEqualTo("docValueOnlyLong")
         mapping.resolve("ipAddress", ElasticsearchFieldUsage.RANGE)
             .assert().isEqualTo("ipAddress")
+        mapping.resolve("integerRange", ElasticsearchFieldUsage.RANGE)
+            .assert().isEqualTo("integerRange")
+        mapping.resolve("ipRange", ElasticsearchFieldUsage.RANGE)
+            .assert().isEqualTo("ipRange")
+        mapping.resolve("sortableText", ElasticsearchFieldUsage.SORT)
+            .assert().isEqualTo("sortableText")
         mapping.resolve("labels.release", ElasticsearchFieldUsage.EXACT)
             .assert().isEqualTo("labels.release")
         mapping.resolve("labels.release", ElasticsearchFieldUsage.SORT)
@@ -197,11 +212,17 @@ class ElasticsearchSnapshotQueryServiceTest : SnapshotQueryServiceSpec() {
                         Condition.eq("docValueOnlyKeyword", "exact"),
                         Condition.gt("docValueOnlyLong", 1),
                         Condition.gt("ipAddress", "192.168.0.1"),
+                        Condition.gt("integerRange", 15),
+                        Condition.gt("ipRange", "192.168.0.128"),
                         Condition.eq("labels.release", "v1.2.3"),
                     ),
                     sort = listOf(
                         Sort("docValueOnlyLong", Sort.Direction.ASC),
+                        Sort("sortableText", Sort.Direction.ASC),
                         Sort("labels.release", Sort.Direction.ASC),
+                        Sort("_score", Sort.Direction.DESC),
+                        Sort("_doc", Sort.Direction.ASC),
+                        Sort("_shard_doc", Sort.Direction.ASC),
                     ),
                     limit = 10,
                 ),

--- a/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryServiceTest.kt
+++ b/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryServiceTest.kt
@@ -13,16 +13,31 @@
 
 package me.ahoo.wow.elasticsearch.query.snapshot
 
+import co.elastic.clients.elasticsearch._types.mapping.RuntimeFieldType
+import co.elastic.clients.elasticsearch.indices.PutMappingRequest
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.ListQuery
+import me.ahoo.wow.api.query.Sort
+import me.ahoo.wow.elasticsearch.IndexNameConverter.toSnapshotIndexName
 import me.ahoo.wow.elasticsearch.ReactiveElasticsearchClients
 import me.ahoo.wow.elasticsearch.TemplateInitializer.initSnapshotTemplate
 import me.ahoo.wow.elasticsearch.eventsourcing.ElasticsearchSnapshotStore
+import me.ahoo.wow.elasticsearch.query.DEFAULT_PIT_KEEP_ALIVE
+import me.ahoo.wow.elasticsearch.query.DEFAULT_SEARCH_BATCH_SIZE
+import me.ahoo.wow.elasticsearch.query.ElasticsearchFieldUsage
+import me.ahoo.wow.elasticsearch.query.ElasticsearchIndexMappingResolver
 import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
 import me.ahoo.wow.query.snapshot.SnapshotQueryServiceFactory
 import me.ahoo.wow.tck.container.ElasticsearchTestFixture
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
+import me.ahoo.wow.tck.mock.MockStateAggregate
 import me.ahoo.wow.tck.query.SnapshotQueryServiceSpec
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
+import reactor.kotlin.test.test
 
 class ElasticsearchSnapshotQueryServiceTest : SnapshotQueryServiceSpec() {
     @JvmField
@@ -44,5 +59,76 @@ class ElasticsearchSnapshotQueryServiceTest : SnapshotQueryServiceSpec() {
 
     override fun createSnapshotStore(): SnapshotStore {
         return ElasticsearchSnapshotStore(elasticsearchClient)
+    }
+
+    @Test
+    fun `active refresh should expose mapped alias and runtime capabilities to new queries`() {
+        val indexName = MOCK_AGGREGATE_METADATA.toSnapshotIndexName()
+        val mappingResolver = ElasticsearchIndexMappingResolver(elasticsearchClient)
+        val initial = mappingResolver.currentOrLoad(indexName).block()!!
+        initial.resolve("state.data", ElasticsearchFieldUsage.SEARCH).assert().isEqualTo("state.data")
+        initial.resolve("state.data", ElasticsearchFieldUsage.EXACT).assert().isEqualTo("state.data.keyword")
+
+        elasticsearchClient.indices().putMapping(
+            PutMappingRequest.of { request ->
+                request.index(indexName)
+                    .properties("aggregateIdAlias") { field ->
+                        field.alias { alias -> alias.path("aggregateId") }
+                    }
+                    .properties("state") { state ->
+                        state.`object` { objectField ->
+                            objectField
+                                .properties("keywordOnly") { it.keyword { keyword -> keyword } }
+                                .properties("textOnly") { it.text { text -> text } }
+                        }
+                    }.runtime("state.runtimeCode") { runtime ->
+                        runtime.type(RuntimeFieldType.Keyword)
+                            .script { script ->
+                                script.source { source -> source.scriptString("emit('runtime')") }
+                            }
+                    }
+            },
+        ).block()
+
+        val refreshed = mappingResolver.refresh(indexName).block()!!
+        refreshed.changed.assert().isTrue()
+        refreshed.mapping.resolve("state.keywordOnly", ElasticsearchFieldUsage.EXACT)
+            .assert().isEqualTo("state.keywordOnly")
+        refreshed.mapping.resolve("state.textOnly", ElasticsearchFieldUsage.SEARCH)
+            .assert().isEqualTo("state.textOnly")
+        refreshed.mapping.resolve("aggregateIdAlias", ElasticsearchFieldUsage.EXACT)
+            .assert().isEqualTo("aggregateIdAlias")
+        refreshed.mapping.resolve("state.runtimeCode", ElasticsearchFieldUsage.SORT)
+            .assert().isEqualTo("state.runtimeCode")
+
+        val queryService = ElasticsearchSnapshotQueryServiceFactory(
+            elasticsearchClient,
+            DEFAULT_SEARCH_BATCH_SIZE,
+            DEFAULT_PIT_KEEP_ALIVE,
+            mappingResolver,
+        ).create<MockStateAggregate>(MOCK_AGGREGATE_METADATA)
+        queryService.dynamicList(
+            ListQuery(
+                condition = Condition.and(
+                    Condition.eq("state.keywordOnly", "exact"),
+                    Condition.match("state.textOnly", "search"),
+                ),
+                limit = 10,
+            ),
+        ).test()
+            .verifyComplete()
+
+        queryService.dynamicList(
+            ListQuery(
+                condition = Condition.and(
+                    Condition.eq("aggregateIdAlias", snapshot.aggregateId.id),
+                    Condition.eq("state.runtimeCode", "runtime"),
+                ),
+                sort = listOf(Sort("state.runtimeCode", Sort.Direction.ASC)),
+                limit = 10,
+            ),
+        ).test()
+            .expectNextCount(1)
+            .verifyComplete()
     }
 }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryService.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryService.kt
@@ -29,6 +29,7 @@ import me.ahoo.wow.api.query.ListQuery
 import me.ahoo.wow.api.query.PagedList
 import me.ahoo.wow.api.query.Queryable
 import me.ahoo.wow.api.query.SimpleDynamicDocument.Companion.toDynamicDocument
+import me.ahoo.wow.api.query.Sort
 import me.ahoo.wow.api.query.isEmpty
 import me.ahoo.wow.elasticsearch.query.ElasticsearchProjectionConverter.toSourceFilter
 import me.ahoo.wow.elasticsearch.query.ElasticsearchSortConverter.toSortOptions
@@ -45,7 +46,12 @@ abstract class AbstractElasticsearchQueryService<R : Any> : QueryService<R> {
     abstract val indexName: String
     protected open val queryBatchSize: Int = DEFAULT_SEARCH_BATCH_SIZE
     protected open val queryKeepAlive: Duration = DEFAULT_PIT_KEEP_ALIVE
+    protected open val indexMappingResolver: ElasticsearchIndexMappingResolver? = null
     abstract fun toTypedResult(document: DynamicDocument): R
+
+    protected open fun resolveCondition(mapping: ElasticsearchIndexMapping, condition: Condition): Condition = condition
+
+    protected open fun resolveSort(mapping: ElasticsearchIndexMapping, sort: List<Sort>): List<Sort> = sort
 
     override fun single(singleQuery: ISingleQuery): Mono<R> {
         return dynamicSingle(singleQuery).map { toTypedResult(it) }
@@ -68,22 +74,27 @@ abstract class AbstractElasticsearchQueryService<R : Any> : QueryService<R> {
     override fun dynamicList(listQuery: IListQuery): Flux<DynamicDocument> {
         require(listQuery.limit >= 0) { "limit must be greater than or equal to 0." }
         if (listQuery.limit == 0 || listQuery.limit > queryBatchSize) {
-            return ElasticsearchQueryPager(elasticsearchClient, indexName, queryBatchSize, queryKeepAlive)
-                .search(
+            return resolve(listQuery.condition, listQuery.sort).flatMapMany { resolved ->
+                ElasticsearchQueryPager(elasticsearchClient, indexName, queryBatchSize, queryKeepAlive).search(
                     limit = listQuery.limit,
-                    query = conditionConverter.convert(listQuery.condition),
+                    query = resolved.query,
                     sourceFilter = listQuery.sourceFilter(),
-                    sort = listQuery.searchAfterSort(),
+                    sort = resolved.sortOptions.searchAfterSort(),
                 )
+            }
                 .mapNotNull { it.toDynamicDocument() }
         }
-        val searchRequest = createSearchRequest(
-            query = listQuery,
-            from = 0,
-            size = listQuery.limit,
-            trackTotalHits = false,
-        )
-        return search(searchRequest).flatMapIterable { it.list }
+        return resolve(listQuery.condition, listQuery.sort)
+            .map { resolved ->
+                createSearchRequest(
+                    query = listQuery,
+                    resolved = resolved,
+                    from = 0,
+                    size = listQuery.limit,
+                    trackTotalHits = false,
+                )
+            }.flatMap(::search)
+            .flatMapIterable { it.list }
     }
 
     override fun paged(pagedQuery: IPagedQuery): Mono<PagedList<R>> {
@@ -98,30 +109,34 @@ abstract class AbstractElasticsearchQueryService<R : Any> : QueryService<R> {
     }
 
     override fun dynamicPaged(pagedQuery: IPagedQuery): Mono<PagedList<DynamicDocument>> {
-        val searchRequest = createSearchRequest(
-            query = pagedQuery,
-            from = pagedQuery.pagination.offset(),
-            size = pagedQuery.pagination.size,
-            trackTotalHits = true,
-        )
-        return search(searchRequest)
+        return resolve(pagedQuery.condition, pagedQuery.sort)
+            .map { resolved ->
+                createSearchRequest(
+                    query = pagedQuery,
+                    resolved = resolved,
+                    from = pagedQuery.pagination.offset(),
+                    size = pagedQuery.pagination.size,
+                    trackTotalHits = true,
+                )
+            }.flatMap(::search)
     }
 
     private fun createSearchRequest(
         query: Queryable<*>,
+        resolved: ResolvedQuery,
         from: Int,
         size: Int,
         trackTotalHits: Boolean,
     ): SearchRequest {
         val searchRequest = SearchRequest.of {
             it.index(indexName)
-                .query(conditionConverter.convert(query.condition))
+                .query(resolved.query)
                 .from(from)
                 .size(size)
 
             it.trackTotalHits { trackHits -> trackHits.enabled(trackTotalHits) }
-            if (query.sort.isNotEmpty()) {
-                it.sort(query.sort.toSortOptions())
+            if (resolved.sortOptions.isNotEmpty()) {
+                it.sort(resolved.sortOptions)
             }
             if (!query.projection.isEmpty()) {
                 it.source {
@@ -137,13 +152,12 @@ abstract class AbstractElasticsearchQueryService<R : Any> : QueryService<R> {
         return if (projection.isEmpty()) null else projection.toSourceFilter()
     }
 
-    private fun IListQuery.searchAfterSort(): List<SortOptions> {
-        val userSort = sort.toSortOptions()
+    private fun List<SortOptions>.searchAfterSort(): List<SortOptions> {
         return buildList {
-            if (userSort.isEmpty()) {
+            if (this@searchAfterSort.isEmpty()) {
                 add(SortOptions.of { it.score { score -> score.order(SortOrder.Desc) } })
             } else {
-                addAll(userSort)
+                addAll(this@searchAfterSort)
             }
             add(
                 SortOptions.of {
@@ -168,10 +182,37 @@ abstract class AbstractElasticsearchQueryService<R : Any> : QueryService<R> {
     }
 
     override fun count(condition: Condition): Mono<Long> {
-        val countRequest = CountRequest.of {
-            it.index(indexName)
-                .query(conditionConverter.convert(condition))
-        }
-        return elasticsearchClient.count(countRequest).map { it.count() }
+        return resolve(condition).map { resolved ->
+            CountRequest.of {
+                it.index(indexName)
+                    .query(resolved.query)
+            }
+        }.flatMap(elasticsearchClient::count).map { it.count() }
     }
+
+    private fun resolve(condition: Condition, sort: List<Sort> = emptyList()): Mono<ResolvedQuery> {
+        val resolver = indexMappingResolver ?: return Mono.just(compile(condition, sort))
+        return resolver.currentOrLoad(indexName)
+            .map { mapping -> compile(resolveCondition(mapping, condition), resolveSort(mapping, sort)) }
+            .onErrorResume(ElasticsearchFieldResolutionException::class.java) {
+                resolver.refresh(indexName)
+                    .map { result ->
+                        compile(
+                            resolveCondition(result.mapping, condition),
+                            resolveSort(result.mapping, sort),
+                        )
+                    }
+            }
+    }
+
+    private fun compile(condition: Condition, sort: List<Sort>): ResolvedQuery =
+        ResolvedQuery(
+            query = conditionConverter.convert(condition),
+            sortOptions = sort.toSortOptions(),
+        )
+
+    private data class ResolvedQuery(
+        val query: Query,
+        val sortOptions: List<SortOptions>,
+    )
 }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolver.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolver.kt
@@ -25,6 +25,7 @@ import co.elastic.clients.elasticsearch._types.mapping.KeywordProperty
 import co.elastic.clients.elasticsearch._types.mapping.NumberPropertyBase
 import co.elastic.clients.elasticsearch._types.mapping.Property
 import co.elastic.clients.elasticsearch._types.mapping.PropertyBase
+import co.elastic.clients.elasticsearch._types.mapping.RangePropertyBase
 import co.elastic.clients.elasticsearch._types.mapping.RuntimeFieldType
 import co.elastic.clients.elasticsearch._types.mapping.SearchAsYouTypeProperty
 import co.elastic.clients.elasticsearch._types.mapping.TextProperty
@@ -201,7 +202,15 @@ data class ElasticsearchIndexMapping private constructor(
         }
 
     fun resolve(sort: List<Sort>): List<Sort> =
-        sort.map { it.copy(field = resolve(it.field, ElasticsearchFieldUsage.SORT)) }
+        sort.map {
+            if (it.field in METADATA_SORT_FIELDS) {
+                it
+            } else {
+                it.copy(
+                    field = resolve(it.field, ElasticsearchFieldUsage.SORT),
+                )
+            }
+        }
 
     private fun Condition.withResolvedField(usage: ElasticsearchFieldUsage): Condition =
         copy(field = resolve(field, usage))
@@ -224,7 +233,7 @@ data class ElasticsearchIndexMapping private constructor(
                 fields[path] = ElasticsearchMappedField(
                     kind = property._kind(),
                     indexed = property.isIndexed(),
-                    sortable = property.hasDocValues(),
+                    sortable = property.isSortable(),
                     multiFields = multiFields,
                 )
                 propertyBase?.fields().orEmpty().forEach { (name, field) -> visit("$path.$name", field) }
@@ -252,6 +261,8 @@ data class ElasticsearchIndexMapping private constructor(
                 ElasticsearchFieldUsage.SEARCH -> listOf("text")
                 else -> listOf("keyword", "exact")
             }
+
+        private val METADATA_SORT_FIELDS = setOf("_score", "_doc", "_shard_doc")
     }
 }
 
@@ -267,7 +278,8 @@ private data class ElasticsearchMappedField(
             ElasticsearchFieldUsage.LITERAL -> indexed && kind in LITERAL_KINDS
             ElasticsearchFieldUsage.RANGE -> isQueryable() && kind in RANGE_KINDS
             ElasticsearchFieldUsage.SEARCH -> indexed && kind in SEARCH_KINDS
-            ElasticsearchFieldUsage.SORT -> sortable && kind in EXACT_KINDS
+            ElasticsearchFieldUsage.SORT ->
+                sortable && (kind in EXACT_KINDS || (indexed && kind == Property.Kind.Text))
         }
 
     private fun isQueryable(): Boolean = indexed || (sortable && kind in DOC_VALUE_QUERY_KINDS)
@@ -292,6 +304,14 @@ private data class ElasticsearchMappedField(
             Property.Kind.IcuCollationKeyword,
         )
         private val TERM_KINDS = KEYWORD_KINDS + Property.Kind.Wildcard
+        private val RANGE_FIELD_KINDS = setOf(
+            Property.Kind.IntegerRange,
+            Property.Kind.FloatRange,
+            Property.Kind.LongRange,
+            Property.Kind.DoubleRange,
+            Property.Kind.DateRange,
+            Property.Kind.IpRange,
+        )
         private val DOC_VALUE_QUERY_KINDS = NUMERIC_KINDS + KEYWORD_KINDS + setOf(
             Property.Kind.Boolean,
             Property.Kind.Date,
@@ -307,7 +327,7 @@ private data class ElasticsearchMappedField(
             Property.Kind.Version,
         )
         private val LITERAL_KINDS = TERM_KINDS
-        private val RANGE_KINDS = NUMERIC_KINDS + KEYWORD_KINDS + setOf(
+        private val RANGE_KINDS = NUMERIC_KINDS + KEYWORD_KINDS + RANGE_FIELD_KINDS + setOf(
             Property.Kind.Date,
             Property.Kind.DateNanos,
             Property.Kind.Ip,
@@ -316,6 +336,7 @@ private data class ElasticsearchMappedField(
             Property.Kind.Text,
             Property.Kind.MatchOnlyText,
             Property.Kind.SearchAsYouType,
+            Property.Kind.SemanticText,
         )
     }
 }
@@ -338,13 +359,14 @@ private fun RuntimeFieldType.toMappedField(): ElasticsearchMappedField? {
     )
 }
 
-private fun Property.hasDocValues(): Boolean =
+private fun Property.isSortable(): Boolean =
     when (_kind()) {
         Property.Kind.ConstantKeyword,
         Property.Kind.CountedKeyword,
         -> true
 
         Property.Kind.Flattened -> flattened().docValues() != false
+        Property.Kind.Text -> text().fielddata() == true
         else -> (_get() as? DocValuesPropertyBase)?.let { it.docValues() != false } == true
     }
 
@@ -362,5 +384,5 @@ private fun Property.isIndexed(): Boolean =
         is SearchAsYouTypeProperty -> property.index() != false
         is TextProperty -> property.index() != false
         is TokenCountProperty -> property.index() != false
-        else -> true
+        else -> (property as? RangePropertyBase)?.index() != false
     }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolver.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolver.kt
@@ -1,0 +1,345 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.elasticsearch.query
+
+import co.elastic.clients.elasticsearch._types.mapping.BooleanProperty
+import co.elastic.clients.elasticsearch._types.mapping.CountedKeywordProperty
+import co.elastic.clients.elasticsearch._types.mapping.DateNanosProperty
+import co.elastic.clients.elasticsearch._types.mapping.DateProperty
+import co.elastic.clients.elasticsearch._types.mapping.DocValuesPropertyBase
+import co.elastic.clients.elasticsearch._types.mapping.IcuCollationProperty
+import co.elastic.clients.elasticsearch._types.mapping.IpProperty
+import co.elastic.clients.elasticsearch._types.mapping.KeywordProperty
+import co.elastic.clients.elasticsearch._types.mapping.NumberPropertyBase
+import co.elastic.clients.elasticsearch._types.mapping.Property
+import co.elastic.clients.elasticsearch._types.mapping.PropertyBase
+import co.elastic.clients.elasticsearch._types.mapping.RuntimeFieldType
+import co.elastic.clients.elasticsearch._types.mapping.SearchAsYouTypeProperty
+import co.elastic.clients.elasticsearch._types.mapping.TextProperty
+import co.elastic.clients.elasticsearch._types.mapping.TokenCountProperty
+import co.elastic.clients.elasticsearch._types.mapping.TypeMapping
+import co.elastic.clients.elasticsearch.indices.GetMappingRequest
+import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.Operator
+import me.ahoo.wow.api.query.Sort
+import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
+import reactor.core.publisher.Mono
+import java.util.concurrent.ConcurrentHashMap
+
+enum class ElasticsearchFieldUsage {
+    EXACT,
+    LITERAL,
+    RANGE,
+    SEARCH,
+    SORT,
+}
+
+class ElasticsearchFieldResolutionException(message: String) : IllegalArgumentException(message)
+
+data class ElasticsearchMappingRefreshResult(
+    val mapping: ElasticsearchIndexMapping,
+    val changed: Boolean,
+)
+
+class ElasticsearchIndexMappingResolver(
+    private val elasticsearchClient: ReactiveElasticsearchClient,
+) {
+    private val mappings = ConcurrentHashMap<String, ElasticsearchIndexMapping>()
+    private val refreshes = ConcurrentHashMap<String, Mono<ElasticsearchMappingRefreshResult>>()
+
+    fun currentOrLoad(indexName: String): Mono<ElasticsearchIndexMapping> =
+        Mono.defer {
+            mappings[indexName]?.let { Mono.just(it) }
+                ?: refresh(indexName).map { it.mapping }
+        }
+
+    fun refresh(indexName: String): Mono<ElasticsearchMappingRefreshResult> =
+        refreshes.computeIfAbsent(indexName) {
+            Mono.defer {
+                val request = GetMappingRequest.of { it.index(indexName) }
+                elasticsearchClient.indices().getMapping(request)
+            }.map { response ->
+                require(response.mappings().size == 1) {
+                    "Elasticsearch index [$indexName] must resolve to exactly one physical index, " +
+                        "but resolved to ${response.mappings().keys}."
+                }
+                val typeMapping = response.mappings().values.single().mappings()
+                val mapping = ElasticsearchIndexMapping.from(indexName, typeMapping)
+                ElasticsearchMappingRefreshResult(
+                    mapping = mapping,
+                    changed = mappings.put(indexName, mapping) != mapping,
+                )
+            }.doOnSuccess {
+                refreshes.remove(indexName)
+            }.doOnError {
+                refreshes.remove(indexName)
+            }.doOnCancel {
+                refreshes.remove(indexName)
+            }.cache()
+        }
+}
+
+@ConsistentCopyVisibility
+data class ElasticsearchIndexMapping private constructor(
+    val indexName: String,
+    private val fields: Map<String, ElasticsearchMappedField>,
+) {
+    val fieldCount: Int
+        get() = fields.size
+
+    fun resolve(field: String, usage: ElasticsearchFieldUsage): String {
+        val mappedField = fields[field]
+            ?: resolutionFailure(
+                "Elasticsearch field [$field] is not mapped in index [$indexName].",
+            )
+        if (mappedField.supports(usage)) {
+            return field
+        }
+
+        preferredSuffixes(usage).forEach { suffix ->
+            val candidate = "$field.$suffix"
+            if (candidate in mappedField.multiFields && fields[candidate]?.supports(usage) == true) {
+                return candidate
+            }
+        }
+
+        val candidates = mappedField.multiFields.filter { fields[it]?.supports(usage) == true }
+        if (candidates.size == 1) {
+            return candidates.single()
+        }
+        if (candidates.size > 1) {
+            resolutionFailure(
+                "Elasticsearch field [$field] has ambiguous ${usage.name.lowercase()} mappings $candidates " +
+                    "in index [$indexName].",
+            )
+        }
+        resolutionFailure(
+            "Elasticsearch field [$field] does not support ${usage.name.lowercase()} queries in index [$indexName].",
+        )
+    }
+
+    fun requireNested(field: String): String {
+        val mappedField = fields[field]
+            ?: throw ElasticsearchFieldResolutionException(
+                "Elasticsearch nested field [$field] is not mapped in index [$indexName].",
+            )
+        if (mappedField.kind != Property.Kind.Nested) {
+            throw ElasticsearchFieldResolutionException(
+                "Elasticsearch field [$field] must be mapped as nested in index [$indexName].",
+            )
+        }
+        return field
+    }
+
+    fun resolve(condition: Condition): Condition =
+        when (condition.operator) {
+            Operator.AND,
+            Operator.OR,
+            Operator.NOR,
+            -> condition.copy(children = condition.children.map(::resolve))
+
+            Operator.EQ,
+            Operator.NE,
+            Operator.IN,
+            Operator.NOT_IN,
+            Operator.ALL_IN,
+            Operator.TRUE,
+            Operator.FALSE,
+            -> condition.withResolvedField(ElasticsearchFieldUsage.EXACT)
+
+            Operator.CONTAINS,
+            Operator.STARTS_WITH,
+            Operator.ENDS_WITH,
+            -> condition.withResolvedField(ElasticsearchFieldUsage.LITERAL)
+
+            Operator.GT,
+            Operator.LT,
+            Operator.GTE,
+            Operator.LTE,
+            Operator.BETWEEN,
+            Operator.TODAY,
+            Operator.BEFORE_TODAY,
+            Operator.TOMORROW,
+            Operator.THIS_WEEK,
+            Operator.NEXT_WEEK,
+            Operator.LAST_WEEK,
+            Operator.THIS_MONTH,
+            Operator.LAST_MONTH,
+            Operator.RECENT_DAYS,
+            Operator.EARLIER_DAYS,
+            -> condition.withResolvedField(ElasticsearchFieldUsage.RANGE)
+
+            Operator.MATCH -> condition.withResolvedField(ElasticsearchFieldUsage.SEARCH)
+            Operator.ELEM_MATCH -> condition.copy(
+                field = requireNested(condition.field),
+                children = condition.children.map(::resolve),
+            )
+
+            else -> condition
+        }
+
+    fun resolve(sort: List<Sort>): List<Sort> =
+        sort.map { it.copy(field = resolve(it.field, ElasticsearchFieldUsage.SORT)) }
+
+    private fun Condition.withResolvedField(usage: ElasticsearchFieldUsage): Condition =
+        copy(field = resolve(field, usage))
+
+    private fun resolutionFailure(message: String): Nothing =
+        throw ElasticsearchFieldResolutionException(message)
+
+    companion object {
+        fun from(indexName: String, typeMapping: TypeMapping): ElasticsearchIndexMapping {
+            val fields = linkedMapOf<String, ElasticsearchMappedField>()
+            val aliases = linkedMapOf<String, String>()
+
+            fun visit(path: String, property: Property) {
+                if (property.isAlias) {
+                    property.alias().path()?.let { aliases[path] = it }
+                    return
+                }
+                val propertyBase = property._get() as? PropertyBase
+                val multiFields = propertyBase?.fields().orEmpty().keys.mapTo(linkedSetOf()) { "$path.$it" }
+                fields[path] = ElasticsearchMappedField(
+                    kind = property._kind(),
+                    indexed = property.isIndexed(),
+                    sortable = property.hasDocValues(),
+                    multiFields = multiFields,
+                )
+                propertyBase?.fields().orEmpty().forEach { (name, field) -> visit("$path.$name", field) }
+                propertyBase?.properties().orEmpty().forEach { (name, field) -> visit("$path.$name", field) }
+            }
+
+            typeMapping.properties().forEach { (name, property) -> visit(name, property) }
+            typeMapping.runtime().forEach { (name, runtimeField) ->
+                if (runtimeField.type() == RuntimeFieldType.Composite) {
+                    runtimeField.fields().forEach { (fieldName, field) ->
+                        field.type().toMappedField()?.let { fields["$name.$fieldName"] = it }
+                    }
+                } else {
+                    runtimeField.type().toMappedField()?.let { fields[name] = it }
+                }
+            }
+            aliases.forEach { (name, target) ->
+                fields[target]?.let { fields[name] = it.copy(multiFields = emptySet()) }
+            }
+            return ElasticsearchIndexMapping(indexName, fields)
+        }
+
+        private fun preferredSuffixes(usage: ElasticsearchFieldUsage): List<String> =
+            when (usage) {
+                ElasticsearchFieldUsage.SEARCH -> listOf("text")
+                else -> listOf("keyword", "exact")
+            }
+    }
+}
+
+private data class ElasticsearchMappedField(
+    val kind: Property.Kind,
+    val indexed: Boolean,
+    val sortable: Boolean,
+    val multiFields: Set<String>,
+) {
+    fun supports(usage: ElasticsearchFieldUsage): Boolean {
+        if (!indexed) return false
+        return when (usage) {
+            ElasticsearchFieldUsage.EXACT -> kind in EXACT_KINDS
+            ElasticsearchFieldUsage.LITERAL -> kind in LITERAL_KINDS
+            ElasticsearchFieldUsage.RANGE -> kind in RANGE_KINDS
+            ElasticsearchFieldUsage.SEARCH -> kind in SEARCH_KINDS
+            ElasticsearchFieldUsage.SORT -> sortable && kind in EXACT_KINDS
+        }
+    }
+
+    companion object {
+        private val NUMERIC_KINDS = setOf(
+            Property.Kind.Byte,
+            Property.Kind.Short,
+            Property.Kind.Integer,
+            Property.Kind.Long,
+            Property.Kind.UnsignedLong,
+            Property.Kind.HalfFloat,
+            Property.Kind.Float,
+            Property.Kind.Double,
+            Property.Kind.ScaledFloat,
+            Property.Kind.TokenCount,
+        )
+        private val KEYWORD_KINDS = setOf(
+            Property.Kind.Keyword,
+            Property.Kind.ConstantKeyword,
+            Property.Kind.CountedKeyword,
+            Property.Kind.IcuCollationKeyword,
+        )
+        private val TERM_KINDS = KEYWORD_KINDS + Property.Kind.Wildcard
+        private val EXACT_KINDS = NUMERIC_KINDS + TERM_KINDS + setOf(
+            Property.Kind.Boolean,
+            Property.Kind.Date,
+            Property.Kind.DateNanos,
+            Property.Kind.Ip,
+            Property.Kind.Version,
+        )
+        private val LITERAL_KINDS = TERM_KINDS
+        private val RANGE_KINDS = NUMERIC_KINDS + KEYWORD_KINDS + setOf(
+            Property.Kind.Date,
+            Property.Kind.DateNanos,
+        )
+        private val SEARCH_KINDS = setOf(
+            Property.Kind.Text,
+            Property.Kind.MatchOnlyText,
+            Property.Kind.SearchAsYouType,
+        )
+    }
+}
+
+private fun RuntimeFieldType.toMappedField(): ElasticsearchMappedField? {
+    val kind = when (this) {
+        RuntimeFieldType.Boolean -> Property.Kind.Boolean
+        RuntimeFieldType.Date -> Property.Kind.Date
+        RuntimeFieldType.Double -> Property.Kind.Double
+        RuntimeFieldType.Ip -> Property.Kind.Ip
+        RuntimeFieldType.Keyword -> Property.Kind.Keyword
+        RuntimeFieldType.Long -> Property.Kind.Long
+        else -> return null
+    }
+    return ElasticsearchMappedField(
+        kind = kind,
+        indexed = true,
+        sortable = true,
+        multiFields = emptySet(),
+    )
+}
+
+private fun Property.hasDocValues(): Boolean =
+    when (_kind()) {
+        Property.Kind.ConstantKeyword,
+        Property.Kind.CountedKeyword,
+        -> true
+
+        else -> (_get() as? DocValuesPropertyBase)?.let { it.docValues() != false } == true
+    }
+
+private fun Property.isIndexed(): Boolean =
+    when (val property = _get()) {
+        is BooleanProperty -> property.index() != false
+        is CountedKeywordProperty -> property.index() != false
+        is DateNanosProperty -> property.index() != false
+        is DateProperty -> property.index() != false
+        is IcuCollationProperty -> property.index() != false
+        is IpProperty -> property.index() != false
+        is KeywordProperty -> property.index() != false
+        is NumberPropertyBase -> property.index() != false
+        is SearchAsYouTypeProperty -> property.index() != false
+        is TextProperty -> property.index() != false
+        is TokenCountProperty -> property.index() != false
+        else -> true
+    }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolver.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolver.kt
@@ -84,8 +84,6 @@ class ElasticsearchIndexMappingResolver(
                 refreshes.remove(indexName)
             }.doOnError {
                 refreshes.remove(indexName)
-            }.doOnCancel {
-                refreshes.remove(indexName)
             }.cache()
         }
 }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolver.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolver.kt
@@ -248,16 +248,14 @@ private data class ElasticsearchMappedField(
     val sortable: Boolean,
     val multiFields: Set<String>,
 ) {
-    fun supports(usage: ElasticsearchFieldUsage): Boolean {
-        if (!indexed) return false
-        return when (usage) {
-            ElasticsearchFieldUsage.EXACT -> kind in EXACT_KINDS
-            ElasticsearchFieldUsage.LITERAL -> kind in LITERAL_KINDS
-            ElasticsearchFieldUsage.RANGE -> kind in RANGE_KINDS
-            ElasticsearchFieldUsage.SEARCH -> kind in SEARCH_KINDS
+    fun supports(usage: ElasticsearchFieldUsage): Boolean =
+        when (usage) {
+            ElasticsearchFieldUsage.EXACT -> (indexed || sortable) && kind in EXACT_KINDS
+            ElasticsearchFieldUsage.LITERAL -> indexed && kind in LITERAL_KINDS
+            ElasticsearchFieldUsage.RANGE -> (indexed || sortable) && kind in RANGE_KINDS
+            ElasticsearchFieldUsage.SEARCH -> indexed && kind in SEARCH_KINDS
             ElasticsearchFieldUsage.SORT -> sortable && kind in EXACT_KINDS
         }
-    }
 
     companion object {
         private val NUMERIC_KINDS = setOf(

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolver.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolver.kt
@@ -18,6 +18,7 @@ import co.elastic.clients.elasticsearch._types.mapping.CountedKeywordProperty
 import co.elastic.clients.elasticsearch._types.mapping.DateNanosProperty
 import co.elastic.clients.elasticsearch._types.mapping.DateProperty
 import co.elastic.clients.elasticsearch._types.mapping.DocValuesPropertyBase
+import co.elastic.clients.elasticsearch._types.mapping.FlattenedProperty
 import co.elastic.clients.elasticsearch._types.mapping.IcuCollationProperty
 import co.elastic.clients.elasticsearch._types.mapping.IpProperty
 import co.elastic.clients.elasticsearch._types.mapping.KeywordProperty
@@ -97,7 +98,7 @@ data class ElasticsearchIndexMapping private constructor(
         get() = fields.size
 
     fun resolve(field: String, usage: ElasticsearchFieldUsage): String {
-        val mappedField = fields[field]
+        val mappedField = findMappedField(field)
             ?: resolutionFailure(
                 "Elasticsearch field [$field] is not mapped in index [$indexName].",
             )
@@ -125,6 +126,18 @@ data class ElasticsearchIndexMapping private constructor(
         resolutionFailure(
             "Elasticsearch field [$field] does not support ${usage.name.lowercase()} queries in index [$indexName].",
         )
+    }
+
+    private fun findMappedField(field: String): ElasticsearchMappedField? {
+        fields[field]?.let { return it }
+        var separator = field.lastIndexOf('.')
+        while (separator > 0) {
+            fields[field.substring(0, separator)]
+                ?.takeIf { it.kind == Property.Kind.Flattened }
+                ?.let { return it }
+            separator = field.lastIndexOf('.', separator - 1)
+        }
+        return null
     }
 
     fun requireNested(field: String): String {
@@ -250,12 +263,14 @@ private data class ElasticsearchMappedField(
 ) {
     fun supports(usage: ElasticsearchFieldUsage): Boolean =
         when (usage) {
-            ElasticsearchFieldUsage.EXACT -> (indexed || sortable) && kind in EXACT_KINDS
+            ElasticsearchFieldUsage.EXACT -> isQueryable() && kind in EXACT_KINDS
             ElasticsearchFieldUsage.LITERAL -> indexed && kind in LITERAL_KINDS
-            ElasticsearchFieldUsage.RANGE -> (indexed || sortable) && kind in RANGE_KINDS
+            ElasticsearchFieldUsage.RANGE -> isQueryable() && kind in RANGE_KINDS
             ElasticsearchFieldUsage.SEARCH -> indexed && kind in SEARCH_KINDS
             ElasticsearchFieldUsage.SORT -> sortable && kind in EXACT_KINDS
         }
+
+    private fun isQueryable(): Boolean = indexed || (sortable && kind in DOC_VALUE_QUERY_KINDS)
 
     companion object {
         private val NUMERIC_KINDS = setOf(
@@ -277,10 +292,17 @@ private data class ElasticsearchMappedField(
             Property.Kind.IcuCollationKeyword,
         )
         private val TERM_KINDS = KEYWORD_KINDS + Property.Kind.Wildcard
+        private val DOC_VALUE_QUERY_KINDS = NUMERIC_KINDS + KEYWORD_KINDS + setOf(
+            Property.Kind.Boolean,
+            Property.Kind.Date,
+            Property.Kind.DateNanos,
+            Property.Kind.Ip,
+        )
         private val EXACT_KINDS = NUMERIC_KINDS + TERM_KINDS + setOf(
             Property.Kind.Boolean,
             Property.Kind.Date,
             Property.Kind.DateNanos,
+            Property.Kind.Flattened,
             Property.Kind.Ip,
             Property.Kind.Version,
         )
@@ -288,6 +310,7 @@ private data class ElasticsearchMappedField(
         private val RANGE_KINDS = NUMERIC_KINDS + KEYWORD_KINDS + setOf(
             Property.Kind.Date,
             Property.Kind.DateNanos,
+            Property.Kind.Ip,
         )
         private val SEARCH_KINDS = setOf(
             Property.Kind.Text,
@@ -321,6 +344,7 @@ private fun Property.hasDocValues(): Boolean =
         Property.Kind.CountedKeyword,
         -> true
 
+        Property.Kind.Flattened -> flattened().docValues() != false
         else -> (_get() as? DocValuesPropertyBase)?.let { it.docValues() != false } == true
     }
 
@@ -330,6 +354,7 @@ private fun Property.isIndexed(): Boolean =
         is CountedKeywordProperty -> property.index() != false
         is DateNanosProperty -> property.index() != false
         is DateProperty -> property.index() != false
+        is FlattenedProperty -> property.index() != false
         is IcuCollationProperty -> property.index() != false
         is IpProperty -> property.index() != false
         is KeywordProperty -> property.index() != false

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryService.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryService.kt
@@ -15,14 +15,18 @@ package me.ahoo.wow.elasticsearch.query.snapshot
 
 import co.elastic.clients.elasticsearch._types.query_dsl.Query
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.MaterializedSnapshot
+import me.ahoo.wow.api.query.Sort
 import me.ahoo.wow.configuration.requiredAggregateType
 import me.ahoo.wow.elasticsearch.IndexNameConverter.toSnapshotIndexName
 import me.ahoo.wow.elasticsearch.eventsourcing.ElasticsearchSnapshotStore
 import me.ahoo.wow.elasticsearch.query.AbstractElasticsearchQueryService
 import me.ahoo.wow.elasticsearch.query.DEFAULT_PIT_KEEP_ALIVE
 import me.ahoo.wow.elasticsearch.query.DEFAULT_SEARCH_BATCH_SIZE
+import me.ahoo.wow.elasticsearch.query.ElasticsearchIndexMapping
+import me.ahoo.wow.elasticsearch.query.ElasticsearchIndexMappingResolver
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.query.converter.ConditionConverter
 import me.ahoo.wow.query.snapshot.SnapshotQueryService
@@ -38,6 +42,10 @@ class ElasticsearchSnapshotQueryService<S : Any>(
 ) : AbstractElasticsearchQueryService<MaterializedSnapshot<S>>(), SnapshotQueryService<S> {
     private var configuredQueryBatchSize: Int = DEFAULT_SEARCH_BATCH_SIZE
     private var configuredQueryKeepAlive: Duration = DEFAULT_PIT_KEEP_ALIVE
+    private var configuredIndexMappingResolver: ElasticsearchIndexMappingResolver? =
+        conditionConverter
+            .takeIf { it === SnapshotConditionConverter }
+            ?.let { ElasticsearchIndexMappingResolver(elasticsearchClient) }
 
     constructor(
         namedAggregate: NamedAggregate,
@@ -50,6 +58,17 @@ class ElasticsearchSnapshotQueryService<S : Any>(
         configuredQueryKeepAlive = queryKeepAlive
     }
 
+    constructor(
+        namedAggregate: NamedAggregate,
+        elasticsearchClient: ReactiveElasticsearchClient,
+        conditionConverter: ConditionConverter<Query>,
+        queryBatchSize: Int,
+        queryKeepAlive: Duration,
+        indexMappingResolver: ElasticsearchIndexMappingResolver,
+    ) : this(namedAggregate, elasticsearchClient, conditionConverter, queryBatchSize, queryKeepAlive) {
+        configuredIndexMappingResolver = indexMappingResolver.takeIf { conditionConverter === SnapshotConditionConverter }
+    }
+
     override val name: String
         get() = ElasticsearchSnapshotStore.NAME
     override val indexName: String = namedAggregate.toSnapshotIndexName()
@@ -57,6 +76,8 @@ class ElasticsearchSnapshotQueryService<S : Any>(
         get() = configuredQueryBatchSize
     protected override val queryKeepAlive: Duration
         get() = configuredQueryKeepAlive
+    override val indexMappingResolver: ElasticsearchIndexMappingResolver?
+        get() = configuredIndexMappingResolver
     private val snapshotType = JsonSerializer.typeFactory
         .constructParametricType(
             MaterializedSnapshot::class.java,
@@ -66,4 +87,10 @@ class ElasticsearchSnapshotQueryService<S : Any>(
     override fun toTypedResult(document: DynamicDocument): MaterializedSnapshot<S> {
         return document.convert(snapshotType)
     }
+
+    override fun resolveCondition(mapping: ElasticsearchIndexMapping, condition: Condition): Condition =
+        mapping.resolve(condition)
+
+    override fun resolveSort(mapping: ElasticsearchIndexMapping, sort: List<Sort>): List<Sort> =
+        mapping.resolve(sort)
 }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryServiceFactory.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryServiceFactory.kt
@@ -16,6 +16,7 @@ package me.ahoo.wow.elasticsearch.query.snapshot
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.elasticsearch.query.DEFAULT_PIT_KEEP_ALIVE
 import me.ahoo.wow.elasticsearch.query.DEFAULT_SEARCH_BATCH_SIZE
+import me.ahoo.wow.elasticsearch.query.ElasticsearchIndexMappingResolver
 import me.ahoo.wow.query.snapshot.AbstractSnapshotQueryServiceFactory
 import me.ahoo.wow.query.snapshot.SnapshotQueryService
 import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
@@ -26,11 +27,22 @@ class ElasticsearchSnapshotQueryServiceFactory(
     private val queryBatchSize: Int,
     private val queryKeepAlive: Duration,
 ) : AbstractSnapshotQueryServiceFactory() {
+    private var indexMappingResolver = ElasticsearchIndexMappingResolver(elasticsearchClient)
+
     constructor(elasticsearchClient: ReactiveElasticsearchClient) : this(
         elasticsearchClient,
         DEFAULT_SEARCH_BATCH_SIZE,
         DEFAULT_PIT_KEEP_ALIVE,
     )
+
+    constructor(
+        elasticsearchClient: ReactiveElasticsearchClient,
+        queryBatchSize: Int,
+        queryKeepAlive: Duration,
+        indexMappingResolver: ElasticsearchIndexMappingResolver,
+    ) : this(elasticsearchClient, queryBatchSize, queryKeepAlive) {
+        this.indexMappingResolver = indexMappingResolver
+    }
 
     override fun createQueryService(namedAggregate: NamedAggregate): SnapshotQueryService<*> {
         return ElasticsearchSnapshotQueryService<Any>(
@@ -39,6 +51,7 @@ class ElasticsearchSnapshotQueryServiceFactory(
             SnapshotConditionConverter,
             queryBatchSize,
             queryKeepAlive,
+            indexMappingResolver,
         )
     }
 }

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryServiceTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryServiceTest.kt
@@ -167,6 +167,36 @@ class AbstractElasticsearchQueryServiceTest {
     }
 
     @Test
+    fun `mapping resolver should preserve fields through default hooks`() {
+        val indicesClient = mockk<ReactiveElasticsearchIndicesClient>()
+        val request = slot<SearchRequest>()
+        val convertedCondition = slot<Condition>()
+        every { elasticsearchClient.indices() } returns indicesClient
+        every { indicesClient.getMapping(any<GetMappingRequest>()) } returns Mono.just(emptyMappingResponse())
+        every { conditionConverter.convert(capture(convertedCondition)) } returns matchAll { it }
+        every { elasticsearchClient.search(capture(request), Map::class.java) } returns Mono.just(
+            searchResponse(total = null),
+        )
+        val condition = Condition.eq("logicalField", "value")
+        val service = MappingTestElasticsearchQueryService(
+            elasticsearchClient,
+            conditionConverter,
+            ElasticsearchIndexMappingResolver(elasticsearchClient),
+        )
+
+        service.dynamicList(
+            ListQuery(
+                condition = condition,
+                sort = listOf(Sort("logicalField", Sort.Direction.ASC)),
+                limit = 1,
+            ),
+        ).collectList().block()
+
+        convertedCondition.captured.assert().isEqualTo(condition)
+        request.captured.sort().single().field().field().assert().isEqualTo("logicalField")
+    }
+
+    @Test
     fun `dynamic list should reject negative limit before searching`() {
         assertThrows<IllegalArgumentException> {
             queryService.dynamicList(ListQuery(Condition.ALL, limit = -1))
@@ -251,7 +281,7 @@ class AbstractElasticsearchQueryServiceTest {
             )
         }
 
-    private class TestElasticsearchQueryService(
+    private open class TestElasticsearchQueryService(
         override val elasticsearchClient: ReactiveElasticsearchClient,
         override val conditionConverter: ConditionConverter<Query>,
     ) : AbstractElasticsearchQueryService<DynamicDocument>() {
@@ -260,4 +290,10 @@ class AbstractElasticsearchQueryServiceTest {
 
         override fun toTypedResult(document: DynamicDocument): DynamicDocument = document
     }
+
+    private class MappingTestElasticsearchQueryService(
+        elasticsearchClient: ReactiveElasticsearchClient,
+        conditionConverter: ConditionConverter<Query>,
+        override val indexMappingResolver: ElasticsearchIndexMappingResolver,
+    ) : TestElasticsearchQueryService(elasticsearchClient, conditionConverter)
 }

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryServiceTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryServiceTest.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.elasticsearch.query
 
 import co.elastic.clients.elasticsearch._types.SortOrder
+import co.elastic.clients.elasticsearch._types.mapping.TypeMapping
 import co.elastic.clients.elasticsearch._types.query_dsl.Query
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.matchAll
 import co.elastic.clients.elasticsearch.core.ClosePointInTimeRequest
@@ -25,6 +26,9 @@ import co.elastic.clients.elasticsearch.core.OpenPointInTimeResponse
 import co.elastic.clients.elasticsearch.core.SearchRequest
 import co.elastic.clients.elasticsearch.core.SearchResponse
 import co.elastic.clients.elasticsearch.core.search.TotalHitsRelation
+import co.elastic.clients.elasticsearch.indices.GetMappingRequest
+import co.elastic.clients.elasticsearch.indices.GetMappingResponse
+import co.elastic.clients.elasticsearch.indices.get_mapping.IndexMappingRecord
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -44,6 +48,7 @@ import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
+import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchIndicesClient
 import reactor.core.publisher.Mono
 import java.time.Duration
 
@@ -139,6 +144,9 @@ class AbstractElasticsearchQueryServiceTest {
     fun `configured snapshot factory should propagate pager settings`() {
         val openRequest = slot<OpenPointInTimeRequest>()
         val searchRequest = slot<SearchRequest>()
+        val indicesClient = mockk<ReactiveElasticsearchIndicesClient>()
+        every { elasticsearchClient.indices() } returns indicesClient
+        every { indicesClient.getMapping(any<GetMappingRequest>()) } returns Mono.just(emptyMappingResponse())
         every { elasticsearchClient.openPointInTime(capture(openRequest)) } returns Mono.just(openPointInTimeResponse())
         every { elasticsearchClient.search(capture(searchRequest), Map::class.java) } returns Mono.just(
             searchResponse(total = null, pitId = "pit-2")
@@ -234,6 +242,14 @@ class AbstractElasticsearchQueryServiceTest {
     private fun closePointInTimeResponse(): ClosePointInTimeResponse {
         return ClosePointInTimeResponse.of { it.succeeded(true).numFreed(1) }
     }
+
+    private fun emptyMappingResponse(): GetMappingResponse =
+        GetMappingResponse.of { response ->
+            response.mappings(
+                "wow.test.aggregate.snapshot",
+                IndexMappingRecord.of { record -> record.mappings(TypeMapping.of { it }) },
+            )
+        }
 
     private class TestElasticsearchQueryService(
         override val elasticsearchClient: ReactiveElasticsearchClient,

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolverTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolverTest.kt
@@ -222,9 +222,9 @@ class ElasticsearchIndexMappingResolverTest {
     }
 
     @Test
-    fun `should honor index capability across mapped field types`() {
+    fun `should honor index and doc values capabilities across mapped field types`() {
         val mapping = ElasticsearchIndexMapping.from(INDEX, indexedFieldVariants())
-        val usages = mapOf(
+        val docValueUsages = mapOf(
             "boolean" to ElasticsearchFieldUsage.EXACT,
             "countedKeyword" to ElasticsearchFieldUsage.EXACT,
             "dateNanos" to ElasticsearchFieldUsage.RANGE,
@@ -233,16 +233,21 @@ class ElasticsearchIndexMappingResolverTest {
             "ip" to ElasticsearchFieldUsage.EXACT,
             "keyword" to ElasticsearchFieldUsage.EXACT,
             "integer" to ElasticsearchFieldUsage.RANGE,
-            "searchAsYouType" to ElasticsearchFieldUsage.SEARCH,
-            "text" to ElasticsearchFieldUsage.SEARCH,
             "tokenCount" to ElasticsearchFieldUsage.RANGE,
         )
 
-        usages.forEach { (field, usage) ->
+        docValueUsages.forEach { (field, usage) ->
             mapping.resolve("${field}True", usage).assert().isEqualTo("${field}True")
-            runCatching { mapping.resolve("${field}False", usage) }
+            mapping.resolve("${field}False", usage).assert().isEqualTo("${field}False")
+        }
+        listOf("searchAsYouType", "text").forEach { field ->
+            mapping.resolve("${field}True", ElasticsearchFieldUsage.SEARCH).assert().isEqualTo("${field}True")
+            runCatching { mapping.resolve("${field}False", ElasticsearchFieldUsage.SEARCH) }
                 .exceptionOrNull()!!.message.assert().contains("does not support")
         }
+        runCatching { mapping.resolve("keywordFalse", ElasticsearchFieldUsage.LITERAL) }
+            .exceptionOrNull()!!.message.assert().contains("does not support")
+        mapping.resolve("keywordFalse", ElasticsearchFieldUsage.SORT).assert().isEqualTo("keywordFalse")
         mapping.resolve("constantKeyword", ElasticsearchFieldUsage.SORT)
             .assert().isEqualTo("constantKeyword")
         mapping.resolve("countedKeywordTrue", ElasticsearchFieldUsage.SORT)

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolverTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolverTest.kt
@@ -62,6 +62,16 @@ class ElasticsearchIndexMappingResolverTest {
     }
 
     @Test
+    fun `refreshing an unchanged mapping should report no change`() {
+        val response = mappingResponse(textWithKeyword())
+        every { indicesClient.getMapping(any<GetMappingRequest>()) } returns Mono.just(response)
+        val resolver = ElasticsearchIndexMappingResolver(client)
+
+        resolver.currentOrLoad(INDEX).block()!!.fieldCount.assert().isEqualTo(6)
+        resolver.refresh(INDEX).block()!!.changed.assert().isFalse()
+    }
+
+    @Test
     fun `failed refresh should keep previous mapping and retry later`() {
         val initial = mappingResponse(textWithKeyword())
         val refreshed = mappingResponse(keywordOnly())
@@ -170,6 +180,18 @@ class ElasticsearchIndexMappingResolverTest {
     }
 
     @Test
+    fun `should use a unique compatible multi-field and reject missing paths`() {
+        val mapping = ElasticsearchIndexMapping.from(INDEX, multiFieldFallbacks())
+
+        mapping.resolve("state.name", ElasticsearchFieldUsage.EXACT).assert().isEqualTo("state.name.raw")
+        mapping.resolve("state.code", ElasticsearchFieldUsage.SEARCH).assert().isEqualTo("state.code.text")
+        runCatching { mapping.resolve("state.missing", ElasticsearchFieldUsage.EXACT) }
+            .exceptionOrNull()!!.message.assert().contains("not mapped")
+        runCatching { mapping.requireNested("state.missing") }
+            .exceptionOrNull()!!.message.assert().contains("not mapped")
+    }
+
+    @Test
     fun `should preserve field alias and runtime field query compatibility`() {
         val mapping = ElasticsearchIndexMapping.from(INDEX, aliasAndRuntimeFields())
 
@@ -183,8 +205,48 @@ class ElasticsearchIndexMappingResolverTest {
             .assert().isEqualTo("state.runtimeScore")
         mapping.resolve("state.runtimeAt", ElasticsearchFieldUsage.SORT)
             .assert().isEqualTo("state.runtimeAt")
+        mapping.resolve("state.runtimeEnabled", ElasticsearchFieldUsage.EXACT)
+            .assert().isEqualTo("state.runtimeEnabled")
+        mapping.resolve("state.runtimeIp", ElasticsearchFieldUsage.EXACT)
+            .assert().isEqualTo("state.runtimeIp")
+        mapping.resolve("state.runtimeLong", ElasticsearchFieldUsage.RANGE)
+            .assert().isEqualTo("state.runtimeLong")
         mapping.resolve("state.runtime.code", ElasticsearchFieldUsage.EXACT)
             .assert().isEqualTo("state.runtime.code")
+        runCatching { mapping.resolve("state.runtimeGeo", ElasticsearchFieldUsage.EXACT) }
+            .exceptionOrNull()!!.message.assert().contains("not mapped")
+        runCatching { mapping.resolve("state.runtime.geo", ElasticsearchFieldUsage.EXACT) }
+            .exceptionOrNull()!!.message.assert().contains("not mapped")
+        runCatching { mapping.resolve("state.missingAlias", ElasticsearchFieldUsage.EXACT) }
+            .exceptionOrNull()!!.message.assert().contains("not mapped")
+    }
+
+    @Test
+    fun `should honor index capability across mapped field types`() {
+        val mapping = ElasticsearchIndexMapping.from(INDEX, indexedFieldVariants())
+        val usages = mapOf(
+            "boolean" to ElasticsearchFieldUsage.EXACT,
+            "countedKeyword" to ElasticsearchFieldUsage.EXACT,
+            "dateNanos" to ElasticsearchFieldUsage.RANGE,
+            "date" to ElasticsearchFieldUsage.RANGE,
+            "icu" to ElasticsearchFieldUsage.EXACT,
+            "ip" to ElasticsearchFieldUsage.EXACT,
+            "keyword" to ElasticsearchFieldUsage.EXACT,
+            "integer" to ElasticsearchFieldUsage.RANGE,
+            "searchAsYouType" to ElasticsearchFieldUsage.SEARCH,
+            "text" to ElasticsearchFieldUsage.SEARCH,
+            "tokenCount" to ElasticsearchFieldUsage.RANGE,
+        )
+
+        usages.forEach { (field, usage) ->
+            mapping.resolve("${field}True", usage).assert().isEqualTo("${field}True")
+            runCatching { mapping.resolve("${field}False", usage) }
+                .exceptionOrNull()!!.message.assert().contains("does not support")
+        }
+        mapping.resolve("constantKeyword", ElasticsearchFieldUsage.SORT)
+            .assert().isEqualTo("constantKeyword")
+        mapping.resolve("countedKeywordTrue", ElasticsearchFieldUsage.SORT)
+            .assert().isEqualTo("countedKeywordTrue")
     }
 
     private fun mappingResponse(mapping: TypeMapping): GetMappingResponse =
@@ -225,6 +287,21 @@ class ElasticsearchIndexMappingResolverTest {
             items = Property.of { property -> property.`object` { it } },
         )
 
+    private fun multiFieldFallbacks(): TypeMapping =
+        stateMapping(
+            name = Property.of { property ->
+                property.text { text ->
+                    text.fields("keyword") { child -> child.text { it } }
+                        .fields("raw") { keyword -> keyword.keyword { it } }
+                }
+            },
+            code = Property.of { property ->
+                property.keyword { keyword ->
+                    keyword.fields("text") { text -> text.text { it } }
+                }
+            },
+        )
+
     private fun aliasAndRuntimeFields(): TypeMapping =
         TypeMapping.of { mapping ->
             mapping
@@ -235,14 +312,48 @@ class ElasticsearchIndexMappingResolverTest {
                             .properties("code") { it.keyword { keyword -> keyword } }
                             .properties("nameAlias") { it.alias { alias -> alias.path("state.name") } }
                             .properties("codeAlias") { it.alias { alias -> alias.path("state.code") } }
+                            .properties("missingAlias") { it.alias { alias -> alias.path("state.missing") } }
                     }
                 }.runtime("state.runtimeCode") { it.type(RuntimeFieldType.Keyword) }
                 .runtime("state.runtimeScore") { it.type(RuntimeFieldType.Double) }
                 .runtime("state.runtimeAt") { it.type(RuntimeFieldType.Date) }
+                .runtime("state.runtimeEnabled") { it.type(RuntimeFieldType.Boolean) }
+                .runtime("state.runtimeIp") { it.type(RuntimeFieldType.Ip) }
+                .runtime("state.runtimeLong") { it.type(RuntimeFieldType.Long) }
+                .runtime("state.runtimeGeo") { it.type(RuntimeFieldType.GeoPoint) }
                 .runtime("state.runtime") { runtime ->
                     runtime.type(RuntimeFieldType.Composite)
                         .fields("code") { it.type(RuntimeFieldType.Keyword) }
+                        .fields("geo") { it.type(RuntimeFieldType.GeoPoint) }
                 }
+        }
+
+    private fun indexedFieldVariants(): TypeMapping =
+        TypeMapping.of { mapping ->
+            mapping
+                .properties("booleanTrue") { it.boolean_ { field -> field.index(true) } }
+                .properties("booleanFalse") { it.boolean_ { field -> field.index(false) } }
+                .properties("constantKeyword") { it.constantKeyword { field -> field } }
+                .properties("countedKeywordTrue") { it.countedKeyword { field -> field.index(true) } }
+                .properties("countedKeywordFalse") { it.countedKeyword { field -> field.index(false) } }
+                .properties("dateNanosTrue") { it.dateNanos { field -> field.index(true) } }
+                .properties("dateNanosFalse") { it.dateNanos { field -> field.index(false) } }
+                .properties("dateTrue") { it.date { field -> field.index(true) } }
+                .properties("dateFalse") { it.date { field -> field.index(false) } }
+                .properties("icuTrue") { it.icuCollationKeyword { field -> field.index(true) } }
+                .properties("icuFalse") { it.icuCollationKeyword { field -> field.index(false) } }
+                .properties("ipTrue") { it.ip { field -> field.index(true) } }
+                .properties("ipFalse") { it.ip { field -> field.index(false) } }
+                .properties("keywordTrue") { it.keyword { field -> field.index(true) } }
+                .properties("keywordFalse") { it.keyword { field -> field.index(false) } }
+                .properties("integerTrue") { it.integer { field -> field.index(true) } }
+                .properties("integerFalse") { it.integer { field -> field.index(false) } }
+                .properties("searchAsYouTypeTrue") { it.searchAsYouType { field -> field.index(true) } }
+                .properties("searchAsYouTypeFalse") { it.searchAsYouType { field -> field.index(false) } }
+                .properties("textTrue") { it.text { field -> field.index(true) } }
+                .properties("textFalse") { it.text { field -> field.index(false) } }
+                .properties("tokenCountTrue") { it.tokenCount { field -> field.index(true) } }
+                .properties("tokenCountFalse") { it.tokenCount { field -> field.index(false) } }
         }
 
     private fun stateMapping(

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolverTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolverTest.kt
@@ -1,0 +1,271 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.elasticsearch.query
+
+import co.elastic.clients.elasticsearch._types.mapping.Property
+import co.elastic.clients.elasticsearch._types.mapping.RuntimeFieldType
+import co.elastic.clients.elasticsearch._types.mapping.TypeMapping
+import co.elastic.clients.elasticsearch.indices.GetMappingRequest
+import co.elastic.clients.elasticsearch.indices.GetMappingResponse
+import co.elastic.clients.elasticsearch.indices.get_mapping.IndexMappingRecord
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.Sort
+import org.junit.jupiter.api.Test
+import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
+import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchIndicesClient
+import reactor.core.publisher.Mono
+import reactor.core.publisher.Sinks
+import reactor.kotlin.test.test
+
+class ElasticsearchIndexMappingResolverTest {
+    private val client = mockk<ReactiveElasticsearchClient>()
+    private val indicesClient = mockk<ReactiveElasticsearchIndicesClient>()
+
+    init {
+        every { client.indices() } returns indicesClient
+    }
+
+    @Test
+    fun `should cache successful mapping and actively refresh it`() {
+        val initial = mappingResponse(textWithKeyword())
+        val refreshed = mappingResponse(keywordOnly())
+        every { indicesClient.getMapping(any<GetMappingRequest>()) } returnsMany
+            listOf(Mono.just(initial), Mono.just(refreshed))
+        val resolver = ElasticsearchIndexMappingResolver(client)
+
+        resolver.currentOrLoad(INDEX).block()!!.resolve("state.name", ElasticsearchFieldUsage.SEARCH)
+            .assert().isEqualTo("state.name")
+        resolver.currentOrLoad(INDEX).block()!!.resolve("state.name", ElasticsearchFieldUsage.SEARCH)
+            .assert().isEqualTo("state.name")
+
+        val refreshResult = resolver.refresh(INDEX).block()!!
+        refreshResult.changed.assert().isTrue()
+        refreshResult.mapping.resolve("state.name", ElasticsearchFieldUsage.EXACT)
+            .assert().isEqualTo("state.name")
+        resolver.currentOrLoad(INDEX).block()!!.resolve("state.name", ElasticsearchFieldUsage.EXACT)
+            .assert().isEqualTo("state.name")
+    }
+
+    @Test
+    fun `failed refresh should keep previous mapping and retry later`() {
+        val initial = mappingResponse(textWithKeyword())
+        val refreshed = mappingResponse(keywordOnly())
+        every { indicesClient.getMapping(any<GetMappingRequest>()) } returnsMany listOf(
+            Mono.just(initial),
+            Mono.error(IllegalStateException("unavailable")),
+            Mono.just(refreshed),
+        )
+        val resolver = ElasticsearchIndexMappingResolver(client)
+        resolver.currentOrLoad(INDEX).block()
+
+        resolver.refresh(INDEX).test()
+            .expectErrorMessage("unavailable")
+            .verify()
+        resolver.currentOrLoad(INDEX).block()!!.resolve("state.name", ElasticsearchFieldUsage.SEARCH)
+            .assert().isEqualTo("state.name")
+
+        resolver.refresh(INDEX).block()!!.changed.assert().isTrue()
+    }
+
+    @Test
+    fun `concurrent loads should share one mapping request`() {
+        val response = Sinks.one<GetMappingResponse>()
+        every { indicesClient.getMapping(any<GetMappingRequest>()) } returns response.asMono()
+        val resolver = ElasticsearchIndexMappingResolver(client)
+
+        val verifier = Mono.zip(resolver.currentOrLoad(INDEX), resolver.currentOrLoad(INDEX)).test()
+        response.tryEmitValue(mappingResponse(textWithKeyword()))
+
+        verifier.expectNextCount(1).verifyComplete()
+        verify(exactly = 1) { indicesClient.getMapping(any<GetMappingRequest>()) }
+    }
+
+    @Test
+    fun `multiple physical indices should fail closed`() {
+        every { indicesClient.getMapping(any<GetMappingRequest>()) } returns Mono.just(
+            GetMappingResponse.of { response ->
+                response
+                    .mappings(
+                        "$INDEX-000001",
+                        IndexMappingRecord.of { record -> record.mappings(textWithKeyword()) },
+                    ).mappings(
+                        "$INDEX-000002",
+                        IndexMappingRecord.of { record -> record.mappings(textWithKeyword()) },
+                    )
+            },
+        )
+
+        ElasticsearchIndexMappingResolver(client).currentOrLoad(INDEX).test()
+            .expectErrorMatches {
+                it.message!!.startsWith(
+                    "Elasticsearch index [$INDEX] must resolve to exactly one physical index",
+                )
+            }.verify()
+    }
+
+    @Test
+    fun `should resolve fields by operation capability`() {
+        val mapping = ElasticsearchIndexMapping.from(INDEX, textWithKeyword())
+
+        mapping.resolve("state.name", ElasticsearchFieldUsage.EXACT).assert().isEqualTo("state.name.keyword")
+        mapping.resolve("state.name", ElasticsearchFieldUsage.LITERAL).assert().isEqualTo("state.name.keyword")
+        mapping.resolve("state.name", ElasticsearchFieldUsage.SEARCH).assert().isEqualTo("state.name")
+        mapping.resolve("state.name", ElasticsearchFieldUsage.SORT).assert().isEqualTo("state.name.keyword")
+        mapping.requireNested("state.items").assert().isEqualTo("state.items")
+
+        val condition = mapping.resolve(
+            Condition.and(
+                Condition.eq("state.name", "Wow"),
+                Condition.match("state.name", "Wow"),
+                Condition.contains("state.name", "ow"),
+                Condition.gt("state.age", 18),
+                Condition.exists("state.name"),
+            ),
+        )
+        condition.children.map { it.field }.assert().containsExactly(
+            "state.name.keyword",
+            "state.name",
+            "state.name.keyword",
+            "state.age",
+            "state.name",
+        )
+        mapping.resolve(listOf(Sort("state.name", Sort.Direction.ASC))).single().field
+            .assert().isEqualTo("state.name.keyword")
+        val elementMatch = mapping.resolve(
+            Condition.elemMatch("state.items", Condition.eq("state.items.name", "item")),
+        )
+        elementMatch.field.assert().isEqualTo("state.items")
+        elementMatch.children.single().field.assert().isEqualTo("state.items.name")
+        val raw = Condition.raw("""{"match_all":{}}""")
+        mapping.resolve(raw).assert().isEqualTo(raw)
+    }
+
+    @Test
+    fun `should fail closed for unsupported and ambiguous fields`() {
+        val mapping = ElasticsearchIndexMapping.from(INDEX, ambiguousText())
+
+        runCatching { mapping.resolve("state.name", ElasticsearchFieldUsage.EXACT) }
+            .exceptionOrNull()!!.message.assert().contains("ambiguous")
+        runCatching { mapping.resolve("state.code", ElasticsearchFieldUsage.SEARCH) }
+            .exceptionOrNull()!!.message.assert().contains("does not support")
+        runCatching { mapping.resolve("state.code", ElasticsearchFieldUsage.SORT) }
+            .exceptionOrNull()!!.message.assert().contains("does not support")
+        runCatching { mapping.requireNested("state.objectItems") }
+            .exceptionOrNull()!!.message.assert().contains("nested")
+    }
+
+    @Test
+    fun `should preserve field alias and runtime field query compatibility`() {
+        val mapping = ElasticsearchIndexMapping.from(INDEX, aliasAndRuntimeFields())
+
+        mapping.resolve("state.nameAlias", ElasticsearchFieldUsage.SEARCH)
+            .assert().isEqualTo("state.nameAlias")
+        mapping.resolve("state.codeAlias", ElasticsearchFieldUsage.EXACT)
+            .assert().isEqualTo("state.codeAlias")
+        mapping.resolve("state.runtimeCode", ElasticsearchFieldUsage.LITERAL)
+            .assert().isEqualTo("state.runtimeCode")
+        mapping.resolve("state.runtimeScore", ElasticsearchFieldUsage.RANGE)
+            .assert().isEqualTo("state.runtimeScore")
+        mapping.resolve("state.runtimeAt", ElasticsearchFieldUsage.SORT)
+            .assert().isEqualTo("state.runtimeAt")
+        mapping.resolve("state.runtime.code", ElasticsearchFieldUsage.EXACT)
+            .assert().isEqualTo("state.runtime.code")
+    }
+
+    private fun mappingResponse(mapping: TypeMapping): GetMappingResponse =
+        GetMappingResponse.of { response ->
+            response.mappings(
+                INDEX,
+                IndexMappingRecord.of { record -> record.mappings(mapping) },
+            )
+        }
+
+    private fun textWithKeyword(): TypeMapping =
+        stateMapping(
+            name = Property.of { property ->
+                property.text { text ->
+                    text.fields("keyword") { keyword -> keyword.keyword { it } }
+                }
+            },
+            age = Property.of { property -> property.integer { it } },
+            items = Property.of { property ->
+                property.nested { nested ->
+                    nested.properties("name") { it.keyword { keyword -> keyword } }
+                }
+            },
+        )
+
+    private fun keywordOnly(): TypeMapping =
+        stateMapping(name = Property.of { property -> property.keyword { it } })
+
+    private fun ambiguousText(): TypeMapping =
+        stateMapping(
+            name = Property.of { property ->
+                property.text { text ->
+                    text.fields("raw") { keyword -> keyword.keyword { it } }
+                        .fields("normalized") { keyword -> keyword.keyword { it } }
+                }
+            },
+            code = Property.of { property -> property.keyword { it.docValues(false) } },
+            items = Property.of { property -> property.`object` { it } },
+        )
+
+    private fun aliasAndRuntimeFields(): TypeMapping =
+        TypeMapping.of { mapping ->
+            mapping
+                .properties("state") { state ->
+                    state.`object` { objectField ->
+                        objectField
+                            .properties("name") { it.text { text -> text } }
+                            .properties("code") { it.keyword { keyword -> keyword } }
+                            .properties("nameAlias") { it.alias { alias -> alias.path("state.name") } }
+                            .properties("codeAlias") { it.alias { alias -> alias.path("state.code") } }
+                    }
+                }.runtime("state.runtimeCode") { it.type(RuntimeFieldType.Keyword) }
+                .runtime("state.runtimeScore") { it.type(RuntimeFieldType.Double) }
+                .runtime("state.runtimeAt") { it.type(RuntimeFieldType.Date) }
+                .runtime("state.runtime") { runtime ->
+                    runtime.type(RuntimeFieldType.Composite)
+                        .fields("code") { it.type(RuntimeFieldType.Keyword) }
+                }
+        }
+
+    private fun stateMapping(
+        name: Property,
+        code: Property? = null,
+        age: Property? = null,
+        items: Property? = null,
+    ): TypeMapping =
+        TypeMapping.of { mapping ->
+            mapping.properties("state") { state ->
+                state.`object` { objectField ->
+                    objectField.properties("name", name)
+                    code?.let { objectField.properties("code", it) }
+                    age?.let { objectField.properties("age", it) }
+                    items?.let {
+                        objectField.properties(if (it._kind() == Property.Kind.Nested) "items" else "objectItems", it)
+                    }
+                    objectField
+                }
+            }
+        }
+
+    companion object {
+        private const val INDEX = "wow.catalog.sku.snapshot"
+    }
+}

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolverTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolverTest.kt
@@ -274,6 +274,30 @@ class ElasticsearchIndexMappingResolverTest {
             .assert().isEqualTo("countedKeywordTrue")
     }
 
+    @Test
+    fun `should support range semantic text fielddata and metadata sorts`() {
+        val mapping = ElasticsearchIndexMapping.from(INDEX, specialCapabilities())
+
+        listOf("integerRange", "floatRange", "longRange", "doubleRange", "dateRange", "ipRange").forEach {
+            mapping.resolve(it, ElasticsearchFieldUsage.RANGE).assert().isEqualTo(it)
+        }
+        mapping.resolve("semanticText", ElasticsearchFieldUsage.SEARCH).assert().isEqualTo("semanticText")
+        mapping.resolve("fielddataText", ElasticsearchFieldUsage.SORT).assert().isEqualTo("fielddataText")
+        listOf("integerRange", "plainText", "unindexedFielddataText").forEach {
+            runCatching { mapping.resolve(it, ElasticsearchFieldUsage.SORT) }
+                .exceptionOrNull()!!.message.assert().contains("does not support")
+        }
+        runCatching { mapping.resolve("unindexedRange", ElasticsearchFieldUsage.RANGE) }
+            .exceptionOrNull()!!.message.assert().contains("does not support")
+        mapping.resolve(
+            listOf(
+                Sort("_score", Sort.Direction.DESC),
+                Sort("_doc", Sort.Direction.ASC),
+                Sort("_shard_doc", Sort.Direction.ASC),
+            ),
+        ).map { it.field }.assert().containsExactly("_score", "_doc", "_shard_doc")
+    }
+
     private fun mappingResponse(mapping: TypeMapping): GetMappingResponse =
         GetMappingResponse.of { response ->
             response.mappings(
@@ -395,6 +419,22 @@ class ElasticsearchIndexMappingResolverTest {
                 .properties("textFalse") { it.text { field -> field.index(false) } }
                 .properties("tokenCountTrue") { it.tokenCount { field -> field.index(true) } }
                 .properties("tokenCountFalse") { it.tokenCount { field -> field.index(false) } }
+        }
+
+    private fun specialCapabilities(): TypeMapping =
+        TypeMapping.of { mapping ->
+            mapping
+                .properties("integerRange") { it.integerRange { field -> field } }
+                .properties("floatRange") { it.floatRange { field -> field } }
+                .properties("longRange") { it.longRange { field -> field } }
+                .properties("doubleRange") { it.doubleRange { field -> field } }
+                .properties("dateRange") { it.dateRange { field -> field } }
+                .properties("ipRange") { it.ipRange { field -> field } }
+                .properties("unindexedRange") { it.integerRange { field -> field.index(false) } }
+                .properties("semanticText") { it.semanticText { field -> field } }
+                .properties("plainText") { it.text { field -> field } }
+                .properties("fielddataText") { it.text { field -> field.fielddata(true) } }
+                .properties("unindexedFielddataText") { it.text { field -> field.index(false).fielddata(true) } }
         }
 
     private fun stateMapping(

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolverTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolverTest.kt
@@ -192,6 +192,26 @@ class ElasticsearchIndexMappingResolverTest {
     }
 
     @Test
+    fun `should resolve concrete paths through a flattened parent`() {
+        val mapping = ElasticsearchIndexMapping.from(INDEX, flattenedFields())
+
+        mapping.resolve("state.labels.release", ElasticsearchFieldUsage.EXACT)
+            .assert().isEqualTo("state.labels.release")
+        mapping.resolve("state.labels.release", ElasticsearchFieldUsage.SORT)
+            .assert().isEqualTo("state.labels.release")
+        mapping.resolve("state.labels.host.ip", ElasticsearchFieldUsage.RANGE)
+            .assert().isEqualTo("state.labels.host.ip")
+        runCatching { mapping.resolve("state.labels.release", ElasticsearchFieldUsage.LITERAL) }
+            .exceptionOrNull()!!.message.assert().contains("does not support")
+        runCatching { mapping.resolve("state.labels.release", ElasticsearchFieldUsage.RANGE) }
+            .exceptionOrNull()!!.message.assert().contains("does not support")
+        runCatching { mapping.resolve("state.unindexedLabels.release", ElasticsearchFieldUsage.EXACT) }
+            .exceptionOrNull()!!.message.assert().contains("does not support")
+        mapping.resolve("state.unindexedLabels.release", ElasticsearchFieldUsage.SORT)
+            .assert().isEqualTo("state.unindexedLabels.release")
+    }
+
+    @Test
     fun `should preserve field alias and runtime field query compatibility`() {
         val mapping = ElasticsearchIndexMapping.from(INDEX, aliasAndRuntimeFields())
 
@@ -306,6 +326,22 @@ class ElasticsearchIndexMappingResolverTest {
                 }
             },
         )
+
+    private fun flattenedFields(): TypeMapping =
+        TypeMapping.of { mapping ->
+            mapping.properties("state") { state ->
+                state.`object` { objectField ->
+                    objectField
+                        .properties("labels") { labels ->
+                            labels.flattened { flattened ->
+                                flattened.properties("host.ip") { field -> field.ip { it } }
+                            }
+                        }.properties("unindexedLabels") { labels ->
+                            labels.flattened { flattened -> flattened.index(false) }
+                        }
+                }
+            }
+        }
 
     private fun aliasAndRuntimeFields(): TypeMapping =
         TypeMapping.of { mapping ->

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotMappingQueryTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotMappingQueryTest.kt
@@ -1,0 +1,163 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.elasticsearch.query.snapshot
+
+import co.elastic.clients.elasticsearch._types.mapping.TypeMapping
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.matchAll
+import co.elastic.clients.elasticsearch.core.SearchRequest
+import co.elastic.clients.elasticsearch.core.SearchResponse
+import co.elastic.clients.elasticsearch.indices.GetMappingRequest
+import co.elastic.clients.elasticsearch.indices.GetMappingResponse
+import co.elastic.clients.elasticsearch.indices.get_mapping.IndexMappingRecord
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.ListQuery
+import me.ahoo.wow.api.query.Projection
+import me.ahoo.wow.api.query.Sort
+import me.ahoo.wow.elasticsearch.query.DEFAULT_PIT_KEEP_ALIVE
+import me.ahoo.wow.elasticsearch.query.DEFAULT_SEARCH_BATCH_SIZE
+import me.ahoo.wow.elasticsearch.query.ElasticsearchIndexMappingResolver
+import me.ahoo.wow.query.converter.ConditionConverter
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
+import org.junit.jupiter.api.Test
+import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
+import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchIndicesClient
+import reactor.core.publisher.Mono
+
+class ElasticsearchSnapshotMappingQueryTest {
+    private val client = mockk<ReactiveElasticsearchClient>()
+    private val indicesClient = mockk<ReactiveElasticsearchIndicesClient>()
+    private val searchRequest = slot<SearchRequest>()
+
+    init {
+        every { client.indices() } returns indicesClient
+        every { client.search(capture(searchRequest), Map::class.java) } returns Mono.just(emptySearchResponse())
+    }
+
+    @Test
+    fun `default snapshot query should compile fields from current mapping`() {
+        every { indicesClient.getMapping(any<GetMappingRequest>()) } returns Mono.just(
+            mappingResponse(queryMapping()),
+        )
+        val condition = Condition.and(
+            Condition.eq("state.name", "Wow"),
+            Condition.match("state.name", "Wow"),
+            Condition.contains("state.name", "ow"),
+            Condition.gt("state.age", 18),
+        )
+
+        queryService().dynamicList(
+            ListQuery(
+                condition = condition,
+                projection = Projection(include = listOf("state.name")),
+                sort = listOf(Sort("state.name", Sort.Direction.ASC)),
+                limit = 10,
+            ),
+        ).collectList().block()
+
+        val filters = searchRequest.captured.query()!!.bool().filter()[1].bool().filter()
+        filters[0].term().field().assert().isEqualTo("state.name.keyword")
+        filters[1].match().field().assert().isEqualTo("state.name")
+        filters[2].wildcard().field().assert().isEqualTo("state.name.keyword")
+        filters[3].range().untyped().field().assert().isEqualTo("state.age")
+        searchRequest.captured.sort().single().field().field().assert().isEqualTo("state.name.keyword")
+        searchRequest.captured.source()!!.filter().includes().assert().containsExactly("state.name")
+    }
+
+    @Test
+    fun `missing field should refresh mapping once before compiling query`() {
+        every { indicesClient.getMapping(any<GetMappingRequest>()) } returnsMany listOf(
+            Mono.just(mappingResponse(queryMapping())),
+            Mono.just(mappingResponse(queryMapping(includeNewField = true))),
+        )
+
+        queryService().dynamicList(
+            ListQuery(condition = Condition.eq("state.newField", "new"), limit = 10),
+        ).collectList().block()
+
+        searchRequest.captured.query()!!.bool().filter()[1].term().field().assert().isEqualTo("state.newField")
+        verify(exactly = 2) { indicesClient.getMapping(any<GetMappingRequest>()) }
+    }
+
+    @Test
+    fun `custom condition converter should keep physical field ownership`() {
+        val convertedCondition = slot<Condition>()
+        val customConverter = mockk<ConditionConverter<Query>> {
+            every { convert(capture(convertedCondition)) } returns matchAll { it }
+        }
+        val condition = Condition.eq("custom.physical", "value")
+        val service = ElasticsearchSnapshotQueryService<Any>(
+            MOCK_AGGREGATE_METADATA,
+            client,
+            customConverter,
+            DEFAULT_SEARCH_BATCH_SIZE,
+            DEFAULT_PIT_KEEP_ALIVE,
+            ElasticsearchIndexMappingResolver(client),
+        )
+
+        service.dynamicList(ListQuery(condition = condition, limit = 10)).collectList().block()
+
+        convertedCondition.captured.assert().isEqualTo(condition)
+        verify(exactly = 0) { client.indices() }
+    }
+
+    private fun queryService(): ElasticsearchSnapshotQueryService<Any> =
+        ElasticsearchSnapshotQueryService(
+            MOCK_AGGREGATE_METADATA,
+            client,
+            SnapshotConditionConverter,
+            DEFAULT_SEARCH_BATCH_SIZE,
+            DEFAULT_PIT_KEEP_ALIVE,
+            ElasticsearchIndexMappingResolver(client),
+        )
+
+    private fun mappingResponse(mapping: TypeMapping): GetMappingResponse =
+        GetMappingResponse.of { response ->
+            response.mappings(
+                "wow.test.aggregate.snapshot",
+                IndexMappingRecord.of { record -> record.mappings(mapping) },
+            )
+        }
+
+    private fun queryMapping(includeNewField: Boolean = false): TypeMapping =
+        TypeMapping.of { mapping ->
+            mapping.properties("state") { state ->
+                state.`object` { objectField ->
+                    objectField
+                        .properties("name") { name ->
+                            name.text { text ->
+                                text.fields("keyword") { keyword -> keyword.keyword { it } }
+                            }
+                        }.properties("age") { age -> age.integer { it } }
+                    if (includeNewField) {
+                        objectField.properties("newField") { field -> field.keyword { it } }
+                    }
+                    objectField
+                }
+            }
+        }
+
+    private fun emptySearchResponse(): SearchResponse<Map<*, *>> =
+        SearchResponse.of<Map<*, *>> {
+            it.took(1)
+                .timedOut(false)
+                .shards { shards -> shards.failed(0).successful(1).total(1) }
+                .hits { hits -> hits.hits(emptyList()) }
+        }
+}

--- a/wow-spring-boot-starter/build.gradle.kts
+++ b/wow-spring-boot-starter/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     api("org.springframework.boot:spring-boot-starter-jackson")
     api("org.springframework.boot:spring-boot-starter-webflux")
     api("org.springframework.boot:spring-boot-starter-webclient")
+    compileOnly("org.springframework.boot:spring-boot-actuator")
     kapt("org.springframework.boot:spring-boot-configuration-processor")
     kapt("org.springframework.boot:spring-boot-autoconfigure-processor")
     testImplementation(project(":wow-test"))

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfiguration.kt
@@ -21,6 +21,7 @@ import me.ahoo.wow.elasticsearch.IndexTemplateInitializer
 import me.ahoo.wow.elasticsearch.WowJsonpMapper
 import me.ahoo.wow.elasticsearch.eventsourcing.ElasticsearchEventStore
 import me.ahoo.wow.elasticsearch.eventsourcing.ElasticsearchSnapshotStore
+import me.ahoo.wow.elasticsearch.query.ElasticsearchIndexMappingResolver
 import me.ahoo.wow.elasticsearch.query.event.ElasticsearchEventStreamQueryServiceFactory
 import me.ahoo.wow.elasticsearch.query.snapshot.ElasticsearchSnapshotQueryServiceFactory
 import me.ahoo.wow.eventsourcing.EventStore
@@ -187,13 +188,23 @@ class ElasticsearchEventSourcingAutoConfiguration @Autowired constructor(
     @ConditionalOnSnapshotStoreStorage(StorageType.ELASTICSEARCH)
     fun elasticsearchSnapshotQueryServiceFactory(
         elasticsearchClient: ReactiveElasticsearchClient,
+        elasticsearchIndexMappingResolver: ElasticsearchIndexMappingResolver,
     ): ElasticsearchSnapshotQueryServiceFactory {
         return ElasticsearchSnapshotQueryServiceFactory(
             elasticsearchClient,
             queryProperties.batchSize,
             queryProperties.keepAlive,
+            elasticsearchIndexMappingResolver,
         )
     }
+
+    @Bean
+    @ConditionalOnSnapshotEnabled
+    @ConditionalOnSnapshotStoreStorage(StorageType.ELASTICSEARCH)
+    @ConditionalOnMissingBean
+    fun elasticsearchIndexMappingResolver(
+        elasticsearchClient: ReactiveElasticsearchClient,
+    ): ElasticsearchIndexMappingResolver = ElasticsearchIndexMappingResolver(elasticsearchClient)
 
     @Bean
     @ConditionalOnSnapshotEnabled

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchMappingEndpointAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchMappingEndpointAutoConfiguration.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.spring.boot.starter.elasticsearch
+
+import me.ahoo.wow.configuration.MetadataSearcher
+import me.ahoo.wow.elasticsearch.IndexNameConverter.toSnapshotIndexName
+import me.ahoo.wow.elasticsearch.query.ElasticsearchIndexMappingResolver
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.spring.boot.starter.ConditionalOnWowEnabled
+import org.springframework.boot.actuate.endpoint.Access
+import org.springframework.boot.actuate.endpoint.InvalidEndpointRequestException
+import org.springframework.boot.actuate.endpoint.annotation.Selector
+import org.springframework.boot.actuate.endpoint.annotation.WriteOperation
+import org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.context.annotation.Bean
+import reactor.core.publisher.Mono
+import java.time.Instant
+
+@AutoConfiguration(after = [ElasticsearchEventSourcingAutoConfiguration::class])
+@ConditionalOnWowEnabled
+@ConditionalOnClass(
+    name = [
+        "me.ahoo.wow.elasticsearch.query.ElasticsearchIndexMappingResolver",
+        "org.springframework.boot.actuate.endpoint.web.annotation.WebEndpoint",
+    ],
+)
+@ConditionalOnBean(ElasticsearchIndexMappingResolver::class)
+class ElasticsearchMappingEndpointAutoConfiguration {
+    @Bean
+    @ConditionalOnMissingBean
+    fun wowElasticsearchMappingEndpoint(
+        mappingResolver: ElasticsearchIndexMappingResolver,
+    ): WowElasticsearchMappingEndpoint = WowElasticsearchMappingEndpoint(mappingResolver)
+}
+
+@WebEndpoint(id = "wowElasticsearchMapping", defaultAccess = Access.NONE)
+class WowElasticsearchMappingEndpoint(
+    private val mappingResolver: ElasticsearchIndexMappingResolver,
+) {
+    @WriteOperation
+    fun refresh(
+        @Selector contextName: String,
+        @Selector aggregateName: String,
+    ): Mono<ElasticsearchMappingEndpointResponse> {
+        val namedAggregate = MaterializedNamedAggregate(contextName, aggregateName)
+        if (!MetadataSearcher.namedAggregateType.containsKey(namedAggregate)) {
+            throw InvalidEndpointRequestException(
+                "NamedAggregate [$namedAggregate] is not registered.",
+                "UNKNOWN_AGGREGATE",
+            )
+        }
+        val indexName = namedAggregate.toSnapshotIndexName()
+        return mappingResolver.refresh(indexName).map { result ->
+            ElasticsearchMappingEndpointResponse(
+                indexName = indexName,
+                fieldCount = result.mapping.fieldCount,
+                changed = result.changed,
+                refreshedAt = Instant.now(),
+            )
+        }
+    }
+}
+
+data class ElasticsearchMappingEndpointResponse(
+    val scope: String = "LOCAL_INSTANCE",
+    val indexName: String,
+    val fieldCount: Int,
+    val changed: Boolean,
+    val refreshedAt: Instant,
+)

--- a/wow-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/wow-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -12,6 +12,7 @@ me.ahoo.wow.spring.boot.starter.mongo.MongoEventSourcingAutoConfiguration
 me.ahoo.wow.spring.boot.starter.redis.RedisEventSourcingAutoConfiguration
 me.ahoo.wow.spring.boot.starter.redis.RedisMessageBusAutoConfiguration
 me.ahoo.wow.spring.boot.starter.elasticsearch.ElasticsearchEventSourcingAutoConfiguration
+me.ahoo.wow.spring.boot.starter.elasticsearch.ElasticsearchMappingEndpointAutoConfiguration
 me.ahoo.wow.spring.boot.starter.kafka.KafkaAutoConfiguration
 me.ahoo.wow.spring.boot.starter.projection.ProjectionDispatcherAutoConfiguration
 me.ahoo.wow.spring.boot.starter.saga.StatelessSagaAutoConfiguration

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchMappingEndpointAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchMappingEndpointAutoConfigurationTest.kt
@@ -1,0 +1,188 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.spring.boot.starter.elasticsearch
+
+import co.elastic.clients.elasticsearch._types.mapping.TypeMapping
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.configuration.MetadataSearcher
+import me.ahoo.wow.elasticsearch.IndexNameConverter.toSnapshotIndexName
+import me.ahoo.wow.elasticsearch.query.ElasticsearchIndexMapping
+import me.ahoo.wow.elasticsearch.query.ElasticsearchIndexMappingResolver
+import me.ahoo.wow.elasticsearch.query.ElasticsearchMappingRefreshResult
+import org.junit.jupiter.api.Test
+import org.springframework.boot.actuate.autoconfigure.endpoint.EndpointAutoConfiguration
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointAutoConfiguration
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties
+import org.springframework.boot.actuate.endpoint.web.EndpointLinksResolver
+import org.springframework.boot.actuate.endpoint.web.EndpointMapping
+import org.springframework.boot.actuate.endpoint.web.EndpointMediaTypes
+import org.springframework.boot.actuate.endpoint.web.WebEndpointsSupplier
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.context.properties.source.ConfigurationPropertySources
+import org.springframework.boot.convert.ApplicationConversionService
+import org.springframework.boot.test.context.FilteredClassLoader
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.boot.test.context.runner.ReactiveWebApplicationContextRunner
+import org.springframework.boot.webflux.actuate.endpoint.web.WebFluxEndpointHandlerMapping
+import org.springframework.boot.webflux.autoconfigure.HttpHandlerAutoConfiguration
+import org.springframework.boot.webflux.autoconfigure.WebFluxAutoConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.MediaType
+import org.springframework.http.server.reactive.HttpHandler
+import org.springframework.test.web.reactive.server.HttpHandlerConnector
+import org.springframework.test.web.reactive.server.WebTestClient
+import reactor.core.publisher.Mono
+
+class ElasticsearchMappingEndpointAutoConfigurationTest {
+    private val mappingResolver = mockk<ElasticsearchIndexMappingResolver>()
+
+    @Test
+    fun `should safely back off without actuator`() {
+        ApplicationContextRunner()
+            .withClassLoader(FilteredClassLoader("org.springframework.boot.actuate"))
+            .withConfiguration(AutoConfigurations.of(ElasticsearchMappingEndpointAutoConfiguration::class.java))
+            .withBean(ElasticsearchIndexMappingResolver::class.java, { mappingResolver })
+            .run { context ->
+                context.assert()
+                    .hasNotFailed()
+                    .doesNotHaveBean(WowElasticsearchMappingEndpoint::class.java)
+            }
+    }
+
+    @Test
+    fun `should safely back off without elasticsearch support`() {
+        ApplicationContextRunner()
+            .withClassLoader(FilteredClassLoader("me.ahoo.wow.elasticsearch"))
+            .withConfiguration(AutoConfigurations.of(ElasticsearchMappingEndpointAutoConfiguration::class.java))
+            .run { context ->
+                context.assert()
+                    .hasNotFailed()
+                    .doesNotHaveBean(WowElasticsearchMappingEndpoint::class.java)
+            }
+    }
+
+    @Test
+    fun `endpoint should be unavailable by default`() {
+        webContextRunner()
+            .withPropertyValues("management.endpoints.web.exposure.include=wowElasticsearchMapping")
+            .run { context ->
+                context.assert().hasNotFailed()
+                webClient(context.getBean(HttpHandler::class.java))
+                    .post()
+                    .uri("/actuator/wowElasticsearchMapping/unknown/unknown")
+                    .exchange()
+                    .expectStatus().isNotFound
+            }
+    }
+
+    @Test
+    fun `enabled endpoint should refresh a registered aggregate`() {
+        val namedAggregate = MetadataSearcher.localAggregates.first()
+        val indexName = namedAggregate.toSnapshotIndexName()
+        val mapping = ElasticsearchIndexMapping.from(indexName, TypeMapping.of { it })
+        every { mappingResolver.refresh(indexName) } returns Mono.just(
+            ElasticsearchMappingRefreshResult(mapping, changed = true),
+        )
+
+        enabledWebContextRunner().run { context ->
+            context.assert().hasNotFailed()
+                .hasSingleBean(WowElasticsearchMappingEndpoint::class.java)
+                .hasSingleBean(WebFluxEndpointHandlerMapping::class.java)
+            context.getBean(WebEndpointsSupplier::class.java).endpoints.map { it.rootPath }
+                .assert().contains("wowElasticsearchMapping")
+            webClient(context.getBean(HttpHandler::class.java))
+                .post()
+                .uri(
+                    "/actuator/wowElasticsearchMapping/{contextName}/{aggregateName}",
+                    namedAggregate.contextName,
+                    namedAggregate.aggregateName,
+                ).accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus().isOk
+                .expectBody()
+                .jsonPath("$.scope").isEqualTo("LOCAL_INSTANCE")
+                .jsonPath("$.indexName").isEqualTo(indexName)
+                .jsonPath("$.fieldCount").isEqualTo(0)
+                .jsonPath("$.changed").isEqualTo(true)
+                .jsonPath("$.refreshedAt").isNotEmpty
+        }
+
+        verify(exactly = 1) { mappingResolver.refresh(indexName) }
+    }
+
+    @Test
+    fun `unknown aggregate should return bad request`() {
+        enabledWebContextRunner().run { context ->
+            context.assert().hasNotFailed()
+            webClient(context.getBean(HttpHandler::class.java))
+                .post()
+                .uri("/actuator/wowElasticsearchMapping/unknown/unknown")
+                .exchange()
+                .expectStatus().isBadRequest
+        }
+
+        verify(exactly = 0) { mappingResolver.refresh(any()) }
+    }
+
+    private fun enabledWebContextRunner(): ReactiveWebApplicationContextRunner =
+        webContextRunner().withPropertyValues(
+            "management.endpoint.wowElasticsearchMapping.access=unrestricted",
+            "management.endpoints.web.exposure.include=wowElasticsearchMapping",
+        )
+
+    private fun webContextRunner(): ReactiveWebApplicationContextRunner =
+        ReactiveWebApplicationContextRunner()
+            .withInitializer {
+                it.environment.conversionService = ApplicationConversionService()
+                ConfigurationPropertySources.attach(it.environment)
+            }
+            .withConfiguration(
+                AutoConfigurations.of(
+                    EndpointAutoConfiguration::class.java,
+                    WebEndpointAutoConfiguration::class.java,
+                    WebFluxAutoConfiguration::class.java,
+                    HttpHandlerAutoConfiguration::class.java,
+                    ElasticsearchMappingEndpointAutoConfiguration::class.java,
+                ),
+            ).withUserConfiguration(TestEndpointWebFluxConfiguration::class.java)
+            .withBean(ElasticsearchIndexMappingResolver::class.java, { mappingResolver })
+
+    private fun webClient(httpHandler: HttpHandler): WebTestClient =
+        WebTestClient.bindToServer(HttpHandlerConnector(httpHandler)).build()
+
+    @Configuration(proxyBeanMethods = false)
+    class TestEndpointWebFluxConfiguration {
+        @Bean
+        fun webEndpointReactiveHandlerMapping(
+            webEndpointsSupplier: WebEndpointsSupplier,
+            endpointMediaTypes: EndpointMediaTypes,
+            webEndpointProperties: WebEndpointProperties,
+        ): WebFluxEndpointHandlerMapping {
+            val endpoints = webEndpointsSupplier.endpoints
+            val basePath = webEndpointProperties.basePath
+            return WebFluxEndpointHandlerMapping(
+                EndpointMapping(basePath),
+                endpoints,
+                endpointMediaTypes,
+                null,
+                EndpointLinksResolver(endpoints, basePath),
+                false,
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- lazily resolve snapshot query fields and capabilities from the current Elasticsearch mapping
- share mapping caches across query services and an opt-in, local-instance Actuator refresh endpoint
- preserve custom converters, field aliases, runtime fields, nested validation, and multi-field selection
- document permissions, endpoint enablement, and multi-replica operational limits

## Verification

- `./gradlew :wow-elasticsearch:check :wow-spring-boot-starter:check --no-daemon`
- `./gradlew :wow-elasticsearch:integrationTest --tests me.ahoo.wow.elasticsearch.query.snapshot.ElasticsearchSnapshotQueryServiceTest --no-daemon`
- `pnpm docs:build`
- `git diff --check`