### PR TITLE
feat(query): add snapshot elements aggregation

### DIFF
--- a/docs/superpowers/plans/2026-08-24-snapshot-elements-aggregation.md
+++ b/docs/superpowers/plans/2026-08-24-snapshot-elements-aggregation.md
@@ -1,0 +1,1146 @@
+# Snapshot Elements Aggregation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add snapshot aggregation with ordered collection expansion, native MongoDB/Elasticsearch execution, the existing query policy chain, HTTP/OpenAPI, and Kotlin/client APIs.
+
+**Architecture:** `AggregationQuery` is a small logical contract in `wow-api`; `wow-query` adds the DSL and routes it through the existing `SnapshotQueryHandler` chain. MongoDB and Elasticsearch each compile the same relative-path model into native aggregation plans, while invalid physical fields and mappings remain backend errors.
+
+**Tech Stack:** Kotlin 2.4.10, JVM 17, Reactor, Jackson, MongoDB reactive streams, Elasticsearch Java client, Spring WebFlux, Victools JSON Schema, JUnit Jupiter 6, MockK, FluentAssert.
+
+**Spec:** `docs/superpowers/specs/2026-08-24-snapshot-elements-aggregation-design.md`
+
+## Global Constraints
+
+- Keep `Aggregation*` naming and `POST .../snapshot/aggregation`; do not add `Analysis*` aliases.
+- Add `aggregate()` to the existing `SnapshotQueryService` and `SnapshotQueryHandler` with source-compatible default errors; do not add capability interfaces or JVM ABI bridges.
+- Fixed limits: result default `100`, result max `10_000`, Elements max `5`, groups max `32`, metrics max `64`, effective sort max `32`.
+- The first Element path is absolute; later Element paths, every Element filter, and leaf group/metric fields are relative to their current scope.
+- Do not use `TypeFieldPaths` for validation and do not create an aggregation field catalog.
+- Do not validate arbitrary Jackson serializers or custom Elasticsearch mapping equivalence.
+- Do not create type-specific field enums, rewrite `FilterExpression` schemas, add aggregation configuration, dependencies, modules, benchmarks, reports, or CI workflows.
+- Reuse the existing snapshot filter chain, ABAC, Guard, ErrorHandler, `FilterDsl`, `SortDsl`, mapping resolver, response streaming, and PIT behavior.
+- `MaskingSnapshotQueryFilter` skips aggregation without rejecting or rewriting results.
+- Count returns `Long`; Sum/Avg/Min/Max return finite `Double` or `null` when no value contributes.
+- Use FluentAssert `.assert()` in Kotlin tests and keep all execution reactive and cancellation-safe.
+- Do not copy or cherry-pick the superseded aggregation branches; implement from the confirmed spec and current `main` only.
+
+## File Structure
+
+New focused production files:
+
+- `wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt` — public query, groups, metrics, expression and structural validation.
+- `wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDsl.kt` — direct Kotlin DSL.
+- `wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompiler.kt` — logical query to Mongo pipeline.
+- `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchPointInTime.kt` — shared PIT lifecycle extracted from the existing pager.
+- `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompiler.kt` — logical query to ES aggregation request parts.
+- `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPager.kt` — composite pagination and exact Top-N.
+- `wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/SnapshotAggregationHandlerFunction.kt` — HTTP handler and route factory.
+- `wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SnapshotAggregationQueryApi.kt` — HTTP interface.
+- `wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/ReactiveSnapshotAggregationQueryApi.kt` — reactive specialization.
+- `wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SynchronousSnapshotAggregationQueryApi.kt` — synchronous specialization.
+
+Existing files change only where the new operation crosses an established boundary: query service/handler/context, two backend services/converters, WebFlux route/guard, OpenAPI route/components, Spring proxy/route module, TCK fixtures, tests and documentation.
+
+---
+
+### Task 1: Public aggregation contract
+
+**Files:**
+- Create: `wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt`
+- Modify: `wow-api/src/main/kotlin/me/ahoo/wow/api/query/FilterExpression.kt`
+- Create: `wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt`
+
+**Interfaces:**
+- Consumes: `FilterExpression`, `FilterCapable`, `LogicalField`, `Sort`, `SortCapable`.
+- Produces: `AggregationQuery`, `AggregationElement`, `AggregationGroup`, `AggregationMetric`, `AggregationExpression`, `AggregationFunction`, `AggregationDateUnit`, `AggregationQuery.effectiveSort()`.
+
+- [ ] **Step 1: Write failing model and JSON tests**
+
+Add tests that construct a query with relative Elements, deserialize a field expression without `type`, append an ABAC filter, and reject only local structural errors:
+
+```kotlin
+@Test
+fun `field expression should be the default JSON subtype`() {
+    val json = """
+        {
+          "metrics": [{
+            "type": "NUMERIC",
+            "function": "SUM",
+            "expression": {"field": "amount"},
+            "alias": "total"
+          }]
+        }
+    """.trimIndent()
+
+    val query = jsonMapper.readValue(json, AggregationQuery::class.java)
+    val metric = query.metrics.single() as AggregationMetric.Numeric
+    metric.expression.assert().isEqualTo(AggregationExpression.Field(LogicalField("amount")))
+}
+
+@Test
+fun `elements should preserve ordered relative paths`() {
+    val query = AggregationQuery(
+        elements = listOf(
+            AggregationElement(LogicalField("state.orders")),
+            AggregationElement(LogicalField("lines")),
+            AggregationElement(LogicalField("discounts")),
+        ),
+        metrics = listOf(AggregationMetric.Count("count")),
+    )
+    query.elements.map { it.path.value }.assert().containsExactly("state.orders", "lines", "discounts")
+}
+
+@Test
+fun `invalid aliases and root element filters should fail`() {
+    assertThrows<IllegalArgumentException> {
+        AggregationQuery(
+            elements = listOf(AggregationElement(LogicalField("state.orders"), TenantIdFilter("tenant"))),
+            metrics = listOf(AggregationMetric.Count("count")),
+        )
+    }
+    assertThrows<IllegalArgumentException> {
+        AggregationQuery(
+            groupBy = listOf(AggregationGroup.Terms(LogicalField("state.status"), "same")),
+            metrics = listOf(AggregationMetric.Count("same")),
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run the API test and verify red**
+
+Run:
+
+```bash
+./gradlew :wow-api:test --tests 'me.ahoo.wow.api.query.AggregationQueryTest'
+```
+
+Expected: compilation fails because the aggregation types do not exist.
+
+- [ ] **Step 3: Implement the minimum public model**
+
+Change `FilterExpression.containsElementUnsupportedFilter()` from file-private to `internal` and reuse it from `AggregationElement`; do not duplicate the operator walk.
+
+Implement the model with Jackson `NAME` polymorphism and `Field` as the default expression:
+
+```kotlin
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    property = "type",
+    defaultImpl = AggregationExpression.Field::class,
+)
+@JsonSubTypes(JsonSubTypes.Type(AggregationExpression.Field::class, name = "FIELD"))
+interface AggregationExpression {
+    data class Field(val field: LogicalField) : AggregationExpression
+}
+
+data class AggregationQuery(
+    override val filter: FilterExpression = MatchAllFilter,
+    val elements: List<AggregationElement> = emptyList(),
+    val groupBy: List<AggregationGroup> = emptyList(),
+    val metrics: List<AggregationMetric>,
+    override val sort: List<Sort> = emptyList(),
+    val limit: Int = DEFAULT_LIMIT,
+) : FilterCapable<AggregationQuery>, SortCapable {
+    override fun withFilter(newFilter: FilterExpression): AggregationQuery = copy(filter = newFilter)
+
+    fun effectiveSort(): List<Sort> = buildList {
+        addAll(sort)
+        val sorted = sort.mapTo(hashSetOf(), Sort::field)
+        groupBy.map(AggregationGroup::alias)
+            .filterNot(sorted::contains)
+            .forEach { add(Sort(it, Sort.Direction.ASC)) }
+    }
+}
+```
+
+Validate metrics non-empty, all fixed limits, finite positive Histogram interval, `ZoneId.of(timeZone)`, one-segment aliases, alias uniqueness, sort alias references, no sort without groups, and effective sort size. Do not inspect aggregate metadata, Java types or mappings.
+
+- [ ] **Step 4: Run API checks**
+
+Run:
+
+```bash
+./gradlew :wow-api:test --tests 'me.ahoo.wow.api.query.AggregationQueryTest' \
+  --tests 'me.ahoo.wow.api.query.FilterExpressionTest'
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt \
+  wow-api/src/main/kotlin/me/ahoo/wow/api/query/FilterExpression.kt \
+  wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt
+git commit -m "feat(query): define snapshot aggregation contract"
+```
+
+### Task 2: Kotlin DSL and execution extension
+
+**Files:**
+- Create: `wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDsl.kt`
+- Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/Dsl.kt`
+- Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/QueryDsl.kt`
+- Create: `wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt`
+
+**Interfaces:**
+- Consumes: all Task 1 aggregation types, existing `FilterDsl`, `SortDsl`, `SnapshotQueryService`.
+- Produces: `aggregation {}`, direct `AggregationQueryDsl` methods, `AggregationQuery.query(SnapshotQueryService)`.
+
+- [ ] **Step 1: Write a failing DSL shape test**
+
+```kotlin
+@Test
+fun `aggregation DSL should preserve relative scopes and explicit aliases`() {
+    val query = aggregation {
+        filter { "state.status" eq "COMPLETED" }
+        expand("state.orders") { "status" eq "PAID" }
+        expand("lines") { "quantity" gt 0 }
+        terms("productId", alias = "product")
+        count(alias = "count")
+        sum("amount", alias = "total")
+        sort { "total".desc() }
+        limit(20)
+    }
+
+    query.elements.map { it.path.value }.assert().containsExactly("state.orders", "lines")
+    query.groupBy.assert().hasSize(1)
+    query.metrics.assert().hasSize(2)
+    query.limit.assert().isEqualTo(20)
+}
+```
+
+- [ ] **Step 2: Run the DSL test and verify red**
+
+```bash
+./gradlew :wow-query:test --tests 'me.ahoo.wow.query.dsl.AggregationQueryDslTest'
+```
+
+Expected: compilation fails because `aggregation` and `AggregationQueryDsl` do not exist.
+
+- [ ] **Step 3: Implement one direct DSL class**
+
+Use mutable lists internally and existing builders for filter/sort:
+
+```kotlin
+@QueryDslMarker
+class AggregationQueryDsl {
+    private var filter: FilterExpression = MatchAllFilter
+    private val elements = mutableListOf<AggregationElement>()
+    private val groups = mutableListOf<AggregationGroup>()
+    private val metrics = mutableListOf<AggregationMetric>()
+    private var sort: List<Sort> = emptyList()
+    private var limit: Int = AggregationQuery.DEFAULT_LIMIT
+
+    fun expand(path: String) = elements.add(AggregationElement(LogicalField(path)))
+    fun expand(path: String, block: FilterDsl.() -> Unit) = elements.add(
+        AggregationElement(LogicalField(path), me.ahoo.wow.query.dsl.filter(block)),
+    )
+
+    fun sum(field: String, alias: String) = numeric(AggregationFunction.SUM, field, alias)
+    fun avg(field: String, alias: String) = numeric(AggregationFunction.AVG, field, alias)
+    fun min(field: String, alias: String) = numeric(AggregationFunction.MIN, field, alias)
+    fun max(field: String, alias: String) = numeric(AggregationFunction.MAX, field, alias)
+    private fun numeric(function: AggregationFunction, field: String, alias: String) {
+        metrics += AggregationMetric.Numeric(function, AggregationExpression.Field(LogicalField(field)), alias)
+    }
+
+    fun terms(field: String, alias: String) {
+        groups += AggregationGroup.Terms(LogicalField(field), alias)
+    }
+
+    fun count(alias: String) {
+        metrics += AggregationMetric.Count(alias)
+    }
+
+    fun build(): AggregationQuery = AggregationQuery(filter, elements, groups, metrics, sort, limit)
+}
+```
+
+Add the approved `filter`, `histogram`, `dateHistogram`, `sort` and `limit` setters with the exact signatures in the spec, plus top-level `aggregation(block)`, and:
+
+```kotlin
+fun AggregationQuery.query(queryService: SnapshotQueryService<*>): Flux<DynamicDocument> =
+    queryService.aggregate(this)
+```
+
+Do not add property-reference overloads, alias inference, nested DSL classes or expression builders.
+
+- [ ] **Step 4: Run DSL tests**
+
+```bash
+./gradlew :wow-query:test --tests 'me.ahoo.wow.query.dsl.AggregationQueryDslTest'
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDsl.kt \
+  wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/Dsl.kt \
+  wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/QueryDsl.kt \
+  wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt
+git commit -m "feat(query): add snapshot aggregation DSL"
+```
+
+### Task 3: Existing snapshot service and filter chain
+
+**Files:**
+- Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/SnapshotQueryService.kt`
+- Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/filter/QueryType.kt`
+- Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/filter/QueryContext.kt`
+- Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/filter/QueryHandler.kt`
+- Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/SnapshotQueryHandler.kt`
+- Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/SnapshotQueryFilter.kt`
+- Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/MaskingSnapshotQueryFilter.kt`
+- Modify: `wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/QueryServiceProxy.kt`
+- Modify tests: `wow-query/src/test/kotlin/me/ahoo/wow/query/filter/QueryTypeTest.kt`
+- Modify tests: `wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/DefaultSnapshotQueryHandlerTest.kt`
+- Modify tests: `wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/AbacQueryFilterTest.kt`
+- Modify tests: `wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/MaskingSnapshotQueryFilterTest.kt`
+- Modify tests: `wow-spring/src/test/kotlin/me/ahoo/wow/spring/query/QueryServiceProxyTest.kt`
+
+**Interfaces:**
+- Consumes: `AggregationQuery` and `DynamicDocument`.
+- Produces: `SnapshotQueryService.aggregate`, `SnapshotQueryHandler.aggregate`, `QueryType.AGGREGATION`, `QueryContext.asAggregationQuery`.
+
+- [ ] **Step 1: Write failing chain tests**
+
+Add tests proving the default publisher is cold, ABAC rewrites only the root filter, masking is skipped, Tail invokes the service, and the Spring proxy enters the handler:
+
+```kotlin
+@Test
+fun `aggregation should use the existing snapshot chain`() {
+    val query = AggregationQuery(metrics = listOf(AggregationMetric.Count("count")))
+    queryHandler.aggregate(MOCK_AGGREGATE_METADATA, query)
+        .test()
+        .expectNextMatches { it["count"] == 1L }
+        .verifyComplete()
+}
+
+@Test
+fun `masking should ignore aggregation`() {
+    val context = DefaultQueryContext<AggregationQuery, Flux<DynamicDocument>>(
+        QueryType.AGGREGATION,
+        MOCK_AGGREGATE_METADATA,
+    ).setQuery(AggregationQuery(metrics = listOf(AggregationMetric.Count("count"))))
+    filter.filter(context, tail).test().verifyComplete()
+    verify(exactly = 0) { masker.mask(any()) }
+}
+```
+
+- [ ] **Step 2: Run query and Spring tests to verify red**
+
+```bash
+./gradlew :wow-query:test \
+  --tests 'me.ahoo.wow.query.snapshot.filter.DefaultSnapshotQueryHandlerTest' \
+  --tests 'me.ahoo.wow.query.snapshot.filter.AbacQueryFilterTest' \
+  --tests 'me.ahoo.wow.query.snapshot.filter.MaskingSnapshotQueryFilterTest' \
+  :wow-spring:test --tests 'me.ahoo.wow.spring.query.QueryServiceProxyTest'
+```
+
+Expected: compilation fails on the missing operation and query type.
+
+- [ ] **Step 3: Thread aggregation through existing types**
+
+Add source-compatible defaults directly on the two existing interfaces:
+
+```kotlin
+fun aggregate(query: AggregationQuery): Flux<DynamicDocument> =
+    Flux.error(UnsupportedOperationException("Snapshot aggregation is not supported by [$name]."))
+
+fun aggregate(namedAggregate: NamedAggregate, query: AggregationQuery): Flux<DynamicDocument> =
+    Flux.error(UnsupportedOperationException("Snapshot aggregation is not supported."))
+```
+
+Put the first method on `SnapshotQueryService` and the second on `SnapshotQueryHandler`. Add `AGGREGATION(true)` to `QueryType`, `asAggregationQuery()` to `QueryContext`, and make `AbstractQueryHandler.flux` protected so `DefaultSnapshotQueryHandler.aggregate()` can call it.
+
+Add one Tail branch:
+
+```kotlin
+QueryType.AGGREGATION -> context.asAggregationQuery().setResult(queryService::aggregate)
+```
+
+In `MaskingSnapshotQueryFilter.mask`, return before `isDynamic` handling when type is `AGGREGATION`. In `SnapshotQueryServiceProxy`, override `aggregate` and call the stored `SnapshotQueryHandler`; do not call the delegate directly or bypass policies.
+
+- [ ] **Step 4: Run chain tests**
+
+```bash
+./gradlew :wow-query:test \
+  --tests 'me.ahoo.wow.query.filter.QueryTypeTest' \
+  --tests 'me.ahoo.wow.query.snapshot.filter.DefaultSnapshotQueryHandlerTest' \
+  --tests 'me.ahoo.wow.query.snapshot.filter.AbacQueryFilterTest' \
+  --tests 'me.ahoo.wow.query.snapshot.filter.MaskingSnapshotQueryFilterTest' \
+  :wow-spring:test --tests 'me.ahoo.wow.spring.query.QueryServiceProxyTest'
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wow-query/src/main/kotlin/me/ahoo/wow/query \
+  wow-query/src/test/kotlin/me/ahoo/wow/query \
+  wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/QueryServiceProxy.kt \
+  wow-spring/src/test/kotlin/me/ahoo/wow/spring/query/QueryServiceProxyTest.kt
+git commit -m "feat(query): route aggregation through snapshot policies"
+```
+
+### Task 4: Relative filter conversion in existing backend converters
+
+**Files:**
+- Modify: `wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoFilterConverter.kt`
+- Modify: `wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/SnapshotFilterConverterTest.kt`
+- Modify: `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchFilterConverter.kt`
+- Modify: `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolver.kt`
+- Modify: `wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchFilterConverterTest.kt`
+- Modify: `wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolverTest.kt`
+
+**Interfaces:**
+- Produces: `AbstractMongoFilterConverter.convert(filter, parent)`, `AbstractElasticsearchFilterConverter.convert(filter, parent)`, `ElasticsearchIndexMapping.resolve(filter, parent)`.
+- Consumed by: both aggregation compilers.
+
+- [ ] **Step 1: Write failing scoped conversion tests**
+
+```kotlin
+@Test
+fun `Mongo filter should prefix relative fields`() {
+    val bson = SnapshotFilterConverter.convert(filter { "quantity" gt 1 }, "state.orders.lines")
+    bson.toBsonDocument().toJson().assert().contains("state.orders.lines.quantity")
+}
+
+@Test
+fun `Elasticsearch filter should prefix relative fields`() {
+    val query = SnapshotFilterConverter.convert(filter { "quantity" gt 1 }, "state.orders.lines")
+    query.range().untyped().field().assert().isEqualTo("state.orders.lines.quantity")
+}
+```
+
+- [ ] **Step 2: Run converter tests and verify red**
+
+```bash
+./gradlew :wow-mongo:test --tests 'me.ahoo.wow.mongo.query.SnapshotFilterConverterTest' \
+  :wow-elasticsearch:test --tests 'me.ahoo.wow.elasticsearch.query.ElasticsearchFilterConverterTest' \
+  --tests 'me.ahoo.wow.elasticsearch.query.ElasticsearchIndexMappingResolverTest'
+```
+
+Expected: missing overload compilation errors.
+
+- [ ] **Step 3: Expose the parent parameter already used internally**
+
+For Elasticsearch, make the existing private parent-aware compile/resolve entry callable without changing its algorithm:
+
+```kotlin
+fun convert(filter: FilterExpression, parent: String? = null): Query =
+    compile(filterNormalizer.normalize(filter), parent)
+
+fun resolve(filter: FilterExpression, parent: String? = null): FilterExpression =
+    resolveTyped(filter, parent)
+```
+
+For MongoDB, add `parent` to recursive compilation and resolve leaf paths before `fieldConverter`:
+
+```kotlin
+private fun LogicalField.path(parent: String?): String =
+    if (parent == null || value == parent || value.startsWith("$parent.")) value else "$parent.$value"
+```
+
+Keep Mongo `$elemMatch` predicates relative inside the `$elemMatch` body; do not prefix those inner fields twice.
+
+- [ ] **Step 4: Run converter tests**
+
+Run the Step 2 command. Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoFilterConverter.kt \
+  wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/SnapshotFilterConverterTest.kt \
+  wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchFilterConverter.kt \
+  wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolver.kt \
+  wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchFilterConverterTest.kt \
+  wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolverTest.kt
+git commit -m "refactor(query): support scoped filter conversion"
+```
+
+### Task 5: MongoDB compiler and service execution
+
+**Files:**
+- Create: `wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompiler.kt`
+- Modify: `wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryService.kt`
+- Create: `wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt`
+
+**Interfaces:**
+- Consumes: `AggregationQuery`, scoped `SnapshotFilterConverter`.
+- Produces: `MongoAggregationCompiler.compile(query): List<Bson>` and Mongo `SnapshotQueryService.aggregate`.
+
+- [ ] **Step 1: Write failing pipeline tests**
+
+Assert exact stage order and resolved paths for root and nested queries:
+
+```kotlin
+@Test
+fun `compiler should unwind and filter every relative element`() {
+    val query = aggregation {
+        expand("state.orders") { "status" eq "PAID" }
+        expand("lines") { "quantity" gt 0 }
+        terms("productId", "product")
+        count("count")
+    }
+    val stages = MongoAggregationCompiler(SnapshotFilterConverter).compile(query)
+        .map { it.toBsonDocument().keys.first() }
+    stages.assert().containsExactly(
+        "\$match", "\$unwind", "\$match", "\$unwind", "\$match",
+        "\$match", "\$group", "\$project", "\$sort", "\$limit",
+    )
+}
+
+@Test
+fun `summary compiler should retain contribution counts`() {
+    val query = aggregation { sum("state.amount", "total") }
+    MongoAggregationCompiler(SnapshotFilterConverter).compile(query)
+        .joinToString { it.toBsonDocument().toJson() }
+        .assert().contains("__wow_value_count_total")
+}
+```
+
+- [ ] **Step 2: Run compiler tests and verify red**
+
+```bash
+./gradlew :wow-mongo:test --tests 'me.ahoo.wow.mongo.query.snapshot.MongoAggregationCompilerTest'
+```
+
+Expected: compilation fails because the compiler does not exist.
+
+- [ ] **Step 3: Implement the minimal pipeline compiler**
+
+Resolve paths by left-folding Elements:
+
+```kotlin
+var parent: String? = null
+query.elements.forEach { element ->
+    parent = if (parent == null) element.path.value else "$parent.${element.path.value}"
+    stages += Aggregates.unwind("\$$parent")
+    if (element.filter !== MatchAllFilter) {
+        stages += Aggregates.match(converter.convert(element.filter, parent))
+    }
+}
+```
+
+Resolve group/metric fields against the final parent, exclude missing/null group keys, build one `$group`, one `$project`, stable `$sort`, and `$limit`. For each numeric metric, add one internal contribution count and project `null` when it is zero. Remove `_id` from output.
+
+Compile group expressions exactly as follows: Terms uses the resolved field value, Histogram uses `floor(field / interval) * interval`, and DateHistogram uses `$dateTrunc` with the requested unit and time zone. Compile Count with `$sum: 1`; compile Sum/Avg/Min/Max with their matching Mongo accumulators.
+
+In `MongoSnapshotQueryService.aggregate`, call `collection.aggregate(stages).toFlux()`, convert each `Document` to `DynamicDocument`, coerce Count to `Long`, numeric metrics to finite `Double`, and emit the one-row empty summary only when `groupBy` is empty.
+
+- [ ] **Step 4: Run compiler and service unit checks**
+
+```bash
+./gradlew :wow-mongo:test --tests 'me.ahoo.wow.mongo.query.snapshot.MongoAggregationCompilerTest' \
+  :wow-mongo:compileIntegrationTestKotlin
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompiler.kt \
+  wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryService.kt \
+  wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
+git commit -m "feat(query): execute snapshot aggregation in MongoDB"
+```
+
+### Task 6: Extract shared Elasticsearch PIT lifecycle
+
+**Files:**
+- Create: `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchPointInTime.kt`
+- Modify: `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchQueryPager.kt`
+- Create: `wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchPointInTimeTest.kt`
+- Modify: `wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchQueryPagerTest.kt`
+
+**Interfaces:**
+- Produces: internal `ElasticsearchPointInTime.use { session -> Publisher<T> }`, `Session.id`, `Session.update(id)` and `keepAliveValue`.
+- Consumed by: existing hit pager and Task 7 aggregation pager.
+
+- [ ] **Step 1: Add a failing PIT lifecycle test**
+
+Create `ElasticsearchPointInTimeTest` and prove the helper closes the latest non-empty ID on cancellation:
+
+```kotlin
+@Test
+fun `should close latest non-empty pit id on cancellation`() {
+    val closeRequest = slot<ClosePointInTimeRequest>()
+    val openResponse = mockk<OpenPointInTimeResponse> { every { id() } returns "pit-1" }
+    val closeResponse = mockk<ClosePointInTimeResponse> { every { succeeded() } returns true }
+    every { client.openPointInTime(any<OpenPointInTimeRequest>()) } returns Mono.just(openResponse)
+    every { client.closePointInTime(capture(closeRequest)) } returns Mono.just(closeResponse)
+
+    ElasticsearchPointInTime(client, "index", Duration.ofMinutes(1)).use { session ->
+        session.update("pit-2")
+        session.update("")
+        Flux.never<String>()
+    }.test().thenCancel().verify()
+
+    closeRequest.captured.id().assert().isEqualTo("pit-2")
+}
+```
+
+- [ ] **Step 2: Run the pager test before extraction**
+
+```bash
+./gradlew :wow-elasticsearch:test \
+  --tests 'me.ahoo.wow.elasticsearch.query.ElasticsearchPointInTimeTest' \
+  --tests 'me.ahoo.wow.elasticsearch.query.ElasticsearchQueryPagerTest'
+```
+
+Expected: compilation fails because `ElasticsearchPointInTime` does not exist.
+
+- [ ] **Step 3: Extract only open/update/close behavior**
+
+Implement a two-consumer internal helper around `Flux.usingWhen`:
+
+```kotlin
+internal class ElasticsearchPointInTime(
+    private val client: ReactiveElasticsearchClient,
+    private val indexName: String,
+    keepAlive: Duration,
+) {
+    internal class Session(var id: String) {
+        fun update(next: String?) {
+            next?.takeIf(String::isNotBlank)?.let { id = it }
+        }
+    }
+
+    fun <T : Any> use(block: (Session) -> Publisher<T>): Flux<T> = Flux.usingWhen(
+        open(),
+        { session -> Flux.from(block(session)) },
+        ::close,
+        { session, _ -> close(session) },
+        ::close,
+    )
+}
+```
+
+Move the existing logging and non-fatal close behavior unchanged. Replace the corresponding private code in `ElasticsearchQueryPager`; do not alter pagination logic.
+
+- [ ] **Step 4: Run the complete pager test**
+
+Run the Step 2 command. Expected: pass, including completion, error and cancellation cleanup.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchPointInTime.kt \
+  wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchQueryPager.kt \
+  wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchPointInTimeTest.kt \
+  wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchQueryPagerTest.kt
+git commit -m "refactor(elasticsearch): share point in time lifecycle"
+```
+
+### Task 7: Elasticsearch compiler, composite pager and service
+
+**Files:**
+- Create: `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompiler.kt`
+- Create: `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPager.kt`
+- Modify: `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryService.kt`
+- Create: `wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt`
+- Create: `wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt`
+
+**Interfaces:**
+- Consumes: aggregation contract, mapping resolver, scoped filter converter and Task 6 PIT helper.
+- Produces: `ElasticsearchAggregationPlan`, compiler, composite pager and ES `SnapshotQueryService.aggregate`.
+
+- [ ] **Step 1: Write failing compiler and pager tests**
+
+Cover nested path normalization, `.keyword` Terms resolution, composite after-key pagination, exact metric Top-N and latest PIT cleanup:
+
+```kotlin
+@Test
+fun `compiler should nest relative elements in order`() {
+    val mapping = mockk<ElasticsearchIndexMapping> {
+        every { requireNested(any()) } answers { firstArg() }
+        every { resolve(any<String>(), any()) } answers { firstArg() }
+        every { resolve(any<FilterExpression>(), any()) } answers { firstArg() }
+    }
+    val compiler = ElasticsearchAggregationCompiler(SnapshotFilterConverter, mapping)
+    val plan = compiler.compile(aggregation {
+        expand("state.orders") { "status" eq "PAID" }
+        expand("lines") { "quantity" gt 0 }
+        terms("productId", "product")
+        sum("amount", "total")
+    })
+    plan.assert().isNotNull()
+    verifyOrder {
+        mapping.requireNested("state.orders")
+        mapping.requireNested("state.orders.lines")
+    }
+}
+
+@Test
+fun `metric sort should retain exact bounded top N`() {
+    val rows = listOf(
+        mapOf("product" to "a", "total" to 3.0).toDynamicDocument(),
+        mapOf("product" to "b", "total" to 9.0).toDynamicDocument(),
+        mapOf("product" to "c", "total" to 7.0).toDynamicDocument(),
+    )
+    selectTopRows(rows, listOf(Sort("total", Sort.Direction.DESC)), limit = 2)
+        .map { it["total"] }.assert().containsExactly(9.0, 7.0)
+}
+```
+
+- [ ] **Step 2: Run ES aggregation tests and verify red**
+
+```bash
+./gradlew :wow-elasticsearch:test \
+  --tests 'me.ahoo.wow.elasticsearch.query.snapshot.ElasticsearchAggregationCompilerTest' \
+  --tests 'me.ahoo.wow.elasticsearch.query.snapshot.ElasticsearchAggregationPagerTest'
+```
+
+Expected: compilation fails because compiler and pager do not exist.
+
+- [ ] **Step 3: Implement compiler and plan**
+
+Use constructor `ElasticsearchAggregationCompiler(filterConverter, mapping: ElasticsearchIndexMapping?)`. Its plan contains only data used by the pager: resolved root query, nested aggregation wrappers, composite sources, metric definitions, alias metadata, effective sort and limit. Resolve standard mappings as follows:
+
+```kotlin
+val termsField = mapping?.resolve(absoluteField, ElasticsearchFieldUsage.EXACT) ?: absoluteField
+val nestedPath = mapping?.requireNested(absoluteElementPath) ?: absoluteElementPath
+val filter = mapping?.resolve(element.filter, absoluteElementPath) ?: element.filter
+val query = filterConverter.convert(filter, absoluteElementPath)
+```
+
+Do not add numeric/JVM type checks or inspect custom mapping features.
+
+Compile Terms, Histogram and DateHistogram as Elasticsearch composite value sources in effective group-sort order. Compile Count from bucket `docCount`; compile Sum/Avg/Min/Max as matching metric sub-aggregations plus a value-count sub-aggregation for the null contract.
+
+- [ ] **Step 4: Implement composite pagination and result normalization**
+
+Use `size(0)` searches inside `ElasticsearchPointInTime.use`. Update the session from every response `pitId`, pass `afterKey` to the next composite request, and stop early only for group-only sort. Implement internal `selectTopRows(rows, sort, limit)` with `java.util.PriorityQueue` capped at `limit`; use the same comparator while streaming all metric-sorted buckets so ties follow the complete effective sort.
+
+Normalize bucket keys and metrics into `DynamicDocument`; Count uses `docCount`, numeric metrics reject non-finite values and return `null` when the companion value-count is zero. For no groups, perform one aggregation request and emit one summary row.
+
+Wire `ElasticsearchSnapshotQueryService.aggregate` to current-or-load mapping only for the standard `SnapshotFilterConverter`; custom converters use the supplied paths unchanged.
+
+- [ ] **Step 5: Run ES unit and integration compilation**
+
+```bash
+./gradlew :wow-elasticsearch:test \
+  --tests 'me.ahoo.wow.elasticsearch.query.snapshot.ElasticsearchAggregationCompilerTest' \
+  --tests 'me.ahoo.wow.elasticsearch.query.snapshot.ElasticsearchAggregationPagerTest' \
+  --tests 'me.ahoo.wow.elasticsearch.query.ElasticsearchQueryPagerTest' \
+  :wow-elasticsearch:compileIntegrationTestKotlin
+```
+
+Expected: pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot \
+  wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot
+git commit -m "feat(query): execute snapshot aggregation in Elasticsearch"
+```
+
+### Task 8: Cross-backend TCK
+
+**Files:**
+- Modify: `test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/mock/MockAggregate.kt`
+- Modify: `test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt`
+- Modify: `wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryServiceTest.kt`
+- Modify: `wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryServiceTest.kt`
+
+**Interfaces:**
+- Consumes: working Mongo and Elasticsearch aggregate implementations.
+- Produces: one backend-neutral executable contract for standard Wow snapshot fields.
+
+- [ ] **Step 1: Add nested TCK fixture state and failing contract tests**
+
+Extend `MockStateAggregate` with defaulted immutable fixture fields so existing tests keep constructing it with only `id`:
+
+```kotlin
+data class MockOrder(val status: String, val lines: List<MockLine>)
+data class MockLine(
+    val productId: String,
+    val quantity: Int,
+    val amount: Double?,
+    val createdAt: Instant,
+    val discounts: List<MockDiscount>,
+)
+data class MockDiscount(val type: String, val amount: Double)
+data class MockStateAggregate(
+    val id: String,
+    val orders: List<MockOrder> = emptyList(),
+) : ReadOnlyStateAggregateAware<MockStateAggregate> {
+    var data: String = ""
+        private set
+}
+```
+
+Create additional snapshots with `MOCK_AGGREGATE_METADATA.toStateAggregate(state, version = 1)` inside aggregation tests, not global setup, so existing count/list expectations remain unchanged.
+
+Add TCK tests for root summary, two-level Elements with filters, all group/metric types, empty/null semantics, stable group sort, metric Top-N and cancellation.
+
+- [ ] **Step 2: Run both integration suites and verify failures**
+
+```bash
+./gradlew :wow-mongo:integrationTest \
+  --tests 'me.ahoo.wow.mongo.query.snapshot.MongoSnapshotQueryServiceTest' \
+  :wow-elasticsearch:integrationTest \
+  --tests 'me.ahoo.wow.elasticsearch.query.snapshot.ElasticsearchSnapshotQueryServiceTest'
+```
+
+Expected: Elasticsearch fixture setup fails until nested mappings are declared, or contract assertions expose backend result differences.
+
+- [ ] **Step 3: Configure only the standard nested ES fixture mappings**
+
+Before saving aggregation fixtures, create or update the test index mapping with `state.orders`, `state.orders.lines`, and `state.orders.lines.discounts` as nested object paths and their leaf fields as keyword/numeric/date. Do not add portability rejection tests for custom mappings.
+
+Fix only real compiler/result differences shown by the shared TCK. Keep invalid-query backend errors out of the TCK because they are explicitly not portable.
+
+- [ ] **Step 4: Run both integration suites**
+
+Run the Step 2 command. Expected: both pass the same aggregation assertions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add test/wow-tck/src/main/kotlin/me/ahoo/wow/tck \
+  wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryServiceTest.kt \
+  wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryServiceTest.kt
+git commit -m "test(query): define snapshot aggregation TCK"
+```
+
+### Task 9: WebFlux route and existing Guard
+
+**Files:**
+- Create: `wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/SnapshotAggregationHandlerFunction.kt`
+- Modify: `wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractor.kt`
+- Modify: `wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilter.kt`
+- Modify: `wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contract/BuiltInHttpRoutes.kt`
+- Modify: `wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/route/QueryRouteModule.kt`
+- Create: `wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/snapshot/SnapshotAggregationHandlerFunctionTest.kt`
+- Modify: `wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractorTest.kt`
+- Modify: `wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt`
+- Modify: `wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt`
+
+**Interfaces:**
+- Consumes: `SnapshotQueryHandler.aggregate`, existing rewrite filter, raw-request context and streaming response.
+- Produces: route factory for the OpenAPI handler key and HTTP cost enforcement with existing options only.
+
+- [ ] **Step 1: Write failing extractor, route and Guard tests**
+
+```kotlin
+@Test
+fun `aggregation route should stream handler rows`() {
+    val request = MockServerRequest.builder().body(
+        AggregationQuery(metrics = listOf(AggregationMetric.Count("count"))).toMono(),
+    )
+    handler.handle(request).test()
+        .consumeNextWith { it.statusCode().assert().isEqualTo(HttpStatus.OK) }
+        .verifyComplete()
+}
+
+@Test
+fun `Guard should reuse existing limits`() {
+    val query = AggregationQuery(
+        elements = listOf(AggregationElement(LogicalField("state.orders"))),
+        metrics = listOf(AggregationMetric.Count("count")),
+        limit = 101,
+    )
+    val context = DefaultQueryContext<AggregationQuery, Flux<DynamicDocument>>(
+        QueryType.AGGREGATION,
+        MOCK_AGGREGATE_METADATA,
+    ).setQuery(query)
+    guard(maxListSize = 100).filter(context, unexpectedBackend())
+        .writeRawRequest(request).test().expectError(IllegalArgumentException::class.java).verify()
+    guard(allowExpensiveOperators = false).filter(context, unexpectedBackend())
+        .writeRawRequest(request).test().expectError(IllegalArgumentException::class.java).verify()
+}
+```
+
+- [ ] **Step 2: Run WebFlux tests and verify red**
+
+```bash
+./gradlew :wow-webflux:test \
+  --tests 'me.ahoo.wow.webflux.route.snapshot.SnapshotAggregationHandlerFunctionTest' \
+  --tests 'me.ahoo.wow.webflux.route.query.QueryBodyExtractorTest' \
+  --tests 'me.ahoo.wow.webflux.route.query.HttpQueryGuardFilterTest' \
+  :wow-spring-boot-starter:test \
+  --tests 'me.ahoo.wow.spring.boot.starter.webflux.WebFluxAutoConfigurationTest'
+```
+
+Expected: missing extractor/factory compilation failures.
+
+- [ ] **Step 3: Implement route with existing machinery**
+
+Add `AGGREGATION_QUERY_EXTRACTOR`. For this type only, allow both `filter` and legacy `condition` to be absent so the data-class `MatchAllFilter` default remains valid; still reject both being present. Decode through the same strict filter-value path and apply scalar-equality checks to the root filter and every Element filter. Rewrite the root filter with `RewriteRequestFilter`, call `SnapshotQueryHandler.aggregate`, write the raw request Reactor context, and return via existing `toServerResponse` so JSON arrays and SSE share established behavior.
+
+Add `BuiltInHttpRouteHandlerKeys.Snapshot.AGGREGATION`, then add the factory once to `QueryRouteModule`; do not add a new route module or auto-configuration bean.
+
+Extend Guard dispatch:
+
+```kotlin
+is AggregationQuery -> {
+    validateResultSize(query.limit, "aggregation")
+    validateFilters(listOf(query.filter) + query.elements.map(AggregationElement::filter), query.filter)
+    require(allowExpensiveOperators || query.elements.isEmpty())
+    val metricAliases = query.metrics.mapTo(hashSetOf(), AggregationMetric::alias)
+    require(allowExpensiveOperators || query.sort.none { it.field in metricAliases })
+}
+```
+
+Do not add properties or constructor parameters.
+
+- [ ] **Step 4: Run WebFlux tests**
+
+Run the Step 2 command. Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wow-webflux/src/main/kotlin/me/ahoo/wow/webflux \
+  wow-webflux/src/test/kotlin/me/ahoo/wow/webflux \
+  wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contract/BuiltInHttpRoutes.kt \
+  wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/route/QueryRouteModule.kt \
+  wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
+git commit -m "feat(webflux): expose snapshot aggregation route"
+```
+
+### Task 10: OpenAPI contract
+
+**Files:**
+- Modify: `wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/QueryComponent.kt`
+- Modify: `wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/QueryContractComponentSupport.kt`
+- Modify: `wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/aggregate/snapshot/SnapshotRouteContributor.kt`
+- Modify: `wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt`
+- Modify snapshot: `wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json`
+- Modify snapshot: `wow-openapi/src/test/resources/openapi/example-domain-contract.snapshot.json`
+
+**Interfaces:**
+- Consumes: generic `AggregationQuery` schema and existing aggregate `*AggregatedFields` component reference.
+- Produces: one aggregation RequestBody, one dynamic-row array response and one aggregate route contract.
+
+- [ ] **Step 1: Write failing OpenAPI assertions**
+
+```kotlin
+@Test
+fun `snapshot aggregation should reuse aggregate field schema`() {
+    val openApi = exampleDomainOpenAPI()
+    val requestBody = openApi.components.requestBodies.getValue("example.cart.AggregationQuery")
+    requestBody.extensions.getValue("x-wow-query-fields")
+        .assert().isEqualTo(mapOf("\$ref" to "#/components/schemas/example.cart.CartAggregatedFields"))
+    requestBody.content["application/json"]!!.schema.`$ref`
+        .assert().isEqualTo("#/components/schemas/wow.api.query.AggregationQuery")
+}
+```
+
+- [ ] **Step 2: Run OpenAPI test and verify red**
+
+```bash
+./gradlew :wow-openapi:test --tests 'me.ahoo.wow.openapi.ExampleDomainOpenAPITest'
+```
+
+Expected: aggregation route/request body is absent.
+
+- [ ] **Step 3: Add one route/component path**
+
+Add an `.AggregationQuery` suffix and `aggregatedAggregationQueryRequestBody(aggregateMetadata)` that calls the existing `aggregatedFieldsSchema` and uses `schema(AggregationQuery::class.java)`. Add the matching `HttpRequestBody`/`HttpResponse` reference helpers in `QueryContractComponentSupport`. The response is an array whose item is an object with free-form nullable properties; do not introduce alias-specific result schemas.
+
+Add the route to each existing tenant/owner query variant with suffix `snapshot/aggregation`, streaming accept values, request timeout and too-many-requests responses.
+
+- [ ] **Step 4: Update snapshots through the supported switch and run checks**
+
+```bash
+./gradlew :wow-openapi:test -Dwow.snapshot.update=true
+./gradlew :wow-openapi:check
+```
+
+Expected: pass; aggregation references the single existing `*AggregatedFields` enum and does not create type-specific field schemas.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wow-openapi/src/main/kotlin/me/ahoo/wow/openapi \
+  wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt \
+  wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json \
+  wow-openapi/src/test/resources/openapi/example-domain-contract.snapshot.json
+git commit -m "feat(openapi): publish snapshot aggregation contract"
+```
+
+### Task 11: ApiClient contract
+
+**Files:**
+- Create: `wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SnapshotAggregationQueryApi.kt`
+- Create: `wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/ReactiveSnapshotAggregationQueryApi.kt`
+- Create: `wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SynchronousSnapshotAggregationQueryApi.kt`
+- Create: `wow-apiclient/src/test/kotlin/me/ahoo/wow/apiclient/query/SnapshotAggregationQueryApiTest.kt`
+
+**Interfaces:**
+- Produces: independent synchronous/reactive aggregation clients; does not modify existing composite snapshot APIs.
+
+- [ ] **Step 1: Write a failing interface contract test**
+
+```kotlin
+@Test
+fun `aggregation API should use the snapshot aggregation resource`() {
+    val method = SnapshotAggregationQueryApi::class.java.getMethod("aggregate", AggregationQuery::class.java)
+    method.getAnnotation(PostExchange::class.java).value
+        .assert().isEqualTo("snapshot/aggregation")
+}
+```
+
+- [ ] **Step 2: Run ApiClient test and verify red**
+
+```bash
+./gradlew :wow-apiclient:test --tests 'me.ahoo.wow.apiclient.query.SnapshotAggregationQueryApiTest'
+```
+
+Expected: compilation fails because the interfaces do not exist.
+
+- [ ] **Step 3: Implement three small interfaces and query extensions**
+
+```kotlin
+const val SNAPSHOT_AGGREGATION_RESOURCE_NAME = "$SNAPSHOT_RESOURCE_NAME/aggregation"
+
+interface SnapshotAggregationQueryApi<R> : SnapshotQueryApi {
+    @PostExchange(SNAPSHOT_AGGREGATION_RESOURCE_NAME)
+    fun aggregate(@RequestBody query: AggregationQuery): R
+}
+
+interface ReactiveSnapshotAggregationQueryApi :
+    SnapshotAggregationQueryApi<Flux<Map<String, Any?>>>
+
+interface SynchronousSnapshotAggregationQueryApi :
+    SnapshotAggregationQueryApi<List<Map<String, Any?>>>
+```
+
+Add `AggregationQuery.query(api)` extensions in the reactive and synchronous files. Do not add these interfaces to `ReactiveSnapshotQueryApi` or `SynchronousSnapshotQueryApi`.
+
+- [ ] **Step 4: Run ApiClient test**
+
+Run the Step 2 command. Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query \
+  wow-apiclient/src/test/kotlin/me/ahoo/wow/apiclient/query/SnapshotAggregationQueryApiTest.kt
+git commit -m "feat(apiclient): add snapshot aggregation API"
+```
+
+### Task 12: Documentation and full verification
+
+**Files:**
+- Modify: `documentation/docs/en/guide/query.md`
+- Modify: `documentation/docs/zh/guide/query.md`
+- Modify: `documentation/docs/en/guide/extensions/mongo.md`
+- Modify: `documentation/docs/zh/guide/extensions/mongo.md`
+- Modify: `documentation/docs/en/guide/extensions/elasticsearch.md`
+- Modify: `documentation/docs/zh/guide/extensions/elasticsearch.md`
+- Modify: `documentation/docs/en/guide/extensions/webflux.md`
+- Modify: `documentation/docs/zh/guide/extensions/webflux.md`
+- Modify: `documentation/docs/en/guide/extensions/apiclient.md`
+- Modify: `documentation/docs/zh/guide/extensions/apiclient.md`
+
+**Interfaces:**
+- Documents the exact shipped API and explicit non-goals; adds no runtime code.
+
+- [ ] **Step 1: Add concise bilingual examples**
+
+Document the approved DSL and equivalent JSON, including:
+
+```kotlin
+aggregation {
+    expand("state.orders") { "status" eq "PAID" }
+    expand("lines") { "quantity" gt 0 }
+    terms("productId", "product")
+    sum("amount", "total")
+    sort { "total".desc() }
+    limit(20)
+}
+```
+
+State that later Element paths and filters are relative, custom serializer/mapping equivalence is not guaranteed, masker is ignored, metric sort is expensive, and Batch/arithmetic are not included.
+
+- [ ] **Step 2: Run focused module checks**
+
+```bash
+./gradlew detekt \
+  :wow-api:check \
+  :wow-query:check \
+  :wow-mongo:check \
+  :wow-elasticsearch:check \
+  :wow-webflux:check \
+  :wow-openapi:check \
+  :wow-apiclient:check \
+  :wow-spring:check \
+  :wow-spring-boot-starter:check
+```
+
+Expected: build succeeds with zero test failures and no Detekt violations.
+
+- [ ] **Step 3: Run both backend integration contracts**
+
+```bash
+./gradlew :wow-mongo:integrationTest \
+  --tests 'me.ahoo.wow.mongo.query.snapshot.MongoSnapshotQueryServiceTest' \
+  :wow-elasticsearch:integrationTest \
+  --tests 'me.ahoo.wow.elasticsearch.query.snapshot.ElasticsearchSnapshotQueryServiceTest'
+```
+
+Expected: both pass the shared aggregation TCK.
+
+- [ ] **Step 4: Build documentation**
+
+```bash
+cd documentation
+pnpm docs:build
+```
+
+Expected: VitePress build exits zero.
+
+- [ ] **Step 5: Verify the live OpenAPI contract**
+
+Build and start the example distribution on an available localhost port, poll health, fetch `/v3/api-docs`, assert the aggregation route and references, then stop the process in a shell trap:
+
+```bash
+./gradlew :example-server:installDist
+```
+
+Required assertions against the fetched JSON:
+
+```text
+components.requestBodies.example.cart.AggregationQuery exists
+its x-wow-query-fields.$ref points to example.cart.CartAggregatedFields
+its application/json schema references wow.api.query.AggregationQuery
+the snapshot/aggregation operation returns an array of dynamic objects
+```
+
+Keep the response and logs in a temporary directory and do not add a verifier script or task to the repository.
+
+- [ ] **Step 6: Check the final diff for scope**
+
+```bash
+git diff --check
+git status --short
+git diff --stat origin/main...HEAD
+rg -n "AggregationFieldCatalog|maxAggregationElements|maxAggregationMetrics|SnapshotAggregationQueryFilter" \
+  wow-* test documentation || true
+```
+
+Expected: no whitespace errors, no unintended generated output, and none of the explicitly rejected abstractions/configuration names.
+
+- [ ] **Step 7: Commit documentation**
+
+```bash
+git add documentation/docs/en/guide documentation/docs/zh/guide
+git commit -m "docs: document snapshot elements aggregation"
+```
+
+- [ ] **Step 8: Request final review**
+
+Invoke `superpowers:requesting-code-review` against the exact final commit. Address only verified correctness or contract findings; reject requests to restore the field catalog, custom mapping proof, dynamic schema rewriting or speculative compatibility infrastructure unless the user changes the approved scope.

--- a/docs/superpowers/specs/2026-08-24-snapshot-elements-aggregation-design.md
+++ b/docs/superpowers/specs/2026-08-24-snapshot-elements-aggregation-design.md
@@ -123,6 +123,7 @@ DSL 提供 `sum("state.amount")` 等快捷方法，调用者不需要手工构�
 公共层只校验请求本身可确定的事实：
 
 - 数量和 limit 不超过固定上限。
+- metrics 不为空。
 - Elements 构成严格父子前缀链。
 - element filter 不包含 ID、租户、所有者、空间、删除、搜索等根级操作符。
 - element filter 中的字段属于当前 element 路径。
@@ -160,6 +161,8 @@ fun aggregate(query: AggregationQuery): Flux<DynamicDocument> =
 默认实现只保证现有实现重新编译时保持源码兼容，不保留旧 JVM method descriptor，也不增加新的 capability interface。
 
 `SnapshotQueryHandler` 增加对应入口，`QueryType` 增加 `AGGREGATION`。聚合复用现有 `QueryContext` 和 `SnapshotQueryFilter` chain：
+
+`SnapshotQueryHandler.aggregate` 同样提供返回 `UnsupportedOperationException` 的默认实现，保证现有自定义 handler 重新编译时源码兼容；`DefaultSnapshotQueryHandler` 覆盖它并进入现有 filter chain。
 
 ```text
 SnapshotQueryHandler.aggregate
@@ -243,6 +246,7 @@ ApiClient 增加独立的 `SnapshotAggregationQueryApi`、`ReactiveSnapshotAggre
 
 - 请求自身结构错误使用 `IllegalArgumentException`，由现有 ErrorHandler 转换。
 - MongoDB/Elasticsearch 不支持路径、字段类型或 mapping 时保留后端错误。
+- 后端返回 NaN 或正负无穷时整体失败，不把非有限数值写入公共结果。
 - 不把错误降级为空结果，不尝试统一两个后端的错误文本。
 - Flux 任一编译、分页或执行阶段失败即整体失败。
 - PIT close 失败只记录日志，不覆盖原始查询结果或错误。
@@ -261,6 +265,7 @@ ApiClient 增加独立的 `SnapshotAggregationQueryApi`、`ReactiveSnapshotAggre
 - `wow-webflux`：HTTP 路由、Guard、JSON/SSE 响应。
 - `wow-openapi`：Schema 快照和一次真实 `example-server /v3/api-docs` 请求。
 - `wow-apiclient`：同步/响应式请求与返回类型。
+- 中英文查询文档：公共模型、Elements 作用域、HTTP/DSL 示例与明确非目标。
 
 不建立 Jackson annotation 与 Elasticsearch mapping 的组合测试矩阵，不设置 patch coverage 百分比目标。
 

--- a/docs/superpowers/specs/2026-08-24-snapshot-elements-aggregation-design.md
+++ b/docs/superpowers/specs/2026-08-24-snapshot-elements-aggregation-design.md
@@ -140,6 +140,91 @@ sealed interface AggregationMetric {
 
 DSL 提供 `sum("state.amount")` 等快捷方法，调用者不需要手工构造 `AggregationExpression.Field`。
 
+### Kotlin DSL
+
+DSL 直接映射 `elements` 数组，不创建递归 `AggregationElementDsl` 或第二套 filter DSL：
+
+```kotlin
+val query = aggregation {
+    filter {
+        "state.status" eq "COMPLETED"
+    }
+
+    expand("state.orders") {
+        "status" eq "PAID"
+    }
+    expand("lines") {
+        "quantity" gt 0
+    }
+    expand("discounts") {
+        "type" eq "MEMBER"
+    }
+
+    terms("productId", alias = "product")
+    histogram("amount", interval = 10.0, alias = "amountRange")
+    dateHistogram(
+        "createdAt",
+        unit = AggregationDateUnit.DAY,
+        alias = "day",
+        timeZone = ZoneId.of("Asia/Shanghai"),
+    )
+
+    count(alias = "count")
+    sum("amount", alias = "total")
+    avg("amount", alias = "average")
+    min("amount", alias = "minimum")
+    max("amount", alias = "maximum")
+
+    sort {
+        "total".desc()
+        "product".asc()
+    }
+    limit(20)
+}
+```
+
+最小 DSL API：
+
+```kotlin
+fun aggregation(block: AggregationQueryDsl.() -> Unit): AggregationQuery
+
+@QueryDslMarker
+class AggregationQueryDsl {
+    fun filter(block: FilterDsl.() -> Unit)
+
+    fun expand(path: String)
+    fun expand(path: String, block: FilterDsl.() -> Unit)
+
+    fun terms(field: String, alias: String)
+    fun histogram(field: String, interval: Double, alias: String)
+    fun dateHistogram(
+        field: String,
+        unit: AggregationDateUnit,
+        alias: String,
+        timeZone: ZoneId = ZoneOffset.UTC,
+    )
+
+    fun count(alias: String)
+    fun sum(field: String, alias: String)
+    fun avg(field: String, alias: String)
+    fun min(field: String, alias: String)
+    fun max(field: String, alias: String)
+
+    fun sort(block: SortDsl.() -> Unit)
+    fun limit(limit: Int)
+    fun build(): AggregationQuery
+}
+```
+
+`expand` 调用顺序就是 `elements` 顺序；带 block 的重载直接调用现有 `filter {}` 构造该层相对 filter。group 与 metric 方法把字段包装为 `LogicalField`，数值指标把字段包装为 `AggregationExpression.Field`。alias 必须显式提供，不根据字段名猜测。
+
+执行扩展沿用现有 snapshot query 命名：
+
+```kotlin
+fun AggregationQuery.query(queryService: SnapshotQueryService<*>): Flux<DynamicDocument> =
+    queryService.aggregate(this)
+```
+
 ### 结构校验
 
 公共层只校验请求本身可确定的事实：

--- a/docs/superpowers/specs/2026-08-24-snapshot-elements-aggregation-design.md
+++ b/docs/superpowers/specs/2026-08-24-snapshot-elements-aggregation-design.md
@@ -65,7 +65,15 @@ data class AggregationElement(
 )
 ```
 
-`elements` 是有序父子展开链。例如：
+`elements` 是有序父子展开链。第一层使用快照绝对路径，后续层使用相对上一层的路径。例如：
+
+```text
+state.orders
+lines
+discounts
+```
+
+每层可以声明自己的相对 filter。两个后端按数组顺序将路径规范化为：
 
 ```text
 state.orders
@@ -73,9 +81,9 @@ state.orders.lines
 state.orders.lines.discounts
 ```
 
-每层可以声明自己的 filter。数组中的后一个路径必须严格以 `前一个路径 + "."` 开头，因此重复路径和兄弟集合都会被拒绝。
+数组顺序本身定义展开链，不再校验绝对父子前缀。若调用者声明不存在的相对路径，保留后端结果或错误。
 
-公共 HTTP 模型始终使用绝对路径。Kotlin DSL 在嵌套 `expand {}` 中允许相对路径，但构建结果必须规范化为绝对路径。
+每层 element filter 字段相对当前层。有 Elements 时，group 与 metric 字段相对最内层；没有 Elements 时使用快照绝对路径。HTTP 与 Kotlin DSL 使用同一规则，编译器在生成物理计划前统一转成绝对路径。
 
 ### 分组
 
@@ -95,7 +103,11 @@ Histogram interval 必须是有限正数。DateHistogram 时区直接使用 JDK 
 ### 表达式与指标
 
 ```kotlin
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    property = "type",
+    defaultImpl = AggregationExpression.Field::class,
+)
 @JsonSubTypes(JsonSubTypes.Type(AggregationExpression.Field::class, name = "FIELD"))
 interface AggregationExpression {
     data class Field(val field: LogicalField) : AggregationExpression
@@ -114,7 +126,17 @@ sealed interface AggregationMetric {
 }
 ```
 
-首期只注册和支持 `FIELD`。表达式接口不使用 `sealed`，避免以后增加 `ADD`、`MULTIPLY` 或 `COALESCE` 时破坏调用方的穷举 `when`。当前编译器遇到非 `Field` 实现时返回 unsupported error。
+`JsonTypeInfo.defaultImpl` 设置为 `AggregationExpression.Field::class`，因此当前字段表达式可以省略 `type`：
+
+```json
+{
+  "expression": {
+    "field": "amount"
+  }
+}
+```
+
+首期只注册和支持 `FIELD`。以后增加算术表达式时，新表达式使用明确的 `type`；已有字段 JSON 保持不变。表达式接口不使用 `sealed`，避免新增表达式类型破坏调用方的穷举 `when`。当前编译器遇到非 `Field` 实现时返回 unsupported error。
 
 DSL 提供 `sum("state.amount")` 等快捷方法，调用者不需要手工构造 `AggregationExpression.Field`。
 
@@ -124,10 +146,7 @@ DSL 提供 `sum("state.amount")` 等快捷方法，调用者不需要手工构�
 
 - 数量和 limit 不超过固定上限。
 - metrics 不为空。
-- Elements 构成严格父子前缀链。
 - element filter 不包含 ID、租户、所有者、空间、删除、搜索等根级操作符。
-- element filter 中的字段属于当前 element 路径。
-- 存在 Elements 时，group 与 metric 字段属于最内层 element 路径。
 - alias 是非空的单个逻辑路径段、全局唯一，且不使用框架内部保留前缀。
 - sort 字段唯一且只引用 group/metric alias。
 - 无 groupBy 时禁止 sort。
@@ -180,6 +199,8 @@ SnapshotQueryHandler.aggregate
 
 MongoDB 使用独立的内部 `MongoAggregationCompiler`，复用现有 `SnapshotFilterConverter`：
 
+编译器先按 `elements` 顺序把相对路径和 filter 字段解析为绝对快照路径，再生成 pipeline：
+
 ```text
 根 $match
 → 对每个 element 执行 $unwind
@@ -198,6 +219,8 @@ MongoDB 使用独立的内部 `MongoAggregationCompiler`，复用现有 `Snapsho
 ## Elasticsearch 编译
 
 Elasticsearch 使用独立的内部 `ElasticsearchAggregationCompiler`：
+
+编译器先按 `elements` 顺序把相对路径、每层 filter、group 与 metric 字段解析为绝对路径，再生成 aggregation：
 
 ```text
 根 query
@@ -257,8 +280,8 @@ ApiClient 增加独立的 `SnapshotAggregationQueryApi`、`ReactiveSnapshotAggre
 
 测试只覆盖公共合同和真实执行路径：
 
-- `wow-api`：模型构造、JSON 多态、alias/sort/Elements 结构校验。
-- `wow-query`：DSL 相对路径规范化、现有 filter chain、ABAC 与 masker 跳过。
+- `wow-api`：模型构造、缺省 `FIELD` JSON、alias/sort 和请求结构校验。
+- `wow-query`：Elements/filter/group/metric 相对路径规范化、现有 filter chain、ABAC 与 masker 跳过。
 - `wow-mongo`：pipeline 编译和实际集成测试。
 - `wow-elasticsearch`：nested/composite 编译、分页、精确 metric Top-N，以及 PIT 完成/错误/取消清理。
 - 双后端 TCK：根快照聚合、单层/多层 Elements、每层 filter、三种分组、五种指标、空集、null、稳定排序和 limit。

--- a/docs/superpowers/specs/2026-08-24-snapshot-elements-aggregation-design.md
+++ b/docs/superpowers/specs/2026-08-24-snapshot-elements-aggregation-design.md
@@ -1,0 +1,299 @@
+# 快照集合聚合设计
+
+## 背景
+
+Wow 当前支持快照的单条、列表、分页与计数查询，但不能把状态中的对象集合展开后进行分组和指标计算。例如，订单快照中的 `state.items` 只能作为整体字段查询，不能按商品统计数量或金额。
+
+此前的实现尝试同时证明任意 Jackson 序列化与任意 Elasticsearch mapping 在 MongoDB、Elasticsearch 上完全等价，导致字段扫描、Schema 重写和 mapping 防御持续扩大。本设计只实现标准 Wow 查询路径的可执行聚合，不建立通用可移植性证明器。
+
+## 目标
+
+- 在现有 `SnapshotQueryService` 增加表格型聚合查询。
+- 支持根快照以及一条父子对象集合展开链。
+- 支持每层 Elements 独立过滤。
+- 支持 Terms、Histogram、DateHistogram 分组。
+- 支持 Count、Sum、Avg、Min、Max 指标。
+- MongoDB 与 Elasticsearch 使用各自原生聚合能力。
+- 复用现有查询 filter chain、ABAC、HTTP Guard、ErrorHandler 和 OpenAPI 组件。
+- 保持实现精炼，只验证请求自身即可确定的结构。
+
+## 非目标
+
+- 不实现 Batch、Facet 或多表返回。
+- 不实现算术表达式；只保留已确认的表达式扩展边界。
+- 不支持兄弟集合展开形成笛卡尔积。
+- 不提供 `reverse_nested`、`$lookup`、窗口函数、原始 Mongo pipeline 或原始 Elasticsearch script。
+- 不使用 `TypeFieldPaths` 判断字段是否存在、是否为对象集合或字段类型。
+- 不保证自定义 Jackson serializer/converter 的跨后端等价性。
+- 不保证自定义 Elasticsearch mapping（包括 runtime、`copy_to`、`null_value` 和类型强制转换）的跨后端等价性。
+- 不生成 Elements、Numeric、Temporal 等专用字段枚举。
+- 不动态复制或改写 `FilterExpression` Schema。
+- 不增加 aggregation 专用配置项、JVM ABI 桥接、JMH benchmark、报告文件或 CI 工作流。
+
+## 公共 API
+
+### AggregationQuery
+
+```kotlin
+data class AggregationQuery(
+    override val filter: FilterExpression = MatchAllFilter,
+    val elements: List<AggregationElement> = emptyList(),
+    val groupBy: List<AggregationGroup> = emptyList(),
+    val metrics: List<AggregationMetric>,
+    override val sort: List<Sort> = emptyList(),
+    val limit: Int = DEFAULT_LIMIT,
+) : FilterCapable<AggregationQuery>, SortCapable
+```
+
+首期使用以下固定上限，不增加对应配置项：
+
+- `DEFAULT_LIMIT = 100`
+- `MAX_LIMIT = 10_000`
+- `MAX_ELEMENTS = 5`
+- `MAX_GROUPS = 32`
+- `MAX_METRICS = 64`
+- `MAX_SORT_FIELDS = 32`
+
+`withFilter` 返回复制了根 filter 的查询，使现有 ABAC 与路由 filter 重写可以直接复用。
+
+### Elements
+
+```kotlin
+data class AggregationElement(
+    val path: LogicalField,
+    val filter: FilterExpression = MatchAllFilter,
+)
+```
+
+`elements` 是有序父子展开链。例如：
+
+```text
+state.orders
+state.orders.lines
+state.orders.lines.discounts
+```
+
+每层可以声明自己的 filter。数组中的后一个路径必须严格以 `前一个路径 + "."` 开头，因此重复路径和兄弟集合都会被拒绝。
+
+公共 HTTP 模型始终使用绝对路径。Kotlin DSL 在嵌套 `expand {}` 中允许相对路径，但构建结果必须规范化为绝对路径。
+
+### 分组
+
+```kotlin
+sealed interface AggregationGroup {
+    val field: LogicalField
+    val alias: String
+
+    data class Terms(...)
+    data class Histogram(..., val interval: Double)
+    data class DateHistogram(..., val unit: AggregationDateUnit, val timeZone: String = "UTC")
+}
+```
+
+Histogram interval 必须是有限正数。DateHistogram 时区直接使用 JDK `ZoneId.of()` 验证，不维护时区资源列表或专用 Schema provider。
+
+### 表达式与指标
+
+```kotlin
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(JsonSubTypes.Type(AggregationExpression.Field::class, name = "FIELD"))
+interface AggregationExpression {
+    data class Field(val field: LogicalField) : AggregationExpression
+}
+
+sealed interface AggregationMetric {
+    val alias: String
+
+    data class Count(override val alias: String) : AggregationMetric
+
+    data class Numeric(
+        val function: AggregationFunction,
+        val expression: AggregationExpression,
+        override val alias: String,
+    ) : AggregationMetric
+}
+```
+
+首期只注册和支持 `FIELD`。表达式接口不使用 `sealed`，避免以后增加 `ADD`、`MULTIPLY` 或 `COALESCE` 时破坏调用方的穷举 `when`。当前编译器遇到非 `Field` 实现时返回 unsupported error。
+
+DSL 提供 `sum("state.amount")` 等快捷方法，调用者不需要手工构造 `AggregationExpression.Field`。
+
+### 结构校验
+
+公共层只校验请求本身可确定的事实：
+
+- 数量和 limit 不超过固定上限。
+- Elements 构成严格父子前缀链。
+- element filter 不包含 ID、租户、所有者、空间、删除、搜索等根级操作符。
+- element filter 中的字段属于当前 element 路径。
+- 存在 Elements 时，group 与 metric 字段属于最内层 element 路径。
+- alias 是非空的单个逻辑路径段、全局唯一，且不使用框架内部保留前缀。
+- sort 字段唯一且只引用 group/metric alias。
+- 无 groupBy 时禁止 sort。
+- interval、时区和其他本地值满足基本格式要求。
+
+公共层明确不校验字段存在性、对象集合类型、数值/时间类型或物理 mapping。
+
+## 返回合同
+
+`aggregate` 返回 `Flux<DynamicDocument>`。每个文档是一行，key 为 group/metric alias。
+
+- 无 `groupBy` 时返回一行汇总结果。
+- 有 `groupBy` 时返回不超过 `limit` 的分组行。
+- Count 返回 `Long`。
+- Sum、Avg、Min、Max 返回有限 `Double`；没有贡献值时返回 `null`。
+- 完全空的数据集仍返回一行汇总：Count 为 `0`，数值指标为 `null`。
+- 不向公共结果暴露 MongoDB `Decimal128` 或 Elasticsearch 专用数值类型。
+- 精确金额由调用方使用缩放整数建模。
+
+sort 只引用输出 alias。未显式排序的 group alias 按声明顺序追加升序，作为稳定决胜字段。group alias 排序是普通操作；metric alias 排序由现有 `allowExpensiveOperators` 控制。
+
+## 服务与过滤链
+
+`SnapshotQueryService` 直接增加：
+
+```kotlin
+fun aggregate(query: AggregationQuery): Flux<DynamicDocument> =
+    Flux.error(UnsupportedOperationException("Snapshot aggregation is not supported by [$name]."))
+```
+
+默认实现只保证现有实现重新编译时保持源码兼容，不保留旧 JVM method descriptor，也不增加新的 capability interface。
+
+`SnapshotQueryHandler` 增加对应入口，`QueryType` 增加 `AGGREGATION`。聚合复用现有 `QueryContext` 和 `SnapshotQueryFilter` chain：
+
+```text
+SnapshotQueryHandler.aggregate
+→ QueryType.AGGREGATION
+→ SnapshotQueryFilter chain
+→ TailSnapshotQueryFilter
+→ SnapshotQueryService.aggregate
+```
+
+- ABAC、租户及路由 filter 继续追加到根 filter。
+- `MaskingSnapshotQueryFilter` 对 `AGGREGATION` 直接跳过：不拒绝、不检查 masker、不处理结果。
+- 不新增 `SnapshotAggregationQueryFilter`、专用 context 或第二套 handler chain。
+
+## MongoDB 编译
+
+MongoDB 使用独立的内部 `MongoAggregationCompiler`，复用现有 `SnapshotFilterConverter`：
+
+```text
+根 $match
+→ 对每个 element 执行 $unwind
+→ 对该层 element filter 执行 $match
+→ 排除缺失或 null 的分组键
+→ $group
+→ $project
+→ $sort
+→ $limit
+```
+
+指标直接使用 MongoDB accumulator。编译器增加最小的贡献值计数，以便把没有贡献值的 Sum、Avg、Min、Max 统一为 `null`，而不是错误地返回 `0`。
+
+编译器不读取 Java 类型或 Mongo schema。不存在、不可展开或类型错误的路径由 MongoDB 执行结果或错误决定。
+
+## Elasticsearch 编译
+
+Elasticsearch 使用独立的内部 `ElasticsearchAggregationCompiler`：
+
+```text
+根 query
+→ 按 elements 顺序构造 nested/filter aggregation
+→ 最内层 composite sources 与 metric sub-aggregations
+→ composite 分页
+→ 精确排序与 limit
+```
+
+标准 `SnapshotFilterConverter` 下复用现有 `ElasticsearchIndexMappingResolver`：
+
+- Elements 调用 `requireNested`。
+- Terms 使用现有 exact field resolution，以解析 `.keyword` 等标准 multi-field。
+- element filter 使用现有 filter mapping resolution。
+- Histogram、DateHistogram 和 numeric metric 只解析出可执行字段；类型不匹配由 Elasticsearch 返回错误。
+
+自定义 filter converter 或 mapping 不获得额外可移植性处理；使用者负责提供可执行物理路径。
+
+group alias 排序使用 composite source 原生顺序，只读取达到 limit 所需的页面。metric alias 排序必须完整遍历 composite buckets，再在客户端维护有界 Top-N；不使用语义不等价的 `terms` 或 `bucket_sort` 近似。
+
+聚合分页复用现有 `ElasticsearchQueryPager` 的 PIT 生命周期。实现时只提取 open、更新最新 PIT ID、close 三项内部逻辑，普通查询和聚合分页共同使用。完成、错误和取消都会关闭最新 PIT ID。
+
+## HTTP Guard、路由与客户端
+
+新增单一路由：
+
+```text
+POST /{context}/{aggregate}/snapshot/aggregation
+```
+
+JSON 响应为数组，SSE 响应为 `DynamicDocument` 流。复用现有 body extractor、ErrorHandler 与 idle timeout。
+
+`HttpQueryGuardFilter` 只增加以下分支：
+
+- 根 filter 与所有 element filter 一起计入现有 filter 节点和值数量。
+- 聚合 limit 复用 `maxListSize`。
+- Elements 与 metric alias 排序复用 `allowExpensiveOperators`。
+
+不增加 `maxAggregationElements`、`maxAggregationMetrics` 或其他 aggregation 配置。
+
+OpenAPI 直接生成通用 `AggregationQuery` Schema。聚合专属 RequestBody 复用 main 已有的 `*AggregatedFields` `$ref`，但不生成 Elements 或类型专用字段枚举，也不修改 `FilterExpression` Schema。
+
+ApiClient 增加独立的 `SnapshotAggregationQueryApi`、`ReactiveSnapshotAggregationQueryApi` 和 `SynchronousSnapshotAggregationQueryApi`，不修改现有 composite query API。
+
+## 错误策略
+
+- 请求自身结构错误使用 `IllegalArgumentException`，由现有 ErrorHandler 转换。
+- MongoDB/Elasticsearch 不支持路径、字段类型或 mapping 时保留后端错误。
+- 不把错误降级为空结果，不尝试统一两个后端的错误文本。
+- Flux 任一编译、分页或执行阶段失败即整体失败。
+- PIT close 失败只记录日志，不覆盖原始查询结果或错误。
+
+对于无效字段、自定义 serializer/converter 或自定义 mapping，MongoDB 与 Elasticsearch 可以在不同阶段产生不同错误或结果；该行为明确不属于跨后端合同。
+
+## 测试策略
+
+测试只覆盖公共合同和真实执行路径：
+
+- `wow-api`：模型构造、JSON 多态、alias/sort/Elements 结构校验。
+- `wow-query`：DSL 相对路径规范化、现有 filter chain、ABAC 与 masker 跳过。
+- `wow-mongo`：pipeline 编译和实际集成测试。
+- `wow-elasticsearch`：nested/composite 编译、分页、精确 metric Top-N，以及 PIT 完成/错误/取消清理。
+- 双后端 TCK：根快照聚合、单层/多层 Elements、每层 filter、三种分组、五种指标、空集、null、稳定排序和 limit。
+- `wow-webflux`：HTTP 路由、Guard、JSON/SSE 响应。
+- `wow-openapi`：Schema 快照和一次真实 `example-server /v3/api-docs` 请求。
+- `wow-apiclient`：同步/响应式请求与返回类型。
+
+不建立 Jackson annotation 与 Elasticsearch mapping 的组合测试矩阵，不设置 patch coverage 百分比目标。
+
+## 验证
+
+实现阶段使用 TDD，从最窄模块测试开始。完成前至少运行：
+
+```bash
+./gradlew detekt \
+  :wow-api:check \
+  :wow-query:check \
+  :wow-mongo:check \
+  :wow-elasticsearch:check \
+  :wow-webflux:check \
+  :wow-openapi:check \
+  :wow-apiclient:check \
+  :wow-spring:check \
+  :wow-spring-boot-starter:check
+
+./gradlew \
+  :wow-mongo:integrationTest \
+  :wow-elasticsearch:integrationTest
+
+cd documentation && pnpm docs:build
+```
+
+另外启动一次 `example-server`，通过实际 HTTP 请求验证 `/v3/api-docs` 中的 aggregation route、RequestBody Schema、`x-wow-query-fields` 引用和响应 Schema。临时响应与日志不提交仓库。
+
+## 完成条件
+
+- 公共模型、DSL、服务入口、HTTP 路由和 ApiClient 使用统一 `Aggregation*` 词汇。
+- MongoDB 与 Elasticsearch 对标准 Wow 数据路径通过同一套 TCK。
+- Elements 多层过滤、稳定排序、精确 metric Top-N 与 PIT 清理均有可运行验证。
+- 现有查询 filter chain、ABAC、Guard 和 ErrorHandler 被复用，没有第二套策略链。
+- 没有引入字段目录、mapping 可移植性证明器、动态 FilterExpression Schema 重写或 aggregation 专用配置。
+- 相关模块检查、双后端集成测试、文档构建和真实 OpenAPI HTTP 验证通过。

--- a/documentation/docs/en/guide/extensions/apiclient.md
+++ b/documentation/docs/en/guide/extensions/apiclient.md
@@ -12,7 +12,7 @@ The API Client module provides a declarative RESTful client for Wow services bas
 - **Reactive and Synchronous APIs** — Choose between `Mono`-based reactive or blocking synchronous interfaces
 - **Service Discovery** — Built-in support via `@CoApi` and `@LoadBalanced` annotations
 - **Command Gateway** — Send commands with wait plans through REST endpoints
-- **Snapshot Query** — Single, list, paged, and count query interfaces
+- **Snapshot Query** — Single, list, paged, count, and independent aggregation query interfaces
 
 ## Installation
 
@@ -181,6 +181,27 @@ interface OrderQueryApi : SynchronousSnapshotQueryApi<OrderState>
 
 The synchronous variant mirrors the reactive API but returns values directly
 (blocking).
+
+### Snapshot Aggregation API
+
+Aggregation is intentionally separate from the composite snapshot query interfaces. Extend `ReactiveSnapshotAggregationQueryApi` or `SynchronousSnapshotAggregationQueryApi` explicitly:
+
+```kotlin
+@CoApi(baseUrl = "http://order-service:8080")
+@HttpExchange("cart")
+interface CartAggregationClient : ReactiveSnapshotAggregationQueryApi
+
+val rows: Flux<Map<String, Any?>> = aggregation {
+    expand("state.orders") { "status" eq "PAID" }
+    expand("lines") { "quantity" gt 0 }
+    terms("productId", "product")
+    sum("amount", "total")
+    sort { "total".desc() }
+    limit(20)
+}.query(cartAggregationClient)
+```
+
+The reactive API returns `Flux<Map<String, Any?>>`; the synchronous API returns `List<Map<String, Any?>>`. Both post the same `AggregationQuery` JSON to `snapshot/aggregation`.
 
 ## Error Handling
 

--- a/documentation/docs/en/guide/extensions/elasticsearch.md
+++ b/documentation/docs/en/guide/extensions/elasticsearch.md
@@ -576,41 +576,11 @@ listQuery {
 
 ## Aggregation Queries
 
-Elasticsearch provides powerful aggregation capabilities:
+`ElasticsearchSnapshotQueryService.aggregate()` compiles the shared `AggregationQuery` contract. It resolves the first Element as an absolute `nested` path, then resolves later Elements and their filters relative to the current nested scope. Terms groups use the existing exact-field resolver, including standard `.keyword` multi-fields; Histogram, DateHistogram, and numeric metrics resolve executable physical fields and leave type mismatches to Elasticsearch.
 
-### Statistical Analysis
+At the innermost scope, Wow uses composite sources and metric sub-aggregations. Group-alias sorting follows composite source order and reads only the pages needed for `limit`. Metric-alias sorting is more expensive: it scans all composite buckets and keeps an exact bounded Top-N in the client instead of using an approximate `terms` or `bucket_sort` plan.
 
-```kotlin
-// Count orders by status
-val aggregation = SearchRequest.of { s ->
-    s.index("wow.order-service.order.snapshot")
-        .aggregations("status_count") { a ->
-            a.terms { t ->
-                t.field("state.status")
-            }
-        }
-}
-```
-
-### Time Range Aggregation
-
-```kotlin
-// Daily order amount statistics
-val aggregation = SearchRequest.of { s ->
-    s.index("wow.order-service.order.snapshot")
-        .aggregations("daily_amount") { a ->
-            a.dateHistogram { d ->
-                d.field("eventTime")
-                    .calendarInterval(CalendarInterval.Day)
-            }
-            .aggregations("total") { sa ->
-                sa.sum { sum ->
-                    sum.field("state.totalAmount")
-                }
-            }
-        }
-}
-```
+Composite paging reuses the normal query pager's point-in-time lifecycle. The latest PIT is closed after completion, error, or cancellation. Custom filter converters and custom mappings such as runtime fields, `copy_to`, `null_value`, or type coercion receive no portability guarantees; callers must provide executable physical paths.
 
 ## Index Design Recommendations
 

--- a/documentation/docs/en/guide/extensions/mongo.md
+++ b/documentation/docs/en/guide/extensions/mongo.md
@@ -414,6 +414,14 @@ query.dynamicQuery(snapshotQueryService)
 
 The `MongoSnapshotQueryService` uses `MaterializedSnapshot<S>` as its typed result wrapper, where `S` is the aggregate's state type resolved from the aggregate metadata. This enables type-safe dynamic queries directly against aggregate state fields -- for example, querying `state.status` or `state.totalAmount` without a separate projection processor.
 
+### Snapshot Aggregation
+
+`MongoSnapshotQueryService.aggregate()` compiles the shared `AggregationQuery` contract into a native pipeline: root `$match`, ordered `$unwind` and per-Element `$match`, group-key filtering, `$group`, `$project`, `$sort`, and `$limit`. The first Element path is absolute; later Element paths, Element filters, and innermost group/metric fields are resolved from their current scope.
+
+MongoDB accumulators implement Terms, Histogram, DateHistogram, Count, Sum, Avg, Min, and Max. Missing or null group keys are excluded. Count is normalized to `Long`; numeric metrics become finite `Double` values or `null` when nothing contributes, including the single summary row returned for an empty ungrouped query.
+
+The compiler does not inspect Java types or a MongoDB schema. Invalid or non-expandable paths remain MongoDB results or errors, and custom Jackson serializers or filter converters are not guaranteed to behave like the standard Wow field mapping.
+
 ## PrepareKey: Distributed Coordination
 
 `MongoPrepareKey` implements Wow's `PrepareKey<V>` interface for distributed key reservation with MongoDB as the coordination backend. Each logical key becomes a `prepare_{name}` collection.

--- a/documentation/docs/en/guide/extensions/webflux.md
+++ b/documentation/docs/en/guide/extensions/webflux.md
@@ -92,7 +92,7 @@ plus `wow-webflux` for these properties to be bound.
 | `query.max-page-window` | `Long` | `10000` | Maximum HTTP `index * size` page window; `0` disables the cap |
 | `query.max-condition-nodes` | `Int` | `64` | Maximum number of HTTP query condition nodes; `0` disables the cap |
 | `query.max-condition-values` | `Int` | `1000` | Maximum values in HTTP `IN`, `NOT_IN`, `ALL_IN`, `IDS`, or `AGGREGATE_IDS` conditions; `0` disables the cap |
-| `query.allow-expensive-operators` | `Boolean` | `true` | Whether HTTP queries may use negative/existence/expensive string operators or unfiltered count/paged queries |
+| `query.allow-expensive-operators` | `Boolean` | `true` | Whether HTTP queries may use negative/existence/expensive string operators, unfiltered count/paged queries, aggregation Elements, or metric-alias aggregation sorting |
 | `query.idle-timeout` | `Duration` | `10s` | Maximum wait between results or completion; JSON arrays are buffered before the response is committed, while SSE remains streaming; `0s` disables the timeout |
 
 ```yaml
@@ -116,6 +116,12 @@ wow:
 
 When `wow-spring-boot-starter` is used, WebFlux is included as the `webflux-support` feature capability. The global error handler is enabled by default; disable it only if you provide your own `WebExceptionHandler`.
 The guard applies whenever the Reactor context contains a WebFlux `ServerRequest` through `writeRawRequest(request)`, including built-in routes and custom HTTP handlers. Injected query services and non-WebFlux request contexts keep their existing behavior. To temporarily restore the previous HTTP behavior after upgrading, set the numeric limits and `idle-timeout` to `0` and enable both `allow-*` switches.
+
+## Snapshot Aggregation Route
+
+WebFlux registers `POST /{context}/{aggregate}/snapshot/aggregation`, with the tenant/owner/space prefixes applicable to the aggregate. The body is an `AggregationQuery`. A normal JSON response is an array of dynamic row objects; `Accept: text/event-stream` streams one row at a time. Strict request decoding rejects unknown properties and invalid scalar equality values in both the root filter and Element filters.
+
+The existing query guard applies `query.max-list-size` to the aggregation `limit`. `query.allow-expensive-operators=false` rejects expensive operators in the root and Element filters, any Elements expansion, and sorting by a metric alias. No aggregation-specific WebFlux properties are added.
 
 ## Wait Plan Integration
 
@@ -188,6 +194,8 @@ paths:
             schema:
               $ref: '#/components/schemas/AddCartItem'
 ```
+
+Snapshot aggregation operations reference an aggregate-specific request body such as `example.cart.AggregationQuery`. Its `x-wow-query-fields.$ref` points to the aggregate's `CartAggregatedFields` component, while its `application/json` schema references the generic `wow.api.query.AggregationQuery` schema. The success response is an array whose items are dynamic objects.
 
 ## Performance Optimization
 

--- a/documentation/docs/en/guide/query.md
+++ b/documentation/docs/en/guide/query.md
@@ -145,6 +145,65 @@ query.query(queryService)
 
 `ListQuery.limit = 0` means unlimited results. HTTP queries remain subject to the WebFlux query-cost guard configuration.
 
+### Snapshot aggregation
+
+Use `aggregation {}` to expand an ordered chain of state collections and return tabular rows:
+
+```kotlin
+val query = aggregation {
+    expand("state.orders") { "status" eq "PAID" }
+    expand("lines") { "quantity" gt 0 }
+    terms("productId", "product")
+    sum("amount", "total")
+    sort { "total".desc() }
+    limit(20)
+}
+
+query.query(snapshotQueryService)
+```
+
+The equivalent JSON is:
+
+```json
+{
+  "elements": [
+    {
+      "path": "state.orders",
+      "filter": { "op": "EQ", "field": "status", "value": "PAID" }
+    },
+    {
+      "path": "lines",
+      "filter": { "op": "GT", "field": "quantity", "value": 0 }
+    }
+  ],
+  "groupBy": [
+    { "type": "TERMS", "field": "productId", "alias": "product" }
+  ],
+  "metrics": [
+    {
+      "type": "NUMERIC",
+      "function": "SUM",
+      "expression": { "field": "amount" },
+      "alias": "total"
+    }
+  ],
+  "sort": [{ "field": "total", "direction": "DESC" }],
+  "limit": 20
+}
+```
+
+The first Element path is an absolute snapshot path. Every later Element path and every Element filter is relative to its current expanded element. Group and metric fields are relative to the innermost Element; without Elements, they are absolute snapshot paths. Elements form one parent-child chain, not sibling expansions.
+
+`TERMS`, `HISTOGRAM`, and `DATE_HISTOGRAM` groups are supported. Metrics are `COUNT`, `SUM`, `AVG`, `MIN`, and `MAX`; `COUNT` returns `Long`, while numeric metrics return a finite `Double` or `null` when no value contributes. A query without groups returns one summary row, including an empty dataset (`COUNT = 0`, numeric metrics `null`). Grouped results contain at most `limit` rows; the default is `100` and the maximum is `10,000`.
+
+Sort fields reference group or metric aliases. Missing group-alias sorts are appended in declaration order for stable results. Sorting by a metric alias is expensive and is controlled by the WebFlux `query.allow-expensive-operators` guard. Fixed structural limits are 5 Elements, 32 groups, 64 metrics, and 32 effective sort fields.
+
+Aggregation uses the existing snapshot filter chain: ABAC and route filters still extend the root filter. The masking filter ignores aggregation queries, so configured maskers do not reject or rewrite aggregation results.
+
+Wow validates the request structure, not field existence, collection shape, or physical field type. It does not maintain an aggregation field catalog or use `TypeFieldPaths` for validation. Equivalent behavior is not guaranteed for custom Jackson serializers, backend filter converters, or custom Elasticsearch mappings. Batch aggregation and arithmetic expressions are not included.
+
+The HTTP endpoint is `POST /{context}/{aggregate}/snapshot/aggregation` (with the route prefixes applicable to the aggregate). JSON responses are arrays of dynamic objects; SSE streams one object at a time. OpenAPI publishes an aggregate-specific `AggregationQuery` request body whose `x-wow-query-fields` references that aggregate's `*AggregatedFields` component, while the JSON schema remains the generic `AggregationQuery` contract.
+
 ### Rewriting queries
 
 Query filters use `withFilter` or `appendFilter`; internal paths no longer rewrite `Condition`:

--- a/documentation/docs/zh/guide/extensions/apiclient.md
+++ b/documentation/docs/zh/guide/extensions/apiclient.md
@@ -12,7 +12,7 @@ API 客户端模块基于 [CoApi](https://github.com/Ahoo-Wang/CoApi) 提供声�
 - **响应式与同步 API** — 可选择基于 `Mono` 的响应式接口或阻塞式同步接口
 - **服务发现** — 通过 `@CoApi` 和 `@LoadBalanced` 注解内置服务发现支持
 - **命令网关** — 通过 REST 端点发送命令，支持等待计划
-- **快照查询** — 单条、列表、分页和计数查询接口
+- **快照查询** — 单条、列表、分页、计数及独立的聚合查询接口
 
 ## 安装
 
@@ -175,6 +175,27 @@ interface OrderQueryApi : SynchronousSnapshotQueryApi<OrderState>
 ```
 
 同步版本与响应式 API 对应，但直接返回值（阻塞）。
+
+### 快照聚合 API
+
+聚合接口有意保持独立，不包含在组合式快照查询接口中。需要显式继承 `ReactiveSnapshotAggregationQueryApi` 或 `SynchronousSnapshotAggregationQueryApi`：
+
+```kotlin
+@CoApi(baseUrl = "http://order-service:8080")
+@HttpExchange("cart")
+interface CartAggregationClient : ReactiveSnapshotAggregationQueryApi
+
+val rows: Flux<Map<String, Any?>> = aggregation {
+    expand("state.orders") { "status" eq "PAID" }
+    expand("lines") { "quantity" gt 0 }
+    terms("productId", "product")
+    sum("amount", "total")
+    sort { "total".desc() }
+    limit(20)
+}.query(cartAggregationClient)
+```
+
+响应式 API 返回 `Flux<Map<String, Any?>>`；同步 API 返回 `List<Map<String, Any?>>`。两者都把同一份 `AggregationQuery` JSON 发送到 `snapshot/aggregation`。
 
 ## 错误处理
 

--- a/documentation/docs/zh/guide/extensions/elasticsearch.md
+++ b/documentation/docs/zh/guide/extensions/elasticsearch.md
@@ -565,41 +565,11 @@ listQuery {
 
 ## 聚合查询
 
-Elasticsearch 提供强大的聚合功能：
+`ElasticsearchSnapshotQueryService.aggregate()` 编译通用 `AggregationQuery` 合同。第一个 Element 按绝对 `nested` 路径解析，后续 Elements 及其 filters 相对当前 nested 作用域解析。Terms 分组复用现有精确字段解析器，包括标准 `.keyword` multi-field；Histogram、DateHistogram 与数值指标解析为可执行物理字段，类型不匹配时保留 Elasticsearch 错误。
 
-### 统计分析
+在最内层作用域，Wow 使用 composite sources 与 metric sub-aggregations。按 group alias 排序遵循 composite source 顺序，只读取满足 `limit` 所需的分页。按 metric alias 排序成本更高：它会遍历全部 composite buckets，并在客户端维护精确的有界 Top-N，而不使用近似的 `terms` 或 `bucket_sort` 方案。
 
-```kotlin
-// 按状态统计订单数量
-val aggregation = SearchRequest.of { s ->
-    s.index("wow.order-service.order.snapshot")
-        .aggregations("status_count") { a ->
-            a.terms { t ->
-                t.field("state.status")
-            }
-        }
-}
-```
-
-### 时间范围聚合
-
-```kotlin
-// 按天统计订单金额
-val aggregation = SearchRequest.of { s ->
-    s.index("wow.order-service.order.snapshot")
-        .aggregations("daily_amount") { a ->
-            a.dateHistogram { d ->
-                d.field("eventTime")
-                    .calendarInterval(CalendarInterval.Day)
-            }
-            .aggregations("total") { sa ->
-                sa.sum { sum ->
-                    sum.field("state.totalAmount")
-                }
-            }
-        }
-}
-```
+Composite 分页复用普通查询 pager 的 point-in-time 生命周期；完成、错误或取消时都会关闭最新 PIT。自定义 filter converter 以及 runtime field、`copy_to`、`null_value`、类型强制转换等自定义 mapping 不提供可移植性保证；调用方必须提供可执行的物理路径。
 
 ## 索引设计建议
 

--- a/documentation/docs/zh/guide/extensions/mongo.md
+++ b/documentation/docs/zh/guide/extensions/mongo.md
@@ -409,6 +409,14 @@ query.dynamicQuery(snapshotQueryService)
 
 `MongoSnapshotQueryService` 使用 `MaterializedSnapshot<S>` 作为其类型化的结果包装器，其中 `S` 是从聚合元数据解析出的聚合状态类型。这支持直接对聚合状态字段进行类型安全的动态查询——例如，查询 `state.status` 或 `state.totalAmount` 而不需要单独的投影处理器。
 
+### 快照聚合
+
+`MongoSnapshotQueryService.aggregate()` 把通用 `AggregationQuery` 合同编译为原生 pipeline：根 `$match`、按顺序执行的 `$unwind` 与每层 Element `$match`、分组键过滤、`$group`、`$project`、`$sort` 和 `$limit`。第一个 Element 路径是绝对路径；后续 Element 路径、Element filter 及最内层 group/metric 字段都从当前作用域解析。
+
+MongoDB accumulator 实现 Terms、Histogram、DateHistogram、Count、Sum、Avg、Min 与 Max。缺失或为 null 的分组键会被排除。Count 统一为 `Long`；数值指标统一为有限 `Double`，没有值参与计算时为 `null`，空数据集的无分组单行汇总也遵循该规则。
+
+编译器不检查 Java 类型或 MongoDB schema。无效或不可展开的路径保留 MongoDB 的结果或错误；自定义 Jackson serializer 或 filter converter 不保证与 Wow 标准字段映射等价。
+
 ## PrepareKey：分布式协调
 
 `MongoPrepareKey` 实现了 Wow 的 `PrepareKey<V>` 接口，以 MongoDB 为协调后端进行分布式键预留。每个逻辑键变成一个 `prepare_{name}` 集合。

--- a/documentation/docs/zh/guide/extensions/webflux.md
+++ b/documentation/docs/zh/guide/extensions/webflux.md
@@ -90,7 +90,7 @@ data class CreateOrder(/* ... */)
 | `query.max-page-window` | `Long` | `10000` | HTTP 分页查询允许的最大 `index * size`；`0` 关闭上限 |
 | `query.max-condition-nodes` | `Int` | `64` | HTTP 查询条件树的最大节点数；`0` 关闭上限 |
 | `query.max-condition-values` | `Int` | `1000` | HTTP `IN`、`NOT_IN`、`ALL_IN`、`IDS`、`AGGREGATE_IDS` 条件的最大值数量；`0` 关闭上限 |
-| `query.allow-expensive-operators` | `Boolean` | `true` | 是否允许 HTTP 查询使用负向/存在性/高成本字符串操作符及无过滤 count/paged 查询 |
+| `query.allow-expensive-operators` | `Boolean` | `true` | 是否允许 HTTP 查询使用负向/存在性/高成本字符串操作符、无过滤 count/paged 查询、聚合 Elements 或按 metric alias 排序 |
 | `query.idle-timeout` | `Duration` | `10s` | 等待下一条结果或完成的最长时间；普通 JSON 数组在提交响应前缓冲，SSE 保持流式；`0s` 关闭超时 |
 
 ```yaml
@@ -114,6 +114,12 @@ wow:
 
 使用 `wow-spring-boot-starter` 时，WebFlux 作为 `webflux-support` 特性能力包含在内。全局异常处理器默认启用；仅当你提供自己的 `WebExceptionHandler` 时才需关闭。
 Reactor Context 通过 `writeRawRequest(request)` 携带 WebFlux `ServerRequest` 时都会启用护栏，包括内置路由和自定义 HTTP Handler；程序内注入的查询服务和非 WebFlux 请求上下文保持原行为。升级后如需临时恢复旧 HTTP 行为，可将数值限制和 `idle-timeout` 设为 `0`，并启用两个 `allow-*` 开关。
+
+## 快照聚合路由
+
+WebFlux 注册 `POST /{context}/{aggregate}/snapshot/aggregation`，并应用聚合自身适用的 tenant/owner/space 路由前缀。请求体为 `AggregationQuery`。普通 JSON 响应是动态行对象数组；`Accept: text/event-stream` 会逐行流式返回。严格请求解码会拒绝未知属性，以及根 filter 和 Element filters 中非法的标量等值条件。
+
+现有查询护栏把 `query.max-list-size` 用作聚合 `limit` 上限。`query.allow-expensive-operators=false` 时，会拒绝根 filter 与 Element filters 中的高成本操作符、任意 Elements 展开，以及按 metric alias 排序。不会增加聚合专用 WebFlux 配置。
 
 ## 等待计划集成
 
@@ -179,6 +185,8 @@ paths:
             schema:
               $ref: '#/components/schemas/AddCartItem'
 ```
+
+快照聚合 operation 引用聚合专属 request body，例如 `example.cart.AggregationQuery`。其 `x-wow-query-fields.$ref` 指向该聚合的 `CartAggregatedFields` 组件，而 `application/json` schema 引用通用 `wow.api.query.AggregationQuery` schema。成功响应是以动态对象为元素的数组。
 
 ## 性能优化
 

--- a/documentation/docs/zh/guide/query.md
+++ b/documentation/docs/zh/guide/query.md
@@ -145,6 +145,65 @@ query.query(queryService)
 
 `ListQuery.limit = 0` 表示不限制结果数量；HTTP 查询仍会受到 WebFlux 查询成本保护配置约束。
 
+### 快照聚合
+
+使用 `aggregation {}` 按顺序展开状态中的集合链，并返回表格型结果：
+
+```kotlin
+val query = aggregation {
+    expand("state.orders") { "status" eq "PAID" }
+    expand("lines") { "quantity" gt 0 }
+    terms("productId", "product")
+    sum("amount", "total")
+    sort { "total".desc() }
+    limit(20)
+}
+
+query.query(snapshotQueryService)
+```
+
+等价 JSON 为：
+
+```json
+{
+  "elements": [
+    {
+      "path": "state.orders",
+      "filter": { "op": "EQ", "field": "status", "value": "PAID" }
+    },
+    {
+      "path": "lines",
+      "filter": { "op": "GT", "field": "quantity", "value": 0 }
+    }
+  ],
+  "groupBy": [
+    { "type": "TERMS", "field": "productId", "alias": "product" }
+  ],
+  "metrics": [
+    {
+      "type": "NUMERIC",
+      "function": "SUM",
+      "expression": { "field": "amount" },
+      "alias": "total"
+    }
+  ],
+  "sort": [{ "field": "total", "direction": "DESC" }],
+  "limit": 20
+}
+```
+
+第一个 Element 路径是快照绝对路径；后续每个 Element 路径及每个 Element filter 都相对当前已展开元素。group 与 metric 字段相对最内层 Element；没有 Elements 时，它们使用快照绝对路径。Elements 只表示一条父子链，不支持兄弟集合展开。
+
+分组支持 `TERMS`、`HISTOGRAM` 与 `DATE_HISTOGRAM`。指标支持 `COUNT`、`SUM`、`AVG`、`MIN` 与 `MAX`；`COUNT` 返回 `Long`，数值指标返回有限 `Double`，没有值参与计算时返回 `null`。没有分组的查询返回一行汇总，空数据集同样如此（`COUNT = 0`，数值指标为 `null`）。分组结果最多返回 `limit` 行；默认值为 `100`，最大值为 `10,000`。
+
+排序字段引用 group 或 metric alias。未显式排序的 group alias 会按声明顺序追加，以保证结果稳定。按 metric alias 排序成本较高，受 WebFlux `query.allow-expensive-operators` 护栏控制。固定结构上限为 5 个 Elements、32 个 groups、64 个 metrics 与 32 个有效排序字段。
+
+聚合复用现有快照过滤链：ABAC 与路由 filter 仍会追加到根 filter。Masking filter 会忽略聚合查询，因此已配置的 masker 不会拒绝或重写聚合结果。
+
+Wow 只校验请求结构，不校验字段是否存在、路径是否为集合或物理字段类型；不会维护聚合字段目录，也不会使用 `TypeFieldPaths` 做校验。自定义 Jackson serializer、后端 filter converter 或 Elasticsearch mapping 不保证跨后端等价。首期不包含 Batch 聚合与算术表达式。
+
+HTTP 端点为 `POST /{context}/{aggregate}/snapshot/aggregation`（并遵循聚合自身适用的路由前缀）。JSON 响应是动态对象数组；SSE 逐个流式返回对象。OpenAPI 为每个聚合发布专属 `AggregationQuery` request body，其 `x-wow-query-fields` 引用该聚合的 `*AggregatedFields` 组件，JSON schema 仍使用通用 `AggregationQuery` 合同。
+
 ### 重写查询
 
 查询过滤器通过 `withFilter` 或 `appendFilter` 重写，不再操作内部 `Condition`：

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/mock/MockAggregate.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/mock/MockAggregate.kt
@@ -22,6 +22,7 @@ import me.ahoo.wow.api.command.validation.CommandValidator
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.modeling.state.ReadOnlyStateAggregate
 import me.ahoo.wow.modeling.state.ReadOnlyStateAggregateAware
+import java.time.Instant
 
 val MOCK_AGGREGATE_METADATA = aggregateMetadata<MockCommandAggregate, MockStateAggregate>()
 
@@ -61,7 +62,24 @@ class MockCommandAggregate(val state: MockStateAggregate) {
     }
 }
 
-data class MockStateAggregate(val id: String) : ReadOnlyStateAggregateAware<MockStateAggregate> {
+data class MockOrder(val status: String, val lines: List<MockLine>)
+
+data class MockLine(
+    val productId: String,
+    val quantity: Int,
+    val amount: Double?,
+    val createdAt: Instant,
+    val discounts: List<MockDiscount>,
+)
+
+data class MockDiscount(val type: String, val amount: Double)
+
+data class MockStateAggregate(
+    val id: String,
+    val orders: List<MockOrder> = emptyList(),
+) : ReadOnlyStateAggregateAware<MockStateAggregate> {
+    constructor(id: String) : this(id, emptyList())
+
     var data: String = ""
         private set
 

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/mock/MockAggregate.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/mock/MockAggregate.kt
@@ -22,6 +22,7 @@ import me.ahoo.wow.api.command.validation.CommandValidator
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.modeling.state.ReadOnlyStateAggregate
 import me.ahoo.wow.modeling.state.ReadOnlyStateAggregateAware
+import java.math.BigDecimal
 import java.time.Instant
 
 val MOCK_AGGREGATE_METADATA = aggregateMetadata<MockCommandAggregate, MockStateAggregate>()
@@ -77,6 +78,7 @@ data class MockDiscount(val type: String, val amount: Double)
 data class MockStateAggregate(
     val id: String,
     val orders: List<MockOrder> = emptyList(),
+    val decimalValue: BigDecimal = BigDecimal.ZERO,
 ) : ReadOnlyStateAggregateAware<MockStateAggregate> {
     constructor(id: String) : this(id, emptyList())
 

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt
@@ -194,10 +194,10 @@ abstract class SnapshotQueryServiceSpec {
                 it.toMap().assert().isEqualTo(
                     mapOf(
                         "count" to 2L,
-                        "total" to 2.0,
-                        "average" to 1.0,
+                        "total" to 3.0,
+                        "average" to 1.5,
                         "minimum" to 1.0,
-                        "maximum" to 1.0,
+                        "maximum" to 2.0,
                     ),
                 )
             }.verifyComplete()
@@ -341,10 +341,10 @@ abstract class SnapshotQueryServiceSpec {
     }
 
     private fun saveAggregationStates(vararg states: MockStateAggregate) {
-        states.forEach { state ->
+        states.forEachIndexed { index, state ->
             snapshotStore.save(
                 SimpleSnapshot(
-                    MOCK_AGGREGATE_METADATA.toStateAggregate(state, version = 1),
+                    MOCK_AGGREGATE_METADATA.toStateAggregate(state, version = index + 1),
                     AGGREGATION_SNAPSHOT_TIME,
                 ),
             ).test().verifyComplete()

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt
@@ -20,6 +20,8 @@ import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.modeling.aggregateId
 import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory
+import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory.toStateAggregate
+import me.ahoo.wow.query.dsl.aggregation
 import me.ahoo.wow.query.dsl.condition
 import me.ahoo.wow.query.dsl.filterExpression
 import me.ahoo.wow.query.dsl.listQuery
@@ -31,11 +33,15 @@ import me.ahoo.wow.query.snapshot.count
 import me.ahoo.wow.query.snapshot.dynamicQuery
 import me.ahoo.wow.query.snapshot.query
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
+import me.ahoo.wow.tck.mock.MockDiscount
+import me.ahoo.wow.tck.mock.MockLine
+import me.ahoo.wow.tck.mock.MockOrder
 import me.ahoo.wow.tck.mock.MockStateAggregate
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import reactor.kotlin.test.test
 import java.time.Clock
+import java.time.Instant
 
 abstract class SnapshotQueryServiceSpec {
     lateinit var snapshotStore: SnapshotStore
@@ -169,5 +175,259 @@ abstract class SnapshotQueryServiceSpec {
             .test()
             .expectNext(1L)
             .verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should summarize standard root fields with every metric`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+
+        aggregation {
+            filter { aggregateIds("aggregation-a", "aggregation-b") }
+            count("count")
+            sum("version", "total")
+            avg("version", "average")
+            min("version", "minimum")
+            max("version", "maximum")
+        }.query(snapshotQueryService)
+            .test()
+            .assertNext {
+                it.toMap().assert().isEqualTo(
+                    mapOf(
+                        "count" to 2L,
+                        "total" to 2.0,
+                        "average" to 1.0,
+                        "minimum" to 1.0,
+                        "maximum" to 1.0,
+                    ),
+                )
+            }.verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should apply two element filters and every group type`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+
+        aggregation {
+            expand("state.orders") { "status" eq "PAID" }
+            expand("lines") { "quantity" gte 2 }
+            terms("productId", "product")
+            histogram("quantity", 2.0, "quantityBucket")
+            dateHistogram("createdAt", me.ahoo.wow.api.query.AggregationDateUnit.DAY, "day")
+            count("count")
+        }.query(snapshotQueryService)
+            .collectList()
+            .test()
+            .assertNext { rows ->
+                rows.map(Map<String, Any?>::toMap).assert().containsExactly(
+                    mapOf(
+                        "product" to "alpha",
+                        "quantityBucket" to 4.0,
+                        "day" to 1_767_398_400_000L,
+                        "count" to 1L,
+                    ),
+                    mapOf(
+                        "product" to "beta",
+                        "quantityBucket" to 2.0,
+                        "day" to 1_767_312_000_000L,
+                        "count" to 2L,
+                    ),
+                    mapOf(
+                        "product" to "delta",
+                        "quantityBucket" to 4.0,
+                        "day" to 1_769_990_400_000L,
+                        "count" to 1L,
+                    ),
+                )
+            }.verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should return one empty summary row`() {
+        aggregation {
+            filter { aggregateId("missing") }
+            count("count")
+            sum("version", "total")
+        }.query(snapshotQueryService)
+            .test()
+            .assertNext {
+                it.toMap().assert().isEqualTo(mapOf("count" to 0L, "total" to null))
+            }.verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should return null when no numeric value contributes`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+
+        aggregation {
+            expand("state.orders") { "status" eq "CANCELLED" }
+            expand("lines") { "productId" eq "gamma" }
+            count("count")
+            sum("amount", "total")
+            avg("amount", "average")
+            min("amount", "minimum")
+            max("amount", "maximum")
+        }.query(snapshotQueryService)
+            .test()
+            .assertNext {
+                it.toMap().assert().isEqualTo(
+                    mapOf(
+                        "count" to 1L,
+                        "total" to null,
+                        "average" to null,
+                        "minimum" to null,
+                        "maximum" to null,
+                    ),
+                )
+            }.verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should append group aliases for stable sorting`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+
+        aggregation {
+            expand("state.orders") { "status" eq "PAID" }
+            expand("lines")
+            terms("productId", "product")
+            histogram("quantity", 2.0, "quantityBucket")
+            count("count")
+            sort { "product".asc() }
+        }.query(snapshotQueryService)
+            .collectList()
+            .test()
+            .assertNext { rows ->
+                rows.map { listOf(it["product"], it["quantityBucket"], it["count"]) }.assert().containsExactly(
+                    listOf("alpha", 0.0, 1L),
+                    listOf("alpha", 4.0, 1L),
+                    listOf("beta", 2.0, 2L),
+                    listOf("delta", 4.0, 1L),
+                )
+            }.verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should select metric Top-N across nested discounts`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+
+        aggregation {
+            expand("state.orders") { "status" eq "PAID" }
+            expand("lines") { "quantity" gte 2 }
+            expand("discounts") { "amount" gt 0 }
+            terms("type", "type")
+            sum("amount", "total")
+            sort { "total".desc() }
+            limit(1)
+        }.query(snapshotQueryService)
+            .test()
+            .assertNext {
+                it.toMap().assert().isEqualTo(mapOf("type" to "PROMO", "total" to 8.0))
+            }.verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should support cancellation after a real result`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+
+        aggregation {
+            expand("state.orders")
+            expand("lines")
+            terms("productId", "product")
+            count("count")
+        }.query(snapshotQueryService)
+            .test()
+            .expectNextCount(1)
+            .thenCancel()
+            .verify()
+    }
+
+    private fun saveAggregationStates(vararg states: MockStateAggregate) {
+        states.forEach { state ->
+            snapshotStore.save(
+                SimpleSnapshot(
+                    MOCK_AGGREGATE_METADATA.toStateAggregate(state, version = 1),
+                    AGGREGATION_SNAPSHOT_TIME,
+                ),
+            ).test().verifyComplete()
+        }
+    }
+
+    private fun aggregationStates(): List<MockStateAggregate> = listOf(aggregationStateA(), aggregationStateB())
+
+    private fun aggregationStateA(): MockStateAggregate =
+        MockStateAggregate(
+            id = "aggregation-a",
+            orders = listOf(
+                MockOrder(
+                    status = "PAID",
+                    lines = listOf(
+                        MockLine(
+                            productId = "alpha",
+                            quantity = 1,
+                            amount = 10.0,
+                            createdAt = Instant.parse("2026-01-01T10:00:00Z"),
+                            discounts = listOf(
+                                MockDiscount("LOYALTY", 1.0),
+                                MockDiscount("PROMO", 2.0),
+                            ),
+                        ),
+                        MockLine(
+                            productId = "beta",
+                            quantity = 2,
+                            amount = 20.0,
+                            createdAt = Instant.parse("2026-01-02T10:00:00Z"),
+                            discounts = listOf(MockDiscount("PROMO", 3.0)),
+                        ),
+                    ),
+                ),
+                MockOrder(
+                    status = "CANCELLED",
+                    lines = listOf(
+                        MockLine(
+                            productId = "gamma",
+                            quantity = 3,
+                            amount = null,
+                            createdAt = Instant.parse("2026-02-01T10:00:00Z"),
+                            discounts = listOf(MockDiscount("LOYALTY", 4.0)),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+    private fun aggregationStateB(): MockStateAggregate =
+        MockStateAggregate(
+            id = "aggregation-b",
+            orders = listOf(
+                MockOrder(
+                    status = "PAID",
+                    lines = listOf(
+                        MockLine(
+                            productId = "alpha",
+                            quantity = 4,
+                            amount = 30.0,
+                            createdAt = Instant.parse("2026-01-03T10:00:00Z"),
+                            discounts = listOf(MockDiscount("PROMO", 5.0)),
+                        ),
+                        MockLine(
+                            productId = "beta",
+                            quantity = 2,
+                            amount = 20.0,
+                            createdAt = Instant.parse("2026-01-02T18:00:00Z"),
+                            discounts = listOf(MockDiscount("LOYALTY", 6.0)),
+                        ),
+                        MockLine(
+                            productId = "delta",
+                            quantity = 5,
+                            amount = 50.0,
+                            createdAt = Instant.parse("2026-02-02T10:00:00Z"),
+                            discounts = emptyList(),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+    private companion object {
+        const val AGGREGATION_SNAPSHOT_TIME = 1_767_225_600_000L
     }
 }

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt
@@ -264,6 +264,26 @@ abstract class SnapshotQueryServiceSpec {
     }
 
     @Test
+    fun `aggregation should support second date histograms`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+
+        aggregation {
+            expand("state.orders")
+            expand("lines") { "productId" eq "beta" }
+            dateHistogram("createdAt", AggregationDateUnit.SECOND, "second")
+            count("count")
+        }.query(snapshotQueryService)
+            .collectList()
+            .test()
+            .assertNext { rows ->
+                rows.map(Map<String, Any?>::toMap).assert().containsExactly(
+                    mapOf("second" to Instant.parse("2026-01-02T10:00:00Z").toEpochMilli(), "count" to 1L),
+                    mapOf("second" to Instant.parse("2026-01-02T18:00:00Z").toEpochMilli(), "count" to 1L),
+                )
+            }.verifyComplete()
+    }
+
+    @Test
     fun `aggregation should return backend neutral decimal Terms keys`() {
         saveAggregationStates(
             MockStateAggregate(id = "decimal-a", decimalValue = BigDecimal("1.25")),

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.tck.query
 
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.AggregationDateUnit
 import me.ahoo.wow.eventsourcing.snapshot.SimpleSnapshot
 import me.ahoo.wow.eventsourcing.snapshot.Snapshot
 import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
@@ -237,6 +238,26 @@ abstract class SnapshotQueryServiceSpec {
                         "day" to 1_769_990_400_000L,
                         "count" to 1L,
                     ),
+                )
+            }.verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should start UTC weeks on Monday`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+
+        aggregation {
+            expand("state.orders")
+            expand("lines") { "productId" isIn listOf("gamma", "delta") }
+            dateHistogram("createdAt", AggregationDateUnit.WEEK, "week")
+            count("count")
+        }.query(snapshotQueryService)
+            .collectList()
+            .test()
+            .assertNext { rows ->
+                rows.map(Map<String, Any?>::toMap).assert().containsExactly(
+                    mapOf("week" to 1_769_385_600_000L, "count" to 1L),
+                    mapOf("week" to 1_769_990_400_000L, "count" to 1L),
                 )
             }.verifyComplete()
     }

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt
@@ -41,6 +41,7 @@ import me.ahoo.wow.tck.mock.MockStateAggregate
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import reactor.kotlin.test.test
+import java.math.BigDecimal
 import java.time.Clock
 import java.time.Instant
 
@@ -258,6 +259,28 @@ abstract class SnapshotQueryServiceSpec {
                 rows.map(Map<String, Any?>::toMap).assert().containsExactly(
                     mapOf("week" to 1_769_385_600_000L, "count" to 1L),
                     mapOf("week" to 1_769_990_400_000L, "count" to 1L),
+                )
+            }.verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should return backend neutral decimal Terms keys`() {
+        saveAggregationStates(
+            MockStateAggregate(id = "decimal-a", decimalValue = BigDecimal("1.25")),
+            MockStateAggregate(id = "decimal-b", decimalValue = BigDecimal("2.50")),
+        )
+
+        aggregation {
+            filter { aggregateIds("decimal-a", "decimal-b") }
+            terms("state.decimalValue", "decimal")
+            count("count")
+        }.query(snapshotQueryService)
+            .collectList()
+            .test()
+            .assertNext { rows ->
+                rows.map(Map<String, Any?>::toMap).assert().containsExactly(
+                    mapOf("decimal" to 1.25, "count" to 1L),
+                    mapOf("decimal" to 2.5, "count" to 1L),
                 )
             }.verifyComplete()
     }

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
@@ -1,0 +1,213 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.api.query
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.ZoneId
+
+data class AggregationQuery(
+    override val filter: FilterExpression = MatchAllFilter,
+    @get:ArraySchema(maxItems = MAX_ELEMENTS)
+    @get:JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val elements: List<AggregationElement> = emptyList(),
+    @get:ArraySchema(maxItems = MAX_GROUPS)
+    @get:JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val groupBy: List<AggregationGroup> = emptyList(),
+    @get:ArraySchema(minItems = 1, maxItems = MAX_METRICS)
+    val metrics: List<AggregationMetric>,
+    @get:ArraySchema(maxItems = MAX_SORT_FIELDS)
+    @get:JsonInclude(JsonInclude.Include.NON_EMPTY)
+    override val sort: List<Sort> = emptyList(),
+    @get:Schema(defaultValue = DEFAULT_LIMIT_TEXT, minimum = "1", maximum = MAX_LIMIT_TEXT)
+    val limit: Int = DEFAULT_LIMIT,
+) : FilterCapable<AggregationQuery>, SortCapable {
+    init {
+        require(elements.size <= MAX_ELEMENTS) { "elements must contain at most $MAX_ELEMENTS paths." }
+        require(groupBy.size <= MAX_GROUPS) { "groupBy must contain at most $MAX_GROUPS dimensions." }
+        require(metrics.isNotEmpty()) { "metrics must not be empty." }
+        require(metrics.size <= MAX_METRICS) { "metrics must contain at most $MAX_METRICS entries." }
+        require(sort.size <= MAX_SORT_FIELDS) { "sort must contain at most $MAX_SORT_FIELDS fields." }
+        require(limit in 1..MAX_LIMIT) { "limit must be between 1 and $MAX_LIMIT." }
+        require(groupBy.isNotEmpty() || sort.isEmpty()) { "sort requires at least one groupBy." }
+
+        val aliases = groupBy.map(AggregationGroup::alias) + metrics.map(AggregationMetric::alias)
+        require(aliases.distinct().size == aliases.size) { "aggregation aliases must be unique." }
+        val sortFields = sort.map(Sort::field)
+        require(sortFields.distinct().size == sortFields.size) { "sort fields must be unique." }
+        require(sortFields.all(aliases::contains)) { "sort fields must reference aggregation aliases." }
+        require(effectiveSort().size <= MAX_SORT_FIELDS) {
+            "effective sort must contain at most $MAX_SORT_FIELDS fields."
+        }
+    }
+
+    override fun withFilter(newFilter: FilterExpression): AggregationQuery = copy(filter = newFilter)
+
+    fun effectiveSort(): List<Sort> = buildList {
+        addAll(sort)
+        val sorted = sort.mapTo(hashSetOf(), Sort::field)
+        groupBy.map(AggregationGroup::alias)
+            .filterNot(sorted::contains)
+            .forEach { add(Sort(it, Sort.Direction.ASC)) }
+    }
+
+    companion object {
+        const val DEFAULT_LIMIT: Int = 100
+        const val MAX_LIMIT: Int = 10_000
+        const val MAX_ELEMENTS: Int = 5
+        const val MAX_GROUPS: Int = 32
+        const val MAX_METRICS: Int = 64
+        const val MAX_SORT_FIELDS: Int = 32
+        private const val DEFAULT_LIMIT_TEXT = "100"
+        private const val MAX_LIMIT_TEXT = "10000"
+
+        @JvmStatic
+        @JsonCreator
+        internal fun fromJson(
+            @JsonProperty("filter") filter: FilterExpression?,
+            @JsonProperty("elements") elements: List<AggregationElement>?,
+            @JsonProperty("groupBy") groupBy: List<AggregationGroup>?,
+            @JsonProperty("metrics") metrics: List<AggregationMetric>?,
+            @JsonProperty("sort") sort: List<Sort>?,
+            @JsonProperty("limit") limit: Int?,
+        ): AggregationQuery = AggregationQuery(
+            filter = filter ?: MatchAllFilter,
+            elements = elements.orEmpty(),
+            groupBy = groupBy.orEmpty(),
+            metrics = metrics.orEmpty(),
+            sort = sort.orEmpty(),
+            limit = limit ?: DEFAULT_LIMIT,
+        )
+    }
+}
+
+data class AggregationElement(
+    val path: LogicalField,
+    val filter: FilterExpression = MatchAllFilter,
+) {
+    init {
+        require(filter.containsElementUnsupportedFilter().not()) {
+            "Aggregation element filter cannot contain root filters."
+        }
+    }
+}
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(
+    JsonSubTypes.Type(AggregationGroup.Terms::class, name = "TERMS"),
+    JsonSubTypes.Type(AggregationGroup.Histogram::class, name = "HISTOGRAM"),
+    JsonSubTypes.Type(AggregationGroup.DateHistogram::class, name = "DATE_HISTOGRAM"),
+)
+sealed interface AggregationGroup {
+    val field: LogicalField
+    val alias: String
+
+    data class Terms(
+        override val field: LogicalField,
+        override val alias: String,
+    ) : AggregationGroup {
+        init {
+            requireAggregationAlias(alias)
+        }
+    }
+
+    data class Histogram(
+        override val field: LogicalField,
+        override val alias: String,
+        @get:Schema(minimum = "0", exclusiveMinimum = true)
+        val interval: Double,
+    ) : AggregationGroup {
+        init {
+            requireAggregationAlias(alias)
+            require(interval.isFinite() && interval > 0.0) {
+                "histogram interval must be finite and greater than 0."
+            }
+        }
+    }
+
+    data class DateHistogram(
+        override val field: LogicalField,
+        override val alias: String,
+        val unit: AggregationDateUnit,
+        val timeZone: String = "UTC",
+    ) : AggregationGroup {
+        init {
+            requireAggregationAlias(alias)
+            ZoneId.of(timeZone)
+        }
+    }
+}
+
+enum class AggregationDateUnit {
+    YEAR,
+    QUARTER,
+    MONTH,
+    WEEK,
+    DAY,
+    HOUR,
+    MINUTE,
+    SECOND,
+}
+
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    property = "type",
+    defaultImpl = AggregationExpression.Field::class,
+)
+@JsonSubTypes(JsonSubTypes.Type(AggregationExpression.Field::class, name = "FIELD"))
+interface AggregationExpression {
+    data class Field(val field: LogicalField) : AggregationExpression
+}
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes(
+    JsonSubTypes.Type(AggregationMetric.Count::class, name = "COUNT"),
+    JsonSubTypes.Type(AggregationMetric.Numeric::class, name = "NUMERIC"),
+)
+sealed interface AggregationMetric {
+    val alias: String
+
+    data class Count(override val alias: String) : AggregationMetric {
+        init {
+            requireAggregationAlias(alias)
+        }
+    }
+
+    data class Numeric(
+        val function: AggregationFunction,
+        val expression: AggregationExpression,
+        override val alias: String,
+    ) : AggregationMetric {
+        init {
+            requireAggregationAlias(alias)
+        }
+    }
+}
+
+enum class AggregationFunction {
+    SUM,
+    AVG,
+    MIN,
+    MAX,
+}
+
+private fun requireAggregationAlias(alias: String) {
+    require('.' !in alias) { "aggregation alias must contain one segment." }
+    LogicalField(alias)
+}

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
@@ -209,5 +209,6 @@ enum class AggregationFunction {
 
 private fun requireAggregationAlias(alias: String) {
     require('.' !in alias) { "aggregation alias must contain one segment." }
+    require(!alias.startsWith("__wow")) { "aggregation alias must not use the reserved __wow prefix." }
     LogicalField(alias)
 }

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/FilterExpression.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/FilterExpression.kt
@@ -220,7 +220,7 @@ data class SearchFilter(
     }
 }
 
-private fun FilterExpression.containsElementUnsupportedFilter(): Boolean = when (this) {
+internal fun FilterExpression.containsElementUnsupportedFilter(): Boolean = when (this) {
     is DeletionFilter,
     is SearchFilter,
     is IdFilter,

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.api.query
+
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import tools.jackson.module.kotlin.jsonMapper
+import java.time.DateTimeException
+
+class AggregationQueryTest {
+    private val jsonMapper = jsonMapper()
+
+    @Test
+    fun `field expression should be the default JSON subtype`() {
+        val json = """
+            {
+              "metrics": [{
+                "type": "NUMERIC",
+                "function": "SUM",
+                "expression": {"field": "amount"},
+                "alias": "total"
+              }]
+            }
+        """.trimIndent()
+
+        val query = jsonMapper.readValue(json, AggregationQuery::class.java)
+        val metric = query.metrics.single() as AggregationMetric.Numeric
+
+        metric.expression.assert().isEqualTo(AggregationExpression.Field(LogicalField("amount")))
+    }
+
+    @Test
+    fun `elements should preserve ordered relative paths`() {
+        val query = AggregationQuery(
+            elements = listOf(
+                AggregationElement(LogicalField("state.orders")),
+                AggregationElement(LogicalField("lines")),
+                AggregationElement(LogicalField("discounts")),
+            ),
+            metrics = listOf(AggregationMetric.Count("count")),
+        )
+
+        query.elements.map { it.path.value }.assert().containsExactly("state.orders", "lines", "discounts")
+    }
+
+    @Test
+    fun `query should append an ABAC filter`() {
+        val query = AggregationQuery(metrics = listOf(AggregationMetric.Count("count")))
+
+        query.appendFilter(TenantIdFilter("tenant")).filter.assert().isEqualTo(TenantIdFilter("tenant"))
+    }
+
+    @Test
+    fun `invalid aliases and root element filters should fail`() {
+        assertThrows<IllegalArgumentException> {
+            AggregationQuery(
+                elements = listOf(AggregationElement(LogicalField("state.orders"), TenantIdFilter("tenant"))),
+                metrics = listOf(AggregationMetric.Count("count")),
+            )
+        }
+        assertThrows<IllegalArgumentException> {
+            AggregationQuery(
+                groupBy = listOf(AggregationGroup.Terms(LogicalField("state.status"), "same")),
+                metrics = listOf(AggregationMetric.Count("same")),
+            )
+        }
+    }
+
+    @Test
+    fun `query should enforce local shape limits and stable group sort`() {
+        assertThrows<IllegalArgumentException> { AggregationQuery(metrics = emptyList()) }
+        assertThrows<IllegalArgumentException> {
+            AggregationQuery(
+                elements = List(AggregationQuery.MAX_ELEMENTS + 1) { AggregationElement(LogicalField("items$it")) },
+                metrics = listOf(AggregationMetric.Count("count")),
+            )
+        }
+        assertThrows<IllegalArgumentException> {
+            AggregationQuery(
+                metrics = listOf(AggregationMetric.Count("count")),
+                limit = AggregationQuery.MAX_LIMIT + 1,
+            )
+        }
+
+        AggregationQuery(
+            groupBy = listOf(
+                AggregationGroup.Terms(LogicalField("status"), "status"),
+                AggregationGroup.Terms(LogicalField("category"), "category"),
+            ),
+            metrics = listOf(AggregationMetric.Count("count")),
+            sort = listOf(Sort("category", Sort.Direction.DESC)),
+        ).effectiveSort().assert().containsExactly(
+            Sort("category", Sort.Direction.DESC),
+            Sort("status", Sort.Direction.ASC),
+        )
+    }
+
+    @Test
+    fun `groups should reject invalid local histogram options`() {
+        listOf(0.0, -1.0, Double.NaN, Double.POSITIVE_INFINITY).forEach { interval ->
+            assertThrows<IllegalArgumentException> {
+                AggregationGroup.Histogram(LogicalField("amount"), "band", interval)
+            }
+        }
+        assertThrows<DateTimeException> {
+            AggregationGroup.DateHistogram(LogicalField("createdAt"), "day", AggregationDateUnit.DAY, "invalid")
+        }
+    }
+}

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt
@@ -79,6 +79,23 @@ class AggregationQueryTest {
     }
 
     @Test
+    fun `groups and metrics should reject internal aliases`() {
+        assertThrows<IllegalArgumentException> {
+            AggregationGroup.Terms(LogicalField("state.status"), "__wow_group")
+        }
+        assertThrows<IllegalArgumentException> {
+            AggregationMetric.Count("__wow_count")
+        }
+        assertThrows<IllegalArgumentException> {
+            AggregationMetric.Numeric(
+                AggregationFunction.SUM,
+                AggregationExpression.Field(LogicalField("state.amount")),
+                "__wow_total",
+            )
+        }
+    }
+
+    @Test
     fun `query should enforce local shape limits and stable group sort`() {
         assertThrows<IllegalArgumentException> { AggregationQuery(metrics = emptyList()) }
         assertThrows<IllegalArgumentException> {

--- a/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/ReactiveSnapshotAggregationQueryApi.kt
+++ b/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/ReactiveSnapshotAggregationQueryApi.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.apiclient.query
+
+import me.ahoo.wow.api.query.AggregationQuery
+import reactor.core.publisher.Flux
+
+interface ReactiveSnapshotAggregationQueryApi : SnapshotAggregationQueryApi<Flux<Map<String, Any?>>>
+
+fun AggregationQuery.query(snapshotQueryApi: ReactiveSnapshotAggregationQueryApi): Flux<Map<String, Any?>> {
+    return snapshotQueryApi.aggregate(this)
+}

--- a/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SnapshotAggregationQueryApi.kt
+++ b/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SnapshotAggregationQueryApi.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.apiclient.query
+
+import me.ahoo.wow.api.query.AggregationQuery
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.service.annotation.PostExchange
+
+const val SNAPSHOT_AGGREGATION_RESOURCE_NAME = "$SNAPSHOT_RESOURCE_NAME/aggregation"
+
+interface SnapshotAggregationQueryApi<R> : SnapshotQueryApi {
+    @PostExchange(SNAPSHOT_AGGREGATION_RESOURCE_NAME)
+    fun aggregate(@RequestBody query: AggregationQuery): R
+}

--- a/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SynchronousSnapshotAggregationQueryApi.kt
+++ b/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SynchronousSnapshotAggregationQueryApi.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.apiclient.query
+
+import me.ahoo.wow.api.query.AggregationQuery
+
+interface SynchronousSnapshotAggregationQueryApi : SnapshotAggregationQueryApi<List<Map<String, Any?>>>
+
+fun AggregationQuery.query(snapshotQueryApi: SynchronousSnapshotAggregationQueryApi): List<Map<String, Any?>> {
+    return snapshotQueryApi.aggregate(this)
+}

--- a/wow-apiclient/src/test/kotlin/me/ahoo/wow/apiclient/query/SnapshotAggregationQueryApiTest.kt
+++ b/wow-apiclient/src/test/kotlin/me/ahoo/wow/apiclient/query/SnapshotAggregationQueryApiTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.apiclient.query
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
+import org.junit.jupiter.api.Test
+import org.springframework.web.service.annotation.PostExchange
+import reactor.core.publisher.Flux
+import reactor.kotlin.test.test
+
+class SnapshotAggregationQueryApiTest {
+    @Test
+    fun `aggregation API should use the snapshot aggregation resource`() {
+        val method = SnapshotAggregationQueryApi::class.java.getMethod("aggregate", AggregationQuery::class.java)
+
+        method.getAnnotation(PostExchange::class.java).value.assert().isEqualTo("snapshot/aggregation")
+    }
+
+    @Test
+    fun `aggregation query extensions should delegate to their API`() {
+        val query = AggregationQuery(metrics = listOf(AggregationMetric.Count("count")))
+        val reactiveResult = Flux.just(mapOf<String, Any?>("count" to 1L))
+        lateinit var reactiveQuery: AggregationQuery
+        val reactiveApi = object : ReactiveSnapshotAggregationQueryApi {
+            override fun aggregate(query: AggregationQuery): Flux<Map<String, Any?>> {
+                reactiveQuery = query
+                return reactiveResult
+            }
+        }
+        val synchronousResult = listOf(mapOf<String, Any?>("count" to 1L))
+        lateinit var synchronousQuery: AggregationQuery
+        val synchronousApi = object : SynchronousSnapshotAggregationQueryApi {
+            override fun aggregate(query: AggregationQuery): List<Map<String, Any?>> {
+                synchronousQuery = query
+                return synchronousResult
+            }
+        }
+
+        query.query(reactiveApi).test().expectNext(mapOf<String, Any?>("count" to 1L)).verifyComplete()
+        reactiveQuery.assert().isEqualTo(query)
+        query.query(synchronousApi).assert().isEqualTo(synchronousResult)
+        synchronousQuery.assert().isEqualTo(query)
+    }
+}

--- a/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryServiceTest.kt
+++ b/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryServiceTest.kt
@@ -53,6 +53,39 @@ class ElasticsearchSnapshotQueryServiceTest : SnapshotQueryServiceSpec() {
         elasticsearchClient = ReactiveElasticsearchClients.createReactiveElasticsearchClient(elasticsearch)
         elasticsearchClient.initSnapshotTemplate()
         super.setup()
+        elasticsearchClient.indices().putMapping(
+            PutMappingRequest.of { request ->
+                request.index(MOCK_AGGREGATE_METADATA.toSnapshotIndexName())
+                    .properties("state") { state ->
+                        state.`object` { stateObject ->
+                            stateObject.properties("orders") { orders ->
+                                orders.nested { ordersNested ->
+                                    ordersNested.properties("status") { it.keyword { keyword -> keyword } }
+                                        .properties("lines") { lines ->
+                                            lines.nested { linesNested ->
+                                                linesNested
+                                                    .properties("productId") { it.keyword { keyword -> keyword } }
+                                                    .properties("quantity") { it.integer { number -> number } }
+                                                    .properties("amount") { it.double_ { number -> number } }
+                                                    .properties("createdAt") { it.date { date -> date } }
+                                                    .properties("discounts") { discounts ->
+                                                        discounts.nested { discountsNested ->
+                                                            discountsNested
+                                                                .properties("type") {
+                                                                    it.keyword { keyword -> keyword }
+                                                                }.properties("amount") {
+                                                                    it.double_ { number -> number }
+                                                                }
+                                                        }
+                                                    }
+                                            }
+                                        }
+                                }
+                            }
+                        }
+                    }
+            },
+        ).block()
     }
 
     override fun createSnapshotQueryServiceFactory(): SnapshotQueryServiceFactory {

--- a/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryServiceTest.kt
+++ b/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryServiceTest.kt
@@ -52,15 +52,16 @@ class ElasticsearchSnapshotQueryServiceTest : SnapshotQueryServiceSpec() {
     override fun setup() {
         elasticsearchClient = ReactiveElasticsearchClients.createReactiveElasticsearchClient(elasticsearch)
         elasticsearchClient.initSnapshotTemplate()
-        super.setup()
-        elasticsearchClient.indices().putMapping(
-            PutMappingRequest.of { request ->
-                request.index(MOCK_AGGREGATE_METADATA.toSnapshotIndexName())
-                    .properties("state") { state ->
+        elasticsearchClient.indices().create { request ->
+            request.index(MOCK_AGGREGATE_METADATA.toSnapshotIndexName())
+                .mappings { mapping ->
+                    mapping.properties("state") { state ->
                         state.`object` { stateObject ->
-                            stateObject.properties("orders") { orders ->
-                                orders.nested { ordersNested ->
-                                    ordersNested.properties("status") { it.keyword { keyword -> keyword } }
+                            stateObject
+                                .properties("decimalValue") { it.double_ { number -> number } }
+                                .properties("orders") { orders ->
+                                    orders.nested { ordersNested ->
+                                        ordersNested.properties("status") { it.keyword { keyword -> keyword } }
                                         .properties("lines") { lines ->
                                             lines.nested { linesNested ->
                                                 linesNested
@@ -80,12 +81,13 @@ class ElasticsearchSnapshotQueryServiceTest : SnapshotQueryServiceSpec() {
                                                     }
                                             }
                                         }
+                                    }
                                 }
-                            }
                         }
                     }
-            },
-        ).block()
+                }
+        }.block()
+        super.setup()
     }
 
     override fun createSnapshotQueryServiceFactory(): SnapshotQueryServiceFactory {

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchFilterConverter.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchFilterConverter.kt
@@ -42,8 +42,8 @@ abstract class AbstractElasticsearchFilterConverter(
 ) {
     private val filterNormalizer = FilterNormalizer(defaultDeletionState = defaultDeletionState)
 
-    fun convert(filter: FilterExpression): Query =
-        compile(filterNormalizer.normalize(filter), parent = null)
+    fun convert(filter: FilterExpression, parent: String? = null): Query =
+        compile(filterNormalizer.normalize(filter), parent)
 
     @Suppress("CyclomaticComplexMethod", "LongMethod")
     private fun compile(filter: FilterExpression, parent: String?): Query = when (filter) {

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolver.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolver.kt
@@ -161,9 +161,7 @@ data class ElasticsearchIndexMapping private constructor(
         return field
     }
 
-    fun resolve(filter: FilterExpression): FilterExpression = resolve(filter, null)
-
-    private fun resolve(filter: FilterExpression, parent: String?): FilterExpression = resolveTyped(filter, parent)
+    fun resolve(filter: FilterExpression, parent: String? = null): FilterExpression = resolveTyped(filter, parent)
 
     @Suppress("CyclomaticComplexMethod", "LongMethod")
     private fun resolveTyped(filter: FilterExpression, parent: String?): FilterExpression = when (filter) {

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchPointInTime.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchPointInTime.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.elasticsearch.query
+
+import co.elastic.clients.elasticsearch.core.ClosePointInTimeRequest
+import co.elastic.clients.elasticsearch.core.OpenPointInTimeRequest
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.reactivestreams.Publisher
+import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.time.Duration
+
+internal class ElasticsearchPointInTime(
+    private val client: ReactiveElasticsearchClient,
+    private val indexName: String,
+    keepAlive: Duration,
+) {
+    internal val keepAliveValue = keepAlive.toMillis().let {
+        if (it % 60_000 == 0L) "${it / 60_000}m" else "${it}ms"
+    }
+
+    internal class Session(var id: String) {
+        fun update(next: String?) {
+            next?.takeIf(String::isNotBlank)?.let { id = it }
+        }
+    }
+
+    fun <T : Any> use(block: (Session) -> Publisher<T>): Flux<T> = Flux.usingWhen(
+        open(),
+        { session -> Flux.from(block(session)) },
+        ::close,
+        { session, _ -> close(session) },
+        ::close,
+    )
+
+    private fun open(): Mono<Session> {
+        return Mono.defer {
+            client.openPointInTime(
+                OpenPointInTimeRequest.of {
+                    it.index(indexName)
+                        .keepAlive { it.time(keepAliveValue) }
+                }
+            )
+        }.map {
+            check(it.id().isNotBlank()) { "Elasticsearch returned an empty PIT ID." }
+            Session(it.id())
+        }
+    }
+
+    private fun close(session: Session): Mono<Void> {
+        return Mono.defer {
+            client.closePointInTime(ClosePointInTimeRequest.of { it.id(session.id) })
+        }.doOnNext {
+            if (!it.succeeded()) {
+                log.warn { "Failed to close Elasticsearch PIT [${session.id}]." }
+            }
+        }.then()
+            .onErrorResume {
+                log.warn(it) { "Failed to close Elasticsearch PIT [${session.id}]." }
+                Mono.empty()
+            }
+    }
+
+    private companion object {
+        val log = KotlinLogging.logger(ElasticsearchPointInTime::class.java.name)
+    }
+}

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchQueryPager.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchQueryPager.kt
@@ -16,12 +16,9 @@ package me.ahoo.wow.elasticsearch.query
 import co.elastic.clients.elasticsearch._types.FieldValue
 import co.elastic.clients.elasticsearch._types.SortOptions
 import co.elastic.clients.elasticsearch._types.query_dsl.Query
-import co.elastic.clients.elasticsearch.core.ClosePointInTimeRequest
-import co.elastic.clients.elasticsearch.core.OpenPointInTimeRequest
 import co.elastic.clients.elasticsearch.core.SearchRequest
 import co.elastic.clients.elasticsearch.core.search.Hit
 import co.elastic.clients.elasticsearch.core.search.SourceFilter
-import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -37,9 +34,7 @@ internal class ElasticsearchQueryPager(
     private val batchSize: Int = DEFAULT_SEARCH_BATCH_SIZE,
     private val keepAlive: Duration = DEFAULT_PIT_KEEP_ALIVE,
 ) {
-    private val keepAliveValue = keepAlive.toMillis().let {
-        if (it % 60_000 == 0L) "${it / 60_000}m" else "${it}ms"
-    }
+    private val pointInTime = ElasticsearchPointInTime(elasticsearchClient, indexName, keepAlive)
 
     init {
         require(batchSize in 1..DEFAULT_SEARCH_BATCH_SIZE) {
@@ -56,39 +51,19 @@ internal class ElasticsearchQueryPager(
     ): Flux<Hit<Map<*, *>>> {
         require(limit >= 0) { "limit must be greater than or equal to 0." }
         require(sort.isNotEmpty()) { "sort must not be empty when using search_after." }
-        return Flux.usingWhen(
-            openPointInTime(),
-            { pit ->
-                searchPage(pit, limit, query, sourceFilter, sort)
-                    .expand { page ->
-                        page.nextSearchAfter?.let {
-                            searchPage(pit, limit, query, sourceFilter, sort, page.fetched, it)
-                        } ?: Mono.empty()
-                    }
-                    .concatMapIterable({ it.hits }, 1)
-            },
-            ::closePointInTime,
-            { pit, _ -> closePointInTime(pit) },
-            ::closePointInTime,
-        )
-    }
-
-    private fun openPointInTime(): Mono<PointInTime> {
-        return Mono.defer {
-            elasticsearchClient.openPointInTime(
-                OpenPointInTimeRequest.of {
-                    it.index(indexName)
-                        .keepAlive { it.time(keepAliveValue) }
+        return pointInTime.use { pit ->
+            searchPage(pit, limit, query, sourceFilter, sort)
+                .expand { page ->
+                    page.nextSearchAfter?.let {
+                        searchPage(pit, limit, query, sourceFilter, sort, page.fetched, it)
+                    } ?: Mono.empty()
                 }
-            )
-        }.map {
-            check(it.id().isNotBlank()) { "Elasticsearch returned an empty PIT ID." }
-            PointInTime(it.id())
+                .concatMapIterable({ it.hits }, 1)
         }
     }
 
     private fun searchPage(
-        pit: PointInTime,
+        pit: ElasticsearchPointInTime.Session,
         limit: Int,
         query: Query,
         sourceFilter: SourceFilter?,
@@ -106,9 +81,9 @@ internal class ElasticsearchQueryPager(
                 it.query(query)
                     .size(pageSize)
                     .trackTotalHits { trackHits -> trackHits.enabled(false) }
-                    .pit { pointInTime ->
-                        pointInTime.id(pit.id)
-                            .keepAlive { it.time(keepAliveValue) }
+                    .pit { pitBuilder ->
+                        pitBuilder.id(pit.id)
+                            .keepAlive { it.time(pointInTime.keepAliveValue) }
                     }
                     .sort(sort)
                 if (searchAfter.isNotEmpty()) {
@@ -121,7 +96,7 @@ internal class ElasticsearchQueryPager(
             }
             elasticsearchClient.search(request, Map::class.java)
         }.map { response ->
-            response.pitId()?.takeIf { it.isNotBlank() }?.let { pit.id = it }
+            pit.update(response.pitId())
             val hits = response.hits().hits()
             val totalFetched = fetched + hits.size
             val hasNextPage = hits.size == pageSize && (limit == 0 || totalFetched < limit.toLong())
@@ -136,29 +111,9 @@ internal class ElasticsearchQueryPager(
         }
     }
 
-    private fun closePointInTime(pit: PointInTime): Mono<Void> {
-        return Mono.defer {
-            elasticsearchClient.closePointInTime(ClosePointInTimeRequest.of { it.id(pit.id) })
-        }.doOnNext {
-            if (!it.succeeded()) {
-                log.warn { "Failed to close Elasticsearch PIT [${pit.id}]." }
-            }
-        }.then()
-            .onErrorResume {
-                log.warn(it) { "Failed to close Elasticsearch PIT [${pit.id}]." }
-                Mono.empty()
-            }
-    }
-
-    private data class PointInTime(var id: String)
-
     private data class SearchPage(
         val hits: List<Hit<Map<*, *>>>,
         val fetched: Long,
         val nextSearchAfter: List<FieldValue>?,
     )
-
-    private companion object {
-        val log = KotlinLogging.logger(ElasticsearchQueryPager::class.java.name)
-    }
 }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompiler.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompiler.kt
@@ -16,6 +16,7 @@ package me.ahoo.wow.elasticsearch.query.snapshot
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeAggregationSource
 import co.elastic.clients.elasticsearch._types.query_dsl.Query
 import co.elastic.clients.util.NamedValue
+import me.ahoo.wow.api.query.AggregationDateUnit
 import me.ahoo.wow.api.query.AggregationExpression
 import me.ahoo.wow.api.query.AggregationFunction
 import me.ahoo.wow.api.query.AggregationGroup
@@ -114,9 +115,12 @@ internal class ElasticsearchAggregationCompiler(
                 it.dateHistogram { dateHistogram ->
                     dateHistogram
                         .field(mapping?.resolve(absoluteField, ElasticsearchFieldUsage.RANGE) ?: absoluteField)
-                        .calendarInterval { interval -> interval.time(unit.name.lowercase()) }
-                        .timeZone(timeZone)
-                        .order(sort.direction.toSortOrder())
+                    if (unit == AggregationDateUnit.SECOND) {
+                        dateHistogram.fixedInterval { interval -> interval.time("1s") }
+                    } else {
+                        dateHistogram.calendarInterval { interval -> interval.time(unit.name.lowercase()) }
+                    }
+                    dateHistogram.timeZone(timeZone).order(sort.direction.toSortOrder())
                 }
             }
         }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompiler.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompiler.kt
@@ -1,0 +1,144 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.elasticsearch.query.snapshot
+
+import co.elastic.clients.elasticsearch._types.aggregations.CompositeAggregationSource
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
+import co.elastic.clients.util.NamedValue
+import me.ahoo.wow.api.query.AggregationExpression
+import me.ahoo.wow.api.query.AggregationFunction
+import me.ahoo.wow.api.query.AggregationGroup
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.AndFilter
+import me.ahoo.wow.api.query.DeletionFilter
+import me.ahoo.wow.api.query.DeletionState
+import me.ahoo.wow.api.query.Sort
+import me.ahoo.wow.elasticsearch.query.AbstractElasticsearchFilterConverter
+import me.ahoo.wow.elasticsearch.query.ElasticsearchFieldUsage
+import me.ahoo.wow.elasticsearch.query.ElasticsearchIndexMapping
+import me.ahoo.wow.elasticsearch.query.ElasticsearchSortConverter.toSortOrder
+
+internal data class ElasticsearchAggregationPlan(
+    val rootQuery: Query,
+    val elements: List<ElasticsearchAggregationElement>,
+    val groupSources: List<NamedValue<CompositeAggregationSource>>,
+    val metrics: List<ElasticsearchAggregationMetric>,
+    val effectiveSort: List<Sort>,
+    val limit: Int,
+    val metricSorted: Boolean,
+)
+
+internal data class ElasticsearchAggregationElement(
+    val path: String,
+    val filter: Query,
+)
+
+internal data class ElasticsearchAggregationMetric(
+    val alias: String,
+    val function: AggregationFunction?,
+    val field: String?,
+) {
+    val valueCountAlias: String
+        get() = "__wow_value_count_$alias"
+}
+
+internal class ElasticsearchAggregationCompiler(
+    private val filterConverter: AbstractElasticsearchFilterConverter,
+    private val mapping: ElasticsearchIndexMapping?,
+) {
+    fun compile(query: AggregationQuery): ElasticsearchAggregationPlan {
+        val rootFilter = mapping?.resolve(query.filter) ?: query.filter
+        val rootQuery = filterConverter.convert(rootFilter)
+        val elements = mutableListOf<ElasticsearchAggregationElement>()
+        var parent: String? = null
+        query.elements.forEach { element ->
+            val absolutePath = if (parent == null) element.path.value else "$parent.${element.path.value}"
+            val nestedPath = mapping?.requireNested(absolutePath) ?: absolutePath
+            val unscopedFilter = AndFilter(listOf(element.filter, DeletionFilter(DeletionState.ALL)))
+            val filter = mapping?.resolve(unscopedFilter, absolutePath) ?: unscopedFilter
+            elements += ElasticsearchAggregationElement(
+                path = nestedPath,
+                filter = filterConverter.convert(filter, absolutePath),
+            )
+            parent = absolutePath
+        }
+
+        val effectiveSort = query.effectiveSort()
+        val groups = query.groupBy.associateBy(AggregationGroup::alias)
+        val groupSources = effectiveSort
+            .mapNotNull { sort -> groups[sort.field]?.let { it.toSource(parent, sort) } }
+        val metrics = query.metrics.map { it.toPlan(parent) }
+        val metricAliases = query.metrics.mapTo(hashSetOf(), AggregationMetric::alias)
+        return ElasticsearchAggregationPlan(
+            rootQuery = rootQuery,
+            elements = elements,
+            groupSources = groupSources,
+            metrics = metrics,
+            effectiveSort = effectiveSort,
+            limit = query.limit,
+            metricSorted = effectiveSort.any { it.field in metricAliases },
+        )
+    }
+
+    private fun AggregationGroup.toSource(parent: String?, sort: Sort): NamedValue<CompositeAggregationSource> {
+        val absoluteField = field.resolve(parent)
+        val source = when (this) {
+            is AggregationGroup.Terms -> CompositeAggregationSource.of {
+                it.terms { terms ->
+                    terms.field(mapping?.resolve(absoluteField, ElasticsearchFieldUsage.EXACT) ?: absoluteField)
+                        .order(sort.direction.toSortOrder())
+                }
+            }
+
+            is AggregationGroup.Histogram -> CompositeAggregationSource.of {
+                it.histogram { histogram ->
+                    histogram.field(mapping?.resolve(absoluteField, ElasticsearchFieldUsage.RANGE) ?: absoluteField)
+                        .interval(interval)
+                        .order(sort.direction.toSortOrder())
+                }
+            }
+
+            is AggregationGroup.DateHistogram -> CompositeAggregationSource.of {
+                it.dateHistogram { dateHistogram ->
+                    dateHistogram
+                        .field(mapping?.resolve(absoluteField, ElasticsearchFieldUsage.RANGE) ?: absoluteField)
+                        .calendarInterval { interval -> interval.time(unit.name.lowercase()) }
+                        .timeZone(timeZone)
+                        .order(sort.direction.toSortOrder())
+                }
+            }
+        }
+        return NamedValue.of(alias, source)
+    }
+
+    private fun AggregationMetric.toPlan(parent: String?): ElasticsearchAggregationMetric = when (this) {
+        is AggregationMetric.Count -> ElasticsearchAggregationMetric(alias, function = null, field = null)
+        is AggregationMetric.Numeric -> {
+            val expressionField = when (val expression = expression) {
+                is AggregationExpression.Field -> expression.field
+                else -> error("Unsupported aggregation expression: ${expression::class.java.name}.")
+            }
+            val absoluteField = expressionField.resolve(parent)
+            ElasticsearchAggregationMetric(
+                alias,
+                function,
+                mapping?.resolve(absoluteField, ElasticsearchFieldUsage.RANGE) ?: absoluteField,
+            )
+        }
+    }
+
+    private fun me.ahoo.wow.api.query.LogicalField.resolve(parent: String?): String =
+        if (parent == null) value else "$parent.$value"
+}

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPager.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPager.kt
@@ -76,7 +76,7 @@ internal class ElasticsearchAggregationPager(
         if (!plan.metricSorted) return rows
 
         return rows.collect(
-            { BoundedTopRows(plan.effectiveSort, plan.limit) },
+            { BoundedTopRows(plan.effectiveSort, plan.limit, plan.groupSources.map { it.name() }) },
             BoundedTopRows::add,
         ).flatMapMany { Flux.fromIterable(it.result()) }
     }
@@ -260,27 +260,54 @@ internal fun selectTopRows(
     limit: Int,
 ): List<DynamicDocument> = BoundedTopRows(sort, limit).apply { rows.forEach(::add) }.result()
 
-private class BoundedTopRows(sort: List<Sort>, private val limit: Int) {
-    private val comparator = rowComparator(sort)
+private class BoundedTopRows(
+    sort: List<Sort>,
+    private val limit: Int,
+    private val groupAliases: List<String> = emptyList(),
+) {
+    private val groupIndexes = groupAliases.withIndex().associate { (index, alias) -> alias to index }
+    private val currentGroupOrder = LongArray(groupAliases.size)
+    private var previous: DynamicDocument? = null
+    private var sequence = 0L
+    private val comparator = rankedRowComparator(sort, groupIndexes)
     private val rows = PriorityQueue(comparator.reversed())
 
     fun add(row: DynamicDocument) {
+        previous?.let { previous ->
+            val firstDifference = groupAliases.indexOfFirst { previous[it] != row[it] }
+            if (firstDifference >= 0) {
+                currentGroupOrder.fill(sequence, firstDifference)
+            }
+        }
+        previous = row
+        val rankedRow = RankedRow(row, currentGroupOrder.copyOf())
+        sequence++
         if (rows.size < limit) {
-            rows += row
-        } else if (comparator.compare(row, rows.peek()) < 0) {
+            rows += rankedRow
+        } else if (comparator.compare(rankedRow, rows.peek()) < 0) {
             rows.poll()
-            rows += row
+            rows += rankedRow
         }
     }
 
-    fun result(): List<DynamicDocument> = rows.sortedWith(comparator)
+    fun result(): List<DynamicDocument> = rows.sortedWith(comparator).map(RankedRow::row)
 }
 
-private fun rowComparator(sort: List<Sort>): Comparator<DynamicDocument> = Comparator { left, right ->
+private data class RankedRow(
+    val row: DynamicDocument,
+    val groupOrder: LongArray,
+)
+
+private fun rankedRowComparator(
+    sort: List<Sort>,
+    groupIndexes: Map<String, Int>,
+): Comparator<RankedRow> = Comparator { left, right ->
     sort.firstNotNullOfOrNull { field ->
-        compareValues(left[field.field], right[field.field])
-            .takeIf { it != 0 }
-            ?.let { if (field.direction == Sort.Direction.ASC) it else -it }
+        val comparison = groupIndexes[field.field]?.let { index ->
+            left.groupOrder[index].compareTo(right.groupOrder[index])
+        } ?: compareValues(left.row[field.field], right.row[field.field])
+            .let { if (field.direction == Sort.Direction.ASC) it else -it }
+        comparison.takeIf { it != 0 }
     } ?: 0
 }
 

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPager.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPager.kt
@@ -288,6 +288,7 @@ private fun compareValues(left: Any?, right: Any?): Int = when {
     left === right -> 0
     left == null -> -1
     right == null -> 1
+    left is Long && right is Long -> left.compareTo(right)
     left is Number && right is Number -> left.toDouble().compareTo(right.toDouble())
     left is String && right is String -> left.compareTo(right)
     left is Boolean && right is Boolean -> left.compareTo(right)

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPager.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPager.kt
@@ -1,0 +1,302 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.elasticsearch.query.snapshot
+
+import co.elastic.clients.elasticsearch._types.FieldValue
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregate
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation
+import co.elastic.clients.elasticsearch._types.aggregations.CompositeBucket
+import co.elastic.clients.elasticsearch.core.SearchRequest
+import co.elastic.clients.elasticsearch.core.search.ResponseBody
+import me.ahoo.wow.api.query.AggregationFunction
+import me.ahoo.wow.api.query.DynamicDocument
+import me.ahoo.wow.api.query.SimpleDynamicDocument.Companion.toDynamicDocument
+import me.ahoo.wow.api.query.Sort
+import me.ahoo.wow.elasticsearch.query.DEFAULT_PIT_KEEP_ALIVE
+import me.ahoo.wow.elasticsearch.query.DEFAULT_SEARCH_BATCH_SIZE
+import me.ahoo.wow.elasticsearch.query.ElasticsearchPointInTime
+import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import java.time.Duration
+import java.util.PriorityQueue
+import kotlin.math.min
+
+private const val ROOT_AGGREGATION = "__wow_aggregation"
+private const val GROUP_AGGREGATION = "__wow_groups"
+
+internal class ElasticsearchAggregationPager(
+    private val client: ReactiveElasticsearchClient,
+    indexName: String,
+    private val batchSize: Int = DEFAULT_SEARCH_BATCH_SIZE,
+    keepAlive: Duration = DEFAULT_PIT_KEEP_ALIVE,
+) {
+    private val pointInTime = ElasticsearchPointInTime(client, indexName, keepAlive)
+
+    init {
+        require(batchSize in 1..DEFAULT_SEARCH_BATCH_SIZE) {
+            "batchSize must be between 1 and $DEFAULT_SEARCH_BATCH_SIZE."
+        }
+        require(keepAlive.toMillis() > 0) { "keepAlive must be greater than or equal to 1ms." }
+    }
+
+    fun execute(plan: ElasticsearchAggregationPlan): Flux<DynamicDocument> = pointInTime.use { pit ->
+        if (plan.groupSources.isEmpty()) {
+            search(plan, pit, afterKey = emptyMap(), pageSize = 0)
+                .map { response -> response.summary(plan) }
+        } else {
+            grouped(plan, pit)
+        }
+    }
+
+    private fun grouped(
+        plan: ElasticsearchAggregationPlan,
+        pit: ElasticsearchPointInTime.Session,
+    ): Flux<DynamicDocument> {
+        val pages = searchPage(plan, pit)
+            .expand { page ->
+                if (page.shouldStop(plan)) {
+                    Mono.empty()
+                } else {
+                    searchPage(plan, pit, page.afterKey, page.fetched)
+                }
+            }
+        val rows = pages.concatMapIterable({ it.rows }, 1)
+        if (!plan.metricSorted) return rows
+
+        return rows.collect(
+            { BoundedTopRows(plan.effectiveSort, plan.limit) },
+            BoundedTopRows::add,
+        ).flatMapMany { Flux.fromIterable(it.result()) }
+    }
+
+    private fun searchPage(
+        plan: ElasticsearchAggregationPlan,
+        pit: ElasticsearchPointInTime.Session,
+        afterKey: Map<String, FieldValue> = emptyMap(),
+        fetched: Int = 0,
+    ): Mono<AggregationPage> {
+        val pageSize = if (plan.metricSorted) batchSize else min(batchSize, plan.limit - fetched)
+        return search(plan, pit, afterKey, pageSize).map { response ->
+            val composite = response.innermost(plan).getValue(GROUP_AGGREGATION).composite()
+            val rows = composite.buckets().array().map { it.toRow(plan) }
+            AggregationPage(rows, composite.afterKey(), fetched + rows.size)
+        }
+    }
+
+    private fun search(
+        plan: ElasticsearchAggregationPlan,
+        pit: ElasticsearchPointInTime.Session,
+        afterKey: Map<String, FieldValue>,
+        pageSize: Int,
+    ): Mono<ResponseBody<Map<*, *>>> = Mono.defer {
+        val request = SearchRequest.of {
+            it.query(plan.rootQuery)
+                .size(0)
+                .trackTotalHits { track -> track.enabled(false) }
+                .pit { pointInTime ->
+                    pointInTime.id(pit.id).keepAlive { keepAlive -> keepAlive.time(this.pointInTime.keepAliveValue) }
+                }
+                .aggregations(ROOT_AGGREGATION, plan.aggregation(afterKey, pageSize))
+        }
+        client.search(request, Map::class.java)
+    }.doOnNext { pit.update(it.pitId()) }
+
+    private fun ElasticsearchAggregationPlan.aggregation(
+        afterKey: Map<String, FieldValue>,
+        pageSize: Int,
+    ): Aggregation {
+        var aggregations = if (groupSources.isEmpty()) {
+            metricAggregations()
+        } else {
+            mapOf(GROUP_AGGREGATION to groupAggregation(afterKey, pageSize))
+        }
+        elements.indices.reversed().forEach { index ->
+            val element = elements[index]
+            val filter = Aggregation.of { builder -> builder.filter(element.filter).aggregations(aggregations) }
+            val nested = Aggregation.of { builder ->
+                builder.nested { it.path(element.path) }
+                    .aggregations(filterAggregationName(index), filter)
+            }
+            aggregations = mapOf(nestedAggregationName(index) to nested)
+        }
+        if (elements.isNotEmpty()) return aggregations.values.single()
+        if (groupSources.isNotEmpty()) return aggregations.getValue(GROUP_AGGREGATION)
+        return Aggregation.of { builder ->
+            builder.filter { it.matchAll { matchAll -> matchAll } }.aggregations(aggregations)
+        }
+    }
+
+    private fun ElasticsearchAggregationPlan.groupAggregation(
+        afterKey: Map<String, FieldValue>,
+        pageSize: Int,
+    ): Aggregation = Aggregation.of { builder ->
+        builder.composite { composite ->
+            composite.sources(groupSources).size(pageSize).apply {
+                if (afterKey.isNotEmpty()) after(afterKey)
+            }
+        }.aggregations(metricAggregations())
+    }
+
+    private fun ElasticsearchAggregationPlan.metricAggregations(): Map<String, Aggregation> = buildMap {
+        metrics.filter { it.function != null }.forEach { metric ->
+            val field = requireNotNull(metric.field)
+            put(
+                metric.alias,
+                Aggregation.of { builder ->
+                    when (metric.function) {
+                        AggregationFunction.SUM -> builder.sum { it.field(field) }
+                        AggregationFunction.AVG -> builder.avg { it.field(field) }
+                        AggregationFunction.MIN -> builder.min { it.field(field) }
+                        AggregationFunction.MAX -> builder.max { it.field(field) }
+                        null -> error("Count does not require a metric aggregation.")
+                    }
+                },
+            )
+            put(metric.valueCountAlias, Aggregation.of { builder -> builder.valueCount { it.field(field) } })
+        }
+    }
+
+    private fun ResponseBody<Map<*, *>>.summary(plan: ElasticsearchAggregationPlan): DynamicDocument {
+        val scope = aggregations().getValue(ROOT_AGGREGATION).let { root ->
+            if (plan.elements.isEmpty()) root.filter() else root.innermostScope(plan)
+        }
+        return plan.toRow(scope.docCount(), scope.aggregations())
+    }
+
+    private fun ResponseBody<Map<*, *>>.innermost(plan: ElasticsearchAggregationPlan): Map<String, Aggregate> {
+        if (plan.elements.isEmpty()) {
+            return mapOf(GROUP_AGGREGATION to aggregations().getValue(ROOT_AGGREGATION))
+        }
+        var aggregations = aggregations()
+        plan.elements.indices.forEach { index ->
+            val nested = aggregations.getValue(if (index == 0) ROOT_AGGREGATION else nestedAggregationName(index))
+                .nested()
+            val filter = nested.aggregations().getValue(filterAggregationName(index)).filter()
+            aggregations = filter.aggregations()
+        }
+        return aggregations
+    }
+
+    private fun Aggregate.innermostScope(
+        plan: ElasticsearchAggregationPlan,
+    ): co.elastic.clients.elasticsearch._types.aggregations.FilterAggregate {
+        var aggregations = nested().aggregations()
+        var scope: co.elastic.clients.elasticsearch._types.aggregations.FilterAggregate? = null
+        plan.elements.indices.forEach { index ->
+            scope = aggregations.getValue(filterAggregationName(index)).filter()
+            aggregations = scope!!.aggregations()
+            if (index + 1 < plan.elements.size) {
+                aggregations = aggregations.getValue(nestedAggregationName(index + 1)).nested().aggregations()
+            }
+        }
+        return requireNotNull(scope)
+    }
+
+    private fun CompositeBucket.toRow(plan: ElasticsearchAggregationPlan): DynamicDocument {
+        val row = key().mapValuesTo(linkedMapOf()) { (_, value) -> value.nativeValue() }
+        plan.metrics.forEach { metric -> row[metric.alias] = metric.value(docCount(), aggregations()) }
+        return row.toDynamicDocument()
+    }
+
+    private fun ElasticsearchAggregationPlan.toRow(
+        docCount: Long,
+        aggregations: Map<String, Aggregate>,
+    ): DynamicDocument = metrics.associateTo(linkedMapOf()) { metric ->
+        metric.alias to metric.value(docCount, aggregations)
+    }.toDynamicDocument()
+
+    private fun ElasticsearchAggregationMetric.value(
+        docCount: Long,
+        aggregations: Map<String, Aggregate>,
+    ): Any? {
+        val function = function ?: return docCount
+        if (aggregations.getValue(valueCountAlias).valueCount().value() == 0.0) return null
+        val value = when (function) {
+            AggregationFunction.SUM -> aggregations.getValue(alias).sum().value()
+            AggregationFunction.AVG -> aggregations.getValue(alias).avg().value()
+            AggregationFunction.MIN -> aggregations.getValue(alias).min().value()
+            AggregationFunction.MAX -> aggregations.getValue(alias).max().value()
+        }
+        require(value != null && value.isFinite()) { "Aggregation metric [$alias] must be finite." }
+        return value
+    }
+
+    private fun FieldValue.nativeValue(): Any? = when {
+        isString -> stringValue()
+        isLong -> longValue()
+        isDouble -> doubleValue()
+        isBoolean -> booleanValue()
+        isNull -> null
+        else -> error("Unsupported Elasticsearch aggregation key [${_kind()}].")
+    }
+
+    private data class AggregationPage(
+        val rows: List<DynamicDocument>,
+        val afterKey: Map<String, FieldValue>,
+        val fetched: Int,
+    ) {
+        fun shouldStop(plan: ElasticsearchAggregationPlan): Boolean {
+            if (afterKey.isEmpty() || rows.isEmpty()) return true
+            return !plan.metricSorted && fetched >= plan.limit
+        }
+    }
+}
+
+internal fun selectTopRows(
+    rows: Iterable<DynamicDocument>,
+    sort: List<Sort>,
+    limit: Int,
+): List<DynamicDocument> = BoundedTopRows(sort, limit).apply { rows.forEach(::add) }.result()
+
+private class BoundedTopRows(sort: List<Sort>, private val limit: Int) {
+    private val comparator = rowComparator(sort)
+    private val rows = PriorityQueue(comparator.reversed())
+
+    fun add(row: DynamicDocument) {
+        if (rows.size < limit) {
+            rows += row
+        } else if (comparator.compare(row, rows.peek()) < 0) {
+            rows.poll()
+            rows += row
+        }
+    }
+
+    fun result(): List<DynamicDocument> = rows.sortedWith(comparator)
+}
+
+private fun rowComparator(sort: List<Sort>): Comparator<DynamicDocument> = Comparator { left, right ->
+    sort.firstNotNullOfOrNull { field ->
+        compareValues(left[field.field], right[field.field])
+            .takeIf { it != 0 }
+            ?.let { if (field.direction == Sort.Direction.ASC) it else -it }
+    } ?: 0
+}
+
+private fun compareValues(left: Any?, right: Any?): Int = when {
+    left === right -> 0
+    left == null -> -1
+    right == null -> 1
+    left is Number && right is Number -> left.toDouble().compareTo(right.toDouble())
+    left is String && right is String -> left.compareTo(right)
+    left is Boolean && right is Boolean -> left.compareTo(right)
+    else -> error(
+        "Aggregation sort values must have comparable types, " +
+            "but were [${left::class.java.name}] and [${right::class.java.name}].",
+    )
+}
+
+private fun nestedAggregationName(index: Int): String = "__wow_element_$index"
+
+private fun filterAggregationName(index: Int): String = "__wow_element_filter_$index"

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryService.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryService.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.elasticsearch.query.snapshot
 
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.MaterializedSnapshot
 import me.ahoo.wow.api.query.Sort
@@ -32,6 +33,7 @@ import me.ahoo.wow.query.snapshot.SnapshotQueryService
 import me.ahoo.wow.serialization.JsonSerializer
 import me.ahoo.wow.serialization.convert
 import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import java.time.Duration
 
@@ -102,4 +104,17 @@ class ElasticsearchSnapshotQueryService<S : Any>(
 
     override fun resolveSort(mapping: ElasticsearchIndexMapping, sort: List<Sort>): List<Sort> =
         mapping.resolve(sort)
+
+    override fun aggregate(query: AggregationQuery): Flux<DynamicDocument> {
+        val execute: (ElasticsearchIndexMapping?) -> Flux<DynamicDocument> = { mapping ->
+            ElasticsearchAggregationPager(
+                elasticsearchClient,
+                indexName,
+                queryBatchSize,
+                queryKeepAlive,
+            ).execute(ElasticsearchAggregationCompiler(filterConverter, mapping).compile(query))
+        }
+        return indexMappingResolver?.currentOrLoad(indexName)?.flatMapMany(execute)
+            ?: Flux.defer { execute(null) }
+    }
 }

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchFilterConverterTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchFilterConverterTest.kt
@@ -33,6 +33,7 @@ import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.query.*
 import me.ahoo.wow.elasticsearch.WowJsonpMapper
 import me.ahoo.wow.elasticsearch.query.snapshot.SnapshotFilterConverter
+import me.ahoo.wow.query.dsl.filter
 import me.ahoo.wow.serialization.JsonSerializer
 import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.serialization.state.StateAggregateRecords
@@ -228,6 +229,13 @@ class ElasticsearchFilterConverterTest {
     fun `relative time filter should normalize before compilation`() {
         SnapshotFilterConverter.convert(TodayFilter(LogicalField("state.time")))._kind().assert()
             .isEqualTo(Query.Kind.Bool)
+    }
+
+    @Test
+    fun `scoped filter fields should be prefixed with parent`() {
+        val query = SnapshotFilterConverter.convert(filter { "quantity" gt 1 }, "state.orders.lines")
+
+        query.bool().filter().last().range().untyped().field().assert().isEqualTo("state.orders.lines.quantity")
     }
 
     companion object {

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolverTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolverTest.kt
@@ -196,6 +196,15 @@ class ElasticsearchIndexMappingResolverTest {
             .isEqualTo("state.items.name")
     }
 
+    @Test
+    fun `should resolve relative filter fields from parent`() {
+        val mapping = ElasticsearchIndexMapping.from(INDEX, textWithKeyword())
+
+        val filter = mapping.resolve(EqualFilter(LogicalField("name"), json("Wow")), "state") as EqualFilter
+
+        filter.field.value.assert().isEqualTo("state.name.keyword")
+    }
+
     private fun json(value: Any?) = me.ahoo.wow.serialization.JsonSerializer.valueToTree<tools.jackson.databind.JsonNode>(
         value
     )

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchPointInTimeTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchPointInTimeTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.elasticsearch.query
+
+import co.elastic.clients.elasticsearch.core.ClosePointInTimeRequest
+import co.elastic.clients.elasticsearch.core.ClosePointInTimeResponse
+import co.elastic.clients.elasticsearch.core.OpenPointInTimeRequest
+import co.elastic.clients.elasticsearch.core.OpenPointInTimeResponse
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.kotlin.test.test
+import java.time.Duration
+
+class ElasticsearchPointInTimeTest {
+    private val client = mockk<ReactiveElasticsearchClient>()
+
+    @Test
+    fun `should close latest non-empty pit id on cancellation`() {
+        val closeRequest = slot<ClosePointInTimeRequest>()
+        val openResponse = mockk<OpenPointInTimeResponse> { every { id() } returns "pit-1" }
+        val closeResponse = mockk<ClosePointInTimeResponse> { every { succeeded() } returns true }
+        every { client.openPointInTime(any<OpenPointInTimeRequest>()) } returns Mono.just(openResponse)
+        every { client.closePointInTime(capture(closeRequest)) } returns Mono.just(closeResponse)
+
+        ElasticsearchPointInTime(client, "index", Duration.ofMinutes(1)).use { session ->
+            session.update("pit-2")
+            session.update("")
+            Flux.never<String>()
+        }.test().thenAwait(Duration.ofMillis(1)).thenCancel().verify()
+
+        closeRequest.captured.id().assert().isEqualTo("pit-2")
+    }
+}

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
@@ -107,6 +107,21 @@ class ElasticsearchAggregationCompilerTest {
     }
 
     @Test
+    fun `second date histogram should use a fixed interval`() {
+        val plan = ElasticsearchAggregationCompiler(SnapshotFilterConverter, mapping = null).compile(
+            aggregation {
+                dateHistogram("state.createdAt", AggregationDateUnit.SECOND, "second")
+                count("count")
+            },
+        )
+
+        plan.groupSources.single().value().dateHistogram().apply {
+            fixedInterval()!!.time().assert().isEqualTo("1s")
+            calendarInterval().assert().isNull()
+        }
+    }
+
+    @Test
     fun `custom converter should receive caller paths without mapping resolution`() {
         val convertedParents = mutableListOf<String?>()
         val converter = mockk<me.ahoo.wow.elasticsearch.query.AbstractElasticsearchFilterConverter> {

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
@@ -44,13 +44,17 @@ class ElasticsearchAggregationCompilerTest {
                 expand("state.orders") { "status" eq "PAID" }
                 expand("lines") { "quantity" gt 0 }
                 terms("productId", "product")
+                histogram("amount", 10.0, "amountRange")
+                dateHistogram("createdAt", AggregationDateUnit.DAY, "day")
                 sum("amount", "total")
             },
         )
 
         plan.elements.map { it.path }.assert().containsExactly("state.orders", "state.orders.lines")
-        plan.groupSources.single().value().terms().field().assert()
+        plan.groupSources[0].value().terms().field().assert()
             .isEqualTo("state.orders.lines.productId.keyword")
+        plan.groupSources[1].value().histogram().field().assert().isEqualTo("state.orders.lines.amount")
+        plan.groupSources[2].value().dateHistogram().field().assert().isEqualTo("state.orders.lines.createdAt")
         plan.metrics.single().field.assert().isEqualTo("state.orders.lines.amount")
         verifyOrder {
             mapping.requireNested("state.orders")
@@ -59,6 +63,7 @@ class ElasticsearchAggregationCompilerTest {
         verify {
             mapping.resolve("state.orders.lines.productId", ElasticsearchFieldUsage.EXACT)
             mapping.resolve("state.orders.lines.amount", ElasticsearchFieldUsage.RANGE)
+            mapping.resolve("state.orders.lines.createdAt", ElasticsearchFieldUsage.RANGE)
         }
     }
 

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
@@ -1,0 +1,131 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.elasticsearch.query.snapshot
+
+import co.elastic.clients.elasticsearch._types.SortOrder
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.AggregationDateUnit
+import me.ahoo.wow.api.query.FilterExpression
+import me.ahoo.wow.api.query.Sort
+import me.ahoo.wow.elasticsearch.query.ElasticsearchFieldUsage
+import me.ahoo.wow.elasticsearch.query.ElasticsearchIndexMapping
+import me.ahoo.wow.query.dsl.aggregation
+import org.junit.jupiter.api.Test
+import java.time.ZoneId
+
+class ElasticsearchAggregationCompilerTest {
+    @Test
+    fun `compiler should nest relative elements in order and resolve exact terms`() {
+        val mapping = mockk<ElasticsearchIndexMapping> {
+            every { requireNested(any()) } answers { firstArg() }
+            every { resolve(any<String>(), any()) } answers {
+                val field = firstArg<String>()
+                if (secondArg<ElasticsearchFieldUsage>() == ElasticsearchFieldUsage.EXACT) "$field.keyword" else field
+            }
+            every { resolve(any<FilterExpression>(), any()) } answers { firstArg() }
+        }
+        val plan = ElasticsearchAggregationCompiler(SnapshotFilterConverter, mapping).compile(
+            aggregation {
+                expand("state.orders") { "status" eq "PAID" }
+                expand("lines") { "quantity" gt 0 }
+                terms("productId", "product")
+                sum("amount", "total")
+            },
+        )
+
+        plan.elements.map { it.path }.assert().containsExactly("state.orders", "state.orders.lines")
+        plan.groupSources.single().value().terms().field().assert()
+            .isEqualTo("state.orders.lines.productId.keyword")
+        plan.metrics.single().field.assert().isEqualTo("state.orders.lines.amount")
+        verifyOrder {
+            mapping.requireNested("state.orders")
+            mapping.requireNested("state.orders.lines")
+        }
+        verify {
+            mapping.resolve("state.orders.lines.productId", ElasticsearchFieldUsage.EXACT)
+            mapping.resolve("state.orders.lines.amount", ElasticsearchFieldUsage.RANGE)
+        }
+    }
+
+    @Test
+    fun `compiler should order composite sources by effective group sort`() {
+        val plan = ElasticsearchAggregationCompiler(SnapshotFilterConverter, mapping = null).compile(
+            aggregation {
+                terms("state.productId", "product")
+                histogram("state.amount", 10.0, "amountRange")
+                dateHistogram("state.createdAt", AggregationDateUnit.DAY, "day", ZoneId.of("Asia/Shanghai"))
+                count("count")
+                sum("state.amount", "total")
+                avg("state.amount", "average")
+                min("state.amount", "minimum")
+                max("state.amount", "maximum")
+                sort {
+                    "amountRange".desc()
+                    "product".asc()
+                }
+                limit(7)
+            },
+        )
+
+        plan.groupSources.map { it.name() }.assert().containsExactly("amountRange", "product", "day")
+        plan.groupSources[0].value().histogram().apply {
+            field().assert().isEqualTo("state.amount")
+            interval().assert().isEqualTo(10.0)
+            order().assert().isEqualTo(SortOrder.Desc)
+        }
+        plan.groupSources[2].value().dateHistogram().apply {
+            field().assert().isEqualTo("state.createdAt")
+            calendarInterval()!!.time().assert().isEqualTo("day")
+            timeZone().assert().isEqualTo("Asia/Shanghai")
+        }
+        plan.metrics.map { it.alias }.assert()
+            .containsExactly("count", "total", "average", "minimum", "maximum")
+        plan.effectiveSort.assert().isEqualTo(
+            listOf(
+                Sort("amountRange", Sort.Direction.DESC),
+                Sort("product", Sort.Direction.ASC),
+                Sort("day", Sort.Direction.ASC),
+            ),
+        )
+        plan.limit.assert().isEqualTo(7)
+        plan.metricSorted.assert().isFalse()
+    }
+
+    @Test
+    fun `custom converter should receive caller paths without mapping resolution`() {
+        val convertedParents = mutableListOf<String?>()
+        val converter = mockk<me.ahoo.wow.elasticsearch.query.AbstractElasticsearchFilterConverter> {
+            every { convert(any(), captureNullable(convertedParents)) } answers {
+                co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.matchAll { it }
+            }
+        }
+
+        val plan = ElasticsearchAggregationCompiler(converter, mapping = null).compile(
+            aggregation {
+                filter { "physical.root" eq "ACTIVE" }
+                expand("physical.items") { "physical.quantity" gt 0 }
+                terms("physical.product", "product")
+                count("count")
+            },
+        )
+
+        plan.elements.single().path.assert().isEqualTo("physical.items")
+        plan.groupSources.single().value().terms().field().assert().isEqualTo("physical.items.physical.product")
+        convertedParents.assert().containsExactly(null, "physical.items")
+    }
+}

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
@@ -31,9 +31,11 @@ import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.query.SimpleDynamicDocument
 import me.ahoo.wow.api.query.Sort
 import me.ahoo.wow.elasticsearch.query.AbstractElasticsearchFilterConverter
+import me.ahoo.wow.elasticsearch.query.DEFAULT_SEARCH_BATCH_SIZE
 import me.ahoo.wow.query.dsl.aggregation
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
 import reactor.core.publisher.Mono
 import reactor.kotlin.test.test
@@ -41,6 +43,19 @@ import java.time.Duration
 
 class ElasticsearchAggregationPagerTest {
     private val client = mockk<ReactiveElasticsearchClient>()
+
+    @Test
+    fun `should reject invalid paging options`() {
+        assertThrows<IllegalArgumentException> {
+            ElasticsearchAggregationPager(client, "test-index", batchSize = 0)
+        }.message.assert().contains("batchSize must be between 1 and")
+        assertThrows<IllegalArgumentException> {
+            ElasticsearchAggregationPager(client, "test-index", batchSize = DEFAULT_SEARCH_BATCH_SIZE + 1)
+        }.message.assert().contains("batchSize must be between 1 and")
+        assertThrows<IllegalArgumentException> {
+            ElasticsearchAggregationPager(client, "test-index", batchSize = 1, keepAlive = Duration.ZERO)
+        }.message.assert().isEqualTo("keepAlive must be greater than or equal to 1ms.")
+    }
 
     @Test
     fun `group sort should pass composite after key and close latest pit`() {
@@ -131,6 +146,31 @@ class ElasticsearchAggregationPagerTest {
     }
 
     @Test
+    fun `top rows should sort boolean and null values`() {
+        val rows = listOf(
+            SimpleDynamicDocument(mutableMapOf("active" to true)),
+            SimpleDynamicDocument(mutableMapOf("active" to null)),
+            SimpleDynamicDocument(mutableMapOf("active" to false)),
+        )
+
+        selectTopRows(rows, listOf(Sort("active", Sort.Direction.ASC)), limit = 3)
+            .map { it["active"] }
+            .assert().containsExactly(null, false, true)
+    }
+
+    @Test
+    fun `top rows should reject incomparable values`() {
+        val rows = listOf(
+            SimpleDynamicDocument(mutableMapOf("value" to 1)),
+            SimpleDynamicDocument(mutableMapOf("value" to "1")),
+        )
+
+        assertThrows<IllegalStateException> {
+            selectTopRows(rows, listOf(Sort("value", Sort.Direction.ASC)), limit = 2)
+        }.message.assert().contains("Aggregation sort values must have comparable types")
+    }
+
+    @Test
     fun `summary should request once and normalize empty values`() {
         stubPointInTime()
         every { client.search(any<SearchRequest>(), Map::class.java) } returns Mono.just(summaryResponse())
@@ -155,7 +195,9 @@ class ElasticsearchAggregationPagerTest {
     @Test
     fun `group aggregation should not emit an empty row`() {
         stubPointInTime()
-        every { client.search(any<SearchRequest>(), Map::class.java) } returns Mono.just(groupResponse("pit-2", emptyList()))
+        every { client.search(any<SearchRequest>(), Map::class.java) } returns Mono.just(
+            groupResponse("pit-2", emptyList(), "next"),
+        )
         val plan = compiler().compile(
             aggregation {
                 terms("state.product", "product")
@@ -164,6 +206,48 @@ class ElasticsearchAggregationPagerTest {
         )
 
         pager().execute(plan).test().verifyComplete()
+        verify(exactly = 1) { client.search(any<SearchRequest>(), Map::class.java) }
+    }
+
+    @Test
+    fun `group aggregation should normalize boolean keys`() {
+        stubPointInTime()
+        every { client.search(any<SearchRequest>(), Map::class.java) } returns Mono.just(
+            groupResponse(
+                "pit-2",
+                listOf(bucket(FieldValue.TRUE, 1)),
+            ),
+        )
+        val plan = compiler().compile(
+            aggregation {
+                terms("state.active", "product")
+                count("count")
+            },
+        )
+
+        pager().execute(plan).collectList().test()
+            .assertNext { rows -> rows.map { it["product"] }.assert().containsExactly(true) }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `group aggregation should stop after reaching the limit`() {
+        stubPointInTime()
+        every { client.search(any<SearchRequest>(), Map::class.java) } returns Mono.just(
+            groupResponse("pit-2", listOf(bucket("a", 1), bucket("b", 1)), "b"),
+        )
+        val plan = compiler().compile(
+            aggregation {
+                terms("state.product", "product")
+                count("count")
+                limit(2)
+            },
+        )
+
+        pager(batchSize = 2).execute(plan).test()
+            .expectNextCount(2)
+            .verifyComplete()
+        verify(exactly = 1) { client.search(any<SearchRequest>(), Map::class.java) }
     }
 
     @Test
@@ -208,12 +292,11 @@ class ElasticsearchAggregationPagerTest {
 
     private fun compiler() = ElasticsearchAggregationCompiler(SnapshotFilterConverter, mapping = null)
 
-    private fun pager(batchSize: Int = 100) = ElasticsearchAggregationPager(
-        client,
-        "test-index",
-        batchSize,
-        Duration.ofMinutes(1),
-    )
+    private fun pager(batchSize: Int? = null) = if (batchSize == null) {
+        ElasticsearchAggregationPager(client, "test-index")
+    } else {
+        ElasticsearchAggregationPager(client, "test-index", batchSize)
+    }
 
     private fun stubPointInTime(closeRequest: io.mockk.CapturingSlot<ClosePointInTimeRequest>? = null) {
         every { client.openPointInTime(any<OpenPointInTimeRequest>()) } returns Mono.just(
@@ -230,6 +313,10 @@ class ElasticsearchAggregationPagerTest {
     }
 
     private fun bucket(product: String, count: Long): CompositeBucket = CompositeBucket.of {
+        it.key("product", product).docCount(count)
+    }
+
+    private fun bucket(product: FieldValue, count: Long): CompositeBucket = CompositeBucket.of {
         it.key("product", product).docCount(count)
     }
 

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
@@ -1,0 +1,266 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.elasticsearch.query.snapshot
+
+import co.elastic.clients.elasticsearch._types.FieldValue
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregate
+import co.elastic.clients.elasticsearch._types.aggregations.Buckets
+import co.elastic.clients.elasticsearch._types.aggregations.CompositeBucket
+import co.elastic.clients.elasticsearch.core.ClosePointInTimeRequest
+import co.elastic.clients.elasticsearch.core.ClosePointInTimeResponse
+import co.elastic.clients.elasticsearch.core.OpenPointInTimeRequest
+import co.elastic.clients.elasticsearch.core.OpenPointInTimeResponse
+import co.elastic.clients.elasticsearch.core.SearchRequest
+import co.elastic.clients.elasticsearch.core.SearchResponse
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.SimpleDynamicDocument
+import me.ahoo.wow.api.query.Sort
+import me.ahoo.wow.elasticsearch.query.AbstractElasticsearchFilterConverter
+import me.ahoo.wow.query.dsl.aggregation
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
+import org.junit.jupiter.api.Test
+import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
+import reactor.core.publisher.Mono
+import reactor.kotlin.test.test
+import java.time.Duration
+
+class ElasticsearchAggregationPagerTest {
+    private val client = mockk<ReactiveElasticsearchClient>()
+
+    @Test
+    fun `group sort should pass composite after key and close latest pit`() {
+        val requests = mutableListOf<SearchRequest>()
+        val closeRequest = slot<ClosePointInTimeRequest>()
+        stubPointInTime(closeRequest)
+        every { client.search(capture(requests), Map::class.java) } returnsMany listOf(
+            Mono.just(groupResponse("pit-2", listOf(bucket("a", 2), bucket("b", 3)), "b")),
+            Mono.just(groupResponse("pit-3", listOf(bucket("c", 1)))),
+        )
+        val plan = compiler().compile(
+            aggregation {
+                terms("state.product", "product")
+                count("count")
+                limit(3)
+            },
+        )
+
+        pager(batchSize = 2).execute(plan)
+            .map { it.getValue<String>("product") }
+            .test()
+            .expectNext("a", "b", "c")
+            .verifyComplete()
+
+        requests.assert().hasSize(2)
+        requests[0].size().assert().isEqualTo(0)
+        requests[0].aggregations().values.single().composite().after().assert().isEmpty()
+        requests[1].aggregations().values.single().composite().after().getValue("product").stringValue()
+            .assert().isEqualTo("b")
+        requests[1].pit()!!.id().assert().isEqualTo("pit-2")
+        closeRequest.captured.id().assert().isEqualTo("pit-3")
+    }
+
+    @Test
+    fun `metric sort should stream every bucket and retain exact bounded top N`() {
+        val requests = mutableListOf<SearchRequest>()
+        stubPointInTime()
+        every { client.search(capture(requests), Map::class.java) } returnsMany listOf(
+            Mono.just(groupResponse("pit-2", listOf(metricBucket("a", 3.0), metricBucket("b", 9.0)), "b")),
+            Mono.just(groupResponse("pit-3", listOf(metricBucket("c", 7.0)))),
+        )
+        val plan = compiler().compile(
+            aggregation {
+                terms("state.product", "product")
+                sum("state.total", "total")
+                sort { "total".desc() }
+                limit(2)
+            },
+        )
+
+        pager(batchSize = 2).execute(plan)
+            .map { it.getValue<Double>("total") }
+            .test()
+            .expectNext(9.0, 7.0)
+            .verifyComplete()
+
+        requests.assert().hasSize(2)
+    }
+
+    @Test
+    fun `metric sort should retain exact bounded top N with complete tie sort`() {
+        val rows = listOf(
+            SimpleDynamicDocument(mutableMapOf("product" to "c", "total" to 7.0)),
+            SimpleDynamicDocument(mutableMapOf("product" to "a", "total" to 7.0)),
+            SimpleDynamicDocument(mutableMapOf("product" to "b", "total" to 7.0)),
+            SimpleDynamicDocument(mutableMapOf("product" to "d", "total" to 3.0)),
+        )
+
+        selectTopRows(
+            rows,
+            listOf(Sort("total", Sort.Direction.DESC), Sort("product", Sort.Direction.ASC)),
+            limit = 2,
+        ).map { it["product"] }.assert().containsExactly("a", "b")
+    }
+
+    @Test
+    fun `summary should request once and normalize empty values`() {
+        stubPointInTime()
+        every { client.search(any<SearchRequest>(), Map::class.java) } returns Mono.just(summaryResponse())
+        val plan = compiler().compile(
+            aggregation {
+                count("count")
+                sum("state.total", "total")
+            },
+        )
+
+        pager().execute(plan).test()
+            .assertNext {
+                it["count"].assert().isEqualTo(0L)
+                it.containsKey("total").assert().isTrue()
+                it["total"].assert().isNull()
+            }
+            .verifyComplete()
+
+        verify(exactly = 1) { client.search(any<SearchRequest>(), Map::class.java) }
+    }
+
+    @Test
+    fun `group aggregation should not emit an empty row`() {
+        stubPointInTime()
+        every { client.search(any<SearchRequest>(), Map::class.java) } returns Mono.just(groupResponse("pit-2", emptyList()))
+        val plan = compiler().compile(
+            aggregation {
+                terms("state.product", "product")
+                count("count")
+            },
+        )
+
+        pager().execute(plan).test().verifyComplete()
+    }
+
+    @Test
+    fun `non finite metric should fail the aggregation`() {
+        stubPointInTime()
+        every { client.search(any<SearchRequest>(), Map::class.java) } returns Mono.just(
+            groupResponse("pit-2", listOf(metricBucket("a", Double.POSITIVE_INFINITY))),
+        )
+        val plan = compiler().compile(
+            aggregation {
+                terms("state.product", "product")
+                sum("state.total", "total")
+            },
+        )
+
+        pager().execute(plan).test()
+            .expectErrorMessage("Aggregation metric [total] must be finite.")
+            .verify()
+    }
+
+    @Test
+    fun `snapshot service with custom converter should aggregate without loading mapping`() {
+        stubPointInTime()
+        every { client.search(any<SearchRequest>(), Map::class.java) } returns Mono.just(summaryResponse())
+        val converter = mockk<AbstractElasticsearchFilterConverter> {
+            every { convert(any(), any()) } returns
+                co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.matchAll { it }
+        }
+        val service = ElasticsearchSnapshotQueryService<Any>(MOCK_AGGREGATE_METADATA, client, converter)
+
+        service.aggregate(
+            aggregation {
+                count("count")
+                sum("physical.total", "total")
+            },
+        ).test()
+            .expectNextCount(1)
+            .verifyComplete()
+
+        verify(exactly = 0) { client.indices() }
+    }
+
+    private fun compiler() = ElasticsearchAggregationCompiler(SnapshotFilterConverter, mapping = null)
+
+    private fun pager(batchSize: Int = 100) = ElasticsearchAggregationPager(
+        client,
+        "test-index",
+        batchSize,
+        Duration.ofMinutes(1),
+    )
+
+    private fun stubPointInTime(closeRequest: io.mockk.CapturingSlot<ClosePointInTimeRequest>? = null) {
+        every { client.openPointInTime(any<OpenPointInTimeRequest>()) } returns Mono.just(
+            OpenPointInTimeResponse.of {
+                it.id("pit-1").shards { shards -> shards.failed(0).successful(1).total(1) }
+            },
+        )
+        val close = ClosePointInTimeResponse.of { it.succeeded(true).numFreed(1) }
+        if (closeRequest == null) {
+            every { client.closePointInTime(any<ClosePointInTimeRequest>()) } returns Mono.just(close)
+        } else {
+            every { client.closePointInTime(capture(closeRequest)) } returns Mono.just(close)
+        }
+    }
+
+    private fun bucket(product: String, count: Long): CompositeBucket = CompositeBucket.of {
+        it.key("product", product).docCount(count)
+    }
+
+    private fun metricBucket(product: String, total: Double): CompositeBucket = CompositeBucket.of {
+        it.key("product", product)
+            .docCount(1)
+            .aggregations("total", Aggregate.of { value -> value.sum { sum -> sum.value(total) } })
+            .aggregations(
+                "__wow_value_count_total",
+                Aggregate.of { value -> value.valueCount { count -> count.value(1.0) } },
+            )
+    }
+
+    private fun groupResponse(
+        pitId: String,
+        buckets: List<CompositeBucket>,
+        afterProduct: String? = null,
+    ): SearchResponse<Map<*, *>> = response(pitId) { aggregate ->
+        aggregate.composite { composite ->
+            composite.buckets(Buckets.of<CompositeBucket> { it.array(buckets) }).apply {
+                if (afterProduct != null) afterKey("product", FieldValue.of(afterProduct))
+            }
+        }
+    }
+
+    private fun summaryResponse(): SearchResponse<Map<*, *>> = response("pit-2") { aggregate ->
+        aggregate.filter { filter ->
+            filter.docCount(0)
+                .aggregations("total", Aggregate.of { value -> value.sum { sum -> sum.value(0.0) } })
+                .aggregations(
+                    "__wow_value_count_total",
+                    Aggregate.of { value -> value.valueCount { count -> count.value(0.0) } },
+                )
+        }
+    }
+
+    private fun response(
+        pitId: String,
+        aggregate: (Aggregate.Builder) -> co.elastic.clients.util.ObjectBuilder<Aggregate>,
+    ): SearchResponse<Map<*, *>> = SearchResponse.of<Map<*, *>> {
+        it.took(1)
+            .timedOut(false)
+            .pitId(pitId)
+            .shards { shards -> shards.failed(0).successful(1).total(1) }
+            .hits { hits -> hits.hits(emptyList()) }
+            .aggregations("__wow_aggregation", Aggregate.of(aggregate))
+    }
+}

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
@@ -116,6 +116,31 @@ class ElasticsearchAggregationPagerTest {
     }
 
     @Test
+    fun `metric ties should preserve native composite group order`() {
+        stubPointInTime()
+        every { client.search(any<SearchRequest>(), Map::class.java) } returns Mono.just(
+            groupResponse(
+                "pit-2",
+                listOf(metricBucket("2.0.0.1", 7.0), metricBucket("10.0.0.1", 7.0)),
+            ),
+        )
+        val plan = compiler().compile(
+            aggregation {
+                terms("state.address", "product")
+                sum("state.total", "total")
+                sort { "total".desc() }
+                limit(1)
+            },
+        )
+
+        pager().execute(plan)
+            .map { it.getValue<String>("product") }
+            .test()
+            .expectNext("2.0.0.1")
+            .verifyComplete()
+    }
+
+    @Test
     fun `metric sort should retain exact bounded top N with complete tie sort`() {
         val rows = listOf(
             SimpleDynamicDocument(mutableMapOf("product" to "c", "total" to 7.0)),

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
@@ -117,6 +117,20 @@ class ElasticsearchAggregationPagerTest {
     }
 
     @Test
+    fun `long sort above double precision should not fall through to tie sort`() {
+        val rows = listOf(
+            SimpleDynamicDocument(mutableMapOf("product" to "z", "count" to 9_007_199_254_740_993L)),
+            SimpleDynamicDocument(mutableMapOf("product" to "a", "count" to 9_007_199_254_740_992L)),
+        )
+
+        selectTopRows(
+            rows,
+            listOf(Sort("count", Sort.Direction.DESC), Sort("product", Sort.Direction.ASC)),
+            limit = 1,
+        ).single()["product"].assert().isEqualTo("z")
+    }
+
+    @Test
     fun `summary should request once and normalize empty values`() {
         stubPointInTime()
         every { client.search(any<SearchRequest>(), Map::class.java) } returns Mono.just(summaryResponse())

--- a/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryServiceTest.kt
+++ b/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryServiceTest.kt
@@ -14,13 +14,22 @@
 package me.ahoo.wow.mongo.query.snapshot
 
 import com.mongodb.reactivestreams.client.MongoDatabase
+import me.ahoo.test.asserts.assert
 import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
+import me.ahoo.wow.mongo.AggregateSchemaInitializer.toSnapshotCollectionName
 import me.ahoo.wow.mongo.MongoSnapshotStore
+import me.ahoo.wow.query.dsl.aggregation
 import me.ahoo.wow.query.snapshot.SnapshotQueryServiceFactory
+import me.ahoo.wow.query.snapshot.query
 import me.ahoo.wow.tck.container.MongoTestFixture
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import me.ahoo.wow.tck.query.SnapshotQueryServiceSpec
+import org.bson.Document
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import reactor.kotlin.core.publisher.toMono
+import reactor.kotlin.test.test
 
 class MongoSnapshotQueryServiceTest : SnapshotQueryServiceSpec() {
     @JvmField
@@ -41,5 +50,29 @@ class MongoSnapshotQueryServiceTest : SnapshotQueryServiceSpec() {
 
     override fun createSnapshotStore(): SnapshotStore {
         return MongoSnapshotStore(database)
+    }
+
+    @Test
+    fun `minimum and maximum should ignore non-numeric BSON values`() {
+        database.getCollection(MOCK_AGGREGATE_METADATA.toSnapshotCollectionName())
+            .insertMany(
+                listOf(
+                    Document("_id", "mixed-number")
+                        .append("deleted", false)
+                        .append("state", Document("mixedValue", 10)),
+                    Document("_id", "mixed-string")
+                        .append("deleted", false)
+                        .append("state", Document("mixedValue", "not-a-number")),
+                ),
+            ).toMono().then().test().verifyComplete()
+
+        aggregation {
+            min("state.mixedValue", "minimum")
+            max("state.mixedValue", "maximum")
+        }.query(snapshotQueryService)
+            .test()
+            .assertNext { row ->
+                row.toMap().assert().isEqualTo(mapOf("minimum" to 10.0, "maximum" to 10.0))
+            }.verifyComplete()
     }
 }

--- a/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryServiceTest.kt
+++ b/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryServiceTest.kt
@@ -75,4 +75,20 @@ class MongoSnapshotQueryServiceTest : SnapshotQueryServiceSpec() {
                 row.toMap().assert().isEqualTo(mapOf("minimum" to 10.0, "maximum" to 10.0))
             }.verifyComplete()
     }
+
+    @Test
+    fun `numeric aggregation should reject non-finite BSON values`() {
+        database.getCollection(MOCK_AGGREGATE_METADATA.toSnapshotCollectionName())
+            .insertOne(
+                Document("_id", "non-finite")
+                    .append("deleted", false)
+                    .append("state", Document("value", Double.NaN)),
+            ).toMono().then().test().verifyComplete()
+
+        aggregation { sum("state.value", "total") }
+            .query(snapshotQueryService)
+            .test()
+            .expectErrorMessage("Aggregation metric [total] must be finite.")
+            .verify()
+    }
 }

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoFilterConverter.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoFilterConverter.kt
@@ -110,7 +110,10 @@ abstract class AbstractMongoFilterConverter(
             filter.value.requiredNativeValue()
         )
         is LessThanFilter -> Filters.lt(filter.field.convert(parent, mapField), filter.value.requiredNativeValue())
-        is LessThanOrEqualFilter -> Filters.lte(filter.field.convert(parent, mapField), filter.value.requiredNativeValue())
+        is LessThanOrEqualFilter -> Filters.lte(
+            filter.field.convert(parent, mapField),
+            filter.value.requiredNativeValue()
+        )
         is ContainsFilter -> regex(
             filter.field.convert(parent, mapField),
             filter.value.escapeRegex(),
@@ -132,7 +135,10 @@ abstract class AbstractMongoFilterConverter(
             Filters.gte(filter.field.convert(parent, mapField), filter.lowerBound.requiredNativeValue()),
             Filters.lte(filter.field.convert(parent, mapField), filter.upperBound.requiredNativeValue()),
         )
-        is ContainsAllFilter -> Filters.all(filter.field.convert(parent, mapField), filter.values.map { it.nativeValue() })
+        is ContainsAllFilter -> Filters.all(
+            filter.field.convert(parent, mapField),
+            filter.values.map { it.nativeValue() }
+        )
         is IsEmptyFilter -> Filters.size(filter.field.convert(parent, mapField), 0)
         is IsNullFilter -> Filters.eq(filter.field.convert(parent, mapField), null)
         is IsNotNullFilter -> Filters.ne(filter.field.convert(parent, mapField), null)

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoFilterConverter.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoFilterConverter.kt
@@ -78,11 +78,11 @@ abstract class AbstractMongoFilterConverter(
 
     private val filterNormalizer = FilterNormalizer(defaultDeletionState = defaultDeletionState)
 
-    fun convert(filter: FilterExpression): Bson =
-        compile(filterNormalizer.normalize(filter), mapField = true)
+    fun convert(filter: FilterExpression, parent: String? = null): Bson =
+        compile(filterNormalizer.normalize(filter), parent, mapField = true)
 
     @Suppress("CyclomaticComplexMethod", "LongMethod")
-    private fun compile(filter: FilterExpression, mapField: Boolean): Bson = when (filter) {
+    private fun compile(filter: FilterExpression, parent: String?, mapField: Boolean): Bson = when (filter) {
         MatchAllFilter -> Filters.empty()
         MatchNoneFilter -> org.bson.Document("\$expr", false)
         is IdFilter -> Filters.eq(Documents.ID_FIELD, filter.value)
@@ -95,53 +95,53 @@ abstract class AbstractMongoFilterConverter(
         is TenantIdFilter -> Filters.eq(MessageRecords.TENANT_ID, filter.value)
         is OwnerIdFilter -> Filters.eq(MessageRecords.OWNER_ID, filter.value)
         is SpaceIdFilter -> Filters.eq(MessageRecords.SPACE_ID, filter.value)
-        is AndFilter -> Filters.and(filter.operands.map { compile(it, mapField) })
-        is OrFilter -> Filters.or(filter.operands.map { compile(it, mapField) })
-        is NorFilter -> Filters.nor(filter.operands.map { compile(it, mapField) })
-        is EqualFilter -> Filters.eq(filter.field.convert(mapField), filter.value.nativeValue())
-        is NotEqualFilter -> Filters.ne(filter.field.convert(mapField), filter.value.nativeValue())
-        is GreaterThanFilter -> Filters.gt(filter.field.convert(mapField), filter.value.requiredNativeValue())
+        is AndFilter -> Filters.and(filter.operands.map { compile(it, parent, mapField) })
+        is OrFilter -> Filters.or(filter.operands.map { compile(it, parent, mapField) })
+        is NorFilter -> Filters.nor(filter.operands.map { compile(it, parent, mapField) })
+        is EqualFilter -> Filters.eq(filter.field.convert(parent, mapField), filter.value.nativeValue())
+        is NotEqualFilter -> Filters.ne(filter.field.convert(parent, mapField), filter.value.nativeValue())
+        is GreaterThanFilter -> Filters.gt(filter.field.convert(parent, mapField), filter.value.requiredNativeValue())
         is GreaterThanOrEqualFilter -> Filters.gte(
-            filter.field.convert(mapField),
+            filter.field.convert(parent, mapField),
             filter.value.requiredNativeValue()
         )
-        is LessThanFilter -> Filters.lt(filter.field.convert(mapField), filter.value.requiredNativeValue())
-        is LessThanOrEqualFilter -> Filters.lte(filter.field.convert(mapField), filter.value.requiredNativeValue())
+        is LessThanFilter -> Filters.lt(filter.field.convert(parent, mapField), filter.value.requiredNativeValue())
+        is LessThanOrEqualFilter -> Filters.lte(filter.field.convert(parent, mapField), filter.value.requiredNativeValue())
         is ContainsFilter -> regex(
-            filter.field.convert(mapField),
+            filter.field.convert(parent, mapField),
             filter.value.escapeRegex(),
             filter.stringComparison.ignoreCase
         )
         is StartsWithFilter -> regex(
-            filter.field.convert(mapField),
+            filter.field.convert(parent, mapField),
             "^${filter.value.escapeRegex()}",
             filter.stringComparison.ignoreCase
         )
         is EndsWithFilter -> regex(
-            filter.field.convert(mapField),
+            filter.field.convert(parent, mapField),
             "${filter.value.escapeRegex()}$",
             filter.stringComparison.ignoreCase
         )
-        is InFilter -> Filters.`in`(filter.field.convert(mapField), filter.values.map { it.nativeValue() })
-        is NotInFilter -> Filters.nin(filter.field.convert(mapField), filter.values.map { it.nativeValue() })
+        is InFilter -> Filters.`in`(filter.field.convert(parent, mapField), filter.values.map { it.nativeValue() })
+        is NotInFilter -> Filters.nin(filter.field.convert(parent, mapField), filter.values.map { it.nativeValue() })
         is BetweenFilter -> Filters.and(
-            Filters.gte(filter.field.convert(mapField), filter.lowerBound.requiredNativeValue()),
-            Filters.lte(filter.field.convert(mapField), filter.upperBound.requiredNativeValue()),
+            Filters.gte(filter.field.convert(parent, mapField), filter.lowerBound.requiredNativeValue()),
+            Filters.lte(filter.field.convert(parent, mapField), filter.upperBound.requiredNativeValue()),
         )
-        is ContainsAllFilter -> Filters.all(filter.field.convert(mapField), filter.values.map { it.nativeValue() })
-        is IsEmptyFilter -> Filters.size(filter.field.convert(mapField), 0)
-        is IsNullFilter -> Filters.eq(filter.field.convert(mapField), null)
-        is IsNotNullFilter -> Filters.ne(filter.field.convert(mapField), null)
-        is ExistsFilter -> Filters.exists(filter.field.convert(mapField))
-        is NotExistsFilter -> Filters.exists(filter.field.convert(mapField), false)
+        is ContainsAllFilter -> Filters.all(filter.field.convert(parent, mapField), filter.values.map { it.nativeValue() })
+        is IsEmptyFilter -> Filters.size(filter.field.convert(parent, mapField), 0)
+        is IsNullFilter -> Filters.eq(filter.field.convert(parent, mapField), null)
+        is IsNotNullFilter -> Filters.ne(filter.field.convert(parent, mapField), null)
+        is ExistsFilter -> Filters.exists(filter.field.convert(parent, mapField))
+        is NotExistsFilter -> Filters.exists(filter.field.convert(parent, mapField), false)
         is DeletionFilter -> when (filter.deletionState) {
             DeletionState.ACTIVE -> Filters.eq(StateAggregateRecords.DELETED, false)
             DeletionState.DELETED -> Filters.eq(StateAggregateRecords.DELETED, true)
             DeletionState.ALL -> Filters.empty()
         }
         is ElementMatchFilter -> Filters.elemMatch(
-            filter.field.convert(mapField),
-            compile(filter.predicate, mapField = false),
+            filter.field.convert(parent, mapField),
+            compile(filter.predicate, parent = null, mapField = false),
         )
         is SearchFilter -> Filters.text(filter.query)
         is TodayFilter,
@@ -158,8 +158,11 @@ abstract class AbstractMongoFilterConverter(
         else -> error("Unsupported filter expression: ${filter::class.java.name}.")
     }
 
-    private fun me.ahoo.wow.api.query.LogicalField.convert(mapField: Boolean): String =
-        if (mapField) fieldConverter.convert(value) else value
+    private fun me.ahoo.wow.api.query.LogicalField.convert(parent: String?, mapField: Boolean): String =
+        path(parent).let { if (mapField) fieldConverter.convert(it) else it }
+
+    private fun me.ahoo.wow.api.query.LogicalField.path(parent: String?): String =
+        if (parent == null || value == parent || value.startsWith("$parent.")) value else "$parent.$value"
 
     private val StringComparison.ignoreCase: Boolean
         get() = this == StringComparison.CASE_INSENSITIVE

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoFilterConverter.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoFilterConverter.kt
@@ -77,9 +77,13 @@ abstract class AbstractMongoFilterConverter(
     protected abstract val fieldConverter: FieldConverter
 
     private val filterNormalizer = FilterNormalizer(defaultDeletionState = defaultDeletionState)
+    private val filterNormalizerWithoutDefaultDeletion = FilterNormalizer(defaultDeletionState = null)
 
     fun convert(filter: FilterExpression, parent: String? = null): Bson =
         compile(filterNormalizer.normalize(filter), parent, mapField = true)
+
+    internal fun convertWithoutDefaultDeletion(filter: FilterExpression, parent: String? = null): Bson =
+        compile(filterNormalizerWithoutDefaultDeletion.normalize(filter), parent, mapField = true)
 
     @Suppress("CyclomaticComplexMethod", "LongMethod")
     private fun compile(filter: FilterExpression, parent: String?, mapField: Boolean): Bson = when (filter) {

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompiler.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompiler.kt
@@ -25,13 +25,8 @@ import me.ahoo.wow.api.query.LogicalField
 import me.ahoo.wow.api.query.MatchAllFilter
 import me.ahoo.wow.api.query.Sort
 import me.ahoo.wow.mongo.query.AbstractMongoFilterConverter
-import me.ahoo.wow.query.converter.FieldConverter
 import org.bson.Document
 import org.bson.conversions.Bson
-
-private object ElementSnapshotFilterConverter : AbstractMongoFilterConverter(defaultDeletionState = null) {
-    override val fieldConverter: FieldConverter = SnapshotFieldConverter
-}
 
 internal class MongoAggregationCompiler(
     private val converter: AbstractMongoFilterConverter,
@@ -44,7 +39,7 @@ internal class MongoAggregationCompiler(
             parent = if (parent == null) element.path.value else "$parent.${element.path.value}"
             add(Aggregates.unwind("\$$parent"))
             if (element.filter !== MatchAllFilter) {
-                add(Aggregates.match(ElementSnapshotFilterConverter.convert(element.filter, parent)))
+                add(Aggregates.match(converter.convertWithoutDefaultDeletion(element.filter, parent)))
             }
         }
 

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompiler.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompiler.kt
@@ -18,6 +18,7 @@ import com.mongodb.client.model.Filters
 import com.mongodb.client.model.Sorts
 import me.ahoo.wow.api.query.AggregationDateUnit
 import me.ahoo.wow.api.query.AggregationExpression
+import me.ahoo.wow.api.query.AggregationFunction
 import me.ahoo.wow.api.query.AggregationGroup
 import me.ahoo.wow.api.query.AggregationMetric
 import me.ahoo.wow.api.query.AggregationQuery
@@ -68,7 +69,15 @@ internal class MongoAggregationCompiler(
                 is AggregationMetric.Count -> group[metric.alias] = Document("\$sum", 1)
                 is AggregationMetric.Numeric -> {
                     val field = metric.expression.field().resolve(parent)
-                    group[metric.alias] = Document("\$${metric.function.name.lowercase()}", "\$$field")
+                    val input = when (metric.function) {
+                        AggregationFunction.MIN, AggregationFunction.MAX -> Document(
+                            "\$cond",
+                            listOf(Document("\$isNumber", "\$$field"), "\$$field", null),
+                        )
+
+                        else -> "\$$field"
+                    }
+                    group[metric.alias] = Document("\$${metric.function.name.lowercase()}", input)
                     group[metric.countAlias] = Document(
                         "\$sum",
                         Document("\$cond", listOf(Document("\$isNumber", "\$$field"), 1, 0)),

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompiler.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompiler.kt
@@ -25,8 +25,13 @@ import me.ahoo.wow.api.query.LogicalField
 import me.ahoo.wow.api.query.MatchAllFilter
 import me.ahoo.wow.api.query.Sort
 import me.ahoo.wow.mongo.query.AbstractMongoFilterConverter
+import me.ahoo.wow.query.converter.FieldConverter
 import org.bson.Document
 import org.bson.conversions.Bson
+
+private object ElementSnapshotFilterConverter : AbstractMongoFilterConverter(defaultDeletionState = null) {
+    override val fieldConverter: FieldConverter = SnapshotFieldConverter
+}
 
 internal class MongoAggregationCompiler(
     private val converter: AbstractMongoFilterConverter,
@@ -39,7 +44,7 @@ internal class MongoAggregationCompiler(
             parent = if (parent == null) element.path.value else "$parent.${element.path.value}"
             add(Aggregates.unwind("\$$parent"))
             if (element.filter !== MatchAllFilter) {
-                add(Aggregates.match(converter.convert(element.filter, parent)))
+                add(Aggregates.match(ElementSnapshotFilterConverter.convert(element.filter, parent)))
             }
         }
 
@@ -71,7 +76,7 @@ internal class MongoAggregationCompiler(
                     group[metric.alias] = Document("\$${metric.function.name.lowercase()}", "\$$field")
                     group[metric.countAlias] = Document(
                         "\$sum",
-                        Document("\$cond", listOf(Document("\$ne", listOf("\$$field", null)), 1, 0)),
+                        Document("\$cond", listOf(Document("\$isNumber", "\$$field"), 1, 0)),
                     )
                 }
             }
@@ -118,7 +123,7 @@ internal class MongoAggregationCompiler(
     }
 
     private fun LogicalField.resolve(parent: String?): String =
-        if (parent == null) value else "$parent.$value"
+        SnapshotFieldConverter.convert(if (parent == null) value else "$parent.$value")
 
     private fun List<Sort>.toBson(): Bson = Sorts.orderBy(map {
         when (it.direction) {

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompiler.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompiler.kt
@@ -17,7 +17,6 @@ import com.mongodb.client.model.Aggregates
 import com.mongodb.client.model.Filters
 import com.mongodb.client.model.Sorts
 import me.ahoo.wow.api.query.AggregationExpression
-import me.ahoo.wow.api.query.AggregationFunction
 import me.ahoo.wow.api.query.AggregationGroup
 import me.ahoo.wow.api.query.AggregationMetric
 import me.ahoo.wow.api.query.AggregationQuery
@@ -123,12 +122,14 @@ internal class MongoAggregationCompiler(
     private fun LogicalField.resolve(parent: String?): String =
         SnapshotFieldConverter.convert(if (parent == null) value else "$parent.$value")
 
-    private fun List<Sort>.toBson(): Bson = Sorts.orderBy(map {
-        when (it.direction) {
-            Sort.Direction.ASC -> Sorts.ascending(it.field)
-            Sort.Direction.DESC -> Sorts.descending(it.field)
+    private fun List<Sort>.toBson(): Bson = Sorts.orderBy(
+        map {
+            when (it.direction) {
+                Sort.Direction.ASC -> Sorts.ascending(it.field)
+                Sort.Direction.DESC -> Sorts.descending(it.field)
+            }
         }
-    })
+    )
 
     private val AggregationMetric.Numeric.countAlias: String
         get() = "__wow_value_count_$alias"

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompiler.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompiler.kt
@@ -105,10 +105,13 @@ internal class MongoAggregationCompiler(
         )
 
         is AggregationGroup.DateHistogram -> Document(
-            "\$dateTrunc",
-            Document("date", "\$${field.resolve(parent)}")
-                .append("unit", unit.name.lowercase())
-                .append("timezone", timeZone),
+            "\$toLong",
+            Document(
+                "\$dateTrunc",
+                Document("date", Document("\$toDate", "\$${field.resolve(parent)}"))
+                    .append("unit", unit.name.lowercase())
+                    .append("timezone", if (timeZone == "Z") "UTC" else timeZone),
+            ),
         )
     }
 

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompiler.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompiler.kt
@@ -16,6 +16,7 @@ package me.ahoo.wow.mongo.query.snapshot
 import com.mongodb.client.model.Aggregates
 import com.mongodb.client.model.Filters
 import com.mongodb.client.model.Sorts
+import me.ahoo.wow.api.query.AggregationDateUnit
 import me.ahoo.wow.api.query.AggregationExpression
 import me.ahoo.wow.api.query.AggregationGroup
 import me.ahoo.wow.api.query.AggregationMetric
@@ -109,7 +110,10 @@ internal class MongoAggregationCompiler(
                 "\$dateTrunc",
                 Document("date", Document("\$toDate", "\$${field.resolve(parent)}"))
                     .append("unit", unit.name.lowercase())
-                    .append("timezone", if (timeZone == "Z") "UTC" else timeZone),
+                    .append("timezone", if (timeZone == "Z") "UTC" else timeZone)
+                    .apply {
+                        if (unit == AggregationDateUnit.WEEK) append("startOfWeek", "Monday")
+                    },
             ),
         )
     }

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompiler.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompiler.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.mongo.query.snapshot
+
+import com.mongodb.client.model.Aggregates
+import com.mongodb.client.model.Filters
+import com.mongodb.client.model.Sorts
+import me.ahoo.wow.api.query.AggregationExpression
+import me.ahoo.wow.api.query.AggregationFunction
+import me.ahoo.wow.api.query.AggregationGroup
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.LogicalField
+import me.ahoo.wow.api.query.MatchAllFilter
+import me.ahoo.wow.api.query.Sort
+import me.ahoo.wow.mongo.query.AbstractMongoFilterConverter
+import org.bson.Document
+import org.bson.conversions.Bson
+
+internal class MongoAggregationCompiler(
+    private val converter: AbstractMongoFilterConverter,
+) {
+    fun compile(query: AggregationQuery): List<Bson> = buildList {
+        add(Aggregates.match(converter.convert(query.filter)))
+
+        var parent: String? = null
+        query.elements.forEach { element ->
+            parent = if (parent == null) element.path.value else "$parent.${element.path.value}"
+            add(Aggregates.unwind("\$$parent"))
+            if (element.filter !== MatchAllFilter) {
+                add(Aggregates.match(converter.convert(element.filter, parent)))
+            }
+        }
+
+        if (query.groupBy.isNotEmpty()) {
+            val groupFields = query.groupBy.map { it.field.resolve(parent) }
+            add(
+                Aggregates.match(
+                    Filters.and(groupFields.flatMap { listOf(Filters.exists(it), Filters.ne(it, null)) }),
+                ),
+            )
+        }
+
+        add(group(query, parent))
+        add(project(query))
+        query.effectiveSort().takeIf { it.isNotEmpty() }?.let { add(Aggregates.sort(it.toBson())) }
+        add(Aggregates.limit(query.limit))
+    }
+
+    private fun group(query: AggregationQuery, parent: String?): Bson {
+        val id = query.groupBy
+            .takeIf { it.isNotEmpty() }
+            ?.associateTo(Document()) { it.alias to it.expression(parent) }
+        val group = Document("_id", id)
+        query.metrics.forEach { metric ->
+            when (metric) {
+                is AggregationMetric.Count -> group[metric.alias] = Document("\$sum", 1)
+                is AggregationMetric.Numeric -> {
+                    val field = metric.expression.field().resolve(parent)
+                    group[metric.alias] = Document("\$${metric.function.name.lowercase()}", "\$$field")
+                    group[metric.countAlias] = Document(
+                        "\$sum",
+                        Document("\$cond", listOf(Document("\$ne", listOf("\$$field", null)), 1, 0)),
+                    )
+                }
+            }
+        }
+        return Document("\$group", group)
+    }
+
+    private fun project(query: AggregationQuery): Bson {
+        val project = Document("_id", 0)
+        query.groupBy.forEach { project[it.alias] = "\$_id.${it.alias}" }
+        query.metrics.forEach { metric ->
+            project[metric.alias] = when (metric) {
+                is AggregationMetric.Count -> 1
+                is AggregationMetric.Numeric -> Document(
+                    "\$cond",
+                    listOf(Document("\$eq", listOf("\$${metric.countAlias}", 0)), null, "\$${metric.alias}"),
+                )
+            }
+        }
+        return Aggregates.project(project)
+    }
+
+    private fun AggregationGroup.expression(parent: String?): Any = when (this) {
+        is AggregationGroup.Terms -> "\$${field.resolve(parent)}"
+        is AggregationGroup.Histogram -> Document(
+            "\$multiply",
+            listOf(
+                Document("\$floor", Document("\$divide", listOf("\$${field.resolve(parent)}", interval))),
+                interval,
+            ),
+        )
+
+        is AggregationGroup.DateHistogram -> Document(
+            "\$dateTrunc",
+            Document("date", "\$${field.resolve(parent)}")
+                .append("unit", unit.name.lowercase())
+                .append("timezone", timeZone),
+        )
+    }
+
+    private fun AggregationExpression.field(): LogicalField = when (this) {
+        is AggregationExpression.Field -> field
+        else -> error("Unsupported aggregation expression: ${this::class.java.name}.")
+    }
+
+    private fun LogicalField.resolve(parent: String?): String =
+        if (parent == null) value else "$parent.$value"
+
+    private fun List<Sort>.toBson(): Bson = Sorts.orderBy(map {
+        when (it.direction) {
+            Sort.Direction.ASC -> Sorts.ascending(it.field)
+            Sort.Direction.DESC -> Sorts.descending(it.field)
+        }
+    })
+
+    private val AggregationMetric.Numeric.countAlias: String
+        get() = "__wow_value_count_$alias"
+}

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryService.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryService.kt
@@ -71,6 +71,9 @@ class MongoSnapshotQueryService<S : Any>(
     }
 
     private fun Document.toAggregationResult(query: AggregationQuery): DynamicDocument {
+        query.groupBy.forEach { group ->
+            (get(group.alias) as? Decimal128)?.let { this[group.alias] = it.toFiniteDouble(group.alias) }
+        }
         query.metrics.forEach { metric ->
             this[metric.alias] = when (metric) {
                 is AggregationMetric.Count -> (get(metric.alias) as Number).toLong()

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryService.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryService.kt
@@ -15,6 +15,8 @@ package me.ahoo.wow.mongo.query.snapshot
 
 import com.mongodb.reactivestreams.client.MongoCollection
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.MaterializedSnapshot
 import me.ahoo.wow.api.query.SimpleDynamicDocument.Companion.toDynamicDocument
@@ -30,6 +32,9 @@ import me.ahoo.wow.mongo.toMaterializedSnapshot
 import me.ahoo.wow.query.snapshot.SnapshotQueryService
 import me.ahoo.wow.serialization.JsonSerializer
 import org.bson.Document
+import org.bson.types.Decimal128
+import reactor.core.publisher.Flux
+import reactor.kotlin.core.publisher.toFlux
 
 class MongoSnapshotQueryService<S : Any>(
     override val namedAggregate: NamedAggregate,
@@ -52,5 +57,41 @@ class MongoSnapshotQueryService<S : Any>(
 
     override fun toDynamicDocument(document: Document): DynamicDocument {
         return document.replacePrimaryKeyToAggregateId().toDynamicDocument()
+    }
+
+    override fun aggregate(query: AggregationQuery): Flux<DynamicDocument> {
+        val result = collection.aggregate(MongoAggregationCompiler(converter).compile(query))
+            .toFlux()
+            .map { it.toAggregationResult(query) }
+        return if (query.groupBy.isEmpty()) {
+            result.switchIfEmpty(Flux.just(query.emptySummary()))
+        } else {
+            result
+        }
+    }
+
+    private fun Document.toAggregationResult(query: AggregationQuery): DynamicDocument {
+        query.metrics.forEach { metric ->
+            this[metric.alias] = when (metric) {
+                is AggregationMetric.Count -> (get(metric.alias) as Number).toLong()
+                is AggregationMetric.Numeric -> get(metric.alias).toFiniteDouble(metric.alias)
+            }
+        }
+        return toDynamicDocument()
+    }
+
+    private fun AggregationQuery.emptySummary(): DynamicDocument = metrics.associateTo(Document()) { metric ->
+        metric.alias to if (metric is AggregationMetric.Count) 0L else null
+    }.toDynamicDocument()
+
+    private fun Any?.toFiniteDouble(alias: String): Double? {
+        val value = when (this) {
+            null -> return null
+            is Decimal128 -> bigDecimalValue().toDouble()
+            is Number -> toDouble()
+            else -> error("Aggregation metric [$alias] must be numeric, but was [${this::class.java.name}].")
+        }
+        require(value.isFinite()) { "Aggregation metric [$alias] must be finite." }
+        return value
     }
 }

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/SnapshotFilterConverterTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/SnapshotFilterConverterTest.kt
@@ -7,6 +7,7 @@ import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.query.*
 import me.ahoo.wow.mongo.Documents
 import me.ahoo.wow.mongo.query.snapshot.SnapshotFilterConverter
+import me.ahoo.wow.query.dsl.filter
 import me.ahoo.wow.serialization.JsonSerializer
 import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.serialization.state.StateAggregateRecords
@@ -137,6 +138,24 @@ class SnapshotFilterConverterTest {
                 "state.items",
                 Filters.eq(MessageRecords.AGGREGATE_ID, "nested-aggregate-id"),
             ),
+        )
+    }
+
+    @Test
+    fun `scoped filter fields should be prefixed with parent`() {
+        val bson = SnapshotFilterConverter.convert(filter { "quantity" gt 1 }, "state.orders.lines")
+
+        bson.toBsonDocument().toJson().assert().contains("state.orders.lines.quantity")
+    }
+
+    @Test
+    fun `scoped element predicate fields should remain relative`() {
+        assertConvert(
+            SnapshotFilterConverter.convert(
+                ElementMatchFilter(LogicalField("items"), EqualFilter(LogicalField("quantity"), json(1))),
+                "state.orders.lines",
+            ),
+            Filters.elemMatch("state.orders.lines.items", Filters.eq("quantity", 1)),
         )
     }
 

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/SnapshotFilterConverterTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/SnapshotFilterConverterTest.kt
@@ -146,6 +146,18 @@ class SnapshotFilterConverterTest {
         val bson = SnapshotFilterConverter.convert(filter { "quantity" gt 1 }, "state.orders.lines")
 
         bson.toBsonDocument().toJson().assert().contains("state.orders.lines.quantity")
+        SnapshotFilterConverter.convert(filter { "state.orders.lines.quantity" gt 1 }, "state.orders.lines")
+            .toBsonDocument().toJson().assert()
+            .contains("state.orders.lines.quantity")
+            .doesNotContain("state.orders.lines.state.orders.lines.quantity")
+        SnapshotFilterConverter.convert(filter { "state.orders.lines".exists() }, "state.orders.lines")
+            .toBsonDocument().toJson().assert().contains("state.orders.lines")
+    }
+
+    @Test
+    fun `element filter conversion should not add a default deletion scope`() {
+        SnapshotFilterConverter.convertWithoutDefaultDeletion(MatchAllFilter)
+            .toBsonDocument().assert().isEqualTo(Filters.empty().toBsonDocument())
     }
 
     @Test

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
@@ -15,7 +15,10 @@ package me.ahoo.wow.mongo.query.snapshot
 
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.query.AggregationDateUnit
+import me.ahoo.wow.api.query.DeletionFilter
+import me.ahoo.wow.api.query.DeletionState
 import me.ahoo.wow.query.dsl.aggregation
+import me.ahoo.wow.serialization.MessageRecords
 import org.junit.jupiter.api.Test
 import java.time.ZoneId
 
@@ -88,5 +91,42 @@ class MongoAggregationCompilerTest {
         MongoAggregationCompiler(SnapshotFilterConverter).compile(query)
             .joinToString { it.toBsonDocument().toJson() }
             .assert().contains("__wow_value_count_total")
+    }
+
+    @Test
+    fun `element filter should not restore active deletion scope`() {
+        val query = aggregation {
+            filter(DeletionFilter(DeletionState.DELETED))
+            expand("state.items") { "quantity" gt 0 }
+            count("count")
+        }
+
+        val pipeline = MongoAggregationCompiler(SnapshotFilterConverter).compile(query)
+        pipeline[0].toBsonDocument().toJson().assert().contains("\"deleted\": true")
+        pipeline[2].toBsonDocument().toJson().assert().doesNotContain("deleted")
+    }
+
+    @Test
+    fun `root aggregate id leaf should use Mongo primary key`() {
+        val query = aggregation {
+            terms(MessageRecords.AGGREGATE_ID, "aggregate")
+            count("count")
+        }
+
+        val pipeline = MongoAggregationCompiler(SnapshotFilterConverter).compile(query)
+        pipeline[1].toBsonDocument().toJson().assert()
+            .contains("\"_id\"")
+            .doesNotContain(MessageRecords.AGGREGATE_ID)
+        pipeline[2].toBsonDocument().toJson().assert().contains("\"\$_id\"")
+    }
+
+    @Test
+    fun `numeric contribution count should accept only Mongo numeric values`() {
+        val query = aggregation { sum("state.amount", "total") }
+
+        val group = MongoAggregationCompiler(SnapshotFilterConverter).compile(query)[1]
+        group.toBsonDocument().toJson().assert()
+            .contains("\$isNumber")
+            .doesNotContain("\$ne")
     }
 }

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
@@ -149,6 +149,22 @@ class MongoAggregationCompilerTest {
     }
 
     @Test
+    fun `minimum and maximum should accumulate only Mongo numeric values`() {
+        val query = aggregation {
+            min("state.amount", "minimum")
+            max("state.amount", "maximum")
+        }
+
+        val group = MongoAggregationCompiler(SnapshotFilterConverter).compile(query)[1]
+            .toBsonDocument().getDocument("\$group")
+        listOf("minimum", "maximum").forEach { alias ->
+            group.getDocument(alias).toJson().assert()
+                .contains("\$cond")
+                .contains("\$isNumber")
+        }
+    }
+
+    @Test
     fun `custom field converter should apply to root and element filters without element deletion scope`() {
         val converter = object : AbstractMongoFilterConverter() {
             override val fieldConverter: FieldConverter = FieldConverter { "physical.$it" }

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.mongo.query.snapshot
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.AggregationDateUnit
+import me.ahoo.wow.query.dsl.aggregation
+import org.junit.jupiter.api.Test
+import java.time.ZoneId
+
+class MongoAggregationCompilerTest {
+
+    @Test
+    fun `compiler should unwind and filter every relative element`() {
+        val query = aggregation {
+            expand("state.orders") { "status" eq "PAID" }
+            expand("lines") { "quantity" gt 0 }
+            terms("productId", "product")
+            count("count")
+        }
+
+        val pipeline = MongoAggregationCompiler(SnapshotFilterConverter).compile(query)
+        pipeline.map { it.toBsonDocument().keys.first() }.assert().containsExactly(
+            "\$match",
+            "\$unwind",
+            "\$match",
+            "\$unwind",
+            "\$match",
+            "\$match",
+            "\$group",
+            "\$project",
+            "\$sort",
+            "\$limit",
+        )
+        pipeline.joinToString { it.toBsonDocument().toJson() }.assert()
+            .contains("state.orders.status")
+            .contains("state.orders.lines.quantity")
+            .contains("state.orders.lines.productId")
+    }
+
+    @Test
+    fun `compiler should compile groups metrics and stable sort`() {
+        val query = aggregation {
+            terms("state.productId", "product")
+            histogram("state.amount", 10.0, "amountRange")
+            dateHistogram("state.createdAt", AggregationDateUnit.DAY, "day", ZoneId.of("Asia/Shanghai"))
+            count("count")
+            sum("state.amount", "total")
+            avg("state.amount", "average")
+            min("state.amount", "minimum")
+            max("state.amount", "maximum")
+            sort { "total".desc() }
+            limit(7)
+        }
+
+        val pipeline = MongoAggregationCompiler(SnapshotFilterConverter).compile(query)
+        val stages = pipeline.associateBy { it.toBsonDocument().keys.first() }
+        stages.getValue("\$group").toBsonDocument().toJson().assert()
+            .contains("\$floor")
+            .contains("\$dateTrunc")
+            .contains("\"unit\": \"day\"")
+            .contains("\"timezone\": \"Asia/Shanghai\"")
+            .contains("\$sum")
+            .contains("\$avg")
+            .contains("\$min")
+            .contains("\$max")
+        stages.getValue("\$sort").toBsonDocument().getDocument("\$sort").keys.assert()
+            .containsExactly("total", "product", "amountRange", "day")
+        stages.getValue("\$sort").toBsonDocument().toJson().assert().contains("\"total\": -1")
+        stages.getValue("\$limit").toBsonDocument().toJson().assert().contains("7")
+    }
+
+    @Test
+    fun `summary compiler should retain contribution counts`() {
+        val query = aggregation { sum("state.amount", "total") }
+
+        MongoAggregationCompiler(SnapshotFilterConverter).compile(query)
+            .joinToString { it.toBsonDocument().toJson() }
+            .assert().contains("__wow_value_count_total")
+    }
+}

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
@@ -103,6 +103,18 @@ class MongoAggregationCompilerTest {
     }
 
     @Test
+    fun `UTC date histogram should use the Mongo UTC timezone`() {
+        val query = aggregation {
+            dateHistogram("state.createdAt", AggregationDateUnit.DAY, "day", ZoneId.of("Z"))
+            count("count")
+        }
+
+        MongoAggregationCompiler(SnapshotFilterConverter).compile(query)
+            .first { it.toBsonDocument().containsKey("\$group") }
+            .toBsonDocument().toJson().assert().contains("\"timezone\": \"UTC\"")
+    }
+
+    @Test
     fun `summary compiler should retain contribution counts`() {
         val query = aggregation { sum("state.amount", "total") }
 

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
@@ -76,6 +76,7 @@ class MongoAggregationCompilerTest {
             .contains("\$dateTrunc")
             .contains("\"unit\": \"day\"")
             .contains("\"timezone\": \"Asia/Shanghai\"")
+            .doesNotContain("startOfWeek")
             .contains("\$sum")
             .contains("\$avg")
             .contains("\$min")
@@ -84,6 +85,21 @@ class MongoAggregationCompilerTest {
             .containsExactly("total", "product", "amountRange", "day")
         stages.getValue("\$sort").toBsonDocument().toJson().assert().contains("\"total\": -1")
         stages.getValue("\$limit").toBsonDocument().toJson().assert().contains("7")
+    }
+
+    @Test
+    fun `weekly date histogram should start on Monday and preserve timezone`() {
+        val query = aggregation {
+            dateHistogram("state.createdAt", AggregationDateUnit.WEEK, "week", ZoneId.of("Asia/Shanghai"))
+            count("count")
+        }
+
+        MongoAggregationCompiler(SnapshotFilterConverter).compile(query)
+            .first { it.toBsonDocument().containsKey("\$group") }
+            .toBsonDocument().toJson().assert()
+            .contains("\"unit\": \"week\"")
+            .contains("\"timezone\": \"Asia/Shanghai\"")
+            .contains("\"startOfWeek\": \"Monday\"")
     }
 
     @Test

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
@@ -18,8 +18,8 @@ import me.ahoo.wow.api.query.AggregationDateUnit
 import me.ahoo.wow.api.query.DeletionFilter
 import me.ahoo.wow.api.query.DeletionState
 import me.ahoo.wow.mongo.query.AbstractMongoFilterConverter
-import me.ahoo.wow.query.dsl.aggregation
 import me.ahoo.wow.query.converter.FieldConverter
+import me.ahoo.wow.query.dsl.aggregation
 import me.ahoo.wow.serialization.MessageRecords
 import org.junit.jupiter.api.Test
 import java.time.ZoneId

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
@@ -17,7 +17,9 @@ import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.query.AggregationDateUnit
 import me.ahoo.wow.api.query.DeletionFilter
 import me.ahoo.wow.api.query.DeletionState
+import me.ahoo.wow.mongo.query.AbstractMongoFilterConverter
 import me.ahoo.wow.query.dsl.aggregation
+import me.ahoo.wow.query.converter.FieldConverter
 import me.ahoo.wow.serialization.MessageRecords
 import org.junit.jupiter.api.Test
 import java.time.ZoneId
@@ -128,5 +130,23 @@ class MongoAggregationCompilerTest {
         group.toBsonDocument().toJson().assert()
             .contains("\$isNumber")
             .doesNotContain("\$ne")
+    }
+
+    @Test
+    fun `custom field converter should apply to root and element filters without element deletion scope`() {
+        val converter = object : AbstractMongoFilterConverter() {
+            override val fieldConverter: FieldConverter = FieldConverter { "physical.$it" }
+        }
+        val query = aggregation {
+            filter { "state.status" eq "PAID" }
+            expand("state.items") { "quantity" gt 0 }
+            count("count")
+        }
+
+        val pipeline = MongoAggregationCompiler(converter).compile(query)
+        pipeline[0].toBsonDocument().toJson().assert().contains("physical.state.status")
+        pipeline[2].toBsonDocument().toJson().assert()
+            .contains("physical.state.items.quantity")
+            .doesNotContain("deleted")
     }
 }

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/QueryComponent.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/QueryComponent.kt
@@ -13,9 +13,16 @@
 
 package me.ahoo.wow.openapi
 
+import io.swagger.v3.oas.models.media.ArraySchema
+import io.swagger.v3.oas.models.media.IntegerSchema
+import io.swagger.v3.oas.models.media.ObjectSchema
 import io.swagger.v3.oas.models.media.StringSchema
 import me.ahoo.wow.api.Wow
+import me.ahoo.wow.api.query.AggregationGroup
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.FilterExpression
+import me.ahoo.wow.api.query.LogicalField
 import me.ahoo.wow.api.query.PagedList
 import me.ahoo.wow.api.query.Pagination
 import me.ahoo.wow.api.query.Projection
@@ -23,6 +30,7 @@ import me.ahoo.wow.api.query.Sort
 import me.ahoo.wow.modeling.metadata.AggregateMetadata
 import me.ahoo.wow.modeling.toStringWithAlias
 import me.ahoo.wow.openapi.CommonComponent.Response.withErrorCodeHeader
+import me.ahoo.wow.openapi.QueryComponent.Schema.aggregationQuerySchema
 import me.ahoo.wow.openapi.QueryComponent.Schema.filterSchema
 import me.ahoo.wow.openapi.QueryComponent.Schema.listQuerySchema
 import me.ahoo.wow.openapi.QueryComponent.Schema.pagedQuerySchema
@@ -36,9 +44,11 @@ object QueryComponent {
     const val COUNT_QUERY_SUFFIX = ".CountQuery"
     const val LIST_QUERY_SUFFIX = ".ListQuery"
     const val PAGED_QUERY_SUFFIX = ".PagedQuery"
+    const val AGGREGATION_QUERY_SUFFIX = ".AggregationQuery"
     const val COUNT_QUERY_KEY = Wow.WOW + COUNT_QUERY_SUFFIX
     const val LIST_QUERY_KEY = Wow.WOW + LIST_QUERY_SUFFIX
     const val PAGED_QUERY_KEY = Wow.WOW + PAGED_QUERY_SUFFIX
+    const val AGGREGATION_QUERY_KEY = "wow.api.query.AggregationQuery"
 
     object Schema {
 
@@ -63,6 +73,48 @@ object QueryComponent {
             val querySchema = baseQuerySchema()
             querySchema.addProperty("pagination", schema(Pagination::class.java).asAnySchema())
             return querySchema
+        }
+
+        fun OpenAPIComponentContext.aggregationQuerySchema(): io.swagger.v3.oas.models.media.Schema<*> {
+            val elementSchema = ObjectSchema()
+            elementSchema.addProperty("path", schema(LogicalField::class.java).asAnySchema())
+            elementSchema.addProperty("filter", filterSchema().asAnySchema())
+            elementSchema.required(listOf("path"))
+            elementSchema.additionalProperties(false)
+
+            val querySchema = ObjectSchema()
+            querySchema.addProperty("filter", filterSchema().asAnySchema())
+            querySchema.addProperty(
+                "elements",
+                ArraySchema().items(elementSchema).maxItems(AggregationQuery.MAX_ELEMENTS).asAnySchema()
+            )
+            querySchema.addProperty(
+                "groupBy",
+                ArraySchema().items(schema(AggregationGroup::class.java))
+                    .maxItems(AggregationQuery.MAX_GROUPS)
+                    .asAnySchema()
+            )
+            querySchema.addProperty(
+                "metrics",
+                ArraySchema().items(schema(AggregationMetric::class.java))
+                    .minItems(1)
+                    .maxItems(AggregationQuery.MAX_METRICS)
+                    .asAnySchema()
+            )
+            querySchema.addProperty(
+                "sort",
+                ArraySchema().items(schema(Sort::class.java))
+                    .maxItems(AggregationQuery.MAX_SORT_FIELDS)
+                    .asAnySchema()
+            )
+            val limitSchema = IntegerSchema()
+            limitSchema.setDefault(AggregationQuery.DEFAULT_LIMIT)
+            limitSchema.minimum(java.math.BigDecimal.ONE)
+            limitSchema.maximum(java.math.BigDecimal.valueOf(AggregationQuery.MAX_LIMIT.toLong()))
+            querySchema.addProperty("limit", limitSchema.asAnySchema())
+            querySchema.required(listOf("metrics"))
+            querySchema.additionalProperties(false)
+            return componentSchema(AGGREGATION_QUERY_KEY, querySchema)
         }
 
         private fun OpenAPIComponentContext.baseQuerySchema(): io.swagger.v3.oas.models.media.ObjectSchema {
@@ -90,6 +142,16 @@ object QueryComponent {
             return requestBody(aggregateMetadata.toStringWithAlias() + SINGLE_QUERY_SUFFIX) {
                 extension(QUERY_FIELDS_EXTENSION, queryFields)
                 content(schema = singleQuerySchema())
+            }
+        }
+
+        fun OpenAPIComponentContext.aggregatedAggregationQueryRequestBody(
+            aggregateMetadata: AggregateMetadata<*, *>
+        ): io.swagger.v3.oas.models.parameters.RequestBody {
+            val queryFields = aggregatedFieldsSchema(aggregateMetadata)
+            return requestBody(aggregateMetadata.toStringWithAlias() + AGGREGATION_QUERY_SUFFIX) {
+                extension(QUERY_FIELDS_EXTENSION, queryFields)
+                content(schema = aggregationQuerySchema())
             }
         }
 

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contract/BuiltInHttpRoutes.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contract/BuiltInHttpRoutes.kt
@@ -53,6 +53,7 @@ object BuiltInHttpRouteHandlerKeys {
     }
 
     object Snapshot {
+        const val AGGREGATION = "$AGGREGATE_SNAPSHOT.aggregation"
         const val COUNT = "$AGGREGATE_SNAPSHOT.count"
         const val LIST_QUERY = "$AGGREGATE_SNAPSHOT.list-query"
         const val LIST_QUERY_STATE = "$AGGREGATE_SNAPSHOT.list-query-state"

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/QueryContractComponentSupport.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/QueryContractComponentSupport.kt
@@ -13,12 +13,16 @@
 
 package me.ahoo.wow.openapi.contributor
 
+import io.swagger.v3.oas.models.media.ArraySchema
+import io.swagger.v3.oas.models.media.ObjectSchema
+import io.swagger.v3.oas.models.media.Schema
 import me.ahoo.wow.api.query.MaterializedSnapshot
 import me.ahoo.wow.api.query.PagedList
 import me.ahoo.wow.modeling.metadata.AggregateMetadata
 import me.ahoo.wow.modeling.toStringWithAlias
 import me.ahoo.wow.openapi.Https
 import me.ahoo.wow.openapi.QueryComponent
+import me.ahoo.wow.openapi.QueryComponent.RequestBody.aggregatedAggregationQueryRequestBody
 import me.ahoo.wow.openapi.QueryComponent.RequestBody.aggregatedCountQueryRequestBody
 import me.ahoo.wow.openapi.QueryComponent.RequestBody.aggregatedListQueryRequestBody
 import me.ahoo.wow.openapi.QueryComponent.RequestBody.aggregatedPagedQueryRequestBody
@@ -58,6 +62,13 @@ internal fun OpenAPIComponentContext.aggregatedCountQueryRequestBodyRef(
     return aggregateMetadata.queryRequestBodyRef(QueryComponent.COUNT_QUERY_SUFFIX)
 }
 
+internal fun OpenAPIComponentContext.aggregatedAggregationQueryRequestBodyRef(
+    aggregateMetadata: AggregateMetadata<*, *>
+): HttpRequestBody {
+    aggregatedAggregationQueryRequestBody(aggregateMetadata)
+    return aggregateMetadata.queryRequestBodyRef(QueryComponent.AGGREGATION_QUERY_SUFFIX)
+}
+
 internal fun OpenAPIComponentContext.aggregatedListQueryRequestBodyRef(
     aggregateMetadata: AggregateMetadata<*, *>
 ): HttpRequestBody {
@@ -84,6 +95,19 @@ internal fun OpenAPIComponentContext.countQueryResponseRef(): HttpResponse {
     return HttpResponse(
         statusCode = Https.Code.OK,
         componentRef = QueryComponent.COUNT_QUERY_KEY
+    )
+}
+
+internal fun OpenAPIComponentContext.aggregationResponse(): HttpResponse {
+    val rowSchema = ObjectSchema().additionalProperties(Schema<Any>().nullable(true))
+    val responseSchema = ArraySchema().items(rowSchema)
+    return HttpResponse(
+        statusCode = Https.Code.OK,
+        headers = listOf(errorCodeHeaderRef()),
+        content = listOf(
+            HttpContent(Https.MediaType.APPLICATION_JSON, HttpSchema.Raw(responseSchema)),
+            HttpContent(Https.MediaType.TEXT_EVENT_STREAM, HttpSchema.Raw(responseSchema))
+        )
     )
 }
 

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/QueryContractComponentSupport.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/QueryContractComponentSupport.kt
@@ -14,8 +14,10 @@
 package me.ahoo.wow.openapi.contributor
 
 import io.swagger.v3.oas.models.media.ArraySchema
+import io.swagger.v3.oas.models.media.IntegerSchema
 import io.swagger.v3.oas.models.media.ObjectSchema
 import io.swagger.v3.oas.models.media.Schema
+import io.swagger.v3.oas.models.media.StringSchema
 import me.ahoo.wow.api.query.MaterializedSnapshot
 import me.ahoo.wow.api.query.PagedList
 import me.ahoo.wow.modeling.metadata.AggregateMetadata
@@ -101,12 +103,20 @@ internal fun OpenAPIComponentContext.countQueryResponseRef(): HttpResponse {
 internal fun OpenAPIComponentContext.aggregationResponse(): HttpResponse {
     val rowSchema = ObjectSchema().additionalProperties(Schema<Any>().nullable(true))
     val responseSchema = ArraySchema().items(rowSchema)
+    val eventStreamSchema = ArraySchema().items(
+        ObjectSchema()
+            .addProperty("id", StringSchema().nullable(true))
+            .addProperty("event", StringSchema().nullable(true))
+            .addProperty("data", rowSchema)
+            .addProperty("retry", IntegerSchema().nullable(true))
+            .required(listOf("data"))
+    )
     return HttpResponse(
         statusCode = Https.Code.OK,
         headers = listOf(errorCodeHeaderRef()),
         content = listOf(
             HttpContent(Https.MediaType.APPLICATION_JSON, HttpSchema.Raw(responseSchema)),
-            HttpContent(Https.MediaType.TEXT_EVENT_STREAM, HttpSchema.Raw(responseSchema))
+            HttpContent(Https.MediaType.TEXT_EVENT_STREAM, HttpSchema.Raw(eventStreamSchema))
         )
     )
 }

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/aggregate/snapshot/SnapshotRouteContributor.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/aggregate/snapshot/SnapshotRouteContributor.kt
@@ -36,10 +36,12 @@ import me.ahoo.wow.openapi.contributor.aggregate.aggregatePath
 import me.ahoo.wow.openapi.contributor.aggregate.aggregateTags
 import me.ahoo.wow.openapi.contributor.aggregate.defaultAppendOwnerPath
 import me.ahoo.wow.openapi.contributor.aggregate.defaultAppendTenantPath
+import me.ahoo.wow.openapi.contributor.aggregatedAggregationQueryRequestBodyRef
 import me.ahoo.wow.openapi.contributor.aggregatedCountQueryRequestBodyRef
 import me.ahoo.wow.openapi.contributor.aggregatedListQueryRequestBodyRef
 import me.ahoo.wow.openapi.contributor.aggregatedPagedQueryRequestBodyRef
 import me.ahoo.wow.openapi.contributor.aggregatedSingleQueryRequestBodyRef
+import me.ahoo.wow.openapi.contributor.aggregationResponse
 import me.ahoo.wow.openapi.contributor.batchAfterIdPathParameterRef
 import me.ahoo.wow.openapi.contributor.batchLimitPathParameterRef
 import me.ahoo.wow.openapi.contributor.batchResultResponseRef
@@ -102,12 +104,42 @@ object SnapshotRouteContributor : RouteContributor {
                     componentContext.tooManyRequestsResponseRef()
                 )
             ),
+            aggregationSnapshotRoute(currentContext, aggregateRouteMetadata, componentContext, variant),
             listQuerySnapshotRoute(currentContext, aggregateRouteMetadata, componentContext, variant),
             listQuerySnapshotStateRoute(currentContext, aggregateRouteMetadata, componentContext, variant),
             pagedQuerySnapshotRoute(currentContext, aggregateRouteMetadata, componentContext, variant),
             pagedQuerySnapshotStateRoute(currentContext, aggregateRouteMetadata, componentContext, variant),
             singleSnapshotRoute(currentContext, aggregateRouteMetadata, componentContext, variant),
             singleSnapshotStateRoute(currentContext, aggregateRouteMetadata, componentContext, variant)
+        )
+    }
+
+    private fun aggregationSnapshotRoute(
+        currentContext: NamedBoundedContext,
+        aggregateRouteMetadata: AggregateRouteMetadata<*>,
+        componentContext: OpenAPIComponentContext,
+        variant: TenantOwnerVariant
+    ): HttpRouteContract {
+        return snapshotRoute(
+            currentContext = currentContext,
+            aggregateRouteMetadata = aggregateRouteMetadata,
+            componentContext = componentContext,
+            handlerKey = BuiltInHttpRouteHandlerKeys.Snapshot.AGGREGATION,
+            resourceName = SNAPSHOT,
+            operation = "aggregation",
+            operationSummary = "Aggregate Snapshot",
+            appendTenantPath = variant.appendTenantPath,
+            appendOwnerPath = variant.appendOwnerPath,
+            appendPathSuffix = "snapshot/aggregation",
+            accept = STREAMING_ACCEPT,
+            requestBody = componentContext.aggregatedAggregationQueryRequestBodyRef(
+                aggregateRouteMetadata.aggregateMetadata
+            ),
+            responses = listOf(
+                componentContext.aggregationResponse(),
+                componentContext.requestTimeoutResponseRef(),
+                componentContext.tooManyRequestsResponseRef()
+            )
         )
     }
 

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt
@@ -109,8 +109,28 @@ internal class ExampleDomainOpenAPITest {
             requestBody.content[Https.MediaType.APPLICATION_JSON]!!.schema.`$ref`
                 .assert().isEqualTo("#/components/schemas/wow.api.query.AggregationQuery")
             val querySchema = requireNotNull(openAPI.components.schemas["wow.api.query.AggregationQuery"])
+            val logicalFieldRef = "#/components/schemas/wow.api.query.LogicalField"
+            openAPI.components.schemas.getValue("wow.api.query.LogicalField").types
+                .assert().contains("string").doesNotContain("object")
             querySchema.properties.getValue("filter").`$ref`
                 .assert().isEqualTo("#/components/schemas/wow.api.query.FilterExpression")
+            openAPI.components.schemas.getValue("wow.api.query.AggregationMetric.Numeric")
+                .properties.getValue("expression").`$ref`
+                .assert().isEqualTo("#/components/schemas/wow.api.query.AggregationExpression.Field")
+            listOf(
+                querySchema.properties.getValue("elements").items.properties.getValue("path"),
+                openAPI.components.schemas.getValue("wow.api.query.AggregationExpression.Field")
+                    .properties.getValue("field"),
+                openAPI.components.schemas.getValue("wow.api.query.AggregationGroup").properties.getValue("field"),
+                openAPI.components.schemas.getValue("wow.api.query.AggregationGroup.DateHistogram")
+                    .properties.getValue("field"),
+                openAPI.components.schemas.getValue("wow.api.query.AggregationGroup.Histogram")
+                    .properties.getValue("field"),
+                openAPI.components.schemas.getValue("wow.api.query.AggregationGroup.Terms")
+                    .properties.getValue("field"),
+            ).forEach { fieldSchema ->
+                fieldSchema.`$ref`.assert().isEqualTo(logicalFieldRef)
+            }
             querySchema.required.assert().containsExactly("metrics")
             querySchema.properties.getValue("metrics").minItems.assert().isEqualTo(1)
             querySchema.properties.getValue("metrics").maxItems.assert().isEqualTo(64)

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt
@@ -105,7 +105,6 @@ internal class ExampleDomainOpenAPITest {
                     ?.get(Https.MediaType.APPLICATION_JSON)
                     ?.schema
             )
-
             queryFields.`$ref`.assert().isEqualTo("#/components/schemas/$fieldsKey")
             requestBody.content[Https.MediaType.APPLICATION_JSON]!!.schema.`$ref`
                 .assert().isEqualTo("#/components/schemas/wow.api.query.AggregationQuery")
@@ -144,7 +143,6 @@ internal class ExampleDomainOpenAPITest {
             responseSchema.type.assert().isEqualTo("array")
             responseSchema.items.type.assert().isEqualTo("object")
             (responseSchema.items.additionalProperties as Schema<*>).nullable.assert().isTrue()
-
             val aggregationRouteIds = catalogRoutes()
                 .filter { it.routeId.endsWith(".snapshot.aggregation") }
                 .map { it.routeId }
@@ -152,6 +150,22 @@ internal class ExampleDomainOpenAPITest {
                 .filter { it.routeId.endsWith(".snapshot.count") }
                 .map { it.routeId.removeSuffix("count") + "aggregation" }
             aggregationRouteIds.assert().containsExactlyInAnyOrder(*countRouteIds.toTypedArray())
+        }
+
+        @Test
+        fun `snapshot aggregation event stream should expose SSE envelopes`() {
+            val eventStreamSchema = requireNotNull(
+                openAPI.paths["/cart/snapshot/aggregation"]
+                    ?.post
+                    ?.responses
+                    ?.get("200")
+                    ?.content
+                    ?.get(Https.MediaType.TEXT_EVENT_STREAM)
+                    ?.schema
+            )
+
+            eventStreamSchema.items.properties.assert().containsKey("data")
+            eventStreamSchema.items.required.assert().contains("data")
         }
 
         @Test

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt
@@ -91,6 +91,47 @@ internal class ExampleDomainOpenAPITest {
         }
 
         @Test
+        fun `snapshot aggregation should reuse aggregate field schema and expose dynamic rows`() {
+            val fieldsKey = "example.cart.CartAggregatedFields"
+            val requestBody = requireNotNull(openAPI.components.requestBodies["example.cart.AggregationQuery"])
+            val queryFields = requestBody.extensions["x-wow-query-fields"] as Schema<*>
+            val responseSchema = requireNotNull(
+                openAPI.paths["/cart/snapshot/aggregation"]
+                    ?.post
+                    ?.responses
+                    ?.get("200")
+                    ?.content
+                    ?.get(Https.MediaType.APPLICATION_JSON)
+                    ?.schema
+            )
+
+            queryFields.`$ref`.assert().isEqualTo("#/components/schemas/$fieldsKey")
+            requestBody.content[Https.MediaType.APPLICATION_JSON]!!.schema.`$ref`
+                .assert().isEqualTo("#/components/schemas/wow.api.query.AggregationQuery")
+            val querySchema = requireNotNull(openAPI.components.schemas["wow.api.query.AggregationQuery"])
+            querySchema.properties.getValue("filter").`$ref`
+                .assert().isEqualTo("#/components/schemas/wow.api.query.FilterExpression")
+            querySchema.required.assert().containsExactly("metrics")
+            querySchema.properties.getValue("metrics").minItems.assert().isEqualTo(1)
+            querySchema.properties.getValue("metrics").maxItems.assert().isEqualTo(64)
+            querySchema.properties.getValue("elements").maxItems.assert().isEqualTo(5)
+            querySchema.properties.getValue("limit").minimum.assert().isEqualTo(java.math.BigDecimal.ONE)
+            querySchema.properties.getValue("limit").maximum.assert()
+                .isEqualTo(java.math.BigDecimal.valueOf(10_000))
+            responseSchema.type.assert().isEqualTo("array")
+            responseSchema.items.type.assert().isEqualTo("object")
+            (responseSchema.items.additionalProperties as Schema<*>).nullable.assert().isTrue()
+
+            val aggregationRouteIds = catalogRoutes()
+                .filter { it.routeId.endsWith(".snapshot.aggregation") }
+                .map { it.routeId }
+            val countRouteIds = catalogRoutes()
+                .filter { it.routeId.endsWith(".snapshot.count") }
+                .map { it.routeId.removeSuffix("count") + "aggregation" }
+            aggregationRouteIds.assert().containsExactlyInAnyOrder(*countRouteIds.toTypedArray())
+        }
+
+        @Test
         fun `should generate cart routes without default tenant path`() {
             // Cart has @StaticTenantId → default appendTenantPath=false
             // MockVariableCommand overrides with appendTenantPath=ALWAYS, so exclude it

--- a/wow-openapi/src/test/resources/openapi/example-domain-contract.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-contract.snapshot.json
@@ -26,6 +26,15 @@
   "responseCodes" : [ "200" ],
   "tagNames" : [ "customer", "example.cart" ]
 }, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "example.cart.snapshot.aggregation",
+  "method" : "POST",
+  "parameterNames" : [ ],
+  "path" : "/cart/snapshot/aggregation",
+  "requestBody" : true,
+  "responseCodes" : [ "200", "408", "429" ],
+  "tagNames" : [ "customer", "example.cart" ]
+}, {
   "accept" : [ "application/json" ],
   "id" : "example.cart.snapshot.count",
   "method" : "POST",
@@ -233,6 +242,15 @@
   "responseCodes" : [ "200", "404" ],
   "tagNames" : [ "customer", "example.cart" ]
 }, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "example.cart.owner.snapshot.aggregation",
+  "method" : "POST",
+  "parameterNames" : [ "ref:#/components/parameters/wow.ownerId" ],
+  "path" : "/owner/{ownerId}/cart/snapshot/aggregation",
+  "requestBody" : true,
+  "responseCodes" : [ "200", "408", "429" ],
+  "tagNames" : [ "customer", "example.cart" ]
+}, {
   "accept" : [ "application/json" ],
   "id" : "example.cart.owner.snapshot.count",
   "method" : "POST",
@@ -368,6 +386,15 @@
   "responseCodes" : [ "200" ],
   "tagNames" : [ "example.order" ]
 }, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "example.order.owner.snapshot.aggregation",
+  "method" : "POST",
+  "parameterNames" : [ "ref:#/components/parameters/wow.ownerId", "ref:#/components/parameters/wow.Wow-Space-Id" ],
+  "path" : "/owner/{ownerId}/sales-order/snapshot/aggregation",
+  "requestBody" : true,
+  "responseCodes" : [ "200", "408", "429" ],
+  "tagNames" : [ "example.order" ]
+}, {
   "accept" : [ "application/json" ],
   "id" : "example.order.owner.snapshot.count",
   "method" : "POST",
@@ -456,6 +483,15 @@
   "path" : "/sales-order/event/paged",
   "requestBody" : true,
   "responseCodes" : [ "200" ],
+  "tagNames" : [ "example.order" ]
+}, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "example.order.snapshot.aggregation",
+  "method" : "POST",
+  "parameterNames" : [ "ref:#/components/parameters/wow.Wow-Space-Id" ],
+  "path" : "/sales-order/snapshot/aggregation",
+  "requestBody" : true,
+  "responseCodes" : [ "200", "408", "429" ],
   "tagNames" : [ "example.order" ]
 }, {
   "accept" : [ "application/json" ],
@@ -566,6 +602,15 @@
   "responseCodes" : [ "200" ],
   "tagNames" : [ "tck.mock_aggregate" ]
 }, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "tck.mock_aggregate.snapshot.aggregation",
+  "method" : "POST",
+  "parameterNames" : [ ],
+  "path" : "/tck/mock_aggregate/snapshot/aggregation",
+  "requestBody" : true,
+  "responseCodes" : [ "200", "408", "429" ],
+  "tagNames" : [ "tck.mock_aggregate" ]
+}, {
   "accept" : [ "application/json" ],
   "id" : "tck.mock_aggregate.snapshot.count",
   "method" : "POST",
@@ -674,6 +719,15 @@
   "responseCodes" : [ "200" ],
   "tagNames" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
 }, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "tck.modeling_command_aggregate_with_tenant_id.snapshot.aggregation",
+  "method" : "POST",
+  "parameterNames" : [ ],
+  "path" : "/tck/modeling_command_aggregate_with_tenant_id/snapshot/aggregation",
+  "requestBody" : true,
+  "responseCodes" : [ "200", "408", "429" ],
+  "tagNames" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
+}, {
   "accept" : [ "application/json" ],
   "id" : "tck.modeling_command_aggregate_with_tenant_id.snapshot.count",
   "method" : "POST",
@@ -780,6 +834,15 @@
   "path" : "/tck/modeling_command_aggregate_without_ctor_parameters/event/paged",
   "requestBody" : true,
   "responseCodes" : [ "200" ],
+  "tagNames" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
+}, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "tck.modeling_command_aggregate_without_ctor_parameters.snapshot.aggregation",
+  "method" : "POST",
+  "parameterNames" : [ ],
+  "path" : "/tck/modeling_command_aggregate_without_ctor_parameters/snapshot/aggregation",
+  "requestBody" : true,
+  "responseCodes" : [ "200", "408", "429" ],
   "tagNames" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
 }, {
   "accept" : [ "application/json" ],
@@ -906,6 +969,15 @@
   "path" : "/tck/tenant/{tenantId}/mock_aggregate/mock_create_aggregate",
   "requestBody" : true,
   "responseCodes" : [ "200", "400", "404", "408", "409", "410", "429" ],
+  "tagNames" : [ "tck.mock_aggregate" ]
+}, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "tck.mock_aggregate.tenant.snapshot.aggregation",
+  "method" : "POST",
+  "parameterNames" : [ "ref:#/components/parameters/wow.tenantId" ],
+  "path" : "/tck/tenant/{tenantId}/mock_aggregate/snapshot/aggregation",
+  "requestBody" : true,
+  "responseCodes" : [ "200", "408", "429" ],
   "tagNames" : [ "tck.mock_aggregate" ]
 }, {
   "accept" : [ "application/json" ],
@@ -1106,6 +1178,15 @@
   "responseCodes" : [ "200" ],
   "tagNames" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
 }, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "tck.modeling_command_aggregate_with_tenant_id.tenant.snapshot.aggregation",
+  "method" : "POST",
+  "parameterNames" : [ "ref:#/components/parameters/wow.tenantId" ],
+  "path" : "/tck/tenant/{tenantId}/modeling_command_aggregate_with_tenant_id/snapshot/aggregation",
+  "requestBody" : true,
+  "responseCodes" : [ "200", "408", "429" ],
+  "tagNames" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
+}, {
   "accept" : [ "application/json" ],
   "id" : "tck.modeling_command_aggregate_with_tenant_id.tenant.snapshot.count",
   "method" : "POST",
@@ -1293,6 +1374,15 @@
   "path" : "/tck/tenant/{tenantId}/modeling_command_aggregate_without_ctor_parameters/event/paged",
   "requestBody" : true,
   "responseCodes" : [ "200" ],
+  "tagNames" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
+}, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "tck.modeling_command_aggregate_without_ctor_parameters.tenant.snapshot.aggregation",
+  "method" : "POST",
+  "parameterNames" : [ "ref:#/components/parameters/wow.tenantId" ],
+  "path" : "/tck/tenant/{tenantId}/modeling_command_aggregate_without_ctor_parameters/snapshot/aggregation",
+  "requestBody" : true,
+  "responseCodes" : [ "200", "408", "429" ],
   "tagNames" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
 }, {
   "accept" : [ "application/json" ],
@@ -1581,6 +1671,15 @@
   "path" : "/tenant/{tenantId}/sales-order/event/paged",
   "requestBody" : true,
   "responseCodes" : [ "200" ],
+  "tagNames" : [ "example.order" ]
+}, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "example.order.tenant.snapshot.aggregation",
+  "method" : "POST",
+  "parameterNames" : [ "ref:#/components/parameters/wow.tenantId", "ref:#/components/parameters/wow.Wow-Space-Id" ],
+  "path" : "/tenant/{tenantId}/sales-order/snapshot/aggregation",
+  "requestBody" : true,
+  "responseCodes" : [ "200", "408", "429" ],
   "tagNames" : [ "example.order" ]
 }, {
   "accept" : [ "application/json" ],

--- a/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
@@ -2983,7 +2983,7 @@
         "type" : "object"
       },
       "tck.mock_aggregate.MockCommandAggregateAggregatedFields" : {
-        "enum" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.data", "state.id", "state.orders", "state.orders.lines", "state.orders.lines.amount", "state.orders.lines.createdAt", "state.orders.lines.discounts", "state.orders.lines.discounts.amount", "state.orders.lines.discounts.type", "state.orders.lines.productId", "state.orders.lines.quantity", "state.orders.status", "tags", "tenantId", "version" ],
+        "enum" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.data", "state.decimalValue", "state.id", "state.orders", "state.orders.lines", "state.orders.lines.amount", "state.orders.lines.createdAt", "state.orders.lines.discounts", "state.orders.lines.discounts.amount", "state.orders.lines.discounts.type", "state.orders.lines.productId", "state.orders.lines.quantity", "state.orders.status", "tags", "tenantId", "version" ],
         "type" : "string"
       },
       "tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedDomainEventStream" : {
@@ -3374,6 +3374,9 @@
           "data" : {
             "type" : "string"
           },
+          "decimalValue" : {
+            "type" : "number"
+          },
           "id" : {
             "type" : "string"
           },
@@ -3588,6 +3591,9 @@
               "data" : {
                 "type" : "string"
               },
+              "decimalValue" : {
+                "type" : "number"
+              },
               "id" : {
                 "type" : "string"
               },
@@ -3732,6 +3738,9 @@
             "properties" : {
               "data" : {
                 "type" : "string"
+              },
+              "decimalValue" : {
+                "type" : "number"
               },
               "id" : {
                 "type" : "string"
@@ -5833,7 +5842,7 @@
         "type" : "string"
       },
       "wow.api.query.LogicalField" : {
-        "type" : "object"
+        "type" : "string"
       },
       "wow.api.query.Pagination" : {
         "properties" : {

--- a/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
@@ -267,6 +267,18 @@
       }
     },
     "requestBodies" : {
+      "example.cart.AggregationQuery" : {
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/wow.api.query.AggregationQuery"
+            }
+          }
+        },
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/example.cart.CartAggregatedFields"
+        }
+      },
       "example.cart.CountQuery" : {
         "content" : {
           "application/json" : {
@@ -370,6 +382,18 @@
         },
         "x-wow-query-fields" : {
           "$ref" : "#/components/schemas/example.cart.CartAggregatedFields"
+        }
+      },
+      "example.order.AggregationQuery" : {
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/wow.api.query.AggregationQuery"
+            }
+          }
+        },
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/example.order.OrderAggregatedFields"
         }
       },
       "example.order.CountQuery" : {
@@ -477,6 +501,18 @@
           "$ref" : "#/components/schemas/example.order.OrderAggregatedFields"
         }
       },
+      "tck.mock_aggregate.AggregationQuery" : {
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/wow.api.query.AggregationQuery"
+            }
+          }
+        },
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedFields"
+        }
+      },
       "tck.mock_aggregate.CountQuery" : {
         "content" : {
           "application/json" : {
@@ -582,6 +618,18 @@
           "$ref" : "#/components/schemas/tck.mock_aggregate.MockCommandAggregateAggregatedFields"
         }
       },
+      "tck.modeling_command_aggregate_with_tenant_id.AggregationQuery" : {
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/wow.api.query.AggregationQuery"
+            }
+          }
+        },
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/tck.modeling_command_aggregate_with_tenant_id.MockCommandAggregateWithTenantIdAggregatedFields"
+        }
+      },
       "tck.modeling_command_aggregate_with_tenant_id.CountQuery" : {
         "content" : {
           "application/json" : {
@@ -685,6 +733,18 @@
         },
         "x-wow-query-fields" : {
           "$ref" : "#/components/schemas/tck.modeling_command_aggregate_with_tenant_id.MockCommandAggregateWithTenantIdAggregatedFields"
+        }
+      },
+      "tck.modeling_command_aggregate_without_ctor_parameters.AggregationQuery" : {
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/wow.api.query.AggregationQuery"
+            }
+          }
+        },
+        "x-wow-query-fields" : {
+          "$ref" : "#/components/schemas/tck.modeling_command_aggregate_without_ctor_parameters.MockCommandAggregateWithoutCtorParametersAggregatedFields"
         }
       },
       "tck.modeling_command_aggregate_without_ctor_parameters.CountQuery" : {
@@ -2923,7 +2983,7 @@
         "type" : "object"
       },
       "tck.mock_aggregate.MockCommandAggregateAggregatedFields" : {
-        "enum" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.data", "state.id", "tags", "tenantId", "version" ],
+        "enum" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.data", "state.id", "state.orders", "state.orders.lines", "state.orders.lines.amount", "state.orders.lines.createdAt", "state.orders.lines.discounts", "state.orders.lines.discounts.amount", "state.orders.lines.discounts.type", "state.orders.lines.productId", "state.orders.lines.quantity", "state.orders.status", "tags", "tenantId", "version" ],
         "type" : "string"
       },
       "tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedDomainEventStream" : {
@@ -3250,6 +3310,65 @@
         "required" : [ "data", "id" ],
         "type" : "object"
       },
+      "tck.mock_aggregate.MockDiscount" : {
+        "properties" : {
+          "amount" : {
+            "format" : "double",
+            "type" : "number"
+          },
+          "type" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "amount", "type" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockLine" : {
+        "properties" : {
+          "amount" : {
+            "anyOf" : [ {
+              "type" : "null"
+            }, {
+              "format" : "double",
+              "type" : "number"
+            } ]
+          },
+          "createdAt" : {
+            "format" : "date-time",
+            "type" : "string"
+          },
+          "discounts" : {
+            "items" : {
+              "$ref" : "#/components/schemas/tck.mock_aggregate.MockDiscount"
+            },
+            "type" : "array"
+          },
+          "productId" : {
+            "type" : "string"
+          },
+          "quantity" : {
+            "format" : "int32",
+            "type" : "integer"
+          }
+        },
+        "required" : [ "amount", "createdAt", "discounts", "productId", "quantity" ],
+        "type" : "object"
+      },
+      "tck.mock_aggregate.MockOrder" : {
+        "properties" : {
+          "lines" : {
+            "items" : {
+              "$ref" : "#/components/schemas/tck.mock_aggregate.MockLine"
+            },
+            "type" : "array"
+          },
+          "status" : {
+            "type" : "string"
+          }
+        },
+        "required" : [ "lines", "status" ],
+        "type" : "object"
+      },
       "tck.mock_aggregate.MockStateAggregate" : {
         "properties" : {
           "data" : {
@@ -3257,6 +3376,12 @@
           },
           "id" : {
             "type" : "string"
+          },
+          "orders" : {
+            "items" : {
+              "$ref" : "#/components/schemas/tck.mock_aggregate.MockOrder"
+            },
+            "type" : "array"
           }
         },
         "required" : [ "id" ],
@@ -3465,6 +3590,12 @@
               },
               "id" : {
                 "type" : "string"
+              },
+              "orders" : {
+                "items" : {
+                  "$ref" : "#/components/schemas/tck.mock_aggregate.MockOrder"
+                },
+                "type" : "array"
               }
             },
             "required" : [ "id" ],
@@ -3604,6 +3735,12 @@
               },
               "id" : {
                 "type" : "string"
+              },
+              "orders" : {
+                "items" : {
+                  "$ref" : "#/components/schemas/tck.mock_aggregate.MockOrder"
+                },
+                "type" : "array"
               }
             },
             "required" : [ "id" ],
@@ -4476,6 +4613,200 @@
           }
         },
         "required" : [ "aggregateId", "aggregateName", "contextName", "tenantId" ],
+        "type" : "object"
+      },
+      "wow.api.query.AggregationDateUnit" : {
+        "enum" : [ "YEAR", "QUARTER", "MONTH", "WEEK", "DAY", "HOUR", "MINUTE", "SECOND" ],
+        "type" : "string"
+      },
+      "wow.api.query.AggregationExpression.Field" : {
+        "properties" : {
+          "field" : {
+            "$ref" : "#/components/schemas/wow.api.query.LogicalField"
+          },
+          "type" : {
+            "const" : "FIELD"
+          }
+        },
+        "required" : [ "field" ],
+        "type" : "object"
+      },
+      "wow.api.query.AggregationFunction" : {
+        "enum" : [ "SUM", "AVG", "MIN", "MAX" ],
+        "type" : "string"
+      },
+      "wow.api.query.AggregationGroup" : {
+        "anyOf" : [ {
+          "$ref" : "#/components/schemas/wow.api.query.AggregationGroup.DateHistogram"
+        }, {
+          "$ref" : "#/components/schemas/wow.api.query.AggregationGroup.Histogram"
+        }, {
+          "$ref" : "#/components/schemas/wow.api.query.AggregationGroup.Terms"
+        } ],
+        "properties" : {
+          "alias" : {
+            "readOnly" : true,
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/wow.api.query.LogicalField",
+            "readOnly" : true
+          }
+        }
+      },
+      "wow.api.query.AggregationGroup.DateHistogram" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/wow.api.query.LogicalField"
+          },
+          "timeZone" : {
+            "type" : "string"
+          },
+          "type" : {
+            "const" : "DATE_HISTOGRAM"
+          },
+          "unit" : {
+            "$ref" : "#/components/schemas/wow.api.query.AggregationDateUnit"
+          }
+        },
+        "required" : [ "alias", "field", "type", "unit" ],
+        "type" : "object"
+      },
+      "wow.api.query.AggregationGroup.Histogram" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/wow.api.query.LogicalField"
+          },
+          "interval" : {
+            "exclusiveMinimum" : 0,
+            "format" : "double",
+            "type" : "number"
+          },
+          "type" : {
+            "const" : "HISTOGRAM"
+          }
+        },
+        "required" : [ "alias", "field", "interval", "type" ],
+        "type" : "object"
+      },
+      "wow.api.query.AggregationGroup.Terms" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/wow.api.query.LogicalField"
+          },
+          "type" : {
+            "const" : "TERMS"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
+      "wow.api.query.AggregationMetric" : {
+        "anyOf" : [ {
+          "$ref" : "#/components/schemas/wow.api.query.AggregationMetric.Count"
+        }, {
+          "$ref" : "#/components/schemas/wow.api.query.AggregationMetric.Numeric"
+        } ],
+        "properties" : {
+          "alias" : {
+            "readOnly" : true,
+            "type" : "string"
+          }
+        }
+      },
+      "wow.api.query.AggregationMetric.Count" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "type" : {
+            "const" : "COUNT"
+          }
+        },
+        "required" : [ "alias", "type" ],
+        "type" : "object"
+      },
+      "wow.api.query.AggregationMetric.Numeric" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/components/schemas/wow.api.query.AggregationExpression.Field"
+          },
+          "function" : {
+            "$ref" : "#/components/schemas/wow.api.query.AggregationFunction"
+          },
+          "type" : {
+            "const" : "NUMERIC"
+          }
+        },
+        "required" : [ "alias", "expression", "function", "type" ],
+        "type" : "object"
+      },
+      "wow.api.query.AggregationQuery" : {
+        "additionalProperties" : false,
+        "properties" : {
+          "elements" : {
+            "items" : {
+              "additionalProperties" : false,
+              "properties" : {
+                "filter" : {
+                  "$ref" : "#/components/schemas/wow.api.query.FilterExpression"
+                },
+                "path" : {
+                  "$ref" : "#/components/schemas/wow.api.query.LogicalField"
+                }
+              },
+              "required" : [ "path" ],
+              "type" : "object"
+            },
+            "maxItems" : 5,
+            "type" : "array"
+          },
+          "filter" : {
+            "$ref" : "#/components/schemas/wow.api.query.FilterExpression"
+          },
+          "groupBy" : {
+            "items" : {
+              "$ref" : "#/components/schemas/wow.api.query.AggregationGroup"
+            },
+            "maxItems" : 32,
+            "type" : "array"
+          },
+          "limit" : {
+            "default" : 100,
+            "format" : "int32",
+            "maximum" : 10000,
+            "minimum" : 1,
+            "type" : "integer"
+          },
+          "metrics" : {
+            "items" : {
+              "$ref" : "#/components/schemas/wow.api.query.AggregationMetric"
+            },
+            "maxItems" : 64,
+            "minItems" : 1,
+            "type" : "array"
+          },
+          "sort" : {
+            "items" : {
+              "$ref" : "#/components/schemas/wow.api.query.Sort"
+            },
+            "maxItems" : 32,
+            "type" : "array"
+          }
+        },
+        "required" : [ "metrics" ],
         "type" : "object"
       },
       "wow.api.query.FilterExpression" : {
@@ -5501,6 +5832,9 @@
         "enum" : [ "MATCH_ALL", "MATCH_NONE", "ID", "IDS", "AGGREGATE_ID", "AGGREGATE_IDS", "TENANT_ID", "OWNER_ID", "SPACE_ID", "AND", "OR", "NOR", "EQ", "NE", "GT", "GTE", "LT", "LTE", "CONTAINS", "STARTS_WITH", "ENDS_WITH", "IN", "NOT_IN", "BETWEEN", "CONTAINS_ALL", "IS_EMPTY", "IS_NULL", "IS_NOT_NULL", "EXISTS", "NOT_EXISTS", "DELETION", "ELEMENT_MATCH", "SEARCH", "TODAY", "BEFORE_TODAY", "TOMORROW", "THIS_WEEK", "NEXT_WEEK", "LAST_WEEK", "THIS_MONTH", "LAST_MONTH", "RECENT_DAYS", "EARLIER_DAYS" ],
         "type" : "string"
       },
+      "wow.api.query.LogicalField" : {
+        "type" : "object"
+      },
       "wow.api.query.Pagination" : {
         "properties" : {
           "index" : {
@@ -6058,6 +6392,51 @@
                 "$ref" : "#/components/headers/wow.Wow-Error-Code"
               }
             }
+          }
+        },
+        "tags" : [ "example.cart", "customer" ]
+      }
+    },
+    "/cart/snapshot/aggregation" : {
+      "post" : {
+        "operationId" : "example.cart.snapshot.aggregation",
+        "parameters" : [ ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/example.cart.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          },
+          "408" : {
+            "$ref" : "#/components/responses/wow.RequestTimeout"
+          },
+          "429" : {
+            "$ref" : "#/components/responses/wow.TooManyRequests"
           }
         },
         "tags" : [ "example.cart", "customer" ]
@@ -6943,6 +7322,53 @@
         "tags" : [ "example.cart", "customer" ]
       }
     },
+    "/owner/{ownerId}/cart/snapshot/aggregation" : {
+      "post" : {
+        "operationId" : "example.cart.owner.snapshot.aggregation",
+        "parameters" : [ {
+          "$ref" : "#/components/parameters/wow.ownerId"
+        } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/example.cart.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          },
+          "408" : {
+            "$ref" : "#/components/responses/wow.RequestTimeout"
+          },
+          "429" : {
+            "$ref" : "#/components/responses/wow.TooManyRequests"
+          }
+        },
+        "tags" : [ "example.cart", "customer" ]
+      }
+    },
     "/owner/{ownerId}/cart/snapshot/count" : {
       "post" : {
         "operationId" : "example.cart.owner.snapshot.count",
@@ -7487,6 +7913,55 @@
         "tags" : [ "example.order" ]
       }
     },
+    "/owner/{ownerId}/sales-order/snapshot/aggregation" : {
+      "post" : {
+        "operationId" : "example.order.owner.snapshot.aggregation",
+        "parameters" : [ {
+          "$ref" : "#/components/parameters/wow.Wow-Space-Id"
+        }, {
+          "$ref" : "#/components/parameters/wow.ownerId"
+        } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/example.order.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          },
+          "408" : {
+            "$ref" : "#/components/responses/wow.RequestTimeout"
+          },
+          "429" : {
+            "$ref" : "#/components/responses/wow.TooManyRequests"
+          }
+        },
+        "tags" : [ "example.order" ]
+      }
+    },
     "/owner/{ownerId}/sales-order/snapshot/count" : {
       "post" : {
         "operationId" : "example.order.owner.snapshot.count",
@@ -7799,6 +8274,53 @@
                 "$ref" : "#/components/headers/wow.Wow-Error-Code"
               }
             }
+          }
+        },
+        "tags" : [ "example.order" ]
+      }
+    },
+    "/sales-order/snapshot/aggregation" : {
+      "post" : {
+        "operationId" : "example.order.snapshot.aggregation",
+        "parameters" : [ {
+          "$ref" : "#/components/parameters/wow.Wow-Space-Id"
+        } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/example.order.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          },
+          "408" : {
+            "$ref" : "#/components/responses/wow.RequestTimeout"
+          },
+          "429" : {
+            "$ref" : "#/components/responses/wow.TooManyRequests"
           }
         },
         "tags" : [ "example.order" ]
@@ -8143,6 +8665,51 @@
         "tags" : [ "tck.mock_aggregate" ]
       }
     },
+    "/tck/mock_aggregate/snapshot/aggregation" : {
+      "post" : {
+        "operationId" : "tck.mock_aggregate.snapshot.aggregation",
+        "parameters" : [ ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/tck.mock_aggregate.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          },
+          "408" : {
+            "$ref" : "#/components/responses/wow.RequestTimeout"
+          },
+          "429" : {
+            "$ref" : "#/components/responses/wow.TooManyRequests"
+          }
+        },
+        "tags" : [ "tck.mock_aggregate" ]
+      }
+    },
     "/tck/mock_aggregate/snapshot/count" : {
       "post" : {
         "operationId" : "tck.mock_aggregate.snapshot.count",
@@ -8464,6 +9031,51 @@
         "tags" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
       }
     },
+    "/tck/modeling_command_aggregate_with_tenant_id/snapshot/aggregation" : {
+      "post" : {
+        "operationId" : "tck.modeling_command_aggregate_with_tenant_id.snapshot.aggregation",
+        "parameters" : [ ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/tck.modeling_command_aggregate_with_tenant_id.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          },
+          "408" : {
+            "$ref" : "#/components/responses/wow.RequestTimeout"
+          },
+          "429" : {
+            "$ref" : "#/components/responses/wow.TooManyRequests"
+          }
+        },
+        "tags" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
+      }
+    },
     "/tck/modeling_command_aggregate_with_tenant_id/snapshot/count" : {
       "post" : {
         "operationId" : "tck.modeling_command_aggregate_with_tenant_id.snapshot.count",
@@ -8780,6 +9392,51 @@
                 "$ref" : "#/components/headers/wow.Wow-Error-Code"
               }
             }
+          }
+        },
+        "tags" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
+      }
+    },
+    "/tck/modeling_command_aggregate_without_ctor_parameters/snapshot/aggregation" : {
+      "post" : {
+        "operationId" : "tck.modeling_command_aggregate_without_ctor_parameters.snapshot.aggregation",
+        "parameters" : [ ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/tck.modeling_command_aggregate_without_ctor_parameters.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          },
+          "408" : {
+            "$ref" : "#/components/responses/wow.RequestTimeout"
+          },
+          "429" : {
+            "$ref" : "#/components/responses/wow.TooManyRequests"
           }
         },
         "tags" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
@@ -9245,6 +9902,53 @@
           },
           "429" : {
             "$ref" : "#/components/responses/wow.CommandTooManyRequests"
+          }
+        },
+        "tags" : [ "tck.mock_aggregate" ]
+      }
+    },
+    "/tck/tenant/{tenantId}/mock_aggregate/snapshot/aggregation" : {
+      "post" : {
+        "operationId" : "tck.mock_aggregate.tenant.snapshot.aggregation",
+        "parameters" : [ {
+          "$ref" : "#/components/parameters/wow.tenantId"
+        } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/tck.mock_aggregate.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          },
+          "408" : {
+            "$ref" : "#/components/responses/wow.RequestTimeout"
+          },
+          "429" : {
+            "$ref" : "#/components/responses/wow.TooManyRequests"
           }
         },
         "tags" : [ "tck.mock_aggregate" ]
@@ -10087,6 +10791,53 @@
         "tags" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
       }
     },
+    "/tck/tenant/{tenantId}/modeling_command_aggregate_with_tenant_id/snapshot/aggregation" : {
+      "post" : {
+        "operationId" : "tck.modeling_command_aggregate_with_tenant_id.tenant.snapshot.aggregation",
+        "parameters" : [ {
+          "$ref" : "#/components/parameters/wow.tenantId"
+        } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/tck.modeling_command_aggregate_with_tenant_id.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          },
+          "408" : {
+            "$ref" : "#/components/responses/wow.RequestTimeout"
+          },
+          "429" : {
+            "$ref" : "#/components/responses/wow.TooManyRequests"
+          }
+        },
+        "tags" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
+      }
+    },
     "/tck/tenant/{tenantId}/modeling_command_aggregate_with_tenant_id/snapshot/count" : {
       "post" : {
         "operationId" : "tck.modeling_command_aggregate_with_tenant_id.tenant.snapshot.count",
@@ -10848,6 +11599,53 @@
                 "$ref" : "#/components/headers/wow.Wow-Error-Code"
               }
             }
+          }
+        },
+        "tags" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
+      }
+    },
+    "/tck/tenant/{tenantId}/modeling_command_aggregate_without_ctor_parameters/snapshot/aggregation" : {
+      "post" : {
+        "operationId" : "tck.modeling_command_aggregate_without_ctor_parameters.tenant.snapshot.aggregation",
+        "parameters" : [ {
+          "$ref" : "#/components/parameters/wow.tenantId"
+        } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/tck.modeling_command_aggregate_without_ctor_parameters.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          },
+          "408" : {
+            "$ref" : "#/components/responses/wow.RequestTimeout"
+          },
+          "429" : {
+            "$ref" : "#/components/responses/wow.TooManyRequests"
           }
         },
         "tags" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
@@ -12324,6 +13122,55 @@
                 "$ref" : "#/components/headers/wow.Wow-Error-Code"
               }
             }
+          }
+        },
+        "tags" : [ "example.order" ]
+      }
+    },
+    "/tenant/{tenantId}/sales-order/snapshot/aggregation" : {
+      "post" : {
+        "operationId" : "example.order.tenant.snapshot.aggregation",
+        "parameters" : [ {
+          "$ref" : "#/components/parameters/wow.Wow-Space-Id"
+        }, {
+          "$ref" : "#/components/parameters/wow.tenantId"
+        } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/example.order.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          },
+          "408" : {
+            "$ref" : "#/components/responses/wow.RequestTimeout"
+          },
+          "429" : {
+            "$ref" : "#/components/responses/wow.TooManyRequests"
           }
         },
         "tags" : [ "example.order" ]

--- a/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
@@ -6142,7 +6142,23 @@
               "text/event-stream" : {
                 "schema" : {
                   "items" : {
-                    "additionalProperties" : { },
+                    "properties" : {
+                      "data" : {
+                        "additionalProperties" : { },
+                        "type" : "object"
+                      },
+                      "event" : {
+                        "type" : "string"
+                      },
+                      "id" : {
+                        "type" : "string"
+                      },
+                      "retry" : {
+                        "format" : "int32",
+                        "type" : "integer"
+                      }
+                    },
+                    "required" : [ "data" ],
                     "type" : "object"
                   },
                   "type" : "array"
@@ -7069,7 +7085,23 @@
               "text/event-stream" : {
                 "schema" : {
                   "items" : {
-                    "additionalProperties" : { },
+                    "properties" : {
+                      "data" : {
+                        "additionalProperties" : { },
+                        "type" : "object"
+                      },
+                      "event" : {
+                        "type" : "string"
+                      },
+                      "id" : {
+                        "type" : "string"
+                      },
+                      "retry" : {
+                        "format" : "int32",
+                        "type" : "integer"
+                      }
+                    },
+                    "required" : [ "data" ],
                     "type" : "object"
                   },
                   "type" : "array"
@@ -7662,7 +7694,23 @@
               "text/event-stream" : {
                 "schema" : {
                   "items" : {
-                    "additionalProperties" : { },
+                    "properties" : {
+                      "data" : {
+                        "additionalProperties" : { },
+                        "type" : "object"
+                      },
+                      "event" : {
+                        "type" : "string"
+                      },
+                      "id" : {
+                        "type" : "string"
+                      },
+                      "retry" : {
+                        "format" : "int32",
+                        "type" : "integer"
+                      }
+                    },
+                    "required" : [ "data" ],
                     "type" : "object"
                   },
                   "type" : "array"
@@ -8026,7 +8074,23 @@
               "text/event-stream" : {
                 "schema" : {
                   "items" : {
-                    "additionalProperties" : { },
+                    "properties" : {
+                      "data" : {
+                        "additionalProperties" : { },
+                        "type" : "object"
+                      },
+                      "event" : {
+                        "type" : "string"
+                      },
+                      "id" : {
+                        "type" : "string"
+                      },
+                      "retry" : {
+                        "format" : "int32",
+                        "type" : "integer"
+                      }
+                    },
+                    "required" : [ "data" ],
                     "type" : "object"
                   },
                   "type" : "array"
@@ -8410,7 +8474,23 @@
               "text/event-stream" : {
                 "schema" : {
                   "items" : {
-                    "additionalProperties" : { },
+                    "properties" : {
+                      "data" : {
+                        "additionalProperties" : { },
+                        "type" : "object"
+                      },
+                      "event" : {
+                        "type" : "string"
+                      },
+                      "id" : {
+                        "type" : "string"
+                      },
+                      "retry" : {
+                        "format" : "int32",
+                        "type" : "integer"
+                      }
+                    },
+                    "required" : [ "data" ],
                     "type" : "object"
                   },
                   "type" : "array"
@@ -8776,7 +8856,23 @@
               "text/event-stream" : {
                 "schema" : {
                   "items" : {
-                    "additionalProperties" : { },
+                    "properties" : {
+                      "data" : {
+                        "additionalProperties" : { },
+                        "type" : "object"
+                      },
+                      "event" : {
+                        "type" : "string"
+                      },
+                      "id" : {
+                        "type" : "string"
+                      },
+                      "retry" : {
+                        "format" : "int32",
+                        "type" : "integer"
+                      }
+                    },
+                    "required" : [ "data" ],
                     "type" : "object"
                   },
                   "type" : "array"
@@ -9142,7 +9238,23 @@
               "text/event-stream" : {
                 "schema" : {
                   "items" : {
-                    "additionalProperties" : { },
+                    "properties" : {
+                      "data" : {
+                        "additionalProperties" : { },
+                        "type" : "object"
+                      },
+                      "event" : {
+                        "type" : "string"
+                      },
+                      "id" : {
+                        "type" : "string"
+                      },
+                      "retry" : {
+                        "format" : "int32",
+                        "type" : "integer"
+                      }
+                    },
+                    "required" : [ "data" ],
                     "type" : "object"
                   },
                   "type" : "array"
@@ -9654,7 +9766,23 @@
               "text/event-stream" : {
                 "schema" : {
                   "items" : {
-                    "additionalProperties" : { },
+                    "properties" : {
+                      "data" : {
+                        "additionalProperties" : { },
+                        "type" : "object"
+                      },
+                      "event" : {
+                        "type" : "string"
+                      },
+                      "id" : {
+                        "type" : "string"
+                      },
+                      "retry" : {
+                        "format" : "int32",
+                        "type" : "integer"
+                      }
+                    },
+                    "required" : [ "data" ],
                     "type" : "object"
                   },
                   "type" : "array"
@@ -10538,7 +10666,23 @@
               "text/event-stream" : {
                 "schema" : {
                   "items" : {
-                    "additionalProperties" : { },
+                    "properties" : {
+                      "data" : {
+                        "additionalProperties" : { },
+                        "type" : "object"
+                      },
+                      "event" : {
+                        "type" : "string"
+                      },
+                      "id" : {
+                        "type" : "string"
+                      },
+                      "retry" : {
+                        "format" : "int32",
+                        "type" : "integer"
+                      }
+                    },
+                    "required" : [ "data" ],
                     "type" : "object"
                   },
                   "type" : "array"
@@ -11351,7 +11495,23 @@
               "text/event-stream" : {
                 "schema" : {
                   "items" : {
-                    "additionalProperties" : { },
+                    "properties" : {
+                      "data" : {
+                        "additionalProperties" : { },
+                        "type" : "object"
+                      },
+                      "event" : {
+                        "type" : "string"
+                      },
+                      "id" : {
+                        "type" : "string"
+                      },
+                      "retry" : {
+                        "format" : "int32",
+                        "type" : "integer"
+                      }
+                    },
+                    "required" : [ "data" ],
                     "type" : "object"
                   },
                   "type" : "array"
@@ -12876,7 +13036,23 @@
               "text/event-stream" : {
                 "schema" : {
                   "items" : {
-                    "additionalProperties" : { },
+                    "properties" : {
+                      "data" : {
+                        "additionalProperties" : { },
+                        "type" : "object"
+                      },
+                      "event" : {
+                        "type" : "string"
+                      },
+                      "id" : {
+                        "type" : "string"
+                      },
+                      "retry" : {
+                        "format" : "int32",
+                        "type" : "integer"
+                      }
+                    },
+                    "required" : [ "data" ],
                     "type" : "object"
                   },
                   "type" : "array"

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDsl.kt
@@ -24,6 +24,8 @@ import me.ahoo.wow.api.query.FilterExpression
 import me.ahoo.wow.api.query.LogicalField
 import me.ahoo.wow.api.query.MatchAllFilter
 import me.ahoo.wow.api.query.Sort
+import java.time.ZoneId
+import java.time.ZoneOffset
 
 @QueryDslMarker
 class AggregationQueryDsl {
@@ -52,12 +54,17 @@ class AggregationQueryDsl {
         groups += AggregationGroup.Terms(LogicalField(field), alias)
     }
 
-    fun histogram(field: String, alias: String, interval: Double) {
+    fun histogram(field: String, interval: Double, alias: String) {
         groups += AggregationGroup.Histogram(LogicalField(field), alias, interval)
     }
 
-    fun dateHistogram(field: String, alias: String, unit: AggregationDateUnit, timeZone: String = "UTC") {
-        groups += AggregationGroup.DateHistogram(LogicalField(field), alias, unit, timeZone)
+    fun dateHistogram(
+        field: String,
+        unit: AggregationDateUnit,
+        alias: String,
+        timeZone: ZoneId = ZoneOffset.UTC,
+    ) {
+        groups += AggregationGroup.DateHistogram(LogicalField(field), alias, unit, timeZone.id)
     }
 
     fun count(alias: String) {

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDsl.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.dsl
+
+import me.ahoo.wow.api.query.AggregationDateUnit
+import me.ahoo.wow.api.query.AggregationElement
+import me.ahoo.wow.api.query.AggregationExpression
+import me.ahoo.wow.api.query.AggregationFunction
+import me.ahoo.wow.api.query.AggregationGroup
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.FilterExpression
+import me.ahoo.wow.api.query.LogicalField
+import me.ahoo.wow.api.query.MatchAllFilter
+import me.ahoo.wow.api.query.Sort
+
+@QueryDslMarker
+class AggregationQueryDsl {
+    private var filter: FilterExpression = MatchAllFilter
+    private val elements = mutableListOf<AggregationElement>()
+    private val groups = mutableListOf<AggregationGroup>()
+    private val metrics = mutableListOf<AggregationMetric>()
+    private var sort: List<Sort> = emptyList()
+    private var limit: Int = AggregationQuery.DEFAULT_LIMIT
+
+    fun filter(filter: FilterExpression) {
+        this.filter = filter
+    }
+
+    fun filter(block: FilterDsl.() -> Unit) {
+        filter(me.ahoo.wow.query.dsl.filter(block))
+    }
+
+    fun expand(path: String) = elements.add(AggregationElement(LogicalField(path)))
+
+    fun expand(path: String, block: FilterDsl.() -> Unit) = elements.add(
+        AggregationElement(LogicalField(path), me.ahoo.wow.query.dsl.filter(block)),
+    )
+
+    fun terms(field: String, alias: String) {
+        groups += AggregationGroup.Terms(LogicalField(field), alias)
+    }
+
+    fun histogram(field: String, alias: String, interval: Double) {
+        groups += AggregationGroup.Histogram(LogicalField(field), alias, interval)
+    }
+
+    fun dateHistogram(field: String, alias: String, unit: AggregationDateUnit, timeZone: String = "UTC") {
+        groups += AggregationGroup.DateHistogram(LogicalField(field), alias, unit, timeZone)
+    }
+
+    fun count(alias: String) {
+        metrics += AggregationMetric.Count(alias)
+    }
+
+    fun sum(field: String, alias: String) = numeric(AggregationFunction.SUM, field, alias)
+
+    fun avg(field: String, alias: String) = numeric(AggregationFunction.AVG, field, alias)
+
+    fun min(field: String, alias: String) = numeric(AggregationFunction.MIN, field, alias)
+
+    fun max(field: String, alias: String) = numeric(AggregationFunction.MAX, field, alias)
+
+    private fun numeric(function: AggregationFunction, field: String, alias: String) {
+        metrics += AggregationMetric.Numeric(
+            function,
+            AggregationExpression.Field(LogicalField(field)),
+            alias,
+        )
+    }
+
+    fun sort(sort: List<Sort>) {
+        this.sort = sort
+    }
+
+    fun sort(block: SortDsl.() -> Unit) {
+        sort(me.ahoo.wow.query.dsl.sort(block))
+    }
+
+    fun limit(limit: Int) {
+        this.limit = limit
+    }
+
+    fun build(): AggregationQuery = AggregationQuery(filter, elements, groups, metrics, sort, limit)
+}

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/Dsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/Dsl.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.query.dsl
 
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.FilterExpression
 import me.ahoo.wow.api.query.IListQuery
@@ -64,6 +65,12 @@ fun listQuery(block: ListQueryDsl.() -> Unit): IListQuery {
  */
 fun pagedQuery(block: PagedQueryDsl.() -> Unit): IPagedQuery {
     val dsl = PagedQueryDsl()
+    dsl.block()
+    return dsl.build()
+}
+
+fun aggregation(block: AggregationQueryDsl.() -> Unit): AggregationQuery {
+    val dsl = AggregationQueryDsl()
     dsl.block()
     return dsl.build()
 }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/event/filter/EventStreamQueryFilter.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/event/filter/EventStreamQueryFilter.kt
@@ -85,6 +85,8 @@ class TailEventStreamQueryFilter(private val queryServiceFactory: EventStreamQue
                 }
                 context.asCountQuery().setResult(result)
             }
+
+            QueryType.AGGREGATION -> error("Event stream query does not support aggregation.")
         }
         return next.filter(context)
     }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/filter/QueryContext.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/filter/QueryContext.kt
@@ -14,6 +14,8 @@
 package me.ahoo.wow.query.filter
 
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.FilterExpression
 import me.ahoo.wow.api.query.IListQuery
 import me.ahoo.wow.api.query.IPagedQuery
@@ -91,6 +93,10 @@ interface QueryContext<Q : Any, R : Any> {
 
     fun asCountQuery(): QueryContext<FilterExpression, Mono<Long>> {
         return this as QueryContext<FilterExpression, Mono<Long>>
+    }
+
+    fun asAggregationQuery(): QueryContext<AggregationQuery, Flux<DynamicDocument>> {
+        return this as QueryContext<AggregationQuery, Flux<DynamicDocument>>
     }
 }
 

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/filter/QueryHandler.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/filter/QueryHandler.kt
@@ -66,7 +66,7 @@ abstract class AbstractQueryHandler<R : Any>(
         handle(context).then(Mono.defer { context.getRequiredResult() })
     }
 
-    private fun <Q : Any, T : Any> flux(
+    protected fun <Q : Any, T : Any> flux(
         namedAggregate: NamedAggregate,
         queryType: QueryType,
         query: Q,

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/filter/QueryType.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/filter/QueryType.kt
@@ -21,4 +21,5 @@ enum class QueryType(val isDynamic: Boolean) {
     PAGED(false),
     DYNAMIC_PAGED(true),
     COUNT(false),
+    AGGREGATION(true),
 }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/QueryDsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/QueryDsl.kt
@@ -13,8 +13,8 @@
 
 package me.ahoo.wow.query.snapshot
 
-import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.FilterExpression
 import me.ahoo.wow.api.query.IListQuery

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/QueryDsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/QueryDsl.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.query.snapshot
 
 import me.ahoo.wow.api.query.Condition
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.FilterExpression
 import me.ahoo.wow.api.query.IListQuery
@@ -62,6 +63,10 @@ fun ISingleQuery.dynamicQuery(queryService: SnapshotQueryService<*>): Mono<Dynam
 
 fun FilterExpression.count(queryService: SnapshotQueryService<*>): Mono<Long> {
     return queryService.count(this)
+}
+
+fun AggregationQuery.query(queryService: SnapshotQueryService<*>): Flux<DynamicDocument> {
+    return queryService.aggregate(this)
 }
 
 @Deprecated("Use FilterExpression.count.")

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/SnapshotQueryService.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/SnapshotQueryService.kt
@@ -15,6 +15,7 @@ package me.ahoo.wow.query.snapshot
 
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.api.naming.Named
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.IListQuery
 import me.ahoo.wow.api.query.IPagedQuery
@@ -26,7 +27,10 @@ import me.ahoo.wow.query.QueryService
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
-interface SnapshotQueryService<S : Any> : Named, QueryService<MaterializedSnapshot<S>>
+interface SnapshotQueryService<S : Any> : Named, QueryService<MaterializedSnapshot<S>> {
+    fun aggregate(query: AggregationQuery): Flux<DynamicDocument> =
+        Flux.error(UnsupportedOperationException("Snapshot aggregation is not supported by [$name]."))
+}
 class NoOpSnapshotQueryService<S : Any>(override val namedAggregate: NamedAggregate) : SnapshotQueryService<S> {
     override val name: String
         get() = NoOpSnapshotStore.NAME

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/MaskingSnapshotQueryFilter.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/MaskingSnapshotQueryFilter.kt
@@ -44,7 +44,7 @@ class MaskingSnapshotQueryFilter(maskerRegistry: StateDataMaskerRegistry) : Snap
 
     @Suppress("LongMethod")
     private fun mask(context: QueryContext<*, *>) {
-        if (context.queryType == QueryType.COUNT) {
+        if (context.queryType == QueryType.COUNT || context.queryType == QueryType.AGGREGATION) {
             return
         }
         if (context.queryType.isDynamic) {

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/SnapshotQueryFilter.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/SnapshotQueryFilter.kt
@@ -84,6 +84,10 @@ class TailSnapshotQueryFilter<S : Any>(private val queryServiceFactory: Snapshot
                 }
                 context.asCountQuery().setResult(result)
             }
+
+            QueryType.AGGREGATION -> {
+                context.asAggregationQuery().setResult(queryService::aggregate)
+            }
         }
         return next.filter(context)
     }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/SnapshotQueryHandler.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/SnapshotQueryHandler.kt
@@ -13,10 +13,10 @@
 
 package me.ahoo.wow.query.snapshot.filter
 
-import me.ahoo.wow.api.query.MaterializedSnapshot
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.DynamicDocument
+import me.ahoo.wow.api.query.MaterializedSnapshot
 import me.ahoo.wow.filter.ErrorHandler
 import me.ahoo.wow.filter.FilterChain
 import me.ahoo.wow.filter.LogErrorHandler

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/SnapshotQueryHandler.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/SnapshotQueryHandler.kt
@@ -14,14 +14,22 @@
 package me.ahoo.wow.query.snapshot.filter
 
 import me.ahoo.wow.api.query.MaterializedSnapshot
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.filter.ErrorHandler
 import me.ahoo.wow.filter.FilterChain
 import me.ahoo.wow.filter.LogErrorHandler
 import me.ahoo.wow.query.filter.AbstractQueryHandler
 import me.ahoo.wow.query.filter.QueryContext
 import me.ahoo.wow.query.filter.QueryHandler
+import me.ahoo.wow.query.filter.QueryType
+import reactor.core.publisher.Flux
 
-interface SnapshotQueryHandler : QueryHandler<MaterializedSnapshot<Any>>
+interface SnapshotQueryHandler : QueryHandler<MaterializedSnapshot<Any>> {
+    fun aggregate(namedAggregate: NamedAggregate, query: AggregationQuery): Flux<DynamicDocument> =
+        Flux.error(UnsupportedOperationException("Snapshot aggregation is not supported."))
+}
 
 class DefaultSnapshotQueryHandler(
     chain: FilterChain<QueryContext<*, *>>,
@@ -29,4 +37,7 @@ class DefaultSnapshotQueryHandler(
 ) : SnapshotQueryHandler, AbstractQueryHandler<MaterializedSnapshot<Any>>(
     chain,
     errorHandler,
-)
+) {
+    override fun aggregate(namedAggregate: NamedAggregate, query: AggregationQuery): Flux<DynamicDocument> =
+        flux(namedAggregate, QueryType.AGGREGATION, query)
+}

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt
@@ -28,6 +28,7 @@ class AggregationQueryDslTest {
             filter { "state.status" eq "COMPLETED" }
             expand("state.orders") { "status" eq "PAID" }
             expand("lines") { "quantity" gt 0 }
+            expand("discounts")
             terms("productId", alias = "product")
             count(alias = "count")
             sum("amount", alias = "total")
@@ -35,7 +36,7 @@ class AggregationQueryDslTest {
             limit(20)
         }
 
-        query.elements.map { it.path.value }.assert().containsExactly("state.orders", "lines")
+        query.elements.map { it.path.value }.assert().containsExactly("state.orders", "lines", "discounts")
         query.groupBy.assert().hasSize(1)
         query.metrics.assert().hasSize(2)
         query.limit.assert().isEqualTo(20)

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.dsl
+
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+
+class AggregationQueryDslTest {
+
+    @Test
+    fun `aggregation DSL should preserve relative scopes and explicit aliases`() {
+        val query = aggregation {
+            filter { "state.status" eq "COMPLETED" }
+            expand("state.orders") { "status" eq "PAID" }
+            expand("lines") { "quantity" gt 0 }
+            terms("productId", alias = "product")
+            count(alias = "count")
+            sum("amount", alias = "total")
+            sort { "total".desc() }
+            limit(20)
+        }
+
+        query.elements.map { it.path.value }.assert().containsExactly("state.orders", "lines")
+        query.groupBy.assert().hasSize(1)
+        query.metrics.assert().hasSize(2)
+        query.limit.assert().isEqualTo(20)
+    }
+}

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt
@@ -14,7 +14,11 @@
 package me.ahoo.wow.query.dsl
 
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.AggregationDateUnit
+import me.ahoo.wow.api.query.AggregationGroup
+import me.ahoo.wow.api.query.LogicalField
 import org.junit.jupiter.api.Test
+import java.time.ZoneId
 
 class AggregationQueryDslTest {
 
@@ -35,5 +39,24 @@ class AggregationQueryDslTest {
         query.groupBy.assert().hasSize(1)
         query.metrics.assert().hasSize(2)
         query.limit.assert().isEqualTo(20)
+    }
+
+    @Test
+    fun `aggregation DSL should map histogram positional arguments`() {
+        val query = aggregation {
+            histogram("amount", 50.0, "amountBucket")
+            dateHistogram("createdAt", AggregationDateUnit.DAY, "day", ZoneId.of("Asia/Shanghai"))
+            count("count")
+        }
+
+        query.groupBy.assert().containsExactly(
+            AggregationGroup.Histogram(LogicalField("amount"), "amountBucket", 50.0),
+            AggregationGroup.DateHistogram(
+                LogicalField("createdAt"),
+                "day",
+                AggregationDateUnit.DAY,
+                "Asia/Shanghai",
+            ),
+        )
     }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/event/filter/DefaultEventStreamQueryHandlerTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/event/filter/DefaultEventStreamQueryHandlerTest.kt
@@ -14,16 +14,25 @@
 package me.ahoo.wow.query.event.filter
 
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.MatchAllFilter
+import me.ahoo.wow.filter.FilterChain
 import me.ahoo.wow.filter.FilterChainBuilder
 import me.ahoo.wow.filter.LogErrorHandler
 import me.ahoo.wow.query.dsl.condition
 import me.ahoo.wow.query.dsl.listQuery
 import me.ahoo.wow.query.dsl.singleQuery
 import me.ahoo.wow.query.event.NoOpEventStreamQueryServiceFactory
+import me.ahoo.wow.query.filter.DefaultQueryContext
 import me.ahoo.wow.query.filter.QueryContext
+import me.ahoo.wow.query.filter.QueryType
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 import reactor.kotlin.test.test
 
 class DefaultEventStreamQueryHandlerTest {
@@ -106,5 +115,17 @@ class DefaultEventStreamQueryHandlerTest {
             .test()
             .expectNext(0)
             .verifyComplete()
+    }
+
+    @Test
+    fun `event stream tail should reject aggregation queries`() {
+        val context = DefaultQueryContext<AggregationQuery, Flux<DynamicDocument>>(
+            QueryType.AGGREGATION,
+            MOCK_AGGREGATE_METADATA,
+        ).setQuery(AggregationQuery(metrics = listOf(AggregationMetric.Count("count"))))
+
+        assertThrows<IllegalStateException> {
+            tailSnapshotQueryFilter.filter(context, FilterChain { Mono.empty() })
+        }.message.assert().isEqualTo("Event stream query does not support aggregation.")
     }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/filter/QueryContextTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/filter/QueryContextTest.kt
@@ -14,6 +14,9 @@
 package me.ahoo.wow.query.filter
 
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.FilterExpression
 import me.ahoo.wow.api.query.ISingleQuery
 import me.ahoo.wow.api.query.IdFilter
@@ -21,6 +24,7 @@ import me.ahoo.wow.api.query.MatchAllFilter
 import me.ahoo.wow.query.dsl.singleQuery
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import org.junit.jupiter.api.Test
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 class QueryContextTest {
@@ -131,6 +135,17 @@ class QueryContextTest {
         ).setQuery(MatchAllFilter)
 
         context.asCountQuery().getQuery().assert().isSameAs(MatchAllFilter)
+    }
+
+    @Test
+    fun `should expose typed aggregation context separately`() {
+        val query = AggregationQuery(metrics = listOf(AggregationMetric.Count("count")))
+        val context = DefaultQueryContext<AggregationQuery, Flux<DynamicDocument>>(
+            queryType = QueryType.AGGREGATION,
+            namedAggregate = MOCK_AGGREGATE_METADATA,
+        ).setQuery(query)
+
+        context.asAggregationQuery().getQuery().assert().isSameAs(query)
     }
 
     @Test

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/filter/QueryHandlerSubscriptionTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/filter/QueryHandlerSubscriptionTest.kt
@@ -247,6 +247,7 @@ class QueryHandlerSubscriptionTest {
                 )
 
                 QueryType.COUNT -> context.asCountQuery().setResult(Mono.just(1L))
+                QueryType.AGGREGATION -> error("Test query handler does not support aggregation.")
             }
             return next.filter(context)
         }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/filter/QueryTypeTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/filter/QueryTypeTest.kt
@@ -52,4 +52,9 @@ class QueryTypeTest {
     fun `count should not be dynamic`() {
         QueryType.COUNT.isDynamic.assert().isFalse()
     }
+
+    @Test
+    fun `aggregation should be dynamic`() {
+        QueryType.AGGREGATION.isDynamic.assert().isTrue()
+    }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/NoOpSnapshotQueryServiceTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/NoOpSnapshotQueryServiceTest.kt
@@ -14,6 +14,8 @@
 package me.ahoo.wow.query.snapshot
 
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.modeling.toNamedAggregate
 import me.ahoo.wow.query.dsl.condition
 import me.ahoo.wow.query.dsl.filterExpression
@@ -115,5 +117,14 @@ class NoOpSnapshotQueryServiceTest {
             .test()
             .expectNext(0L)
             .verifyComplete()
+    }
+
+    @Test
+    fun `aggregation DSL should return a cold unsupported error`() {
+        AggregationQuery(metrics = listOf(AggregationMetric.Count("count")))
+            .query(queryService)
+            .test()
+            .expectError(UnsupportedOperationException::class.java)
+            .verify()
     }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/NoOpSnapshotQueryServiceTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/NoOpSnapshotQueryServiceTest.kt
@@ -16,7 +16,9 @@ package me.ahoo.wow.query.snapshot
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.query.AggregationMetric
 import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.MaterializedSnapshot
 import me.ahoo.wow.modeling.toNamedAggregate
+import me.ahoo.wow.query.QueryService
 import me.ahoo.wow.query.dsl.condition
 import me.ahoo.wow.query.dsl.filterExpression
 import me.ahoo.wow.query.dsl.listQuery
@@ -121,10 +123,16 @@ class NoOpSnapshotQueryServiceTest {
 
     @Test
     fun `aggregation DSL should return a cold unsupported error`() {
+        val fallback = object :
+            SnapshotQueryService<Any>,
+            QueryService<MaterializedSnapshot<Any>> by queryService {
+            override val name: String = "fallback"
+        }
+
         AggregationQuery(metrics = listOf(AggregationMetric.Count("count")))
-            .query(queryService)
+            .query(fallback)
             .test()
-            .expectError(UnsupportedOperationException::class.java)
+            .expectErrorMessage("Snapshot aggregation is not supported by [fallback].")
             .verify()
     }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/AbacQueryFilterTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/AbacQueryFilterTest.kt
@@ -18,6 +18,9 @@ import me.ahoo.wow.api.abac.AbacTagValue
 import me.ahoo.wow.api.abac.AbacTags
 import me.ahoo.wow.api.abac.EMPTY_ABAC_TAGS
 import me.ahoo.wow.api.abac.wildcard
+import me.ahoo.wow.api.query.AggregationElement
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.AndFilter
 import me.ahoo.wow.api.query.ExistsFilter
 import me.ahoo.wow.api.query.LogicalField
@@ -96,6 +99,27 @@ class AbacQueryFilterTest {
             it.getQuery().assert().isInstanceOf(AndFilter::class.java)
             Mono.empty()
         }
+        MockAbacQueryFilter.filter(context, chain).test().verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should append ABAC filter only to root filter`() {
+        val query = AggregationQuery(
+            filter = ExistsFilter(LogicalField("tenantId")),
+            elements = listOf(AggregationElement(LogicalField("state.items"), ExistsFilter(LogicalField("sku")))),
+            metrics = listOf(AggregationMetric.Count("count")),
+        )
+        val context = DefaultQueryContext<AggregationQuery, Any>(
+            queryType = QueryType.AGGREGATION,
+            MOCK_AGGREGATE_METADATA,
+        ).setQuery(query)
+        val chain = FilterChain<QueryContext<*, *>> {
+            val rewritten = it.getQuery() as AggregationQuery
+            rewritten.filter.assert().isInstanceOf(AndFilter::class.java)
+            rewritten.elements.assert().isEqualTo(query.elements)
+            Mono.empty()
+        }
+
         MockAbacQueryFilter.filter(context, chain).test().verifyComplete()
     }
 

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/DefaultSnapshotQueryHandlerTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/DefaultSnapshotQueryHandlerTest.kt
@@ -19,6 +19,7 @@ import me.ahoo.wow.api.query.AggregationMetric
 import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.MatchAllFilter
+import me.ahoo.wow.api.query.MaterializedSnapshot
 import me.ahoo.wow.api.query.SimpleDynamicDocument.Companion.toDynamicDocument
 import me.ahoo.wow.filter.FilterChainBuilder
 import me.ahoo.wow.filter.LogErrorHandler
@@ -26,6 +27,7 @@ import me.ahoo.wow.query.dsl.condition
 import me.ahoo.wow.query.dsl.listQuery
 import me.ahoo.wow.query.dsl.singleQuery
 import me.ahoo.wow.query.filter.QueryContext
+import me.ahoo.wow.query.filter.QueryHandler
 import me.ahoo.wow.query.snapshot.NoOpSnapshotQueryService
 import me.ahoo.wow.query.snapshot.NoOpSnapshotQueryServiceFactory
 import me.ahoo.wow.query.snapshot.SnapshotQueryService
@@ -143,5 +145,19 @@ class DefaultSnapshotQueryHandlerTest {
             .test()
             .expectNextMatches { it["count"] == 1L }
             .verifyComplete()
+    }
+
+    @Test
+    fun `legacy snapshot handler should inherit unsupported aggregation`() {
+        val fallback = object :
+            SnapshotQueryHandler,
+            QueryHandler<MaterializedSnapshot<Any>> by queryHandler {}
+
+        fallback.aggregate(
+            MOCK_AGGREGATE_METADATA,
+            AggregationQuery(metrics = listOf(AggregationMetric.Count("count"))),
+        ).test()
+            .expectErrorMessage("Snapshot aggregation is not supported.")
+            .verify()
     }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/DefaultSnapshotQueryHandlerTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/DefaultSnapshotQueryHandlerTest.kt
@@ -45,7 +45,9 @@ class DefaultSnapshotQueryHandlerTest {
         snapshotQueryFilterChain,
         LogErrorHandler()
     )
-    private val aggregateQueryService = object : SnapshotQueryService<Any> by NoOpSnapshotQueryService(MOCK_AGGREGATE_METADATA) {
+    private val aggregateQueryService = object : SnapshotQueryService<Any> by NoOpSnapshotQueryService(
+        MOCK_AGGREGATE_METADATA
+    ) {
         override fun aggregate(query: AggregationQuery): Flux<DynamicDocument> =
             Flux.just(mutableMapOf<String, Any?>("count" to 1L).toDynamicDocument())
     }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/DefaultSnapshotQueryHandlerTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/DefaultSnapshotQueryHandlerTest.kt
@@ -14,16 +14,25 @@
 package me.ahoo.wow.query.snapshot.filter
 
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.MatchAllFilter
+import me.ahoo.wow.api.query.SimpleDynamicDocument.Companion.toDynamicDocument
 import me.ahoo.wow.filter.FilterChainBuilder
 import me.ahoo.wow.filter.LogErrorHandler
 import me.ahoo.wow.query.dsl.condition
 import me.ahoo.wow.query.dsl.listQuery
 import me.ahoo.wow.query.dsl.singleQuery
 import me.ahoo.wow.query.filter.QueryContext
+import me.ahoo.wow.query.snapshot.NoOpSnapshotQueryService
 import me.ahoo.wow.query.snapshot.NoOpSnapshotQueryServiceFactory
+import me.ahoo.wow.query.snapshot.SnapshotQueryService
+import me.ahoo.wow.query.snapshot.SnapshotQueryServiceFactory
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import org.junit.jupiter.api.Test
+import reactor.core.publisher.Flux
 import reactor.kotlin.test.test
 
 class DefaultSnapshotQueryHandlerTest {
@@ -34,6 +43,22 @@ class DefaultSnapshotQueryHandlerTest {
         .build()
     private val queryHandler = DefaultSnapshotQueryHandler(
         snapshotQueryFilterChain,
+        LogErrorHandler()
+    )
+    private val aggregateQueryService = object : SnapshotQueryService<Any> by NoOpSnapshotQueryService(MOCK_AGGREGATE_METADATA) {
+        override fun aggregate(query: AggregationQuery): Flux<DynamicDocument> =
+            Flux.just(mutableMapOf<String, Any?>("count" to 1L).toDynamicDocument())
+    }
+    private val aggregateQueryServiceFactory = object : SnapshotQueryServiceFactory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <S : Any> create(namedAggregate: NamedAggregate): SnapshotQueryService<S> =
+            aggregateQueryService as SnapshotQueryService<S>
+    }
+    private val aggregateQueryHandler = DefaultSnapshotQueryHandler(
+        FilterChainBuilder<QueryContext<*, *>>()
+            .addFilters(listOf(TailSnapshotQueryFilter<Any>(aggregateQueryServiceFactory)))
+            .filterCondition(SnapshotQueryHandler::class)
+            .build(),
         LogErrorHandler()
     )
 
@@ -105,6 +130,16 @@ class DefaultSnapshotQueryHandlerTest {
         queryHandler.count(MOCK_AGGREGATE_METADATA, MatchAllFilter)
             .test()
             .expectNext(0)
+            .verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should use the existing snapshot chain`() {
+        val query = AggregationQuery(metrics = listOf(AggregationMetric.Count("count")))
+
+        aggregateQueryHandler.aggregate(MOCK_AGGREGATE_METADATA, query)
+            .test()
+            .expectNextMatches { it["count"] == 1L }
             .verifyComplete()
     }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/MaskingSnapshotQueryFilterTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/MaskingSnapshotQueryFilterTest.kt
@@ -13,8 +13,12 @@
 
 package me.ahoo.wow.query.snapshot.filter
 
+import io.mockk.spyk
+import io.mockk.verify
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.IListQuery
 import me.ahoo.wow.api.query.IPagedQuery
@@ -28,7 +32,9 @@ import me.ahoo.wow.filter.LogErrorHandler
 import me.ahoo.wow.modeling.toNamedAggregate
 import me.ahoo.wow.query.dsl.listQuery
 import me.ahoo.wow.query.dsl.singleQuery
+import me.ahoo.wow.query.filter.DefaultQueryContext
 import me.ahoo.wow.query.filter.QueryContext
+import me.ahoo.wow.query.filter.QueryType
 import me.ahoo.wow.query.mask.DataMasking
 import me.ahoo.wow.query.mask.StateDataMaskerRegistry
 import me.ahoo.wow.query.mask.StateDynamicDocumentMasker
@@ -138,6 +144,20 @@ class MaskingSnapshotQueryFilterTest {
                 it.assert().isOne()
             }
             .verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should not look up a masker`() {
+        val maskerRegistry = spyk(StateDataMaskerRegistry())
+        val filter = MaskingSnapshotQueryFilter(maskerRegistry)
+        val context = DefaultQueryContext<AggregationQuery, Flux<DynamicDocument>>(
+            QueryType.AGGREGATION,
+            MockSnapshotQueryService.namedAggregate,
+        ).setQuery(AggregationQuery(metrics = listOf(AggregationMetric.Count("count"))))
+
+        filter.filter(context) { Mono.empty() }.test().verifyComplete()
+
+        verify(exactly = 0) { maskerRegistry.getAggregateDataMasker(any()) }
     }
 
     data class DataMaskable(val pwd: String) : DataMasking<DataMaskable> {

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowDefinitionProviderRegistry.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/WowDefinitionProviderRegistry.kt
@@ -25,6 +25,7 @@ import me.ahoo.wow.schema.typed.SnapshotDefinitionProvider
 import me.ahoo.wow.schema.typed.StateAggregateDefinitionProvider
 import me.ahoo.wow.schema.typed.StateEventDefinitionProvider
 import me.ahoo.wow.schema.typed.query.FilterExpressionDefinitionProvider
+import me.ahoo.wow.schema.typed.query.LogicalFieldDefinitionProvider
 import me.ahoo.wow.schema.web.ServerSentEventCustomDefinitionProvider
 
 internal object WowDefinitionProviderRegistry {
@@ -39,6 +40,7 @@ internal object WowDefinitionProviderRegistry {
         StateEventDefinitionProvider,
         ServerSentEventCustomDefinitionProvider,
         FilterExpressionDefinitionProvider,
+        LogicalFieldDefinitionProvider,
         MapDefinitionProvider,
         EnumTextDefinitionProvider
     )

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/query/LogicalFieldDefinitionProvider.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/query/LogicalFieldDefinitionProvider.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.schema.typed.query
+
+import com.fasterxml.classmate.ResolvedType
+import com.github.victools.jsonschema.generator.CustomDefinition
+import com.github.victools.jsonschema.generator.CustomDefinitionProviderV2
+import com.github.victools.jsonschema.generator.SchemaGenerationContext
+import com.github.victools.jsonschema.generator.SchemaKeyword
+import me.ahoo.wow.api.query.LogicalField
+
+object LogicalFieldDefinitionProvider : CustomDefinitionProviderV2 {
+    override fun provideCustomSchemaDefinition(
+        javaType: ResolvedType,
+        context: SchemaGenerationContext,
+    ): CustomDefinition? {
+        if (javaType.erasedType != LogicalField::class.java) return null
+        val definition = context.generatorConfig.createObjectNode()
+        definition.put(
+            context.getKeyword(SchemaKeyword.TAG_TYPE),
+            context.getKeyword(SchemaKeyword.TAG_TYPE_STRING),
+        )
+        return CustomDefinition(definition)
+    }
+}

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/WowDefinitionProviderRegistryTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/WowDefinitionProviderRegistryTest.kt
@@ -33,6 +33,7 @@ class WowDefinitionProviderRegistryTest {
             "StateEventDefinitionProvider",
             "ServerSentEventCustomDefinitionProvider",
             "FilterExpressionDefinitionProvider",
+            "LogicalFieldDefinitionProvider",
             "MapDefinitionProvider",
             "EnumTextDefinitionProvider"
         )

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilderTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/openapi/OpenAPISchemaBuilderTest.kt
@@ -3,6 +3,7 @@ package me.ahoo.wow.schema.openapi
 import com.fasterxml.classmate.TypeResolver
 import com.github.victools.jsonschema.generator.Option
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.LogicalField
 import me.ahoo.wow.api.query.MaterializedSnapshot
 import me.ahoo.wow.api.query.PagedList
 import me.ahoo.wow.command.wait.SimpleWaitSignal
@@ -16,6 +17,15 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.codec.ServerSentEvent
 
 class OpenAPISchemaBuilderTest {
+
+    @Test
+    fun `should expose delegating logical field as a string`() {
+        val openAPISchemaBuilder = OpenAPISchemaBuilder()
+        openAPISchemaBuilder.generateSchema(LogicalField::class.java)
+
+        openAPISchemaBuilder.build().getValue("wow.api.query.LogicalField")
+            .types.assert().contains("string").doesNotContain("object")
+    }
 
     @Test
     fun `should build open api schema with component references`() {

--- a/wow-schema/src/test/resources/META-INF/wow-schema-e2e/MockStateAggregate.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema-e2e/MockStateAggregate.json
@@ -61,8 +61,67 @@
         "data" : {
           "type" : "string"
         },
+        "decimalValue" : {
+          "type" : "number"
+        },
         "id" : {
           "type" : "string"
+        },
+        "orders" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "properties" : {
+              "lines" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "amount" : {
+                      "anyOf" : [ {
+                        "type" : "null"
+                      }, {
+                        "type" : "number",
+                        "format" : "double"
+                      } ]
+                    },
+                    "createdAt" : {
+                      "type" : "string",
+                      "format" : "date-time"
+                    },
+                    "discounts" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "amount" : {
+                            "type" : "number",
+                            "format" : "double"
+                          },
+                          "type" : {
+                            "type" : "string"
+                          }
+                        },
+                        "required" : [ "amount", "type" ]
+                      }
+                    },
+                    "productId" : {
+                      "type" : "string"
+                    },
+                    "quantity" : {
+                      "type" : "integer",
+                      "format" : "int32"
+                    }
+                  },
+                  "required" : [ "amount", "createdAt", "discounts", "productId", "quantity" ]
+                }
+              },
+              "status" : {
+                "type" : "string"
+              }
+            },
+            "required" : [ "lines", "status" ]
+          }
         }
       },
       "required" : [ "id" ],

--- a/wow-schema/src/test/resources/META-INF/wow-schema-e2e/MockStateAggregateSnapshot.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema-e2e/MockStateAggregateSnapshot.json
@@ -61,8 +61,67 @@
         "data" : {
           "type" : "string"
         },
+        "decimalValue" : {
+          "type" : "number"
+        },
         "id" : {
           "type" : "string"
+        },
+        "orders" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "properties" : {
+              "lines" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "amount" : {
+                      "anyOf" : [ {
+                        "type" : "null"
+                      }, {
+                        "type" : "number",
+                        "format" : "double"
+                      } ]
+                    },
+                    "createdAt" : {
+                      "type" : "string",
+                      "format" : "date-time"
+                    },
+                    "discounts" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "amount" : {
+                            "type" : "number",
+                            "format" : "double"
+                          },
+                          "type" : {
+                            "type" : "string"
+                          }
+                        },
+                        "required" : [ "amount", "type" ]
+                      }
+                    },
+                    "productId" : {
+                      "type" : "string"
+                    },
+                    "quantity" : {
+                      "type" : "integer",
+                      "format" : "int32"
+                    }
+                  },
+                  "required" : [ "amount", "createdAt", "discounts", "productId", "quantity" ]
+                }
+              },
+              "status" : {
+                "type" : "string"
+              }
+            },
+            "required" : [ "lines", "status" ]
+          }
         }
       },
       "required" : [ "id" ],

--- a/wow-schema/src/test/resources/META-INF/wow-schema-e2e/MockStateAggregateStateEvent.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema-e2e/MockStateAggregateStateEvent.json
@@ -143,8 +143,67 @@
         "data" : {
           "type" : "string"
         },
+        "decimalValue" : {
+          "type" : "number"
+        },
         "id" : {
           "type" : "string"
+        },
+        "orders" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "properties" : {
+              "lines" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "amount" : {
+                      "anyOf" : [ {
+                        "type" : "null"
+                      }, {
+                        "type" : "number",
+                        "format" : "double"
+                      } ]
+                    },
+                    "createdAt" : {
+                      "type" : "string",
+                      "format" : "date-time"
+                    },
+                    "discounts" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "amount" : {
+                            "type" : "number",
+                            "format" : "double"
+                          },
+                          "type" : {
+                            "type" : "string"
+                          }
+                        },
+                        "required" : [ "amount", "type" ]
+                      }
+                    },
+                    "productId" : {
+                      "type" : "string"
+                    },
+                    "quantity" : {
+                      "type" : "integer",
+                      "format" : "int32"
+                    }
+                  },
+                  "required" : [ "amount", "createdAt", "discounts", "productId", "quantity" ]
+                }
+              },
+              "status" : {
+                "type" : "string"
+              }
+            },
+            "required" : [ "lines", "status" ]
+          }
         }
       },
       "required" : [ "id" ],

--- a/wow-schema/src/test/resources/META-INF/wow-schema/MockStateAggregate.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/MockStateAggregate.json
@@ -61,8 +61,67 @@
         "data" : {
           "type" : "string"
         },
+        "decimalValue" : {
+          "type" : "number"
+        },
         "id" : {
           "type" : "string"
+        },
+        "orders" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "properties" : {
+              "lines" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "amount" : {
+                      "anyOf" : [ {
+                        "type" : "null"
+                      }, {
+                        "type" : "number",
+                        "format" : "double"
+                      } ]
+                    },
+                    "createdAt" : {
+                      "type" : "string",
+                      "format" : "date-time"
+                    },
+                    "discounts" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "amount" : {
+                            "type" : "number",
+                            "format" : "double"
+                          },
+                          "type" : {
+                            "type" : "string"
+                          }
+                        },
+                        "required" : [ "amount", "type" ]
+                      }
+                    },
+                    "productId" : {
+                      "type" : "string"
+                    },
+                    "quantity" : {
+                      "type" : "integer",
+                      "format" : "int32"
+                    }
+                  },
+                  "required" : [ "amount", "createdAt", "discounts", "productId", "quantity" ]
+                }
+              },
+              "status" : {
+                "type" : "string"
+              }
+            },
+            "required" : [ "lines", "status" ]
+          }
         }
       },
       "required" : [ "id" ],

--- a/wow-schema/src/test/resources/META-INF/wow-schema/MockStateAggregateSnapshot.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/MockStateAggregateSnapshot.json
@@ -61,8 +61,67 @@
         "data" : {
           "type" : "string"
         },
+        "decimalValue" : {
+          "type" : "number"
+        },
         "id" : {
           "type" : "string"
+        },
+        "orders" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "properties" : {
+              "lines" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "amount" : {
+                      "anyOf" : [ {
+                        "type" : "null"
+                      }, {
+                        "type" : "number",
+                        "format" : "double"
+                      } ]
+                    },
+                    "createdAt" : {
+                      "type" : "string",
+                      "format" : "date-time"
+                    },
+                    "discounts" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "amount" : {
+                            "type" : "number",
+                            "format" : "double"
+                          },
+                          "type" : {
+                            "type" : "string"
+                          }
+                        },
+                        "required" : [ "amount", "type" ]
+                      }
+                    },
+                    "productId" : {
+                      "type" : "string"
+                    },
+                    "quantity" : {
+                      "type" : "integer",
+                      "format" : "int32"
+                    }
+                  },
+                  "required" : [ "amount", "createdAt", "discounts", "productId", "quantity" ]
+                }
+              },
+              "status" : {
+                "type" : "string"
+              }
+            },
+            "required" : [ "lines", "status" ]
+          }
         }
       },
       "required" : [ "id" ],

--- a/wow-schema/src/test/resources/META-INF/wow-schema/MockStateAggregateStateEvent.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/MockStateAggregateStateEvent.json
@@ -143,8 +143,67 @@
         "data" : {
           "type" : "string"
         },
+        "decimalValue" : {
+          "type" : "number"
+        },
         "id" : {
           "type" : "string"
+        },
+        "orders" : {
+          "type" : "array",
+          "items" : {
+            "type" : "object",
+            "properties" : {
+              "lines" : {
+                "type" : "array",
+                "items" : {
+                  "type" : "object",
+                  "properties" : {
+                    "amount" : {
+                      "anyOf" : [ {
+                        "type" : "null"
+                      }, {
+                        "type" : "number",
+                        "format" : "double"
+                      } ]
+                    },
+                    "createdAt" : {
+                      "type" : "string",
+                      "format" : "date-time"
+                    },
+                    "discounts" : {
+                      "type" : "array",
+                      "items" : {
+                        "type" : "object",
+                        "properties" : {
+                          "amount" : {
+                            "type" : "number",
+                            "format" : "double"
+                          },
+                          "type" : {
+                            "type" : "string"
+                          }
+                        },
+                        "required" : [ "amount", "type" ]
+                      }
+                    },
+                    "productId" : {
+                      "type" : "string"
+                    },
+                    "quantity" : {
+                      "type" : "integer",
+                      "format" : "int32"
+                    }
+                  },
+                  "required" : [ "amount", "createdAt", "discounts", "productId", "quantity" ]
+                }
+              },
+              "status" : {
+                "type" : "string"
+              }
+            },
+            "required" : [ "lines", "status" ]
+          }
         }
       },
       "required" : [ "id" ],

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/route/QueryRouteModule.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/route/QueryRouteModule.kt
@@ -23,7 +23,6 @@ import me.ahoo.wow.webflux.route.event.LoadEventStreamHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.event.PagedQueryEventStreamHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.query.RewriteRequestFilter
 import me.ahoo.wow.webflux.route.snapshot.CountSnapshotHandlerFunctionFactory
-import me.ahoo.wow.webflux.route.snapshot.SnapshotAggregationHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.snapshot.ListQuerySnapshotHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.snapshot.ListQuerySnapshotStateHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.snapshot.LoadSnapshotHandlerFunctionFactory
@@ -31,6 +30,7 @@ import me.ahoo.wow.webflux.route.snapshot.PagedQuerySnapshotHandlerFunctionFacto
 import me.ahoo.wow.webflux.route.snapshot.PagedQuerySnapshotStateHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.snapshot.SingleSnapshotHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.snapshot.SingleSnapshotStateHandlerFunctionFactory
+import me.ahoo.wow.webflux.route.snapshot.SnapshotAggregationHandlerFunctionFactory
 
 class QueryRouteModule(
     snapshotQueryHandler: SnapshotQueryHandler,

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/route/QueryRouteModule.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/route/QueryRouteModule.kt
@@ -23,6 +23,7 @@ import me.ahoo.wow.webflux.route.event.LoadEventStreamHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.event.PagedQueryEventStreamHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.query.RewriteRequestFilter
 import me.ahoo.wow.webflux.route.snapshot.CountSnapshotHandlerFunctionFactory
+import me.ahoo.wow.webflux.route.snapshot.SnapshotAggregationHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.snapshot.ListQuerySnapshotHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.snapshot.ListQuerySnapshotStateHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.snapshot.LoadSnapshotHandlerFunctionFactory
@@ -73,6 +74,11 @@ class QueryRouteModule(
             exceptionHandler = exceptionHandler
         ),
         CountSnapshotHandlerFunctionFactory(
+            snapshotQueryHandler = snapshotQueryHandler,
+            rewriteRequestFilter = rewriteRequestFilter,
+            exceptionHandler = exceptionHandler
+        ),
+        SnapshotAggregationHandlerFunctionFactory(
             snapshotQueryHandler = snapshotQueryHandler,
             rewriteRequestFilter = rewriteRequestFilter,
             exceptionHandler = exceptionHandler

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
@@ -951,6 +951,7 @@ internal class WebFluxAutoConfigurationTest {
             BuiltInHttpRouteHandlerKeys.Global.COMMAND_FACADE,
             BuiltInHttpRouteHandlerKeys.State.LOAD_AGGREGATE,
             BuiltInHttpRouteHandlerKeys.Snapshot.LOAD,
+            BuiltInHttpRouteHandlerKeys.Snapshot.AGGREGATION,
             BuiltInHttpRouteHandlerKeys.Event.LOAD,
             BuiltInHttpRouteHandlerKeys.Snapshot.REGENERATE,
             BuiltInHttpRouteHandlerKeys.Event.RESEND_STATE,

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/QueryServiceProxy.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/QueryServiceProxy.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.spring.query
 
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.FilterExpression
 import me.ahoo.wow.api.query.IListQuery
@@ -33,7 +34,7 @@ import reactor.core.publisher.Mono
 
 internal class SnapshotQueryServiceProxy<S : Any>(
     private val delegate: SnapshotQueryService<S>,
-    handler: SnapshotQueryHandler,
+    private val handler: SnapshotQueryHandler,
 ) : QueryServiceProxy<MaterializedSnapshot<S>>(
     delegate.namedAggregate,
     handler.cast(),
@@ -41,6 +42,9 @@ internal class SnapshotQueryServiceProxy<S : Any>(
     SnapshotQueryService<S> {
     override val name: String
         get() = delegate.name
+
+    override fun aggregate(query: AggregationQuery): Flux<DynamicDocument> =
+        handler.aggregate(namedAggregate, query)
 }
 
 internal class EventStreamQueryServiceProxy(

--- a/wow-spring/src/test/kotlin/me/ahoo/wow/spring/query/QueryServiceProxyTest.kt
+++ b/wow-spring/src/test/kotlin/me/ahoo/wow/spring/query/QueryServiceProxyTest.kt
@@ -15,6 +15,8 @@ package me.ahoo.wow.spring.query
 
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.FilterExpression
 import me.ahoo.wow.api.query.IListQuery
@@ -24,6 +26,7 @@ import me.ahoo.wow.api.query.MatchAllFilter
 import me.ahoo.wow.api.query.PagedList
 import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.filter.EmptyFilterChain
+import me.ahoo.wow.filter.FilterChain
 import me.ahoo.wow.modeling.MaterializedNamedAggregate
 import me.ahoo.wow.query.dsl.listQuery
 import me.ahoo.wow.query.dsl.pagedQuery
@@ -77,6 +80,24 @@ class QueryServiceProxyTest {
 
         proxy.name.assert().isEqualTo(delegate.name)
         proxy.namedAggregate.assert().isSameAs(delegate.namedAggregate)
+    }
+
+    @Test
+    fun `snapshot proxy should route aggregation through handler`() {
+        val handler = DefaultSnapshotQueryHandler(
+            FilterChain { context ->
+                context.queryType.assert().isEqualTo(QueryType.AGGREGATION)
+                context.asAggregationQuery().setResult(Flux.empty())
+                Mono.empty()
+            }
+        )
+        val proxy = SnapshotQueryServiceProxy(NoOpSnapshotQueryService<Any>(namedAggregate), handler)
+
+        proxy.aggregate(AggregationQuery(metrics = listOf(AggregationMetric.Count("count"))))
+            .collectList()
+            .block()
+            .assert()
+            .isEmpty()
     }
 
     @Test

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilter.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilter.kt
@@ -76,8 +76,10 @@ class HttpQueryGuardFilter(
         when (query) {
             is AggregationQuery -> {
                 validateResultSize(query.limit, "aggregation")
-                (listOf(query.filter) + query.elements.map(AggregationElement::filter))
-                    .forEach { validateFilter(it, rejectMatchAll = false, enforceLimits = false) }
+                validateFilters(
+                    listOf(query.filter) + query.elements.map(AggregationElement::filter),
+                    rejectMatchAll = false,
+                )
                 require(allowExpensiveOperators || query.elements.isEmpty()) {
                     "HTTP aggregation elements are disabled because expensive operators are not allowed."
                 }
@@ -95,8 +97,8 @@ class HttpQueryGuardFilter(
             is FilterCapable<*> -> query.filter
             else -> return
         }
-        validateFilter(
-            filter = filter,
+        validateFilters(
+            filters = listOf(filter),
             rejectMatchAll = !allowExpensiveOperators && queryType in COUNTING_QUERY_TYPES,
         )
     }
@@ -128,19 +130,17 @@ class HttpQueryGuardFilter(
         }
     }
 
-    private fun validateFilter(filter: FilterExpression, rejectMatchAll: Boolean, enforceLimits: Boolean = true) {
+    private fun validateFilters(filters: List<FilterExpression>, rejectMatchAll: Boolean) {
         val pending = ArrayDeque<FilterExpression>()
-        pending.add(filter)
+        pending.addAll(filters)
         var nodes = 0
         while (pending.isNotEmpty()) {
             val current = pending.removeLast()
             nodes++
-            if (enforceLimits) {
-                require(maxFilterNodes == 0 || nodes <= maxFilterNodes) {
-                    "HTTP query filter nodes[$nodes] must not exceed $maxFilterNodes."
-                }
+            require(maxFilterNodes == 0 || nodes <= maxFilterNodes) {
+                "HTTP query filter nodes[$nodes] must not exceed $maxFilterNodes."
             }
-            validateFilterNode(current, enforceLimits)
+            validateFilterNode(current)
             when (current) {
                 is AndFilter -> pending.addAll(current.operands)
                 is OrFilter -> pending.addAll(current.operands)
@@ -149,17 +149,17 @@ class HttpQueryGuardFilter(
                 else -> Unit
             }
         }
-        require(!rejectMatchAll || !filter.isMatchAll()) {
+        require(!rejectMatchAll || filters.none { it.isMatchAll() }) {
             "HTTP counting query must not match all documents."
         }
     }
 
-    private fun validateFilterNode(filter: FilterExpression, enforceLimits: Boolean) {
+    private fun validateFilterNode(filter: FilterExpression) {
         require(allowExpensiveOperators || !filter.isExpensive()) {
             "HTTP query operator[${filter.operator}] is disabled because expensive operators are not allowed."
         }
         val valueCount = filter.valueCount()
-        if (enforceLimits && valueCount != null) {
+        if (valueCount != null) {
             require(maxFilterValues == 0 || valueCount <= maxFilterValues) {
                 "HTTP query filter values[$valueCount] must not exceed $maxFilterValues."
             }

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilter.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilter.kt
@@ -74,6 +74,19 @@ class HttpQueryGuardFilter(
 
     private fun validate(queryType: QueryType, query: Any) {
         when (query) {
+            is AggregationQuery -> {
+                validateResultSize(query.limit, "aggregation")
+                (listOf(query.filter) + query.elements.map(AggregationElement::filter))
+                    .forEach { validateFilter(it, rejectMatchAll = false, enforceLimits = false) }
+                require(allowExpensiveOperators || query.elements.isEmpty()) {
+                    "HTTP aggregation elements are disabled because expensive operators are not allowed."
+                }
+                val metricAliases = query.metrics.mapTo(hashSetOf(), AggregationMetric::alias)
+                require(allowExpensiveOperators || query.sort.none { it.field in metricAliases }) {
+                    "HTTP aggregation metric sorting is disabled because expensive operators are not allowed."
+                }
+                return
+            }
             is IListQuery -> validateList(query)
             is IPagedQuery -> validatePage(query)
         }
@@ -89,9 +102,13 @@ class HttpQueryGuardFilter(
     }
 
     private fun validateList(query: IListQuery) {
+        validateResultSize(query.limit, "list")
+    }
+
+    private fun validateResultSize(limit: Int, queryName: String) {
         val minimum = if (maxListSize == 0) 0 else 1
-        require(query.limit >= minimum && (maxListSize == 0 || query.limit <= maxListSize)) {
-            "HTTP list query limit[${query.limit}] must be between $minimum and $maxListSize."
+        require(limit >= minimum && (maxListSize == 0 || limit <= maxListSize)) {
+            "HTTP $queryName query limit[$limit] must be between $minimum and $maxListSize."
         }
     }
 
@@ -111,17 +128,19 @@ class HttpQueryGuardFilter(
         }
     }
 
-    private fun validateFilter(filter: FilterExpression, rejectMatchAll: Boolean) {
+    private fun validateFilter(filter: FilterExpression, rejectMatchAll: Boolean, enforceLimits: Boolean = true) {
         val pending = ArrayDeque<FilterExpression>()
         pending.add(filter)
         var nodes = 0
         while (pending.isNotEmpty()) {
             val current = pending.removeLast()
             nodes++
-            require(maxFilterNodes == 0 || nodes <= maxFilterNodes) {
-                "HTTP query filter nodes[$nodes] must not exceed $maxFilterNodes."
+            if (enforceLimits) {
+                require(maxFilterNodes == 0 || nodes <= maxFilterNodes) {
+                    "HTTP query filter nodes[$nodes] must not exceed $maxFilterNodes."
+                }
             }
-            validateFilterNode(current)
+            validateFilterNode(current, enforceLimits)
             when (current) {
                 is AndFilter -> pending.addAll(current.operands)
                 is OrFilter -> pending.addAll(current.operands)
@@ -135,12 +154,12 @@ class HttpQueryGuardFilter(
         }
     }
 
-    private fun validateFilterNode(filter: FilterExpression) {
+    private fun validateFilterNode(filter: FilterExpression, enforceLimits: Boolean) {
         require(allowExpensiveOperators || !filter.isExpensive()) {
             "HTTP query operator[${filter.operator}] is disabled because expensive operators are not allowed."
         }
         val valueCount = filter.valueCount()
-        if (valueCount != null) {
+        if (enforceLimits && valueCount != null) {
             require(maxFilterValues == 0 || valueCount <= maxFilterValues) {
                 "HTTP query filter values[$valueCount] must not exceed $maxFilterValues."
             }
@@ -191,6 +210,16 @@ class HttpQueryGuardFilter(
                 context.asPagedQuery<Any>().rewriteResult { it.timeout(idleTimeout) }
 
             QueryType.COUNT -> context.asCountQuery().rewriteResult { it.timeout(idleTimeout) }
+
+            QueryType.AGGREGATION -> context.asAggregationQuery().rewriteResult {
+                if (request.acceptsEventStream()) {
+                    it.timeout(idleTimeout)
+                } else {
+                    it.timeout(idleTimeout)
+                        .collectList()
+                        .flatMapMany(Flux<Any>::fromIterable)
+                }
+            }
         }
     }
 

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractor.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractor.kt
@@ -13,8 +13,8 @@
 
 package me.ahoo.wow.webflux.route.query
 
-import me.ahoo.wow.api.query.AndFilter
 import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.AndFilter
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.ElementMatchFilter
 import me.ahoo.wow.api.query.EqualFilter

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractor.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractor.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.webflux.route.query
 
 import me.ahoo.wow.api.query.AndFilter
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.ElementMatchFilter
 import me.ahoo.wow.api.query.EqualFilter
@@ -41,6 +42,7 @@ import tools.jackson.databind.node.ObjectNode
 class QueryBodyExtractor<Q : Any>(private val queryType: Class<Q>) : BodyExtractor<Mono<Q>, ReactiveHttpInputMessage> {
     companion object {
         val FILTER_EXPRESSION_EXTRACTOR = QueryBodyExtractor(FilterExpression::class.java)
+        val AGGREGATION_QUERY_EXTRACTOR = QueryBodyExtractor(AggregationQuery::class.java)
         val LIST_QUERY_EXTRACTOR = QueryBodyExtractor(ListQuery::class.java)
         val PAGED_QUERY_EXTRACTOR = QueryBodyExtractor(PagedQuery::class.java)
         val SINGLE_QUERY_EXTRACTOR = QueryBodyExtractor(SingleQuery::class.java)
@@ -62,8 +64,13 @@ class QueryBodyExtractor<Q : Any>(private val queryType: Class<Q>) : BodyExtract
         }
         val hasFilter = objectNode.has("filter")
         val hasCondition = objectNode.has("condition")
-        require(hasFilter.xor(hasCondition)) { "Exactly one of filter or condition is required." }
+        require(hasFilter.xor(hasCondition) || queryType == AggregationQuery::class.java && !hasFilter) {
+            "Exactly one of filter or condition is required."
+        }
         if (hasFilter) {
+            return strictDecode(objectNode)
+        }
+        if (!hasCondition) {
             return strictDecode(objectNode)
         }
         val condition = objectNode.remove("condition").toObject(Condition::class.java)
@@ -98,6 +105,11 @@ class QueryBodyExtractor<Q : Any>(private val queryType: Class<Q>) : BodyExtract
     private fun requireStrictFilterValues(decoded: Q) {
         when (decoded) {
             is FilterExpression -> decoded
+            is AggregationQuery -> {
+                decoded.filter.requireScalarEqualityValues()
+                decoded.elements.forEach { it.filter.requireScalarEqualityValues() }
+                null
+            }
             is FilterCapable<*> -> decoded.filter
             else -> null
         }?.requireScalarEqualityValues()

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractor.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractor.kt
@@ -73,11 +73,28 @@ class QueryBodyExtractor<Q : Any>(private val queryType: Class<Q>) : BodyExtract
         if (!hasCondition) {
             return strictDecode(objectNode)
         }
-        val condition = objectNode.remove("condition").toObject(Condition::class.java)
+        val conditionNode = objectNode.remove("condition")
+        val condition = if (queryType == AggregationQuery::class.java) {
+            strictDecodeCondition(conditionNode)
+        } else {
+            conditionNode.toObject(Condition::class.java)
+        }
+        if (queryType == AggregationQuery::class.java) {
+            objectNode.set("filter", JsonSerializer.valueToTree(condition.toFilterExpression()))
+            return strictDecode(objectNode)
+        }
         objectNode.set("filter", JsonSerializer.valueToTree(MatchAllFilter))
         val query = objectNode.toObject(queryType)
         @Suppress("UNCHECKED_CAST")
         return (query as FilterCapable<*>).withFilter(condition.toFilterExpression()) as Q
+    }
+
+    private fun strictDecodeCondition(conditionNode: tools.jackson.databind.JsonNode): Condition = try {
+        JsonSerializer.readerFor(Condition::class.java)
+            .with(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .readValue(conditionNode)
+    } catch (error: JacksonException) {
+        throw IllegalArgumentException("Invalid filter request body.", error)
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/SnapshotAggregationHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/SnapshotAggregationHandlerFunction.kt
@@ -38,7 +38,10 @@ class SnapshotAggregationHandlerFunction(
     override fun handle(request: ServerRequest): Mono<ServerResponse> =
         request.body(AGGREGATION_QUERY_EXTRACTOR)
             .flatMapMany { query ->
-                queryHandler.aggregate(aggregateMetadata, rewriteRequestFilter.rewrite(aggregateMetadata, request, query))
+                queryHandler.aggregate(
+                    aggregateMetadata,
+                    rewriteRequestFilter.rewrite(aggregateMetadata, request, query)
+                )
             }
             .writeRawRequest(request)
             .toServerResponse(request, exceptionHandler)

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/SnapshotAggregationHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/snapshot/SnapshotAggregationHandlerFunction.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.route.snapshot
+
+import me.ahoo.wow.modeling.metadata.AggregateMetadata
+import me.ahoo.wow.openapi.contract.BuiltInHttpRouteHandlerKeys
+import me.ahoo.wow.openapi.contract.HttpRouteContract
+import me.ahoo.wow.openapi.contract.HttpRouteHandlerMetadata
+import me.ahoo.wow.query.filter.Contexts.writeRawRequest
+import me.ahoo.wow.query.snapshot.filter.SnapshotQueryHandler
+import me.ahoo.wow.webflux.exception.RequestExceptionHandler
+import me.ahoo.wow.webflux.route.AggregateRouteHandlerFunctionFactorySupport
+import me.ahoo.wow.webflux.route.query.QueryBodyExtractor.Companion.AGGREGATION_QUERY_EXTRACTOR
+import me.ahoo.wow.webflux.route.query.RewriteRequestFilter
+import me.ahoo.wow.webflux.route.toServerResponse
+import org.springframework.web.reactive.function.server.HandlerFunction
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import reactor.core.publisher.Mono
+
+class SnapshotAggregationHandlerFunction(
+    private val aggregateMetadata: AggregateMetadata<*, *>,
+    private val queryHandler: SnapshotQueryHandler,
+    private val rewriteRequestFilter: RewriteRequestFilter,
+    private val exceptionHandler: RequestExceptionHandler,
+) : HandlerFunction<ServerResponse> {
+    override fun handle(request: ServerRequest): Mono<ServerResponse> =
+        request.body(AGGREGATION_QUERY_EXTRACTOR)
+            .flatMapMany { query ->
+                queryHandler.aggregate(aggregateMetadata, rewriteRequestFilter.rewrite(aggregateMetadata, request, query))
+            }
+            .writeRawRequest(request)
+            .toServerResponse(request, exceptionHandler)
+}
+
+class SnapshotAggregationHandlerFunctionFactory(
+    private val snapshotQueryHandler: SnapshotQueryHandler,
+    private val rewriteRequestFilter: RewriteRequestFilter,
+    private val exceptionHandler: RequestExceptionHandler,
+) : AggregateRouteHandlerFunctionFactorySupport(BuiltInHttpRouteHandlerKeys.Snapshot.AGGREGATION) {
+    override fun create(
+        contract: HttpRouteContract,
+        metadata: HttpRouteHandlerMetadata.Aggregate,
+    ): HandlerFunction<ServerResponse> = SnapshotAggregationHandlerFunction(
+        aggregateMetadata = aggregateMetadata(metadata),
+        queryHandler = snapshotQueryHandler,
+        rewriteRequestFilter = rewriteRequestFilter,
+        exceptionHandler = exceptionHandler,
+    )
+}

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
@@ -17,6 +17,10 @@ import io.mockk.mockk
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.abac.AbacTags
 import me.ahoo.wow.api.query.AggregateIdsFilter
+import me.ahoo.wow.api.query.AggregationElement
+import me.ahoo.wow.api.query.AggregationGroup
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.DeletionFilter
 import me.ahoo.wow.api.query.DeletionState
@@ -120,6 +124,39 @@ class HttpQueryGuardFilterTest {
                 .expectError(IllegalArgumentException::class.java)
                 .verify()
         }
+    }
+
+    @Test
+    fun `aggregation Guard should reuse existing limits and reject expensive work`() {
+        val oversized = AggregationQuery(
+            elements = listOf(AggregationElement(LogicalField("state.orders"))),
+            metrics = listOf(AggregationMetric.Count("count")),
+            limit = 101,
+        )
+        guard(maxListSize = 100).filter(aggregationContext(oversized), unexpectedBackend())
+            .writeRawRequest(request).test().expectError(IllegalArgumentException::class.java).verify()
+
+        val expensive = oversized.copy(limit = 1)
+        guard(allowExpensiveOperators = false).filter(aggregationContext(expensive), unexpectedBackend())
+            .writeRawRequest(request).test().expectError(IllegalArgumentException::class.java).verify()
+
+        val metricSort = AggregationQuery(
+            groupBy = listOf(AggregationGroup.Terms(LogicalField("state.status"), "status")),
+            metrics = listOf(AggregationMetric.Count("count")),
+            sort = listOf(Sort("count", Sort.Direction.ASC)),
+        )
+        guard(allowExpensiveOperators = false).filter(aggregationContext(metricSort), unexpectedBackend())
+            .writeRawRequest(request).test().expectError(IllegalArgumentException::class.java).verify()
+
+        val filtered = AggregationQuery(
+            filter = filterExpression {
+                "state.customer" eq "customer-1"
+                "state.status" eq "ACTIVE"
+            },
+            metrics = listOf(AggregationMetric.Count("count")),
+        )
+        guard(maxFilterNodes = 1, idleTimeout = Duration.ZERO).filter(aggregationContext(filtered), FilterChain { Mono.empty() })
+            .writeRawRequest(request).test().verifyComplete()
     }
 
     @Test
@@ -517,6 +554,12 @@ class HttpQueryGuardFilterTest {
             QueryType.COUNT,
             MOCK_AGGREGATE_METADATA,
         ).setQuery(filter)
+
+    private fun aggregationContext(query: AggregationQuery): QueryContext<AggregationQuery, Flux<DynamicDocument>> =
+        DefaultQueryContext<AggregationQuery, Flux<DynamicDocument>>(
+            QueryType.AGGREGATION,
+            MOCK_AGGREGATE_METADATA,
+        ).setQuery(query)
 
     private fun unexpectedBackend(): FilterChain<QueryContext<*, *>> = FilterChain {
         error("Backend must not be invoked.")

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
@@ -39,6 +39,7 @@ import me.ahoo.wow.api.query.Operator
 import me.ahoo.wow.api.query.PagedList
 import me.ahoo.wow.api.query.PagedQuery
 import me.ahoo.wow.api.query.Pagination
+import me.ahoo.wow.api.query.SimpleDynamicDocument
 import me.ahoo.wow.api.query.Sort
 import me.ahoo.wow.api.query.StringComparison
 import me.ahoo.wow.api.query.toFilterExpression
@@ -72,7 +73,9 @@ import me.ahoo.wow.webflux.route.event.LoadEventStreamHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.snapshot.LoadSnapshotHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.testAggregateRouteContract
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest
 import org.springframework.mock.web.reactive.function.server.MockServerRequest
 import org.springframework.mock.web.server.MockServerWebExchange
@@ -205,6 +208,28 @@ class HttpQueryGuardFilterTest {
                 .filter(aggregationContext(query), unexpectedBackend())
                 .writeRawRequest(request).test().expectError(IllegalArgumentException::class.java).verify()
         }
+    }
+
+    @Test
+    fun `aggregation guard should allow safe group sorting without expensive operators`() {
+        val row = SimpleDynamicDocument(mutableMapOf("status" to "ACTIVE", "count" to 1L))
+        val context = aggregationContext(
+            AggregationQuery(
+                groupBy = listOf(AggregationGroup.Terms(LogicalField("state.status"), "status")),
+                metrics = listOf(AggregationMetric.Count("count")),
+                sort = listOf(Sort("status", Sort.Direction.ASC)),
+            ),
+        )
+
+        guard(maxListSize = 0, idleTimeout = Duration.ZERO).filter(
+            context,
+            FilterChain {
+                it.asAggregationQuery().setResult(Flux.just(row))
+                Mono.empty()
+            },
+        ).writeRawRequest(request).test().verifyComplete()
+
+        context.getRequiredResult().test().expectNext(row).verifyComplete()
     }
 
     @Test
@@ -458,6 +483,44 @@ class HttpQueryGuardFilterTest {
         ).writeRawRequest(request).test().verifyComplete()
 
         context.getRequiredResult().test()
+            .expectError(TimeoutException::class.java)
+            .verify()
+    }
+
+    @Test
+    fun `json aggregation should time out before emitting a partial response`() {
+        val row = SimpleDynamicDocument(mutableMapOf("count" to 1L))
+        val context = aggregationContext(AggregationQuery(metrics = listOf(AggregationMetric.Count("count"))))
+        guard(idleTimeout = Duration.ofMillis(10)).filter(
+            context,
+            FilterChain {
+                it.asAggregationQuery().setResult(Flux.concat(Flux.just(row), Flux.never()))
+                Mono.empty()
+            },
+        ).writeRawRequest(request).test().verifyComplete()
+
+        context.getRequiredResult().test()
+            .expectError(TimeoutException::class.java)
+            .verify()
+    }
+
+    @Test
+    fun `event stream aggregation should emit rows before an idle timeout`() {
+        val row = SimpleDynamicDocument(mutableMapOf("count" to 1L))
+        val context = aggregationContext(AggregationQuery(metrics = listOf(AggregationMetric.Count("count"))))
+        val eventStreamRequest = MockServerRequest.builder()
+            .header(HttpHeaders.ACCEPT, MediaType.TEXT_EVENT_STREAM_VALUE)
+            .build()
+        guard(idleTimeout = Duration.ofMillis(10)).filter(
+            context,
+            FilterChain {
+                it.asAggregationQuery().setResult(Flux.concat(Flux.just(row), Flux.never()))
+                Mono.empty()
+            },
+        ).writeRawRequest(eventStreamRequest).test().verifyComplete()
+
+        context.getRequiredResult().test()
+            .expectNext(row)
             .expectError(TimeoutException::class.java)
             .verify()
     }

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
@@ -155,7 +155,10 @@ class HttpQueryGuardFilterTest {
             },
             metrics = listOf(AggregationMetric.Count("count")),
         )
-        guard(maxFilterNodes = 1, idleTimeout = Duration.ZERO).filter(aggregationContext(filtered), FilterChain { Mono.empty() })
+        guard(
+            maxFilterNodes = 1,
+            idleTimeout = Duration.ZERO
+        ).filter(aggregationContext(filtered), FilterChain { Mono.empty() })
             .writeRawRequest(request).test().verifyComplete()
     }
 

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
@@ -158,8 +158,53 @@ class HttpQueryGuardFilterTest {
         guard(
             maxFilterNodes = 1,
             idleTimeout = Duration.ZERO
-        ).filter(aggregationContext(filtered), FilterChain { Mono.empty() })
-            .writeRawRequest(request).test().verifyComplete()
+        ).filter(aggregationContext(filtered), unexpectedBackend())
+            .writeRawRequest(request).test().expectError(IllegalArgumentException::class.java).verify()
+    }
+
+    @Test
+    fun `aggregation Guard should share the filter node budget across root and elements`() {
+        val query = AggregationQuery(
+            filter = filterExpression { "state.status" eq "ACTIVE" },
+            elements = listOf(
+                AggregationElement(
+                    path = LogicalField("state.orders"),
+                    filter = filterExpression { "status" eq "PAID" },
+                ),
+            ),
+            metrics = listOf(AggregationMetric.Count("count")),
+        )
+
+        guard(maxFilterNodes = 1, allowExpensiveOperators = true)
+            .filter(aggregationContext(query), unexpectedBackend())
+            .writeRawRequest(request).test().expectError(IllegalArgumentException::class.java).verify()
+    }
+
+    @Test
+    fun `aggregation Guard should enforce filter value limits in every scope`() {
+        val rootIn = AggregationQuery(
+            filter = filterExpression { "state.status" isIn listOf("ACTIVE", "PAID") },
+            metrics = listOf(AggregationMetric.Count("count")),
+        )
+        val elementIn = AggregationQuery(
+            elements = listOf(
+                AggregationElement(
+                    path = LogicalField("state.orders"),
+                    filter = filterExpression { "status" isIn listOf("ACTIVE", "PAID") },
+                ),
+            ),
+            metrics = listOf(AggregationMetric.Count("count")),
+        )
+        val rootMetadata = AggregationQuery(
+            filter = AggregateIdsFilter(listOf("order-1", "order-2")),
+            metrics = listOf(AggregationMetric.Count("count")),
+        )
+
+        listOf(rootIn, elementIn, rootMetadata).forEach { query ->
+            guard(maxFilterValues = 1, allowExpensiveOperators = true)
+                .filter(aggregationContext(query), unexpectedBackend())
+                .writeRawRequest(request).test().expectError(IllegalArgumentException::class.java).verify()
+        }
     }
 
     @Test

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractorTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractorTest.kt
@@ -79,6 +79,12 @@ class QueryBodyExtractorTest {
         client.post().uri("/sku/snapshot/aggregation").contentType(MediaType.APPLICATION_JSON)
             .bodyValue("{$metric}").exchange().expectStatus().isOk
         client.post().uri("/sku/snapshot/aggregation").contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("{\"condition\":{\"operator\":\"ALL\"},$metric}").exchange().expectStatus().isOk
+        client.post().uri("/sku/snapshot/aggregation").contentType(MediaType.APPLICATION_JSON)
+            .bodyValue(
+                "{\"elements\":[{\"path\":\"state.items\",\"filter\":{\"op\":\"EQ\",\"field\":\"sku\",\"value\":\"a\"}}],$metric}"
+            ).exchange().expectStatus().isOk
+        client.post().uri("/sku/snapshot/aggregation").contentType(MediaType.APPLICATION_JSON)
             .bodyValue("{\"filter\":{\"op\":\"MATCH_ALL\"},\"condition\":{\"operator\":\"ALL\"},$metric}")
             .exchange().expectStatus().isBadRequest
         client.post().uri("/sku/snapshot/aggregation").contentType(MediaType.APPLICATION_JSON)

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractorTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractorTest.kt
@@ -18,6 +18,8 @@ import io.mockk.mockk
 import io.mockk.slot
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.query.AndFilter
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.EqualFilter
 import me.ahoo.wow.api.query.FilterExpression
@@ -33,8 +35,10 @@ import me.ahoo.wow.openapi.aggregate.command.CommandComponent
 import me.ahoo.wow.openapi.contract.BuiltInHttpRouteHandlerKeys
 import me.ahoo.wow.query.filter.Contexts.getRawRequest
 import me.ahoo.wow.query.filter.QueryHandler
+import me.ahoo.wow.query.snapshot.filter.SnapshotQueryHandler
 import me.ahoo.wow.webflux.exception.WebFluxRequestExceptionHandler
 import me.ahoo.wow.webflux.route.RouteTestFixtures
+import me.ahoo.wow.webflux.route.snapshot.SnapshotAggregationHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.testAggregateRouteContract
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
@@ -55,6 +59,37 @@ import reactor.kotlin.core.publisher.toMono
 import reactor.kotlin.test.test
 
 class QueryBodyExtractorTest {
+
+    @Test
+    fun `aggregation body should default omitted filter and reject ambiguous or non scalar element equality`() {
+        val queryHandler = mockk<SnapshotQueryHandler> {
+            every { aggregate(any(), any()) } returns Flux.empty()
+        }
+        val handler = SnapshotAggregationHandlerFunctionFactory(
+            snapshotQueryHandler = queryHandler,
+            rewriteRequestFilter = DefaultRewriteRequestFilter,
+            exceptionHandler = WebFluxRequestExceptionHandler(),
+        ).create(
+            testAggregateRouteContract(
+                handlerKey = BuiltInHttpRouteHandlerKeys.Snapshot.AGGREGATION,
+                aggregateRouteMetadata = RouteTestFixtures.MOCK_AGGREGATE_ROUTE_METADATA,
+            ),
+        )
+        val client = WebTestClient.bindToRouterFunction(route(POST("/sku/snapshot/aggregation"), handler)).build()
+        val metric = "\"metrics\":[{\"type\":\"COUNT\",\"alias\":\"count\"}]"
+
+        client.post().uri("/sku/snapshot/aggregation").contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("{$metric}").exchange().expectStatus().isOk
+        client.post().uri("/sku/snapshot/aggregation").contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("{\"filter\":{\"op\":\"MATCH_ALL\"},\"condition\":{\"operator\":\"ALL\"},$metric}")
+            .exchange().expectStatus().isBadRequest
+        client.post().uri("/sku/snapshot/aggregation").contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("{\"filter\":{\"op\":\"EQ\",\"field\":\"state.tags\",\"value\":[\"a\"]},$metric}")
+            .exchange().expectStatus().isBadRequest
+        client.post().uri("/sku/snapshot/aggregation").contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("{\"elements\":[{\"path\":\"state.items\",\"filter\":{\"op\":\"EQ\",\"field\":\"sku\",\"value\":[\"a\"]}}],$metric}")
+            .exchange().expectStatus().isBadRequest
+    }
 
     @Test
     fun `should reject malformed request body as bad request`() {

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractorTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractorTest.kt
@@ -18,8 +18,6 @@ import io.mockk.mockk
 import io.mockk.slot
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.query.AndFilter
-import me.ahoo.wow.api.query.AggregationMetric
-import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.EqualFilter
 import me.ahoo.wow.api.query.FilterExpression
@@ -87,7 +85,9 @@ class QueryBodyExtractorTest {
             .bodyValue("{\"filter\":{\"op\":\"EQ\",\"field\":\"state.tags\",\"value\":[\"a\"]},$metric}")
             .exchange().expectStatus().isBadRequest
         client.post().uri("/sku/snapshot/aggregation").contentType(MediaType.APPLICATION_JSON)
-            .bodyValue("{\"elements\":[{\"path\":\"state.items\",\"filter\":{\"op\":\"EQ\",\"field\":\"sku\",\"value\":[\"a\"]}}],$metric}")
+            .bodyValue(
+                "{\"elements\":[{\"path\":\"state.items\",\"filter\":{\"op\":\"EQ\",\"field\":\"sku\",\"value\":[\"a\"]}}],$metric}"
+            )
             .exchange().expectStatus().isBadRequest
         client.post().uri("/sku/snapshot/aggregation").contentType(MediaType.APPLICATION_JSON)
             .bodyValue("{\"condition\":{\"operator\":\"ALL\",\"unexpected\":true},$metric}")
@@ -96,7 +96,9 @@ class QueryBodyExtractorTest {
             .bodyValue("{\"condition\":{\"field\":\"state.tags\",\"operator\":\"EQ\",\"value\":[\"a\"]},$metric}")
             .exchange().expectStatus().isBadRequest
         client.post().uri("/sku/snapshot/aggregation").contentType(MediaType.APPLICATION_JSON)
-            .bodyValue("{\"condition\":{\"operator\":\"ALL\"},\"elements\":[{\"path\":\"state.items\",\"filter\":{\"op\":\"NE\",\"field\":\"sku\",\"value\":{\"value\":\"a\"},\"unexpected\":true}}],$metric}")
+            .bodyValue(
+                "{\"condition\":{\"operator\":\"ALL\"},\"elements\":[{\"path\":\"state.items\",\"filter\":{\"op\":\"NE\",\"field\":\"sku\",\"value\":{\"value\":\"a\"},\"unexpected\":true}}],$metric}"
+            )
             .exchange().expectStatus().isBadRequest
     }
 

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractorTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/QueryBodyExtractorTest.kt
@@ -89,6 +89,15 @@ class QueryBodyExtractorTest {
         client.post().uri("/sku/snapshot/aggregation").contentType(MediaType.APPLICATION_JSON)
             .bodyValue("{\"elements\":[{\"path\":\"state.items\",\"filter\":{\"op\":\"EQ\",\"field\":\"sku\",\"value\":[\"a\"]}}],$metric}")
             .exchange().expectStatus().isBadRequest
+        client.post().uri("/sku/snapshot/aggregation").contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("{\"condition\":{\"operator\":\"ALL\",\"unexpected\":true},$metric}")
+            .exchange().expectStatus().isBadRequest
+        client.post().uri("/sku/snapshot/aggregation").contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("{\"condition\":{\"field\":\"state.tags\",\"operator\":\"EQ\",\"value\":[\"a\"]},$metric}")
+            .exchange().expectStatus().isBadRequest
+        client.post().uri("/sku/snapshot/aggregation").contentType(MediaType.APPLICATION_JSON)
+            .bodyValue("{\"condition\":{\"operator\":\"ALL\"},\"elements\":[{\"path\":\"state.items\",\"filter\":{\"op\":\"NE\",\"field\":\"sku\",\"value\":{\"value\":\"a\"},\"unexpected\":true}}],$metric}")
+            .exchange().expectStatus().isBadRequest
     }
 
     @Test

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/snapshot/SnapshotAggregationHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/snapshot/SnapshotAggregationHandlerFunctionTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.route.snapshot
+
+import io.mockk.every
+import io.mockk.mockk
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.SimpleDynamicDocument.Companion.toDynamicDocument
+import me.ahoo.wow.openapi.contract.BuiltInHttpRouteHandlerKeys
+import me.ahoo.wow.query.filter.Contexts.getRawRequest
+import me.ahoo.wow.query.snapshot.filter.SnapshotQueryHandler
+import me.ahoo.wow.webflux.exception.WebFluxRequestExceptionHandler
+import me.ahoo.wow.webflux.route.RouteTestFixtures
+import me.ahoo.wow.webflux.route.query.DefaultRewriteRequestFilter
+import me.ahoo.wow.webflux.route.testAggregateRouteContract
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.mock.web.reactive.function.server.MockServerRequest
+import org.springframework.mock.web.server.MockServerWebExchange
+import org.springframework.web.reactive.function.server.HandlerStrategies
+import org.springframework.web.reactive.function.server.ServerResponse
+import reactor.core.publisher.Flux
+import reactor.kotlin.core.publisher.toMono
+import java.util.concurrent.atomic.AtomicBoolean
+
+class SnapshotAggregationHandlerFunctionTest {
+    @Test
+    fun `aggregation route should stream handler rows`() {
+        val subscribed = AtomicBoolean()
+        val handler = mockk<SnapshotQueryHandler> {
+            every { aggregate(any(), any()) } returns Flux.deferContextual {
+                it.getRawRequest<MockServerRequest>().assert().isNotNull()
+                subscribed.set(true)
+                Flux.just(mutableMapOf("count" to 1L).toDynamicDocument())
+            }
+        }
+        val function = SnapshotAggregationHandlerFunctionFactory(
+            snapshotQueryHandler = handler,
+            rewriteRequestFilter = DefaultRewriteRequestFilter,
+            exceptionHandler = WebFluxRequestExceptionHandler(),
+        ).create(
+            testAggregateRouteContract(
+                handlerKey = BuiltInHttpRouteHandlerKeys.Snapshot.AGGREGATION,
+                aggregateRouteMetadata = RouteTestFixtures.MOCK_AGGREGATE_ROUTE_METADATA,
+            ),
+        )
+        val request = MockServerRequest.builder().body(
+            AggregationQuery(metrics = listOf(AggregationMetric.Count("count"))).toMono(),
+        )
+
+        val response = function.handle(request).block()!!
+        val exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/test").build())
+
+        response.statusCode().assert().isEqualTo(HttpStatus.OK)
+        response.writeTo(exchange, SERVER_RESPONSE_CONTEXT).block()
+        subscribed.get().assert().isTrue()
+    }
+
+    private companion object {
+        private val SERVER_RESPONSE_CONTEXT = object : ServerResponse.Context {
+            private val strategies = HandlerStrategies.withDefaults()
+            override fun messageWriters() = strategies.messageWriters()
+            override fun viewResolvers() = strategies.viewResolvers()
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Add a clean snapshot aggregation API with ordered nested Elements, backend-neutral result semantics, and first-class MongoDB, Elasticsearch, WebFlux, OpenAPI, ApiClient, DSL, and documentation support.

## Changes

- Adds the `AggregationQuery` public contract and direct Kotlin DSL while keeping the existing `SnapshotQueryService` source-compatible.
- Routes aggregation through the existing snapshot filter chain: ABAC rewrites the root filter and aggregation intentionally skips masking.
- Implements MongoDB pipelines and Elasticsearch composite/PIT pagination with stable sorting, exact metric Top-N, null/finite numeric normalization, ISO-week alignment, and Decimal128 key normalization.
- Adds shared real-backend TCK coverage for nested Elements, filters, all group/metric types, empty/null behavior, sorting, cancellation, week boundaries, and decimal Terms.
- Adds strict WebFlux extraction and Guard limits, `POST snapshot/aggregation`, generic OpenAPI schemas, independent reactive/synchronous ApiClient contracts, and bilingual documentation.
- Reuses main schema generation improvements from #3015; `LogicalField` is published as its actual string wire type.

## Verification

- `./gradlew detekt :wow-api:check :wow-query:check :wow-mongo:check :wow-elasticsearch:check :wow-webflux:check :wow-openapi:check :wow-apiclient:check :wow-spring:check :wow-spring-boot-starter:check --rerun-tasks` — 150/150 tasks executed, passed.
- MongoDB and Elasticsearch aggregation integration classes with `--rerun-tasks` — 34/34 tasks executed, passed.
- `pnpm docs:build` — passed.
- Example server live health and `/v3/api-docs` assertions — passed, including aggregation request/response refs, closed query schemas, and `LogicalField` string type.
- Final comprehensive review — Ready to merge, no remaining findings.

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

Existing `SnapshotQueryService` implementations remain source-compatible through a default unsupported aggregation publisher; no ABI bridge or capability interface is added. Metric sorting is intentionally expensive and remains controlled by the existing HTTP Guard. Custom serializer/converter/mapping portability, field catalogs, Batch, and arithmetic expressions are explicitly out of scope.