### PR TITLE
fix(compensation): migrate dashboard to fetcher-wow 3.18 filter API

### DIFF
--- a/compensation/dashboard/src/features/Failed/FailedSearch.tsx
+++ b/compensation/dashboard/src/features/Failed/FailedSearch.tsx
@@ -130,7 +130,7 @@ export function FailedSearch({ onSearch, loading }: FailedSearchProps) {
         ? filter.matchAll()
         : filters.length === 1
           ? filters[0]
-          : filter.and(filters[0], ...filters.slice(1)),
+          : filter.and(filters),
       filters.length > 0,
     );
   };

--- a/compensation/dashboard/src/features/Failed/RetryConditions.ts
+++ b/compensation/dashboard/src/features/Failed/RetryConditions.ts
@@ -34,18 +34,18 @@ const ACTIVE_STATUSES = [
 
 export class RetryConditions {
   static toRetryCondition(now: number): FilterExpression {
-    return filter.and(
+    return filter.and([
       filter.isIn(
         ExecutionFailedAggregatedFields.STATE_RECOVERABLE,
-        ...RETRYABLE_RECOVERABILITY,
+        RETRYABLE_RECOVERABILITY,
       ),
       filter.eq(ExecutionFailedAggregatedFields.STATE_IS_RETRYABLE, true),
-      filter.or(
+      filter.or([
         filter.eq(
           ExecutionFailedAggregatedFields.STATE_STATUS,
           ExecutionFailedStatus.FAILED,
         ),
-        filter.and(
+        filter.and([
           filter.eq(
             ExecutionFailedAggregatedFields.STATE_STATUS,
             ExecutionFailedStatus.PREPARED,
@@ -54,13 +54,13 @@ export class RetryConditions {
             ExecutionFailedAggregatedFields.STATE_RETRY_STATE_TIMEOUT_AT,
             now,
           ),
-        ),
-      ),
-    );
+        ]),
+      ]),
+    ]);
   }
 
   static executingCondition(now: number): FilterExpression {
-    return filter.and(
+    return filter.and([
       filter.eq(
         ExecutionFailedAggregatedFields.STATE_STATUS,
         ExecutionFailedStatus.PREPARED,
@@ -69,26 +69,26 @@ export class RetryConditions {
         ExecutionFailedAggregatedFields.STATE_RETRY_STATE_TIMEOUT_AT,
         now,
       ),
-    );
+    ]);
   }
 
   static nextRetryCondition(now: number): FilterExpression {
-    return filter.and(
+    return filter.and([
       filter.isIn(
         ExecutionFailedAggregatedFields.STATE_RECOVERABLE,
-        ...RETRYABLE_RECOVERABILITY,
+        RETRYABLE_RECOVERABILITY,
       ),
       filter.eq(ExecutionFailedAggregatedFields.STATE_IS_RETRYABLE, true),
       filter.lte(
         ExecutionFailedAggregatedFields.STATE_RETRY_STATE_NEXT_RETRY_AT,
         now,
       ),
-      filter.or(
+      filter.or([
         filter.eq(
           ExecutionFailedAggregatedFields.STATE_STATUS,
           ExecutionFailedStatus.FAILED,
         ),
-        filter.and(
+        filter.and([
           filter.eq(
             ExecutionFailedAggregatedFields.STATE_STATUS,
             ExecutionFailedStatus.PREPARED,
@@ -97,41 +97,41 @@ export class RetryConditions {
             ExecutionFailedAggregatedFields.STATE_RETRY_STATE_TIMEOUT_AT,
             now,
           ),
-        ),
-      ),
-    );
+        ]),
+      ]),
+    ]);
   }
 
-  static nonRetryableCondition = filter.and(
+  static nonRetryableCondition = filter.and([
     filter.isIn(
       ExecutionFailedAggregatedFields.STATE_RECOVERABLE,
-      ...RETRYABLE_RECOVERABILITY,
+      RETRYABLE_RECOVERABILITY,
     ),
     filter.isIn(
       ExecutionFailedAggregatedFields.STATE_STATUS,
-      ...ACTIVE_STATUSES,
+      ACTIVE_STATUSES,
     ),
     filter.eq(
       ExecutionFailedAggregatedFields.STATE_IS_BELOW_RETRY_THRESHOLD,
       false,
     ),
-  );
+  ]);
 
   static successCondition = filter.eq(
     ExecutionFailedAggregatedFields.STATE_STATUS,
     ExecutionFailedStatus.SUCCEEDED,
   );
 
-  static unrecoverableCondition = filter.and(
+  static unrecoverableCondition = filter.and([
     filter.eq(
       ExecutionFailedAggregatedFields.STATE_RECOVERABLE,
       RecoverableType.UNRECOVERABLE,
     ),
     filter.isIn(
       ExecutionFailedAggregatedFields.STATE_STATUS,
-      ...ACTIVE_STATUSES,
+      ACTIVE_STATUSES,
     ),
-  );
+  ]);
 
   static categoryToCondition(
     category: FindCategory,

--- a/compensation/dashboard/src/features/Failed/__tests__/FailedSearch.test.tsx
+++ b/compensation/dashboard/src/features/Failed/__tests__/FailedSearch.test.tsx
@@ -46,7 +46,7 @@ describe("FailedSearch", () => {
     fireEvent.click(screen.getByRole("button", { name: "Search" }));
 
     expect(onSearch).toHaveBeenCalledWith(
-      filter.and(filter.id("EXC-1"), filter.eq("state.eventId.id", "EVT-1")),
+      filter.and([filter.id("EXC-1"), filter.eq("state.eventId.id", "EVT-1")]),
       true,
     );
   });

--- a/compensation/dashboard/src/features/Failed/__tests__/FindCategory.test.ts
+++ b/compensation/dashboard/src/features/Failed/__tests__/FindCategory.test.ts
@@ -32,18 +32,18 @@ describe("FindCategory", () => {
 
     it("uses index-friendly recoverability values for to-retry", () => {
       expect(RetryConditions.toRetryCondition(currentTime)).toEqual(
-        filter.and(
+        filter.and([
           filter.isIn(
             ExecutionFailedAggregatedFields.STATE_RECOVERABLE,
-            ...retryableRecoverability,
+            retryableRecoverability,
           ),
           filter.eq(ExecutionFailedAggregatedFields.STATE_IS_RETRYABLE, true),
-          filter.or(
+          filter.or([
             filter.eq(
               ExecutionFailedAggregatedFields.STATE_STATUS,
               ExecutionFailedStatus.FAILED,
             ),
-            filter.and(
+            filter.and([
               filter.eq(
                 ExecutionFailedAggregatedFields.STATE_STATUS,
                 ExecutionFailedStatus.PREPARED,
@@ -52,15 +52,15 @@ describe("FindCategory", () => {
                 ExecutionFailedAggregatedFields.STATE_RETRY_STATE_TIMEOUT_AT,
                 currentTime,
               ),
-            ),
-          ),
-        ),
+            ]),
+          ]),
+        ]),
       );
     });
 
     it("keeps the executing range condition", () => {
       expect(RetryConditions.executingCondition(currentTime)).toEqual(
-        filter.and(
+        filter.and([
           filter.eq(
             ExecutionFailedAggregatedFields.STATE_STATUS,
             ExecutionFailedStatus.PREPARED,
@@ -69,28 +69,28 @@ describe("FindCategory", () => {
             ExecutionFailedAggregatedFields.STATE_RETRY_STATE_TIMEOUT_AT,
             currentTime,
           ),
-        ),
+        ]),
       );
     });
 
     it("uses index-friendly recoverability values for next-retry", () => {
       expect(RetryConditions.nextRetryCondition(currentTime)).toEqual(
-        filter.and(
+        filter.and([
           filter.isIn(
             ExecutionFailedAggregatedFields.STATE_RECOVERABLE,
-            ...retryableRecoverability,
+            retryableRecoverability,
           ),
           filter.eq(ExecutionFailedAggregatedFields.STATE_IS_RETRYABLE, true),
           filter.lte(
             ExecutionFailedAggregatedFields.STATE_RETRY_STATE_NEXT_RETRY_AT,
             currentTime,
           ),
-          filter.or(
+          filter.or([
             filter.eq(
               ExecutionFailedAggregatedFields.STATE_STATUS,
               ExecutionFailedStatus.FAILED,
             ),
-            filter.and(
+            filter.and([
               filter.eq(
                 ExecutionFailedAggregatedFields.STATE_STATUS,
                 ExecutionFailedStatus.PREPARED,
@@ -99,28 +99,28 @@ describe("FindCategory", () => {
                 ExecutionFailedAggregatedFields.STATE_RETRY_STATE_TIMEOUT_AT,
                 currentTime,
               ),
-            ),
-          ),
-        ),
+            ]),
+          ]),
+        ]),
       );
     });
 
     it("uses closed enum values for non-retryable", () => {
       expect(RetryConditions.nonRetryableCondition).toEqual(
-        filter.and(
+        filter.and([
           filter.isIn(
             ExecutionFailedAggregatedFields.STATE_RECOVERABLE,
-            ...retryableRecoverability,
+            retryableRecoverability,
           ),
           filter.isIn(
             ExecutionFailedAggregatedFields.STATE_STATUS,
-            ...activeStatuses,
+            activeStatuses,
           ),
           filter.eq(
             ExecutionFailedAggregatedFields.STATE_IS_BELOW_RETRY_THRESHOLD,
             false,
           ),
-        ),
+        ]),
       );
     });
 
@@ -130,16 +130,16 @@ describe("FindCategory", () => {
 
     it("uses active status values for unrecoverable", () => {
       expect(RetryConditions.unrecoverableCondition).toEqual(
-        filter.and(
+        filter.and([
           filter.eq(
             ExecutionFailedAggregatedFields.STATE_RECOVERABLE,
             RecoverableType.UNRECOVERABLE,
           ),
           filter.isIn(
             ExecutionFailedAggregatedFields.STATE_STATUS,
-            ...activeStatuses,
+            activeStatuses,
           ),
-        ),
+        ]),
       );
     });
   });

--- a/compensation/dashboard/src/features/Failed/useFailedQueueController.ts
+++ b/compensation/dashboard/src/features/Failed/useFailedQueueController.ts
@@ -212,10 +212,10 @@ export function useFailedQueueController({
       clearSelection();
       updateQuery(
         pagedQuery({
-          filter: filter.and(
+          filter: filter.and([
             RetryConditions.categoryToCondition(category, Date.now()),
             nextSearchFilter,
-          ),
+          ]),
           sort: executionFailedSort(),
         }),
       );
@@ -234,10 +234,10 @@ export function useFailedQueueController({
       clearSelection();
       updateQuery({
         ...query,
-        filter: filter.and(
+        filter: filter.and([
           RetryConditions.categoryToCondition(category, Date.now()),
           searchFilter,
-        ),
+        ]),
         sort: executionFailedSort(),
         pagination: { index: nextPage, size: nextPageSize },
       });
@@ -256,10 +256,10 @@ export function useFailedQueueController({
     setQueryTransition("refresh");
     updateQuery({
       ...query,
-      filter: filter.and(
+      filter: filter.and([
         RetryConditions.categoryToCondition(category, Date.now()),
         searchFilter,
-      ),
+      ]),
       sort: executionFailedSort(),
     });
   }, [category, query, searchFilter, updateQuery]);


### PR DESCRIPTION
## Summary

Fixes the failing [Compensation Docker Image Deploy → Build Dashboard-UI](https://github.com/Ahoo-Wang/Wow/actions/runs/33181231301/job/98882628622) job, which failed at `pnpm build` with 34 TypeScript errors.

## Root Cause

`@ahoo-wang/fetcher-wow` 3.18.0 (bumped in cbd9d2132) changed the `filter` builder API from rest-parameter style to array-argument style:

| Call | 3.17.x | 3.18.0 |
|---|---|---|
| `filter.and/or/nor` | `(...operands)` | `(operands: readonly FilterExpression[])` |
| `filter.isIn/notIn/containsAll` | `(field, v0, ...values)` | `(field, values: readonly T[])` |

The `src/features/Failed/` call sites still used the old spread style, so `tsc -b` failed. This was not caught at PR time because the Compensation Test workflow only runs Gradle checks; the dashboard typecheck runs only in the deploy workflow.

## Changes

- `RetryConditions.ts`: wrap `filter.and`/`filter.or` operands in arrays; pass the `as const` tuples directly to `filter.isIn`
- `FailedSearch.tsx`: `filter.and(filters[0], ...filters.slice(1))` → `filter.and(filters)`
- `useFailedQueueController.ts`: wrap the three `filter.and(...)` call sites in arrays
- `__tests__/FailedSearch.test.tsx`, `__tests__/FindCategory.test.ts`: migrate expected filter expressions to the array-based API

Runtime filter shapes are unchanged — this is purely a call-signature migration.

## Testing

- [x] Reproduced the 34 `tsc` errors locally with lockfile deps (fetcher-wow 3.18.0) before the fix
- [x] `tsc -b` passes with zero errors
- [x] `vite build` succeeds
- [x] `vitest run`: 144 tests in 33 files, all passing
- [x] `eslint .` clean
