### PR TITLE
perf(elasticsearch): optimize unordered PIT scans

### DIFF
--- a/documentation/docs/en/guide/extensions/elasticsearch.md
+++ b/documentation/docs/en/guide/extensions/elasticsearch.md
@@ -611,6 +611,8 @@ spring:
 3. **Full List Queries**: `ListQuery.limit=0` streams all matches with PIT + `search_after`; by default, limits from 1 through 10,000 use one request, while larger limits use the same internal pager. The 10,000 value is only the default internal batch size, not a result cap.
 4. **Paged Queries**: `PagedQuery` keeps its `from/size` contract and remains subject to Elasticsearch `index.max_result_window`. Use a list query when the complete result set is required.
 
+PIT list queries without an explicit `sort` scan only by `_shard_doc`, and their result order is not part of the contract. Add `_score DESC` explicitly when relevance order is required.
+
 Set `wow.elasticsearch.query.batch-size` no higher than the target index's `index.max_result_window` when it is below 10,000. Increase `wow.elasticsearch.query.keep-alive` above its `1m` default when a slow subscriber may take longer than that to consume one batch.
 
 ## Troubleshooting

--- a/documentation/docs/zh/guide/extensions/elasticsearch.md
+++ b/documentation/docs/zh/guide/extensions/elasticsearch.md
@@ -601,6 +601,8 @@ spring:
 3. **全量列表查询**：`ListQuery.limit=0` 使用 PIT + `search_after` 流式返回全部匹配结果；默认情况下，`1..10_000` 使用单次请求，更大的正数 limit 使用同一内部分页器。10,000 只是默认内部批大小，不是结果上限。
 4. **分页查询**：`PagedQuery` 保持 `from/size` 语义，仍受 Elasticsearch `index.max_result_window` 限制。需要完整结果集时应使用列表查询。
 
+PIT 列表查询未指定 `sort` 时只按 `_shard_doc` 扫描，结果顺序不属于契约。需要相关性顺序时应显式添加 `_score DESC`。
+
 当目标索引的 `index.max_result_window` 小于 10,000 时，将 `wow.elasticsearch.query.batch-size` 配置为不超过该值；当慢速订阅者消费一批数据可能超过默认 `1m` 时，应增大 `wow.elasticsearch.query.keep-alive`。
 
 ## 故障排查

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryService.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryService.kt
@@ -154,9 +154,7 @@ abstract class AbstractElasticsearchQueryService<R : Any> : QueryService<R> {
 
     private fun List<SortOptions>.searchAfterSort(): List<SortOptions> {
         return buildList {
-            if (this@searchAfterSort.isEmpty()) {
-                add(SortOptions.of { it.score { score -> score.order(SortOrder.Desc) } })
-            } else {
+            if (this@searchAfterSort.isNotEmpty()) {
                 addAll(this@searchAfterSort)
             }
             add(

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryServiceTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryServiceTest.kt
@@ -13,7 +13,6 @@
 
 package me.ahoo.wow.elasticsearch.query
 
-import co.elastic.clients.elasticsearch._types.SortOrder
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping
 import co.elastic.clients.elasticsearch._types.query_dsl.Query
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.matchAll
@@ -104,12 +103,8 @@ class AbstractElasticsearchQueryServiceTest {
         searchRequest.captured.index().assert().isEmpty()
         searchRequest.captured.pit()!!.id().assert().isEqualTo("pit-1")
         searchRequest.captured.pit()!!.keepAlive()!!.time().assert().isEqualTo("1m")
-        searchRequest.captured.sort().assert().hasSize(2)
-        searchRequest.captured.sort()[0].isScore.assert().isTrue()
-        searchRequest.captured.sort()[0].score().order().assert().isEqualTo(
-            SortOrder.Desc
-        )
-        searchRequest.captured.sort()[1].field().field().assert().isEqualTo("_shard_doc")
+        searchRequest.captured.sort().assert().hasSize(1)
+        searchRequest.captured.sort().single().field().field().assert().isEqualTo("_shard_doc")
         closeRequest.captured.id().assert().isEqualTo("pit-2")
     }
 
@@ -130,14 +125,18 @@ class AbstractElasticsearchQueryServiceTest {
             ListQuery(
                 condition = Condition.ALL,
                 projection = Projection(include = listOf("field")),
-                sort = listOf(Sort("field", Sort.Direction.ASC)),
+                sort = listOf(
+                    Sort("_score", Sort.Direction.DESC),
+                    Sort("field", Sort.Direction.ASC),
+                ),
                 limit = DEFAULT_SEARCH_BATCH_SIZE + 1,
             )
         ).collectList().block()
 
         searchRequest.captured.size().assert().isEqualTo(DEFAULT_SEARCH_BATCH_SIZE)
         searchRequest.captured.source()!!.filter().includes().assert().containsExactly("field")
-        searchRequest.captured.sort().map { it.field().field() }.assert().containsExactly("field", "_shard_doc")
+        searchRequest.captured.sort().map { it.field().field() }.assert()
+            .containsExactly("_score", "field", "_shard_doc")
     }
 
     @Test


### PR DESCRIPTION
## 概要
- 无显式排序的 PIT 扫描仅使用 _shard_doc
- 显式排序继续保留业务排序并追加稳定游标字段
- 补充排序语义文档和测试

## 验证
- ./gradlew :wow-elasticsearch:check --stacktrace