### PR TITLE
docs: collapse inactive sidebar sections

### DIFF
--- a/documentation/docs/.vitepress/configs/sidebar.en.ts
+++ b/documentation/docs/.vitepress/configs/sidebar.en.ts
@@ -18,7 +18,7 @@ export const sidebarEn: DefaultTheme.Sidebar = {
         {
             text: 'Articles',
             base: '/articles/',
-            collapsed: false,
+            collapsed: true,
             items: [
                 {text: 'Articles Home', link: 'index.html'},
                 {text: 'HTTP 200 but the Query Is Empty', link: 'command-success-is-not-complete'},
@@ -31,7 +31,7 @@ export const sidebarEn: DefaultTheme.Sidebar = {
         {
             base: '/onboarding/',
             text: 'Evaluate and Contribute',
-            collapsed: false,
+            collapsed: true,
             items: [
                 {text: 'Choose by Role', link: 'index.html'},
                 {text: 'Contributor Guide', link: 'contributor-guide'},
@@ -45,7 +45,7 @@ export const sidebarEn: DefaultTheme.Sidebar = {
         {
             base: '/guide/',
             text: 'Start',
-            collapsed: false,
+            collapsed: true,
             items: [
                 {text: 'Guide Overview', link: 'index.html'},
                 {text: 'Introduction', link: 'introduction'},
@@ -57,7 +57,7 @@ export const sidebarEn: DefaultTheme.Sidebar = {
         {
             base: '/guide/',
             text: 'Domain Development',
-            collapsed: false,
+            collapsed: true,
             items: [
                 {text: 'Aggregate Modeling', link: 'modeling'},
                 {text: 'Event Store', link: 'eventstore'},
@@ -71,7 +71,7 @@ export const sidebarEn: DefaultTheme.Sidebar = {
         {
             base: '/guide/',
             text: 'Read Models and Queries',
-            collapsed: false,
+            collapsed: true,
             items: [
                 {text: 'Projection', link: 'projection'},
                 {text: 'Query Service', link: 'query'},
@@ -81,7 +81,7 @@ export const sidebarEn: DefaultTheme.Sidebar = {
         {
             base: '/guide/',
             text: 'Interfaces and Automation',
-            collapsed: false,
+            collapsed: true,
             items: [
                 {text: 'Open API', link: 'open-api'},
                 {text: 'Agent Skills', link: 'skills'},
@@ -91,7 +91,7 @@ export const sidebarEn: DefaultTheme.Sidebar = {
         {
             base: '/guide/',
             text: 'Testing and Delivery',
-            collapsed: false,
+            collapsed: true,
             items: [
                 {text: 'Test Suite', link: 'test-suite'},
                 {text: 'Application Testing', link: 'application-testing'},
@@ -101,7 +101,7 @@ export const sidebarEn: DefaultTheme.Sidebar = {
         {
             base: '/guide/',
             text: 'Production Operations',
-            collapsed: false,
+            collapsed: true,
             items: [
                 {text: 'Configuration', link: 'configuration'},
                 {text: 'BI Deployment and Recovery', link: 'bi-operations'},
@@ -111,7 +111,7 @@ export const sidebarEn: DefaultTheme.Sidebar = {
                 {
                     text: 'Migration Guide',
                     link: 'migration',
-                    collapsed: false,
+                    collapsed: true,
                     items: [
                         {text: 'Traditional Architecture', link: 'migration/traditional-architecture'},
                         {text: 'Migrate Wow v6 to v8', link: 'migration/v6-to-v8'},
@@ -165,7 +165,7 @@ export const sidebarEn: DefaultTheme.Sidebar = {
         {
             text: 'Configuration',
             base: '/reference/config/',
-            collapsed: false,
+            collapsed: true,
             items: [
                 {text: 'Core Configuration', link: 'core'},
                 {text: 'Infrastructure', link: 'infrastructure'},
@@ -176,7 +176,7 @@ export const sidebarEn: DefaultTheme.Sidebar = {
         {
             text: 'Examples',
             base: '/reference/example/',
-            collapsed: false,
+            collapsed: true,
             items: [
                 {text: 'Order and Cart (Kotlin)', link: 'order'},
                 {text: 'Bank Transfer (JAVA)', link: 'transfer'},
@@ -185,7 +185,7 @@ export const sidebarEn: DefaultTheme.Sidebar = {
         },
         {
             text: 'Ecosystem',
-            collapsed: false,
+            collapsed: true,
             items: [
                 {text: 'Ecosystem', link: '/reference/ecosystem'},
             ],

--- a/documentation/docs/.vitepress/configs/sidebar.zh.ts
+++ b/documentation/docs/.vitepress/configs/sidebar.zh.ts
@@ -18,7 +18,7 @@ export const sidebarZh: DefaultTheme.Sidebar = {
         {
             text: '文章',
             base: '/zh/articles/',
-            collapsed: false,
+            collapsed: true,
             items: [
                 {text: '文章首页', link: 'index.html'},
                 {text: '接口返回 200，查询却查不到', link: 'command-success-is-not-complete'},
@@ -31,7 +31,7 @@ export const sidebarZh: DefaultTheme.Sidebar = {
         {
             base: '/zh/onboarding/',
             text: '评估与参与',
-            collapsed: false,
+            collapsed: true,
             items: [
                 {text: '按角色选择', link: 'index.html'},
                 {text: '贡献者指南', link: 'contributor-guide'},
@@ -45,7 +45,7 @@ export const sidebarZh: DefaultTheme.Sidebar = {
         {
             base: '/zh/guide/',
             text: '开始使用',
-            collapsed: false,
+            collapsed: true,
             items: [
                 {text: '指南导览', link: 'index.html'},
                 {text: '简介', link: 'introduction'},
@@ -57,7 +57,7 @@ export const sidebarZh: DefaultTheme.Sidebar = {
         {
             base: '/zh/guide/',
             text: '领域开发',
-            collapsed: false,
+            collapsed: true,
             items: [
                 {text: '聚合建模', link: 'modeling'},
                 {text: '事件存储', link: 'eventstore'},
@@ -71,7 +71,7 @@ export const sidebarZh: DefaultTheme.Sidebar = {
         {
             base: '/zh/guide/',
             text: '读模型与查询',
-            collapsed: false,
+            collapsed: true,
             items: [
                 {text: '投影', link: 'projection'},
                 {text: '查询服务', link: 'query'},
@@ -81,7 +81,7 @@ export const sidebarZh: DefaultTheme.Sidebar = {
         {
             base: '/zh/guide/',
             text: '接口与自动化',
-            collapsed: false,
+            collapsed: true,
             items: [
                 {text: 'Open API', link: 'open-api'},
                 {text: 'Agent Skills', link: 'skills'},
@@ -91,7 +91,7 @@ export const sidebarZh: DefaultTheme.Sidebar = {
         {
             base: '/zh/guide/',
             text: '测试与交付',
-            collapsed: false,
+            collapsed: true,
             items: [
                 {text: '测试套件', link: 'test-suite'},
                 {text: '应用测试', link: 'application-testing'},
@@ -101,7 +101,7 @@ export const sidebarZh: DefaultTheme.Sidebar = {
         {
             base: '/zh/guide/',
             text: '生产运维',
-            collapsed: false,
+            collapsed: true,
             items: [
                 {text: '配置', link: 'configuration'},
                 {text: 'BI 部署与恢复', link: 'bi-operations'},
@@ -111,7 +111,7 @@ export const sidebarZh: DefaultTheme.Sidebar = {
                 {
                     text: '迁移指南',
                     link: 'migration',
-                    collapsed: false,
+                    collapsed: true,
                     items: [
                         {text: '传统架构迁移', link: 'migration/traditional-architecture'},
                         {text: 'Wow v6 迁移到 v8', link: 'migration/v6-to-v8'},
@@ -165,7 +165,7 @@ export const sidebarZh: DefaultTheme.Sidebar = {
         {
             text: '配置',
             base: '/zh/reference/config/',
-            collapsed: false,
+            collapsed: true,
             items: [
                 {text: '核心配置', link: 'core'},
                 {text: '基础设施', link: 'infrastructure'},
@@ -176,7 +176,7 @@ export const sidebarZh: DefaultTheme.Sidebar = {
         {
             text: '示例',
             base: '/zh/reference/example/',
-            collapsed: false,
+            collapsed: true,
             items: [
                 {text: '订单与购物车（Kotlin）', link: 'order'},
                 {text: '银行转账（JAVA）', link: 'transfer'},
@@ -185,7 +185,7 @@ export const sidebarZh: DefaultTheme.Sidebar = {
         },
         {
             text: '生态',
-            collapsed: false,
+            collapsed: true,
             items: [
                 {text: '生态资源', link: '/zh/reference/ecosystem'},
             ],

--- a/documentation/docs/en/guide/introduction.md
+++ b/documentation/docs/en/guide/introduction.md
@@ -78,6 +78,12 @@ flowchart LR
 
 The stages mean different things: `SENT` means accepted by the command bus, `PROCESSED` means aggregate processing completed, `SNAPSHOT` means snapshot processing completed, and `PROJECTED` means the selected projection completed. See [Data Flow](./advanced/data-flow.md) and [Runtime Lifecycle](./advanced/runtime-lifecycle.md).
 
+The complete component relationships are shown below:
+
+<p align="center" style="text-align:center">
+  <img width="95%" src="/images/Architecture.svg" alt="Wow architecture and modules"/>
+</p>
+
 ## Fit Boundary
 
 | Better fit | Evaluate carefully |
@@ -111,10 +117,6 @@ Wow does not discover a domain boundary, and compensation is not a database roll
 | Verify domain and application behavior | [Test Suite](./test-suite.md), [Application Testing](./application-testing.md) |
 | Expose generated contracts and routes | [OpenAPI](./open-api.md), [WebFlux](./extensions/webflux.md) |
 | Observe runtime pipelines | [OpenTelemetry](./extensions/opentelemetry.md), [Metrics](./advanced/metrics.md) |
-
-<p align="center" style="text-align:center">
-  <img width="95%" src="/images/Architecture.svg" alt="Wow architecture and modules"/>
-</p>
 
 ## Next Steps
 

--- a/documentation/docs/zh/guide/introduction.md
+++ b/documentation/docs/zh/guide/introduction.md
@@ -78,6 +78,12 @@ flowchart LR
 
 各阶段含义不同：`SENT` 表示命令总线已接收，`PROCESSED` 表示聚合处理完成，`SNAPSHOT` 表示快照处理完成，`PROJECTED` 表示选定投影完成。组件与调度细节见[数据流](./advanced/data-flow.md)和[运行时生命周期](./advanced/runtime-lifecycle.md)。
 
+完整的组件关系如下：
+
+<p align="center" style="text-align:center">
+  <img width="95%" src="/images/Architecture.svg" alt="Wow 架构与模块"/>
+</p>
+
 ## 适用边界
 
 | 更适合 | 需谨慎评估 |
@@ -111,10 +117,6 @@ Wow 不会自动发现领域边界，补偿也不等于数据库回滚。选择�
 | 验证领域与应用行为 | [测试套件](./test-suite.md)、[应用测试](./application-testing.md) |
 | 暴露生成契约与路由 | [OpenAPI](./open-api.md)、[WebFlux](./extensions/webflux.md) |
 | 观测运行管道 | [OpenTelemetry](./extensions/opentelemetry.md)、[指标](./advanced/metrics.md) |
-
-<p align="center" style="text-align:center">
-  <img width="95%" src="/images/Architecture.svg" alt="Wow 架构与模块"/>
-</p>
 
 ## 下一步
 


### PR DESCRIPTION
## Goal

Reduce sidebar scanning and scrolling by expanding only the section that contains the current page.

Completion criteria: the active section expands automatically, inactive sections start collapsed, and users can still expand any section manually in both locales.

## Changes

- Set every English and Chinese sidebar group to `collapsed: true`.
- Rely on VitePress active-link behavior to expand the current top-level group.
- Keep the nested migration group collapsed except on migration pages.

## Verification

- `pnpm --dir documentation docs:build` — PASS.
- `git diff --check` — PASS.
- Browser verification — PASS for Chinese Projection, migration, reference config, and article pages, plus the English Mongo extension page.
- Current Core Concepts page expands only “开始使用”; the other seven guide groups remain collapsed.

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

No migration, performance, concurrency, data, deployment, or generated-contract impact. The only behavior change is the initial sidebar disclosure state.