### PR TITLE
feat(webflux): expose event stream aggregation REST API

### DIFF
--- a/docs/superpowers/specs/2026-08-28-event-stream-aggregation-rest-api-design.md
+++ b/docs/superpowers/specs/2026-08-28-event-stream-aggregation-rest-api-design.md
@@ -1,0 +1,165 @@
+# EventStream 聚合 REST API 设计
+
+## 背景
+
+EventStream 聚合已经由 `EventStreamQueryService`、`EventStreamQueryGateway`、Query Schema、MongoDB 和 Elasticsearch 实现，并经过后端共享 TCK 验证。当前缺口仅在 HTTP 边界：Event 路由已有 list、paged、count，但没有把现有聚合能力暴露为 REST API。
+
+本设计在现有 Event 查询路由中增加 aggregation 端点。实现复用 Snapshot aggregation 已验证的请求提取、动态结果响应和异常链，同时保持 Event 路由自己的合同约定。
+
+## 目标
+
+- 为 EventStream 增加 `POST .../event/aggregation`。
+- 复用 Event 查询现有的基础、tenant、owner 路由变体。
+- 请求体使用公共 `AggregationQuery`。
+- `Accept: application/json` 返回动态行数组。
+- `Accept: text/event-stream` 逐行返回 SSE。
+- 请求继续经过 tenant/owner rewrite、EventStream QueryGateway、Query Filter、HTTP guard、Schema 解析和后端聚合链。
+- OpenAPI 与运行时路由来自同一个 route contract。
+- 中英文 WebFlux 文档同步说明端点与 EventStream payload 能力边界。
+
+## 非目标
+
+- 不修改 `AggregationQuery`、Query DSL、`QueryService`、`EventStreamQueryGateway` 或后端聚合实现。
+- 不新增 EventStream Schema HTTP 端点。
+- 不扩展 `wow-apiclient`。
+- 不新增 EventStream 专用 OpenAPI 请求组件或 `x-wow-query-fields`。
+- 不重构 Snapshot aggregation handler，也不引入通用 aggregation handler 抽象。
+- 不新增配置项、依赖、Gradle 模块、CI/CD 或发布逻辑。
+
+## HTTP 合同
+
+`EventRouteContributor` 使用现有 `tenantOwnerVariants`、`aggregatePath` 和 `eventRoute` 生成路由。新增合同的固定部分如下：
+
+| 属性 | 值 |
+| --- | --- |
+| Method | `POST` |
+| Path suffix | `event/aggregation` |
+| Handler key | `wow.openapi.aggregate.event.aggregation` |
+| Request body | 全局 `wow.AggregationQuery` 组件 |
+| Accept | `application/json`、`text/event-stream` |
+| Success response | 现有 aggregation `200` JSON/SSE 合同 |
+
+实际完整路径继续由聚合 metadata 决定。对于适用的聚合，route contributor 与 event/list、event/paged、event/count 一样生成：
+
+- 无作用域变体；
+- tenant 变体；
+- owner 变体。
+
+OpenAPI 遵循其他 Event 查询路由的响应声明习惯，只在该 route contract 中显式声明 aggregation `200` 响应，不额外添加 Snapshot aggregation 当前声明的 `408`、`429` response refs。运行时已有 timeout、guard 与全局异常处理不因此改变。
+
+## 组件设计
+
+### Route contract
+
+`BuiltInHttpRouteHandlerKeys.Event` 增加 `AGGREGATION`。`EventRouteContributor.queryRoutes` 在每个现有 tenant/owner variant 中增加 aggregation contract：
+
+- `operation = "aggregation"`；
+- `operationSummary = "Aggregate Event Stream"`；
+- `resourceName = EVENT`；
+- request body 使用 `aggregationQueryRequestBodyRef()`；
+- response 使用 `aggregationResponse()`；
+- streaming accept 与 Event list、Snapshot aggregation 保持一致。
+
+不新增 EventStream 专用 request-body schema。运行时 EventStream Query Schema 仍负责字段解析与 capability 校验；OpenAPI 只表达公共 `AggregationQuery` wire contract。
+
+### WebFlux handler
+
+新增 `EventStreamAggregationHandlerFunction`，结构与现有 `SnapshotAggregationHandlerFunction` 对称，但依赖 `EventStreamQueryGateway`：
+
+1. 使用现有 `AGGREGATION_QUERY_EXTRACTOR` 读取请求体；
+2. 使用 `RewriteRequestFilter` 注入 route scope；
+3. 调用 `EventStreamQueryGateway.aggregate(aggregateMetadata, query)`；
+4. 使用 `writeRawRequest` 把当前 HTTP request 放入查询上下文；
+5. 使用现有 `toServerResponse` 输出 JSON 或 SSE，并交给 `RequestExceptionHandler` 处理失败。
+
+同文件提供 `EventStreamAggregationHandlerFunctionFactory`，绑定新增 handler key。保持独立 handler，避免为了两个调用点改造稳定的 Snapshot handler。
+
+### Starter 注册
+
+`QueryRouteModule` 把 `EventStreamAggregationHandlerFunctionFactory` 加入现有 Event 查询 factory 列表。无需新增 bean、条件注解或配置属性。
+
+## 数据流
+
+```text
+POST .../event/aggregation
+  -> Event route contract / RouterFunction
+  -> AggregationQuery body extractor
+  -> tenant/owner RewriteRequestFilter
+  -> EventStreamQueryGateway.aggregate
+  -> EventStream Query Filter chain + HTTP guard
+  -> EventStream Query Schema resolution
+  -> MongoDB or Elasticsearch aggregation
+  -> JSON array or SSE rows
+```
+
+EventStream 聚合的字段语义保持现有服务合同：根 filter 作用于 EventStream 文档；`elements = [body]` 展开事件数组；后续 element/group/metric 字段相对当前 element。Elasticsearch 现有 `body.body` payload mapping 限制保持不变，REST API 不提供扫描或静默降级。
+
+## 错误处理与安全边界
+
+- JSON 反序列化、`AggregationQuery` 构造约束和公共 HTTP guard 继续拒绝非法输入。
+- tenant/owner 只表达资源作用域；认证与主体绑定仍由应用安全层负责。
+- Schema 冲突、字段 capability 不匹配、严格模式未知字段及后端异常沿现有查询链传播。
+- 不捕获后端错误并返回空数组或空 SSE。
+- 第三方 `EventStreamQueryService` 若继承默认不支持 aggregation 的实现，端点保留失败语义，不伪装为可用能力。
+- JSON/SSE cancellation、idle timeout 和全局错误映射继续由现有 WebFlux 响应策略处理。
+
+## 兼容性
+
+该变更只新增 HTTP route、handler key 和 OpenAPI operation，不修改现有路径、DTO 或 JVM API。现有 Event list、paged、count、load、compensate 和 resend 路由保持不变。
+
+新增 route 可能被应用现有的通配安全规则覆盖。应用升级时必须检查认证、授权、网关和限流策略是否按预期保护 `event/aggregation`；生成路由本身不构成授权证明。
+
+## 文档
+
+同步更新：
+
+- `documentation/docs/zh/guide/extensions/webflux.md`
+- `documentation/docs/en/guide/extensions/webflux.md`
+
+文档说明 EventStream aggregation 与 Snapshot aggregation 使用相同的 JSON/SSE 响应方式，但请求字段来自 EventStream Schema；同时明确 Elasticsearch payload 聚合限制。
+
+## 测试策略
+
+### OpenAPI 与 route contract
+
+- 验证基础、tenant、owner 三类 `event/aggregation` 路由。
+- 验证 method、path suffix、route ID、handler key 和 aggregate handler metadata。
+- 验证 request body 引用全局 `wow.AggregationQuery`。
+- 验证 `200` 同时声明 JSON 数组和 SSE 响应。
+- 更新并审查 OpenAPI 与 route-contract snapshots。
+
+### WebFlux
+
+- 新增一个聚焦的 `EventStreamAggregationHandlerFunctionTest`。
+- 验证请求体被提取并传给 `EventStreamQueryGateway.aggregate`。
+- 验证 route scope rewrite 后的 query 进入 gateway。
+- 验证动态聚合行通过现有响应策略返回。
+- 使用现有 route module/registrar 合同测试验证 factory 可物化；仅在现有覆盖不足时补最小断言。
+
+### 不重复的验证
+
+不新增 MongoDB/Elasticsearch 聚合集成用例。两种后端的 EventStream aggregation 已由共享 TCK 覆盖，本次数据和后端执行链未改变。
+
+## 验证命令
+
+```bash
+./gradlew \
+  :wow-openapi:check \
+  :wow-webflux:check \
+  :wow-spring-boot-starter:check
+
+cd documentation
+pnpm docs:build
+
+git diff --check
+```
+
+## 完成条件
+
+- 现有适用聚合生成基础、tenant、owner `event/aggregation` route contracts。
+- WebFlux 能通过 EventStream QueryGateway 执行 `AggregationQuery`。
+- JSON 与 SSE 响应合同通过 handler 和 OpenAPI 测试。
+- OpenAPI 请求使用全局 `AggregationQuery`，不新增 Event 专用字段组件。
+- Event 其他查询路由合同保持不变。
+- 中英文文档同步且构建通过。
+- 未修改后端、API client、依赖、配置或模块结构。

--- a/documentation/docs/en/guide/extensions/webflux.md
+++ b/documentation/docs/en/guide/extensions/webflux.md
@@ -63,9 +63,16 @@ wow:
 
 `0` disables each numeric HTTP guard; `idle-timeout=0s` disables idle timeout. Do not duplicate backend field-type, mapping, or uniqueness checks. `HttpQueryGuardFilter` protects HTTP queries with WebFlux request context; programmatic query services retain their public behavior.
 
-## Snapshot Aggregation Route
+## Aggregation Query Routes
 
-The aggregation route accepts `AggregationQuery`. Normal JSON collects dynamic rows into an array; `Accept: text/event-stream` streams rows. Query guards also limit conditions, values, limits, Elements, metric sorting, and expensive expressions.
+Both Snapshot and EventStream routes accept `AggregationQuery`:
+
+- `.../snapshot/aggregation` aggregates the snapshot model;
+- `.../event/aggregation` aggregates the event-stream model and follows the same base, tenant, and owner route rules as event/list, event/paged, and event/count.
+
+Normal JSON collects dynamic rows into an array; `Accept: text/event-stream` streams rows. Query guards also limit conditions, values, limits, Elements, metric sorting, and expensive expressions.
+
+An EventStream root filter applies to the event-stream document. After `elements = [{"path":"body"}]` expands the event array, group and metric fields are relative to each event item. Elasticsearch currently does not index the `body.body` payload, so the cross-backend aggregation scope is the event-stream envelope and `body` event metadata. Payload aggregation requires a separate mapping and historical reindex design first.
 
 ## Wait Plan Integration
 

--- a/documentation/docs/zh/guide/extensions/webflux.md
+++ b/documentation/docs/zh/guide/extensions/webflux.md
@@ -63,9 +63,16 @@ wow:
 
 数值上限为 `0` 时关闭对应 HTTP guard；`idle-timeout=0s` 关闭 idle timeout。不要复制后端已负责的字段类型、mapping 或唯一性校验。`HttpQueryGuardFilter` 只保护带 WebFlux request context 的 HTTP 查询，程序内查询保持公共 service 行为。
 
-## 快照聚合路由
+## 聚合查询路由
 
-聚合 route 接收 `AggregationQuery`，普通 JSON 会先收集动态行数组，`Accept: text/event-stream` 则逐行流式返回。query guards 同样限制 condition、values、limit、Elements、metric sort 和高成本表达式。
+Snapshot 与 EventStream 都接收 `AggregationQuery`：
+
+- `.../snapshot/aggregation` 聚合快照模型；
+- `.../event/aggregation` 聚合事件流模型，并与 event/list、event/paged、event/count 使用相同的基础、tenant、owner 路由规则。
+
+普通 JSON 会先收集动态行数组，`Accept: text/event-stream` 则逐行流式返回。query guards 同样限制 condition、values、limit、Elements、metric sort 和高成本表达式。
+
+EventStream 的根 filter 作用于事件流文档；使用 `elements = [{"path":"body"}]` 展开事件数组后，group 和 metric 字段相对事件项。Elasticsearch 当前不索引 `body.body` payload，因此跨后端聚合范围是事件流 envelope 与 `body` 事件元数据；需要 payload 聚合时必须先单独设计 mapping 与历史数据重建。
 
 ## 等待计划集成
 

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contract/BuiltInHttpRoutes.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contract/BuiltInHttpRoutes.kt
@@ -69,6 +69,7 @@ object BuiltInHttpRouteHandlerKeys {
     }
 
     object Event {
+        const val AGGREGATION = "$AGGREGATE_EVENT.aggregation"
         const val COUNT = "$AGGREGATE_EVENT.count"
         const val LIST_QUERY = "$AGGREGATE_EVENT.list-query"
         const val PAGED_QUERY = "$AGGREGATE_EVENT.paged-query"

--- a/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/aggregate/event/EventRouteContributor.kt
+++ b/wow-openapi/src/main/kotlin/me/ahoo/wow/openapi/contributor/aggregate/event/EventRouteContributor.kt
@@ -35,6 +35,8 @@ import me.ahoo.wow.openapi.contributor.aggregate.aggregateTags
 import me.ahoo.wow.openapi.contributor.aggregate.defaultAppendOwnerPath
 import me.ahoo.wow.openapi.contributor.aggregate.defaultAppendTenantPath
 import me.ahoo.wow.openapi.contributor.aggregate.versionPathParameterRef
+import me.ahoo.wow.openapi.contributor.aggregationQueryRequestBodyRef
+import me.ahoo.wow.openapi.contributor.aggregationResponse
 import me.ahoo.wow.openapi.contributor.badRequestResponseRef
 import me.ahoo.wow.openapi.contributor.batchAfterIdPathParameterRef
 import me.ahoo.wow.openapi.contributor.batchLimitPathParameterRef
@@ -73,6 +75,7 @@ object EventRouteContributor : RouteContributor {
         }
     }
 
+    @Suppress("LongMethod")
     private fun queryRoutes(
         currentContext: NamedBoundedContext,
         aggregateRouteMetadata: AggregateRouteMetadata<*>,
@@ -81,6 +84,21 @@ object EventRouteContributor : RouteContributor {
     ): List<HttpRouteContract> {
         val aggregateMetadata = aggregateRouteMetadata.aggregateMetadata
         return listOf(
+            eventRoute(
+                currentContext = currentContext,
+                aggregateRouteMetadata = aggregateRouteMetadata,
+                componentContext = componentContext,
+                handlerKey = BuiltInHttpRouteHandlerKeys.Event.AGGREGATION,
+                resourceName = EVENT,
+                operation = "aggregation",
+                operationSummary = "Aggregate Event Stream",
+                appendTenantPath = variant.appendTenantPath,
+                appendOwnerPath = variant.appendOwnerPath,
+                appendPathSuffix = "event/aggregation",
+                accept = STREAMING_ACCEPT,
+                requestBody = componentContext.aggregationQueryRequestBodyRef(),
+                responses = listOf(componentContext.aggregationResponse()),
+            ),
             eventRoute(
                 currentContext = currentContext,
                 aggregateRouteMetadata = aggregateRouteMetadata,

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt
@@ -203,6 +203,42 @@ internal class ExampleDomainOpenAPITest {
         }
 
         @Test
+        fun `event aggregation should use event query conventions`() {
+            val operation = requireNotNull(openAPI.paths["/cart/event/aggregation"]?.post)
+
+            operation.operationId.assert().isEqualTo("example.cart.event.aggregation")
+            operation.requestBody.`$ref`.assert()
+                .isEqualTo("#/components/requestBodies/wow.AggregationQuery")
+            operation.responses.keys.assert().containsExactly("200")
+
+            val jsonSchema = requireNotNull(
+                operation.responses["200"]
+                    ?.content
+                    ?.get(Https.MediaType.APPLICATION_JSON)
+                    ?.schema
+            )
+            jsonSchema.type.assert().isEqualTo("array")
+            jsonSchema.items.type.assert().isEqualTo("object")
+
+            val eventStreamSchema = requireNotNull(
+                operation.responses["200"]
+                    ?.content
+                    ?.get(Https.MediaType.TEXT_EVENT_STREAM)
+                    ?.schema
+            )
+            eventStreamSchema.items.properties.assert().containsKey("data")
+            eventStreamSchema.items.required.assert().contains("data")
+
+            val aggregationRouteIds = catalogRoutes()
+                .filter { it.routeId.endsWith(".event.aggregation") }
+                .map { it.routeId }
+            val expectedRouteIds = catalogRoutes()
+                .filter { it.routeId.endsWith(".event.count") }
+                .map { it.routeId.removeSuffix("count") + "aggregation" }
+            aggregationRouteIds.assert().containsExactlyInAnyOrder(*expectedRouteIds.toTypedArray())
+        }
+
+        @Test
         fun `snapshot schema routes should be aggregate scoped and independently identified`() {
             val get = requireNotNull(openAPI.paths["/cart/snapshot/schema"]?.get)
             val refresh = requireNotNull(openAPI.paths["/cart/snapshot/schema/refresh"]?.post)

--- a/wow-openapi/src/test/resources/openapi/example-domain-contract.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-contract.snapshot.json
@@ -1,4 +1,13 @@
 [ {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "example.cart.event.aggregation",
+  "method" : "POST",
+  "parameterNames" : [ ],
+  "path" : "/cart/event/aggregation",
+  "requestBody" : true,
+  "responseCodes" : [ "200" ],
+  "tagNames" : [ "customer", "example.cart" ]
+}, {
   "accept" : [ "application/json" ],
   "id" : "example.cart.event.count",
   "method" : "POST",
@@ -197,6 +206,15 @@
   "responseCodes" : [ "200", "400", "404", "408", "409", "410", "429" ],
   "tagNames" : [ "customer", "example.cart" ]
 }, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "example.cart.owner.event.aggregation",
+  "method" : "POST",
+  "parameterNames" : [ "ref:#/components/parameters/wow.ownerId" ],
+  "path" : "/owner/{ownerId}/cart/event/aggregation",
+  "requestBody" : true,
+  "responseCodes" : [ "200" ],
+  "tagNames" : [ "customer", "example.cart" ]
+}, {
   "accept" : [ "application/json" ],
   "id" : "example.cart.owner.event.count",
   "method" : "POST",
@@ -377,6 +395,15 @@
   "responseCodes" : [ "200", "400", "404", "408", "409", "410", "429" ],
   "tagNames" : [ "customer", "example.cart" ]
 }, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "example.order.owner.event.aggregation",
+  "method" : "POST",
+  "parameterNames" : [ "ref:#/components/parameters/wow.ownerId", "ref:#/components/parameters/wow.Wow-Space-Id" ],
+  "path" : "/owner/{ownerId}/sales-order/event/aggregation",
+  "requestBody" : true,
+  "responseCodes" : [ "200" ],
+  "tagNames" : [ "example.order" ]
+}, {
   "accept" : [ "application/json" ],
   "id" : "example.order.owner.event.count",
   "method" : "POST",
@@ -474,6 +501,15 @@
   "path" : "/owner/{ownerId}/sales-order/snapshot/single/state",
   "requestBody" : true,
   "responseCodes" : [ "200", "404" ],
+  "tagNames" : [ "example.order" ]
+}, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "example.order.event.aggregation",
+  "method" : "POST",
+  "parameterNames" : [ "ref:#/components/parameters/wow.Wow-Space-Id" ],
+  "path" : "/sales-order/event/aggregation",
+  "requestBody" : true,
+  "responseCodes" : [ "200" ],
   "tagNames" : [ "example.order" ]
 }, {
   "accept" : [ "application/json" ],
@@ -611,6 +647,15 @@
   "responseCodes" : [ "200", "408" ],
   "tagNames" : [ "example.order" ]
 }, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "tck.mock_aggregate.event.aggregation",
+  "method" : "POST",
+  "parameterNames" : [ ],
+  "path" : "/tck/mock_aggregate/event/aggregation",
+  "requestBody" : true,
+  "responseCodes" : [ "200" ],
+  "tagNames" : [ "tck.mock_aggregate" ]
+}, {
   "accept" : [ "application/json" ],
   "id" : "tck.mock_aggregate.event.count",
   "method" : "POST",
@@ -745,6 +790,15 @@
   "requestBody" : false,
   "responseCodes" : [ "200", "408" ],
   "tagNames" : [ "tck.mock_aggregate" ]
+}, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "tck.modeling_command_aggregate_with_tenant_id.event.aggregation",
+  "method" : "POST",
+  "parameterNames" : [ ],
+  "path" : "/tck/modeling_command_aggregate_with_tenant_id/event/aggregation",
+  "requestBody" : true,
+  "responseCodes" : [ "200" ],
+  "tagNames" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
 }, {
   "accept" : [ "application/json" ],
   "id" : "tck.modeling_command_aggregate_with_tenant_id.event.count",
@@ -881,6 +935,15 @@
   "responseCodes" : [ "200", "408" ],
   "tagNames" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
 }, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "tck.modeling_command_aggregate_without_ctor_parameters.event.aggregation",
+  "method" : "POST",
+  "parameterNames" : [ ],
+  "path" : "/tck/modeling_command_aggregate_without_ctor_parameters/event/aggregation",
+  "requestBody" : true,
+  "responseCodes" : [ "200" ],
+  "tagNames" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
+}, {
   "accept" : [ "application/json" ],
   "id" : "tck.modeling_command_aggregate_without_ctor_parameters.event.count",
   "method" : "POST",
@@ -1015,6 +1078,15 @@
   "requestBody" : false,
   "responseCodes" : [ "200", "408" ],
   "tagNames" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
+}, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "tck.mock_aggregate.tenant.event.aggregation",
+  "method" : "POST",
+  "parameterNames" : [ "ref:#/components/parameters/wow.tenantId" ],
+  "path" : "/tck/tenant/{tenantId}/mock_aggregate/event/aggregation",
+  "requestBody" : true,
+  "responseCodes" : [ "200" ],
+  "tagNames" : [ "tck.mock_aggregate" ]
 }, {
   "accept" : [ "application/json" ],
   "id" : "tck.mock_aggregate.tenant.event.count",
@@ -1241,6 +1313,15 @@
   "responseCodes" : [ "200", "400" ],
   "tagNames" : [ "tck.mock_aggregate" ]
 }, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "tck.modeling_command_aggregate_with_tenant_id.tenant.event.aggregation",
+  "method" : "POST",
+  "parameterNames" : [ "ref:#/components/parameters/wow.tenantId" ],
+  "path" : "/tck/tenant/{tenantId}/modeling_command_aggregate_with_tenant_id/event/aggregation",
+  "requestBody" : true,
+  "responseCodes" : [ "200" ],
+  "tagNames" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
+}, {
   "accept" : [ "application/json" ],
   "id" : "tck.modeling_command_aggregate_with_tenant_id.tenant.event.count",
   "method" : "POST",
@@ -1438,6 +1519,15 @@
   "requestBody" : true,
   "responseCodes" : [ "200", "400" ],
   "tagNames" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
+}, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "tck.modeling_command_aggregate_without_ctor_parameters.tenant.event.aggregation",
+  "method" : "POST",
+  "parameterNames" : [ "ref:#/components/parameters/wow.tenantId" ],
+  "path" : "/tck/tenant/{tenantId}/modeling_command_aggregate_without_ctor_parameters/event/aggregation",
+  "requestBody" : true,
+  "responseCodes" : [ "200" ],
+  "tagNames" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
 }, {
   "accept" : [ "application/json" ],
   "id" : "tck.modeling_command_aggregate_without_ctor_parameters.tenant.event.count",
@@ -1734,6 +1824,15 @@
   "path" : "/tenant/{tenantId}/owner/{ownerId}/sales-order/{id}/tags",
   "requestBody" : true,
   "responseCodes" : [ "200", "400", "404", "408", "409", "410", "429" ],
+  "tagNames" : [ "example.order" ]
+}, {
+  "accept" : [ "application/json", "text/event-stream" ],
+  "id" : "example.order.tenant.event.aggregation",
+  "method" : "POST",
+  "parameterNames" : [ "ref:#/components/parameters/wow.tenantId", "ref:#/components/parameters/wow.Wow-Space-Id" ],
+  "path" : "/tenant/{tenantId}/sales-order/event/aggregation",
+  "requestBody" : true,
+  "responseCodes" : [ "200" ],
   "tagNames" : [ "example.order" ]
 }, {
   "accept" : [ "application/json" ],

--- a/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
@@ -567,6 +567,15 @@
           "$ref" : "#/components/schemas/tck.modeling_command_aggregate_without_ctor_parameters.MockCommandAggregateWithoutCtorParametersAggregatedFields"
         }
       },
+      "wow.AggregationQuery" : {
+        "content" : {
+          "application/json" : {
+            "schema" : {
+              "$ref" : "#/components/schemas/wow.api.query.AggregationQuery"
+            }
+          }
+        }
+      },
       "wow.CompensationTarget" : {
         "content" : {
           "application/json" : {
@@ -6504,6 +6513,61 @@
   },
   "openapi" : "3.1.0",
   "paths" : {
+    "/cart/event/aggregation" : {
+      "post" : {
+        "operationId" : "example.cart.event.aggregation",
+        "parameters" : [ ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/wow.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "properties" : {
+                      "data" : {
+                        "additionalProperties" : { },
+                        "type" : "object"
+                      },
+                      "event" : {
+                        "type" : "string"
+                      },
+                      "id" : {
+                        "type" : "string"
+                      },
+                      "retry" : {
+                        "format" : "int32",
+                        "type" : "integer"
+                      }
+                    },
+                    "required" : [ "data" ],
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          }
+        },
+        "tags" : [ "example.cart", "customer" ]
+      }
+    },
     "/cart/event/count" : {
       "post" : {
         "operationId" : "example.cart.event.count",
@@ -7251,6 +7315,63 @@
           },
           "429" : {
             "$ref" : "#/components/responses/wow.CommandTooManyRequests"
+          }
+        },
+        "tags" : [ "example.cart", "customer" ]
+      }
+    },
+    "/owner/{ownerId}/cart/event/aggregation" : {
+      "post" : {
+        "operationId" : "example.cart.owner.event.aggregation",
+        "parameters" : [ {
+          "$ref" : "#/components/parameters/wow.ownerId"
+        } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/wow.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "properties" : {
+                      "data" : {
+                        "additionalProperties" : { },
+                        "type" : "object"
+                      },
+                      "event" : {
+                        "type" : "string"
+                      },
+                      "id" : {
+                        "type" : "string"
+                      },
+                      "retry" : {
+                        "format" : "int32",
+                        "type" : "integer"
+                      }
+                    },
+                    "required" : [ "data" ],
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
           }
         },
         "tags" : [ "example.cart", "customer" ]
@@ -8092,6 +8213,65 @@
         "tags" : [ "example.cart", "customer" ]
       }
     },
+    "/owner/{ownerId}/sales-order/event/aggregation" : {
+      "post" : {
+        "operationId" : "example.order.owner.event.aggregation",
+        "parameters" : [ {
+          "$ref" : "#/components/parameters/wow.Wow-Space-Id"
+        }, {
+          "$ref" : "#/components/parameters/wow.ownerId"
+        } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/wow.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "properties" : {
+                      "data" : {
+                        "additionalProperties" : { },
+                        "type" : "object"
+                      },
+                      "event" : {
+                        "type" : "string"
+                      },
+                      "id" : {
+                        "type" : "string"
+                      },
+                      "retry" : {
+                        "format" : "int32",
+                        "type" : "integer"
+                      }
+                    },
+                    "required" : [ "data" ],
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          }
+        },
+        "tags" : [ "example.order" ]
+      }
+    },
     "/owner/{ownerId}/sales-order/event/count" : {
       "post" : {
         "operationId" : "example.order.owner.event.count",
@@ -8475,6 +8655,63 @@
           },
           "404" : {
             "$ref" : "#/components/responses/wow.NotFound"
+          }
+        },
+        "tags" : [ "example.order" ]
+      }
+    },
+    "/sales-order/event/aggregation" : {
+      "post" : {
+        "operationId" : "example.order.event.aggregation",
+        "parameters" : [ {
+          "$ref" : "#/components/parameters/wow.Wow-Space-Id"
+        } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/wow.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "properties" : {
+                      "data" : {
+                        "additionalProperties" : { },
+                        "type" : "object"
+                      },
+                      "event" : {
+                        "type" : "string"
+                      },
+                      "id" : {
+                        "type" : "string"
+                      },
+                      "retry" : {
+                        "format" : "int32",
+                        "type" : "integer"
+                      }
+                    },
+                    "required" : [ "data" ],
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
           }
         },
         "tags" : [ "example.order" ]
@@ -8944,6 +9181,61 @@
         "tags" : [ "example.order" ]
       }
     },
+    "/tck/mock_aggregate/event/aggregation" : {
+      "post" : {
+        "operationId" : "tck.mock_aggregate.event.aggregation",
+        "parameters" : [ ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/wow.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "properties" : {
+                      "data" : {
+                        "additionalProperties" : { },
+                        "type" : "object"
+                      },
+                      "event" : {
+                        "type" : "string"
+                      },
+                      "id" : {
+                        "type" : "string"
+                      },
+                      "retry" : {
+                        "format" : "int32",
+                        "type" : "integer"
+                      }
+                    },
+                    "required" : [ "data" ],
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          }
+        },
+        "tags" : [ "tck.mock_aggregate" ]
+      }
+    },
     "/tck/mock_aggregate/event/count" : {
       "post" : {
         "operationId" : "tck.mock_aggregate.event.count",
@@ -9376,6 +9668,61 @@
           }
         },
         "tags" : [ "tck.mock_aggregate" ]
+      }
+    },
+    "/tck/modeling_command_aggregate_with_tenant_id/event/aggregation" : {
+      "post" : {
+        "operationId" : "tck.modeling_command_aggregate_with_tenant_id.event.aggregation",
+        "parameters" : [ ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/wow.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "properties" : {
+                      "data" : {
+                        "additionalProperties" : { },
+                        "type" : "object"
+                      },
+                      "event" : {
+                        "type" : "string"
+                      },
+                      "id" : {
+                        "type" : "string"
+                      },
+                      "retry" : {
+                        "format" : "int32",
+                        "type" : "integer"
+                      }
+                    },
+                    "required" : [ "data" ],
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          }
+        },
+        "tags" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
       }
     },
     "/tck/modeling_command_aggregate_with_tenant_id/event/count" : {
@@ -9812,6 +10159,61 @@
         "tags" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
       }
     },
+    "/tck/modeling_command_aggregate_without_ctor_parameters/event/aggregation" : {
+      "post" : {
+        "operationId" : "tck.modeling_command_aggregate_without_ctor_parameters.event.aggregation",
+        "parameters" : [ ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/wow.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "properties" : {
+                      "data" : {
+                        "additionalProperties" : { },
+                        "type" : "object"
+                      },
+                      "event" : {
+                        "type" : "string"
+                      },
+                      "id" : {
+                        "type" : "string"
+                      },
+                      "retry" : {
+                        "format" : "int32",
+                        "type" : "integer"
+                      }
+                    },
+                    "required" : [ "data" ],
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          }
+        },
+        "tags" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
+      }
+    },
     "/tck/modeling_command_aggregate_without_ctor_parameters/event/count" : {
       "post" : {
         "operationId" : "tck.modeling_command_aggregate_without_ctor_parameters.event.count",
@@ -10244,6 +10646,63 @@
           }
         },
         "tags" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
+      }
+    },
+    "/tck/tenant/{tenantId}/mock_aggregate/event/aggregation" : {
+      "post" : {
+        "operationId" : "tck.mock_aggregate.tenant.event.aggregation",
+        "parameters" : [ {
+          "$ref" : "#/components/parameters/wow.tenantId"
+        } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/wow.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "properties" : {
+                      "data" : {
+                        "additionalProperties" : { },
+                        "type" : "object"
+                      },
+                      "event" : {
+                        "type" : "string"
+                      },
+                      "id" : {
+                        "type" : "string"
+                      },
+                      "retry" : {
+                        "format" : "int32",
+                        "type" : "integer"
+                      }
+                    },
+                    "required" : [ "data" ],
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          }
+        },
+        "tags" : [ "tck.mock_aggregate" ]
       }
     },
     "/tck/tenant/{tenantId}/mock_aggregate/event/count" : {
@@ -11284,6 +11743,63 @@
         "tags" : [ "tck.mock_aggregate" ]
       }
     },
+    "/tck/tenant/{tenantId}/modeling_command_aggregate_with_tenant_id/event/aggregation" : {
+      "post" : {
+        "operationId" : "tck.modeling_command_aggregate_with_tenant_id.tenant.event.aggregation",
+        "parameters" : [ {
+          "$ref" : "#/components/parameters/wow.tenantId"
+        } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/wow.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "properties" : {
+                      "data" : {
+                        "additionalProperties" : { },
+                        "type" : "object"
+                      },
+                      "event" : {
+                        "type" : "string"
+                      },
+                      "id" : {
+                        "type" : "string"
+                      },
+                      "retry" : {
+                        "format" : "int32",
+                        "type" : "integer"
+                      }
+                    },
+                    "required" : [ "data" ],
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          }
+        },
+        "tags" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
+      }
+    },
     "/tck/tenant/{tenantId}/modeling_command_aggregate_with_tenant_id/event/count" : {
       "post" : {
         "operationId" : "tck.modeling_command_aggregate_with_tenant_id.tenant.event.count",
@@ -12111,6 +12627,63 @@
           }
         },
         "tags" : [ "tck.modeling_command_aggregate_with_tenant_id" ]
+      }
+    },
+    "/tck/tenant/{tenantId}/modeling_command_aggregate_without_ctor_parameters/event/aggregation" : {
+      "post" : {
+        "operationId" : "tck.modeling_command_aggregate_without_ctor_parameters.tenant.event.aggregation",
+        "parameters" : [ {
+          "$ref" : "#/components/parameters/wow.tenantId"
+        } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/wow.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "properties" : {
+                      "data" : {
+                        "additionalProperties" : { },
+                        "type" : "object"
+                      },
+                      "event" : {
+                        "type" : "string"
+                      },
+                      "id" : {
+                        "type" : "string"
+                      },
+                      "retry" : {
+                        "format" : "int32",
+                        "type" : "integer"
+                      }
+                    },
+                    "required" : [ "data" ],
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
+          }
+        },
+        "tags" : [ "tck.modeling_command_aggregate_without_ctor_parameters" ]
       }
     },
     "/tck/tenant/{tenantId}/modeling_command_aggregate_without_ctor_parameters/event/count" : {
@@ -13641,6 +14214,65 @@
           },
           "429" : {
             "$ref" : "#/components/responses/wow.CommandTooManyRequests"
+          }
+        },
+        "tags" : [ "example.order" ]
+      }
+    },
+    "/tenant/{tenantId}/sales-order/event/aggregation" : {
+      "post" : {
+        "operationId" : "example.order.tenant.event.aggregation",
+        "parameters" : [ {
+          "$ref" : "#/components/parameters/wow.Wow-Space-Id"
+        }, {
+          "$ref" : "#/components/parameters/wow.tenantId"
+        } ],
+        "requestBody" : {
+          "$ref" : "#/components/requestBodies/wow.AggregationQuery"
+        },
+        "responses" : {
+          "200" : {
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "items" : {
+                    "additionalProperties" : { },
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              },
+              "text/event-stream" : {
+                "schema" : {
+                  "items" : {
+                    "properties" : {
+                      "data" : {
+                        "additionalProperties" : { },
+                        "type" : "object"
+                      },
+                      "event" : {
+                        "type" : "string"
+                      },
+                      "id" : {
+                        "type" : "string"
+                      },
+                      "retry" : {
+                        "format" : "int32",
+                        "type" : "integer"
+                      }
+                    },
+                    "required" : [ "data" ],
+                    "type" : "object"
+                  },
+                  "type" : "array"
+                }
+              }
+            },
+            "headers" : {
+              "Wow-Error-Code" : {
+                "$ref" : "#/components/headers/wow.Wow-Error-Code"
+              }
+            }
           }
         },
         "tags" : [ "example.order" ]

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/route/QueryRouteModule.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/route/QueryRouteModule.kt
@@ -19,6 +19,7 @@ import me.ahoo.wow.query.snapshot.SnapshotQueryServiceFactory
 import me.ahoo.wow.webflux.exception.RequestExceptionHandler
 import me.ahoo.wow.webflux.route.HttpRouteHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.event.CountEventStreamHandlerFunctionFactory
+import me.ahoo.wow.webflux.route.event.EventStreamAggregationHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.event.ListQueryEventStreamHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.event.LoadEventStreamHandlerFunctionFactory
 import me.ahoo.wow.webflux.route.event.PagedQueryEventStreamHandlerFunctionFactory
@@ -98,6 +99,11 @@ class QueryRouteModule(
         LoadEventStreamHandlerFunctionFactory(
             eventStreamQueryGateway = eventStreamQueryGateway,
             exceptionHandler = exceptionHandler
+        ),
+        EventStreamAggregationHandlerFunctionFactory(
+            eventStreamQueryGateway = eventStreamQueryGateway,
+            rewriteRequestFilter = rewriteRequestFilter,
+            exceptionHandler = exceptionHandler,
         ),
         ListQueryEventStreamHandlerFunctionFactory(
             eventStreamQueryGateway = eventStreamQueryGateway,

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
@@ -968,6 +968,7 @@ internal class WebFluxAutoConfigurationTest {
             BuiltInHttpRouteHandlerKeys.Snapshot.SCHEMA_REFRESH,
             BuiltInHttpRouteHandlerKeys.Snapshot.AGGREGATION,
             BuiltInHttpRouteHandlerKeys.Event.LOAD,
+            BuiltInHttpRouteHandlerKeys.Event.AGGREGATION,
             BuiltInHttpRouteHandlerKeys.Snapshot.REGENERATE,
             BuiltInHttpRouteHandlerKeys.Event.RESEND_STATE,
             BuiltInHttpRouteHandlerKeys.Global.GLOBAL_ID,

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/event/EventStreamAggregationHandlerFunction.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/event/EventStreamAggregationHandlerFunction.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)]
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.route.event
+
+import me.ahoo.wow.modeling.metadata.AggregateMetadata
+import me.ahoo.wow.openapi.contract.BuiltInHttpRouteHandlerKeys
+import me.ahoo.wow.openapi.contract.HttpRouteContract
+import me.ahoo.wow.openapi.contract.HttpRouteHandlerMetadata
+import me.ahoo.wow.query.event.EventStreamQueryGateway
+import me.ahoo.wow.query.filter.Contexts.writeRawRequest
+import me.ahoo.wow.webflux.exception.RequestExceptionHandler
+import me.ahoo.wow.webflux.route.AggregateRouteHandlerFunctionFactorySupport
+import me.ahoo.wow.webflux.route.query.QueryBodyExtractor.Companion.AGGREGATION_QUERY_EXTRACTOR
+import me.ahoo.wow.webflux.route.query.RewriteRequestFilter
+import me.ahoo.wow.webflux.route.toServerResponse
+import org.springframework.web.reactive.function.server.HandlerFunction
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import reactor.core.publisher.Mono
+
+class EventStreamAggregationHandlerFunction(
+    private val aggregateMetadata: AggregateMetadata<*, *>,
+    private val queryGateway: EventStreamQueryGateway,
+    private val rewriteRequestFilter: RewriteRequestFilter,
+    private val exceptionHandler: RequestExceptionHandler,
+) : HandlerFunction<ServerResponse> {
+    override fun handle(request: ServerRequest): Mono<ServerResponse> =
+        request.body(AGGREGATION_QUERY_EXTRACTOR)
+            .flatMapMany { query ->
+                queryGateway.aggregate(
+                    aggregateMetadata,
+                    rewriteRequestFilter.rewrite(aggregateMetadata, request, query),
+                )
+            }
+            .writeRawRequest(request)
+            .toServerResponse(request, exceptionHandler)
+}
+
+class EventStreamAggregationHandlerFunctionFactory(
+    private val eventStreamQueryGateway: EventStreamQueryGateway,
+    private val rewriteRequestFilter: RewriteRequestFilter,
+    private val exceptionHandler: RequestExceptionHandler,
+) : AggregateRouteHandlerFunctionFactorySupport(BuiltInHttpRouteHandlerKeys.Event.AGGREGATION) {
+    override fun create(
+        contract: HttpRouteContract,
+        metadata: HttpRouteHandlerMetadata.Aggregate,
+    ): HandlerFunction<ServerResponse> = EventStreamAggregationHandlerFunction(
+        aggregateMetadata = aggregateMetadata(metadata),
+        queryGateway = eventStreamQueryGateway,
+        rewriteRequestFilter = rewriteRequestFilter,
+        exceptionHandler = exceptionHandler,
+    )
+}

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/event/EventStreamAggregationHandlerFunctionTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/event/EventStreamAggregationHandlerFunctionTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)]
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.webflux.route.event
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.OwnerIdFilter
+import me.ahoo.wow.api.query.SimpleDynamicDocument.Companion.toDynamicDocument
+import me.ahoo.wow.id.generateGlobalId
+import me.ahoo.wow.openapi.contract.BuiltInHttpRouteHandlerKeys
+import me.ahoo.wow.query.event.EventStreamQueryGateway
+import me.ahoo.wow.query.filter.Contexts.getRawRequest
+import me.ahoo.wow.serialization.MessageRecords
+import me.ahoo.wow.webflux.exception.WebFluxRequestExceptionHandler
+import me.ahoo.wow.webflux.route.RouteTestFixtures
+import me.ahoo.wow.webflux.route.query.DefaultRewriteRequestFilter
+import me.ahoo.wow.webflux.route.testAggregateRouteContract
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest
+import org.springframework.mock.web.reactive.function.server.MockServerRequest
+import org.springframework.mock.web.server.MockServerWebExchange
+import org.springframework.web.reactive.function.server.HandlerStrategies
+import org.springframework.web.reactive.function.server.ServerResponse
+import reactor.core.publisher.Flux
+import reactor.kotlin.core.publisher.toMono
+import java.util.concurrent.atomic.AtomicBoolean
+
+class EventStreamAggregationHandlerFunctionTest {
+    @Test
+    fun `aggregation route should rewrite scope and stream handler rows`() {
+        val ownerId = generateGlobalId()
+        val capturedQuery = slot<AggregationQuery>()
+        val subscribed = AtomicBoolean()
+        val gateway = mockk<EventStreamQueryGateway> {
+            every { aggregate(any(), capture(capturedQuery)) } returns Flux.deferContextual {
+                it.getRawRequest<MockServerRequest>().assert().isNotNull()
+                subscribed.set(true)
+                Flux.just(mutableMapOf("count" to 1L).toDynamicDocument())
+            }
+        }
+        val function = EventStreamAggregationHandlerFunctionFactory(
+            eventStreamQueryGateway = gateway,
+            rewriteRequestFilter = DefaultRewriteRequestFilter,
+            exceptionHandler = WebFluxRequestExceptionHandler(),
+        ).create(
+            testAggregateRouteContract(
+                handlerKey = BuiltInHttpRouteHandlerKeys.Event.AGGREGATION,
+                aggregateRouteMetadata = RouteTestFixtures.MOCK_AGGREGATE_ROUTE_METADATA,
+            ),
+        )
+        val request = MockServerRequest.builder()
+            .pathVariable(MessageRecords.OWNER_ID, ownerId)
+            .body(AggregationQuery(metrics = listOf(AggregationMetric.Count("count"))).toMono())
+
+        val response = function.handle(request).block()!!
+        val exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/test").build())
+
+        response.statusCode().assert().isEqualTo(HttpStatus.OK)
+        response.writeTo(exchange, SERVER_RESPONSE_CONTEXT).block()
+        capturedQuery.captured.filter.assert().isEqualTo(OwnerIdFilter(ownerId))
+        subscribed.get().assert().isTrue()
+    }
+
+    private companion object {
+        private val SERVER_RESPONSE_CONTEXT = object : ServerResponse.Context {
+            private val strategies = HandlerStrategies.withDefaults()
+            override fun messageWriters() = strategies.messageWriters()
+            override fun viewResolvers() = strategies.viewResolvers()
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Expose the existing EventStream aggregation capability through the generated REST and OpenAPI route contract while preserving Event query conventions.

## Changes

- add POST .../event/aggregation for the existing base, tenant, and owner route variants
- reuse the global AggregationQuery request body and existing JSON/SSE aggregation response contract
- add a focused EventStream WebFlux handler that preserves scope rewrite, HTTP query guards, Reactor request context, and existing error handling
- register the handler factory in the Starter route module
- update OpenAPI compatibility snapshots and bilingual WebFlux documentation
- leave Query DSL, query services, MongoDB, Elasticsearch, and wow-apiclient unchanged

## Verification

- ./gradlew build — BUILD SUCCESSFUL, 334 actionable tasks
- cd documentation && pnpm docs:build — build complete
- focused OpenAPI and WebFlux tests verified RED then GREEN during implementation
- git diff --check — passed
- task-level and whole-branch Codex reviews — no findings

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

This is an additive HTTP route with no storage migration, data rewrite, dependency, configuration, performance, or concurrency change. Applications must verify that authentication, authorization, gateway, and rate-limit rules cover the new path. Elasticsearch payload aggregation remains limited by the existing body.body mapping. Local validation does not prove deployment or production behavior.