### PR TITLE
refactor(query): use Kotlin defaults for aggregation JSON

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,7 @@ Before changing release or publish behavior, inspect the workflow and Gradle pub
 - Always add or update tests when changing command handling, event sourcing, projections, sagas, compensation behavior, serialization, schema generation, or generated metadata.
 - Always preserve public API compatibility unless the user explicitly asks for a breaking change.
 - Prefer clean source and the smallest correct implementation. Do not add compatibility bridges, custom serialization or creators, duplicate validation, or tests of dependency behavior without a concrete requirement or reproduced failure.
+- Do not add `@JsonCreator` factories solely to reproduce Kotlin constructor defaults. Configure the Kotlin Jackson module instead; reserve creators for non-object wire shapes or Java constructors and cover them with contract tests.
 - Treat source, binary, and wire compatibility as separate scopes. Implement only the compatibility scope the user requested; do not infer binary or wire compatibility from source compatibility.
 - Trust installed framework modules and backend-native semantics. Add validation only for the public contract, security, data-loss prevention, or a demonstrated backend requirement.
 - Ask first before changing Gradle module structure, feature capabilities, generated OpenAPI/schema contracts, CI/CD workflows, publishing credentials, or release automation.

--- a/documentation/docs/en/guide/advanced/serialization.md
+++ b/documentation/docs/en/guide/advanced/serialization.md
@@ -18,10 +18,10 @@ A serialization shape can be an HTTP, messaging, and persistence contract at the
 |---|---|---|
 | Wow Spring Boot application | Inject Spring's `ObjectMapper` | The starter provides a `WowModule` bean automatically |
 | Wow runtime or in-application conversion | `JsonSerializer` and its extensions | Kotlin and Wow Jackson modules are discovered automatically |
-| Fully custom mapper | Register `WowModule` | Enables all Wow type serialization support |
-| `wow-api`-only consumer | Register `MissingTypeImplProblemHandler` | Enables only `@MissingTypeImpl` fallback |
+| Fully custom mapper | Register the Kotlin module and `WowModule` | Enables Kotlin and Wow type serialization support |
+| `wow-api`-only consumer | Register the Kotlin module; optionally register `MissingTypeImplProblemHandler` | Supports Kotlin models and optional `@MissingTypeImpl` fallback |
 
-A bare `ObjectMapper` or `JsonMapper` does not automatically inherit Wow configuration or missing-type fallback.
+A bare `ObjectMapper` or `JsonMapper` does not automatically inherit Kotlin or Wow configuration or missing-type fallback.
 
 ## JsonSerializer
 
@@ -81,8 +81,10 @@ It also registers `MissingTypeImplProblemHandler`. Do not duplicate individual s
 ```kotlin
 import me.ahoo.wow.serialization.WowModule
 import tools.jackson.module.kotlin.jsonMapper
+import tools.jackson.module.kotlin.kotlinModule
 
 val mapper = jsonMapper {
+    addModule(kotlinModule())
     addModule(WowModule())
 }
 ```
@@ -93,7 +95,7 @@ The Spring Boot starter contributes a `WowModule` bean before Jackson auto-confi
 
 Spring's mapper keeps its Spring Boot feature configuration. `WowModule` adds Wow serializers, deserializers, and the handler; it does not copy every global feature from `JsonSerializer`.
 
-Applications that replace Spring's `ObjectMapper` completely or disable module discovery must register `WowModule` themselves.
+Applications that replace Spring's `ObjectMapper` completely or disable module discovery must register the Kotlin module and `WowModule` themselves.
 
 ## Missing Polymorphic Type Fallback
 

--- a/documentation/docs/zh/guide/advanced/serialization.md
+++ b/documentation/docs/zh/guide/advanced/serialization.md
@@ -18,10 +18,10 @@ Wow 使用 Jackson 3 处理命令、事件流、快照、状态聚合和查询�
 |---|---|---|
 | Wow Spring Boot 应用 | 注入 Spring 管理的 `ObjectMapper` | Starter 自动提供 `WowModule` Bean |
 | Wow 运行时或应用内辅助转换 | `JsonSerializer` 与扩展函数 | 自动发现 Kotlin 和 Wow Jackson 模块 |
-| 自行构建完整 Mapper | 注册 `WowModule` | 获得全部 Wow 类型序列化支持 |
-| 只依赖 `wow-api` | 注册 `MissingTypeImplProblemHandler` | 只获得 `@MissingTypeImpl` 缺失类型回退 |
+| 自行构建完整 Mapper | 注册 Kotlin Module 与 `WowModule` | 获得 Kotlin 与 Wow 类型序列化支持 |
+| 只依赖 `wow-api` | 注册 Kotlin Module；按需注册 `MissingTypeImplProblemHandler` | 支持 Kotlin 模型及可选的 `@MissingTypeImpl` 缺失类型回退 |
 
-裸 `ObjectMapper` 或 `JsonMapper` 不会自动具有 Wow 的配置和缺失类型回退。
+裸 `ObjectMapper` 或 `JsonMapper` 不会自动具有 Kotlin、Wow 的配置和缺失类型回退。
 
 ## JsonSerializer
 
@@ -81,8 +81,10 @@ val properties = decoded.toLinkedHashMap()
 ```kotlin
 import me.ahoo.wow.serialization.WowModule
 import tools.jackson.module.kotlin.jsonMapper
+import tools.jackson.module.kotlin.kotlinModule
 
 val mapper = jsonMapper {
+    addModule(kotlinModule())
     addModule(WowModule())
 }
 ```
@@ -96,7 +98,7 @@ Spring Boot Starter 在 Jackson 自动配置前提供 `WowModule` Bean。`wow-co
 Spring 管理的 Mapper 继续使用 Spring Boot 自身的 feature 配置；`WowModule` 只增加 Wow serializer、
 deserializer 与 Handler，不会复制 `JsonSerializer` 的全部全局 feature。
 
-如果应用完全替换 Spring 的 `ObjectMapper` 或禁用模块发现，需要自行注册 `WowModule`。
+如果应用完全替换 Spring 的 `ObjectMapper` 或禁用模块发现，需要自行注册 Kotlin Module 与 `WowModule`。
 
 ## 缺失多态类型回退
 

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
@@ -13,9 +13,7 @@
 
 package me.ahoo.wow.api.query
 
-import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import io.swagger.v3.oas.annotations.media.ArraySchema
@@ -81,24 +79,6 @@ data class AggregationQuery(
         const val MAX_EXPRESSION_NODES: Int = 256
         private const val DEFAULT_LIMIT_TEXT = "100"
         private const val MAX_LIMIT_TEXT = "10000"
-
-        @JvmStatic
-        @JsonCreator
-        internal fun fromJson(
-            @JsonProperty("filter") filter: FilterExpression?,
-            @JsonProperty("elements") elements: List<AggregationElement>?,
-            @JsonProperty("groupBy") groupBy: List<AggregationGroup>?,
-            @JsonProperty("metrics") metrics: List<AggregationMetric>?,
-            @JsonProperty("sort") sort: List<Sort>?,
-            @JsonProperty("limit") limit: Int?,
-        ): AggregationQuery = AggregationQuery(
-            filter = filter ?: MatchAllFilter,
-            elements = elements.orEmpty(),
-            groupBy = groupBy.orEmpty(),
-            metrics = metrics.orEmpty(),
-            sort = sort.orEmpty(),
-            limit = limit ?: DEFAULT_LIMIT,
-        )
     }
 }
 

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt
@@ -17,14 +17,51 @@ import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.serialization.MissingTypeImplProblemHandler
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import tools.jackson.core.JacksonException
 import tools.jackson.databind.exc.InvalidTypeIdException
 import tools.jackson.module.kotlin.jsonMapper
+import tools.jackson.module.kotlin.kotlinModule
 import java.time.DateTimeException
 
 class AggregationQueryTest {
-    private val jsonMapper = jsonMapper()
-    private val mapperWithMissingTypeImpl = jsonMapper {
+    private val bareMapper = jsonMapper()
+    private val configuredMapper = jsonMapper {
+        addModule(kotlinModule())
         addHandler(MissingTypeImplProblemHandler())
+    }
+
+    @Test
+    fun `configured mapper should apply omitted query defaults`() {
+        val json = """{"metrics":[{"type":"COUNT","alias":"count"}]}"""
+
+        val query = configuredMapper.readValue(json, AggregationQuery::class.java)
+
+        query.filter.assert().isEqualTo(MatchAllFilter)
+        query.elements.assert().isEmpty()
+        query.groupBy.assert().isEmpty()
+        query.sort.assert().isEmpty()
+        query.limit.assert().isEqualTo(100)
+    }
+
+    @Test
+    fun `configured mapper should reject explicit null`() {
+        val json = """
+            {
+              "filter": null,
+              "metrics": [{"type": "COUNT", "alias": "count"}]
+            }
+        """.trimIndent()
+
+        assertThrows<JacksonException> {
+            configuredMapper.readValue(json, AggregationQuery::class.java)
+        }
+    }
+
+    @Test
+    fun `configured mapper should reject missing metrics`() {
+        assertThrows<JacksonException> {
+            configuredMapper.readValue("{}", AggregationQuery::class.java)
+        }
     }
 
     @Test
@@ -41,7 +78,7 @@ class AggregationQueryTest {
         """.trimIndent()
 
         assertThrows<InvalidTypeIdException> {
-            jsonMapper.readValue(json, AggregationQuery::class.java)
+            bareMapper.readValue(json, AggregationQuery::class.java)
         }
     }
 
@@ -59,7 +96,7 @@ class AggregationQueryTest {
         """.trimIndent()
 
         assertThrows<InvalidTypeIdException> {
-            jsonMapper.readValue(json, AggregationQuery::class.java)
+            bareMapper.readValue(json, AggregationQuery::class.java)
         }
     }
 
@@ -86,7 +123,7 @@ class AggregationQueryTest {
             }
         """.trimIndent()
 
-        val query = mapperWithMissingTypeImpl.readValue(json, AggregationQuery::class.java)
+        val query = configuredMapper.readValue(json, AggregationQuery::class.java)
         val expression = (query.metrics.single() as AggregationMetric.Numeric).expression
 
         expression.assert().isEqualTo(
@@ -100,7 +137,7 @@ class AggregationQueryTest {
                 AggregationExpression.Constant(10.0),
             ),
         )
-        mapperWithMissingTypeImpl.writeValueAsString(query).assert()
+        configuredMapper.writeValueAsString(query).assert()
             .contains("\"type\":\"BINARY\"")
             .contains("\"type\":\"CONSTANT\"")
     }


### PR DESCRIPTION
## Goal

Remove the redundant `AggregationQuery.fromJson` creator and make the supported Jackson mapper contract explicit. Completion means configured Kotlin mappers preserve omitted defaults while rejecting explicit nulls and missing metrics.

## Changes

- Remove the nullable `@JsonCreator` factory and rely on Kotlin constructor defaults.
- Separate bare and configured mapper tests, covering omitted defaults, explicit null, and missing metrics.
- Document Kotlin Module plus `WowModule` registration in Chinese and English.
- Add a repository boundary against creators that only reproduce Kotlin defaults.

## Verification

- `./gradlew build` — passed.
- `cd documentation && pnpm docs:build` — passed.
- Mutation check without Kotlin Module — the omitted-defaults test failed on `limit` as intended; restoring the module returned it to green.
- `git diff --check` — passed.

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

The public Kotlin constructor and generated schema are unchanged. Configured Wow and Spring mappers preserve omitted defaults. Explicit JSON nulls are now rejected, and custom mappers must register the Kotlin Module. Rollback is a revert of this commit.