### PR TITLE
docs: clarify architecture diagram caption

### DIFF
--- a/documentation/docs/en/guide/introduction.md
+++ b/documentation/docs/en/guide/introduction.md
@@ -78,7 +78,7 @@ flowchart LR
 
 The stages mean different things: `SENT` means accepted by the command bus, `PROCESSED` means aggregate processing completed, `SNAPSHOT` means snapshot processing completed, and `PROJECTED` means the selected projection completed. See [Data Flow](./advanced/data-flow.md) and [Runtime Lifecycle](./advanced/runtime-lifecycle.md).
 
-The complete component relationships are shown below:
+The complete runtime architecture and data flow are shown below:
 
 <p align="center" style="text-align:center">
   <img width="95%" src="/images/Architecture.svg" alt="Wow architecture and modules"/>

--- a/documentation/docs/zh/guide/introduction.md
+++ b/documentation/docs/zh/guide/introduction.md
@@ -78,7 +78,7 @@ flowchart LR
 
 各阶段含义不同：`SENT` 表示命令总线已接收，`PROCESSED` 表示聚合处理完成，`SNAPSHOT` 表示快照处理完成，`PROJECTED` 表示选定投影完成。组件与调度细节见[数据流](./advanced/data-flow.md)和[运行时生命周期](./advanced/runtime-lifecycle.md)。
 
-完整的组件关系如下：
+完整的运行时架构与数据流如下：
 
 <p align="center" style="text-align:center">
   <img width="95%" src="/images/Architecture.svg" alt="Wow 架构与模块"/>


### PR DESCRIPTION
## Goal

Describe the architecture diagram accurately as a runtime architecture and data-flow view instead of only component relationships.

## Changes

- Clarify the Chinese introduction caption before the architecture diagram.
- Keep the English introduction caption semantically aligned.

## Verification

- `cd documentation && pnpm docs:build` — passed.
- `git diff --check` — passed.
- Independent review — no findings.

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

Documentation-only wording change. No migration, rollback, performance, concurrency, data, or deployment impact.