### PR TITLE
refactor(compensation): use filter DSL for retry query

### DIFF
--- a/compensation/wow-compensation-server/src/main/kotlin/me/ahoo/wow/compensation/server/failed/SnapshotFindNextRetry.kt
+++ b/compensation/wow-compensation-server/src/main/kotlin/me/ahoo/wow/compensation/server/failed/SnapshotFindNextRetry.kt
@@ -25,7 +25,7 @@ import me.ahoo.wow.compensation.domain.ExecutionFailedStateProperties.STATUS
 import me.ahoo.wow.compensation.domain.FindNextRetry
 import me.ahoo.wow.query.dsl.listQuery
 import me.ahoo.wow.query.snapshot.SnapshotQueryService
-import me.ahoo.wow.query.snapshot.nestedState
+import me.ahoo.wow.query.snapshot.pathState
 import me.ahoo.wow.query.snapshot.query
 import me.ahoo.wow.query.snapshot.toState
 import me.ahoo.wow.serialization.MessageRecords
@@ -43,19 +43,20 @@ class SnapshotFindNextRetry(
         val currentTime = System.currentTimeMillis()
         return listQuery {
             limit(limit)
-            condition {
-                nestedState()
-                RECOVERABLE isIn listOf(
-                    RecoverableType.RECOVERABLE.name,
-                    RecoverableType.UNKNOWN.name,
-                )
-                IS_RETRYABLE eq true
-                RETRY_STATE__NEXT_RETRY_AT lte currentTime
-                or {
-                    STATUS eq ExecutionFailedStatus.FAILED.name
-                    and {
-                        STATUS eq ExecutionFailedStatus.PREPARED.name
-                        RETRY_STATE__TIMEOUT_AT lte currentTime
+            filter {
+                pathState {
+                    RECOVERABLE isIn listOf(
+                        RecoverableType.RECOVERABLE.name,
+                        RecoverableType.UNKNOWN.name,
+                    )
+                    IS_RETRYABLE eq true
+                    RETRY_STATE__NEXT_RETRY_AT lte currentTime
+                    or {
+                        STATUS eq ExecutionFailedStatus.FAILED.name
+                        and {
+                            STATUS eq ExecutionFailedStatus.PREPARED.name
+                            RETRY_STATE__TIMEOUT_AT lte currentTime
+                        }
                     }
                 }
             }

--- a/compensation/wow-compensation-server/src/test/kotlin/me/ahoo/wow/compensation/server/failed/SnapshotFindNextRetryTest.kt
+++ b/compensation/wow-compensation-server/src/test/kotlin/me/ahoo/wow/compensation/server/failed/SnapshotFindNextRetryTest.kt
@@ -5,10 +5,12 @@ import io.mockk.mockk
 import io.mockk.slot
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.exception.RecoverableType
+import me.ahoo.wow.api.query.AndFilter
 import me.ahoo.wow.api.query.IListQuery
+import me.ahoo.wow.api.query.LessThanOrEqualFilter
 import me.ahoo.wow.compensation.api.ExecutionFailedStatus
 import me.ahoo.wow.compensation.domain.ExecutionFailedState
-import me.ahoo.wow.query.dsl.condition
+import me.ahoo.wow.query.dsl.filter
 import me.ahoo.wow.query.snapshot.SnapshotQueryService
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Flux
@@ -26,7 +28,7 @@ class SnapshotFindNextRetryTest {
     }
 
     @Test
-    fun `should build correct find next retry condition`() {
+    fun `should build correct find next retry filter`() {
         val querySlot = slot<IListQuery>()
         val queryService = mockk<SnapshotQueryService<ExecutionFailedState>> {
             every { list(capture(querySlot)) } returns Flux.empty()
@@ -35,11 +37,10 @@ class SnapshotFindNextRetryTest {
         SnapshotFindNextRetry(queryService).findNextRetry(10).collectList().block()
         val after = System.currentTimeMillis()
         val nextQuery = querySlot.captured
-        val currentTime = nextQuery.condition.children
-            .first { it.field == NEXT_RETRY_AT_FIELD }
-            .value as Long
+        val actualFilter = nextQuery.filter as AndFilter
+        val currentTime = (actualFilter.operands[2] as LessThanOrEqualFilter).value.asLong()
 
-        val originalCondition = condition {
+        val expectedFilter = filter {
             RECOVERABLE_FIELD isIn listOf(
                 RecoverableType.RECOVERABLE.name,
                 RecoverableType.UNKNOWN.name,
@@ -58,6 +59,6 @@ class SnapshotFindNextRetryTest {
         currentTime.assert().isGreaterThanOrEqualTo(before)
         currentTime.assert().isLessThanOrEqualTo(after)
         nextQuery.limit.assert().isEqualTo(10)
-        nextQuery.condition.assert().isEqualTo(originalCondition)
+        actualFilter.assert().isEqualTo(expectedFilter)
     }
 }


### PR DESCRIPTION
## Summary

- migrate `SnapshotFindNextRetry` from deprecated `condition`/`nestedState` to typed `filter`/`pathState`
- verify the emitted typed filter against absolute `state.*` fields
- remove legacy `Condition` usage from the focused test

## Verification

- `./gradlew :wow-compensation-server:test --tests "me.ahoo.wow.compensation.server.failed.SnapshotFindNextRetryTest"`
- `./gradlew :wow-compensation-server:check --rerun-tasks`
- mutation check: removing `pathState` makes the focused test fail