### PR TITLE
feat(query): support event stream aggregation

### DIFF
--- a/docs/superpowers/plans/2026-08-27-event-stream-aggregation-schema.md
+++ b/docs/superpowers/plans/2026-08-27-event-stream-aggregation-schema.md
@@ -1,0 +1,610 @@
+# EventStream Aggregation and Query Schema Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为 `EventStreamQueryService` 增加完整 `AggregationQuery` 能力，并让所有 EventStream 查询通过可扩展、跨 MongoDB/Elasticsearch 的 `EVENT_STREAM` Query Schema。
+
+**Architecture:** 在现有 Query Schema 核心增加 `EVENT_STREAM` model 与固定 wire-shape 声明；现有 MongoDB/Elasticsearch Adapter 通过保留旧构造签名的内部参数支持不同 model。EventStream 服务复用 Snapshot 的 resolver、聚合 compiler/pager 和默认 `COMPATIBLE` 行为，不新增 HTTP 路由或 payload 自动推断。
+
+**Tech Stack:** Kotlin 2.4.10、JVM 17、Reactor、JUnit Jupiter、FluentAssert、MongoDB Reactive Streams、Spring Data Elasticsearch。
+
+**Spec:** `docs/superpowers/specs/2026-08-27-event-stream-aggregation-schema-design.md`
+
+## Global Constraints
+
+- 默认使用中文文档与说明。
+- 不新增依赖、Gradle 模块、配置项、HTTP/OpenAPI/Schema HTTP 端点、CI/CD 或发布逻辑。
+- `body.body.*` 不从 aggregate state 或事件类型自动推断；只允许现有显式 `QuerySchemaSource` 声明。
+- 默认 `QuerySchemaValidationMode.COMPATIBLE` 保留未知 payload 字段透传；`STRICT` 保持 fail-closed。
+- 保留现有公开构造函数 JVM 签名和第三方 `EventStreamQueryService`/`EventStreamQueryHandler` 实现兼容性。
+- 不把 `aggregate` 提升到通用 `QueryService`/`QueryHandler`。
+- 每个非平凡行为先写失败测试，使用 `me.ahoo.test.asserts.assert`，完成前运行双后端真实 EventStream TCK。
+
+---
+
+### Task 1: 定义 EVENT_STREAM Schema 模型与系统字段
+
+**Files:**
+- Modify: `wow-api/src/main/kotlin/me/ahoo/wow/api/query/schema/QuerySchemaTypes.kt`
+- Modify: `wow-api/src/test/kotlin/me/ahoo/wow/api/query/schema/QuerySchemaTypesTest.kt`
+- Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/schema/SystemQuerySchemaSource.kt`
+- Modify: `wow-query/src/test/kotlin/me/ahoo/wow/query/schema/SystemQuerySchemaSourceTest.kt`
+- Modify: `wow-schema/src/main/kotlin/me/ahoo/wow/schema/query/JsonQuerySchemaSource.kt`
+- Modify: `wow-schema/src/test/kotlin/me/ahoo/wow/schema/query/JsonQuerySchemaSourceTest.kt`
+
+**Interfaces:**
+- Consumes: `MessageRecords`、`DomainEventRecords`、现有 `QuerySchemaDeclaration`。
+- Produces: `QueryModel.EVENT_STREAM`；`SystemQuerySchemaSource.declaration(QueryModel.EVENT_STREAM)`；Snapshot-only 默认 `JsonQuerySchemaSource`。
+
+- [ ] **Step 1: 写 QueryModel 与系统字段失败测试**
+
+在 `QuerySchemaTypesTest` 增加：
+
+```kotlin
+@Test
+fun `should provide event stream query model`() {
+    QueryModel("EVENT_STREAM").assert().isEqualTo(QueryModel.EVENT_STREAM)
+}
+```
+
+在 `SystemQuerySchemaSourceTest` 增加一个测试，断言：
+
+```kotlin
+val fields = SystemQuerySchemaSource.declaration(QueryModel.EVENT_STREAM).fields
+fields.keys.map(LogicalField::value).assert().contains(
+    "id", "contextName", "aggregateName", "name", "header",
+    "aggregateId", "tenantId", "ownerId", "spaceId", "commandId",
+    "requestId", "version", "createTime", "body", "body.id",
+    "body.name", "body.revision", "body.bodyType", "body.body",
+)
+fields.getValue(LogicalField("body")).cardinality.assert()
+    .isEqualTo(DeclarationValue.Set(QueryCardinality.MANY))
+fields.getValue(LogicalField("body.body")).dynamicChildren.assert()
+    .isEqualTo(DeclarationValue.Set(false))
+fields.getValue(LogicalField("createTime")).semanticType.assert()
+    .isEqualTo(DeclarationValue.Set(Temporal.Epoch(TimeUnit.MILLISECONDS)))
+```
+
+- [ ] **Step 2: 运行测试确认失败**
+
+Run:
+
+```bash
+./gradlew :wow-api:test --tests "me.ahoo.wow.api.query.schema.QuerySchemaTypesTest" \
+  :wow-query:test --tests "me.ahoo.wow.query.schema.SystemQuerySchemaSourceTest"
+```
+
+Expected: FAIL，`EVENT_STREAM` 或对应 system declaration 不存在。
+
+- [ ] **Step 3: 实现最小公共模型与系统声明**
+
+在 `QueryModel` companion 增加：
+
+```kotlin
+val EVENT_STREAM = QueryModel("EVENT_STREAM")
+```
+
+将 `SystemQuerySchemaSource.declaration` 改为穷尽式 model 分派，并新增不可变 `EVENT_STREAM_DECLARATION`。复用现有 `stringField`、`integerField`、`objectField`、`epochField`，只给 `body` 设置 `QueryCardinality.MANY`，只给 `header` 设置 `dynamicChildren = true`，给 `body.body` 明确设置 `dynamicChildren = false`。给 `field` helper 增加带默认值的 `cardinality` 参数，不新增第二套 builder。
+
+- [ ] **Step 4: 写 JsonQuerySchemaSource model 隔离失败测试**
+
+在 `JsonQuerySchemaSourceTest` 使用计数 resolver：
+
+```kotlin
+var resolutions = 0
+val source = JsonQuerySchemaSource(
+    stateTypeResolver = { resolutions++; StructuralState::class.java },
+)
+val context = QuerySchemaContext(MOCK_AGGREGATE_METADATA, QueryModel.EVENT_STREAM)
+
+source.load(context).collectList().block().assert().isEmpty()
+resolutions.assert().isZero()
+```
+
+- [ ] **Step 5: 运行测试确认失败并实现 Snapshot-only 推断**
+
+Run:
+
+```bash
+./gradlew :wow-schema:test --tests "me.ahoo.wow.schema.query.JsonQuerySchemaSourceTest"
+```
+
+Expected: FAIL，resolver 被调用并产生状态声明。
+
+在 `load` 的 `Flux.defer` 开头增加：
+
+```kotlin
+if (context.model != QueryModel.SNAPSHOT) {
+    return@defer Flux.empty()
+}
+```
+
+- [ ] **Step 6: 运行三个模块测试并提交**
+
+```bash
+./gradlew :wow-api:test --tests "me.ahoo.wow.api.query.schema.QuerySchemaTypesTest" \
+  :wow-query:test --tests "me.ahoo.wow.query.schema.SystemQuerySchemaSourceTest" \
+  :wow-schema:test --tests "me.ahoo.wow.schema.query.JsonQuerySchemaSourceTest"
+git add wow-api wow-query wow-schema
+git commit -m "feat(query): add event stream schema model"
+```
+
+Expected: PASS。
+
+---
+
+### Task 2: 让后端 Schema Adapter 支持不同 QueryModel
+
+**Files:**
+- Modify: `wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/schema/MongoQuerySchemaAdapter.kt`
+- Modify: `wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/schema/MongoQuerySchemaAdapterTest.kt`
+- Modify: `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/schema/ElasticsearchQuerySchemaAdapter.kt`
+- Modify: `wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/schema/ElasticsearchQuerySchemaAdapterTest.kt`
+
+**Interfaces:**
+- Consumes: `QueryModel.EVENT_STREAM`、`EventStreamFieldConverter`。
+- Produces: 保留旧公开构造签名的 model-aware Adapter 内部构造函数。
+
+- [ ] **Step 1: 写 MongoDB Adapter 失败测试**
+
+增加测试，通过内部构造函数创建 EventStream adapter，并断言 `id` binding：
+
+```kotlin
+val id = LogicalField("id")
+val schema = MongoQuerySchemaAdapter.bind(
+    logicalSchema = LogicalQuerySchema(mapOf(id to field(QueryValueType.STRING))),
+    indexes = emptyList(),
+    validatorSchema = null,
+    model = QueryModel.EVENT_STREAM,
+    fieldConverter = EventStreamFieldConverter,
+)
+
+schema.model.assert().isEqualTo(QueryModel.EVENT_STREAM)
+schema.fields.getValue(id)
+    .bindings.getValue(QueryCapability.EXACT_MATCH)
+    .physicalPath.assert().isEqualTo("_id")
+```
+
+- [ ] **Step 2: 运行 MongoDB 测试确认失败并实现**
+
+Run: `./gradlew :wow-mongo:test --tests "me.ahoo.wow.mongo.query.schema.MongoQuerySchemaAdapterTest"`
+
+Expected: FAIL，内部构造函数不存在或 model 仍为 Snapshot。
+
+保留现有公开二参数 JVM 构造函数：
+
+```kotlin
+class MongoQuerySchemaAdapter internal constructor(
+    private val collection: MongoCollection<Document>,
+    private val database: MongoDatabase?,
+    private val model: QueryModel,
+    private val fieldConverter: FieldConverter,
+) : QuerySchemaBackendAdapter {
+    @JvmOverloads
+    constructor(
+        collection: MongoCollection<Document>,
+        database: MongoDatabase? = null,
+    ) : this(collection, database, QueryModel.SNAPSHOT, SnapshotFieldConverter)
+
+}
+```
+
+让 invalid-container 检查、physical path 和 `QueryModelSchema.model` 使用实例参数；为 companion `bind` 增加 `model`、`fieldConverter` 参数的 overload，现有三参数 overload 委托 Snapshot 默认值。
+
+- [ ] **Step 3: 写 Elasticsearch Adapter 失败测试**
+
+```kotlin
+val body = LogicalField("body")
+val name = LogicalField("body.name")
+val logical = LogicalQuerySchema(
+    linkedMapOf(
+        body to field(QueryValueType.OBJECT, QueryCardinality.MANY),
+        name to field(QueryValueType.STRING),
+    ),
+)
+val mapping = ElasticsearchIndexMapping.from(
+    INDEX,
+    TypeMapping.of { type ->
+        type.properties("body") { property ->
+            property.nested { nested ->
+                nested.properties("name") { it.keyword { keyword -> keyword } }
+            }
+        }
+    },
+)
+val schema = ElasticsearchQuerySchemaAdapter.bind(
+    logical,
+    mapping,
+    QueryModel.EVENT_STREAM,
+)
+schema.model.assert().isEqualTo(QueryModel.EVENT_STREAM)
+schema.fields.getValue(body)
+    .bindings.assert().containsKey(QueryCapability.ELEMENT_SCOPE)
+```
+
+- [ ] **Step 4: 运行 Elasticsearch 测试确认失败并实现**
+
+Run: `./gradlew :wow-elasticsearch:test --tests "me.ahoo.wow.elasticsearch.query.schema.ElasticsearchQuerySchemaAdapterTest"`
+
+Expected: FAIL，model 参数不存在或结果仍为 Snapshot。
+
+保留公开二参数构造函数，增加内部三参数构造函数；保留现有二参数 `bind` 并委托新三参数 overload：
+
+```kotlin
+internal fun bind(
+    logicalSchema: LogicalQuerySchema,
+    mapping: ElasticsearchIndexMapping,
+): QueryModelSchema = bind(logicalSchema, mapping, QueryModel.SNAPSHOT)
+```
+
+- [ ] **Step 5: 运行 Adapter 测试并提交**
+
+```bash
+./gradlew :wow-mongo:test --tests "me.ahoo.wow.mongo.query.schema.MongoQuerySchemaAdapterTest" \
+  :wow-elasticsearch:test --tests "me.ahoo.wow.elasticsearch.query.schema.ElasticsearchQuerySchemaAdapterTest"
+git add wow-mongo wow-elasticsearch
+git commit -m "refactor(query): parameterize backend schema models"
+```
+
+Expected: PASS，Snapshot 现有测试仍通过。
+
+---
+
+### Task 3: 开放 EventStream 聚合查询入口
+
+**Files:**
+- Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/event/EventStreamQueryService.kt`
+- Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/event/QueryDsl.kt`
+- Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/event/filter/EventStreamQueryHandler.kt`
+- Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/event/filter/EventStreamQueryFilter.kt`
+- Modify: `wow-query/src/test/kotlin/me/ahoo/wow/query/event/filter/DefaultEventStreamQueryHandlerTest.kt`
+- Modify: `wow-query/src/test/kotlin/me/ahoo/wow/query/event/NoOpSnapshotQueryServiceFactoryTest.kt`
+- Modify: `wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/QueryServiceProxy.kt`
+- Modify: `wow-spring/src/test/kotlin/me/ahoo/wow/spring/query/QueryServiceProxyTest.kt`
+
+**Interfaces:**
+- Consumes: `AggregationQuery`、`QueryType.AGGREGATION`、`QueryModelSchemaProvider`。
+- Produces: `EventStreamQueryService.aggregate`、`EventStreamQueryHandler.aggregate`、`AggregationQuery.query(EventStreamQueryService)`、EventStream provider requirement extension。
+
+- [ ] **Step 1: 把 Tail Filter 拒绝测试改为转发失败测试**
+
+用记录型 service factory 替换当前 `event stream tail should reject aggregation queries`：
+
+```kotlin
+val query = AggregationQuery(metrics = listOf(AggregationMetric.Count("count")))
+val service = object : EventStreamQueryService by NoOpEventStreamQueryService(MOCK_AGGREGATE_METADATA) {
+    override fun aggregate(query: AggregationQuery): Flux<DynamicDocument> = Flux.just(mapOf("count" to 0L))
+}
+val context = DefaultQueryContext<AggregationQuery, Flux<DynamicDocument>>(
+    QueryType.AGGREGATION,
+    MOCK_AGGREGATE_METADATA,
+).setQuery(query)
+
+TailEventStreamQueryFilter(EventStreamQueryServiceFactory { service })
+    .filter(context, FilterChain { Mono.empty() }).block()
+context.getRequiredResult().test().expectNextCount(1).verifyComplete()
+```
+
+- [ ] **Step 2: 写 handler、DSL、proxy 失败断言并运行**
+
+在 handler 测试调用 `queryHandler.aggregate(...)`；在 proxy 测试调用 `proxy.aggregate(...)` 并断言 handler 记录 `QueryType.AGGREGATION`；在 event Query DSL 测试或现有 factory 测试中调用 `query.query(service)`。
+
+Run:
+
+```bash
+./gradlew :wow-query:test --tests "me.ahoo.wow.query.event.filter.DefaultEventStreamQueryHandlerTest" \
+  :wow-spring:test --tests "me.ahoo.wow.spring.query.QueryServiceProxyTest"
+```
+
+Expected: compilation FAIL，聚合方法不存在。
+
+- [ ] **Step 3: 实现最小接口与路由**
+
+给 `EventStreamQueryService` 和 `EventStreamQueryHandler` 增加返回 `UnsupportedOperationException` 的默认 `aggregate`。`DefaultEventStreamQueryHandler.aggregate` 调用：
+
+```kotlin
+flux(namedAggregate, QueryType.AGGREGATION, query)
+```
+
+Tail Filter 的 AGGREGATION 分支改为：
+
+```kotlin
+context.asAggregationQuery().setResult(queryService::aggregate)
+```
+
+Spring proxy 显式调用 `handler.aggregate(namedAggregate, query)`；EventStream Query DSL 直接调用 `queryService.aggregate(this)`。增加与 Snapshot 同形的 `requiredQueryModelSchemaProvider()`。
+
+- [ ] **Step 4: 运行测试并提交**
+
+```bash
+./gradlew :wow-query:check :wow-spring:check
+git add wow-query wow-spring
+git commit -m "feat(query): expose event stream aggregation"
+```
+
+Expected: PASS。
+
+---
+
+### Task 4: 提取双后端共享聚合执行路径
+
+**Files:**
+- Move: `wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompiler.kt` → `wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoAggregationCompiler.kt`
+- Modify: `wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoQueryService.kt`
+- Modify: `wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryService.kt`
+- Modify: `wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt`
+- Move: `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompiler.kt` → `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationCompiler.kt`
+- Move: `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPager.kt` → `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationPager.kt`
+- Modify: `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryService.kt`
+- Modify: `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryService.kt`
+- Modify: `wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt`
+- Modify: `wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt`
+
+**Interfaces:**
+- Consumes: `ResolvedAggregationQuery`、各服务已有 collection/client/converter/batch/keepAlive。
+- Produces: `AbstractMongoQueryService.executeAggregation(ResolvedAggregationQuery)`；`AbstractElasticsearchQueryService.executeAggregation(ResolvedAggregationQuery)`。
+
+- [ ] **Step 1: 移动 compiler/pager package 并确认 Snapshot 测试先失败**
+
+只修改 package 声明和测试/服务 imports，不改算法。
+
+Run: `./gradlew :wow-mongo:test :wow-elasticsearch:test`
+
+Expected: 若 imports 未完整更新则 compilation FAIL；全部更新后现有 compiler/pager 测试 PASS。
+
+- [ ] **Step 2: 在抽象 MongoDB 服务写共享执行入口**
+
+把 Snapshot service 当前 result normalization 与 empty summary 逻辑移动到 `AbstractMongoQueryService` 的 protected 方法：
+
+```kotlin
+protected fun executeAggregation(resolved: ResolvedAggregationQuery): Flux<DynamicDocument> {
+    val query = resolved.query
+    val result = collection.aggregate(
+        MongoAggregationCompiler(converter).compile(query, resolved.schema),
+    ).toFlux().map { it.toAggregationResult(query) }
+    return if (query.groupBy.isEmpty()) result.switchIfEmpty(Flux.just(query.emptySummary())) else result
+}
+```
+
+保留有限 Double、Decimal128、Count/Any/Numeric 规范化的现有代码原样。Snapshot service 改为 `schemaProvider.resolve(...).flatMapMany(::executeAggregation)`。
+
+- [ ] **Step 3: 在抽象 Elasticsearch 服务写共享执行入口**
+
+```kotlin
+protected fun executeAggregation(resolved: ResolvedAggregationQuery): Flux<DynamicDocument> =
+    ElasticsearchAggregationPager(
+        elasticsearchClient,
+        indexName,
+        queryBatchSize,
+        queryKeepAlive,
+    ).execute(ElasticsearchAggregationCompiler(filterConverter).compile(resolved.query, resolved.schema))
+```
+
+Snapshot service 只保留 schema resolve + method reference。
+
+- [ ] **Step 4: 运行 Snapshot 回归并提交**
+
+```bash
+./gradlew :wow-mongo:check :wow-elasticsearch:check
+git add wow-mongo wow-elasticsearch
+git commit -m "refactor(query): share aggregation execution paths"
+```
+
+Expected: Snapshot compiler、pager、service 测试全部 PASS；没有行为变更。
+
+---
+
+### Task 5: 给 MongoDB 与 Elasticsearch EventStream 服务接入 Schema 和聚合
+
+**Files:**
+- Modify: `wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/event/MongoEventStreamQueryService.kt`
+- Modify: `wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/event/MongoEventStreamQueryServiceFactory.kt`
+- Modify: `wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/query/event/MongoEventStreamQueryServiceTest.kt`
+- Modify: `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/event/ElasticsearchEventStreamQueryService.kt`
+- Modify: `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/event/ElasticsearchEventStreamQueryServiceFactory.kt`
+- Modify: `wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/event/ElasticsearchEventStreamQueryServiceTest.kt`
+
+**Interfaces:**
+- Consumes: Task 1 `EVENT_STREAM`；Task 2 model-aware adapters；Task 4 shared execution methods。
+- Produces: 实现 `QueryModelSchemaProvider` 的两种 EventStream 服务；带 sources/mode 的兼容工厂构造函数。
+
+- [ ] **Step 1: 写服务 Schema 失败测试**
+
+在两种 integration test 中增加：
+
+```kotlin
+@Test
+fun `should provide event stream query schema`() {
+    val schema = eventStreamQueryService.requiredQueryModelSchemaProvider().schema().block()!!
+    schema.model.assert().isEqualTo(QueryModel.EVENT_STREAM)
+    schema.fields.assert().containsKey(LogicalField("body.name"))
+    schema.fields.getValue(LogicalField("body"))
+        .bindings.assert().containsKey(QueryCapability.ELEMENT_SCOPE)
+}
+```
+
+- [ ] **Step 2: 运行定向集成测试确认失败**
+
+```bash
+./gradlew :wow-mongo:integrationTest \
+  --tests "me.ahoo.wow.mongo.query.event.MongoEventStreamQueryServiceTest.should provide event stream query schema" \
+  :wow-elasticsearch:integrationTest \
+  --tests "me.ahoo.wow.elasticsearch.query.event.ElasticsearchEventStreamQueryServiceTest.should provide event stream query schema"
+```
+
+Expected: FAIL，服务不是 provider。
+
+- [ ] **Step 3: 实现 MongoDB service/factory**
+
+按 Snapshot service 的 private-primary/public-compatible/internal-provider 构造模式改造。服务委托 `QueryModelSchemaProvider`，覆盖四个 `resolve` overload，并实现：
+
+```kotlin
+override fun aggregate(query: AggregationQuery): Flux<DynamicDocument> =
+    schemaProvider.resolve(query, validationMode).flatMapMany(::executeAggregation)
+```
+
+Factory 使用：
+
+```kotlin
+DefaultQueryModelSchemaProvider(
+    QuerySchemaContext(materialized, QueryModel.EVENT_STREAM),
+    schemaSources,
+    MongoQuerySchemaAdapter(collection, database, QueryModel.EVENT_STREAM, EventStreamFieldConverter),
+)
+```
+
+公开 `MongoEventStreamQueryServiceFactory(database)` 签名必须保留。
+
+- [ ] **Step 4: 实现 Elasticsearch service/factory**
+
+保留现有 public 3 参数与 5 参数 service 构造签名、factory 1 参数与 3 参数构造签名。Factory 复用单个 `ElasticsearchIndexMappingResolver` 并创建：
+
+```kotlin
+DefaultQueryModelSchemaProvider(
+    QuerySchemaContext(materialized, QueryModel.EVENT_STREAM),
+    schemaSources,
+    ElasticsearchQuerySchemaAdapter(indexName, indexMappingResolver, QueryModel.EVENT_STREAM),
+)
+```
+
+服务覆盖所有 resolve overload，并通过 Task 4 protected 方法执行聚合。
+
+- [ ] **Step 5: 运行 Schema 集成测试与现有 EventStream 回归并提交**
+
+```bash
+./gradlew :wow-mongo:integrationTest \
+  --tests "me.ahoo.wow.mongo.query.event.MongoEventStreamQueryServiceTest" \
+  :wow-elasticsearch:integrationTest \
+  --tests "me.ahoo.wow.elasticsearch.query.event.ElasticsearchEventStreamQueryServiceTest"
+git add wow-mongo wow-elasticsearch
+git commit -m "feat(query): add event stream backend aggregation"
+```
+
+Expected: PASS，现有 id/limit/null 查询仍通过默认 compatible 模式。
+
+---
+
+### Task 6: 接入 Spring Boot sources 并用共享 TCK 证明跨后端聚合
+
+**Files:**
+- Modify: `wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfiguration.kt`
+- Modify: `wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfigurationTest.kt`
+- Modify: `wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfiguration.kt`
+- Modify: `wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfigurationTest.kt`
+- Modify: `test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/EventStreamQueryServiceSpec.kt`
+- Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/event/EventStreamQueryService.kt` (KDoc only if needed)
+
+**Interfaces:**
+- Consumes: sources/mode-aware factories；`AggregationQuery.query(EventStreamQueryService)`。
+- Produces: 自动配置完整 Schema sources；MongoDB/Elasticsearch 共用的真实聚合证明。
+
+- [ ] **Step 1: 写自动配置失败测试**
+
+为 MongoDB 和 Elasticsearch 各增加与 Snapshot 对称的 EventStream source 传递测试。复用测试文件已有 helper：
+
+```kotlin
+val expected = IllegalStateException("query schema source was used")
+val factory = configuration.mongoEventStreamQueryServiceFactory(
+    mongoClient = mongoClient("order-service"),
+    dataMongoProperties = null,
+    currentBoundedContext = MaterializedNamedBoundedContext("order-service"),
+    sources = listOf(failingQuerySchemaSource(expected)),
+    queryProperties = QueryProperties(QueryProperties.Schema(QuerySchemaValidationMode.STRICT)),
+)
+(factory.create(MOCK_AGGREGATE_METADATA) as QueryModelSchemaProvider)
+    .schema().test().expectErrorSatisfies { it.assert().isSameAs(expected) }.verify()
+```
+
+Elasticsearch 测试使用相同 expected/source/properties，并额外传入已有 mock `ElasticsearchIndexMappingResolver`。这两个调用同时固定 auto-configuration 向 factory 传递 sources 与 validation mode 的参数合同。
+
+- [ ] **Step 2: 运行自动配置测试确认失败并接线**
+
+Run:
+
+```bash
+./gradlew :wow-spring-boot-starter:test \
+  --tests "me.ahoo.wow.spring.boot.starter.mongo.MongoEventSourcingAutoConfigurationTest" \
+  --tests "me.ahoo.wow.spring.boot.starter.elasticsearch.ElasticsearchEventSourcingAutoConfigurationTest"
+```
+
+Expected: FAIL，EventStream factory 没有接收 sources/mode。
+
+给两个 EventStream factory bean 注入已有 `List<QuerySchemaSource>` 与 `QueryProperties`；Elasticsearch 同时注入已有 `ElasticsearchIndexMappingResolver`。不增加属性类。
+
+- [ ] **Step 3: 在 EventStream TCK 写聚合失败测试**
+
+复用 `generateEventStream` 的 1 个 `MockAggregateCreated` 与 9 个 `MockAggregateChanged`：
+
+```kotlin
+@Test
+fun aggregateEventsByName() {
+    val tenantId = generateGlobalId()
+    eventStore.append(generateEventStream(namedAggregate.aggregateId(tenantId = tenantId))).block()
+
+    aggregation {
+        filter { tenantId(tenantId) }
+        expand("body")
+        terms("name", "eventName")
+        count("count")
+    }.query(eventStreamQueryService)
+        .collectMap({ it["eventName"] as String }, { it["count"] as Long })
+        .test()
+        .assertNext { counts -> counts.values.sum().assert().isEqualTo(10L) }
+        .verifyComplete()
+}
+```
+
+再增加无分组、无匹配文档摘要测试，断言唯一 row 的 `count == 0L`。
+
+- [ ] **Step 4: 运行双后端定向 TCK 确认失败后修正最小实现**
+
+```bash
+./gradlew :wow-mongo:integrationTest \
+  --tests "me.ahoo.wow.mongo.query.event.MongoEventStreamQueryServiceTest.aggregateEventsByName" \
+  :wow-elasticsearch:integrationTest \
+  --tests "me.ahoo.wow.elasticsearch.query.event.ElasticsearchEventStreamQueryServiceTest.aggregateEventsByName"
+```
+
+Expected before final wiring: FAIL；完成后 PASS。只修复真实服务/Schema/adapter 缺口，不在 TCK 加后端分支。
+
+- [ ] **Step 5: 运行完整相关检查**
+
+```bash
+./gradlew \
+  :wow-api:check \
+  :wow-query:check \
+  :wow-schema:check \
+  :wow-spring:check \
+  :wow-spring-boot-starter:check \
+  :wow-mongo:check \
+  :wow-elasticsearch:check
+
+./gradlew \
+  :wow-mongo:integrationTest \
+  :wow-elasticsearch:integrationTest \
+  --stacktrace
+
+./gradlew detekt
+git diff --check
+```
+
+Expected: 所有命令 `BUILD SUCCESSFUL`，双后端 EventStream TCK 均执行新增聚合与 Schema 测试。
+
+- [ ] **Step 6: 提交最终接线**
+
+```bash
+git add wow-spring-boot-starter test wow-query
+git commit -m "test(query): verify event stream aggregation across backends"
+```
+
+---
+
+## Completion Audit
+
+- [ ] `git status --short` 只显示预期状态，且 `git diff main...HEAD --check` 通过。
+- [ ] `rg "Event stream query does not support aggregation"` 不再命中生产 Tail Filter。
+- [ ] `rg "model = QueryModel.SNAPSHOT"` 只保留 Snapshot 专属构造，不残留 backend adapter 硬编码。
+- [ ] EventStream 所有 resolve overload 与 aggregation 都使用同一 provider/mode。
+- [ ] 默认 factory 构造签名仍被现有源码测试调用；第三方默认接口测试覆盖 unsupported fallback。
+- [ ] MongoDB 与 Elasticsearch 的新增 TCK 测试均实际执行且通过。
+- [ ] 未新增 `event/aggregation` 路由、OpenAPI operation、依赖、配置项或模块。

--- a/docs/superpowers/plans/2026-08-27-event-stream-aggregation-schema.md
+++ b/docs/superpowers/plans/2026-08-27-event-stream-aggregation-schema.md
@@ -246,6 +246,7 @@ Expected: PASS，Snapshot 现有测试仍通过。
 
 **Files:**
 - Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/event/EventStreamQueryService.kt`
+- Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/QueryService.kt`
 - Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/event/QueryDsl.kt`
 - Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/event/filter/EventStreamQueryHandler.kt`
 - Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/event/filter/EventStreamQueryFilter.kt`
@@ -256,7 +257,7 @@ Expected: PASS，Snapshot 现有测试仍通过。
 
 **Interfaces:**
 - Consumes: `AggregationQuery`、`QueryType.AGGREGATION`、`QueryModelSchemaProvider`。
-- Produces: `EventStreamQueryService.aggregate`、`EventStreamQueryHandler.aggregate`、`AggregationQuery.query(EventStreamQueryService)`、EventStream provider requirement extension。
+- Produces: `QueryService.aggregate`、`EventStreamQueryHandler.aggregate`、`AggregationQuery.query(EventStreamQueryService)`、EventStream provider requirement extension。
 
 - [ ] **Step 1: 把 Tail Filter 拒绝测试改为转发失败测试**
 
@@ -292,7 +293,7 @@ Expected: compilation FAIL，聚合方法不存在。
 
 - [ ] **Step 3: 实现最小接口与路由**
 
-给 `EventStreamQueryService` 和 `EventStreamQueryHandler` 增加返回 `UnsupportedOperationException` 的默认 `aggregate`。`DefaultEventStreamQueryHandler.aggregate` 调用：
+把 Snapshot 与 EventStream 共用的默认 `aggregate` 提升到 `QueryService`，并给 `EventStreamQueryHandler` 增加返回 `UnsupportedOperationException` 的默认方法。`DefaultEventStreamQueryHandler.aggregate` 调用：
 
 ```kotlin
 flux(namedAggregate, QueryType.AGGREGATION, query)

--- a/docs/superpowers/plans/2026-08-27-event-stream-aggregation-schema.md
+++ b/docs/superpowers/plans/2026-08-27-event-stream-aggregation-schema.md
@@ -4,7 +4,7 @@
 
 **Goal:** 为 `EventStreamQueryService` 增加完整 `AggregationQuery` 能力，并让所有 EventStream 查询通过可扩展、跨 MongoDB/Elasticsearch 的 `EVENT_STREAM` Query Schema。
 
-**Architecture:** 在现有 Query Schema 核心增加 `EVENT_STREAM` model 与固定 wire-shape 声明；现有 MongoDB/Elasticsearch Adapter 通过保留旧构造签名的内部参数支持不同 model。EventStream 服务复用 Snapshot 的 resolver、聚合 compiler/pager 和默认 `COMPATIBLE` 行为，不新增 HTTP 路由或 payload 自动推断。
+**Architecture:** 在现有 Query Schema 核心增加 `EVENT_STREAM` model 与固定 wire-shape 声明；`JsonQuerySchemaSource` 复用参数化 `AggregatedDomainEventStream` JSON Schema 推断各聚合根的事件 payload；现有 MongoDB/Elasticsearch Adapter 通过保留旧构造签名的内部参数支持不同 model。EventStream 服务复用 Snapshot 的 resolver、聚合 compiler/pager 和默认 `COMPATIBLE` 行为，不新增 HTTP 路由。
 
 **Tech Stack:** Kotlin 2.4.10、JVM 17、Reactor、JUnit Jupiter、FluentAssert、MongoDB Reactive Streams、Spring Data Elasticsearch。
 
@@ -14,7 +14,7 @@
 
 - 默认使用中文文档与说明。
 - 不新增依赖、Gradle 模块、配置项、HTTP/OpenAPI/Schema HTTP 端点、CI/CD 或发布逻辑。
-- `body.body.*` 不从 aggregate state 或事件类型自动推断；只允许现有显式 `QuerySchemaSource` 声明。
+- `body.body.*` 从当前聚合根的已知事件类型推断；不从 aggregate state 投射，也不复制事件发现逻辑。
 - 默认 `QuerySchemaValidationMode.COMPATIBLE` 保留未知 payload 字段透传；`STRICT` 保持 fail-closed。
 - 保留现有公开构造函数 JVM 签名和第三方 `EventStreamQueryService`/`EventStreamQueryHandler` 实现兼容性。
 - 不把 `aggregate` 提升到通用 `QueryService`/`QueryHandler`。
@@ -34,7 +34,7 @@
 
 **Interfaces:**
 - Consumes: `MessageRecords`、`DomainEventRecords`、现有 `QuerySchemaDeclaration`。
-- Produces: `QueryModel.EVENT_STREAM`；`SystemQuerySchemaSource.declaration(QueryModel.EVENT_STREAM)`；Snapshot-only 默认 `JsonQuerySchemaSource`。
+- Produces: `QueryModel.EVENT_STREAM`；`SystemQuerySchemaSource.declaration(QueryModel.EVENT_STREAM)`；按 QueryModel 推断的默认 `JsonQuerySchemaSource`。
 
 - [ ] **Step 1: 写 QueryModel 与系统字段失败测试**
 
@@ -52,7 +52,7 @@ fun `should provide event stream query model`() {
 ```kotlin
 val fields = SystemQuerySchemaSource.declaration(QueryModel.EVENT_STREAM).fields
 fields.keys.map(LogicalField::value).assert().contains(
-    "id", "contextName", "aggregateName", "name", "header",
+    "id", "contextName", "aggregateName", "header",
     "aggregateId", "tenantId", "ownerId", "spaceId", "commandId",
     "requestId", "version", "createTime", "body", "body.id",
     "body.name", "body.revision", "body.bodyType", "body.body",
@@ -86,22 +86,20 @@ val EVENT_STREAM = QueryModel("EVENT_STREAM")
 
 将 `SystemQuerySchemaSource.declaration` 改为穷尽式 model 分派，并新增不可变 `EVENT_STREAM_DECLARATION`。复用现有 `stringField`、`integerField`、`objectField`、`epochField`，只给 `body` 设置 `QueryCardinality.MANY`，只给 `header` 设置 `dynamicChildren = true`，给 `body.body` 明确设置 `dynamicChildren = false`。给 `field` helper 增加带默认值的 `cardinality` 参数，不新增第二套 builder。
 
-- [ ] **Step 4: 写 JsonQuerySchemaSource model 隔离失败测试**
+- [ ] **Step 4: 写 EventStream payload 推断与 model 缓存隔离失败测试**
 
-在 `JsonQuerySchemaSourceTest` 使用计数 resolver：
+在 `JsonQuerySchemaSourceTest` 使用真实 `Cart` 聚合根，断言其已知事件 payload 被合并到 `body.body.*`；再使用同一 source 依次加载 Snapshot 和 EventStream，断言不会复用错误 model 的缓存声明：
 
 ```kotlin
-var resolutions = 0
-val source = JsonQuerySchemaSource(
-    stateTypeResolver = { resolutions++; StructuralState::class.java },
-)
-val context = QuerySchemaContext(MOCK_AGGREGATE_METADATA, QueryModel.EVENT_STREAM)
-
-source.load(context).collectList().block().assert().isEmpty()
-resolutions.assert().isZero()
+val declaration = JsonQuerySchemaSource()
+    .load(QuerySchemaContext(CART_NAMED_AGGREGATE, QueryModel.EVENT_STREAM))
+    .single().block()!!
+declaration.fields.keys.assert()
+    .contains(LogicalField("body.body.added.productId"))
+    .contains(LogicalField("body.body.productIds"))
 ```
 
-- [ ] **Step 5: 运行测试确认失败并实现 Snapshot-only 推断**
+- [ ] **Step 5: 运行测试确认失败并实现 model-aware 推断**
 
 Run:
 
@@ -109,15 +107,9 @@ Run:
 ./gradlew :wow-schema:test --tests "me.ahoo.wow.schema.query.JsonQuerySchemaSourceTest"
 ```
 
-Expected: FAIL，resolver 被调用并产生状态声明。
+Expected: FAIL，EventStream source 返回空流。
 
-在 `load` 的 `Flux.defer` 开头增加：
-
-```kotlin
-if (context.model != QueryModel.SNAPSHOT) {
-    return@defer Flux.empty()
-}
-```
+缓存键使用 `(QueryModel, Class<*>)`。Snapshot 保持现有状态类型推断；EventStream 生成 `AggregatedDomainEventStream<CommandAggregateType>` JSON Schema，抽取 `body.items.anyOf[*].body`，复用 `JsonSchemaWalker` 的 alternative 合并并以 `body.body` 为逻辑根。事件集合为空时返回空声明。
 
 - [ ] **Step 6: 运行三个模块测试并提交**
 

--- a/docs/superpowers/specs/2026-08-27-event-stream-aggregation-schema-design.md
+++ b/docs/superpowers/specs/2026-08-27-event-stream-aggregation-schema-design.md
@@ -1,0 +1,198 @@
+# EventStream 聚合与查询 Schema 设计
+
+## 背景
+
+`AggregationQuery` 已由 Snapshot 查询链路、MongoDB 和 Elasticsearch 实现，但 `EventStreamQueryService` 明确不支持聚合。EventStream 的 single、list、paged 和 count 也直接把逻辑字段交给后端，不经过 `QueryModelSchemaProvider`。
+
+只给 EventStream 后端调用现有聚合编译器并传入 `schema = null` 虽然能够执行简单查询，但会把逻辑字段直接当作物理字段，跳过字段类型、Element scope、聚合 capability 和 Elasticsearch mapping binding。这不构成与 Snapshot 对等的跨后端能力。
+
+本设计为 EventStream 增加完整 Query Schema，并在同一条受策略保护的查询链路中开放 `AggregationQuery`。
+
+## 目标
+
+- `EventStreamQueryService`、`EventStreamQueryHandler` 和 Kotlin 查询扩展支持 `AggregationQuery`。
+- MongoDB 与 Elasticsearch EventStream 服务执行相同的聚合合同。
+- 新增 `QueryModel.EVENT_STREAM`，为 EventStream 固定 wire shape 提供系统 Schema。
+- EventStream 的 single、list、paged、count 和 aggregation 统一经过同一个 Schema Provider。
+- 默认 `COMPATIBLE` 模式保持未声明 payload 字段的现有透传行为；`STRICT` 模式要求字段和 capability 完整声明。
+- 复用现有 Schema source、resolver、compiler 和 backend adapter，不复制平行实现。
+- 现有第三方 `EventStreamQueryService` 与 `EventStreamQueryHandler` 实现仍可加载和编译。
+
+## 非目标
+
+- 不新增 EventStream HTTP、OpenAPI 或 Schema HTTP 端点。
+- 不从聚合状态类型推断事件 payload，也不扫描或合并领域事件类型。
+- 不改变 Elasticsearch EventStream 模板中 `body.body.enabled = false` 的约束。
+- 不增加依赖、Gradle 模块、配置项、CI/CD 或发布逻辑。
+- 不把 `aggregate` 提升到通用 `QueryService`/`QueryHandler`。
+- 不增加独立 EventStream Schema Adapter、Schema 注册 SPI 或兼容桥。
+
+## 公共合同与兼容性
+
+`QueryModel` 增加常量：
+
+```kotlin
+val EVENT_STREAM = QueryModel("EVENT_STREAM")
+```
+
+`EventStreamQueryService` 增加：
+
+```kotlin
+fun aggregate(query: AggregationQuery): Flux<DynamicDocument> =
+    Flux.error(UnsupportedOperationException("Event stream aggregation is not supported."))
+```
+
+默认实现避免要求已有第三方实现立即新增方法。`EventStreamQueryHandler` 使用相同策略增加默认方法，`DefaultEventStreamQueryHandler` 则把请求放入 `QueryType.AGGREGATION` 上下文。Spring 的 `EventStreamQueryServiceProxy` 必须显式转发至 handler，确保授权、query rewrite 和其他现有过滤器不能被注入式服务绕过。
+
+`AggregationQuery.query(EventStreamQueryService)` 只作为现有 Snapshot 扩展的对称入口，不新增 DSL 模型。
+
+`EventStreamQueryService.requiredQueryModelSchemaProvider()` 与 Snapshot 的现有扩展保持一致：需要读取 Schema 的低层调用方可以显式要求能力；普通查询调用方不感知 Provider。
+
+## EventStream 系统 Schema
+
+`SystemQuerySchemaSource` 按 `QueryModel` 返回不可变声明。`EVENT_STREAM` 声明以 `MessageSerializer` 和 `AbstractEventStreamJsonSerializer` 的实际 wire shape 为准：
+
+| 字段 | 类型 | Cardinality | 说明 |
+| --- | --- | --- | --- |
+| `id` | STRING | SINGLE | EventStream 消息 ID |
+| `contextName` | STRING | SINGLE | 限界上下文 |
+| `aggregateName` | STRING | SINGLE | 聚合名 |
+| `name` | STRING | SINGLE | EventStream 消息名 |
+| `header` | OBJECT | SINGLE | 允许动态子字段 |
+| `aggregateId` | STRING | SINGLE | 聚合 ID |
+| `tenantId` | STRING | SINGLE | 租户 ID |
+| `ownerId` | STRING | SINGLE | 所有者 ID |
+| `spaceId` | STRING | SINGLE | 空间 ID |
+| `commandId` | STRING | SINGLE | 命令 ID |
+| `requestId` | STRING | SINGLE | 请求 ID |
+| `version` | INTEGER | SINGLE | 事件流版本 |
+| `createTime` | INTEGER + epoch milliseconds | SINGLE | 创建时间 |
+| `body` | OBJECT | MANY | 事件数组，可作为 Element scope |
+| `body.id` | STRING | SINGLE | 事件 ID |
+| `body.name` | STRING | SINGLE | 事件名 |
+| `body.revision` | STRING | SINGLE | 事件 revision |
+| `body.bodyType` | STRING | SINGLE | 事件 payload 类型 |
+| `body.body` | OBJECT | SINGLE | payload 容器，不允许未声明动态子字段 |
+
+系统字段声明不包含 `body.body.*`。现有 `BeanQuerySchemaSource`、working-directory 和 classpath 约定已经按 `QuerySchemaContext(namedAggregate, model)` 精确匹配；调用方可为 `EVENT_STREAM` 显式声明允许查询的 payload 字段。
+
+`JsonQuerySchemaSource` 默认只为 `QueryModel.SNAPSHOT` 推断聚合状态类型；收到其他 model 时返回空流。这样 EventStream 不会错误地出现 `state.*` 或把聚合状态字段投射到事件 payload。
+
+## Schema 解析与兼容模式
+
+EventStream 后端服务像 Snapshot 服务一样实现 `QueryModelSchemaProvider`，并覆盖 single、list、paged、count 和 aggregation 的 `resolve`：
+
+1. Provider 合并系统声明与当前聚合、当前 model 的显式 sources。
+2. Backend adapter 结合 MongoDB collection facts 或 Elasticsearch mapping 生成物理 bindings。
+3. `QuerySchemaResolver` 校验并改写所有查询形态。
+4. 后端只接收已经解析的查询；聚合编译器同时接收 resolved Schema。
+
+默认 `QuerySchemaValidationMode.COMPATIBLE` 的现有规则保持不变：未声明字段是 `COMPATIBLE`，按原始路径透传；已声明但缺少所需 capability 的字段是 `INCOMPATIBLE` 并被拒绝。因此已有 MongoDB payload 查询不会仅因新增系统 Schema 而失效，严格治理可通过现有 `STRICT` 配置启用。
+
+`body.body` 系统字段明确设置 `dynamicChildren = false`。显式 source 可以增加具体子字段；未声明 payload 字段在 `COMPATIBLE` 下仍沿用全局兼容语义，但在 `STRICT` 下被拒绝。
+
+## 后端 Schema Adapter
+
+不新增 EventStream 专用 Adapter。
+
+`MongoQuerySchemaAdapter` 增加带默认值的 `model` 与 `FieldConverter` 构造参数。Snapshot 保持 `QueryModel.SNAPSHOT + SnapshotFieldConverter`；EventStream 使用 `QueryModel.EVENT_STREAM + EventStreamFieldConverter`，使逻辑 `id` 正确绑定 MongoDB `_id`。`QueryModelSchema.model` 使用传入 model，不再硬编码 Snapshot。
+
+`ElasticsearchQuerySchemaAdapter` 增加带默认值的 `model`。EventStream 模板的字段路径与逻辑路径一致，`id` 也是 `_source` 中的 keyword，因此不需要新的 field converter。Adapter 继续从 mapping 识别 `body` 的 nested capability 和字段的 keyword/numeric/temporal capability，并把结果 model 设置为 `EVENT_STREAM`。
+
+保留现有默认构造行为，避免破坏直接构造 Snapshot Adapter 的调用方和测试。
+
+## 后端服务与工厂
+
+MongoDB 和 Elasticsearch EventStream 工厂接收与 Snapshot 工厂相同的 `schemaSources` 和 `validationMode`，默认仍是 `emptyList()` 与 `COMPATIBLE`。Spring Boot 自动配置把已有 `List<QuerySchemaSource>` 与 `QueryProperties.schema.validationMode` 注入 EventStream 工厂；不增加新属性。
+
+两种 EventStream 服务委托 Provider，并统一解析现有查询操作。聚合执行复用已有实现：
+
+- MongoDB 使用 `MongoAggregationCompiler(EventStreamFilterConverter)`，传入 resolved Schema，并复用现有聚合结果规范化与空摘要逻辑。
+- Elasticsearch 使用 `ElasticsearchAggregationCompiler(EventStreamFilterConverter)` 与 `ElasticsearchAggregationPager`，传入 EventStream index、batch size、keep-alive 和 resolved Schema。
+
+现有编译器和 pager 从 Snapshot package 移到 backend-neutral 的 query aggregation package；不复制代码，不改变行为。
+
+根 `filter` 作用于 EventStream 文档。`elements = [body]` 展开事件数组；Element filter、group 和 metric 字段相对该事件项，例如：
+
+```kotlin
+aggregation {
+    element("body")
+    terms("name", "eventName")
+    count("count")
+}
+```
+
+## payload 边界
+
+MongoDB 保存可查询的 `body.body`，显式 EventStream Schema source 可以为 payload 字段提供能力。Elasticsearch 当前模板把 `body.body` 设置为 `enabled = false`，Adapter 因而不会为其子字段提供物理 capability；这些查询在严格解析时失败，不能伪装为空结果或降级为 `_source` 扫描。
+
+本次跨后端保证范围是 EventStream envelope 与 `body` 事件元数据。若未来需要 Elasticsearch payload 聚合，应单独设计 mapping、索引迁移、历史数据重建和回滚方案。
+
+## 错误处理
+
+- 默认接口实现返回 `UnsupportedOperationException`，用于未升级的第三方后端。
+- Schema 冲突、已声明字段 capability 不匹配和严格模式未知字段继续抛出现有 Query Schema 异常。
+- `COMPATIBLE` 只沿用现有未知字段/Schema unavailable 回退规则，不新增 EventStream 特例。
+- MongoDB pipeline、Elasticsearch mapping/PIT/aggregation 和结果解析错误直接传播。
+- 无分组且没有匹配文档时，MongoDB 与 Elasticsearch 继续返回现有空摘要：Count 为 `0L`，其他 metric 为 `null`。
+- 不捕获后端错误并返回空 Flux，不进行跨后端静默降级。
+
+## 测试策略
+
+### API 与 Schema
+
+- `wow-api` 验证 `QueryModel.EVENT_STREAM` 值与 JSON 往返。
+- `SystemQuerySchemaSourceTest` 验证完整 EventStream wire 字段、`body` MANY、`body.body` 非动态和 `createTime` epoch。
+- `JsonQuerySchemaSourceTest` 验证 EventStream 不触发状态类型推断。
+- Query Schema source 测试验证 `EVENT_STREAM` classpath/working-directory/bean 声明按 model 隔离。
+
+### 查询链路
+
+- EventStream handler 测试验证 `QueryType.AGGREGATION` 转发，不再在 Tail Filter 中拒绝。
+- Spring proxy 测试验证 aggregate 必须经过 handler。
+- EventStream Query DSL 测试验证扩展直接调用服务。
+- NoOp 与第三方默认实现测试验证兼容错误合同。
+
+### 后端与集成
+
+- MongoDB Adapter 测试验证 `EVENT_STREAM` model 与 `id -> _id` binding。
+- Elasticsearch Adapter 测试验证 `EVENT_STREAM` model、`body` nested 和事件 metadata capability。
+- EventStream TCK 写入多个事件流，通过 `elements = [body]` 按 `name` 分组并 Count；MongoDB 与 Elasticsearch 运行同一测试。
+- TCK 同时验证无分组摘要和根 filter，防止只覆盖 compiler 结构而未执行真实后端。
+- EventStream service 集成测试验证 Schema model、系统字段和 refresh。
+- Spring Boot 自动配置测试验证 sources 与 validation mode 传入 EventStream 工厂。
+
+## 文档
+
+公共 KDoc 说明 EventStream 聚合的 root/Element 相对路径语义，以及 Elasticsearch payload 限制。现阶段不新增 HTTP 使用文档或 OpenAPI 快照；若未来开放端点，再同步中英文 WebFlux 文档。
+
+## 验证
+
+实现阶段从最窄测试开始，完成前至少运行：
+
+```bash
+./gradlew \
+  :wow-api:check \
+  :wow-query:check \
+  :wow-schema:check \
+  :wow-spring:check \
+  :wow-spring-boot-starter:check \
+  :wow-mongo:check \
+  :wow-elasticsearch:check
+
+./gradlew \
+  :wow-mongo:integrationTest \
+  :wow-elasticsearch:integrationTest \
+  --stacktrace
+```
+
+若生产文件触发 Detekt 范围，再运行根 `./gradlew detekt`。不以编译器 BSON/JSON 断言替代双后端真实 EventStream TCK。
+
+## 完成条件
+
+- EventStream 的所有查询形态使用同一 `EVENT_STREAM` Schema Provider。
+- EventStream 聚合经 handler/proxy/filter 链执行，MongoDB 与 Elasticsearch 行为通过共享 TCK。
+- 系统 Schema 与权威序列化 wire shape 一致，payload 不被自动推断。
+- 默认兼容模式不收紧未声明 payload 字段；严格模式和 capability 错误保持 fail-closed。
+- 不存在复制的 EventStream backend Schema Adapter 或聚合编译器。
+- 未新增 EventStream HTTP/OpenAPI 路由、依赖、配置项或模块。

--- a/docs/superpowers/specs/2026-08-27-event-stream-aggregation-schema-design.md
+++ b/docs/superpowers/specs/2026-08-27-event-stream-aggregation-schema-design.md
@@ -25,7 +25,7 @@
 - 不新增独立的事件发现或合并逻辑；复用 `AggregatedDomainEventStreamDefinitionProvider` 已有的聚合元数据推断。
 - 不改变 Elasticsearch EventStream 模板中 `body.body.enabled = false` 的约束。
 - 不增加依赖、Gradle 模块、配置项、CI/CD 或发布逻辑。
-- 不把 `aggregate` 提升到通用 `QueryService`/`QueryHandler`。
+- 不把 `aggregate` 提升到通用 `QueryHandler`。
 - 不增加独立 EventStream Schema Adapter、Schema 注册 SPI 或兼容桥。
 
 ## 公共合同与兼容性
@@ -36,14 +36,14 @@
 val EVENT_STREAM = QueryModel("EVENT_STREAM")
 ```
 
-`EventStreamQueryService` 增加：
+`QueryService` 提供 Snapshot 与 EventStream 共用的默认方法：
 
 ```kotlin
 fun aggregate(query: AggregationQuery): Flux<DynamicDocument> =
-    Flux.error(UnsupportedOperationException("Event stream aggregation is not supported."))
+    Flux.error(UnsupportedOperationException("Aggregation is not supported."))
 ```
 
-默认实现避免要求已有第三方实现立即新增方法。`EventStreamQueryHandler` 使用相同策略增加默认方法，`DefaultEventStreamQueryHandler` 则把请求放入 `QueryType.AGGREGATION` 上下文。Spring 的 `EventStreamQueryServiceProxy` 必须显式转发至 handler，确保授权、query rewrite 和其他现有过滤器不能被注入式服务绕过。
+`SnapshotQueryService` 与 `EventStreamQueryService` 直接继承该合同，默认实现避免要求已有第三方实现立即新增方法。`EventStreamQueryHandler` 使用相同策略增加默认方法，`DefaultEventStreamQueryHandler` 则把请求放入 `QueryType.AGGREGATION` 上下文。Spring 的 `EventStreamQueryServiceProxy` 必须显式转发至 handler，确保授权、query rewrite 和其他现有过滤器不能被注入式服务绕过。
 
 `AggregationQuery.query(EventStreamQueryService)` 只作为现有 Snapshot 扩展的对称入口，不新增 DSL 模型。
 

--- a/docs/superpowers/specs/2026-08-27-event-stream-aggregation-schema-design.md
+++ b/docs/superpowers/specs/2026-08-27-event-stream-aggregation-schema-design.md
@@ -14,6 +14,7 @@
 - MongoDB 与 Elasticsearch EventStream 服务执行相同的聚合合同。
 - 新增 `QueryModel.EVENT_STREAM`，为 EventStream 固定 wire shape 提供系统 Schema。
 - EventStream 的 single、list、paged、count 和 aggregation 统一经过同一个 Schema Provider。
+- `JsonQuerySchemaSource` 按聚合根推断其事件类型，并把事件 payload 字段声明到 `body.body.*`。
 - 默认 `COMPATIBLE` 模式保持未声明 payload 字段的现有透传行为；`STRICT` 模式要求字段和 capability 完整声明。
 - 复用现有 Schema source、resolver、compiler 和 backend adapter，不复制平行实现。
 - 现有第三方 `EventStreamQueryService` 与 `EventStreamQueryHandler` 实现仍可加载和编译。
@@ -21,7 +22,7 @@
 ## 非目标
 
 - 不新增 EventStream HTTP、OpenAPI 或 Schema HTTP 端点。
-- 不从聚合状态类型推断事件 payload，也不扫描或合并领域事件类型。
+- 不新增独立的事件发现或合并逻辑；复用 `AggregatedDomainEventStreamDefinitionProvider` 已有的聚合元数据推断。
 - 不改变 Elasticsearch EventStream 模板中 `body.body.enabled = false` 的约束。
 - 不增加依赖、Gradle 模块、配置项、CI/CD 或发布逻辑。
 - 不把 `aggregate` 提升到通用 `QueryService`/`QueryHandler`。
@@ -57,7 +58,6 @@ fun aggregate(query: AggregationQuery): Flux<DynamicDocument> =
 | `id` | STRING | SINGLE | EventStream 消息 ID |
 | `contextName` | STRING | SINGLE | 限界上下文 |
 | `aggregateName` | STRING | SINGLE | 聚合名 |
-| `name` | STRING | SINGLE | EventStream 消息名 |
 | `header` | OBJECT | SINGLE | 允许动态子字段 |
 | `aggregateId` | STRING | SINGLE | 聚合 ID |
 | `tenantId` | STRING | SINGLE | 租户 ID |
@@ -74,9 +74,9 @@ fun aggregate(query: AggregationQuery): Flux<DynamicDocument> =
 | `body.bodyType` | STRING | SINGLE | 事件 payload 类型 |
 | `body.body` | OBJECT | SINGLE | payload 容器，不允许未声明动态子字段 |
 
-系统字段声明不包含 `body.body.*`。现有 `BeanQuerySchemaSource`、working-directory 和 classpath 约定已经按 `QuerySchemaContext(namedAggregate, model)` 精确匹配；调用方可为 `EVENT_STREAM` 显式声明允许查询的 payload 字段。
+系统字段声明不包含 `body.body.*`。`JsonQuerySchemaSource` 通过参数化的 `AggregatedDomainEventStream<CommandAggregateType>` JSON Schema 获取当前聚合根的事件集合，合并各事件的 payload 分支并映射为 `body.body.*`。现有 `BeanQuerySchemaSource`、working-directory 和 classpath source 仍可按 `QuerySchemaContext(namedAggregate, model)` 增补或覆盖声明。
 
-`JsonQuerySchemaSource` 默认只为 `QueryModel.SNAPSHOT` 推断聚合状态类型；收到其他 model 时返回空流。这样 EventStream 不会错误地出现 `state.*` 或把聚合状态字段投射到事件 payload。
+`JsonQuerySchemaSource` 对 Snapshot 推断聚合状态类型，对 EventStream 推断命令聚合类型对应的事件 payload。两种 model 的缓存键相互隔离；无法发现事件类型时返回空声明，由其他 source 和兼容模式处理。
 
 ## Schema 解析与兼容模式
 
@@ -89,7 +89,7 @@ EventStream 后端服务像 Snapshot 服务一样实现 `QueryModelSchemaProvide
 
 默认 `QuerySchemaValidationMode.COMPATIBLE` 的现有规则保持不变：未声明字段是 `COMPATIBLE`，按原始路径透传；已声明但缺少所需 capability 的字段是 `INCOMPATIBLE` 并被拒绝。因此已有 MongoDB payload 查询不会仅因新增系统 Schema 而失效，严格治理可通过现有 `STRICT` 配置启用。
 
-`body.body` 系统字段明确设置 `dynamicChildren = false`。显式 source 可以增加具体子字段；未声明 payload 字段在 `COMPATIBLE` 下仍沿用全局兼容语义，但在 `STRICT` 下被拒绝。
+`body.body` 系统字段明确设置 `dynamicChildren = false`。自动推断和显式 source 可以增加具体子字段；仍未声明的 payload 字段在 `COMPATIBLE` 下沿用全局兼容语义，但在 `STRICT` 下被拒绝。
 
 ## 后端 Schema Adapter
 
@@ -124,7 +124,7 @@ aggregation {
 
 ## payload 边界
 
-MongoDB 保存可查询的 `body.body`，显式 EventStream Schema source 可以为 payload 字段提供能力。Elasticsearch 当前模板把 `body.body` 设置为 `enabled = false`，Adapter 因而不会为其子字段提供物理 capability；这些查询在严格解析时失败，不能伪装为空结果或降级为 `_source` 扫描。
+MongoDB 保存可查询的 `body.body`，自动推断或显式 EventStream Schema source 可以为 payload 字段提供逻辑声明。Elasticsearch 当前模板把 `body.body` 设置为 `enabled = false`，Adapter 因而不会为其子字段提供物理 capability；这些查询在严格解析时失败，不能伪装为空结果或降级为 `_source` 扫描。
 
 本次跨后端保证范围是 EventStream envelope 与 `body` 事件元数据。若未来需要 Elasticsearch payload 聚合，应单独设计 mapping、索引迁移、历史数据重建和回滚方案。
 
@@ -143,7 +143,7 @@ MongoDB 保存可查询的 `body.body`，显式 EventStream Schema source 可以
 
 - `wow-api` 验证 `QueryModel.EVENT_STREAM` 值与 JSON 往返。
 - `SystemQuerySchemaSourceTest` 验证完整 EventStream wire 字段、`body` MANY、`body.body` 非动态和 `createTime` epoch。
-- `JsonQuerySchemaSourceTest` 验证 EventStream 不触发状态类型推断。
+- `JsonQuerySchemaSourceTest` 使用真实 `Cart` 聚合元数据验证不同事件 payload 合并为 `body.body.*`，并验证 Snapshot/EventStream 缓存隔离。
 - Query Schema source 测试验证 `EVENT_STREAM` classpath/working-directory/bean 声明按 model 隔离。
 
 ### 查询链路
@@ -192,7 +192,7 @@ MongoDB 保存可查询的 `body.body`，显式 EventStream Schema source 可以
 
 - EventStream 的所有查询形态使用同一 `EVENT_STREAM` Schema Provider。
 - EventStream 聚合经 handler/proxy/filter 链执行，MongoDB 与 Elasticsearch 行为通过共享 TCK。
-- 系统 Schema 与权威序列化 wire shape 一致，payload 不被自动推断。
+- 系统 Schema 与权威序列化 wire shape 一致，payload 由当前聚合根的已知事件类型推断。
 - 默认兼容模式不收紧未声明 payload 字段；严格模式和 capability 错误保持 fail-closed。
 - 不存在复制的 EventStream backend Schema Adapter 或聚合编译器。
 - 未新增 EventStream HTTP/OpenAPI 路由、依赖、配置项或模块。

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/EventStreamQueryServiceSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/EventStreamQueryServiceSpec.kt
@@ -18,6 +18,7 @@ import me.ahoo.wow.eventsourcing.EventStore
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.modeling.MaterializedNamedAggregate
 import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.query.dsl.aggregation
 import me.ahoo.wow.query.dsl.condition
 import me.ahoo.wow.query.dsl.filterExpression
 import me.ahoo.wow.query.dsl.listQuery
@@ -150,6 +151,38 @@ abstract class EventStreamQueryServiceSpec {
         }.count(eventStreamQueryService)
             .test()
             .expectNextCount(1)
+            .verifyComplete()
+    }
+
+    @Test
+    fun aggregateEventsByName() {
+        val tenantId = generateGlobalId()
+        eventStore.append(generateEventStream(namedAggregate.aggregateId(tenantId = tenantId))).block()
+
+        aggregation {
+            filter { tenantId(tenantId) }
+            expand("body")
+            terms("name", "eventName")
+            count("count")
+        }.query(eventStreamQueryService)
+            .collectList()
+            .test()
+            .assertNext { rows ->
+                rows.map { it.getValue<Long>("count") }.sorted().assert().containsExactly(1L, 9L)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun aggregateEmptySummary() {
+        eventStore.append(generateEventStream(namedAggregate.aggregateId(tenantId = generateGlobalId()))).block()
+
+        aggregation {
+            filter { tenantId(generateGlobalId()) }
+            count("count")
+        }.query(eventStreamQueryService)
+            .test()
+            .assertNext { it.getValue<Long>("count").assert().isZero() }
             .verifyComplete()
     }
 }

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/schema/QuerySchemaTypes.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/schema/QuerySchemaTypes.kt
@@ -31,6 +31,7 @@ data class QueryModel(
 
     companion object {
         val SNAPSHOT = QueryModel("SNAPSHOT")
+        val EVENT_STREAM = QueryModel("EVENT_STREAM")
 
         @JvmStatic
         @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/query/schema/QuerySchemaTypesTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/query/schema/QuerySchemaTypesTest.kt
@@ -34,6 +34,11 @@ class QuerySchemaTypesTest {
     }
 
     @Test
+    fun `should provide event stream query model`() {
+        QueryModel("EVENT_STREAM").assert().isEqualTo(QueryModel.EVENT_STREAM)
+    }
+
+    @Test
     fun `temporal variants should round trip through semantic JSON`() {
         val semantics = listOf(
             Temporal.Date to "TEMPORAL_DATE",

--- a/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/event/ElasticsearchEventStreamQueryServiceTest.kt
+++ b/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/event/ElasticsearchEventStreamQueryServiceTest.kt
@@ -20,6 +20,7 @@ import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.elasticsearch.ReactiveElasticsearchClients
 import me.ahoo.wow.elasticsearch.TemplateInitializer.initEventStreamTemplate
 import me.ahoo.wow.elasticsearch.eventsourcing.ElasticsearchEventStore
+import me.ahoo.wow.elasticsearch.query.AbstractElasticsearchFilterConverter
 import me.ahoo.wow.eventsourcing.EventStore
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.modeling.aggregateId
@@ -29,6 +30,7 @@ import me.ahoo.wow.query.event.EventStreamQueryServiceFactory
 import me.ahoo.wow.query.event.count
 import me.ahoo.wow.query.event.query
 import me.ahoo.wow.query.event.requiredQueryModelSchemaProvider
+import me.ahoo.wow.query.schema.QuerySchemaUnavailableException
 import me.ahoo.wow.tck.container.ElasticsearchTestFixture
 import me.ahoo.wow.tck.event.MockDomainEventStreams.generateEventStream
 import me.ahoo.wow.tck.query.EventStreamQueryServiceSpec
@@ -38,6 +40,7 @@ import org.junit.jupiter.api.extension.RegisterExtension
 import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
 import reactor.core.publisher.Flux
 import reactor.kotlin.test.test
+import java.time.Duration
 
 class ElasticsearchEventStreamQueryServiceTest : EventStreamQueryServiceSpec() {
     @JvmField
@@ -70,6 +73,58 @@ class ElasticsearchEventStreamQueryServiceTest : EventStreamQueryServiceSpec() {
         schema.fields.assert().containsKey(LogicalField("body.name"))
         schema.fields.getValue(LogicalField("body")).bindings.assert()
             .containsKey(QueryCapability.ELEMENT_SCOPE)
+    }
+
+    @Test
+    fun `public constructor should expose default event stream schema`() {
+        eventStore.append(generateEventStream(namedAggregate.aggregateId(generateGlobalId()))).block()
+        val queryService = ElasticsearchEventStreamQueryService(namedAggregate, elasticsearchClient)
+
+        queryService.schema().test()
+            .assertNext { schema -> schema.model.assert().isEqualTo(QueryModel.EVENT_STREAM) }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `configured constructors should expose event stream schema`() {
+        val batchSize = 17
+        val keepAlive = Duration.ofSeconds(23)
+        eventStore.append(generateEventStream(namedAggregate.aggregateId(generateGlobalId()))).block()
+        val queryService = ElasticsearchEventStreamQueryService(
+            namedAggregate,
+            elasticsearchClient,
+            EventStreamFilterConverter,
+            batchSize,
+            keepAlive,
+        )
+        val factoryService = ElasticsearchEventStreamQueryServiceFactory(
+            elasticsearchClient,
+            batchSize,
+            keepAlive,
+        ).create(namedAggregate) as ElasticsearchEventStreamQueryService
+
+        Flux.concat(queryService.schema(), factoryService.schema())
+            .test()
+            .assertNext { schema -> schema.model.assert().isEqualTo(QueryModel.EVENT_STREAM) }
+            .assertNext { schema -> schema.model.assert().isEqualTo(QueryModel.EVENT_STREAM) }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `custom filter converter should make schema unavailable`() {
+        val converter = object : AbstractElasticsearchFilterConverter() {}
+        val queryService = ElasticsearchEventStreamQueryService(
+            namedAggregate,
+            elasticsearchClient,
+            converter,
+        )
+
+        queryService.schema().test()
+            .expectError(QuerySchemaUnavailableException::class.java)
+            .verify()
+        queryService.refresh().test()
+            .expectError(QuerySchemaUnavailableException::class.java)
+            .verify()
     }
 
     @Test

--- a/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/event/ElasticsearchEventStreamQueryServiceTest.kt
+++ b/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/event/ElasticsearchEventStreamQueryServiceTest.kt
@@ -13,6 +13,10 @@
 
 package me.ahoo.wow.elasticsearch.query.event
 
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.LogicalField
+import me.ahoo.wow.api.query.schema.QueryCapability
+import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.elasticsearch.ReactiveElasticsearchClients
 import me.ahoo.wow.elasticsearch.TemplateInitializer.initEventStreamTemplate
 import me.ahoo.wow.elasticsearch.eventsourcing.ElasticsearchEventStore
@@ -24,6 +28,7 @@ import me.ahoo.wow.query.dsl.listQuery
 import me.ahoo.wow.query.event.EventStreamQueryServiceFactory
 import me.ahoo.wow.query.event.count
 import me.ahoo.wow.query.event.query
+import me.ahoo.wow.query.event.requiredQueryModelSchemaProvider
 import me.ahoo.wow.tck.container.ElasticsearchTestFixture
 import me.ahoo.wow.tck.event.MockDomainEventStreams.generateEventStream
 import me.ahoo.wow.tck.query.EventStreamQueryServiceSpec
@@ -54,6 +59,17 @@ class ElasticsearchEventStreamQueryServiceTest : EventStreamQueryServiceSpec() {
 
     override fun createEventStreamQueryServiceFactory(): EventStreamQueryServiceFactory {
         return ElasticsearchEventStreamQueryServiceFactory(elasticsearchClient)
+    }
+
+    @Test
+    fun `should provide event stream query schema`() {
+        eventStore.append(generateEventStream(namedAggregate.aggregateId(generateGlobalId()))).block()
+        val schema = eventStreamQueryService.requiredQueryModelSchemaProvider().schema().block()!!
+
+        schema.model.assert().isEqualTo(QueryModel.EVENT_STREAM)
+        schema.fields.assert().containsKey(LogicalField("body.name"))
+        schema.fields.getValue(LogicalField("body")).bindings.assert()
+            .containsKey(QueryCapability.ELEMENT_SCOPE)
     }
 
     @Test

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryService.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryService.kt
@@ -33,7 +33,10 @@ import me.ahoo.wow.api.query.Sort
 import me.ahoo.wow.api.query.isEmpty
 import me.ahoo.wow.elasticsearch.query.ElasticsearchProjectionConverter.toSourceFilter
 import me.ahoo.wow.elasticsearch.query.ElasticsearchSortConverter.toSortOptions
+import me.ahoo.wow.elasticsearch.query.aggregation.ElasticsearchAggregationCompiler
+import me.ahoo.wow.elasticsearch.query.aggregation.ElasticsearchAggregationPager
 import me.ahoo.wow.query.QueryService
+import me.ahoo.wow.query.schema.ResolvedAggregationQuery
 import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -193,6 +196,16 @@ abstract class AbstractElasticsearchQueryService<R : Any> : QueryService<R> {
             }
         }.flatMap(elasticsearchClient::count).map { it.count() }
     }
+
+    protected fun executeAggregation(resolved: ResolvedAggregationQuery): Flux<DynamicDocument> =
+        ElasticsearchAggregationPager(
+            elasticsearchClient,
+            indexName,
+            queryBatchSize,
+            queryKeepAlive,
+        ).execute(
+            ElasticsearchAggregationCompiler(filterConverter).compile(resolved.query, resolved.schema),
+        )
 
     private fun compile(filter: FilterExpression, sort: List<Sort>): ResolvedQuery =
         ResolvedQuery(

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationCompiler.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationCompiler.kt
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.elasticsearch.query.snapshot
+package me.ahoo.wow.elasticsearch.query.aggregation
 
 import co.elastic.clients.elasticsearch._types.Script
 import co.elastic.clients.elasticsearch._types.ScriptLanguage

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationPager.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationPager.kt
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.elasticsearch.query.snapshot
+package me.ahoo.wow.elasticsearch.query.aggregation
 
 import co.elastic.clients.elasticsearch._types.FieldValue
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregate

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/event/ElasticsearchEventStreamQueryService.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/event/ElasticsearchEventStreamQueryService.kt
@@ -14,25 +14,57 @@
 package me.ahoo.wow.elasticsearch.query.event
 
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.DynamicDocument
+import me.ahoo.wow.api.query.FilterExpression
+import me.ahoo.wow.api.query.IListQuery
+import me.ahoo.wow.api.query.IPagedQuery
+import me.ahoo.wow.api.query.ISingleQuery
+import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.elasticsearch.IndexNameConverter.toEventStreamIndexName
 import me.ahoo.wow.elasticsearch.query.AbstractElasticsearchFilterConverter
 import me.ahoo.wow.elasticsearch.query.AbstractElasticsearchQueryService
 import me.ahoo.wow.elasticsearch.query.DEFAULT_PIT_KEEP_ALIVE
 import me.ahoo.wow.elasticsearch.query.DEFAULT_SEARCH_BATCH_SIZE
+import me.ahoo.wow.elasticsearch.query.ElasticsearchIndexMappingResolver
+import me.ahoo.wow.elasticsearch.query.schema.ElasticsearchQuerySchemaAdapter
 import me.ahoo.wow.event.DomainEventStream
+import me.ahoo.wow.modeling.materialize
 import me.ahoo.wow.query.event.EventStreamQueryService
+import me.ahoo.wow.query.schema.DefaultQueryModelSchemaProvider
+import me.ahoo.wow.query.schema.QueryModelSchemaProvider
+import me.ahoo.wow.query.schema.QuerySchemaContext
+import me.ahoo.wow.query.schema.QuerySchemaUnavailableException
+import me.ahoo.wow.query.schema.QuerySchemaValidationMode
+import me.ahoo.wow.query.schema.resolve
 import me.ahoo.wow.serialization.convert
 import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
 import java.time.Duration
 
-class ElasticsearchEventStreamQueryService(
+class ElasticsearchEventStreamQueryService private constructor(
     override val namedAggregate: NamedAggregate,
     override val elasticsearchClient: ReactiveElasticsearchClient,
-    override val filterConverter: AbstractElasticsearchFilterConverter = EventStreamFilterConverter
-) : AbstractElasticsearchQueryService<DomainEventStream>(), EventStreamQueryService {
-    private var configuredQueryBatchSize: Int = DEFAULT_SEARCH_BATCH_SIZE
-    private var configuredQueryKeepAlive: Duration = DEFAULT_PIT_KEEP_ALIVE
+    override val filterConverter: AbstractElasticsearchFilterConverter,
+    override val queryBatchSize: Int,
+    override val queryKeepAlive: Duration,
+    private val schemaProvider: QueryModelSchemaProvider,
+    private val validationMode: QuerySchemaValidationMode,
+) : AbstractElasticsearchQueryService<DomainEventStream>(),
+    EventStreamQueryService,
+    QueryModelSchemaProvider by schemaProvider {
+    constructor(
+        namedAggregate: NamedAggregate,
+        elasticsearchClient: ReactiveElasticsearchClient,
+        filterConverter: AbstractElasticsearchFilterConverter = EventStreamFilterConverter,
+    ) : this(
+        namedAggregate,
+        elasticsearchClient,
+        filterConverter,
+        DEFAULT_SEARCH_BATCH_SIZE,
+        DEFAULT_PIT_KEEP_ALIVE,
+        defaultSchemaProvider(namedAggregate, elasticsearchClient, filterConverter),
+        QuerySchemaValidationMode.COMPATIBLE,
+    )
 
     constructor(
         namedAggregate: NamedAggregate,
@@ -40,18 +72,84 @@ class ElasticsearchEventStreamQueryService(
         filterConverter: AbstractElasticsearchFilterConverter,
         queryBatchSize: Int,
         queryKeepAlive: Duration,
-    ) : this(namedAggregate, elasticsearchClient, filterConverter) {
-        configuredQueryBatchSize = queryBatchSize
-        configuredQueryKeepAlive = queryKeepAlive
-    }
+    ) : this(
+        namedAggregate,
+        elasticsearchClient,
+        filterConverter,
+        queryBatchSize,
+        queryKeepAlive,
+        defaultSchemaProvider(namedAggregate, elasticsearchClient, filterConverter),
+        QuerySchemaValidationMode.COMPATIBLE,
+    )
+
+    internal constructor(
+        namedAggregate: NamedAggregate,
+        elasticsearchClient: ReactiveElasticsearchClient,
+        schemaProvider: QueryModelSchemaProvider,
+        validationMode: QuerySchemaValidationMode,
+        filterConverter: AbstractElasticsearchFilterConverter = EventStreamFilterConverter,
+        queryBatchSize: Int = DEFAULT_SEARCH_BATCH_SIZE,
+        queryKeepAlive: Duration = DEFAULT_PIT_KEEP_ALIVE,
+    ) : this(
+        namedAggregate,
+        elasticsearchClient,
+        filterConverter,
+        queryBatchSize,
+        queryKeepAlive,
+        schemaProvider,
+        validationMode,
+    )
 
     override val indexName: String = namedAggregate.toEventStreamIndexName()
-    protected override val queryBatchSize: Int
-        get() = configuredQueryBatchSize
-    protected override val queryKeepAlive: Duration
-        get() = configuredQueryKeepAlive
 
     override fun toTypedResult(document: DynamicDocument): DomainEventStream {
         return document.convert<DomainEventStream>()
+    }
+
+    override fun resolve(query: ISingleQuery) = schemaProvider.resolve(query, validationMode)
+
+    override fun resolve(query: IListQuery) = schemaProvider.resolve(query, validationMode)
+
+    override fun resolve(query: IPagedQuery) = schemaProvider.resolve(query, validationMode)
+
+    override fun resolve(filter: FilterExpression) = schemaProvider.resolve(filter, validationMode)
+
+    override fun aggregate(query: AggregationQuery): reactor.core.publisher.Flux<DynamicDocument> =
+        schemaProvider.resolve(query, validationMode).flatMapMany(::executeAggregation)
+
+    companion object {
+        private fun defaultSchemaProvider(
+            namedAggregate: NamedAggregate,
+            elasticsearchClient: ReactiveElasticsearchClient,
+            filterConverter: AbstractElasticsearchFilterConverter,
+            mappingResolver: ElasticsearchIndexMappingResolver = ElasticsearchIndexMappingResolver(elasticsearchClient),
+        ): QueryModelSchemaProvider {
+            if (filterConverter !== EventStreamFilterConverter) {
+                return object : QueryModelSchemaProvider {
+                    override fun schema(): reactor.core.publisher.Mono<me.ahoo.wow.query.schema.QueryModelSchema> =
+                        unavailable()
+
+                    override fun refresh(): reactor.core.publisher.Mono<me.ahoo.wow.query.schema.QueryModelSchema> =
+                        unavailable()
+
+                    private fun unavailable(): reactor.core.publisher.Mono<me.ahoo.wow.query.schema.QueryModelSchema> =
+                        reactor.core.publisher.Mono.error(
+                            QuerySchemaUnavailableException(
+                                "Elasticsearch query schema is unavailable for custom filter converters.",
+                            ),
+                        )
+                }
+            }
+            val materialized = namedAggregate.materialize()
+            return DefaultQueryModelSchemaProvider(
+                context = QuerySchemaContext(materialized, QueryModel.EVENT_STREAM),
+                sources = emptyList(),
+                adapter = ElasticsearchQuerySchemaAdapter(
+                    materialized.toEventStreamIndexName(),
+                    mappingResolver,
+                    QueryModel.EVENT_STREAM,
+                ),
+            )
+        }
     }
 }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/event/ElasticsearchEventStreamQueryService.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/event/ElasticsearchEventStreamQueryService.kt
@@ -41,65 +41,18 @@ import me.ahoo.wow.serialization.convert
 import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
 import java.time.Duration
 
-class ElasticsearchEventStreamQueryService private constructor(
+class ElasticsearchEventStreamQueryService(
     override val namedAggregate: NamedAggregate,
     override val elasticsearchClient: ReactiveElasticsearchClient,
-    override val filterConverter: AbstractElasticsearchFilterConverter,
-    override val queryBatchSize: Int,
-    override val queryKeepAlive: Duration,
-    private val schemaProvider: QueryModelSchemaProvider,
-    private val validationMode: QuerySchemaValidationMode,
+    override val filterConverter: AbstractElasticsearchFilterConverter = EventStreamFilterConverter,
+    override val queryBatchSize: Int = DEFAULT_SEARCH_BATCH_SIZE,
+    override val queryKeepAlive: Duration = DEFAULT_PIT_KEEP_ALIVE,
+    private val schemaProvider: QueryModelSchemaProvider =
+        defaultSchemaProvider(namedAggregate, elasticsearchClient, filterConverter),
+    private val validationMode: QuerySchemaValidationMode = QuerySchemaValidationMode.COMPATIBLE,
 ) : AbstractElasticsearchQueryService<DomainEventStream>(),
     EventStreamQueryService,
     QueryModelSchemaProvider by schemaProvider {
-    constructor(
-        namedAggregate: NamedAggregate,
-        elasticsearchClient: ReactiveElasticsearchClient,
-        filterConverter: AbstractElasticsearchFilterConverter = EventStreamFilterConverter,
-    ) : this(
-        namedAggregate,
-        elasticsearchClient,
-        filterConverter,
-        DEFAULT_SEARCH_BATCH_SIZE,
-        DEFAULT_PIT_KEEP_ALIVE,
-        defaultSchemaProvider(namedAggregate, elasticsearchClient, filterConverter),
-        QuerySchemaValidationMode.COMPATIBLE,
-    )
-
-    constructor(
-        namedAggregate: NamedAggregate,
-        elasticsearchClient: ReactiveElasticsearchClient,
-        filterConverter: AbstractElasticsearchFilterConverter,
-        queryBatchSize: Int,
-        queryKeepAlive: Duration,
-    ) : this(
-        namedAggregate,
-        elasticsearchClient,
-        filterConverter,
-        queryBatchSize,
-        queryKeepAlive,
-        defaultSchemaProvider(namedAggregate, elasticsearchClient, filterConverter),
-        QuerySchemaValidationMode.COMPATIBLE,
-    )
-
-    internal constructor(
-        namedAggregate: NamedAggregate,
-        elasticsearchClient: ReactiveElasticsearchClient,
-        schemaProvider: QueryModelSchemaProvider,
-        validationMode: QuerySchemaValidationMode,
-        filterConverter: AbstractElasticsearchFilterConverter = EventStreamFilterConverter,
-        queryBatchSize: Int = DEFAULT_SEARCH_BATCH_SIZE,
-        queryKeepAlive: Duration = DEFAULT_PIT_KEEP_ALIVE,
-    ) : this(
-        namedAggregate,
-        elasticsearchClient,
-        filterConverter,
-        queryBatchSize,
-        queryKeepAlive,
-        schemaProvider,
-        validationMode,
-    )
-
     override val indexName: String = namedAggregate.toEventStreamIndexName()
 
     override fun toTypedResult(document: DynamicDocument): DomainEventStream {

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/event/ElasticsearchEventStreamQueryServiceFactory.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/event/ElasticsearchEventStreamQueryServiceFactory.kt
@@ -14,10 +14,19 @@
 package me.ahoo.wow.elasticsearch.query.event
 
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.schema.QueryModel
+import me.ahoo.wow.elasticsearch.IndexNameConverter.toEventStreamIndexName
 import me.ahoo.wow.elasticsearch.query.DEFAULT_PIT_KEEP_ALIVE
 import me.ahoo.wow.elasticsearch.query.DEFAULT_SEARCH_BATCH_SIZE
+import me.ahoo.wow.elasticsearch.query.ElasticsearchIndexMappingResolver
+import me.ahoo.wow.elasticsearch.query.schema.ElasticsearchQuerySchemaAdapter
+import me.ahoo.wow.modeling.materialize
 import me.ahoo.wow.query.event.AbstractEventStreamQueryServiceFactory
 import me.ahoo.wow.query.event.EventStreamQueryService
+import me.ahoo.wow.query.schema.DefaultQueryModelSchemaProvider
+import me.ahoo.wow.query.schema.QuerySchemaContext
+import me.ahoo.wow.query.schema.QuerySchemaSource
+import me.ahoo.wow.query.schema.QuerySchemaValidationMode
 import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
 import java.time.Duration
 
@@ -25,20 +34,50 @@ class ElasticsearchEventStreamQueryServiceFactory(
     private val elasticsearchClient: ReactiveElasticsearchClient,
     private val queryBatchSize: Int,
     private val queryKeepAlive: Duration,
+    private val indexMappingResolver: ElasticsearchIndexMappingResolver,
+    private val schemaSources: List<QuerySchemaSource>,
+    private val validationMode: QuerySchemaValidationMode,
 ) : AbstractEventStreamQueryServiceFactory() {
     constructor(elasticsearchClient: ReactiveElasticsearchClient) : this(
         elasticsearchClient,
         DEFAULT_SEARCH_BATCH_SIZE,
         DEFAULT_PIT_KEEP_ALIVE,
+        ElasticsearchIndexMappingResolver(elasticsearchClient),
+        emptyList(),
+        QuerySchemaValidationMode.COMPATIBLE,
+    )
+
+    constructor(
+        elasticsearchClient: ReactiveElasticsearchClient,
+        queryBatchSize: Int,
+        queryKeepAlive: Duration,
+    ) : this(
+        elasticsearchClient,
+        queryBatchSize,
+        queryKeepAlive,
+        ElasticsearchIndexMappingResolver(elasticsearchClient),
+        emptyList(),
+        QuerySchemaValidationMode.COMPATIBLE,
     )
 
     override fun createQueryService(namedAggregate: NamedAggregate): EventStreamQueryService {
+        val materialized = namedAggregate.materialize()
+        val provider = DefaultQueryModelSchemaProvider(
+            context = QuerySchemaContext(materialized, QueryModel.EVENT_STREAM),
+            sources = schemaSources,
+            adapter = ElasticsearchQuerySchemaAdapter(
+                materialized.toEventStreamIndexName(),
+                indexMappingResolver,
+                QueryModel.EVENT_STREAM,
+            ),
+        )
         return ElasticsearchEventStreamQueryService(
-            namedAggregate,
+            materialized,
             elasticsearchClient,
-            EventStreamFilterConverter,
-            queryBatchSize,
-            queryKeepAlive,
+            provider,
+            validationMode,
+            queryBatchSize = queryBatchSize,
+            queryKeepAlive = queryKeepAlive,
         )
     }
 }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/event/ElasticsearchEventStreamQueryServiceFactory.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/event/ElasticsearchEventStreamQueryServiceFactory.kt
@@ -32,34 +32,13 @@ import java.time.Duration
 
 class ElasticsearchEventStreamQueryServiceFactory(
     private val elasticsearchClient: ReactiveElasticsearchClient,
-    private val queryBatchSize: Int,
-    private val queryKeepAlive: Duration,
-    private val indexMappingResolver: ElasticsearchIndexMappingResolver,
-    private val schemaSources: List<QuerySchemaSource>,
-    private val validationMode: QuerySchemaValidationMode,
+    private val queryBatchSize: Int = DEFAULT_SEARCH_BATCH_SIZE,
+    private val queryKeepAlive: Duration = DEFAULT_PIT_KEEP_ALIVE,
+    private val indexMappingResolver: ElasticsearchIndexMappingResolver =
+        ElasticsearchIndexMappingResolver(elasticsearchClient),
+    private val schemaSources: List<QuerySchemaSource> = emptyList(),
+    private val validationMode: QuerySchemaValidationMode = QuerySchemaValidationMode.COMPATIBLE,
 ) : AbstractEventStreamQueryServiceFactory() {
-    constructor(elasticsearchClient: ReactiveElasticsearchClient) : this(
-        elasticsearchClient,
-        DEFAULT_SEARCH_BATCH_SIZE,
-        DEFAULT_PIT_KEEP_ALIVE,
-        ElasticsearchIndexMappingResolver(elasticsearchClient),
-        emptyList(),
-        QuerySchemaValidationMode.COMPATIBLE,
-    )
-
-    constructor(
-        elasticsearchClient: ReactiveElasticsearchClient,
-        queryBatchSize: Int,
-        queryKeepAlive: Duration,
-    ) : this(
-        elasticsearchClient,
-        queryBatchSize,
-        queryKeepAlive,
-        ElasticsearchIndexMappingResolver(elasticsearchClient),
-        emptyList(),
-        QuerySchemaValidationMode.COMPATIBLE,
-    )
-
     override fun createQueryService(namedAggregate: NamedAggregate): EventStreamQueryService {
         val materialized = namedAggregate.materialize()
         val provider = DefaultQueryModelSchemaProvider(
@@ -72,12 +51,12 @@ class ElasticsearchEventStreamQueryServiceFactory(
             ),
         )
         return ElasticsearchEventStreamQueryService(
-            materialized,
-            elasticsearchClient,
-            provider,
-            validationMode,
+            namedAggregate = materialized,
+            elasticsearchClient = elasticsearchClient,
             queryBatchSize = queryBatchSize,
             queryKeepAlive = queryKeepAlive,
+            schemaProvider = provider,
+            validationMode = validationMode,
         )
     }
 }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/schema/ElasticsearchQuerySchemaAdapter.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/schema/ElasticsearchQuerySchemaAdapter.kt
@@ -33,16 +33,11 @@ import me.ahoo.wow.query.schema.QuerySchemaUnavailableException
 import me.ahoo.wow.query.schema.QueryStorageType
 import reactor.core.publisher.Mono
 
-class ElasticsearchQuerySchemaAdapter internal constructor(
+class ElasticsearchQuerySchemaAdapter(
     private val indexName: String,
     private val mappingResolver: ElasticsearchIndexMappingResolver,
-    private val model: QueryModel,
+    private val model: QueryModel = QueryModel.SNAPSHOT,
 ) : QuerySchemaBackendAdapter {
-    constructor(
-        indexName: String,
-        mappingResolver: ElasticsearchIndexMappingResolver,
-    ) : this(indexName, mappingResolver, QueryModel.SNAPSHOT)
-
     override fun resolve(logicalSchema: LogicalQuerySchema): Mono<QueryModelSchema> =
         load(logicalSchema, mappingResolver.currentOrLoad(indexName))
 

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/schema/ElasticsearchQuerySchemaAdapter.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/schema/ElasticsearchQuerySchemaAdapter.kt
@@ -33,10 +33,16 @@ import me.ahoo.wow.query.schema.QuerySchemaUnavailableException
 import me.ahoo.wow.query.schema.QueryStorageType
 import reactor.core.publisher.Mono
 
-class ElasticsearchQuerySchemaAdapter(
+class ElasticsearchQuerySchemaAdapter internal constructor(
     private val indexName: String,
     private val mappingResolver: ElasticsearchIndexMappingResolver,
+    private val model: QueryModel,
 ) : QuerySchemaBackendAdapter {
+    constructor(
+        indexName: String,
+        mappingResolver: ElasticsearchIndexMappingResolver,
+    ) : this(indexName, mappingResolver, QueryModel.SNAPSHOT)
+
     override fun resolve(logicalSchema: LogicalQuerySchema): Mono<QueryModelSchema> =
         load(logicalSchema, mappingResolver.currentOrLoad(indexName))
 
@@ -46,7 +52,7 @@ class ElasticsearchQuerySchemaAdapter(
     private fun load(
         logicalSchema: LogicalQuerySchema,
         mapping: Mono<ElasticsearchIndexMapping>,
-    ): Mono<QueryModelSchema> = mapping.map { bind(logicalSchema, it) }
+    ): Mono<QueryModelSchema> = mapping.map { bind(logicalSchema, it, model) }
         .onErrorMap { error ->
             if (error is QuerySchemaUnavailableException) {
                 error
@@ -62,6 +68,12 @@ class ElasticsearchQuerySchemaAdapter(
         internal fun bind(
             logicalSchema: LogicalQuerySchema,
             mapping: ElasticsearchIndexMapping,
+        ): QueryModelSchema = bind(logicalSchema, mapping, QueryModel.SNAPSHOT)
+
+        internal fun bind(
+            logicalSchema: LogicalQuerySchema,
+            mapping: ElasticsearchIndexMapping,
+            model: QueryModel,
         ): QueryModelSchema {
             val invalidNestedParents = mapping.invalidNestedParents(logicalSchema)
             val nestedPaths = mapping.fields.filterValues { it.kind == Property.Kind.Nested }.keys
@@ -69,7 +81,7 @@ class ElasticsearchQuerySchemaAdapter(
                 nestedPaths.none { path.startsWith("$it.") }
             }.values
             return QueryModelSchema(
-                model = QueryModel.SNAPSHOT,
+                model = model,
                 capabilities = buildSet {
                     if (rootSearchFields.any(ElasticsearchMappedField::supportsModelFullText)) {
                         add(QueryCapability.FULL_TEXT_TERMS)

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryService.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotQueryService.kt
@@ -144,16 +144,7 @@ class ElasticsearchSnapshotQueryService<S : Any> private constructor(
     override fun resolve(filter: FilterExpression) = schemaProvider.resolve(filter, validationMode)
 
     override fun aggregate(query: AggregationQuery): Flux<DynamicDocument> =
-        schemaProvider.resolve(query, validationMode).flatMapMany { resolved ->
-            ElasticsearchAggregationPager(
-                elasticsearchClient,
-                indexName,
-                queryBatchSize,
-                queryKeepAlive,
-            ).execute(
-                ElasticsearchAggregationCompiler(filterConverter).compile(resolved.query, resolved.schema),
-            )
-        }
+        schemaProvider.resolve(query, validationMode).flatMapMany(::executeAggregation)
 
     companion object {
         private fun defaultSchemaProvider(

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/schema/ElasticsearchQuerySchemaAdapterTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/schema/ElasticsearchQuerySchemaAdapterTest.kt
@@ -32,6 +32,7 @@ import me.ahoo.wow.api.query.Sort
 import me.ahoo.wow.api.query.schema.QueryCapability
 import me.ahoo.wow.api.query.schema.QueryCardinality
 import me.ahoo.wow.api.query.schema.QueryCompatibilityLevel
+import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.api.query.schema.QueryValueType
 import me.ahoo.wow.api.query.schema.Temporal
 import me.ahoo.wow.elasticsearch.query.ElasticsearchIndexMapping
@@ -57,6 +58,34 @@ import java.util.concurrent.TimeUnit
 
 @Suppress("LargeClass")
 class ElasticsearchQuerySchemaAdapterTest {
+    @Test
+    fun `event stream schema should retain model and nested body capability`() {
+        val body = LogicalField("body")
+        val name = LogicalField("body.name")
+        val logical = LogicalQuerySchema(
+            linkedMapOf(
+                body to field(QueryValueType.OBJECT, QueryCardinality.MANY),
+                name to field(QueryValueType.STRING),
+            ),
+        )
+        val mapping = TypeMapping.of { type ->
+            type.properties("body") { property ->
+                property.nested { nested ->
+                    nested.properties("name") { it.keyword { keyword -> keyword } }
+                }
+            }
+        }
+        val schema = ElasticsearchQuerySchemaAdapter.bind(
+            logical,
+            ElasticsearchIndexMapping.from(INDEX, mapping),
+            QueryModel.EVENT_STREAM,
+        )
+
+        schema.model.assert().isEqualTo(QueryModel.EVENT_STREAM)
+        schema.fields.getValue(body).bindings.assert().containsKey(QueryCapability.ELEMENT_SCOPE)
+        schema.fields.getValue(name).bindings.assert().containsKey(QueryCapability.AGGREGATE_TERMS)
+    }
+
     @Test
     fun `nested-only search fields should not advertise root model search`() {
         val child = LogicalField("state.orders.note")

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
@@ -28,6 +28,8 @@ import me.ahoo.wow.api.query.schema.QueryCardinality
 import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.api.query.schema.QueryValueType
 import me.ahoo.wow.api.query.schema.Temporal
+import me.ahoo.wow.elasticsearch.query.aggregation.ElasticsearchAggregationCompiler
+import me.ahoo.wow.elasticsearch.query.aggregation.ElasticsearchAggregationMetric
 import me.ahoo.wow.query.dsl.aggregation
 import me.ahoo.wow.query.schema.QueryFieldBinding
 import me.ahoo.wow.query.schema.QueryFieldSchema

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
@@ -35,6 +35,9 @@ import me.ahoo.wow.api.query.SimpleDynamicDocument
 import me.ahoo.wow.api.query.Sort
 import me.ahoo.wow.elasticsearch.query.AbstractElasticsearchFilterConverter
 import me.ahoo.wow.elasticsearch.query.DEFAULT_SEARCH_BATCH_SIZE
+import me.ahoo.wow.elasticsearch.query.aggregation.ElasticsearchAggregationCompiler
+import me.ahoo.wow.elasticsearch.query.aggregation.ElasticsearchAggregationPager
+import me.ahoo.wow.elasticsearch.query.aggregation.selectTopRows
 import me.ahoo.wow.query.dsl.aggregation
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import org.junit.jupiter.api.Test

--- a/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/query/event/MongoEventStreamQueryServiceTest.kt
+++ b/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/query/event/MongoEventStreamQueryServiceTest.kt
@@ -4,22 +4,34 @@ import com.mongodb.reactivestreams.client.MongoDatabase
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.query.LogicalField
 import me.ahoo.wow.api.query.schema.QueryCapability
+import me.ahoo.wow.api.query.schema.QueryCardinality
 import me.ahoo.wow.api.query.schema.QueryModel
+import me.ahoo.wow.api.query.schema.QueryValueType
 import me.ahoo.wow.eventsourcing.EventStore
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.modeling.aggregateId
 import me.ahoo.wow.mongo.MongoEventStore
+import me.ahoo.wow.query.dsl.aggregation
 import me.ahoo.wow.query.dsl.singleQuery
 import me.ahoo.wow.query.event.EventStreamQueryServiceFactory
 import me.ahoo.wow.query.event.query
 import me.ahoo.wow.query.event.requiredQueryModelSchemaProvider
+import me.ahoo.wow.query.schema.DeclarationValue
+import me.ahoo.wow.query.schema.QueryFieldDeclaration
+import me.ahoo.wow.query.schema.QuerySchemaContext
+import me.ahoo.wow.query.schema.QuerySchemaDeclaration
+import me.ahoo.wow.query.schema.QuerySchemaSource
+import me.ahoo.wow.query.schema.QuerySchemaSourcePriority
+import me.ahoo.wow.query.schema.QuerySchemaValidationMode
 import me.ahoo.wow.tck.container.MongoTestFixture
 import me.ahoo.wow.tck.event.MockDomainEventStreams.generateEventStream
+import me.ahoo.wow.tck.mock.MockAggregateCreated
 import me.ahoo.wow.tck.query.EventStreamQueryServiceSpec
 import me.ahoo.wow.serialization.MessageRecords
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import reactor.core.publisher.Flux
 import reactor.kotlin.test.test
 
 class MongoEventStreamQueryServiceTest : EventStreamQueryServiceSpec() {
@@ -67,5 +79,51 @@ class MongoEventStreamQueryServiceTest : EventStreamQueryServiceSpec() {
             .test()
             .expectNext(eventStream)
             .verifyComplete()
+    }
+
+    @Test
+    fun `strict aggregation should use explicit event payload schema`() {
+        val tenantId = generateGlobalId()
+        val eventStream = generateEventStream(
+            namedAggregate.aggregateId(tenantId = tenantId),
+            eventCount = 1,
+            createdEventSupplier = { MockAggregateCreated("created") },
+        )
+        eventStore.append(eventStream).block()
+        val queryService = MongoEventStreamQueryServiceFactory(
+            database,
+            listOf(eventPayloadSource()),
+            QuerySchemaValidationMode.STRICT,
+        ).create(namedAggregate)
+
+        aggregation {
+            filter { tenantId(tenantId) }
+            expand("body")
+            terms("body.data", "data")
+            count("count")
+        }.query(queryService)
+            .test()
+            .assertNext { row ->
+                row.getValue<String>("data").assert().isEqualTo("created")
+                row.getValue<Long>("count").assert().isEqualTo(1L)
+            }
+            .verifyComplete()
+    }
+
+    private fun eventPayloadSource(): QuerySchemaSource = object : QuerySchemaSource {
+        override val priority: Int = QuerySchemaSourcePriority.BEAN
+
+        override fun load(context: QuerySchemaContext): Flux<QuerySchemaDeclaration> = Flux.just(
+            QuerySchemaDeclaration(
+                mapOf(
+                    LogicalField("body.body.data") to QueryFieldDeclaration(
+                        valueTypes = DeclarationValue.Set(setOf(QueryValueType.STRING)),
+                        nullable = DeclarationValue.Set(false),
+                        required = DeclarationValue.Set(true),
+                        cardinality = DeclarationValue.Set(QueryCardinality.SINGLE),
+                    ),
+                ),
+            ),
+        )
     }
 }

--- a/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/query/event/MongoEventStreamQueryServiceTest.kt
+++ b/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/query/event/MongoEventStreamQueryServiceTest.kt
@@ -10,7 +10,9 @@ import me.ahoo.wow.api.query.schema.QueryValueType
 import me.ahoo.wow.eventsourcing.EventStore
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.mongo.AggregateSchemaInitializer.toEventStreamCollectionName
 import me.ahoo.wow.mongo.MongoEventStore
+import me.ahoo.wow.mongo.query.AbstractMongoFilterConverter
 import me.ahoo.wow.query.dsl.aggregation
 import me.ahoo.wow.query.dsl.singleQuery
 import me.ahoo.wow.query.event.EventStreamQueryServiceFactory
@@ -22,6 +24,7 @@ import me.ahoo.wow.query.schema.QuerySchemaContext
 import me.ahoo.wow.query.schema.QuerySchemaDeclaration
 import me.ahoo.wow.query.schema.QuerySchemaSource
 import me.ahoo.wow.query.schema.QuerySchemaSourcePriority
+import me.ahoo.wow.query.schema.QuerySchemaUnavailableException
 import me.ahoo.wow.query.schema.QuerySchemaValidationMode
 import me.ahoo.wow.tck.container.MongoTestFixture
 import me.ahoo.wow.tck.event.MockDomainEventStreams.generateEventStream
@@ -63,6 +66,37 @@ class MongoEventStreamQueryServiceTest : EventStreamQueryServiceSpec() {
         schema.fields.assert().containsKey(LogicalField("body.name"))
         schema.fields.getValue(LogicalField("body")).bindings.assert()
             .containsKey(QueryCapability.ELEMENT_SCOPE)
+    }
+
+    @Test
+    fun `public constructor should expose default event stream schema`() {
+        val queryService = MongoEventStreamQueryService(
+            namedAggregate,
+            database.getCollection(namedAggregate.toEventStreamCollectionName()),
+        )
+
+        queryService.schema().test()
+            .assertNext { schema -> schema.model.assert().isEqualTo(QueryModel.EVENT_STREAM) }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `custom filter converter should make schema unavailable`() {
+        val converter = object : AbstractMongoFilterConverter() {
+            override val fieldConverter = EventStreamFieldConverter
+        }
+        val queryService = MongoEventStreamQueryService(
+            namedAggregate,
+            database.getCollection(namedAggregate.toEventStreamCollectionName()),
+            converter,
+        )
+
+        queryService.schema().test()
+            .expectError(QuerySchemaUnavailableException::class.java)
+            .verify()
+        queryService.refresh().test()
+            .expectError(QuerySchemaUnavailableException::class.java)
+            .verify()
     }
 
     @Test

--- a/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/query/event/MongoEventStreamQueryServiceTest.kt
+++ b/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/query/event/MongoEventStreamQueryServiceTest.kt
@@ -1,6 +1,10 @@
 package me.ahoo.wow.mongo.query.event
 
 import com.mongodb.reactivestreams.client.MongoDatabase
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.LogicalField
+import me.ahoo.wow.api.query.schema.QueryCapability
+import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.eventsourcing.EventStore
 import me.ahoo.wow.id.generateGlobalId
 import me.ahoo.wow.modeling.aggregateId
@@ -8,6 +12,7 @@ import me.ahoo.wow.mongo.MongoEventStore
 import me.ahoo.wow.query.dsl.singleQuery
 import me.ahoo.wow.query.event.EventStreamQueryServiceFactory
 import me.ahoo.wow.query.event.query
+import me.ahoo.wow.query.event.requiredQueryModelSchemaProvider
 import me.ahoo.wow.tck.container.MongoTestFixture
 import me.ahoo.wow.tck.event.MockDomainEventStreams.generateEventStream
 import me.ahoo.wow.tck.query.EventStreamQueryServiceSpec
@@ -36,6 +41,16 @@ class MongoEventStreamQueryServiceTest : EventStreamQueryServiceSpec() {
 
     override fun createEventStreamQueryServiceFactory(): EventStreamQueryServiceFactory {
         return MongoEventStreamQueryServiceFactory(database)
+    }
+
+    @Test
+    fun `should provide event stream query schema`() {
+        val schema = eventStreamQueryService.requiredQueryModelSchemaProvider().schema().block()!!
+
+        schema.model.assert().isEqualTo(QueryModel.EVENT_STREAM)
+        schema.fields.assert().containsKey(LogicalField("body.name"))
+        schema.fields.getValue(LogicalField("body")).bindings.assert()
+            .containsKey(QueryCapability.ELEMENT_SCOPE)
     }
 
     @Test

--- a/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryServiceTest.kt
+++ b/wow-mongo/src/integrationTest/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryServiceTest.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.mongo.query.snapshot
 
+import me.ahoo.wow.mongo.query.aggregation.MongoAggregationCompiler
 import com.mongodb.reactivestreams.client.MongoDatabase
 import com.mongodb.client.model.Filters
 import com.mongodb.client.model.Indexes

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoFilterConverter.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoFilterConverter.kt
@@ -86,6 +86,8 @@ abstract class AbstractMongoFilterConverter(
     internal fun convertWithoutDefaultDeletion(filter: FilterExpression, parent: String? = null): Bson =
         compile(filterNormalizerWithoutDefaultDeletion.normalize(filter), parent, mapField = true)
 
+    internal fun convertField(field: String): String = fieldConverter.convert(field)
+
     @Suppress("CyclomaticComplexMethod", "LongMethod")
     private fun compile(filter: FilterExpression, parent: String?, mapField: Boolean): Bson = when (filter) {
         MatchAllFilter -> Filters.empty()

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoQueryService.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoQueryService.kt
@@ -15,6 +15,8 @@ package me.ahoo.wow.mongo.query
 
 import com.mongodb.reactivestreams.client.FindPublisher
 import com.mongodb.reactivestreams.client.MongoCollection
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.FilterExpression
 import me.ahoo.wow.api.query.IListQuery
@@ -22,8 +24,12 @@ import me.ahoo.wow.api.query.IPagedQuery
 import me.ahoo.wow.api.query.ISingleQuery
 import me.ahoo.wow.api.query.PagedList
 import me.ahoo.wow.api.query.Queryable
+import me.ahoo.wow.api.query.SimpleDynamicDocument.Companion.toDynamicDocument
+import me.ahoo.wow.mongo.query.aggregation.MongoAggregationCompiler
 import me.ahoo.wow.query.QueryService
+import me.ahoo.wow.query.schema.ResolvedAggregationQuery
 import org.bson.Document
+import org.bson.types.Decimal128
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toFlux
@@ -131,5 +137,49 @@ abstract class AbstractMongoQueryService<R : Any> : QueryService<R> {
         return resolve(filter).flatMap { resolved ->
             collection.countDocuments(converter.convert(resolved)).toMono()
         }
+    }
+
+    protected fun executeAggregation(resolved: ResolvedAggregationQuery): Flux<DynamicDocument> {
+        val query = resolved.query
+        val result = collection.aggregate(
+            MongoAggregationCompiler(converter).compile(query, resolved.schema),
+        ).toFlux().map { it.toAggregationResult(query) }
+        return if (query.groupBy.isEmpty()) {
+            result.switchIfEmpty(Flux.just(query.emptySummary()))
+        } else {
+            result
+        }
+    }
+
+    private fun Document.toAggregationResult(query: AggregationQuery): DynamicDocument {
+        query.groupBy.forEach { group ->
+            this[group.alias] = get(group.alias).toTermsValue(group.alias)
+        }
+        query.metrics.forEach { metric ->
+            this[metric.alias] = when (metric) {
+                is AggregationMetric.Count -> (get(metric.alias) as Number).toLong()
+                is AggregationMetric.Any -> get(metric.alias).toTermsValue(metric.alias)
+                is AggregationMetric.Numeric -> get(metric.alias).toFiniteDouble(metric.alias)
+            }
+        }
+        return toDynamicDocument()
+    }
+
+    private fun Any?.toTermsValue(alias: String): Any? =
+        if (this is Decimal128) toFiniteDouble(alias) else this
+
+    private fun AggregationQuery.emptySummary(): DynamicDocument = metrics.associateTo(Document()) { metric ->
+        metric.alias to if (metric is AggregationMetric.Count) 0L else null
+    }.toDynamicDocument()
+
+    private fun Any?.toFiniteDouble(alias: String): Double? {
+        val value = when (this) {
+            null -> return null
+            is Decimal128 -> bigDecimalValue().toDouble()
+            is Number -> toDouble()
+            else -> error("Aggregation metric [$alias] must be numeric, but was [${this::class.java.name}].")
+        }
+        require(value.isFinite()) { "Aggregation metric [$alias] must be finite." }
+        return value
     }
 }

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoAggregationCompiler.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoAggregationCompiler.kt
@@ -11,7 +11,7 @@
  * limitations under the License.
  */
 
-package me.ahoo.wow.mongo.query.snapshot
+package me.ahoo.wow.mongo.query.aggregation
 
 import com.mongodb.client.model.Accumulators
 import com.mongodb.client.model.Aggregates
@@ -299,7 +299,7 @@ internal class MongoAggregationCompiler(
         val logicalField = field.absolute(parent)
         val fieldSchema = schema?.resolve(logicalField)
         if (fieldSchema == null) {
-            return Document("\$toDate", "\$${SnapshotFieldConverter.convert(logicalField.value)}")
+            return Document("\$toDate", "\$${converter.convertField(logicalField.value)}")
         }
         val physicalPath = fieldSchema.bindings[QueryCapability.AGGREGATE_TEMPORAL]?.physicalPath
             ?: throw QuerySchemaValidationException(
@@ -396,7 +396,7 @@ internal class MongoAggregationCompiler(
         val logicalField = absolute(parent)
         schema?.resolve(logicalField)?.bindings?.get(capability)?.physicalPath?.let { return it }
         if (schema == null || logicalField !in schema.fields) {
-            return SnapshotFieldConverter.convert(logicalField.value)
+            return converter.convertField(logicalField.value)
         }
         throw QuerySchemaValidationException("Query field [$logicalField] does not support [$capability].")
     }

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/event/MongoEventStreamQueryService.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/event/MongoEventStreamQueryService.kt
@@ -15,9 +15,16 @@ package me.ahoo.wow.mongo.query.event
 
 import com.mongodb.reactivestreams.client.MongoCollection
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.DynamicDocument
+import me.ahoo.wow.api.query.FilterExpression
+import me.ahoo.wow.api.query.IListQuery
+import me.ahoo.wow.api.query.IPagedQuery
+import me.ahoo.wow.api.query.ISingleQuery
 import me.ahoo.wow.api.query.SimpleDynamicDocument.Companion.toDynamicDocument
+import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.event.DomainEventStream
+import me.ahoo.wow.modeling.materialize
 import me.ahoo.wow.mongo.Documents.replacePrimaryKeyToId
 import me.ahoo.wow.mongo.query.AbstractMongoFilterConverter
 import me.ahoo.wow.mongo.query.AbstractMongoQueryService
@@ -25,13 +32,44 @@ import me.ahoo.wow.mongo.query.MongoProjectionConverter
 import me.ahoo.wow.mongo.query.MongoSortConverter
 import me.ahoo.wow.mongo.toDomainEventStream
 import me.ahoo.wow.query.event.EventStreamQueryService
+import me.ahoo.wow.query.schema.DefaultQueryModelSchemaProvider
+import me.ahoo.wow.query.schema.QueryModelSchemaProvider
+import me.ahoo.wow.query.schema.QuerySchemaContext
+import me.ahoo.wow.query.schema.QuerySchemaUnavailableException
+import me.ahoo.wow.query.schema.QuerySchemaValidationMode
+import me.ahoo.wow.query.schema.resolve
 import org.bson.Document
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
-class MongoEventStreamQueryService(
+class MongoEventStreamQueryService private constructor(
     override val namedAggregate: NamedAggregate,
     override val collection: MongoCollection<Document>,
-    override val converter: AbstractMongoFilterConverter = EventStreamFilterConverter
-) : AbstractMongoQueryService<DomainEventStream>(), EventStreamQueryService {
+    override val converter: AbstractMongoFilterConverter,
+    private val schemaProvider: QueryModelSchemaProvider,
+    private val validationMode: QuerySchemaValidationMode,
+) : AbstractMongoQueryService<DomainEventStream>(),
+    EventStreamQueryService,
+    QueryModelSchemaProvider by schemaProvider {
+    constructor(
+        namedAggregate: NamedAggregate,
+        collection: MongoCollection<Document>,
+        converter: AbstractMongoFilterConverter = EventStreamFilterConverter,
+    ) : this(
+        namedAggregate,
+        collection,
+        converter,
+        defaultSchemaProvider(namedAggregate, collection, converter),
+        QuerySchemaValidationMode.COMPATIBLE,
+    )
+
+    internal constructor(
+        namedAggregate: NamedAggregate,
+        collection: MongoCollection<Document>,
+        schemaProvider: QueryModelSchemaProvider,
+        validationMode: QuerySchemaValidationMode,
+        converter: AbstractMongoFilterConverter = EventStreamFilterConverter,
+    ) : this(namedAggregate, collection, converter, schemaProvider, validationMode)
 
     override val projectionConverter: MongoProjectionConverter = MongoProjectionConverter(EventStreamFieldConverter)
     override val sortConverter: MongoSortConverter = MongoSortConverter(EventStreamFieldConverter)
@@ -41,5 +79,48 @@ class MongoEventStreamQueryService(
 
     override fun toDynamicDocument(document: Document): DynamicDocument {
         return document.replacePrimaryKeyToId().toDynamicDocument()
+    }
+
+    override fun resolve(query: ISingleQuery) = schemaProvider.resolve(query, validationMode)
+
+    override fun resolve(query: IListQuery) = schemaProvider.resolve(query, validationMode)
+
+    override fun resolve(query: IPagedQuery) = schemaProvider.resolve(query, validationMode)
+
+    override fun resolve(filter: FilterExpression) = schemaProvider.resolve(filter, validationMode)
+
+    override fun aggregate(query: AggregationQuery): Flux<DynamicDocument> =
+        schemaProvider.resolve(query, validationMode).flatMapMany(::executeAggregation)
+
+    companion object {
+        private fun defaultSchemaProvider(
+            namedAggregate: NamedAggregate,
+            collection: MongoCollection<Document>,
+            converter: AbstractMongoFilterConverter,
+        ): QueryModelSchemaProvider {
+            if (converter !== EventStreamFilterConverter) {
+                return object : QueryModelSchemaProvider {
+                    override fun schema(): Mono<me.ahoo.wow.query.schema.QueryModelSchema> = unavailable()
+
+                    override fun refresh(): Mono<me.ahoo.wow.query.schema.QueryModelSchema> = unavailable()
+
+                    private fun unavailable(): Mono<me.ahoo.wow.query.schema.QueryModelSchema> = Mono.error(
+                        QuerySchemaUnavailableException(
+                            "MongoDB query schema is unavailable for custom filter converters.",
+                        ),
+                    )
+                }
+            }
+            return DefaultQueryModelSchemaProvider(
+                context = QuerySchemaContext(namedAggregate.materialize(), QueryModel.EVENT_STREAM),
+                sources = emptyList(),
+                adapter = me.ahoo.wow.mongo.query.schema.MongoQuerySchemaAdapter(
+                    collection,
+                    null,
+                    QueryModel.EVENT_STREAM,
+                    EventStreamFieldConverter,
+                ),
+            )
+        }
     }
 }

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/event/MongoEventStreamQueryService.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/event/MongoEventStreamQueryService.kt
@@ -42,35 +42,16 @@ import org.bson.Document
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
-class MongoEventStreamQueryService private constructor(
+class MongoEventStreamQueryService(
     override val namedAggregate: NamedAggregate,
     override val collection: MongoCollection<Document>,
-    override val converter: AbstractMongoFilterConverter,
-    private val schemaProvider: QueryModelSchemaProvider,
-    private val validationMode: QuerySchemaValidationMode,
+    override val converter: AbstractMongoFilterConverter = EventStreamFilterConverter,
+    private val schemaProvider: QueryModelSchemaProvider =
+        defaultSchemaProvider(namedAggregate, collection, converter),
+    private val validationMode: QuerySchemaValidationMode = QuerySchemaValidationMode.COMPATIBLE,
 ) : AbstractMongoQueryService<DomainEventStream>(),
     EventStreamQueryService,
     QueryModelSchemaProvider by schemaProvider {
-    constructor(
-        namedAggregate: NamedAggregate,
-        collection: MongoCollection<Document>,
-        converter: AbstractMongoFilterConverter = EventStreamFilterConverter,
-    ) : this(
-        namedAggregate,
-        collection,
-        converter,
-        defaultSchemaProvider(namedAggregate, collection, converter),
-        QuerySchemaValidationMode.COMPATIBLE,
-    )
-
-    internal constructor(
-        namedAggregate: NamedAggregate,
-        collection: MongoCollection<Document>,
-        schemaProvider: QueryModelSchemaProvider,
-        validationMode: QuerySchemaValidationMode,
-        converter: AbstractMongoFilterConverter = EventStreamFilterConverter,
-    ) : this(namedAggregate, collection, converter, schemaProvider, validationMode)
-
     override val projectionConverter: MongoProjectionConverter = MongoProjectionConverter(EventStreamFieldConverter)
     override val sortConverter: MongoSortConverter = MongoSortConverter(EventStreamFieldConverter)
     override fun toTypedResult(document: Document): DomainEventStream {

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/event/MongoEventStreamQueryServiceFactory.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/event/MongoEventStreamQueryServiceFactory.kt
@@ -15,17 +15,37 @@ package me.ahoo.wow.mongo.query.event
 
 import com.mongodb.reactivestreams.client.MongoDatabase
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.modeling.materialize
 import me.ahoo.wow.mongo.AggregateSchemaInitializer.toEventStreamCollectionName
 import me.ahoo.wow.query.event.AbstractEventStreamQueryServiceFactory
 import me.ahoo.wow.query.event.EventStreamQueryService
+import me.ahoo.wow.query.schema.DefaultQueryModelSchemaProvider
+import me.ahoo.wow.query.schema.QuerySchemaContext
+import me.ahoo.wow.query.schema.QuerySchemaSource
+import me.ahoo.wow.query.schema.QuerySchemaValidationMode
 
-class MongoEventStreamQueryServiceFactory(private val database: MongoDatabase) :
+class MongoEventStreamQueryServiceFactory @JvmOverloads constructor(
+    private val database: MongoDatabase,
+    private val schemaSources: List<QuerySchemaSource> = emptyList(),
+    private val validationMode: QuerySchemaValidationMode = QuerySchemaValidationMode.COMPATIBLE,
+) :
     AbstractEventStreamQueryServiceFactory() {
 
     override fun createQueryService(namedAggregate: NamedAggregate): EventStreamQueryService {
         val collectionName = namedAggregate.toEventStreamCollectionName()
         val collection = database.getCollection(collectionName)
-        return MongoEventStreamQueryService(namedAggregate.materialize(), collection)
+        val materialized = namedAggregate.materialize()
+        val provider = DefaultQueryModelSchemaProvider(
+            context = QuerySchemaContext(materialized, QueryModel.EVENT_STREAM),
+            sources = schemaSources,
+            adapter = me.ahoo.wow.mongo.query.schema.MongoQuerySchemaAdapter(
+                collection,
+                database,
+                QueryModel.EVENT_STREAM,
+                EventStreamFieldConverter,
+            ),
+        )
+        return MongoEventStreamQueryService(materialized, collection, provider, validationMode)
     }
 }

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/event/MongoEventStreamQueryServiceFactory.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/event/MongoEventStreamQueryServiceFactory.kt
@@ -25,7 +25,7 @@ import me.ahoo.wow.query.schema.QuerySchemaContext
 import me.ahoo.wow.query.schema.QuerySchemaSource
 import me.ahoo.wow.query.schema.QuerySchemaValidationMode
 
-class MongoEventStreamQueryServiceFactory @JvmOverloads constructor(
+class MongoEventStreamQueryServiceFactory(
     private val database: MongoDatabase,
     private val schemaSources: List<QuerySchemaSource> = emptyList(),
     private val validationMode: QuerySchemaValidationMode = QuerySchemaValidationMode.COMPATIBLE,
@@ -46,6 +46,11 @@ class MongoEventStreamQueryServiceFactory @JvmOverloads constructor(
                 EventStreamFieldConverter,
             ),
         )
-        return MongoEventStreamQueryService(materialized, collection, provider, validationMode)
+        return MongoEventStreamQueryService(
+            namedAggregate = materialized,
+            collection = collection,
+            schemaProvider = provider,
+            validationMode = validationMode,
+        )
     }
 }

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/schema/MongoQuerySchemaAdapter.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/schema/MongoQuerySchemaAdapter.kt
@@ -22,6 +22,7 @@ import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.api.query.schema.QueryValueType
 import me.ahoo.wow.api.query.schema.Temporal
 import me.ahoo.wow.mongo.query.snapshot.SnapshotFieldConverter
+import me.ahoo.wow.query.converter.FieldConverter
 import me.ahoo.wow.query.schema.LogicalQueryFieldSchema
 import me.ahoo.wow.query.schema.LogicalQuerySchema
 import me.ahoo.wow.query.schema.QueryFieldBinding
@@ -35,10 +36,17 @@ import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toFlux
 import java.util.Optional
 
-class MongoQuerySchemaAdapter(
+class MongoQuerySchemaAdapter internal constructor(
     private val collection: MongoCollection<Document>,
-    private val database: MongoDatabase? = null,
+    private val database: MongoDatabase?,
+    private val model: QueryModel,
+    private val fieldConverter: FieldConverter,
 ) : QuerySchemaBackendAdapter {
+    constructor(
+        collection: MongoCollection<Document>,
+        database: MongoDatabase? = null,
+    ) : this(collection, database, QueryModel.SNAPSHOT, SnapshotFieldConverter)
+
     override fun resolve(logicalSchema: LogicalQuerySchema): Mono<QueryModelSchema> = loadFacts(logicalSchema)
 
     private fun loadFacts(logicalSchema: LogicalQuerySchema): Mono<QueryModelSchema> = Mono.defer {
@@ -51,7 +59,7 @@ class MongoQuerySchemaAdapter(
             ?.defaultIfEmpty(Optional.empty())
             ?: Mono.just(Optional.empty())
         Mono.zip(indexes, validator).map { facts ->
-            bind(logicalSchema, facts.t1, facts.t2.orElse(null))
+            bind(logicalSchema, facts.t1, facts.t2.orElse(null), model, fieldConverter)
         }
     }.onErrorMap { error ->
         if (error is QuerySchemaUnavailableException) {
@@ -66,6 +74,20 @@ class MongoQuerySchemaAdapter(
             logicalSchema: LogicalQuerySchema,
             indexes: List<Document>,
             validatorSchema: Document?,
+        ): QueryModelSchema = bind(
+            logicalSchema,
+            indexes,
+            validatorSchema,
+            QueryModel.SNAPSHOT,
+            SnapshotFieldConverter,
+        )
+
+        internal fun bind(
+            logicalSchema: LogicalQuerySchema,
+            indexes: List<Document>,
+            validatorSchema: Document?,
+            model: QueryModel,
+            fieldConverter: FieldConverter,
         ): QueryModelSchema {
             val storageSchemas = validatorSchema.storageSchemas()
             val capabilities = if (indexes.hasTextIndex()) {
@@ -74,14 +96,14 @@ class MongoQuerySchemaAdapter(
                 emptySet()
             }
             val invalidContainers = logicalSchema.fields.mapNotNullTo(linkedSetOf()) { (logicalField, fieldSchema) ->
-                val storageSchema = storageSchemas[SnapshotFieldConverter.convert(logicalField.value)]
+                val storageSchema = storageSchemas[fieldConverter.convert(logicalField.value)]
                 logicalField.value.takeIf { fieldSchema.invalidContainer(storageSchema) }
             }
             return QueryModelSchema(
-                model = QueryModel.SNAPSHOT,
+                model = model,
                 capabilities = capabilities,
                 fields = logicalSchema.fields.mapValues { (logicalField, logicalSchema) ->
-                    val physicalPath = SnapshotFieldConverter.convert(logicalField.value)
+                    val physicalPath = fieldConverter.convert(logicalField.value)
                     val storageSchema = storageSchemas[physicalPath]
                     val binding = QueryFieldBinding(physicalPath, storageSchema?.types?.singleOrNull())
                     if (invalidContainers.any { logicalField.value == it || logicalField.value.startsWith("$it.") }) {

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/schema/MongoQuerySchemaAdapter.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/schema/MongoQuerySchemaAdapter.kt
@@ -36,17 +36,12 @@ import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toFlux
 import java.util.Optional
 
-class MongoQuerySchemaAdapter internal constructor(
+class MongoQuerySchemaAdapter(
     private val collection: MongoCollection<Document>,
-    private val database: MongoDatabase?,
-    private val model: QueryModel,
-    private val fieldConverter: FieldConverter,
+    private val database: MongoDatabase? = null,
+    private val model: QueryModel = QueryModel.SNAPSHOT,
+    private val fieldConverter: FieldConverter = SnapshotFieldConverter,
 ) : QuerySchemaBackendAdapter {
-    constructor(
-        collection: MongoCollection<Document>,
-        database: MongoDatabase? = null,
-    ) : this(collection, database, QueryModel.SNAPSHOT, SnapshotFieldConverter)
-
     override fun resolve(logicalSchema: LogicalQuerySchema): Mono<QueryModelSchema> = loadFacts(logicalSchema)
 
     private fun loadFacts(logicalSchema: LogicalQuerySchema): Mono<QueryModelSchema> = Mono.defer {

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryService.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoSnapshotQueryService.kt
@@ -15,7 +15,6 @@ package me.ahoo.wow.mongo.query.snapshot
 
 import com.mongodb.reactivestreams.client.MongoCollection
 import me.ahoo.wow.api.modeling.NamedAggregate
-import me.ahoo.wow.api.query.AggregationMetric
 import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.FilterExpression
@@ -45,10 +44,8 @@ import me.ahoo.wow.query.schema.resolve
 import me.ahoo.wow.query.snapshot.SnapshotQueryService
 import me.ahoo.wow.serialization.JsonSerializer
 import org.bson.Document
-import org.bson.types.Decimal128
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
-import reactor.kotlin.core.publisher.toFlux
 
 class MongoSnapshotQueryService<S : Any> private constructor(
     override val namedAggregate: NamedAggregate,
@@ -106,49 +103,7 @@ class MongoSnapshotQueryService<S : Any> private constructor(
     override fun resolve(filter: FilterExpression) = schemaProvider.resolve(filter, validationMode)
 
     override fun aggregate(query: AggregationQuery): Flux<DynamicDocument> {
-        return schemaProvider.resolve(query, validationMode).flatMapMany { resolved ->
-            val executionQuery = resolved.query
-            val result = collection.aggregate(
-                MongoAggregationCompiler(converter).compile(executionQuery, resolved.schema),
-            ).toFlux().map { it.toAggregationResult(executionQuery) }
-            if (executionQuery.groupBy.isEmpty()) {
-                result.switchIfEmpty(Flux.just(executionQuery.emptySummary()))
-            } else {
-                result
-            }
-        }
-    }
-
-    private fun Document.toAggregationResult(query: AggregationQuery): DynamicDocument {
-        query.groupBy.forEach { group ->
-            this[group.alias] = get(group.alias).toTermsValue(group.alias)
-        }
-        query.metrics.forEach { metric ->
-            this[metric.alias] = when (metric) {
-                is AggregationMetric.Count -> (get(metric.alias) as Number).toLong()
-                is AggregationMetric.Any -> get(metric.alias).toTermsValue(metric.alias)
-                is AggregationMetric.Numeric -> get(metric.alias).toFiniteDouble(metric.alias)
-            }
-        }
-        return toDynamicDocument()
-    }
-
-    private fun Any?.toTermsValue(alias: String): Any? =
-        if (this is Decimal128) toFiniteDouble(alias) else this
-
-    private fun AggregationQuery.emptySummary(): DynamicDocument = metrics.associateTo(Document()) { metric ->
-        metric.alias to if (metric is AggregationMetric.Count) 0L else null
-    }.toDynamicDocument()
-
-    private fun Any?.toFiniteDouble(alias: String): Double? {
-        val value = when (this) {
-            null -> return null
-            is Decimal128 -> bigDecimalValue().toDouble()
-            is Number -> toDouble()
-            else -> error("Aggregation metric [$alias] must be numeric, but was [${this::class.java.name}].")
-        }
-        require(value.isFinite()) { "Aggregation metric [$alias] must be finite." }
-        return value
+        return schemaProvider.resolve(query, validationMode).flatMapMany(::executeAggregation)
     }
 
     companion object {

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/schema/MongoQuerySchemaAdapterTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/schema/MongoQuerySchemaAdapterTest.kt
@@ -33,9 +33,11 @@ import me.ahoo.wow.api.query.TodayFilter
 import me.ahoo.wow.api.query.schema.QueryCapability
 import me.ahoo.wow.api.query.schema.QueryCardinality
 import me.ahoo.wow.api.query.schema.QueryCompatibilityLevel
+import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.api.query.schema.QueryValueType
 import me.ahoo.wow.api.query.schema.Temporal
 import me.ahoo.wow.mongo.query.AbstractMongoFilterConverter
+import me.ahoo.wow.mongo.query.event.EventStreamFieldConverter
 import me.ahoo.wow.mongo.query.snapshot.MongoSnapshotQueryService
 import me.ahoo.wow.mongo.query.snapshot.MongoSnapshotQueryServiceFactory
 import me.ahoo.wow.query.converter.FieldConverter
@@ -59,6 +61,22 @@ import java.util.concurrent.atomic.AtomicInteger
 
 @Suppress("LargeClass")
 class MongoQuerySchemaAdapterTest {
+    @Test
+    fun `event stream schema should bind logical id to MongoDB document id`() {
+        val id = LogicalField("id")
+        val schema = MongoQuerySchemaAdapter.bind(
+            logicalSchema = LogicalQuerySchema(mapOf(id to field(QueryValueType.STRING))),
+            indexes = emptyList(),
+            validatorSchema = null,
+            model = QueryModel.EVENT_STREAM,
+            fieldConverter = EventStreamFieldConverter,
+        )
+
+        schema.model.assert().isEqualTo(QueryModel.EVENT_STREAM)
+        schema.fields.getValue(id).bindings.getValue(QueryCapability.EXACT_MATCH).physicalPath.assert()
+            .isEqualTo("_id")
+    }
+
     @Test
     fun `numeric arrays should retain backend-supported range and aggregation bindings`() {
         val amount = LogicalField("state.amounts")

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
@@ -24,6 +24,7 @@ import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.api.query.schema.QueryValueType
 import me.ahoo.wow.api.query.schema.Temporal
 import me.ahoo.wow.mongo.query.AbstractMongoFilterConverter
+import me.ahoo.wow.mongo.query.aggregation.MongoAggregationCompiler
 import me.ahoo.wow.query.converter.FieldConverter
 import me.ahoo.wow.query.dsl.aggregation
 import me.ahoo.wow.query.schema.QueryFieldBinding
@@ -389,6 +390,20 @@ class MongoAggregationCompilerTest {
         pipeline[2].toBsonDocument().toJson().assert()
             .contains("physical.state.items.quantity")
             .doesNotContain("deleted")
+    }
+
+    @Test
+    fun `custom field converter should apply to aggregation fields without schema`() {
+        val converter = object : AbstractMongoFilterConverter() {
+            override val fieldConverter: FieldConverter = FieldConverter { "physical.$it" }
+        }
+        val query = aggregation {
+            terms("state.status", "status")
+            count("count")
+        }
+
+        MongoAggregationCompiler(converter).compile(query)[2].toBsonDocument().toJson().assert()
+            .contains("\$physical.state.status")
     }
 
     private fun schema(vararg fields: Pair<LogicalField, QueryFieldSchema>) = QueryModelSchema(

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/QueryService.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/QueryService.kt
@@ -16,6 +16,7 @@
 package me.ahoo.wow.query
 
 import me.ahoo.wow.api.modeling.NamedAggregateDecorator
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.FilterExpression
@@ -30,7 +31,7 @@ import reactor.core.publisher.Mono
 /**
  * Interface for performing various query operations on an aggregate.
  *
- * This service provides methods to execute single, list, and paged queries, as well as count operations,
+ * This service provides methods to execute single, list, paged, aggregation, and count queries,
  * with support for both typed and dynamic (untyped) results.
  *
 */
@@ -41,6 +42,9 @@ interface QueryService<R : Any> : NamedAggregateDecorator {
     fun dynamicList(listQuery: IListQuery): Flux<DynamicDocument>
     fun paged(pagedQuery: IPagedQuery): Mono<PagedList<R>>
     fun dynamicPaged(pagedQuery: IPagedQuery): Mono<PagedList<DynamicDocument>>
+
+    fun aggregate(query: AggregationQuery): Flux<DynamicDocument> =
+        Flux.error(UnsupportedOperationException("Aggregation is not supported."))
 
     fun count(filter: FilterExpression): Mono<Long>
 

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/event/EventStreamQueryService.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/event/EventStreamQueryService.kt
@@ -28,6 +28,13 @@ import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
 interface EventStreamQueryService : QueryService<DomainEventStream> {
+    /**
+     * Aggregates persisted event-stream documents.
+     *
+     * The root filter applies to the event-stream envelope. Expanding `body` creates an event-item scope, so its
+     * filters, groups, and metrics use fields relative to each event item. Event payload fields are available only
+     * when an explicit EventStream query schema declares them and the selected backend indexes them.
+     */
     fun aggregate(query: AggregationQuery): Flux<DynamicDocument> =
         Flux.error(UnsupportedOperationException("Event stream aggregation is not supported."))
 }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/event/EventStreamQueryService.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/event/EventStreamQueryService.kt
@@ -14,7 +14,6 @@
 package me.ahoo.wow.query.event
 
 import me.ahoo.wow.api.modeling.NamedAggregate
-import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.IListQuery
 import me.ahoo.wow.api.query.IPagedQuery
@@ -27,17 +26,7 @@ import me.ahoo.wow.query.schema.QuerySchemaUnavailableException
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
-interface EventStreamQueryService : QueryService<DomainEventStream> {
-    /**
-     * Aggregates persisted event-stream documents.
-     *
-     * The root filter applies to the event-stream envelope. Expanding `body` creates an event-item scope, so its
-     * filters, groups, and metrics use fields relative to each event item. Event payload fields are available only
-     * when an explicit EventStream query schema declares them and the selected backend indexes them.
-     */
-    fun aggregate(query: AggregationQuery): Flux<DynamicDocument> =
-        Flux.error(UnsupportedOperationException("Event stream aggregation is not supported."))
-}
+interface EventStreamQueryService : QueryService<DomainEventStream>
 
 fun EventStreamQueryService.requiredQueryModelSchemaProvider(): QueryModelSchemaProvider =
     this as? QueryModelSchemaProvider

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/event/EventStreamQueryService.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/event/EventStreamQueryService.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.query.event
 
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.IListQuery
 import me.ahoo.wow.api.query.IPagedQuery
@@ -21,10 +22,21 @@ import me.ahoo.wow.api.query.ISingleQuery
 import me.ahoo.wow.api.query.PagedList
 import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.query.QueryService
+import me.ahoo.wow.query.schema.QueryModelSchemaProvider
+import me.ahoo.wow.query.schema.QuerySchemaUnavailableException
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
-interface EventStreamQueryService : QueryService<DomainEventStream>
+interface EventStreamQueryService : QueryService<DomainEventStream> {
+    fun aggregate(query: AggregationQuery): Flux<DynamicDocument> =
+        Flux.error(UnsupportedOperationException("Event stream aggregation is not supported."))
+}
+
+fun EventStreamQueryService.requiredQueryModelSchemaProvider(): QueryModelSchemaProvider =
+    this as? QueryModelSchemaProvider
+        ?: throw QuerySchemaUnavailableException(
+            "Event stream query service [$namedAggregate] does not provide QueryModelSchema.",
+        )
 
 class NoOpEventStreamQueryService(override val namedAggregate: NamedAggregate) : EventStreamQueryService {
     override fun single(singleQuery: ISingleQuery): Mono<DomainEventStream> {

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/event/QueryDsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/event/QueryDsl.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.query.event
 
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.FilterExpression
@@ -55,4 +56,8 @@ fun FilterExpression.count(queryService: EventStreamQueryService): Mono<Long> {
 @Deprecated("Use FilterExpression.count.")
 fun Condition.count(queryService: EventStreamQueryService): Mono<Long> {
     return queryService.count(this)
+}
+
+fun AggregationQuery.query(queryService: EventStreamQueryService): Flux<DynamicDocument> {
+    return queryService.aggregate(this)
 }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/event/QueryDsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/event/QueryDsl.kt
@@ -58,6 +58,7 @@ fun Condition.count(queryService: EventStreamQueryService): Mono<Long> {
     return queryService.count(this)
 }
 
+/** Executes this aggregation against persisted event-stream documents. */
 fun AggregationQuery.query(queryService: EventStreamQueryService): Flux<DynamicDocument> {
     return queryService.aggregate(this)
 }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/event/filter/EventStreamQueryFilter.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/event/filter/EventStreamQueryFilter.kt
@@ -86,7 +86,9 @@ class TailEventStreamQueryFilter(private val queryServiceFactory: EventStreamQue
                 context.asCountQuery().setResult(result)
             }
 
-            QueryType.AGGREGATION -> error("Event stream query does not support aggregation.")
+            QueryType.AGGREGATION -> {
+                context.asAggregationQuery().setResult(queryService::aggregate)
+            }
         }
         return next.filter(context)
     }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/event/filter/EventStreamQueryHandler.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/event/filter/EventStreamQueryHandler.kt
@@ -13,6 +13,9 @@
 
 package me.ahoo.wow.query.event.filter
 
+import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.filter.ErrorHandler
 import me.ahoo.wow.filter.FilterChain
@@ -20,8 +23,13 @@ import me.ahoo.wow.filter.LogErrorHandler
 import me.ahoo.wow.query.filter.AbstractQueryHandler
 import me.ahoo.wow.query.filter.QueryContext
 import me.ahoo.wow.query.filter.QueryHandler
+import me.ahoo.wow.query.filter.QueryType
+import reactor.core.publisher.Flux
 
-interface EventStreamQueryHandler : QueryHandler<DomainEventStream>
+interface EventStreamQueryHandler : QueryHandler<DomainEventStream> {
+    fun aggregate(namedAggregate: NamedAggregate, query: AggregationQuery): Flux<DynamicDocument> =
+        Flux.error(UnsupportedOperationException("Event stream aggregation is not supported."))
+}
 
 class DefaultEventStreamQueryHandler(
     chain: FilterChain<QueryContext<*, *>>,
@@ -29,4 +37,7 @@ class DefaultEventStreamQueryHandler(
 ) : EventStreamQueryHandler, AbstractQueryHandler<DomainEventStream>(
     chain,
     errorHandler,
-)
+) {
+    override fun aggregate(namedAggregate: NamedAggregate, query: AggregationQuery): Flux<DynamicDocument> =
+        flux(namedAggregate, QueryType.AGGREGATION, query)
+}

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/event/filter/EventStreamQueryHandler.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/event/filter/EventStreamQueryHandler.kt
@@ -13,9 +13,6 @@
 
 package me.ahoo.wow.query.event.filter
 
-import me.ahoo.wow.api.modeling.NamedAggregate
-import me.ahoo.wow.api.query.AggregationQuery
-import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.filter.ErrorHandler
 import me.ahoo.wow.filter.FilterChain
@@ -23,13 +20,8 @@ import me.ahoo.wow.filter.LogErrorHandler
 import me.ahoo.wow.query.filter.AbstractQueryHandler
 import me.ahoo.wow.query.filter.QueryContext
 import me.ahoo.wow.query.filter.QueryHandler
-import me.ahoo.wow.query.filter.QueryType
-import reactor.core.publisher.Flux
 
-interface EventStreamQueryHandler : QueryHandler<DomainEventStream> {
-    fun aggregate(namedAggregate: NamedAggregate, query: AggregationQuery): Flux<DynamicDocument> =
-        Flux.error(UnsupportedOperationException("Event stream aggregation is not supported."))
-}
+interface EventStreamQueryHandler : QueryHandler<DomainEventStream>
 
 class DefaultEventStreamQueryHandler(
     chain: FilterChain<QueryContext<*, *>>,
@@ -37,7 +29,4 @@ class DefaultEventStreamQueryHandler(
 ) : EventStreamQueryHandler, AbstractQueryHandler<DomainEventStream>(
     chain,
     errorHandler,
-) {
-    override fun aggregate(namedAggregate: NamedAggregate, query: AggregationQuery): Flux<DynamicDocument> =
-        flux(namedAggregate, QueryType.AGGREGATION, query)
-}
+)

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/filter/QueryHandler.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/filter/QueryHandler.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.query.filter
 
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.FilterExpression
@@ -36,6 +37,8 @@ interface QueryHandler<R : Any> : Handler<QueryContext<*, *>> {
     fun dynamicList(namedAggregate: NamedAggregate, listQuery: IListQuery): Flux<DynamicDocument>
     fun paged(namedAggregate: NamedAggregate, pagedQuery: IPagedQuery): Mono<PagedList<R>>
     fun dynamicPaged(namedAggregate: NamedAggregate, pagedQuery: IPagedQuery): Mono<PagedList<DynamicDocument>>
+    fun aggregate(namedAggregate: NamedAggregate, query: AggregationQuery): Flux<DynamicDocument> =
+        Flux.error(UnsupportedOperationException("Aggregation is not supported."))
     fun count(namedAggregate: NamedAggregate, filter: FilterExpression): Mono<Long>
 
     @Deprecated("Use count with FilterExpression.")
@@ -96,6 +99,9 @@ abstract class AbstractQueryHandler<R : Any>(
         namedAggregate: NamedAggregate,
         pagedQuery: IPagedQuery
     ): Mono<PagedList<DynamicDocument>> = mono(namedAggregate, QueryType.DYNAMIC_PAGED, pagedQuery)
+
+    override fun aggregate(namedAggregate: NamedAggregate, query: AggregationQuery): Flux<DynamicDocument> =
+        flux(namedAggregate, QueryType.AGGREGATION, query)
 
     override fun count(namedAggregate: NamedAggregate, filter: FilterExpression): Mono<Long> =
         mono(namedAggregate, QueryType.COUNT, filter)

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaMerger.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaMerger.kt
@@ -24,15 +24,22 @@ import me.ahoo.wow.query.schema.QuerySchemaDeclarationProperties.REQUIRED
 import me.ahoo.wow.query.schema.QuerySchemaDeclarationProperties.SEMANTIC_TYPE
 import me.ahoo.wow.query.schema.QuerySchemaDeclarationProperties.TITLE
 import me.ahoo.wow.query.schema.QuerySchemaDeclarationProperties.VALUE_TYPES
+import me.ahoo.wow.serialization.MessageRecords
+import me.ahoo.wow.serialization.state.StateAggregateRecords
 
 internal class QuerySchemaMerger {
     fun merge(
         system: QuerySchemaDeclaration,
         extensions: List<PrioritizedQuerySchemaDeclaration>,
     ): LogicalQuerySchema {
+        val extensionRoot = if (LogicalField(StateAggregateRecords.STATE) in system.fields) {
+            StateAggregateRecords.STATE
+        } else {
+            "${MessageRecords.BODY}.${MessageRecords.BODY}"
+        }
         extensions.forEach { extension ->
             extension.declaration.fields.forEach { (field, declaration) ->
-                validateExtensionPath(field)
+                validateExtensionPath(field, extensionRoot)
                 system.fields[field]?.rejectSystemOverwrite(field, declaration)
             }
         }
@@ -63,9 +70,9 @@ internal class QuerySchemaMerger {
         )
     }
 
-    private fun validateExtensionPath(field: LogicalField) {
-        if (field.value != "state" && !field.value.startsWith("state.")) {
-            throw QuerySchemaConflictException("Snapshot query schema extension must be under [state]: [$field].")
+    private fun validateExtensionPath(field: LogicalField, extensionRoot: String) {
+        if (field.value != extensionRoot && !field.value.startsWith("$extensionRoot.")) {
+            throw QuerySchemaConflictException("Query schema extension must be under [$extensionRoot]: [$field].")
         }
     }
 

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/SystemQuerySchemaSource.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/SystemQuerySchemaSource.kt
@@ -68,7 +68,6 @@ object SystemQuerySchemaSource : QuerySchemaSource {
                 MessageRecords.ID.stringField(),
                 MessageRecords.CONTEXT_NAME.stringField(),
                 MessageRecords.AGGREGATE_NAME.stringField(),
-                MessageRecords.NAME.stringField(),
                 MessageRecords.HEADER.objectField(DeclarationValue.Set(true)),
                 MessageRecords.AGGREGATE_ID.stringField(),
                 MessageRecords.TENANT_ID.stringField(),

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/SystemQuerySchemaSource.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/SystemQuerySchemaSource.kt
@@ -20,6 +20,7 @@ import me.ahoo.wow.api.query.schema.QuerySemanticType
 import me.ahoo.wow.api.query.schema.QueryValueType
 import me.ahoo.wow.api.query.schema.Temporal
 import me.ahoo.wow.serialization.MessageRecords
+import me.ahoo.wow.serialization.event.DomainEventRecords
 import me.ahoo.wow.serialization.state.SnapshotRecords
 import me.ahoo.wow.serialization.state.StateAggregateRecords
 import reactor.core.publisher.Flux
@@ -32,11 +33,10 @@ object SystemQuerySchemaSource : QuerySchemaSource {
     override fun load(context: QuerySchemaContext): Flux<QuerySchemaDeclaration> =
         Flux.just(declaration(context.model))
 
-    fun declaration(model: QueryModel): QuerySchemaDeclaration {
-        if (model != QueryModel.SNAPSHOT) {
-            throw QuerySchemaValidationException("Unsupported System query model: [$model].")
-        }
-        return SNAPSHOT_DECLARATION
+    fun declaration(model: QueryModel): QuerySchemaDeclaration = when (model) {
+        QueryModel.SNAPSHOT -> SNAPSHOT_DECLARATION
+        QueryModel.EVENT_STREAM -> EVENT_STREAM_DECLARATION
+        else -> throw QuerySchemaValidationException("Unsupported System query model: [$model].")
     }
 
     private val SNAPSHOT_DECLARATION = QuerySchemaDeclaration(
@@ -62,6 +62,32 @@ object SystemQuerySchemaSource : QuerySchemaSource {
         ),
     )
 
+    private val EVENT_STREAM_DECLARATION = QuerySchemaDeclaration(
+        Collections.unmodifiableMap(
+            linkedMapOf(
+                MessageRecords.ID.stringField(),
+                MessageRecords.CONTEXT_NAME.stringField(),
+                MessageRecords.AGGREGATE_NAME.stringField(),
+                MessageRecords.NAME.stringField(),
+                MessageRecords.HEADER.objectField(DeclarationValue.Set(true)),
+                MessageRecords.AGGREGATE_ID.stringField(),
+                MessageRecords.TENANT_ID.stringField(),
+                MessageRecords.OWNER_ID.stringField(),
+                MessageRecords.SPACE_ID.stringField(),
+                MessageRecords.COMMAND_ID.stringField(),
+                MessageRecords.REQUEST_ID.stringField(),
+                MessageRecords.VERSION.integerField(),
+                MessageRecords.CREATE_TIME.epochField(),
+                MessageRecords.BODY.objectField(cardinality = QueryCardinality.MANY),
+                "${MessageRecords.BODY}.${MessageRecords.ID}".stringField(),
+                "${MessageRecords.BODY}.${MessageRecords.NAME}".stringField(),
+                "${MessageRecords.BODY}.${DomainEventRecords.REVISION}".stringField(),
+                "${MessageRecords.BODY}.${MessageRecords.BODY_TYPE}".stringField(),
+                "${MessageRecords.BODY}.${MessageRecords.BODY}".objectField(DeclarationValue.Set(false)),
+            ),
+        ),
+    )
+
     private fun String.stringField() = field(QueryValueType.STRING)
 
     private fun String.integerField() = field(QueryValueType.INTEGER)
@@ -70,7 +96,8 @@ object SystemQuerySchemaSource : QuerySchemaSource {
 
     private fun String.objectField(
         dynamicChildren: DeclarationValue<Boolean> = DeclarationValue.Unset,
-    ) = field(QueryValueType.OBJECT, dynamicChildren = dynamicChildren)
+        cardinality: QueryCardinality = QueryCardinality.SINGLE,
+    ) = field(QueryValueType.OBJECT, dynamicChildren = dynamicChildren, cardinality = cardinality)
 
     private fun String.epochField() = field(
         QueryValueType.INTEGER,
@@ -81,11 +108,12 @@ object SystemQuerySchemaSource : QuerySchemaSource {
         valueType: QueryValueType,
         semanticType: DeclarationValue<QuerySemanticType?> = DeclarationValue.Unset,
         dynamicChildren: DeclarationValue<Boolean> = DeclarationValue.Unset,
+        cardinality: QueryCardinality = QueryCardinality.SINGLE,
     ): Pair<LogicalField, QueryFieldDeclaration> = LogicalField(this) to QueryFieldDeclaration(
         valueTypes = DeclarationValue.Set(setOf(valueType)),
         nullable = DeclarationValue.Set(false),
         required = DeclarationValue.Set(true),
-        cardinality = DeclarationValue.Set(QueryCardinality.SINGLE),
+        cardinality = DeclarationValue.Set(cardinality),
         semanticType = semanticType,
         dynamicChildren = dynamicChildren,
     )

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/SnapshotQueryService.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/SnapshotQueryService.kt
@@ -15,7 +15,6 @@ package me.ahoo.wow.query.snapshot
 
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.api.naming.Named
-import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.IListQuery
 import me.ahoo.wow.api.query.IPagedQuery
@@ -29,10 +28,7 @@ import me.ahoo.wow.query.schema.QuerySchemaUnavailableException
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 
-interface SnapshotQueryService<S : Any> : Named, QueryService<MaterializedSnapshot<S>> {
-    fun aggregate(query: AggregationQuery): Flux<DynamicDocument> =
-        Flux.error(UnsupportedOperationException("Snapshot aggregation is not supported by [$name]."))
-}
+interface SnapshotQueryService<S : Any> : Named, QueryService<MaterializedSnapshot<S>>
 
 fun SnapshotQueryService<*>.requiredQueryModelSchemaProvider(): QueryModelSchemaProvider =
     this as? QueryModelSchemaProvider

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/SnapshotQueryHandler.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/filter/SnapshotQueryHandler.kt
@@ -13,9 +13,6 @@
 
 package me.ahoo.wow.query.snapshot.filter
 
-import me.ahoo.wow.api.modeling.NamedAggregate
-import me.ahoo.wow.api.query.AggregationQuery
-import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.MaterializedSnapshot
 import me.ahoo.wow.filter.ErrorHandler
 import me.ahoo.wow.filter.FilterChain
@@ -23,13 +20,8 @@ import me.ahoo.wow.filter.LogErrorHandler
 import me.ahoo.wow.query.filter.AbstractQueryHandler
 import me.ahoo.wow.query.filter.QueryContext
 import me.ahoo.wow.query.filter.QueryHandler
-import me.ahoo.wow.query.filter.QueryType
-import reactor.core.publisher.Flux
 
-interface SnapshotQueryHandler : QueryHandler<MaterializedSnapshot<Any>> {
-    fun aggregate(namedAggregate: NamedAggregate, query: AggregationQuery): Flux<DynamicDocument> =
-        Flux.error(UnsupportedOperationException("Snapshot aggregation is not supported."))
-}
+interface SnapshotQueryHandler : QueryHandler<MaterializedSnapshot<Any>>
 
 class DefaultSnapshotQueryHandler(
     chain: FilterChain<QueryContext<*, *>>,
@@ -37,7 +29,4 @@ class DefaultSnapshotQueryHandler(
 ) : SnapshotQueryHandler, AbstractQueryHandler<MaterializedSnapshot<Any>>(
     chain,
     errorHandler,
-) {
-    override fun aggregate(namedAggregate: NamedAggregate, query: AggregationQuery): Flux<DynamicDocument> =
-        flux(namedAggregate, QueryType.AGGREGATION, query)
-}
+)

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/QueryServiceCompatibilityTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/QueryServiceCompatibilityTest.kt
@@ -47,19 +47,10 @@ class QueryServiceCompatibilityTest {
     }
 
     @Test
-    fun `legacy query service should inherit unsupported aggregation`() {
-        val service = LegacyQueryService()
-        val query = AggregationQuery(metrics = listOf(AggregationMetric.Count("count")))
-
-        service.aggregate(query).test()
-            .expectErrorMessage("Aggregation is not supported.")
-            .verify()
-
-        @Suppress("UNCHECKED_CAST")
-        val legacyResult = Class.forName("${QueryService::class.java.name}\$DefaultImpls")
-            .getMethod("aggregate", QueryService::class.java, AggregationQuery::class.java)
-            .invoke(null, service, query) as Flux<DynamicDocument>
-        legacyResult.test()
+    fun `query service should inherit unsupported aggregation`() {
+        LegacyQueryService().aggregate(
+            AggregationQuery(metrics = listOf(AggregationMetric.Count("count"))),
+        ).test()
             .expectErrorMessage("Aggregation is not supported.")
             .verify()
     }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/QueryServiceCompatibilityTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/QueryServiceCompatibilityTest.kt
@@ -14,6 +14,8 @@
 package me.ahoo.wow.query
 
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.FilterExpression
@@ -33,14 +35,7 @@ class QueryServiceCompatibilityTest {
     @Test
     fun `legacy count should delegate once to filter implementation`() {
         lateinit var captured: FilterExpression
-        val service = object : QueryService<Any> {
-            override val namedAggregate = "test.test".toNamedAggregate()
-            override fun single(singleQuery: ISingleQuery): Mono<Any> = Mono.empty()
-            override fun dynamicSingle(singleQuery: ISingleQuery): Mono<DynamicDocument> = Mono.empty()
-            override fun list(listQuery: IListQuery): Flux<Any> = Flux.empty()
-            override fun dynamicList(listQuery: IListQuery): Flux<DynamicDocument> = Flux.empty()
-            override fun paged(pagedQuery: IPagedQuery): Mono<PagedList<Any>> = Mono.empty()
-            override fun dynamicPaged(pagedQuery: IPagedQuery): Mono<PagedList<DynamicDocument>> = Mono.empty()
+        val service = object : LegacyQueryService() {
             override fun count(filter: FilterExpression): Mono<Long> {
                 captured = filter
                 return Mono.just(1)
@@ -49,5 +44,34 @@ class QueryServiceCompatibilityTest {
 
         service.count(Condition.id("id-1")).test().expectNext(1).verifyComplete()
         captured.assert().isEqualTo(IdFilter("id-1"))
+    }
+
+    @Test
+    fun `legacy query service should inherit unsupported aggregation`() {
+        val service = LegacyQueryService()
+        val query = AggregationQuery(metrics = listOf(AggregationMetric.Count("count")))
+
+        service.aggregate(query).test()
+            .expectErrorMessage("Aggregation is not supported.")
+            .verify()
+
+        @Suppress("UNCHECKED_CAST")
+        val legacyResult = Class.forName("${QueryService::class.java.name}\$DefaultImpls")
+            .getMethod("aggregate", QueryService::class.java, AggregationQuery::class.java)
+            .invoke(null, service, query) as Flux<DynamicDocument>
+        legacyResult.test()
+            .expectErrorMessage("Aggregation is not supported.")
+            .verify()
+    }
+
+    private open class LegacyQueryService : QueryService<Any> {
+        override val namedAggregate = "test.test".toNamedAggregate()
+        override fun single(singleQuery: ISingleQuery): Mono<Any> = Mono.empty()
+        override fun dynamicSingle(singleQuery: ISingleQuery): Mono<DynamicDocument> = Mono.empty()
+        override fun list(listQuery: IListQuery): Flux<Any> = Flux.empty()
+        override fun dynamicList(listQuery: IListQuery): Flux<DynamicDocument> = Flux.empty()
+        override fun paged(pagedQuery: IPagedQuery): Mono<PagedList<Any>> = Mono.empty()
+        override fun dynamicPaged(pagedQuery: IPagedQuery): Mono<PagedList<DynamicDocument>> = Mono.empty()
+        override fun count(filter: FilterExpression): Mono<Long> = Mono.just(0)
     }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/event/NoOpSnapshotQueryServiceFactoryTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/event/NoOpSnapshotQueryServiceFactoryTest.kt
@@ -125,4 +125,12 @@ class NoOpSnapshotQueryServiceFactoryTest {
             .expectErrorMessage("Aggregation is not supported.")
             .verify()
     }
+
+    @Test
+    fun `aggregation DSL should delegate to event stream query service`() {
+        aggregation { count("count") }.query(queryService)
+            .test()
+            .expectErrorMessage("Aggregation is not supported.")
+            .verify()
+    }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/event/NoOpSnapshotQueryServiceFactoryTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/event/NoOpSnapshotQueryServiceFactoryTest.kt
@@ -15,6 +15,7 @@ package me.ahoo.wow.query.event
 
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.modeling.toNamedAggregate
+import me.ahoo.wow.query.dsl.aggregation
 import me.ahoo.wow.query.dsl.condition
 import me.ahoo.wow.query.dsl.filterExpression
 import me.ahoo.wow.query.dsl.listQuery
@@ -111,5 +112,13 @@ class NoOpSnapshotQueryServiceFactoryTest {
             .test()
             .expectNext(0)
             .verifyComplete()
+    }
+
+    @Test
+    fun `should report unsupported aggregation through query extension`() {
+        aggregation { count("count") }.query(queryService)
+            .test()
+            .expectError(UnsupportedOperationException::class.java)
+            .verify()
     }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/event/NoOpSnapshotQueryServiceFactoryTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/event/NoOpSnapshotQueryServiceFactoryTest.kt
@@ -14,7 +14,9 @@
 package me.ahoo.wow.query.event
 
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.modeling.toNamedAggregate
+import me.ahoo.wow.query.QueryService
 import me.ahoo.wow.query.dsl.aggregation
 import me.ahoo.wow.query.dsl.condition
 import me.ahoo.wow.query.dsl.filterExpression
@@ -115,10 +117,12 @@ class NoOpSnapshotQueryServiceFactoryTest {
     }
 
     @Test
-    fun `should report unsupported aggregation through query extension`() {
-        aggregation { count("count") }.query(queryService)
+    fun `generic query service should report unsupported aggregation`() {
+        val genericQueryService: QueryService<DomainEventStream> = queryService
+
+        genericQueryService.aggregate(aggregation { count("count") })
             .test()
-            .expectError(UnsupportedOperationException::class.java)
+            .expectErrorMessage("Aggregation is not supported.")
             .verify()
     }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/event/filter/DefaultEventStreamQueryHandlerTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/event/filter/DefaultEventStreamQueryHandlerTest.kt
@@ -14,11 +14,14 @@
 package me.ahoo.wow.query.event.filter
 
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.api.query.AggregationMetric
 import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.MatchAllFilter
 import me.ahoo.wow.api.query.SimpleDynamicDocument.Companion.toDynamicDocument
+import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.filter.FilterChain
 import me.ahoo.wow.filter.FilterChainBuilder
 import me.ahoo.wow.filter.LogErrorHandler
@@ -31,6 +34,7 @@ import me.ahoo.wow.query.event.NoOpEventStreamQueryService
 import me.ahoo.wow.query.event.NoOpEventStreamQueryServiceFactory
 import me.ahoo.wow.query.filter.DefaultQueryContext
 import me.ahoo.wow.query.filter.QueryContext
+import me.ahoo.wow.query.filter.QueryHandler
 import me.ahoo.wow.query.filter.QueryType
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import org.junit.jupiter.api.Test
@@ -136,5 +140,39 @@ class DefaultEventStreamQueryHandlerTest {
             .block()
 
         context.getRequiredResult().test().expectNext(row).verifyComplete()
+    }
+
+    @Test
+    fun `legacy event stream handler should inherit unsupported aggregation`() {
+        val legacy = object :
+            EventStreamQueryHandler,
+            QueryHandler<DomainEventStream> by queryHandler {}
+        val query = AggregationQuery(metrics = listOf(AggregationMetric.Count("count")))
+
+        legacy.aggregate(MOCK_AGGREGATE_METADATA, query).test()
+            .expectErrorMessage("Event stream aggregation is not supported.")
+            .verify()
+
+        @Suppress("UNCHECKED_CAST")
+        val legacyResult = Class.forName("${EventStreamQueryHandler::class.java.name}\$DefaultImpls")
+            .getMethod(
+                "aggregate",
+                EventStreamQueryHandler::class.java,
+                NamedAggregate::class.java,
+                AggregationQuery::class.java,
+            ).invoke(null, legacy, MOCK_AGGREGATE_METADATA, query) as Flux<DynamicDocument>
+        legacyResult.test()
+            .expectErrorMessage("Event stream aggregation is not supported.")
+            .verify()
+
+        @Suppress("UNCHECKED_CAST")
+        val legacyCount = Class.forName("${EventStreamQueryHandler::class.java.name}\$DefaultImpls")
+            .getMethod(
+                "count",
+                EventStreamQueryHandler::class.java,
+                NamedAggregate::class.java,
+                Condition::class.java,
+            ).invoke(null, legacy, MOCK_AGGREGATE_METADATA, Condition.id("id")) as Mono<Long>
+        legacyCount.test().expectNext(0).verifyComplete()
     }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/event/filter/DefaultEventStreamQueryHandlerTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/event/filter/DefaultEventStreamQueryHandlerTest.kt
@@ -18,19 +18,22 @@ import me.ahoo.wow.api.query.AggregationMetric
 import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.MatchAllFilter
+import me.ahoo.wow.api.query.SimpleDynamicDocument.Companion.toDynamicDocument
 import me.ahoo.wow.filter.FilterChain
 import me.ahoo.wow.filter.FilterChainBuilder
 import me.ahoo.wow.filter.LogErrorHandler
 import me.ahoo.wow.query.dsl.condition
 import me.ahoo.wow.query.dsl.listQuery
 import me.ahoo.wow.query.dsl.singleQuery
+import me.ahoo.wow.query.event.EventStreamQueryService
+import me.ahoo.wow.query.event.EventStreamQueryServiceFactory
+import me.ahoo.wow.query.event.NoOpEventStreamQueryService
 import me.ahoo.wow.query.event.NoOpEventStreamQueryServiceFactory
 import me.ahoo.wow.query.filter.DefaultQueryContext
 import me.ahoo.wow.query.filter.QueryContext
 import me.ahoo.wow.query.filter.QueryType
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.kotlin.test.test
@@ -118,14 +121,20 @@ class DefaultEventStreamQueryHandlerTest {
     }
 
     @Test
-    fun `event stream tail should reject aggregation queries`() {
+    fun `event stream tail should execute aggregation queries`() {
+        val row = mutableMapOf<String, Any?>("count" to 0L).toDynamicDocument()
+        val queryService = object : EventStreamQueryService by NoOpEventStreamQueryService(MOCK_AGGREGATE_METADATA) {
+            override fun aggregate(query: AggregationQuery): Flux<DynamicDocument> = Flux.just(row)
+        }
         val context = DefaultQueryContext<AggregationQuery, Flux<DynamicDocument>>(
             QueryType.AGGREGATION,
             MOCK_AGGREGATE_METADATA,
         ).setQuery(AggregationQuery(metrics = listOf(AggregationMetric.Count("count"))))
 
-        assertThrows<IllegalStateException> {
-            tailSnapshotQueryFilter.filter(context, FilterChain { Mono.empty() })
-        }.message.assert().isEqualTo("Event stream query does not support aggregation.")
+        TailEventStreamQueryFilter(EventStreamQueryServiceFactory { queryService })
+            .filter(context, FilterChain { Mono.empty() })
+            .block()
+
+        context.getRequiredResult().test().expectNext(row).verifyComplete()
     }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/event/filter/DefaultEventStreamQueryHandlerTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/event/filter/DefaultEventStreamQueryHandlerTest.kt
@@ -14,10 +14,8 @@
 package me.ahoo.wow.query.event.filter
 
 import me.ahoo.test.asserts.assert
-import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.api.query.AggregationMetric
 import me.ahoo.wow.api.query.AggregationQuery
-import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.MatchAllFilter
 import me.ahoo.wow.api.query.SimpleDynamicDocument.Companion.toDynamicDocument
@@ -143,36 +141,16 @@ class DefaultEventStreamQueryHandlerTest {
     }
 
     @Test
-    fun `legacy event stream handler should inherit unsupported aggregation`() {
-        val legacy = object :
+    fun `event stream handler should inherit unsupported aggregation`() {
+        val handler = object :
             EventStreamQueryHandler,
             QueryHandler<DomainEventStream> by queryHandler {}
-        val query = AggregationQuery(metrics = listOf(AggregationMetric.Count("count")))
 
-        legacy.aggregate(MOCK_AGGREGATE_METADATA, query).test()
+        handler.aggregate(
+            MOCK_AGGREGATE_METADATA,
+            AggregationQuery(metrics = listOf(AggregationMetric.Count("count"))),
+        ).test()
             .expectErrorMessage("Event stream aggregation is not supported.")
             .verify()
-
-        @Suppress("UNCHECKED_CAST")
-        val legacyResult = Class.forName("${EventStreamQueryHandler::class.java.name}\$DefaultImpls")
-            .getMethod(
-                "aggregate",
-                EventStreamQueryHandler::class.java,
-                NamedAggregate::class.java,
-                AggregationQuery::class.java,
-            ).invoke(null, legacy, MOCK_AGGREGATE_METADATA, query) as Flux<DynamicDocument>
-        legacyResult.test()
-            .expectErrorMessage("Event stream aggregation is not supported.")
-            .verify()
-
-        @Suppress("UNCHECKED_CAST")
-        val legacyCount = Class.forName("${EventStreamQueryHandler::class.java.name}\$DefaultImpls")
-            .getMethod(
-                "count",
-                EventStreamQueryHandler::class.java,
-                NamedAggregate::class.java,
-                Condition::class.java,
-            ).invoke(null, legacy, MOCK_AGGREGATE_METADATA, Condition.id("id")) as Mono<Long>
-        legacyCount.test().expectNext(0).verifyComplete()
     }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/event/filter/DefaultEventStreamQueryHandlerTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/event/filter/DefaultEventStreamQueryHandlerTest.kt
@@ -19,7 +19,6 @@ import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.MatchAllFilter
 import me.ahoo.wow.api.query.SimpleDynamicDocument.Companion.toDynamicDocument
-import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.filter.FilterChain
 import me.ahoo.wow.filter.FilterChainBuilder
 import me.ahoo.wow.filter.LogErrorHandler
@@ -32,7 +31,6 @@ import me.ahoo.wow.query.event.NoOpEventStreamQueryService
 import me.ahoo.wow.query.event.NoOpEventStreamQueryServiceFactory
 import me.ahoo.wow.query.filter.DefaultQueryContext
 import me.ahoo.wow.query.filter.QueryContext
-import me.ahoo.wow.query.filter.QueryHandler
 import me.ahoo.wow.query.filter.QueryType
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import org.junit.jupiter.api.Test
@@ -138,19 +136,5 @@ class DefaultEventStreamQueryHandlerTest {
             .block()
 
         context.getRequiredResult().test().expectNext(row).verifyComplete()
-    }
-
-    @Test
-    fun `event stream handler should inherit unsupported aggregation`() {
-        val handler = object :
-            EventStreamQueryHandler,
-            QueryHandler<DomainEventStream> by queryHandler {}
-
-        handler.aggregate(
-            MOCK_AGGREGATE_METADATA,
-            AggregationQuery(metrics = listOf(AggregationMetric.Count("count"))),
-        ).test()
-            .expectErrorMessage("Event stream aggregation is not supported.")
-            .verify()
     }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/filter/QueryHandlerSubscriptionTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/filter/QueryHandlerSubscriptionTest.kt
@@ -14,6 +14,8 @@
 package me.ahoo.wow.query.filter
 
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.Condition
 import me.ahoo.wow.api.query.DynamicDocument
 import me.ahoo.wow.api.query.FilterExpression
@@ -161,6 +163,10 @@ class QueryHandlerSubscriptionTest {
             QueryType.DYNAMIC_LIST to handler.dynamicList(MOCK_AGGREGATE_METADATA, listQuery { }),
             QueryType.PAGED to handler.paged(MOCK_AGGREGATE_METADATA, pagedQuery { }),
             QueryType.DYNAMIC_PAGED to handler.dynamicPaged(MOCK_AGGREGATE_METADATA, pagedQuery { }),
+            QueryType.AGGREGATION to handler.aggregate(
+                MOCK_AGGREGATE_METADATA,
+                AggregationQuery(metrics = listOf(AggregationMetric.Count("count"))),
+            ),
             QueryType.COUNT to handler.count(MOCK_AGGREGATE_METADATA, MatchAllFilter),
         )
 
@@ -247,7 +253,9 @@ class QueryHandlerSubscriptionTest {
                 )
 
                 QueryType.COUNT -> context.asCountQuery().setResult(Mono.just(1L))
-                QueryType.AGGREGATION -> error("Test query handler does not support aggregation.")
+                QueryType.AGGREGATION -> context.asAggregationQuery().setResult(
+                    Flux.just(mutableMapOf("count" to 1L).toDynamicDocument())
+                )
             }
             return next.filter(context)
         }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaMergerTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaMergerTest.kt
@@ -121,6 +121,16 @@ class QuerySchemaMergerTest {
     }
 
     @Test
+    fun `event stream payload descendants should be allowed`() {
+        val payload = declaration("body.body.data", valueTypes = setOf(QueryValueType.STRING))
+
+        merger.merge(
+            SystemQuerySchemaSource.declaration(QueryModel.EVENT_STREAM),
+            listOf(PrioritizedQuerySchemaDeclaration(300, payload)),
+        ).fields.assert().containsKey(LogicalField("body.body.data"))
+    }
+
+    @Test
     fun `arbitrary snapshot top level extension should conflict`() {
         val exception = assertThrows<QuerySchemaConflictException> {
             merger.merge(

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/SystemQuerySchemaSourceTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/SystemQuerySchemaSourceTest.kt
@@ -20,8 +20,13 @@ import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.api.query.schema.QueryValueType
 import me.ahoo.wow.api.query.schema.Temporal
 import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.serialization.MessageRecords
+import me.ahoo.wow.serialization.toJsonNode
+import me.ahoo.wow.tck.event.MockDomainEventStreams.generateEventStream
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import tools.jackson.databind.node.ObjectNode
 import java.util.concurrent.TimeUnit
 
 class SystemQuerySchemaSourceTest {
@@ -125,30 +130,15 @@ class SystemQuerySchemaSourceTest {
     @Test
     fun `event stream system declaration should match serialized fields`() {
         val fields = SystemQuerySchemaSource.declaration(QueryModel.EVENT_STREAM).fields
+        val serialized = generateEventStream(
+            MaterializedNamedAggregate("sales", "Order").aggregateId("order-1"),
+            eventCount = 1,
+        ).toJsonNode<ObjectNode>()
+        val serializedFields = serialized.properties().mapTo(mutableSetOf()) { it.key }
+        val event = serialized[MessageRecords.BODY][0] as ObjectNode
+        serializedFields += event.properties().map { "${MessageRecords.BODY}.${it.key}" }
 
-        fields.keys.map(LogicalField::value).toSet().assert().isEqualTo(
-            setOf(
-                "id",
-                "contextName",
-                "aggregateName",
-                "name",
-                "header",
-                "aggregateId",
-                "tenantId",
-                "ownerId",
-                "spaceId",
-                "commandId",
-                "requestId",
-                "version",
-                "createTime",
-                "body",
-                "body.id",
-                "body.name",
-                "body.revision",
-                "body.bodyType",
-                "body.body",
-            ),
-        )
+        fields.keys.map(LogicalField::value).toSet().assert().isEqualTo(serializedFields)
         fields.values.forEach { field ->
             field.required.assert().isEqualTo(DeclarationValue.Set(true))
             field.nullable.assert().isEqualTo(DeclarationValue.Set(false))

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/SystemQuerySchemaSourceTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/SystemQuerySchemaSourceTest.kt
@@ -121,4 +121,45 @@ class SystemQuerySchemaSourceTest {
                 .assert().isEqualTo(DeclarationValue.Set(setOf(QueryValueType.INTEGER)))
         }
     }
+
+    @Test
+    fun `event stream system declaration should match serialized fields`() {
+        val fields = SystemQuerySchemaSource.declaration(QueryModel.EVENT_STREAM).fields
+
+        fields.keys.map(LogicalField::value).toSet().assert().isEqualTo(
+            setOf(
+                "id",
+                "contextName",
+                "aggregateName",
+                "name",
+                "header",
+                "aggregateId",
+                "tenantId",
+                "ownerId",
+                "spaceId",
+                "commandId",
+                "requestId",
+                "version",
+                "createTime",
+                "body",
+                "body.id",
+                "body.name",
+                "body.revision",
+                "body.bodyType",
+                "body.body",
+            ),
+        )
+        fields.values.forEach { field ->
+            field.required.assert().isEqualTo(DeclarationValue.Set(true))
+            field.nullable.assert().isEqualTo(DeclarationValue.Set(false))
+        }
+        fields.getValue(LogicalField("body")).cardinality.assert()
+            .isEqualTo(DeclarationValue.Set(QueryCardinality.MANY))
+        fields.getValue(LogicalField("body.body")).dynamicChildren.assert()
+            .isEqualTo(DeclarationValue.Set(false))
+        fields.getValue(LogicalField("header")).dynamicChildren.assert()
+            .isEqualTo(DeclarationValue.Set(true))
+        fields.getValue(LogicalField("createTime")).semanticType.assert()
+            .isEqualTo(DeclarationValue.Set(Temporal.Epoch(TimeUnit.MILLISECONDS)))
+    }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/SystemQuerySchemaSourceTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/SystemQuerySchemaSourceTest.kt
@@ -31,6 +31,13 @@ import java.util.concurrent.TimeUnit
 
 class SystemQuerySchemaSourceTest {
     @Test
+    fun `unsupported query model should be rejected`() {
+        assertThrows<QuerySchemaValidationException> {
+            SystemQuerySchemaSource.declaration(QueryModel("OTHER"))
+        }
+    }
+
+    @Test
     fun `snapshot system fields should reject forced mutable map mutation`() {
         val declaration = SystemQuerySchemaSource.declaration(QueryModel.SNAPSHOT)
         val state = LogicalField("state")

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/NoOpSnapshotQueryServiceTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/NoOpSnapshotQueryServiceTest.kt
@@ -16,9 +16,7 @@ package me.ahoo.wow.query.snapshot
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.query.AggregationMetric
 import me.ahoo.wow.api.query.AggregationQuery
-import me.ahoo.wow.api.query.MaterializedSnapshot
 import me.ahoo.wow.modeling.toNamedAggregate
-import me.ahoo.wow.query.QueryService
 import me.ahoo.wow.query.dsl.condition
 import me.ahoo.wow.query.dsl.filterExpression
 import me.ahoo.wow.query.dsl.listQuery
@@ -123,16 +121,10 @@ class NoOpSnapshotQueryServiceTest {
 
     @Test
     fun `aggregation DSL should return a cold unsupported error`() {
-        val fallback = object :
-            SnapshotQueryService<Any>,
-            QueryService<MaterializedSnapshot<Any>> by queryService {
-            override val name: String = "fallback"
-        }
-
         AggregationQuery(metrics = listOf(AggregationMetric.Count("count")))
-            .query(fallback)
+            .query(queryService)
             .test()
-            .expectErrorMessage("Snapshot aggregation is not supported by [fallback].")
+            .expectErrorMessage("Aggregation is not supported.")
             .verify()
     }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/DefaultSnapshotQueryHandlerTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/DefaultSnapshotQueryHandlerTest.kt
@@ -148,16 +148,21 @@ class DefaultSnapshotQueryHandlerTest {
     }
 
     @Test
-    fun `legacy snapshot handler should inherit unsupported aggregation`() {
+    fun `snapshot handler should inherit generic unsupported aggregation`() {
         val fallback = object :
             SnapshotQueryHandler,
-            QueryHandler<MaterializedSnapshot<Any>> by queryHandler {}
+            QueryHandler<MaterializedSnapshot<Any>> by queryHandler {
+            override fun aggregate(
+                namedAggregate: NamedAggregate,
+                query: AggregationQuery,
+            ): Flux<DynamicDocument> = super<SnapshotQueryHandler>.aggregate(namedAggregate, query)
+        }
 
         fallback.aggregate(
             MOCK_AGGREGATE_METADATA,
             AggregationQuery(metrics = listOf(AggregationMetric.Count("count"))),
         ).test()
-            .expectErrorMessage("Snapshot aggregation is not supported.")
+            .expectErrorMessage("Aggregation is not supported.")
             .verify()
     }
 }

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/query/JsonQuerySchemaSource.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/query/JsonQuerySchemaSource.kt
@@ -22,6 +22,7 @@ import com.github.victools.jsonschema.generator.MethodScope
 import com.github.victools.jsonschema.generator.Option
 import com.github.victools.jsonschema.generator.SchemaGenerationContext
 import me.ahoo.wow.api.query.schema.QueryTemporal
+import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.configuration.requiredAggregateType
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.query.schema.QuerySchemaContext
@@ -65,6 +66,9 @@ class JsonQuerySchemaSource internal constructor(
     override val priority: Int = QuerySchemaSourcePriority.JSON_SCHEMA
 
     override fun load(context: QuerySchemaContext): Flux<QuerySchemaDeclaration> = Flux.defer {
+        if (context.model != QueryModel.SNAPSHOT) {
+            return@defer Flux.empty()
+        }
         val stateType = stateTypeResolver(context)
         Flux.just(declarations.computeIfAbsent(stateType) { declarationResolver(it) })
     }.subscribeOn(Schedulers.boundedElastic()).onErrorMap { error ->

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/query/JsonQuerySchemaSource.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/query/JsonQuerySchemaSource.kt
@@ -21,6 +21,7 @@ import com.github.victools.jsonschema.generator.MemberScope
 import com.github.victools.jsonschema.generator.MethodScope
 import com.github.victools.jsonschema.generator.Option
 import com.github.victools.jsonschema.generator.SchemaGenerationContext
+import me.ahoo.wow.api.query.LogicalField
 import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.api.query.schema.QueryTemporal
 import me.ahoo.wow.configuration.requiredAggregateType
@@ -33,7 +34,9 @@ import me.ahoo.wow.query.schema.QuerySchemaSourcePriority
 import me.ahoo.wow.query.schema.QuerySchemaUnavailableException
 import me.ahoo.wow.schema.SchemaGeneratorBuilder
 import me.ahoo.wow.schema.Types.isStdType
+import me.ahoo.wow.schema.typed.AggregatedDomainEventStream
 import me.ahoo.wow.serialization.JsonSerializer
+import me.ahoo.wow.serialization.MessageRecords
 import reactor.core.publisher.Flux
 import reactor.core.scheduler.Schedulers
 import tools.jackson.databind.ValueSerializer
@@ -49,28 +52,33 @@ import java.util.concurrent.ConcurrentHashMap
 internal const val TEMPORAL_UNIT = "x-wow-query-temporal-unit"
 
 class JsonQuerySchemaSource internal constructor(
-    private val stateTypeResolver: (QuerySchemaContext) -> Class<*>,
-    private val declarationResolver: (Class<*>) -> QuerySchemaDeclaration,
+    private val typeResolver: (QuerySchemaContext) -> Class<*>,
+    private val declarationResolver: (QueryModel, Class<*>) -> QuerySchemaDeclaration,
 ) : QuerySchemaSource {
     internal constructor(
-        stateTypeResolver: (QuerySchemaContext) -> Class<*>,
-    ) : this(stateTypeResolver, ::inferDeclaration)
+        typeResolver: (QuerySchemaContext) -> Class<*>,
+    ) : this(typeResolver, ::inferDeclaration)
 
     constructor() : this({ context ->
-        context.namedAggregate.requiredAggregateType<Any>()
-            .aggregateMetadata<Any, Any>().state.aggregateType
+        val aggregateType = context.namedAggregate.requiredAggregateType<Any>()
+        if (context.model == QueryModel.EVENT_STREAM) {
+            aggregateType
+        } else {
+            aggregateType.aggregateMetadata<Any, Any>().state.aggregateType
+        }
     })
 
-    private val declarations = ConcurrentHashMap<Class<*>, QuerySchemaDeclaration>()
+    private val declarations = ConcurrentHashMap<Pair<QueryModel, Class<*>>, QuerySchemaDeclaration>()
 
     override val priority: Int = QuerySchemaSourcePriority.JSON_SCHEMA
 
     override fun load(context: QuerySchemaContext): Flux<QuerySchemaDeclaration> = Flux.defer {
-        if (context.model != QueryModel.SNAPSHOT) {
+        if (context.model != QueryModel.SNAPSHOT && context.model != QueryModel.EVENT_STREAM) {
             return@defer Flux.empty()
         }
-        val stateType = stateTypeResolver(context)
-        Flux.just(declarations.computeIfAbsent(stateType) { declarationResolver(it) })
+        val type = typeResolver(context)
+        val key = context.model to type
+        Flux.just(declarations.computeIfAbsent(key) { declarationResolver(context.model, type) })
     }.subscribeOn(Schedulers.boundedElastic()).onErrorMap { error ->
         when (error) {
             is QuerySchemaException -> error
@@ -83,9 +91,29 @@ class JsonQuerySchemaSource internal constructor(
     }
 
     private companion object {
-        fun inferDeclaration(stateType: Class<*>): QuerySchemaDeclaration {
-            val rootSchema = schemaGenerator.generateSchema(stateType)
-            return JsonSchemaWalker(rootSchema).declaration()
+        val eventPayloadField = LogicalField("${MessageRecords.BODY}.${MessageRecords.BODY}")
+
+        fun inferDeclaration(model: QueryModel, type: Class<*>): QuerySchemaDeclaration =
+            if (model == QueryModel.EVENT_STREAM) {
+                inferEventStreamDeclaration(type)
+            } else {
+                JsonSchemaWalker(schemaGenerator.generateSchema(type)).declaration()
+            }
+
+        fun inferEventStreamDeclaration(aggregateType: Class<*>): QuerySchemaDeclaration {
+            val rootSchema = schemaGenerator.generateSchema(AggregatedDomainEventStream::class.java, aggregateType)
+            val eventSchemas = rootSchema.path("properties").path(MessageRecords.BODY).path("items").path("anyOf")
+            val payloadSchema = JsonSerializer.createObjectNode()
+            val payloadAlternatives = payloadSchema.putArray("anyOf")
+            eventSchemas.forEach { eventSchema ->
+                eventSchema.path("properties").path(MessageRecords.BODY)
+                    .takeUnless { it.isMissingNode }
+                    ?.let(payloadAlternatives::add)
+            }
+            if (payloadAlternatives.isEmpty) {
+                return QuerySchemaDeclaration(emptyMap())
+            }
+            return JsonSchemaWalker(payloadSchema, rootSchema).declaration(eventPayloadField, includeRoot = false)
         }
 
         val schemaGenerator by lazy {

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/query/JsonQuerySchemaSource.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/query/JsonQuerySchemaSource.kt
@@ -21,8 +21,8 @@ import com.github.victools.jsonschema.generator.MemberScope
 import com.github.victools.jsonschema.generator.MethodScope
 import com.github.victools.jsonschema.generator.Option
 import com.github.victools.jsonschema.generator.SchemaGenerationContext
-import me.ahoo.wow.api.query.schema.QueryTemporal
 import me.ahoo.wow.api.query.schema.QueryModel
+import me.ahoo.wow.api.query.schema.QueryTemporal
 import me.ahoo.wow.configuration.requiredAggregateType
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.query.schema.QuerySchemaContext

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/query/JsonSchemaDeclarationWalker.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/query/JsonSchemaDeclarationWalker.kt
@@ -73,30 +73,35 @@ private val COMPOSITIONS by lazy {
 }
 
 internal class JsonSchemaWalker(
-    private val rootSchema: JsonNode,
+    private val schema: JsonNode,
+    private val rootSchema: JsonNode = schema,
 ) {
     private val fields = linkedMapOf<LogicalField, QueryFieldDeclaration>()
 
-    fun declaration(): QuerySchemaDeclaration {
-        val stateField = LogicalField(StateAggregateRecords.STATE)
-        val rootNodes = rootSchema.effectiveNodes()
-        fields[stateField] = QueryFieldDeclaration(
-            title = DeclarationValue.Set(
-                rootNodes.consistentValue(stateField, TITLE) {
-                    it.textValueOrNull(JsonSchemaProperty.TITLE)
-                },
-            ),
-            description = DeclarationValue.Set(
-                rootNodes.consistentValue(stateField, DESCRIPTION) {
-                    it.textValueOrNull(JsonSchemaProperty.DESCRIPTION)
-                },
-            ),
-            enumValues = DeclarationValue.Set(
-                rootNodes.consistentValue(stateField, ENUM_VALUES, JsonNode::enumValuesOrNull),
-            ),
-            dynamicChildren = DeclarationValue.Set(rootNodes.any(JsonNode::hasAdditionalProperties)),
-        )
-        fields.putAll(rootSchema.collectProperties(StateAggregateRecords.STATE, setOf(ROOT_REFERENCE)))
+    fun declaration(
+        rootField: LogicalField = LogicalField(StateAggregateRecords.STATE),
+        includeRoot: Boolean = true,
+    ): QuerySchemaDeclaration {
+        if (includeRoot) {
+            val rootNodes = schema.effectiveNodes()
+            fields[rootField] = QueryFieldDeclaration(
+                title = DeclarationValue.Set(
+                    rootNodes.consistentValue(rootField, TITLE) {
+                        it.textValueOrNull(JsonSchemaProperty.TITLE)
+                    },
+                ),
+                description = DeclarationValue.Set(
+                    rootNodes.consistentValue(rootField, DESCRIPTION) {
+                        it.textValueOrNull(JsonSchemaProperty.DESCRIPTION)
+                    },
+                ),
+                enumValues = DeclarationValue.Set(
+                    rootNodes.consistentValue(rootField, ENUM_VALUES, JsonNode::enumValuesOrNull),
+                ),
+                dynamicChildren = DeclarationValue.Set(rootNodes.any(JsonNode::hasAdditionalProperties)),
+            )
+        }
+        fields.putAll(schema.collectProperties(rootField.value, setOf(ROOT_REFERENCE)))
         return QuerySchemaDeclaration(fields)
     }
 

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/query/JsonQuerySchemaSourceTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/query/JsonQuerySchemaSourceTest.kt
@@ -51,6 +51,18 @@ class JsonQuerySchemaSourceTest {
     }
 
     @Test
+    fun `should not infer aggregate state for event stream model`() {
+        val resolutions = AtomicInteger()
+        val source = JsonQuerySchemaSource {
+            resolutions.incrementAndGet()
+            StructuralState::class.java
+        }
+
+        source.load(context.copy(model = QueryModel.EVENT_STREAM)).collectList().block().assert().isEmpty()
+        resolutions.get().assert().isZero()
+    }
+
+    @Test
     fun `should reuse inferred declaration for the same state type across contexts`() {
         val source = JsonQuerySchemaSource { StructuralState::class.java }
         val otherContext = context.copy(

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/query/JsonQuerySchemaSourceTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/query/JsonQuerySchemaSourceTest.kt
@@ -20,7 +20,9 @@ import me.ahoo.wow.api.query.schema.QueryCardinality
 import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.api.query.schema.QueryValueType
 import me.ahoo.wow.api.query.schema.Temporal
+import me.ahoo.wow.example.domain.cart.Cart
 import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.modeling.annotation.aggregateMetadata
 import me.ahoo.wow.query.schema.DeclarationValue
 import me.ahoo.wow.query.schema.QueryFieldDeclaration
 import me.ahoo.wow.query.schema.QuerySchemaConflictException
@@ -28,6 +30,7 @@ import me.ahoo.wow.query.schema.QuerySchemaContext
 import me.ahoo.wow.query.schema.QuerySchemaDeclaration
 import me.ahoo.wow.query.schema.QuerySchemaSourcePriority
 import me.ahoo.wow.query.schema.QuerySchemaUnavailableException
+import me.ahoo.wow.schema.MockEmptyAggregate
 import me.ahoo.wow.serialization.JsonSerializer
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -51,14 +54,66 @@ class JsonQuerySchemaSourceTest {
     }
 
     @Test
-    fun `should not infer aggregate state for event stream model`() {
+    fun `should infer event payload fields for event stream model`() {
+        val eventStreamContext = QuerySchemaContext(
+            Cart::class.java.aggregateMetadata<Any, Any>().namedAggregate,
+            QueryModel.EVENT_STREAM,
+        )
+        val declaration = JsonQuerySchemaSource().load(eventStreamContext).single().block()!!
+
+        declaration.fields.keys.assert()
+            .contains(LogicalField("body.body.added.productId"))
+            .contains(LogicalField("body.body.added.quantity"))
+            .contains(LogicalField("body.body.productIds"))
+            .contains(LogicalField("body.body.changed.productId"))
+            .contains(LogicalField("body.body.changed.quantity"))
+        declaration.field("body.body.added.productId").valueTypes.assert()
+            .isEqualTo(DeclarationValue.Set(setOf(QueryValueType.STRING)))
+        declaration.field("body.body.productIds").cardinality.assert()
+            .isEqualTo(DeclarationValue.Set(QueryCardinality.MANY))
+        declaration.field("body.body.changed.quantity").valueTypes.assert()
+            .isEqualTo(DeclarationValue.Set(setOf(QueryValueType.INTEGER)))
+        declaration.field("body.body.added").required.assert()
+            .isEqualTo(DeclarationValue.Set(false))
+    }
+
+    @Test
+    fun `should infer aggregate state fields for snapshot model`() {
+        val snapshotContext = QuerySchemaContext(
+            Cart::class.java.aggregateMetadata<Any, Any>().namedAggregate,
+            QueryModel.SNAPSHOT,
+        )
+
+        JsonQuerySchemaSource().load(snapshotContext).single().block()!!
+            .fields.keys.assert().contains(LogicalField("state.items.productId"))
+    }
+
+    @Test
+    fun `should cache the same type independently by query model`() {
+        val source = JsonQuerySchemaSource { Cart::class.java }
+
+        source.load(context).single().block()!!
+        val eventStream = source.load(context.copy(model = QueryModel.EVENT_STREAM)).single().block()!!
+
+        eventStream.fields.keys.assert().contains(LogicalField("body.body.added.productId"))
+    }
+
+    @Test
+    fun `should return an empty declaration when aggregate events are unknown`() {
+        JsonQuerySchemaSource { MockEmptyAggregate::class.java }
+            .load(context.copy(model = QueryModel.EVENT_STREAM)).single().block()!!
+            .fields.assert().isEmpty()
+    }
+
+    @Test
+    fun `should ignore unsupported query models`() {
         val resolutions = AtomicInteger()
         val source = JsonQuerySchemaSource {
             resolutions.incrementAndGet()
             StructuralState::class.java
         }
 
-        source.load(context.copy(model = QueryModel.EVENT_STREAM)).collectList().block().assert().isEmpty()
+        source.load(context.copy(model = QueryModel("OTHER"))).collectList().block().assert().isEmpty()
         resolutions.get().assert().isZero()
     }
 
@@ -79,8 +134,8 @@ class JsonQuerySchemaSourceTest {
     fun `should infer once for concurrent contexts sharing a state type`() {
         val inferenceCount = AtomicInteger()
         val source = JsonQuerySchemaSource(
-            stateTypeResolver = { StructuralState::class.java },
-            declarationResolver = {
+            typeResolver = { StructuralState::class.java },
+            declarationResolver = { _, _ ->
                 val inference = inferenceCount.incrementAndGet()
                 QuerySchemaDeclaration(
                     mapOf(
@@ -111,11 +166,11 @@ class JsonQuerySchemaSourceTest {
         val stateTypeResolutionThread = AtomicReference<Thread>()
         val declarationResolutionThread = AtomicReference<Thread>()
         val source = JsonQuerySchemaSource(
-            stateTypeResolver = {
+            typeResolver = {
                 stateTypeResolutionThread.set(Thread.currentThread())
                 StructuralState::class.java
             },
-            declarationResolver = {
+            declarationResolver = { _, _ ->
                 declarationResolutionThread.set(Thread.currentThread())
                 QuerySchemaDeclaration(emptyMap())
             },
@@ -131,14 +186,14 @@ class JsonQuerySchemaSourceTest {
     fun `should cache different state types independently`() {
         val inferenceCounts = ConcurrentHashMap<Class<*>, AtomicInteger>()
         val source = JsonQuerySchemaSource(
-            stateTypeResolver = { loadContext ->
+            typeResolver = { loadContext ->
                 if (loadContext.namedAggregate.aggregateName == "structural") {
                     StructuralState::class.java
                 } else {
                     JacksonState::class.java
                 }
             },
-            declarationResolver = { stateType ->
+            declarationResolver = { _, stateType ->
                 inferenceCounts.computeIfAbsent(stateType) { AtomicInteger() }.incrementAndGet()
                 QuerySchemaDeclaration(emptyMap())
             },
@@ -166,8 +221,8 @@ class JsonQuerySchemaSourceTest {
         val inferenceCount = AtomicInteger()
         val recovered = QuerySchemaDeclaration(emptyMap())
         val source = JsonQuerySchemaSource(
-            stateTypeResolver = { StructuralState::class.java },
-            declarationResolver = {
+            typeResolver = { StructuralState::class.java },
+            declarationResolver = { _, _ ->
                 if (inferenceCount.incrementAndGet() == 1) throw failure
                 recovered
             },

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfiguration.kt
@@ -138,12 +138,18 @@ class ElasticsearchEventSourcingAutoConfiguration @Autowired constructor(
     @Bean
     @ConditionalOnEventStoreStorage(StorageType.ELASTICSEARCH)
     fun elasticsearchEventStreamQueryServiceFactory(
-        elasticsearchClient: ReactiveElasticsearchClient
+        elasticsearchClient: ReactiveElasticsearchClient,
+        elasticsearchIndexMappingResolver: ElasticsearchIndexMappingResolver,
+        sources: List<QuerySchemaSource>,
+        schemaQueryProperties: QueryProperties,
     ): ElasticsearchEventStreamQueryServiceFactory {
         return ElasticsearchEventStreamQueryServiceFactory(
             elasticsearchClient,
             queryProperties.batchSize,
             queryProperties.keepAlive,
+            elasticsearchIndexMappingResolver,
+            sources,
+            schemaQueryProperties.schema.validationMode,
         )
     }
 
@@ -206,8 +212,6 @@ class ElasticsearchEventSourcingAutoConfiguration @Autowired constructor(
     }
 
     @Bean
-    @ConditionalOnSnapshotEnabled
-    @ConditionalOnSnapshotStoreStorage(StorageType.ELASTICSEARCH)
     @ConditionalOnMissingBean
     fun elasticsearchIndexMappingResolver(
         elasticsearchClient: ReactiveElasticsearchClient,

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfiguration.kt
@@ -153,6 +153,14 @@ class ElasticsearchEventSourcingAutoConfiguration @Autowired constructor(
         )
     }
 
+    fun elasticsearchEventStreamQueryServiceFactory(
+        elasticsearchClient: ReactiveElasticsearchClient,
+    ): ElasticsearchEventStreamQueryServiceFactory = ElasticsearchEventStreamQueryServiceFactory(
+        elasticsearchClient,
+        queryProperties.batchSize,
+        queryProperties.keepAlive,
+    )
+
     @Bean
     @ConditionalOnEventStoreStorage(StorageType.ELASTICSEARCH)
     fun elasticsearchEventStreamQueryServiceFactoryBinding(

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfiguration.kt
@@ -139,9 +139,10 @@ class ElasticsearchEventSourcingAutoConfiguration @Autowired constructor(
     @ConditionalOnEventStoreStorage(StorageType.ELASTICSEARCH)
     fun elasticsearchEventStreamQueryServiceFactory(
         elasticsearchClient: ReactiveElasticsearchClient,
-        elasticsearchIndexMappingResolver: ElasticsearchIndexMappingResolver,
-        sources: List<QuerySchemaSource>,
-        schemaQueryProperties: QueryProperties,
+        elasticsearchIndexMappingResolver: ElasticsearchIndexMappingResolver =
+            ElasticsearchIndexMappingResolver(elasticsearchClient),
+        sources: List<QuerySchemaSource> = emptyList(),
+        schemaQueryProperties: QueryProperties = QueryProperties(),
     ): ElasticsearchEventStreamQueryServiceFactory {
         return ElasticsearchEventStreamQueryServiceFactory(
             elasticsearchClient,
@@ -152,14 +153,6 @@ class ElasticsearchEventSourcingAutoConfiguration @Autowired constructor(
             schemaQueryProperties.schema.validationMode,
         )
     }
-
-    fun elasticsearchEventStreamQueryServiceFactory(
-        elasticsearchClient: ReactiveElasticsearchClient,
-    ): ElasticsearchEventStreamQueryServiceFactory = ElasticsearchEventStreamQueryServiceFactory(
-        elasticsearchClient,
-        queryProperties.batchSize,
-        queryProperties.keepAlive,
-    )
 
     @Bean
     @ConditionalOnEventStoreStorage(StorageType.ELASTICSEARCH)

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfiguration.kt
@@ -114,8 +114,8 @@ class MongoEventSourcingAutoConfiguration(
         dataMongoProperties: org.springframework.boot.mongodb.autoconfigure.MongoProperties?,
         @Qualifier(WowAutoConfiguration.WOW_CURRENT_BOUNDED_CONTEXT)
         currentBoundedContext: NamedBoundedContext,
-        sources: List<QuerySchemaSource>,
-        queryProperties: QueryProperties,
+        sources: List<QuerySchemaSource> = emptyList(),
+        queryProperties: QueryProperties = QueryProperties(),
     ): MongoEventStreamQueryServiceFactory {
         val eventStoreDatabase = getEventStreamDatabase(dataMongoProperties, mongoClient)
         MongoDatabaseContextGuard(eventStoreDatabase)
@@ -126,18 +126,6 @@ class MongoEventSourcingAutoConfiguration(
             queryProperties.schema.validationMode,
         )
     }
-
-    fun mongoEventStreamQueryServiceFactory(
-        mongoClient: MongoClient,
-        dataMongoProperties: org.springframework.boot.mongodb.autoconfigure.MongoProperties?,
-        currentBoundedContext: NamedBoundedContext,
-    ): MongoEventStreamQueryServiceFactory = mongoEventStreamQueryServiceFactory(
-        mongoClient,
-        dataMongoProperties,
-        currentBoundedContext,
-        emptyList(),
-        QueryProperties(),
-    )
 
     @Bean
     @ConditionalOnEventStoreStorage(StorageType.MONGO)

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfiguration.kt
@@ -114,11 +114,17 @@ class MongoEventSourcingAutoConfiguration(
         dataMongoProperties: org.springframework.boot.mongodb.autoconfigure.MongoProperties?,
         @Qualifier(WowAutoConfiguration.WOW_CURRENT_BOUNDED_CONTEXT)
         currentBoundedContext: NamedBoundedContext,
+        sources: List<QuerySchemaSource>,
+        queryProperties: QueryProperties,
     ): MongoEventStreamQueryServiceFactory {
         val eventStoreDatabase = getEventStreamDatabase(dataMongoProperties, mongoClient)
         MongoDatabaseContextGuard(eventStoreDatabase)
             .ensureContext(currentBoundedContext.contextName)
-        return MongoEventStreamQueryServiceFactory(eventStoreDatabase)
+        return MongoEventStreamQueryServiceFactory(
+            eventStoreDatabase,
+            sources,
+            queryProperties.schema.validationMode,
+        )
     }
 
     @Bean

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfiguration.kt
@@ -127,6 +127,18 @@ class MongoEventSourcingAutoConfiguration(
         )
     }
 
+    fun mongoEventStreamQueryServiceFactory(
+        mongoClient: MongoClient,
+        dataMongoProperties: org.springframework.boot.mongodb.autoconfigure.MongoProperties?,
+        currentBoundedContext: NamedBoundedContext,
+    ): MongoEventStreamQueryServiceFactory = mongoEventStreamQueryServiceFactory(
+        mongoClient,
+        dataMongoProperties,
+        currentBoundedContext,
+        emptyList(),
+        QueryProperties(),
+    )
+
     @Bean
     @ConditionalOnEventStoreStorage(StorageType.MONGO)
     fun mongoEventStreamQueryServiceFactoryBinding(

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfigurationTest.kt
@@ -72,13 +72,7 @@ internal class ElasticsearchEventSourcingAutoConfigurationTest {
     ).getBeanProvider(WowMetrics::class.java)
 
     @Test
-    fun `should preserve executable legacy event stream query factory JVM signature`() {
-        val method = ElasticsearchEventSourcingAutoConfiguration::class.java.getMethod(
-            "elasticsearchEventStreamQueryServiceFactory",
-            ReactiveElasticsearchClient::class.java,
-        )
-
-        method.returnType.assert().isEqualTo(ElasticsearchEventStreamQueryServiceFactory::class.java)
+    fun `event stream query factory should use default schema collaborators`() {
         ElasticsearchEventSourcingAutoConfiguration(
             elasticsearchProperties = ElasticsearchProperties(autoInitTemplate = false),
             eventStoreBatchProperties = ElasticsearchEventStoreBatchProperties(),

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfigurationTest.kt
@@ -72,6 +72,16 @@ internal class ElasticsearchEventSourcingAutoConfigurationTest {
     ).getBeanProvider(WowMetrics::class.java)
 
     @Test
+    fun `should preserve legacy event stream query factory JVM signature`() {
+        val method = ElasticsearchEventSourcingAutoConfiguration::class.java.getMethod(
+            "elasticsearchEventStreamQueryServiceFactory",
+            ReactiveElasticsearchClient::class.java,
+        )
+
+        method.returnType.assert().isEqualTo(ElasticsearchEventStreamQueryServiceFactory::class.java)
+    }
+
+    @Test
     fun `default batch properties should be used`() {
         val autoConfiguration = ElasticsearchEventSourcingAutoConfiguration(
             elasticsearchProperties = ElasticsearchProperties(autoInitTemplate = false),

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfigurationTest.kt
@@ -72,13 +72,20 @@ internal class ElasticsearchEventSourcingAutoConfigurationTest {
     ).getBeanProvider(WowMetrics::class.java)
 
     @Test
-    fun `should preserve legacy event stream query factory JVM signature`() {
+    fun `should preserve executable legacy event stream query factory JVM signature`() {
         val method = ElasticsearchEventSourcingAutoConfiguration::class.java.getMethod(
             "elasticsearchEventStreamQueryServiceFactory",
             ReactiveElasticsearchClient::class.java,
         )
 
         method.returnType.assert().isEqualTo(ElasticsearchEventStreamQueryServiceFactory::class.java)
+        ElasticsearchEventSourcingAutoConfiguration(
+            elasticsearchProperties = ElasticsearchProperties(autoInitTemplate = false),
+            eventStoreBatchProperties = ElasticsearchEventStoreBatchProperties(),
+            snapshotStoreBatchProperties = ElasticsearchSnapshotStoreBatchProperties(),
+        ).elasticsearchEventStreamQueryServiceFactory(
+            mock(ReactiveElasticsearchClient::class.java),
+        ).assert().isInstanceOf(ElasticsearchEventStreamQueryServiceFactory::class.java)
     }
 
     @Test

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/elasticsearch/ElasticsearchEventSourcingAutoConfigurationTest.kt
@@ -116,6 +116,30 @@ internal class ElasticsearchEventSourcingAutoConfigurationTest {
     }
 
     @Test
+    fun `should pass query schema sources to event stream factory`() {
+        val expected = IllegalStateException("query schema source was used")
+        val configuration = ElasticsearchEventSourcingAutoConfiguration(
+            elasticsearchProperties = ElasticsearchProperties(autoInitTemplate = false),
+            eventStoreBatchProperties = ElasticsearchEventStoreBatchProperties(),
+            snapshotStoreBatchProperties = ElasticsearchSnapshotStoreBatchProperties(),
+        )
+        val factory = configuration.elasticsearchEventStreamQueryServiceFactory(
+            elasticsearchClient = mock(ReactiveElasticsearchClient::class.java),
+            elasticsearchIndexMappingResolver = mockk<ElasticsearchIndexMappingResolver>(),
+            sources = listOf(failingQuerySchemaSource(expected)),
+            schemaQueryProperties = QueryProperties(
+                QueryProperties.Schema(me.ahoo.wow.query.schema.QuerySchemaValidationMode.STRICT),
+            ),
+        )
+
+        (factory.create(MOCK_AGGREGATE_METADATA) as QueryModelSchemaProvider)
+            .schema()
+            .test()
+            .expectErrorSatisfies { it.assert().isSameAs(expected) }
+            .verify()
+    }
+
+    @Test
     fun `should auto configure reactive elasticsearch infrastructure from feature dependencies`() {
         ApplicationContextRunner()
             .enableWow()

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfigurationTest.kt
@@ -67,7 +67,7 @@ class MongoEventSourcingAutoConfigurationTest {
         .withUserConfiguration(QuerySchemaAutoConfiguration::class.java)
 
     @Test
-    fun `should preserve legacy event stream query factory JVM signature`() {
+    fun `should preserve executable legacy event stream query factory JVM signature`() {
         val method = MongoEventSourcingAutoConfiguration::class.java.getMethod(
             "mongoEventStreamQueryServiceFactory",
             MongoClient::class.java,
@@ -78,6 +78,15 @@ class MongoEventSourcingAutoConfigurationTest {
         method.returnType.assert().isEqualTo(
             me.ahoo.wow.mongo.query.event.MongoEventStreamQueryServiceFactory::class.java,
         )
+        MongoEventSourcingAutoConfiguration(
+            mongoProperties = MongoProperties(autoInitSchema = false, eventStreamDatabase = "testEventStream"),
+            eventStoreBatchProperties = MongoEventStoreBatchProperties(),
+            snapshotStoreBatchProperties = MongoSnapshotStoreBatchProperties(),
+        ).mongoEventStreamQueryServiceFactory(
+            mongoClient = mongoClient("order-service"),
+            dataMongoProperties = null,
+            currentBoundedContext = MaterializedNamedBoundedContext("order-service"),
+        ).assert().isInstanceOf(me.ahoo.wow.mongo.query.event.MongoEventStreamQueryServiceFactory::class.java)
     }
 
     @Test

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfigurationTest.kt
@@ -67,6 +67,20 @@ class MongoEventSourcingAutoConfigurationTest {
         .withUserConfiguration(QuerySchemaAutoConfiguration::class.java)
 
     @Test
+    fun `should preserve legacy event stream query factory JVM signature`() {
+        val method = MongoEventSourcingAutoConfiguration::class.java.getMethod(
+            "mongoEventStreamQueryServiceFactory",
+            MongoClient::class.java,
+            org.springframework.boot.mongodb.autoconfigure.MongoProperties::class.java,
+            me.ahoo.wow.api.naming.NamedBoundedContext::class.java,
+        )
+
+        method.returnType.assert().isEqualTo(
+            me.ahoo.wow.mongo.query.event.MongoEventStreamQueryServiceFactory::class.java,
+        )
+    }
+
+    @Test
     fun `constructor creates mongo snapshot store`() {
         val configuration = MongoEventSourcingAutoConfiguration(
             mongoProperties = MongoProperties(

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfigurationTest.kt
@@ -67,17 +67,7 @@ class MongoEventSourcingAutoConfigurationTest {
         .withUserConfiguration(QuerySchemaAutoConfiguration::class.java)
 
     @Test
-    fun `should preserve executable legacy event stream query factory JVM signature`() {
-        val method = MongoEventSourcingAutoConfiguration::class.java.getMethod(
-            "mongoEventStreamQueryServiceFactory",
-            MongoClient::class.java,
-            org.springframework.boot.mongodb.autoconfigure.MongoProperties::class.java,
-            me.ahoo.wow.api.naming.NamedBoundedContext::class.java,
-        )
-
-        method.returnType.assert().isEqualTo(
-            me.ahoo.wow.mongo.query.event.MongoEventStreamQueryServiceFactory::class.java,
-        )
+    fun `event stream query factory should use default schema collaborators`() {
         MongoEventSourcingAutoConfiguration(
             mongoProperties = MongoProperties(autoInitSchema = false, eventStreamDatabase = "testEventStream"),
             eventStoreBatchProperties = MongoEventStoreBatchProperties(),

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/mongo/MongoEventSourcingAutoConfigurationTest.kt
@@ -117,6 +117,32 @@ class MongoEventSourcingAutoConfigurationTest {
     }
 
     @Test
+    fun `should pass query schema sources to event stream factory`() {
+        val expected = IllegalStateException("query schema source was used")
+        val configuration = MongoEventSourcingAutoConfiguration(
+            mongoProperties = MongoProperties(autoInitSchema = false, eventStreamDatabase = "testEventStream"),
+            eventStoreBatchProperties = MongoEventStoreBatchProperties(),
+            snapshotStoreBatchProperties = MongoSnapshotStoreBatchProperties(),
+        )
+
+        val factory = configuration.mongoEventStreamQueryServiceFactory(
+            mongoClient = mongoClient("order-service"),
+            dataMongoProperties = null,
+            currentBoundedContext = MaterializedNamedBoundedContext("order-service"),
+            sources = listOf(failingQuerySchemaSource(expected)),
+            queryProperties = QueryProperties(
+                QueryProperties.Schema(me.ahoo.wow.query.schema.QuerySchemaValidationMode.STRICT)
+            ),
+        )
+
+        (factory.create(MOCK_AGGREGATE_METADATA) as QueryModelSchemaProvider)
+            .schema()
+            .test()
+            .expectErrorSatisfies { it.assert().isSameAs(expected) }
+            .verify()
+    }
+
+    @Test
     fun `should load context with mongo event sourcing beans`() {
         contextRunner
             .enableWow()

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/QueryServiceProxy.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/QueryServiceProxy.kt
@@ -26,7 +26,10 @@ import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.query.QueryService
 import me.ahoo.wow.query.event.EventStreamQueryService
 import me.ahoo.wow.query.event.filter.EventStreamQueryHandler
+import me.ahoo.wow.query.event.requiredQueryModelSchemaProvider
 import me.ahoo.wow.query.filter.QueryHandler
+import me.ahoo.wow.query.schema.QueryModelSchema
+import me.ahoo.wow.query.schema.QueryModelSchemaProvider
 import me.ahoo.wow.query.snapshot.SnapshotQueryService
 import me.ahoo.wow.query.snapshot.filter.SnapshotQueryHandler
 import reactor.core.publisher.Flux
@@ -48,12 +51,19 @@ internal class SnapshotQueryServiceProxy<S : Any>(
 }
 
 internal class EventStreamQueryServiceProxy(
-    delegate: EventStreamQueryService,
+    private val delegate: EventStreamQueryService,
     private val handler: EventStreamQueryHandler,
 ) : QueryServiceProxy<DomainEventStream>(delegate.namedAggregate, handler),
-    EventStreamQueryService {
+    EventStreamQueryService,
+    QueryModelSchemaProvider {
     override fun aggregate(query: AggregationQuery): Flux<DynamicDocument> =
         handler.aggregate(namedAggregate, query)
+
+    override fun schema(): Mono<QueryModelSchema> =
+        Mono.defer { delegate.requiredQueryModelSchemaProvider().schema() }
+
+    override fun refresh(): Mono<QueryModelSchema> =
+        Mono.defer { delegate.requiredQueryModelSchemaProvider().refresh() }
 }
 
 internal abstract class QueryServiceProxy<R : Any>(

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/QueryServiceProxy.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/QueryServiceProxy.kt
@@ -37,7 +37,7 @@ import reactor.core.publisher.Mono
 
 internal class SnapshotQueryServiceProxy<S : Any>(
     private val delegate: SnapshotQueryService<S>,
-    private val handler: SnapshotQueryHandler,
+    handler: SnapshotQueryHandler,
 ) : QueryServiceProxy<MaterializedSnapshot<S>>(
     delegate.namedAggregate,
     handler.cast(),
@@ -45,20 +45,14 @@ internal class SnapshotQueryServiceProxy<S : Any>(
     SnapshotQueryService<S> {
     override val name: String
         get() = delegate.name
-
-    override fun aggregate(query: AggregationQuery): Flux<DynamicDocument> =
-        handler.aggregate(namedAggregate, query)
 }
 
 internal class EventStreamQueryServiceProxy(
     private val delegate: EventStreamQueryService,
-    private val handler: EventStreamQueryHandler,
+    handler: EventStreamQueryHandler,
 ) : QueryServiceProxy<DomainEventStream>(delegate.namedAggregate, handler),
     EventStreamQueryService,
     QueryModelSchemaProvider {
-    override fun aggregate(query: AggregationQuery): Flux<DynamicDocument> =
-        handler.aggregate(namedAggregate, query)
-
     override fun schema(): Mono<QueryModelSchema> =
         Mono.defer { delegate.requiredQueryModelSchemaProvider().schema() }
 
@@ -84,6 +78,8 @@ internal abstract class QueryServiceProxy<R : Any>(
 
     override fun dynamicPaged(pagedQuery: IPagedQuery): Mono<PagedList<DynamicDocument>> =
         handler.dynamicPaged(namedAggregate, pagedQuery)
+
+    override fun aggregate(query: AggregationQuery): Flux<DynamicDocument> = handler.aggregate(namedAggregate, query)
 
     override fun count(filter: FilterExpression): Mono<Long> = handler.count(namedAggregate, filter)
 }

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/QueryServiceProxy.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/QueryServiceProxy.kt
@@ -49,9 +49,12 @@ internal class SnapshotQueryServiceProxy<S : Any>(
 
 internal class EventStreamQueryServiceProxy(
     delegate: EventStreamQueryService,
-    handler: EventStreamQueryHandler,
+    private val handler: EventStreamQueryHandler,
 ) : QueryServiceProxy<DomainEventStream>(delegate.namedAggregate, handler),
-    EventStreamQueryService
+    EventStreamQueryService {
+    override fun aggregate(query: AggregationQuery): Flux<DynamicDocument> =
+        handler.aggregate(namedAggregate, query)
+}
 
 internal abstract class QueryServiceProxy<R : Any>(
     final override val namedAggregate: NamedAggregate,

--- a/wow-spring/src/test/kotlin/me/ahoo/wow/spring/query/QueryServiceProxyTest.kt
+++ b/wow-spring/src/test/kotlin/me/ahoo/wow/spring/query/QueryServiceProxyTest.kt
@@ -24,6 +24,7 @@ import me.ahoo.wow.api.query.IPagedQuery
 import me.ahoo.wow.api.query.ISingleQuery
 import me.ahoo.wow.api.query.MatchAllFilter
 import me.ahoo.wow.api.query.PagedList
+import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.filter.EmptyFilterChain
 import me.ahoo.wow.filter.FilterChain
@@ -35,11 +36,16 @@ import me.ahoo.wow.query.event.EventStreamQueryService
 import me.ahoo.wow.query.event.EventStreamQueryServiceFactory
 import me.ahoo.wow.query.event.NoOpEventStreamQueryService
 import me.ahoo.wow.query.event.filter.EventStreamQueryHandler
+import me.ahoo.wow.query.event.requiredQueryModelSchemaProvider
 import me.ahoo.wow.query.filter.QueryContext
 import me.ahoo.wow.query.filter.QueryType
+import me.ahoo.wow.query.schema.QueryModelSchema
+import me.ahoo.wow.query.schema.QueryModelSchemaProvider
+import me.ahoo.wow.query.schema.QuerySchemaUnavailableException
 import me.ahoo.wow.query.snapshot.NoOpSnapshotQueryService
 import me.ahoo.wow.query.snapshot.filter.DefaultSnapshotQueryHandler
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.support.DefaultListableBeanFactory
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -72,6 +78,40 @@ class QueryServiceProxyTest {
             QueryType.AGGREGATION,
         )
         handler.namedAggregates.toSet().assert().containsExactly(namedAggregate)
+    }
+
+    @Test
+    fun `event stream proxy should preserve schema provider capability`() {
+        val initial = QueryModelSchema(QueryModel.EVENT_STREAM, emptySet(), emptyMap())
+        val refreshed = QueryModelSchema(QueryModel.EVENT_STREAM, emptySet(), emptyMap())
+        val delegate = object :
+            EventStreamQueryService by NoOpEventStreamQueryService(namedAggregate),
+            QueryModelSchemaProvider {
+            override fun schema(): Mono<QueryModelSchema> = Mono.just(initial)
+
+            override fun refresh(): Mono<QueryModelSchema> = Mono.just(refreshed)
+        }
+        val provider = EventStreamQueryServiceProxy(
+            delegate,
+            RecordingEventStreamQueryHandler(),
+        ).requiredQueryModelSchemaProvider()
+
+        provider.schema().block().assert().isSameAs(initial)
+        provider.refresh().block().assert().isSameAs(refreshed)
+    }
+
+    @Test
+    fun `event stream proxy should report unavailable schema reactively`() {
+        val proxy = EventStreamQueryServiceProxy(
+            NoOpEventStreamQueryService(namedAggregate),
+            RecordingEventStreamQueryHandler(),
+        )
+
+        val unavailableSchema = proxy.requiredQueryModelSchemaProvider().schema()
+
+        assertThrows<QuerySchemaUnavailableException> {
+            unavailableSchema.block()
+        }
     }
 
     @Test

--- a/wow-spring/src/test/kotlin/me/ahoo/wow/spring/query/QueryServiceProxyTest.kt
+++ b/wow-spring/src/test/kotlin/me/ahoo/wow/spring/query/QueryServiceProxyTest.kt
@@ -59,6 +59,7 @@ class QueryServiceProxyTest {
         proxy.paged(pagedQuery { })
         proxy.dynamicPaged(pagedQuery { })
         proxy.count(MatchAllFilter)
+        proxy.aggregate(AggregationQuery(metrics = listOf(AggregationMetric.Count("count"))))
 
         handler.queryTypes.assert().containsExactly(
             QueryType.SINGLE,
@@ -68,6 +69,7 @@ class QueryServiceProxyTest {
             QueryType.PAGED,
             QueryType.DYNAMIC_PAGED,
             QueryType.COUNT,
+            QueryType.AGGREGATION,
         )
         handler.namedAggregates.toSet().assert().containsExactly(namedAggregate)
     }
@@ -150,6 +152,11 @@ class QueryServiceProxyTest {
 
         override fun count(namedAggregate: NamedAggregate, filter: FilterExpression): Mono<Long> =
             record(QueryType.COUNT, namedAggregate, Mono.just(0L))
+
+        override fun aggregate(
+            namedAggregate: NamedAggregate,
+            query: AggregationQuery,
+        ): Flux<DynamicDocument> = record(QueryType.AGGREGATION, namedAggregate, Flux.empty())
 
         private fun <T> record(queryType: QueryType, namedAggregate: NamedAggregate, result: T): T {
             queryTypes += queryType


### PR DESCRIPTION
## Goal

让 EventStreamQueryService 支持 AggregationQuery，并提供与 Snapshot 查询一致、按聚合根推断的 Query Schema 能力。

完成标准：
- EventStream 的 single/list/paged/count/aggregation 查询均经过 EVENT_STREAM schema 解析
- MongoDB 与 Elasticsearch 均可执行事件流聚合
- 已知事件 payload 从当前聚合根元数据推断；显式 source 可继续增补，默认 COMPATIBLE 模式保持未知字段兼容
- 不新增 EventStream HTTP/OpenAPI 端点

## Changes

- 增加 EVENT_STREAM 系统 schema，覆盖事件流元数据与 body 结构
- 将 AggregationQuery 接入 EventStream service、handler、filter、proxy 与 Spring factory
- 将 Snapshot/EventStream 共用的 aggregate 默认合同提升到 QueryService，子接口删除重复声明
- 在 MongoDB/Elasticsearch 复用共享 aggregation compiler/pager 执行事件流聚合
- 修正 schema 合并根：Snapshot 使用 state，EventStream 使用 body.body
- JsonQuerySchemaSource 复用参数化 AggregatedDomainEventStream JSON Schema，按聚合根合并事件 payload 到 body.body.*
- 按 QueryModel 隔离 JSON Schema 缓存；事件类型未知时返回空声明
- 用真实 Cart 聚合覆盖默认元数据解析、多事件 anyOf、嵌套 ref、required 合并与回退
- 增加共享后端 TCK、模块测试、设计与实施文档

## Verification

- [x] ./gradlew :wow-query:check :wow-spring:check :wow-spring-boot-starter:check :wow-mongo:check :wow-elasticsearch:check
- [x] ./gradlew :wow-query:check --rerun
- [x] javap 确认 default aggregate 实例方法归属 QueryService；子接口保留 Kotlin 编译器生成的继承访问桥
- [x] ./gradlew :wow-mongo:integrationTest
- [x] Elasticsearch 原整轮 115 个集成测试中 104 个通过；11 个因宿主机瞬时时钟回拨失败，受影响的 EventStream 与 SnapshotStore 测试类分别重跑通过
- [x] ./gradlew :wow-schema:test --tests me.ahoo.wow.schema.query.JsonQuerySchemaSourceTest --rerun
- [x] ./gradlew :wow-schema:jacocoTestReport（wow-schema line 93%，query package line 98%）
- [x] git diff --check

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

- QueryService 的 aggregate 以默认接口方法引入，SnapshotQueryService 与 EventStreamQueryService 直接继承，普通第三方实现无需立即 override。
- 已核对 MongoDB/Elasticsearch 公开构造器签名；未新增依赖、模块、配置项或生成契约。
- Elasticsearch 的 event payload mapping 保持 enabled=false，因此推断出的逻辑字段仍受后端 mapping capability 约束；MongoDB 可在 STRICT 模式执行 payload 聚合。
- 无数据迁移或部署步骤；回滚可直接撤销本 PR。