### PR TITLE
fix(schema): support nullable default values

### DIFF
--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/TypedDefaultValueDefinitionProvider.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/TypedDefaultValueDefinitionProvider.kt
@@ -47,7 +47,7 @@ internal object TypedDefaultValueDefinitionProvider : Module {
             if (
                 textualDefault == "null" &&
                 context.generatorConfig.isNullable(scope) &&
-                !scope.allowsStringDefault()
+                !scope.allowsStringDefault(context)
             ) {
                 return null
             }
@@ -59,10 +59,10 @@ internal object TypedDefaultValueDefinitionProvider : Module {
             scope: FieldScope,
             context: SchemaGenerationContext,
         ) {
-            attributes.normalizeNullDefault(
-                scope.textualDefault(),
-                context.generatorConfig.isNullable(scope) && !scope.allowsStringDefault(),
-            )
+            val default = attributes.path("default")
+            if (!default.isString || default.stringValue() != "null") return
+            if (!context.generatorConfig.isNullable(scope) || scope.allowsStringDefault(context)) return
+            attributes.putNull("default")
         }
     }
 
@@ -83,14 +83,13 @@ internal object TypedDefaultValueDefinitionProvider : Module {
             ?.takeIf(String::isNotEmpty)
     }
 
-    private fun MemberScope<*, *>.allowsStringDefault(): Boolean {
+    private fun FieldScope.allowsStringDefault(context: SchemaGenerationContext): Boolean {
         val schema = getAnnotationConsideringFieldAndGetterIfSupported(Schema::class.java)
         val declaredTypes = schema?.types.orEmpty().toList() + listOfNotNull(schema?.type?.takeIf(String::isNotEmpty))
-        return if (declaredTypes.isEmpty()) type.erasedType == String::class.java else "string" in declaredTypes
-    }
-
-    private fun ObjectNode.normalizeNullDefault(textualDefault: String?, nullable: Boolean) {
-        if (textualDefault == "null" && nullable) putNull("default")
+        if (declaredTypes.isNotEmpty()) return "string" in declaredTypes
+        return context.createDefinition(type).schemaFragments()
+            .flatMap { it.path("type").typeNames() }
+            .any { it == "string" }
     }
 
     private fun JsonNode.withTypedDefault(): CustomPropertyDefinition? {

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/TypedDefaultValueDefinitionProvider.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/TypedDefaultValueDefinitionProvider.kt
@@ -45,7 +45,7 @@ internal object TypedDefaultValueDefinitionProvider : Module {
         ): CustomPropertyDefinition? {
             val textualDefault = scope.textualDefault() ?: return null
             if (
-                textualDefault == "null" &&
+                textualDefault.isJsonNull() &&
                 context.generatorConfig.isNullable(scope) &&
                 !scope.allowsStringDefault(context)
             ) {
@@ -60,7 +60,7 @@ internal object TypedDefaultValueDefinitionProvider : Module {
             context: SchemaGenerationContext,
         ) {
             val default = attributes.path("default")
-            if (!default.isString || default.stringValue() != "null") return
+            if (!default.isString || !default.stringValue().isJsonNull()) return
             if (!context.generatorConfig.isNullable(scope) || scope.allowsStringDefault(context)) return
             attributes.putNull("default")
         }
@@ -82,6 +82,8 @@ internal object TypedDefaultValueDefinitionProvider : Module {
             ?.defaultValue
             ?.takeIf(String::isNotEmpty)
     }
+
+    private fun String.isJsonNull(): Boolean = runCatching { JsonSerializer.readTree(this) }.getOrNull()?.isNull == true
 
     private fun FieldScope.allowsStringDefault(context: SchemaGenerationContext): Boolean {
         val schema = getAnnotationConsideringFieldAndGetterIfSupported(Schema::class.java)

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/TypedDefaultValueDefinitionProvider.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/TypedDefaultValueDefinitionProvider.kt
@@ -17,6 +17,7 @@ import com.github.victools.jsonschema.generator.CustomDefinition.AttributeInclus
 import com.github.victools.jsonschema.generator.CustomPropertyDefinition
 import com.github.victools.jsonschema.generator.CustomPropertyDefinitionProvider
 import com.github.victools.jsonschema.generator.FieldScope
+import com.github.victools.jsonschema.generator.InstanceAttributeOverrideV2
 import com.github.victools.jsonschema.generator.MemberScope
 import com.github.victools.jsonschema.generator.MethodScope
 import com.github.victools.jsonschema.generator.Module
@@ -29,17 +30,30 @@ import tools.jackson.databind.node.ObjectNode
 
 internal object TypedDefaultValueDefinitionProvider : Module {
     override fun applyToConfigBuilder(builder: SchemaGeneratorConfigBuilder) {
-        builder.forFields().withCustomDefinitionProvider(FieldProvider)
+        builder.forFields()
+            .withCustomDefinitionProvider(FieldProvider)
+            .withInstanceAttributeOverride(FieldProvider)
         builder.forMethods().withCustomDefinitionProvider(MethodProvider)
     }
 
-    private object FieldProvider : CustomPropertyDefinitionProvider<FieldScope> {
+    private object FieldProvider :
+        CustomPropertyDefinitionProvider<FieldScope>,
+        InstanceAttributeOverrideV2<FieldScope> {
         override fun provideCustomSchemaDefinition(
             scope: FieldScope,
             context: SchemaGenerationContext,
         ): CustomPropertyDefinition? {
-            if (!scope.hasTextualDefault()) return null
+            val textualDefault = scope.textualDefault() ?: return null
+            if (textualDefault == "null" && context.generatorConfig.isNullable(scope)) return null
             return context.createStandardDefinition(scope, this).withTypedDefault()
+        }
+
+        override fun overrideInstanceAttributes(
+            attributes: ObjectNode,
+            scope: FieldScope,
+            context: SchemaGenerationContext,
+        ) {
+            attributes.normalizeNullDefault(scope.textualDefault(), context.generatorConfig.isNullable(scope))
         }
     }
 
@@ -48,16 +62,21 @@ internal object TypedDefaultValueDefinitionProvider : Module {
             scope: MethodScope,
             context: SchemaGenerationContext,
         ): CustomPropertyDefinition? {
-            if (!scope.hasTextualDefault()) return null
+            if (scope.textualDefault() == null) return null
             return context.createStandardDefinition(scope, this).withTypedDefault()
         }
     }
 
-    private fun MemberScope<*, *>.hasTextualDefault(): Boolean =
-        !isFakeContainerItemScope &&
-            getAnnotationConsideringFieldAndGetterIfSupported(Schema::class.java)
-                ?.defaultValue
-                ?.isNotEmpty() == true
+    private fun MemberScope<*, *>.textualDefault(): String? {
+        if (isFakeContainerItemScope) return null
+        return getAnnotationConsideringFieldAndGetterIfSupported(Schema::class.java)
+            ?.defaultValue
+            ?.takeIf(String::isNotEmpty)
+    }
+
+    private fun ObjectNode.normalizeNullDefault(textualDefault: String?, nullable: Boolean) {
+        if (textualDefault == "null" && nullable) putNull("default")
+    }
 
     private fun JsonNode.withTypedDefault(): CustomPropertyDefinition? {
         if (this !is ObjectNode) return null
@@ -93,7 +112,6 @@ internal object TypedDefaultValueDefinitionProvider : Module {
             "boolean" -> isBoolean
             "array" -> isArray
             "object" -> isObject
-            "null" -> isNull
             else -> false
         }
     }

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/TypedDefaultValueDefinitionProvider.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/TypedDefaultValueDefinitionProvider.kt
@@ -44,7 +44,13 @@ internal object TypedDefaultValueDefinitionProvider : Module {
             context: SchemaGenerationContext,
         ): CustomPropertyDefinition? {
             val textualDefault = scope.textualDefault() ?: return null
-            if (textualDefault == "null" && context.generatorConfig.isNullable(scope)) return null
+            if (
+                textualDefault == "null" &&
+                context.generatorConfig.isNullable(scope) &&
+                !scope.allowsStringDefault()
+            ) {
+                return null
+            }
             return context.createStandardDefinition(scope, this).withTypedDefault()
         }
 
@@ -53,7 +59,10 @@ internal object TypedDefaultValueDefinitionProvider : Module {
             scope: FieldScope,
             context: SchemaGenerationContext,
         ) {
-            attributes.normalizeNullDefault(scope.textualDefault(), context.generatorConfig.isNullable(scope))
+            attributes.normalizeNullDefault(
+                scope.textualDefault(),
+                context.generatorConfig.isNullable(scope) && !scope.allowsStringDefault(),
+            )
         }
     }
 
@@ -72,6 +81,12 @@ internal object TypedDefaultValueDefinitionProvider : Module {
         return getAnnotationConsideringFieldAndGetterIfSupported(Schema::class.java)
             ?.defaultValue
             ?.takeIf(String::isNotEmpty)
+    }
+
+    private fun MemberScope<*, *>.allowsStringDefault(): Boolean {
+        val schema = getAnnotationConsideringFieldAndGetterIfSupported(Schema::class.java)
+        val declaredTypes = schema?.types.orEmpty().toList() + listOfNotNull(schema?.type?.takeIf(String::isNotEmpty))
+        return if (declaredTypes.isEmpty()) type.erasedType == String::class.java else "string" in declaredTypes
     }
 
     private fun ObjectNode.normalizeNullDefault(textualDefault: String?, nullable: Boolean) {

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/openapi/StandaloneSchemaEmbeddingRebaserTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/openapi/StandaloneSchemaEmbeddingRebaserTest.kt
@@ -21,6 +21,33 @@ class StandaloneSchemaEmbeddingRebaserTest {
     private val objectMapper = JsonMapper.builder().build()
 
     @Test
+    fun `should preserve non-object schema`() {
+        val schema = objectMapper.readTree("\"string\"")
+
+        StandaloneSchemaEmbeddingRebaser.rebase(schema, "wow.schema.Node", "components/schemas")
+
+        schema.stringValue().assert().isEqualTo("string")
+    }
+
+    @Test
+    fun `should preserve schema without id`() {
+        val schema = objectMapper.createObjectNode().put("\$ref", "#")
+
+        StandaloneSchemaEmbeddingRebaser.rebase(schema, "wow.schema.Node", "components/schemas")
+
+        schema["\$ref"].stringValue().assert().isEqualTo("#")
+    }
+
+    @Test
+    fun `should preserve schema without references`() {
+        val schema = objectMapper.createObjectNode().put("\$id", "urn:root")
+
+        StandaloneSchemaEmbeddingRebaser.rebase(schema, "wow.schema.Node", "components/schemas")
+
+        schema["\$id"].stringValue().assert().isEqualTo("urn:root")
+    }
+
+    @Test
     fun `should rebase supported local references`() {
         val schema = objectMapper.createObjectNode()
             .put("\$id", "urn:root")

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/typed/TypedDefaultValueDefinitionProviderTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/typed/TypedDefaultValueDefinitionProviderTest.kt
@@ -59,6 +59,19 @@ class TypedDefaultValueDefinitionProviderTest {
     }
 
     @Test
+    fun `should preserve literal null default for nullable string`() {
+        val generator = SchemaGeneratorBuilder().customizer { }.build()
+
+        val default = generator.generateSchema(NullableStringDefault::class.java)
+            .path("properties")
+            .path("value")
+            .path("default")
+
+        default.isString.assert().isTrue()
+        default.stringValue().assert().isEqualTo("null")
+    }
+
+    @Test
     fun `should preserve defaults incompatible with declared type`() {
         val generator = SchemaGeneratorBuilder().customizer { }.build()
 
@@ -104,6 +117,11 @@ class TypedDefaultValueDefinitionProviderTest {
         val number: Double
             get() = 1.5
     }
+
+    private data class NullableStringDefault(
+        @get:Schema(defaultValue = "null")
+        val value: String? = "null",
+    )
 
     private data class IncompatibleDefaults(
         @get:Schema(defaultValue = "true")

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/typed/TypedDefaultValueDefinitionProviderTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/typed/TypedDefaultValueDefinitionProviderTest.kt
@@ -30,13 +30,43 @@ class TypedDefaultValueDefinitionProviderTest {
             isIntegralNumber.assert().isTrue()
             intValue().assert().isZero()
         }
+        properties.path("unionInteger").path("default").isIntegralNumber.assert().isTrue()
         properties.path("array").path("default").isArray.assert().isTrue()
         properties.path("objectValue").path("default").isObject.assert().isTrue()
         properties.path("booleanValue").path("default").booleanValue().assert().isTrue()
+        properties.path("nullableInteger").run {
+            path("default").isNull.assert().isTrue()
+            path("anyOf").path(0).path("type").stringValue().assert().isEqualTo("null")
+            path("anyOf").path(1).path("type").stringValue().assert().isEqualTo("integer")
+        }
         properties.path("stringValue").path("default").run {
             isString.assert().isTrue()
             stringValue().assert().isEqualTo("true")
         }
+    }
+
+    @Test
+    fun `should generate typed default for getter-only property`() {
+        val generator = SchemaGeneratorBuilder().customizer { }.build()
+
+        val default = generator.generateSchema(GetterDefault::class.java)
+            .path("properties")
+            .path("number")
+            .path("default")
+
+        default.isNumber.assert().isTrue()
+        default.doubleValue().assert().isEqualTo(1.5)
+    }
+
+    @Test
+    fun `should preserve defaults incompatible with declared type`() {
+        val generator = SchemaGeneratorBuilder().customizer { }.build()
+
+        val properties = generator.generateSchema(IncompatibleDefaults::class.java).path("properties")
+
+        properties.path("mismatchedInteger").path("default").stringValue().assert().isEqualTo("true")
+        properties.path("malformedInteger").path("default").stringValue().assert().isEqualTo("not-json")
+        properties.path("nonNullableInteger").path("default").stringValue().assert().isEqualTo("null")
     }
 
     @Test
@@ -55,14 +85,33 @@ class TypedDefaultValueDefinitionProviderTest {
     private data class TypedDefaults(
         @get:Schema(defaultValue = "0")
         val integer: Int = 0,
+        @get:Schema(types = ["integer", "null"], defaultValue = "0")
+        val unionInteger: Int = 0,
         @get:Schema(defaultValue = "[]")
         val array: List<String> = emptyList(),
         @get:Schema(defaultValue = "{}")
         val objectValue: Map<String, String> = emptyMap(),
         @get:Schema(defaultValue = "true")
         val booleanValue: Boolean = true,
+        @get:Schema(defaultValue = "null")
+        val nullableInteger: Int? = null,
         @get:Schema(defaultValue = "true")
         val stringValue: String = "true",
+    )
+
+    private class GetterDefault {
+        @get:Schema(defaultValue = "1.5")
+        val number: Double
+            get() = 1.5
+    }
+
+    private data class IncompatibleDefaults(
+        @get:Schema(defaultValue = "true")
+        val mismatchedInteger: Int = 0,
+        @get:Schema(defaultValue = "not-json")
+        val malformedInteger: Int = 0,
+        @get:Schema(defaultValue = "null")
+        val nonNullableInteger: Int = 0,
     )
 
     private class FieldDefault {

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/typed/TypedDefaultValueDefinitionProviderTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/typed/TypedDefaultValueDefinitionProviderTest.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.schema.typed
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.swagger.v3.oas.annotations.media.Schema
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.schema.SchemaGeneratorBuilder
@@ -72,6 +73,34 @@ class TypedDefaultValueDefinitionProviderTest {
     }
 
     @Test
+    fun `should preserve literal null default for nullable flattened enum`() {
+        val generator = SchemaGeneratorBuilder().customizer { }.build()
+
+        val default = generator.generateSchema(NullableEnumDefault::class.java)
+            .path("properties")
+            .path("value")
+            .path("default")
+
+        default.isString.assert().isTrue()
+        default.stringValue().assert().isEqualTo("null")
+    }
+
+    @Test
+    fun `should omit swagger default when swagger module is disabled`() {
+        val generator = SchemaGeneratorBuilder()
+            .swagger2Module(null)
+            .customizer { }
+            .build()
+
+        val default = generator.generateSchema(NullableIntegerDefault::class.java)
+            .path("properties")
+            .path("value")
+            .path("default")
+
+        default.isMissingNode.assert().isTrue()
+    }
+
+    @Test
     fun `should preserve defaults incompatible with declared type`() {
         val generator = SchemaGeneratorBuilder().customizer { }.build()
 
@@ -121,6 +150,21 @@ class TypedDefaultValueDefinitionProviderTest {
     private data class NullableStringDefault(
         @get:Schema(defaultValue = "null")
         val value: String? = "null",
+    )
+
+    private enum class FlattenedDefault {
+        @JsonProperty("null")
+        NULL,
+    }
+
+    private data class NullableEnumDefault(
+        @get:Schema(defaultValue = "null")
+        val value: FlattenedDefault? = FlattenedDefault.NULL,
+    )
+
+    private data class NullableIntegerDefault(
+        @get:Schema(defaultValue = "null")
+        val value: Int? = null,
     )
 
     private data class IncompatibleDefaults(

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/typed/TypedDefaultValueDefinitionProviderTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/typed/TypedDefaultValueDefinitionProviderTest.kt
@@ -101,6 +101,18 @@ class TypedDefaultValueDefinitionProviderTest {
     }
 
     @Test
+    fun `should parse whitespace padded json null default`() {
+        val generator = SchemaGeneratorBuilder().customizer { }.build()
+
+        val default = generator.generateSchema(PaddedNullDefault::class.java)
+            .path("properties")
+            .path("value")
+            .path("default")
+
+        default.isNull.assert().isTrue()
+    }
+
+    @Test
     fun `should preserve defaults incompatible with declared type`() {
         val generator = SchemaGeneratorBuilder().customizer { }.build()
 
@@ -164,6 +176,11 @@ class TypedDefaultValueDefinitionProviderTest {
 
     private data class NullableIntegerDefault(
         @get:Schema(defaultValue = "null")
+        val value: Int? = null,
+    )
+
+    private data class PaddedNullDefault(
+        @get:Schema(defaultValue = " null ")
         val value: Int? = null,
     )
 


### PR DESCRIPTION
## Summary

- preserve the standard nullable wrapper for field-backed Kotlin properties with `@Schema(defaultValue = "null")`
- emit the JSON-null default at the property root through the typed-default provider
- cover getter defaults, incompatible defaults, nullable wrapper behavior, and standalone-schema no-op guards

Follow-up to #3015.

## Verification

- `./gradlew :wow-schema:check :wow-openapi:check --rerun-tasks`
- actual example service `/v3/api-docs`: OpenAPI 3.1.0, 0 unresolved local refs, 0 invalid typed defaults