### PR TITLE
fix(webflux): remove HTTP query field allowlists

### DIFF
--- a/documentation/docs/en/guide/extensions/webflux.md
+++ b/documentation/docs/en/guide/extensions/webflux.md
@@ -92,8 +92,6 @@ plus `wow-webflux` for these properties to be bound.
 | `query.max-page-window` | `Long` | `10000` | Maximum HTTP `index * size` page window; `0` disables the cap |
 | `query.max-condition-nodes` | `Int` | `64` | Maximum number of HTTP query condition nodes; `0` disables the cap |
 | `query.max-condition-values` | `Int` | `1000` | Maximum values in HTTP `IN`, `NOT_IN`, `ALL_IN`, `IDS`, or `AGGREGATE_IDS` conditions; `0` disables the cap |
-| `query.allowed-sort-fields` | `Set<String>` | `[]` | Indexed logical fields allowed for explicit HTTP sorting; an empty set rejects all explicit sorts and `["*"]` disables the restriction |
-| `query.allowed-condition-fields` | `Set<String>` | `[]` | Additional indexed logical fields allowed in HTTP predicates; an empty set keeps built-in `aggregateId`, aggregate-ID-scoped `version`, and indexed fieldless logical/metadata operators; `spaceId` requires explicit allowlisting, while `["*"]` disables the restriction |
 | `query.allow-raw` | `Boolean` | `false` | Whether HTTP queries may use native `RAW` conditions |
 | `query.allow-expensive-operators` | `Boolean` | `false` | Whether HTTP queries may use negative/existence/expensive string operators or unfiltered count/paged queries |
 | `query.idle-timeout` | `Duration` | `10s` | Maximum wait between results or completion; JSON arrays are buffered before the response is committed, while SSE remains streaming; `0s` disables the timeout |
@@ -113,15 +111,13 @@ wow:
       max-page-window: 10000
       max-condition-nodes: 64
       max-condition-values: 1000
-      allowed-sort-fields: []
-      allowed-condition-fields: []
       allow-raw: false
       allow-expensive-operators: false
       idle-timeout: 10s
 ```
 
 When `wow-spring-boot-starter` is used, WebFlux is included as the `webflux-support` feature capability. The global error handler is enabled by default; disable it only if you provide your own `WebExceptionHandler`.
-The guard applies whenever the Reactor context contains a WebFlux `ServerRequest` through `writeRawRequest(request)`, including built-in routes and custom HTTP handlers. Injected query services and non-WebFlux request contexts keep their existing behavior. For `ELEM_MATCH`, Mongo request children use relative fields such as `productId`, while Elasticsearch nested children use full logical fields such as `state.items.productId`; `allowed-condition-fields` always lists the full effective path. To temporarily restore the previous HTTP behavior after upgrading, set the numeric limits and `idle-timeout` to `0`, enable both `allow-*` switches, and set both `allowed-*-fields` properties to `["*"]`.
+The guard applies whenever the Reactor context contains a WebFlux `ServerRequest` through `writeRawRequest(request)`, including built-in routes and custom HTTP handlers. Injected query services and non-WebFlux request contexts keep their existing behavior. To temporarily restore the previous HTTP behavior after upgrading, set the numeric limits and `idle-timeout` to `0` and enable both `allow-*` switches.
 
 ## Wait Plan Integration
 

--- a/documentation/docs/en/reference/config/infrastructure.md
+++ b/documentation/docs/en/reference/config/infrastructure.md
@@ -178,8 +178,6 @@ snapshots.
 | `wow.webflux.query.max-page-window` | Long | `10000` | Maximum HTTP page window; `0` disables the cap |
 | `wow.webflux.query.max-condition-nodes` | Integer | `64` | Maximum HTTP query condition nodes; `0` disables the cap |
 | `wow.webflux.query.max-condition-values` | Integer | `1000` | Maximum values in HTTP `IN`, `NOT_IN`, `ALL_IN`, `IDS`, or `AGGREGATE_IDS` conditions; `0` disables the cap |
-| `wow.webflux.query.allowed-sort-fields` | `Set<String>` | `[]` | Indexed logical fields allowed for explicit HTTP sorting; an empty set rejects all explicit sorts and `["*"]` disables the restriction |
-| `wow.webflux.query.allowed-condition-fields` | `Set<String>` | `[]` | Additional indexed logical fields allowed in HTTP predicates; `spaceId` requires explicit allowlisting, and `["*"]` disables the restriction |
 | `wow.webflux.query.allow-raw` | Boolean | `false` | Allow native HTTP `RAW` queries |
 | `wow.webflux.query.allow-expensive-operators` | Boolean | `false` | Allow HTTP negative/existence/expensive string operators or unfiltered count/paged queries |
 | `wow.webflux.query.idle-timeout` | Duration | `10s` | Maximum wait between results or completion; JSON arrays are buffered before commit, while SSE remains streaming; `0s` disables it |
@@ -201,8 +199,6 @@ wow:
       max-page-window: 10000
       max-condition-nodes: 64
       max-condition-values: 1000
-      allowed-sort-fields: []
-      allowed-condition-fields: []
       allow-raw: false
       allow-expensive-operators: false
       idle-timeout: 10s

--- a/documentation/docs/zh/guide/extensions/webflux.md
+++ b/documentation/docs/zh/guide/extensions/webflux.md
@@ -90,8 +90,6 @@ data class CreateOrder(/* ... */)
 | `query.max-page-window` | `Long` | `10000` | HTTP 分页查询允许的最大 `index * size`；`0` 关闭上限 |
 | `query.max-condition-nodes` | `Int` | `64` | HTTP 查询条件树的最大节点数；`0` 关闭上限 |
 | `query.max-condition-values` | `Int` | `1000` | HTTP `IN`、`NOT_IN`、`ALL_IN`、`IDS`、`AGGREGATE_IDS` 条件的最大值数量；`0` 关闭上限 |
-| `query.allowed-sort-fields` | `Set<String>` | `[]` | HTTP 显式排序允许的已索引逻辑字段；空集拒绝所有显式排序，`["*"]` 关闭限制 |
-| `query.allowed-condition-fields` | `Set<String>` | `[]` | HTTP 条件允许的额外已索引逻辑字段；空集保留内置 `aggregateId`、受聚合 ID 约束的 `version` 以及已索引的无字段逻辑/元数据操作符；`spaceId` 必须显式加入白名单，`["*"]` 关闭限制 |
 | `query.allow-raw` | `Boolean` | `false` | 是否允许 HTTP 查询使用 `RAW` 原生条件 |
 | `query.allow-expensive-operators` | `Boolean` | `false` | 是否允许 HTTP 查询使用负向/存在性/高成本字符串操作符及无过滤 count/paged 查询 |
 | `query.idle-timeout` | `Duration` | `10s` | 等待下一条结果或完成的最长时间；普通 JSON 数组在提交响应前缓冲，SSE 保持流式；`0s` 关闭超时 |
@@ -111,15 +109,13 @@ wow:
       max-page-window: 10000
       max-condition-nodes: 64
       max-condition-values: 1000
-      allowed-sort-fields: []
-      allowed-condition-fields: []
       allow-raw: false
       allow-expensive-operators: false
       idle-timeout: 10s
 ```
 
 使用 `wow-spring-boot-starter` 时，WebFlux 作为 `webflux-support` 特性能力包含在内。全局异常处理器默认启用；仅当你提供自己的 `WebExceptionHandler` 时才需关闭。
-Reactor Context 通过 `writeRawRequest(request)` 携带 WebFlux `ServerRequest` 时都会启用护栏，包括内置路由和自定义 HTTP Handler；程序内注入的查询服务和非 WebFlux 请求上下文保持原行为。`ELEM_MATCH` 的 Mongo 请求子字段使用 `productId` 这类相对路径，Elasticsearch nested 请求子字段使用 `state.items.productId` 这类完整逻辑路径；`allowed-condition-fields` 始终配置完整有效路径。升级后如需临时恢复旧 HTTP 行为，可将数值限制和 `idle-timeout` 设为 `0`，启用两个 `allow-*` 开关，并将两个 `allowed-*-fields` 设为 `["*"]`。
+Reactor Context 通过 `writeRawRequest(request)` 携带 WebFlux `ServerRequest` 时都会启用护栏，包括内置路由和自定义 HTTP Handler；程序内注入的查询服务和非 WebFlux 请求上下文保持原行为。升级后如需临时恢复旧 HTTP 行为，可将数值限制和 `idle-timeout` 设为 `0`，并启用两个 `allow-*` 开关。
 
 ## 等待计划集成
 

--- a/documentation/docs/zh/reference/config/infrastructure.md
+++ b/documentation/docs/zh/reference/config/infrastructure.md
@@ -177,8 +177,6 @@ direct 和 batch 模式下都使用基于 `_source.version` 的原子保护更�
 | `wow.webflux.query.max-page-window` | Long | `10000` | HTTP 查询最大分页窗口；`0` 关闭上限 |
 | `wow.webflux.query.max-condition-nodes` | Integer | `64` | HTTP 查询条件节点上限；`0` 关闭上限 |
 | `wow.webflux.query.max-condition-values` | Integer | `1000` | HTTP `IN`、`NOT_IN`、`ALL_IN`、`IDS`、`AGGREGATE_IDS` 条件值数量上限；`0` 关闭上限 |
-| `wow.webflux.query.allowed-sort-fields` | `Set<String>` | `[]` | HTTP 显式排序允许的已索引逻辑字段；空集拒绝所有显式排序，`["*"]` 关闭限制 |
-| `wow.webflux.query.allowed-condition-fields` | `Set<String>` | `[]` | HTTP 条件允许的额外已索引逻辑字段；`spaceId` 必须显式加入白名单，`["*"]` 关闭限制 |
 | `wow.webflux.query.allow-raw` | Boolean | `false` | 允许 HTTP `RAW` 查询 |
 | `wow.webflux.query.allow-expensive-operators` | Boolean | `false` | 允许 HTTP 负向/存在性/高成本字符串操作符及无过滤 count/paged 查询 |
 | `wow.webflux.query.idle-timeout` | Duration | `10s` | 等待下一条结果或完成的最长时间；普通 JSON 数组在提交前缓冲，SSE 保持流式；`0s` 关闭 |
@@ -200,8 +198,6 @@ wow:
       max-page-window: 10000
       max-condition-nodes: 64
       max-condition-values: 1000
-      allowed-sort-fields: []
-      allowed-condition-fields: []
       allow-raw: false
       allow-expensive-operators: false
       idle-timeout: 10s

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfiguration.kt
@@ -132,8 +132,6 @@ class WebFluxAutoConfiguration {
             maxPageWindow = query.maxPageWindow,
             maxConditionNodes = query.maxConditionNodes,
             maxConditionValues = query.maxConditionValues,
-            allowedSortFields = query.allowedSortFields,
-            allowedConditionFields = query.allowedConditionFields,
             allowRaw = query.allowRaw,
             allowExpensiveOperators = query.allowExpensiveOperators,
             idleTimeout = query.idleTimeout,

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxProperties.kt
@@ -60,22 +60,11 @@ constructor(
         var maxConditionNodes: Int = 64,
         @DefaultValue("1000")
         var maxConditionValues: Int = 1000,
-        var allowedSortFields: Set<String> = emptySet(),
-        var allowedConditionFields: Set<String> = emptySet(),
         @DefaultValue("false")
         var allowRaw: Boolean = false,
         @DefaultValue("false")
         var allowExpensiveOperators: Boolean = false,
         @DefaultValue("10s")
         var idleTimeout: Duration = Duration.ofSeconds(10),
-    ) {
-        init {
-            require(maxListSize >= 0) { "maxListSize must be greater than or equal to 0." }
-            require(maxPageSize >= 0) { "maxPageSize must be greater than or equal to 0." }
-            require(maxPageWindow >= 0) { "maxPageWindow must be greater than or equal to 0." }
-            require(maxConditionNodes >= 0) { "maxConditionNodes must be greater than or equal to 0." }
-            require(maxConditionValues >= 0) { "maxConditionValues must be greater than or equal to 0." }
-            require(!idleTimeout.isNegative) { "idleTimeout must be greater than or equal to 0." }
-        }
-    }
+    )
 }

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
@@ -186,8 +186,6 @@ internal class WebFluxAutoConfigurationTest {
                 "${WebFluxProperties.PREFIX}.query.max-page-window=2000",
                 "${WebFluxProperties.PREFIX}.query.max-condition-nodes=32",
                 "${WebFluxProperties.PREFIX}.query.max-condition-values=50",
-                "${WebFluxProperties.PREFIX}.query.allowed-sort-fields=state.createdAt,state.id",
-                "${WebFluxProperties.PREFIX}.query.allowed-condition-fields=state.status,state.id",
                 "${WebFluxProperties.PREFIX}.query.allow-raw=true",
                 "${WebFluxProperties.PREFIX}.query.allow-expensive-operators=true",
                 "${WebFluxProperties.PREFIX}.query.idle-timeout=5s",
@@ -224,8 +222,6 @@ internal class WebFluxAutoConfigurationTest {
                 properties.query.maxPageWindow.assert().isEqualTo(2000)
                 properties.query.maxConditionNodes.assert().isEqualTo(32)
                 properties.query.maxConditionValues.assert().isEqualTo(50)
-                properties.query.allowedSortFields.assert().isEqualTo(setOf("state.createdAt", "state.id"))
-                properties.query.allowedConditionFields.assert().isEqualTo(setOf("state.status", "state.id"))
                 properties.query.allowRaw.assert().isTrue()
                 properties.query.allowExpensiveOperators.assert().isTrue()
                 properties.query.idleTimeout.assert().isEqualTo(Duration.ofSeconds(5))

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilter.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilter.kt
@@ -21,7 +21,6 @@ import me.ahoo.wow.api.query.DeletionState
 import me.ahoo.wow.api.query.IListQuery
 import me.ahoo.wow.api.query.IPagedQuery
 import me.ahoo.wow.api.query.Operator
-import me.ahoo.wow.api.query.Queryable
 import me.ahoo.wow.filter.FilterChain
 import me.ahoo.wow.filter.FilterType
 import me.ahoo.wow.query.event.filter.EventStreamQueryHandler
@@ -30,7 +29,6 @@ import me.ahoo.wow.query.filter.QueryContext
 import me.ahoo.wow.query.filter.QueryFilter
 import me.ahoo.wow.query.filter.QueryType
 import me.ahoo.wow.query.snapshot.filter.SnapshotQueryHandler
-import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.webflux.route.acceptsEventStream
 import org.springframework.web.reactive.function.server.ServerRequest
 import reactor.core.publisher.Flux
@@ -46,8 +44,6 @@ class HttpQueryGuardFilter(
     private val maxPageWindow: Long = 10_000,
     private val maxConditionNodes: Int = 64,
     private val maxConditionValues: Int = 1000,
-    private val allowedSortFields: Set<String> = emptySet(),
-    private val allowedConditionFields: Set<String> = emptySet(),
     private val allowRaw: Boolean = false,
     private val allowExpensiveOperators: Boolean = false,
     private val idleTimeout: Duration = Duration.ofSeconds(10),
@@ -82,12 +78,6 @@ class HttpQueryGuardFilter(
         when (query) {
             is IListQuery -> validateList(query)
             is IPagedQuery -> validatePage(query)
-        }
-        if (query is Queryable<*>) {
-            val rejectedSortFields = query.sort.map { it.field }.filterNot { allowedSortFields.allows(it) }
-            require(rejectedSortFields.isEmpty()) {
-                "HTTP query sort fields$rejectedSortFields are not allowed."
-            }
         }
         val condition = when (query) {
             is Condition -> query
@@ -124,56 +114,28 @@ class HttpQueryGuardFilter(
     }
 
     private fun validateCondition(condition: Condition, rejectMatchAll: Boolean) {
-        val pending = ArrayDeque<Pair<Condition, String>>()
-        pending.add(condition to "")
-        val validatedNodes = mutableListOf<Pair<Condition, String>>()
+        val pending = ArrayDeque<Condition>()
+        pending.add(condition)
         var nodes = 0
         while (pending.isNotEmpty()) {
-            val (current, parentField) = pending.removeLast()
+            val current = pending.removeLast()
             nodes++
             require(maxConditionNodes == 0 || nodes <= maxConditionNodes) {
                 "HTTP query condition nodes[$nodes] must not exceed $maxConditionNodes."
             }
-            val effectiveField = when {
-                current.operator == Operator.SPACE_ID -> MessageRecords.SPACE_ID
-                current.field.isEmpty() -> ""
-                parentField.isEmpty() -> current.field
-                current.field == parentField || current.field.startsWith("$parentField.") -> current.field
-                else -> "$parentField.${current.field}"
-            }
-            validatedNodes.add(current to effectiveField)
-            val childParentField = if (current.operator == Operator.ELEM_MATCH) effectiveField else parentField
-            current.children.forEach { pending.add(it to childParentField) }
-        }
-        val aggregateIdScoped = condition.isAggregateIdScoped()
-        validatedNodes.forEach { (current, effectiveField) ->
-            validateConditionNode(current, effectiveField, aggregateIdScoped)
+            validateConditionNode(current)
+            pending.addAll(current.children)
         }
         require(!rejectMatchAll || !condition.isMatchAll()) {
             "HTTP counting query must not match all documents."
         }
     }
 
-    private fun validateConditionNode(
-        condition: Condition,
-        effectiveField: String,
-        aggregateIdScoped: Boolean,
-    ) {
+    private fun validateConditionNode(condition: Condition) {
         if (condition.operator == Operator.ELEM_MATCH) {
             require(condition.children.size == 1) {
                 "HTTP ELEM_MATCH condition must contain exactly one child."
             }
-        }
-        val fieldAllowed = effectiveField.isEmpty() && condition.operator in FIELDLESS_OPERATORS ||
-            effectiveField in BUILT_IN_CONDITION_FIELDS ||
-            effectiveField == MessageRecords.VERSION && aggregateIdScoped ||
-            allowedConditionFields.allows(effectiveField)
-        val hasIndexedElementChild = condition.operator == Operator.ELEM_MATCH &&
-            condition.children.single().hasFieldOrDescendant()
-        require(
-            fieldAllowed || hasIndexedElementChild
-        ) {
-            "HTTP query condition field[$effectiveField] is not allowed."
         }
         require(allowRaw || condition.operator != Operator.RAW) {
             "HTTP query operator[RAW] is not allowed."
@@ -189,31 +151,10 @@ class HttpQueryGuardFilter(
         }
     }
 
-    private fun Condition.hasFieldOrDescendant(): Boolean {
-        if (field.isNotEmpty()) return true
-        val pending = ArrayDeque(children)
-        while (pending.isNotEmpty()) {
-            val current = pending.removeLast()
-            if (current.field.isNotEmpty()) return true
-            pending.addAll(current.children)
-        }
-        return false
-    }
-
-    private fun Set<String>.allows(field: String): Boolean = FIELD_WILDCARD in this || field in this
-
     private fun Condition.isExpensive(): Boolean =
         operator in EXPENSIVE_OPERATORS ||
             operator == Operator.EXISTS && value == false ||
             operator == Operator.STARTS_WITH && ((value as? String).isNullOrEmpty() || ignoreCase() == true)
-
-    private fun Condition.isAggregateIdScoped(): Boolean = when (operator) {
-        Operator.AGGREGATE_ID -> true
-        Operator.EQ -> field == MessageRecords.AGGREGATE_ID
-        Operator.AND -> children.any { it.isAggregateIdScoped() }
-        Operator.OR -> children.isNotEmpty() && children.all { it.isAggregateIdScoped() }
-        else -> false
-    }
 
     private fun Condition.isMatchAll(): Boolean {
         val values = value
@@ -261,23 +202,7 @@ class HttpQueryGuardFilter(
             Operator.CONTAINS,
             Operator.ENDS_WITH,
         )
-        val BUILT_IN_CONDITION_FIELDS = setOf(MessageRecords.AGGREGATE_ID)
-        val FIELDLESS_OPERATORS = setOf(
-            Operator.AND,
-            Operator.OR,
-            Operator.NOR,
-            Operator.ID,
-            Operator.IDS,
-            Operator.AGGREGATE_ID,
-            Operator.AGGREGATE_IDS,
-            Operator.TENANT_ID,
-            Operator.OWNER_ID,
-            Operator.DELETED,
-            Operator.ALL,
-            Operator.RAW,
-        )
         val COUNTING_QUERY_TYPES = setOf(QueryType.PAGED, QueryType.DYNAMIC_PAGED, QueryType.COUNT)
-        const val FIELD_WILDCARD = "*"
         val COLLECTION_OPERATORS = setOf(
             Operator.IN,
             Operator.NOT_IN,

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
@@ -89,14 +89,10 @@ class HttpQueryGuardFilterTest {
             ListQuery(Condition.isNull(MessageRecords.AGGREGATE_ID), limit = 1),
             ListQuery(Condition.notNull(MessageRecords.AGGREGATE_ID), limit = 1),
             ListQuery(Condition.exists(MessageRecords.AGGREGATE_ID, false), limit = 1),
-            ListQuery(Condition.spaceId("space-id"), limit = 1),
-            ListQuery(Condition.eq("state.unindexed", "value"), limit = 1),
-            ListQuery(Condition.eq(MessageRecords.VERSION, 1), limit = 1),
             ListQuery(Condition(operator = Operator.NE, value = "value"), limit = 1),
             ListQuery(Condition.isIn(MessageRecords.AGGREGATE_ID, List(1001) { it }), limit = 1),
             ListQuery(Condition(operator = Operator.IDS, value = List(1001) { it }), limit = 1),
             ListQuery(Condition(operator = Operator.AGGREGATE_IDS, value = List(1001) { it }), limit = 1),
-            ListQuery(Condition.ALL, limit = 1, sort = listOf(Sort("state.unindexed", Sort.Direction.ASC))),
             ListQuery(Condition.and(List(65) { Condition.eq(MessageRecords.AGGREGATE_ID, it) }), limit = 1),
         ).forEach { query ->
             guard().filter(listContext(query), unexpectedBackend())
@@ -174,66 +170,35 @@ class HttpQueryGuardFilterTest {
     }
 
     @Test
-    fun `should allow indexed sort fields explicitly`() {
-        val context = listContext(
-            ListQuery(
-                Condition.eq("state.status", "ACTIVE"),
-                limit = 1,
-                sort = listOf(Sort("state.createdAt", Sort.Direction.DESC)),
+    fun `should allow application sort and condition fields`() {
+        val context = pagedContext(
+            PagedQuery(
+                Condition.and(
+                    Condition.eq("state.status", "ACTIVE"),
+                    Condition.spaceId("space-id"),
+                    Condition.eq(MessageRecords.VERSION, 1),
+                ),
+                sort = listOf(Sort(MessageRecords.AGGREGATE_ID, Sort.Direction.DESC)),
             ),
         )
-        guard(
-            allowedSortFields = setOf("state.createdAt"),
-            allowedConditionFields = setOf("state.status"),
-        ).filter(
+        guard().filter(
             context,
             FilterChain {
-                it.asListQuery<Any>().setResult(Flux.empty())
-                Mono.empty()
-            },
-        ).writeRawRequest(request).test().verifyComplete()
-
-        val spaceContext = listContext(ListQuery(Condition.spaceId("space-id"), limit = 1))
-        guard(allowedConditionFields = setOf(MessageRecords.SPACE_ID)).filter(
-            spaceContext,
-            FilterChain {
-                it.asListQuery<Any>().setResult(Flux.empty())
+                it.asPagedQuery<Any>().setResult(Mono.empty())
                 Mono.empty()
             },
         ).writeRawRequest(request).test().verifyComplete()
     }
 
     @Test
-    fun `should allow legacy fields with wildcard`() {
-        val context = listContext(
-            ListQuery(
-                Condition.eq("state.unindexed", "value"),
-                limit = 1,
-                sort = listOf(Sort("state.unindexed", Sort.Direction.ASC)),
-            ),
-        )
-        guard(
-            allowedSortFields = setOf("*"),
-            allowedConditionFields = setOf("*"),
-        ).filter(
-            context,
-            FilterChain {
-                it.asListQuery<Any>().setResult(Flux.empty())
-                Mono.empty()
-            },
-        ).writeRawRequest(request).test().verifyComplete()
-    }
-
-    @Test
-    fun `should validate element match children with effective paths`() {
-        val guard = guard(allowedConditionFields = setOf("state.items.productId"))
+    fun `should require one element match child`() {
         val context = listContext(
             ListQuery(
                 Condition.elemMatch("state.items", Condition.eq("productId", "product-1")),
                 limit = 1,
             ),
         )
-        guard.filter(
+        guard().filter(
             context,
             FilterChain {
                 it.asListQuery<Any>().setResult(Flux.empty())
@@ -241,38 +206,7 @@ class HttpQueryGuardFilterTest {
             },
         ).writeRawRequest(request).test().verifyComplete()
 
-        val qualifiedContext = listContext(
-            ListQuery(
-                Condition.elemMatch(
-                    "state.items",
-                    Condition.eq("state.items.productId", "product-1"),
-                ),
-                limit = 1,
-            ),
-        )
-        guard.filter(
-            qualifiedContext,
-            FilterChain {
-                it.asListQuery<Any>().setResult(Flux.empty())
-                Mono.empty()
-            },
-        ).writeRawRequest(request).test().verifyComplete()
-
-        guard.filter(
-            listContext(ListQuery(Condition.eq("productId", "product-1"), limit = 1)),
-            unexpectedBackend(),
-        ).writeRawRequest(request).test()
-            .expectError(IllegalArgumentException::class.java)
-            .verify()
-
-        guard.filter(
-            listContext(ListQuery(Condition.elemMatch("state.unindexed", Condition.ALL), limit = 1)),
-            unexpectedBackend(),
-        ).writeRawRequest(request).test()
-            .expectError(IllegalArgumentException::class.java)
-            .verify()
-
-        guard.filter(
+        guard().filter(
             listContext(
                 ListQuery(
                     Condition(
@@ -400,7 +334,7 @@ class HttpQueryGuardFilterTest {
     @Test
     fun `should run before concrete abac filters in the real snapshot chain`() {
         val handler = snapshotQueryHandler(
-            guard = guard(maxConditionNodes = 1, allowedConditionFields = setOf("state.status")),
+            guard = guard(maxConditionNodes = 1),
             abacQueryFilter = TestAbacQueryFilter,
         )
 
@@ -508,8 +442,6 @@ class HttpQueryGuardFilterTest {
         maxPageWindow: Long = 10_000,
         maxConditionNodes: Int = 64,
         maxConditionValues: Int = 1000,
-        allowedSortFields: Set<String> = emptySet(),
-        allowedConditionFields: Set<String> = emptySet(),
         allowRaw: Boolean = false,
         allowExpensiveOperators: Boolean = false,
         idleTimeout: Duration = Duration.ofSeconds(10),
@@ -519,8 +451,6 @@ class HttpQueryGuardFilterTest {
         maxPageWindow = maxPageWindow,
         maxConditionNodes = maxConditionNodes,
         maxConditionValues = maxConditionValues,
-        allowedSortFields = allowedSortFields,
-        allowedConditionFields = allowedConditionFields,
         allowRaw = allowRaw,
         allowExpensiveOperators = allowExpensiveOperators,
         idleTimeout = idleTimeout,


### PR DESCRIPTION
## Summary

- remove HTTP sort and condition field allowlists that reject valid application queries by default
- keep list, page, condition-size, RAW, expensive-operator, match-all counting, and idle-timeout safeguards
- remove duplicate configuration validation and simplify condition traversal
- update English and Chinese WebFlux configuration documentation

## Root cause

Wow 8.10.9 introduced empty field allowlists as the default. The compensation dashboard already sends aggregateId sorting and state.* predicates, so its built-in paged query is rejected before reaching the backend.

## Verification

- ./gradlew :wow-webflux:test --tests me.ahoo.wow.webflux.route.query.HttpQueryGuardFilterTest --console=plain
- ./gradlew :wow-spring-boot-starter:test --tests me.ahoo.wow.spring.boot.starter.webflux.WebFluxAutoConfigurationTest --console=plain
- ./gradlew :wow-webflux:check :wow-spring-boot-starter:check --console=plain
- pnpm docs:build
- git diff --check origin/main...HEAD