### PR TITLE
fix(compensation): correct selected row border

### DIFF
--- a/compensation/dashboard/src/features/Failed/FailedTable.tsx
+++ b/compensation/dashboard/src/features/Failed/FailedTable.tsx
@@ -283,7 +283,7 @@ export function FailedTable({
                       "h-[82px] border-b-slate-200",
                       loading ? "cursor-wait" : "cursor-pointer",
                       selected &&
-                        "rounded-md ring-1 ring-inset ring-blue-500 data-[state=selected]:bg-blue-50/70 data-[state=selected]:hover:bg-blue-50/80",
+                        "rounded-md outline-1 -outline-offset-1 outline-blue-500 data-[state=selected]:bg-blue-50/70 data-[state=selected]:hover:bg-blue-50/80",
                     )}
                     onClick={() => {
                       if (!loading) {


### PR DESCRIPTION
## Goal

Fix the selected compensation row's top border so all four sides render consistently in a collapsed table.

## Changes

- Replace the selected row's inset ring with a 1px inward outline.
- Preserve the existing selected background, hover state, and rounded corners.

## Verification

- `pnpm exec vitest run src/features/Failed/__tests__/FailedTable.test.tsx` — 8 tests passed.
- `pnpm exec eslint src/features/Failed/FailedTable.tsx` — passed.
- `pnpm build` — passed.
- Ran the local dashboard with development data and verified the selected row visually; details loaded successfully and the browser console reported no errors.

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes. (Not applicable: this only corrects an existing visual style.)
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

CSS-only change. No migration, data, performance, concurrency, deployment, or rollback impact; rollback is a single commit revert.