### PR TITLE
feat(query): add phrase search mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,9 @@ Before changing release or publish behavior, inspect the workflow and Gradle pub
 - Always run the narrowest relevant Gradle, pnpm, or docs command before reporting a change as complete.
 - Always add or update tests when changing command handling, event sourcing, projections, sagas, compensation behavior, serialization, schema generation, or generated metadata.
 - Always preserve public API compatibility unless the user explicitly asks for a breaking change.
+- Prefer clean source and the smallest correct implementation. Do not add compatibility bridges, custom serialization or creators, duplicate validation, or tests of dependency behavior without a concrete requirement or reproduced failure.
+- Treat source, binary, and wire compatibility as separate scopes. Implement only the compatibility scope the user requested; do not infer binary or wire compatibility from source compatibility.
+- Trust installed framework modules and backend-native semantics. Add validation only for the public contract, security, data-loss prevention, or a demonstrated backend requirement.
 - Ask first before changing Gradle module structure, feature capabilities, generated OpenAPI/schema contracts, CI/CD workflows, publishing credentials, or release automation.
 - Ask first before adding dependencies or moving responsibilities across module boundaries.
 - Never commit secrets, signing keys, Maven credentials, GitHub tokens, generated build output, `node_modules/`, `.gradle/`, or IDE-local state.

--- a/documentation/docs/en/guide/extensions/elasticsearch.md
+++ b/documentation/docs/en/guide/extensions/elasticsearch.md
@@ -206,6 +206,8 @@ For example, one logical field can support both full-text and exact operations:
 
 Clients always use the logical field and do not need to hard-code `.keyword` or `.text`.
 
+The default `TERMS` mode for `SEARCH` uses `multi_match`; `PHRASE` uses `multi_match(type = phrase)` with the same field-resolution rules.
+
 For a multi-field, Wow tries the current field, `.keyword`/`.text`, `.exact`, and finally a single compatible child.
 Multiple compatible children fail as ambiguous rather than silently changing semantics. Projection remains on the
 logical field; the parent of `ELEMENT_MATCH` must be mapped as `nested`. A custom

--- a/documentation/docs/en/guide/extensions/mongo.md
+++ b/documentation/docs/en/guide/extensions/mongo.md
@@ -388,7 +388,8 @@ The compilation pipeline is: `FilterExpression` -> `AbstractMongoFilterConverter
 | `EQ` | `Filters.eq()` |
 | `GT` / `GTE` / `LT` / `LTE` | `Filters.gt()` / `gte()` / `lt()` / `lte()` |
 | `CONTAINS` | `Filters.regex()` (escaped) |
-| `SEARCH` | `Filters.text()` |
+| `SEARCH` (`TERMS`) | `Filters.text(query)` |
+| `SEARCH` (`PHRASE`) | `Filters.text("\"$query\"")` |
 | `BETWEEN` | `Filters.and(Filters.gte(), Filters.lte())` |
 | `IN` / `NOT_IN` | `Filters.in()` / `nin()` |
 | `DELETION` | `Filters.eq("deleted", true/false)` or `Filters.empty()` |

--- a/documentation/docs/en/guide/query.md
+++ b/documentation/docs/en/guide/query.md
@@ -35,7 +35,7 @@ description: Query snapshots and event streams with FilterExpression, the query 
 | Empty, null, and existence | `IS_EMPTY`, `IS_NULL`, `IS_NOT_NULL`, `EXISTS`, `NOT_EXISTS` | `field` | Compiled to each backend's native existence and empty-value semantics |
 | Deletion | `DELETION` | `state` | `ACTIVE`, `DELETED`, or `ALL`; deletion is part of the filter model |
 | Array element | `ELEMENT_MATCH` | `field`, `predicate` | `predicate` cannot contain `DELETION`, `SEARCH`, or metadata Filters |
-| Full-text search | `SEARCH` | `query`, `fields` | `query` cannot be blank; field support is backend-specific |
+| Full-text search | `SEARCH` | `query`, `fields`, `mode` | `mode` defaults to `TERMS` and may be set to `PHRASE`; field support is backend-specific |
 | Relative time | `TODAY`, `YESTERDAY`, `BEFORE_TODAY`, `TOMORROW`, `THIS_WEEK`, `NEXT_WEEK`, `LAST_WEEK`, `THIS_MONTH`, `NEXT_MONTH`, `LAST_MONTH`, `LAST_YEAR`, `THIS_YEAR`, `NEXT_YEAR`, `RECENT_DAYS`, `EARLIER_DAYS` | `field`; operation-specific `time` or `days`; optional `zoneId` | Normalized to absolute ranges before backend compilation |
 
 `field` is a logical field path. Valid examples are:
@@ -52,7 +52,7 @@ Aggregate-specific OpenAPI request bodies publish valid filter, projection, and 
 Snapshot queries default to `DELETION = ACTIVE`. A top-level `DELETION`, or one used directly inside the top-level `AND`, explicitly overrides that scope; nesting deletion inside `OR` or `NOR` does not disable the active guard. Event-stream queries do not add a deletion scope, preserving complete audit history.
 
 :::info Backend differences
-MongoDB `SEARCH` uses the collection text index and does not restrict the query to `fields`; Elasticsearch can resolve search fields and multi-fields. Use relative child fields inside `ELEMENT_MATCH` for portable MongoDB and Elasticsearch behavior.
+MongoDB `SEARCH` uses the collection text index and does not restrict the query to `fields`; Elasticsearch can resolve search fields and multi-fields. `PHRASE` compiles to a quoted `$text` phrase in MongoDB and to `multi_match(type = phrase)` in Elasticsearch. Use relative child fields inside `ELEMENT_MATCH` for portable MongoDB and Elasticsearch behavior.
 :::
 
 ## Kotlin DSL
@@ -73,6 +73,14 @@ val orderFilter = filterExpression {
         "productId" eq "product-1"
         "quantity" gt 0
     }
+}
+```
+
+Use `PHRASE` to match consecutive terms produced by the backend analyzer. Omitting `mode` preserves the existing `TERMS` behavior:
+
+```kotlin
+val phraseFilter = filterExpression {
+    search("event sourcing", SearchMode.PHRASE, "state.title", "state.description")
 }
 ```
 

--- a/documentation/docs/zh/guide/extensions/elasticsearch.md
+++ b/documentation/docs/zh/guide/extensions/elasticsearch.md
@@ -199,6 +199,8 @@ flattened 父字段，并保留原路径执行精确和排序操作。flattened 
 
 客户端始终使用逻辑字段，不需要固定写入 `.keyword` 或 `.text`。
 
+`SEARCH` 的默认 `TERMS` 模式使用 `multi_match`；`PHRASE` 模式使用 `multi_match(type = phrase)`，字段解析规则不变。
+
 对于 multi-field，依次选择当前字段、`.keyword`/`.text`、`.exact`，最后才选择唯一的兼容子字段；存在多个兼容候选时
 查询失败，避免静默改变语义。projection 仍使用逻辑字段，`ELEMENT_MATCH` 的父路径
 必须映射为 `nested`。自定义 `AbstractElasticsearchFilterConverter` 继续负责解释自己的物理字段，不经过上述重写。

--- a/documentation/docs/zh/guide/extensions/mongo.md
+++ b/documentation/docs/zh/guide/extensions/mongo.md
@@ -383,7 +383,8 @@ context，应先迁移或清空原事件流、快照与 PrepareKey 数据，再�
 | `EQ` | `Filters.eq()` |
 | `GT` / `GTE` / `LT` / `LTE` | `Filters.gt()` / `gte()` / `lt()` / `lte()` |
 | `CONTAINS` | `Filters.regex()`（已转义） |
-| `SEARCH` | `Filters.text()` |
+| `SEARCH` (`TERMS`) | `Filters.text(query)` |
+| `SEARCH` (`PHRASE`) | `Filters.text("\"$query\"")` |
 | `BETWEEN` | `Filters.and(Filters.gte(), Filters.lte())` |
 | `IN` / `NOT_IN` | `Filters.in()` / `nin()` |
 | `DELETION` | `Filters.eq("deleted", true/false)` 或 `Filters.empty()` |

--- a/documentation/docs/zh/guide/query.md
+++ b/documentation/docs/zh/guide/query.md
@@ -35,7 +35,7 @@ description: 使用 FilterExpression、查询 DSL 与 REST API 查询快照和�
 | 空值与存在性 | `IS_EMPTY`、`IS_NULL`、`IS_NOT_NULL`、`EXISTS`、`NOT_EXISTS` | `field` | 按各后端原生的存在性与空值语义编译 |
 | 删除状态 | `DELETION` | `state` | `ACTIVE`、`DELETED` 或 `ALL`；删除状态本身也是过滤器 |
 | 数组元素 | `ELEMENT_MATCH` | `field`、`predicate` | `predicate` 内不允许 `DELETION`、`SEARCH` 或元数据 Filter |
-| 全文搜索 | `SEARCH` | `query`、`fields` | `query` 不能为空；具体字段能力由后端决定 |
+| 全文搜索 | `SEARCH` | `query`、`fields`、`mode` | `mode` 默认为 `TERMS`，可设为 `PHRASE`；具体字段能力由后端决定 |
 | 相对时间 | `TODAY`、`YESTERDAY`、`BEFORE_TODAY`、`TOMORROW`、`THIS_WEEK`、`NEXT_WEEK`、`LAST_WEEK`、`THIS_MONTH`、`NEXT_MONTH`、`LAST_MONTH`、`LAST_YEAR`、`THIS_YEAR`、`NEXT_YEAR`、`RECENT_DAYS`、`EARLIER_DAYS` | `field`；特定操作使用 `time` 或 `days`；可选 `zoneId` | 执行前统一规范化为绝对时间范围 |
 
 `field` 是逻辑字段路径。合法示例：
@@ -52,7 +52,7 @@ state.items.0.productId
 快照查询默认使用 `DELETION = ACTIVE`。顶层 `DELETION`，或顶层 `AND` 的直接 `DELETION` 子项，可以显式覆盖该范围；嵌套在 `OR` 或 `NOR` 中的删除过滤器不会关闭 active guard。事件流查询不会自动追加删除状态过滤，以保证审计事件完整。
 
 :::info 后端差异
-MongoDB 的 `SEARCH` 使用集合文本索引，不会把查询限制到 `fields`；Elasticsearch 可解析搜索字段和多字段映射。`ELEMENT_MATCH` 的子字段建议使用相对路径，以同时兼容 MongoDB 与 Elasticsearch。
+MongoDB 的 `SEARCH` 使用集合文本索引，不会把查询限制到 `fields`；Elasticsearch 可解析搜索字段和多字段映射。`PHRASE` 在 MongoDB 中编译为带引号的 `$text` 短语，在 Elasticsearch 中编译为 `multi_match(type = phrase)`。`ELEMENT_MATCH` 的子字段建议使用相对路径，以同时兼容 MongoDB 与 Elasticsearch。
 :::
 
 ## Kotlin DSL
@@ -73,6 +73,14 @@ val orderFilter = filterExpression {
         "productId" eq "product-1"
         "quantity" gt 0
     }
+}
+```
+
+使用 `PHRASE` 搜索后端分析器识别的连续词项；省略 `mode` 时保持原有 `TERMS` 行为：
+
+```kotlin
+val phraseFilter = filterExpression {
+    search("event sourcing", SearchMode.PHRASE, "state.title", "state.description")
 }
 ```
 

--- a/schema/query/v2/filter-expression.schema.json
+++ b/schema/query/v2/filter-expression.schema.json
@@ -242,7 +242,7 @@
     },
     "search": {
       "type": "object",
-      "properties": { "op": { "enum": ["SEARCH"] }, "query": { "type": "string", "minLength": 1 }, "fields": { "type": "array", "uniqueItems": true, "items": { "$ref": "#/definitions/logicalField" }, "default": [] } },
+      "properties": { "op": { "enum": ["SEARCH"] }, "query": { "type": "string", "minLength": 1 }, "fields": { "type": "array", "uniqueItems": true, "items": { "$ref": "#/definitions/logicalField" }, "default": [] }, "mode": { "type": "string", "enum": ["TERMS", "PHRASE"], "default": "TERMS" } },
       "required": ["op", "query"],
       "additionalProperties": false
     },

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/FilterExpression.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/FilterExpression.kt
@@ -222,12 +222,18 @@ data class ElementMatchFilter(
 data class SearchFilter(
     val query: String,
     val fields: Set<LogicalField> = emptySet(),
+    val mode: SearchMode = SearchMode.TERMS,
 ) : FilterExpression {
     override val operator: FilterOperator = FilterOperator.SEARCH
 
     init {
         require(query.isNotBlank()) { "SEARCH query cannot be blank." }
     }
+}
+
+enum class SearchMode {
+    TERMS,
+    PHRASE,
 }
 
 internal fun FilterExpression.containsElementUnsupportedFilter(): Boolean = when (this) {

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/query/FilterExpressionTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/query/FilterExpressionTest.kt
@@ -16,13 +16,13 @@ package me.ahoo.wow.api.query
 import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import tools.jackson.databind.JsonNode
-import tools.jackson.module.kotlin.jsonMapper
+import tools.jackson.module.kotlin.jacksonObjectMapper
 import java.time.LocalTime
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 class FilterExpressionTest {
-    private val jsonMapper = jsonMapper()
+    private val jsonMapper = jacksonObjectMapper()
 
     @Test
     fun `new relative calendar filters should round trip through the common contract`() {
@@ -83,6 +83,40 @@ class FilterExpressionTest {
         json.contains("\"op\":\"AND\"").assert().isTrue()
         json.contains("\"operator\"").assert().isFalse()
         decoded.assert().isEqualTo(expression)
+    }
+
+    @Test
+    fun `search mode should default to terms`() {
+        val decoded = jsonMapper.readValue(
+            """{"op":"SEARCH","query":"wow","fields":["state.name"]}""",
+            FilterExpression::class.java,
+        ) as SearchFilter
+
+        decoded.assert().isEqualTo(SearchFilter("wow", setOf(LogicalField("state.name"))))
+        decoded.mode.assert().isEqualTo(SearchMode.TERMS)
+    }
+
+    @Test
+    fun `phrase search should round trip`() {
+        val phrase = SearchFilter(
+            query = "event sourcing",
+            fields = setOf(LogicalField("state.description")),
+            mode = SearchMode.PHRASE,
+        )
+
+        val json = jsonMapper.writeValueAsString(phrase)
+        val decoded = jsonMapper.readValue(json, FilterExpression::class.java)
+
+        json.contains("\"op\":\"SEARCH\"").assert().isTrue()
+        json.contains("\"mode\":\"PHRASE\"").assert().isTrue()
+        decoded.assert().isEqualTo(phrase)
+    }
+
+    @Test
+    fun `phrase search should preserve embedded quotes`() {
+        val filter = SearchFilter("event \"sourcing\"", mode = SearchMode.PHRASE)
+
+        filter.query.assert().isEqualTo("event \"sourcing\"")
     }
 
     @Suppress("DEPRECATION")

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchFilterConverter.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchFilterConverter.kt
@@ -30,6 +30,7 @@ import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.term
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.terms
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.termsSet
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.wildcard
+import co.elastic.clients.elasticsearch._types.query_dsl.TextQueryType
 import co.elastic.clients.json.JsonData
 import me.ahoo.wow.api.query.*
 import me.ahoo.wow.query.FilterNormalizer
@@ -140,6 +141,7 @@ abstract class AbstractElasticsearchFilterConverter(
         is SearchFilter -> multiMatch {
             it.query(filter.query)
             if (filter.fields.isNotEmpty()) it.fields(filter.fields.map { field -> field.path(parent) })
+            if (filter.mode == SearchMode.PHRASE) it.type(TextQueryType.Phrase)
             it
         }
         is DeletionFilter -> when (filter.deletionState) {

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolver.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolver.kt
@@ -46,6 +46,7 @@ enum class ElasticsearchFieldUsage {
     RANGE,
     PRESENCE,
     SEARCH,
+    PHRASE_SEARCH,
     MATCH,
     SORT,
 }
@@ -221,9 +222,13 @@ data class ElasticsearchIndexMapping private constructor(
         is NextYearFilter -> filter.copy(field = filter.field.resolve(parent, ElasticsearchFieldUsage.RANGE))
         is RecentDaysFilter -> filter.copy(field = filter.field.resolve(parent, ElasticsearchFieldUsage.RANGE))
         is EarlierDaysFilter -> filter.copy(field = filter.field.resolve(parent, ElasticsearchFieldUsage.RANGE))
-        is SearchFilter -> filter.copy(
-            fields = filter.fields.mapTo(linkedSetOf()) { it.resolve(parent, ElasticsearchFieldUsage.SEARCH) },
-        )
+        is SearchFilter -> {
+            val usage = when (filter.mode) {
+                SearchMode.TERMS -> ElasticsearchFieldUsage.SEARCH
+                SearchMode.PHRASE -> ElasticsearchFieldUsage.PHRASE_SEARCH
+            }
+            filter.copy(fields = filter.fields.mapTo(linkedSetOf()) { it.resolve(parent, usage) })
+        }
         is ElementMatchFilter -> {
             val nestedPath = filter.field.path(parent)
             ElementMatchFilter(LogicalField(requireNested(nestedPath)), resolve(filter.predicate, nestedPath))
@@ -293,7 +298,9 @@ data class ElasticsearchIndexMapping private constructor(
 
         private fun preferredSuffixes(usage: ElasticsearchFieldUsage): List<String> =
             when (usage) {
-                ElasticsearchFieldUsage.SEARCH -> listOf("text")
+                ElasticsearchFieldUsage.SEARCH,
+                ElasticsearchFieldUsage.PHRASE_SEARCH,
+                -> listOf("text")
                 else -> listOf("keyword", "exact")
             }
 
@@ -314,6 +321,7 @@ private data class ElasticsearchMappedField(
             ElasticsearchFieldUsage.RANGE -> isQueryable() && kind in RANGE_KINDS
             ElasticsearchFieldUsage.PRESENCE -> isQueryable()
             ElasticsearchFieldUsage.SEARCH,
+            ElasticsearchFieldUsage.PHRASE_SEARCH,
             ElasticsearchFieldUsage.MATCH,
             -> indexed && kind in SEARCH_KINDS_BY_USAGE.getValue(usage)
             ElasticsearchFieldUsage.SORT ->
@@ -379,6 +387,7 @@ private data class ElasticsearchMappedField(
         private val MATCH_KINDS = SEARCH_KINDS + EXACT_KINDS
         private val SEARCH_KINDS_BY_USAGE = mapOf(
             ElasticsearchFieldUsage.SEARCH to SEARCH_KINDS,
+            ElasticsearchFieldUsage.PHRASE_SEARCH to SEARCH_KINDS - Property.Kind.SemanticText,
             ElasticsearchFieldUsage.MATCH to MATCH_KINDS,
         )
     }

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchFilterConverterTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchFilterConverterTest.kt
@@ -28,6 +28,7 @@ import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.term
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.terms
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.termsSet
 import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders.wildcard
+import co.elastic.clients.elasticsearch._types.query_dsl.TextQueryType
 import co.elastic.clients.json.JsonData
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.query.*
@@ -194,6 +195,8 @@ class ElasticsearchFilterConverterTest {
                 nested { it.path("state.items").query(term { term -> term.field("state.items.name").value("value") }) },
             SearchFilter("value", linkedSetOf(field)) to
                 multiMatch { it.query("value").fields("state.value") },
+            SearchFilter("event sourcing", linkedSetOf(field), SearchMode.PHRASE) to
+                multiMatch { it.query("event sourcing").fields("state.value").type(TextQueryType.Phrase) },
         )
 
         cases.forEach { (filter, expected) -> assertQuery(RawFilterConverter.convert(filter), expected) }

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolverTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolverTest.kt
@@ -47,6 +47,7 @@ import me.ahoo.wow.api.query.NotExistsFilter
 import me.ahoo.wow.api.query.OwnerIdFilter
 import me.ahoo.wow.api.query.RelativeTimeFilter
 import me.ahoo.wow.api.query.SearchFilter
+import me.ahoo.wow.api.query.SearchMode
 import me.ahoo.wow.api.query.Sort
 import me.ahoo.wow.api.query.SpaceIdFilter
 import me.ahoo.wow.api.query.TenantIdFilter
@@ -177,7 +178,11 @@ class ElasticsearchIndexMappingResolverTest {
             AndFilter(
                 listOf(
                     EqualFilter(LogicalField("state.name"), json("Wow")),
-                    SearchFilter("Wow", linkedSetOf(LogicalField("state.name"))),
+                    SearchFilter(
+                        "Wow",
+                        linkedSetOf(LogicalField("state.name")),
+                        SearchMode.PHRASE,
+                    ),
                     ContainsFilter(LogicalField("state.name"), "ow"),
                     GreaterThanFilter(LogicalField("state.age"), json(18)),
                     ExistsFilter(LogicalField("state.name")),
@@ -186,6 +191,7 @@ class ElasticsearchIndexMappingResolverTest {
         ) as AndFilter
         (filter.operands[0] as EqualFilter).field.value.assert().isEqualTo("state.name.keyword")
         (filter.operands[1] as SearchFilter).fields.single().value.assert().isEqualTo("state.name")
+        (filter.operands[1] as SearchFilter).mode.assert().isEqualTo(SearchMode.PHRASE)
         (filter.operands[2] as ContainsFilter).field.value.assert().isEqualTo("state.name.keyword")
         (filter.operands[3] as GreaterThanFilter).field.value.assert().isEqualTo("state.age")
         (filter.operands[4] as ExistsFilter).field.value.assert().isEqualTo("state.name")

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolverTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchIndexMappingResolverTest.kt
@@ -55,6 +55,7 @@ import me.ahoo.wow.api.query.ThisYearFilter
 import me.ahoo.wow.api.query.YesterdayFilter
 import me.ahoo.wow.api.query.toFilterExpression
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
 import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchIndicesClient
 import reactor.core.publisher.Mono
@@ -440,6 +441,21 @@ class ElasticsearchIndexMappingResolverTest {
                 Sort("_shard_doc", Sort.Direction.ASC),
             ),
         ).map { it.field }.assert().containsExactly("_score", "_doc", "_shard_doc")
+    }
+
+    @Test
+    fun `should reject phrase search on semantic text`() {
+        val mapping = ElasticsearchIndexMapping.from(INDEX, specialCapabilities())
+
+        assertThrows<ElasticsearchFieldResolutionException> {
+            mapping.resolve(
+                SearchFilter(
+                    "event sourcing",
+                    linkedSetOf(LogicalField("semanticText")),
+                    SearchMode.PHRASE,
+                ),
+            )
+        }
     }
 
     private fun mappingResponse(mapping: TypeMapping): GetMappingResponse =

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoFilterConverter.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoFilterConverter.kt
@@ -52,6 +52,7 @@ import me.ahoo.wow.api.query.OrFilter
 import me.ahoo.wow.api.query.OwnerIdFilter
 import me.ahoo.wow.api.query.RecentDaysFilter
 import me.ahoo.wow.api.query.SearchFilter
+import me.ahoo.wow.api.query.SearchMode
 import me.ahoo.wow.api.query.SpaceIdFilter
 import me.ahoo.wow.api.query.StartsWithFilter
 import me.ahoo.wow.api.query.StringComparison
@@ -153,7 +154,9 @@ abstract class AbstractMongoFilterConverter(
             filter.field.convert(parent, mapField),
             compile(filter.predicate, parent = null, mapField = false),
         )
-        is SearchFilter -> Filters.text(filter.query)
+        is SearchFilter -> Filters.text(
+            if (filter.mode == SearchMode.PHRASE) "\"${filter.query}\"" else filter.query,
+        )
         is TodayFilter,
         is BeforeTodayFilter,
         is TomorrowFilter,

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoFilterConverter.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoFilterConverter.kt
@@ -155,7 +155,12 @@ abstract class AbstractMongoFilterConverter(
             compile(filter.predicate, parent = null, mapField = false),
         )
         is SearchFilter -> Filters.text(
-            if (filter.mode == SearchMode.PHRASE) "\"${filter.query}\"" else filter.query,
+            if (filter.mode == SearchMode.PHRASE) {
+                require('"' !in filter.query) { "MongoDB PHRASE search query cannot contain double quotes." }
+                "\"${filter.query}\""
+            } else {
+                filter.query
+            },
         )
         is TodayFilter,
         is BeforeTodayFilter,

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/SnapshotFilterConverterTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/SnapshotFilterConverterTest.kt
@@ -14,6 +14,7 @@ import me.ahoo.wow.serialization.state.StateAggregateRecords
 import org.bson.conversions.Bson
 import org.bson.types.ObjectId
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -192,6 +193,13 @@ class SnapshotFilterConverterTest {
     fun `match none should absorb the default deletion scope`() {
         SnapshotFilterConverter.convert(MatchNoneFilter).toBsonDocument().assert()
             .isEqualTo(org.bson.Document("\$expr", false).toBsonDocument())
+    }
+
+    @Test
+    fun `mongo phrase search should reject embedded quotes`() {
+        assertThrows<IllegalArgumentException> {
+            SnapshotFilterConverter.convert(SearchFilter("event \"sourcing\"", mode = SearchMode.PHRASE))
+        }
     }
 
     @ParameterizedTest

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/SnapshotFilterConverterTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/SnapshotFilterConverterTest.kt
@@ -252,6 +252,10 @@ class SnapshotFilterConverterTest {
                     Filters.elemMatch("state.value", Filters.eq("name", "value")),
                 ),
                 Arguments.of(SearchFilter("value", linkedSetOf(field)), Filters.text("value")),
+                Arguments.of(
+                    SearchFilter("event sourcing", mode = SearchMode.PHRASE),
+                    Filters.text("\"event sourcing\""),
+                ),
             )
         }
     }

--- a/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
@@ -5418,6 +5418,11 @@
                 "type" : "array",
                 "uniqueItems" : true
               },
+              "mode" : {
+                "default" : "TERMS",
+                "enum" : [ "TERMS", "PHRASE" ],
+                "type" : "string"
+              },
               "op" : {
                 "enum" : [ "SEARCH" ]
               },

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/FilterDsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/FilterDsl.kt
@@ -55,6 +55,7 @@ import me.ahoo.wow.api.query.OrFilter
 import me.ahoo.wow.api.query.OwnerIdFilter
 import me.ahoo.wow.api.query.RecentDaysFilter
 import me.ahoo.wow.api.query.SearchFilter
+import me.ahoo.wow.api.query.SearchMode
 import me.ahoo.wow.api.query.SpaceIdFilter
 import me.ahoo.wow.api.query.StartsWithFilter
 import me.ahoo.wow.api.query.StringComparison
@@ -203,8 +204,10 @@ class FilterDsl private constructor(
 
     fun String.notExists() = add(NotExistsFilter(field(this)))
 
-    fun search(query: String, vararg fields: String) =
-        add(SearchFilter(query, fields.mapTo(linkedSetOf(), ::field)))
+    fun search(query: String, vararg fields: String) = search(query, SearchMode.TERMS, *fields)
+
+    fun search(query: String, mode: SearchMode, vararg fields: String) =
+        add(SearchFilter(query, fields.mapTo(linkedSetOf(), ::field), mode))
 
     infix fun String.search(query: String) = search(query, this)
 

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/FilterDslTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/FilterDslTest.kt
@@ -24,6 +24,21 @@ import java.time.ZoneOffset
 
 class FilterDslTest {
     @Test
+    fun `should build phrase search`() {
+        val expression = filter {
+            search("event sourcing", SearchMode.PHRASE, "title", "description")
+        }
+
+        expression.assert().isEqualTo(
+            SearchFilter(
+                query = "event sourcing",
+                fields = linkedSetOf(LogicalField("title"), LogicalField("description")),
+                mode = SearchMode.PHRASE,
+            ),
+        )
+    }
+
+    @Test
     fun `should build extended relative calendar filters`() {
         val field = LogicalField("createdAt")
         val expression = filter {

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/typed/query/FilterExpressionDefinitionProviderTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/typed/query/FilterExpressionDefinitionProviderTest.kt
@@ -23,6 +23,26 @@ import tools.jackson.databind.json.JsonMapper
 
 class FilterExpressionDefinitionProviderTest {
     @Test
+    fun `filter schema should publish search modes`() {
+        val schemaDocument = WowSchemaLoader.load(FilterExpression::class.java)
+        val mode = schemaDocument.path("definitions").path("search").path("properties").path("mode")
+
+        mode.path("enum").toList().map { it.stringValue() }.assert().containsExactly("TERMS", "PHRASE")
+        mode.path("default").stringValue().assert().isEqualTo("TERMS")
+
+        val schema = SchemaRegistry.withDefaultDialect(SpecificationVersion.DRAFT_7).getSchema(schemaDocument)
+        val mapper = JsonMapper.builder().build()
+        schema.validate(mapper.readTree("""{"op":"SEARCH","query":"event sourcing"}"""))
+            .assert().isEmpty()
+        schema.validate(
+            mapper.readTree("""{"op":"SEARCH","query":"event sourcing","mode":"PHRASE"}"""),
+        ).assert().isEmpty()
+        schema.validate(
+            mapper.readTree("""{"op":"SEARCH","query":"event \"sourcing\"","mode":"PHRASE"}"""),
+        ).assert().isEmpty()
+    }
+
+    @Test
     fun `filter schema should publish metadata operators`() {
         val schema = WowSchemaLoader.load(FilterExpression::class.java)
         val definitions = schema.path("definitions")

--- a/wow-schema/src/test/resources/META-INF/wow-schema-e2e/FilterExpression.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema-e2e/FilterExpression.json
@@ -781,6 +781,11 @@
             "$ref" : "#/definitions/logicalField"
           },
           "default" : [ ]
+        },
+        "mode" : {
+          "type" : "string",
+          "enum" : [ "TERMS", "PHRASE" ],
+          "default" : "TERMS"
         }
       },
       "required" : [ "op", "query" ],


### PR DESCRIPTION
## Goal

Add backend-native phrase search to the existing `SEARCH` filter without introducing a new filter operator. Existing callers continue to use `TERMS` by default.

## Changes

- Add `SearchMode.TERMS` and `SearchMode.PHRASE` to `SearchFilter`.
- Compile `PHRASE` to quoted `$text` search in MongoDB.
- Compile `PHRASE` to `multi_match(type = phrase)` in Elasticsearch.
- Extend the Kotlin DSL while preserving the existing `search(query, fields...)` call shape.
- Update JSON Schema, OpenAPI snapshots, backend tests, and bilingual documentation.

## Verification

- `./gradlew :wow-api:check :wow-query:check :wow-mongo:check :wow-elasticsearch:check :wow-schema:check :wow-openapi:check` — passed.
- `cd documentation && pnpm docs:build` — passed; only the existing large-chunk warning remains.
- `git diff --check origin/main...HEAD` — passed.

## Compatibility and risks

- [ ] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

Kotlin source compatibility is preserved because `mode` defaults to `TERMS`. JVM binary compatibility for clients compiled against the previous `SearchFilter` constructor is not guaranteed. Existing JSON requests remain valid when deserialized with Jackson's Kotlin module. Phrase matching otherwise follows each backend's native analyzer and text-index semantics. No dependency, configuration, concurrency, data-migration, or deployment changes are required.
