### PR TITLE
feat(serialization): add missing type implementation strategy

### DIFF
--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Schema
+import me.ahoo.wow.api.serialization.MissingTypeImpl
 import java.time.ZoneId
 
 @Schema(additionalProperties = Schema.AdditionalPropertiesValue.FALSE)
@@ -167,11 +168,8 @@ enum class AggregationDateUnit {
     SECOND,
 }
 
-@JsonTypeInfo(
-    use = JsonTypeInfo.Id.NAME,
-    property = "type",
-    defaultImpl = AggregationExpression.Field::class,
-)
+@MissingTypeImpl(AggregationExpression.Field::class)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes(JsonSubTypes.Type(AggregationExpression.Field::class, name = "FIELD"))
 interface AggregationExpression {
     data class Field(val field: LogicalField) : AggregationExpression

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/serialization/MissingTypeImpl.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/serialization/MissingTypeImpl.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.api.serialization
+
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.JavaType
+import tools.jackson.databind.deser.DeserializationProblemHandler
+import tools.jackson.databind.jsontype.TypeIdResolver
+import kotlin.reflect.KClass
+
+/**
+ * Declares the default implementation of a polymorphic base type when its JSON type id is missing.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class MissingTypeImpl(val impl: KClass<*>)
+
+/**
+ * Resolves missing Jackson polymorphic type ids using [MissingTypeImpl].
+ */
+class MissingTypeImplProblemHandler : DeserializationProblemHandler() {
+    override fun handleMissingTypeId(
+        ctxt: DeserializationContext,
+        baseType: JavaType,
+        idResolver: TypeIdResolver,
+        failureMsg: String,
+    ): JavaType? = baseType.rawClass.getAnnotation(MissingTypeImpl::class.java)
+        ?.let { ctxt.constructSpecializedType(baseType, it.impl.java) }
+}

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt
@@ -16,6 +16,7 @@ package me.ahoo.wow.api.query
 import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import tools.jackson.databind.exc.InvalidTypeIdException
 import tools.jackson.module.kotlin.jsonMapper
 import java.time.DateTimeException
 
@@ -23,7 +24,7 @@ class AggregationQueryTest {
     private val jsonMapper = jsonMapper()
 
     @Test
-    fun `field expression should be the default JSON subtype`() {
+    fun `bare mapper should reject missing field expression type`() {
         val json = """
             {
               "metrics": [{
@@ -35,10 +36,9 @@ class AggregationQueryTest {
             }
         """.trimIndent()
 
-        val query = jsonMapper.readValue(json, AggregationQuery::class.java)
-        val metric = query.metrics.single() as AggregationMetric.Numeric
-
-        metric.expression.assert().isEqualTo(AggregationExpression.Field(LogicalField("amount")))
+        assertThrows<InvalidTypeIdException> {
+            jsonMapper.readValue(json, AggregationQuery::class.java)
+        }
     }
 
     @Test

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/serialization/MissingTypeImplProblemHandlerTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/serialization/MissingTypeImplProblemHandlerTest.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.api.serialization
+
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import me.ahoo.test.asserts.assert
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import tools.jackson.databind.exc.InvalidTypeIdException
+import tools.jackson.databind.json.JsonMapper
+
+class MissingTypeImplProblemHandlerTest {
+    private val mapper = JsonMapper.builder()
+        .addHandler(MissingTypeImplProblemHandler())
+        .build()
+
+    @Test
+    fun `explicit handler should use annotated implementation for missing type`() {
+        val message = mapper.readValue("""{"value":"fallback"}""", TestMessage::class.java)
+
+        message.assert().isInstanceOf(DefaultMessage::class.java)
+        (message as DefaultMessage).value.assert().isEqualTo("fallback")
+    }
+
+    @Test
+    fun `mapper without handler should preserve Jackson missing type error`() {
+        val mapper = JsonMapper.builder().build()
+
+        assertThrows<InvalidTypeIdException> {
+            mapper.readValue("""{"value":"missing"}""", TestMessage::class.java)
+        }
+    }
+
+    @Test
+    fun `known type should deserialize and round trip`() {
+        val message = mapper.readValue(
+            """{"type":"KNOWN","value":"known"}""",
+            TestMessage::class.java,
+        )
+        val roundTripped = mapper.readValue(mapper.writeValueAsString(message), TestMessage::class.java)
+
+        message.assert().isInstanceOf(KnownMessage::class.java)
+        (roundTripped as KnownMessage).value.assert().isEqualTo("known")
+    }
+
+    @Test
+    fun `unknown type should preserve Jackson default error`() {
+        assertThrows<InvalidTypeIdException> {
+            mapper.readValue("""{"type":"UNKNOWN","value":"unknown"}""", TestMessage::class.java)
+        }
+    }
+
+    @Test
+    fun `missing type without annotation should preserve Jackson error`() {
+        assertThrows<InvalidTypeIdException> {
+            mapper.readValue("""{"value":"missing"}""", UnannotatedMessage::class.java)
+        }
+    }
+
+    @MissingTypeImpl(DefaultMessage::class)
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonSubTypes(JsonSubTypes.Type(KnownMessage::class, name = "KNOWN"))
+    private interface TestMessage
+
+    private class DefaultMessage : TestMessage {
+        var value: String = ""
+    }
+
+    private class KnownMessage : TestMessage {
+        var value: String = ""
+    }
+
+    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+    @JsonSubTypes(JsonSubTypes.Type(UnannotatedKnownMessage::class, name = "KNOWN"))
+    private interface UnannotatedMessage
+
+    private class UnannotatedKnownMessage : UnannotatedMessage {
+        var value: String = ""
+    }
+}

--- a/wow-core/src/main/kotlin/me/ahoo/wow/serialization/WowModule.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/serialization/WowModule.kt
@@ -16,6 +16,7 @@ package me.ahoo.wow.serialization
 import me.ahoo.wow.api.command.CommandMessage
 import me.ahoo.wow.api.event.DomainEvent
 import me.ahoo.wow.api.modeling.AggregateId
+import me.ahoo.wow.api.serialization.MissingTypeImplProblemHandler
 import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.eventsourcing.snapshot.Snapshot
 import me.ahoo.wow.eventsourcing.state.StateEvent
@@ -32,6 +33,7 @@ import me.ahoo.wow.serialization.state.SnapshotDeserializer
 import me.ahoo.wow.serialization.state.SnapshotSerializer
 import me.ahoo.wow.serialization.state.StateAggregateDeserializer
 import me.ahoo.wow.serialization.state.StateAggregateSerializer
+import tools.jackson.databind.JacksonModule
 import tools.jackson.databind.module.SimpleModule
 
 class WowModule : SimpleModule() {
@@ -56,5 +58,10 @@ class WowModule : SimpleModule() {
 
         addSerializer(StateEvent::class.java, StateEventJsonSerializer)
         addDeserializer(StateEvent::class.java, StateEventJsonDeserializer)
+    }
+
+    override fun setupModule(context: JacksonModule.SetupContext) {
+        super.setupModule(context)
+        context.addHandler(MissingTypeImplProblemHandler())
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/jackson/JacksonCompatibilityTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/jackson/JacksonCompatibilityTest.kt
@@ -15,6 +15,8 @@ package me.ahoo.wow.jackson
 
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.modeling.AggregateId
+import me.ahoo.wow.api.query.AggregationExpression
+import me.ahoo.wow.api.query.LogicalField
 import me.ahoo.wow.modeling.MaterializedNamedAggregate
 import me.ahoo.wow.modeling.aggregateId
 import me.ahoo.wow.serialization.toJsonString
@@ -39,6 +41,13 @@ internal class JacksonCompatibilityTest {
         val decoded = dto.toJsonString().toObject<ConstructorOnlyDto>()
 
         decoded.assert().isEqualTo(dto)
+    }
+
+    @Test
+    fun `SPI discovered Wow module should apply missing type implementation`() {
+        val decoded = """{"field":"amount"}""".toObject<AggregationExpression>()
+
+        decoded.assert().isEqualTo(AggregationExpression.Field(LogicalField("amount")))
     }
 
     private data class ConstructorOnlyDto(val id: String)

--- a/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
@@ -4324,7 +4324,7 @@
             "const" : "FIELD"
           }
         },
-        "required" : [ "field" ],
+        "required" : [ "field", "type" ],
         "type" : "object"
       },
       "wow.api.query.AggregationFunction" : {


### PR DESCRIPTION
## Goal

Provide a reusable missing-type fallback for Jackson 3 polymorphic types without coupling the behavior to `JsonTypeInfo.defaultImpl`.

Completion criteria:

- publish a runtime `MissingTypeImpl` annotation and a stateless, Java-friendly `MissingTypeImplProblemHandler` from `wow-api`;
- preserve Jackson's native behavior for unannotated bases and unknown type ids;
- register the handler through the existing `WowModule` paths;
- keep legacy field-only aggregation expression JSON readable through `WowModule`.

## Changes

- Add `MissingTypeImpl` and `MissingTypeImplProblemHandler`; the handler only overrides `handleMissingTypeId` and specializes the annotated base type.
- Replace `AggregationExpression`'s `JsonTypeInfo.defaultImpl` with `@MissingTypeImpl(AggregationExpression.Field::class)`.
- Register the handler from `WowModule.setupModule()` after `super.setupModule(context)`.
- Add focused tests for explicit registration, no-handler behavior, known/unknown type ids, unannotated bases, SPI discovery, and the real legacy aggregation expression payload.
- Update the OpenAPI compatibility snapshot for the expected discriminator requirement after removing `defaultImpl`.

## Verification

- TDD red/green cycles observed for the missing public API, bare-mapper boundary, and `WowModule` SPI fallback.
- `./gradlew :wow-api:check :wow-core:check :wow-spring-boot-starter:check :wow-schema:check :wow-openapi:check` — BUILD SUCCESSFUL (123 tasks).
- `git diff --check` — passed.
- Public JVM signatures verified with `javap`: the annotation exposes `Class<?> impl()` and the handler has a public no-arg constructor.

## Compatibility and risks

- [ ] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [ ] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

Source compatibility is preserved, but a bare `ObjectMapper`/`JsonMapper` no longer gets the missing-type fallback. Downstream callers must explicitly use `JsonMapper.builder().addHandler(MissingTypeImplProblemHandler())` or register/use `WowModule` (including its existing Spring bean and SPI discovery paths).

Unknown type ids are not handled by this problem handler and continue to follow the caller's Jackson configuration, including `FAIL_ON_INVALID_SUBTYPE`.

Removing `JsonTypeInfo.defaultImpl` makes the generated OpenAPI schema require the `type` discriminator for `AggregationExpression.Field`. `WowModule` still accepts the legacy payload `{"field":"amount"}` as `Field`; no storage, dependency, deployment, or configuration migration is introduced.
