### PR TITLE
refactor(query): centralize protocol constants

### DIFF
--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
@@ -94,7 +94,7 @@ data class AggregationElement(
     }
 }
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = QueryProtocol.Polymorphic.TYPE)
 @JsonSubTypes(
     JsonSubTypes.Type(AggregationGroup.Terms::class, name = "TERMS"),
     JsonSubTypes.Type(AggregationGroup.Histogram::class, name = "HISTOGRAM"),
@@ -152,7 +152,7 @@ enum class AggregationDateUnit {
 }
 
 @MissingTypeImpl(AggregationExpression.Field::class)
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = QueryProtocol.Polymorphic.TYPE)
 @JsonSubTypes(
     JsonSubTypes.Type(AggregationExpression.Field::class, name = "FIELD"),
     JsonSubTypes.Type(AggregationExpression.Constant::class, name = "CONSTANT"),
@@ -164,7 +164,7 @@ enum class AggregationDateUnit {
         AggregationExpression.Constant::class,
         AggregationExpression.Binary::class,
     ],
-    discriminatorProperty = "type",
+    discriminatorProperty = QueryProtocol.Polymorphic.TYPE,
 )
 interface AggregationExpression {
     data class Field(val field: LogicalField) : AggregationExpression
@@ -189,7 +189,7 @@ enum class AggregationExpressionOperator {
     DIVIDE,
 }
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = QueryProtocol.Polymorphic.TYPE)
 @JsonSubTypes(
     JsonSubTypes.Type(AggregationMetric.Count::class, name = "COUNT"),
     JsonSubTypes.Type(AggregationMetric.Numeric::class, name = "NUMERIC"),
@@ -201,7 +201,7 @@ enum class AggregationExpressionOperator {
         AggregationMetric.Numeric::class,
         AggregationMetric.Any::class,
     ],
-    discriminatorProperty = "type",
+    discriminatorProperty = QueryProtocol.Polymorphic.TYPE,
 )
 sealed interface AggregationMetric {
     @get:Schema(accessMode = Schema.AccessMode.READ_WRITE)

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/FilterExpression.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/FilterExpression.kt
@@ -109,61 +109,61 @@ enum class StringComparison {
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
     include = JsonTypeInfo.As.EXISTING_PROPERTY,
-    property = "op",
+    property = QueryProtocol.FilterExpression.OP,
 )
 @JsonSubTypes(
-    JsonSubTypes.Type(MatchAllFilter::class, name = "MATCH_ALL"),
-    JsonSubTypes.Type(MatchNoneFilter::class, name = "MATCH_NONE"),
-    JsonSubTypes.Type(IdFilter::class, name = "ID"),
-    JsonSubTypes.Type(IdsFilter::class, name = "IDS"),
-    JsonSubTypes.Type(AggregateIdFilter::class, name = "AGGREGATE_ID"),
-    JsonSubTypes.Type(AggregateIdsFilter::class, name = "AGGREGATE_IDS"),
-    JsonSubTypes.Type(TenantIdFilter::class, name = "TENANT_ID"),
-    JsonSubTypes.Type(OwnerIdFilter::class, name = "OWNER_ID"),
-    JsonSubTypes.Type(SpaceIdFilter::class, name = "SPACE_ID"),
-    JsonSubTypes.Type(AndFilter::class, name = "AND"),
-    JsonSubTypes.Type(OrFilter::class, name = "OR"),
-    JsonSubTypes.Type(NorFilter::class, name = "NOR"),
-    JsonSubTypes.Type(EqualFilter::class, name = "EQ"),
-    JsonSubTypes.Type(NotEqualFilter::class, name = "NE"),
-    JsonSubTypes.Type(GreaterThanFilter::class, name = "GT"),
-    JsonSubTypes.Type(GreaterThanOrEqualFilter::class, name = "GTE"),
-    JsonSubTypes.Type(LessThanFilter::class, name = "LT"),
-    JsonSubTypes.Type(LessThanOrEqualFilter::class, name = "LTE"),
-    JsonSubTypes.Type(ContainsFilter::class, name = "CONTAINS"),
-    JsonSubTypes.Type(StartsWithFilter::class, name = "STARTS_WITH"),
-    JsonSubTypes.Type(EndsWithFilter::class, name = "ENDS_WITH"),
-    JsonSubTypes.Type(InFilter::class, name = "IN"),
-    JsonSubTypes.Type(NotInFilter::class, name = "NOT_IN"),
-    JsonSubTypes.Type(BetweenFilter::class, name = "BETWEEN"),
-    JsonSubTypes.Type(ContainsAllFilter::class, name = "CONTAINS_ALL"),
-    JsonSubTypes.Type(IsEmptyFilter::class, name = "IS_EMPTY"),
-    JsonSubTypes.Type(IsNullFilter::class, name = "IS_NULL"),
-    JsonSubTypes.Type(IsNotNullFilter::class, name = "IS_NOT_NULL"),
-    JsonSubTypes.Type(ExistsFilter::class, name = "EXISTS"),
-    JsonSubTypes.Type(NotExistsFilter::class, name = "NOT_EXISTS"),
-    JsonSubTypes.Type(DeletionFilter::class, name = "DELETION"),
-    JsonSubTypes.Type(ElementMatchFilter::class, name = "ELEMENT_MATCH"),
-    JsonSubTypes.Type(SearchFilter::class, name = "SEARCH"),
-    JsonSubTypes.Type(TodayFilter::class, name = "TODAY"),
-    JsonSubTypes.Type(BeforeTodayFilter::class, name = "BEFORE_TODAY"),
-    JsonSubTypes.Type(TomorrowFilter::class, name = "TOMORROW"),
-    JsonSubTypes.Type(ThisWeekFilter::class, name = "THIS_WEEK"),
-    JsonSubTypes.Type(NextWeekFilter::class, name = "NEXT_WEEK"),
-    JsonSubTypes.Type(LastWeekFilter::class, name = "LAST_WEEK"),
-    JsonSubTypes.Type(ThisMonthFilter::class, name = "THIS_MONTH"),
-    JsonSubTypes.Type(LastMonthFilter::class, name = "LAST_MONTH"),
-    JsonSubTypes.Type(RecentDaysFilter::class, name = "RECENT_DAYS"),
-    JsonSubTypes.Type(EarlierDaysFilter::class, name = "EARLIER_DAYS"),
-    JsonSubTypes.Type(YesterdayFilter::class, name = "YESTERDAY"),
-    JsonSubTypes.Type(NextMonthFilter::class, name = "NEXT_MONTH"),
-    JsonSubTypes.Type(LastYearFilter::class, name = "LAST_YEAR"),
-    JsonSubTypes.Type(ThisYearFilter::class, name = "THIS_YEAR"),
-    JsonSubTypes.Type(NextYearFilter::class, name = "NEXT_YEAR"),
+    JsonSubTypes.Type(MatchAllFilter::class, name = QueryProtocol.FilterExpression.Operator.MATCH_ALL),
+    JsonSubTypes.Type(MatchNoneFilter::class, name = QueryProtocol.FilterExpression.Operator.MATCH_NONE),
+    JsonSubTypes.Type(IdFilter::class, name = QueryProtocol.FilterExpression.Operator.ID),
+    JsonSubTypes.Type(IdsFilter::class, name = QueryProtocol.FilterExpression.Operator.IDS),
+    JsonSubTypes.Type(AggregateIdFilter::class, name = QueryProtocol.FilterExpression.Operator.AGGREGATE_ID),
+    JsonSubTypes.Type(AggregateIdsFilter::class, name = QueryProtocol.FilterExpression.Operator.AGGREGATE_IDS),
+    JsonSubTypes.Type(TenantIdFilter::class, name = QueryProtocol.FilterExpression.Operator.TENANT_ID),
+    JsonSubTypes.Type(OwnerIdFilter::class, name = QueryProtocol.FilterExpression.Operator.OWNER_ID),
+    JsonSubTypes.Type(SpaceIdFilter::class, name = QueryProtocol.FilterExpression.Operator.SPACE_ID),
+    JsonSubTypes.Type(AndFilter::class, name = QueryProtocol.FilterExpression.Operator.AND),
+    JsonSubTypes.Type(OrFilter::class, name = QueryProtocol.FilterExpression.Operator.OR),
+    JsonSubTypes.Type(NorFilter::class, name = QueryProtocol.FilterExpression.Operator.NOR),
+    JsonSubTypes.Type(EqualFilter::class, name = QueryProtocol.FilterExpression.Operator.EQ),
+    JsonSubTypes.Type(NotEqualFilter::class, name = QueryProtocol.FilterExpression.Operator.NE),
+    JsonSubTypes.Type(GreaterThanFilter::class, name = QueryProtocol.FilterExpression.Operator.GT),
+    JsonSubTypes.Type(GreaterThanOrEqualFilter::class, name = QueryProtocol.FilterExpression.Operator.GTE),
+    JsonSubTypes.Type(LessThanFilter::class, name = QueryProtocol.FilterExpression.Operator.LT),
+    JsonSubTypes.Type(LessThanOrEqualFilter::class, name = QueryProtocol.FilterExpression.Operator.LTE),
+    JsonSubTypes.Type(ContainsFilter::class, name = QueryProtocol.FilterExpression.Operator.CONTAINS),
+    JsonSubTypes.Type(StartsWithFilter::class, name = QueryProtocol.FilterExpression.Operator.STARTS_WITH),
+    JsonSubTypes.Type(EndsWithFilter::class, name = QueryProtocol.FilterExpression.Operator.ENDS_WITH),
+    JsonSubTypes.Type(InFilter::class, name = QueryProtocol.FilterExpression.Operator.IN),
+    JsonSubTypes.Type(NotInFilter::class, name = QueryProtocol.FilterExpression.Operator.NOT_IN),
+    JsonSubTypes.Type(BetweenFilter::class, name = QueryProtocol.FilterExpression.Operator.BETWEEN),
+    JsonSubTypes.Type(ContainsAllFilter::class, name = QueryProtocol.FilterExpression.Operator.CONTAINS_ALL),
+    JsonSubTypes.Type(IsEmptyFilter::class, name = QueryProtocol.FilterExpression.Operator.IS_EMPTY),
+    JsonSubTypes.Type(IsNullFilter::class, name = QueryProtocol.FilterExpression.Operator.IS_NULL),
+    JsonSubTypes.Type(IsNotNullFilter::class, name = QueryProtocol.FilterExpression.Operator.IS_NOT_NULL),
+    JsonSubTypes.Type(ExistsFilter::class, name = QueryProtocol.FilterExpression.Operator.EXISTS),
+    JsonSubTypes.Type(NotExistsFilter::class, name = QueryProtocol.FilterExpression.Operator.NOT_EXISTS),
+    JsonSubTypes.Type(DeletionFilter::class, name = QueryProtocol.FilterExpression.Operator.DELETION),
+    JsonSubTypes.Type(ElementMatchFilter::class, name = QueryProtocol.FilterExpression.Operator.ELEMENT_MATCH),
+    JsonSubTypes.Type(SearchFilter::class, name = QueryProtocol.FilterExpression.Operator.SEARCH),
+    JsonSubTypes.Type(TodayFilter::class, name = QueryProtocol.FilterExpression.Operator.TODAY),
+    JsonSubTypes.Type(BeforeTodayFilter::class, name = QueryProtocol.FilterExpression.Operator.BEFORE_TODAY),
+    JsonSubTypes.Type(TomorrowFilter::class, name = QueryProtocol.FilterExpression.Operator.TOMORROW),
+    JsonSubTypes.Type(ThisWeekFilter::class, name = QueryProtocol.FilterExpression.Operator.THIS_WEEK),
+    JsonSubTypes.Type(NextWeekFilter::class, name = QueryProtocol.FilterExpression.Operator.NEXT_WEEK),
+    JsonSubTypes.Type(LastWeekFilter::class, name = QueryProtocol.FilterExpression.Operator.LAST_WEEK),
+    JsonSubTypes.Type(ThisMonthFilter::class, name = QueryProtocol.FilterExpression.Operator.THIS_MONTH),
+    JsonSubTypes.Type(LastMonthFilter::class, name = QueryProtocol.FilterExpression.Operator.LAST_MONTH),
+    JsonSubTypes.Type(RecentDaysFilter::class, name = QueryProtocol.FilterExpression.Operator.RECENT_DAYS),
+    JsonSubTypes.Type(EarlierDaysFilter::class, name = QueryProtocol.FilterExpression.Operator.EARLIER_DAYS),
+    JsonSubTypes.Type(YesterdayFilter::class, name = QueryProtocol.FilterExpression.Operator.YESTERDAY),
+    JsonSubTypes.Type(NextMonthFilter::class, name = QueryProtocol.FilterExpression.Operator.NEXT_MONTH),
+    JsonSubTypes.Type(LastYearFilter::class, name = QueryProtocol.FilterExpression.Operator.LAST_YEAR),
+    JsonSubTypes.Type(ThisYearFilter::class, name = QueryProtocol.FilterExpression.Operator.THIS_YEAR),
+    JsonSubTypes.Type(NextYearFilter::class, name = QueryProtocol.FilterExpression.Operator.NEXT_YEAR),
 )
 @JsonTypeResolver(FilterExpressionTypeResolverBuilder::class)
 sealed interface FilterExpression : RewritableFilter<FilterExpression> {
-    @get:JsonProperty("op")
+    @get:JsonProperty(QueryProtocol.FilterExpression.OP)
     val operator: FilterOperator
 
     override fun withFilter(newFilter: FilterExpression): FilterExpression = newFilter
@@ -195,8 +195,10 @@ private class FilterExpressionTypeDeserializer(
         ctxt: DeserializationContext,
     ): Any {
         val node = ctxt.readTree(p)
-        require(!(node.has("op") && node.has("operator"))) { "op and operator cannot be used together." }
-        if (!node.has("op")) {
+        require(
+            !(node.has(QueryProtocol.FilterExpression.OP) && node.has(QueryProtocol.Condition.OPERATOR))
+        ) { "op and operator cannot be used together." }
+        if (!node.has(QueryProtocol.FilterExpression.OP)) {
             if (property != null) {
                 return ctxt.reportInputMismatch(
                     FilterExpression::class.java,
@@ -215,10 +217,14 @@ private class FilterExpressionTypeDeserializer(
 }
 
 private fun JsonNode.requireCanonicalFilterPayload() {
-    require(has("op")) { "Nested filter expression must use op." }
-    when (get("op").asString()) {
-        "AND", "OR", "NOR" -> get("operands")?.forEach { it.requireCanonicalFilterPayload() }
-        "ELEMENT_MATCH" -> get("predicate")?.requireCanonicalFilterPayload()
+    require(has(QueryProtocol.FilterExpression.OP)) { "Nested filter expression must use op." }
+    when (get(QueryProtocol.FilterExpression.OP).asString()) {
+        QueryProtocol.FilterExpression.Operator.AND,
+        QueryProtocol.FilterExpression.Operator.OR,
+        QueryProtocol.FilterExpression.Operator.NOR ->
+            get(QueryProtocol.FilterExpression.OPERANDS)?.forEach { it.requireCanonicalFilterPayload() }
+        QueryProtocol.FilterExpression.Operator.ELEMENT_MATCH ->
+            get(QueryProtocol.FilterExpression.PREDICATE)?.requireCanonicalFilterPayload()
     }
 }
 
@@ -236,17 +242,17 @@ private fun JsonNode.requireScalarEqualityValue(operator: String) {
     }
 }
 
-@JsonTypeName("MATCH_ALL")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.MATCH_ALL)
 data object MatchAllFilter : FilterExpression {
     override val operator: FilterOperator = FilterOperator.MATCH_ALL
 }
 
-@JsonTypeName("MATCH_NONE")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.MATCH_NONE)
 data object MatchNoneFilter : FilterExpression {
     override val operator: FilterOperator = FilterOperator.MATCH_NONE
 }
 
-@JsonTypeName("AND")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.AND)
 data class AndFilter(val operands: List<FilterExpression>) : FilterExpression {
     override val operator: FilterOperator = FilterOperator.AND
 
@@ -255,7 +261,7 @@ data class AndFilter(val operands: List<FilterExpression>) : FilterExpression {
     }
 }
 
-@JsonTypeName("OR")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.OR)
 data class OrFilter(val operands: List<FilterExpression>) : FilterExpression {
     override val operator: FilterOperator = FilterOperator.OR
 
@@ -264,7 +270,7 @@ data class OrFilter(val operands: List<FilterExpression>) : FilterExpression {
     }
 }
 
-@JsonTypeName("NOR")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.NOR)
 data class NorFilter(val operands: List<FilterExpression>) : FilterExpression {
     override val operator: FilterOperator = FilterOperator.NOR
 
@@ -273,14 +279,14 @@ data class NorFilter(val operands: List<FilterExpression>) : FilterExpression {
     }
 }
 
-@JsonTypeName("DELETION")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.DELETION)
 data class DeletionFilter(
     @get:JsonProperty("state") val deletionState: DeletionState,
 ) : FilterExpression {
     override val operator: FilterOperator = FilterOperator.DELETION
 }
 
-@JsonTypeName("ELEMENT_MATCH")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.ELEMENT_MATCH)
 data class ElementMatchFilter(
     val field: LogicalField,
     val predicate: FilterExpression,
@@ -294,7 +300,7 @@ data class ElementMatchFilter(
     }
 }
 
-@JsonTypeName("SEARCH")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.SEARCH)
 data class SearchFilter(
     val query: String,
     val fields: Set<LogicalField> = emptySet(),

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/MetadataFilters.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/MetadataFilters.kt
@@ -15,12 +15,12 @@ package me.ahoo.wow.api.query
 
 import com.fasterxml.jackson.annotation.JsonTypeName
 
-@JsonTypeName("ID")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.ID)
 data class IdFilter(val value: String) : FilterExpression {
     override val operator = FilterOperator.ID
 }
 
-@JsonTypeName("IDS")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.IDS)
 data class IdsFilter(val values: List<String>) : FilterExpression {
     override val operator = FilterOperator.IDS
 
@@ -29,12 +29,12 @@ data class IdsFilter(val values: List<String>) : FilterExpression {
     }
 }
 
-@JsonTypeName("AGGREGATE_ID")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.AGGREGATE_ID)
 data class AggregateIdFilter(val value: String) : FilterExpression {
     override val operator = FilterOperator.AGGREGATE_ID
 }
 
-@JsonTypeName("AGGREGATE_IDS")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.AGGREGATE_IDS)
 data class AggregateIdsFilter(val values: List<String>) : FilterExpression {
     override val operator = FilterOperator.AGGREGATE_IDS
 
@@ -43,17 +43,17 @@ data class AggregateIdsFilter(val values: List<String>) : FilterExpression {
     }
 }
 
-@JsonTypeName("TENANT_ID")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.TENANT_ID)
 data class TenantIdFilter(val value: String) : FilterExpression {
     override val operator = FilterOperator.TENANT_ID
 }
 
-@JsonTypeName("OWNER_ID")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.OWNER_ID)
 data class OwnerIdFilter(val value: String) : FilterExpression {
     override val operator = FilterOperator.OWNER_ID
 }
 
-@JsonTypeName("SPACE_ID")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.SPACE_ID)
 data class SpaceIdFilter(val value: String) : FilterExpression {
     override val operator = FilterOperator.SPACE_ID
 }

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/PredicateFilters.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/PredicateFilters.kt
@@ -43,7 +43,7 @@ private fun List<JsonNode>.requireFilterLiterals(operator: FilterOperator) {
     }
 }
 
-@JsonTypeName("EQ")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.EQ)
 data class EqualFilter(val field: LogicalField, val value: JsonNode) : FilterExpression {
     override val operator: FilterOperator = FilterOperator.EQ
 
@@ -52,7 +52,7 @@ data class EqualFilter(val field: LogicalField, val value: JsonNode) : FilterExp
     }
 }
 
-@JsonTypeName("NE")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.NE)
 data class NotEqualFilter(val field: LogicalField, val value: JsonNode) : FilterExpression {
     override val operator: FilterOperator = FilterOperator.NE
 
@@ -61,7 +61,7 @@ data class NotEqualFilter(val field: LogicalField, val value: JsonNode) : Filter
     }
 }
 
-@JsonTypeName("GT")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.GT)
 data class GreaterThanFilter(val field: LogicalField, val value: JsonNode) : FilterExpression {
     override val operator: FilterOperator = FilterOperator.GT
 
@@ -70,7 +70,7 @@ data class GreaterThanFilter(val field: LogicalField, val value: JsonNode) : Fil
     }
 }
 
-@JsonTypeName("GTE")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.GTE)
 data class GreaterThanOrEqualFilter(val field: LogicalField, val value: JsonNode) : FilterExpression {
     override val operator: FilterOperator = FilterOperator.GTE
 
@@ -79,7 +79,7 @@ data class GreaterThanOrEqualFilter(val field: LogicalField, val value: JsonNode
     }
 }
 
-@JsonTypeName("LT")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.LT)
 data class LessThanFilter(val field: LogicalField, val value: JsonNode) : FilterExpression {
     override val operator: FilterOperator = FilterOperator.LT
 
@@ -88,7 +88,7 @@ data class LessThanFilter(val field: LogicalField, val value: JsonNode) : Filter
     }
 }
 
-@JsonTypeName("LTE")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.LTE)
 data class LessThanOrEqualFilter(val field: LogicalField, val value: JsonNode) : FilterExpression {
     override val operator: FilterOperator = FilterOperator.LTE
 
@@ -97,7 +97,7 @@ data class LessThanOrEqualFilter(val field: LogicalField, val value: JsonNode) :
     }
 }
 
-@JsonTypeName("CONTAINS")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.CONTAINS)
 data class ContainsFilter(
     val field: LogicalField,
     val value: String,
@@ -106,7 +106,7 @@ data class ContainsFilter(
     override val operator: FilterOperator = FilterOperator.CONTAINS
 }
 
-@JsonTypeName("STARTS_WITH")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.STARTS_WITH)
 data class StartsWithFilter(
     val field: LogicalField,
     val value: String,
@@ -115,7 +115,7 @@ data class StartsWithFilter(
     override val operator: FilterOperator = FilterOperator.STARTS_WITH
 }
 
-@JsonTypeName("ENDS_WITH")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.ENDS_WITH)
 data class EndsWithFilter(
     val field: LogicalField,
     val value: String,
@@ -124,7 +124,7 @@ data class EndsWithFilter(
     override val operator: FilterOperator = FilterOperator.ENDS_WITH
 }
 
-@JsonTypeName("IN")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.IN)
 data class InFilter(val field: LogicalField, val values: List<JsonNode>) : FilterExpression {
     override val operator: FilterOperator = FilterOperator.IN
 
@@ -133,7 +133,7 @@ data class InFilter(val field: LogicalField, val values: List<JsonNode>) : Filte
     }
 }
 
-@JsonTypeName("NOT_IN")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.NOT_IN)
 data class NotInFilter(val field: LogicalField, val values: List<JsonNode>) : FilterExpression {
     override val operator: FilterOperator = FilterOperator.NOT_IN
 
@@ -142,7 +142,7 @@ data class NotInFilter(val field: LogicalField, val values: List<JsonNode>) : Fi
     }
 }
 
-@JsonTypeName("BETWEEN")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.BETWEEN)
 data class BetweenFilter(
     val field: LogicalField,
     val lowerBound: JsonNode,
@@ -156,7 +156,7 @@ data class BetweenFilter(
     }
 }
 
-@JsonTypeName("CONTAINS_ALL")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.CONTAINS_ALL)
 data class ContainsAllFilter(val field: LogicalField, val values: List<JsonNode>) : FilterExpression {
     override val operator: FilterOperator = FilterOperator.CONTAINS_ALL
 
@@ -165,27 +165,27 @@ data class ContainsAllFilter(val field: LogicalField, val values: List<JsonNode>
     }
 }
 
-@JsonTypeName("IS_EMPTY")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.IS_EMPTY)
 data class IsEmptyFilter(val field: LogicalField) : FilterExpression {
     override val operator: FilterOperator = FilterOperator.IS_EMPTY
 }
 
-@JsonTypeName("IS_NULL")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.IS_NULL)
 data class IsNullFilter(val field: LogicalField) : FilterExpression {
     override val operator: FilterOperator = FilterOperator.IS_NULL
 }
 
-@JsonTypeName("IS_NOT_NULL")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.IS_NOT_NULL)
 data class IsNotNullFilter(val field: LogicalField) : FilterExpression {
     override val operator: FilterOperator = FilterOperator.IS_NOT_NULL
 }
 
-@JsonTypeName("EXISTS")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.EXISTS)
 data class ExistsFilter(val field: LogicalField) : FilterExpression {
     override val operator: FilterOperator = FilterOperator.EXISTS
 }
 
-@JsonTypeName("NOT_EXISTS")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.NOT_EXISTS)
 data class NotExistsFilter(val field: LogicalField) : FilterExpression {
     override val operator: FilterOperator = FilterOperator.NOT_EXISTS
 }

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/QueryJsonDeserializer.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/QueryJsonDeserializer.kt
@@ -66,15 +66,15 @@ private fun ObjectNode.prepareCompatibleFilter(
     ctxt: DeserializationContext,
     inputType: Class<*>,
 ) {
-    val hasFilter = has("filter")
-    val hasCondition = has("condition")
+    val hasFilter = has(QueryProtocol.QueryEnvelope.FILTER)
+    val hasCondition = has(QueryProtocol.QueryEnvelope.CONDITION)
     if (hasFilter && hasCondition) {
         ctxt.reportInputMismatch<Nothing>(inputType, "filter and condition cannot be used together.")
     }
     if (!hasFilter && !hasCondition) {
         ctxt.reportInputMismatch<Nothing>(inputType, "Exactly one of filter or condition is required.")
     }
-    listOf("filter", "condition").forEach { property ->
+    listOf(QueryProtocol.QueryEnvelope.FILTER, QueryProtocol.QueryEnvelope.CONDITION).forEach { property ->
         if (get(property)?.isNull == true) {
             ctxt.reportInputMismatch<Nothing>(inputType, "$property cannot be null.")
         }
@@ -84,24 +84,47 @@ private fun ObjectNode.prepareCompatibleFilter(
     }
 }
 
-private val LEGACY_CONDITION_PROPERTIES = setOf("field", "operator", "value", "children", "options")
-private val LEGACY_PROJECTION_PROPERTIES = setOf("include", "exclude")
-private val LEGACY_SORT_PROPERTIES = setOf("field", "direction")
-private val LEGACY_PAGINATION_PROPERTIES = setOf("index", "size")
+private val LEGACY_CONDITION_PROPERTIES = setOf(
+    QueryProtocol.Condition.FIELD,
+    QueryProtocol.Condition.OPERATOR,
+    QueryProtocol.Condition.VALUE,
+    QueryProtocol.Condition.CHILDREN,
+    QueryProtocol.Condition.OPTIONS,
+)
+private val LEGACY_PROJECTION_PROPERTIES = setOf(
+    QueryProtocol.Projection.INCLUDE,
+    QueryProtocol.Projection.EXCLUDE,
+)
+private val LEGACY_SORT_PROPERTIES = setOf(QueryProtocol.Sort.FIELD, QueryProtocol.Sort.DIRECTION)
+private val LEGACY_PAGINATION_PROPERTIES = setOf(QueryProtocol.Pagination.INDEX, QueryProtocol.Pagination.SIZE)
 
 // The legacy WebFlux path ignored unknown properties across the entire query body.
 private fun ObjectNode.removeUnknownLegacyQueryProperties(inputType: Class<*>) {
     val queryProperties = when (inputType) {
-        ListQueryJson::class.java -> setOf("condition", "projection", "sort", "limit")
-        PagedQueryJson::class.java -> setOf("condition", "projection", "sort", "pagination")
-        SingleQueryJson::class.java -> setOf("condition", "projection", "sort")
+        ListQueryJson::class.java -> setOf(
+            QueryProtocol.QueryEnvelope.CONDITION,
+            QueryProtocol.QueryEnvelope.PROJECTION,
+            QueryProtocol.QueryEnvelope.SORT,
+            QueryProtocol.QueryEnvelope.LIMIT,
+        )
+        PagedQueryJson::class.java -> setOf(
+            QueryProtocol.QueryEnvelope.CONDITION,
+            QueryProtocol.QueryEnvelope.PROJECTION,
+            QueryProtocol.QueryEnvelope.SORT,
+            QueryProtocol.QueryEnvelope.PAGINATION,
+        )
+        SingleQueryJson::class.java -> setOf(
+            QueryProtocol.QueryEnvelope.CONDITION,
+            QueryProtocol.QueryEnvelope.PROJECTION,
+            QueryProtocol.QueryEnvelope.SORT,
+        )
         else -> error("Unsupported legacy query type: ${inputType.name}.")
     }
     remove(propertyNames().filterNot(queryProperties::contains))
-    get("condition")?.removeUnknownLegacyConditionProperties()
-    get("projection")?.removeUnknownProperties(LEGACY_PROJECTION_PROPERTIES)
-    get("sort")?.forEach { it.removeUnknownProperties(LEGACY_SORT_PROPERTIES) }
-    get("pagination")?.removeUnknownProperties(LEGACY_PAGINATION_PROPERTIES)
+    get(QueryProtocol.QueryEnvelope.CONDITION)?.removeUnknownLegacyConditionProperties()
+    get(QueryProtocol.QueryEnvelope.PROJECTION)?.removeUnknownProperties(LEGACY_PROJECTION_PROPERTIES)
+    get(QueryProtocol.QueryEnvelope.SORT)?.forEach { it.removeUnknownProperties(LEGACY_SORT_PROPERTIES) }
+    get(QueryProtocol.QueryEnvelope.PAGINATION)?.removeUnknownProperties(LEGACY_PAGINATION_PROPERTIES)
 }
 
 private fun JsonNode.removeUnknownProperties(properties: Set<String>) {
@@ -115,7 +138,7 @@ private fun JsonNode.removeUnknownLegacyConditionProperties() {
         return
     }
     remove(propertyNames().filterNot(LEGACY_CONDITION_PROPERTIES::contains))
-    get("children")?.forEach(JsonNode::removeUnknownLegacyConditionProperties)
+    get(QueryProtocol.Condition.CHILDREN)?.forEach(JsonNode::removeUnknownLegacyConditionProperties)
 }
 
 internal fun JsonNode.toLegacyFilterExpression(ctxt: DeserializationContext): FilterExpression {

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/QueryProtocol.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/QueryProtocol.kt
@@ -1,0 +1,109 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.api.query
+
+internal object QueryProtocol {
+    object Polymorphic {
+        const val TYPE = "type"
+    }
+
+    object FilterExpression {
+        const val OP = "op"
+        const val OPERANDS = "operands"
+        const val PREDICATE = "predicate"
+
+        object Operator {
+            const val MATCH_ALL = "MATCH_ALL"
+            const val MATCH_NONE = "MATCH_NONE"
+            const val ID = "ID"
+            const val IDS = "IDS"
+            const val AGGREGATE_ID = "AGGREGATE_ID"
+            const val AGGREGATE_IDS = "AGGREGATE_IDS"
+            const val TENANT_ID = "TENANT_ID"
+            const val OWNER_ID = "OWNER_ID"
+            const val SPACE_ID = "SPACE_ID"
+            const val AND = "AND"
+            const val OR = "OR"
+            const val NOR = "NOR"
+            const val EQ = "EQ"
+            const val NE = "NE"
+            const val GT = "GT"
+            const val GTE = "GTE"
+            const val LT = "LT"
+            const val LTE = "LTE"
+            const val CONTAINS = "CONTAINS"
+            const val STARTS_WITH = "STARTS_WITH"
+            const val ENDS_WITH = "ENDS_WITH"
+            const val IN = "IN"
+            const val NOT_IN = "NOT_IN"
+            const val BETWEEN = "BETWEEN"
+            const val CONTAINS_ALL = "CONTAINS_ALL"
+            const val IS_EMPTY = "IS_EMPTY"
+            const val IS_NULL = "IS_NULL"
+            const val IS_NOT_NULL = "IS_NOT_NULL"
+            const val EXISTS = "EXISTS"
+            const val NOT_EXISTS = "NOT_EXISTS"
+            const val DELETION = "DELETION"
+            const val ELEMENT_MATCH = "ELEMENT_MATCH"
+            const val SEARCH = "SEARCH"
+            const val TODAY = "TODAY"
+            const val BEFORE_TODAY = "BEFORE_TODAY"
+            const val TOMORROW = "TOMORROW"
+            const val THIS_WEEK = "THIS_WEEK"
+            const val NEXT_WEEK = "NEXT_WEEK"
+            const val LAST_WEEK = "LAST_WEEK"
+            const val THIS_MONTH = "THIS_MONTH"
+            const val LAST_MONTH = "LAST_MONTH"
+            const val RECENT_DAYS = "RECENT_DAYS"
+            const val EARLIER_DAYS = "EARLIER_DAYS"
+            const val YESTERDAY = "YESTERDAY"
+            const val NEXT_MONTH = "NEXT_MONTH"
+            const val LAST_YEAR = "LAST_YEAR"
+            const val THIS_YEAR = "THIS_YEAR"
+            const val NEXT_YEAR = "NEXT_YEAR"
+        }
+    }
+
+    object QueryEnvelope {
+        const val FILTER = "filter"
+        const val CONDITION = "condition"
+        const val PROJECTION = "projection"
+        const val SORT = "sort"
+        const val PAGINATION = "pagination"
+        const val LIMIT = "limit"
+    }
+
+    object Condition {
+        const val FIELD = "field"
+        const val OPERATOR = "operator"
+        const val VALUE = "value"
+        const val CHILDREN = "children"
+        const val OPTIONS = "options"
+    }
+
+    object Projection {
+        const val INCLUDE = "include"
+        const val EXCLUDE = "exclude"
+    }
+
+    object Sort {
+        const val FIELD = "field"
+        const val DIRECTION = "direction"
+    }
+
+    object Pagination {
+        const val INDEX = "index"
+        const val SIZE = "size"
+    }
+}

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/RelativeTimeFilters.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/RelativeTimeFilters.kt
@@ -52,7 +52,7 @@ private fun RelativeTimeFilter.validateConfiguration() {
     datePattern.toDateFormatter()
 }
 
-@JsonTypeName("TODAY")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.TODAY)
 data class TodayFilter(
     override val field: LogicalField,
     override val zoneId: String? = null,
@@ -67,7 +67,7 @@ data class TodayFilter(
     }
 }
 
-@JsonTypeName("BEFORE_TODAY")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.BEFORE_TODAY)
 data class BeforeTodayFilter(
     override val field: LogicalField,
     val time: String,
@@ -84,7 +84,7 @@ data class BeforeTodayFilter(
     }
 }
 
-@JsonTypeName("TOMORROW")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.TOMORROW)
 data class TomorrowFilter(
     override val field: LogicalField,
     override val zoneId: String? = null,
@@ -99,7 +99,7 @@ data class TomorrowFilter(
     }
 }
 
-@JsonTypeName("THIS_WEEK")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.THIS_WEEK)
 data class ThisWeekFilter(
     override val field: LogicalField,
     override val zoneId: String? = null,
@@ -114,7 +114,7 @@ data class ThisWeekFilter(
     }
 }
 
-@JsonTypeName("NEXT_WEEK")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.NEXT_WEEK)
 data class NextWeekFilter(
     override val field: LogicalField,
     override val zoneId: String? = null,
@@ -129,7 +129,7 @@ data class NextWeekFilter(
     }
 }
 
-@JsonTypeName("LAST_WEEK")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.LAST_WEEK)
 data class LastWeekFilter(
     override val field: LogicalField,
     override val zoneId: String? = null,
@@ -144,7 +144,7 @@ data class LastWeekFilter(
     }
 }
 
-@JsonTypeName("THIS_MONTH")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.THIS_MONTH)
 data class ThisMonthFilter(
     override val field: LogicalField,
     override val zoneId: String? = null,
@@ -159,7 +159,7 @@ data class ThisMonthFilter(
     }
 }
 
-@JsonTypeName("LAST_MONTH")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.LAST_MONTH)
 data class LastMonthFilter(
     override val field: LogicalField,
     override val zoneId: String? = null,
@@ -174,7 +174,7 @@ data class LastMonthFilter(
     }
 }
 
-@JsonTypeName("RECENT_DAYS")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.RECENT_DAYS)
 data class RecentDaysFilter(
     override val field: LogicalField,
     val days: Int,
@@ -191,7 +191,7 @@ data class RecentDaysFilter(
     }
 }
 
-@JsonTypeName("EARLIER_DAYS")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.EARLIER_DAYS)
 data class EarlierDaysFilter(
     override val field: LogicalField,
     val days: Int,
@@ -208,7 +208,7 @@ data class EarlierDaysFilter(
     }
 }
 
-@JsonTypeName("YESTERDAY")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.YESTERDAY)
 data class YesterdayFilter(
     override val field: LogicalField,
     override val zoneId: String? = null,
@@ -221,7 +221,7 @@ data class YesterdayFilter(
     init { validateConfiguration() }
 }
 
-@JsonTypeName("NEXT_MONTH")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.NEXT_MONTH)
 data class NextMonthFilter(
     override val field: LogicalField,
     override val zoneId: String? = null,
@@ -234,7 +234,7 @@ data class NextMonthFilter(
     init { validateConfiguration() }
 }
 
-@JsonTypeName("LAST_YEAR")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.LAST_YEAR)
 data class LastYearFilter(
     override val field: LogicalField,
     override val zoneId: String? = null,
@@ -247,7 +247,7 @@ data class LastYearFilter(
     init { validateConfiguration() }
 }
 
-@JsonTypeName("THIS_YEAR")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.THIS_YEAR)
 data class ThisYearFilter(
     override val field: LogicalField,
     override val zoneId: String? = null,
@@ -260,7 +260,7 @@ data class ThisYearFilter(
     init { validateConfiguration() }
 }
 
-@JsonTypeName("NEXT_YEAR")
+@JsonTypeName(QueryProtocol.FilterExpression.Operator.NEXT_YEAR)
 data class NextYearFilter(
     override val field: LogicalField,
     override val zoneId: String? = null,

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/schema/QueryTemporal.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/schema/QueryTemporal.kt
@@ -17,10 +17,11 @@ import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import io.swagger.v3.oas.annotations.media.Schema
+import me.ahoo.wow.api.query.QueryProtocol
 import java.time.format.DateTimeFormatter
 import java.util.concurrent.TimeUnit
 
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = QueryProtocol.Polymorphic.TYPE)
 @JsonSubTypes(
     JsonSubTypes.Type(Temporal.Date::class, name = "TEMPORAL_DATE"),
     JsonSubTypes.Type(Temporal.Epoch::class, name = "TEMPORAL_EPOCH"),
@@ -28,7 +29,7 @@ import java.util.concurrent.TimeUnit
 )
 @Schema(
     oneOf = [Temporal.Date::class, Temporal.Epoch::class, Temporal.Formatted::class],
-    discriminatorProperty = "type",
+    discriminatorProperty = QueryProtocol.Polymorphic.TYPE,
 )
 interface QuerySemanticType
 


### PR DESCRIPTION
## Summary

- centralize query JSON property names in a hierarchical internal `QueryProtocol`
- reuse explicit filter operator constants across Jackson subtype annotations and compatibility parsing
- keep aggregation/temporal subtype values and the public wire contract unchanged

## Verification

- `./gradlew :wow-api:check :wow-webflux:check :wow-schema:check :wow-openapi:check --rerun-tasks` — 69 tasks executed
- `git diff --check`