### PR TITLE
docs: fix infrastructure config type markup

### DIFF
--- a/documentation/docs/en/reference/config/infrastructure.md
+++ b/documentation/docs/en/reference/config/infrastructure.md
@@ -178,8 +178,8 @@ snapshots.
 | `wow.webflux.query.max-page-window` | Long | `10000` | Maximum HTTP page window; `0` disables the cap |
 | `wow.webflux.query.max-condition-nodes` | Integer | `64` | Maximum HTTP query condition nodes; `0` disables the cap |
 | `wow.webflux.query.max-condition-values` | Integer | `1000` | Maximum values in HTTP `IN`, `NOT_IN`, `ALL_IN`, `IDS`, or `AGGREGATE_IDS` conditions; `0` disables the cap |
-| `wow.webflux.query.allowed-sort-fields` | Set<String> | `[]` | Indexed logical fields allowed for explicit HTTP sorting; an empty set rejects all explicit sorts and `["*"]` disables the restriction |
-| `wow.webflux.query.allowed-condition-fields` | Set<String> | `[]` | Additional indexed logical fields allowed in HTTP predicates; `spaceId` requires explicit allowlisting, and `["*"]` disables the restriction |
+| `wow.webflux.query.allowed-sort-fields` | `Set<String>` | `[]` | Indexed logical fields allowed for explicit HTTP sorting; an empty set rejects all explicit sorts and `["*"]` disables the restriction |
+| `wow.webflux.query.allowed-condition-fields` | `Set<String>` | `[]` | Additional indexed logical fields allowed in HTTP predicates; `spaceId` requires explicit allowlisting, and `["*"]` disables the restriction |
 | `wow.webflux.query.allow-raw` | Boolean | `false` | Allow native HTTP `RAW` queries |
 | `wow.webflux.query.allow-expensive-operators` | Boolean | `false` | Allow HTTP negative/existence/expensive string operators or unfiltered count/paged queries |
 | `wow.webflux.query.idle-timeout` | Duration | `10s` | Maximum wait between results or completion; JSON arrays are buffered before commit, while SSE remains streaming; `0s` disables it |

--- a/documentation/docs/zh/reference/config/infrastructure.md
+++ b/documentation/docs/zh/reference/config/infrastructure.md
@@ -177,8 +177,8 @@ direct 和 batch 模式下都使用基于 `_source.version` 的原子保护更�
 | `wow.webflux.query.max-page-window` | Long | `10000` | HTTP 查询最大分页窗口；`0` 关闭上限 |
 | `wow.webflux.query.max-condition-nodes` | Integer | `64` | HTTP 查询条件节点上限；`0` 关闭上限 |
 | `wow.webflux.query.max-condition-values` | Integer | `1000` | HTTP `IN`、`NOT_IN`、`ALL_IN`、`IDS`、`AGGREGATE_IDS` 条件值数量上限；`0` 关闭上限 |
-| `wow.webflux.query.allowed-sort-fields` | Set<String> | `[]` | HTTP 显式排序允许的已索引逻辑字段；空集拒绝所有显式排序，`["*"]` 关闭限制 |
-| `wow.webflux.query.allowed-condition-fields` | Set<String> | `[]` | HTTP 条件允许的额外已索引逻辑字段；`spaceId` 必须显式加入白名单，`["*"]` 关闭限制 |
+| `wow.webflux.query.allowed-sort-fields` | `Set<String>` | `[]` | HTTP 显式排序允许的已索引逻辑字段；空集拒绝所有显式排序，`["*"]` 关闭限制 |
+| `wow.webflux.query.allowed-condition-fields` | `Set<String>` | `[]` | HTTP 条件允许的额外已索引逻辑字段；`spaceId` 必须显式加入白名单，`["*"]` 关闭限制 |
 | `wow.webflux.query.allow-raw` | Boolean | `false` | 允许 HTTP `RAW` 查询 |
 | `wow.webflux.query.allow-expensive-operators` | Boolean | `false` | 允许 HTTP 负向/存在性/高成本字符串操作符及无过滤 count/paged 查询 |
 | `wow.webflux.query.idle-timeout` | Duration | `10s` | 等待下一条结果或完成的最长时间；普通 JSON 数组在提交前缓冲，SSE 保持流式；`0s` 关闭 |


### PR DESCRIPTION
Fixes the VitePress build failure caused by unescaped Kotlin generic types in the English and Chinese infrastructure configuration tables.

Validation:
- CI=true pnpm docs:build
- git diff --check

Failed job: https://github.com/Ahoo-Wang/Wow/actions/runs/32517422962/job/96882072893