### PR TITLE
fix(query): expose fields and reduce client error logs

### DIFF
--- a/documentation/docs/en/guide/query.md
+++ b/documentation/docs/en/guide/query.md
@@ -46,6 +46,8 @@ state.items.0.productId
 
 A named segment starts with a letter or underscore and may contain letters, digits, underscores, and hyphens. Pure numeric segments are valid array indexes. MongoDB and Elasticsearch query implementations own physical field mapping.
 
+Aggregate-specific OpenAPI request bodies publish valid filter, projection, and sort paths in `x-wow-query-fields`. Use those paths even when a `/state` response unwraps the `state` object; for example, query the response property `status` as `state.status`.
+
 Snapshot queries default to `DELETION = ACTIVE`. A top-level `DELETION`, or one used directly inside the top-level `AND`, explicitly overrides that scope; nesting deletion inside `OR` or `NOR` does not disable the active guard. Event-stream queries do not add a deletion scope, preserving complete audit history.
 
 :::info Backend differences

--- a/documentation/docs/zh/guide/query.md
+++ b/documentation/docs/zh/guide/query.md
@@ -46,6 +46,8 @@ state.items.0.productId
 
 字段段以字母或下划线开头，可包含字母、数字、下划线和连字符；数组索引允许使用纯数字段。物理字段映射由 MongoDB 或 Elasticsearch 查询实现负责。
 
+聚合级 OpenAPI 请求体通过 `x-wow-query-fields` 发布可用的过滤、投影和排序字段路径。即使 `/state` 响应已解包 `state` 对象，查询仍应使用这里声明的路径；例如响应中的 `status` 应查询为 `state.status`。
+
 快照查询默认使用 `DELETION = ACTIVE`。顶层 `DELETION`，或顶层 `AND` 的直接 `DELETION` 子项，可以显式覆盖该范围；嵌套在 `OR` 或 `NOR` 中的删除过滤器不会关闭 active guard。事件流查询不会自动追加删除状态过滤，以保证审计事件完整。
 
 :::info 后端差异

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/QueryComponent.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/QueryComponent.kt
@@ -135,7 +135,7 @@ object QueryComponent {
         }
 
         private fun AggregateMetadata<*, *>.queryFields(): List<String> =
-            command.aggregateType.kotlin.commandAggregatedFieldPaths().filter(String::isNotBlank).sorted()
+            command.aggregateType.kotlin.commandAggregatedFieldPaths().sorted()
     }
 
     object Response {

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/QueryComponent.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/QueryComponent.kt
@@ -27,6 +27,7 @@ import me.ahoo.wow.openapi.QueryComponent.Schema.listQuerySchema
 import me.ahoo.wow.openapi.QueryComponent.Schema.pagedQuerySchema
 import me.ahoo.wow.openapi.QueryComponent.Schema.singleQuerySchema
 import me.ahoo.wow.openapi.context.OpenAPIComponentContext
+import me.ahoo.wow.schema.AggregatedFieldPaths.commandAggregatedFieldPaths
 import me.ahoo.wow.schema.typed.AggregatedDomainEventStream
 
 object QueryComponent {
@@ -81,8 +82,11 @@ object QueryComponent {
 
     object RequestBody {
 
+        private const val QUERY_FIELDS_EXTENSION = "x-wow-query-fields"
+
         fun OpenAPIComponentContext.aggregatedSingleQueryRequestBody(aggregateMetadata: AggregateMetadata<*, *>): io.swagger.v3.oas.models.parameters.RequestBody {
             return requestBody(aggregateMetadata.toStringWithAlias() + SINGLE_QUERY_SUFFIX) {
+                extension(QUERY_FIELDS_EXTENSION, aggregateMetadata.queryFields())
                 content(schema = singleQuerySchema())
             }
         }
@@ -95,6 +99,7 @@ object QueryComponent {
 
         fun OpenAPIComponentContext.aggregatedCountQueryRequestBody(aggregateMetadata: AggregateMetadata<*, *>): io.swagger.v3.oas.models.parameters.RequestBody {
             return requestBody(aggregateMetadata.toStringWithAlias() + COUNT_QUERY_SUFFIX) {
+                extension(QUERY_FIELDS_EXTENSION, aggregateMetadata.queryFields())
                 content(schema = filterSchema())
             }
         }
@@ -109,6 +114,7 @@ object QueryComponent {
             aggregateMetadata: AggregateMetadata<*, *>
         ): io.swagger.v3.oas.models.parameters.RequestBody {
             return requestBody(aggregateMetadata.toStringWithAlias() + LIST_QUERY_SUFFIX) {
+                extension(QUERY_FIELDS_EXTENSION, aggregateMetadata.queryFields())
                 content(schema = listQuerySchema())
             }
         }
@@ -123,9 +129,13 @@ object QueryComponent {
             aggregateMetadata: AggregateMetadata<*, *>
         ): io.swagger.v3.oas.models.parameters.RequestBody {
             return requestBody(aggregateMetadata.toStringWithAlias() + PAGED_QUERY_SUFFIX) {
+                extension(QUERY_FIELDS_EXTENSION, aggregateMetadata.queryFields())
                 content(schema = pagedQuerySchema())
             }
         }
+
+        private fun AggregateMetadata<*, *>.queryFields(): List<String> =
+            command.aggregateType.kotlin.commandAggregatedFieldPaths().filter(String::isNotBlank).sorted()
     }
 
     object Response {

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RequestBodyBuilder.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/RequestBodyBuilder.kt
@@ -26,6 +26,11 @@ class RequestBodyBuilder {
         return this
     }
 
+    fun extension(name: String, value: Any): RequestBodyBuilder {
+        requestBody.addExtension(name, value)
+        return this
+    }
+
     fun content(name: String = DEFAULT_MEDIA_TYPE_NAME, mediaType: MediaType): RequestBodyBuilder {
         requestBody.content.addMediaType(name, mediaType)
         return this

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt
@@ -72,6 +72,15 @@ internal class ExampleDomainOpenAPITest {
     inner class AggregateRoutes {
 
         @Test
+        fun `should expose aggregate query fields`() {
+            listOf("CountQuery", "ListQuery", "PagedQuery", "SingleQuery").forEach { queryType ->
+                val requestBody = requireNotNull(openAPI.components.requestBodies["example.cart.$queryType"])
+                val queryFields = requestBody.extensions["x-wow-query-fields"] as List<*>
+                queryFields.assert().contains("state.items.productId").doesNotContain("")
+            }
+        }
+
+        @Test
         fun `should generate cart routes without default tenant path`() {
             // Cart has @StaticTenantId → default appendTenantPath=false
             // MockVariableCommand overrides with appendTenantPath=ALWAYS, so exclude it

--- a/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
@@ -275,7 +275,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
       },
       "example.cart.ListQuery" : {
         "content" : {
@@ -307,7 +307,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
       },
       "example.cart.PagedQuery" : {
         "content" : {
@@ -336,7 +336,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
       },
       "example.cart.SingleQuery" : {
         "content" : {
@@ -362,7 +362,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
       },
       "example.order.CountQuery" : {
         "content" : {
@@ -372,7 +372,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
       },
       "example.order.ListQuery" : {
         "content" : {
@@ -404,7 +404,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
       },
       "example.order.PagedQuery" : {
         "content" : {
@@ -433,7 +433,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
       },
       "example.order.SingleQuery" : {
         "content" : {
@@ -459,7 +459,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
       },
       "tck.mock_aggregate.CountQuery" : {
         "content" : {
@@ -469,7 +469,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
       },
       "tck.mock_aggregate.ListQuery" : {
         "content" : {
@@ -501,7 +501,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
       },
       "tck.mock_aggregate.PagedQuery" : {
         "content" : {
@@ -530,7 +530,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
       },
       "tck.mock_aggregate.SingleQuery" : {
         "content" : {
@@ -556,7 +556,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_with_tenant_id.CountQuery" : {
         "content" : {
@@ -566,7 +566,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_with_tenant_id.ListQuery" : {
         "content" : {
@@ -598,7 +598,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_with_tenant_id.PagedQuery" : {
         "content" : {
@@ -627,7 +627,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_with_tenant_id.SingleQuery" : {
         "content" : {
@@ -653,7 +653,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_without_ctor_parameters.CountQuery" : {
         "content" : {
@@ -663,7 +663,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_without_ctor_parameters.ListQuery" : {
         "content" : {
@@ -695,7 +695,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_without_ctor_parameters.PagedQuery" : {
         "content" : {
@@ -724,7 +724,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_without_ctor_parameters.SingleQuery" : {
         "content" : {
@@ -750,7 +750,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "tags", "tenantId", "version" ]
       },
       "wow.CompensationTarget" : {
         "content" : {

--- a/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
@@ -274,7 +274,8 @@
               "$ref" : "#/components/schemas/wow.api.query.FilterExpression"
             }
           }
-        }
+        },
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
       },
       "example.cart.ListQuery" : {
         "content" : {
@@ -305,7 +306,8 @@
               "type" : "object"
             }
           }
-        }
+        },
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
       },
       "example.cart.PagedQuery" : {
         "content" : {
@@ -333,7 +335,8 @@
               "type" : "object"
             }
           }
-        }
+        },
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
       },
       "example.cart.SingleQuery" : {
         "content" : {
@@ -358,7 +361,8 @@
               "type" : "object"
             }
           }
-        }
+        },
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
       },
       "example.order.CountQuery" : {
         "content" : {
@@ -367,7 +371,8 @@
               "$ref" : "#/components/schemas/wow.api.query.FilterExpression"
             }
           }
-        }
+        },
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
       },
       "example.order.ListQuery" : {
         "content" : {
@@ -398,7 +403,8 @@
               "type" : "object"
             }
           }
-        }
+        },
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
       },
       "example.order.PagedQuery" : {
         "content" : {
@@ -426,7 +432,8 @@
               "type" : "object"
             }
           }
-        }
+        },
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
       },
       "example.order.SingleQuery" : {
         "content" : {
@@ -451,7 +458,8 @@
               "type" : "object"
             }
           }
-        }
+        },
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
       },
       "tck.mock_aggregate.CountQuery" : {
         "content" : {
@@ -460,7 +468,8 @@
               "$ref" : "#/components/schemas/wow.api.query.FilterExpression"
             }
           }
-        }
+        },
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
       },
       "tck.mock_aggregate.ListQuery" : {
         "content" : {
@@ -491,7 +500,8 @@
               "type" : "object"
             }
           }
-        }
+        },
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
       },
       "tck.mock_aggregate.PagedQuery" : {
         "content" : {
@@ -519,7 +529,8 @@
               "type" : "object"
             }
           }
-        }
+        },
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
       },
       "tck.mock_aggregate.SingleQuery" : {
         "content" : {
@@ -544,7 +555,8 @@
               "type" : "object"
             }
           }
-        }
+        },
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_with_tenant_id.CountQuery" : {
         "content" : {
@@ -553,7 +565,8 @@
               "$ref" : "#/components/schemas/wow.api.query.FilterExpression"
             }
           }
-        }
+        },
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_with_tenant_id.ListQuery" : {
         "content" : {
@@ -584,7 +597,8 @@
               "type" : "object"
             }
           }
-        }
+        },
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_with_tenant_id.PagedQuery" : {
         "content" : {
@@ -612,7 +626,8 @@
               "type" : "object"
             }
           }
-        }
+        },
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_with_tenant_id.SingleQuery" : {
         "content" : {
@@ -637,7 +652,8 @@
               "type" : "object"
             }
           }
-        }
+        },
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_without_ctor_parameters.CountQuery" : {
         "content" : {
@@ -646,7 +662,8 @@
               "$ref" : "#/components/schemas/wow.api.query.FilterExpression"
             }
           }
-        }
+        },
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_without_ctor_parameters.ListQuery" : {
         "content" : {
@@ -677,7 +694,8 @@
               "type" : "object"
             }
           }
-        }
+        },
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_without_ctor_parameters.PagedQuery" : {
         "content" : {
@@ -705,7 +723,8 @@
               "type" : "object"
             }
           }
-        }
+        },
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_without_ctor_parameters.SingleQuery" : {
         "content" : {
@@ -730,7 +749,8 @@
               "type" : "object"
             }
           }
-        }
+        },
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "tags", "tenantId", "version" ]
       },
       "wow.CompensationTarget" : {
         "content" : {

--- a/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
@@ -275,7 +275,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
       },
       "example.cart.ListQuery" : {
         "content" : {
@@ -307,7 +307,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
       },
       "example.cart.PagedQuery" : {
         "content" : {
@@ -336,7 +336,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
       },
       "example.cart.SingleQuery" : {
         "content" : {
@@ -362,7 +362,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
       },
       "example.order.CountQuery" : {
         "content" : {
@@ -372,7 +372,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
       },
       "example.order.ListQuery" : {
         "content" : {
@@ -404,7 +404,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
       },
       "example.order.PagedQuery" : {
         "content" : {
@@ -433,7 +433,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
       },
       "example.order.SingleQuery" : {
         "content" : {
@@ -459,7 +459,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
       },
       "tck.mock_aggregate.CountQuery" : {
         "content" : {
@@ -469,7 +469,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
       },
       "tck.mock_aggregate.ListQuery" : {
         "content" : {
@@ -501,7 +501,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
       },
       "tck.mock_aggregate.PagedQuery" : {
         "content" : {
@@ -530,7 +530,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
       },
       "tck.mock_aggregate.SingleQuery" : {
         "content" : {
@@ -556,7 +556,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_with_tenant_id.CountQuery" : {
         "content" : {
@@ -566,7 +566,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_with_tenant_id.ListQuery" : {
         "content" : {
@@ -598,7 +598,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_with_tenant_id.PagedQuery" : {
         "content" : {
@@ -627,7 +627,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_with_tenant_id.SingleQuery" : {
         "content" : {
@@ -653,7 +653,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_without_ctor_parameters.CountQuery" : {
         "content" : {
@@ -663,7 +663,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_without_ctor_parameters.ListQuery" : {
         "content" : {
@@ -695,7 +695,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_without_ctor_parameters.PagedQuery" : {
         "content" : {
@@ -724,7 +724,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "tags", "tenantId", "version" ]
       },
       "tck.modeling_command_aggregate_without_ctor_parameters.SingleQuery" : {
         "content" : {
@@ -750,7 +750,7 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "spaceId", "state", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : [ "aggregateId", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "tags", "tenantId", "version" ]
       },
       "wow.CompensationTarget" : {
         "content" : {

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/SchemaGeneratorBuilder.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/SchemaGeneratorBuilder.kt
@@ -29,6 +29,7 @@ import me.ahoo.wow.schema.jackson.WowJacksonModule
 import me.ahoo.wow.schema.joda.money.JodaMoneyModule
 import me.ahoo.wow.schema.kotlin.KotlinModule
 import me.ahoo.wow.schema.naming.SchemaNamingModule
+import tools.jackson.databind.ObjectMapper
 import java.util.function.Consumer
 
 /**
@@ -37,6 +38,9 @@ import java.util.function.Consumer
  * Jackson, Jakarta Validation, Swagger2, Kotlin, Joda Money, and Wow-specific modules.
  */
 class SchemaGeneratorBuilder {
+    var objectMapper: ObjectMapper? = null
+        private set
+
     /** Whether to use OpenAPI 3.1 specification. */
     var openapi31: Boolean = true
         private set
@@ -103,6 +107,11 @@ class SchemaGeneratorBuilder {
 
     fun openapi31(openapi31: Boolean): SchemaGeneratorBuilder {
         this.openapi31 = openapi31
+        return this
+    }
+
+    fun objectMapper(objectMapper: ObjectMapper): SchemaGeneratorBuilder {
+        this.objectMapper = objectMapper
         return this
     }
 

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/SchemaGeneratorConfigFactory.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/SchemaGeneratorConfigFactory.kt
@@ -20,7 +20,10 @@ import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder
 internal object SchemaGeneratorConfigFactory {
 
     fun create(builder: SchemaGeneratorBuilder): SchemaGeneratorConfigBuilder {
-        return SchemaGeneratorConfigBuilder(builder.schemaVersion, builder.optionPreset)
+        val configBuilder = builder.objectMapper?.let {
+            SchemaGeneratorConfigBuilder(it, builder.schemaVersion, builder.optionPreset)
+        } ?: SchemaGeneratorConfigBuilder(builder.schemaVersion, builder.optionPreset)
+        return configBuilder
             .withModuleIfPresent(builder.jacksonModule)
             .withModuleIfPresent(builder.jakartaValidationModule)
             .withModuleIfPresent(builder.swagger2Module)

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
@@ -125,7 +125,7 @@ object TypeFieldPaths {
         if (parentName.isBlank()) fieldName else "$parentName${JOIN_DELIMITER}$fieldName"
 
     private fun String.isLogicalFieldSegment(): Boolean =
-        JOIN_DELIMITER !in this && runCatching { LogicalField("_.$this") }.isSuccess
+        JOIN_DELIMITER !in this && runCatching { LogicalField(this) }.isSuccess
 
     private fun MemberScope<*, *>.customSerializerDefinition(
         context: SchemaGenerationContext,

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
@@ -168,6 +168,8 @@ object AggregatedFieldPaths {
             parentName = StateAggregateRecords.STATE,
             fields = listOf(
                 "",
+                MessageRecords.CONTEXT_NAME,
+                MessageRecords.AGGREGATE_NAME,
                 MessageRecords.AGGREGATE_ID,
                 MessageRecords.TENANT_ID,
                 MessageRecords.OWNER_ID,

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
@@ -24,6 +24,7 @@ import me.ahoo.wow.schema.TypeFieldPaths.allFieldPaths
 import me.ahoo.wow.schema.Types.isStdType
 import me.ahoo.wow.serialization.JsonSerializer
 import me.ahoo.wow.serialization.MessageRecords
+import me.ahoo.wow.serialization.state.SnapshotRecords
 import me.ahoo.wow.serialization.state.StateAggregateRecords
 import tools.jackson.databind.JsonNode
 import tools.jackson.databind.ValueSerializer
@@ -179,7 +180,8 @@ object AggregatedFieldPaths {
                 StateAggregateRecords.EVENT_TIME,
                 StateAggregateRecords.TAGS,
                 StateAggregateRecords.DELETED,
-                StateAggregateRecords.STATE
+                StateAggregateRecords.STATE,
+                SnapshotRecords.SNAPSHOT_TIME,
             )
         ).filterTo(linkedSetOf()) { field ->
             runCatching { LogicalField(field) }.isSuccess

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
@@ -138,11 +138,9 @@ object TypeFieldPaths {
     }
 
     private fun JsonSerialize.definesWireShape(): Boolean =
-        using != ValueSerializer.None::class.java ||
-            contentUsing != ValueSerializer.None::class.java ||
-            keyUsing != ValueSerializer.None::class.java ||
-            converter != Converter.None::class.java ||
-            contentConverter != Converter.None::class.java
+        listOf(contentUsing, keyUsing, converter, contentConverter, using).any {
+            it != ValueSerializer.None::class.java && it != Converter.None::class.java
+        }
 
     private fun Class<*>.registeredSerializerDefinition(context: SchemaGenerationContext): CustomDefinition? {
         if (isStdType()) {

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
@@ -13,22 +13,20 @@
 
 package me.ahoo.wow.schema
 
-import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import me.ahoo.wow.api.modeling.AggregateId
-import me.ahoo.wow.infra.reflection.AnnotationScanner.scanAnnotation
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.schema.TypeFieldPaths.allFieldPaths
 import me.ahoo.wow.schema.Types.isStdType
+import me.ahoo.wow.serialization.JsonSerializer
 import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.serialization.state.StateAggregateRecords
+import me.ahoo.wow.serialization.toBeanDescription
+import tools.jackson.databind.JavaType
+import tools.jackson.databind.introspect.BeanPropertyDefinition
 import kotlin.reflect.KClass
-import kotlin.reflect.KProperty1
-import kotlin.reflect.KVisibility
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.isSubclassOf
-import kotlin.reflect.full.memberProperties
-import kotlin.reflect.jvm.jvmErasure
 
 /**
  * Utility object to handle state field paths.
@@ -57,7 +55,7 @@ object TypeFieldPaths {
         if (fields.isNotEmpty()) {
             fieldPaths.addAll(fields)
         }
-        allFieldPathsInternal(fieldPaths, parentName, 1, maxDepth)
+        JsonSerializer.constructType(java).allFieldPathsInternal(fieldPaths, parentName, 1, maxDepth)
         return fieldPaths
     }
 
@@ -69,7 +67,7 @@ object TypeFieldPaths {
      * @param depth The current nested-property depth.
      * @param maxDepth The maximum nested-property depth to inspect.
      */
-    private fun KClass<*>.allFieldPathsInternal(
+    private fun JavaType.allFieldPathsInternal(
         fieldPaths: LinkedHashSet<String>,
         parentName: String,
         depth: Int,
@@ -78,7 +76,8 @@ object TypeFieldPaths {
         if (depth > maxDepth) {
             return
         }
-        if (isSubclassOf(AggregateId::class)) {
+        val kotlinType = rawClass.kotlin
+        if (kotlinType.isSubclassOf(AggregateId::class)) {
             listOf(
                 MessageRecords.CONTEXT_NAME,
                 MessageRecords.AGGREGATE_NAME,
@@ -88,11 +87,10 @@ object TypeFieldPaths {
                 fieldPaths.add(resolveFieldName(parentName, field))
             }
         }
-        val jsonSubTypes = this.findAnnotation<JsonSubTypes>()
+        val jsonSubTypes = kotlinType.findAnnotation<JsonSubTypes>()
         if (jsonSubTypes != null) {
             for (jsonSubType in jsonSubTypes.value) {
-                val subType = jsonSubType.value
-                subType.allFieldPathsInternal(
+                JsonSerializer.constructType(jsonSubType.value.java).allFieldPathsInternal(
                     fieldPaths = fieldPaths,
                     parentName = parentName,
                     depth = depth,
@@ -102,31 +100,19 @@ object TypeFieldPaths {
             return
         }
 
-        memberProperties.filter {
-            it.visibility == KVisibility.PUBLIC &&
-                it.isConst.not() &&
-                it.scanAnnotation<JsonIgnore>()?.value != true
-        }.forEach { property ->
-            val fullName = property.resolveFieldName(parentName)
-            fieldPaths.add(fullName)
-            val nestedType = property.resolveNestedType() ?: return@forEach
-            nestedType.allFieldPathsInternal(
-                fieldPaths = fieldPaths,
-                parentName = fullName,
-                depth = depth + 1,
-                maxDepth = maxDepth
-            )
-        }
-    }
-
-    /**
-     * Resolves the full field name including the parent name.
-     *
-     * @param parentName The name of the parent field.
-     * @return The full field name.
-     */
-    private fun KProperty1<*, *>.resolveFieldName(parentName: String): String {
-        return resolveFieldName(parentName, name)
+        toBeanDescription().findProperties().asSequence()
+            .filter(BeanPropertyDefinition::couldSerialize)
+            .forEach { property ->
+                val fullName = resolveFieldName(parentName, property.name)
+                fieldPaths.add(fullName)
+                val nestedType = property.primaryType.resolveNestedType() ?: return@forEach
+                nestedType.allFieldPathsInternal(
+                    fieldPaths = fieldPaths,
+                    parentName = fullName,
+                    depth = depth + 1,
+                    maxDepth = maxDepth
+                )
+            }
     }
 
     private fun resolveFieldName(parentName: String, fieldName: String): String =
@@ -137,15 +123,14 @@ object TypeFieldPaths {
      *
      * @return The nested type if it's not a standard type, otherwise null.
      */
-    private fun KProperty1<*, *>.resolveNestedType(): KClass<*>? {
-        val returnKClass = returnType.jvmErasure
-        val nestedType = if (returnKClass.isSubclassOf(Collection::class) || returnKClass.java.isArray) {
-            returnType.arguments.firstOrNull()?.type?.jvmErasure ?: return null
+    private fun JavaType.resolveNestedType(): JavaType? {
+        val nestedType = if (isCollectionLikeType || isArrayType) {
+            contentType ?: return null
         } else {
-            returnType.jvmErasure
+            this
         }
 
-        if (nestedType.java.isStdType()) {
+        if (nestedType.rawClass.isStdType()) {
             return null
         }
         return nestedType

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
@@ -13,40 +13,21 @@
 
 package me.ahoo.wow.schema
 
-import com.fasterxml.jackson.annotation.JsonSubTypes
-import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.schema.TypeFieldPaths.allFieldPaths
-import me.ahoo.wow.schema.Types.isStdType
-import me.ahoo.wow.serialization.JsonSerializer
 import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.serialization.state.StateAggregateRecords
-import me.ahoo.wow.serialization.toBeanDescription
-import tools.jackson.databind.JavaType
-import tools.jackson.databind.introspect.BeanPropertyDefinition
-import tools.jackson.databind.util.NameTransformer
+import tools.jackson.databind.JsonNode
 import kotlin.reflect.KClass
-import kotlin.reflect.full.findAnnotation
-import kotlin.reflect.full.isSubclassOf
 
 /**
  * Utility object to handle state field paths.
  */
 object TypeFieldPaths {
-    /**
-     * Delimiter used to join property names in the path.
-     */
     const val JOIN_DELIMITER = "."
     const val MAX_DEPTH = 5
+    private val schemaGenerator by lazy { SchemaGeneratorBuilder().build() }
 
-    /**
-     * Retrieves all property paths for a given KClass.
-     *
-     * @param parentName The name of the parent property (used for nested properties).
-     * @param fields A list of initial properties to include in the result.
-     * @param maxDepth The maximum nested-property depth to inspect.
-     * @return A list of all property paths.
-     */
     fun KClass<*>.allFieldPaths(
         parentName: String = "",
         fields: List<String> = emptyList(),
@@ -56,110 +37,61 @@ object TypeFieldPaths {
         if (fields.isNotEmpty()) {
             fieldPaths.addAll(fields)
         }
-        JsonSerializer.constructType(java).allFieldPathsInternal(fieldPaths, parentName, 1, maxDepth)
+        val rootSchema = schemaGenerator.generateSchema(java)
+        rootSchema.collectFieldPaths(rootSchema, fieldPaths, parentName, 1, maxDepth, emptySet())
         return fieldPaths
     }
 
-    /**
-     * Internal method to recursively retrieve all property paths.
-     *
-     * @param fieldPaths The list to store property paths.
-     * @param parentName The name of the parent property (used for nested properties).
-     * @param depth The current nested-property depth.
-     * @param maxDepth The maximum nested-property depth to inspect.
-     * @param nameTransformer The Jackson name transformer inherited from an unwrapped parent.
-     */
-    private fun JavaType.allFieldPathsInternal(
+    private fun JsonNode.collectFieldPaths(
+        rootSchema: JsonNode,
         fieldPaths: LinkedHashSet<String>,
         parentName: String,
         depth: Int,
         maxDepth: Int,
-        nameTransformer: NameTransformer? = null,
+        resolvingReferences: Set<String>,
     ) {
         if (depth > maxDepth) {
             return
         }
-        val kotlinType = rawClass.kotlin
-        if (kotlinType.isSubclassOf(AggregateId::class)) {
-            listOf(
-                MessageRecords.CONTEXT_NAME,
-                MessageRecords.AGGREGATE_NAME,
-                MessageRecords.AGGREGATE_ID,
-                MessageRecords.TENANT_ID
-            ).forEach { field ->
-                fieldPaths.add(resolveFieldName(parentName, field))
-            }
+        get("\$ref")?.asString()?.takeIf { it.startsWith("#/") && it !in resolvingReferences }?.let { reference ->
+            rootSchema.at(reference.removePrefix("#")).collectFieldPaths(
+                rootSchema,
+                fieldPaths,
+                parentName,
+                depth,
+                maxDepth,
+                resolvingReferences + reference,
+            )
         }
-        val jsonSubTypes = kotlinType.findAnnotation<JsonSubTypes>()
-        if (jsonSubTypes != null) {
-            for (jsonSubType in jsonSubTypes.value) {
-                JsonSerializer.constructType(jsonSubType.value.java).allFieldPathsInternal(
-                    fieldPaths = fieldPaths,
-                    parentName = parentName,
-                    depth = depth,
-                    maxDepth = maxDepth,
-                    nameTransformer = nameTransformer,
+        listOf("allOf", "anyOf", "oneOf").forEach { composition ->
+            get(composition)?.forEach { alternative ->
+                alternative.collectFieldPaths(
+                    rootSchema,
+                    fieldPaths,
+                    parentName,
+                    depth,
+                    maxDepth,
+                    resolvingReferences,
                 )
             }
-            return
         }
-
-        toBeanDescription().findProperties().asSequence()
-            .filter(BeanPropertyDefinition::couldSerialize)
-            .forEach { property ->
-                val nestedType = property.primaryType.resolveNestedType()
-                val unwrappingTransformer = nestedType?.let { property.unwrappingNameTransformer() }
-                if (unwrappingTransformer != null) {
-                    requireNotNull(nestedType).allFieldPathsInternal(
-                        fieldPaths = fieldPaths,
-                        parentName = parentName,
-                        depth = depth,
-                        maxDepth = maxDepth,
-                        nameTransformer = nameTransformer?.let {
-                            NameTransformer.chainedTransformer(it, unwrappingTransformer)
-                        } ?: unwrappingTransformer,
-                    )
-                    return@forEach
-                }
-
-                val propertyName = nameTransformer?.transform(property.name) ?: property.name
-                val fullName = resolveFieldName(parentName, propertyName)
-                fieldPaths.add(fullName)
-                nestedType?.allFieldPathsInternal(
-                    fieldPaths = fieldPaths,
-                    parentName = fullName,
-                    depth = depth + 1,
-                    maxDepth = maxDepth,
-                )
-            }
-    }
-
-    private fun BeanPropertyDefinition.unwrappingNameTransformer(): NameTransformer? {
-        val member = primaryMember ?: accessor ?: return null
-        val config = JsonSerializer.serializationConfig()
-        return config.annotationIntrospector.findUnwrappingNameTransformer(config, member)
+        get("properties")?.properties()?.forEach { (propertyName, propertySchema) ->
+            val fullName = resolveFieldName(parentName, propertyName)
+            fieldPaths.add(fullName)
+            propertySchema.collectFieldPaths(rootSchema, fieldPaths, fullName, depth + 1, maxDepth, emptySet())
+        }
+        get("items")?.collectFieldPaths(
+            rootSchema,
+            fieldPaths,
+            parentName,
+            depth,
+            maxDepth,
+            resolvingReferences,
+        )
     }
 
     private fun resolveFieldName(parentName: String, fieldName: String): String =
         if (parentName.isBlank()) fieldName else "$parentName${JOIN_DELIMITER}$fieldName"
-
-    /**
-     * Resolves the nested type of a property.
-     *
-     * @return The nested type if it's not a standard type, otherwise null.
-     */
-    private fun JavaType.resolveNestedType(): JavaType? {
-        val nestedType = if (isCollectionLikeType || isArrayType) {
-            contentType ?: return null
-        } else {
-            this
-        }
-
-        if (nestedType.rawClass.isStdType()) {
-            return null
-        }
-        return nestedType
-    }
 }
 
 object AggregatedFieldPaths {

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
@@ -24,6 +24,7 @@ import me.ahoo.wow.serialization.state.StateAggregateRecords
 import me.ahoo.wow.serialization.toBeanDescription
 import tools.jackson.databind.JavaType
 import tools.jackson.databind.introspect.BeanPropertyDefinition
+import tools.jackson.databind.util.NameTransformer
 import kotlin.reflect.KClass
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.isSubclassOf
@@ -66,12 +67,14 @@ object TypeFieldPaths {
      * @param parentName The name of the parent property (used for nested properties).
      * @param depth The current nested-property depth.
      * @param maxDepth The maximum nested-property depth to inspect.
+     * @param nameTransformer The Jackson name transformer inherited from an unwrapped parent.
      */
     private fun JavaType.allFieldPathsInternal(
         fieldPaths: LinkedHashSet<String>,
         parentName: String,
         depth: Int,
-        maxDepth: Int
+        maxDepth: Int,
+        nameTransformer: NameTransformer? = null,
     ) {
         if (depth > maxDepth) {
             return
@@ -94,7 +97,8 @@ object TypeFieldPaths {
                     fieldPaths = fieldPaths,
                     parentName = parentName,
                     depth = depth,
-                    maxDepth = maxDepth
+                    maxDepth = maxDepth,
+                    nameTransformer = nameTransformer,
                 )
             }
             return
@@ -103,16 +107,37 @@ object TypeFieldPaths {
         toBeanDescription().findProperties().asSequence()
             .filter(BeanPropertyDefinition::couldSerialize)
             .forEach { property ->
-                val fullName = resolveFieldName(parentName, property.name)
+                val nestedType = property.primaryType.resolveNestedType()
+                val unwrappingTransformer = nestedType?.let { property.unwrappingNameTransformer() }
+                if (unwrappingTransformer != null) {
+                    requireNotNull(nestedType).allFieldPathsInternal(
+                        fieldPaths = fieldPaths,
+                        parentName = parentName,
+                        depth = depth,
+                        maxDepth = maxDepth,
+                        nameTransformer = nameTransformer?.let {
+                            NameTransformer.chainedTransformer(it, unwrappingTransformer)
+                        } ?: unwrappingTransformer,
+                    )
+                    return@forEach
+                }
+
+                val propertyName = nameTransformer?.transform(property.name) ?: property.name
+                val fullName = resolveFieldName(parentName, propertyName)
                 fieldPaths.add(fullName)
-                val nestedType = property.primaryType.resolveNestedType() ?: return@forEach
-                nestedType.allFieldPathsInternal(
+                nestedType?.allFieldPathsInternal(
                     fieldPaths = fieldPaths,
                     parentName = fullName,
                     depth = depth + 1,
-                    maxDepth = maxDepth
+                    maxDepth = maxDepth,
                 )
             }
+    }
+
+    private fun BeanPropertyDefinition.unwrappingNameTransformer(): NameTransformer? {
+        val member = primaryMember ?: accessor ?: return null
+        val config = JsonSerializer.serializationConfig()
+        return config.annotationIntrospector.findUnwrappingNameTransformer(config, member)
     }
 
     private fun resolveFieldName(parentName: String, fieldName: String): String =

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
@@ -13,13 +13,26 @@
 
 package me.ahoo.wow.schema
 
+import com.github.victools.jsonschema.generator.CustomDefinition
+import com.github.victools.jsonschema.generator.CustomPropertyDefinition
+import com.github.victools.jsonschema.generator.MemberScope
+import com.github.victools.jsonschema.generator.Option
+import com.github.victools.jsonschema.generator.SchemaGenerationContext
 import me.ahoo.wow.api.query.LogicalField
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.schema.TypeFieldPaths.allFieldPaths
+import me.ahoo.wow.schema.Types.isStdType
 import me.ahoo.wow.serialization.JsonSerializer
 import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.serialization.state.StateAggregateRecords
 import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ValueSerializer
+import tools.jackson.databind.annotation.JsonSerialize
+import tools.jackson.databind.ser.bean.BeanSerializerBase
+import tools.jackson.databind.ser.impl.UnknownSerializer
+import tools.jackson.databind.ser.std.ReferenceTypeSerializer
+import tools.jackson.databind.ser.std.StdContainerSerializer
+import tools.jackson.databind.util.Converter
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
 
@@ -29,7 +42,20 @@ import kotlin.reflect.KClass
 object TypeFieldPaths {
     const val JOIN_DELIMITER = "."
     const val MAX_DEPTH = 5
-    private val schemaGenerator by lazy { SchemaGeneratorBuilder().objectMapper(JsonSerializer).build() }
+    private val schemaGenerator by lazy {
+        SchemaGeneratorBuilder().objectMapper(JsonSerializer).customizer { config ->
+            config.with(Option.DEFINITIONS_FOR_ALL_OBJECTS)
+            config.forFields().withCustomDefinitionProvider { scope, context ->
+                scope.customSerializerDefinition(context)
+            }
+            config.forMethods().withCustomDefinitionProvider { scope, context ->
+                scope.customSerializerDefinition(context)
+            }
+            config.forTypesInGeneral().withCustomDefinitionProvider { javaType, context ->
+                javaType.erasedType.registeredSerializerDefinition(context)
+            }
+        }.build()
+    }
 
     fun KClass<*>.allFieldPaths(
         parentName: String = "",
@@ -100,6 +126,37 @@ object TypeFieldPaths {
 
     private fun String.isLogicalFieldSegment(): Boolean =
         JOIN_DELIMITER !in this && runCatching { LogicalField("_.$this") }.isSuccess
+
+    private fun MemberScope<*, *>.customSerializerDefinition(
+        context: SchemaGenerationContext,
+    ): CustomPropertyDefinition? {
+        val annotation = getAnnotationConsideringFieldAndGetterIfSupported(JsonSerialize::class.java)
+        return annotation?.takeIf { it.definesWireShape() }?.let {
+            CustomPropertyDefinition(context.generatorConfig.createObjectNode())
+        }
+    }
+
+    private fun JsonSerialize.definesWireShape(): Boolean =
+        using != ValueSerializer.None::class.java ||
+            contentUsing != ValueSerializer.None::class.java ||
+            keyUsing != ValueSerializer.None::class.java ||
+            converter != Converter.None::class.java ||
+            contentConverter != Converter.None::class.java
+
+    private fun Class<*>.registeredSerializerDefinition(context: SchemaGenerationContext): CustomDefinition? {
+        if (isStdType()) {
+            return null
+        }
+        val serializer = runCatching { JsonSerializer._serializationContext().findValueSerializer(this) }.getOrNull()
+        return serializer?.takeUnless {
+            it is BeanSerializerBase ||
+                it is UnknownSerializer ||
+                it is StdContainerSerializer<*> ||
+                it is ReferenceTypeSerializer<*>
+        }?.let {
+            CustomDefinition(context.generatorConfig.createObjectNode())
+        }
+    }
 }
 
 object AggregatedFieldPaths {

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
@@ -79,9 +79,11 @@ object TypeFieldPaths {
             }
         }
         get("properties")?.properties()?.forEach { (propertyName, propertySchema) ->
-            val fullName = resolveFieldName(parentName, propertyName)
-            fieldPaths.add(fullName)
-            propertySchema.collectFieldPaths(rootSchema, fieldPaths, fullName, depth + 1, maxDepth, emptySet())
+            if (propertyName.isLogicalFieldSegment() && propertySchema.get("writeOnly")?.asBoolean() != true) {
+                val fullName = resolveFieldName(parentName, propertyName)
+                fieldPaths.add(fullName)
+                propertySchema.collectFieldPaths(rootSchema, fieldPaths, fullName, depth + 1, maxDepth, emptySet())
+            }
         }
         get("items")?.collectFieldPaths(
             rootSchema,
@@ -95,6 +97,9 @@ object TypeFieldPaths {
 
     private fun resolveFieldName(parentName: String, fieldName: String): String =
         if (parentName.isBlank()) fieldName else "$parentName${JOIN_DELIMITER}$fieldName"
+
+    private fun String.isLogicalFieldSegment(): Boolean =
+        JOIN_DELIMITER !in this && runCatching { LogicalField("_.$this") }.isSuccess
 }
 
 object AggregatedFieldPaths {

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/TypeFieldPaths.kt
@@ -13,11 +13,14 @@
 
 package me.ahoo.wow.schema
 
+import me.ahoo.wow.api.query.LogicalField
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.schema.TypeFieldPaths.allFieldPaths
+import me.ahoo.wow.serialization.JsonSerializer
 import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.serialization.state.StateAggregateRecords
 import tools.jackson.databind.JsonNode
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.reflect.KClass
 
 /**
@@ -26,7 +29,7 @@ import kotlin.reflect.KClass
 object TypeFieldPaths {
     const val JOIN_DELIMITER = "."
     const val MAX_DEPTH = 5
-    private val schemaGenerator by lazy { SchemaGeneratorBuilder().build() }
+    private val schemaGenerator by lazy { SchemaGeneratorBuilder().objectMapper(JsonSerializer).build() }
 
     fun KClass<*>.allFieldPaths(
         parentName: String = "",
@@ -95,6 +98,8 @@ object TypeFieldPaths {
 }
 
 object AggregatedFieldPaths {
+    private val commandFieldPaths = ConcurrentHashMap<Class<*>, Set<String>>()
+
     fun KClass<*>.stateAggregatedFieldPaths(): Set<String> {
         return allFieldPaths(
             parentName = StateAggregateRecords.STATE,
@@ -114,12 +119,14 @@ object AggregatedFieldPaths {
                 StateAggregateRecords.DELETED,
                 StateAggregateRecords.STATE
             )
-        )
+        ).filterTo(linkedSetOf()) { field ->
+            runCatching { LogicalField(field) }.isSuccess
+        }
     }
 
-    fun KClass<*>.commandAggregatedFieldPaths(): Set<String> {
-        val aggregateMetadata = this.java.aggregateMetadata<Any, Any>()
-        val stateAggregateType = aggregateMetadata.state.aggregateType.kotlin
-        return stateAggregateType.stateAggregatedFieldPaths()
+    fun KClass<*>.commandAggregatedFieldPaths(): Set<String> = commandFieldPaths.computeIfAbsent(
+        java
+    ) { aggregateType ->
+        aggregateType.aggregateMetadata<Any, Any>().state.aggregateType.kotlin.stateAggregatedFieldPaths()
     }
 }

--- a/wow-schema/src/test/java/me/ahoo/wow/schema/JavaBeanFieldPathFixture.java
+++ b/wow-schema/src/test/java/me/ahoo/wow/schema/JavaBeanFieldPathFixture.java
@@ -18,6 +18,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class JavaBeanFieldPathFixture {
     @JsonProperty("display_name")
     private String name = "";
+    @JsonProperty("display name")
+    private String invalidName = "";
     private boolean frozen;
 
     public String getName() {
@@ -26,5 +28,9 @@ public class JavaBeanFieldPathFixture {
 
     public boolean isFrozen() {
         return frozen;
+    }
+
+    public String getInvalidName() {
+        return invalidName;
     }
 }

--- a/wow-schema/src/test/java/me/ahoo/wow/schema/JavaBeanFieldPathFixture.java
+++ b/wow-schema/src/test/java/me/ahoo/wow/schema/JavaBeanFieldPathFixture.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.schema;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class JavaBeanFieldPathFixture {
+    @JsonProperty("display_name")
+    private String name = "";
+    private boolean frozen;
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isFrozen() {
+        return frozen;
+    }
+}

--- a/wow-schema/src/test/java/me/ahoo/wow/schema/JavaBeanFieldPathFixture.java
+++ b/wow-schema/src/test/java/me/ahoo/wow/schema/JavaBeanFieldPathFixture.java
@@ -20,6 +20,10 @@ public class JavaBeanFieldPathFixture {
     private String name = "";
     @JsonProperty("display name")
     private String invalidName = "";
+    @JsonProperty("display.name")
+    private String dottedName = "";
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private String secret = "";
     private boolean frozen;
 
     public String getName() {
@@ -32,5 +36,13 @@ public class JavaBeanFieldPathFixture {
 
     public String getInvalidName() {
         return invalidName;
+    }
+
+    public String getDottedName() {
+        return dottedName;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
     }
 }

--- a/wow-schema/src/test/java/me/ahoo/wow/schema/JavaBeanFieldPathFixture.java
+++ b/wow-schema/src/test/java/me/ahoo/wow/schema/JavaBeanFieldPathFixture.java
@@ -22,6 +22,8 @@ public class JavaBeanFieldPathFixture {
     private String invalidName = "";
     @JsonProperty("display.name")
     private String dottedName = "";
+    @JsonProperty("0")
+    private String numericName = "";
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String secret = "";
     private boolean frozen;
@@ -40,6 +42,10 @@ public class JavaBeanFieldPathFixture {
 
     public String getDottedName() {
         return dottedName;
+    }
+
+    public String getNumericName() {
+        return numericName;
     }
 
     public void setSecret(String secret) {

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
@@ -24,6 +24,7 @@ import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.PagedList
 import me.ahoo.wow.api.query.PagedQuery
 import me.ahoo.wow.schema.AggregatedFieldPaths.commandAggregatedFieldPaths
+import me.ahoo.wow.schema.AggregatedFieldPaths.stateAggregatedFieldPaths
 import me.ahoo.wow.schema.TypeFieldPaths.allFieldPaths
 import org.junit.jupiter.api.Test
 
@@ -50,8 +51,18 @@ class AggregatedFieldPathsTest {
 
         paths.assert()
             .contains("state.display_name")
+            .contains("state.display name")
             .contains("state.frozen")
             .doesNotContain("state.name")
+    }
+
+    @Test
+    fun `should exclude field paths rejected by logical field grammar`() {
+        val paths = JavaBeanFieldPathFixture::class.stateAggregatedFieldPaths()
+
+        paths.assert()
+            .contains("state.display_name")
+            .doesNotContain("state.display name")
     }
 
     @Test

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
@@ -27,6 +27,7 @@ import me.ahoo.wow.schema.AggregatedFieldPaths.commandAggregatedFieldPaths
 import me.ahoo.wow.schema.AggregatedFieldPaths.stateAggregatedFieldPaths
 import me.ahoo.wow.schema.TypeFieldPaths.allFieldPaths
 import me.ahoo.wow.serialization.JsonSerializer
+import me.ahoo.wow.serialization.state.SnapshotRecords
 import org.junit.jupiter.api.Test
 import tools.jackson.core.JsonGenerator
 import tools.jackson.databind.SerializationContext
@@ -146,7 +147,7 @@ class AggregatedFieldPathsTest {
     @Test
     fun `should list command aggregated field paths`() {
         val paths = TestAggregate::class.commandAggregatedFieldPaths()
-        paths.assert().isNotEmpty()
+        paths.assert().contains(SnapshotRecords.SNAPSHOT_TIME)
     }
 
     class FieldPathDemoState(override val id: String) : Identifier {

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
@@ -62,6 +62,7 @@ class AggregatedFieldPathsTest {
             .contains("state.frozen")
             .doesNotContain("state.display name")
             .doesNotContain("state.display.name")
+            .doesNotContain("state.0")
             .doesNotContain("state.secret")
             .doesNotContain("state.name")
     }
@@ -74,6 +75,7 @@ class AggregatedFieldPathsTest {
             .contains("state.display_name")
             .doesNotContain("state.display name")
             .doesNotContain("state.display.name")
+            .doesNotContain("state.0")
             .doesNotContain("state.secret")
     }
 

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
@@ -26,6 +26,7 @@ import me.ahoo.wow.api.query.PagedQuery
 import me.ahoo.wow.schema.AggregatedFieldPaths.commandAggregatedFieldPaths
 import me.ahoo.wow.schema.AggregatedFieldPaths.stateAggregatedFieldPaths
 import me.ahoo.wow.schema.TypeFieldPaths.allFieldPaths
+import me.ahoo.wow.serialization.JsonSerializer
 import org.junit.jupiter.api.Test
 
 class AggregatedFieldPathsTest {
@@ -47,12 +48,17 @@ class AggregatedFieldPathsTest {
 
     @Test
     fun `should use Jackson names for JavaBean field paths`() {
+        SchemaGeneratorBuilder().objectMapper(JsonSerializer).build()
+            .generateSchema(JavaBeanFieldPathFixture::class.java)
+            .findValue("writeOnly").asBoolean().assert().isTrue()
         val paths = JavaBeanFieldPathFixture::class.allFieldPaths(parentName = "state")
 
         paths.assert()
             .contains("state.display_name")
-            .contains("state.display name")
             .contains("state.frozen")
+            .doesNotContain("state.display name")
+            .doesNotContain("state.display.name")
+            .doesNotContain("state.secret")
             .doesNotContain("state.name")
     }
 
@@ -63,6 +69,8 @@ class AggregatedFieldPathsTest {
         paths.assert()
             .contains("state.display_name")
             .doesNotContain("state.display name")
+            .doesNotContain("state.display.name")
+            .doesNotContain("state.secret")
     }
 
     @Test

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
@@ -42,6 +42,16 @@ class AggregatedFieldPathsTest {
     }
 
     @Test
+    fun `should use Jackson names for JavaBean field paths`() {
+        val paths = JavaBeanFieldPathFixture::class.allFieldPaths(parentName = "state")
+
+        paths.assert()
+            .contains("state.display_name")
+            .contains("state.frozen")
+            .doesNotContain("state.name")
+    }
+
+    @Test
     fun `should follow aggregate id serialized field paths`() {
         val paths = AggregateIdFixture::class.allFieldPaths(parentName = "state")
 

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
@@ -28,6 +28,10 @@ import me.ahoo.wow.schema.AggregatedFieldPaths.stateAggregatedFieldPaths
 import me.ahoo.wow.schema.TypeFieldPaths.allFieldPaths
 import me.ahoo.wow.serialization.JsonSerializer
 import org.junit.jupiter.api.Test
+import tools.jackson.core.JsonGenerator
+import tools.jackson.databind.SerializationContext
+import tools.jackson.databind.annotation.JsonSerialize
+import tools.jackson.databind.ser.std.StdSerializer
 
 class AggregatedFieldPathsTest {
     @Test
@@ -97,6 +101,16 @@ class AggregatedFieldPathsTest {
     }
 
     @Test
+    fun `should treat custom serializer wire shape as opaque`() {
+        JsonSerializer.writeValueAsString(CustomSerializedFixture(CustomSerializedValue("wire")))
+            .assert().isEqualTo("{\"value\":\"wire\"}")
+
+        CustomSerializedFixture::class.allFieldPaths(parentName = "state").assert()
+            .contains("state.value")
+            .doesNotContain("state.value.hidden")
+    }
+
+    @Test
     fun `should respect the requested maximum depth`() {
         val paths = TestState::class.allFieldPaths(parentName = "state", maxDepth = 1)
 
@@ -161,3 +175,20 @@ private data class UnwrappedDetails(val nestedValue: String)
 private sealed interface SyntheticTypeInfoFixture
 
 private data class CardPayment(val cardNumber: String) : SyntheticTypeInfoFixture
+
+private data class CustomSerializedFixture(val value: CustomSerializedValue)
+
+@JsonSerialize(using = CustomSerializedValueSerializer::class)
+private data class CustomSerializedValue(val hidden: String)
+
+private class CustomSerializedValueSerializer : StdSerializer<CustomSerializedValue>(
+    CustomSerializedValue::class.java,
+) {
+    override fun serialize(
+        value: CustomSerializedValue,
+        generator: JsonGenerator,
+        provider: SerializationContext,
+    ) {
+        generator.writeString(value.hidden)
+    }
+}

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.schema
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonUnwrapped
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.Identifier
 import me.ahoo.wow.api.modeling.AggregateId
@@ -49,6 +50,16 @@ class AggregatedFieldPathsTest {
             .contains("state.display_name")
             .contains("state.frozen")
             .doesNotContain("state.name")
+    }
+
+    @Test
+    fun `should flatten Jackson unwrapped field paths`() {
+        val paths = UnwrappedFieldPathFixture::class.allFieldPaths(parentName = "state")
+
+        paths.assert()
+            .contains("state.detail_nestedValue_value")
+            .doesNotContain("state.details")
+            .doesNotContain("state.details.nestedValue")
     }
 
     @Test
@@ -107,3 +118,10 @@ class AggregatedFieldPathsTest {
 
     data class AggregateIdFixture(val aggregateId: AggregateId)
 }
+
+private data class UnwrappedFieldPathFixture(
+    @get:JsonUnwrapped(prefix = "detail_", suffix = "_value")
+    val details: UnwrappedDetails,
+)
+
+private data class UnwrappedDetails(val nestedValue: String)

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
@@ -27,6 +27,7 @@ import me.ahoo.wow.schema.AggregatedFieldPaths.commandAggregatedFieldPaths
 import me.ahoo.wow.schema.AggregatedFieldPaths.stateAggregatedFieldPaths
 import me.ahoo.wow.schema.TypeFieldPaths.allFieldPaths
 import me.ahoo.wow.serialization.JsonSerializer
+import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.serialization.state.SnapshotRecords
 import org.junit.jupiter.api.Test
 import tools.jackson.core.JsonGenerator
@@ -147,7 +148,10 @@ class AggregatedFieldPathsTest {
     @Test
     fun `should list command aggregated field paths`() {
         val paths = TestAggregate::class.commandAggregatedFieldPaths()
-        paths.assert().contains(SnapshotRecords.SNAPSHOT_TIME)
+        paths.assert()
+            .contains(MessageRecords.CONTEXT_NAME)
+            .contains(MessageRecords.AGGREGATE_NAME)
+            .contains(SnapshotRecords.SNAPSHOT_TIME)
     }
 
     class FieldPathDemoState(override val id: String) : Identifier {

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
@@ -14,6 +14,8 @@
 package me.ahoo.wow.schema
 
 import com.fasterxml.jackson.annotation.JsonIgnore
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.Identifier
@@ -71,8 +73,8 @@ class AggregatedFieldPathsTest {
             .contains("state.aggregateId.aggregateName")
             .contains("state.aggregateId.aggregateId")
             .contains("state.aggregateId.tenantId")
-            .contains("state.aggregateId.namedAggregate")
-            .contains("state.aggregateId.id")
+            .doesNotContain("state.aggregateId.namedAggregate")
+            .doesNotContain("state.aggregateId.id")
     }
 
     @Test
@@ -88,6 +90,15 @@ class AggregatedFieldPathsTest {
     fun `should list all field paths for polymorphic fixture`() {
         val paths = PolymorphicFixture::class.allFieldPaths()
         paths.assert().isNotEmpty()
+    }
+
+    @Test
+    fun `should include Jackson polymorphic discriminator`() {
+        val paths = SyntheticTypeInfoFixture::class.allFieldPaths(parentName = "state.payment")
+
+        paths.assert()
+            .contains("state.payment.kind")
+            .contains("state.payment.cardNumber")
     }
 
     @Test
@@ -125,3 +136,9 @@ private data class UnwrappedFieldPathFixture(
 )
 
 private data class UnwrappedDetails(val nestedValue: String)
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "kind")
+@JsonSubTypes(JsonSubTypes.Type(value = CardPayment::class, name = "card"))
+private sealed interface SyntheticTypeInfoFixture
+
+private data class CardPayment(val cardNumber: String) : SyntheticTypeInfoFixture

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/AggregatedFieldPathsTest.kt
@@ -115,6 +115,16 @@ class AggregatedFieldPathsTest {
     }
 
     @Test
+    fun `should treat property custom serializer wire shape as opaque`() {
+        JsonSerializer.writeValueAsString(PropertyCustomSerializedFixture(PropertyCustomSerializedValue("wire")))
+            .assert().isEqualTo("{\"value\":\"wire\"}")
+
+        PropertyCustomSerializedFixture::class.allFieldPaths(parentName = "state").assert()
+            .contains("state.value")
+            .doesNotContain("state.value.hidden")
+    }
+
+    @Test
     fun `should respect the requested maximum depth`() {
         val paths = TestState::class.allFieldPaths(parentName = "state", maxDepth = 1)
 
@@ -193,6 +203,25 @@ private class CustomSerializedValueSerializer : StdSerializer<CustomSerializedVa
 ) {
     override fun serialize(
         value: CustomSerializedValue,
+        generator: JsonGenerator,
+        provider: SerializationContext,
+    ) {
+        generator.writeString(value.hidden)
+    }
+}
+
+private data class PropertyCustomSerializedFixture(
+    @get:JsonSerialize(using = PropertyCustomSerializedValueSerializer::class)
+    val value: PropertyCustomSerializedValue,
+)
+
+private data class PropertyCustomSerializedValue(val hidden: String)
+
+private class PropertyCustomSerializedValueSerializer : StdSerializer<PropertyCustomSerializedValue>(
+    PropertyCustomSerializedValue::class.java,
+) {
+    override fun serialize(
+        value: PropertyCustomSerializedValue,
         generator: JsonGenerator,
         provider: SerializationContext,
     ) {

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/SchemaGeneratorBuilderTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/SchemaGeneratorBuilderTest.kt
@@ -25,6 +25,7 @@ import me.ahoo.wow.schema.jackson.WowJacksonModule
 import me.ahoo.wow.schema.kotlin.KotlinModule
 import me.ahoo.wow.schema.naming.SchemaNamingModule
 import org.junit.jupiter.api.Test
+import tools.jackson.module.kotlin.jsonMapper
 import java.util.function.Consumer
 
 class SchemaGeneratorBuilderTest {
@@ -41,7 +42,9 @@ class SchemaGeneratorBuilderTest {
         val options = listOf<Option>()
         val customizer = Consumer<SchemaGeneratorConfigBuilder> {
         }
+        val objectMapper = jsonMapper()
         val schemaGeneratorBuilder = SchemaGeneratorBuilder()
+            .objectMapper(objectMapper)
             .openapi31(true)
             .schemaVersion(SchemaVersion.DRAFT_2020_12)
             .optionPreset(OptionPreset.PLAIN_JSON)
@@ -55,6 +58,7 @@ class SchemaGeneratorBuilderTest {
             .options(options)
             .customizer(customizer)
         schemaGeneratorBuilder.openapi31.assert().isTrue()
+        schemaGeneratorBuilder.objectMapper.assert().isSameAs(objectMapper)
         schemaGeneratorBuilder.schemaVersion.assert().isEqualTo(SchemaVersion.DRAFT_2020_12)
         schemaGeneratorBuilder.optionPreset.assert().isEqualTo(OptionPreset.PLAIN_JSON)
         schemaGeneratorBuilder.jacksonModule.assert().isSameAs(jacksonModule)
@@ -73,6 +77,7 @@ class SchemaGeneratorBuilderTest {
         val schemaGenerator = schemaGeneratorBuilder.build()
 
         schemaGenerator.assert().isNotNull()
+        schemaGenerator.config.objectMapper.assert().isSameAs(objectMapper)
         schemaGeneratorBuilder.typeContext.assert().isNotNull()
         schemaGeneratorBuilder.requiredTypeContent.assert().isNotNull()
     }

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/RequestExceptionHandler.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/RequestExceptionHandler.kt
@@ -35,7 +35,7 @@ class WebFluxRequestExceptionHandler(
     override fun handle(request: ServerRequest, throwable: Throwable): Mono<ServerResponse> {
         return Mono.defer {
             val logged = AtomicBoolean()
-            errorStrategy.toServerResponse(request, throwable)
+            Mono.defer { errorStrategy.toServerResponse(request, throwable) }
                 .doOnNext { response ->
                     if (logged.compareAndSet(false, true)) {
                         if (response.statusCode().is4xxClientError) {

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/RequestExceptionHandler.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/RequestExceptionHandler.kt
@@ -17,6 +17,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
 import reactor.core.publisher.Mono
+import java.util.concurrent.atomic.AtomicBoolean
 
 interface RequestExceptionHandler {
     fun handle(request: ServerRequest, throwable: Throwable): Mono<ServerResponse>
@@ -32,25 +33,38 @@ class WebFluxRequestExceptionHandler(
     }
 
     override fun handle(request: ServerRequest, throwable: Throwable): Mono<ServerResponse> {
-        return Mono.defer { errorStrategy.toServerResponse(request, throwable) }
-            .doOnNext { response ->
-                if (response.statusCode().is4xxClientError) {
-                    log.warn { "${request.formatRequest()} - ${throwable.singleLineMessage()}" }
-                } else {
-                    log.warn(throwable) { request.formatRequest() }
+        return Mono.defer {
+            val logged = AtomicBoolean()
+            errorStrategy.toServerResponse(request, throwable)
+                .doOnNext { response ->
+                    if (logged.compareAndSet(false, true)) {
+                        if (response.statusCode().is4xxClientError) {
+                            log.warn { "${request.formatRequest()} - ${throwable.singleLineMessage()}" }
+                        } else {
+                            log.warn(throwable) { request.formatRequest() }
+                        }
+                    }
                 }
-            }
-            .switchIfEmpty(
-                Mono.defer {
-                    log.warn(throwable) { "${request.formatRequest()} - Error response was empty." }
-                    Mono.empty()
+                .switchIfEmpty(
+                    Mono.defer {
+                        if (logged.compareAndSet(false, true)) {
+                            log.warn(throwable) { "${request.formatRequest()} - Error response was empty." }
+                        }
+                        Mono.empty()
+                    }
+                ).doOnError { responseFailure ->
+                    if (logged.compareAndSet(false, true)) {
+                        log.warn(throwable) {
+                            "${request.formatRequest()} - Failed to render error response: " +
+                                responseFailure.singleLineMessage()
+                        }
+                    }
+                }.doOnCancel {
+                    if (logged.compareAndSet(false, true)) {
+                        log.warn(throwable) { "${request.formatRequest()} - Error response rendering was cancelled." }
+                    }
                 }
-            ).doOnError { responseFailure ->
-                log.warn(throwable) {
-                    "${request.formatRequest()} - Failed to render error response: " +
-                        responseFailure.singleLineMessage()
-                }
-            }
+        }
     }
 
     private fun Throwable.singleLineMessage(): String = message.orEmpty().replace('\r', ' ').replace('\n', ' ')

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/RequestExceptionHandler.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/RequestExceptionHandler.kt
@@ -32,9 +32,12 @@ class WebFluxRequestExceptionHandler(
     }
 
     override fun handle(request: ServerRequest, throwable: Throwable): Mono<ServerResponse> {
-        log.warn(throwable) {
-            request.formatRequest()
+        return errorStrategy.toServerResponse(request, throwable).doOnNext { response ->
+            if (response.statusCode().is4xxClientError) {
+                log.warn { "${request.formatRequest()} - ${throwable.message.orEmpty()}" }
+            } else {
+                log.warn(throwable) { request.formatRequest() }
+            }
         }
-        return errorStrategy.toServerResponse(request, throwable)
     }
 }

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/RequestExceptionHandler.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/exception/RequestExceptionHandler.kt
@@ -32,12 +32,26 @@ class WebFluxRequestExceptionHandler(
     }
 
     override fun handle(request: ServerRequest, throwable: Throwable): Mono<ServerResponse> {
-        return errorStrategy.toServerResponse(request, throwable).doOnNext { response ->
-            if (response.statusCode().is4xxClientError) {
-                log.warn { "${request.formatRequest()} - ${throwable.message.orEmpty()}" }
-            } else {
-                log.warn(throwable) { request.formatRequest() }
+        return Mono.defer { errorStrategy.toServerResponse(request, throwable) }
+            .doOnNext { response ->
+                if (response.statusCode().is4xxClientError) {
+                    log.warn { "${request.formatRequest()} - ${throwable.singleLineMessage()}" }
+                } else {
+                    log.warn(throwable) { request.formatRequest() }
+                }
             }
-        }
+            .switchIfEmpty(
+                Mono.defer {
+                    log.warn(throwable) { "${request.formatRequest()} - Error response was empty." }
+                    Mono.empty()
+                }
+            ).doOnError { responseFailure ->
+                log.warn(throwable) {
+                    "${request.formatRequest()} - Failed to render error response: " +
+                        responseFailure.singleLineMessage()
+                }
+            }
     }
+
+    private fun Throwable.singleLineMessage(): String = message.orEmpty().replace('\r', ' ').replace('\n', ' ')
 }

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/WebFluxRequestExceptionHandlerTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/WebFluxRequestExceptionHandlerTest.kt
@@ -23,8 +23,10 @@ import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import org.slf4j.LoggerFactory
 import org.springframework.mock.web.reactive.function.server.MockServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
 import reactor.core.publisher.Mono
 import reactor.kotlin.test.test
+import reactor.test.publisher.TestPublisher
 
 class WebFluxRequestExceptionHandlerTest {
     @Test
@@ -134,6 +136,27 @@ class WebFluxRequestExceptionHandlerTest {
 
         warnings.assert().hasSize(1)
         warnings.single().throwableProxy.assert().isNotNull()
+    }
+
+    @Test
+    fun `should not duplicate warning when response is cancelled after emission`() {
+        val response = ServerResponse.badRequest().build().block()!!
+        val responses = TestPublisher.create<ServerResponse>()
+        val errorStrategy = mockk<WebFluxErrorStrategy> {
+            every { toServerResponse(any(), any()) } returns responses.mono()
+        }
+        val warnings = captureWarnings {
+            WebFluxRequestExceptionHandler(errorStrategy).handle(
+                MockServerRequest.builder().build(),
+                IllegalArgumentException("invalid request"),
+            ).test()
+                .then { responses.next(response) }
+                .expectNext(response)
+                .thenCancel()
+                .verify()
+        }
+
+        warnings.assert().hasSize(1)
     }
 
     private fun captureWarnings(block: () -> Unit): List<ILoggingEvent> {

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/WebFluxRequestExceptionHandlerTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/WebFluxRequestExceptionHandlerTest.kt
@@ -105,6 +105,22 @@ class WebFluxRequestExceptionHandlerTest {
     }
 
     @Test
+    fun `should retain original exception when error strategy throws`() {
+        val errorStrategy = mockk<WebFluxErrorStrategy> {
+            every { toServerResponse(any(), any()) } throws IllegalStateException("render failed")
+        }
+        val warnings = captureWarnings {
+            WebFluxRequestExceptionHandler(errorStrategy).handle(
+                MockServerRequest.builder().build(),
+                IllegalArgumentException("invalid request"),
+            ).test().expectErrorMessage("render failed").verify()
+        }
+
+        warnings.assert().hasSize(1)
+        warnings.single().throwableProxy.assert().isNotNull()
+    }
+
+    @Test
     fun `should retain original exception when error response is cancelled`() {
         val errorStrategy = mockk<WebFluxErrorStrategy> {
             every { toServerResponse(any(), any()) } returns Mono.never()

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/WebFluxRequestExceptionHandlerTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/WebFluxRequestExceptionHandlerTest.kt
@@ -104,6 +104,22 @@ class WebFluxRequestExceptionHandlerTest {
         warnings.single().throwableProxy.assert().isNotNull()
     }
 
+    @Test
+    fun `should retain original exception when error response is cancelled`() {
+        val errorStrategy = mockk<WebFluxErrorStrategy> {
+            every { toServerResponse(any(), any()) } returns Mono.never()
+        }
+        val warnings = captureWarnings {
+            WebFluxRequestExceptionHandler(errorStrategy).handle(
+                MockServerRequest.builder().build(),
+                IllegalArgumentException("invalid request"),
+            ).test().thenCancel().verify()
+        }
+
+        warnings.assert().hasSize(1)
+        warnings.single().throwableProxy.assert().isNotNull()
+    }
+
     private fun captureWarnings(block: () -> Unit): List<ILoggingEvent> {
         val logger = LoggerFactory.getLogger(WebFluxRequestExceptionHandler::class.java) as Logger
         val appender = ListAppender<ILoggingEvent>().apply { start() }

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/WebFluxRequestExceptionHandlerTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/WebFluxRequestExceptionHandlerTest.kt
@@ -17,10 +17,13 @@ import ch.qos.logback.classic.Level
 import ch.qos.logback.classic.Logger
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.read.ListAppender
+import io.mockk.every
+import io.mockk.mockk
 import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import org.slf4j.LoggerFactory
 import org.springframework.mock.web.reactive.function.server.MockServerRequest
+import reactor.core.publisher.Mono
 import reactor.kotlin.test.test
 
 class WebFluxRequestExceptionHandlerTest {
@@ -40,12 +43,15 @@ class WebFluxRequestExceptionHandlerTest {
         val warnings = captureWarnings {
             WebFluxRequestExceptionHandler().handle(
                 MockServerRequest.builder().build(),
-                IllegalArgumentException("invalid request"),
+                IllegalArgumentException("invalid\r\nrequest"),
             ).block()
         }
 
         warnings.assert().hasSize(1)
-        warnings.single().formattedMessage.assert().contains("invalid request")
+        warnings.single().formattedMessage.assert()
+            .contains("invalid  request")
+            .doesNotContain("\r")
+            .doesNotContain("\n")
         warnings.single().throwableProxy.assert().isNull()
     }
 
@@ -59,6 +65,42 @@ class WebFluxRequestExceptionHandlerTest {
         }
 
         warnings.assert().hasSize(1)
+        warnings.single().throwableProxy.assert().isNotNull()
+    }
+
+    @Test
+    fun `should retain original exception when error response is empty`() {
+        val errorStrategy = mockk<WebFluxErrorStrategy> {
+            every { toServerResponse(any(), any()) } returns Mono.empty()
+        }
+        val warnings = captureWarnings {
+            WebFluxRequestExceptionHandler(errorStrategy).handle(
+                MockServerRequest.builder().build(),
+                IllegalArgumentException("invalid request"),
+            ).test().verifyComplete()
+        }
+
+        warnings.assert().hasSize(1)
+        warnings.single().throwableProxy.assert().isNotNull()
+    }
+
+    @Test
+    fun `should retain original exception when error response fails`() {
+        val errorStrategy = mockk<WebFluxErrorStrategy> {
+            every { toServerResponse(any(), any()) } returns Mono.error(IllegalStateException("render\r\nfailed"))
+        }
+        val warnings = captureWarnings {
+            WebFluxRequestExceptionHandler(errorStrategy).handle(
+                MockServerRequest.builder().build(),
+                IllegalArgumentException("invalid request"),
+            ).test().expectErrorMessage("render\r\nfailed").verify()
+        }
+
+        warnings.assert().hasSize(1)
+        warnings.single().formattedMessage.assert()
+            .contains("render  failed")
+            .doesNotContain("\r")
+            .doesNotContain("\n")
         warnings.single().throwableProxy.assert().isNotNull()
     }
 

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/WebFluxRequestExceptionHandlerTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/exception/WebFluxRequestExceptionHandlerTest.kt
@@ -13,8 +13,13 @@
 
 package me.ahoo.wow.webflux.exception
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
 import org.springframework.mock.web.reactive.function.server.MockServerRequest
 import reactor.kotlin.test.test
 
@@ -28,5 +33,45 @@ class WebFluxRequestExceptionHandlerTest {
             .consumeNextWith {
                 it.statusCode().is4xxClientError.assert().isTrue()
             }.verifyComplete()
+    }
+
+    @Test
+    fun `should log client error without stack trace`() {
+        val warnings = captureWarnings {
+            WebFluxRequestExceptionHandler().handle(
+                MockServerRequest.builder().build(),
+                IllegalArgumentException("invalid request"),
+            ).block()
+        }
+
+        warnings.assert().hasSize(1)
+        warnings.single().formattedMessage.assert().contains("invalid request")
+        warnings.single().throwableProxy.assert().isNull()
+    }
+
+    @Test
+    fun `should retain stack trace for server error`() {
+        val warnings = captureWarnings {
+            WebFluxRequestExceptionHandler().handle(
+                MockServerRequest.builder().build(),
+                RuntimeException("server error"),
+            ).block()
+        }
+
+        warnings.assert().hasSize(1)
+        warnings.single().throwableProxy.assert().isNotNull()
+    }
+
+    private fun captureWarnings(block: () -> Unit): List<ILoggingEvent> {
+        val logger = LoggerFactory.getLogger(WebFluxRequestExceptionHandler::class.java) as Logger
+        val appender = ListAppender<ILoggingEvent>().apply { start() }
+        logger.addAppender(appender)
+        return try {
+            block()
+            appender.list.filter { it.level == Level.WARN }
+        } finally {
+            logger.detachAppender(appender)
+            appender.stop()
+        }
     }
 }


### PR DESCRIPTION
## 变更

- 在聚合级 Single/List/Paged/Count OpenAPI request body 上发布 `x-wow-query-fields`，字段来自现有聚合元数据
- 4xx 请求错误仅记录单行 WARN，5xx 继续保留异常堆栈
- 同步中英文查询文档与 OpenAPI 兼容快照

## 验证

- `./gradlew :wow-openapi:check :wow-webflux:check --console=plain`
- `pnpm docs:build`