### PR TITLE
fix(webflux): use permissive query guard defaults

### DIFF
--- a/documentation/docs/en/guide/extensions/webflux.md
+++ b/documentation/docs/en/guide/extensions/webflux.md
@@ -92,7 +92,7 @@ plus `wow-webflux` for these properties to be bound.
 | `query.max-page-window` | `Long` | `10000` | Maximum HTTP `index * size` page window; `0` disables the cap |
 | `query.max-condition-nodes` | `Int` | `64` | Maximum number of HTTP query condition nodes; `0` disables the cap |
 | `query.max-condition-values` | `Int` | `1000` | Maximum values in HTTP `IN`, `NOT_IN`, `ALL_IN`, `IDS`, or `AGGREGATE_IDS` conditions; `0` disables the cap |
-| `query.allow-expensive-operators` | `Boolean` | `false` | Whether HTTP queries may use negative/existence/expensive string operators or unfiltered count/paged queries |
+| `query.allow-expensive-operators` | `Boolean` | `true` | Whether HTTP queries may use negative/existence/expensive string operators or unfiltered count/paged queries |
 | `query.idle-timeout` | `Duration` | `10s` | Maximum wait between results or completion; JSON arrays are buffered before the response is committed, while SSE remains streaming; `0s` disables the timeout |
 
 ```yaml
@@ -110,7 +110,7 @@ wow:
       max-page-window: 10000
       max-condition-nodes: 64
       max-condition-values: 1000
-      allow-expensive-operators: false
+      allow-expensive-operators: true
       idle-timeout: 10s
 ```
 

--- a/documentation/docs/en/reference/config/infrastructure.md
+++ b/documentation/docs/en/reference/config/infrastructure.md
@@ -178,7 +178,7 @@ snapshots.
 | `wow.webflux.query.max-page-window` | Long | `10000` | Maximum HTTP page window; `0` disables the cap |
 | `wow.webflux.query.max-condition-nodes` | Integer | `64` | Maximum HTTP query condition nodes; `0` disables the cap |
 | `wow.webflux.query.max-condition-values` | Integer | `1000` | Maximum values in HTTP `IN`, `NOT_IN`, `ALL_IN`, `IDS`, or `AGGREGATE_IDS` conditions; `0` disables the cap |
-| `wow.webflux.query.allow-expensive-operators` | Boolean | `false` | Allow HTTP negative/existence/expensive string operators or unfiltered count/paged queries |
+| `wow.webflux.query.allow-expensive-operators` | Boolean | `true` | Allow HTTP negative/existence/expensive string operators or unfiltered count/paged queries |
 | `wow.webflux.query.idle-timeout` | Duration | `10s` | Maximum wait between results or completion; JSON arrays are buffered before commit, while SSE remains streaming; `0s` disables it |
 | `wow.webflux.command.request.appender.agent.enabled` | Boolean | `true` | Append the client `User-Agent` to the command request context (set `false` to disable) |
 | `wow.webflux.command.request.appender.ip.enabled` | Boolean | `true` | Append the client IP to the command request context (set `false` to disable) |
@@ -198,7 +198,7 @@ wow:
       max-page-window: 10000
       max-condition-nodes: 64
       max-condition-values: 1000
-      allow-expensive-operators: false
+      allow-expensive-operators: true
       idle-timeout: 10s
     command:
       request:

--- a/documentation/docs/zh/guide/extensions/webflux.md
+++ b/documentation/docs/zh/guide/extensions/webflux.md
@@ -90,7 +90,7 @@ data class CreateOrder(/* ... */)
 | `query.max-page-window` | `Long` | `10000` | HTTP 分页查询允许的最大 `index * size`；`0` 关闭上限 |
 | `query.max-condition-nodes` | `Int` | `64` | HTTP 查询条件树的最大节点数；`0` 关闭上限 |
 | `query.max-condition-values` | `Int` | `1000` | HTTP `IN`、`NOT_IN`、`ALL_IN`、`IDS`、`AGGREGATE_IDS` 条件的最大值数量；`0` 关闭上限 |
-| `query.allow-expensive-operators` | `Boolean` | `false` | 是否允许 HTTP 查询使用负向/存在性/高成本字符串操作符及无过滤 count/paged 查询 |
+| `query.allow-expensive-operators` | `Boolean` | `true` | 是否允许 HTTP 查询使用负向/存在性/高成本字符串操作符及无过滤 count/paged 查询 |
 | `query.idle-timeout` | `Duration` | `10s` | 等待下一条结果或完成的最长时间；普通 JSON 数组在提交响应前缓冲，SSE 保持流式；`0s` 关闭超时 |
 
 ```yaml
@@ -108,7 +108,7 @@ wow:
       max-page-window: 10000
       max-condition-nodes: 64
       max-condition-values: 1000
-      allow-expensive-operators: false
+      allow-expensive-operators: true
       idle-timeout: 10s
 ```
 

--- a/documentation/docs/zh/reference/config/infrastructure.md
+++ b/documentation/docs/zh/reference/config/infrastructure.md
@@ -177,7 +177,7 @@ direct 和 batch 模式下都使用基于 `_source.version` 的原子保护更�
 | `wow.webflux.query.max-page-window` | Long | `10000` | HTTP 查询最大分页窗口；`0` 关闭上限 |
 | `wow.webflux.query.max-condition-nodes` | Integer | `64` | HTTP 查询条件节点上限；`0` 关闭上限 |
 | `wow.webflux.query.max-condition-values` | Integer | `1000` | HTTP `IN`、`NOT_IN`、`ALL_IN`、`IDS`、`AGGREGATE_IDS` 条件值数量上限；`0` 关闭上限 |
-| `wow.webflux.query.allow-expensive-operators` | Boolean | `false` | 允许 HTTP 负向/存在性/高成本字符串操作符及无过滤 count/paged 查询 |
+| `wow.webflux.query.allow-expensive-operators` | Boolean | `true` | 允许 HTTP 负向/存在性/高成本字符串操作符及无过滤 count/paged 查询 |
 | `wow.webflux.query.idle-timeout` | Duration | `10s` | 等待下一条结果或完成的最长时间；普通 JSON 数组在提交前缓冲，SSE 保持流式；`0s` 关闭 |
 | `wow.webflux.command.request.appender.agent.enabled` | Boolean | `true` | 将客户端 `User-Agent` 追加到命令请求上下文（设为 `false` 可禁用） |
 | `wow.webflux.command.request.appender.ip.enabled` | Boolean | `true` | 将客户端 IP 追加到命令请求上下文（设为 `false` 可禁用） |
@@ -197,7 +197,7 @@ wow:
       max-page-window: 10000
       max-condition-nodes: 64
       max-condition-values: 1000
-      allow-expensive-operators: false
+      allow-expensive-operators: true
       idle-timeout: 10s
     command:
       request:

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxProperties.kt
@@ -60,8 +60,8 @@ constructor(
         var maxConditionNodes: Int = 64,
         @DefaultValue("1000")
         var maxConditionValues: Int = 1000,
-        @DefaultValue("false")
-        var allowExpensiveOperators: Boolean = false,
+        @DefaultValue("true")
+        var allowExpensiveOperators: Boolean = true,
         @DefaultValue("10s")
         var idleTimeout: Duration = Duration.ofSeconds(10),
     )

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
@@ -158,19 +158,9 @@ internal class WebFluxAutoConfigurationTest {
                 val batchExecutionPolicy = context.getBean(BatchExecutionPolicy::class.java)
                 batchExecutionPolicy.concurrency.assert().isOne()
                 batchExecutionPolicy.prefetch.assert().isOne()
+                context.getBean(WebFluxProperties::class.java).query.allowExpensiveOperators.assert().isTrue()
 
-                listOf(
-                    BuiltInHttpRouteHandlerKeys.Global.COMMAND_FACADE,
-                    BuiltInHttpRouteHandlerKeys.State.LOAD_AGGREGATE,
-                    BuiltInHttpRouteHandlerKeys.Snapshot.LOAD,
-                    BuiltInHttpRouteHandlerKeys.Event.LOAD,
-                    BuiltInHttpRouteHandlerKeys.Snapshot.REGENERATE,
-                    BuiltInHttpRouteHandlerKeys.Event.RESEND_STATE,
-                    BuiltInHttpRouteHandlerKeys.Global.GLOBAL_ID,
-                    BuiltInHttpRouteHandlerKeys.Global.BI_SCRIPT,
-                ).forEach { handlerKey ->
-                    context.assertRouteFactoryRegistered(handlerKey)
-                }
+                context.assertDefaultRouteFactoriesRegistered()
             }
     }
 
@@ -186,7 +176,7 @@ internal class WebFluxAutoConfigurationTest {
                 "${WebFluxProperties.PREFIX}.query.max-page-window=2000",
                 "${WebFluxProperties.PREFIX}.query.max-condition-nodes=32",
                 "${WebFluxProperties.PREFIX}.query.max-condition-values=50",
-                "${WebFluxProperties.PREFIX}.query.allow-expensive-operators=true",
+                "${WebFluxProperties.PREFIX}.query.allow-expensive-operators=false",
                 "${WebFluxProperties.PREFIX}.query.idle-timeout=5s",
             )
             .withBean(CommandWaitNotifier::class.java, { mockk() })
@@ -221,7 +211,7 @@ internal class WebFluxAutoConfigurationTest {
                 properties.query.maxPageWindow.assert().isEqualTo(2000)
                 properties.query.maxConditionNodes.assert().isEqualTo(32)
                 properties.query.maxConditionValues.assert().isEqualTo(50)
-                properties.query.allowExpensiveOperators.assert().isTrue()
+                properties.query.allowExpensiveOperators.assert().isFalse()
                 properties.query.idleTimeout.assert().isEqualTo(Duration.ofSeconds(5))
                 val batchExecutionPolicy = context.getBean(BatchExecutionPolicy::class.java)
                 batchExecutionPolicy.concurrency.assert().isEqualTo(4)
@@ -954,6 +944,19 @@ internal class WebFluxAutoConfigurationTest {
     private fun AssertableApplicationContext.assertRouteFactoryRegistered(handlerKey: String) {
         val registrar = getBean(RouteHandlerFunctionRegistrar::class.java)
         registrar.getHttpFactory(handlerKey).assert().isNotNull()
+    }
+
+    private fun AssertableApplicationContext.assertDefaultRouteFactoriesRegistered() {
+        listOf(
+            BuiltInHttpRouteHandlerKeys.Global.COMMAND_FACADE,
+            BuiltInHttpRouteHandlerKeys.State.LOAD_AGGREGATE,
+            BuiltInHttpRouteHandlerKeys.Snapshot.LOAD,
+            BuiltInHttpRouteHandlerKeys.Event.LOAD,
+            BuiltInHttpRouteHandlerKeys.Snapshot.REGENERATE,
+            BuiltInHttpRouteHandlerKeys.Event.RESEND_STATE,
+            BuiltInHttpRouteHandlerKeys.Global.GLOBAL_ID,
+            BuiltInHttpRouteHandlerKeys.Global.BI_SCRIPT,
+        ).forEach { handlerKey -> assertRouteFactoryRegistered(handlerKey) }
     }
 
     private fun AssertableApplicationContext.biScriptRouteFactory(): HttpRouteHandlerFunctionFactory {

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilter.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilter.kt
@@ -43,7 +43,7 @@ class HttpQueryGuardFilter(
     private val maxPageWindow: Long = 10_000,
     private val maxConditionNodes: Int = 64,
     private val maxConditionValues: Int = 1000,
-    private val allowExpensiveOperators: Boolean = false,
+    private val allowExpensiveOperators: Boolean = true,
     private val idleTimeout: Duration = Duration.ofSeconds(10),
 ) : QueryFilter<QueryContext<*, *>> {
 

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
@@ -23,6 +23,7 @@ import me.ahoo.wow.api.query.FilterExpression
 import me.ahoo.wow.api.query.IListQuery
 import me.ahoo.wow.api.query.IPagedQuery
 import me.ahoo.wow.api.query.IsEmptyFilter
+import me.ahoo.wow.api.query.IsNotNullFilter
 import me.ahoo.wow.api.query.ListQuery
 import me.ahoo.wow.api.query.LogicalField
 import me.ahoo.wow.api.query.MatchAllFilter
@@ -154,14 +155,9 @@ class HttpQueryGuardFilterTest {
     }
 
     @Test
-    fun `should allow explicitly enabled expensive http behavior`() {
-        val context = listContext(ListQuery(MatchAllFilter))
-        guard(
-            maxListSize = 0,
-            maxConditionNodes = 0,
-            allowExpensiveOperators = true,
-            idleTimeout = Duration.ZERO,
-        ).filter(
+    fun `should allow expensive http operators by default`() {
+        val context = listContext(ListQuery(IsNotNullFilter(LogicalField("state.status")), limit = 1))
+        HttpQueryGuardFilter(idleTimeout = Duration.ZERO).filter(
             context,
             FilterChain {
                 it.asListQuery<Any>().setResult(Flux.empty())
@@ -170,6 +166,20 @@ class HttpQueryGuardFilterTest {
         ).writeRawRequest(request).test().verifyComplete()
 
         context.getRequiredResult().test().verifyComplete()
+    }
+
+    @Test
+    fun `should allow unfiltered counting queries by default`() {
+        val context = countContext(Condition.ALL)
+        HttpQueryGuardFilter(idleTimeout = Duration.ZERO).filter(
+            context,
+            FilterChain {
+                it.asFilterCountQuery().setResult(Mono.just(0))
+                Mono.empty()
+            },
+        ).writeRawRequest(request).test().verifyComplete()
+
+        context.getRequiredResult().test().expectNext(0).verifyComplete()
     }
 
     @Test


### PR DESCRIPTION
## Summary
- default HTTP expensive-query operators to allowed so framework upgrades remain non-blocking
- preserve explicit strict mode with `wow.webflux.query.allow-expensive-operators=false`
- document the permissive default in English and Chinese

## Validation
- `./gradlew :wow-webflux:check :wow-spring-boot-starter:check --no-build-cache --console=plain`
- `./gradlew build --no-build-cache --console=plain`
- `pnpm docs:build`