### PR TITLE
feat(query): add aggregation any metric

### DIFF
--- a/docs/superpowers/plans/2026-08-27-aggregation-any-metric.md
+++ b/docs/superpowers/plans/2026-08-27-aggregation-any-metric.md
@@ -1,0 +1,1069 @@
+# 聚合 ANY 代表值指标实现计划
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为 `AggregationQuery` 增加不改变分组键的 `ANY` 代表值指标，使按 `productId` 分组时可直接返回组内任意非空 `productName`。
+
+**Architecture:** 在公开 `AggregationMetric` sealed 层次中增加 `Any(field, alias)`，DSL 只增加 `any(field, alias)`。字段复用 `AGGREGATE_TERMS` 和现有 Elements 相对路径；MongoDB 编译为 `$max`，Elasticsearch 编译为 `terms(size = 1)`，结果继续进入现有动态行、排序与 HTTP guard 流程。
+
+**Tech Stack:** Kotlin 2.4、JUnit Jupiter 6、FluentAssert、Reactor Test、MongoDB Java Driver、Elasticsearch Java Client 9.4、Spring Data、Jackson、springdoc/OpenAPI、VitePress。
+
+**Spec:** `docs/superpowers/specs/2026-08-27-aggregation-any-metric-design.md`
+
+## Global Constraints
+
+- `ANY` 返回组内任意非 `null` 标量；全部为空时返回 `null`，不得承诺执行间或后端间稳定。
+- 输入字段必须具备 `AGGREGATE_TERMS`，已知 `QueryCardinality.MANY` 按现有 validation mode 判定为不兼容。
+- 不支持表达式、对象、多值字段、`FIRST`、`LAST`、`LATEST`、`ARG_MAX` 或自定义选择排序。
+- 不增加兼容别名、`selections` 平行通道、Catalog、Scanner、Lookup、Join、脚本、配置、依赖、模块或 CI 改动。
+- 不修改 `compensation/dashboard/src/generated/`；OpenAPI 只更新模型与既有快照。
+- MongoDB 与 Elasticsearch 必须执行真实集成测试；编译器字符串断言不能替代后端证据。
+- 所有 Kotlin 测试沿用 FluentAssert `.assert()`，不引入 AssertJ。
+
+---
+
+## File Structure
+
+不创建新的生产源码文件，按现有职责修改：
+
+- `wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt`：公开 `AggregationMetric.Any` 与 JSON subtype。
+- `wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDsl.kt`：Kotlin DSL 入口。
+- `wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolver.kt`：ANY 字段 capability 与 cardinality 兼容性。
+- `wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompiler.kt`：`$max` accumulator 与投影。
+- `wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryService.kt`：ANY 结果采用 Terms key 规范化。
+- `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompiler.kt`：显式 Count/Numeric/Any 内部计划和物理字段解析。
+- `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPager.kt`：生成 `terms(size=1)`，读取 string/long/double/unmapped bucket。
+- `test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/mock/MockAggregate.kt`：为共享聚合数据增加单值 `productName`。
+- `test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt`：MongoDB 与 Elasticsearch 共用真实合同。
+- `wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt`：ANY alias 排序沿用昂贵查询门禁。
+- `wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt` 与两个 JSON snapshot：固定联合类型合同。
+- `documentation/docs/zh/guide/query.md`、`documentation/docs/en/guide/query.md`：同步 DSL、JSON、空值与不稳定语义。
+
+---
+
+### Task 1: 公共 ANY 模型与 Kotlin DSL
+
+**Files:**
+- Modify: `wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt:192-215`
+- Test: `wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt:20-275`
+- Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDsl.kt:71-122`
+- Test: `wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt:25-104`
+
+**Interfaces:**
+- Consumes: 现有 `LogicalField`、`AggregationMetric.alias`、`requireAggregationAlias(alias)` 与 `metrics` 集合。
+- Produces: `AggregationMetric.Any(val field: LogicalField, override val alias: String)`、JSON subtype `ANY`、`AggregationQueryDsl.any(field: String, alias: String)`。
+
+- [ ] **Step 1: 写入 API JSON 与 alias RED 测试**
+
+在 `AggregationQueryTest` 增加：
+
+```kotlin
+@Test
+fun `any metric should round trip through JSON`() {
+    val json = """
+        {
+          "metrics": [{
+            "type": "ANY",
+            "field": "state.productName",
+            "alias": "productName"
+          }]
+        }
+    """.trimIndent()
+
+    val query = configuredMapper.readValue(json, AggregationQuery::class.java)
+
+    query.metrics.assert().containsExactly(
+        AggregationMetric.Any(LogicalField("state.productName"), "productName"),
+    )
+    configuredMapper.writeValueAsString(query).assert().contains("\"type\":\"ANY\"")
+}
+
+@Test
+fun `any metric should reject internal aliases`() {
+    assertThrows<IllegalArgumentException> {
+        AggregationMetric.Any(LogicalField("state.productName"), "__wow_productName")
+    }
+}
+```
+
+- [ ] **Step 2: 运行 API RED 测试**
+
+Run:
+
+```bash
+./gradlew :wow-api:test --tests "me.ahoo.wow.api.query.AggregationQueryTest" --stacktrace
+```
+
+Expected: Kotlin 编译失败，包含 `Unresolved reference 'Any'`。
+
+- [ ] **Step 3: 写入 DSL RED 测试**
+
+在 `AggregationQueryDslTest` 增加：
+
+```kotlin
+@Test
+fun `aggregation DSL should add an any metric without another group`() {
+    val query = aggregation {
+        terms("productId", "productId")
+        any("productName", "productName")
+        count("count")
+    }
+
+    query.groupBy.assert().containsExactly(
+        AggregationGroup.Terms(LogicalField("productId"), "productId"),
+    )
+    query.metrics.assert().containsExactly(
+        AggregationMetric.Any(LogicalField("productName"), "productName"),
+        AggregationMetric.Count("count"),
+    )
+}
+```
+
+- [ ] **Step 4: 运行 DSL RED 测试**
+
+Run:
+
+```bash
+./gradlew :wow-query:test --tests "me.ahoo.wow.query.dsl.AggregationQueryDslTest" --stacktrace
+```
+
+Expected: Kotlin 编译失败，包含 `Unresolved reference 'any'` 和 `Unresolved reference 'Any'`。
+
+- [ ] **Step 5: 实现最小公开模型与 DSL**
+
+在 `AggregationMetric` subtype 注册中加入：
+
+```kotlin
+JsonSubTypes.Type(AggregationMetric.Any::class, name = "ANY"),
+```
+
+在 sealed interface 上显式固定 OpenAPI union，并在 `AggregationMetric` 内加入：
+
+```kotlin
+@Schema(
+    oneOf = [
+        AggregationMetric.Count::class,
+        AggregationMetric.Numeric::class,
+        AggregationMetric.Any::class,
+    ],
+    discriminatorProperty = "type",
+)
+sealed interface AggregationMetric {
+    val alias: String
+
+    data class Any(
+        val field: LogicalField,
+        override val alias: String,
+    ) : AggregationMetric {
+        init {
+            requireAggregationAlias(alias)
+        }
+    }
+}
+```
+
+在 `AggregationQueryDsl` 的 `count` 后加入：
+
+```kotlin
+fun any(field: String, alias: String) {
+    metrics += AggregationMetric.Any(LogicalField(field), alias)
+}
+```
+
+不改变 `AggregationFunction`，不增加表达式重载。
+
+- [ ] **Step 6: 运行公共模型与 DSL GREEN 测试**
+
+Run:
+
+```bash
+./gradlew :wow-api:test :wow-query:test \
+  --tests "*AggregationQueryTest" \
+  --tests "*AggregationQueryDslTest" \
+  --stacktrace
+```
+
+Expected: 两个测试类全部 PASS。其他后端模块尚未重编译，不在本步骤声称全仓可编译。
+
+- [ ] **Step 7: 提交公共合同**
+
+```bash
+git add \
+  wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt \
+  wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt \
+  wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDsl.kt \
+  wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt
+git commit -m "feat(query): add aggregation any metric contract"
+```
+
+---
+
+### Task 2: ANY 字段 Schema 解析
+
+**Files:**
+- Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolver.kt:146-180`
+- Test: `wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolverTest.kt:1000-1210`
+
+**Interfaces:**
+- Consumes: Task 1 的 `AggregationMetric.Any`；现有 `resolveAggregationField`、`FieldResolution.fieldSchema`、`QueryCapability.AGGREGATE_TERMS`。
+- Produces: SINGLE 精确字段为 `EXACT`，缺少 capability 或已知 MANY 为 `INCOMPATIBLE`，Elements 字段仍按最内层相对路径解析。
+
+- [ ] **Step 1: 写入 capability、相对路径与 cardinality RED 测试**
+
+在 `QuerySchemaResolverTest` 增加：
+
+```kotlin
+@Test
+fun `aggregation any should require a single terms-capable field in the innermost element`() {
+    val productName = LogicalField("state.orders.lines.productName")
+    val baseFields = linkedMapOf(
+        LogicalField("state.orders") to fieldSchema(
+            QueryCapability.ELEMENT_SCOPE to "document.orders",
+            cardinality = QueryCardinality.MANY,
+            valueTypes = setOf(QueryValueType.OBJECT),
+        ),
+        LogicalField("state.orders.lines") to fieldSchema(
+            QueryCapability.ELEMENT_SCOPE to "document.orders.lines",
+            cardinality = QueryCardinality.MANY,
+            valueTypes = setOf(QueryValueType.OBJECT),
+        ),
+        productName to fieldSchema(
+            QueryCapability.AGGREGATE_TERMS to "document.orders.lines.productName.keyword",
+            valueTypes = setOf(QueryValueType.STRING),
+        ),
+    )
+    val query = AggregationQuery(
+        elements = listOf(
+            AggregationElement(LogicalField("state.orders")),
+            AggregationElement(LogicalField("lines")),
+        ),
+        metrics = listOf(AggregationMetric.Any(LogicalField("productName"), "productName")),
+    )
+
+    QuerySchemaResolver(schema(baseFields)).resolve(query).compatibility.assert()
+        .isEqualTo(QueryCompatibilityLevel.EXACT)
+
+    val manyField = baseFields.getValue(productName).copy(cardinality = QueryCardinality.MANY)
+    QuerySchemaResolver(schema(baseFields + (productName to manyField)))
+        .resolve(query).compatibility.assert().isEqualTo(QueryCompatibilityLevel.INCOMPATIBLE)
+
+    val withoutTerms = baseFields.getValue(productName).copy(bindings = emptyMap())
+    QuerySchemaResolver(schema(baseFields + (productName to withoutTerms)))
+        .resolve(query).compatibility.assert().isEqualTo(QueryCompatibilityLevel.INCOMPATIBLE)
+}
+```
+
+- [ ] **Step 2: 运行 Schema RED 测试**
+
+Run:
+
+```bash
+./gradlew :wow-query:test \
+  --tests "me.ahoo.wow.query.schema.QuerySchemaResolverTest.aggregation any should require a single terms-capable field in the innermost element" \
+  --stacktrace
+```
+
+Expected: MANY 与 missing-capability 分支错误地保持 `EXACT`，测试 FAIL。
+
+- [ ] **Step 3: 在现有 aggregation resolve 流程加入 ANY 检查**
+
+在 Numeric 表达式检查前加入：
+
+```kotlin
+query.metrics.filterIsInstance<AggregationMetric.Any>().forEach { metric ->
+    val resolved = resolveAggregationField(
+        metric.field,
+        QueryCapability.AGGREGATE_TERMS,
+        logicalParent,
+        physicalParent,
+    )
+    levels += resolved.compatibility
+    if (resolved.fieldSchema?.cardinality == QueryCardinality.MANY) {
+        levels += QueryCompatibilityLevel.INCOMPATIBLE
+    }
+}
+```
+
+补充 `QueryCardinality` import。不要新增 `AGGREGATE_ANY` capability，也不要改写 query 中的逻辑字段。
+
+- [ ] **Step 4: 运行 Schema GREEN 与回归测试**
+
+Run:
+
+```bash
+./gradlew :wow-query:test --tests "me.ahoo.wow.query.schema.QuerySchemaResolverTest" --stacktrace
+```
+
+Expected: `QuerySchemaResolverTest` 全部 PASS。
+
+- [ ] **Step 5: 提交 Schema 解析**
+
+```bash
+git add \
+  wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolver.kt \
+  wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolverTest.kt
+git commit -m "feat(query): validate aggregation any fields"
+```
+
+---
+
+### Task 3: MongoDB ANY 编译、结果与共享真实合同
+
+**Files:**
+- Modify: `wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompiler.kt:92-141`
+- Modify: `wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryService.kt:122-147`
+- Test: `wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt:35-360`
+- Modify: `test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/mock/MockAggregate.kt:70-77`
+- Test: `test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt:283-665`
+
+**Interfaces:**
+- Consumes: Task 1 的 `AggregationMetric.Any`，Task 2 的 `AGGREGATE_TERMS`/SINGLE 约束。
+- Produces: Mongo `$max` accumulator、ANY 投影、Terms-key 结果规范化，以及由 Mongo/Elasticsearch 两个 integrationTest 类继承的共享合同。
+
+- [ ] **Step 1: 给共享 TCK 数据增加显示名称**
+
+在 `MockLine` 末尾增加默认字段：
+
+```kotlin
+val productName: String? = null,
+```
+
+在 `aggregationStateA()` 的 `alpha` line 设置：
+
+```kotlin
+productName = "Alpha",
+```
+
+在 `aggregationStateB()` 的 `alpha` line 设置：
+
+```kotlin
+productName = "Alpha 2026",
+```
+
+保留 `gamma` 的缺省 `null`，用于全空场景。
+
+- [ ] **Step 2: 写入共享 Mongo RED 合同**
+
+在 `SnapshotQueryServiceSpec` 增加：
+
+```kotlin
+@Test
+fun `aggregation should select any non-null value without splitting the group`() {
+    saveAggregationStates(*aggregationStates().toTypedArray())
+
+    aggregation {
+        expand("state.orders")
+        expand("lines") { "productId" eq "alpha" }
+        terms("productId", "productId")
+        any("productName", "productName")
+        count("count")
+    }.query(snapshotQueryService)
+        .test()
+        .assertNext { row ->
+            row["productId"].assert().isEqualTo("alpha")
+            setOf("Alpha", "Alpha 2026").contains(row["productName"]).assert().isTrue()
+            row["count"].assert().isEqualTo(2L)
+        }.verifyComplete()
+}
+
+@Test
+fun `aggregation any should return null when every value is absent`() {
+    saveAggregationStates(*aggregationStates().toTypedArray())
+
+    aggregation {
+        expand("state.orders")
+        expand("lines") { "productId" eq "gamma" }
+        any("productName", "productName")
+        count("count")
+    }.query(snapshotQueryService)
+        .test()
+        .assertNext { row ->
+            row.containsKey("productName").assert().isTrue()
+            row["productName"].assert().isNull()
+            row["count"].assert().isEqualTo(1L)
+        }.verifyComplete()
+}
+```
+
+同时扩展现有 `aggregation should return one empty summary row`：
+
+```kotlin
+aggregation {
+    filter { aggregateId("missing") }
+    any("state.data", "anyData")
+    count("count")
+    sum("version", "total")
+}.query(snapshotQueryService)
+    .test()
+    .assertNext {
+        it.toMap().assert().isEqualTo(
+            mapOf("anyData" to null, "count" to 0L, "total" to null),
+        )
+    }.verifyComplete()
+```
+
+- [ ] **Step 3: 写入 Mongo compiler RED 测试**
+
+在 `MongoAggregationCompilerTest` 增加：
+
+```kotlin
+@Test
+fun `any metric should compile a resolved max accumulator and projection`() {
+    val schema = schema(
+        field(
+            "state.productName",
+            QueryCapability.AGGREGATE_TERMS,
+            "document.productName",
+        ),
+    )
+    val pipeline = compiler.compile(
+        aggregation {
+            any("state.productName", "productName")
+            count("count")
+        },
+        schema,
+    ).map { it.toBsonDocument() }
+
+    val group = pipeline.single { it.containsKey("\$group") }.getDocument("\$group")
+    group.getDocument("productName").assert()
+        .isEqualTo(BsonDocument("\$max", BsonString("\$document.productName")))
+    pipeline.single { it.containsKey("\$project") }.toJson().assert().contains("productName")
+}
+```
+
+复用该测试文件现有 `compiler`、`schema`、`field` helper；按现有 imports 使用 `BsonDocument`/`BsonString`，不要比较整条 pipeline 字符串。
+
+- [ ] **Step 4: 运行 Mongo RED 测试**
+
+Run:
+
+```bash
+./gradlew :wow-mongo:test \
+  --tests "*MongoAggregationCompilerTest.any metric should compile a resolved max accumulator and projection" \
+  --stacktrace
+```
+
+Expected: `when` 不穷尽或 ANY 未产生 accumulator，测试 FAIL。
+
+- [ ] **Step 5: 实现 Mongo `$max` 与投影**
+
+在 `MongoAggregationCompiler.group()` 的 metric `when` 中加入：
+
+```kotlin
+is AggregationMetric.Any -> add(
+    Accumulators.max(
+        metric.alias,
+        "\$${metric.field.resolve(parent, schema, QueryCapability.AGGREGATE_TERMS)}",
+    ),
+)
+```
+
+在 `project()` 的 metric `when` 中加入：
+
+```kotlin
+is AggregationMetric.Any -> Projections.include(metric.alias)
+```
+
+- [ ] **Step 6: 实现 Mongo ANY 结果规范化**
+
+在 `MongoSnapshotQueryService` 增加：
+
+```kotlin
+private fun Any?.toTermsValue(alias: String): Any? =
+    if (this is Decimal128) toFiniteDouble(alias) else this
+```
+
+把 group key 转换改为调用 `toTermsValue`，并在 metric `when` 中加入：
+
+```kotlin
+is AggregationMetric.Any -> get(metric.alias).toTermsValue(metric.alias)
+```
+
+保留现有 empty-summary 表达式；它已经让非 Count 指标返回 `null`。
+
+- [ ] **Step 7: 运行 Mongo 单元与真实集成 GREEN 测试**
+
+Run:
+
+```bash
+./gradlew :wow-mongo:test --tests "*MongoAggregationCompilerTest" --stacktrace
+./gradlew :wow-mongo:integrationTest \
+  --tests "*MongoSnapshotQueryServiceTest.aggregation should select any non-null value without splitting the group" \
+  --tests "*MongoSnapshotQueryServiceTest.aggregation any should return null when every value is absent" \
+  --tests "*MongoSnapshotQueryServiceTest.aggregation should return one empty summary row" \
+  --stacktrace
+```
+
+Expected: compiler 测试与三个真实 MongoDB 合同均 PASS。
+
+- [ ] **Step 8: 提交 Mongo 与共享合同**
+
+```bash
+git add \
+  wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompiler.kt \
+  wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryService.kt \
+  wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt \
+  test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/mock/MockAggregate.kt \
+  test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt
+git commit -m "feat(mongo): execute aggregation any metrics"
+```
+
+---
+
+### Task 4: Elasticsearch ANY 计划、请求与结果读取
+
+**Files:**
+- Modify: `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompiler.kt:36-69,226-247`
+- Modify: `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPager.kt:130-230`
+- Test: `wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt:35-360`
+- Test: `wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt:30-410`
+
+**Interfaces:**
+- Consumes: 共享 TCK 的 `productName` 数据与 `AggregationMetric.Any`。
+- Produces: sealed internal `ElasticsearchAggregationMetric.Count/Numeric/Any`，`terms(field, size=1)` 请求，string/long/double/unmapped 结果读取。
+
+- [ ] **Step 1: 写入 compiler RED 测试**
+
+在 `ElasticsearchAggregationCompilerTest` 增加：
+
+```kotlin
+@Test
+fun `any metric should resolve a terms-capable field without a runtime mapping`() {
+    val schema = schema(
+        field(
+            "state.productName",
+            QueryCapability.AGGREGATE_TERMS,
+            "document.productName.keyword",
+            "keyword",
+        ),
+    )
+    val plan = ElasticsearchAggregationCompiler(SnapshotFilterConverter).compile(
+        aggregation { any("state.productName", "productName") },
+        schema,
+    )
+
+    val metric = plan.metrics.single() as ElasticsearchAggregationMetric.Any
+    metric.alias.assert().isEqualTo("productName")
+    metric.field.assert().isEqualTo("document.productName.keyword")
+    plan.runtimeMappings.assert().isEmpty()
+}
+```
+
+- [ ] **Step 2: 写入 pager RED 测试与 response helper**
+
+在 `ElasticsearchAggregationPagerTest` import `DoubleTermsBucket`、`LongTermsBucket`、`StringTermsBucket`，增加 helper：
+
+```kotlin
+private fun stringTerms(value: String?): Aggregate = Aggregate.of { aggregate ->
+    aggregate.sterms { terms ->
+        terms.buckets(
+            Buckets.of<StringTermsBucket> { buckets ->
+                buckets.array(
+                    value?.let {
+                        listOf(StringTermsBucket.of { bucket -> bucket.key(it).docCount(1) })
+                    }.orEmpty(),
+                )
+            },
+        )
+    }
+}
+
+private fun booleanTerms(value: Boolean): Aggregate = Aggregate.of { aggregate ->
+    aggregate.sterms { terms ->
+        terms.buckets(
+            Buckets.of<StringTermsBucket> { buckets ->
+                buckets.array(listOf(StringTermsBucket.of { it.key(value).docCount(1) }))
+            },
+        )
+    }
+}
+
+private fun longTerms(value: Long): Aggregate = Aggregate.of { aggregate ->
+    aggregate.lterms { terms ->
+        terms.buckets(
+            Buckets.of<LongTermsBucket> { buckets ->
+                buckets.array(listOf(LongTermsBucket.of { it.key(value).docCount(1) }))
+            },
+        )
+    }
+}
+
+private fun doubleTerms(value: Double): Aggregate = Aggregate.of { aggregate ->
+    aggregate.dterms { terms ->
+        terms.buckets(
+            Buckets.of<DoubleTermsBucket> { buckets ->
+                buckets.array(listOf(DoubleTermsBucket.of { it.key(value).docCount(1) }))
+            },
+        )
+    }
+}
+
+private fun anyBucket(product: String, productName: Aggregate): CompositeBucket = CompositeBucket.of {
+    it.key("product", product)
+        .docCount(1)
+        .aggregations("productName", productName)
+}
+```
+
+增加测试：
+
+```kotlin
+@Test
+fun `any metric should request one terms bucket and read its scalar key`() {
+    val requests = mutableListOf<SearchRequest>()
+    stubPointInTime()
+    every { client.search(capture(requests), Map::class.java) } returns Mono.just(
+        groupResponse("pit-2", listOf(anyBucket("alpha", stringTerms("Alpha")))),
+    )
+    val plan = compiler().compile(
+        aggregation {
+            terms("state.productId", "product")
+            any("state.productName", "productName")
+        },
+    )
+
+    pager().execute(plan).test()
+        .assertNext { row -> row["productName"].assert().isEqualTo("Alpha") }
+        .verifyComplete()
+
+    requests.single().aggregations().values.single().composite()
+        .aggregations().getValue("productName").terms().apply {
+            field().assert().isEqualTo("state.productName")
+            size().assert().isEqualTo(1)
+        }
+}
+```
+
+在同一测试类增加以下原生类型测试：
+
+```kotlin
+@Test
+fun `any metric should normalize boolean long double and empty terms buckets`() {
+    stubPointInTime()
+    every { client.search(any<SearchRequest>(), Map::class.java) } returns Mono.just(
+        groupResponse(
+            "pit-2",
+            listOf(
+                anyBucket("a", booleanTerms(true)),
+                anyBucket("b", longTerms(7L)),
+                anyBucket("c", doubleTerms(7.5)),
+                anyBucket("d", stringTerms(null)),
+            ),
+        ),
+    )
+    val plan = compiler().compile(
+        aggregation {
+            terms("state.productId", "product")
+            any("state.value", "productName")
+        },
+    )
+
+    pager().execute(plan).map { it["productName"] }.collectList().test()
+        .assertNext { values -> values.assert().containsExactly(true, 7L, 7.5, null) }
+        .verifyComplete()
+}
+```
+
+- [ ] **Step 3: 运行 Elasticsearch RED 测试**
+
+Run:
+
+```bash
+./gradlew :wow-elasticsearch:test \
+  --tests "*ElasticsearchAggregationCompilerTest.any metric should resolve a terms-capable field without a runtime mapping" \
+  --tests "*ElasticsearchAggregationPagerTest.any metric should request one terms bucket and read its scalar key" \
+  --stacktrace
+```
+
+Expected: internal `Any` plan 不存在，且 production `when` 不穷尽，编译或断言 FAIL。
+
+- [ ] **Step 4: 把 nullable-function data class 改为显式内部 sealed 计划**
+
+在 `ElasticsearchAggregationCompiler.kt` 替换现有内部 metric data class：
+
+```kotlin
+internal sealed interface ElasticsearchAggregationMetric {
+    val alias: String
+
+    data class Count(override val alias: String) : ElasticsearchAggregationMetric
+
+    data class Numeric(
+        override val alias: String,
+        val function: AggregationFunction,
+        val field: String,
+    ) : ElasticsearchAggregationMetric {
+        val valueCountAlias: String
+            get() = "__wow_value_count_$alias"
+    }
+
+    data class Any(
+        override val alias: String,
+        val field: String,
+    ) : ElasticsearchAggregationMetric
+}
+```
+
+将 `AggregationMetric.toPlan()` 改为：
+
+```kotlin
+is AggregationMetric.Count -> ElasticsearchAggregationMetric.Count(alias)
+is AggregationMetric.Any -> ElasticsearchAggregationMetric.Any(
+    alias,
+    field.resolve(parent, schema, QueryCapability.AGGREGATE_TERMS),
+)
+is AggregationMetric.Numeric -> {
+    val metricField = when (val expression = expression) {
+        is AggregationExpression.Field -> expression.field.resolve(
+            parent,
+            schema,
+            QueryCapability.AGGREGATE_NUMERIC,
+        )
+        else -> "__wow_expression_$index".also { runtimeFieldName ->
+            runtimeMappings[runtimeFieldName] = RuntimeExpressionCompiler(parent, schema).compile(expression)
+        }
+    }
+    ElasticsearchAggregationMetric.Numeric(alias, function, metricField)
+}
+```
+
+- [ ] **Step 5: 为三种内部计划生成聚合请求**
+
+把 `metricAggregations()` 改为对 sealed 计划穷尽处理：
+
+```kotlin
+private fun ElasticsearchAggregationPlan.metricAggregations(): Map<String, Aggregation> = buildMap {
+    metrics.forEach { metric ->
+        when (metric) {
+            is ElasticsearchAggregationMetric.Count -> Unit
+            is ElasticsearchAggregationMetric.Any -> put(
+                metric.alias,
+                Aggregation.of { builder ->
+                    builder.terms { terms -> terms.field(metric.field).size(1) }
+                },
+            )
+            is ElasticsearchAggregationMetric.Numeric -> {
+                put(
+                    metric.alias,
+                    Aggregation.of { builder ->
+                        when (metric.function) {
+                            AggregationFunction.SUM -> builder.sum { it.field(metric.field) }
+                            AggregationFunction.AVG -> builder.avg { it.field(metric.field) }
+                            AggregationFunction.MIN -> builder.min { it.field(metric.field) }
+                            AggregationFunction.MAX -> builder.max { it.field(metric.field) }
+                        }
+                    },
+                )
+                put(
+                    metric.valueCountAlias,
+                    Aggregation.of { builder -> builder.valueCount { it.field(metric.field) } },
+                )
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 6: 读取 ANY bucket key**
+
+把 metric value 读取改为 sealed `when`，保留 Numeric 的 finite 检查：
+
+```kotlin
+private fun ElasticsearchAggregationMetric.value(
+    docCount: Long,
+    aggregations: Map<String, Aggregate>,
+): Any? = when (this) {
+    is ElasticsearchAggregationMetric.Count -> docCount
+    is ElasticsearchAggregationMetric.Any -> aggregations.getValue(alias).anyValue(alias)
+    is ElasticsearchAggregationMetric.Numeric -> numericValue(aggregations)
+}
+
+private fun Aggregate.anyValue(alias: String): Any? = when {
+    isSterms -> sterms().buckets().array().firstOrNull()?.key()?.nativeValue()
+    isLterms -> lterms().buckets().array().firstOrNull()?.key()
+    isDterms -> dterms().buckets().array().firstOrNull()?.key()
+    isUmterms -> null
+    else -> error("Aggregation ANY metric [$alias] returned unsupported Elasticsearch aggregate [${_kind()}].")
+}
+```
+
+将现有 Numeric 读取主体移动到一个 helper，保持唯一实现：
+
+```kotlin
+private fun ElasticsearchAggregationMetric.Numeric.numericValue(
+    aggregations: Map<String, Aggregate>,
+): Double? {
+    if (aggregations.getValue(valueCountAlias).valueCount().value() == 0.0) return null
+    val value = when (function) {
+        AggregationFunction.SUM -> aggregations.getValue(alias).sum().value()
+        AggregationFunction.AVG -> aggregations.getValue(alias).avg().value()
+        AggregationFunction.MIN -> aggregations.getValue(alias).min().value()
+        AggregationFunction.MAX -> aggregations.getValue(alias).max().value()
+    }
+    require(value != null && value.isFinite()) { "Aggregation metric [$alias] must be finite." }
+    return value
+}
+```
+
+- [ ] **Step 7: 运行 Elasticsearch 单元与真实集成 GREEN 测试**
+
+Run:
+
+```bash
+./gradlew :wow-elasticsearch:test \
+  --tests "*ElasticsearchAggregationCompilerTest" \
+  --tests "*ElasticsearchAggregationPagerTest" \
+  --stacktrace
+./gradlew :wow-elasticsearch:integrationTest \
+  --tests "*ElasticsearchSnapshotQueryServiceTest.aggregation should select any non-null value without splitting the group" \
+  --tests "*ElasticsearchSnapshotQueryServiceTest.aggregation any should return null when every value is absent" \
+  --tests "*ElasticsearchSnapshotQueryServiceTest.aggregation should return one empty summary row" \
+  --stacktrace
+```
+
+Expected: 单元测试和三个真实 Elasticsearch 共享合同全部 PASS；请求没有 runtime mapping 或 script。
+
+- [ ] **Step 8: 提交 Elasticsearch 实现**
+
+```bash
+git add \
+  wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompiler.kt \
+  wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPager.kt \
+  wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt \
+  wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
+git commit -m "feat(elasticsearch): execute aggregation any metrics"
+```
+
+---
+
+### Task 5: HTTP Guard、OpenAPI 合同与中英文文档
+
+**Files:**
+- Test: `wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt:130-205`
+- Test: `wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt:99-170`
+- Modify generated snapshot: `wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json`
+- Modify generated snapshot: `wow-openapi/src/test/resources/openapi/example-domain-contract.snapshot.json`
+- Modify: `documentation/docs/zh/guide/query.md:163-254,390-430`
+- Modify: `documentation/docs/en/guide/query.md:163-254,392-432`
+
+**Interfaces:**
+- Consumes: 完整 `AggregationMetric.Any`、现有 metric-alias guard、springdoc subtype discovery。
+- Produces: 明确的 guard 回归证据、OpenAPI `ANY` union/discriminator、双语使用示例。
+
+- [ ] **Step 1: 固定 ANY alias 排序的现有门禁**
+
+在 `HttpQueryGuardFilterTest` 增加：
+
+```kotlin
+@Test
+fun `aggregation Guard should treat any alias sorting as expensive but allow plain any`() {
+    val query = AggregationQuery(
+        groupBy = listOf(AggregationGroup.Terms(LogicalField("state.productId"), "productId")),
+        metrics = listOf(AggregationMetric.Any(LogicalField("state.productName"), "productName")),
+        sort = listOf(Sort("productName", Sort.Direction.ASC)),
+    )
+
+    guard(allowExpensiveOperators = false)
+        .filter(aggregationContext(query), unexpectedBackend())
+        .writeRawRequest(request).test()
+        .expectError(IllegalArgumentException::class.java)
+        .verify()
+
+    guard(allowExpensiveOperators = false, idleTimeout = Duration.ZERO)
+        .filter(
+            aggregationContext(query.copy(sort = emptyList())),
+            FilterChain { context ->
+                context.asAggregationQuery().setResult(Flux.empty())
+                Mono.empty()
+            },
+        ).writeRawRequest(request).test().verifyComplete()
+}
+```
+
+Run:
+
+```bash
+./gradlew :wow-webflux:test \
+  --tests "*HttpQueryGuardFilterTest.aggregation Guard should treat any alias sorting as expensive but allow plain any" \
+  --stacktrace
+```
+
+Expected: PASS，无需修改 `HttpQueryGuardFilter` 生产代码。若失败，修复只能复用 `query.metrics.map(AggregationMetric::alias)`，不得新增 ANY 专属开关。
+
+- [ ] **Step 2: 写入 OpenAPI ANY 联合类型断言**
+
+在 `snapshot aggregation should use generic query body and expose dynamic rows` 测试中加入：
+
+```kotlin
+val metricSchema = openAPI.components.schemas.getValue("wow.api.query.AggregationMetric")
+querySchema.properties.getValue("metrics").items.`$ref`.assert()
+    .isEqualTo("#/components/schemas/wow.api.query.AggregationMetric")
+metricSchema.oneOf.map { it.`$ref` }.assert().containsExactlyInAnyOrder(
+    "#/components/schemas/wow.api.query.AggregationMetric.Count",
+    "#/components/schemas/wow.api.query.AggregationMetric.Numeric",
+    "#/components/schemas/wow.api.query.AggregationMetric.Any",
+)
+metricSchema.discriminator.propertyName.assert().isEqualTo("type")
+val anySchema = openAPI.components.schemas.getValue("wow.api.query.AggregationMetric.Any")
+anySchema.required.assert().containsExactlyInAnyOrder("field", "alias", "type")
+anySchema.properties.getValue("field").`$ref`.assert().isEqualTo(logicalFieldRef)
+```
+
+- [ ] **Step 3: 运行 OpenAPI RED 并受控更新快照**
+
+Run:
+
+```bash
+./gradlew :wow-openapi:test --tests "*ExampleDomainOpenAPITest*" --stacktrace
+```
+
+Expected: snapshot mismatch，FAIL 并显示新增 `AggregationMetric.Any`。
+
+Update:
+
+```bash
+./gradlew :wow-openapi:test \
+  -Dwow.snapshot.update=true \
+  --tests "*ExampleDomainOpenAPITest*" \
+  --stacktrace
+```
+
+Review:
+
+```bash
+git diff -- \
+  wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json \
+  wow-openapi/src/test/resources/openapi/example-domain-contract.snapshot.json
+```
+
+Expected diff: 只新增 `AggregationMetric.Any`、`ANY` discriminator mapping/ref 及对应必填字段；不得出现路由、endpoint 或无关 Schema 漂移。
+
+- [ ] **Step 4: 更新中文聚合说明与案例**
+
+在指标说明中把指标集合更新为包含 `ANY`，并加入：
+
+```kotlin
+val query = aggregation {
+    expand("state.items")
+    terms("productId", "productId")
+    any("productName", "productName")
+    count("count")
+}
+```
+
+对应 JSON：
+
+```json
+{
+  "elements": [{"path": "state.items"}],
+  "groupBy": [
+    {"type": "TERMS", "field": "productId", "alias": "productId"}
+  ],
+  "metrics": [
+    {"type": "ANY", "field": "productName", "alias": "productName"},
+    {"type": "COUNT", "alias": "count"}
+  ]
+}
+```
+
+紧随示例说明：`ANY` 不参与分组；忽略 `null`/缺失；全部为空返回 `null`；MongoDB、Elasticsearch 或重复执行可能选择不同非空名称；需要确定名称时应修复冗余数据或使用明确业务查询，不要依赖 `ANY`。
+
+- [ ] **Step 5: 镜像更新英文文档**
+
+使用同一 DSL/JSON，英文语义固定为：
+
+```text
+ANY does not add another group key. It returns one non-null scalar from the current group, or null when no value contributes. The selected value is intentionally unstable across executions and backends.
+```
+
+中文和英文示例字段、alias、null 语义必须逐项一致。
+
+- [ ] **Step 6: 运行合同、守卫与文档 GREEN 验证**
+
+Run:
+
+```bash
+./gradlew :wow-webflux:check :wow-openapi:check --stacktrace
+cd documentation && pnpm docs:build
+```
+
+Expected: Gradle 两模块 PASS，VitePress build 成功且无死链。
+
+- [ ] **Step 7: 提交合同与文档**
+
+```bash
+git add \
+  wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt \
+  wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt \
+  wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json \
+  wow-openapi/src/test/resources/openapi/example-domain-contract.snapshot.json \
+  documentation/docs/zh/guide/query.md \
+  documentation/docs/en/guide/query.md
+git commit -m "docs(query): document aggregation any metrics"
+```
+
+---
+
+### Task 6: 全量相关验证与完成审计
+
+**Files:**
+- Verify only: all files modified in Tasks 1-5
+
+**Interfaces:**
+- Consumes: Tasks 1-5 的完整实现。
+- Produces: 可复核的 module check、双后端 integration、Detekt、文档构建和干净补丁证据。
+
+- [ ] **Step 1: 运行所有相关 module checks**
+
+```bash
+./gradlew \
+  :wow-api:check \
+  :wow-query:check \
+  :wow-mongo:check \
+  :wow-elasticsearch:check \
+  :wow-webflux:check \
+  :wow-openapi:check \
+  --stacktrace
+```
+
+Expected: 全部任务 BUILD SUCCESSFUL；不得把缺失依赖或容器失败误报为源码通过。
+
+- [ ] **Step 2: 运行完整 MongoDB 与 Elasticsearch integration suites**
+
+```bash
+./gradlew \
+  :wow-mongo:integrationTest \
+  :wow-elasticsearch:integrationTest \
+  --stacktrace
+```
+
+Expected: 两个完整 integrationTest suite PASS，包括共享 `SnapshotQueryServiceSpec` 的两个 ANY 场景。
+
+- [ ] **Step 3: 运行 Detekt 与文档构建**
+
+```bash
+./gradlew detekt --stacktrace
+cd documentation && pnpm docs:build
+```
+
+Expected: Detekt 与 VitePress 均成功。
+
+- [ ] **Step 4: 审计范围与补丁卫生**
+
+```bash
+git diff --check
+git status --short
+git diff --stat HEAD~5..HEAD
+rg -n "AggregationMetric\.Any|fun any\(" \
+  wow-api wow-query wow-mongo wow-elasticsearch wow-webflux wow-openapi test documentation
+```
+
+Expected:
+
+- `git diff --check` 无输出。
+- 工作树不包含构建产物、`node_modules`、`.gradle`、生成 dashboard 客户端或未解释文件。
+- 生产引用只出现在已批准的 API、DSL、Schema、MongoDB、Elasticsearch 边界。
+- 文档与测试引用覆盖中英文、OpenAPI 和双后端 TCK。
+
+- [ ] **Step 5: 确认验证任务不产生额外提交**
+
+Task 6 只验证，不编辑文件。任一命令失败时返回拥有该文件的 Task 1-5，在该任务中完成 RED/GREEN 修复、重跑其最窄测试并使用该任务的提交范围；全部通过时不创建空提交，记录 Steps 1-4 的命令输出作为完成证据。

--- a/docs/superpowers/specs/2026-08-27-aggregation-any-metric-design.md
+++ b/docs/superpowers/specs/2026-08-27-aggregation-any-metric-design.md
@@ -1,0 +1,272 @@
+# 聚合 ANY 代表值指标设计
+
+## 背景
+
+Wow 的 `AggregationQuery` 已支持通过 `TERMS` 按精确值分组，以及 `COUNT`、`SUM`、`AVG`、`MIN`、`MAX` 指标。当前查询可以按 `productId` 分组，但不能在不改变分组键的前提下返回冗余的 `productName`。把 `productName` 也声明为 `TERMS` 会形成 `(productId, productName)` 联合分组；同一 ID 下名称不一致时会拆成多行。
+
+本设计增加类似 ClickHouse `any` 的代表值指标：`productId` 继续决定分组，`productName` 只从组内选择一个非空标量用于展示。
+
+## 目标
+
+- 新增独立的 `AggregationMetric.Any` 公共模型和 JSON subtype `ANY`。
+- Kotlin DSL 支持 `any(field, alias)`。
+- `ANY` 不改变分组，只为每个分组或无分组摘要返回一个代表值。
+- 字段复用现有 `AGGREGATE_TERMS` 能力、Elements 相对路径和 Schema 验证链路。
+- MongoDB 与 Elasticsearch 使用各自的原生聚合能力，不增加脚本、排序阶段或依赖。
+- `null` 和缺失值不参与选择；全部为空时返回 `null`。
+- OpenAPI、查询文档和双后端真实集成测试同步更新。
+
+## 非目标
+
+- 不保证同一查询的多次执行、不同分片布局或不同后端返回同一个代表值。
+- 不提供 `FIRST`、`LAST`、`LATEST`、`ARG_MAX`、自定义排序或确定性选择策略。
+- 不支持表达式、对象或多值字段作为 `ANY` 输入。
+- 不增加通用选择表达式、字段 Catalog、Scanner、Lookup、Join 或结果补全服务。
+- 不增加配置项、依赖、Gradle 模块、CI 工作流或发布逻辑。
+- 不提供兼容别名、旧解析器适配、平行 `selections` 通道或其他源码、二进制、线协议兼容桥。
+
+## 公共语义
+
+给定以下逻辑数据：
+
+| productId | productName |
+| --- | --- |
+| `p1` | `Apple` |
+| `p1` | `Apple 2026` |
+| `p1` | `null` |
+
+查询：
+
+```kotlin
+aggregation {
+    terms("productId", "productId")
+    any("productName", "productName")
+    count("count")
+}
+```
+
+只返回一个 `p1` 分组。`productName` 可以是 `Apple` 或 `Apple 2026`，但不能因为名称不同拆分分组，也不能在存在非空名称时返回 `null`。
+
+完整合同如下：
+
+- `TERMS` 决定分组键；`ANY` 是指标，不参与分组。
+- 每个 `ANY` 从当前聚合作用域选择一个非 `null`、非缺失的标量。
+- 组内至少有一个有效值时返回其中任意一个；全部无值时返回 `null`。
+- 没有 `groupBy` 时，从整个根快照或最内层 Element 作用域选择一个值，返回单行摘要。
+- 字段值类型和结果规范化沿用现有 `TERMS` 分组键语义。
+- 同一组存在多个不同值时，调用方不得依赖具体返回哪一个。
+- MongoDB 与 Elasticsearch 可以为同一不一致数据选择不同值。
+
+## 公共模型与 JSON
+
+`AggregationMetric` 保持现有 sealed 层次并增加一个 subtype：
+
+```kotlin
+@JsonSubTypes(
+    JsonSubTypes.Type(AggregationMetric.Count::class, name = "COUNT"),
+    JsonSubTypes.Type(AggregationMetric.Numeric::class, name = "NUMERIC"),
+    JsonSubTypes.Type(AggregationMetric.Any::class, name = "ANY"),
+)
+sealed interface AggregationMetric {
+    val alias: String
+
+    data class Any(
+        val field: LogicalField,
+        override val alias: String,
+    ) : AggregationMetric
+}
+```
+
+JSON 请求示例：
+
+```json
+{
+  "groupBy": [
+    {"type": "TERMS", "field": "productId", "alias": "productId"}
+  ],
+  "metrics": [
+    {"type": "ANY", "field": "productName", "alias": "productName"},
+    {"type": "COUNT", "alias": "count"}
+  ]
+}
+```
+
+`Any` 构造时复用现有聚合 alias 校验。`AggregationQuery` 现有的 group 与 metric alias 唯一性、sort 字段引用和数量上限自动覆盖 `ANY`。
+
+新增 subtype 会影响下游对公开 sealed `AggregationMetric` 的穷尽式 `when`。本次需求已明确不考虑兼容，不改为非 sealed 接口，不增加 `else` 协议或第二套模型。
+
+## Kotlin DSL
+
+`AggregationQueryDsl` 只增加一个入口：
+
+```kotlin
+fun any(field: String, alias: String) {
+    metrics += AggregationMetric.Any(LogicalField(field), alias)
+}
+```
+
+不增加 `AnyDsl`、alias 推断、表达式重载或排序参数。需要在 DSL 外构造查询的调用方直接使用公开模型。
+
+## 字段解析与 Schema
+
+`QuerySchemaResolver.resolve(AggregationQuery)` 对每个 `AggregationMetric.Any`：
+
+1. 按当前最内层 Element 的逻辑与物理父路径解析字段。
+2. 要求字段具有 `QueryCapability.AGGREGATE_TERMS` binding。
+3. 已知 `QueryCardinality.MANY` 时把查询标记为不兼容。
+4. 继续由现有 `QuerySchemaValidationMode` 决定不兼容或 Schema 不可用时是拒绝、告警还是回退。
+
+不新增 `AGGREGATE_ANY` capability。`ANY` 与 `TERMS` 需要相同的精确标量物理值，复用现有 capability 可以直接获得 Elasticsearch `keyword` 子字段、MongoDB 原生字段和动态子字段解析。
+
+Schema 不可用且当前验证模式允许回退时，编译器沿用现有逻辑字段路径。调用方仍须满足公开的单值标量合同；本设计不收紧现有默认验证模式。
+
+## MongoDB 编译
+
+`MongoAggregationCompiler.group()` 把 `AggregationMetric.Any` 编译为：
+
+```javascript
+{ $max: "$<resolved-field>" }
+```
+
+选择 `$max` 是后端实现细节：最大非空值属于合法的 `ANY` 结果，同时避免 `$push` 全量物化、额外排序和自定义函数。
+
+MongoDB `$max` 在 `$group` 中忽略部分 `null` 和缺失值；全部为空时返回 `null`。字段通过最内层 Element 作用域和 `AGGREGATE_TERMS` binding 解析。公开合同限制为单值字段，因此不为数组增加 `$unwind`、`$reduce` 或兼容处理。
+
+投影阶段直接包含 `ANY` alias。`MongoSnapshotQueryService.toAggregationResult()` 对该值采用与 `TERMS` 分组键相同的结果规范化；不会把它转换为有限 `Double` 数值指标。
+
+无分组且没有匹配文档时，现有 empty-summary 补全逻辑为 `ANY` 返回 `null`，`COUNT` 仍返回 `0L`，数值指标仍返回 `null`。
+
+## Elasticsearch 编译与分页
+
+`ElasticsearchAggregationCompiler` 为 `AggregationMetric.Any` 解析 `AGGREGATE_TERMS` 物理字段，并在当前聚合桶下生成一个 `terms` 子聚合：
+
+```json
+{
+  "productName": {
+    "terms": {
+      "field": "state.productName.keyword",
+      "size": 1
+    }
+  }
+}
+```
+
+Elasticsearch 默认忽略缺失字段；`size = 1` 返回一个候选 term bucket。其 bucket key 即 `ANY` 结果，没有 bucket 时返回 `null`。默认按文档数选择最常见值只是实现细节，不提升为公共语义。
+
+`ElasticsearchAggregationPlan` 明确区分 Count、Numeric 和 Any 三种内部指标计划；不继续用 `function == null` 隐式区分更多类型。`ElasticsearchAggregationPager` 在 grouped row 和 summary row 两条路径中读取 `ANY` 的唯一 bucket key，并规范化为与现有 group key 相同的原生标量结果。
+
+`ANY` 不生成 runtime field、不使用 Painless、不读取 `_source`，也不使用 `top_hits`。PIT、Composite 分页、Elements nested/filter 包装和数值 value-count 逻辑不变。
+
+## 排序与昂贵查询守卫
+
+`ANY` alias 与其他 metric alias 一样可被 `sort` 引用：
+
+- MongoDB 在投影后使用现有 `$sort`。
+- Elasticsearch 复用现有 metric-sorted 分页和有界 Top-N 行选择。
+- `HttpQueryGuardFilter` 现有“按指标 alias 排序”判断自然包含 `ANY`，`allow-expensive-operators=false` 时继续拒绝。
+
+只读取 `ANY` 而不按其排序时不增加新的 HTTP expensive 条件。它使用后端原生字段聚合，与现有 `TERMS` 分组处于同一能力边界。
+
+## 错误策略
+
+- 非法 alias 和重复 alias 继续由 `AggregationQuery` 构造校验拒绝。
+- 字段缺少 `AGGREGATE_TERMS`、已知为 `MANY` 或物理 mapping 不兼容时，由现有 Schema resolution 与 validation mode 处理。
+- 未知 JSON subtype、缺少 `field`/`alias` 或额外属性由现有严格反序列化拒绝。
+- 组内部分 `null` 或缺失不是错误；全部无值返回 `null`。
+- 后端 mapping 漂移、Elasticsearch 聚合失败、MongoDB pipeline 失败或框架结果解析缺陷直接传播，不伪装成空值。
+- 不统一 MongoDB 与 Elasticsearch 的错误文本，也不为 `ANY` 增加降级查询。
+
+## OpenAPI 与文档
+
+OpenAPI 的 `AggregationMetric` union 增加 `AggregationMetric.Any`，使用 `type: ANY` discriminator。新 Schema 包含必填 `field` 和 `alias`，不改变聚合端点、RequestBody 名称或动态响应类型。
+
+同步更新：
+
+- `wow-openapi` 示例域 OpenAPI 与 contract 快照。
+- `documentation/docs/zh/guide/query.md`。
+- `documentation/docs/en/guide/query.md`。
+
+文档示例展示 `terms(productId) + any(productName) + count`，明确名称不一致时结果不稳定，以及 `ANY` 不等同于增加第二个 `TERMS` 分组。
+
+不直接修改 compensation dashboard 生成客户端；生成客户端更新不属于本设计范围。
+
+## 测试策略
+
+### 公共模型、DSL 与 Schema
+
+- `wow-api` 验证 `ANY` JSON 反序列化、序列化、必填字段和 alias 规则。
+- 验证 `ANY` 与 group、Count、Numeric alias 冲突仍被拒绝。
+- `wow-query` 验证 `any(field, alias)` 生成准确模型。
+- `QuerySchemaResolver` 验证 `AGGREGATE_TERMS`、最内层 Element 相对路径、SINGLE 接受和 MANY 不兼容。
+
+### MongoDB
+
+- 编译器测试验证 `$max` 使用解析后的物理字段，且投影包含 alias。
+- 真实集成测试写入同一 `productId` 下两个不同名称、一个 `null`，断言只返回一个分组、名称属于非空候选集合、Count 保持完整计数。
+- 覆盖全部名称为空、无分组摘要和 Elements 相对字段。
+
+### Elasticsearch
+
+- 编译器测试验证 `terms(field, size = 1)`，且不生成 runtime mapping 或 script。
+- Pager 测试覆盖 string、integer、double、boolean bucket key 与空 bucket。
+- 真实集成测试执行与 MongoDB 相同的代表值、全空、摘要和 Elements 场景。
+- 覆盖按 `ANY` alias 排序继续走现有 metric-sorted 路径。
+
+### 合同与守卫
+
+- `wow-webflux` 验证按 `ANY` alias 排序受 `allow-expensive-operators` 控制，不排序时不新增限制。
+- `wow-openapi` 验证 union/discriminator 和必填字段，更新 JSON 快照。
+- 文档构建验证中英文示例和链接。
+
+## 影响范围
+
+预计只修改现有职责内文件：
+
+- `wow-api/.../AggregationQuery.kt` 及其测试。
+- `wow-query/.../AggregationQueryDsl.kt`、`QuerySchemaResolver.kt` 及其测试。
+- MongoDB aggregation compiler、snapshot query service 及测试。
+- Elasticsearch aggregation compiler、plan/pager 及测试。
+- `HttpQueryGuardFilter` 测试；生产代码仅在现有通用判断不能自然覆盖时修改。
+- OpenAPI 测试与快照。
+- 中英文 query 文档。
+
+不增加 endpoint、service、module、dependency、配置或兼容层。
+
+## 验证
+
+实现阶段从最窄测试开始，完成前至少运行：
+
+```bash
+./gradlew \
+  :wow-api:check \
+  :wow-query:check \
+  :wow-mongo:check \
+  :wow-elasticsearch:check \
+  :wow-webflux:check \
+  :wow-openapi:check
+
+./gradlew \
+  :wow-mongo:integrationTest \
+  :wow-elasticsearch:integrationTest \
+  --stacktrace
+
+cd documentation && pnpm docs:build
+```
+
+若改动触及 Detekt 所覆盖的生产文件，再运行根 `./gradlew detekt`。不以编译器 BSON/JSON 字符串断言代替双后端真实执行证据。
+
+## 完成条件
+
+- `AggregationMetric.Any`、JSON `ANY` 和 DSL `any(field, alias)` 合同一致。
+- `terms(productId) + any(productName)` 对名称不一致的数据只产生一个 ID 分组。
+- 部分空值仍返回非空代表值，全部空值返回 `null`。
+- 已知 MANY 字段按现有验证模式判定为不兼容。
+- MongoDB `$max` 与 Elasticsearch `terms(size = 1)` 均通过真实集成测试。
+- Count、Numeric、Elements、Composite 分页、排序和空摘要现有行为没有回归。
+- OpenAPI union/快照与中英文文档同步。
+- 没有新增脚本、兼容层、依赖、配置、模块或 CI 改动。
+
+## 参考资料
+
+- [MongoDB `$max` accumulator](https://www.mongodb.com/docs/manual/reference/operator/aggregation/max/)
+- [Elasticsearch terms aggregation](https://www.elastic.co/docs/reference/aggregations/search-aggregations-bucket-terms-aggregation)

--- a/documentation/docs/en/guide/query.md
+++ b/documentation/docs/en/guide/query.md
@@ -241,9 +241,35 @@ The equivalent expression JSON uses recursive `BINARY` nodes; field leaves can r
 }
 ```
 
+`ANY` returns one non-null scalar name from the current group; it does not add another group key:
+
+```kotlin
+val query = aggregation {
+    expand("state.items")
+    terms("productId", "productId")
+    any("productName", "productName")
+    count("count")
+}
+```
+
+```json
+{
+  "elements": [{"path": "state.items"}],
+  "groupBy": [
+    {"type": "TERMS", "field": "productId", "alias": "productId"}
+  ],
+  "metrics": [
+    {"type": "ANY", "field": "productName", "alias": "productName"},
+    {"type": "COUNT", "alias": "count"}
+  ]
+}
+```
+
+ANY does not add another group key. It returns one non-null scalar from the current group, or `null` when no value contributes. The selected value is intentionally unstable across executions and backends. When a stable name is required, repair redundant data or use an explicit business query instead of relying on `ANY`.
+
 The first Element path is an absolute snapshot path. Every later Element path and every Element filter is relative to its current expanded element. Group and metric fields are relative to the innermost Element; without Elements, they are absolute snapshot paths. Elements form one parent-child chain, not sibling expansions.
 
-`TERMS`, `HISTOGRAM`, and `DATE_HISTOGRAM` groups are supported. Metrics are `COUNT`, `SUM`, `AVG`, `MIN`, and `MAX`; `COUNT` returns `Long`, while numeric metrics return a finite `Double` or `null` when no value contributes. A query without groups returns one summary row, including an empty dataset (`COUNT = 0`, numeric metrics `null`). Grouped results contain at most `limit` rows; the default is `100` and the maximum is `10,000`.
+`TERMS`, `HISTOGRAM`, and `DATE_HISTOGRAM` groups are supported. Metrics are `COUNT`, `SUM`, `AVG`, `MIN`, `MAX`, and `ANY`; `COUNT` returns `Long`, while numeric metrics return a finite `Double` or `null` when no value contributes. A query without groups returns one summary row, including an empty dataset (`COUNT = 0`, numeric metrics `null`). Grouped results contain at most `limit` rows; the default is `100` and the maximum is `10,000`.
 
 Sort fields reference group or metric aliases. Missing group-alias sorts are appended in declaration order for stable results. Sorting by a metric alias is expensive and is controlled by the WebFlux `query.allow-expensive-operators` guard. Fixed structural limits are 5 Elements, 32 groups, 64 metrics, and 32 effective sort fields; each numeric expression has a maximum depth of 8, and all expressions in one query can contain at most 256 nodes.
 

--- a/documentation/docs/zh/guide/query.md
+++ b/documentation/docs/zh/guide/query.md
@@ -241,9 +241,35 @@ val query = aggregation {
 }
 ```
 
+`ANY` 返回当前分组中的一个非空标量名称；它不增加分组键：
+
+```kotlin
+val query = aggregation {
+    expand("state.items")
+    terms("productId", "productId")
+    any("productName", "productName")
+    count("count")
+}
+```
+
+```json
+{
+  "elements": [{"path": "state.items"}],
+  "groupBy": [
+    {"type": "TERMS", "field": "productId", "alias": "productId"}
+  ],
+  "metrics": [
+    {"type": "ANY", "field": "productName", "alias": "productName"},
+    {"type": "COUNT", "alias": "count"}
+  ]
+}
+```
+
+`ANY` 不参与分组；它忽略 `null`/缺失值，全部为空时返回 `null`。MongoDB、Elasticsearch 或重复执行可能选择不同的非空名称；需要确定名称时，应修复冗余数据或使用明确的业务查询，不要依赖 `ANY`。
+
 第一个 Element 路径是快照绝对路径；后续每个 Element 路径及每个 Element filter 都相对当前已展开元素。group 与 metric 字段相对最内层 Element；没有 Elements 时，它们使用快照绝对路径。Elements 只表示一条父子链，不支持兄弟集合展开。
 
-分组支持 `TERMS`、`HISTOGRAM` 与 `DATE_HISTOGRAM`。指标支持 `COUNT`、`SUM`、`AVG`、`MIN` 与 `MAX`；`COUNT` 返回 `Long`，数值指标返回有限 `Double`，没有值参与计算时返回 `null`。没有分组的查询返回一行汇总，空数据集同样如此（`COUNT = 0`，数值指标为 `null`）。分组结果最多返回 `limit` 行；默认值为 `100`，最大值为 `10,000`。
+分组支持 `TERMS`、`HISTOGRAM` 与 `DATE_HISTOGRAM`。指标支持 `COUNT`、`SUM`、`AVG`、`MIN`、`MAX` 与 `ANY`；`COUNT` 返回 `Long`，数值指标返回有限 `Double`，没有值参与计算时返回 `null`。没有分组的查询返回一行汇总，空数据集同样如此（`COUNT = 0`，数值指标为 `null`）。分组结果最多返回 `limit` 行；默认值为 `100`，最大值为 `10,000`。
 
 排序字段引用 group 或 metric alias。未显式排序的 group alias 会按声明顺序追加，以保证结果稳定。按 metric alias 排序成本较高，受 WebFlux `query.allow-expensive-operators` 护栏控制。固定结构上限为 5 个 Elements、32 个 groups、64 个 metrics、32 个有效排序字段；每个数值表达式最大深度为 8，单个查询中的表达式节点总数最多 256。
 

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/mock/MockAggregate.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/mock/MockAggregate.kt
@@ -74,6 +74,7 @@ data class MockLine(
     val createdAt: Instant,
     val discounts: List<MockDiscount>,
     val samples: List<Double> = emptyList(),
+    val productName: String? = null,
 )
 
 data class MockDiscount(val type: String, val amount: Double)

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt
@@ -488,7 +488,7 @@ abstract class SnapshotQueryServiceSpec {
 
     @Test
     fun `aggregation should select any non-null value without splitting the group`() {
-        saveAggregationStates(*aggregationStates().toTypedArray())
+        saveAggregationStates(*(aggregationStates() + aggregationAnyNullState()).toTypedArray())
 
         aggregation {
             expand("state.orders")
@@ -501,7 +501,7 @@ abstract class SnapshotQueryServiceSpec {
             .assertNext { row ->
                 row["productId"].assert().isEqualTo("alpha")
                 setOf("Alpha", "Alpha 2026").contains(row["productName"]).assert().isTrue()
-                row["count"].assert().isEqualTo(2L)
+                row["count"].assert().isEqualTo(3L)
             }.verifyComplete()
     }
 
@@ -694,6 +694,26 @@ abstract class SnapshotQueryServiceSpec {
                             amount = 50.0,
                             createdAt = Instant.parse("2026-02-02T10:00:00Z"),
                             discounts = emptyList(),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+    private fun aggregationAnyNullState(): MockStateAggregate =
+        MockStateAggregate(
+            id = "aggregation-any-null",
+            orders = listOf(
+                MockOrder(
+                    status = "PAID",
+                    lines = listOf(
+                        MockLine(
+                            productId = "alpha",
+                            quantity = 1,
+                            amount = 40.0,
+                            createdAt = Instant.parse("2026-01-04T10:00:00Z"),
+                            discounts = emptyList(),
+                            productName = null,
                         ),
                     ),
                 ),

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt
@@ -57,6 +57,7 @@ import java.time.Clock
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 
+@Suppress("LargeClass")
 abstract class SnapshotQueryServiceSpec {
     protected val querySchemaSources: List<QuerySchemaSource> = listOf(JsonQuerySchemaSource())
     lateinit var snapshotStore: SnapshotStore

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryServiceSpec.kt
@@ -476,12 +476,50 @@ abstract class SnapshotQueryServiceSpec {
     fun `aggregation should return one empty summary row`() {
         aggregation {
             filter { aggregateId("missing") }
+            any("state.data", "anyData")
             count("count")
             sum("version", "total")
         }.query(snapshotQueryService)
             .test()
             .assertNext {
-                it.toMap().assert().isEqualTo(mapOf("count" to 0L, "total" to null))
+                it.toMap().assert().isEqualTo(mapOf("anyData" to null, "count" to 0L, "total" to null))
+            }.verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should select any non-null value without splitting the group`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+
+        aggregation {
+            expand("state.orders")
+            expand("lines") { "productId" eq "alpha" }
+            terms("productId", "productId")
+            any("productName", "productName")
+            count("count")
+        }.query(snapshotQueryService)
+            .test()
+            .assertNext { row ->
+                row["productId"].assert().isEqualTo("alpha")
+                setOf("Alpha", "Alpha 2026").contains(row["productName"]).assert().isTrue()
+                row["count"].assert().isEqualTo(2L)
+            }.verifyComplete()
+    }
+
+    @Test
+    fun `aggregation any should return null when every value is absent`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+
+        aggregation {
+            expand("state.orders")
+            expand("lines") { "productId" eq "gamma" }
+            any("productName", "productName")
+            count("count")
+        }.query(snapshotQueryService)
+            .test()
+            .assertNext { row ->
+                row.containsKey("productName").assert().isTrue()
+                row["productName"].assert().isNull()
+                row["count"].assert().isEqualTo(1L)
             }.verifyComplete()
     }
 
@@ -601,6 +639,7 @@ abstract class SnapshotQueryServiceSpec {
                                 MockDiscount("PROMO", 2.0),
                             ),
                             samples = listOf(7.0),
+                            productName = "Alpha",
                         ),
                         MockLine(
                             productId = "beta",
@@ -640,6 +679,7 @@ abstract class SnapshotQueryServiceSpec {
                             amount = 30.0,
                             createdAt = Instant.parse("2026-01-03T10:00:00Z"),
                             discounts = listOf(MockDiscount("PROMO", 5.0)),
+                            productName = "Alpha 2026",
                         ),
                         MockLine(
                             productId = "beta",

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
@@ -204,6 +204,7 @@ enum class AggregationExpressionOperator {
     discriminatorProperty = "type",
 )
 sealed interface AggregationMetric {
+    @get:Schema(accessMode = Schema.AccessMode.READ_WRITE)
     val alias: String
 
     data class Count(override val alias: String) : AggregationMetric {

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
@@ -193,6 +193,15 @@ enum class AggregationExpressionOperator {
 @JsonSubTypes(
     JsonSubTypes.Type(AggregationMetric.Count::class, name = "COUNT"),
     JsonSubTypes.Type(AggregationMetric.Numeric::class, name = "NUMERIC"),
+    JsonSubTypes.Type(AggregationMetric.Any::class, name = "ANY"),
+)
+@Schema(
+    oneOf = [
+        AggregationMetric.Count::class,
+        AggregationMetric.Numeric::class,
+        AggregationMetric.Any::class,
+    ],
+    discriminatorProperty = "type",
 )
 sealed interface AggregationMetric {
     val alias: String
@@ -206,6 +215,15 @@ sealed interface AggregationMetric {
     data class Numeric(
         val function: AggregationFunction,
         val expression: AggregationExpression,
+        override val alias: String,
+    ) : AggregationMetric {
+        init {
+            requireAggregationAlias(alias)
+        }
+    }
+
+    data class Any(
+        val field: LogicalField,
         override val alias: String,
     ) : AggregationMetric {
         init {

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
@@ -30,7 +30,7 @@ data class AggregationQuery(
     @get:ArraySchema(maxItems = MAX_GROUPS)
     @get:JsonInclude(JsonInclude.Include.NON_EMPTY)
     val groupBy: List<AggregationGroup> = emptyList(),
-    @get:ArraySchema(minItems = 1, maxItems = MAX_METRICS)
+    @get:ArraySchema(minItems = 1, maxItems = MAX_METRICS, schema = Schema(implementation = AggregationMetric::class))
     val metrics: List<AggregationMetric>,
     @get:ArraySchema(maxItems = MAX_SORT_FIELDS)
     @get:JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt
@@ -143,6 +143,33 @@ class AggregationQueryTest {
     }
 
     @Test
+    fun `any metric should round trip through JSON`() {
+        val json = """
+            {
+              "metrics": [{
+                "type": "ANY",
+                "field": "state.productName",
+                "alias": "productName"
+              }]
+            }
+        """.trimIndent()
+
+        val query = configuredMapper.readValue(json, AggregationQuery::class.java)
+
+        query.metrics.assert().containsExactly(
+            AggregationMetric.Any(LogicalField("state.productName"), "productName"),
+        )
+        configuredMapper.writeValueAsString(query).assert().contains("\"type\":\"ANY\"")
+    }
+
+    @Test
+    fun `any metric should reject internal aliases`() {
+        assertThrows<IllegalArgumentException> {
+            AggregationMetric.Any(LogicalField("state.productName"), "__wow_productName")
+        }
+    }
+
+    @Test
     fun `constant should require a finite double`() {
         listOf(Double.NaN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY).forEach { value ->
             assertThrows<IllegalArgumentException> { AggregationExpression.Constant(value) }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompiler.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompiler.kt
@@ -57,13 +57,24 @@ internal data class ElasticsearchAggregationElement(
     val filter: Query,
 )
 
-internal data class ElasticsearchAggregationMetric(
-    val alias: String,
-    val function: AggregationFunction?,
-    val field: String?,
-) {
-    val valueCountAlias: String
-        get() = "__wow_value_count_$alias"
+internal sealed interface ElasticsearchAggregationMetric {
+    val alias: String
+
+    data class Count(override val alias: String) : ElasticsearchAggregationMetric
+
+    data class Numeric(
+        override val alias: String,
+        val function: AggregationFunction,
+        val field: String,
+    ) : ElasticsearchAggregationMetric {
+        val valueCountAlias: String
+            get() = "__wow_value_count_$alias"
+    }
+
+    data class Any(
+        override val alias: String,
+        val field: String,
+    ) : ElasticsearchAggregationMetric
 }
 
 internal class ElasticsearchAggregationCompiler(
@@ -229,7 +240,11 @@ internal class ElasticsearchAggregationCompiler(
         schema: QueryModelSchema?,
         runtimeMappings: MutableMap<String, RuntimeField>,
     ): ElasticsearchAggregationMetric = when (this) {
-        is AggregationMetric.Count -> ElasticsearchAggregationMetric(alias, function = null, field = null)
+        is AggregationMetric.Count -> ElasticsearchAggregationMetric.Count(alias)
+        is AggregationMetric.Any -> ElasticsearchAggregationMetric.Any(
+            alias,
+            field.resolve(parent, schema, QueryCapability.AGGREGATE_TERMS),
+        )
         is AggregationMetric.Numeric -> {
             val metricField = when (val expression = expression) {
                 is AggregationExpression.Field -> expression.field.resolve(
@@ -241,7 +256,7 @@ internal class ElasticsearchAggregationCompiler(
                     runtimeMappings[runtimeFieldName] = RuntimeExpressionCompiler(parent, schema).compile(expression)
                 }
             }
-            ElasticsearchAggregationMetric(alias, function, metricField)
+            ElasticsearchAggregationMetric.Numeric(alias, function, metricField)
         }
     }
 

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPager.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPager.kt
@@ -151,21 +151,34 @@ internal class ElasticsearchAggregationPager(
     }
 
     private fun ElasticsearchAggregationPlan.metricAggregations(): Map<String, Aggregation> = buildMap {
-        metrics.filter { it.function != null }.forEach { metric ->
-            val field = requireNotNull(metric.field)
-            put(
-                metric.alias,
-                Aggregation.of { builder ->
-                    when (metric.function) {
-                        AggregationFunction.SUM -> builder.sum { it.field(field) }
-                        AggregationFunction.AVG -> builder.avg { it.field(field) }
-                        AggregationFunction.MIN -> builder.min { it.field(field) }
-                        AggregationFunction.MAX -> builder.max { it.field(field) }
-                        null -> error("Count does not require a metric aggregation.")
-                    }
-                },
-            )
-            put(metric.valueCountAlias, Aggregation.of { builder -> builder.valueCount { it.field(field) } })
+        metrics.forEach { metric ->
+            when (metric) {
+                is ElasticsearchAggregationMetric.Count -> Unit
+                is ElasticsearchAggregationMetric.Any -> put(
+                    metric.alias,
+                    Aggregation.of { builder ->
+                        builder.terms { terms -> terms.field(metric.field).size(1) }
+                    },
+                )
+
+                is ElasticsearchAggregationMetric.Numeric -> {
+                    put(
+                        metric.alias,
+                        Aggregation.of { builder ->
+                            when (metric.function) {
+                                AggregationFunction.SUM -> builder.sum { it.field(metric.field) }
+                                AggregationFunction.AVG -> builder.avg { it.field(metric.field) }
+                                AggregationFunction.MIN -> builder.min { it.field(metric.field) }
+                                AggregationFunction.MAX -> builder.max { it.field(metric.field) }
+                            }
+                        },
+                    )
+                    put(
+                        metric.valueCountAlias,
+                        Aggregation.of { builder -> builder.valueCount { it.field(metric.field) } },
+                    )
+                }
+            }
         }
     }
 
@@ -221,8 +234,23 @@ internal class ElasticsearchAggregationPager(
     private fun ElasticsearchAggregationMetric.value(
         docCount: Long,
         aggregations: Map<String, Aggregate>,
-    ): Any? {
-        val function = function ?: return docCount
+    ): Any? = when (this) {
+        is ElasticsearchAggregationMetric.Count -> docCount
+        is ElasticsearchAggregationMetric.Any -> aggregations.getValue(alias).anyValue(alias)
+        is ElasticsearchAggregationMetric.Numeric -> numericValue(aggregations)
+    }
+
+    private fun Aggregate.anyValue(alias: String): Any? = when {
+        isSterms -> sterms().buckets().array().firstOrNull()?.key()?.nativeValue()
+        isLterms -> lterms().buckets().array().firstOrNull()?.key()
+        isDterms -> dterms().buckets().array().firstOrNull()?.key()
+        isUmterms -> null
+        else -> error("Aggregation ANY metric [$alias] returned unsupported Elasticsearch aggregate [${_kind()}].")
+    }
+
+    private fun ElasticsearchAggregationMetric.Numeric.numericValue(
+        aggregations: Map<String, Aggregate>,
+    ): Double? {
         if (aggregations.getValue(valueCountAlias).valueCount().value() == 0.0) return null
         val value = when (function) {
             AggregationFunction.SUM -> aggregations.getValue(alias).sum().value()

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPager.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPager.kt
@@ -87,7 +87,9 @@ internal class ElasticsearchAggregationPager(
         afterKey: Map<String, FieldValue> = emptyMap(),
         fetched: Int = 0,
     ): Mono<AggregationPage> {
-        val pageSize = if (plan.metricSorted) batchSize else min(batchSize, plan.limit - fetched)
+        val bucketWidth = 1 + plan.metrics.count { it is ElasticsearchAggregationMetric.Any }
+        val pageCapacity = (batchSize / bucketWidth).coerceAtLeast(1)
+        val pageSize = if (plan.metricSorted) pageCapacity else min(pageCapacity, plan.limit - fetched)
         return search(plan, pit, afterKey, pageSize).map { response ->
             val composite = response.innermost(plan).getValue(GROUP_AGGREGATION).composite()
             val rows = composite.buckets().array().map { it.toRow(plan) }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPager.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPager.kt
@@ -244,7 +244,9 @@ internal class ElasticsearchAggregationPager(
 
     private fun Aggregate.anyValue(alias: String): Any? = when {
         isSterms -> sterms().buckets().array().firstOrNull()?.key()?.nativeValue()
-        isLterms -> lterms().buckets().array().firstOrNull()?.key()
+        isLterms -> lterms().buckets().array().firstOrNull()?.let {
+            it.keyAsString()?.toBooleanStrictOrNull() ?: it.key()
+        }
         isDterms -> dterms().buckets().array().firstOrNull()?.key()
         isUmterms -> null
         else -> error("Aggregation ANY metric [$alias] returned unsupported Elasticsearch aggregate [${_kind()}].")

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
@@ -97,7 +97,7 @@ class ElasticsearchAggregationCompilerTest {
             },
         )
 
-        plan.metrics.single().field.assert().isEqualTo("__wow_expression_0")
+        (plan.metrics.single() as ElasticsearchAggregationMetric.Numeric).field.assert().isEqualTo("__wow_expression_0")
         val runtime = plan.runtimeMappings.getValue("__wow_expression_0")
         runtime.type().assert().isEqualTo(RuntimeFieldType.Double)
         val script = requireNotNull(runtime.script())
@@ -133,7 +133,7 @@ class ElasticsearchAggregationCompilerTest {
             .contains("catch (Exception ignored)")
             .contains("size() == 1")
             .contains("doubleValue() != 0.0")
-        plan.metrics.last().field.assert().isEqualTo("physical.amount")
+        (plan.metrics.last() as ElasticsearchAggregationMetric.Numeric).field.assert().isEqualTo("physical.amount")
         plan.runtimeMappings.values.single().script()!!.params().values.map { it.to(Any::class.java) }.assert()
             .contains("physical.unreadable")
     }
@@ -145,7 +145,28 @@ class ElasticsearchAggregationCompilerTest {
         )
 
         plan.runtimeMappings.assert().isEmpty()
-        plan.metrics.single().field.assert().isEqualTo("state.amount")
+        (plan.metrics.single() as ElasticsearchAggregationMetric.Numeric).field.assert().isEqualTo("state.amount")
+    }
+
+    @Test
+    fun `any metric should resolve a terms-capable field without a runtime mapping`() {
+        val schema = schema(
+            field(
+                "state.productName",
+                QueryCapability.AGGREGATE_TERMS,
+                "document.productName.keyword",
+                "keyword",
+            ),
+        )
+        val plan = ElasticsearchAggregationCompiler(SnapshotFilterConverter).compile(
+            aggregation { any("state.productName", "productName") },
+            schema,
+        )
+
+        val metric = plan.metrics.single() as ElasticsearchAggregationMetric.Any
+        metric.alias.assert().isEqualTo("productName")
+        metric.field.assert().isEqualTo("document.productName.keyword")
+        plan.runtimeMappings.assert().isEmpty()
     }
 
     @Test
@@ -195,7 +216,8 @@ class ElasticsearchAggregationCompilerTest {
             .isEqualTo("document.orders.lines.productId.keyword")
         plan.groupSources[1].value().histogram().field().assert().isEqualTo("document.orders.lines.amount")
         plan.groupSources[2].value().dateHistogram().field().assert().isEqualTo("document.orders.lines.createdAt")
-        plan.metrics.single().field.assert().isEqualTo("document.orders.lines.amount")
+        (plan.metrics.single() as ElasticsearchAggregationMetric.Numeric).field.assert()
+            .isEqualTo("document.orders.lines.amount")
     }
 
     @Test

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
@@ -17,6 +17,9 @@ import co.elastic.clients.elasticsearch._types.FieldValue
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregate
 import co.elastic.clients.elasticsearch._types.aggregations.Buckets
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeBucket
+import co.elastic.clients.elasticsearch._types.aggregations.DoubleTermsBucket
+import co.elastic.clients.elasticsearch._types.aggregations.LongTermsBucket
+import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket
 import co.elastic.clients.elasticsearch.core.ClosePointInTimeRequest
 import co.elastic.clients.elasticsearch.core.ClosePointInTimeResponse
 import co.elastic.clients.elasticsearch.core.OpenPointInTimeRequest
@@ -259,6 +262,57 @@ class ElasticsearchAggregationPagerTest {
     }
 
     @Test
+    fun `any metric should request one terms bucket and read its scalar key`() {
+        val requests = mutableListOf<SearchRequest>()
+        stubPointInTime()
+        every { client.search(capture(requests), Map::class.java) } returns Mono.just(
+            groupResponse("pit-2", listOf(anyBucket("alpha", stringTerms("Alpha")))),
+        )
+        val plan = compiler().compile(
+            aggregation {
+                terms("state.productId", "product")
+                any("state.productName", "productName")
+            },
+        )
+
+        pager().execute(plan).test()
+            .assertNext { row -> row["productName"].assert().isEqualTo("Alpha") }
+            .verifyComplete()
+
+        requests.single().aggregations().values.single()
+            .aggregations().getValue("productName").terms().apply {
+                field().assert().isEqualTo("state.productName")
+                size().assert().isEqualTo(1)
+            }
+    }
+
+    @Test
+    fun `any metric should normalize boolean long double and empty terms buckets`() {
+        stubPointInTime()
+        every { client.search(any<SearchRequest>(), Map::class.java) } returns Mono.just(
+            groupResponse(
+                "pit-2",
+                listOf(
+                    anyBucket("a", booleanTerms(true)),
+                    anyBucket("b", longTerms(7L)),
+                    anyBucket("c", doubleTerms(7.5)),
+                    anyBucket("d", stringTerms(null)),
+                ),
+            ),
+        )
+        val plan = compiler().compile(
+            aggregation {
+                terms("state.productId", "product")
+                any("state.value", "productName")
+            },
+        )
+
+        pager().execute(plan).collectList().test()
+            .assertNext { rows -> rows.map { it["productName"] }.assert().containsExactly(true, 7L, 7.5, null) }
+            .verifyComplete()
+    }
+
+    @Test
     fun `group aggregation should stop after reaching the limit`() {
         stubPointInTime()
         every { client.search(any<SearchRequest>(), Map::class.java) } returns Mono.just(
@@ -356,6 +410,56 @@ class ElasticsearchAggregationPagerTest {
                 "__wow_value_count_total",
                 Aggregate.of { value -> value.valueCount { count -> count.value(1.0) } },
             )
+    }
+
+    private fun stringTerms(value: String?): Aggregate = Aggregate.of { aggregate ->
+        aggregate.sterms { terms ->
+            terms.buckets(
+                Buckets.of<StringTermsBucket> { buckets ->
+                    buckets.array(
+                        value?.let {
+                            listOf(StringTermsBucket.of { bucket -> bucket.key(it).docCount(1) })
+                        }.orEmpty(),
+                    )
+                },
+            )
+        }
+    }
+
+    private fun booleanTerms(value: Boolean): Aggregate = Aggregate.of { aggregate ->
+        aggregate.sterms { terms ->
+            terms.buckets(
+                Buckets.of<StringTermsBucket> { buckets ->
+                    buckets.array(listOf(StringTermsBucket.of { it.key(value).docCount(1) }))
+                },
+            )
+        }
+    }
+
+    private fun longTerms(value: Long): Aggregate = Aggregate.of { aggregate ->
+        aggregate.lterms { terms ->
+            terms.buckets(
+                Buckets.of<LongTermsBucket> { buckets ->
+                    buckets.array(listOf(LongTermsBucket.of { it.key(value).docCount(1) }))
+                },
+            )
+        }
+    }
+
+    private fun doubleTerms(value: Double): Aggregate = Aggregate.of { aggregate ->
+        aggregate.dterms { terms ->
+            terms.buckets(
+                Buckets.of<DoubleTermsBucket> { buckets ->
+                    buckets.array(listOf(DoubleTermsBucket.of { it.key(value).docCount(1) }))
+                },
+            )
+        }
+    }
+
+    private fun anyBucket(product: String, productName: Aggregate): CompositeBucket = CompositeBucket.of {
+        it.key("product", product)
+            .docCount(1)
+            .aggregations("productName", productName)
     }
 
     private fun groupResponse(

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
@@ -122,6 +122,33 @@ class ElasticsearchAggregationPagerTest {
     }
 
     @Test
+    fun `numeric metrics should request every supported aggregation`() {
+        val requests = mutableListOf<SearchRequest>()
+        stubPointInTime()
+        every { client.search(capture(requests), Map::class.java) } returns Mono.just(
+            groupResponse("pit-2", emptyList()),
+        )
+        val plan = compiler().compile(
+            aggregation {
+                terms("state.product", "product")
+                sum("state.amount", "total")
+                avg("state.amount", "average")
+                min("state.amount", "minimum")
+                max("state.amount", "maximum")
+            },
+        )
+
+        pager().execute(plan).test().verifyComplete()
+
+        requests.single().aggregations().values.single().aggregations().apply {
+            getValue("total").sum().field().assert().isEqualTo("state.amount")
+            getValue("average").avg().field().assert().isEqualTo("state.amount")
+            getValue("minimum").min().field().assert().isEqualTo("state.amount")
+            getValue("maximum").max().field().assert().isEqualTo("state.amount")
+        }
+    }
+
+    @Test
     fun `metric ties should preserve native composite group order`() {
         stubPointInTime()
         every { client.search(any<SearchRequest>(), Map::class.java) } returns Mono.just(
@@ -318,6 +345,8 @@ class ElasticsearchAggregationPagerTest {
                     anyBucket("b", longTerms(7L)),
                     anyBucket("c", doubleTerms(7.5)),
                     anyBucket("d", stringTerms(null)),
+                    anyBucket("e", longTerms(null)),
+                    anyBucket("f", doubleTerms(null)),
                 ),
             ),
         )
@@ -329,8 +358,53 @@ class ElasticsearchAggregationPagerTest {
         )
 
         pager().execute(plan).collectList().test()
-            .assertNext { rows -> rows.map { it["productName"] }.assert().containsExactly(true, 7L, 7.5, null) }
+            .assertNext { rows ->
+                rows.map { it["productName"] }.assert().containsExactly(true, 7L, 7.5, null, null, null)
+            }
             .verifyComplete()
+    }
+
+    @Test
+    fun `any metric should normalize unmapped and reject unsupported aggregates`() {
+        stubPointInTime()
+        every { client.search(any<SearchRequest>(), Map::class.java) } returnsMany listOf(
+            Mono.just(
+                groupResponse(
+                    "pit-2",
+                    listOf(
+                        anyBucket(
+                            "a",
+                            Aggregate.of {
+                                it.umterms { unmapped ->
+                                    unmapped.buckets { buckets -> buckets.array(emptyList()) }
+                                }
+                            },
+                        ),
+                    ),
+                ),
+            ),
+            Mono.just(
+                groupResponse(
+                    "pit-3",
+                    listOf(anyBucket("a", Aggregate.of { it.sum { sum -> sum.value(1.0) } })),
+                ),
+            ),
+        )
+        val plan = compiler().compile(
+            aggregation {
+                terms("state.productId", "product")
+                any("state.value", "productName")
+            },
+        )
+
+        pager().execute(plan).test()
+            .assertNext { row -> row["productName"].assert().isNull() }
+            .verifyComplete()
+        pager().execute(plan).test()
+            .expectErrorMessage(
+                "Aggregation ANY metric [productName] returned unsupported Elasticsearch aggregate [Sum].",
+            )
+            .verify()
     }
 
     @Test
@@ -457,21 +531,25 @@ class ElasticsearchAggregationPagerTest {
         }
     }
 
-    private fun longTerms(value: Long): Aggregate = Aggregate.of { aggregate ->
+    private fun longTerms(value: Long?): Aggregate = Aggregate.of { aggregate ->
         aggregate.lterms { terms ->
             terms.buckets(
                 Buckets.of<LongTermsBucket> { buckets ->
-                    buckets.array(listOf(LongTermsBucket.of { it.key(value).docCount(1) }))
+                    buckets.array(
+                        value?.let { listOf(LongTermsBucket.of { bucket -> bucket.key(it).docCount(1) }) }.orEmpty(),
+                    )
                 },
             )
         }
     }
 
-    private fun doubleTerms(value: Double): Aggregate = Aggregate.of { aggregate ->
+    private fun doubleTerms(value: Double?): Aggregate = Aggregate.of { aggregate ->
         aggregate.dterms { terms ->
             terms.buckets(
                 Buckets.of<DoubleTermsBucket> { buckets ->
-                    buckets.array(listOf(DoubleTermsBucket.of { it.key(value).docCount(1) }))
+                    buckets.array(
+                        value?.let { listOf(DoubleTermsBucket.of { bucket -> bucket.key(it).docCount(1) }) }.orEmpty(),
+                    )
                 },
             )
         }

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
@@ -342,11 +342,12 @@ class ElasticsearchAggregationPagerTest {
                 "pit-2",
                 listOf(
                     anyBucket("a", booleanTerms(true)),
-                    anyBucket("b", longTerms(7L)),
-                    anyBucket("c", doubleTerms(7.5)),
-                    anyBucket("d", stringTerms(null)),
-                    anyBucket("e", longTerms(null)),
-                    anyBucket("f", doubleTerms(null)),
+                    anyBucket("b", booleanTerms(false)),
+                    anyBucket("c", longTerms(7L)),
+                    anyBucket("d", doubleTerms(7.5)),
+                    anyBucket("e", stringTerms(null)),
+                    anyBucket("f", longTerms(null)),
+                    anyBucket("g", doubleTerms(null)),
                 ),
             ),
         )
@@ -359,7 +360,7 @@ class ElasticsearchAggregationPagerTest {
 
         pager().execute(plan).collectList().test()
             .assertNext { rows ->
-                rows.map { it["productName"] }.assert().containsExactly(true, 7L, 7.5, null, null, null)
+                rows.map { it["productName"] }.assert().containsExactly(true, false, 7L, 7.5, null, null, null)
             }
             .verifyComplete()
     }
@@ -522,10 +523,18 @@ class ElasticsearchAggregationPagerTest {
     }
 
     private fun booleanTerms(value: Boolean): Aggregate = Aggregate.of { aggregate ->
-        aggregate.sterms { terms ->
+        aggregate.lterms { terms ->
             terms.buckets(
-                Buckets.of<StringTermsBucket> { buckets ->
-                    buckets.array(listOf(StringTermsBucket.of { it.key(value).docCount(1) }))
+                Buckets.of<LongTermsBucket> { buckets ->
+                    buckets.array(
+                        listOf(
+                            LongTermsBucket.of {
+                                it.key(if (value) 1L else 0L)
+                                    .keyAsString(value.toString())
+                                    .docCount(1)
+                            },
+                        ),
+                    )
                 },
             )
         }

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
@@ -287,6 +287,27 @@ class ElasticsearchAggregationPagerTest {
     }
 
     @Test
+    fun `any metrics should bound metric-sorted composite page size`() {
+        val requests = mutableListOf<SearchRequest>()
+        stubPointInTime()
+        every { client.search(capture(requests), Map::class.java) } returns Mono.just(
+            groupResponse("pit-2", emptyList()),
+        )
+        val plan = compiler().compile(
+            aggregation {
+                terms("state.productId", "product")
+                any("state.productName", "productName")
+                any("state.category", "category")
+                sort { "productName".asc() }
+            },
+        )
+
+        pager(batchSize = 10).execute(plan).test().verifyComplete()
+
+        requests.single().aggregations().values.single().composite().size().assert().isEqualTo(3)
+    }
+
+    @Test
     fun `any metric should normalize boolean long double and empty terms buckets`() {
         stubPointInTime()
         every { client.search(any<SearchRequest>(), Map::class.java) } returns Mono.just(

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompiler.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompiler.kt
@@ -97,6 +97,12 @@ internal class MongoAggregationCompiler(
             query.metrics.forEach { metric ->
                 when (metric) {
                     is AggregationMetric.Count -> add(Accumulators.sum(metric.alias, 1))
+                    is AggregationMetric.Any -> add(
+                        Accumulators.max(
+                            metric.alias,
+                            "\$${metric.field.resolve(parent, schema, QueryCapability.AGGREGATE_TERMS)}",
+                        ),
+                    )
                     is AggregationMetric.Numeric -> {
                         val (input, contributes) = metric.toMongoInput(parent, schema)
                         add(metric.function.accumulate(metric.alias, input))
@@ -121,6 +127,7 @@ internal class MongoAggregationCompiler(
                 add(
                     when (metric) {
                         is AggregationMetric.Count -> Projections.include(metric.alias)
+                        is AggregationMetric.Any -> Projections.include(metric.alias)
                         is AggregationMetric.Numeric -> Projections.computed(
                             metric.alias,
                             Document(

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryService.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryService.kt
@@ -121,16 +121,20 @@ class MongoSnapshotQueryService<S : Any> private constructor(
 
     private fun Document.toAggregationResult(query: AggregationQuery): DynamicDocument {
         query.groupBy.forEach { group ->
-            (get(group.alias) as? Decimal128)?.let { this[group.alias] = it.toFiniteDouble(group.alias) }
+            this[group.alias] = get(group.alias).toTermsValue(group.alias)
         }
         query.metrics.forEach { metric ->
             this[metric.alias] = when (metric) {
                 is AggregationMetric.Count -> (get(metric.alias) as Number).toLong()
+                is AggregationMetric.Any -> get(metric.alias).toTermsValue(metric.alias)
                 is AggregationMetric.Numeric -> get(metric.alias).toFiniteDouble(metric.alias)
             }
         }
         return toDynamicDocument()
     }
+
+    private fun Any?.toTermsValue(alias: String): Any? =
+        if (this is Decimal128) toFiniteDouble(alias) else this
 
     private fun AggregationQuery.emptySummary(): DynamicDocument = metrics.associateTo(Document()) { metric ->
         metric.alias to if (metric is AggregationMetric.Count) 0L else null

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
@@ -32,12 +32,37 @@ import me.ahoo.wow.query.schema.QueryModelSchema
 import me.ahoo.wow.query.schema.QuerySchemaValidationException
 import me.ahoo.wow.query.schema.QueryStorageType
 import me.ahoo.wow.serialization.MessageRecords
+import org.bson.BsonDocument
+import org.bson.BsonString
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.ZoneId
 import java.util.concurrent.TimeUnit
 
 class MongoAggregationCompilerTest {
+
+    @Test
+    fun `any metric should compile a resolved max accumulator and projection`() {
+        val schema = schema(
+            field(
+                "state.productName",
+                QueryCapability.AGGREGATE_TERMS,
+                "document.productName",
+            ),
+        )
+        val pipeline = MongoAggregationCompiler(SnapshotFilterConverter).compile(
+            aggregation {
+                any("state.productName", "productName")
+                count("count")
+            },
+            schema,
+        ).map { it.toBsonDocument() }
+
+        val group = pipeline.single { it.containsKey("\$group") }.getDocument("\$group")
+        group.getDocument("productName").assert()
+            .isEqualTo(BsonDocument("\$max", BsonString("\$document.productName")))
+        pipeline.single { it.containsKey("\$project") }.toJson().assert().contains("productName")
+    }
 
     @Test
     fun `schema bindings should drive element group and metric physical paths`() {

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt
@@ -132,6 +132,7 @@ internal class ExampleDomainOpenAPITest {
             querySchema.required.assert().containsExactly("metrics")
             querySchema.properties.getValue("metrics").minItems.assert().isEqualTo(1)
             querySchema.properties.getValue("metrics").maxItems.assert().isEqualTo(64)
+            assertAggregationMetricSchema(querySchema, logicalFieldRef)
             querySchema.properties.getValue("elements").maxItems.assert().isEqualTo(5)
             querySchema.properties.getValue("limit").minimum.assert().isEqualTo(BigDecimal.ONE)
             querySchema.properties.getValue("limit").maximum.intValueExact().assert().isEqualTo(10_000)
@@ -148,6 +149,21 @@ internal class ExampleDomainOpenAPITest {
                 .filter { it.routeId.endsWith(".snapshot.count") }
                 .map { it.routeId.removeSuffix("count") + "aggregation" }
             aggregationRouteIds.assert().containsExactlyInAnyOrder(*countRouteIds.toTypedArray())
+        }
+
+        private fun assertAggregationMetricSchema(querySchema: Schema<*>, logicalFieldRef: String) {
+            val metricSchema = openAPI.components.schemas.getValue("wow.api.query.AggregationMetric")
+            querySchema.properties.getValue("metrics").items.`$ref`.assert()
+                .isEqualTo("#/components/schemas/wow.api.query.AggregationMetric")
+            metricSchema.oneOf.map { it.`$ref` }.assert().containsExactlyInAnyOrder(
+                "#/components/schemas/wow.api.query.AggregationMetric.Count",
+                "#/components/schemas/wow.api.query.AggregationMetric.Numeric",
+                "#/components/schemas/wow.api.query.AggregationMetric.Any",
+            )
+            metricSchema.discriminator.propertyName.assert().isEqualTo("type")
+            val anySchema = openAPI.components.schemas.getValue("wow.api.query.AggregationMetric.Any")
+            anySchema.required.assert().containsExactlyInAnyOrder("field", "alias", "type")
+            anySchema.properties.getValue("field").`$ref`.assert().isEqualTo(logicalFieldRef)
         }
 
         private fun assertAggregationExpressionSchema() {

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt
@@ -161,6 +161,7 @@ internal class ExampleDomainOpenAPITest {
                 "#/components/schemas/wow.api.query.AggregationMetric.Any",
             )
             metricSchema.discriminator.propertyName.assert().isEqualTo("type")
+            (metricSchema.properties.getValue("alias").readOnly == true).assert().isFalse()
             val anySchema = openAPI.components.schemas.getValue("wow.api.query.AggregationMetric.Any")
             anySchema.required.assert().containsExactlyInAnyOrder("field", "alias", "type")
             anySchema.properties.getValue("field").`$ref`.assert().isEqualTo(logicalFieldRef)

--- a/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
@@ -4488,7 +4488,6 @@
         } ],
         "properties" : {
           "alias" : {
-            "readOnly" : true,
             "type" : "string"
           }
         }

--- a/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
@@ -2662,7 +2662,7 @@
         "type" : "object"
       },
       "tck.mock_aggregate.MockCommandAggregateAggregatedFields" : {
-        "enum" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.createdAt", "state.data", "state.decimalValue", "state.id", "state.orders", "state.orders.lines", "state.orders.lines.amount", "state.orders.lines.createdAt", "state.orders.lines.discounts", "state.orders.lines.discounts.amount", "state.orders.lines.discounts.type", "state.orders.lines.productId", "state.orders.lines.quantity", "state.orders.lines.samples", "state.orders.status", "tags", "tenantId", "version" ],
+        "enum" : [ "aggregateId", "aggregateName", "contextName", "deleted", "eventId", "eventTime", "firstEventTime", "firstOperator", "operator", "ownerId", "snapshotTime", "spaceId", "state", "state.createdAt", "state.data", "state.decimalValue", "state.id", "state.orders", "state.orders.lines", "state.orders.lines.amount", "state.orders.lines.createdAt", "state.orders.lines.discounts", "state.orders.lines.discounts.amount", "state.orders.lines.discounts.type", "state.orders.lines.productId", "state.orders.lines.productName", "state.orders.lines.quantity", "state.orders.lines.samples", "state.orders.status", "tags", "tenantId", "version" ],
         "type" : "string"
       },
       "tck.mock_aggregate.MockCommandAggregateWithTenantIdAggregatedDomainEventStream" : {
@@ -3024,6 +3024,13 @@
           },
           "productId" : {
             "type" : "string"
+          },
+          "productName" : {
+            "anyOf" : [ {
+              "type" : "null"
+            }, {
+              "type" : "string"
+            } ]
           },
           "quantity" : {
             "format" : "int32",
@@ -4463,6 +4470,44 @@
         "required" : [ "alias", "field", "type" ],
         "type" : "object"
       },
+      "wow.api.query.AggregationMetric" : {
+        "discriminator" : {
+          "mapping" : {
+            "ANY" : "#/components/schemas/wow.api.query.AggregationMetric.Any",
+            "COUNT" : "#/components/schemas/wow.api.query.AggregationMetric.Count",
+            "NUMERIC" : "#/components/schemas/wow.api.query.AggregationMetric.Numeric"
+          },
+          "propertyName" : "type"
+        },
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/wow.api.query.AggregationMetric.Any"
+        }, {
+          "$ref" : "#/components/schemas/wow.api.query.AggregationMetric.Count"
+        }, {
+          "$ref" : "#/components/schemas/wow.api.query.AggregationMetric.Numeric"
+        } ],
+        "properties" : {
+          "alias" : {
+            "readOnly" : true,
+            "type" : "string"
+          }
+        }
+      },
+      "wow.api.query.AggregationMetric.Any" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "field" : {
+            "$ref" : "#/components/schemas/wow.api.query.LogicalField"
+          },
+          "type" : {
+            "const" : "ANY"
+          }
+        },
+        "required" : [ "alias", "field", "type" ],
+        "type" : "object"
+      },
       "wow.api.query.AggregationMetric.Count" : {
         "properties" : {
           "alias" : {
@@ -4528,11 +4573,7 @@
           },
           "metrics" : {
             "items" : {
-              "anyOf" : [ {
-                "$ref" : "#/components/schemas/wow.api.query.AggregationMetric.Count"
-              }, {
-                "$ref" : "#/components/schemas/wow.api.query.AggregationMetric.Numeric"
-              } ]
+              "$ref" : "#/components/schemas/wow.api.query.AggregationMetric"
             },
             "maxItems" : 64,
             "minItems" : 1,

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDsl.kt
@@ -72,6 +72,10 @@ class AggregationQueryDsl {
         metrics += AggregationMetric.Count(alias)
     }
 
+    fun any(field: String, alias: String) {
+        metrics += AggregationMetric.Any(LogicalField(field), alias)
+    }
+
     fun field(name: String): AggregationExpression = AggregationExpression.Field(LogicalField(name))
 
     fun constant(value: Double): AggregationExpression = AggregationExpression.Constant(value)

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolver.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolver.kt
@@ -172,6 +172,18 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
                 physicalParent,
             ).compatibility
         }
+        query.metrics.filterIsInstance<AggregationMetric.Any>().forEach { metric ->
+            val resolved = resolveAggregationField(
+                metric.field,
+                QueryCapability.AGGREGATE_TERMS,
+                logicalParent,
+                physicalParent,
+            )
+            levels += resolved.compatibility
+            if (resolved.fieldSchema?.cardinality == QueryCardinality.MANY) {
+                levels += QueryCompatibilityLevel.INCOMPATIBLE
+            }
+        }
         query.metrics.filterIsInstance<AggregationMetric.Numeric>().forEach { metric ->
             collectExpressionLevels(metric.expression, logicalParent, physicalParent, levels)
         }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt
@@ -66,6 +66,23 @@ class AggregationQueryDslTest {
     }
 
     @Test
+    fun `aggregation DSL should add an any metric without another group`() {
+        val query = aggregation {
+            terms("productId", "productId")
+            any("productName", "productName")
+            count("count")
+        }
+
+        query.groupBy.assert().containsExactly(
+            AggregationGroup.Terms(LogicalField("productId"), "productId"),
+        )
+        query.metrics.assert().containsExactly(
+            AggregationMetric.Any(LogicalField("productName"), "productName"),
+            AggregationMetric.Count("count"),
+        )
+    }
+
+    @Test
     fun `aggregation DSL should build arithmetic metric expressions`() {
         val query = aggregation {
             sum(field("price") * field("quantity") - constant(10.0), "total")

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolverTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolverTest.kt
@@ -1178,6 +1178,45 @@ class QuerySchemaResolverTest {
         )
     }
 
+    @Test
+    fun `aggregation any should require a single terms-capable field in the innermost element`() {
+        val productName = LogicalField("state.orders.lines.productName")
+        val baseFields = linkedMapOf(
+            LogicalField("state.orders") to fieldSchema(
+                QueryCapability.ELEMENT_SCOPE to "document.orders",
+                cardinality = QueryCardinality.MANY,
+                valueTypes = setOf(QueryValueType.OBJECT),
+            ),
+            LogicalField("state.orders.lines") to fieldSchema(
+                QueryCapability.ELEMENT_SCOPE to "document.orders.lines",
+                cardinality = QueryCardinality.MANY,
+                valueTypes = setOf(QueryValueType.OBJECT),
+            ),
+            productName to fieldSchema(
+                QueryCapability.AGGREGATE_TERMS to "document.orders.lines.productName.keyword",
+                valueTypes = setOf(QueryValueType.STRING),
+            ),
+        )
+        val query = AggregationQuery(
+            elements = listOf(
+                AggregationElement(LogicalField("state.orders")),
+                AggregationElement(LogicalField("lines")),
+            ),
+            metrics = listOf(AggregationMetric.Any(LogicalField("productName"), "productName")),
+        )
+
+        QuerySchemaResolver(schema(baseFields)).resolve(query).compatibility.assert()
+            .isEqualTo(QueryCompatibilityLevel.EXACT)
+
+        val manyField = baseFields.getValue(productName).copy(cardinality = QueryCardinality.MANY)
+        QuerySchemaResolver(schema(baseFields + (productName to manyField)))
+            .resolve(query).compatibility.assert().isEqualTo(QueryCompatibilityLevel.INCOMPATIBLE)
+
+        val withoutTerms = baseFields.getValue(productName).copy(bindings = emptyMap())
+        QuerySchemaResolver(schema(baseFields + (productName to withoutTerms)))
+            .resolve(query).compatibility.assert().isEqualTo(QueryCompatibilityLevel.INCOMPATIBLE)
+    }
+
     private fun schema(
         fields: Map<LogicalField, QueryFieldSchema> = emptyMap(),
         capabilities: Set<QueryCapability> = emptySet(),

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/kotlin/KotlinCustomDefinitionProvider.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/kotlin/KotlinCustomDefinitionProvider.kt
@@ -74,12 +74,18 @@ object KotlinCustomDefinitionProvider : CustomDefinitionProviderV2 {
                 val methodScope: MethodScope =
                     context.typeContext.createMethodScope(resolvedMethod, declarationDetails)
                 val getterNode = createStandardDefinition(methodScope, context)
-                val readOnly = SchemaKeyword.TAG_READ_ONLY.toPropertyName()
-                getterNode.put(readOnly, true)
+                getterNode.markReadOnlyIfNecessary(kotlinGetter)
                 propertiesNode.set(kotlinGetter.name, getterNode)
             }
         }
         return rootSchema.asCustomDefinition()
+    }
+
+    private fun ObjectNode.markReadOnlyIfNecessary(kotlinGetter: KProperty1<*, *>) {
+        val accessMode = kotlinGetter.scanAnnotation<Schema>()?.accessMode
+        if (accessMode == null || accessMode == Schema.AccessMode.AUTO || accessMode == Schema.AccessMode.READ_ONLY) {
+            put(SchemaKeyword.TAG_READ_ONLY.toPropertyName(), true)
+        }
     }
 
     private fun createStandardDefinition(

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/TestFixtures.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/TestFixtures.kt
@@ -125,6 +125,9 @@ data class KotlinFixture(
     val readOnlyField: String = "readOnly"
     val readOnlyGetter: String get() = "readOnlyGetter"
 
+    @get:Schema(accessMode = Schema.AccessMode.READ_ONLY)
+    val explicitReadOnlyGetter: String get() = "explicitReadOnlyGetter"
+
     @get:Schema(accessMode = Schema.AccessMode.READ_WRITE)
     val readWriteGetter: String get() = "readWriteGetter"
     val readOnlyByLazy: String by lazy { "lazy" }

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/TestFixtures.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/TestFixtures.kt
@@ -124,6 +124,9 @@ data class KotlinFixture(
     private var writeOnlyField: String = "writeOnly"
     val readOnlyField: String = "readOnly"
     val readOnlyGetter: String get() = "readOnlyGetter"
+
+    @get:Schema(accessMode = Schema.AccessMode.READ_WRITE)
+    val readWriteGetter: String get() = "readWriteGetter"
     val readOnlyByLazy: String by lazy { "lazy" }
 }
 

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/kotlin/KotlinModuleTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/kotlin/KotlinModuleTest.kt
@@ -54,6 +54,13 @@ class KotlinModuleTest {
     }
 
     @Test
+    fun `should respect read write getter access mode`() {
+        val schema = jsonSchemaGenerator.generateSchema(KotlinFixture::class.java)
+        val readWriteGetter = schema.get("properties").get("readWriteGetter")
+        (readWriteGetter.get("readOnly")?.booleanValue() == true).assert().isFalse()
+    }
+
+    @Test
     fun `should not include private writeOnly field in schema`() {
         val schema = jsonSchemaGenerator.generateSchema(KotlinFixture::class.java)
         val properties = schema.get("properties")

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/kotlin/KotlinModuleTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/kotlin/KotlinModuleTest.kt
@@ -51,6 +51,8 @@ class KotlinModuleTest {
         val schema = jsonSchemaGenerator.generateSchema(KotlinFixture::class.java)
         val readOnlyGetter = schema.get("properties").get("readOnlyGetter")
         readOnlyGetter.get("readOnly").booleanValue().assert().isTrue()
+        val explicitReadOnlyGetter = schema.get("properties").get("explicitReadOnlyGetter")
+        explicitReadOnlyGetter.get("readOnly").booleanValue().assert().isTrue()
     }
 
     @Test

--- a/wow-schema/src/test/resources/META-INF/wow-schema-e2e/MockStateAggregate.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema-e2e/MockStateAggregate.json
@@ -112,6 +112,13 @@
                     "productId" : {
                       "type" : "string"
                     },
+                    "productName" : {
+                      "anyOf" : [ {
+                        "type" : "null"
+                      }, {
+                        "type" : "string"
+                      } ]
+                    },
                     "quantity" : {
                       "type" : "integer",
                       "format" : "int32"

--- a/wow-schema/src/test/resources/META-INF/wow-schema-e2e/MockStateAggregateSnapshot.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema-e2e/MockStateAggregateSnapshot.json
@@ -112,6 +112,13 @@
                     "productId" : {
                       "type" : "string"
                     },
+                    "productName" : {
+                      "anyOf" : [ {
+                        "type" : "null"
+                      }, {
+                        "type" : "string"
+                      } ]
+                    },
                     "quantity" : {
                       "type" : "integer",
                       "format" : "int32"

--- a/wow-schema/src/test/resources/META-INF/wow-schema-e2e/MockStateAggregateStateEvent.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema-e2e/MockStateAggregateStateEvent.json
@@ -194,6 +194,13 @@
                     "productId" : {
                       "type" : "string"
                     },
+                    "productName" : {
+                      "anyOf" : [ {
+                        "type" : "null"
+                      }, {
+                        "type" : "string"
+                      } ]
+                    },
                     "quantity" : {
                       "type" : "integer",
                       "format" : "int32"

--- a/wow-schema/src/test/resources/META-INF/wow-schema/MockStateAggregate.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/MockStateAggregate.json
@@ -112,6 +112,13 @@
                     "productId" : {
                       "type" : "string"
                     },
+                    "productName" : {
+                      "anyOf" : [ {
+                        "type" : "null"
+                      }, {
+                        "type" : "string"
+                      } ]
+                    },
                     "quantity" : {
                       "type" : "integer",
                       "format" : "int32"

--- a/wow-schema/src/test/resources/META-INF/wow-schema/MockStateAggregateSnapshot.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/MockStateAggregateSnapshot.json
@@ -112,6 +112,13 @@
                     "productId" : {
                       "type" : "string"
                     },
+                    "productName" : {
+                      "anyOf" : [ {
+                        "type" : "null"
+                      }, {
+                        "type" : "string"
+                      } ]
+                    },
                     "quantity" : {
                       "type" : "integer",
                       "format" : "int32"

--- a/wow-schema/src/test/resources/META-INF/wow-schema/MockStateAggregateStateEvent.json
+++ b/wow-schema/src/test/resources/META-INF/wow-schema/MockStateAggregateStateEvent.json
@@ -194,6 +194,13 @@
                     "productId" : {
                       "type" : "string"
                     },
+                    "productName" : {
+                      "anyOf" : [ {
+                        "type" : "null"
+                      }, {
+                        "type" : "string"
+                      } ]
+                    },
                     "quantity" : {
                       "type" : "integer",
                       "format" : "int32"

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
@@ -93,6 +93,7 @@ import java.time.Duration
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicBoolean
 
+@Suppress("LargeClass")
 class HttpQueryGuardFilterTest {
     private val request = MockServerRequest.builder().build()
 
@@ -166,6 +167,30 @@ class HttpQueryGuardFilterTest {
             idleTimeout = Duration.ZERO
         ).filter(aggregationContext(filtered), unexpectedBackend())
             .writeRawRequest(request).test().expectError(IllegalArgumentException::class.java).verify()
+    }
+
+    @Test
+    fun `aggregation Guard should treat any alias sorting as expensive but allow plain any`() {
+        val query = AggregationQuery(
+            groupBy = listOf(AggregationGroup.Terms(LogicalField("state.productId"), "productId")),
+            metrics = listOf(AggregationMetric.Any(LogicalField("state.productName"), "productName")),
+            sort = listOf(Sort("productName", Sort.Direction.ASC)),
+        )
+
+        guard(allowExpensiveOperators = false)
+            .filter(aggregationContext(query), unexpectedBackend())
+            .writeRawRequest(request).test()
+            .expectError(IllegalArgumentException::class.java)
+            .verify()
+
+        guard(allowExpensiveOperators = false, idleTimeout = Duration.ZERO)
+            .filter(
+                aggregationContext(query.copy(sort = emptyList())),
+                FilterChain { context ->
+                    context.asAggregationQuery().setResult(Flux.empty())
+                    Mono.empty()
+                },
+            ).writeRawRequest(request).test().verifyComplete()
     }
 
     @Test


### PR DESCRIPTION
## Goal

Allow snapshot aggregation results to display a denormalized value, such as `productName`, without adding it to the grouping key. Completion means `terms(productId) + any(productName)` returns one row per product ID, chooses a non-null scalar when available, and behaves consistently across the MongoDB and Elasticsearch query services.

## Changes

- Add public `AggregationMetric.Any`, JSON subtype `ANY`, and Kotlin DSL `any(field, alias)`.
- Validate `ANY` fields through the existing `AGGREGATE_TERMS` capability and reject known multi-valued fields through the current schema validation modes.
- Compile MongoDB `ANY` to native `$max` and Elasticsearch `ANY` to `terms(size = 1)` without scripts, runtime fields, `_source`, or `top_hits`.
- Bound Elasticsearch composite page size by the number of `ANY` sub-buckets to stay within the existing bucket budget.
- Preserve metric sorting and HTTP expensive-query guard behavior.
- Expose the new metric union through OpenAPI and make explicitly `READ_WRITE` Kotlin getter-only properties writable in generated schemas.
- Add shared real-backend tests for inconsistent names, mixed null/non-null values, all-null values, and empty summaries.
- Update English and Chinese query documentation, OpenAPI snapshots, and schema golden files.

## Verification

- `./gradlew build --stacktrace` — passed, 334 actionable tasks.
- `./gradlew :wow-mongo:integrationTest :wow-elasticsearch:integrationTest --rerun-tasks --stacktrace` — passed, 43/43 tasks executed.
- `./gradlew detekt :wow-api:check :wow-query:check :wow-mongo:check :wow-elasticsearch:check :wow-webflux:check :wow-openapi:check :wow-schema:check --stacktrace` — passed.
- `cd documentation && pnpm docs:build` — passed.
- Final whole-feature review and scoped fix re-reviews found no remaining Critical, Important, or Minor issues.

## Compatibility and risks

- [ ] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

Compatibility is intentionally not preserved: adding a subtype to the public sealed `AggregationMetric` hierarchy requires downstream exhaustive `when` expressions to handle `Any`, and generated OpenAPI clients see the new metric union/base reference.

`ANY` is intentionally non-deterministic across executions and backends. MongoDB uses `$max`; Elasticsearch selects one terms bucket. Callers that require a stable display name must repair the denormalized data or use an explicit business query.

Elasticsearch reduces per-page composite rows as the number of `ANY` metrics grows. This prevents bucket-limit failures at the cost of additional PIT pagination requests for wide aggregation queries.

No storage migration, deployment, release, or production rollout is included. Rollback is a normal revert of this PR.
