### PR TITLE
feat(query): support snapshot aggregation

### DIFF
--- a/documentation/docs/en/guide/extensions/apiclient.md
+++ b/documentation/docs/en/guide/extensions/apiclient.md
@@ -182,7 +182,7 @@ interface OrderQueryApi : SynchronousSnapshotQueryApi<OrderState>
 The synchronous variant mirrors the reactive API but returns values directly
 (blocking).
 
-### Aggregation Query API
+### Snapshot Aggregation API
 
 Aggregation remains opt-in and does not change the existing composite query interfaces:
 

--- a/documentation/docs/en/guide/extensions/apiclient.md
+++ b/documentation/docs/en/guide/extensions/apiclient.md
@@ -182,6 +182,22 @@ interface OrderQueryApi : SynchronousSnapshotQueryApi<OrderState>
 The synchronous variant mirrors the reactive API but returns values directly
 (blocking).
 
+### Aggregation Query API
+
+Aggregation remains opt-in and does not change the existing composite query interfaces:
+
+```kotlin
+@CoApi
+interface OrderAggregationApi : ReactiveSnapshotAggregationQueryApi
+
+val rows = aggregationQuery {
+    groupBy("state.status", "status")
+    count("orderCount")
+}.aggregate(orderAggregationApi)
+```
+
+Use `SynchronousSnapshotAggregationQueryApi` for blocking calls.
+
 ## Error Handling
 
 `RestCommandGatewayException` wraps command errors with full request context:

--- a/documentation/docs/en/guide/extensions/elasticsearch.md
+++ b/documentation/docs/en/guide/extensions/elasticsearch.md
@@ -501,41 +501,19 @@ listQuery {
 
 ## Aggregation Queries
 
-Elasticsearch provides powerful aggregation capabilities:
-
-### Statistical Analysis
+Use the portable `AggregationQuery` so aggregation still passes through Wow condition rewriting, ABAC, and tenant/owner filters:
 
 ```kotlin
-// Count orders by status
-val aggregation = SearchRequest.of { s ->
-    s.index("wow.order-service.order.snapshot")
-        .aggregations("status_count") { a ->
-            a.terms { t ->
-                t.field("state.status")
-            }
-        }
-}
+aggregationQuery {
+    groupBy("state.status", "status")
+    dateHistogram("snapshotTime", "day", AggregationDateUnit.DAY, "Asia/Shanghai")
+    count("orderCount")
+    sum("state.totalAmount", "totalAmount")
+    sort { "totalAmount".desc() }
+}.aggregate(snapshotQueryService)
 ```
 
-### Time Range Aggregation
-
-```kotlin
-// Daily order amount statistics
-val aggregation = SearchRequest.of { s ->
-    s.index("wow.order-service.order.snapshot")
-        .aggregations("daily_amount") { a ->
-            a.dateHistogram { d ->
-                d.field("eventTime")
-                    .calendarInterval(CalendarInterval.Day)
-            }
-            .aggregations("total") { sa ->
-                sa.sum { sum ->
-                    sum.field("state.totalAmount")
-                }
-            }
-        }
-}
-```
+Elasticsearch uses PIT plus paged composite aggregations. Group-key ordering stops after the requested limit; metric ordering scans every bucket and keeps an exact Top-N in `O(limit)` memory. Logical string fields are resolved from the mapping to an aggregatable `keyword`/`exact` field, so callers must not use physical `.keyword` paths.
 
 ## Index Design Recommendations
 

--- a/documentation/docs/en/guide/extensions/elasticsearch.md
+++ b/documentation/docs/en/guide/extensions/elasticsearch.md
@@ -515,7 +515,7 @@ listQuery {
 }.dynamicQuery(snapshotQueryService)
 ```
 
-## Aggregation Queries
+## Snapshot Aggregation
 
 Use the portable `AggregationQuery` so aggregation still passes through Wow condition rewriting, ABAC, and tenant/owner filters:
 

--- a/documentation/docs/en/guide/extensions/mongo.md
+++ b/documentation/docs/en/guide/extensions/mongo.md
@@ -413,6 +413,21 @@ snapshotQueryService.dynamicQuery(condition)
 
 The `MongoSnapshotQueryService` uses `MaterializedSnapshot<S>` as its typed result wrapper, where `S` is the aggregate's state type resolved from the aggregate metadata. This enables type-safe dynamic queries directly against aggregate state fields -- for example, querying `state.status` or `state.totalAmount` without a separate projection processor.
 
+### Snapshot Aggregation
+
+`AggregationQuery` compiles to `$match -> $group -> $project -> $sort -> $limit`. Composite `_id` values implement multiple dimensions, arithmetic expressions implement numeric histograms, and `$dateTrunc` implements date histograms:
+
+```kotlin
+aggregationQuery {
+    groupBy("state.status", "status")
+    histogram("state.totalAmount", "amountBand", interval = 100.0)
+    count("orderCount")
+    avg("state.totalAmount", "averageAmount")
+}.aggregate(snapshotQueryService)
+```
+
+The portable API accepts scalar group fields and numeric metric fields. MongoDB values are normalized to the same `Long`, `Double`, and epoch-millisecond shapes returned by the Elasticsearch implementation.
+
 ## PrepareKey: Distributed Coordination
 
 `MongoPrepareKey` implements Wow's `PrepareKey<V>` interface for distributed key reservation with MongoDB as the coordination backend. Each logical key becomes a `prepare_{name}` collection.

--- a/documentation/docs/en/guide/extensions/webflux.md
+++ b/documentation/docs/en/guide/extensions/webflux.md
@@ -88,6 +88,7 @@ plus `wow-webflux` for these properties to be bound.
 | `batch.concurrency` | `Int` | `1` | Maximum concurrent requests processed in a single batch execution |
 | `batch.prefetch` | `Int` | `1` | Prefetch window for batch request processing |
 | `query.max-list-size` | `Int` | `1000` | Maximum positive limit for HTTP list and aggregation queries; `0` disables the cap and restores unlimited list queries with `limit=0` |
+| `query.max-aggregation-metrics` | `Int` | `32` | Maximum metrics per HTTP aggregation query; `0` disables the cap |
 | `query.max-page-size` | `Int` | `100` | Maximum HTTP page size; `0` disables the cap |
 | `query.max-page-window` | `Long` | `10000` | Maximum HTTP `index * size` page window; `0` disables the cap |
 | `query.max-condition-nodes` | `Int` | `64` | Maximum number of HTTP query condition nodes; `0` disables the cap |
@@ -109,6 +110,7 @@ wow:
       prefetch: 4
     query:
       max-list-size: 1000
+      max-aggregation-metrics: 32
       max-page-size: 100
       max-page-window: 10000
       max-condition-nodes: 64

--- a/documentation/docs/en/guide/extensions/webflux.md
+++ b/documentation/docs/en/guide/extensions/webflux.md
@@ -92,7 +92,7 @@ plus `wow-webflux` for these properties to be bound.
 | `query.max-page-window` | `Long` | `10000` | Maximum HTTP `index * size` page window; `0` disables the cap |
 | `query.max-condition-nodes` | `Int` | `64` | Maximum number of HTTP query condition nodes; `0` disables the cap |
 | `query.max-condition-values` | `Int` | `1000` | Maximum values in HTTP `IN`, `NOT_IN`, `ALL_IN`, `IDS`, or `AGGREGATE_IDS` conditions; `0` disables the cap |
-| `query.allowed-sort-fields` | `Set<String>` | `[]` | Indexed logical fields allowed for explicit HTTP sorting; an empty set rejects all explicit sorts and `["*"]` disables the restriction |
+| `query.allowed-sort-fields` | `Set<String>` | `[]` | Indexed logical fields allowed for explicit HTTP sorting; an empty set rejects all explicit sorts and `["*"]` disables the restriction. Aggregation sorts use request-defined aliases and therefore require `["*"]` |
 | `query.allowed-condition-fields` | `Set<String>` | `[]` | Additional indexed logical fields allowed in HTTP predicates; an empty set keeps built-in `aggregateId`, aggregate-ID-scoped `version`, and indexed fieldless logical/metadata operators; `spaceId` requires explicit allowlisting, while `["*"]` disables the restriction |
 | `query.allow-raw` | `Boolean` | `false` | Whether HTTP queries may use native `RAW` conditions |
 | `query.allow-expensive-operators` | `Boolean` | `false` | Whether HTTP queries may use negative/existence/expensive string operators or unfiltered count/paged/aggregation queries |

--- a/documentation/docs/en/guide/query.md
+++ b/documentation/docs/en/guide/query.md
@@ -262,9 +262,9 @@ pagedQuery {
 }.query(queryService)
 ```
 
-## Execute Aggregation Query
+## Execute Snapshot Aggregation
 
-`SnapshotQueryService` provides snapshot aggregation with the same public semantics on MongoDB and Elasticsearch. Ordered group dimensions form a composite key and aliases are flattened into each result row:
+`SnapshotQueryService` provides snapshot aggregation with the same public semantics on MongoDB and Elasticsearch. Ordered group dimensions form a composite key, aliases are flattened into each result row, and the HTTP endpoint is `POST .../snapshot/aggregation`:
 
 ```kotlin
 aggregationQuery {

--- a/documentation/docs/en/guide/query.md
+++ b/documentation/docs/en/guide/query.md
@@ -287,9 +287,9 @@ aggregationQuery {
 }.aggregate(snapshotQueryService)
 ```
 
-The portable groups are `Terms`, `Histogram`, and `DateHistogram`; metrics are `Count`, `Sum`, `Avg`, `Min`, and `Max`. Count values are `Long`, date bucket keys are epoch-millisecond `Long` values, and other numeric results are normalized to `Double`. Group fields must be scalar and metric fields numeric; missing or null group values do not create buckets.
+The portable groups are `Terms`, `Histogram`, and `DateHistogram`; metrics are `Count`, `Sum`, `Avg`, `Min`, and `Max`. Count values are `Long`, date bucket keys are epoch-millisecond `Long` values, and other numeric results are normalized to `Double`. Group fields must be scalar and metric fields numeric. Statically declared fields are prevalidated by the common query chain, while dynamic map keys and Elasticsearch runtime fields are delegated to the backend. Missing or null group values do not create buckets.
 
-An aggregation without groups always returns one row. With no matching documents, Count is `0`, Sum is `0.0`, and the remaining metrics are `null`. A query allows at most 32 metrics; grouped queries default to 100 rows and allow at most 10,000. Aggregation is rejected when snapshot data masking is configured so grouping cannot bypass result masking.
+An aggregation without groups always returns one row. With no matching documents, Count is `0`, Sum is `0.0`, and the remaining metrics are `null`. Grouped queries default to 100 rows and allow at most 10,000; the HTTP entry point accepts at most 32 metrics by default and can be tuned with `max-aggregation-metrics`. Aggregation is rejected when snapshot data masking is configured so grouping cannot bypass result masking.
 
 :::warning High cardinality and money
 When Elasticsearch results are ordered by a metric, Wow scans all composite buckets and computes an exact Top-N. Validate high-cardinality queries with production-scale data. Numeric metrics are normalized to `Double`; use scaled integers in the read model when money requires exact arithmetic.

--- a/documentation/docs/en/guide/query.md
+++ b/documentation/docs/en/guide/query.md
@@ -262,6 +262,39 @@ pagedQuery {
 }.query(queryService)
 ```
 
+## Execute Aggregation Query
+
+`SnapshotQueryService` provides snapshot aggregation with the same public semantics on MongoDB and Elasticsearch. Ordered group dimensions form a composite key and aliases are flattened into each result row:
+
+```kotlin
+aggregationQuery {
+    condition {
+        "state.status" ne "CANCELLED"
+    }
+    groupBy("state.country", "country")
+    dateHistogram(
+        field = "snapshotTime",
+        alias = "month",
+        unit = AggregationDateUnit.MONTH,
+        timeZone = "Asia/Shanghai",
+    )
+    count("orderCount")
+    sum("state.totalAmount", "totalAmount")
+    sort {
+        "totalAmount".desc()
+    }
+    limit(100)
+}.aggregate(snapshotQueryService)
+```
+
+The portable groups are `Terms`, `Histogram`, and `DateHistogram`; metrics are `Count`, `Sum`, `Avg`, `Min`, and `Max`. Count values are `Long`, date bucket keys are epoch-millisecond `Long` values, and other numeric results are normalized to `Double`. Group fields must be scalar and metric fields numeric; missing or null group values do not create buckets.
+
+An aggregation without groups always returns one row. With no matching documents, Count is `0`, Sum is `0.0`, and the remaining metrics are `null`. Grouped queries default to 100 rows and allow at most 10,000. Aggregation is rejected when snapshot data masking is configured so grouping cannot bypass result masking.
+
+:::warning High cardinality and money
+When Elasticsearch results are ordered by a metric, Wow scans all composite buckets and computes an exact Top-N. Validate high-cardinality queries with production-scale data. Numeric metrics are normalized to `Double`; use scaled integers in the read model when money requires exact arithmetic.
+:::
+
 ## Rewrite Query
 
 ```kotlin

--- a/documentation/docs/en/reference/config/infrastructure.md
+++ b/documentation/docs/en/reference/config/infrastructure.md
@@ -174,6 +174,7 @@ snapshots.
 | `wow.webflux.batch.concurrency` | Integer | `1` | Concurrency for batch command requests |
 | `wow.webflux.batch.prefetch` | Integer | `1` | Prefetch count for batch command requests |
 | `wow.webflux.query.max-list-size` | Integer | `1000` | Maximum HTTP list/aggregation-query limit; `0` disables the cap |
+| `wow.webflux.query.max-aggregation-metrics` | Integer | `32` | Maximum metrics per HTTP aggregation query; `0` disables the cap |
 | `wow.webflux.query.max-page-size` | Integer | `100` | Maximum HTTP page size; `0` disables the cap |
 | `wow.webflux.query.max-page-window` | Long | `10000` | Maximum HTTP page window; `0` disables the cap |
 | `wow.webflux.query.max-condition-nodes` | Integer | `64` | Maximum HTTP query condition nodes; `0` disables the cap |
@@ -197,6 +198,7 @@ wow:
       prefetch: 1
     query:
       max-list-size: 1000
+      max-aggregation-metrics: 32
       max-page-size: 100
       max-page-window: 10000
       max-condition-nodes: 64

--- a/documentation/docs/zh/guide/extensions/apiclient.md
+++ b/documentation/docs/zh/guide/extensions/apiclient.md
@@ -176,6 +176,22 @@ interface OrderQueryApi : SynchronousSnapshotQueryApi<OrderState>
 
 同步版本与响应式 API 对应，但直接返回值（阻塞）。
 
+### 聚合查询 API
+
+聚合接口保持可选，不修改已有组合接口：
+
+```kotlin
+@CoApi
+interface OrderAggregationApi : ReactiveSnapshotAggregationQueryApi
+
+val rows = aggregationQuery {
+    groupBy("state.status", "status")
+    count("orderCount")
+}.aggregate(orderAggregationApi)
+```
+
+同步调用使用 `SynchronousSnapshotAggregationQueryApi`。
+
 ## 错误处理
 
 `RestCommandGatewayException` 封装命令错误并携带完整的请求上下文：

--- a/documentation/docs/zh/guide/extensions/apiclient.md
+++ b/documentation/docs/zh/guide/extensions/apiclient.md
@@ -176,7 +176,7 @@ interface OrderQueryApi : SynchronousSnapshotQueryApi<OrderState>
 
 同步版本与响应式 API 对应，但直接返回值（阻塞）。
 
-### 聚合查询 API
+### 快照统计分析 API
 
 聚合接口保持可选，不修改已有组合接口：
 

--- a/documentation/docs/zh/guide/extensions/elasticsearch.md
+++ b/documentation/docs/zh/guide/extensions/elasticsearch.md
@@ -505,7 +505,7 @@ listQuery {
 }.dynamicQuery(snapshotQueryService)
 ```
 
-## 聚合查询
+## 快照统计分析
 
 使用公共 `AggregationQuery`，可以让聚合继续经过 Wow 的条件改写、ABAC 与租户/所有者过滤：
 

--- a/documentation/docs/zh/guide/extensions/elasticsearch.md
+++ b/documentation/docs/zh/guide/extensions/elasticsearch.md
@@ -491,41 +491,19 @@ listQuery {
 
 ## 聚合查询
 
-Elasticsearch 提供强大的聚合功能：
-
-### 统计分析
+使用公共 `AggregationQuery`，可以让聚合继续经过 Wow 的条件改写、ABAC 与租户/所有者过滤：
 
 ```kotlin
-// 按状态统计订单数量
-val aggregation = SearchRequest.of { s ->
-    s.index("wow.order-service.order.snapshot")
-        .aggregations("status_count") { a ->
-            a.terms { t ->
-                t.field("state.status")
-            }
-        }
-}
+aggregationQuery {
+    groupBy("state.status", "status")
+    dateHistogram("snapshotTime", "day", AggregationDateUnit.DAY, "Asia/Shanghai")
+    count("orderCount")
+    sum("state.totalAmount", "totalAmount")
+    sort { "totalAmount".desc() }
+}.aggregate(snapshotQueryService)
 ```
 
-### 时间范围聚合
-
-```kotlin
-// 按天统计订单金额
-val aggregation = SearchRequest.of { s ->
-    s.index("wow.order-service.order.snapshot")
-        .aggregations("daily_amount") { a ->
-            a.dateHistogram { d ->
-                d.field("eventTime")
-                    .calendarInterval(CalendarInterval.Day)
-            }
-            .aggregations("total") { sa ->
-                sa.sum { sum ->
-                    sum.field("state.totalAmount")
-                }
-            }
-        }
-}
-```
+Elasticsearch 使用 PIT + composite aggregation 分页。按分组键排序达到 limit 后停止；按指标排序会遍历所有 buckets，以 `O(limit)` 内存维护精确 Top-N。逻辑字符串字段会根据 mapping 自动解析到可聚合的 `keyword`/`exact` 字段，调用方不应书写 `.keyword` 物理路径。
 
 ## 索引设计建议
 

--- a/documentation/docs/zh/guide/extensions/mongo.md
+++ b/documentation/docs/zh/guide/extensions/mongo.md
@@ -408,7 +408,7 @@ snapshotQueryService.dynamicQuery(condition)
 
 `MongoSnapshotQueryService` 使用 `MaterializedSnapshot<S>` 作为其类型化的结果包装器，其中 `S` 是从聚合元数据解析出的聚合状态类型。这支持直接对聚合状态字段进行类型安全的动态查询——例如，查询 `state.status` 或 `state.totalAmount` 而不需要单独的投影处理器。
 
-### 快照聚合
+### 快照统计分析
 
 `AggregationQuery` 会编译成 `$match -> $group -> $project -> $sort -> $limit`。多维分组使用复合 `_id`，数值直方图使用取整表达式，时间直方图使用 `$dateTrunc`：
 

--- a/documentation/docs/zh/guide/extensions/mongo.md
+++ b/documentation/docs/zh/guide/extensions/mongo.md
@@ -408,6 +408,21 @@ snapshotQueryService.dynamicQuery(condition)
 
 `MongoSnapshotQueryService` 使用 `MaterializedSnapshot<S>` 作为其类型化的结果包装器，其中 `S` 是从聚合元数据解析出的聚合状态类型。这支持直接对聚合状态字段进行类型安全的动态查询——例如，查询 `state.status` 或 `state.totalAmount` 而不需要单独的投影处理器。
 
+### 快照聚合
+
+`AggregationQuery` 会编译成 `$match -> $group -> $project -> $sort -> $limit`。多维分组使用复合 `_id`，数值直方图使用取整表达式，时间直方图使用 `$dateTrunc`：
+
+```kotlin
+aggregationQuery {
+    groupBy("state.status", "status")
+    histogram("state.totalAmount", "amountBand", interval = 100.0)
+    count("orderCount")
+    avg("state.totalAmount", "averageAmount")
+}.aggregate(snapshotQueryService)
+```
+
+公共 API 只接受标量分组字段和数值指标字段；MongoDB 返回值会被归一化为与 Elasticsearch 相同的 `Long`/`Double`/epoch-millisecond 结构。
+
 ## PrepareKey：分布式协调
 
 `MongoPrepareKey` 实现了 Wow 的 `PrepareKey<V>` 接口，以 MongoDB 为协调后端进行分布式键预留。每个逻辑键变成一个 `prepare_{name}` 集合。

--- a/documentation/docs/zh/guide/extensions/webflux.md
+++ b/documentation/docs/zh/guide/extensions/webflux.md
@@ -90,7 +90,7 @@ data class CreateOrder(/* ... */)
 | `query.max-page-window` | `Long` | `10000` | HTTP 分页查询允许的最大 `index * size`；`0` 关闭上限 |
 | `query.max-condition-nodes` | `Int` | `64` | HTTP 查询条件树的最大节点数；`0` 关闭上限 |
 | `query.max-condition-values` | `Int` | `1000` | HTTP `IN`、`NOT_IN`、`ALL_IN`、`IDS`、`AGGREGATE_IDS` 条件的最大值数量；`0` 关闭上限 |
-| `query.allowed-sort-fields` | `Set<String>` | `[]` | HTTP 显式排序允许的已索引逻辑字段；空集拒绝所有显式排序，`["*"]` 关闭限制 |
+| `query.allowed-sort-fields` | `Set<String>` | `[]` | HTTP 显式排序允许的已索引逻辑字段；空集拒绝所有显式排序，`["*"]` 关闭限制。聚合排序使用请求自定义 alias，因此只能通过 `["*"]` 启用 |
 | `query.allowed-condition-fields` | `Set<String>` | `[]` | HTTP 条件允许的额外已索引逻辑字段；空集保留内置 `aggregateId`、受聚合 ID 约束的 `version` 以及已索引的无字段逻辑/元数据操作符；`spaceId` 必须显式加入白名单，`["*"]` 关闭限制 |
 | `query.allow-raw` | `Boolean` | `false` | 是否允许 HTTP 查询使用 `RAW` 原生条件 |
 | `query.allow-expensive-operators` | `Boolean` | `false` | 是否允许 HTTP 查询使用负向/存在性/高成本字符串操作符及无过滤 count/paged/aggregation 查询 |

--- a/documentation/docs/zh/guide/extensions/webflux.md
+++ b/documentation/docs/zh/guide/extensions/webflux.md
@@ -86,6 +86,7 @@ data class CreateOrder(/* ... */)
 | `batch.concurrency` | `Int` | `1` | 单次批量执行中并发处理的最大请求数 |
 | `batch.prefetch` | `Int` | `1` | 批量请求处理的预取窗口 |
 | `query.max-list-size` | `Int` | `1000` | HTTP 列表与聚合查询允许的最大正数 limit；`0` 关闭上限并恢复列表 `limit=0` 全量查询 |
+| `query.max-aggregation-metrics` | `Int` | `32` | HTTP 聚合查询允许的最大指标数量；`0` 关闭上限 |
 | `query.max-page-size` | `Int` | `100` | HTTP 分页查询的最大页大小；`0` 关闭上限 |
 | `query.max-page-window` | `Long` | `10000` | HTTP 分页查询允许的最大 `index * size`；`0` 关闭上限 |
 | `query.max-condition-nodes` | `Int` | `64` | HTTP 查询条件树的最大节点数；`0` 关闭上限 |
@@ -107,6 +108,7 @@ wow:
       prefetch: 4
     query:
       max-list-size: 1000
+      max-aggregation-metrics: 32
       max-page-size: 100
       max-page-window: 10000
       max-condition-nodes: 64

--- a/documentation/docs/zh/guide/query.md
+++ b/documentation/docs/zh/guide/query.md
@@ -262,6 +262,39 @@ pagedQuery {
 }.query(queryService)
 ```
 
+## 执行聚合查询
+
+`SnapshotQueryService` 支持 MongoDB 与 Elasticsearch 语义一致的快照聚合。多个分组维度按声明顺序组成组合键，结果以 alias 扁平返回：
+
+```kotlin
+aggregationQuery {
+    condition {
+        "state.status" ne "CANCELLED"
+    }
+    groupBy("state.country", "country")
+    dateHistogram(
+        field = "snapshotTime",
+        alias = "month",
+        unit = AggregationDateUnit.MONTH,
+        timeZone = "Asia/Shanghai",
+    )
+    count("orderCount")
+    sum("state.totalAmount", "totalAmount")
+    sort {
+        "totalAmount".desc()
+    }
+    limit(100)
+}.aggregate(snapshotQueryService)
+```
+
+公共分组类型为 `Terms`、`Histogram`、`DateHistogram`，指标为 `Count`、`Sum`、`Avg`、`Min`、`Max`。`Count` 返回 `Long`，时间 bucket 返回 epoch milliseconds `Long`，其他数值统一为 `Double`。分组字段必须是标量，指标字段必须是数值；缺失或 `null` 的分组值不会生成 bucket。
+
+没有分组时固定返回一行；无匹配数据时 `Count` 为 `0`、`Sum` 为 `0.0`，其余指标为 `null`。分组查询默认最多返回 100 行，最大 10,000 行。注册了快照数据脱敏器时聚合查询会被拒绝，避免通过分组或统计绕过脱敏。
+
+:::warning 高基数与金额精度
+Elasticsearch 按指标排序时会遍历所有 composite buckets，再计算精确 Top-N；应使用生产规模数据验证高基数字段。`Sum` 等数值结果统一为 `Double`，要求精确金额统计时应在读模型中保存缩放整数。
+:::
+
 ## 重写查询
 
 ```kotlin

--- a/documentation/docs/zh/guide/query.md
+++ b/documentation/docs/zh/guide/query.md
@@ -287,9 +287,9 @@ aggregationQuery {
 }.aggregate(snapshotQueryService)
 ```
 
-公共分组类型为 `Terms`、`Histogram`、`DateHistogram`，指标为 `Count`、`Sum`、`Avg`、`Min`、`Max`。`Count` 返回 `Long`，时间 bucket 返回 epoch milliseconds `Long`，其他数值统一为 `Double`。分组字段必须是标量，指标字段必须是数值；缺失或 `null` 的分组值不会生成 bucket。
+公共分组类型为 `Terms`、`Histogram`、`DateHistogram`，指标为 `Count`、`Sum`、`Avg`、`Min`、`Max`。`Count` 返回 `Long`，时间 bucket 返回 epoch milliseconds `Long`，其他数值统一为 `Double`。分组字段必须是标量，指标字段必须是数值；静态声明字段会在公共查询链预检，动态 Map 键和 Elasticsearch runtime field 交由后端校验。缺失或 `null` 的分组值不会生成 bucket。
 
-没有分组时固定返回一行；无匹配数据时 `Count` 为 `0`、`Sum` 为 `0.0`，其余指标为 `null`。单个查询最多包含 32 个指标；分组查询默认最多返回 100 行，最大 10,000 行。注册了快照数据脱敏器时聚合查询会被拒绝，避免通过分组或统计绕过脱敏。
+没有分组时固定返回一行；无匹配数据时 `Count` 为 `0`、`Sum` 为 `0.0`，其余指标为 `null`。分组查询默认最多返回 100 行，最大 10,000 行；HTTP 入口默认最多接收 32 个指标，可通过 `max-aggregation-metrics` 调整。注册了快照数据脱敏器时聚合查询会被拒绝，避免通过分组或统计绕过脱敏。
 
 :::warning 高基数与金额精度
 Elasticsearch 按指标排序时会遍历所有 composite buckets，再计算精确 Top-N；应使用生产规模数据验证高基数字段。`Sum` 等数值结果统一为 `Double`，要求精确金额统计时应在读模型中保存缩放整数。

--- a/documentation/docs/zh/guide/query.md
+++ b/documentation/docs/zh/guide/query.md
@@ -262,9 +262,9 @@ pagedQuery {
 }.query(queryService)
 ```
 
-## 执行聚合查询
+## 执行快照统计分析
 
-`SnapshotQueryService` 支持 MongoDB 与 Elasticsearch 语义一致的快照聚合。多个分组维度按声明顺序组成组合键，结果以 alias 扁平返回：
+`SnapshotQueryService` 支持 MongoDB 与 Elasticsearch 语义一致的快照统计分析。多个分组维度按声明顺序组成组合键，结果以 alias 扁平返回；HTTP 入口为 `POST .../snapshot/aggregation`：
 
 ```kotlin
 aggregationQuery {

--- a/documentation/docs/zh/reference/config/infrastructure.md
+++ b/documentation/docs/zh/reference/config/infrastructure.md
@@ -173,6 +173,7 @@ direct 和 batch 模式下都使用基于 `_source.version` 的原子保护更�
 | `wow.webflux.batch.concurrency` | Integer | `1` | 批量命令请求的并发数 |
 | `wow.webflux.batch.prefetch` | Integer | `1` | 批量命令请求的预取数 |
 | `wow.webflux.query.max-list-size` | Integer | `1000` | HTTP 列表/聚合查询最大 limit；`0` 关闭上限 |
+| `wow.webflux.query.max-aggregation-metrics` | Integer | `32` | HTTP 聚合查询指标数量上限；`0` 关闭上限 |
 | `wow.webflux.query.max-page-size` | Integer | `100` | HTTP 查询最大页大小；`0` 关闭上限 |
 | `wow.webflux.query.max-page-window` | Long | `10000` | HTTP 查询最大分页窗口；`0` 关闭上限 |
 | `wow.webflux.query.max-condition-nodes` | Integer | `64` | HTTP 查询条件节点上限；`0` 关闭上限 |
@@ -196,6 +197,7 @@ wow:
       prefetch: 1
     query:
       max-list-size: 1000
+      max-aggregation-metrics: 32
       max-page-size: 100
       max-page-window: 10000
       max-condition-nodes: 64

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt
@@ -199,6 +199,20 @@ abstract class SnapshotQueryServiceSpec {
     }
 
     @Test
+    fun aggregateIntegralTerms() {
+        aggregationQuery {
+            groupBy("version", "version")
+            count("snapshotCount")
+        }.aggregate(snapshotQueryService)
+            .test()
+            .consumeNextWith { result ->
+                result["version"].assert().isEqualTo(snapshot.version.toLong())
+                result["snapshotCount"].assert().isEqualTo(1L)
+            }
+            .verifyComplete()
+    }
+
+    @Test
     fun aggregateMultiDimensionalBuckets() {
         saveSnapshot(FIXED_SNAPSHOT_TIME + 1_000)
         saveSnapshot(FIXED_SNAPSHOT_TIME + HOUR_MILLIS)

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt
@@ -14,18 +14,21 @@
 package me.ahoo.wow.tck.query
 
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.AggregationDateUnit
 import me.ahoo.wow.eventsourcing.snapshot.SimpleSnapshot
 import me.ahoo.wow.eventsourcing.snapshot.Snapshot
 import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.modeling.aggregateId
 import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory
+import me.ahoo.wow.query.dsl.aggregationQuery
 import me.ahoo.wow.query.dsl.condition
 import me.ahoo.wow.query.dsl.listQuery
 import me.ahoo.wow.query.dsl.pagedQuery
 import me.ahoo.wow.query.dsl.singleQuery
 import me.ahoo.wow.query.snapshot.SnapshotQueryService
 import me.ahoo.wow.query.snapshot.SnapshotQueryServiceFactory
+import me.ahoo.wow.query.snapshot.aggregate
 import me.ahoo.wow.query.snapshot.count
 import me.ahoo.wow.query.snapshot.dynamicQuery
 import me.ahoo.wow.query.snapshot.query
@@ -34,7 +37,8 @@ import me.ahoo.wow.tck.mock.MockStateAggregate
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import reactor.kotlin.test.test
-import java.time.Clock
+import java.time.Instant
+import java.time.temporal.ChronoUnit
 
 abstract class SnapshotQueryServiceSpec {
     lateinit var snapshotStore: SnapshotStore
@@ -51,7 +55,7 @@ abstract class SnapshotQueryServiceSpec {
         val stateAggregate =
             ConstructorStateAggregateFactory.create(MOCK_AGGREGATE_METADATA.state, aggregateId)
         snapshot =
-            SimpleSnapshot(stateAggregate, Clock.systemUTC().millis())
+            SimpleSnapshot(stateAggregate, FIXED_SNAPSHOT_TIME)
         snapshotStore.save(snapshot)
             .test()
             .verifyComplete()
@@ -168,5 +172,110 @@ abstract class SnapshotQueryServiceSpec {
             .test()
             .expectNext(1L)
             .verifyComplete()
+    }
+
+    @Test
+    fun aggregateGlobalMetrics() {
+        val second = saveSnapshot(FIXED_SNAPSHOT_TIME + 1_000)
+
+        aggregationQuery {
+            count("snapshotCount")
+            sum("snapshotTime", "totalSnapshotTime")
+            avg("snapshotTime", "averageSnapshotTime")
+            min("snapshotTime", "minimumSnapshotTime")
+            max("snapshotTime", "maximumSnapshotTime")
+        }.aggregate(snapshotQueryService)
+            .test()
+            .consumeNextWith { result ->
+                result["snapshotCount"].assert().isEqualTo(2L)
+                result["totalSnapshotTime"].assert()
+                    .isEqualTo(FIXED_SNAPSHOT_TIME.toDouble() + second.snapshotTime.toDouble())
+                result["averageSnapshotTime"].assert()
+                    .isEqualTo((FIXED_SNAPSHOT_TIME.toDouble() + second.snapshotTime.toDouble()) / 2)
+                result["minimumSnapshotTime"].assert().isEqualTo(FIXED_SNAPSHOT_TIME.toDouble())
+                result["maximumSnapshotTime"].assert().isEqualTo(second.snapshotTime.toDouble())
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun aggregateMultiDimensionalBuckets() {
+        saveSnapshot(FIXED_SNAPSHOT_TIME + 1_000)
+        saveSnapshot(FIXED_SNAPSHOT_TIME + HOUR_MILLIS)
+
+        aggregationQuery {
+            groupBy("contextName", "context")
+            histogram("snapshotTime", "hour", HOUR_MILLIS.toDouble())
+            count("snapshotCount")
+            sort {
+                "snapshotCount".desc()
+            }
+            limit(10)
+        }.aggregate(snapshotQueryService)
+            .collectList()
+            .test()
+            .consumeNextWith { result ->
+                result.assert().hasSize(2)
+                result[0]["snapshotCount"].assert().isEqualTo(2L)
+                result[0]["hour"].assert().isEqualTo(hourBucket(FIXED_SNAPSHOT_TIME))
+                result[1]["snapshotCount"].assert().isEqualTo(1L)
+                result[1]["hour"].assert().isEqualTo(hourBucket(FIXED_SNAPSHOT_TIME + HOUR_MILLIS))
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun aggregateDateHistogram() {
+        saveSnapshot(FIXED_SNAPSHOT_TIME + 1_000)
+
+        aggregationQuery {
+            groupBy("contextName", "context")
+            dateHistogram("snapshotTime", "day", AggregationDateUnit.DAY)
+            count("snapshotCount")
+        }.aggregate(snapshotQueryService)
+            .test()
+            .consumeNextWith { result ->
+                result["context"].assert().isEqualTo(MOCK_AGGREGATE_METADATA.contextName)
+                result["day"].assert().isEqualTo(
+                    Instant.ofEpochMilli(FIXED_SNAPSHOT_TIME).truncatedTo(ChronoUnit.DAYS).toEpochMilli()
+                )
+                result["snapshotCount"].assert().isEqualTo(2L)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun aggregateEmptyGlobalMetrics() {
+        aggregationQuery {
+            condition {
+                id("missing")
+            }
+            count("snapshotCount")
+            sum("snapshotTime", "totalSnapshotTime")
+            avg("snapshotTime", "averageSnapshotTime")
+        }.aggregate(snapshotQueryService)
+            .test()
+            .consumeNextWith { result ->
+                result["snapshotCount"].assert().isEqualTo(0L)
+                result["totalSnapshotTime"].assert().isEqualTo(0.0)
+                result["averageSnapshotTime"].assert().isNull()
+            }
+            .verifyComplete()
+    }
+
+    private fun saveSnapshot(snapshotTime: Long): Snapshot<MockStateAggregate> {
+        val aggregateId = MOCK_AGGREGATE_METADATA.aggregateId(generateGlobalId())
+        val stateAggregate = ConstructorStateAggregateFactory.create(MOCK_AGGREGATE_METADATA.state, aggregateId)
+        val additionalSnapshot = SimpleSnapshot(stateAggregate, snapshotTime)
+        snapshotStore.save(additionalSnapshot).block()
+        return additionalSnapshot
+    }
+
+    private companion object {
+        const val FIXED_SNAPSHOT_TIME = 1_700_000_000_000L
+        const val HOUR_MILLIS = 3_600_000L
+
+        fun hourBucket(value: Long): Double =
+            (value / HOUR_MILLIS * HOUR_MILLIS).toDouble()
     }
 }

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
@@ -16,11 +16,14 @@ package me.ahoo.wow.api.query
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.ZoneId
+import java.time.ZoneOffset
 
 data class AggregationQuery(
     override val condition: Condition = Condition.ALL,
+    @get:ArraySchema(maxItems = MAX_GROUPS)
     @get:JsonInclude(JsonInclude.Include.NON_EMPTY)
     val groupBy: List<AggregationGroup> = emptyList(),
     val metrics: List<AggregationMetric>,
@@ -32,6 +35,7 @@ data class AggregationQuery(
     init {
         require(metrics.isNotEmpty()) { "metrics must not be empty." }
         require(limit in 1..MAX_LIMIT) { "limit must be between 1 and $MAX_LIMIT." }
+        require(groupBy.size <= MAX_GROUPS) { "groupBy must contain at most $MAX_GROUPS dimensions." }
         require(groupBy.isNotEmpty() || sort.isEmpty()) { "sort requires at least one groupBy." }
 
         val aliases = groupBy.map(AggregationGroup::alias) + metrics.map(AggregationMetric::alias)
@@ -39,6 +43,10 @@ data class AggregationQuery(
         val sortFields = sort.map(Sort::field)
         require(sortFields.distinct().size == sortFields.size) { "sort fields must be unique." }
         require(sortFields.all(aliases::contains)) { "sort fields must reference aggregation aliases." }
+        val groupAliases = groupBy.mapTo(hashSetOf(), AggregationGroup::alias)
+        require(groupBy.size + sortFields.count { it !in groupAliases } <= MAX_GROUPS) {
+            "aggregation sort must contain at most $MAX_GROUPS effective fields."
+        }
     }
 
     override fun withCondition(newCondition: Condition): AggregationQuery = copy(condition = newCondition)
@@ -46,6 +54,7 @@ data class AggregationQuery(
     companion object {
         const val DEFAULT_LIMIT: Int = 100
         const val MAX_LIMIT: Int = 10_000
+        const val MAX_GROUPS: Int = 32
         private const val DEFAULT_LIMIT_TEXT = "100"
         private const val MAX_LIMIT_TEXT = "10000"
     }
@@ -94,9 +103,7 @@ sealed interface AggregationGroup {
         init {
             requireAggregationField(field)
             requireAggregationAlias(alias)
-            require(timeZone.isNotBlank()) { "date histogram timeZone must not be blank." }
-            runCatching { ZoneId.of(timeZone) }
-                .getOrElse { throw IllegalArgumentException("Invalid date histogram timeZone: $timeZone.", it) }
+            requireAggregationTimeZone(timeZone)
         }
     }
 }
@@ -181,6 +188,19 @@ private fun requireAggregationField(field: String) {
 private fun requireAggregationAlias(alias: String) {
     require(alias.isNotBlank()) { "aggregation alias must not be blank." }
     require('.' !in alias) { "aggregation alias must not contain '.'." }
+    require('\u0000' !in alias) { "aggregation alias must not contain NUL." }
     require(!alias.startsWith('$')) { "aggregation alias must not start with '$'." }
     require(alias != "_id") { "aggregation alias [_id] is reserved." }
+}
+
+private val PORTABLE_TIME_ZONE_IDS: Set<String> = ZoneId.getAvailableZoneIds()
+private val PORTABLE_TIME_ZONE_OFFSET = Regex("[+-](?:0\\d|1\\d):[0-5]\\d")
+
+private fun requireAggregationTimeZone(timeZone: String) {
+    require(timeZone.isNotBlank()) { "date histogram timeZone must not be blank." }
+    val isPortableOffset = PORTABLE_TIME_ZONE_OFFSET.matches(timeZone) &&
+        runCatching { ZoneOffset.of(timeZone) }.isSuccess
+    require(timeZone in PORTABLE_TIME_ZONE_IDS || isPortableOffset) {
+        "Invalid date histogram timeZone [$timeZone]: use an IANA identifier or an offset in [+/-]HH:MM form."
+    }
 }

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
@@ -1,0 +1,186 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.api.query
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.ZoneId
+
+data class AggregationQuery(
+    override val condition: Condition = Condition.ALL,
+    @get:JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val groupBy: List<AggregationGroup> = emptyList(),
+    val metrics: List<AggregationMetric>,
+    @get:JsonInclude(JsonInclude.Include.NON_EMPTY)
+    override val sort: List<Sort> = emptyList(),
+    @get:Schema(defaultValue = DEFAULT_LIMIT_TEXT, minimum = "1", maximum = MAX_LIMIT_TEXT)
+    val limit: Int = DEFAULT_LIMIT,
+) : ConditionCapable<AggregationQuery>, SortCapable {
+    init {
+        require(metrics.isNotEmpty()) { "metrics must not be empty." }
+        require(limit in 1..MAX_LIMIT) { "limit must be between 1 and $MAX_LIMIT." }
+        require(groupBy.isNotEmpty() || sort.isEmpty()) { "sort requires at least one groupBy." }
+
+        val aliases = groupBy.map(AggregationGroup::alias) + metrics.map(AggregationMetric::alias)
+        require(aliases.distinct().size == aliases.size) { "aggregation aliases must be unique." }
+        val sortFields = sort.map(Sort::field)
+        require(sortFields.distinct().size == sortFields.size) { "sort fields must be unique." }
+        require(sortFields.all(aliases::contains)) { "sort fields must reference aggregation aliases." }
+    }
+
+    override fun withCondition(newCondition: Condition): AggregationQuery = copy(condition = newCondition)
+
+    companion object {
+        const val DEFAULT_LIMIT: Int = 100
+        const val MAX_LIMIT: Int = 10_000
+        private const val DEFAULT_LIMIT_TEXT = "100"
+        private const val MAX_LIMIT_TEXT = "10000"
+    }
+}
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(
+    JsonSubTypes.Type(value = AggregationGroup.Terms::class, name = "TERMS"),
+    JsonSubTypes.Type(value = AggregationGroup.Histogram::class, name = "HISTOGRAM"),
+    JsonSubTypes.Type(value = AggregationGroup.DateHistogram::class, name = "DATE_HISTOGRAM"),
+)
+sealed interface AggregationGroup {
+    val field: String
+    val alias: String
+
+    data class Terms(
+        override val field: String,
+        override val alias: String,
+    ) : AggregationGroup {
+        init {
+            requireAggregationField(field)
+            requireAggregationAlias(alias)
+        }
+    }
+
+    data class Histogram(
+        override val field: String,
+        override val alias: String,
+        val interval: Double,
+        val offset: Double = 0.0,
+    ) : AggregationGroup {
+        init {
+            requireAggregationField(field)
+            requireAggregationAlias(alias)
+            require(interval.isFinite() && interval > 0.0) { "histogram interval must be finite and greater than 0." }
+            require(offset.isFinite()) { "histogram offset must be finite." }
+        }
+    }
+
+    data class DateHistogram(
+        override val field: String,
+        override val alias: String,
+        val unit: AggregationDateUnit,
+        val timeZone: String = "UTC",
+    ) : AggregationGroup {
+        init {
+            requireAggregationField(field)
+            requireAggregationAlias(alias)
+            require(timeZone.isNotBlank()) { "date histogram timeZone must not be blank." }
+            runCatching { ZoneId.of(timeZone) }
+                .getOrElse { throw IllegalArgumentException("Invalid date histogram timeZone: $timeZone.", it) }
+        }
+    }
+}
+
+enum class AggregationDateUnit {
+    YEAR,
+    QUARTER,
+    MONTH,
+    WEEK,
+    DAY,
+    HOUR,
+    MINUTE,
+    SECOND,
+}
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(
+    JsonSubTypes.Type(value = AggregationMetric.Count::class, name = "COUNT"),
+    JsonSubTypes.Type(value = AggregationMetric.Sum::class, name = "SUM"),
+    JsonSubTypes.Type(value = AggregationMetric.Avg::class, name = "AVG"),
+    JsonSubTypes.Type(value = AggregationMetric.Min::class, name = "MIN"),
+    JsonSubTypes.Type(value = AggregationMetric.Max::class, name = "MAX"),
+)
+sealed interface AggregationMetric {
+    val alias: String
+
+    data class Count(override val alias: String) : AggregationMetric {
+        init {
+            requireAggregationAlias(alias)
+        }
+    }
+
+    sealed interface Numeric : AggregationMetric {
+        val field: String
+    }
+
+    data class Sum(
+        override val field: String,
+        override val alias: String,
+    ) : Numeric {
+        init {
+            requireAggregationField(field)
+            requireAggregationAlias(alias)
+        }
+    }
+
+    data class Avg(
+        override val field: String,
+        override val alias: String,
+    ) : Numeric {
+        init {
+            requireAggregationField(field)
+            requireAggregationAlias(alias)
+        }
+    }
+
+    data class Min(
+        override val field: String,
+        override val alias: String,
+    ) : Numeric {
+        init {
+            requireAggregationField(field)
+            requireAggregationAlias(alias)
+        }
+    }
+
+    data class Max(
+        override val field: String,
+        override val alias: String,
+    ) : Numeric {
+        init {
+            requireAggregationField(field)
+            requireAggregationAlias(alias)
+        }
+    }
+}
+
+private fun requireAggregationField(field: String) {
+    require(field.isNotBlank()) { "aggregation field must not be blank." }
+}
+
+private fun requireAggregationAlias(alias: String) {
+    require(alias.isNotBlank()) { "aggregation alias must not be blank." }
+    require('.' !in alias) { "aggregation alias must not contain '.'." }
+    require(!alias.startsWith('$')) { "aggregation alias must not start with '$'." }
+    require(alias != "_id") { "aggregation alias [_id] is reserved." }
+}

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
@@ -26,7 +26,7 @@ data class AggregationQuery(
     @get:ArraySchema(maxItems = MAX_GROUPS)
     @get:JsonInclude(JsonInclude.Include.NON_EMPTY)
     val groupBy: List<AggregationGroup> = emptyList(),
-    @get:ArraySchema(minItems = 1, maxItems = MAX_METRICS)
+    @get:ArraySchema(minItems = 1)
     val metrics: List<AggregationMetric>,
     @get:JsonInclude(JsonInclude.Include.NON_EMPTY)
     override val sort: List<Sort> = emptyList(),
@@ -35,7 +35,6 @@ data class AggregationQuery(
 ) : ConditionCapable<AggregationQuery>, SortCapable {
     init {
         require(metrics.isNotEmpty()) { "metrics must not be empty." }
-        require(metrics.size <= MAX_METRICS) { "metrics must contain at most $MAX_METRICS items." }
         require(limit in 1..MAX_LIMIT) { "limit must be between 1 and $MAX_LIMIT." }
         require(groupBy.size <= MAX_GROUPS) { "groupBy must contain at most $MAX_GROUPS dimensions." }
         require(groupBy.isNotEmpty() || sort.isEmpty()) { "sort requires at least one groupBy." }
@@ -57,7 +56,6 @@ data class AggregationQuery(
         const val DEFAULT_LIMIT: Int = 100
         const val MAX_LIMIT: Int = 10_000
         const val MAX_GROUPS: Int = 32
-        const val MAX_METRICS: Int = 32
         private const val DEFAULT_LIMIT_TEXT = "100"
         private const val MAX_LIMIT_TEXT = "10000"
     }

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
@@ -84,6 +84,7 @@ sealed interface AggregationGroup {
     data class Histogram(
         override val field: String,
         override val alias: String,
+        @get:Schema(minimum = "0", exclusiveMinimum = true)
         val interval: Double,
         val offset: Double = 0.0,
     ) : AggregationGroup {

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt
@@ -82,11 +82,56 @@ class AggregationQueryTest {
             )
         }
         assertThrows<IllegalArgumentException> {
+            AggregationMetric.Count("bad\u0000alias")
+        }
+        assertThrows<IllegalArgumentException> {
             AggregationQuery(
                 groupBy = listOf(AggregationGroup.Terms("state.status", "status")),
                 metrics = listOf(AggregationMetric.Count("count")),
                 limit = AggregationQuery.MAX_LIMIT + 1,
             )
+        }
+    }
+
+    @Test
+    fun `should reject aggregation exceeding MongoDB sort key limit`() {
+        assertThrows<IllegalArgumentException> {
+            AggregationQuery(
+                groupBy = List(AggregationQuery.MAX_GROUPS + 1) {
+                    AggregationGroup.Terms("state.field$it", "field$it")
+                },
+                metrics = listOf(AggregationMetric.Count("count")),
+            )
+        }
+        assertThrows<IllegalArgumentException> {
+            AggregationQuery(
+                groupBy = List(AggregationQuery.MAX_GROUPS) {
+                    AggregationGroup.Terms("state.field$it", "field$it")
+                },
+                metrics = listOf(AggregationMetric.Count("count")),
+                sort = listOf(Sort("count", Sort.Direction.DESC)),
+            )
+        }
+    }
+
+    @Test
+    fun `should accept only portable date histogram time zones`() {
+        AggregationGroup.DateHistogram(
+            field = "snapshotTime",
+            alias = "hour",
+            unit = AggregationDateUnit.HOUR,
+            timeZone = "+08:00",
+        ).timeZone.assert().isEqualTo("+08:00")
+
+        listOf("UTC+08:00", "GMT+08:00", "Z", "+19:00").forEach { timeZone ->
+            assertThrows<IllegalArgumentException> {
+                AggregationGroup.DateHistogram(
+                    field = "snapshotTime",
+                    alias = "hour",
+                    unit = AggregationDateUnit.HOUR,
+                    timeZone = timeZone,
+                )
+            }
         }
     }
 }

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.api.query
+
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class AggregationQueryTest {
+    @Test
+    fun `should create a valid multi-dimensional aggregation`() {
+        val query = AggregationQuery(
+            groupBy = listOf(
+                AggregationGroup.Terms("state.country", "country"),
+                AggregationGroup.DateHistogram(
+                    field = "eventTime",
+                    alias = "month",
+                    unit = AggregationDateUnit.MONTH,
+                    timeZone = "Asia/Shanghai",
+                ),
+                AggregationGroup.Histogram("state.totalAmount", "amountBand", 100.0),
+            ),
+            metrics = listOf(
+                AggregationMetric.Count("orderCount"),
+                AggregationMetric.Sum("state.totalAmount", "totalAmount"),
+            ),
+            sort = listOf(Sort("totalAmount", Sort.Direction.DESC)),
+            limit = 10,
+        )
+
+        query.limit.assert().isEqualTo(10)
+        query.groupBy.assert().hasSize(3)
+        query.metrics.assert().hasSize(2)
+        query.withCondition(Condition.id("id")).condition.assert().isEqualTo(Condition.id("id"))
+    }
+
+    @Test
+    fun `should reject invalid aggregation contracts`() {
+        assertThrows<IllegalArgumentException> {
+            AggregationQuery(metrics = emptyList())
+        }
+        assertThrows<IllegalArgumentException> {
+            AggregationQuery(
+                groupBy = listOf(AggregationGroup.Terms("state.status", "value")),
+                metrics = listOf(AggregationMetric.Count("value")),
+            )
+        }
+        assertThrows<IllegalArgumentException> {
+            AggregationQuery(
+                metrics = listOf(AggregationMetric.Count("count")),
+                sort = listOf(Sort("count", Sort.Direction.ASC)),
+            )
+        }
+        assertThrows<IllegalArgumentException> {
+            AggregationQuery(
+                groupBy = listOf(AggregationGroup.Terms("state.status", "status")),
+                metrics = listOf(AggregationMetric.Count("count")),
+                sort = listOf(Sort("missing", Sort.Direction.ASC)),
+            )
+        }
+        assertThrows<IllegalArgumentException> {
+            AggregationQuery(
+                groupBy = listOf(AggregationGroup.Histogram("state.totalAmount", "band", 0.0)),
+                metrics = listOf(AggregationMetric.Count("count")),
+            )
+        }
+        assertThrows<IllegalArgumentException> {
+            AggregationQuery(
+                groupBy = listOf(AggregationGroup.Terms("state.status", "bad.alias")),
+                metrics = listOf(AggregationMetric.Count("count")),
+            )
+        }
+        assertThrows<IllegalArgumentException> {
+            AggregationQuery(
+                groupBy = listOf(AggregationGroup.Terms("state.status", "status")),
+                metrics = listOf(AggregationMetric.Count("count")),
+                limit = AggregationQuery.MAX_LIMIT + 1,
+            )
+        }
+    }
+}

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt
@@ -115,17 +115,6 @@ class AggregationQueryTest {
     }
 
     @Test
-    fun `should reject too many metrics`() {
-        assertThrows<IllegalArgumentException> {
-            AggregationQuery(
-                metrics = List(AggregationQuery.MAX_METRICS + 1) {
-                    AggregationMetric.Count("count$it")
-                },
-            )
-        }
-    }
-
-    @Test
     fun `should accept only portable date histogram time zones`() {
         AggregationGroup.DateHistogram(
             field = "snapshotTime",

--- a/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/ReactiveSnapshotAggregationQueryApi.kt
+++ b/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/ReactiveSnapshotAggregationQueryApi.kt
@@ -11,15 +11,13 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.query.filter
+package me.ahoo.wow.apiclient.query
 
-enum class QueryType(val isDynamic: Boolean) {
-    SINGLE(false),
-    DYNAMIC_SINGLE(true),
-    LIST(false),
-    DYNAMIC_LIST(true),
-    PAGED(false),
-    DYNAMIC_PAGED(true),
-    COUNT(false),
-    AGGREGATE(true),
-}
+import me.ahoo.wow.api.query.AggregationQuery
+import reactor.core.publisher.Flux
+
+interface ReactiveSnapshotAggregationQueryApi :
+    SnapshotAggregationQueryApi<Flux<Map<String, Any?>>>
+
+fun AggregationQuery.aggregate(snapshotQueryApi: ReactiveSnapshotAggregationQueryApi): Flux<Map<String, Any?>> =
+    snapshotQueryApi.aggregate(this)

--- a/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SnapshotAggregationQueryApi.kt
+++ b/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SnapshotAggregationQueryApi.kt
@@ -17,7 +17,7 @@ import me.ahoo.wow.api.query.AggregationQuery
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.service.annotation.PostExchange
 
-const val SNAPSHOT_AGGREGATION_RESOURCE_NAME = "$SNAPSHOT_RESOURCE_NAME/aggregate"
+const val SNAPSHOT_AGGREGATION_RESOURCE_NAME = "$SNAPSHOT_RESOURCE_NAME/aggregation"
 
 interface SnapshotAggregationQueryApi<R> : SnapshotQueryApi {
     @PostExchange(SNAPSHOT_AGGREGATION_RESOURCE_NAME)

--- a/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SnapshotAggregationQueryApi.kt
+++ b/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SnapshotAggregationQueryApi.kt
@@ -11,15 +11,15 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.query.filter
+package me.ahoo.wow.apiclient.query
 
-enum class QueryType(val isDynamic: Boolean) {
-    SINGLE(false),
-    DYNAMIC_SINGLE(true),
-    LIST(false),
-    DYNAMIC_LIST(true),
-    PAGED(false),
-    DYNAMIC_PAGED(true),
-    COUNT(false),
-    AGGREGATE(true),
+import me.ahoo.wow.api.query.AggregationQuery
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.service.annotation.PostExchange
+
+const val SNAPSHOT_AGGREGATION_RESOURCE_NAME = "$SNAPSHOT_RESOURCE_NAME/aggregate"
+
+interface SnapshotAggregationQueryApi<R> : SnapshotQueryApi {
+    @PostExchange(SNAPSHOT_AGGREGATION_RESOURCE_NAME)
+    fun aggregate(@RequestBody query: AggregationQuery): R
 }

--- a/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SynchronousSnapshotAggregationQueryApi.kt
+++ b/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SynchronousSnapshotAggregationQueryApi.kt
@@ -11,15 +11,12 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.query.filter
+package me.ahoo.wow.apiclient.query
 
-enum class QueryType(val isDynamic: Boolean) {
-    SINGLE(false),
-    DYNAMIC_SINGLE(true),
-    LIST(false),
-    DYNAMIC_LIST(true),
-    PAGED(false),
-    DYNAMIC_PAGED(true),
-    COUNT(false),
-    AGGREGATE(true),
-}
+import me.ahoo.wow.api.query.AggregationQuery
+
+interface SynchronousSnapshotAggregationQueryApi :
+    SnapshotAggregationQueryApi<List<Map<String, Any?>>>
+
+fun AggregationQuery.aggregate(snapshotQueryApi: SynchronousSnapshotAggregationQueryApi): List<Map<String, Any?>> =
+    snapshotQueryApi.aggregate(this)

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryService.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryService.kt
@@ -190,20 +190,24 @@ abstract class AbstractElasticsearchQueryService<R : Any> : QueryService<R> {
         }.flatMap(elasticsearchClient::count).map { it.count() }
     }
 
-    private fun resolve(condition: Condition, sort: List<Sort> = emptyList()): Mono<ResolvedQuery> {
-        val resolver = indexMappingResolver ?: return Mono.just(compile(condition, sort))
+    protected fun <T : Any> resolveWithMapping(resolve: (ElasticsearchIndexMapping?) -> T): Mono<T> {
+        val resolver = indexMappingResolver ?: return Mono.fromSupplier { resolve(null) }
         return resolver.currentOrLoad(indexName)
-            .map { mapping -> compile(resolveCondition(mapping, condition), resolveSort(mapping, sort)) }
+            .map(resolve)
             .onErrorResume(ElasticsearchFieldResolutionException::class.java) {
                 resolver.refresh(indexName)
-                    .map { result ->
-                        compile(
-                            resolveCondition(result.mapping, condition),
-                            resolveSort(result.mapping, sort),
-                        )
-                    }
+                    .map { result -> resolve(result.mapping) }
             }
     }
+
+    private fun resolve(condition: Condition, sort: List<Sort> = emptyList()): Mono<ResolvedQuery> =
+        resolveWithMapping { mapping ->
+            if (mapping == null) {
+                compile(condition, sort)
+            } else {
+                compile(resolveCondition(mapping, condition), resolveSort(mapping, sort))
+            }
+        }
 
     private fun compile(condition: Condition, sort: List<Sort>): ResolvedQuery =
         ResolvedQuery(

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchAggregationPager.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchAggregationPager.kt
@@ -19,6 +19,7 @@ import co.elastic.clients.elasticsearch._types.aggregations.CompositeAggregation
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeBucket
 import co.elastic.clients.elasticsearch._types.query_dsl.Query
 import co.elastic.clients.elasticsearch.core.SearchRequest
+import co.elastic.clients.elasticsearch.core.search.ResponseBody
 import co.elastic.clients.util.NamedValue
 import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
 import reactor.core.publisher.Flux
@@ -87,6 +88,7 @@ internal class ElasticsearchAggregationPager(
             }
             val request = SearchRequest.of {
                 it.size(0)
+                    .allowPartialSearchResults(false)
                     .trackTotalHits { trackTotalHits -> trackTotalHits.enabled(false) }
                     .query(query)
                     .pit { pointInTime ->
@@ -98,6 +100,7 @@ internal class ElasticsearchAggregationPager(
             elasticsearchClient.search(request, Map::class.java)
         }.map { response ->
             response.pitId()?.takeIf(String::isNotBlank)?.let { pit.id = it }
+            response.requireCompleteAggregationResponse()
             val aggregate = checkNotNull(response.aggregations()[ROOT_AGGREGATION]) {
                 "Elasticsearch aggregation response is missing [$ROOT_AGGREGATION]."
             }
@@ -127,5 +130,12 @@ internal class ElasticsearchAggregationPager(
 
     private companion object {
         const val ROOT_AGGREGATION = "__wow_aggregation__"
+    }
+}
+
+internal fun ResponseBody<*>.requireCompleteAggregationResponse() {
+    check(!timedOut()) { "Elasticsearch aggregation search timed out." }
+    check(shards().failed().toInt() == 0) {
+        "Elasticsearch aggregation search failed on ${shards().failed()} shard(s)."
     }
 }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchAggregationPager.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchAggregationPager.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.elasticsearch.query
+
+import co.elastic.clients.elasticsearch._types.FieldValue
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation
+import co.elastic.clients.elasticsearch._types.aggregations.CompositeAggregationSource
+import co.elastic.clients.elasticsearch._types.aggregations.CompositeBucket
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import co.elastic.clients.elasticsearch.core.SearchRequest
+import co.elastic.clients.util.NamedValue
+import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.time.Duration
+
+internal class ElasticsearchAggregationPager(
+    private val elasticsearchClient: ReactiveElasticsearchClient,
+    indexName: String,
+    private val batchSize: Int = DEFAULT_SEARCH_BATCH_SIZE,
+    keepAlive: Duration = DEFAULT_PIT_KEEP_ALIVE,
+) {
+    private val pointInTime = ElasticsearchPointInTime(elasticsearchClient, indexName, keepAlive)
+
+    init {
+        require(batchSize in 1..DEFAULT_SEARCH_BATCH_SIZE) {
+            "batchSize must be between 1 and $DEFAULT_SEARCH_BATCH_SIZE."
+        }
+    }
+
+    fun search(
+        query: Query,
+        sources: List<NamedValue<CompositeAggregationSource>>,
+        metrics: Map<String, Aggregation>,
+        limit: Int = 0,
+    ): Flux<CompositeBucket> {
+        require(sources.isNotEmpty()) { "aggregation sources must not be empty." }
+        require(limit >= 0) { "limit must be greater than or equal to 0." }
+        return pointInTime.use { pit ->
+            searchPage(pit, query, sources, metrics, limit)
+                .expand { page ->
+                    page.afterKey?.let { afterKey ->
+                        searchPage(pit, query, sources, metrics, limit, page.fetched, afterKey)
+                    } ?: Mono.empty()
+                }
+                .concatMapIterable({ it.buckets }, 1)
+        }
+    }
+
+    private fun searchPage(
+        pit: ElasticsearchPointInTime.Session,
+        query: Query,
+        sources: List<NamedValue<CompositeAggregationSource>>,
+        metrics: Map<String, Aggregation>,
+        limit: Int,
+        fetched: Long = 0,
+        afterKey: Map<String, FieldValue> = emptyMap(),
+    ): Mono<AggregationPage> {
+        val pageSize = if (limit == 0) {
+            batchSize
+        } else {
+            minOf(batchSize.toLong(), limit.toLong() - fetched).toInt()
+        }
+        return Mono.defer {
+            val rootAggregation = Aggregation.of { aggregation ->
+                if (metrics.isNotEmpty()) {
+                    aggregation.aggregations(metrics)
+                }
+                aggregation.composite { composite ->
+                    composite.size(pageSize).sources(sources)
+                    if (afterKey.isNotEmpty()) {
+                        composite.after(afterKey)
+                    }
+                    composite
+                }
+            }
+            val request = SearchRequest.of {
+                it.size(0)
+                    .trackTotalHits { trackTotalHits -> trackTotalHits.enabled(false) }
+                    .query(query)
+                    .pit { pointInTime ->
+                        pointInTime.id(pit.id)
+                            .keepAlive { keepAlive -> keepAlive.time(this.pointInTime.keepAliveValue) }
+                    }
+                    .aggregations(ROOT_AGGREGATION, rootAggregation)
+            }
+            elasticsearchClient.search(request, Map::class.java)
+        }.map { response ->
+            response.pitId()?.takeIf(String::isNotBlank)?.let { pit.id = it }
+            val aggregate = checkNotNull(response.aggregations()[ROOT_AGGREGATION]) {
+                "Elasticsearch aggregation response is missing [$ROOT_AGGREGATION]."
+            }
+            check(aggregate.isComposite) {
+                "Elasticsearch aggregation response [$ROOT_AGGREGATION] must be composite."
+            }
+            val composite = aggregate.composite()
+            check(composite.buckets().isArray) {
+                "Elasticsearch composite aggregation must return array buckets."
+            }
+            val buckets = composite.buckets().array()
+            val totalFetched = fetched + buckets.size
+            val hasNextPage = buckets.size == pageSize && (limit == 0 || totalFetched < limit.toLong())
+            AggregationPage(
+                buckets = buckets,
+                fetched = totalFetched,
+                afterKey = composite.afterKey().takeIf { hasNextPage && it.isNotEmpty() },
+            )
+        }
+    }
+
+    private data class AggregationPage(
+        val buckets: List<CompositeBucket>,
+        val fetched: Long,
+        val afterKey: Map<String, FieldValue>?,
+    )
+
+    private companion object {
+        const val ROOT_AGGREGATION = "__wow_aggregation__"
+    }
+}

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolver.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolver.kt
@@ -45,6 +45,7 @@ enum class ElasticsearchFieldUsage {
     RANGE,
     SEARCH,
     SORT,
+    TERMS,
     NUMERIC,
     DATE,
 }
@@ -276,6 +277,7 @@ private data class ElasticsearchMappedField(
 ) {
     fun supports(usage: ElasticsearchFieldUsage): Boolean =
         when (usage) {
+            ElasticsearchFieldUsage.TERMS,
             ElasticsearchFieldUsage.NUMERIC,
             ElasticsearchFieldUsage.DATE,
             -> supportsAggregation(usage)
@@ -297,6 +299,7 @@ private data class ElasticsearchMappedField(
 
     private fun supportsAggregation(usage: ElasticsearchFieldUsage): Boolean =
         when (usage) {
+            ElasticsearchFieldUsage.TERMS -> isSortable(EXACT_KINDS)
             ElasticsearchFieldUsage.NUMERIC -> isSortable(NUMERIC_KINDS)
             ElasticsearchFieldUsage.DATE -> isSortable(DATE_KINDS + NUMERIC_KINDS)
             else -> error("Unsupported aggregation field usage: $usage")

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolver.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolver.kt
@@ -45,6 +45,8 @@ enum class ElasticsearchFieldUsage {
     RANGE,
     SEARCH,
     SORT,
+    NUMERIC,
+    DATE,
 }
 
 class ElasticsearchFieldResolutionException(message: String) : IllegalArgumentException(message)
@@ -274,15 +276,35 @@ private data class ElasticsearchMappedField(
 ) {
     fun supports(usage: ElasticsearchFieldUsage): Boolean =
         when (usage) {
+            ElasticsearchFieldUsage.NUMERIC,
+            ElasticsearchFieldUsage.DATE,
+            -> supportsAggregation(usage)
+
+            else -> supportsQuery(usage)
+        }
+
+    private fun supportsQuery(usage: ElasticsearchFieldUsage): Boolean =
+        when (usage) {
             ElasticsearchFieldUsage.EXACT -> isQueryable() && kind in EXACT_KINDS
             ElasticsearchFieldUsage.LITERAL -> indexed && kind in LITERAL_KINDS
             ElasticsearchFieldUsage.RANGE -> isQueryable() && kind in RANGE_KINDS
             ElasticsearchFieldUsage.SEARCH -> indexed && kind in SEARCH_KINDS
             ElasticsearchFieldUsage.SORT ->
                 sortable && (kind in EXACT_KINDS || (indexed && kind == Property.Kind.Text))
+
+            else -> error("Unsupported query field usage: $usage")
+        }
+
+    private fun supportsAggregation(usage: ElasticsearchFieldUsage): Boolean =
+        when (usage) {
+            ElasticsearchFieldUsage.NUMERIC -> isSortable(NUMERIC_KINDS)
+            ElasticsearchFieldUsage.DATE -> isSortable(DATE_KINDS + NUMERIC_KINDS)
+            else -> error("Unsupported aggregation field usage: $usage")
         }
 
     private fun isQueryable(): Boolean = indexed || (sortable && kind in DOC_VALUE_QUERY_KINDS)
+
+    private fun isSortable(kinds: Set<Property.Kind>): Boolean = sortable && kind in kinds
 
     companion object {
         private val NUMERIC_KINDS = setOf(
@@ -318,6 +340,7 @@ private data class ElasticsearchMappedField(
             Property.Kind.DateNanos,
             Property.Kind.Ip,
         )
+        private val DATE_KINDS = setOf(Property.Kind.Date, Property.Kind.DateNanos)
         private val EXACT_KINDS = NUMERIC_KINDS + TERM_KINDS + setOf(
             Property.Kind.Boolean,
             Property.Kind.Date,

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchPointInTime.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchPointInTime.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.elasticsearch.query
+
+import co.elastic.clients.elasticsearch.core.ClosePointInTimeRequest
+import co.elastic.clients.elasticsearch.core.OpenPointInTimeRequest
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.time.Duration
+
+internal class ElasticsearchPointInTime(
+    private val elasticsearchClient: ReactiveElasticsearchClient,
+    private val indexName: String,
+    keepAlive: Duration,
+) {
+    val keepAliveValue: String = keepAlive.toMillis().let {
+        if (it % 60_000 == 0L) "${it / 60_000}m" else "${it}ms"
+    }
+
+    init {
+        require(keepAlive.toMillis() > 0) { "keepAlive must be greater than or equal to 1ms." }
+    }
+
+    fun <T : Any> use(action: (Session) -> Flux<T>): Flux<T> = Flux.usingWhen(
+        open(),
+        action,
+        ::close,
+        { session, _ -> close(session) },
+        ::close,
+    )
+
+    private fun open(): Mono<Session> = Mono.defer {
+        elasticsearchClient.openPointInTime(
+            OpenPointInTimeRequest.of {
+                it.index(indexName)
+                    .keepAlive { keepAlive -> keepAlive.time(keepAliveValue) }
+            }
+        )
+    }.map {
+        check(it.id().isNotBlank()) { "Elasticsearch returned an empty PIT ID." }
+        Session(it.id())
+    }
+
+    private fun close(session: Session): Mono<Void> = Mono.defer {
+        elasticsearchClient.closePointInTime(ClosePointInTimeRequest.of { it.id(session.id) })
+    }.doOnNext {
+        if (!it.succeeded()) {
+            log.warn { "Failed to close Elasticsearch PIT [${session.id}]." }
+        }
+    }.then()
+        .onErrorResume {
+            log.warn(it) { "Failed to close Elasticsearch PIT [${session.id}]." }
+            Mono.empty()
+        }
+
+    data class Session(var id: String)
+
+    private companion object {
+        val log = KotlinLogging.logger(ElasticsearchPointInTime::class.java.name)
+    }
+}

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchQueryPager.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchQueryPager.kt
@@ -16,12 +16,9 @@ package me.ahoo.wow.elasticsearch.query
 import co.elastic.clients.elasticsearch._types.FieldValue
 import co.elastic.clients.elasticsearch._types.SortOptions
 import co.elastic.clients.elasticsearch._types.query_dsl.Query
-import co.elastic.clients.elasticsearch.core.ClosePointInTimeRequest
-import co.elastic.clients.elasticsearch.core.OpenPointInTimeRequest
 import co.elastic.clients.elasticsearch.core.SearchRequest
 import co.elastic.clients.elasticsearch.core.search.Hit
 import co.elastic.clients.elasticsearch.core.search.SourceFilter
-import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -37,15 +34,12 @@ internal class ElasticsearchQueryPager(
     private val batchSize: Int = DEFAULT_SEARCH_BATCH_SIZE,
     private val keepAlive: Duration = DEFAULT_PIT_KEEP_ALIVE,
 ) {
-    private val keepAliveValue = keepAlive.toMillis().let {
-        if (it % 60_000 == 0L) "${it / 60_000}m" else "${it}ms"
-    }
+    private val pointInTime = ElasticsearchPointInTime(elasticsearchClient, indexName, keepAlive)
 
     init {
         require(batchSize in 1..DEFAULT_SEARCH_BATCH_SIZE) {
             "batchSize must be between 1 and $DEFAULT_SEARCH_BATCH_SIZE."
         }
-        require(keepAlive.toMillis() > 0) { "keepAlive must be greater than or equal to 1ms." }
     }
 
     fun search(
@@ -56,39 +50,19 @@ internal class ElasticsearchQueryPager(
     ): Flux<Hit<Map<*, *>>> {
         require(limit >= 0) { "limit must be greater than or equal to 0." }
         require(sort.isNotEmpty()) { "sort must not be empty when using search_after." }
-        return Flux.usingWhen(
-            openPointInTime(),
-            { pit ->
-                searchPage(pit, limit, query, sourceFilter, sort)
-                    .expand { page ->
-                        page.nextSearchAfter?.let {
-                            searchPage(pit, limit, query, sourceFilter, sort, page.fetched, it)
-                        } ?: Mono.empty()
-                    }
-                    .concatMapIterable({ it.hits }, 1)
-            },
-            ::closePointInTime,
-            { pit, _ -> closePointInTime(pit) },
-            ::closePointInTime,
-        )
-    }
-
-    private fun openPointInTime(): Mono<PointInTime> {
-        return Mono.defer {
-            elasticsearchClient.openPointInTime(
-                OpenPointInTimeRequest.of {
-                    it.index(indexName)
-                        .keepAlive { it.time(keepAliveValue) }
+        return pointInTime.use { pit ->
+            searchPage(pit, limit, query, sourceFilter, sort)
+                .expand { page ->
+                    page.nextSearchAfter?.let {
+                        searchPage(pit, limit, query, sourceFilter, sort, page.fetched, it)
+                    } ?: Mono.empty()
                 }
-            )
-        }.map {
-            check(it.id().isNotBlank()) { "Elasticsearch returned an empty PIT ID." }
-            PointInTime(it.id())
+                .concatMapIterable({ it.hits }, 1)
         }
     }
 
     private fun searchPage(
-        pit: PointInTime,
+        pit: ElasticsearchPointInTime.Session,
         limit: Int,
         query: Query,
         sourceFilter: SourceFilter?,
@@ -108,7 +82,7 @@ internal class ElasticsearchQueryPager(
                     .trackTotalHits { trackHits -> trackHits.enabled(false) }
                     .pit { pointInTime ->
                         pointInTime.id(pit.id)
-                            .keepAlive { it.time(keepAliveValue) }
+                            .keepAlive { it.time(this.pointInTime.keepAliveValue) }
                     }
                     .sort(sort)
                 if (searchAfter.isNotEmpty()) {
@@ -136,29 +110,9 @@ internal class ElasticsearchQueryPager(
         }
     }
 
-    private fun closePointInTime(pit: PointInTime): Mono<Void> {
-        return Mono.defer {
-            elasticsearchClient.closePointInTime(ClosePointInTimeRequest.of { it.id(pit.id) })
-        }.doOnNext {
-            if (!it.succeeded()) {
-                log.warn { "Failed to close Elasticsearch PIT [${pit.id}]." }
-            }
-        }.then()
-            .onErrorResume {
-                log.warn(it) { "Failed to close Elasticsearch PIT [${pit.id}]." }
-                Mono.empty()
-            }
-    }
-
-    private data class PointInTime(var id: String)
-
     private data class SearchPage(
         val hits: List<Hit<Map<*, *>>>,
         val fetched: Long,
         val nextSearchAfter: List<FieldValue>?,
     )
-
-    private companion object {
-        val log = KotlinLogging.logger(ElasticsearchQueryPager::class.java.name)
-    }
 }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryService.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryService.kt
@@ -46,6 +46,7 @@ import me.ahoo.wow.elasticsearch.query.ElasticsearchFieldUsage
 import me.ahoo.wow.elasticsearch.query.ElasticsearchIndexMapping
 import me.ahoo.wow.elasticsearch.query.ElasticsearchIndexMappingResolver
 import me.ahoo.wow.elasticsearch.query.ElasticsearchMappingRefreshResult
+import me.ahoo.wow.elasticsearch.query.requireCompleteAggregationResponse
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.query.converter.ConditionConverter
 import me.ahoo.wow.query.snapshot.SnapshotQueryService
@@ -55,6 +56,7 @@ import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchCl
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import java.time.Duration
+import java.util.Arrays
 import java.util.PriorityQueue
 
 class ElasticsearchSnapshotQueryService<S : Any>(
@@ -138,6 +140,7 @@ class ElasticsearchSnapshotQueryService<S : Any>(
         val request = SearchRequest.of {
             it.index(indexName)
                 .size(0)
+                .allowPartialSearchResults(false)
                 .query(resolved.condition)
                 .trackTotalHits { trackTotalHits ->
                     trackTotalHits.enabled(resolved.query.metrics.any { metric -> metric is AggregationMetric.Count })
@@ -149,6 +152,7 @@ class ElasticsearchSnapshotQueryService<S : Any>(
         }
         return elasticsearchClient.search(request, Map::class.java)
             .map<Map<String, Any?>> { response ->
+                response.requireCompleteAggregationResponse()
                 buildMap {
                     resolved.query.metrics.forEach { metric ->
                         put(
@@ -200,7 +204,7 @@ class ElasticsearchSnapshotQueryService<S : Any>(
         val resolvedGroups = groupBy.map { group ->
             when (group) {
                 is AggregationGroup.Terms -> group.copy(
-                    field = mapping.resolve(group.field, ElasticsearchFieldUsage.EXACT)
+                    field = mapping.resolve(group.field, ElasticsearchFieldUsage.TERMS)
                 )
 
                 is AggregationGroup.Histogram -> group.copy(
@@ -404,14 +408,23 @@ private fun aggregationComparator(sort: List<Sort>): Comparator<Map<String, Any?
 }
 
 @Suppress("UNCHECKED_CAST")
-private fun compareAggregationValues(left: Any?, right: Any?, direction: Sort.Direction): Int {
+internal fun compareAggregationValues(left: Any?, right: Any?, direction: Sort.Direction): Int {
     val ascending = when {
         left === right -> 0
         left == null -> -1
         right == null -> 1
+        left.isIntegral() && right.isIntegral() -> (left as Number).toLong().compareTo((right as Number).toLong())
         left is Number && right is Number -> left.toDouble().compareTo(right.toDouble())
+        left is String && right is String -> left.compareUtf8(right)
         left::class == right::class && left is Comparable<*> -> (left as Comparable<Any>).compareTo(right)
-        else -> left.toString().compareTo(right.toString())
+        else -> left.toString().compareUtf8(right.toString())
     }
     return if (direction == Sort.Direction.ASC) ascending else -ascending
 }
+
+private fun Any?.isIntegral(): Boolean = this is Byte || this is Short || this is Int || this is Long
+
+private fun String.compareUtf8(other: String): Int = Arrays.compareUnsigned(
+    encodeToByteArray(),
+    other.encodeToByteArray(),
+)

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryService.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryService.kt
@@ -13,8 +13,24 @@
 
 package me.ahoo.wow.elasticsearch.query.snapshot
 
+import co.elastic.clients.elasticsearch._types.FieldValue
+import co.elastic.clients.elasticsearch._types.Script
+import co.elastic.clients.elasticsearch._types.ScriptLanguage
+import co.elastic.clients.elasticsearch._types.SortOrder
+import co.elastic.clients.elasticsearch._types.Time
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregate
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation
+import co.elastic.clients.elasticsearch._types.aggregations.CompositeAggregationSource
+import co.elastic.clients.elasticsearch._types.aggregations.CompositeBucket
 import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import co.elastic.clients.elasticsearch.core.SearchRequest
+import co.elastic.clients.json.JsonData
+import co.elastic.clients.util.NamedValue
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.AggregationDateUnit
+import me.ahoo.wow.api.query.AggregationGroup
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.MaterializedSnapshot
@@ -25,6 +41,8 @@ import me.ahoo.wow.elasticsearch.eventsourcing.ElasticsearchSnapshotStore
 import me.ahoo.wow.elasticsearch.query.AbstractElasticsearchQueryService
 import me.ahoo.wow.elasticsearch.query.DEFAULT_PIT_KEEP_ALIVE
 import me.ahoo.wow.elasticsearch.query.DEFAULT_SEARCH_BATCH_SIZE
+import me.ahoo.wow.elasticsearch.query.ElasticsearchAggregationPager
+import me.ahoo.wow.elasticsearch.query.ElasticsearchFieldUsage
 import me.ahoo.wow.elasticsearch.query.ElasticsearchIndexMapping
 import me.ahoo.wow.elasticsearch.query.ElasticsearchIndexMappingResolver
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
@@ -33,7 +51,9 @@ import me.ahoo.wow.query.snapshot.SnapshotQueryService
 import me.ahoo.wow.serialization.JsonSerializer
 import me.ahoo.wow.serialization.convert
 import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
+import reactor.core.publisher.Flux
 import java.time.Duration
+import java.util.PriorityQueue
 
 class ElasticsearchSnapshotQueryService<S : Any>(
     override val namedAggregate: NamedAggregate,
@@ -93,4 +113,296 @@ class ElasticsearchSnapshotQueryService<S : Any>(
 
     override fun resolveSort(mapping: ElasticsearchIndexMapping, sort: List<Sort>): List<Sort> =
         mapping.resolve(sort)
+
+    override fun aggregate(aggregationQuery: AggregationQuery): Flux<Map<String, Any?>> =
+        resolveWithMapping { mapping -> aggregationQuery.resolve(mapping) }
+            .flatMapMany { resolved ->
+                if (resolved.query.groupBy.isEmpty()) {
+                    aggregateGlobal(resolved)
+                } else {
+                    aggregateGrouped(resolved)
+                }
+            }
+
+    private fun aggregateGlobal(resolved: ResolvedAggregationQuery): Flux<Map<String, Any?>> {
+        val metricAggregations = resolved.query.metricAggregations()
+        val request = SearchRequest.of {
+            it.index(indexName)
+                .size(0)
+                .query(resolved.condition)
+                .trackTotalHits { trackTotalHits ->
+                    trackTotalHits.enabled(resolved.query.metrics.any { metric -> metric is AggregationMetric.Count })
+                }
+            if (metricAggregations.isNotEmpty()) {
+                it.aggregations(metricAggregations)
+            }
+            it
+        }
+        return elasticsearchClient.search(request, Map::class.java)
+            .map<Map<String, Any?>> { response ->
+                buildMap {
+                    resolved.query.metrics.forEach { metric ->
+                        put(
+                            metric.alias,
+                            metric.toResultValue(
+                                aggregations = response.aggregations(),
+                                documentCount = response.hits().total()?.value() ?: 0,
+                            ),
+                        )
+                    }
+                }
+            }.flux()
+    }
+
+    private fun aggregateGrouped(resolved: ResolvedAggregationQuery): Flux<Map<String, Any?>> {
+        val effectiveSort = resolved.query.effectiveSort()
+        val groupAliases = resolved.query.groupBy.mapTo(hashSetOf(), AggregationGroup::alias)
+        val sortByGroupsOnly = effectiveSort.all { it.field in groupAliases }
+        val groupsByAlias = resolved.query.groupBy.associateBy(AggregationGroup::alias)
+        val orderedGroups = if (sortByGroupsOnly) {
+            effectiveSort.map { sort -> checkNotNull(groupsByAlias[sort.field]) to sort.direction }
+        } else {
+            resolved.query.groupBy.map { it to Sort.Direction.ASC }
+        }
+        val sources = orderedGroups.map { (group, direction) -> group.toCompositeSource(direction) }
+        val buckets = ElasticsearchAggregationPager(
+            elasticsearchClient = elasticsearchClient,
+            indexName = indexName,
+            batchSize = queryBatchSize,
+            keepAlive = queryKeepAlive,
+        ).search(
+            query = resolved.condition,
+            sources = sources,
+            metrics = resolved.query.metricAggregations(),
+            limit = if (sortByGroupsOnly) resolved.query.limit else 0,
+        ).map { bucket -> bucket.toResult(resolved.query) }
+
+        return if (sortByGroupsOnly) {
+            buckets.take(resolved.query.limit.toLong())
+        } else {
+            buckets.top(resolved.query.limit, effectiveSort)
+        }
+    }
+
+    private fun AggregationQuery.resolve(mapping: ElasticsearchIndexMapping?): ResolvedAggregationQuery {
+        if (mapping == null) {
+            return ResolvedAggregationQuery(conditionConverter.convert(condition), this)
+        }
+        val resolvedGroups = groupBy.map { group ->
+            when (group) {
+                is AggregationGroup.Terms -> group.copy(
+                    field = mapping.resolve(group.field, ElasticsearchFieldUsage.EXACT)
+                )
+
+                is AggregationGroup.Histogram -> group.copy(
+                    field = mapping.resolve(group.field, ElasticsearchFieldUsage.NUMERIC)
+                )
+
+                is AggregationGroup.DateHistogram -> group.copy(
+                    field = mapping.resolve(group.field, ElasticsearchFieldUsage.DATE)
+                )
+            }
+        }
+        val resolvedMetrics = metrics.map { metric ->
+            when (metric) {
+                is AggregationMetric.Count -> metric
+                is AggregationMetric.Sum -> metric.copy(
+                    field = mapping.resolve(metric.field, ElasticsearchFieldUsage.NUMERIC)
+                )
+
+                is AggregationMetric.Avg -> metric.copy(
+                    field = mapping.resolve(metric.field, ElasticsearchFieldUsage.NUMERIC)
+                )
+
+                is AggregationMetric.Min -> metric.copy(
+                    field = mapping.resolve(metric.field, ElasticsearchFieldUsage.NUMERIC)
+                )
+
+                is AggregationMetric.Max -> metric.copy(
+                    field = mapping.resolve(metric.field, ElasticsearchFieldUsage.NUMERIC)
+                )
+            }
+        }
+        return ResolvedAggregationQuery(
+            condition = conditionConverter.convert(mapping.resolve(condition)),
+            query = copy(groupBy = resolvedGroups, metrics = resolvedMetrics),
+        )
+    }
+
+    private data class ResolvedAggregationQuery(
+        val condition: Query,
+        val query: AggregationQuery,
+    )
+}
+
+private fun AggregationQuery.metricAggregations(): Map<String, Aggregation> = buildMap {
+    metrics.forEach { metric ->
+        metric.toAggregation()?.let { put(metric.alias, it) }
+    }
+}
+
+private fun AggregationMetric.toAggregation(): Aggregation? = when (this) {
+    is AggregationMetric.Count -> null
+    is AggregationMetric.Sum -> Aggregation.of { it.sum { sum -> sum.field(field) } }
+    is AggregationMetric.Avg -> Aggregation.of { it.avg { avg -> avg.field(field) } }
+    is AggregationMetric.Min -> Aggregation.of { it.min { min -> min.field(field) } }
+    is AggregationMetric.Max -> Aggregation.of { it.max { max -> max.field(field) } }
+}
+
+private fun AggregationGroup.toCompositeSource(direction: Sort.Direction): NamedValue<CompositeAggregationSource> {
+    val sortOrder = if (direction == Sort.Direction.ASC) SortOrder.Asc else SortOrder.Desc
+    val source = CompositeAggregationSource.of { source ->
+        when (this) {
+            is AggregationGroup.Terms -> source.terms {
+                it.field(field)
+                    .missingBucket(false)
+                    .order(sortOrder)
+            }
+
+            is AggregationGroup.Histogram -> source.histogram {
+                it.interval(interval)
+                    .missingBucket(false)
+                    .order(sortOrder)
+                    .also { histogram ->
+                        if (offset != 0.0) {
+                            histogram.field(null)
+                                .script(offsetScript(field, offset))
+                        } else {
+                            histogram.field(field)
+                        }
+                    }
+            }
+
+            is AggregationGroup.DateHistogram -> source.dateHistogram {
+                it.script(fieldValueScript(field))
+                    .missingBucket(false)
+                    .order(sortOrder)
+                    .timeZone(timeZone)
+                    .also { histogram ->
+                        val interval = Time.of { time -> time.time(unit.toElasticsearchInterval()) }
+                        if (unit == AggregationDateUnit.SECOND) {
+                            histogram.fixedInterval(interval)
+                        } else {
+                            histogram.calendarInterval(interval)
+                        }
+                    }
+            }
+        }
+    }
+    return NamedValue.of(alias, source)
+}
+
+private fun offsetScript(field: String, offset: Double): Script = Script.of {
+    it.lang(ScriptLanguage.Painless)
+        .source { source ->
+            source.scriptString("doc[params.field].size() == 0 ? null : doc[params.field].value - params.offset")
+        }
+        .params("field", JsonData.of(field))
+        .params("offset", JsonData.of(offset))
+}
+
+private fun fieldValueScript(field: String): Script = Script.of {
+    it.lang(ScriptLanguage.Painless)
+        .source { source -> source.scriptString("doc[params.field].size() == 0 ? null : doc[params.field].value") }
+        .params("field", JsonData.of(field))
+}
+
+private fun AggregationDateUnit.toElasticsearchInterval(): String = when (this) {
+    AggregationDateUnit.YEAR -> "1y"
+    AggregationDateUnit.QUARTER -> "1q"
+    AggregationDateUnit.MONTH -> "1M"
+    AggregationDateUnit.WEEK -> "1w"
+    AggregationDateUnit.DAY -> "1d"
+    AggregationDateUnit.HOUR -> "1h"
+    AggregationDateUnit.MINUTE -> "1m"
+    AggregationDateUnit.SECOND -> "1s"
+}
+
+private fun CompositeBucket.toResult(query: AggregationQuery): Map<String, Any?> = buildMap {
+    query.groupBy.forEach { group ->
+        val value = checkNotNull(key()[group.alias]) {
+            "Elasticsearch composite bucket is missing group [${group.alias}]."
+        }.toAggregationValue()
+        put(
+            group.alias,
+            if (group is AggregationGroup.Histogram && group.offset != 0.0) {
+                (value as Number).toDouble() + group.offset
+            } else {
+                value
+            },
+        )
+    }
+    query.metrics.forEach { metric ->
+        put(metric.alias, metric.toResultValue(aggregations(), docCount()))
+    }
+}
+
+private fun FieldValue.toAggregationValue(): Any? = when {
+    isString -> stringValue()
+    isLong -> longValue()
+    isDouble -> doubleValue()
+    isBoolean -> booleanValue()
+    isNull -> null
+    else -> error("Elasticsearch aggregation group values must be scalar.")
+}
+
+private fun AggregationMetric.toResultValue(
+    aggregations: Map<String, Aggregate>,
+    documentCount: Long,
+): Any? = when (this) {
+    is AggregationMetric.Count -> documentCount
+    is AggregationMetric.Sum -> aggregations.required(alias).sum().value().finiteOrNull() ?: 0.0
+    is AggregationMetric.Avg -> aggregations.required(alias).avg().value().finiteOrNull()
+    is AggregationMetric.Min -> aggregations.required(alias).min().value().finiteOrNull()
+    is AggregationMetric.Max -> aggregations.required(alias).max().value().finiteOrNull()
+}
+
+private fun Map<String, Aggregate>.required(alias: String): Aggregate = checkNotNull(get(alias)) {
+    "Elasticsearch aggregation response is missing metric [$alias]."
+}
+
+private fun Double?.finiteOrNull(): Double? = this?.takeIf(Double::isFinite)
+
+private fun AggregationQuery.effectiveSort(): List<Sort> = buildList {
+    addAll(sort)
+    val sortedAliases = sort.mapTo(hashSetOf(), Sort::field)
+    groupBy.map(AggregationGroup::alias)
+        .filterNot(sortedAliases::contains)
+        .forEach { add(Sort(it, Sort.Direction.ASC)) }
+}
+
+private fun Flux<Map<String, Any?>>.top(limit: Int, sort: List<Sort>): Flux<Map<String, Any?>> {
+    val comparator = aggregationComparator(sort)
+    return collect(
+        { PriorityQueue(limit + 1, comparator.reversed()) },
+        { rows, row ->
+            rows += row
+            if (rows.size > limit) {
+                rows.poll()
+            }
+        },
+    ).flatMapMany { rows -> Flux.fromIterable(rows.sortedWith(comparator)) }
+}
+
+private fun aggregationComparator(sort: List<Sort>): Comparator<Map<String, Any?>> = Comparator { left, right ->
+    for (criterion in sort) {
+        val compared = compareAggregationValues(left[criterion.field], right[criterion.field], criterion.direction)
+        if (compared != 0) {
+            return@Comparator compared
+        }
+    }
+    0
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun compareAggregationValues(left: Any?, right: Any?, direction: Sort.Direction): Int {
+    val ascending = when {
+        left === right -> 0
+        left == null -> -1
+        right == null -> 1
+        left is Number && right is Number -> left.toDouble().compareTo(right.toDouble())
+        left::class == right::class && left is Comparable<*> -> (left as Comparable<Any>).compareTo(right)
+        else -> left.toString().compareTo(right.toString())
+    }
+    return if (direction == Sort.Direction.ASC) ascending else -ascending
 }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryService.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryService.kt
@@ -422,7 +422,10 @@ internal fun compareAggregationValues(left: Any?, right: Any?, direction: Sort.D
         left is Number && right is Number -> left.toDouble().compareTo(right.toDouble())
         left is String && right is String -> left.compareUtf8(right)
         left::class == right::class && left is Comparable<*> -> (left as Comparable<Any>).compareTo(right)
-        else -> left.toString().compareUtf8(right.toString())
+        else -> error(
+            "Elasticsearch aggregation sort values must have compatible scalar types " +
+                "[${left::class.qualifiedName}, ${right::class.qualifiedName}]."
+        )
     }
     return if (direction == Sort.Direction.ASC) ascending else -ascending
 }

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchAggregationPagerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchAggregationPagerTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.elasticsearch.query
+
+import co.elastic.clients.elasticsearch._types.FieldValue
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregate
+import co.elastic.clients.elasticsearch._types.aggregations.CompositeAggregate
+import co.elastic.clients.elasticsearch._types.aggregations.CompositeAggregationSource
+import co.elastic.clients.elasticsearch._types.aggregations.CompositeBucket
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.matchAll
+import co.elastic.clients.elasticsearch.core.ClosePointInTimeRequest
+import co.elastic.clients.elasticsearch.core.ClosePointInTimeResponse
+import co.elastic.clients.elasticsearch.core.OpenPointInTimeRequest
+import co.elastic.clients.elasticsearch.core.OpenPointInTimeResponse
+import co.elastic.clients.elasticsearch.core.SearchRequest
+import co.elastic.clients.elasticsearch.core.SearchResponse
+import co.elastic.clients.util.NamedValue
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
+import reactor.core.publisher.Mono
+import reactor.kotlin.test.test
+
+class ElasticsearchAggregationPagerTest {
+    private val elasticsearchClient = mockk<ReactiveElasticsearchClient>()
+    private val source = NamedValue.of(
+        "group",
+        CompositeAggregationSource.of { it.terms { terms -> terms.field("group") } },
+    )
+
+    @Test
+    fun `should page composite buckets and close latest pit`() {
+        val searchRequests = mutableListOf<SearchRequest>()
+        val closeRequest = slot<ClosePointInTimeRequest>()
+        stubPointInTime(closeRequest)
+        every { elasticsearchClient.search(capture(searchRequests), Map::class.java) } returnsMany listOf(
+            Mono.just(aggregationResponse("pit-2", listOf(bucket(1), bucket(2)), FieldValue.of(2L))),
+            Mono.just(aggregationResponse("pit-3", listOf(bucket(3)))),
+        )
+
+        ElasticsearchAggregationPager(elasticsearchClient, "test-index", batchSize = 2)
+            .search(matchAll { it }, listOf(source), emptyMap())
+            .map { it.key()["group"]!!.longValue() }
+            .test()
+            .expectNext(1L, 2L, 3L)
+            .verifyComplete()
+
+        searchRequests.assert().hasSize(2)
+        searchRequests[0].aggregations()[ROOT]!!.composite().after().assert().isEmpty()
+        searchRequests[1].aggregations()[ROOT]!!.composite().after()["group"]!!.longValue().assert().isEqualTo(2L)
+        closeRequest.captured.id().assert().isEqualTo("pit-3")
+    }
+
+    @Test
+    fun `should close pit when composite paging is cancelled`() {
+        val closeRequest = slot<ClosePointInTimeRequest>()
+        stubPointInTime(closeRequest)
+        every { elasticsearchClient.search(any<SearchRequest>(), Map::class.java) } returnsMany listOf(
+            Mono.just(aggregationResponse("pit-2", listOf(bucket(1), bucket(2)), FieldValue.of(2L))),
+            Mono.never(),
+        )
+
+        ElasticsearchAggregationPager(elasticsearchClient, "test-index", batchSize = 2)
+            .search(matchAll { it }, listOf(source), emptyMap())
+            .test()
+            .expectNextCount(1)
+            .thenCancel()
+            .verify()
+
+        closeRequest.captured.id().assert().isEqualTo("pit-2")
+    }
+
+    private fun stubPointInTime(closeRequest: io.mockk.CapturingSlot<ClosePointInTimeRequest>) {
+        every { elasticsearchClient.openPointInTime(any<OpenPointInTimeRequest>()) } returns Mono.just(
+            OpenPointInTimeResponse.of {
+                it.id("pit-1").shards { shards -> shards.failed(0).successful(1).total(1) }
+            }
+        )
+        every { elasticsearchClient.closePointInTime(capture(closeRequest)) } returns Mono.just(
+            ClosePointInTimeResponse.of { it.succeeded(true).numFreed(1) }
+        )
+    }
+
+    private fun bucket(key: Long): CompositeBucket = CompositeBucket.of {
+        it.key("group", key).docCount(1)
+    }
+
+    private fun aggregationResponse(
+        pitId: String,
+        buckets: List<CompositeBucket>,
+        afterKey: FieldValue? = null,
+    ): SearchResponse<Map<*, *>> = SearchResponse.of {
+        it.took(1)
+            .timedOut(false)
+            .shards { shards -> shards.failed(0).successful(1).total(1) }
+            .hits { hits -> hits.hits(emptyList()) }
+            .aggregations(
+                ROOT,
+                Aggregate(
+                    CompositeAggregate.of { composite ->
+                        composite.buckets { bucketContainer -> bucketContainer.array(buckets) }
+                        if (afterKey != null) {
+                            composite.afterKey("group", afterKey)
+                        }
+                        composite
+                    }
+                ),
+            ).pitId(pitId)
+    }
+
+    private companion object {
+        const val ROOT = "__wow_aggregation__"
+    }
+}

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchAggregationPagerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchAggregationPagerTest.kt
@@ -60,6 +60,7 @@ class ElasticsearchAggregationPagerTest {
             .verifyComplete()
 
         searchRequests.assert().hasSize(2)
+        searchRequests.forEach { it.allowPartialSearchResults().assert().isFalse() }
         searchRequests[0].aggregations()[ROOT]!!.composite().after().assert().isEmpty()
         searchRequests[1].aggregations()[ROOT]!!.composite().after()["group"]!!.longValue().assert().isEqualTo(2L)
         closeRequest.captured.id().assert().isEqualTo("pit-3")
@@ -84,6 +85,23 @@ class ElasticsearchAggregationPagerTest {
         closeRequest.captured.id().assert().isEqualTo("pit-2")
     }
 
+    @Test
+    fun `should reject failed shard responses`() {
+        val closeRequest = slot<ClosePointInTimeRequest>()
+        stubPointInTime(closeRequest)
+        every { elasticsearchClient.search(any<SearchRequest>(), Map::class.java) } returns Mono.just(
+            aggregationResponse("pit-2", emptyList(), failedShards = 1),
+        )
+
+        ElasticsearchAggregationPager(elasticsearchClient, "test-index", batchSize = 2)
+            .search(matchAll { it }, listOf(source), emptyMap())
+            .test()
+            .expectErrorMessage("Elasticsearch aggregation search failed on 1 shard(s).")
+            .verify()
+
+        closeRequest.captured.id().assert().isEqualTo("pit-2")
+    }
+
     private fun stubPointInTime(closeRequest: io.mockk.CapturingSlot<ClosePointInTimeRequest>) {
         every { elasticsearchClient.openPointInTime(any<OpenPointInTimeRequest>()) } returns Mono.just(
             OpenPointInTimeResponse.of {
@@ -103,10 +121,11 @@ class ElasticsearchAggregationPagerTest {
         pitId: String,
         buckets: List<CompositeBucket>,
         afterKey: FieldValue? = null,
+        failedShards: Int = 0,
     ): SearchResponse<Map<*, *>> = SearchResponse.of {
         it.took(1)
             .timedOut(false)
-            .shards { shards -> shards.failed(0).successful(1).total(1) }
+            .shards { shards -> shards.failed(failedShards).successful(1).total(1 + failedShards) }
             .hits { hits -> hits.hits(emptyList()) }
             .aggregations(
                 ROOT,

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchAggregationPagerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchAggregationPagerTest.kt
@@ -15,9 +15,11 @@ package me.ahoo.wow.elasticsearch.query
 
 import co.elastic.clients.elasticsearch._types.FieldValue
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregate
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeAggregate
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeAggregationSource
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeBucket
+import co.elastic.clients.elasticsearch._types.aggregations.SumAggregate
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.matchAll
 import co.elastic.clients.elasticsearch.core.ClosePointInTimeRequest
 import co.elastic.clients.elasticsearch.core.ClosePointInTimeResponse
@@ -31,6 +33,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
 import reactor.core.publisher.Mono
 import reactor.kotlin.test.test
@@ -102,6 +105,69 @@ class ElasticsearchAggregationPagerTest {
         closeRequest.captured.id().assert().isEqualTo("pit-2")
     }
 
+    @Test
+    fun `should validate arguments`() {
+        assertThrows<IllegalArgumentException> {
+            ElasticsearchAggregationPager(elasticsearchClient, "test-index", batchSize = 0)
+        }
+        val pager = ElasticsearchAggregationPager(elasticsearchClient, "test-index")
+        assertThrows<IllegalArgumentException> {
+            pager.search(matchAll { it }, emptyList(), emptyMap())
+        }
+        assertThrows<IllegalArgumentException> {
+            pager.search(matchAll { it }, listOf(source), emptyMap(), limit = -1)
+        }
+    }
+
+    @Test
+    fun `should honor limit and include metrics`() {
+        val request = slot<SearchRequest>()
+        stubPointInTime(slot())
+        every { elasticsearchClient.search(capture(request), Map::class.java) } returns Mono.just(
+            aggregationResponse("pit-2", listOf(bucket(1))),
+        )
+        val metrics = mapOf(
+            "sum" to Aggregation.of {
+                it.sum { sum -> sum.field("amount") }
+            },
+        )
+
+        ElasticsearchAggregationPager(elasticsearchClient, "test-index", batchSize = 2)
+            .search(matchAll { it }, listOf(source), metrics, limit = 1)
+            .test()
+            .expectNextCount(1)
+            .verifyComplete()
+
+        val root = request.captured.aggregations()[ROOT]!!
+        root.composite().size().assert().isEqualTo(1)
+        root.aggregations().assert().containsKey("sum")
+    }
+
+    @Test
+    fun `should reject malformed aggregation responses`() {
+        listOf(
+            malformedResponse(null) to "Elasticsearch aggregation response is missing [$ROOT].",
+            malformedResponse(Aggregate(SumAggregate.of { it.value(1.0) })) to
+                "Elasticsearch aggregation response [$ROOT] must be composite.",
+            malformedResponse(
+                Aggregate(
+                    CompositeAggregate.of { composite ->
+                        composite.buckets { buckets -> buckets.keyed(mapOf("key" to bucket(1))) }
+                    },
+                ),
+            ) to "Elasticsearch composite aggregation must return array buckets.",
+        ).forEach { (response, message) ->
+            stubPointInTime(slot())
+            every { elasticsearchClient.search(any<SearchRequest>(), Map::class.java) } returns Mono.just(response)
+
+            ElasticsearchAggregationPager(elasticsearchClient, "test-index")
+                .search(matchAll { it }, listOf(source), emptyMap())
+                .test()
+                .expectErrorMessage(message)
+                .verify()
+        }
+    }
+
     private fun stubPointInTime(closeRequest: io.mockk.CapturingSlot<ClosePointInTimeRequest>) {
         every { elasticsearchClient.openPointInTime(any<OpenPointInTimeRequest>()) } returns Mono.just(
             OpenPointInTimeResponse.of {
@@ -139,6 +205,17 @@ class ElasticsearchAggregationPagerTest {
                     }
                 ),
             ).pitId(pitId)
+    }
+
+    private fun malformedResponse(root: Aggregate?): SearchResponse<Map<*, *>> = SearchResponse.of {
+        it.took(1)
+            .timedOut(false)
+            .shards { shards -> shards.failed(0).successful(1).total(1) }
+            .hits { hits -> hits.hits(emptyList()) }
+        if (root != null) {
+            it.aggregations(ROOT, root)
+        }
+        it
     }
 
     private companion object {

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolverTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolverTest.kt
@@ -136,6 +136,7 @@ class ElasticsearchIndexMappingResolverTest {
         mapping.resolve("state.name", ElasticsearchFieldUsage.LITERAL).assert().isEqualTo("state.name.keyword")
         mapping.resolve("state.name", ElasticsearchFieldUsage.SEARCH).assert().isEqualTo("state.name")
         mapping.resolve("state.name", ElasticsearchFieldUsage.SORT).assert().isEqualTo("state.name.keyword")
+        mapping.resolve("state.name", ElasticsearchFieldUsage.TERMS).assert().isEqualTo("state.name.keyword")
         mapping.requireNested("state.items").assert().isEqualTo("state.items")
 
         val condition = mapping.resolve(
@@ -174,6 +175,9 @@ class ElasticsearchIndexMappingResolverTest {
         runCatching { mapping.resolve("state.code", ElasticsearchFieldUsage.SEARCH) }
             .exceptionOrNull()!!.message.assert().contains("does not support")
         runCatching { mapping.resolve("state.code", ElasticsearchFieldUsage.SORT) }
+            .exceptionOrNull()!!.message.assert().contains("does not support")
+        mapping.resolve("state.code", ElasticsearchFieldUsage.EXACT).assert().isEqualTo("state.code")
+        runCatching { mapping.resolve("state.code", ElasticsearchFieldUsage.TERMS) }
             .exceptionOrNull()!!.message.assert().contains("does not support")
         runCatching { mapping.requireNested("state.objectItems") }
             .exceptionOrNull()!!.message.assert().contains("nested")

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationComparatorTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationComparatorTest.kt
@@ -16,6 +16,7 @@ package me.ahoo.wow.elasticsearch.query.snapshot
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.query.Sort
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class ElasticsearchAggregationComparatorTest {
     @Test
@@ -24,5 +25,14 @@ class ElasticsearchAggregationComparatorTest {
             .assert().isLessThan(0)
         compareAggregationValues("\uD800\uDC00", "\uE000", Sort.Direction.ASC)
             .assert().isGreaterThan(0)
+        compareAggregationValues(null, null, Sort.Direction.ASC).assert().isZero()
+        compareAggregationValues(null, 1L, Sort.Direction.ASC).assert().isLessThan(0)
+        compareAggregationValues(1L, null, Sort.Direction.DESC).assert().isLessThan(0)
+        compareAggregationValues(1L, 1.0, Sort.Direction.ASC).assert().isZero()
+        compareAggregationValues(true, false, Sort.Direction.ASC).assert().isGreaterThan(0)
+
+        assertThrows<IllegalStateException> {
+            compareAggregationValues(true, "true", Sort.Direction.ASC)
+        }.message.assert().contains("must have compatible scalar types")
     }
 }

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationComparatorTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationComparatorTest.kt
@@ -11,17 +11,18 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.schema.typed
+package me.ahoo.wow.elasticsearch.query.snapshot
 
-interface AggregatedFields<CommandAggregateType : Any> {
-    companion object {
-        val EMPTY = object : AggregatedFields<Any> {}
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.Sort
+import org.junit.jupiter.api.Test
 
-        @Suppress("UNCHECKED_CAST")
-        fun <CommandAggregateType : Any> empty(): AggregatedFields<CommandAggregateType> {
-            return EMPTY as AggregatedFields<CommandAggregateType>
-        }
+class ElasticsearchAggregationComparatorTest {
+    @Test
+    fun `should preserve integral and UTF-8 binary order`() {
+        compareAggregationValues(9_007_199_254_740_992L, 9_007_199_254_740_993L, Sort.Direction.ASC)
+            .assert().isLessThan(0)
+        compareAggregationValues("\uD800\uDC00", "\uE000", Sort.Direction.ASC)
+            .assert().isGreaterThan(0)
     }
 }
-
-interface SnapshotAggregatedFields<CommandAggregateType : Any>

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotMappingQueryTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotMappingQueryTest.kt
@@ -26,6 +26,8 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.ListQuery
 import me.ahoo.wow.api.query.Projection
@@ -164,6 +166,24 @@ class ElasticsearchSnapshotMappingQueryTest {
         verify(exactly = 0) { client.indices() }
     }
 
+    @Test
+    fun `global aggregation should reject timed out responses`() {
+        every { indicesClient.getMapping(any<GetMappingRequest>()) } returns Mono.just(
+            mappingResponse(queryMapping()),
+        )
+        every { client.search(capture(searchRequest), Map::class.java) } returns Mono.just(
+            emptySearchResponse(timedOut = true),
+        )
+
+        queryService().aggregate(
+            AggregationQuery(metrics = listOf(AggregationMetric.Count("count"))),
+        ).test()
+            .expectErrorMessage("Elasticsearch aggregation search timed out.")
+            .verify()
+
+        searchRequest.captured.allowPartialSearchResults().assert().isFalse()
+    }
+
     private fun queryService(
         resolver: ElasticsearchIndexMappingResolver = ElasticsearchIndexMappingResolver(client),
     ): ElasticsearchSnapshotQueryService<Any> =
@@ -202,10 +222,10 @@ class ElasticsearchSnapshotMappingQueryTest {
             }
         }
 
-    private fun emptySearchResponse(): SearchResponse<Map<*, *>> =
+    private fun emptySearchResponse(timedOut: Boolean = false): SearchResponse<Map<*, *>> =
         SearchResponse.of<Map<*, *>> {
             it.took(1)
-                .timedOut(false)
+                .timedOut(timedOut)
                 .shards { shards -> shards.failed(0).successful(1).total(1) }
                 .hits { hits -> hits.hits(emptyList()) }
         }

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotMappingQueryTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotMappingQueryTest.kt
@@ -13,13 +13,24 @@
 
 package me.ahoo.wow.elasticsearch.query.snapshot
 
+import co.elastic.clients.elasticsearch._types.FieldValue
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregate
+import co.elastic.clients.elasticsearch._types.aggregations.AvgAggregate
+import co.elastic.clients.elasticsearch._types.aggregations.CompositeAggregate
+import co.elastic.clients.elasticsearch._types.aggregations.CompositeBucket
+import co.elastic.clients.elasticsearch._types.aggregations.MaxAggregate
+import co.elastic.clients.elasticsearch._types.aggregations.MinAggregate
 import co.elastic.clients.elasticsearch._types.aggregations.SumAggregate
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping
 import co.elastic.clients.elasticsearch._types.query_dsl.Query
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.matchAll
+import co.elastic.clients.elasticsearch.core.ClosePointInTimeRequest
+import co.elastic.clients.elasticsearch.core.ClosePointInTimeResponse
+import co.elastic.clients.elasticsearch.core.OpenPointInTimeRequest
+import co.elastic.clients.elasticsearch.core.OpenPointInTimeResponse
 import co.elastic.clients.elasticsearch.core.SearchRequest
 import co.elastic.clients.elasticsearch.core.SearchResponse
+import co.elastic.clients.elasticsearch.core.search.TotalHitsRelation
 import co.elastic.clients.elasticsearch.indices.GetMappingRequest
 import co.elastic.clients.elasticsearch.indices.GetMappingResponse
 import co.elastic.clients.elasticsearch.indices.get_mapping.IndexMappingRecord
@@ -28,6 +39,8 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.AggregationDateUnit
+import me.ahoo.wow.api.query.AggregationGroup
 import me.ahoo.wow.api.query.AggregationMetric
 import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
@@ -202,6 +215,86 @@ class ElasticsearchSnapshotMappingQueryTest {
             .verify()
     }
 
+    @Test
+    fun `global aggregation should return every metric type`() {
+        every { indicesClient.getMapping(any<GetMappingRequest>()) } returns Mono.just(
+            mappingResponse(queryMapping()),
+        )
+        every { client.search(capture(searchRequest), Map::class.java) } returns Mono.just(
+            metricSearchResponse(),
+        )
+
+        queryService().aggregate(
+            AggregationQuery(
+                metrics = listOf(
+                    AggregationMetric.Count("count"),
+                    AggregationMetric.Sum("state.age", "sum"),
+                    AggregationMetric.Avg("state.age", "avg"),
+                    AggregationMetric.Min("state.age", "min"),
+                    AggregationMetric.Max("state.age", "max"),
+                ),
+            ),
+        ).test()
+            .expectNext(
+                mapOf(
+                    "count" to 2L,
+                    "sum" to 4.0,
+                    "avg" to 2.0,
+                    "min" to 1.0,
+                    "max" to 3.0,
+                ),
+            ).verifyComplete()
+    }
+
+    @Test
+    fun `grouped aggregation should compile every group and return metric top result`() {
+        every { indicesClient.getMapping(any<GetMappingRequest>()) } returns Mono.just(
+            mappingResponse(queryMapping()),
+        )
+        stubPointInTime()
+        every { client.search(capture(searchRequest), Map::class.java) } returns Mono.just(
+            groupedSearchResponse(
+                groupedBucket("A", 19.0, 1_700_000_000_000, 2, 40.0),
+                groupedBucket("B", 29.0, 1_700_000_000_000, 1, 30.0),
+            ),
+        )
+
+        queryService().aggregate(
+            AggregationQuery(
+                groupBy = listOf(
+                    AggregationGroup.Terms("state.name", "name"),
+                    AggregationGroup.Histogram("state.age", "ageBand", 10.0, 1.0),
+                    AggregationGroup.DateHistogram("snapshotTime", "day", AggregationDateUnit.DAY),
+                    AggregationGroup.DateHistogram("snapshotTime", "second", AggregationDateUnit.SECOND),
+                ),
+                metrics = listOf(
+                    AggregationMetric.Count("count"),
+                    AggregationMetric.Sum("state.age", "sum"),
+                ),
+                sort = listOf(Sort("sum", Sort.Direction.DESC)),
+                limit = 1,
+            ),
+        ).test()
+            .expectNext(
+                mapOf(
+                    "name" to "A",
+                    "ageBand" to 20.0,
+                    "day" to 1_700_000_000_000L,
+                    "second" to 1_700_000_000_000L,
+                    "count" to 2L,
+                    "sum" to 40.0,
+                ),
+            ).verifyComplete()
+
+        val root = searchRequest.captured.aggregations()[ROOT_AGGREGATION]!!
+        val sources = root.composite().sources()
+        sources[0].value().terms().field().assert().isEqualTo("state.name.keyword")
+        sources[1].value().histogram().script().assert().isNotNull()
+        sources[2].value().dateHistogram().script().assert().isNotNull()
+        sources[3].value().dateHistogram().fixedInterval()!!.time().assert().isEqualTo("1s")
+        root.aggregations()["sum"]!!.sum().field().assert().isEqualTo("state.age")
+    }
+
     private fun queryService(
         resolver: ElasticsearchIndexMappingResolver = ElasticsearchIndexMappingResolver(client),
     ): ElasticsearchSnapshotQueryService<Any> =
@@ -237,7 +330,50 @@ class ElasticsearchSnapshotMappingQueryTest {
                     }
                     objectField
                 }
-            }
+            }.properties("snapshotTime") { snapshotTime -> snapshotTime.long_ { it } }
+        }
+
+    private fun stubPointInTime() {
+        every { client.openPointInTime(any<OpenPointInTimeRequest>()) } returns Mono.just(
+            OpenPointInTimeResponse.of { it.id("pit-1").shards { shards -> shards.failed(0).successful(1).total(1) } },
+        )
+        every { client.closePointInTime(any<ClosePointInTimeRequest>()) } returns Mono.just(
+            ClosePointInTimeResponse.of { it.succeeded(true).numFreed(1) },
+        )
+    }
+
+    private fun groupedBucket(
+        name: String,
+        ageBand: Double,
+        day: Long,
+        count: Long,
+        sum: Double,
+    ): CompositeBucket = CompositeBucket.of {
+        it.key(
+            mapOf(
+                "name" to FieldValue.of(name),
+                "ageBand" to FieldValue.of(ageBand),
+                "day" to FieldValue.of(day),
+                "second" to FieldValue.of(day),
+            ),
+        ).docCount(count)
+            .aggregations("sum", Aggregate(SumAggregate.of { metric -> metric.value(sum) }))
+    }
+
+    private fun groupedSearchResponse(vararg buckets: CompositeBucket): SearchResponse<Map<*, *>> =
+        SearchResponse.of {
+            it.took(1)
+                .timedOut(false)
+                .shards { shards -> shards.failed(0).successful(1).total(1) }
+                .hits { hits -> hits.hits(emptyList()) }
+                .aggregations(
+                    ROOT_AGGREGATION,
+                    Aggregate(
+                        CompositeAggregate.of { composite ->
+                            composite.buckets { bucketContainer -> bucketContainer.array(buckets.toList()) }
+                        },
+                    ),
+                ).pitId("pit-2")
         }
 
     private fun emptySearchResponse(timedOut: Boolean = false): SearchResponse<Map<*, *>> =
@@ -256,4 +392,22 @@ class ElasticsearchSnapshotMappingQueryTest {
                 .hits { hits -> hits.hits(emptyList()) }
                 .aggregations("sum", Aggregate(SumAggregate.of { sum -> sum.value(value) }))
         }
+
+    private fun metricSearchResponse(): SearchResponse<Map<*, *>> =
+        SearchResponse.of<Map<*, *>> {
+            it.took(1)
+                .timedOut(false)
+                .shards { shards -> shards.failed(0).successful(1).total(1) }
+                .hits { hits ->
+                    hits.total { total -> total.relation(TotalHitsRelation.Eq).value(2) }
+                        .hits(emptyList())
+                }.aggregations("sum", Aggregate(SumAggregate.of { sum -> sum.value(4.0) }))
+                .aggregations("avg", Aggregate(AvgAggregate.of { avg -> avg.value(2.0) }))
+                .aggregations("min", Aggregate(MinAggregate.of { min -> min.value(1.0) }))
+                .aggregations("max", Aggregate(MaxAggregate.of { max -> max.value(3.0) }))
+        }
+
+    private companion object {
+        const val ROOT_AGGREGATION = "__wow_aggregation__"
+    }
 }

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryService.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryService.kt
@@ -13,11 +13,18 @@
 
 package me.ahoo.wow.mongo.query.snapshot
 
+import com.mongodb.client.model.Aggregates
+import com.mongodb.client.model.Filters
 import com.mongodb.reactivestreams.client.MongoCollection
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.AggregationDateUnit
+import me.ahoo.wow.api.query.AggregationGroup
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.MaterializedSnapshot
 import me.ahoo.wow.api.query.SimpleDynamicDocument.Companion.toDynamicDocument
+import me.ahoo.wow.api.query.Sort
 import me.ahoo.wow.configuration.requiredAggregateType
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.mongo.Documents.replacePrimaryKeyToAggregateId
@@ -31,6 +38,8 @@ import me.ahoo.wow.query.snapshot.SnapshotQueryService
 import me.ahoo.wow.serialization.JsonSerializer
 import org.bson.Document
 import org.bson.conversions.Bson
+import reactor.core.publisher.Flux
+import reactor.kotlin.core.publisher.toFlux
 
 class MongoSnapshotQueryService<S : Any>(
     override val namedAggregate: NamedAggregate,
@@ -53,5 +62,159 @@ class MongoSnapshotQueryService<S : Any>(
 
     override fun toDynamicDocument(document: Document): DynamicDocument {
         return document.replacePrimaryKeyToAggregateId().toDynamicDocument()
+    }
+
+    override fun aggregate(aggregationQuery: AggregationQuery): Flux<Map<String, Any?>> = Flux.defer {
+        val pipeline = aggregationQuery.toMongoPipeline(converter)
+        collection.aggregate(pipeline)
+            .toFlux()
+            .map<Map<String, Any?>> { LinkedHashMap(it) }
+            .let { result ->
+                if (aggregationQuery.groupBy.isEmpty()) {
+                    result.switchIfEmpty(Flux.just(aggregationQuery.emptyGlobalResult()))
+                } else {
+                    result
+                }
+            }
+    }
+}
+
+private fun AggregationQuery.toMongoPipeline(conditionConverter: ConditionConverter<Bson>): List<Bson> = buildList {
+    val fieldConverter = SnapshotFieldConverter
+    add(Aggregates.match(Filters.and(toMongoFilters(conditionConverter, fieldConverter))))
+    add(Document("\$group", toMongoGroup(fieldConverter)))
+    add(Document("\$project", toMongoProjection()))
+
+    if (groupBy.isNotEmpty()) {
+        add(Document("\$sort", toMongoSort()))
+        add(Document("\$limit", limit))
+    }
+}
+
+private fun AggregationQuery.toMongoFilters(
+    conditionConverter: ConditionConverter<Bson>,
+    fieldConverter: SnapshotFieldConverter,
+): List<Bson> = buildList {
+    add(conditionConverter.convert(condition))
+    groupBy.forEach { group ->
+        val field = fieldConverter.convert(group.field)
+        add(Filters.exists(field, true))
+        add(Filters.ne(field, null))
+    }
+}
+
+private fun AggregationQuery.toMongoGroup(fieldConverter: SnapshotFieldConverter): Document {
+    val groupId = groupBy.takeIf { it.isNotEmpty() }?.let {
+        Document().apply {
+            groupBy.forEach { group -> put(group.alias, group.toMongoExpression(fieldConverter)) }
+        }
+    }
+    return Document("_id", groupId).apply {
+        metrics.forEach { metric -> put(metric.alias, metric.toMongoAccumulator(fieldConverter)) }
+    }
+}
+
+private fun AggregationQuery.toMongoProjection(): Document = Document("_id", 0).apply {
+    groupBy.forEach { group ->
+        val value = "\$_id.${group.alias}"
+        put(group.alias, if (group is AggregationGroup.DateHistogram) Document("\$toLong", value) else value)
+    }
+    metrics.forEach { metric ->
+        val value = "\$${metric.alias}"
+        put(
+            metric.alias,
+            if (metric is AggregationMetric.Count) {
+                Document("\$toLong", value)
+            } else {
+                Document("\$convert", Document("input", value).append("to", "double"))
+            },
+        )
+    }
+}
+
+private fun AggregationQuery.toMongoSort(): Document = Document().apply {
+    effectiveSort().forEach { sort -> put(sort.field, sort.direction.toMongoDirection()) }
+}
+
+private fun AggregationGroup.toMongoExpression(fieldConverter: SnapshotFieldConverter): Any {
+    val field = "\$${fieldConverter.convert(field)}"
+    return when (this) {
+        is AggregationGroup.Terms -> field
+        is AggregationGroup.Histogram -> Document(
+            "\$add",
+            listOf(
+                offset,
+                Document(
+                    "\$multiply",
+                    listOf(
+                        Document(
+                            "\$floor",
+                            Document(
+                                "\$divide",
+                                listOf(
+                                    Document("\$subtract", listOf(field.toMongoDouble(), offset)),
+                                    interval,
+                                ),
+                            ),
+                        ),
+                        interval,
+                    ),
+                ),
+            ),
+        )
+
+        is AggregationGroup.DateHistogram -> Document(
+            "\$dateTrunc",
+            Document("date", field.toMongoDate())
+                .append("unit", unit.toMongoDateUnit())
+                .append("timezone", timeZone)
+                .also { options ->
+                    if (unit == AggregationDateUnit.WEEK) {
+                        options.append("startOfWeek", "monday")
+                    }
+                },
+        )
+    }
+}
+
+private fun AggregationMetric.toMongoAccumulator(fieldConverter: SnapshotFieldConverter): Document = when (this) {
+    is AggregationMetric.Count -> Document("\$sum", 1)
+    is AggregationMetric.Sum -> Document("\$sum", "\$${fieldConverter.convert(field)}".toMongoDouble())
+    is AggregationMetric.Avg -> Document("\$avg", "\$${fieldConverter.convert(field)}".toMongoDouble())
+    is AggregationMetric.Min -> Document("\$min", "\$${fieldConverter.convert(field)}".toMongoDouble())
+    is AggregationMetric.Max -> Document("\$max", "\$${fieldConverter.convert(field)}".toMongoDouble())
+}
+
+private fun String.toMongoDouble(): Document =
+    Document("\$convert", Document("input", this).append("to", "double"))
+
+private fun String.toMongoDate(): Document =
+    Document("\$convert", Document("input", this).append("to", "date"))
+
+private fun AggregationDateUnit.toMongoDateUnit(): String = name.lowercase()
+
+private fun Sort.Direction.toMongoDirection(): Int = if (this == Sort.Direction.ASC) 1 else -1
+
+private fun AggregationQuery.effectiveSort(): List<Sort> = buildList {
+    addAll(sort)
+    val sortedAliases = sort.mapTo(hashSetOf(), Sort::field)
+    groupBy.map(AggregationGroup::alias)
+        .filterNot(sortedAliases::contains)
+        .forEach { add(Sort(it, Sort.Direction.ASC)) }
+}
+
+private fun AggregationQuery.emptyGlobalResult(): Map<String, Any?> = buildMap {
+    metrics.forEach { metric ->
+        put(
+            metric.alias,
+            when (metric) {
+                is AggregationMetric.Count -> 0L
+                is AggregationMetric.Sum -> 0.0
+                is AggregationMetric.Avg,
+                is AggregationMetric.Min,
+                is AggregationMetric.Max,
+                -> null
+            },
+        )
     }
 }

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryService.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryService.kt
@@ -68,7 +68,16 @@ class MongoSnapshotQueryService<S : Any>(
         val pipeline = aggregationQuery.toMongoPipeline(converter)
         collection.aggregate(pipeline)
             .toFlux()
-            .map<Map<String, Any?>> { LinkedHashMap(it) }
+            .map<Map<String, Any?>> { document ->
+                LinkedHashMap<String, Any?>(document).apply {
+                    aggregationQuery.groupBy.filterIsInstance<AggregationGroup.Terms>().forEach { group ->
+                        val value = get(group.alias)
+                        if (value is Int) {
+                            put(group.alias, value.toLong())
+                        }
+                    }
+                }
+            }
             .let { result ->
                 if (aggregationQuery.groupBy.isEmpty()) {
                     result.switchIfEmpty(Flux.just(aggregationQuery.emptyGlobalResult()))

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/QueryComponent.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/QueryComponent.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.openapi
 
 import me.ahoo.wow.api.Wow
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.ListQuery
 import me.ahoo.wow.api.query.PagedList
@@ -26,6 +27,7 @@ import me.ahoo.wow.openapi.QueryComponent.Schema.listQuerySchema
 import me.ahoo.wow.openapi.QueryComponent.Schema.pagedQuerySchema
 import me.ahoo.wow.openapi.context.OpenAPIComponentContext
 import me.ahoo.wow.schema.typed.AggregatedDomainEventStream
+import me.ahoo.wow.schema.typed.query.AggregatedAggregationQuery
 import me.ahoo.wow.schema.typed.query.AggregatedCondition
 import me.ahoo.wow.schema.typed.query.AggregatedListQuery
 import me.ahoo.wow.schema.typed.query.AggregatedPagedQuery
@@ -34,9 +36,11 @@ import me.ahoo.wow.schema.typed.query.AggregatedSingleQuery
 object QueryComponent {
     const val SINGLE_QUERY_SUFFIX = ".SingleQuery"
     const val COUNT_QUERY_SUFFIX = ".CountQuery"
+    const val AGGREGATION_QUERY_SUFFIX = ".AggregationQuery"
     const val LIST_QUERY_SUFFIX = ".ListQuery"
     const val PAGED_QUERY_SUFFIX = ".PagedQuery"
     const val COUNT_QUERY_KEY = Wow.WOW + COUNT_QUERY_SUFFIX
+    const val AGGREGATION_QUERY_KEY = Wow.WOW + AGGREGATION_QUERY_SUFFIX
     const val LIST_QUERY_KEY = Wow.WOW + LIST_QUERY_SUFFIX
     const val PAGED_QUERY_KEY = Wow.WOW + PAGED_QUERY_SUFFIX
 
@@ -44,6 +48,10 @@ object QueryComponent {
 
         fun OpenAPIComponentContext.conditionSchema(): io.swagger.v3.oas.models.media.Schema<*> {
             return schema(Condition::class.java)
+        }
+
+        fun OpenAPIComponentContext.aggregationQuerySchema(): io.swagger.v3.oas.models.media.Schema<*> {
+            return schema(AggregationQuery::class.java)
         }
 
         fun OpenAPIComponentContext.listQuerySchema(): io.swagger.v3.oas.models.media.Schema<*> {
@@ -56,6 +64,19 @@ object QueryComponent {
     }
 
     object RequestBody {
+
+        fun OpenAPIComponentContext.aggregatedAggregationQueryRequestBody(
+            aggregateMetadata: AggregateMetadata<*, *>
+        ): io.swagger.v3.oas.models.parameters.RequestBody {
+            return requestBody(aggregateMetadata.toStringWithAlias() + AGGREGATION_QUERY_SUFFIX) {
+                content(
+                    schema = schema(
+                        AggregatedAggregationQuery::class.java,
+                        aggregateMetadata.command.aggregateType,
+                    )
+                )
+            }
+        }
 
         fun OpenAPIComponentContext.aggregatedSingleQueryRequestBody(aggregateMetadata: AggregateMetadata<*, *>): io.swagger.v3.oas.models.parameters.RequestBody {
             return requestBody(aggregateMetadata.toStringWithAlias() + SINGLE_QUERY_SUFFIX) {

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contract/BuiltInHttpRoutes.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contract/BuiltInHttpRoutes.kt
@@ -54,6 +54,7 @@ object BuiltInHttpRouteHandlerKeys {
 
     object Snapshot {
         const val COUNT = "$AGGREGATE_SNAPSHOT.count"
+        const val AGGREGATE = "$AGGREGATE_SNAPSHOT.aggregate"
         const val LIST_QUERY = "$AGGREGATE_SNAPSHOT.list-query"
         const val LIST_QUERY_STATE = "$AGGREGATE_SNAPSHOT.list-query-state"
         const val PAGED_QUERY = "$AGGREGATE_SNAPSHOT.paged-query"

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contract/BuiltInHttpRoutes.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contract/BuiltInHttpRoutes.kt
@@ -54,7 +54,7 @@ object BuiltInHttpRouteHandlerKeys {
 
     object Snapshot {
         const val COUNT = "$AGGREGATE_SNAPSHOT.count"
-        const val AGGREGATE = "$AGGREGATE_SNAPSHOT.aggregate"
+        const val AGGREGATION = "$AGGREGATE_SNAPSHOT.aggregation"
         const val LIST_QUERY = "$AGGREGATE_SNAPSHOT.list-query"
         const val LIST_QUERY_STATE = "$AGGREGATE_SNAPSHOT.list-query-state"
         const val PAGED_QUERY = "$AGGREGATE_SNAPSHOT.paged-query"

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/QueryContractComponentSupport.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/QueryContractComponentSupport.kt
@@ -19,6 +19,7 @@ import me.ahoo.wow.modeling.metadata.AggregateMetadata
 import me.ahoo.wow.modeling.toStringWithAlias
 import me.ahoo.wow.openapi.Https
 import me.ahoo.wow.openapi.QueryComponent
+import me.ahoo.wow.openapi.QueryComponent.RequestBody.aggregatedAggregationQueryRequestBody
 import me.ahoo.wow.openapi.QueryComponent.RequestBody.aggregatedCountQueryRequestBody
 import me.ahoo.wow.openapi.QueryComponent.RequestBody.aggregatedListQueryRequestBody
 import me.ahoo.wow.openapi.QueryComponent.RequestBody.aggregatedPagedQueryRequestBody
@@ -39,6 +40,13 @@ import java.lang.reflect.Type
 internal fun OpenAPIComponentContext.countQueryRequestBodyRef(): HttpRequestBody {
     countQueryRequestBody()
     return HttpRequestBody(componentRef = QueryComponent.COUNT_QUERY_KEY)
+}
+
+internal fun OpenAPIComponentContext.aggregatedAggregationQueryRequestBodyRef(
+    aggregateMetadata: AggregateMetadata<*, *>
+): HttpRequestBody {
+    aggregatedAggregationQueryRequestBody(aggregateMetadata)
+    return aggregateMetadata.queryRequestBodyRef(QueryComponent.AGGREGATION_QUERY_SUFFIX)
 }
 
 internal fun OpenAPIComponentContext.listQueryRequestBodyRef(): HttpRequestBody {
@@ -122,6 +130,10 @@ internal fun OpenAPIComponentContext.stateListResponse(
     aggregateMetadata: AggregateMetadata<*, *>
 ): HttpResponse {
     return listResponse(mainTargetType = aggregateMetadata.state.aggregateType)
+}
+
+internal fun OpenAPIComponentContext.aggregationListResponse(): HttpResponse {
+    return listResponse(Map::class.java)
 }
 
 internal fun OpenAPIComponentContext.materializedSnapshotPagedResponse(

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/aggregate/snapshot/SnapshotRouteContributor.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/aggregate/snapshot/SnapshotRouteContributor.kt
@@ -123,13 +123,13 @@ object SnapshotRouteContributor : RouteContributor {
         currentContext = currentContext,
         aggregateRouteMetadata = aggregateRouteMetadata,
         componentContext = componentContext,
-        handlerKey = BuiltInHttpRouteHandlerKeys.Snapshot.AGGREGATE,
+        handlerKey = BuiltInHttpRouteHandlerKeys.Snapshot.AGGREGATION,
         resourceName = SNAPSHOT,
-        operation = "aggregate",
-        operationSummary = "Aggregate Snapshot",
+        operation = "aggregation",
+        operationSummary = "Snapshot Aggregation",
         appendTenantPath = variant.appendTenantPath,
         appendOwnerPath = variant.appendOwnerPath,
-        appendPathSuffix = "snapshot/aggregate",
+        appendPathSuffix = "snapshot/aggregation",
         accept = STREAMING_ACCEPT,
         requestBody = componentContext.aggregatedAggregationQueryRequestBodyRef(
             aggregateRouteMetadata.aggregateMetadata

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/aggregate/snapshot/SnapshotRouteContributor.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/aggregate/snapshot/SnapshotRouteContributor.kt
@@ -36,10 +36,12 @@ import me.ahoo.wow.openapi.contributor.aggregate.aggregatePath
 import me.ahoo.wow.openapi.contributor.aggregate.aggregateTags
 import me.ahoo.wow.openapi.contributor.aggregate.defaultAppendOwnerPath
 import me.ahoo.wow.openapi.contributor.aggregate.defaultAppendTenantPath
+import me.ahoo.wow.openapi.contributor.aggregatedAggregationQueryRequestBodyRef
 import me.ahoo.wow.openapi.contributor.aggregatedCountQueryRequestBodyRef
 import me.ahoo.wow.openapi.contributor.aggregatedListQueryRequestBodyRef
 import me.ahoo.wow.openapi.contributor.aggregatedPagedQueryRequestBodyRef
 import me.ahoo.wow.openapi.contributor.aggregatedSingleQueryRequestBodyRef
+import me.ahoo.wow.openapi.contributor.aggregationListResponse
 import me.ahoo.wow.openapi.contributor.batchAfterIdPathParameterRef
 import me.ahoo.wow.openapi.contributor.batchLimitPathParameterRef
 import me.ahoo.wow.openapi.contributor.batchResultResponseRef
@@ -84,6 +86,7 @@ object SnapshotRouteContributor : RouteContributor {
     ): List<HttpRouteContract> {
         val aggregateMetadata = aggregateRouteMetadata.aggregateMetadata
         return listOf(
+            aggregationSnapshotRoute(currentContext, aggregateRouteMetadata, componentContext, variant),
             snapshotRoute(
                 currentContext = currentContext,
                 aggregateRouteMetadata = aggregateRouteMetadata,
@@ -110,6 +113,29 @@ object SnapshotRouteContributor : RouteContributor {
             singleSnapshotStateRoute(currentContext, aggregateRouteMetadata, componentContext, variant)
         )
     }
+
+    private fun aggregationSnapshotRoute(
+        currentContext: NamedBoundedContext,
+        aggregateRouteMetadata: AggregateRouteMetadata<*>,
+        componentContext: OpenAPIComponentContext,
+        variant: TenantOwnerVariant,
+    ): HttpRouteContract = snapshotRoute(
+        currentContext = currentContext,
+        aggregateRouteMetadata = aggregateRouteMetadata,
+        componentContext = componentContext,
+        handlerKey = BuiltInHttpRouteHandlerKeys.Snapshot.AGGREGATE,
+        resourceName = SNAPSHOT,
+        operation = "aggregate",
+        operationSummary = "Aggregate Snapshot",
+        appendTenantPath = variant.appendTenantPath,
+        appendOwnerPath = variant.appendOwnerPath,
+        appendPathSuffix = "snapshot/aggregate",
+        accept = STREAMING_ACCEPT,
+        requestBody = componentContext.aggregatedAggregationQueryRequestBodyRef(
+            aggregateRouteMetadata.aggregateMetadata
+        ),
+        responses = listOf(componentContext.aggregationListResponse()),
+    )
 
     private fun listQuerySnapshotRoute(
         currentContext: NamedBoundedContext,

--- a/wow-openapi/src/test/resources/openapi/example-domain-contract.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-contract.snapshot.json
@@ -27,10 +27,10 @@
   "tagNames" : [ "customer", "example.cart" ]
 }, {
   "accept" : [ "application/json", "text/event-stream" ],
-  "id" : "example.cart.snapshot.aggregate",
+  "id" : "example.cart.snapshot.aggregation",
   "method" : "POST",
   "parameterNames" : [ ],
-  "path" : "/cart/snapshot/aggregate",
+  "path" : "/cart/snapshot/aggregation",
   "requestBody" : true,
   "responseCodes" : [ "200" ],
   "tagNames" : [ "customer", "example.cart" ]
@@ -243,10 +243,10 @@
   "tagNames" : [ "customer", "example.cart" ]
 }, {
   "accept" : [ "application/json", "text/event-stream" ],
-  "id" : "example.cart.owner.snapshot.aggregate",
+  "id" : "example.cart.owner.snapshot.aggregation",
   "method" : "POST",
   "parameterNames" : [ "ref:#/components/parameters/wow.ownerId" ],
-  "path" : "/owner/{ownerId}/cart/snapshot/aggregate",
+  "path" : "/owner/{ownerId}/cart/snapshot/aggregation",
   "requestBody" : true,
   "responseCodes" : [ "200" ],
   "tagNames" : [ "customer", "example.cart" ]
@@ -387,10 +387,10 @@
   "tagNames" : [ "example.order" ]
 }, {
   "accept" : [ "application/json", "text/event-stream" ],
-  "id" : "example.order.owner.snapshot.aggregate",
+  "id" : "example.order.owner.snapshot.aggregation",
   "method" : "POST",
   "parameterNames" : [ "ref:#/components/parameters/wow.ownerId", "ref:#/components/parameters/wow.Wow-Space-Id" ],
-  "path" : "/owner/{ownerId}/sales-order/snapshot/aggregate",
+  "path" : "/owner/{ownerId}/sales-order/snapshot/aggregation",
   "requestBody" : true,
   "responseCodes" : [ "200" ],
   "tagNames" : [ "example.order" ]
@@ -486,10 +486,10 @@
   "tagNames" : [ "example.order" ]
 }, {
   "accept" : [ "application/json", "text/event-stream" ],
-  "id" : "example.order.snapshot.aggregate",
+  "id" : "example.order.snapshot.aggregation",
   "method" : "POST",
   "parameterNames" : [ "ref:#/components/parameters/wow.Wow-Space-Id" ],
-  "path" : "/sales-order/snapshot/aggregate",
+  "path" : "/sales-order/snapshot/aggregation",
   "requestBody" : true,
   "responseCodes" : [ "200" ],
   "tagNames" : [ "example.order" ]
@@ -603,10 +603,10 @@
   "tagNames" : [ "tck.mock_aggregate" ]
 }, {
   "accept" : [ "application/json", "text/event-stream" ],
-  "id" : "tck.mock_aggregate.snapshot.aggregate",
+  "id" : "tck.mock_aggregate.snapshot.aggregation",
   "method" : "POST",
   "parameterNames" : [ ],
-  "path" : "/tck/mock_aggregate/snapshot/aggregate",
+  "path" : "/tck/mock_aggregate/snapshot/aggregation",
   "requestBody" : true,
   "responseCodes" : [ "200" ],
   "tagNames" : [ "tck.mock_aggregate" ]
@@ -720,10 +720,10 @@
   "tagNames" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
 }, {
   "accept" : [ "application/json", "text/event-stream" ],
-  "id" : "tck.modeling_command_aggregate_with_tenant_id.snapshot.aggregate",
+  "id" : "tck.modeling_command_aggregate_with_tenant_id.snapshot.aggregation",
   "method" : "POST",
   "parameterNames" : [ ],
-  "path" : "/tck/modeling_command_aggregate_with_tenant_id/snapshot/aggregate",
+  "path" : "/tck/modeling_command_aggregate_with_tenant_id/snapshot/aggregation",
   "requestBody" : true,
   "responseCodes" : [ "200" ],
   "tagNames" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
@@ -837,10 +837,10 @@
   "tagNames" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
 }, {
   "accept" : [ "application/json", "text/event-stream" ],
-  "id" : "tck.modeling_command_aggregate_without_ctor_parameters.snapshot.aggregate",
+  "id" : "tck.modeling_command_aggregate_without_ctor_parameters.snapshot.aggregation",
   "method" : "POST",
   "parameterNames" : [ ],
-  "path" : "/tck/modeling_command_aggregate_without_ctor_parameters/snapshot/aggregate",
+  "path" : "/tck/modeling_command_aggregate_without_ctor_parameters/snapshot/aggregation",
   "requestBody" : true,
   "responseCodes" : [ "200" ],
   "tagNames" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
@@ -972,10 +972,10 @@
   "tagNames" : [ "tck.mock_aggregate" ]
 }, {
   "accept" : [ "application/json", "text/event-stream" ],
-  "id" : "tck.mock_aggregate.tenant.snapshot.aggregate",
+  "id" : "tck.mock_aggregate.tenant.snapshot.aggregation",
   "method" : "POST",
   "parameterNames" : [ "ref:#/components/parameters/wow.tenantId" ],
-  "path" : "/tck/tenant/{tenantId}/mock_aggregate/snapshot/aggregate",
+  "path" : "/tck/tenant/{tenantId}/mock_aggregate/snapshot/aggregation",
   "requestBody" : true,
   "responseCodes" : [ "200" ],
   "tagNames" : [ "tck.mock_aggregate" ]
@@ -1179,10 +1179,10 @@
   "tagNames" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
 }, {
   "accept" : [ "application/json", "text/event-stream" ],
-  "id" : "tck.modeling_command_aggregate_with_tenant_id.tenant.snapshot.aggregate",
+  "id" : "tck.modeling_command_aggregate_with_tenant_id.tenant.snapshot.aggregation",
   "method" : "POST",
   "parameterNames" : [ "ref:#/components/parameters/wow.tenantId" ],
-  "path" : "/tck/tenant/{tenantId}/modeling_command_aggregate_with_tenant_id/snapshot/aggregate",
+  "path" : "/tck/tenant/{tenantId}/modeling_command_aggregate_with_tenant_id/snapshot/aggregation",
   "requestBody" : true,
   "responseCodes" : [ "200" ],
   "tagNames" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
@@ -1377,10 +1377,10 @@
   "tagNames" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
 }, {
   "accept" : [ "application/json", "text/event-stream" ],
-  "id" : "tck.modeling_command_aggregate_without_ctor_parameters.tenant.snapshot.aggregate",
+  "id" : "tck.modeling_command_aggregate_without_ctor_parameters.tenant.snapshot.aggregation",
   "method" : "POST",
   "parameterNames" : [ "ref:#/components/parameters/wow.tenantId" ],
-  "path" : "/tck/tenant/{tenantId}/modeling_command_aggregate_without_ctor_parameters/snapshot/aggregate",
+  "path" : "/tck/tenant/{tenantId}/modeling_command_aggregate_without_ctor_parameters/snapshot/aggregation",
   "requestBody" : true,
   "responseCodes" : [ "200" ],
   "tagNames" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
@@ -1674,10 +1674,10 @@
   "tagNames" : [ "example.order" ]
 }, {
   "accept" : [ "application/json", "text/event-stream" ],
-  "id" : "example.order.tenant.snapshot.aggregate",
+  "id" : "example.order.tenant.snapshot.aggregation",
   "method" : "POST",
   "parameterNames" : [ "ref:#/components/parameters/wow.tenantId", "ref:#/components/parameters/wow.Wow-Space-Id" ],
-  "path" : "/tenant/{tenantId}/sales-order/snapshot/aggregate",
+  "path" : "/tenant/{tenantId}/sales-order/snapshot/aggregation",
   "requestBody" : true,
   "responseCodes" : [ "200" ],
   "tagNames" : [ "example.order" ]

--- a/wow-openapi/src/test/resources/openapi/example-domain-contract.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-contract.snapshot.json
@@ -26,6 +26,15 @@
   "responseCodes" : [ "200" ],
   "tagNames" : [ "customer", "example.cart" ]
 }, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "example.cart.snapshot.aggregate",
+  "method" : "POST",
+  "parameterNames" : [ ],
+  "path" : "/cart/snapshot/aggregate",
+  "requestBody" : true,
+  "responseCodes" : [ "200" ],
+  "tagNames" : [ "customer", "example.cart" ]
+}, {
   "accept" : [ "application/json" ],
   "id" : "example.cart.snapshot.count",
   "method" : "POST",
@@ -233,6 +242,15 @@
   "responseCodes" : [ "200", "404" ],
   "tagNames" : [ "customer", "example.cart" ]
 }, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "example.cart.owner.snapshot.aggregate",
+  "method" : "POST",
+  "parameterNames" : [ "ref:#/components/parameters/wow.ownerId" ],
+  "path" : "/owner/{ownerId}/cart/snapshot/aggregate",
+  "requestBody" : true,
+  "responseCodes" : [ "200" ],
+  "tagNames" : [ "customer", "example.cart" ]
+}, {
   "accept" : [ "application/json" ],
   "id" : "example.cart.owner.snapshot.count",
   "method" : "POST",
@@ -368,6 +386,15 @@
   "responseCodes" : [ "200" ],
   "tagNames" : [ "example.order" ]
 }, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "example.order.owner.snapshot.aggregate",
+  "method" : "POST",
+  "parameterNames" : [ "ref:#/components/parameters/wow.ownerId", "ref:#/components/parameters/wow.Wow-Space-Id" ],
+  "path" : "/owner/{ownerId}/sales-order/snapshot/aggregate",
+  "requestBody" : true,
+  "responseCodes" : [ "200" ],
+  "tagNames" : [ "example.order" ]
+}, {
   "accept" : [ "application/json" ],
   "id" : "example.order.owner.snapshot.count",
   "method" : "POST",
@@ -454,6 +481,15 @@
   "method" : "POST",
   "parameterNames" : [ "ref:#/components/parameters/wow.Wow-Space-Id" ],
   "path" : "/sales-order/event/paged",
+  "requestBody" : true,
+  "responseCodes" : [ "200" ],
+  "tagNames" : [ "example.order" ]
+}, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "example.order.snapshot.aggregate",
+  "method" : "POST",
+  "parameterNames" : [ "ref:#/components/parameters/wow.Wow-Space-Id" ],
+  "path" : "/sales-order/snapshot/aggregate",
   "requestBody" : true,
   "responseCodes" : [ "200" ],
   "tagNames" : [ "example.order" ]
@@ -566,6 +602,15 @@
   "responseCodes" : [ "200" ],
   "tagNames" : [ "tck.mock_aggregate" ]
 }, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "tck.mock_aggregate.snapshot.aggregate",
+  "method" : "POST",
+  "parameterNames" : [ ],
+  "path" : "/tck/mock_aggregate/snapshot/aggregate",
+  "requestBody" : true,
+  "responseCodes" : [ "200" ],
+  "tagNames" : [ "tck.mock_aggregate" ]
+}, {
   "accept" : [ "application/json" ],
   "id" : "tck.mock_aggregate.snapshot.count",
   "method" : "POST",
@@ -674,6 +719,15 @@
   "responseCodes" : [ "200" ],
   "tagNames" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
 }, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "tck.modeling_command_aggregate_with_tenant_id.snapshot.aggregate",
+  "method" : "POST",
+  "parameterNames" : [ ],
+  "path" : "/tck/modeling_command_aggregate_with_tenant_id/snapshot/aggregate",
+  "requestBody" : true,
+  "responseCodes" : [ "200" ],
+  "tagNames" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
+}, {
   "accept" : [ "application/json" ],
   "id" : "tck.modeling_command_aggregate_with_tenant_id.snapshot.count",
   "method" : "POST",
@@ -778,6 +832,15 @@
   "method" : "POST",
   "parameterNames" : [ ],
   "path" : "/tck/modeling_command_aggregate_without_ctor_parameters/event/paged",
+  "requestBody" : true,
+  "responseCodes" : [ "200" ],
+  "tagNames" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
+}, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "tck.modeling_command_aggregate_without_ctor_parameters.snapshot.aggregate",
+  "method" : "POST",
+  "parameterNames" : [ ],
+  "path" : "/tck/modeling_command_aggregate_without_ctor_parameters/snapshot/aggregate",
   "requestBody" : true,
   "responseCodes" : [ "200" ],
   "tagNames" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
@@ -906,6 +969,15 @@
   "path" : "/tck/tenant/{tenantId}/mock_aggregate/mock_create_aggregate",
   "requestBody" : true,
   "responseCodes" : [ "200", "400", "404", "408", "409", "410", "429" ],
+  "tagNames" : [ "tck.mock_aggregate" ]
+}, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "tck.mock_aggregate.tenant.snapshot.aggregate",
+  "method" : "POST",
+  "parameterNames" : [ "ref:#/components/parameters/wow.tenantId" ],
+  "path" : "/tck/tenant/{tenantId}/mock_aggregate/snapshot/aggregate",
+  "requestBody" : true,
+  "responseCodes" : [ "200" ],
   "tagNames" : [ "tck.mock_aggregate" ]
 }, {
   "accept" : [ "application/json" ],
@@ -1106,6 +1178,15 @@
   "responseCodes" : [ "200" ],
   "tagNames" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
 }, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "tck.modeling_command_aggregate_with_tenant_id.tenant.snapshot.aggregate",
+  "method" : "POST",
+  "parameterNames" : [ "ref:#/components/parameters/wow.tenantId" ],
+  "path" : "/tck/tenant/{tenantId}/modeling_command_aggregate_with_tenant_id/snapshot/aggregate",
+  "requestBody" : true,
+  "responseCodes" : [ "200" ],
+  "tagNames" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
+}, {
   "accept" : [ "application/json" ],
   "id" : "tck.modeling_command_aggregate_with_tenant_id.tenant.snapshot.count",
   "method" : "POST",
@@ -1291,6 +1372,15 @@
   "method" : "POST",
   "parameterNames" : [ "ref:#/components/parameters/wow.tenantId" ],
   "path" : "/tck/tenant/{tenantId}/modeling_command_aggregate_without_ctor_parameters/event/paged",
+  "requestBody" : true,
+  "responseCodes" : [ "200" ],
+  "tagNames" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
+}, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "tck.modeling_command_aggregate_without_ctor_parameters.tenant.snapshot.aggregate",
+  "method" : "POST",
+  "parameterNames" : [ "ref:#/components/parameters/wow.tenantId" ],
+  "path" : "/tck/tenant/{tenantId}/modeling_command_aggregate_without_ctor_parameters/snapshot/aggregate",
   "requestBody" : true,
   "responseCodes" : [ "200" ],
   "tagNames" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
@@ -1579,6 +1669,15 @@
   "method" : "POST",
   "parameterNames" : [ "ref:#/components/parameters/wow.tenantId", "ref:#/components/parameters/wow.Wow-Space-Id" ],
   "path" : "/tenant/{tenantId}/sales-order/event/paged",
+  "requestBody" : true,
+  "responseCodes" : [ "200" ],
+  "tagNames" : [ "example.order" ]
+}, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "example.order.tenant.snapshot.aggregate",
+  "method" : "POST",
+  "parameterNames" : [ "ref:#/components/parameters/wow.tenantId", "ref:#/components/parameters/wow.Wow-Space-Id" ],
+  "path" : "/tenant/{tenantId}/sales-order/snapshot/aggregate",
   "requestBody" : true,
   "responseCodes" : [ "200" ],
   "tagNames" : [ "example.order" ]

--- a/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
@@ -956,7 +956,6 @@
                 "$ref" : "#/components/schemas/example.cart.CartAggregatedAggregationMetric.Sum"
               } ]
             },
-            "maxItems" : 32,
             "minItems" : 1,
             "type" : "array"
           },
@@ -1991,7 +1990,6 @@
                 "$ref" : "#/components/schemas/example.order.OrderAggregatedAggregationMetric.Sum"
               } ]
             },
-            "maxItems" : 32,
             "minItems" : 1,
             "type" : "array"
           },
@@ -3122,7 +3120,6 @@
                 "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedAggregationMetric.Sum"
               } ]
             },
-            "maxItems" : 32,
             "minItems" : 1,
             "type" : "array"
           },
@@ -3590,7 +3587,6 @@
                 "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedAggregationMetric.Sum"
               } ]
             },
-            "maxItems" : 32,
             "minItems" : 1,
             "type" : "array"
           },
@@ -4027,7 +4023,6 @@
                 "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedAggregationMetric.Sum"
               } ]
             },
-            "maxItems" : 32,
             "minItems" : 1,
             "type" : "array"
           },

--- a/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
@@ -6178,9 +6178,9 @@
         "tags" : [ "example.cart", "customer" ]
       }
     },
-    "/cart/snapshot/aggregate" : {
+    "/cart/snapshot/aggregation" : {
       "post" : {
-        "operationId" : "example.cart.snapshot.aggregate",
+        "operationId" : "example.cart.snapshot.aggregation",
         "parameters" : [ ],
         "requestBody" : {
           "$ref" : "#/components/requestBodies/example.cart.AggregationQuery"
@@ -7095,9 +7095,9 @@
         "tags" : [ "example.cart", "customer" ]
       }
     },
-    "/owner/{ownerId}/cart/snapshot/aggregate" : {
+    "/owner/{ownerId}/cart/snapshot/aggregation" : {
       "post" : {
-        "operationId" : "example.cart.owner.snapshot.aggregate",
+        "operationId" : "example.cart.owner.snapshot.aggregation",
         "parameters" : [ {
           "$ref" : "#/components/parameters/wow.ownerId"
         } ],
@@ -7678,9 +7678,9 @@
         "tags" : [ "example.order" ]
       }
     },
-    "/owner/{ownerId}/sales-order/snapshot/aggregate" : {
+    "/owner/{ownerId}/sales-order/snapshot/aggregation" : {
       "post" : {
-        "operationId" : "example.order.owner.snapshot.aggregate",
+        "operationId" : "example.order.owner.snapshot.aggregation",
         "parameters" : [ {
           "$ref" : "#/components/parameters/wow.Wow-Space-Id"
         }, {
@@ -8036,9 +8036,9 @@
         "tags" : [ "example.order" ]
       }
     },
-    "/sales-order/snapshot/aggregate" : {
+    "/sales-order/snapshot/aggregation" : {
       "post" : {
-        "operationId" : "example.order.snapshot.aggregate",
+        "operationId" : "example.order.snapshot.aggregation",
         "parameters" : [ {
           "$ref" : "#/components/parameters/wow.Wow-Space-Id"
         } ],
@@ -8414,9 +8414,9 @@
         "tags" : [ "tck.mock_aggregate" ]
       }
     },
-    "/tck/mock_aggregate/snapshot/aggregate" : {
+    "/tck/mock_aggregate/snapshot/aggregation" : {
       "post" : {
-        "operationId" : "tck.mock_aggregate.snapshot.aggregate",
+        "operationId" : "tck.mock_aggregate.snapshot.aggregation",
         "parameters" : [ ],
         "requestBody" : {
           "$ref" : "#/components/requestBodies/tck.mock_aggregate.AggregationQuery"
@@ -8772,9 +8772,9 @@
         "tags" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
       }
     },
-    "/tck/modeling_command_aggregate_with_tenant_id/snapshot/aggregate" : {
+    "/tck/modeling_command_aggregate_with_tenant_id/snapshot/aggregation" : {
       "post" : {
-        "operationId" : "tck.modeling_command_aggregate_with_tenant_id.snapshot.aggregate",
+        "operationId" : "tck.modeling_command_aggregate_with_tenant_id.snapshot.aggregation",
         "parameters" : [ ],
         "requestBody" : {
           "$ref" : "#/components/requestBodies/tck.modeling_command_aggregate_with_tenant_id.AggregationQuery"
@@ -9130,9 +9130,9 @@
         "tags" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
       }
     },
-    "/tck/modeling_command_aggregate_without_ctor_parameters/snapshot/aggregate" : {
+    "/tck/modeling_command_aggregate_without_ctor_parameters/snapshot/aggregation" : {
       "post" : {
-        "operationId" : "tck.modeling_command_aggregate_without_ctor_parameters.snapshot.aggregate",
+        "operationId" : "tck.modeling_command_aggregate_without_ctor_parameters.snapshot.aggregation",
         "parameters" : [ ],
         "requestBody" : {
           "$ref" : "#/components/requestBodies/tck.modeling_command_aggregate_without_ctor_parameters.AggregationQuery"
@@ -9632,9 +9632,9 @@
         "tags" : [ "tck.mock_aggregate" ]
       }
     },
-    "/tck/tenant/{tenantId}/mock_aggregate/snapshot/aggregate" : {
+    "/tck/tenant/{tenantId}/mock_aggregate/snapshot/aggregation" : {
       "post" : {
-        "operationId" : "tck.mock_aggregate.tenant.snapshot.aggregate",
+        "operationId" : "tck.mock_aggregate.tenant.snapshot.aggregation",
         "parameters" : [ {
           "$ref" : "#/components/parameters/wow.tenantId"
         } ],
@@ -10508,9 +10508,9 @@
         "tags" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
       }
     },
-    "/tck/tenant/{tenantId}/modeling_command_aggregate_with_tenant_id/snapshot/aggregate" : {
+    "/tck/tenant/{tenantId}/modeling_command_aggregate_with_tenant_id/snapshot/aggregation" : {
       "post" : {
-        "operationId" : "tck.modeling_command_aggregate_with_tenant_id.tenant.snapshot.aggregate",
+        "operationId" : "tck.modeling_command_aggregate_with_tenant_id.tenant.snapshot.aggregation",
         "parameters" : [ {
           "$ref" : "#/components/parameters/wow.tenantId"
         } ],
@@ -11313,9 +11313,9 @@
         "tags" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
       }
     },
-    "/tck/tenant/{tenantId}/modeling_command_aggregate_without_ctor_parameters/snapshot/aggregate" : {
+    "/tck/tenant/{tenantId}/modeling_command_aggregate_without_ctor_parameters/snapshot/aggregation" : {
       "post" : {
-        "operationId" : "tck.modeling_command_aggregate_without_ctor_parameters.tenant.snapshot.aggregate",
+        "operationId" : "tck.modeling_command_aggregate_without_ctor_parameters.tenant.snapshot.aggregation",
         "parameters" : [ {
           "$ref" : "#/components/parameters/wow.tenantId"
         } ],
@@ -12828,9 +12828,9 @@
         "tags" : [ "example.order" ]
       }
     },
-    "/tenant/{tenantId}/sales-order/snapshot/aggregate" : {
+    "/tenant/{tenantId}/sales-order/snapshot/aggregation" : {
       "post" : {
-        "operationId" : "example.order.tenant.snapshot.aggregate",
+        "operationId" : "example.order.tenant.snapshot.aggregation",
         "parameters" : [ {
           "$ref" : "#/components/parameters/wow.Wow-Space-Id"
         }, {

--- a/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
@@ -792,7 +792,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/example.cart.CartAggregatedFields"
+            "$ref" : "#/components/schemas/example.cart.CartSnapshotAggregatedFields"
           },
           "timeZone" : {
             "type" : "string"
@@ -813,7 +813,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/example.cart.CartAggregatedFields"
+            "$ref" : "#/components/schemas/example.cart.CartSnapshotAggregatedFields"
           },
           "interval" : {
             "format" : "double",
@@ -836,7 +836,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/example.cart.CartAggregatedFields"
+            "$ref" : "#/components/schemas/example.cart.CartSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "TERMS"
@@ -851,7 +851,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/example.cart.CartAggregatedFields"
+            "$ref" : "#/components/schemas/example.cart.CartSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "AVG"
@@ -878,7 +878,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/example.cart.CartAggregatedFields"
+            "$ref" : "#/components/schemas/example.cart.CartSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "MAX"
@@ -893,7 +893,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/example.cart.CartAggregatedFields"
+            "$ref" : "#/components/schemas/example.cart.CartSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "MIN"
@@ -908,7 +908,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/example.cart.CartAggregatedFields"
+            "$ref" : "#/components/schemas/example.cart.CartSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "SUM"
@@ -932,6 +932,7 @@
                 "$ref" : "#/components/schemas/example.cart.CartAggregatedAggregationGroup.Terms"
               } ]
             },
+            "maxItems" : 32,
             "type" : "array"
           },
           "limit" : {
@@ -1316,6 +1317,10 @@
         },
         "required" : [ "changed" ],
         "type" : "object"
+      },
+      "example.cart.CartSnapshotAggregatedFields" : {
+        "enum" : [ "aggregateId", "tenantId", "ownerId", "spaceId", "version", "eventId", "firstOperator", "operator", "firstEventTime", "eventTime", "tags", "deleted", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "contextName", "aggregateName", "snapshotTime" ],
+        "type" : "string"
       },
       "example.cart.CartState" : {
         "properties" : {
@@ -1820,7 +1825,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/example.order.OrderAggregatedFields"
+            "$ref" : "#/components/schemas/example.order.OrderSnapshotAggregatedFields"
           },
           "timeZone" : {
             "type" : "string"
@@ -1841,7 +1846,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/example.order.OrderAggregatedFields"
+            "$ref" : "#/components/schemas/example.order.OrderSnapshotAggregatedFields"
           },
           "interval" : {
             "format" : "double",
@@ -1864,7 +1869,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/example.order.OrderAggregatedFields"
+            "$ref" : "#/components/schemas/example.order.OrderSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "TERMS"
@@ -1879,7 +1884,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/example.order.OrderAggregatedFields"
+            "$ref" : "#/components/schemas/example.order.OrderSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "AVG"
@@ -1906,7 +1911,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/example.order.OrderAggregatedFields"
+            "$ref" : "#/components/schemas/example.order.OrderSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "MAX"
@@ -1921,7 +1926,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/example.order.OrderAggregatedFields"
+            "$ref" : "#/components/schemas/example.order.OrderSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "MIN"
@@ -1936,7 +1941,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/example.order.OrderAggregatedFields"
+            "$ref" : "#/components/schemas/example.order.OrderSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "SUM"
@@ -1960,6 +1965,7 @@
                 "$ref" : "#/components/schemas/example.order.OrderAggregatedAggregationGroup.Terms"
               } ]
             },
+            "maxItems" : 32,
             "type" : "array"
           },
           "limit" : {
@@ -2414,6 +2420,10 @@
       },
       "example.order.OrderShipped" : {
         "type" : "object"
+      },
+      "example.order.OrderSnapshotAggregatedFields" : {
+        "enum" : [ "aggregateId", "tenantId", "ownerId", "spaceId", "version", "eventId", "firstOperator", "operator", "firstEventTime", "eventTime", "tags", "deleted", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "contextName", "aggregateName", "snapshotTime" ],
+        "type" : "string"
       },
       "example.order.OrderStatus" : {
         "enum" : [ "CREATED", "PAID", "SHIPPED", "RECEIVED" ],
@@ -2944,7 +2954,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedFields"
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateSnapshotAggregatedFields"
           },
           "timeZone" : {
             "type" : "string"
@@ -2965,7 +2975,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedFields"
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateSnapshotAggregatedFields"
           },
           "interval" : {
             "format" : "double",
@@ -2988,7 +2998,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedFields"
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "TERMS"
@@ -3003,7 +3013,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedFields"
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "AVG"
@@ -3030,7 +3040,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedFields"
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "MAX"
@@ -3045,7 +3055,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedFields"
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "MIN"
@@ -3060,7 +3070,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedFields"
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "SUM"
@@ -3084,6 +3094,7 @@
                 "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedAggregationGroup.Terms"
               } ]
             },
+            "maxItems" : 32,
             "type" : "array"
           },
           "limit" : {
@@ -3399,13 +3410,17 @@
         "required" : [ "condition" ],
         "type" : "object"
       },
+      "tck.mock_aggregate.MockCommandAggregateSnapshotAggregatedFields" : {
+        "enum" : [ "aggregateId", "tenantId", "ownerId", "spaceId", "version", "eventId", "firstOperator", "operator", "firstEventTime", "eventTime", "tags", "deleted", "state", "state.data", "state.id", "contextName", "aggregateName", "snapshotTime" ],
+        "type" : "string"
+      },
       "tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedAggregationGroup.DateHistogram" : {
         "properties" : {
           "alias" : {
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedFields"
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdSnapshotAggregatedFields"
           },
           "timeZone" : {
             "type" : "string"
@@ -3426,7 +3441,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedFields"
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdSnapshotAggregatedFields"
           },
           "interval" : {
             "format" : "double",
@@ -3449,7 +3464,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedFields"
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "TERMS"
@@ -3464,7 +3479,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedFields"
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "AVG"
@@ -3491,7 +3506,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedFields"
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "MAX"
@@ -3506,7 +3521,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedFields"
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "MIN"
@@ -3521,7 +3536,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedFields"
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "SUM"
@@ -3545,6 +3560,7 @@
                 "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedAggregationGroup.Terms"
               } ]
             },
+            "maxItems" : 32,
             "type" : "array"
           },
           "limit" : {
@@ -3829,13 +3845,17 @@
         "required" : [ "condition" ],
         "type" : "object"
       },
+      "tck.mock_aggregate.MockCommandAggregateWithTenantIdSnapshotAggregatedFields" : {
+        "enum" : [ "aggregateId", "tenantId", "ownerId", "spaceId", "version", "eventId", "firstOperator", "operator", "firstEventTime", "eventTime", "tags", "deleted", "state", "state.id", "state.tenantId", "contextName", "aggregateName", "snapshotTime" ],
+        "type" : "string"
+      },
       "tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedAggregationGroup.DateHistogram" : {
         "properties" : {
           "alias" : {
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedFields"
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersSnapshotAggregatedFields"
           },
           "timeZone" : {
             "type" : "string"
@@ -3856,7 +3876,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedFields"
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersSnapshotAggregatedFields"
           },
           "interval" : {
             "format" : "double",
@@ -3879,7 +3899,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedFields"
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "TERMS"
@@ -3894,7 +3914,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedFields"
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "AVG"
@@ -3921,7 +3941,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedFields"
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "MAX"
@@ -3936,7 +3956,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedFields"
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "MIN"
@@ -3951,7 +3971,7 @@
             "type" : "string"
           },
           "field" : {
-            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedFields"
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersSnapshotAggregatedFields"
           },
           "type" : {
             "const" : "SUM"
@@ -3975,6 +3995,7 @@
                 "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedAggregationGroup.Terms"
               } ]
             },
+            "maxItems" : 32,
             "type" : "array"
           },
           "limit" : {
@@ -4258,6 +4279,10 @@
         },
         "required" : [ "condition" ],
         "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersSnapshotAggregatedFields" : {
+        "enum" : [ "aggregateId", "tenantId", "ownerId", "spaceId", "version", "eventId", "firstOperator", "operator", "firstEventTime", "eventTime", "tags", "deleted", "state", "contextName", "aggregateName", "snapshotTime" ],
+        "type" : "string"
       },
       "tck.mock_aggregate.MockCreateAggregate" : {
         "properties" : {

--- a/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
@@ -816,6 +816,7 @@
             "$ref" : "#/components/schemas/example.cart.CartSnapshotAggregatedFields"
           },
           "interval" : {
+            "exclusiveMinimum" : 0,
             "format" : "double",
             "type" : "number"
           },
@@ -1850,6 +1851,7 @@
             "$ref" : "#/components/schemas/example.order.OrderSnapshotAggregatedFields"
           },
           "interval" : {
+            "exclusiveMinimum" : 0,
             "format" : "double",
             "type" : "number"
           },
@@ -2980,6 +2982,7 @@
             "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateSnapshotAggregatedFields"
           },
           "interval" : {
+            "exclusiveMinimum" : 0,
             "format" : "double",
             "type" : "number"
           },
@@ -3447,6 +3450,7 @@
             "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdSnapshotAggregatedFields"
           },
           "interval" : {
+            "exclusiveMinimum" : 0,
             "format" : "double",
             "type" : "number"
           },
@@ -3883,6 +3887,7 @@
             "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersSnapshotAggregatedFields"
           },
           "interval" : {
+            "exclusiveMinimum" : 0,
             "format" : "double",
             "type" : "number"
           },

--- a/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
@@ -267,6 +267,15 @@
       }
     },
     "requestBodies" : {
+      "example.cart.AggregationQuery" : {
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/example.cart.CartAggregatedAggregationQuery"
+            }
+          }
+        }
+      },
       "example.cart.CountQuery" : {
         "content" : {
           "application/json" : {
@@ -299,6 +308,15 @@
           "application/json" : {
             "schema" : {
               "$ref" : "#/components/schemas/example.cart.CartAggregatedSingleQuery"
+            }
+          }
+        }
+      },
+      "example.order.AggregationQuery" : {
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/example.order.OrderAggregatedAggregationQuery"
             }
           }
         }
@@ -339,6 +357,15 @@
           }
         }
       },
+      "tck.mock_aggregate.AggregationQuery" : {
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedAggregationQuery"
+            }
+          }
+        }
+      },
       "tck.mock_aggregate.CountQuery" : {
         "content" : {
           "application/json" : {
@@ -375,6 +402,15 @@
           }
         }
       },
+      "tck.modeling_command_aggregate_with_tenant_id.AggregationQuery" : {
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedAggregationQuery"
+            }
+          }
+        }
+      },
       "tck.modeling_command_aggregate_with_tenant_id.CountQuery" : {
         "content" : {
           "application/json" : {
@@ -407,6 +443,15 @@
           "application/json" : {
             "schema" : {
               "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedSingleQuery"
+            }
+          }
+        }
+      },
+      "tck.modeling_command_aggregate_without_ctor_parameters.AggregationQuery" : {
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedAggregationQuery"
             }
           }
         }
@@ -709,6 +754,10 @@
       }
     },
     "schemas" : {
+      "example.ObjectObjectMap" : {
+        "type" : "object",
+        "x-map-key-schema" : { }
+      },
       "example.StringObjectMap" : {
         "type" : "object"
       },
@@ -735,6 +784,187 @@
         },
         "required" : [ "productId" ],
         "title" : "加入购物车",
+        "type" : "object"
+      },
+      "example.cart.CartAggregatedAggregationGroup.DateHistogram" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/example.cart.CartAggregatedFields"
+          },
+          "timeZone" : {
+            "type" : "string"
+          },
+          "type" : {
+            "const" : "DATE_HISTOGRAM"
+          },
+          "unit" : {
+            "$ref" : "#/components/schemas/wow.api.query.AggregationDateUnit"
+          }
+        },
+        "required" : [ "alias", "field", "type", "unit" ],
+        "type" : "object"
+      },
+      "example.cart.CartAggregatedAggregationGroup.Histogram" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/example.cart.CartAggregatedFields"
+          },
+          "interval" : {
+            "format" : "double",
+            "type" : "number"
+          },
+          "offset" : {
+            "format" : "double",
+            "type" : "number"
+          },
+          "type" : {
+            "const" : "HISTOGRAM"
+          }
+        },
+        "required" : [ "alias", "field", "interval", "type" ],
+        "type" : "object"
+      },
+      "example.cart.CartAggregatedAggregationGroup.Terms" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/example.cart.CartAggregatedFields"
+          },
+          "type" : {
+            "const" : "TERMS"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "example.cart.CartAggregatedAggregationMetric.Avg" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/example.cart.CartAggregatedFields"
+          },
+          "type" : {
+            "const" : "AVG"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "example.cart.CartAggregatedAggregationMetric.Count" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "type" : {
+            "const" : "COUNT"
+          }
+        },
+        "required" : [ "alias", "type" ],
+        "type" : "object"
+      },
+      "example.cart.CartAggregatedAggregationMetric.Max" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/example.cart.CartAggregatedFields"
+          },
+          "type" : {
+            "const" : "MAX"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "example.cart.CartAggregatedAggregationMetric.Min" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/example.cart.CartAggregatedFields"
+          },
+          "type" : {
+            "const" : "MIN"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "example.cart.CartAggregatedAggregationMetric.Sum" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/example.cart.CartAggregatedFields"
+          },
+          "type" : {
+            "const" : "SUM"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "example.cart.CartAggregatedAggregationQuery" : {
+        "properties" : {
+          "condition" : {
+            "$ref" : "#/components/schemas/example.cart.CartAggregatedCondition"
+          },
+          "groupBy" : {
+            "items" : {
+              "anyOf" : [ {
+                "$ref" : "#/components/schemas/example.cart.CartAggregatedAggregationGroup.DateHistogram"
+              }, {
+                "$ref" : "#/components/schemas/example.cart.CartAggregatedAggregationGroup.Histogram"
+              }, {
+                "$ref" : "#/components/schemas/example.cart.CartAggregatedAggregationGroup.Terms"
+              } ]
+            },
+            "type" : "array"
+          },
+          "limit" : {
+            "default" : "100",
+            "format" : "int32",
+            "maximum" : 10000,
+            "minimum" : 1,
+            "type" : "integer"
+          },
+          "metrics" : {
+            "items" : {
+              "anyOf" : [ {
+                "$ref" : "#/components/schemas/example.cart.CartAggregatedAggregationMetric.Avg"
+              }, {
+                "$ref" : "#/components/schemas/example.cart.CartAggregatedAggregationMetric.Count"
+              }, {
+                "$ref" : "#/components/schemas/example.cart.CartAggregatedAggregationMetric.Max"
+              }, {
+                "$ref" : "#/components/schemas/example.cart.CartAggregatedAggregationMetric.Min"
+              }, {
+                "$ref" : "#/components/schemas/example.cart.CartAggregatedAggregationMetric.Sum"
+              } ]
+            },
+            "type" : "array"
+          },
+          "sort" : {
+            "items" : {
+              "$ref" : "#/components/schemas/wow.api.query.Sort"
+            },
+            "type" : "array"
+          }
+        },
+        "required" : [ "metrics" ],
         "type" : "object"
       },
       "example.cart.CartAggregatedCondition" : {
@@ -1582,6 +1812,187 @@
           }
         },
         "required" : [ "price", "productId", "quantity" ],
+        "type" : "object"
+      },
+      "example.order.OrderAggregatedAggregationGroup.DateHistogram" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/example.order.OrderAggregatedFields"
+          },
+          "timeZone" : {
+            "type" : "string"
+          },
+          "type" : {
+            "const" : "DATE_HISTOGRAM"
+          },
+          "unit" : {
+            "$ref" : "#/components/schemas/wow.api.query.AggregationDateUnit"
+          }
+        },
+        "required" : [ "alias", "field", "type", "unit" ],
+        "type" : "object"
+      },
+      "example.order.OrderAggregatedAggregationGroup.Histogram" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/example.order.OrderAggregatedFields"
+          },
+          "interval" : {
+            "format" : "double",
+            "type" : "number"
+          },
+          "offset" : {
+            "format" : "double",
+            "type" : "number"
+          },
+          "type" : {
+            "const" : "HISTOGRAM"
+          }
+        },
+        "required" : [ "alias", "field", "interval", "type" ],
+        "type" : "object"
+      },
+      "example.order.OrderAggregatedAggregationGroup.Terms" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/example.order.OrderAggregatedFields"
+          },
+          "type" : {
+            "const" : "TERMS"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "example.order.OrderAggregatedAggregationMetric.Avg" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/example.order.OrderAggregatedFields"
+          },
+          "type" : {
+            "const" : "AVG"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "example.order.OrderAggregatedAggregationMetric.Count" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "type" : {
+            "const" : "COUNT"
+          }
+        },
+        "required" : [ "alias", "type" ],
+        "type" : "object"
+      },
+      "example.order.OrderAggregatedAggregationMetric.Max" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/example.order.OrderAggregatedFields"
+          },
+          "type" : {
+            "const" : "MAX"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "example.order.OrderAggregatedAggregationMetric.Min" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/example.order.OrderAggregatedFields"
+          },
+          "type" : {
+            "const" : "MIN"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "example.order.OrderAggregatedAggregationMetric.Sum" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/example.order.OrderAggregatedFields"
+          },
+          "type" : {
+            "const" : "SUM"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "example.order.OrderAggregatedAggregationQuery" : {
+        "properties" : {
+          "condition" : {
+            "$ref" : "#/components/schemas/example.order.OrderAggregatedCondition"
+          },
+          "groupBy" : {
+            "items" : {
+              "anyOf" : [ {
+                "$ref" : "#/components/schemas/example.order.OrderAggregatedAggregationGroup.DateHistogram"
+              }, {
+                "$ref" : "#/components/schemas/example.order.OrderAggregatedAggregationGroup.Histogram"
+              }, {
+                "$ref" : "#/components/schemas/example.order.OrderAggregatedAggregationGroup.Terms"
+              } ]
+            },
+            "type" : "array"
+          },
+          "limit" : {
+            "default" : "100",
+            "format" : "int32",
+            "maximum" : 10000,
+            "minimum" : 1,
+            "type" : "integer"
+          },
+          "metrics" : {
+            "items" : {
+              "anyOf" : [ {
+                "$ref" : "#/components/schemas/example.order.OrderAggregatedAggregationMetric.Avg"
+              }, {
+                "$ref" : "#/components/schemas/example.order.OrderAggregatedAggregationMetric.Count"
+              }, {
+                "$ref" : "#/components/schemas/example.order.OrderAggregatedAggregationMetric.Max"
+              }, {
+                "$ref" : "#/components/schemas/example.order.OrderAggregatedAggregationMetric.Min"
+              }, {
+                "$ref" : "#/components/schemas/example.order.OrderAggregatedAggregationMetric.Sum"
+              } ]
+            },
+            "type" : "array"
+          },
+          "sort" : {
+            "items" : {
+              "$ref" : "#/components/schemas/wow.api.query.Sort"
+            },
+            "type" : "array"
+          }
+        },
+        "required" : [ "metrics" ],
         "type" : "object"
       },
       "example.order.OrderAggregatedCondition" : {
@@ -2527,6 +2938,187 @@
         "required" : [ "data", "id" ],
         "type" : "object"
       },
+      "tck.mock_aggregate.MockCommandAggregateAggregatedAggregationGroup.DateHistogram" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedFields"
+          },
+          "timeZone" : {
+            "type" : "string"
+          },
+          "type" : {
+            "const" : "DATE_HISTOGRAM"
+          },
+          "unit" : {
+            "$ref" : "#/components/schemas/wow.api.query.AggregationDateUnit"
+          }
+        },
+        "required" : [ "alias", "field", "type", "unit" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateAggregatedAggregationGroup.Histogram" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedFields"
+          },
+          "interval" : {
+            "format" : "double",
+            "type" : "number"
+          },
+          "offset" : {
+            "format" : "double",
+            "type" : "number"
+          },
+          "type" : {
+            "const" : "HISTOGRAM"
+          }
+        },
+        "required" : [ "alias", "field", "interval", "type" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateAggregatedAggregationGroup.Terms" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedFields"
+          },
+          "type" : {
+            "const" : "TERMS"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateAggregatedAggregationMetric.Avg" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedFields"
+          },
+          "type" : {
+            "const" : "AVG"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateAggregatedAggregationMetric.Count" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "type" : {
+            "const" : "COUNT"
+          }
+        },
+        "required" : [ "alias", "type" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateAggregatedAggregationMetric.Max" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedFields"
+          },
+          "type" : {
+            "const" : "MAX"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateAggregatedAggregationMetric.Min" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedFields"
+          },
+          "type" : {
+            "const" : "MIN"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateAggregatedAggregationMetric.Sum" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedFields"
+          },
+          "type" : {
+            "const" : "SUM"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateAggregatedAggregationQuery" : {
+        "properties" : {
+          "condition" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedCondition"
+          },
+          "groupBy" : {
+            "items" : {
+              "anyOf" : [ {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedAggregationGroup.DateHistogram"
+              }, {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedAggregationGroup.Histogram"
+              }, {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedAggregationGroup.Terms"
+              } ]
+            },
+            "type" : "array"
+          },
+          "limit" : {
+            "default" : "100",
+            "format" : "int32",
+            "maximum" : 10000,
+            "minimum" : 1,
+            "type" : "integer"
+          },
+          "metrics" : {
+            "items" : {
+              "anyOf" : [ {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedAggregationMetric.Avg"
+              }, {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedAggregationMetric.Count"
+              }, {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedAggregationMetric.Max"
+              }, {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedAggregationMetric.Min"
+              }, {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedAggregationMetric.Sum"
+              } ]
+            },
+            "type" : "array"
+          },
+          "sort" : {
+            "items" : {
+              "$ref" : "#/components/schemas/wow.api.query.Sort"
+            },
+            "type" : "array"
+          }
+        },
+        "required" : [ "metrics" ],
+        "type" : "object"
+      },
       "tck.mock_aggregate.MockCommandAggregateAggregatedCondition" : {
         "properties" : {
           "children" : {
@@ -2807,6 +3399,187 @@
         "required" : [ "condition" ],
         "type" : "object"
       },
+      "tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedAggregationGroup.DateHistogram" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedFields"
+          },
+          "timeZone" : {
+            "type" : "string"
+          },
+          "type" : {
+            "const" : "DATE_HISTOGRAM"
+          },
+          "unit" : {
+            "$ref" : "#/components/schemas/wow.api.query.AggregationDateUnit"
+          }
+        },
+        "required" : [ "alias", "field", "type", "unit" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedAggregationGroup.Histogram" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedFields"
+          },
+          "interval" : {
+            "format" : "double",
+            "type" : "number"
+          },
+          "offset" : {
+            "format" : "double",
+            "type" : "number"
+          },
+          "type" : {
+            "const" : "HISTOGRAM"
+          }
+        },
+        "required" : [ "alias", "field", "interval", "type" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedAggregationGroup.Terms" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedFields"
+          },
+          "type" : {
+            "const" : "TERMS"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedAggregationMetric.Avg" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedFields"
+          },
+          "type" : {
+            "const" : "AVG"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedAggregationMetric.Count" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "type" : {
+            "const" : "COUNT"
+          }
+        },
+        "required" : [ "alias", "type" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedAggregationMetric.Max" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedFields"
+          },
+          "type" : {
+            "const" : "MAX"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedAggregationMetric.Min" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedFields"
+          },
+          "type" : {
+            "const" : "MIN"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedAggregationMetric.Sum" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedFields"
+          },
+          "type" : {
+            "const" : "SUM"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedAggregationQuery" : {
+        "properties" : {
+          "condition" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedCondition"
+          },
+          "groupBy" : {
+            "items" : {
+              "anyOf" : [ {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedAggregationGroup.DateHistogram"
+              }, {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedAggregationGroup.Histogram"
+              }, {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedAggregationGroup.Terms"
+              } ]
+            },
+            "type" : "array"
+          },
+          "limit" : {
+            "default" : "100",
+            "format" : "int32",
+            "maximum" : 10000,
+            "minimum" : 1,
+            "type" : "integer"
+          },
+          "metrics" : {
+            "items" : {
+              "anyOf" : [ {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedAggregationMetric.Avg"
+              }, {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedAggregationMetric.Count"
+              }, {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedAggregationMetric.Max"
+              }, {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedAggregationMetric.Min"
+              }, {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedAggregationMetric.Sum"
+              } ]
+            },
+            "type" : "array"
+          },
+          "sort" : {
+            "items" : {
+              "$ref" : "#/components/schemas/wow.api.query.Sort"
+            },
+            "type" : "array"
+          }
+        },
+        "required" : [ "metrics" ],
+        "type" : "object"
+      },
       "tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedCondition" : {
         "properties" : {
           "children" : {
@@ -3054,6 +3827,187 @@
           }
         },
         "required" : [ "condition" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedAggregationGroup.DateHistogram" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedFields"
+          },
+          "timeZone" : {
+            "type" : "string"
+          },
+          "type" : {
+            "const" : "DATE_HISTOGRAM"
+          },
+          "unit" : {
+            "$ref" : "#/components/schemas/wow.api.query.AggregationDateUnit"
+          }
+        },
+        "required" : [ "alias", "field", "type", "unit" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedAggregationGroup.Histogram" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedFields"
+          },
+          "interval" : {
+            "format" : "double",
+            "type" : "number"
+          },
+          "offset" : {
+            "format" : "double",
+            "type" : "number"
+          },
+          "type" : {
+            "const" : "HISTOGRAM"
+          }
+        },
+        "required" : [ "alias", "field", "interval", "type" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedAggregationGroup.Terms" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedFields"
+          },
+          "type" : {
+            "const" : "TERMS"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedAggregationMetric.Avg" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedFields"
+          },
+          "type" : {
+            "const" : "AVG"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedAggregationMetric.Count" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "type" : {
+            "const" : "COUNT"
+          }
+        },
+        "required" : [ "alias", "type" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedAggregationMetric.Max" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedFields"
+          },
+          "type" : {
+            "const" : "MAX"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedAggregationMetric.Min" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedFields"
+          },
+          "type" : {
+            "const" : "MIN"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedAggregationMetric.Sum" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedFields"
+          },
+          "type" : {
+            "const" : "SUM"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedAggregationQuery" : {
+        "properties" : {
+          "condition" : {
+            "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedCondition"
+          },
+          "groupBy" : {
+            "items" : {
+              "anyOf" : [ {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedAggregationGroup.DateHistogram"
+              }, {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedAggregationGroup.Histogram"
+              }, {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedAggregationGroup.Terms"
+              } ]
+            },
+            "type" : "array"
+          },
+          "limit" : {
+            "default" : "100",
+            "format" : "int32",
+            "maximum" : 10000,
+            "minimum" : 1,
+            "type" : "integer"
+          },
+          "metrics" : {
+            "items" : {
+              "anyOf" : [ {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedAggregationMetric.Avg"
+              }, {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedAggregationMetric.Count"
+              }, {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedAggregationMetric.Max"
+              }, {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedAggregationMetric.Min"
+              }, {
+                "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedAggregationMetric.Sum"
+              } ]
+            },
+            "type" : "array"
+          },
+          "sort" : {
+            "items" : {
+              "$ref" : "#/components/schemas/wow.api.query.Sort"
+            },
+            "type" : "array"
+          }
+        },
+        "required" : [ "metrics" ],
         "type" : "object"
       },
       "tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedCondition" : {
@@ -4439,6 +5393,37 @@
         "required" : [ "data" ],
         "type" : "object"
       },
+      "wow.ObjectObjectMapServerSentEventNonNullData" : {
+        "properties" : {
+          "data" : {
+            "$ref" : "#/components/schemas/example.ObjectObjectMap"
+          },
+          "event" : {
+            "anyOf" : [ {
+              "type" : "null"
+            }, {
+              "type" : "string"
+            } ]
+          },
+          "id" : {
+            "anyOf" : [ {
+              "type" : "null"
+            }, {
+              "type" : "string"
+            } ]
+          },
+          "retry" : {
+            "anyOf" : [ {
+              "type" : "null"
+            }, {
+              "format" : "int32",
+              "type" : "integer"
+            } ]
+          }
+        },
+        "required" : [ "data" ],
+        "type" : "object"
+      },
       "wow.api.BindingError" : {
         "properties" : {
           "msg" : {
@@ -4536,6 +5521,10 @@
         },
         "required" : [ "aggregateId", "aggregateName", "contextName", "tenantId" ],
         "type" : "object"
+      },
+      "wow.api.query.AggregationDateUnit" : {
+        "enum" : [ "YEAR", "QUARTER", "MONTH", "WEEK", "DAY", "HOUR", "MINUTE", "SECOND" ],
+        "type" : "string"
       },
       "wow.api.query.Condition" : {
         "properties" : {
@@ -5176,6 +6165,43 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/example.cart.CartAggregatedDomainEventStreamPagedList"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          }
+        },
+        "tags" : [ "example.cart", "customer" ]
+      }
+    },
+    "/cart/snapshot/aggregate" : {
+      "post" : {
+        "operationId" : "example.cart.snapshot.aggregate",
+        "parameters" : [ ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/example.cart.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/example.ObjectObjectMap"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/wow.ObjectObjectMapServerSentEventNonNullData"
+                  },
+                  "type" : "array"
                 }
               }
             },
@@ -6069,6 +7095,45 @@
         "tags" : [ "example.cart", "customer" ]
       }
     },
+    "/owner/{ownerId}/cart/snapshot/aggregate" : {
+      "post" : {
+        "operationId" : "example.cart.owner.snapshot.aggregate",
+        "parameters" : [ {
+          "$ref" : "#/components/parameters/wow.ownerId"
+        } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/example.cart.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/example.ObjectObjectMap"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/wow.ObjectObjectMapServerSentEventNonNullData"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          }
+        },
+        "tags" : [ "example.cart", "customer" ]
+      }
+    },
     "/owner/{ownerId}/cart/snapshot/count" : {
       "post" : {
         "operationId" : "example.cart.owner.snapshot.count",
@@ -6613,6 +7678,47 @@
         "tags" : [ "example.order" ]
       }
     },
+    "/owner/{ownerId}/sales-order/snapshot/aggregate" : {
+      "post" : {
+        "operationId" : "example.order.owner.snapshot.aggregate",
+        "parameters" : [ {
+          "$ref" : "#/components/parameters/wow.Wow-Space-Id"
+        }, {
+          "$ref" : "#/components/parameters/wow.ownerId"
+        } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/example.order.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/example.ObjectObjectMap"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/wow.ObjectObjectMapServerSentEventNonNullData"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          }
+        },
+        "tags" : [ "example.order" ]
+      }
+    },
     "/owner/{ownerId}/sales-order/snapshot/count" : {
       "post" : {
         "operationId" : "example.order.owner.snapshot.count",
@@ -6917,6 +8023,45 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/example.order.OrderAggregatedDomainEventStreamPagedList"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          }
+        },
+        "tags" : [ "example.order" ]
+      }
+    },
+    "/sales-order/snapshot/aggregate" : {
+      "post" : {
+        "operationId" : "example.order.snapshot.aggregate",
+        "parameters" : [ {
+          "$ref" : "#/components/parameters/wow.Wow-Space-Id"
+        } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/example.order.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/example.ObjectObjectMap"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/wow.ObjectObjectMapServerSentEventNonNullData"
+                  },
+                  "type" : "array"
                 }
               }
             },
@@ -7269,6 +8414,43 @@
         "tags" : [ "tck.mock_aggregate" ]
       }
     },
+    "/tck/mock_aggregate/snapshot/aggregate" : {
+      "post" : {
+        "operationId" : "tck.mock_aggregate.snapshot.aggregate",
+        "parameters" : [ ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/tck.mock_aggregate.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/example.ObjectObjectMap"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/wow.ObjectObjectMapServerSentEventNonNullData"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          }
+        },
+        "tags" : [ "tck.mock_aggregate" ]
+      }
+    },
     "/tck/mock_aggregate/snapshot/count" : {
       "post" : {
         "operationId" : "tck.mock_aggregate.snapshot.count",
@@ -7590,6 +8772,43 @@
         "tags" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
       }
     },
+    "/tck/modeling_command_aggregate_with_tenant_id/snapshot/aggregate" : {
+      "post" : {
+        "operationId" : "tck.modeling_command_aggregate_with_tenant_id.snapshot.aggregate",
+        "parameters" : [ ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/tck.modeling_command_aggregate_with_tenant_id.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/example.ObjectObjectMap"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/wow.ObjectObjectMapServerSentEventNonNullData"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          }
+        },
+        "tags" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
+      }
+    },
     "/tck/modeling_command_aggregate_with_tenant_id/snapshot/count" : {
       "post" : {
         "operationId" : "tck.modeling_command_aggregate_with_tenant_id.snapshot.count",
@@ -7898,6 +9117,43 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedDomainEventStreamPagedList"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          }
+        },
+        "tags" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
+      }
+    },
+    "/tck/modeling_command_aggregate_without_ctor_parameters/snapshot/aggregate" : {
+      "post" : {
+        "operationId" : "tck.modeling_command_aggregate_without_ctor_parameters.snapshot.aggregate",
+        "parameters" : [ ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/tck.modeling_command_aggregate_without_ctor_parameters.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/example.ObjectObjectMap"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/wow.ObjectObjectMapServerSentEventNonNullData"
+                  },
+                  "type" : "array"
                 }
               }
             },
@@ -8371,6 +9627,45 @@
           },
           "429" : {
             "$ref" : "#/components/responses/wow.CommandTooManyRequests"
+          }
+        },
+        "tags" : [ "tck.mock_aggregate" ]
+      }
+    },
+    "/tck/tenant/{tenantId}/mock_aggregate/snapshot/aggregate" : {
+      "post" : {
+        "operationId" : "tck.mock_aggregate.tenant.snapshot.aggregate",
+        "parameters" : [ {
+          "$ref" : "#/components/parameters/wow.tenantId"
+        } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/tck.mock_aggregate.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/example.ObjectObjectMap"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/wow.ObjectObjectMapServerSentEventNonNullData"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
           }
         },
         "tags" : [ "tck.mock_aggregate" ]
@@ -9213,6 +10508,45 @@
         "tags" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
       }
     },
+    "/tck/tenant/{tenantId}/modeling_command_aggregate_with_tenant_id/snapshot/aggregate" : {
+      "post" : {
+        "operationId" : "tck.modeling_command_aggregate_with_tenant_id.tenant.snapshot.aggregate",
+        "parameters" : [ {
+          "$ref" : "#/components/parameters/wow.tenantId"
+        } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/tck.modeling_command_aggregate_with_tenant_id.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/example.ObjectObjectMap"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/wow.ObjectObjectMapServerSentEventNonNullData"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          }
+        },
+        "tags" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
+      }
+    },
     "/tck/tenant/{tenantId}/modeling_command_aggregate_with_tenant_id/snapshot/count" : {
       "post" : {
         "operationId" : "tck.modeling_command_aggregate_with_tenant_id.tenant.snapshot.count",
@@ -9966,6 +11300,45 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateWithoutCtorParametersAggregatedDomainEventStreamPagedList"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          }
+        },
+        "tags" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
+      }
+    },
+    "/tck/tenant/{tenantId}/modeling_command_aggregate_without_ctor_parameters/snapshot/aggregate" : {
+      "post" : {
+        "operationId" : "tck.modeling_command_aggregate_without_ctor_parameters.tenant.snapshot.aggregate",
+        "parameters" : [ {
+          "$ref" : "#/components/parameters/wow.tenantId"
+        } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/tck.modeling_command_aggregate_without_ctor_parameters.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/example.ObjectObjectMap"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/wow.ObjectObjectMapServerSentEventNonNullData"
+                  },
+                  "type" : "array"
                 }
               }
             },
@@ -11442,6 +12815,47 @@
               "application/json" : {
                 "schema" : {
                   "$ref" : "#/components/schemas/example.order.OrderAggregatedDomainEventStreamPagedList"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          }
+        },
+        "tags" : [ "example.order" ]
+      }
+    },
+    "/tenant/{tenantId}/sales-order/snapshot/aggregate" : {
+      "post" : {
+        "operationId" : "example.order.tenant.snapshot.aggregate",
+        "parameters" : [ {
+          "$ref" : "#/components/parameters/wow.Wow-Space-Id"
+        }, {
+          "$ref" : "#/components/parameters/wow.tenantId"
+        } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/example.order.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/example.ObjectObjectMap"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "$ref" : "#/components/schemas/wow.ObjectObjectMapServerSentEventNonNullData"
+                  },
+                  "type" : "array"
                 }
               }
             },

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDsl.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.dsl
+
+import me.ahoo.wow.api.query.AggregationDateUnit
+import me.ahoo.wow.api.query.AggregationGroup
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.Sort
+
+@QueryDslMarker
+class AggregationQueryDsl {
+    private var condition: Condition = Condition.ALL
+    private val groupBy = mutableListOf<AggregationGroup>()
+    private val metrics = mutableListOf<AggregationMetric>()
+    private var sort: List<Sort> = emptyList()
+    private var limit: Int = AggregationQuery.DEFAULT_LIMIT
+
+    fun condition(condition: Condition) {
+        this.condition = condition
+    }
+
+    fun condition(block: ConditionDsl.() -> Unit) {
+        condition(ConditionDsl().apply(block).build())
+    }
+
+    fun groupBy(field: String, alias: String) {
+        groupBy += AggregationGroup.Terms(field, alias)
+    }
+
+    fun histogram(field: String, alias: String, interval: Double, offset: Double = 0.0) {
+        groupBy += AggregationGroup.Histogram(field, alias, interval, offset)
+    }
+
+    fun dateHistogram(
+        field: String,
+        alias: String,
+        unit: AggregationDateUnit,
+        timeZone: String = "UTC",
+    ) {
+        groupBy += AggregationGroup.DateHistogram(field, alias, unit, timeZone)
+    }
+
+    fun count(alias: String) {
+        metrics += AggregationMetric.Count(alias)
+    }
+
+    fun sum(field: String, alias: String) {
+        metrics += AggregationMetric.Sum(field, alias)
+    }
+
+    fun avg(field: String, alias: String) {
+        metrics += AggregationMetric.Avg(field, alias)
+    }
+
+    fun min(field: String, alias: String) {
+        metrics += AggregationMetric.Min(field, alias)
+    }
+
+    fun max(field: String, alias: String) {
+        metrics += AggregationMetric.Max(field, alias)
+    }
+
+    fun sort(sort: List<Sort>) {
+        this.sort = sort
+    }
+
+    fun sort(block: SortDsl.() -> Unit) {
+        sort(SortDsl().apply(block).build())
+    }
+
+    fun limit(limit: Int) {
+        this.limit = limit
+    }
+
+    fun build(): AggregationQuery = AggregationQuery(
+        condition = condition,
+        groupBy = groupBy.toList(),
+        metrics = metrics.toList(),
+        sort = sort,
+        limit = limit,
+    )
+}

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/Dsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/Dsl.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.query.dsl
 
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.IListQuery
 import me.ahoo.wow.api.query.IPagedQuery
@@ -20,6 +21,10 @@ import me.ahoo.wow.api.query.ISingleQuery
 import me.ahoo.wow.api.query.Pagination
 import me.ahoo.wow.api.query.Projection
 import me.ahoo.wow.api.query.Sort
+
+fun aggregationQuery(block: AggregationQueryDsl.() -> Unit): AggregationQuery {
+    return AggregationQueryDsl().apply(block).build()
+}
 
 /**
  * Executes a single query using the provided DSL block.

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/event/filter/EventStreamQueryFilter.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/event/filter/EventStreamQueryFilter.kt
@@ -81,7 +81,7 @@ class TailEventStreamQueryFilter(private val queryServiceFactory: EventStreamQue
                 }
             }
 
-            QueryType.AGGREGATE -> error("Event stream aggregation is not supported.")
+            QueryType.AGGREGATION -> error("Event stream aggregation is not supported.")
         }
         return next.filter(context)
     }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/event/filter/EventStreamQueryFilter.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/event/filter/EventStreamQueryFilter.kt
@@ -80,6 +80,8 @@ class TailEventStreamQueryFilter(private val queryServiceFactory: EventStreamQue
                     queryService.count(it)
                 }
             }
+
+            QueryType.AGGREGATE -> error("Event stream aggregation is not supported.")
         }
         return next.filter(context)
     }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/filter/QueryContext.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/filter/QueryContext.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.query.filter
 
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.IListQuery
 import me.ahoo.wow.api.query.IPagedQuery
@@ -87,6 +88,10 @@ interface QueryContext<Q : Any, R : Any> {
 
     fun asCountQuery(): QueryContext<Condition, Mono<Long>> {
         return this as QueryContext<Condition, Mono<Long>>
+    }
+
+    fun asAggregationQuery(): QueryContext<AggregationQuery, Flux<Map<String, Any?>>> {
+        return this as QueryContext<AggregationQuery, Flux<Map<String, Any?>>>
     }
 }
 

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/filter/QueryHandler.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/filter/QueryHandler.kt
@@ -60,7 +60,7 @@ abstract class AbstractQueryHandler<R : Any>(
         handle(context).then(Mono.defer { context.getRequiredResult() })
     }
 
-    private fun <Q : Any, T : Any> flux(
+    protected fun <Q : Any, T : Any> flux(
         namedAggregate: NamedAggregate,
         queryType: QueryType,
         query: Q,

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/filter/QueryType.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/filter/QueryType.kt
@@ -21,5 +21,5 @@ enum class QueryType(val isDynamic: Boolean) {
     PAGED(false),
     DYNAMIC_PAGED(true),
     COUNT(false),
-    AGGREGATE(true),
+    AGGREGATION(true),
 }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/AggregationFieldTypeValidator.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/AggregationFieldTypeValidator.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.snapshot
+
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.AggregationGroup
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.MaterializedSnapshot
+import me.ahoo.wow.configuration.requiredAggregateType
+import me.ahoo.wow.modeling.annotation.aggregateMetadata
+import me.ahoo.wow.serialization.JsonSerializer
+import me.ahoo.wow.serialization.toBeanDescription
+import tools.jackson.databind.JavaType
+import java.time.temporal.TemporalAccessor
+import java.util.Date
+
+internal fun AggregationQuery.validateFieldTypes(namedAggregate: NamedAggregate) {
+    if (groupBy.isEmpty() && metrics.none { it is AggregationMetric.Numeric }) {
+        return
+    }
+    val stateType = namedAggregate.requiredAggregateType<Any>()
+        .aggregateMetadata<Any, Any>()
+        .state.aggregateType
+    val snapshotType = JsonSerializer.typeFactory.constructParametricType(MaterializedSnapshot::class.java, stateType)
+
+    groupBy.forEach { group ->
+        val fieldType = snapshotType.resolveField(group.field)
+        require(fieldType.isScalar) { "Aggregation group field [${group.field}] must be scalar." }
+        when (group) {
+            is AggregationGroup.Terms -> Unit
+            is AggregationGroup.Histogram -> require(fieldType.isNumeric) {
+                "Histogram field [${group.field}] must be numeric."
+            }
+
+            is AggregationGroup.DateHistogram -> require(fieldType.isDate) {
+                "Date histogram field [${group.field}] must be a date or epoch number."
+            }
+        }
+    }
+    metrics.filterIsInstance<AggregationMetric.Numeric>().forEach { metric ->
+        require(snapshotType.resolveField(metric.field).isNumeric) {
+            "Aggregation metric field [${metric.field}] must be numeric."
+        }
+    }
+}
+
+private fun JavaType.resolveField(path: String): JavaType {
+    var current = this
+    path.split('.').forEach { segment ->
+        val property = current.toBeanDescription().findProperties()
+            .firstOrNull { it.name == segment }
+        requireNotNull(property) { "Aggregation field [$path] does not exist." }
+        current = property.primaryType
+    }
+    return current
+}
+
+private val JavaType.isScalar: Boolean
+    get() = !isArrayType && !isCollectionLikeType && !isMapLikeType
+
+private val JavaType.isNumeric: Boolean
+    get() = (rawClass.isPrimitive && rawClass != Boolean::class.javaPrimitiveType && rawClass != Char::class.javaPrimitiveType) ||
+        Number::class.java.isAssignableFrom(rawClass)
+
+private val JavaType.isDate: Boolean
+    get() = isNumeric || Date::class.java.isAssignableFrom(rawClass) || TemporalAccessor::class.java.isAssignableFrom(rawClass)

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/AggregationFieldTypeValidator.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/AggregationFieldTypeValidator.kt
@@ -23,8 +23,14 @@ import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.serialization.JsonSerializer
 import me.ahoo.wow.serialization.toBeanDescription
 import tools.jackson.databind.JavaType
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.time.ZonedDateTime
 import java.time.temporal.TemporalAccessor
 import java.util.Date
+import java.util.UUID
 
 internal fun AggregationQuery.validateFieldTypes(namedAggregate: NamedAggregate) {
     if (groupBy.isEmpty() && metrics.none { it is AggregationMetric.Numeric }) {
@@ -37,14 +43,14 @@ internal fun AggregationQuery.validateFieldTypes(namedAggregate: NamedAggregate)
 
     groupBy.forEach { group ->
         val fieldType = snapshotType.resolveField(group.field)
-        require(fieldType.isScalar) { "Aggregation group field [${group.field}] must be scalar." }
+        require(fieldType.isAggregationScalar) { "Aggregation group field [${group.field}] must be scalar." }
         when (group) {
             is AggregationGroup.Terms -> Unit
             is AggregationGroup.Histogram -> require(fieldType.isNumeric) {
                 "Histogram field [${group.field}] must be numeric."
             }
 
-            is AggregationGroup.DateHistogram -> require(fieldType.isDate) {
+            is AggregationGroup.DateHistogram -> require(fieldType.isAggregationDate) {
                 "Date histogram field [${group.field}] must be a date or epoch number."
             }
         }
@@ -67,12 +73,23 @@ private fun JavaType.resolveField(path: String): JavaType {
     return current
 }
 
-private val JavaType.isScalar: Boolean
-    get() = !isArrayType && !isCollectionLikeType && !isMapLikeType
+internal val JavaType.isAggregationScalar: Boolean
+    get() = isNumeric || isAggregationDate || rawClass.isPrimitive || rawClass.isEnum ||
+        CharSequence::class.java.isAssignableFrom(rawClass) ||
+        rawClass == Boolean::class.javaObjectType || rawClass == Char::class.javaObjectType || rawClass == UUID::class.java
 
 private val JavaType.isNumeric: Boolean
     get() = (rawClass.isPrimitive && rawClass != Boolean::class.javaPrimitiveType && rawClass != Char::class.javaPrimitiveType) ||
         Number::class.java.isAssignableFrom(rawClass)
 
-private val JavaType.isDate: Boolean
-    get() = isNumeric || Date::class.java.isAssignableFrom(rawClass) || TemporalAccessor::class.java.isAssignableFrom(rawClass)
+internal val JavaType.isAggregationDate: Boolean
+    get() = isNumeric || Date::class.java.isAssignableFrom(rawClass) ||
+        rawClass in SUPPORTED_AGGREGATION_TEMPORAL_TYPES
+
+private val SUPPORTED_AGGREGATION_TEMPORAL_TYPES: Set<Class<out TemporalAccessor>> = setOf(
+    Instant::class.java,
+    LocalDate::class.java,
+    LocalDateTime::class.java,
+    OffsetDateTime::class.java,
+    ZonedDateTime::class.java,
+)

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/AggregationFieldTypeValidator.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/AggregationFieldTypeValidator.kt
@@ -42,7 +42,7 @@ internal fun AggregationQuery.validateFieldTypes(namedAggregate: NamedAggregate)
     val snapshotType = JsonSerializer.typeFactory.constructParametricType(MaterializedSnapshot::class.java, stateType)
 
     groupBy.forEach { group ->
-        val fieldType = snapshotType.resolveField(group.field)
+        val fieldType = snapshotType.resolveDeclaredField(group.field) ?: return@forEach
         require(fieldType.isAggregationScalar) { "Aggregation group field [${group.field}] must be scalar." }
         when (group) {
             is AggregationGroup.Terms -> Unit
@@ -56,19 +56,20 @@ internal fun AggregationQuery.validateFieldTypes(namedAggregate: NamedAggregate)
         }
     }
     metrics.filterIsInstance<AggregationMetric.Numeric>().forEach { metric ->
-        require(snapshotType.resolveField(metric.field).isNumeric) {
+        val fieldType = snapshotType.resolveDeclaredField(metric.field) ?: return@forEach
+        require(fieldType.isNumeric) {
             "Aggregation metric field [${metric.field}] must be numeric."
         }
     }
 }
 
-private fun JavaType.resolveField(path: String): JavaType {
+private fun JavaType.resolveDeclaredField(path: String): JavaType? {
     var current = this
-    path.split('.').forEach { segment ->
-        val property = current.toBeanDescription().findProperties()
+    for (segment in path.split('.')) {
+        current = current.toBeanDescription().findProperties()
             .firstOrNull { it.name == segment }
-        requireNotNull(property) { "Aggregation field [$path] does not exist." }
-        current = property.primaryType
+            ?.primaryType
+            ?: return null
     }
     return current
 }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/AggregationFieldTypeValidator.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/AggregationFieldTypeValidator.kt
@@ -18,8 +18,7 @@ import me.ahoo.wow.api.query.AggregationGroup
 import me.ahoo.wow.api.query.AggregationMetric
 import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.MaterializedSnapshot
-import me.ahoo.wow.configuration.requiredAggregateType
-import me.ahoo.wow.modeling.annotation.aggregateMetadata
+import me.ahoo.wow.modeling.metadata.asAggregateMetadata
 import me.ahoo.wow.serialization.JsonSerializer
 import me.ahoo.wow.serialization.toBeanDescription
 import tools.jackson.databind.JavaType
@@ -36,8 +35,7 @@ internal fun AggregationQuery.validateFieldTypes(namedAggregate: NamedAggregate)
     if (groupBy.isEmpty() && metrics.none { it is AggregationMetric.Numeric }) {
         return
     }
-    val stateType = namedAggregate.requiredAggregateType<Any>()
-        .aggregateMetadata<Any, Any>()
+    val stateType = namedAggregate.asAggregateMetadata<Any, Any>()
         .state.aggregateType
     val snapshotType = JsonSerializer.typeFactory.constructParametricType(MaterializedSnapshot::class.java, stateType)
 
@@ -65,11 +63,18 @@ internal fun AggregationQuery.validateFieldTypes(namedAggregate: NamedAggregate)
 
 private fun JavaType.resolveDeclaredField(path: String): JavaType? {
     var current = this
-    for (segment in path.split('.')) {
+    val segments = path.split('.')
+    for ((index, segment) in segments.withIndex()) {
         current = current.toBeanDescription().findProperties()
             .firstOrNull { it.name == segment }
             ?.primaryType
             ?: return null
+        require(
+            index == segments.lastIndex || (!current.isArrayType && !current.isCollectionLikeType),
+        ) {
+            val collectionPath = segments.take(index + 1).joinToString(".")
+            "Aggregation field [$path] must not traverse collection field [$collectionPath]."
+        }
     }
     return current
 }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/QueryDsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/QueryDsl.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.query.snapshot
 
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.IListQuery
@@ -55,4 +56,8 @@ fun ISingleQuery.dynamicQuery(queryService: SnapshotQueryService<*>): Mono<Dynam
 
 fun Condition.count(queryService: SnapshotQueryService<*>): Mono<Long> {
     return queryService.count(this)
+}
+
+fun AggregationQuery.aggregate(queryService: SnapshotQueryService<*>): Flux<Map<String, Any?>> {
+    return queryService.aggregate(this)
 }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/SnapshotQueryService.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/SnapshotQueryService.kt
@@ -15,6 +15,7 @@ package me.ahoo.wow.query.snapshot
 
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.api.naming.Named
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.IListQuery
@@ -27,7 +28,11 @@ import me.ahoo.wow.query.QueryService
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
-interface SnapshotQueryService<S : Any> : Named, QueryService<MaterializedSnapshot<S>>
+interface SnapshotQueryService<S : Any> : Named, QueryService<MaterializedSnapshot<S>> {
+    fun aggregate(aggregationQuery: AggregationQuery): Flux<Map<String, Any?>> = Flux.error(
+        UnsupportedOperationException("Snapshot aggregation is not supported by [$name].")
+    )
+}
 class NoOpSnapshotQueryService<S : Any>(override val namedAggregate: NamedAggregate) : SnapshotQueryService<S> {
     override val name: String
         get() = NoOpSnapshotStore.NAME

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/MaskingSnapshotQueryFilter.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/MaskingSnapshotQueryFilter.kt
@@ -35,7 +35,7 @@ class MaskingSnapshotQueryFilter(maskerRegistry: StateDataMaskerRegistry) : Snap
         next: FilterChain<QueryContext<*, *>>
     ): Mono<Void> {
         if (
-            context.queryType == QueryType.AGGREGATE &&
+            context.queryType == QueryType.AGGREGATION &&
             !maskerRegistry.getAggregateDataMasker(context.namedAggregate).isEmpty()
         ) {
             return Mono.error(

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/MaskingSnapshotQueryFilter.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/MaskingSnapshotQueryFilter.kt
@@ -34,6 +34,14 @@ class MaskingSnapshotQueryFilter(maskerRegistry: StateDataMaskerRegistry) : Snap
         context: QueryContext<*, *>,
         next: FilterChain<QueryContext<*, *>>
     ): Mono<Void> {
+        if (
+            context.queryType == QueryType.AGGREGATE &&
+            !maskerRegistry.getAggregateDataMasker(context.namedAggregate).isEmpty()
+        ) {
+            return Mono.error(
+                IllegalStateException("Snapshot aggregation is unavailable when data masking is configured.")
+            )
+        }
         return next.filter(context).then(
             Mono.defer {
                 mask(context)

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/SnapshotQueryFilter.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/SnapshotQueryFilter.kt
@@ -80,7 +80,7 @@ class TailSnapshotQueryFilter<S : Any>(private val queryServiceFactory: Snapshot
                 }
             }
 
-            QueryType.AGGREGATE -> {
+            QueryType.AGGREGATION -> {
                 context.asAggregationQuery().setResult {
                     queryService.aggregate(it)
                 }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/SnapshotQueryFilter.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/SnapshotQueryFilter.kt
@@ -23,6 +23,7 @@ import me.ahoo.wow.query.filter.QueryContext
 import me.ahoo.wow.query.filter.QueryFilter
 import me.ahoo.wow.query.filter.QueryType
 import me.ahoo.wow.query.snapshot.SnapshotQueryServiceFactory
+import me.ahoo.wow.query.snapshot.validateFieldTypes
 import reactor.core.publisher.Mono
 
 @FilterType(SnapshotQueryHandler::class)
@@ -35,7 +36,7 @@ class TailSnapshotQueryFilter<S : Any>(private val queryServiceFactory: Snapshot
     override fun filter(
         context: QueryContext<*, *>,
         next: FilterChain<QueryContext<*, *>>
-    ): Mono<Void> {
+    ): Mono<Void> = Mono.defer {
         val queryService = queryServiceFactory.create<S>(context.namedAggregate)
         when (context.queryType) {
             QueryType.SINGLE -> {
@@ -81,11 +82,13 @@ class TailSnapshotQueryFilter<S : Any>(private val queryServiceFactory: Snapshot
             }
 
             QueryType.AGGREGATION -> {
-                context.asAggregationQuery().setResult {
+                val aggregationContext = context.asAggregationQuery()
+                aggregationContext.getQuery().validateFieldTypes(context.namedAggregate)
+                aggregationContext.setResult {
                     queryService.aggregate(it)
                 }
             }
         }
-        return next.filter(context)
+        next.filter(context)
     }
 }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/SnapshotQueryFilter.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/SnapshotQueryFilter.kt
@@ -79,6 +79,12 @@ class TailSnapshotQueryFilter<S : Any>(private val queryServiceFactory: Snapshot
                     queryService.count(it)
                 }
             }
+
+            QueryType.AGGREGATE -> {
+                context.asAggregationQuery().setResult {
+                    queryService.aggregate(it)
+                }
+            }
         }
         return next.filter(context)
     }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/SnapshotQueryHandler.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/SnapshotQueryHandler.kt
@@ -47,6 +47,6 @@ class DefaultSnapshotQueryHandler(
         aggregationQuery: AggregationQuery,
     ): Flux<Map<String, Any?>> = Flux.defer {
         aggregationQuery.validateFieldTypes(namedAggregate)
-        flux(namedAggregate, QueryType.AGGREGATE, aggregationQuery)
+        flux(namedAggregate, QueryType.AGGREGATION, aggregationQuery)
     }
 }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/SnapshotQueryHandler.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/SnapshotQueryHandler.kt
@@ -13,6 +13,8 @@
 
 package me.ahoo.wow.query.snapshot.filter
 
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.MaterializedSnapshot
 import me.ahoo.wow.filter.ErrorHandler
 import me.ahoo.wow.filter.FilterChain
@@ -20,8 +22,18 @@ import me.ahoo.wow.filter.LogErrorHandler
 import me.ahoo.wow.query.filter.AbstractQueryHandler
 import me.ahoo.wow.query.filter.QueryContext
 import me.ahoo.wow.query.filter.QueryHandler
+import me.ahoo.wow.query.filter.QueryType
+import me.ahoo.wow.query.snapshot.validateFieldTypes
+import reactor.core.publisher.Flux
 
-interface SnapshotQueryHandler : QueryHandler<MaterializedSnapshot<Any>>
+interface SnapshotQueryHandler : QueryHandler<MaterializedSnapshot<Any>> {
+    fun aggregate(
+        namedAggregate: NamedAggregate,
+        aggregationQuery: AggregationQuery,
+    ): Flux<Map<String, Any?>> = Flux.error(
+        UnsupportedOperationException("Snapshot aggregation is not supported by this query handler.")
+    )
+}
 
 class DefaultSnapshotQueryHandler(
     chain: FilterChain<QueryContext<*, *>>,
@@ -29,4 +41,12 @@ class DefaultSnapshotQueryHandler(
 ) : SnapshotQueryHandler, AbstractQueryHandler<MaterializedSnapshot<Any>>(
     chain,
     errorHandler,
-)
+) {
+    override fun aggregate(
+        namedAggregate: NamedAggregate,
+        aggregationQuery: AggregationQuery,
+    ): Flux<Map<String, Any?>> = Flux.defer {
+        aggregationQuery.validateFieldTypes(namedAggregate)
+        flux(namedAggregate, QueryType.AGGREGATE, aggregationQuery)
+    }
+}

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/SnapshotQueryHandler.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/SnapshotQueryHandler.kt
@@ -23,7 +23,6 @@ import me.ahoo.wow.query.filter.AbstractQueryHandler
 import me.ahoo.wow.query.filter.QueryContext
 import me.ahoo.wow.query.filter.QueryHandler
 import me.ahoo.wow.query.filter.QueryType
-import me.ahoo.wow.query.snapshot.validateFieldTypes
 import reactor.core.publisher.Flux
 
 interface SnapshotQueryHandler : QueryHandler<MaterializedSnapshot<Any>> {
@@ -45,8 +44,5 @@ class DefaultSnapshotQueryHandler(
     override fun aggregate(
         namedAggregate: NamedAggregate,
         aggregationQuery: AggregationQuery,
-    ): Flux<Map<String, Any?>> = Flux.defer {
-        aggregationQuery.validateFieldTypes(namedAggregate)
-        flux(namedAggregate, QueryType.AGGREGATION, aggregationQuery)
-    }
+    ): Flux<Map<String, Any?>> = flux(namedAggregate, QueryType.AGGREGATION, aggregationQuery)
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt
@@ -57,5 +57,13 @@ class AggregationQueryDslTest {
         )
         query.limit.assert().isEqualTo(20)
         query.toJsonString().toObject<AggregationQuery>().assert().isEqualTo(query)
+
+        val defaultedGroups = aggregationQuery {
+            histogram("version", "versionBand", 1.0)
+            dateHistogram("snapshotTime", "day", AggregationDateUnit.DAY)
+            count("count")
+        }.groupBy
+        (defaultedGroups[0] as AggregationGroup.Histogram).offset.assert().isEqualTo(0.0)
+        (defaultedGroups[1] as AggregationGroup.DateHistogram).timeZone.assert().isEqualTo("UTC")
     }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.dsl
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.AggregationDateUnit
+import me.ahoo.wow.api.query.AggregationGroup
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.Operator
+import me.ahoo.wow.api.query.Sort
+import me.ahoo.wow.serialization.toJsonString
+import me.ahoo.wow.serialization.toObject
+import org.junit.jupiter.api.Test
+
+class AggregationQueryDslTest {
+    @Test
+    fun `should build aggregation query`() {
+        val query = aggregationQuery {
+            condition {
+                "state.status" eq "PAID"
+            }
+            groupBy("state.country", "country")
+            histogram("state.totalAmount", "amountBand", interval = 100.0, offset = 10.0)
+            dateHistogram("eventTime", "month", AggregationDateUnit.MONTH, "Asia/Shanghai")
+            count("orderCount")
+            sum("state.totalAmount", "totalAmount")
+            avg("state.totalAmount", "averageAmount")
+            min("state.totalAmount", "minimumAmount")
+            max("state.totalAmount", "maximumAmount")
+            sort {
+                "month".asc()
+                "totalAmount".desc()
+            }
+            limit(20)
+        }
+
+        query.condition.operator.assert().isEqualTo(Operator.EQ)
+        query.groupBy.assert().hasSize(3)
+        query.groupBy[0].assert().isInstanceOf(AggregationGroup.Terms::class.java)
+        query.metrics.assert().hasSize(5)
+        query.metrics[0].assert().isInstanceOf(AggregationMetric.Count::class.java)
+        query.sort.assert().containsExactly(
+            Sort("month", Sort.Direction.ASC),
+            Sort("totalAmount", Sort.Direction.DESC),
+        )
+        query.limit.assert().isEqualTo(20)
+        query.toJsonString().toObject<AggregationQuery>().assert().isEqualTo(query)
+    }
+}

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/filter/QueryHandlerSubscriptionTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/filter/QueryHandlerSubscriptionTest.kt
@@ -97,7 +97,7 @@ class QueryHandlerSubscriptionTest {
             QueryType.PAGED to handler.paged(MOCK_AGGREGATE_METADATA, pagedQuery { }),
             QueryType.DYNAMIC_PAGED to handler.dynamicPaged(MOCK_AGGREGATE_METADATA, pagedQuery { }),
             QueryType.COUNT to handler.count(MOCK_AGGREGATE_METADATA, Condition.ALL),
-            QueryType.AGGREGATE to handler.aggregate(AGGREGATION_QUERY),
+            QueryType.AGGREGATION to handler.aggregate(AGGREGATION_QUERY),
         )
 
     private class TestQueryHandler(chain: FilterChain<QueryContext<*, *>>) :
@@ -106,7 +106,7 @@ class QueryHandlerSubscriptionTest {
             ErrorHandler<QueryContext<*, *>> { _, error -> Mono.error(error) }
         ) {
         fun aggregate(aggregationQuery: AggregationQuery): Flux<Map<String, Any?>> =
-            flux(MOCK_AGGREGATE_METADATA, QueryType.AGGREGATE, aggregationQuery)
+            flux(MOCK_AGGREGATE_METADATA, QueryType.AGGREGATION, aggregationQuery)
     }
 
     private class NonIdempotentTestFilter(
@@ -188,7 +188,7 @@ class QueryHandlerSubscriptionTest {
                 )
 
                 QueryType.COUNT -> context.asCountQuery().setResult(Mono.just(1L))
-                QueryType.AGGREGATE -> context.asAggregationQuery().setResult(
+                QueryType.AGGREGATION -> context.asAggregationQuery().setResult(
                     Flux.just(mapOf("result" to RESULT))
                 )
             }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/filter/QueryHandlerSubscriptionTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/filter/QueryHandlerSubscriptionTest.kt
@@ -14,6 +14,8 @@
 package me.ahoo.wow.query.filter
 
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.ConditionCapable
 import me.ahoo.wow.api.query.DynamicDocument
@@ -95,13 +97,17 @@ class QueryHandlerSubscriptionTest {
             QueryType.PAGED to handler.paged(MOCK_AGGREGATE_METADATA, pagedQuery { }),
             QueryType.DYNAMIC_PAGED to handler.dynamicPaged(MOCK_AGGREGATE_METADATA, pagedQuery { }),
             QueryType.COUNT to handler.count(MOCK_AGGREGATE_METADATA, Condition.ALL),
+            QueryType.AGGREGATE to handler.aggregate(AGGREGATION_QUERY),
         )
 
     private class TestQueryHandler(chain: FilterChain<QueryContext<*, *>>) :
         AbstractQueryHandler<String>(
             chain,
             ErrorHandler<QueryContext<*, *>> { _, error -> Mono.error(error) }
-        )
+        ) {
+        fun aggregate(aggregationQuery: AggregationQuery): Flux<Map<String, Any?>> =
+            flux(MOCK_AGGREGATE_METADATA, QueryType.AGGREGATE, aggregationQuery)
+    }
 
     private class NonIdempotentTestFilter(
         private val failures: AtomicInteger = AtomicInteger(),
@@ -182,6 +188,9 @@ class QueryHandlerSubscriptionTest {
                 )
 
                 QueryType.COUNT -> context.asCountQuery().setResult(Mono.just(1L))
+                QueryType.AGGREGATE -> context.asAggregationQuery().setResult(
+                    Flux.just(mapOf("result" to RESULT))
+                )
             }
             return next.filter(context)
         }
@@ -191,6 +200,7 @@ class QueryHandlerSubscriptionTest {
         const val RESULT = "result"
         const val MASK_COUNT_KEY = "maskCount"
         val APPENDED_CONDITION: Condition = Condition.id("subscription")
+        val AGGREGATION_QUERY = AggregationQuery(metrics = listOf(AggregationMetric.Count("count")))
 
         fun queryCondition(context: QueryContext<*, *>): Condition =
             when (val query = context.getQuery()) {

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/AggregationFieldTypeValidatorTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/AggregationFieldTypeValidatorTest.kt
@@ -18,6 +18,8 @@ import me.ahoo.wow.api.query.AggregationDateUnit
 import me.ahoo.wow.api.query.AggregationGroup
 import me.ahoo.wow.api.query.AggregationMetric
 import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.modeling.annotation.stateAggregateMetadata
+import me.ahoo.wow.modeling.metadata.AggregateMetadata
 import me.ahoo.wow.serialization.JsonSerializer
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import org.junit.jupiter.api.Test
@@ -92,11 +94,41 @@ class AggregationFieldTypeValidatorTest {
         ).validateFieldTypes(MOCK_AGGREGATE_METADATA)
     }
 
+    @Test
+    fun `should reject aggregation paths through collections`() {
+        val aggregateMetadata = AggregateMetadata(
+            namedAggregate = MOCK_AGGREGATE_METADATA.namedAggregate,
+            staticTenantId = MOCK_AGGREGATE_METADATA.staticTenantId,
+            state = CollectionState::class.java.stateAggregateMetadata(),
+            command = MOCK_AGGREGATE_METADATA.command,
+        )
+        listOf(
+            AggregationQuery(
+                groupBy = listOf(AggregationGroup.Terms("state.items.value", "value")),
+                metrics = listOf(AggregationMetric.Count("count")),
+            ) to "state.items.value",
+            AggregationQuery(
+                metrics = listOf(AggregationMetric.Sum("state.items.amount", "amount")),
+            ) to "state.items.amount",
+        ).forEach { (query, field) ->
+            assertThrows<IllegalArgumentException> {
+                query.validateFieldTypes(aggregateMetadata)
+            }.message.assert().isEqualTo(
+                "Aggregation field [$field] " +
+                    "must not traverse collection field [state.items].",
+            )
+        }
+    }
+
     private fun Class<*>.toJavaType() = JsonSerializer.typeFactory.constructType(this)
 
     private enum class TestEnum {
         VALUE,
     }
 
-    private data class TestPojo(val value: String)
+    private data class TestPojo(val value: String, val amount: Int = 0)
+
+    private class CollectionState(val id: String) {
+        val items: List<TestPojo> = emptyList()
+    }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/AggregationFieldTypeValidatorTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/AggregationFieldTypeValidatorTest.kt
@@ -14,8 +14,14 @@
 package me.ahoo.wow.query.snapshot
 
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.AggregationDateUnit
+import me.ahoo.wow.api.query.AggregationGroup
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.serialization.JsonSerializer
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
@@ -40,6 +46,50 @@ class AggregationFieldTypeValidatorTest {
         Month::class.java.toJavaType().isAggregationDate.assert().isFalse()
         MonthDay::class.java.toJavaType().isAggregationDate.assert().isFalse()
         LocalTime::class.java.toJavaType().isAggregationDate.assert().isFalse()
+    }
+
+    @Test
+    fun `should validate group and metric field types`() {
+        AggregationQuery(
+            groupBy = listOf(
+                AggregationGroup.Terms("state.data", "data"),
+                AggregationGroup.Histogram("version", "versionBand", 1.0),
+                AggregationGroup.DateHistogram("snapshotTime", "day", AggregationDateUnit.DAY),
+            ),
+            metrics = listOf(
+                AggregationMetric.Count("count"),
+                AggregationMetric.Sum("version", "totalVersion"),
+            ),
+        ).validateFieldTypes(MOCK_AGGREGATE_METADATA)
+
+        listOf(
+            AggregationQuery(
+                groupBy = listOf(AggregationGroup.Terms("state", "state")),
+                metrics = listOf(AggregationMetric.Count("count")),
+            ) to "Aggregation group field [state] must be scalar.",
+            AggregationQuery(
+                groupBy = listOf(AggregationGroup.Histogram("state.data", "dataBand", 1.0)),
+                metrics = listOf(AggregationMetric.Count("count")),
+            ) to "Histogram field [state.data] must be numeric.",
+            AggregationQuery(
+                groupBy = listOf(
+                    AggregationGroup.DateHistogram("state.data", "day", AggregationDateUnit.DAY),
+                ),
+                metrics = listOf(AggregationMetric.Count("count")),
+            ) to "Date histogram field [state.data] must be a date or epoch number.",
+        ).forEach { (query, expectedMessage) ->
+            assertThrows<IllegalArgumentException> {
+                query.validateFieldTypes(MOCK_AGGREGATE_METADATA)
+            }.message.assert().isEqualTo(expectedMessage)
+        }
+    }
+
+    @Test
+    fun `should defer undeclared fields to backend validation`() {
+        AggregationQuery(
+            groupBy = listOf(AggregationGroup.Terms("state.labels.runtime", "runtime")),
+            metrics = listOf(AggregationMetric.Sum("state.runtimeScore", "score")),
+        ).validateFieldTypes(MOCK_AGGREGATE_METADATA)
     }
 
     private fun Class<*>.toJavaType() = JsonSerializer.typeFactory.constructType(this)

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/AggregationFieldTypeValidatorTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/AggregationFieldTypeValidatorTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.snapshot
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.serialization.JsonSerializer
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.Month
+import java.time.MonthDay
+import java.time.OffsetDateTime
+
+class AggregationFieldTypeValidatorTest {
+    @Test
+    fun `should recognize only scalar terms types`() {
+        String::class.java.toJavaType().isAggregationScalar.assert().isTrue()
+        Int::class.java.toJavaType().isAggregationScalar.assert().isTrue()
+        TestEnum::class.java.toJavaType().isAggregationScalar.assert().isTrue()
+        TestPojo::class.java.toJavaType().isAggregationScalar.assert().isFalse()
+    }
+
+    @Test
+    fun `should reject partial temporal date histogram types`() {
+        Instant::class.java.toJavaType().isAggregationDate.assert().isTrue()
+        LocalDate::class.java.toJavaType().isAggregationDate.assert().isTrue()
+        OffsetDateTime::class.java.toJavaType().isAggregationDate.assert().isTrue()
+        Month::class.java.toJavaType().isAggregationDate.assert().isFalse()
+        MonthDay::class.java.toJavaType().isAggregationDate.assert().isFalse()
+        LocalTime::class.java.toJavaType().isAggregationDate.assert().isFalse()
+    }
+
+    private fun Class<*>.toJavaType() = JsonSerializer.typeFactory.constructType(this)
+
+    private enum class TestEnum {
+        VALUE,
+    }
+
+    private data class TestPojo(val value: String)
+}

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/DefaultSnapshotQueryHandlerTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/DefaultSnapshotQueryHandlerTest.kt
@@ -24,6 +24,7 @@ import me.ahoo.wow.query.filter.QueryContext
 import me.ahoo.wow.query.snapshot.NoOpSnapshotQueryServiceFactory
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import org.junit.jupiter.api.Test
+import reactor.core.publisher.Mono
 import reactor.kotlin.test.test
 
 class DefaultSnapshotQueryHandlerTest {
@@ -105,13 +106,17 @@ class DefaultSnapshotQueryHandlerTest {
     }
 
     @Test
-    fun `should reject non-numeric metric fields before backend access`() {
+    fun `should route field validation errors through configured error handler`() {
+        val handledQueryHandler = DefaultSnapshotQueryHandler(snapshotQueryFilterChain) { _, error ->
+            error.message.assert().isEqualTo("Aggregation metric field [state.data] must be numeric.")
+            Mono.error(IllegalStateException("handled"))
+        }
         val query = aggregationQuery {
             sum("state.data", "total")
         }
-        queryHandler.aggregate(MOCK_AGGREGATE_METADATA, query)
+        handledQueryHandler.aggregate(MOCK_AGGREGATE_METADATA, query)
             .test()
-            .expectErrorMessage("Aggregation metric field [state.data] must be numeric.")
+            .expectErrorMessage("handled")
             .verify()
     }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/DefaultSnapshotQueryHandlerTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/DefaultSnapshotQueryHandlerTest.kt
@@ -16,6 +16,7 @@ package me.ahoo.wow.query.snapshot.filter
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.filter.FilterChainBuilder
 import me.ahoo.wow.filter.LogErrorHandler
+import me.ahoo.wow.query.dsl.aggregationQuery
 import me.ahoo.wow.query.dsl.condition
 import me.ahoo.wow.query.dsl.listQuery
 import me.ahoo.wow.query.dsl.singleQuery
@@ -101,5 +102,16 @@ class DefaultSnapshotQueryHandlerTest {
                 it.assert().isZero()
             }
             .verifyComplete()
+    }
+
+    @Test
+    fun `should reject non-numeric metric fields before backend access`() {
+        val query = aggregationQuery {
+            sum("state.data", "total")
+        }
+        queryHandler.aggregate(MOCK_AGGREGATE_METADATA, query)
+            .test()
+            .expectErrorMessage("Aggregation metric field [state.data] must be numeric.")
+            .verify()
     }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/DefaultSnapshotQueryHandlerTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/DefaultSnapshotQueryHandlerTest.kt
@@ -13,6 +13,8 @@
 
 package me.ahoo.wow.query.snapshot.filter
 
+import io.mockk.every
+import io.mockk.mockk
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.filter.FilterChainBuilder
 import me.ahoo.wow.filter.LogErrorHandler
@@ -117,6 +119,30 @@ class DefaultSnapshotQueryHandlerTest {
         handledQueryHandler.aggregate(MOCK_AGGREGATE_METADATA, query)
             .test()
             .expectErrorMessage("handled")
+            .verify()
+    }
+
+    @Test
+    fun `should route supported aggregation to query service`() {
+        queryHandler.aggregate(
+            MOCK_AGGREGATE_METADATA,
+            aggregationQuery { count("count") },
+        ).test()
+            .expectErrorMessage("Snapshot aggregation is not supported by [no_op].")
+            .verify()
+    }
+
+    @Test
+    fun `default handler should reject aggregation`() {
+        val handler = mockk<SnapshotQueryHandler> {
+            every { aggregate(any(), any()) } answers { callOriginal() }
+        }
+
+        handler.aggregate(
+            MOCK_AGGREGATE_METADATA,
+            aggregationQuery { count("count") },
+        ).test()
+            .expectErrorMessage("Snapshot aggregation is not supported by this query handler.")
             .verify()
     }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/MaskingSnapshotQueryFilterTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/MaskingSnapshotQueryFilterTest.kt
@@ -146,7 +146,7 @@ class MaskingSnapshotQueryFilterTest {
     fun `should reject aggregation when masking is configured`() {
         queryHandler.aggregate(
             MockSnapshotQueryService.namedAggregate,
-            AggregationQuery(metrics = listOf(AggregationMetric.Count("count"))),
+            AggregationQuery(metrics = listOf(AggregationMetric.Sum("state.unknown", "total"))),
         ).test()
             .expectErrorMessage("Snapshot aggregation is unavailable when data masking is configured.")
             .verify()

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/MaskingSnapshotQueryFilterTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/MaskingSnapshotQueryFilterTest.kt
@@ -15,6 +15,8 @@ package me.ahoo.wow.query.snapshot.filter
 
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.IListQuery
@@ -140,6 +142,16 @@ class MaskingSnapshotQueryFilterTest {
             .verifyComplete()
     }
 
+    @Test
+    fun `should reject aggregation when masking is configured`() {
+        queryHandler.aggregate(
+            MockSnapshotQueryService.namedAggregate,
+            AggregationQuery(metrics = listOf(AggregationMetric.Count("count"))),
+        ).test()
+            .expectErrorMessage("Snapshot aggregation is unavailable when data masking is configured.")
+            .verify()
+    }
+
     data class DataMaskable(val pwd: String) : DataMasking<DataMaskable> {
         companion object {
             const val MASKED_PWD = "******"
@@ -216,6 +228,10 @@ class MaskingSnapshotQueryFilterTest {
 
         override fun count(condition: Condition): Mono<Long> {
             return 1L.toMono()
+        }
+
+        override fun aggregate(aggregationQuery: AggregationQuery): Flux<Map<String, Any?>> {
+            return Flux.just(mapOf("count" to 1L))
         }
     }
 }

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
@@ -21,6 +21,7 @@ import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.schema.TypeFieldPaths.allFieldPaths
 import me.ahoo.wow.schema.Types.isStdType
 import me.ahoo.wow.serialization.MessageRecords
+import me.ahoo.wow.serialization.state.SnapshotRecords
 import me.ahoo.wow.serialization.state.StateAggregateRecords
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty1
@@ -175,9 +176,24 @@ object AggregatedFieldPaths {
         )
     }
 
+    fun KClass<*>.snapshotAggregatedFieldPaths(): Set<String> {
+        return buildSet {
+            addAll(stateAggregatedFieldPaths().filter(String::isNotEmpty))
+            add(MessageRecords.CONTEXT_NAME)
+            add(MessageRecords.AGGREGATE_NAME)
+            add(SnapshotRecords.SNAPSHOT_TIME)
+        }
+    }
+
     fun KClass<*>.commandAggregatedFieldPaths(): Set<String> {
         val aggregateMetadata = this.java.aggregateMetadata<Any, Any>()
         val stateAggregateType = aggregateMetadata.state.aggregateType.kotlin
         return stateAggregateType.stateAggregatedFieldPaths()
+    }
+
+    fun KClass<*>.commandSnapshotAggregatedFieldPaths(): Set<String> {
+        val aggregateMetadata = this.java.aggregateMetadata<Any, Any>()
+        val stateAggregateType = aggregateMetadata.state.aggregateType.kotlin
+        return stateAggregateType.snapshotAggregatedFieldPaths()
     }
 }

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/AggregatedFieldsDefinitionProvider.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/AggregatedFieldsDefinitionProvider.kt
@@ -19,16 +19,18 @@ import com.github.victools.jsonschema.generator.CustomDefinitionProviderV2
 import com.github.victools.jsonschema.generator.SchemaGenerationContext
 import com.github.victools.jsonschema.generator.SchemaKeyword
 import me.ahoo.wow.schema.AggregatedFieldPaths.commandAggregatedFieldPaths
+import me.ahoo.wow.schema.AggregatedFieldPaths.commandSnapshotAggregatedFieldPaths
 import me.ahoo.wow.schema.JsonSchema.Companion.toPropertyName
 
 object AggregatedFieldsDefinitionProvider : CustomDefinitionProviderV2 {
     private val type: Class<*> = AggregatedFields::class.java
+    private val snapshotType: Class<*> = SnapshotAggregatedFields::class.java
 
     override fun provideCustomSchemaDefinition(
         javaType: ResolvedType,
         context: SchemaGenerationContext
     ): CustomDefinition? {
-        if (!javaType.isInstanceOf(type)) {
+        if (!javaType.isInstanceOf(type) && !javaType.isInstanceOf(snapshotType)) {
             return null
         }
 
@@ -42,7 +44,11 @@ object AggregatedFieldsDefinitionProvider : CustomDefinitionProviderV2 {
         if (commandAggregateType == Any::class.java) {
             return CustomDefinition(rootNode)
         }
-        val enumValues = commandAggregateType.kotlin.commandAggregatedFieldPaths()
+        val enumValues = if (javaType.isInstanceOf(snapshotType)) {
+            commandAggregateType.kotlin.commandSnapshotAggregatedFieldPaths()
+        } else {
+            commandAggregateType.kotlin.commandAggregatedFieldPaths()
+        }
         rootNode.putPOJO(SchemaKeyword.TAG_ENUM.toPropertyName(schemaVersion), enumValues)
 
         return CustomDefinition(rootNode)

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/query/AggregatedAggregationQuery.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/query/AggregatedAggregationQuery.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.schema.typed.query
+
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import io.swagger.v3.oas.annotations.media.Schema
+import me.ahoo.wow.api.query.AggregationDateUnit
+import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.Sort
+import me.ahoo.wow.schema.typed.AggregatedFields
+
+data class AggregatedAggregationQuery<CommandAggregateType : Any>(
+    val condition: AggregatedCondition<CommandAggregateType> = AggregatedCondition(),
+    val groupBy: List<AggregatedAggregationGroup<CommandAggregateType>> = emptyList(),
+    val metrics: List<AggregatedAggregationMetric<CommandAggregateType>>,
+    val sort: List<Sort> = emptyList(),
+    @get:Schema(defaultValue = "100", minimum = "1", maximum = "10000")
+    val limit: Int = AggregationQuery.DEFAULT_LIMIT,
+)
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(
+    JsonSubTypes.Type(value = AggregatedAggregationGroup.Terms::class, name = "TERMS"),
+    JsonSubTypes.Type(value = AggregatedAggregationGroup.Histogram::class, name = "HISTOGRAM"),
+    JsonSubTypes.Type(value = AggregatedAggregationGroup.DateHistogram::class, name = "DATE_HISTOGRAM"),
+)
+sealed interface AggregatedAggregationGroup<CommandAggregateType : Any> {
+    val field: AggregatedFields<CommandAggregateType>
+    val alias: String
+
+    data class Terms<CommandAggregateType : Any>(
+        override val field: AggregatedFields<CommandAggregateType>,
+        override val alias: String,
+    ) : AggregatedAggregationGroup<CommandAggregateType>
+
+    data class Histogram<CommandAggregateType : Any>(
+        override val field: AggregatedFields<CommandAggregateType>,
+        override val alias: String,
+        val interval: Double,
+        val offset: Double = 0.0,
+    ) : AggregatedAggregationGroup<CommandAggregateType>
+
+    data class DateHistogram<CommandAggregateType : Any>(
+        override val field: AggregatedFields<CommandAggregateType>,
+        override val alias: String,
+        val unit: AggregationDateUnit,
+        val timeZone: String = "UTC",
+    ) : AggregatedAggregationGroup<CommandAggregateType>
+}
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(
+    JsonSubTypes.Type(value = AggregatedAggregationMetric.Count::class, name = "COUNT"),
+    JsonSubTypes.Type(value = AggregatedAggregationMetric.Sum::class, name = "SUM"),
+    JsonSubTypes.Type(value = AggregatedAggregationMetric.Avg::class, name = "AVG"),
+    JsonSubTypes.Type(value = AggregatedAggregationMetric.Min::class, name = "MIN"),
+    JsonSubTypes.Type(value = AggregatedAggregationMetric.Max::class, name = "MAX"),
+)
+sealed interface AggregatedAggregationMetric<CommandAggregateType : Any> {
+    val alias: String
+
+    data class Count<CommandAggregateType : Any>(
+        override val alias: String,
+    ) : AggregatedAggregationMetric<CommandAggregateType>
+
+    data class Sum<CommandAggregateType : Any>(
+        val field: AggregatedFields<CommandAggregateType>,
+        override val alias: String,
+    ) : AggregatedAggregationMetric<CommandAggregateType>
+
+    data class Avg<CommandAggregateType : Any>(
+        val field: AggregatedFields<CommandAggregateType>,
+        override val alias: String,
+    ) : AggregatedAggregationMetric<CommandAggregateType>
+
+    data class Min<CommandAggregateType : Any>(
+        val field: AggregatedFields<CommandAggregateType>,
+        override val alias: String,
+    ) : AggregatedAggregationMetric<CommandAggregateType>
+
+    data class Max<CommandAggregateType : Any>(
+        val field: AggregatedFields<CommandAggregateType>,
+        override val alias: String,
+    ) : AggregatedAggregationMetric<CommandAggregateType>
+}

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/query/AggregatedAggregationQuery.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/query/AggregatedAggregationQuery.kt
@@ -26,7 +26,7 @@ data class AggregatedAggregationQuery<CommandAggregateType : Any>(
     val condition: AggregatedCondition<CommandAggregateType> = AggregatedCondition(),
     @get:ArraySchema(maxItems = AggregationQuery.MAX_GROUPS)
     val groupBy: List<AggregatedAggregationGroup<CommandAggregateType>> = emptyList(),
-    @get:ArraySchema(minItems = 1, maxItems = AggregationQuery.MAX_METRICS)
+    @get:ArraySchema(minItems = 1)
     val metrics: List<AggregatedAggregationMetric<CommandAggregateType>>,
     val sort: List<Sort> = emptyList(),
     @get:Schema(defaultValue = "100", minimum = "1", maximum = "10000")

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/query/AggregatedAggregationQuery.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/query/AggregatedAggregationQuery.kt
@@ -15,14 +15,16 @@ package me.ahoo.wow.schema.typed.query
 
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
 import me.ahoo.wow.api.query.AggregationDateUnit
 import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Sort
-import me.ahoo.wow.schema.typed.AggregatedFields
+import me.ahoo.wow.schema.typed.SnapshotAggregatedFields
 
 data class AggregatedAggregationQuery<CommandAggregateType : Any>(
     val condition: AggregatedCondition<CommandAggregateType> = AggregatedCondition(),
+    @get:ArraySchema(maxItems = AggregationQuery.MAX_GROUPS)
     val groupBy: List<AggregatedAggregationGroup<CommandAggregateType>> = emptyList(),
     val metrics: List<AggregatedAggregationMetric<CommandAggregateType>>,
     val sort: List<Sort> = emptyList(),
@@ -37,23 +39,23 @@ data class AggregatedAggregationQuery<CommandAggregateType : Any>(
     JsonSubTypes.Type(value = AggregatedAggregationGroup.DateHistogram::class, name = "DATE_HISTOGRAM"),
 )
 sealed interface AggregatedAggregationGroup<CommandAggregateType : Any> {
-    val field: AggregatedFields<CommandAggregateType>
+    val field: SnapshotAggregatedFields<CommandAggregateType>
     val alias: String
 
     data class Terms<CommandAggregateType : Any>(
-        override val field: AggregatedFields<CommandAggregateType>,
+        override val field: SnapshotAggregatedFields<CommandAggregateType>,
         override val alias: String,
     ) : AggregatedAggregationGroup<CommandAggregateType>
 
     data class Histogram<CommandAggregateType : Any>(
-        override val field: AggregatedFields<CommandAggregateType>,
+        override val field: SnapshotAggregatedFields<CommandAggregateType>,
         override val alias: String,
         val interval: Double,
         val offset: Double = 0.0,
     ) : AggregatedAggregationGroup<CommandAggregateType>
 
     data class DateHistogram<CommandAggregateType : Any>(
-        override val field: AggregatedFields<CommandAggregateType>,
+        override val field: SnapshotAggregatedFields<CommandAggregateType>,
         override val alias: String,
         val unit: AggregationDateUnit,
         val timeZone: String = "UTC",
@@ -76,22 +78,22 @@ sealed interface AggregatedAggregationMetric<CommandAggregateType : Any> {
     ) : AggregatedAggregationMetric<CommandAggregateType>
 
     data class Sum<CommandAggregateType : Any>(
-        val field: AggregatedFields<CommandAggregateType>,
+        val field: SnapshotAggregatedFields<CommandAggregateType>,
         override val alias: String,
     ) : AggregatedAggregationMetric<CommandAggregateType>
 
     data class Avg<CommandAggregateType : Any>(
-        val field: AggregatedFields<CommandAggregateType>,
+        val field: SnapshotAggregatedFields<CommandAggregateType>,
         override val alias: String,
     ) : AggregatedAggregationMetric<CommandAggregateType>
 
     data class Min<CommandAggregateType : Any>(
-        val field: AggregatedFields<CommandAggregateType>,
+        val field: SnapshotAggregatedFields<CommandAggregateType>,
         override val alias: String,
     ) : AggregatedAggregationMetric<CommandAggregateType>
 
     data class Max<CommandAggregateType : Any>(
-        val field: AggregatedFields<CommandAggregateType>,
+        val field: SnapshotAggregatedFields<CommandAggregateType>,
         override val alias: String,
     ) : AggregatedAggregationMetric<CommandAggregateType>
 }

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/query/AggregatedAggregationQuery.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/query/AggregatedAggregationQuery.kt
@@ -51,6 +51,7 @@ sealed interface AggregatedAggregationGroup<CommandAggregateType : Any> {
     data class Histogram<CommandAggregateType : Any>(
         override val field: SnapshotAggregatedFields<CommandAggregateType>,
         override val alias: String,
+        @get:Schema(minimum = "0", exclusiveMinimum = true)
         val interval: Double,
         val offset: Double = 0.0,
     ) : AggregatedAggregationGroup<CommandAggregateType>

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
@@ -21,6 +21,7 @@ import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.PagedList
 import me.ahoo.wow.api.query.PagedQuery
 import me.ahoo.wow.schema.AggregatedFieldPaths.commandAggregatedFieldPaths
+import me.ahoo.wow.schema.AggregatedFieldPaths.commandSnapshotAggregatedFieldPaths
 import me.ahoo.wow.schema.TypeFieldPaths.allFieldPaths
 import org.junit.jupiter.api.Test
 
@@ -80,6 +81,20 @@ class AggregatedFieldPathsTest {
     fun `should list command aggregated field paths`() {
         val paths = TestAggregate::class.commandAggregatedFieldPaths()
         paths.assert().isNotEmpty()
+            .doesNotContain("contextName")
+            .doesNotContain("aggregateName")
+            .doesNotContain("snapshotTime")
+    }
+
+    @Test
+    fun `should list command snapshot aggregated field paths`() {
+        val paths = TestAggregate::class.commandSnapshotAggregatedFieldPaths()
+        paths.assert()
+            .contains("contextName")
+            .contains("aggregateName")
+            .contains("snapshotTime")
+            .contains("state.id")
+            .doesNotContain("")
     }
 
     class FieldPathDemoState(override val id: String) : Identifier {

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/typed/query/AggregatedAggregationQueryTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/typed/query/AggregatedAggregationQueryTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.schema.typed.query
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.AggregationDateUnit
+import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.Operator
+import me.ahoo.wow.schema.TestAggregate
+import me.ahoo.wow.schema.typed.SnapshotAggregatedFields
+import org.junit.jupiter.api.Test
+
+class AggregatedAggregationQueryTest {
+    private val field = object : SnapshotAggregatedFields<TestAggregate> {}
+
+    @Test
+    fun `should construct every aggregation schema variant`() {
+        val query = AggregatedAggregationQuery(
+            groupBy = listOf(
+                AggregatedAggregationGroup.Terms(field, "terms"),
+                AggregatedAggregationGroup.Histogram(field, "histogram", 1.0),
+                AggregatedAggregationGroup.DateHistogram(field, "day", AggregationDateUnit.DAY),
+            ),
+            metrics = listOf(
+                AggregatedAggregationMetric.Count("count"),
+                AggregatedAggregationMetric.Sum(field, "sum"),
+                AggregatedAggregationMetric.Avg(field, "avg"),
+                AggregatedAggregationMetric.Min(field, "min"),
+                AggregatedAggregationMetric.Max(field, "max"),
+            ),
+        )
+
+        query.condition.operator.assert().isEqualTo(Operator.ALL)
+        query.groupBy.assert().hasSize(3)
+        (query.groupBy[1] as AggregatedAggregationGroup.Histogram).offset.assert().isEqualTo(0.0)
+        (query.groupBy[2] as AggregatedAggregationGroup.DateHistogram).timeZone.assert().isEqualTo("UTC")
+        query.metrics.map { it.alias }.assert().containsExactly("count", "sum", "avg", "min", "max")
+        query.sort.assert().isEmpty()
+        query.limit.assert().isEqualTo(AggregationQuery.DEFAULT_LIMIT)
+    }
+}

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfiguration.kt
@@ -128,6 +128,7 @@ class WebFluxAutoConfiguration {
         val query = webFluxProperties.query
         return HttpQueryGuardFilter(
             maxListSize = query.maxListSize,
+            maxAggregationMetrics = query.maxAggregationMetrics,
             maxPageSize = query.maxPageSize,
             maxPageWindow = query.maxPageWindow,
             maxConditionNodes = query.maxConditionNodes,

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxProperties.kt
@@ -52,6 +52,8 @@ constructor(
     data class Query(
         @DefaultValue("1000")
         var maxListSize: Int = 1000,
+        @DefaultValue("32")
+        var maxAggregationMetrics: Int = 32,
         @DefaultValue("100")
         var maxPageSize: Int = 100,
         @DefaultValue("10000")
@@ -71,6 +73,7 @@ constructor(
     ) {
         init {
             require(maxListSize >= 0) { "maxListSize must be greater than or equal to 0." }
+            require(maxAggregationMetrics >= 0) { "maxAggregationMetrics must be greater than or equal to 0." }
             require(maxPageSize >= 0) { "maxPageSize must be greater than or equal to 0." }
             require(maxPageWindow >= 0) { "maxPageWindow must be greater than or equal to 0." }
             require(maxConditionNodes >= 0) { "maxConditionNodes must be greater than or equal to 0." }

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxProperties.kt
@@ -52,8 +52,6 @@ constructor(
     data class Query(
         @DefaultValue("1000")
         var maxListSize: Int = 1000,
-        @DefaultValue("32")
-        var maxAggregationMetrics: Int = 32,
         @DefaultValue("100")
         var maxPageSize: Int = 100,
         @DefaultValue("10000")
@@ -70,6 +68,8 @@ constructor(
         var allowExpensiveOperators: Boolean = false,
         @DefaultValue("10s")
         var idleTimeout: Duration = Duration.ofSeconds(10),
+        @DefaultValue("32")
+        var maxAggregationMetrics: Int = 32,
     ) {
         init {
             require(maxListSize >= 0) { "maxListSize must be greater than or equal to 0." }

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/route/QueryRouteModule.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/route/QueryRouteModule.kt
@@ -22,6 +22,7 @@ import me.ahoo.wow.webflux.route.event.ListQueryEventStreamHandlerFunctionFactor
 import me.ahoo.wow.webflux.route.event.LoadEventStreamHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.event.PagedQueryEventStreamHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.query.RewriteRequestCondition
+import me.ahoo.wow.webflux.route.snapshot.AggregateSnapshotHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.snapshot.CountSnapshotHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.snapshot.ListQuerySnapshotHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.snapshot.ListQuerySnapshotStateHandlerFunctionFactory
@@ -38,6 +39,11 @@ class QueryRouteModule(
     exceptionHandler: RequestExceptionHandler
 ) : WebFluxRouteModule {
     override val httpFactories: List<HttpRouteHandlerFunctionFactory> = listOf(
+        AggregateSnapshotHandlerFunctionFactory(
+            snapshotQueryHandler = snapshotQueryHandler,
+            rewriteRequestCondition = rewriteRequestCondition,
+            exceptionHandler = exceptionHandler
+        ),
         LoadSnapshotHandlerFunctionFactory(
             snapshotQueryHandler = snapshotQueryHandler,
             exceptionHandler = exceptionHandler

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/route/QueryRouteModule.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/route/QueryRouteModule.kt
@@ -22,7 +22,6 @@ import me.ahoo.wow.webflux.route.event.ListQueryEventStreamHandlerFunctionFactor
 import me.ahoo.wow.webflux.route.event.LoadEventStreamHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.event.PagedQueryEventStreamHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.query.RewriteRequestCondition
-import me.ahoo.wow.webflux.route.snapshot.AggregateSnapshotHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.snapshot.CountSnapshotHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.snapshot.ListQuerySnapshotHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.snapshot.ListQuerySnapshotStateHandlerFunctionFactory
@@ -31,6 +30,7 @@ import me.ahoo.wow.webflux.route.snapshot.PagedQuerySnapshotHandlerFunctionFacto
 import me.ahoo.wow.webflux.route.snapshot.PagedQuerySnapshotStateHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.snapshot.SingleSnapshotHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.snapshot.SingleSnapshotStateHandlerFunctionFactory
+import me.ahoo.wow.webflux.route.snapshot.SnapshotAggregationHandlerFunctionFactory
 
 class QueryRouteModule(
     snapshotQueryHandler: SnapshotQueryHandler,
@@ -39,7 +39,7 @@ class QueryRouteModule(
     exceptionHandler: RequestExceptionHandler
 ) : WebFluxRouteModule {
     override val httpFactories: List<HttpRouteHandlerFunctionFactory> = listOf(
-        AggregateSnapshotHandlerFunctionFactory(
+        SnapshotAggregationHandlerFunctionFactory(
             snapshotQueryHandler = snapshotQueryHandler,
             rewriteRequestCondition = rewriteRequestCondition,
             exceptionHandler = exceptionHandler

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
@@ -182,6 +182,7 @@ internal class WebFluxAutoConfigurationTest {
                 "${WebFluxProperties.PREFIX}.batch.concurrency=4",
                 "${WebFluxProperties.PREFIX}.batch.prefetch=8",
                 "${WebFluxProperties.PREFIX}.query.max-list-size=200",
+                "${WebFluxProperties.PREFIX}.query.max-aggregation-metrics=16",
                 "${WebFluxProperties.PREFIX}.query.max-page-size=20",
                 "${WebFluxProperties.PREFIX}.query.max-page-window=2000",
                 "${WebFluxProperties.PREFIX}.query.max-condition-nodes=32",
@@ -213,13 +214,11 @@ internal class WebFluxAutoConfigurationTest {
                 WebFluxAutoConfiguration::class.java,
             )
             .run { context: AssertableApplicationContext ->
-                context.assert()
-                    .hasSingleBean(BatchExecutionPolicy::class.java)
-                    .hasSingleBean(WebFluxProperties::class.java)
                 val properties = context.getBean(WebFluxProperties::class.java)
                 properties.batch.concurrency.assert().isEqualTo(4)
                 properties.batch.prefetch.assert().isEqualTo(8)
                 properties.query.maxListSize.assert().isEqualTo(200)
+                properties.query.maxAggregationMetrics.assert().isEqualTo(16)
                 properties.query.maxPageSize.assert().isEqualTo(20)
                 properties.query.maxPageWindow.assert().isEqualTo(2000)
                 properties.query.maxConditionNodes.assert().isEqualTo(32)

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
@@ -235,6 +235,14 @@ internal class WebFluxAutoConfigurationTest {
     }
 
     @Test
+    fun `query properties should preserve positional constructor arguments`() {
+        val query = WebFluxProperties.Query(1000, 20)
+
+        query.maxPageSize.assert().isEqualTo(20)
+        query.maxAggregationMetrics.assert().isEqualTo(32)
+    }
+
+    @Test
     fun `should generate SQL from every explicit BI property and bind the domain strategy directly`() {
         webFluxContextRunner()
             .withPropertyValues(

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/QueryServiceProxy.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/QueryServiceProxy.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.spring.query
 
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.IListQuery
@@ -33,7 +34,7 @@ import reactor.core.publisher.Mono
 
 internal class SnapshotQueryServiceProxy<S : Any>(
     private val delegate: SnapshotQueryService<S>,
-    handler: SnapshotQueryHandler,
+    private val handler: SnapshotQueryHandler,
 ) : QueryServiceProxy<MaterializedSnapshot<S>>(
     delegate.namedAggregate,
     handler.cast(),
@@ -41,6 +42,9 @@ internal class SnapshotQueryServiceProxy<S : Any>(
     SnapshotQueryService<S> {
     override val name: String
         get() = delegate.name
+
+    override fun aggregate(aggregationQuery: AggregationQuery): Flux<Map<String, Any?>> =
+        handler.aggregate(namedAggregate, aggregationQuery)
 }
 
 internal class EventStreamQueryServiceProxy(

--- a/wow-spring/src/test/kotlin/me/ahoo/wow/spring/query/QueryServiceProxyTest.kt
+++ b/wow-spring/src/test/kotlin/me/ahoo/wow/spring/query/QueryServiceProxyTest.kt
@@ -13,8 +13,13 @@
 
 package me.ahoo.wow.spring.query
 
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.IListQuery
@@ -35,6 +40,7 @@ import me.ahoo.wow.query.filter.QueryContext
 import me.ahoo.wow.query.filter.QueryType
 import me.ahoo.wow.query.snapshot.NoOpSnapshotQueryService
 import me.ahoo.wow.query.snapshot.filter.DefaultSnapshotQueryHandler
+import me.ahoo.wow.query.snapshot.filter.SnapshotQueryHandler
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.support.DefaultListableBeanFactory
 import reactor.core.publisher.Flux
@@ -76,6 +82,20 @@ class QueryServiceProxyTest {
 
         proxy.name.assert().isEqualTo(delegate.name)
         proxy.namedAggregate.assert().isSameAs(delegate.namedAggregate)
+    }
+
+    @Test
+    fun `snapshot proxy should route aggregation through handler`() {
+        val delegate = NoOpSnapshotQueryService<Any>(namedAggregate)
+        val query = AggregationQuery(metrics = listOf(AggregationMetric.Count("count")))
+        val handler = mockk<SnapshotQueryHandler> {
+            every { aggregate(namedAggregate, query) } returns Flux.just(mapOf("count" to 1L))
+        }
+        val proxy = SnapshotQueryServiceProxy(delegate, handler)
+
+        proxy.aggregate(query).collectList().block()!!.assert().containsExactly(mapOf("count" to 1L))
+
+        verify(exactly = 1) { handler.aggregate(namedAggregate, query) }
     }
 
     @Test

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilter.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilter.kt
@@ -255,7 +255,7 @@ class HttpQueryGuardFilter(
 
             QueryType.COUNT -> context.asCountQuery().rewriteResult { it.timeout(idleTimeout) }
 
-            QueryType.AGGREGATE -> context.asAggregationQuery().rewriteResult {
+            QueryType.AGGREGATION -> context.asAggregationQuery().rewriteResult {
                 if (request.acceptsEventStream()) {
                     it.timeout(idleTimeout)
                 } else {
@@ -296,7 +296,7 @@ class HttpQueryGuardFilter(
             QueryType.PAGED,
             QueryType.DYNAMIC_PAGED,
             QueryType.COUNT,
-            QueryType.AGGREGATE,
+            QueryType.AGGREGATION,
         )
         const val FIELD_WILDCARD = "*"
         val COLLECTION_OPERATORS = setOf(

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilter.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilter.kt
@@ -43,7 +43,6 @@ import java.util.ArrayDeque
 @FilterType(SnapshotQueryHandler::class, EventStreamQueryHandler::class)
 class HttpQueryGuardFilter(
     private val maxListSize: Int = 1000,
-    private val maxAggregationMetrics: Int = 32,
     private val maxPageSize: Int = 100,
     private val maxPageWindow: Long = 10_000,
     private val maxConditionNodes: Int = 64,
@@ -53,6 +52,7 @@ class HttpQueryGuardFilter(
     private val allowRaw: Boolean = false,
     private val allowExpensiveOperators: Boolean = false,
     private val idleTimeout: Duration = Duration.ofSeconds(10),
+    private val maxAggregationMetrics: Int = 32,
 ) : QueryFilter<QueryContext<*, *>> {
 
     init {

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilter.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilter.kt
@@ -43,6 +43,7 @@ import java.util.ArrayDeque
 @FilterType(SnapshotQueryHandler::class, EventStreamQueryHandler::class)
 class HttpQueryGuardFilter(
     private val maxListSize: Int = 1000,
+    private val maxAggregationMetrics: Int = 32,
     private val maxPageSize: Int = 100,
     private val maxPageWindow: Long = 10_000,
     private val maxConditionNodes: Int = 64,
@@ -56,6 +57,7 @@ class HttpQueryGuardFilter(
 
     init {
         require(maxListSize >= 0) { "maxListSize must be greater than or equal to 0." }
+        require(maxAggregationMetrics >= 0) { "maxAggregationMetrics must be greater than or equal to 0." }
         require(maxPageSize >= 0) { "maxPageSize must be greater than or equal to 0." }
         require(maxPageWindow >= 0) { "maxPageWindow must be greater than or equal to 0." }
         require(maxConditionNodes >= 0) { "maxConditionNodes must be greater than or equal to 0." }
@@ -85,6 +87,9 @@ class HttpQueryGuardFilter(
             is IPagedQuery -> validatePage(query)
             is AggregationQuery -> {
                 validateResultSize(query.limit, "aggregation")
+                require(maxAggregationMetrics == 0 || query.metrics.size <= maxAggregationMetrics) {
+                    "HTTP aggregation metrics[${query.metrics.size}] must not exceed $maxAggregationMetrics."
+                }
                 require(query.sort.isEmpty() || FIELD_WILDCARD in allowedSortFields) {
                     "HTTP aggregation sort requires the allowed-sort-fields wildcard."
                 }

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilter.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilter.kt
@@ -83,7 +83,12 @@ class HttpQueryGuardFilter(
         when (query) {
             is IListQuery -> validateList(query)
             is IPagedQuery -> validatePage(query)
-            is AggregationQuery -> validateResultSize(query.limit, "aggregation")
+            is AggregationQuery -> {
+                validateResultSize(query.limit, "aggregation")
+                require(query.sort.isEmpty() || FIELD_WILDCARD in allowedSortFields) {
+                    "HTTP aggregation sort requires the allowed-sort-fields wildcard."
+                }
+            }
         }
         if (query is Queryable<*>) {
             val rejectedSortFields = query.sort.map { it.field }.filterNot { allowedSortFields.allows(it) }

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractor.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractor.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.webflux.route.query
 
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.ListQuery
 import me.ahoo.wow.api.query.PagedQuery
@@ -26,6 +27,7 @@ import tools.jackson.databind.node.ObjectNode
 
 class QueryBodyExtractor<Q : Any>(private val queryType: Class<Q>) : BodyExtractor<Mono<Q>, ReactiveHttpInputMessage> {
     companion object {
+        val AGGREGATION_QUERY_EXTRACTOR = QueryBodyExtractor(AggregationQuery::class.java)
         val CONDITION_EXTRACTOR = QueryBodyExtractor(Condition::class.java)
         val LIST_QUERY_EXTRACTOR = QueryBodyExtractor(ListQuery::class.java)
         val PAGED_QUERY_EXTRACTOR = QueryBodyExtractor(PagedQuery::class.java)

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/AggregateSnapshotHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/AggregateSnapshotHandlerFunction.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.route.snapshot
+
+import me.ahoo.wow.modeling.metadata.AggregateMetadata
+import me.ahoo.wow.openapi.contract.BuiltInHttpRouteHandlerKeys
+import me.ahoo.wow.openapi.contract.HttpRouteContract
+import me.ahoo.wow.openapi.contract.HttpRouteHandlerMetadata
+import me.ahoo.wow.query.filter.Contexts.writeRawRequest
+import me.ahoo.wow.query.snapshot.filter.SnapshotQueryHandler
+import me.ahoo.wow.webflux.exception.RequestExceptionHandler
+import me.ahoo.wow.webflux.route.AggregateRouteHandlerFunctionFactorySupport
+import me.ahoo.wow.webflux.route.query.QueryBodyExtractor.Companion.AGGREGATION_QUERY_EXTRACTOR
+import me.ahoo.wow.webflux.route.query.RewriteRequestCondition
+import me.ahoo.wow.webflux.route.toServerResponse
+import org.springframework.web.reactive.function.server.HandlerFunction
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import reactor.core.publisher.Mono
+
+class AggregateSnapshotHandlerFunction(
+    private val aggregateMetadata: AggregateMetadata<*, *>,
+    private val snapshotQueryHandler: SnapshotQueryHandler,
+    private val rewriteRequestCondition: RewriteRequestCondition,
+    private val exceptionHandler: RequestExceptionHandler,
+) : HandlerFunction<ServerResponse> {
+    override fun handle(request: ServerRequest): Mono<ServerResponse> =
+        request.body(AGGREGATION_QUERY_EXTRACTOR)
+            .flatMapMany { query ->
+                snapshotQueryHandler.aggregate(
+                    aggregateMetadata,
+                    rewriteRequestCondition.rewrite(aggregateMetadata, request, query),
+                )
+            }.writeRawRequest(request)
+            .toServerResponse(request, exceptionHandler)
+}
+
+class AggregateSnapshotHandlerFunctionFactory(
+    private val snapshotQueryHandler: SnapshotQueryHandler,
+    private val rewriteRequestCondition: RewriteRequestCondition,
+    private val exceptionHandler: RequestExceptionHandler,
+) : AggregateRouteHandlerFunctionFactorySupport(BuiltInHttpRouteHandlerKeys.Snapshot.AGGREGATE) {
+    override fun create(
+        contract: HttpRouteContract,
+        metadata: HttpRouteHandlerMetadata.Aggregate,
+    ): HandlerFunction<ServerResponse> = AggregateSnapshotHandlerFunction(
+        aggregateMetadata = aggregateMetadata(metadata),
+        snapshotQueryHandler = snapshotQueryHandler,
+        rewriteRequestCondition = rewriteRequestCondition,
+        exceptionHandler = exceptionHandler,
+    )
+}

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/SnapshotAggregationHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/SnapshotAggregationHandlerFunction.kt
@@ -29,7 +29,7 @@ import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
 import reactor.core.publisher.Mono
 
-class AggregateSnapshotHandlerFunction(
+class SnapshotAggregationHandlerFunction(
     private val aggregateMetadata: AggregateMetadata<*, *>,
     private val snapshotQueryHandler: SnapshotQueryHandler,
     private val rewriteRequestCondition: RewriteRequestCondition,
@@ -46,15 +46,15 @@ class AggregateSnapshotHandlerFunction(
             .toServerResponse(request, exceptionHandler)
 }
 
-class AggregateSnapshotHandlerFunctionFactory(
+class SnapshotAggregationHandlerFunctionFactory(
     private val snapshotQueryHandler: SnapshotQueryHandler,
     private val rewriteRequestCondition: RewriteRequestCondition,
     private val exceptionHandler: RequestExceptionHandler,
-) : AggregateRouteHandlerFunctionFactorySupport(BuiltInHttpRouteHandlerKeys.Snapshot.AGGREGATE) {
+) : AggregateRouteHandlerFunctionFactorySupport(BuiltInHttpRouteHandlerKeys.Snapshot.AGGREGATION) {
     override fun create(
         contract: HttpRouteContract,
         metadata: HttpRouteHandlerMetadata.Aggregate,
-    ): HandlerFunction<ServerResponse> = AggregateSnapshotHandlerFunction(
+    ): HandlerFunction<ServerResponse> = SnapshotAggregationHandlerFunction(
         aggregateMetadata = aggregateMetadata(metadata),
         snapshotQueryHandler = snapshotQueryHandler,
         rewriteRequestCondition = rewriteRequestCondition,

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
@@ -375,6 +375,21 @@ class HttpQueryGuardFilterTest {
             .expectError(IllegalArgumentException::class.java)
             .verify()
 
+        guard(maxAggregationMetrics = 1).filter(
+            aggregationContext(
+                AggregationQuery(
+                    condition = Condition.id("aggregate-id"),
+                    metrics = listOf(
+                        AggregationMetric.Count("count"),
+                        AggregationMetric.Sum("version", "versionSum"),
+                    ),
+                ),
+            ),
+            unexpectedBackend(),
+        ).writeRawRequest(request).test()
+            .expectErrorMessage("HTTP aggregation metrics[2] must not exceed 1.")
+            .verify()
+
         val context = aggregationContext(
             AggregationQuery(
                 condition = Condition.id("aggregate-id"),
@@ -577,6 +592,7 @@ class HttpQueryGuardFilterTest {
 
     private fun guard(
         maxListSize: Int = 1000,
+        maxAggregationMetrics: Int = 32,
         maxPageSize: Int = 100,
         maxPageWindow: Long = 10_000,
         maxConditionNodes: Int = 64,
@@ -588,6 +604,7 @@ class HttpQueryGuardFilterTest {
         idleTimeout: Duration = Duration.ofSeconds(10),
     ) = HttpQueryGuardFilter(
         maxListSize = maxListSize,
+        maxAggregationMetrics = maxAggregationMetrics,
         maxPageSize = maxPageSize,
         maxPageWindow = maxPageWindow,
         maxConditionNodes = maxConditionNodes,

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
@@ -16,6 +16,7 @@ package me.ahoo.wow.webflux.route.query
 import io.mockk.mockk
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.abac.AbacTags
+import me.ahoo.wow.api.query.AggregationGroup
 import me.ahoo.wow.api.query.AggregationMetric
 import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
@@ -391,6 +392,35 @@ class HttpQueryGuardFilterTest {
         context.getRequiredResult().test()
             .expectError(TimeoutException::class.java)
             .verify()
+    }
+
+    @Test
+    fun `should require wildcard to enable aggregation sorting`() {
+        val query = AggregationQuery(
+            condition = Condition.id("aggregate-id"),
+            groupBy = listOf(AggregationGroup.Terms("state.status", "status")),
+            metrics = listOf(AggregationMetric.Count("count")),
+            sort = listOf(Sort("count", Sort.Direction.DESC)),
+        )
+        listOf(
+            guard(),
+            guard(allowedSortFields = setOf("count")),
+        ).forEach { guard ->
+            guard.filter(aggregationContext(query), unexpectedBackend())
+                .writeRawRequest(request)
+                .test()
+                .expectError(IllegalArgumentException::class.java)
+                .verify()
+        }
+
+        val context = aggregationContext(query)
+        guard(allowedSortFields = setOf("*")).filter(
+            context,
+            FilterChain {
+                it.asAggregationQuery().setResult(Flux.empty())
+                Mono.empty()
+            },
+        ).writeRawRequest(request).test().verifyComplete()
     }
 
     @Test

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
@@ -591,7 +591,7 @@ class HttpQueryGuardFilterTest {
         query: AggregationQuery,
     ): QueryContext<AggregationQuery, Flux<Map<String, Any?>>> =
         DefaultQueryContext<AggregationQuery, Flux<Map<String, Any?>>>(
-            QueryType.AGGREGATE,
+            QueryType.AGGREGATION,
             MOCK_AGGREGATE_METADATA,
         ).setQuery(query)
 

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
@@ -131,6 +131,15 @@ class HttpQueryGuardFilterTest {
         ).writeRawRequest(request).test()
             .expectError(IllegalArgumentException::class.java)
             .verify()
+
+        HttpQueryGuardFilter(1000, 1).filter(
+            pagedContext(
+                PagedQuery(Condition.id("aggregate-id"), pagination = Pagination(index = 1, size = 2)),
+            ),
+            unexpectedBackend(),
+        ).writeRawRequest(request).test()
+            .expectErrorMessage("HTTP page size[2] must be between 1 and 1.")
+            .verify()
     }
 
     @Test

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractorTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractorTest.kt
@@ -29,7 +29,7 @@ import me.ahoo.wow.query.filter.QueryHandler
 import me.ahoo.wow.query.snapshot.filter.SnapshotQueryHandler
 import me.ahoo.wow.webflux.exception.WebFluxRequestExceptionHandler
 import me.ahoo.wow.webflux.route.RouteTestFixtures
-import me.ahoo.wow.webflux.route.snapshot.AggregateSnapshotHandlerFunctionFactory
+import me.ahoo.wow.webflux.route.snapshot.SnapshotAggregationHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.testAggregateRouteContract
 import org.junit.jupiter.api.Test
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest
@@ -49,13 +49,13 @@ class QueryBodyExtractorTest {
         val queryHandler = mockk<SnapshotQueryHandler> {
             every { aggregate(any(), any()) } returns Flux.just(mapOf("count" to 1L))
         }
-        val handlerFunction = AggregateSnapshotHandlerFunctionFactory(
+        val handlerFunction = SnapshotAggregationHandlerFunctionFactory(
             snapshotQueryHandler = queryHandler,
             rewriteRequestCondition = DefaultRewriteRequestCondition,
             exceptionHandler = WebFluxRequestExceptionHandler(),
         ).create(
             testAggregateRouteContract(
-                handlerKey = BuiltInHttpRouteHandlerKeys.Snapshot.AGGREGATE,
+                handlerKey = BuiltInHttpRouteHandlerKeys.Snapshot.AGGREGATION,
                 aggregateRouteMetadata = RouteTestFixtures.MOCK_AGGREGATE_ROUTE_METADATA,
             )
         )

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractorTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractorTest.kt
@@ -16,6 +16,8 @@ package me.ahoo.wow.webflux.route.query
 import io.mockk.every
 import io.mockk.mockk
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.ListQuery
 import me.ahoo.wow.api.query.PagedQuery
@@ -24,8 +26,10 @@ import me.ahoo.wow.api.query.SingleQuery
 import me.ahoo.wow.openapi.contract.BuiltInHttpRouteHandlerKeys
 import me.ahoo.wow.query.filter.Contexts.getRawRequest
 import me.ahoo.wow.query.filter.QueryHandler
+import me.ahoo.wow.query.snapshot.filter.SnapshotQueryHandler
 import me.ahoo.wow.webflux.exception.WebFluxRequestExceptionHandler
 import me.ahoo.wow.webflux.route.RouteTestFixtures
+import me.ahoo.wow.webflux.route.snapshot.AggregateSnapshotHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.testAggregateRouteContract
 import org.junit.jupiter.api.Test
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest
@@ -39,6 +43,30 @@ import reactor.kotlin.core.publisher.toMono
 import reactor.kotlin.test.test
 
 class QueryBodyExtractorTest {
+
+    @Test
+    fun `should extract aggregation query via snapshot handler`() {
+        val queryHandler = mockk<SnapshotQueryHandler> {
+            every { aggregate(any(), any()) } returns Flux.just(mapOf("count" to 1L))
+        }
+        val handlerFunction = AggregateSnapshotHandlerFunctionFactory(
+            snapshotQueryHandler = queryHandler,
+            rewriteRequestCondition = DefaultRewriteRequestCondition,
+            exceptionHandler = WebFluxRequestExceptionHandler(),
+        ).create(
+            testAggregateRouteContract(
+                handlerKey = BuiltInHttpRouteHandlerKeys.Snapshot.AGGREGATE,
+                aggregateRouteMetadata = RouteTestFixtures.MOCK_AGGREGATE_ROUTE_METADATA,
+            )
+        )
+        val request = MockServerRequest.builder()
+            .body(AggregationQuery(metrics = listOf(AggregationMetric.Count("count"))).toMono())
+
+        handlerFunction.handle(request)
+            .test()
+            .consumeNextWith { it.statusCode().assert().isEqualTo(org.springframework.http.HttpStatus.OK) }
+            .verifyComplete()
+    }
 
     @Test
     fun `should extract condition via count handler`() {

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractorTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractorTest.kt
@@ -15,6 +15,7 @@ package me.ahoo.wow.webflux.route.query
 
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.query.AggregationMetric
 import me.ahoo.wow.api.query.AggregationQuery
@@ -45,7 +46,7 @@ import reactor.kotlin.test.test
 class QueryBodyExtractorTest {
 
     @Test
-    fun `should extract aggregation query via snapshot handler`() {
+    fun `should route aggregation query via snapshot handler`() {
         val queryHandler = mockk<SnapshotQueryHandler> {
             every { aggregate(any(), any()) } returns Flux.just(mapOf("count" to 1L))
         }
@@ -59,13 +60,23 @@ class QueryBodyExtractorTest {
                 aggregateRouteMetadata = RouteTestFixtures.MOCK_AGGREGATE_ROUTE_METADATA,
             )
         )
-        val request = MockServerRequest.builder()
-            .body(AggregationQuery(metrics = listOf(AggregationMetric.Count("count"))).toMono())
+        val query = AggregationQuery(metrics = listOf(AggregationMetric.Count("count")))
+        val request = mockk<ServerRequest>(relaxed = true)
+        every { request.body(QueryBodyExtractor.AGGREGATION_QUERY_EXTRACTOR) } returns query.toMono()
 
         handlerFunction.handle(request)
             .test()
-            .consumeNextWith { it.statusCode().assert().isEqualTo(org.springframework.http.HttpStatus.OK) }
+            .consumeNextWith { response ->
+                response.statusCode().assert().isEqualTo(org.springframework.http.HttpStatus.OK)
+                val exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/test").build())
+                response.writeTo(exchange, SERVER_RESPONSE_CONTEXT)
+                    .test()
+                    .verifyComplete()
+                exchange.response.bodyAsString.block()!!.assert().contains("count")
+            }
             .verifyComplete()
+
+        verify(exactly = 1) { queryHandler.aggregate(any(), query) }
     }
 
     @Test


### PR DESCRIPTION
## Goal

Add a backend-neutral snapshot aggregation API with matching MongoDB and Elasticsearch semantics, while preserving the existing query lifecycle, authorization, and data-masking boundaries.

## Changes

- add `AggregationQuery`, ordered `Terms`/`Histogram`/`DateHistogram` groups, `Count`/`Sum`/`Avg`/`Min`/`Max` metrics, DSL validation, sorting, and flat alias result rows
- implement MongoDB aggregation pipelines and Elasticsearch PIT + composite pagination with exact metric-sorted Top-N
- route aggregation through snapshot handlers, filters, Spring proxies, WebFlux, OpenAPI schemas/contracts, and optional reactive/synchronous API clients
- reject aggregation when snapshot masking is configured and validate group/metric field types before backend execution
- add shared MongoDB/Elasticsearch TCK coverage plus unit tests and Chinese/English documentation

## Verification

- `./gradlew :wow-api:check :wow-query:check :wow-spring:check :wow-webflux:check :wow-schema:check :wow-openapi:check :wow-apiclient:check :wow-mongo:check :wow-elasticsearch:check`
- `./gradlew detekt`
- `./gradlew :wow-mongo:integrationTest --tests me.ahoo.wow.mongo.query.snapshot.MongoSnapshotQueryServiceTest --stacktrace`
- `./gradlew :wow-elasticsearch:integrationTest --tests me.ahoo.wow.elasticsearch.query.snapshot.ElasticsearchSnapshotQueryServiceTest --stacktrace`
- `pnpm docs:build` in `documentation`
- `git diff --check`

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

The API and generated contracts are additive. Elasticsearch metric sorting scans all composite buckets and retains only `O(limit)` rows, so high-cardinality workloads should be benchmarked with production-scale data. Numeric metrics normalize to `Double`; exact money analytics should use scaled integer read-model fields. Aggregation fails closed when snapshot masking is configured.