### PR TITLE
fix(query): reject incompatible schema literals

### DIFF
--- a/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryServiceTest.kt
+++ b/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryServiceTest.kt
@@ -375,6 +375,18 @@ class ElasticsearchSnapshotQueryServiceTest : SnapshotQueryServiceSpec() {
     }
 
     @Test
+    fun `all modes should reject invalid declared epoch literals before Elasticsearch`() {
+        listOf(snapshotQueryService, strictService()).forEach { service ->
+            service.dynamicList(
+                ListQuery(
+                    filter = filterExpression { "firstEventTime" lte "not-a-timestamp" },
+                    limit = 10,
+                ),
+            ).test().expectError(QuerySchemaValidationException::class.java).verify()
+        }
+    }
+
+    @Test
     fun `all modes should reject dynamic ABAC before ignored values can fail open`() {
         updateDocument(
             mapOf(

--- a/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryServiceTest.kt
+++ b/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryServiceTest.kt
@@ -202,6 +202,24 @@ class MongoSnapshotQueryServiceTest : SnapshotQueryServiceSpec() {
     }
 
     @Test
+    fun `all modes should reject invalid declared epoch literals before MongoDB`() {
+        QuerySchemaValidationMode.entries.forEach { mode ->
+            val service = MongoSnapshotQueryServiceFactory(
+                database,
+                schemaSources = querySchemaSources,
+                validationMode = mode,
+            ).create<MockStateAggregate>(MOCK_AGGREGATE_METADATA)
+
+            service.dynamicList(
+                ListQuery(
+                    filter = filterExpression { "firstEventTime" lte "not-a-timestamp" },
+                    limit = 10,
+                ),
+            ).test().expectError(QuerySchemaValidationException::class.java).verify()
+        }
+    }
+
+    @Test
     fun `strict should execute a client-declared formatted temporal range`() {
         val field = LogicalField("state.formattedDate")
         val today = Instant.now().atZone(ZoneOffset.UTC).toLocalDate().toString()

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolver.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolver.kt
@@ -19,11 +19,26 @@ import me.ahoo.wow.api.query.*
 import me.ahoo.wow.api.query.schema.QueryCapability
 import me.ahoo.wow.api.query.schema.QueryCardinality
 import me.ahoo.wow.api.query.schema.QueryCompatibilityLevel
+import me.ahoo.wow.api.query.schema.QueryValueType
 import me.ahoo.wow.api.query.schema.Temporal
 import me.ahoo.wow.serialization.MessageRecords
 import me.ahoo.wow.serialization.state.StateAggregateRecords
 import reactor.core.publisher.Mono
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.node.JsonNodeFactory
+import tools.jackson.databind.node.POJONode
+import java.math.BigDecimal
+import java.math.BigInteger
 import java.util.concurrent.TimeUnit
+import java.lang.reflect.Array as ReflectArray
+
+private val BUILT_IN_QUERY_VALUE_TYPES = setOf(
+    QueryValueType.STRING,
+    QueryValueType.INTEGER,
+    QueryValueType.DECIMAL,
+    QueryValueType.BOOLEAN,
+    QueryValueType.OBJECT,
+)
 
 enum class QuerySchemaValidationMode {
     COMPATIBLE,
@@ -194,6 +209,7 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
             if (filter.value.isNull) QueryCapability.PRESENCE else QueryCapability.EXACT_MATCH,
             logicalParent,
             physicalParent,
+            filter.value.queryValues(),
         ) {
             filter.copy(field = it)
         }
@@ -202,11 +218,24 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
             if (filter.value.isNull) QueryCapability.PRESENCE else QueryCapability.EXACT_MATCH,
             logicalParent,
             physicalParent,
+            filter.value.queryValues(),
         ) { filter.copy(field = it) }
-        is InFilter -> resolveFieldFilter(filter.field, QueryCapability.EXACT_MATCH, logicalParent, physicalParent) {
+        is InFilter -> resolveFieldFilter(
+            filter.field,
+            QueryCapability.EXACT_MATCH,
+            logicalParent,
+            physicalParent,
+            filter.values,
+        ) {
             filter.copy(field = it)
         }
-        is NotInFilter -> resolveFieldFilter(filter.field, QueryCapability.EXACT_MATCH, logicalParent, physicalParent) {
+        is NotInFilter -> resolveFieldFilter(
+            filter.field,
+            QueryCapability.EXACT_MATCH,
+            logicalParent,
+            physicalParent,
+            filter.values,
+        ) {
             filter.copy(field = it)
         }
         is ContainsAllFilter -> resolveCollectionFieldFilter(
@@ -214,6 +243,7 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
             QueryCapability.EXACT_MATCH,
             logicalParent,
             physicalParent,
+            filter.values,
         ) { filter.copy(field = it) }
         is ContainsFilter -> resolveFieldFilter(
             filter.field,
@@ -238,14 +268,22 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
             QueryCapability.RANGE,
             logicalParent,
             physicalParent,
+            listOf(filter.value),
         ) { filter.copy(field = it) }
         is GreaterThanOrEqualFilter -> resolveFieldFilter(
             filter.field,
             QueryCapability.RANGE,
             logicalParent,
             physicalParent,
+            listOf(filter.value),
         ) { filter.copy(field = it) }
-        is LessThanFilter -> resolveFieldFilter(filter.field, QueryCapability.RANGE, logicalParent, physicalParent) {
+        is LessThanFilter -> resolveFieldFilter(
+            filter.field,
+            QueryCapability.RANGE,
+            logicalParent,
+            physicalParent,
+            listOf(filter.value),
+        ) {
             filter.copy(field = it)
         }
         is LessThanOrEqualFilter -> resolveFieldFilter(
@@ -253,8 +291,15 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
             QueryCapability.RANGE,
             logicalParent,
             physicalParent,
+            listOf(filter.value),
         ) { filter.copy(field = it) }
-        is BetweenFilter -> resolveFieldFilter(filter.field, QueryCapability.RANGE, logicalParent, physicalParent) {
+        is BetweenFilter -> resolveFieldFilter(
+            filter.field,
+            QueryCapability.RANGE,
+            logicalParent,
+            physicalParent,
+            listOf(filter.lowerBound, filter.upperBound),
+        ) {
             filter.copy(field = it)
         }
         is IsEmptyFilter -> resolveCollectionFieldFilter(
@@ -355,10 +400,14 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
         capability: QueryCapability,
         logicalParent: LogicalField?,
         physicalParent: String?,
+        values: Iterable<JsonNode> = emptyList(),
         copy: (LogicalField) -> FilterExpression,
     ): QuerySchemaResolution<FilterExpression> {
         val resolved = resolveField(field, capability, logicalParent, physicalParent)
-        return QuerySchemaResolution(copy(LogicalField(resolved.value)), resolved.compatibility)
+        return QuerySchemaResolution(
+            copy(LogicalField(resolved.value)),
+            listOf(resolved.compatibility, resolved.valueCompatibility(values)).combined(),
+        )
     }
 
     private inline fun resolveCollectionFieldFilter(
@@ -366,14 +415,20 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
         capability: QueryCapability,
         logicalParent: LogicalField?,
         physicalParent: String?,
+        values: Iterable<JsonNode> = emptyList(),
         copy: (LogicalField) -> FilterExpression,
     ): QuerySchemaResolution<FilterExpression> {
         val resolved = resolveField(field, capability, logicalParent, physicalParent)
-        val compatibility = if (schema.fields[resolved.logical]?.cardinality == QueryCardinality.SINGLE) {
+        val cardinality = if (schema.fields[resolved.logical]?.cardinality == QueryCardinality.SINGLE) {
             QueryCompatibilityLevel.INCOMPATIBLE
         } else {
-            resolved.compatibility
+            QueryCompatibilityLevel.EXACT
         }
+        val compatibility = listOf(
+            resolved.compatibility,
+            cardinality,
+            resolved.valueCompatibility(values),
+        ).combined()
         return QuerySchemaResolution(copy(LogicalField(resolved.value)), compatibility)
     }
 
@@ -517,6 +572,7 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
             binding.physicalPath,
             QueryCompatibilityLevel.EXACT,
             fieldSchema = fieldSchema,
+            declaredValueTypes = declaredFieldSchema?.valueTypes.orEmpty(),
         )
     }
 
@@ -548,8 +604,23 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
         val physicalPath: String?,
         val compatibility: QueryCompatibilityLevel,
         val fieldSchema: QueryFieldSchema? = null,
+        val declaredValueTypes: Set<QueryValueType> = emptySet(),
         val elementScopeAccepted: Boolean = true,
-    )
+    ) {
+        fun valueCompatibility(values: Iterable<JsonNode>): QueryCompatibilityLevel {
+            if (declaredValueTypes.isEmpty() || declaredValueTypes.any { it !in BUILT_IN_QUERY_VALUE_TYPES }) {
+                return QueryCompatibilityLevel.EXACT
+            }
+            return if (values.all { value ->
+                    value.isNull || declaredValueTypes.any { type -> value.matches(type) }
+                }
+            ) {
+                QueryCompatibilityLevel.EXACT
+            } else {
+                QueryCompatibilityLevel.INCOMPATIBLE
+            }
+        }
+    }
 
     private fun resolveAggregationField(
         field: LogicalField,
@@ -588,6 +659,64 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
         startsWith("$parent.") -> substring(parent.length + 1)
         else -> null
     }
+}
+
+private fun JsonNode.queryValues(): Iterable<JsonNode> {
+    val pojo = pojoValue
+    return when {
+        isArray -> this
+        pojo is Iterable<*> -> pojo.map { JsonNodeFactory.instance.pojoNode(it) }
+        pojo?.javaClass?.isArray == true -> (0 until ReflectArray.getLength(pojo)).map {
+            JsonNodeFactory.instance.pojoNode(ReflectArray.get(pojo, it))
+        }
+        else -> listOf(this)
+    }
+}
+
+private fun JsonNode.matches(type: QueryValueType): Boolean {
+    if (isPojo) return pojoValue.matches(type)
+    return when (type) {
+        QueryValueType.STRING -> isString
+        QueryValueType.INTEGER -> isNumber && canConvertToExactIntegral()
+        QueryValueType.DECIMAL -> isNumber
+        QueryValueType.BOOLEAN -> isBoolean
+        QueryValueType.OBJECT -> isObject
+        else -> true
+    }
+}
+
+private val JsonNode.pojoValue: Any?
+    get() = (this as? POJONode)?.pojo
+
+private fun Any?.matches(type: QueryValueType): Boolean = when (this) {
+    is CharSequence,
+    is Char,
+    is Enum<*>,
+    -> type == QueryValueType.STRING
+    is Boolean -> type == QueryValueType.BOOLEAN
+    is Byte,
+    is Short,
+    is Int,
+    is Long,
+    is BigInteger,
+    -> type == QueryValueType.INTEGER || type == QueryValueType.DECIMAL
+    is Float,
+    is Double,
+    is BigDecimal,
+    -> type.matchesNumber(this as Number)
+    else -> true
+}
+
+private fun QueryValueType.matchesNumber(value: Number): Boolean {
+    if (this == QueryValueType.DECIMAL) return true
+    if (this != QueryValueType.INTEGER) return false
+    val node = when (value) {
+        is Float -> JsonNodeFactory.instance.numberNode(value)
+        is Double -> JsonNodeFactory.instance.numberNode(value)
+        is BigDecimal -> JsonNodeFactory.instance.numberNode(value)
+        else -> return true
+    }
+    return node.canConvertToExactIntegral()
 }
 
 private fun Iterable<QueryCompatibilityLevel>.combined(): QueryCompatibilityLevel = when {

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolverTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolverTest.kt
@@ -92,7 +92,10 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import tools.jackson.databind.JsonNode
 import tools.jackson.databind.node.JsonNodeFactory
+import java.math.BigDecimal
+import java.time.Instant
 import java.time.format.DateTimeFormatter
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 @Suppress("LargeClass")
@@ -140,6 +143,105 @@ class QuerySchemaResolverTest {
         cases.forEach { (input, expected) ->
             resolver.resolve(input).assert().isEqualTo(
                 QuerySchemaResolution(expected, QueryCompatibilityLevel.EXACT),
+            )
+        }
+    }
+
+    @Test
+    fun `declared built-in field types should reject incompatible predicate values`() {
+        val integer = LogicalField("state.createdAt")
+        val string = LogicalField("state.status")
+        val boolean = LogicalField("state.active")
+        val strings = LogicalField("state.labels")
+        val resolver = QuerySchemaResolver(
+            schema(
+                mapOf(
+                    integer to fieldSchema(
+                        QueryCapability.EXACT_MATCH to "document.created_at",
+                        QueryCapability.RANGE to "document.created_at",
+                        valueTypes = setOf(QueryValueType.INTEGER),
+                    ),
+                    string to fieldSchema(
+                        QueryCapability.EXACT_MATCH to "document.status",
+                        valueTypes = setOf(QueryValueType.STRING),
+                    ),
+                    boolean to fieldSchema(
+                        QueryCapability.EXACT_MATCH to "document.active",
+                        valueTypes = setOf(QueryValueType.BOOLEAN),
+                    ),
+                    strings to fieldSchema(
+                        QueryCapability.EXACT_MATCH to "document.labels",
+                        valueTypes = setOf(QueryValueType.STRING),
+                        cardinality = QueryCardinality.MANY,
+                    ),
+                ),
+            ),
+        )
+        val text = JsonNodeFactory.instance.stringNode("not-a-timestamp")
+        val number = JsonNodeFactory.instance.numberNode(1)
+        val filters = listOf(
+            EqualFilter(integer, text),
+            EqualFilter(integer, JsonNodeFactory.instance.numberNode(1.5)),
+            EqualFilter(integer, JsonNodeFactory.instance.pojoNode(1.5)),
+            EqualFilter(strings, JsonNodeFactory.instance.pojoNode(listOf("value", 1))),
+            NotEqualFilter(boolean, number),
+            InFilter(string, listOf(number)),
+            NotInFilter(string, listOf(number)),
+            ContainsAllFilter(strings, listOf(number)),
+            GreaterThanFilter(integer, text),
+            GreaterThanOrEqualFilter(integer, text),
+            LessThanFilter(integer, text),
+            LessThanOrEqualFilter(integer, text),
+            BetweenFilter(integer, number, text),
+        )
+
+        filters.forEach { filter ->
+            val resolution = resolver.resolve(filter)
+
+            resolution.compatibility.assert().isEqualTo(QueryCompatibilityLevel.INCOMPATIBLE)
+            QuerySchemaValidationMode.entries.forEach { mode ->
+                assertThrows<QuerySchemaValidationException> {
+                    resolution.requireAccepted(mode)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `declared built-in field types should accept matching values`() {
+        val field = LogicalField("state.value")
+        val physical = LogicalField("document.value")
+
+        listOf(
+            QueryValueType.STRING to JsonNodeFactory.instance.stringNode("value"),
+            QueryValueType.INTEGER to JsonNodeFactory.instance.numberNode(1),
+            QueryValueType.INTEGER to JsonNodeFactory.instance.numberNode(1.0),
+            QueryValueType.INTEGER to JsonNodeFactory.instance.pojoNode(1.0),
+            QueryValueType.INTEGER to JsonNodeFactory.instance.pojoNode(BigDecimal("1.0")),
+            QueryValueType.DECIMAL to JsonNodeFactory.instance.numberNode(1.5),
+            QueryValueType.BOOLEAN to JsonNodeFactory.instance.booleanNode(true),
+            QueryValueType.OBJECT to JsonNodeFactory.instance.pojoNode(mapOf("id" to "value")),
+            QueryValueType.STRING to JsonNodeFactory.instance.pojoNode(listOf("one", "two")),
+            QueryValueType.INTEGER to JsonNodeFactory.instance.pojoNode(Instant.EPOCH),
+            QueryValueType.STRING to JsonNodeFactory.instance.pojoNode(UUID.randomUUID()),
+            QueryValueType.from("UUID") to JsonNodeFactory.instance.stringNode("value"),
+        ).forEach { (valueType, value) ->
+            val resolver = QuerySchemaResolver(
+                schema(
+                    mapOf(
+                        field to fieldSchema(
+                            QueryCapability.EXACT_MATCH to physical.value,
+                            valueTypes = setOf(valueType),
+                        ),
+                    ),
+                ),
+            )
+
+            resolver.resolve(EqualFilter(field, value)).assert().isEqualTo(
+                QuerySchemaResolution(
+                    EqualFilter(physical, value),
+                    QueryCompatibilityLevel.EXACT,
+                ),
             )
         }
     }
@@ -1087,11 +1189,12 @@ class QuerySchemaResolverTest {
         semanticType: QuerySemanticType? = null,
         projectionPath: String? = null,
         cardinality: QueryCardinality = QueryCardinality.SINGLE,
+        valueTypes: Set<QueryValueType> = emptySet(),
     ) = QueryFieldSchema(
         title = null,
         description = null,
         enumValues = null,
-        valueTypes = setOf(QueryValueType.STRING),
+        valueTypes = valueTypes,
         nullable = false,
         required = true,
         cardinality = cardinality,


### PR DESCRIPTION
## Goal

Reject semantically incompatible predicate literals before backend execution so MongoDB and Elasticsearch return the same query validation contract.

Completion criteria:
- declared built-in query field types reject incompatible literals in both COMPATIBLE and STRICT modes;
- unknown fields, dynamic descendants, custom value types, null presence, and unknown runtime POJOs preserve existing behavior;
- MongoDB and Elasticsearch never receive the reproduced invalid epoch literal.

## Changes

- Validate EQ/NE, IN/NOT_IN/CONTAINS_ALL, GT/GTE/LT/LTE, and BETWEEN values against declared built-in QueryValueType metadata in QuerySchemaResolver.
- Preserve permissive handling for unknown/custom schemas and arbitrary runtime POJOs; validate recognized POJO scalars and collection elements only.
- Follow JSON Schema integer semantics: accept exact integral values such as 1.0 and reject fractional values such as 1.5.
- Add resolver unit coverage plus real MongoDB and Elasticsearch regression tests for invalid epoch literals in both validation modes.

## Verification

- Red/Green: resolver unit test initially returned EXACT instead of INCOMPATIBLE.
- Red/Green: with value-type propagation disabled, MongoDB completed silently while Elasticsearch raised ElasticsearchException; both now raise QuerySchemaValidationException before backend execution.
- `./gradlew :wow-query:check :wow-mongo:check :wow-elasticsearch:check :wow-mongo:integrationTest :wow-elasticsearch:integrationTest --rerun-tasks --console=plain` — BUILD SUCCESSFUL, 53 tasks executed.
- `git diff --check` — passed.
- Independent code review — APPROVED, no Critical/Important/Minor findings.

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

No migration, storage, concurrency, or deployment changes. Invalid literals for declared built-in fields now fail consistently with QuerySchemaValidation instead of reaching the backend and producing divergent empty results or internal errors. Existing documentation already describes validation-mode and schema semantics, so no documentation update is required.