### PR TITLE
feat(openapi): reference aggregate query field schemas

### DIFF
--- a/docs/superpowers/specs/2026-08-24-aggregated-query-fields-schema-design.md
+++ b/docs/superpowers/specs/2026-08-24-aggregated-query-fields-schema-design.md
@@ -102,15 +102,43 @@ example.cart.CartAggregatedFields
 
 ## 测试策略
 
+### 模块测试
+
 - `DefaultOpenAPIComponentContextTest`：显式 schema 注册返回正确 Reference，并在 `finish()` 后进入 `schemas`；同名生成 schema 冲突失败。
 - `ExampleDomainOpenAPITest`：每个聚合只有一个 `*AggregatedFields` Schema；四类 RequestBody 的扩展引用相同 Schema；enum 包含真实嵌套字段且不含空字符串。
 - OpenAPI snapshot：字段数组只存在于 `*AggregatedFields.enum`，RequestBody 中仅出现 `$ref`。
 
-验证命令：
-
 ```bash
 ./gradlew :wow-openapi:check
 ```
+
+### 实际服务契约验证
+
+模块测试和快照不能替代运行时证明。实现完成后必须构建并启动 `example-server` 的实际 distribution，通过 HTTP 获取真实 `/v3/api-docs`；不得直接读取测试快照或在测试中调用 `RouterSpecs` 代替服务请求。
+
+验证流程：
+
+1. 运行 `./gradlew :example-server:installDist`。
+2. 从 `example/example-server/build/install/example-server` 启动发行包，使用 distribution 自带的 in-memory storage 配置，不依赖 MongoDB 或 Elasticsearch。
+3. 按条件轮询 `/actuator/health`，确认服务 ready；不使用固定 sleep。
+4. 请求 `http://127.0.0.1:<port>/v3/api-docs` 并保存本次响应到临时文件。
+5. 对实际响应至少断言：
+   - `components.schemas.example.cart.CartAggregatedFields` 存在，类型为字符串 enum；
+   - enum 包含 `state.items.productId`，且不包含空字符串；
+   - `example.cart.SingleQuery`、`CountQuery`、`ListQuery`、`PagedQuery` 的 `x-wow-query-fields.$ref` 都等于 `#/components/schemas/example.cart.CartAggregatedFields`；
+   - RequestBody 的 `x-wow-query-fields` 不再是数组；
+   - 字段枚举只在 `CartAggregatedFields` Schema 中出现一次。
+6. 无论成功或失败都停止服务；失败时输出服务日志和实际 `/v3/api-docs` 响应位置。
+
+该 smoke test 必须可由单条仓库命令重复执行并用于 CI，具体脚本只负责进程生命周期、HTTP 探测和上述断言，不引入测试框架或外部服务。
+
+验证入口：
+
+```bash
+./gradlew :example-server:verifyOpenApi
+```
+
+`verifyOpenApi` 是本次实现需要提供的任务；它依赖 `installDist`，并封装上述真实服务验证流程。
 
 ## 完成条件
 
@@ -118,3 +146,4 @@ example.cart.CartAggregatedFields
 - 四类聚合查询 RequestBody 指向同一个 `*AggregatedFields` Schema。
 - Wow OpenAPI 不再输出数组形式的 `x-wow-query-fields`。
 - `:wow-openapi:check` 通过，OpenAPI 快照符合新协议。
+- `:example-server:verifyOpenApi` 启动实际服务并通过真实 `/v3/api-docs` 契约验证。

--- a/docs/superpowers/specs/2026-08-24-aggregated-query-fields-schema-design.md
+++ b/docs/superpowers/specs/2026-08-24-aggregated-query-fields-schema-design.md
@@ -1,0 +1,167 @@
+# 聚合查询字段 Schema 契约设计
+
+## 背景
+
+Wow 8.11.1–8.11.3 将聚合可查询字段以 `x-wow-query-fields` 字符串数组写入每个聚合的 `SingleQuery`、`CountQuery`、`ListQuery` 和 `PagedQuery` RequestBody。字段集合属于聚合级元数据，却在 OpenAPI 中按请求类型重复四次；字段较多时会明显放大文档，并要求下游生成器自行合成字段类型。
+
+本次变更明确破坏旧协议，不保留数组形式或 Wow 8.10 `properties.field` 形式的兼容逻辑。
+
+## 目标
+
+- 每个聚合只发布一份可查询字段集合。
+- 字段集合继续作为可生成客户端类型的字符串枚举 Schema。
+- 四类聚合查询 RequestBody 通过同一个 `$ref` 关联字段 Schema。
+- Wow 是字段枚举及 Schema 名称的唯一来源；消费者不推导或合成 Schema。
+- Fetcher Generator 只实现新协议，并在协议缺失或错误时快速失败。
+
+## 非目标
+
+- 不兼容 Wow 8.11.1–8.11.3 的 `x-wow-query-fields: string[]`。
+- 不兼容 Wow 8.10 的 `AggregatedCondition.properties.field`。
+- 不把字段集合移动到 Tag 或根级扩展。
+- 不恢复 `AggregatedCondition` 或旧查询请求结构。
+- 不增加协议版本协商、配置开关或迁移适配层。
+
+## OpenAPI 契约
+
+每个聚合注入一个 `*AggregatedFields` Schema：
+
+```yaml
+components:
+  schemas:
+    compensation.execution_failed.ExecutionFailedAggregatedFields:
+      type: string
+      enum:
+        - aggregateId
+        - state.status
+        - state.retryState.retries
+```
+
+该聚合的四类查询 RequestBody 均使用 `x-wow-query-fields` 指向同一 Schema：
+
+```yaml
+components:
+  requestBodies:
+    compensation.execution_failed.CountQuery:
+      x-wow-query-fields:
+        $ref: "#/components/schemas/compensation.execution_failed.ExecutionFailedAggregatedFields"
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/wow.api.query.FilterExpression"
+```
+
+`SingleQuery`、`ListQuery` 和 `PagedQuery` 使用完全相同的扩展引用。扩展名称保持 `x-wow-query-fields`，其唯一合法值是 OpenAPI Reference Object，不再接受数组。
+
+Schema key 沿用原有生成模型命名：
+
+```text
+<contextAlias>.<aggregateAlias>.<AggregateTypeSimpleName>AggregatedFields
+```
+
+例如：
+
+```text
+compensation.execution_failed.ExecutionFailedAggregatedFields
+example.cart.CartAggregatedFields
+```
+
+枚举值来自 `commandAggregatedFieldPaths()` 的排序结果，原样发布，不补回旧协议中的空字符串。
+
+## Wow 实现设计
+
+### 显式组件 Schema 注册
+
+`OpenAPIComponentContext` 增加一个聚焦的显式 Schema 注册入口，接受 component key 和 `Schema<*>`，注册后返回对应 `#/components/schemas/...` Reference。`DefaultOpenAPIComponentContext` 在 `finish()` 时将显式 schemas 与类型生成器产出的 schemas 合并。
+
+注册规则：
+
+- key 不得为空；
+- 同一个 key 可被相同聚合的多个路由重复注册，最终只保留一项；
+- 显式 schema 不得覆盖类型生成器产生的同名 schema，冲突时直接失败；
+- 显式组件始终进入 `components.schemas`，因为该协议必须通过 `$ref` 引用，不受普通类型 schema 的 inline 设置影响。
+
+不为这一项能力引入新的 registry、provider 或 SPI；复用 `OpenAPIComponentContext` 现有的组件收集与 `RouterSpecs` 合并流程。
+
+### 查询组件
+
+`QueryComponent` 为聚合创建 `StringSchema`：
+
+- key 使用上述确定性命名；
+- enum 使用已排序的 `commandAggregatedFieldPaths()`；
+- 注册后取得 Reference；
+- 四个 aggregated RequestBody 将该 Reference 写入 `x-wow-query-fields`。
+
+删除当前四处直接写入字段数组的逻辑。通用 `wow.CountQuery`、`wow.ListQuery` 和 `wow.PagedQuery` 不属于具体聚合，继续不发布 `x-wow-query-fields`。
+
+## Fetcher Generator 设计
+
+`AggregateResolver.fields()` 只处理 operation id 以 `.snapshot.count` 结尾的聚合 count 操作，并执行以下步骤：
+
+1. 解析 operation 的 RequestBody component。
+2. 读取 `x-wow-query-fields`。
+3. 要求其为合法 OpenAPI Reference Object。
+4. 通过现有 `keySchema()` 解析字段 Schema。
+5. 将得到的 `KeySchema` 赋给 operation tag 对应的聚合。
+
+不再解析 count body 的 `FilterExpression`，也不在 Fetcher 中生成或注入 `AggregatedFields` Schema。后续 `ModelGenerator` 和 `QueryClientGenerator` 继续使用已有 `KeySchema` 流程，无需修改公共生成模型。
+
+## 错误处理
+
+对于聚合 count 操作，以下情况都属于无效 Wow OpenAPI 契约并立即抛出带上下文的错误：
+
+- RequestBody 不存在或无法解析；
+- 缺少 `x-wow-query-fields`；
+- 扩展值不是 Reference Object；
+- Reference 不在 `components.schemas` 中；
+- 目标 Schema 不是非空字符串 enum。
+
+错误信息至少包含 operation id 和失败的 component/ref。不得以跳过聚合、退化为 `string` 或合成空 enum 的方式继续生成。
+
+## 测试策略
+
+### Wow
+
+- `DefaultOpenAPIComponentContextTest`：显式 schema 注册返回正确 Reference，并在 `finish()` 后进入 `schemas`；同名生成 schema 冲突失败。
+- `ExampleDomainOpenAPITest`：每个聚合只有一个 `*AggregatedFields` Schema；四类 RequestBody 的扩展引用相同 Schema；enum 包含真实嵌套字段且不含空字符串。
+- OpenAPI snapshot：字段数组只存在于 `*AggregatedFields.enum`，RequestBody 中仅出现 `$ref`。
+
+验证命令：
+
+```bash
+./gradlew :wow-openapi:check
+```
+
+### Fetcher
+
+- `AggregateResolver` 单元测试使用 `$ref` 扩展并断言得到既有 `KeySchema`。
+- 覆盖扩展缺失、非 Reference、目标缺失和非字符串 enum 的失败信息。
+- 使用 Wow 新契约 OpenAPI 执行一次真实代码生成，确认生成 `ExecutionFailedAggregatedFields` 及查询客户端。
+- 删除旧数组及 `properties.field` 测试。
+
+验证命令：
+
+```bash
+pnpm --filter @ahoo-wang/fetcher-generator test
+pnpm --filter @ahoo-wang/fetcher-generator build
+```
+
+## CI 与发布顺序
+
+这是 Wow 与 Fetcher Generator 的协同破坏升级：
+
+1. Wow 合入并发布包含新 Schema/$ref 契约的版本。
+2. Fetcher Generator PR 同时实现新协议并把真实生成工作流升级到该 Wow 镜像。
+3. `generator-test` 改为构建并执行当前 checkout 的 Generator；当前“安装 npm latest”的做法无法在发布前验证本 PR，会形成发布与 CI 的循环依赖。
+4. Fetcher 的 `generator-test` 与 `integration-test` 通过后合入并发布 Generator。
+5. 发布后再以已发布包对同一 Wow 镜像执行一次 smoke test，作为发布证明而非 PR 源码检查。
+
+Fetcher 修复 PR 将覆盖 PR #1351 的镜像升级内容，因此 #1351 应在该 PR 合入后关闭或重建，不单独合并。升级窗口内旧 Generator 无法消费新 Wow，新 Generator也不消费旧 Wow；这是本设计明确接受的破坏边界。不得以临时 fallback 延长双协议状态。
+
+## 完成条件
+
+- 每个聚合的字段枚举在序列化 OpenAPI 中只出现一次。
+- 四类聚合查询 RequestBody 指向同一个 `*AggregatedFields` Schema。
+- Wow OpenAPI 不再输出数组形式的 `x-wow-query-fields`。
+- Fetcher Generator 不再读取 `FilterExpression.properties.field` 或接受字段数组。
+- Wow 与 Fetcher 的定向测试、真实生成以及 PR #1351 两个失败工作流全部通过。

--- a/docs/superpowers/specs/2026-08-24-aggregated-query-fields-schema-design.md
+++ b/docs/superpowers/specs/2026-08-24-aggregated-query-fields-schema-design.md
@@ -114,7 +114,7 @@ example.cart.CartAggregatedFields
 
 ### 实际服务契约验证
 
-模块测试和快照不能替代运行时证明。实现完成后必须构建并启动 `example-server` 的实际 distribution，通过 HTTP 获取真实 `/v3/api-docs`；不得直接读取测试快照或在测试中调用 `RouterSpecs` 代替服务请求。
+模块测试和快照不能替代运行时证明。实现完成后必须主动构建并启动一次 `example-server` 的实际 distribution，通过 HTTP 获取真实 `/v3/api-docs`；不得直接读取测试快照或在测试中调用 `RouterSpecs` 代替服务请求。
 
 验证流程：
 
@@ -130,15 +130,7 @@ example.cart.CartAggregatedFields
    - 字段枚举只在 `CartAggregatedFields` Schema 中出现一次。
 6. 无论成功或失败都停止服务；失败时输出服务日志和实际 `/v3/api-docs` 响应位置。
 
-该 smoke test 必须可由单条仓库命令重复执行并用于 CI，具体脚本只负责进程生命周期、HTTP 探测和上述断言，不引入测试框架或外部服务。
-
-验证入口：
-
-```bash
-./gradlew :example-server:verifyOpenApi
-```
-
-`verifyOpenApi` 是本次实现需要提供的任务；它依赖 `installDist`，并封装上述真实服务验证流程。
+这是实现完成后的单次主动验收，不向仓库增加 verifier 源码、Gradle task、脚本或 CI 接线。执行者在最终交付中报告实际请求地址、断言结果和日志/响应位置即可。
 
 ## 完成条件
 
@@ -146,4 +138,4 @@ example.cart.CartAggregatedFields
 - 四类聚合查询 RequestBody 指向同一个 `*AggregatedFields` Schema。
 - Wow OpenAPI 不再输出数组形式的 `x-wow-query-fields`。
 - `:wow-openapi:check` 通过，OpenAPI 快照符合新协议。
-- `:example-server:verifyOpenApi` 启动实际服务并通过真实 `/v3/api-docs` 契约验证。
+- 实现完成后已主动启动一次实际服务，并通过真实 `/v3/api-docs` 契约验证。

--- a/docs/superpowers/specs/2026-08-24-aggregated-query-fields-schema-design.md
+++ b/docs/superpowers/specs/2026-08-24-aggregated-query-fields-schema-design.md
@@ -2,7 +2,7 @@
 
 ## 背景
 
-Wow 8.11.1–8.11.3 将聚合可查询字段以 `x-wow-query-fields` 字符串数组写入每个聚合的 `SingleQuery`、`CountQuery`、`ListQuery` 和 `PagedQuery` RequestBody。字段集合属于聚合级元数据，却在 OpenAPI 中按请求类型重复四次；字段较多时会明显放大文档，并要求下游生成器自行合成字段类型。
+Wow 8.11.1–8.11.3 将聚合可查询字段以 `x-wow-query-fields` 字符串数组写入每个聚合的 `SingleQuery`、`CountQuery`、`ListQuery` 和 `PagedQuery` RequestBody。字段集合属于聚合级元数据，却在 OpenAPI 中按请求类型重复四次；字段较多时会明显放大文档。
 
 本次变更明确破坏旧协议，不保留数组形式或 Wow 8.10 `properties.field` 形式的兼容逻辑。
 
@@ -11,8 +11,7 @@ Wow 8.11.1–8.11.3 将聚合可查询字段以 `x-wow-query-fields` 字符串�
 - 每个聚合只发布一份可查询字段集合。
 - 字段集合继续作为可生成客户端类型的字符串枚举 Schema。
 - 四类聚合查询 RequestBody 通过同一个 `$ref` 关联字段 Schema。
-- Wow 是字段枚举及 Schema 名称的唯一来源；消费者不推导或合成 Schema。
-- Fetcher Generator 只实现新协议，并在协议缺失或错误时快速失败。
+- Wow 是字段枚举及 Schema 名称的唯一来源。
 
 ## 非目标
 
@@ -21,6 +20,7 @@ Wow 8.11.1–8.11.3 将聚合可查询字段以 `x-wow-query-fields` 字符串�
 - 不把字段集合移动到 Tag 或根级扩展。
 - 不恢复 `AggregatedCondition` 或旧查询请求结构。
 - 不增加协议版本协商、配置开关或迁移适配层。
+- 不规定下游消费者的解析、测试、CI 与发布策略。
 
 ## OpenAPI 契约
 
@@ -94,33 +94,13 @@ example.cart.CartAggregatedFields
 
 删除当前四处直接写入字段数组的逻辑。通用 `wow.CountQuery`、`wow.ListQuery` 和 `wow.PagedQuery` 不属于具体聚合，继续不发布 `x-wow-query-fields`。
 
-## Fetcher Generator 设计
-
-`AggregateResolver.fields()` 只处理 operation id 以 `.snapshot.count` 结尾的聚合 count 操作，并执行以下步骤：
-
-1. 解析 operation 的 RequestBody component。
-2. 读取 `x-wow-query-fields`。
-3. 要求其为合法 OpenAPI Reference Object。
-4. 通过现有 `keySchema()` 解析字段 Schema。
-5. 将得到的 `KeySchema` 赋给 operation tag 对应的聚合。
-
-不再解析 count body 的 `FilterExpression`，也不在 Fetcher 中生成或注入 `AggregatedFields` Schema。后续 `ModelGenerator` 和 `QueryClientGenerator` 继续使用已有 `KeySchema` 流程，无需修改公共生成模型。
-
 ## 错误处理
 
-对于聚合 count 操作，以下情况都属于无效 Wow OpenAPI 契约并立即抛出带上下文的错误：
+显式组件 Schema 注册拒绝空 key。若显式 Schema 与类型生成器产生的 Schema 同名，`finish()` 立即失败并报告 component key，不允许静默覆盖。
 
-- RequestBody 不存在或无法解析；
-- 缺少 `x-wow-query-fields`；
-- 扩展值不是 Reference Object；
-- Reference 不在 `components.schemas` 中；
-- 目标 Schema 不是非空字符串 enum。
-
-错误信息至少包含 operation id 和失败的 component/ref。不得以跳过聚合、退化为 `string` 或合成空 enum 的方式继续生成。
+聚合查询字段 Schema 必须是字符串 enum，扩展值必须是指向该 Schema 的 Reference。生成阶段不以跳过 Schema、输出内联数组或空 enum 的方式降级。
 
 ## 测试策略
-
-### Wow
 
 - `DefaultOpenAPIComponentContextTest`：显式 schema 注册返回正确 Reference，并在 `finish()` 后进入 `schemas`；同名生成 schema 冲突失败。
 - `ExampleDomainOpenAPITest`：每个聚合只有一个 `*AggregatedFields` Schema；四类 RequestBody 的扩展引用相同 Schema；enum 包含真实嵌套字段且不含空字符串。
@@ -132,36 +112,9 @@ example.cart.CartAggregatedFields
 ./gradlew :wow-openapi:check
 ```
 
-### Fetcher
-
-- `AggregateResolver` 单元测试使用 `$ref` 扩展并断言得到既有 `KeySchema`。
-- 覆盖扩展缺失、非 Reference、目标缺失和非字符串 enum 的失败信息。
-- 使用 Wow 新契约 OpenAPI 执行一次真实代码生成，确认生成 `ExecutionFailedAggregatedFields` 及查询客户端。
-- 删除旧数组及 `properties.field` 测试。
-
-验证命令：
-
-```bash
-pnpm --filter @ahoo-wang/fetcher-generator test
-pnpm --filter @ahoo-wang/fetcher-generator build
-```
-
-## CI 与发布顺序
-
-这是 Wow 与 Fetcher Generator 的协同破坏升级：
-
-1. Wow 合入并发布包含新 Schema/$ref 契约的版本。
-2. Fetcher Generator PR 同时实现新协议并把真实生成工作流升级到该 Wow 镜像。
-3. `generator-test` 改为构建并执行当前 checkout 的 Generator；当前“安装 npm latest”的做法无法在发布前验证本 PR，会形成发布与 CI 的循环依赖。
-4. Fetcher 的 `generator-test` 与 `integration-test` 通过后合入并发布 Generator。
-5. 发布后再以已发布包对同一 Wow 镜像执行一次 smoke test，作为发布证明而非 PR 源码检查。
-
-Fetcher 修复 PR 将覆盖 PR #1351 的镜像升级内容，因此 #1351 应在该 PR 合入后关闭或重建，不单独合并。升级窗口内旧 Generator 无法消费新 Wow，新 Generator也不消费旧 Wow；这是本设计明确接受的破坏边界。不得以临时 fallback 延长双协议状态。
-
 ## 完成条件
 
 - 每个聚合的字段枚举在序列化 OpenAPI 中只出现一次。
 - 四类聚合查询 RequestBody 指向同一个 `*AggregatedFields` Schema。
 - Wow OpenAPI 不再输出数组形式的 `x-wow-query-fields`。
-- Fetcher Generator 不再读取 `FilterExpression.properties.field` 或接受字段数组。
-- Wow 与 Fetcher 的定向测试、真实生成以及 PR #1351 两个失败工作流全部通过。
+- `:wow-openapi:check` 通过，OpenAPI 快照符合新协议。

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/QueryComponent.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/QueryComponent.kt
@@ -145,9 +145,6 @@ object QueryComponent {
             val fields = aggregateMetadata.command.aggregateType.kotlin
                 .commandAggregatedFieldPaths()
                 .sorted()
-            require(fields.isNotEmpty()) {
-                "Aggregate query fields must not be empty: ${aggregateMetadata.toStringWithAlias()}"
-            }
             val key = "${aggregateMetadata.toStringWithAlias()}." +
                 "${aggregateMetadata.command.aggregateType.simpleName}AggregatedFields"
             return componentSchema(key, StringSchema()._enum(fields))

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/QueryComponent.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/QueryComponent.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.openapi
 
+import io.swagger.v3.oas.models.media.StringSchema
 import me.ahoo.wow.api.Wow
 import me.ahoo.wow.api.query.FilterExpression
 import me.ahoo.wow.api.query.PagedList
@@ -85,8 +86,9 @@ object QueryComponent {
         private const val QUERY_FIELDS_EXTENSION = "x-wow-query-fields"
 
         fun OpenAPIComponentContext.aggregatedSingleQueryRequestBody(aggregateMetadata: AggregateMetadata<*, *>): io.swagger.v3.oas.models.parameters.RequestBody {
+            val queryFields = aggregatedFieldsSchema(aggregateMetadata)
             return requestBody(aggregateMetadata.toStringWithAlias() + SINGLE_QUERY_SUFFIX) {
-                extension(QUERY_FIELDS_EXTENSION, aggregateMetadata.queryFields())
+                extension(QUERY_FIELDS_EXTENSION, queryFields)
                 content(schema = singleQuerySchema())
             }
         }
@@ -98,8 +100,9 @@ object QueryComponent {
         }
 
         fun OpenAPIComponentContext.aggregatedCountQueryRequestBody(aggregateMetadata: AggregateMetadata<*, *>): io.swagger.v3.oas.models.parameters.RequestBody {
+            val queryFields = aggregatedFieldsSchema(aggregateMetadata)
             return requestBody(aggregateMetadata.toStringWithAlias() + COUNT_QUERY_SUFFIX) {
-                extension(QUERY_FIELDS_EXTENSION, aggregateMetadata.queryFields())
+                extension(QUERY_FIELDS_EXTENSION, queryFields)
                 content(schema = filterSchema())
             }
         }
@@ -113,8 +116,9 @@ object QueryComponent {
         fun OpenAPIComponentContext.aggregatedListQueryRequestBody(
             aggregateMetadata: AggregateMetadata<*, *>
         ): io.swagger.v3.oas.models.parameters.RequestBody {
+            val queryFields = aggregatedFieldsSchema(aggregateMetadata)
             return requestBody(aggregateMetadata.toStringWithAlias() + LIST_QUERY_SUFFIX) {
-                extension(QUERY_FIELDS_EXTENSION, aggregateMetadata.queryFields())
+                extension(QUERY_FIELDS_EXTENSION, queryFields)
                 content(schema = listQuerySchema())
             }
         }
@@ -128,14 +132,26 @@ object QueryComponent {
         fun OpenAPIComponentContext.aggregatedPagedQueryRequestBody(
             aggregateMetadata: AggregateMetadata<*, *>
         ): io.swagger.v3.oas.models.parameters.RequestBody {
+            val queryFields = aggregatedFieldsSchema(aggregateMetadata)
             return requestBody(aggregateMetadata.toStringWithAlias() + PAGED_QUERY_SUFFIX) {
-                extension(QUERY_FIELDS_EXTENSION, aggregateMetadata.queryFields())
+                extension(QUERY_FIELDS_EXTENSION, queryFields)
                 content(schema = pagedQuerySchema())
             }
         }
 
-        private fun AggregateMetadata<*, *>.queryFields(): List<String> =
-            command.aggregateType.kotlin.commandAggregatedFieldPaths().sorted()
+        private fun OpenAPIComponentContext.aggregatedFieldsSchema(
+            aggregateMetadata: AggregateMetadata<*, *>
+        ): io.swagger.v3.oas.models.media.Schema<*> {
+            val fields = aggregateMetadata.command.aggregateType.kotlin
+                .commandAggregatedFieldPaths()
+                .sorted()
+            require(fields.isNotEmpty()) {
+                "Aggregate query fields must not be empty: ${aggregateMetadata.toStringWithAlias()}"
+            }
+            val key = "${aggregateMetadata.toStringWithAlias()}." +
+                "${aggregateMetadata.command.aggregateType.simpleName}AggregatedFields"
+            return componentSchema(key, StringSchema()._enum(fields))
+        }
     }
 
     object Response {

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/context/DefaultOpenAPIComponentContext.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/context/DefaultOpenAPIComponentContext.kt
@@ -27,6 +27,7 @@ import me.ahoo.wow.openapi.context.OpenAPIComponentContext.Companion.COMPONENTS_
 import me.ahoo.wow.openapi.context.OpenAPIComponentContext.Companion.COMPONENTS_PARAMETERS_REF
 import me.ahoo.wow.openapi.context.OpenAPIComponentContext.Companion.COMPONENTS_REQUEST_BODIES_REF
 import me.ahoo.wow.openapi.context.OpenAPIComponentContext.Companion.COMPONENTS_RESPONSES_REF
+import me.ahoo.wow.openapi.context.OpenAPIComponentContext.Companion.COMPONENTS_SCHEMAS_REF
 import me.ahoo.wow.schema.openapi.InlineSchemaCapable
 import me.ahoo.wow.schema.openapi.OpenAPISchemaBuilder
 import java.lang.reflect.Type
@@ -39,6 +40,7 @@ class DefaultOpenAPIComponentContext(private val schemaBuilder: OpenAPISchemaBui
     override val headers: MutableMap<String, Header> = mutableMapOf()
     override val requestBodies: MutableMap<String, RequestBody> = mutableMapOf()
     override val responses: MutableMap<String, ApiResponse> = mutableMapOf()
+    private val explicitSchemas: MutableMap<String, Schema<*>> = mutableMapOf()
     override fun resolveType(mainTargetType: Type, vararg typeParameters: Type): ResolvedType {
         return schemaBuilder.resolveType(mainTargetType, *typeParameters)
     }
@@ -51,6 +53,14 @@ class DefaultOpenAPIComponentContext(private val schemaBuilder: OpenAPISchemaBui
 
     override fun schema(mainTargetType: Type, vararg typeParameters: Type): Schema<*> {
         return schemaBuilder.generateSchema(mainTargetType, *typeParameters)
+    }
+
+    override fun componentSchema(key: String, schema: Schema<*>): Schema<*> {
+        key.requiredKeyNotBlank()
+        explicitSchemas[key] = schema
+        return Schema<Any>().also {
+            it.`$ref` = "$COMPONENTS_SCHEMAS_REF$key"
+        }
     }
 
     private fun String.requiredKeyNotBlank() {
@@ -118,6 +128,11 @@ class DefaultOpenAPIComponentContext(private val schemaBuilder: OpenAPISchemaBui
     }
 
     override fun finish() {
-        schemas = schemaBuilder.build()
+        val generatedSchemas = schemaBuilder.build()
+        val collisions = generatedSchemas.keys.intersect(explicitSchemas.keys)
+        require(collisions.isEmpty()) {
+            "Schema component key collision: ${collisions.sorted().joinToString()}"
+        }
+        schemas = generatedSchemas + explicitSchemas
     }
 }

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/context/OpenAPIComponentContext.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/context/OpenAPIComponentContext.kt
@@ -65,7 +65,26 @@ interface OpenAPIComponentContext : InlineSchemaCapable {
 
     fun resolveType(mainTargetType: Type, vararg typeParameters: Type): ResolvedType
     fun schema(mainTargetType: Type, vararg typeParameters: Type): Schema<*>
-    fun componentSchema(key: String, schema: Schema<*>): Schema<*>
+    fun componentSchema(key: String, schema: Schema<*>): Schema<*> {
+        require(key.isNotBlank()) {
+            "key must not be blank"
+        }
+        val writableSchemas = schemas as? MutableMap<String, Schema<*>>
+            ?: throw IllegalStateException(
+                "Cannot register schema component '$key': ${javaClass.name} exposes a read-only schemas map"
+            )
+        try {
+            writableSchemas[key] = schema
+        } catch (exception: UnsupportedOperationException) {
+            throw IllegalStateException(
+                "Cannot register schema component '$key': ${javaClass.name} exposes an unwritable schemas map",
+                exception
+            )
+        }
+        return Schema<Any>().also {
+            it.`$ref` = "$COMPONENTS_SCHEMAS_REF$key"
+        }
+    }
     fun arraySchema(mainTargetType: Type, vararg typeParameters: Type): Schema<*>
     fun parameter(key: String = "", builder: Parameter.() -> Unit): Parameter
     fun header(key: String = "", builder: Header.() -> Unit): Header

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/context/OpenAPIComponentContext.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/context/OpenAPIComponentContext.kt
@@ -32,6 +32,7 @@ interface OpenAPIComponentContext : InlineSchemaCapable {
     companion object {
         const val COMPONENTS_PREFIX = "#/components/"
         const val COMPONENTS_HEADERS_REF = "${COMPONENTS_PREFIX}headers/"
+        const val COMPONENTS_SCHEMAS_REF = "${COMPONENTS_PREFIX}schemas/"
         const val COMPONENTS_PARAMETERS_REF = "${COMPONENTS_PREFIX}parameters/"
         const val COMPONENTS_REQUEST_BODIES_REF = "${COMPONENTS_PREFIX}requestBodies/"
         const val COMPONENTS_RESPONSES_REF = "${COMPONENTS_PREFIX}responses/"
@@ -64,6 +65,7 @@ interface OpenAPIComponentContext : InlineSchemaCapable {
 
     fun resolveType(mainTargetType: Type, vararg typeParameters: Type): ResolvedType
     fun schema(mainTargetType: Type, vararg typeParameters: Type): Schema<*>
+    fun componentSchema(key: String, schema: Schema<*>): Schema<*>
     fun arraySchema(mainTargetType: Type, vararg typeParameters: Type): Schema<*>
     fun parameter(key: String = "", builder: Parameter.() -> Unit): Parameter
     fun header(key: String = "", builder: Header.() -> Unit): Header

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.openapi
 
 import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.media.Schema
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.configuration.MetadataSearcher
 import me.ahoo.wow.example.domain.cart.Cart
@@ -72,11 +73,20 @@ internal class ExampleDomainOpenAPITest {
     inner class AggregateRoutes {
 
         @Test
-        fun `should expose aggregate query fields`() {
+        fun `should expose aggregate query fields through one schema`() {
+            val fieldsKey = "example.cart.CartAggregatedFields"
+            val fieldsRef = "#/components/schemas/$fieldsKey"
+            val fieldsSchema = requireNotNull(openAPI.components.schemas[fieldsKey])
+
+            fieldsSchema.type.assert().isEqualTo("string")
+            fieldsSchema.`enum`.assert()
+                .contains("state.items.productId")
+                .doesNotContain("")
+
             listOf("CountQuery", "ListQuery", "PagedQuery", "SingleQuery").forEach { queryType ->
                 val requestBody = requireNotNull(openAPI.components.requestBodies["example.cart.$queryType"])
-                val queryFields = requestBody.extensions["x-wow-query-fields"] as List<*>
-                queryFields.assert().contains("state.items.productId").doesNotContain("")
+                val queryFields = requestBody.extensions["x-wow-query-fields"] as Schema<*>
+                queryFields.`$ref`.assert().isEqualTo(fieldsRef)
             }
         }
 

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/context/DefaultOpenAPIComponentContextTest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/context/DefaultOpenAPIComponentContextTest.kt
@@ -13,8 +13,12 @@
 
 package me.ahoo.wow.openapi.context
 
+import io.swagger.v3.oas.models.media.StringSchema
 import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+private data class GeneratedSchema(val value: String)
 
 internal class DefaultOpenAPIComponentContextTest {
 
@@ -61,5 +65,40 @@ internal class DefaultOpenAPIComponentContextTest {
             description("OK")
         }
         context.responses.assert().containsKey("test-response")
+    }
+
+    @Test
+    fun `should register explicit component schema`() {
+        val schema = StringSchema()._enum(listOf("state.id"))
+
+        val reference = context.componentSchema("example.TestFields", schema)
+        context.finish()
+
+        reference.`$ref`.assert()
+            .isEqualTo("#/components/schemas/example.TestFields")
+        context.schemas["example.TestFields"].assert().isEqualTo(schema)
+    }
+
+    @Test
+    fun `should reject blank explicit schema key`() {
+        val error = assertThrows<IllegalArgumentException> {
+            context.componentSchema("", StringSchema())
+        }
+
+        error.message.assert().contains("key must not be blank")
+    }
+
+    @Test
+    fun `should reject collision with generated schema`() {
+        val generatedReference = context.schema(GeneratedSchema::class.java)
+        context.finish()
+        val generatedKey = requireNotNull(generatedReference.`$ref`).substringAfterLast('/')
+        context.componentSchema(generatedKey, StringSchema())
+
+        val error = assertThrows<IllegalArgumentException> {
+            context.finish()
+        }
+
+        error.message.assert().contains(generatedKey)
     }
 }

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/context/OpenAPIComponentContextTest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/context/OpenAPIComponentContextTest.kt
@@ -13,9 +13,19 @@
 
 package me.ahoo.wow.openapi.context
 
+import com.fasterxml.classmate.ResolvedType
 import com.github.victools.jsonschema.generator.SchemaVersion
+import io.swagger.v3.oas.models.headers.Header
+import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.media.StringSchema
+import io.swagger.v3.oas.models.parameters.Parameter
+import io.swagger.v3.oas.models.parameters.RequestBody
+import io.swagger.v3.oas.models.responses.ApiResponse
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.openapi.ApiResponseBuilder
+import me.ahoo.wow.openapi.RequestBodyBuilder
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 internal class OpenAPIComponentContextTest {
 
@@ -40,5 +50,83 @@ internal class OpenAPIComponentContextTest {
         OpenAPIComponentContext.COMPONENTS_PARAMETERS_REF.assert().isEqualTo("#/components/parameters/")
         OpenAPIComponentContext.COMPONENTS_REQUEST_BODIES_REF.assert().isEqualTo("#/components/requestBodies/")
         OpenAPIComponentContext.COMPONENTS_RESPONSES_REF.assert().isEqualTo("#/components/responses/")
+    }
+
+    @Test
+    fun `should register a component schema through the default method for a legacy context`() {
+        val context = LegacyOpenAPIComponentContext()
+        val schema = StringSchema()._enum(listOf("state.id"))
+
+        val reference = context.componentSchema("example.LegacyFields", schema)
+
+        context.schemas["example.LegacyFields"].assert().isEqualTo(schema)
+        reference.`$ref`.assert().isEqualTo("#/components/schemas/example.LegacyFields")
+    }
+
+    @Test
+    fun `should identify the unwritable legacy context when component schema registration fails`() {
+        val error = assertThrows<IllegalStateException> {
+            LegacyOpenAPIComponentContext(emptyMap()).componentSchema("example.LegacyFields", StringSchema())
+        }
+
+        error.message.assert().contains("example.LegacyFields")
+        error.message.assert().contains("LegacyOpenAPIComponentContext")
+    }
+}
+
+private class LegacyOpenAPIComponentContext(
+    override val schemas: Map<String, Schema<*>> = mutableMapOf()
+) : OpenAPIComponentContext {
+    private val delegate = OpenAPIComponentContext.default()
+
+    override val inline: Boolean = false
+    override val parameters: Map<String, Parameter>
+        get() = delegate.parameters
+    override val headers: Map<String, Header>
+        get() = delegate.headers
+    override val requestBodies: Map<String, RequestBody>
+        get() = delegate.requestBodies
+    override val responses: Map<String, ApiResponse>
+        get() = delegate.responses
+
+    override fun resolveType(
+        mainTargetType: java.lang.reflect.Type,
+        vararg typeParameters: java.lang.reflect.Type
+    ): ResolvedType {
+        return delegate.resolveType(mainTargetType, *typeParameters)
+    }
+
+    override fun schema(
+        mainTargetType: java.lang.reflect.Type,
+        vararg typeParameters: java.lang.reflect.Type
+    ): Schema<*> {
+        return delegate.schema(mainTargetType, *typeParameters)
+    }
+
+    override fun arraySchema(
+        mainTargetType: java.lang.reflect.Type,
+        vararg typeParameters: java.lang.reflect.Type
+    ): Schema<*> {
+        return delegate.arraySchema(mainTargetType, *typeParameters)
+    }
+
+    override fun parameter(key: String, builder: Parameter.() -> Unit): Parameter {
+        return delegate.parameter(key, builder)
+    }
+
+    override fun header(key: String, builder: Header.() -> Unit): Header {
+        return delegate.header(key, builder)
+    }
+
+    override fun requestBody(key: String, builder: RequestBodyBuilder.() -> Unit): RequestBody {
+        return delegate.requestBody(key, builder)
+    }
+
+    override fun response(key: String, builder: ApiResponseBuilder.() -> Unit): ApiResponse {
+        return delegate.response(key, builder)
+    }
+
+    override fun finish() {
+        delegate.finish()
     }
 }

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/context/OpenAPIComponentContextTest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/context/OpenAPIComponentContextTest.kt
@@ -36,6 +36,7 @@ internal class OpenAPIComponentContextTest {
     fun `should have correct component reference constants`() {
         OpenAPIComponentContext.COMPONENTS_PREFIX.assert().isEqualTo("#/components/")
         OpenAPIComponentContext.COMPONENTS_HEADERS_REF.assert().isEqualTo("#/components/headers/")
+        OpenAPIComponentContext.COMPONENTS_SCHEMAS_REF.assert().isEqualTo("#/components/schemas/")
         OpenAPIComponentContext.COMPONENTS_PARAMETERS_REF.assert().isEqualTo("#/components/parameters/")
         OpenAPIComponentContext.COMPONENTS_REQUEST_BODIES_REF.assert().isEqualTo("#/components/requestBodies/")
         OpenAPIComponentContext.COMPONENTS_RESPONSES_REF.assert().isEqualTo("#/components/responses/")

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/context/OpenAPIComponentContextTest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/context/OpenAPIComponentContextTest.kt
@@ -26,6 +26,7 @@ import me.ahoo.wow.openapi.ApiResponseBuilder
 import me.ahoo.wow.openapi.RequestBodyBuilder
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import java.util.Collections
 
 internal class OpenAPIComponentContextTest {
 
@@ -64,6 +65,15 @@ internal class OpenAPIComponentContextTest {
     }
 
     @Test
+    fun `should reject a blank component schema key through the default method`() {
+        val error = assertThrows<IllegalArgumentException> {
+            LegacyOpenAPIComponentContext().componentSchema(" ", StringSchema())
+        }
+
+        error.message.assert().contains("key must not be blank")
+    }
+
+    @Test
     fun `should identify the unwritable legacy context when component schema registration fails`() {
         val error = assertThrows<IllegalStateException> {
             LegacyOpenAPIComponentContext(emptyMap()).componentSchema("example.LegacyFields", StringSchema())
@@ -71,6 +81,19 @@ internal class OpenAPIComponentContextTest {
 
         error.message.assert().contains("example.LegacyFields")
         error.message.assert().contains("LegacyOpenAPIComponentContext")
+    }
+
+    @Test
+    fun `should wrap an unsupported component schema write through the default method`() {
+        val schemas = Collections.unmodifiableMap(mutableMapOf<String, Schema<*>>())
+
+        val error = assertThrows<IllegalStateException> {
+            LegacyOpenAPIComponentContext(schemas).componentSchema("example.LegacyFields", StringSchema())
+        }
+
+        error.message.assert().contains("example.LegacyFields")
+        error.message.assert().contains("unwritable schemas map")
+        error.cause.assert().isInstanceOf(UnsupportedOperationException::class.java)
     }
 }
 

--- a/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
@@ -275,7 +275,9 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/example.cart.CartAggregatedFields"
+        }
       },
       "example.cart.ListQuery" : {
         "content" : {
@@ -307,7 +309,9 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/example.cart.CartAggregatedFields"
+        }
       },
       "example.cart.PagedQuery" : {
         "content" : {
@@ -336,7 +340,9 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/example.cart.CartAggregatedFields"
+        }
       },
       "example.cart.SingleQuery" : {
         "content" : {
@@ -362,7 +368,9 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/example.cart.CartAggregatedFields"
+        }
       },
       "example.order.CountQuery" : {
         "content" : {
@@ -372,7 +380,9 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/example.order.OrderAggregatedFields"
+        }
       },
       "example.order.ListQuery" : {
         "content" : {
@@ -404,7 +414,9 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/example.order.OrderAggregatedFields"
+        }
       },
       "example.order.PagedQuery" : {
         "content" : {
@@ -433,7 +445,9 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/example.order.OrderAggregatedFields"
+        }
       },
       "example.order.SingleQuery" : {
         "content" : {
@@ -459,7 +473,9 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/example.order.OrderAggregatedFields"
+        }
       },
       "tck.mock_aggregate.CountQuery" : {
         "content" : {
@@ -469,7 +485,9 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedFields"
+        }
       },
       "tck.mock_aggregate.ListQuery" : {
         "content" : {
@@ -501,7 +519,9 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedFields"
+        }
       },
       "tck.mock_aggregate.PagedQuery" : {
         "content" : {
@@ -530,7 +550,9 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedFields"
+        }
       },
       "tck.mock_aggregate.SingleQuery" : {
         "content" : {
@@ -556,7 +578,9 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedFields"
+        }
       },
       "tck.modeling_command_aggregate_with_tenant_id.CountQuery" : {
         "content" : {
@@ -566,7 +590,9 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/tck.modeling_command_aggregate_with_tenant_id.MockCommandAggregateWithTenantIdAggregatedFields"
+        }
       },
       "tck.modeling_command_aggregate_with_tenant_id.ListQuery" : {
         "content" : {
@@ -598,7 +624,9 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/tck.modeling_command_aggregate_with_tenant_id.MockCommandAggregateWithTenantIdAggregatedFields"
+        }
       },
       "tck.modeling_command_aggregate_with_tenant_id.PagedQuery" : {
         "content" : {
@@ -627,7 +655,9 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/tck.modeling_command_aggregate_with_tenant_id.MockCommandAggregateWithTenantIdAggregatedFields"
+        }
       },
       "tck.modeling_command_aggregate_with_tenant_id.SingleQuery" : {
         "content" : {
@@ -653,7 +683,9 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/tck.modeling_command_aggregate_with_tenant_id.MockCommandAggregateWithTenantIdAggregatedFields"
+        }
       },
       "tck.modeling_command_aggregate_without_ctor_parameters.CountQuery" : {
         "content" : {
@@ -663,7 +695,9 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/tck.modeling_command_aggregate_without_ctor_parameters.MockCommandAggregateWithoutCtorParametersAggregatedFields"
+        }
       },
       "tck.modeling_command_aggregate_without_ctor_parameters.ListQuery" : {
         "content" : {
@@ -695,7 +729,9 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/tck.modeling_command_aggregate_without_ctor_parameters.MockCommandAggregateWithoutCtorParametersAggregatedFields"
+        }
       },
       "tck.modeling_command_aggregate_without_ctor_parameters.PagedQuery" : {
         "content" : {
@@ -724,7 +760,9 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/tck.modeling_command_aggregate_without_ctor_parameters.MockCommandAggregateWithoutCtorParametersAggregatedFields"
+        }
       },
       "tck.modeling_command_aggregate_without_ctor_parameters.SingleQuery" : {
         "content" : {
@@ -750,7 +788,9 @@
             }
           }
         },
-        "x-wow-query-fields" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "tags", "tenantId", "version" ]
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/tck.modeling_command_aggregate_without_ctor_parameters.MockCommandAggregateWithoutCtorParametersAggregatedFields"
+        }
       },
       "wow.CompensationTarget" : {
         "content" : {
@@ -1295,6 +1335,10 @@
         },
         "required" : [ "data" ],
         "type" : "object"
+      },
+      "example.cart.CartAggregatedFields" : {
+        "enum" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.items", "state.items.productId", "state.items.quantity", "state.size", "tags", "tenantId", "version" ],
+        "type" : "string"
       },
       "example.cart.CartItem" : {
         "properties" : {
@@ -2102,6 +2146,10 @@
         "required" : [ "data" ],
         "type" : "object"
       },
+      "example.order.OrderAggregatedFields" : {
+        "enum" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.address", "state.address.city", "state.address.country", "state.address.detail", "state.address.district", "state.address.province", "state.id", "state.items", "state.items.id", "state.items.price", "state.items.productId", "state.items.quantity", "state.items.totalPrice", "state.paidAmount", "state.payable", "state.status", "state.totalAmount", "tags", "tenantId", "version" ],
+        "type" : "string"
+      },
       "example.order.OrderCreated" : {
         "properties" : {
           "address" : {
@@ -2873,6 +2921,10 @@
         },
         "required" : [ "data" ],
         "type" : "object"
+      },
+      "tck.mock_aggregate.MockCommandAggregateAggregatedFields" : {
+        "enum" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ],
+        "type" : "string"
       },
       "tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedDomainEventStream" : {
         "$schema" : "https://json-schema.org/draft/2020-12/schema",
@@ -4319,6 +4371,14 @@
         },
         "required" : [ "data" ],
         "type" : "object"
+      },
+      "tck.modeling_command_aggregate_with_tenant_id.MockCommandAggregateWithTenantIdAggregatedFields" : {
+        "enum" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.id", "state.tenantId", "tags", "tenantId", "version" ],
+        "type" : "string"
+      },
+      "tck.modeling_command_aggregate_without_ctor_parameters.MockCommandAggregateWithoutCtorParametersAggregatedFields" : {
+        "enum" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "tags", "tenantId", "version" ],
+        "type" : "string"
       },
       "wow.api.BindingError" : {
         "properties" : {


### PR DESCRIPTION
## Goal

Publish each aggregate's queryable fields once in OpenAPI instead of repeating the same field array across Single, Count, List, and Paged query request bodies.

## Changes

- Add explicit OpenAPI component Schema registration with blank-key and generated-Schema collision checks.
- Generate one `<contextAlias>.<aggregateAlias>.<AggregateType>AggregatedFields` string enum per aggregate.
- Change `x-wow-query-fields` to a `$ref`-only Reference Object shared by all four aggregate query request bodies.
- Update contract tests, the compatibility snapshot, and the design documentation.

## Verification

- `./gradlew :wow-openapi:check --rerun-tasks` — PASS, 53 tasks executed.
- Built and started the packaged `example-server`, then fetched the live `/v3/api-docs` endpoint.
- Live contract assertion — PASS: `CartAggregatedFields` is a non-empty string enum, contains `state.items.productId`, omits the legacy empty field, appears once, and is referenced by all four aggregate query bodies.
- Independent task reviews and final whole-branch review — no Critical, Important, or Minor findings.

## Compatibility and risks

- [ ] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

This intentionally breaks the Wow 8.11.1–8.11.3 OpenAPI extension shape: `x-wow-query-fields` changes from `string[]` to a Schema Reference Object. No legacy array or `AggregatedCondition.properties.field` fallback is retained. Consumers must resolve the referenced `*AggregatedFields` Schema.
