### PR TITLE
fix(elasticsearch): harden built-in index templates

### DIFF
--- a/documentation/docs/en/guide/extensions/elasticsearch.md
+++ b/documentation/docs/en/guide/extensions/elasticsearch.md
@@ -296,6 +296,11 @@ Publish a mapping change in this order:
 
 ## Configure Event Stream Index Template
 
+The built-in templates disable automatic date detection; map domain date fields explicitly in an aggregate-specific
+template. Event entries are `nested`, while `body[].body` remains available in `_source` but is not indexed, preventing
+arbitrary event payloads from breaking event persistence through mapping conflicts. Use `ELEM_MATCH` for event-entry
+metadata queries, and install an explicit higher-priority mapping only when payload search is required.
+
 ```http request
 POST _index_template/wow-event-stream-template
 {
@@ -304,6 +309,7 @@ POST _index_template/wow-event-stream-template
   ],
   "template": {
     "mappings": {
+      "date_detection": false,
       "properties": {
         "aggregateId": {
           "type": "keyword"
@@ -312,7 +318,12 @@ POST _index_template/wow-event-stream-template
           "type": "keyword"
         },
         "body": {
+          "type": "nested",
           "properties": {
+            "body": {
+              "type": "object",
+              "enabled": false
+            },
             "bodyType": {
               "type": "keyword"
             },
@@ -355,6 +366,12 @@ POST _index_template/wow-event-stream-template
         "tenantId": {
           "type": "keyword"
         },
+        "ownerId": {
+          "type": "keyword"
+        },
+        "spaceId": {
+          "type": "keyword"
+        },
         "version": {
           "type": "integer"
         }
@@ -364,7 +381,8 @@ POST _index_template/wow-event-stream-template
           "string_as_keyword": {
             "match_mapping_type": "string",
             "mapping": {
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 8191
             }
           }
         }
@@ -384,6 +402,7 @@ POST _index_template/wow-snapshot-template
   ],
   "template": {
     "mappings": {
+      "date_detection": false,
       "properties": {
         "contextName": {
           "type": "keyword"
@@ -401,6 +420,12 @@ POST _index_template/wow-snapshot-template
           "type": "integer"
         },
         "eventId": {
+          "type": "keyword"
+        },
+        "ownerId": {
+          "type": "keyword"
+        },
+        "spaceId": {
           "type": "keyword"
         },
         "firstOperator": {
@@ -421,6 +446,10 @@ POST _index_template/wow-snapshot-template
         "deleted": {
           "type": "boolean"
         },
+        "tags": {
+          "type": "object",
+          "dynamic": true
+        },
         "state": {
           "properties": {
             "id": {
@@ -434,11 +463,22 @@ POST _index_template/wow-snapshot-template
       },
       "dynamic_templates": [
         {
+          "tags_strings_as_keyword": {
+            "match_mapping_type": "string",
+            "path_match": "tags.*",
+            "mapping": {
+              "type": "keyword",
+              "ignore_above": 8191
+            }
+          }
+        },
+        {
           "id_string_as_keyword": {
             "match": "id",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 8191
             }
           }
         },
@@ -447,7 +487,8 @@ POST _index_template/wow-snapshot-template
             "match": "*Id",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 8191
             }
           }
         }

--- a/documentation/docs/en/guide/extensions/elasticsearch.md
+++ b/documentation/docs/en/guide/extensions/elasticsearch.md
@@ -298,8 +298,38 @@ Publish a mapping change in this order:
 
 The built-in templates disable automatic date detection; map domain date fields explicitly in an aggregate-specific
 template. Event entries are `nested`, while `body[].body` remains available in `_source` but is not indexed, preventing
-arbitrary event payloads from breaking event persistence through mapping conflicts. Use `ELEM_MATCH` for event-entry
-metadata queries, and install an explicit higher-priority mapping only when payload search is required.
+arbitrary payloads from breaking persistence through mapping conflicts. One event stream is limited to 10,000 events,
+matching Elasticsearch's default nested-object limit.
+
+Elasticsearch `ELEM_MATCH` children use fully qualified paths:
+
+```kotlin
+condition {
+    "body" elemMatch {
+        "body.name" eq "Created"
+    }
+}
+```
+
+```json
+{
+  "condition": {
+    "field": "body",
+    "operator": "ELEM_MATCH",
+    "children": [
+      {
+        "field": "body.name",
+        "operator": "EQ",
+        "value": "Created"
+      }
+    ]
+  }
+}
+```
+
+Payload search or custom nested semantics require an application-owned higher-priority template and matching query
+converter. That template must reproduce the complete built-in baseline because composable templates do not merge by
+priority.
 
 ```http request
 POST _index_template/wow-event-stream-template

--- a/documentation/docs/en/guide/extensions/elasticsearch.md
+++ b/documentation/docs/en/guide/extensions/elasticsearch.md
@@ -534,30 +534,21 @@ Leverage Elasticsearch's full-text search capabilities for complex queries on sn
 
 ### Add Full-Text Index for State Fields
 
-```http request
-POST _index_template/wow-order-snapshot-template
+The following is only the custom `state.properties` fragment; do not submit it as an index template:
+
+```json
 {
-  "index_patterns": [
-    "wow.*.order.snapshot"
-  ],
-  "priority": 100,
-  "template": {
-    "mappings": {
-      "properties": {
-        "state": {
-          "properties": {
-            "description": {
-              "type": "text",
-              "analyzer": "standard"
-            },
-            "customerName": {
-              "type": "text",
-              "fields": {
-                "keyword": {
-                  "type": "keyword"
-                }
-              }
-            }
+  "state": {
+    "properties": {
+      "description": {
+        "type": "text",
+        "analyzer": "standard"
+      },
+      "customerName": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
           }
         }
       }
@@ -566,9 +557,10 @@ POST _index_template/wow-order-snapshot-template
 }
 ```
 
-The higher priority makes the aggregate template win over Wow's default snapshot template. The shortened example
-shows only the custom fields; a production replacement must also include the required baseline snapshot mappings, or
-compose both baseline and custom mappings from component templates.
+To publish `wow-order-snapshot-template`, copy the complete built-in snapshot template shown above, merge this fragment
+into `mappings.properties`, narrow `index_patterns`, and then set `priority: 100`. A higher-priority composable template
+replaces Wow's default template instead of merging with it; never publish the fragment alone. Alternatively, build the
+complete mapping from operator-owned baseline and custom component templates.
 
 ### Execute Full-Text Search
 

--- a/documentation/docs/zh/guide/extensions/elasticsearch.md
+++ b/documentation/docs/zh/guide/extensions/elasticsearch.md
@@ -519,30 +519,21 @@ POST _index_template/wow-snapshot-template
 
 ### 为状态字段添加全文索引
 
-```http request
-POST _index_template/wow-order-snapshot-template
+以下内容只是自定义 `state.properties` 片段，不能作为索引模板直接提交：
+
+```json
 {
-  "index_patterns": [
-    "wow.*.order.snapshot"
-  ],
-  "priority": 100,
-  "template": {
-    "mappings": {
-      "properties": {
-        "state": {
-          "properties": {
-            "description": {
-              "type": "text",
-              "analyzer": "standard"
-            },
-            "customerName": {
-              "type": "text",
-              "fields": {
-                "keyword": {
-                  "type": "keyword"
-                }
-              }
-            }
+  "state": {
+    "properties": {
+      "description": {
+        "type": "text",
+        "analyzer": "standard"
+      },
+      "customerName": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
           }
         }
       }
@@ -551,8 +542,10 @@ POST _index_template/wow-order-snapshot-template
 }
 ```
 
-更高的优先级会使聚合模板覆盖 Wow 默认快照模板。上例为简洁起见只展示自定义字段；生产模板还必须包含快照所需的
-基础映射，或者通过 component template 组合基础映射与自定义映射。
+发布 `wow-order-snapshot-template` 时，先复制上文完整的内置快照模板，将该片段合并到
+`mappings.properties`，收窄 `index_patterns`，最后设置 `priority: 100`。高优先级 composable template 会替换而非
+合并 Wow 默认模板，绝不能单独发布上述片段。也可以通过运维自有的基础 component template 和自定义 component
+template 组合出完整 Mapping。
 
 ::: tip
 如果需要中文分词支持，可以安装 [IK 分析器插件](https://github.com/medcl/elasticsearch-analysis-ik)，然后使用 `ik_max_word` 和 `ik_smart` 分析器。

--- a/documentation/docs/zh/guide/extensions/elasticsearch.md
+++ b/documentation/docs/zh/guide/extensions/elasticsearch.md
@@ -283,9 +283,38 @@ Mapping 发布必须按以下顺序执行：
 
 ## 配置事件流索引模板
 
-内置模板关闭自动日期探测，业务日期字段应在聚合专用模板中显式映射。事件条目使用 `nested`，其中的
-`body[].body` 仍保留在 `_source`，但不参与索引，避免任意事件载荷因 Mapping 冲突阻断事件持久化。
-查询事件条目元数据时使用 `ELEM_MATCH`；只有确实需要检索事件载荷时，才安装显式的高优先级 Mapping。
+内置模板关闭自动日期探测，业务日期字段应在聚合专用模板中显式映射。事件条目使用 `nested`；`body[].body`
+仍保留在 `_source`，但不参与索引，避免任意载荷因 Mapping 冲突阻断持久化。单个事件流最多包含 10,000 个事件，
+与 Elasticsearch 默认的 nested-object 上限一致。
+
+Elasticsearch 的 `ELEM_MATCH` 子条件必须使用完整路径：
+
+```kotlin
+condition {
+    "body" elemMatch {
+        "body.name" eq "Created"
+    }
+}
+```
+
+```json
+{
+  "condition": {
+    "field": "body",
+    "operator": "ELEM_MATCH",
+    "children": [
+      {
+        "field": "body.name",
+        "operator": "EQ",
+        "value": "Created"
+      }
+    ]
+  }
+}
+```
+
+需要检索载荷或自定义 nested 语义时，应用必须提供高优先级模板和匹配的查询转换器。由于 composable template
+不会按优先级合并，该模板必须完整复现内置基础 Mapping。
 
 ```http request
 POST _index_template/wow-event-stream-template

--- a/documentation/docs/zh/guide/extensions/elasticsearch.md
+++ b/documentation/docs/zh/guide/extensions/elasticsearch.md
@@ -283,6 +283,10 @@ Mapping 发布必须按以下顺序执行：
 
 ## 配置事件流索引模板
 
+内置模板关闭自动日期探测，业务日期字段应在聚合专用模板中显式映射。事件条目使用 `nested`，其中的
+`body[].body` 仍保留在 `_source`，但不参与索引，避免任意事件载荷因 Mapping 冲突阻断事件持久化。
+查询事件条目元数据时使用 `ELEM_MATCH`；只有确实需要检索事件载荷时，才安装显式的高优先级 Mapping。
+
 ```http request
 POST _index_template/wow-event-stream-template
 {
@@ -291,6 +295,7 @@ POST _index_template/wow-event-stream-template
   ],
   "template": {
     "mappings": {
+      "date_detection": false,
       "properties": {
         "aggregateId": {
           "type": "keyword"
@@ -299,7 +304,12 @@ POST _index_template/wow-event-stream-template
           "type": "keyword"
         },
         "body": {
+          "type": "nested",
           "properties": {
+            "body": {
+              "type": "object",
+              "enabled": false
+            },
             "bodyType": {
               "type": "keyword"
             },
@@ -342,6 +352,12 @@ POST _index_template/wow-event-stream-template
         "tenantId": {
           "type": "keyword"
         },
+        "ownerId": {
+          "type": "keyword"
+        },
+        "spaceId": {
+          "type": "keyword"
+        },
         "version": {
           "type": "integer"
         }
@@ -351,7 +367,8 @@ POST _index_template/wow-event-stream-template
           "string_as_keyword": {
             "match_mapping_type": "string",
             "mapping": {
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 8191
             }
           }
         }
@@ -371,6 +388,7 @@ POST _index_template/wow-snapshot-template
   ],
   "template": {
     "mappings": {
+      "date_detection": false,
       "properties": {
         "contextName": {
           "type": "keyword"
@@ -388,6 +406,12 @@ POST _index_template/wow-snapshot-template
           "type": "integer"
         },
         "eventId": {
+          "type": "keyword"
+        },
+        "ownerId": {
+          "type": "keyword"
+        },
+        "spaceId": {
           "type": "keyword"
         },
         "firstOperator": {
@@ -408,6 +432,10 @@ POST _index_template/wow-snapshot-template
         "deleted": {
           "type": "boolean"
         },
+        "tags": {
+          "type": "object",
+          "dynamic": true
+        },
         "state": {
           "properties": {
             "id": {
@@ -421,11 +449,22 @@ POST _index_template/wow-snapshot-template
       },
       "dynamic_templates": [
         {
+          "tags_strings_as_keyword": {
+            "match_mapping_type": "string",
+            "path_match": "tags.*",
+            "mapping": {
+              "type": "keyword",
+              "ignore_above": 8191
+            }
+          }
+        },
+        {
           "id_string_as_keyword": {
             "match": "id",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 8191
             }
           }
         },
@@ -434,7 +473,8 @@ POST _index_template/wow-snapshot-template
             "match": "*Id",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 8191
             }
           }
         }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchEventStore.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchEventStore.kt
@@ -59,6 +59,7 @@ class ElasticsearchEventStore(
     companion object {
         private const val NOT_FOUND_CODE = 404
         private const val DEFAULT_BATCH_SIZE = 10000
+        private const val MAX_EVENT_STREAM_SIZE = 10000
     }
 
     init {
@@ -71,7 +72,13 @@ class ElasticsearchEventStore(
     )
 
     override fun appendStream(eventStream: DomainEventStream): Mono<Void> {
-        return appender.append(eventStream)
+        return Mono.defer {
+            require(eventStream.size <= MAX_EVENT_STREAM_SIZE) {
+                "eventStream.size[${eventStream.size}] must not exceed Elasticsearch nested object limit" +
+                    "[$MAX_EVENT_STREAM_SIZE]."
+            }
+            appender.append(eventStream)
+        }
     }
 
     override fun loadStream(

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchSortConverter.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchSortConverter.kt
@@ -17,6 +17,7 @@ import co.elastic.clients.elasticsearch._types.SortOptions
 import co.elastic.clients.elasticsearch._types.SortOrder
 import me.ahoo.wow.api.query.Sort
 import me.ahoo.wow.query.converter.SortConverter
+import me.ahoo.wow.serialization.MessageRecords
 
 object ElasticsearchSortConverter : SortConverter<List<SortOptions>> {
     override fun convert(sort: List<Sort>): List<SortOptions> {
@@ -24,6 +25,10 @@ object ElasticsearchSortConverter : SortConverter<List<SortOptions>> {
             SortOptions.of { sortBuilder ->
                 sortBuilder.field { fieldBuilder ->
                     fieldBuilder.field(it.field).order(it.direction.toSortOrder())
+                    if (it.field.startsWith("${MessageRecords.BODY}.")) {
+                        fieldBuilder.nested { nested -> nested.path(MessageRecords.BODY) }
+                    }
+                    fieldBuilder
                 }
             }
         }

--- a/wow-elasticsearch/src/main/resources/templates/wow-event-stream-template.json
+++ b/wow-elasticsearch/src/main/resources/templates/wow-event-stream-template.json
@@ -4,6 +4,7 @@
   ],
   "template": {
     "mappings": {
+      "date_detection": false,
       "properties": {
         "aggregateId": {
           "type": "keyword"
@@ -12,7 +13,12 @@
           "type": "keyword"
         },
         "body": {
+          "type": "nested",
           "properties": {
+            "body": {
+              "type": "object",
+              "enabled": false
+            },
             "bodyType": {
               "type": "keyword"
             },
@@ -70,7 +76,8 @@
           "string_as_keyword": {
             "match_mapping_type": "string",
             "mapping": {
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 8191
             }
           }
         }

--- a/wow-elasticsearch/src/main/resources/templates/wow-snapshot-template.json
+++ b/wow-elasticsearch/src/main/resources/templates/wow-snapshot-template.json
@@ -4,6 +4,7 @@
   ],
   "template": {
     "mappings": {
+      "date_detection": false,
       "properties": {
         "contextName": {
           "type": "keyword"
@@ -68,7 +69,8 @@
             "match_mapping_type": "string",
             "path_match": "tags.*",
             "mapping": {
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 8191
             }
           }
         },
@@ -77,7 +79,8 @@
             "match": "id",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 8191
             }
           }
         },
@@ -86,7 +89,8 @@
             "match": "*Id",
             "match_mapping_type": "string",
             "mapping": {
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 8191
             }
           }
         }

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/IndexTemplateInitializerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/IndexTemplateInitializerTest.kt
@@ -17,12 +17,15 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.serialization.JsonSerializer
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.springframework.core.io.ClassPathResource
 import org.springframework.data.elasticsearch.core.ReactiveElasticsearchOperations
 import org.springframework.data.elasticsearch.core.ReactiveIndexOperations
 import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates
 import reactor.core.publisher.Mono
+import tools.jackson.databind.JsonNode
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -32,6 +35,24 @@ class IndexTemplateInitializerTest {
         every { indexOps(any<IndexCoordinates>()) } returns indexOperations
     }
     private val initializer = IndexTemplateInitializer(elasticsearchOperations)
+
+    @Test
+    fun `built-in templates should protect dynamic mappings`() {
+        val eventMappings = readMappings("wow-event-stream-template")
+        eventMappings["date_detection"].asBoolean().assert().isEqualTo(false)
+        eventMappings["properties"]["body"]["type"].asString().assert().isEqualTo("nested")
+        eventMappings["properties"]["body"]["properties"]["body"]["enabled"]
+            .asBoolean().assert().isEqualTo(false)
+        eventMappings["dynamic_templates"][0]["string_as_keyword"]["mapping"]["ignore_above"]
+            .asInt().assert().isEqualTo(8191)
+
+        val snapshotMappings = readMappings("wow-snapshot-template")
+        snapshotMappings["date_detection"].asBoolean().assert().isEqualTo(false)
+        snapshotMappings["dynamic_templates"].forEach { template ->
+            template.properties().single().value["mapping"]["ignore_above"]
+                .asInt().assert().isEqualTo(8191)
+        }
+    }
 
     @Test
     fun `init all should complete both template requests before returning`() {
@@ -86,4 +107,9 @@ class IndexTemplateInitializerTest {
     fun `legacy init subscriber should retain its name`() {
         IndexTemplateInitializer.InitSubscriber("legacy").name.assert().isEqualTo("legacy")
     }
+
+    private fun readMappings(templateName: String): JsonNode =
+        ClassPathResource("templates/$templateName.json").inputStream.use {
+            JsonSerializer.readValue(it, JsonNode::class.java)["template"]["mappings"]
+        }
 }

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchEventStoreAppendTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchEventStoreAppendTest.kt
@@ -68,6 +68,21 @@ class ElasticsearchEventStoreAppendTest {
     }
 
     @Test
+    fun `event stream should not exceed nested object limit`() {
+        ElasticsearchEventStore(client)
+            .append(eventStream("order-too-many-events", eventCount = 10001))
+            .test()
+            .expectErrorMatches {
+                it is IllegalArgumentException &&
+                    it.message ==
+                    "eventStream.size[10001] must not exceed Elasticsearch nested object limit[10000]."
+            }
+            .verify()
+
+        verify(exactly = 0) { client.index(any<IndexRequest<Map<String, Any?>>>()) }
+    }
+
+    @Test
     fun `direct create conflict should preserve version conflict semantics`() {
         val failure = mockk<ElasticsearchException> {
             every { status() } returns 409
@@ -385,11 +400,12 @@ class ElasticsearchEventStoreAppendTest {
     private fun eventStream(
         id: String,
         aggregateVersion: Int = 0,
+        eventCount: Int = 1,
     ): DomainEventStream {
         return MockDomainEventStreams.generateEventStream(
             aggregateId = namedAggregate.aggregateId(id),
             aggregateVersion = aggregateVersion,
-            eventCount = 1,
+            eventCount = eventCount,
         )
     }
 

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchSortConverterTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchSortConverterTest.kt
@@ -18,6 +18,7 @@ import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.query.Sort
 import me.ahoo.wow.elasticsearch.query.ElasticsearchSortConverter.toSortOptions
 import me.ahoo.wow.query.dsl.sort
+import me.ahoo.wow.serialization.MessageRecords
 import org.junit.jupiter.api.Test
 
 class ElasticsearchSortConverterTest {
@@ -48,5 +49,14 @@ class ElasticsearchSortConverterTest {
         val actual = sort.toSortOptions()
 
         actual.isEmpty().assert().isTrue()
+    }
+
+    @Test
+    fun `should add nested context to event body sort`() {
+        val actual = sort {
+            "${MessageRecords.BODY}.name".asc()
+        }.toSortOptions().single().field()
+
+        requireNotNull(actual.nested()).path().assert().isEqualTo(MessageRecords.BODY)
     }
 }


### PR DESCRIPTION
## Goal

Prevent Elasticsearch dynamic mapping from rejecting event streams or snapshots when domain strings look like dates, event payload schemas evolve, or dynamic keyword values exceed Lucene's term limit. Preserve per-event query semantics for the event array.

## Changes

- disable automatic date detection in the built-in event stream and snapshot mappings
- map event entries as `nested` and keep arbitrary `body[].body` payloads in `_source` without indexing them
- reject event streams above Elasticsearch default 10,000 nested-object limit before persistence
- add UTF-8-safe `ignore_above: 8191` guards to dynamic keyword mappings
- add a focused template contract test
- synchronize the English and Chinese Elasticsearch documentation with the shipped templates

## Verification

- `./gradlew :wow-elasticsearch:check` — passed, 133 tests
- `cd documentation && pnpm docs:build` — passed
- Elasticsearch 9.2.6 live verification — evolving payload types, date-shaped strings, and 40,000-byte dynamic values indexed successfully; nested metadata queries returned 0 cross-entry matches and 1 same-entry match
- embedded documentation templates compared equal to the resource JSON after normalized `jq` parsing

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

Index templates apply only to indices created after the template update. Existing indices keep their current mappings and require a controlled reindex or rebuild to adopt `nested` event entries. Event payloads remain available in `_source` but are no longer searchable through the built-in template; applications that require payload search must provide an explicit higher-priority aggregate template. Rollback of mapping behavior likewise requires recreating affected indices.