### PR TITLE
fix(mongo): reject negative list limits

### DIFF
--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoQueryService.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoQueryService.kt
@@ -63,6 +63,7 @@ abstract class AbstractMongoQueryService<R : Any> : QueryService<R> {
     }
 
     private fun listDocument(listQuery: IListQuery): Flux<Document> {
+        require(listQuery.limit >= 0) { "limit must be greater than or equal to 0." }
         return findDocument(listQuery)
             .limit(listQuery.limit)
             .toFlux()

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/AbstractMongoQueryServiceTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/AbstractMongoQueryServiceTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.mongo.query
+
+import com.mongodb.reactivestreams.client.MongoCollection
+import io.mockk.mockk
+import io.mockk.verify
+import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.DynamicDocument
+import me.ahoo.wow.api.query.ListQuery
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.query.converter.ConditionConverter
+import org.bson.Document
+import org.bson.conversions.Bson
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class AbstractMongoQueryServiceTest {
+    private val collection = mockk<MongoCollection<Document>>()
+    private val service = object : AbstractMongoQueryService<Document>() {
+        override val namedAggregate = MaterializedNamedAggregate("test", "aggregate")
+        override val collection: MongoCollection<Document> = this@AbstractMongoQueryServiceTest.collection
+        override val converter = mockk<ConditionConverter<Bson>>()
+        override val projectionConverter = mockk<MongoProjectionConverter>()
+        override val sortConverter = mockk<MongoSortConverter>()
+        override fun toTypedResult(document: Document): Document = document
+        override fun toDynamicDocument(document: Document): DynamicDocument = error("Not used.")
+    }
+
+    @Test
+    fun `negative list limit should fail before calling MongoDB`() {
+        assertThrows<IllegalArgumentException> {
+            service.list(ListQuery(Condition.ALL, limit = -1))
+        }
+
+        verify(exactly = 0) { collection.find(any<Bson>()) }
+    }
+}

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/AbstractMongoQueryServiceTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/AbstractMongoQueryServiceTest.kt
@@ -13,7 +13,9 @@
 
 package me.ahoo.wow.mongo.query
 
+import com.mongodb.reactivestreams.client.FindPublisher
 import com.mongodb.reactivestreams.client.MongoCollection
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import me.ahoo.wow.api.query.Condition
@@ -45,5 +47,22 @@ class AbstractMongoQueryServiceTest {
         }
 
         verify(exactly = 0) { collection.find(any<Bson>()) }
+    }
+
+    @Test
+    fun `non-negative list limit should reach MongoDB`() {
+        val bson = mockk<Bson>()
+        val publisher = mockk<FindPublisher<Document>>()
+        every { service.converter.convert(any()) } returns bson
+        every { service.projectionConverter.convert(any()) } returns bson
+        every { service.sortConverter.convert(any()) } returns bson
+        every { collection.find(bson) } returns publisher
+        every { publisher.projection(bson) } returns publisher
+        every { publisher.sort(bson) } returns publisher
+        every { publisher.limit(1) } returns publisher
+
+        service.list(ListQuery(Condition.ALL, limit = 1))
+
+        verify(exactly = 1) { publisher.limit(1) }
     }
 }


### PR DESCRIPTION
## 概要
- 在共享 MongoDB 列表查询入口拒绝负数 limit
- 确保非法输入不会触达 converter、collection 或 driver
- 补充回归测试

## 验证
- ./gradlew :wow-mongo:check --stacktrace