### PR TITLE
docs(query): clarify snapshot aggregation HTTP usage

### DIFF
--- a/documentation/docs/en/guide/extensions/webflux.md
+++ b/documentation/docs/en/guide/extensions/webflux.md
@@ -119,7 +119,7 @@ The guard applies whenever the Reactor context contains a WebFlux `ServerRequest
 
 ## Snapshot Aggregation Route
 
-WebFlux registers `POST /{context}/{aggregate}/snapshot/aggregation`, with the tenant/owner/space prefixes applicable to the aggregate. The body is an `AggregationQuery`. A normal JSON response is an array of dynamic row objects; `Accept: text/event-stream` streams one row at a time. Strict request decoding rejects unknown properties and invalid scalar equality values in both the root filter and Element filters.
+WebFlux registers `POST /{aggregate}/snapshot/aggregation`; tenant-, owner-, or space-scoped aggregates prepend their applicable route prefix. The body is an `AggregationQuery`. A normal JSON response is an array of dynamic row objects; `Accept: text/event-stream` streams one row at a time. Strict request decoding rejects unknown properties and invalid scalar equality values in both the root filter and Element filters.
 
 The existing query guard applies `query.max-list-size` to the aggregation `limit`. `query.allow-expensive-operators=false` rejects expensive operators in the root and Element filters, any Elements expansion, and sorting by a metric alias. No aggregation-specific WebFlux properties are added.
 

--- a/documentation/docs/en/guide/query.md
+++ b/documentation/docs/en/guide/query.md
@@ -202,7 +202,37 @@ Aggregation uses the existing snapshot filter chain: ABAC and route filters stil
 
 Wow validates the request structure, not field existence, collection shape, or physical field type. It does not maintain an aggregation field catalog or use `TypeFieldPaths` for validation. Equivalent behavior is not guaranteed for custom Jackson serializers, backend filter converters, or custom Elasticsearch mappings. Batch aggregation and arithmetic expressions are not included.
 
-The HTTP endpoint is `POST /{context}/{aggregate}/snapshot/aggregation` (with the route prefixes applicable to the aggregate). JSON responses are arrays of dynamic objects; SSE streams one object at a time. OpenAPI publishes an aggregate-specific `AggregationQuery` request body whose `x-wow-query-fields` references that aggregate's `*AggregatedFields` component, while the JSON schema remains the generic `AggregationQuery` contract.
+The HTTP endpoint is `POST /{aggregate}/snapshot/aggregation`. Tenant-, owner-, or space-scoped aggregates prepend their applicable route prefix; use the running instance's OpenAPI paths as the source of truth. JSON responses are arrays of dynamic objects; SSE streams one object at a time. OpenAPI publishes an aggregate-specific `AggregationQuery` request body whose `x-wow-query-fields` references that aggregate's `*AggregatedFields` component, while the JSON schema remains the generic `AggregationQuery` contract.
+
+For example, the compensation control plane can count failed executions by status:
+
+```bash
+curl --request POST 'http://localhost:8080/execution_failed/snapshot/aggregation' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "groupBy": [
+      {"type": "TERMS", "field": "state.status", "alias": "status"}
+    ],
+    "metrics": [
+      {"type": "COUNT", "alias": "count"}
+    ],
+    "sort": [
+      {"field": "status", "direction": "ASC"}
+    ],
+    "limit": 10
+  }'
+```
+
+The response has the following shape; counts depend on the current data:
+
+```json
+[
+  {"status": "FAILED", "count": 12},
+  {"status": "SUCCEEDED", "count": 3}
+]
+```
+
+The same `AggregationQuery` contract can run through MongoDB and Elasticsearch snapshot query services and return the same row shape. Backend-specific field mappings, nested models, and custom serialization remain subject to the constraints documented by each extension.
 
 ### Rewriting queries
 

--- a/documentation/docs/zh/guide/extensions/webflux.md
+++ b/documentation/docs/zh/guide/extensions/webflux.md
@@ -117,7 +117,7 @@ Reactor Context 通过 `writeRawRequest(request)` 携带 WebFlux `ServerRequest`
 
 ## 快照聚合路由
 
-WebFlux 注册 `POST /{context}/{aggregate}/snapshot/aggregation`，并应用聚合自身适用的 tenant/owner/space 路由前缀。请求体为 `AggregationQuery`。普通 JSON 响应是动态行对象数组；`Accept: text/event-stream` 会逐行流式返回。严格请求解码会拒绝未知属性，以及根 filter 和 Element filters 中非法的标量等值条件。
+WebFlux 注册 `POST /{aggregate}/snapshot/aggregation`；tenant、owner 或 space 作用域的聚合会在前面增加各自的路由前缀。请求体为 `AggregationQuery`。普通 JSON 响应是动态行对象数组；`Accept: text/event-stream` 会逐行流式返回。严格请求解码会拒绝未知属性，以及根 filter 和 Element filters 中非法的标量等值条件。
 
 现有查询护栏把 `query.max-list-size` 用作聚合 `limit` 上限。`query.allow-expensive-operators=false` 时，会拒绝根 filter 与 Element filters 中的高成本操作符、任意 Elements 展开，以及按 metric alias 排序。不会增加聚合专用 WebFlux 配置。
 

--- a/documentation/docs/zh/guide/query.md
+++ b/documentation/docs/zh/guide/query.md
@@ -202,7 +202,37 @@ query.query(snapshotQueryService)
 
 Wow 只校验请求结构，不校验字段是否存在、路径是否为集合或物理字段类型；不会维护聚合字段目录，也不会使用 `TypeFieldPaths` 做校验。自定义 Jackson serializer、后端 filter converter 或 Elasticsearch mapping 不保证跨后端等价。首期不包含 Batch 聚合与算术表达式。
 
-HTTP 端点为 `POST /{context}/{aggregate}/snapshot/aggregation`（并遵循聚合自身适用的路由前缀）。JSON 响应是动态对象数组；SSE 逐个流式返回对象。OpenAPI 为每个聚合发布专属 `AggregationQuery` request body，其 `x-wow-query-fields` 引用该聚合的 `*AggregatedFields` 组件，JSON schema 仍使用通用 `AggregationQuery` 合同。
+HTTP 端点为 `POST /{aggregate}/snapshot/aggregation`。tenant、owner 或 space 作用域的聚合会在前面增加各自的路由前缀；以运行实例的 OpenAPI 路径为准。JSON 响应是动态对象数组；SSE 逐个流式返回对象。OpenAPI 为每个聚合发布专属 `AggregationQuery` request body，其 `x-wow-query-fields` 引用该聚合的 `*AggregatedFields` 组件，JSON schema 仍使用通用 `AggregationQuery` 合同。
+
+例如，补偿控制面可以按执行状态统计失败记录：
+
+```bash
+curl --request POST 'http://localhost:8080/execution_failed/snapshot/aggregation' \
+  --header 'Content-Type: application/json' \
+  --data '{
+    "groupBy": [
+      {"type": "TERMS", "field": "state.status", "alias": "status"}
+    ],
+    "metrics": [
+      {"type": "COUNT", "alias": "count"}
+    ],
+    "sort": [
+      {"field": "status", "direction": "ASC"}
+    ],
+    "limit": 10
+  }'
+```
+
+响应结构如下，具体计数取决于当前数据：
+
+```json
+[
+  {"status": "FAILED", "count": 12},
+  {"status": "SUCCEEDED", "count": 3}
+]
+```
+
+同一份 `AggregationQuery` 合同可由 MongoDB 与 Elasticsearch 快照查询服务执行并返回相同的行结构；字段映射、嵌套模型及自定义序列化的后端差异仍遵循各扩展文档中的约束。
 
 ### 重写查询
 


### PR DESCRIPTION
## Goal

Make the snapshot aggregation documentation accurate and directly executable.

## Changes

- Correct the default route from /{context}/{aggregate}/snapshot/aggregation to /{aggregate}/snapshot/aggregation in Chinese and English Query/WebFlux guides.
- Explain tenant, owner, and space route prefixes.
- Add a compensation control-plane curl request and stable response-shape example without live counts.
- Clarify the shared MongoDB/Elasticsearch response contract and backend-specific mapping constraints.

## Verification

- pnpm docs:build — passed
- git diff --check — passed
- Verified the obsolete route template no longer appears under documentation/docs.

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

Documentation only; no runtime or generated contract changes.