### PR TITLE
fix(query): refine filter DSL path scopes

### DIFF
--- a/documentation/docs/en/guide/query.md
+++ b/documentation/docs/en/guide/query.md
@@ -87,6 +87,22 @@ val filter = filterExpression {
 }
 ```
 
+Use `String.path` to create a lexical path scope for relative fields; `pathState` is shorthand for `"state".path`. Nested `path` blocks append relative paths, complete paths already under the current scope are not prefixed again, and leaving a block automatically restores its parent path. Multiple expressions in a `path` block form one implicit `AND` operand, even when the block appears inside `or` or `nor`:
+
+```kotlin
+val filter = filterExpression {
+    pathState {
+        "status" eq "CREATED"
+        "customer".path {
+            "id" eq customerId
+        }
+    }
+    "tenantId" eq tenantId
+}
+```
+
+`expression(...)` adds a prebuilt expression only at the current query-context root and cannot be called inside a `path` scope. Its `LogicalField` values must already match the insertion context; for example, the independent element root inside `elementMatch` uses element-relative paths.
+
 ### Query DSL
 
 `singleQuery`, `listQuery`, and `pagedQuery` all use `filter {}`:

--- a/documentation/docs/en/guide/query.md
+++ b/documentation/docs/en/guide/query.md
@@ -87,7 +87,7 @@ val filter = filterExpression {
 }
 ```
 
-Use `String.path` to create a lexical path scope for relative fields; `pathState` is shorthand for `"state".path`. Nested `path` blocks append relative paths, complete paths already under the current scope are not prefixed again, and leaving a block automatically restores its parent path. Multiple expressions in a `path` block form one implicit `AND` operand, even when the block appears inside `or` or `nor`:
+Use `String.path` to create a lexical path scope for relative fields; `pathState` is shorthand for `"state".path`. Nested `path` blocks append relative paths. Only paths starting with the current scope plus `.` are already qualified, so a field whose name equals the scope remains relative. Leaving a block automatically restores its parent path. Multiple expressions in a `path` block form one implicit `AND` operand, even when the block appears inside `or` or `nor`:
 
 ```kotlin
 val filter = filterExpression {
@@ -101,7 +101,7 @@ val filter = filterExpression {
 }
 ```
 
-`expression(...)` adds a prebuilt expression only at the current query-context root and cannot be called inside a `path` scope. Its `LogicalField` values must already match the insertion context; for example, the independent element root inside `elementMatch` uses element-relative paths.
+`expression(...)` adds a prebuilt expression only at the current query-context root and cannot be called inside a `path` scope, including through deprecated `nested` blocks. `deletion(...)` is also query-root scoped and is rejected inside `path`. Prebuilt `LogicalField` values must already match the insertion context; for example, the independent element root inside `elementMatch` uses element-relative paths.
 
 ### Query DSL
 

--- a/documentation/docs/zh/guide/query.md
+++ b/documentation/docs/zh/guide/query.md
@@ -87,7 +87,7 @@ val filter = filterExpression {
 }
 ```
 
-使用 `String.path` 为块内的相对字段设置词法路径作用域，`pathState` 等价于 `"state".path`。嵌套 `path` 会追加相对路径，已经包含当前作用域的完整路径不会重复添加前缀；退出代码块后自动回到父级路径。`path` 块内的多个表达式组成一个隐式 `AND` 操作数，即使它位于 `or` 或 `nor` 中也不会被摊平：
+使用 `String.path` 为块内的相对字段设置词法路径作用域，`pathState` 等价于 `"state".path`。嵌套 `path` 会追加相对路径。只有以当前作用域加 `.` 开头的路径才视为已经限定，因此与作用域同名的字段仍按相对字段处理。退出代码块后自动回到父级路径。`path` 块内的多个表达式组成一个隐式 `AND` 操作数，即使它位于 `or` 或 `nor` 中也不会被摊平：
 
 ```kotlin
 val filter = filterExpression {
@@ -101,7 +101,7 @@ val filter = filterExpression {
 }
 ```
 
-`expression(...)` 只能在当前查询上下文根直接加入已经构造的表达式，不能在 `path` 作用域内调用。其中的 `LogicalField` 必须已经适配插入位置的查询上下文；例如，`elementMatch` 的独立元素根上下文使用元素相对路径。
+`expression(...)` 只能在当前查询上下文根直接加入已经构造的表达式，不能在 `path` 作用域内调用，包括经由已弃用的 `nested` 块调用。`deletion(...)` 同样属于查询根作用域，在 `path` 内会被拒绝。预构造表达式中的 `LogicalField` 必须已经适配插入位置的查询上下文；例如，`elementMatch` 的独立元素根上下文使用元素相对路径。
 
 ### 查询 DSL
 

--- a/documentation/docs/zh/guide/query.md
+++ b/documentation/docs/zh/guide/query.md
@@ -87,6 +87,22 @@ val filter = filterExpression {
 }
 ```
 
+使用 `String.path` 为块内的相对字段设置词法路径作用域，`pathState` 等价于 `"state".path`。嵌套 `path` 会追加相对路径，已经包含当前作用域的完整路径不会重复添加前缀；退出代码块后自动回到父级路径。`path` 块内的多个表达式组成一个隐式 `AND` 操作数，即使它位于 `or` 或 `nor` 中也不会被摊平：
+
+```kotlin
+val filter = filterExpression {
+    pathState {
+        "status" eq "CREATED"
+        "customer".path {
+            "id" eq customerId
+        }
+    }
+    "tenantId" eq tenantId
+}
+```
+
+`expression(...)` 只能在当前查询上下文根直接加入已经构造的表达式，不能在 `path` 作用域内调用。其中的 `LogicalField` 必须已经适配插入位置的查询上下文；例如，`elementMatch` 的独立元素根上下文使用元素相对路径。
+
 ### 查询 DSL
 
 `singleQuery`、`listQuery` 和 `pagedQuery` 统一使用 `filter {}`：

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/FilterDsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/FilterDsl.kt
@@ -89,7 +89,7 @@ class FilterDsl private constructor(
 
     fun matchNone() = add(MatchNoneFilter)
 
-    fun deletion(deletionState: DeletionState) = add(DeletionFilter(deletionState))
+    fun deletion(deletionState: DeletionState) = expression(DeletionFilter(deletionState))
 
     fun and(block: FilterDsl.() -> Unit) = add(nestedLogical("AND", ::AndFilter, block))
 
@@ -100,7 +100,7 @@ class FilterDsl private constructor(
     /**
      * Applies [block] in the logical field path scope represented by this string.
      *
-     * Relative paths extend the current scope, while paths already under the current scope remain unchanged.
+     * Relative paths extend the current scope, while paths starting with the current scope plus `.` remain unchanged.
      * Multiple expressions in [block] form one implicit AND operand.
      */
     fun String.path(block: FilterDsl.() -> Unit) {
@@ -111,7 +111,10 @@ class FilterDsl private constructor(
 
     @Deprecated("Use path. Unlike nested, path groups multiple expressions with AND.")
     fun String.nested(block: FilterDsl.() -> Unit) {
-        val nested = FilterDsl(field(this).value, allowScopedExpression = true).apply(block)
+        val nested = FilterDsl(
+            prefix = field(this).value,
+            allowScopedExpression = prefix == "" || allowScopedExpression,
+        ).apply(block)
         require(nested.expressions.isNotEmpty()) { "nested block cannot be empty." }
         nested.expressions.forEach(::add)
     }
@@ -224,7 +227,7 @@ class FilterDsl private constructor(
     private fun field(value: String): LogicalField = LogicalField(resolvePath(value))
 
     private fun resolvePath(value: String): String =
-        if (prefix == "" || value == prefix || value.startsWith(prefix = "$prefix.")) value else "$prefix.$value"
+        if (prefix == "" || value.startsWith(prefix = "$prefix.")) value else "$prefix.$value"
 
     private fun Any?.literal(): JsonNode = JsonSerializer.valueToTree(this)
 

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/FilterDsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/FilterDsl.kt
@@ -61,9 +61,9 @@ import java.time.ZoneId
 @QueryDslMarker
 class FilterDsl private constructor(
     private val prefix: String,
-    private val allowScopedExpression: Boolean = false,
+    private val allowScopedExpression: Boolean,
 ) {
-    internal constructor() : this(prefix = "")
+    internal constructor() : this(prefix = "", allowScopedExpression = false)
 
     internal constructor(prefix: String) : this(prefix, allowScopedExpression = false)
 

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/FilterDsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/FilterDsl.kt
@@ -59,119 +59,151 @@ import java.time.LocalTime
 import java.time.ZoneId
 
 @QueryDslMarker
-class FilterDsl internal constructor(private val prefix: String = "") {
+class FilterDsl private constructor(
+    private val prefix: String,
+    private val allowScopedExpression: Boolean = false,
+) {
+    internal constructor() : this(prefix = "")
+
+    internal constructor(prefix: String) : this(prefix, allowScopedExpression = false)
+
     private val expressions = mutableListOf<FilterExpression>()
 
-    fun expression(expression: FilterExpression) {
+    private fun add(expression: FilterExpression) {
         expressions += expression
     }
 
-    fun matchAll() = expression(MatchAllFilter)
+    /**
+     * Adds a prebuilt filter expression unchanged at the current query context root.
+     *
+     * Logical fields in [expression] must already be valid for the insertion context.
+     */
+    fun expression(expression: FilterExpression) {
+        require(prefix == "" || allowScopedExpression) {
+            "Prebuilt expression cannot be added inside a path scope."
+        }
+        add(expression)
+    }
 
-    fun matchNone() = expression(MatchNoneFilter)
+    fun matchAll() = add(MatchAllFilter)
 
-    fun deletion(deletionState: DeletionState) = expression(DeletionFilter(deletionState))
+    fun matchNone() = add(MatchNoneFilter)
 
-    fun and(block: FilterDsl.() -> Unit) = expression(nestedLogical("AND", ::AndFilter, block))
+    fun deletion(deletionState: DeletionState) = add(DeletionFilter(deletionState))
 
-    fun or(block: FilterDsl.() -> Unit) = expression(nestedLogical("OR", ::OrFilter, block))
+    fun and(block: FilterDsl.() -> Unit) = add(nestedLogical("AND", ::AndFilter, block))
 
-    fun nor(block: FilterDsl.() -> Unit) = expression(nestedLogical("NOR", ::NorFilter, block))
+    fun or(block: FilterDsl.() -> Unit) = add(nestedLogical("OR", ::OrFilter, block))
 
+    fun nor(block: FilterDsl.() -> Unit) = add(nestedLogical("NOR", ::NorFilter, block))
+
+    /**
+     * Applies [block] in the logical field path scope represented by this string.
+     *
+     * Relative paths extend the current scope, while paths already under the current scope remain unchanged.
+     * Multiple expressions in [block] form one implicit AND operand.
+     */
+    fun String.path(block: FilterDsl.() -> Unit) {
+        val scoped = FilterDsl(field(this).value).apply(block)
+        require(scoped.expressions.isNotEmpty()) { "path block cannot be empty." }
+        add(scoped.build())
+    }
+
+    @Deprecated("Use path. Unlike nested, path groups multiple expressions with AND.")
     fun String.nested(block: FilterDsl.() -> Unit) {
-        val nested = FilterDsl(field(this).value).apply(block)
+        val nested = FilterDsl(field(this).value, allowScopedExpression = true).apply(block)
         require(nested.expressions.isNotEmpty()) { "nested block cannot be empty." }
-        expressions += nested.expressions
+        nested.expressions.forEach(::add)
     }
 
     fun String.elementMatch(block: FilterDsl.() -> Unit) {
         val nested = FilterDsl().apply(block)
         require(nested.expressions.isNotEmpty()) { "elementMatch block cannot be empty." }
-        expression(ElementMatchFilter(field(this), nested.build()))
+        add(ElementMatchFilter(field(this), nested.build()))
     }
 
-    infix fun String.eq(value: Any?) = expression(
+    infix fun String.eq(value: Any?) = add(
         value.literal().let {
             if (it.isNull) IsNullFilter(field(this)) else EqualFilter(field(this), it)
         }
     )
 
-    infix fun String.ne(value: Any?) = expression(
+    infix fun String.ne(value: Any?) = add(
         value.literal().let {
             if (it.isNull) IsNotNullFilter(field(this)) else NotEqualFilter(field(this), it)
         }
     )
 
-    infix fun String.gt(value: Any?) = expression(GreaterThanFilter(field(this), value.literal()))
+    infix fun String.gt(value: Any?) = add(GreaterThanFilter(field(this), value.literal()))
 
-    infix fun String.gte(value: Any?) = expression(GreaterThanOrEqualFilter(field(this), value.literal()))
+    infix fun String.gte(value: Any?) = add(GreaterThanOrEqualFilter(field(this), value.literal()))
 
-    infix fun String.lt(value: Any?) = expression(LessThanFilter(field(this), value.literal()))
+    infix fun String.lt(value: Any?) = add(LessThanFilter(field(this), value.literal()))
 
-    infix fun String.lte(value: Any?) = expression(LessThanOrEqualFilter(field(this), value.literal()))
+    infix fun String.lte(value: Any?) = add(LessThanOrEqualFilter(field(this), value.literal()))
 
     fun String.contains(value: String, comparison: StringComparison = StringComparison.CASE_SENSITIVE) =
-        expression(ContainsFilter(field(this), value, comparison))
+        add(ContainsFilter(field(this), value, comparison))
 
     fun String.startsWith(value: String, comparison: StringComparison = StringComparison.CASE_SENSITIVE) =
-        expression(StartsWithFilter(field(this), value, comparison))
+        add(StartsWithFilter(field(this), value, comparison))
 
     fun String.endsWith(value: String, comparison: StringComparison = StringComparison.CASE_SENSITIVE) =
-        expression(EndsWithFilter(field(this), value, comparison))
+        add(EndsWithFilter(field(this), value, comparison))
 
-    infix fun String.isIn(values: Iterable<*>) = expression(InFilter(field(this), values.literals()))
+    infix fun String.isIn(values: Iterable<*>) = add(InFilter(field(this), values.literals()))
 
-    infix fun String.notIn(values: Iterable<*>) = expression(NotInFilter(field(this), values.literals()))
+    infix fun String.notIn(values: Iterable<*>) = add(NotInFilter(field(this), values.literals()))
 
     fun String.between(lowerBound: Any?, upperBound: Any?) =
-        expression(BetweenFilter(field(this), lowerBound.literal(), upperBound.literal()))
+        add(BetweenFilter(field(this), lowerBound.literal(), upperBound.literal()))
 
-    infix fun String.containsAll(values: Iterable<*>) = expression(ContainsAllFilter(field(this), values.literals()))
+    infix fun String.containsAll(values: Iterable<*>) = add(ContainsAllFilter(field(this), values.literals()))
 
-    fun String.isEmptyCollection() = expression(IsEmptyFilter(field(this)))
+    fun String.isEmptyCollection() = add(IsEmptyFilter(field(this)))
 
-    fun String.isNull() = expression(IsNullFilter(field(this)))
+    fun String.isNull() = add(IsNullFilter(field(this)))
 
-    fun String.isNotNull() = expression(IsNotNullFilter(field(this)))
+    fun String.isNotNull() = add(IsNotNullFilter(field(this)))
 
-    fun String.exists() = expression(ExistsFilter(field(this)))
+    fun String.exists() = add(ExistsFilter(field(this)))
 
-    fun String.notExists() = expression(NotExistsFilter(field(this)))
+    fun String.notExists() = add(NotExistsFilter(field(this)))
 
     fun search(query: String, vararg fields: String) =
-        expression(SearchFilter(query, fields.mapTo(linkedSetOf(), ::field)))
+        add(SearchFilter(query, fields.mapTo(linkedSetOf(), ::field)))
 
     infix fun String.search(query: String) = search(query, this)
 
     fun String.today(zoneId: ZoneId? = null, datePattern: String? = null) =
-        expression(TodayFilter(field(this), zoneId?.id, datePattern))
+        add(TodayFilter(field(this), zoneId?.id, datePattern))
 
     fun String.beforeToday(time: LocalTime, zoneId: ZoneId? = null, datePattern: String? = null) =
-        expression(BeforeTodayFilter(field(this), time.toString(), zoneId?.id, datePattern))
+        add(BeforeTodayFilter(field(this), time.toString(), zoneId?.id, datePattern))
 
     fun String.tomorrow(zoneId: ZoneId? = null, datePattern: String? = null) =
-        expression(TomorrowFilter(field(this), zoneId?.id, datePattern))
+        add(TomorrowFilter(field(this), zoneId?.id, datePattern))
 
     fun String.thisWeek(zoneId: ZoneId? = null, datePattern: String? = null) =
-        expression(ThisWeekFilter(field(this), zoneId?.id, datePattern))
+        add(ThisWeekFilter(field(this), zoneId?.id, datePattern))
 
     fun String.nextWeek(zoneId: ZoneId? = null, datePattern: String? = null) =
-        expression(NextWeekFilter(field(this), zoneId?.id, datePattern))
+        add(NextWeekFilter(field(this), zoneId?.id, datePattern))
 
     fun String.lastWeek(zoneId: ZoneId? = null, datePattern: String? = null) =
-        expression(LastWeekFilter(field(this), zoneId?.id, datePattern))
+        add(LastWeekFilter(field(this), zoneId?.id, datePattern))
 
     fun String.thisMonth(zoneId: ZoneId? = null, datePattern: String? = null) =
-        expression(ThisMonthFilter(field(this), zoneId?.id, datePattern))
+        add(ThisMonthFilter(field(this), zoneId?.id, datePattern))
 
     fun String.lastMonth(zoneId: ZoneId? = null, datePattern: String? = null) =
-        expression(LastMonthFilter(field(this), zoneId?.id, datePattern))
+        add(LastMonthFilter(field(this), zoneId?.id, datePattern))
 
     fun String.recentDays(days: Int, zoneId: ZoneId? = null, datePattern: String? = null) =
-        expression(RecentDaysFilter(field(this), days, zoneId?.id, datePattern))
+        add(RecentDaysFilter(field(this), days, zoneId?.id, datePattern))
 
     fun String.earlierDays(days: Int, zoneId: ZoneId? = null, datePattern: String? = null) =
-        expression(EarlierDaysFilter(field(this), days, zoneId?.id, datePattern))
+        add(EarlierDaysFilter(field(this), days, zoneId?.id, datePattern))
 
     internal fun build(): FilterExpression = when (expressions.size) {
         0 -> MatchAllFilter
@@ -184,14 +216,15 @@ class FilterDsl internal constructor(private val prefix: String = "") {
         create: (List<FilterExpression>) -> FilterExpression,
         block: FilterDsl.() -> Unit,
     ): FilterExpression {
-        val nested = FilterDsl(prefix).apply(block)
+        val nested = FilterDsl(prefix, allowScopedExpression).apply(block)
         require(nested.expressions.isNotEmpty()) { "$name block cannot be empty." }
         return create(nested.expressions.toList())
     }
 
-    private fun field(value: String): LogicalField = LogicalField(
-        if (prefix == "") value else "$prefix.$value",
-    )
+    private fun field(value: String): LogicalField = LogicalField(resolvePath(value))
+
+    private fun resolvePath(value: String): String =
+        if (prefix == "" || value == prefix || value.startsWith(prefix = "$prefix.")) value else "$prefix.$value"
 
     private fun Any?.literal(): JsonNode = JsonSerializer.valueToTree(this)
 

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/QueryDsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/QueryDsl.kt
@@ -20,6 +20,7 @@ import me.ahoo.wow.api.query.IPagedQuery
 import me.ahoo.wow.api.query.ISingleQuery
 import me.ahoo.wow.api.query.MaterializedSnapshot
 import me.ahoo.wow.api.query.PagedList
+import me.ahoo.wow.query.dsl.FilterDsl
 import me.ahoo.wow.query.dsl.NestedFieldDsl
 import me.ahoo.wow.serialization.state.StateAggregateRecords
 import reactor.core.publisher.Flux
@@ -27,6 +28,11 @@ import reactor.core.publisher.Mono
 
 fun NestedFieldDsl.nestedState() {
     this.nested(StateAggregateRecords.STATE)
+}
+
+/** Applies [block] in the snapshot state path scope. */
+fun FilterDsl.pathState(block: FilterDsl.() -> Unit) {
+    StateAggregateRecords.STATE.path(block)
 }
 
 fun <S : Any> IListQuery.query(queryService: SnapshotQueryService<S>): Flux<MaterializedSnapshot<S>> {

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/AbacQueryFilter.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/AbacQueryFilter.kt
@@ -83,7 +83,7 @@ abstract class AbacQueryFilter : SnapshotQueryFilter {
          */
         fun Map.Entry<AbacTagKey, AbacTagValue>.toFilterExpression(): me.ahoo.wow.api.query.FilterExpression =
             me.ahoo.wow.query.dsl.filter {
-                TAGS.nested {
+                TAGS.path {
                     if (value.wildcard) {
                         key.exists()
                     } else {

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/FilterDslTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/FilterDslTest.kt
@@ -17,6 +17,7 @@ package me.ahoo.wow.query.dsl
 
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.query.*
+import me.ahoo.wow.query.snapshot.pathState
 import org.junit.jupiter.api.Test
 import java.time.LocalTime
 import java.time.ZoneOffset
@@ -51,6 +52,127 @@ class FilterDslTest {
     }
 
     @Test
+    fun `should resolve scoped paths without duplicate prefixes`() {
+        val expression = filter {
+            "state".path {
+                "state.name" eq "Wow"
+                "statement" eq "value"
+                "items".path {
+                    "productId" eq "product-1"
+                }
+            }
+            "tenantId" eq "tenant-1"
+        } as AndFilter
+
+        expression.operands.assert().hasSize(2)
+        val state = expression.operands[0] as AndFilter
+        (state.operands[0] as EqualFilter).field.assert().isEqualTo(LogicalField("state.name"))
+        (state.operands[1] as EqualFilter).field.assert().isEqualTo(LogicalField("state.statement"))
+        (state.operands[2] as EqualFilter).field.assert().isEqualTo(LogicalField("state.items.productId"))
+        (expression.operands[1] as EqualFilter).field.assert().isEqualTo(LogicalField("tenantId"))
+    }
+
+    @Test
+    fun `should keep path block as one OR operand`() {
+        val expression = filter {
+            or {
+                "state".path {
+                    "status" eq "CREATED"
+                    "ownerId" eq "owner-1"
+                }
+                "tenantId" eq "tenant-1"
+            }
+        } as OrFilter
+
+        expression.operands.assert().hasSize(2)
+        (expression.operands[0] as AndFilter).operands.assert().hasSize(2)
+        (expression.operands[1] as EqualFilter).field.assert().isEqualTo(LogicalField("tenantId"))
+    }
+
+    @Test
+    fun `should reject injected expression inside path scope`() {
+        val prebuilt = filter { "name" eq "Wow" }
+
+        org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            filter {
+                "state".path {
+                    expression(prebuilt)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should reject invalid path scope`() {
+        org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            filter {
+                "invalid path".path {
+                    matchAll()
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `should keep injected element fields relative`() {
+        val itemFilter = filter { "productId" eq "product-1" }
+
+        val expression = filter {
+            "state.items".elementMatch {
+                expression(itemFilter)
+            }
+        } as ElementMatchFilter
+
+        expression.predicate.assert().isSameAs(itemFilter)
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `should preserve deprecated nested source compatibility`() {
+        val expression = filter {
+            "state".nested {
+                "name" eq "Wow"
+            }
+        }
+
+        (expression as EqualFilter).field.assert().isEqualTo(LogicalField("state.name"))
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `should preserve deprecated nested logical semantics`() {
+        val expression = filter {
+            or {
+                "state".nested {
+                    "status" eq "CREATED"
+                    "ownerId" eq "owner-1"
+                }
+                "tenantId" eq "tenant-1"
+            }
+        } as OrFilter
+
+        expression.operands.assert().hasSize(3)
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `should preserve prebuilt expressions in deprecated nested logical blocks`() {
+        val prebuilt = filter { "name" eq "Wow" }
+
+        val expression = filter {
+            "state".nested {
+                or {
+                    expression(prebuilt)
+                    "status" eq "CREATED"
+                }
+            }
+        } as OrFilter
+
+        expression.operands[0].assert().isSameAs(prebuilt)
+        (expression.operands[1] as EqualFilter).field.assert().isEqualTo(LogicalField("state.status"))
+    }
+
+    @Test
     fun `should reject empty logical block`() {
         org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
             filter { and { } }
@@ -66,7 +188,7 @@ class FilterDslTest {
             and { "and" eq 1 }
             or { "or" eq 1 }
             nor { "nor" eq 1 }
-            "state".nested { "name" eq "Wow" }
+            pathState { "name" eq "Wow" }
             "items".elementMatch { "quantity" gt 0 }
             "null" eq null
             "notNull" ne null

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/FilterDslTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/FilterDslTest.kt
@@ -55,6 +55,7 @@ class FilterDslTest {
     fun `should resolve scoped paths without duplicate prefixes`() {
         val expression = filter {
             "state".path {
+                "state" eq "root"
                 "state.name" eq "Wow"
                 "statement" eq "value"
                 "items".path {
@@ -66,9 +67,11 @@ class FilterDslTest {
 
         expression.operands.assert().hasSize(2)
         val state = expression.operands[0] as AndFilter
-        (state.operands[0] as EqualFilter).field.assert().isEqualTo(LogicalField("state.name"))
-        (state.operands[1] as EqualFilter).field.assert().isEqualTo(LogicalField("state.statement"))
-        (state.operands[2] as EqualFilter).field.assert().isEqualTo(LogicalField("state.items.productId"))
+        state.operands.assert().hasSize(4)
+        (state.operands[0] as EqualFilter).field.assert().isEqualTo(LogicalField("state"))
+        (state.operands[1] as EqualFilter).field.assert().isEqualTo(LogicalField("state.name"))
+        (state.operands[2] as EqualFilter).field.assert().isEqualTo(LogicalField("state.statement"))
+        (state.operands[3] as EqualFilter).field.assert().isEqualTo(LogicalField("state.items.productId"))
         (expression.operands[1] as EqualFilter).field.assert().isEqualTo(LogicalField("tenantId"))
     }
 
@@ -114,6 +117,15 @@ class FilterDslTest {
     }
 
     @Test
+    fun `should reject empty path block`() {
+        org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            filter {
+                "state".path { }
+            }
+        }
+    }
+
+    @Test
     fun `should keep injected element fields relative`() {
         val itemFilter = filter { "productId" eq "product-1" }
 
@@ -136,6 +148,25 @@ class FilterDslTest {
         }
 
         (expression as EqualFilter).field.assert().isEqualTo(LogicalField("state.name"))
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `should reject empty nested block`() {
+        org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            filter {
+                "state".nested { }
+            }
+        }
+    }
+
+    @Test
+    fun `should reject empty element match block`() {
+        org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            filter {
+                "items".elementMatch { }
+            }
+        }
     }
 
     @Test
@@ -199,6 +230,7 @@ class FilterDslTest {
             "lessThan" lt 1
             "lessThanOrEqual" lte 1
             "contains".contains("value", StringComparison.CASE_INSENSITIVE)
+            "containsDefault".contains("value")
             "startsWith".startsWith("value")
             "endsWith".endsWith("value")
             "in" isIn listOf(1, 2)
@@ -222,9 +254,19 @@ class FilterDslTest {
             "lastMonth".lastMonth()
             "recentDays".recentDays(2)
             "earlierDays".earlierDays(2)
+            "todayDefault".today()
+            "beforeTodayDefault".beforeToday(LocalTime.NOON)
+            "tomorrowUtc".tomorrow(ZoneOffset.UTC)
+            "thisWeekUtc".thisWeek(ZoneOffset.UTC)
+            "nextWeekUtc".nextWeek(ZoneOffset.UTC)
+            "lastWeekUtc".lastWeek(ZoneOffset.UTC)
+            "thisMonthUtc".thisMonth(ZoneOffset.UTC)
+            "lastMonthUtc".lastMonth(ZoneOffset.UTC)
+            "recentDaysUtc".recentDays(2, ZoneOffset.UTC)
+            "earlierDaysUtc".earlierDays(2, ZoneOffset.UTC)
         } as AndFilter
 
-        expression.operands.assert().hasSize(40)
+        expression.operands.assert().hasSize(51)
         (expression.operands[6] as EqualFilter).field.assert().isEqualTo(LogicalField("state.name"))
     }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/FilterDslTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/FilterDslTest.kt
@@ -68,7 +68,7 @@ class FilterDslTest {
         expression.operands.assert().hasSize(2)
         val state = expression.operands[0] as AndFilter
         state.operands.assert().hasSize(4)
-        (state.operands[0] as EqualFilter).field.assert().isEqualTo(LogicalField("state"))
+        (state.operands[0] as EqualFilter).field.assert().isEqualTo(LogicalField("state.state"))
         (state.operands[1] as EqualFilter).field.assert().isEqualTo(LogicalField("state.name"))
         (state.operands[2] as EqualFilter).field.assert().isEqualTo(LogicalField("state.statement"))
         (state.operands[3] as EqualFilter).field.assert().isEqualTo(LogicalField("state.items.productId"))
@@ -106,6 +106,22 @@ class FilterDslTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
+    fun `should reject injected expression inside nested path scope`() {
+        val prebuilt = filter { "productId" eq "product-1" }
+
+        org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            filter {
+                "state".path {
+                    "items".nested {
+                        expression(prebuilt)
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
     fun `should reject invalid path scope`() {
         org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
             filter {
@@ -121,6 +137,17 @@ class FilterDslTest {
         org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
             filter {
                 "state".path { }
+            }
+        }
+    }
+
+    @Test
+    fun `should reject deletion inside path scope`() {
+        org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            filter {
+                "state".path {
+                    deletion(DeletionState.DELETED)
+                }
             }
         }
     }
@@ -201,6 +228,22 @@ class FilterDslTest {
 
         expression.operands[0].assert().isSameAs(prebuilt)
         (expression.operands[1] as EqualFilter).field.assert().isEqualTo(LogicalField("state.status"))
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun `should preserve prebuilt expressions in nested chains from root`() {
+        val prebuilt = filter { "name" eq "Wow" }
+
+        val expression = filter {
+            "state".nested {
+                "child".nested {
+                    expression(prebuilt)
+                }
+            }
+        }
+
+        expression.assert().isSameAs(prebuilt)
     }
 
     @Test

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/AbacQueryFilterTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/AbacQueryFilterTest.kt
@@ -23,7 +23,9 @@ import me.ahoo.wow.api.abac.EMPTY_ABAC_TAGS
 import me.ahoo.wow.api.abac.wildcard
 import me.ahoo.wow.api.query.AndFilter
 import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.ExistsFilter
 import me.ahoo.wow.api.query.FilterExpression
+import me.ahoo.wow.api.query.LogicalField
 import me.ahoo.wow.api.query.MatchAllFilter
 import me.ahoo.wow.api.query.Operator
 import me.ahoo.wow.api.query.toCondition
@@ -92,6 +94,13 @@ class AbacQueryFilterTest {
 
         filter.assert().isInstanceOf(AndFilter::class.java)
         (filter as AndFilter).operands.assert().hasSize(2)
+    }
+
+    @Test
+    fun `tag key equal to tags path should remain relative`() {
+        val filter = mapOf("tags" to listOf("*")).entries.first().toFilterExpression()
+
+        (filter as ExistsFilter).field.assert().isEqualTo(LogicalField("tags.tags"))
     }
 
     @Test


### PR DESCRIPTION
## Summary

- add lexical `String.path` scopes and `pathState` without duplicate field prefixes
- keep deprecated `nested` source/binary compatibility and legacy flattening semantics
- preserve implicit AND grouping inside logical operators and reject ambiguous prebuilt expressions in scoped paths
- update English and Chinese query DSL documentation

## Verification

- `./gradlew :wow-query:check`
- `cd documentation && pnpm docs:build`
- `git diff --check`