### PR TITLE
docs(query): add diagrams to query guides

### DIFF
--- a/documentation/docs/en/guide/query.md
+++ b/documentation/docs/en/guide/query.md
@@ -30,8 +30,17 @@ Data queries return snapshot or event-stream documents. Aggregation queries retu
 
 ## Execution Chain
 
-```text
-query DTO / DSL -> QueryServiceProxy -> QueryGateway -> QueryFilter chain -> QueryServiceFactory -> backend
+```mermaid
+flowchart LR
+    Local["Typed JVM Bean"] --> Proxy["QueryServiceProxy"]
+    Client["Remote API Client"] --> HTTP["WebFlux / OpenAPI"]
+    HTTP --> Rewrite["Request-scope rewrite"]
+    Proxy --> Gateway["Query Gateway"]
+    Rewrite --> Gateway
+    Gateway --> Filters["QueryFilter chain"]
+    Filters --> Backend["Query backend"]
+    Models["Snapshot / projection / event stream"] --> Backend
+    Backend --> Storage["MongoDB / Elasticsearch"]
 ```
 
 The Gateway is the policy boundary for managed queries; calling a Factory directly bypasses it. See [Query Gateway](./query/query-gateway.md) for filter applicability, the WebFlux request context, and bypass conditions.

--- a/documentation/docs/en/guide/query/aggregation-query.md
+++ b/documentation/docs/en/guide/query/aggregation-query.md
@@ -11,12 +11,16 @@ description: Define the public AggregationQuery AST, counting unit, and dynamic 
 
 ```mermaid
 flowchart LR
-    Q[AggregationQuery] --> F[filter]
-    Q --> E[elements]
-    Q --> G[groupBy]
-    Q --> M[metrics]
-    Q --> S[sort]
-    Q --> L[limit]
+    Q["AggregationQuery"] --> F["filter: root filter"]
+    F --> E{"elements?"}
+    E -->|No expansion| RootUnit["Counting unit: root document"]
+    E -->|Expand collection| ElementUnit["Counting unit: innermost element"]
+    RootUnit --> G["groupBy: buckets"]
+    ElementUnit --> G
+    G --> M["metrics: calculations"]
+    M --> Rows["Dynamic result rows"]
+    Rows --> S["sort"]
+    S --> L["limit"]
 ```
 
 `filter`, ordered `elements`, `groupBy`, `metrics`, `sort`, and `limit` together determine the result. `metrics` cannot be empty; `elements`, `groupBy`, and `sort` can be empty. With no group, the result is a whole-input summary rather than dimension buckets.

--- a/documentation/docs/en/guide/query/data-query.md
+++ b/documentation/docs/en/guide/query/data-query.md
@@ -16,6 +16,22 @@ description: Use shared query shapes to read snapshot or event-stream data.
 | `PagedQuery` | `filter`, `projection`, `sort`, `pagination` | Current-page data and total |
 | Count | A `FilterExpression` directly | An exact count (`Long`) |
 
+```mermaid
+flowchart LR
+    Source{"Choose the data source"} --> Snapshot["Snapshot: current state"]
+    Source --> Event["EventStream: historical body"]
+    Shape{"Choose the result shape"} --> Single["SingleQuery: at most one"]
+    Shape --> List["ListQuery: list"]
+    Shape --> Paged["PagedQuery: page + total"]
+    Shape --> Count["FilterExpression: count"]
+    Snapshot --> Execute["Query entry point"]
+    Event --> Execute
+    Single --> Execute
+    List --> Execute
+    Paged --> Execute
+    Count --> Execute
+```
+
 These shapes can operate on different data models. See [Snapshot Queries](./snapshot-query.md) and [Event Stream Queries](./event-stream-query.md) for their field paths and model-specific defaults. This page does not assume `state.*` or `body.*` paths.
 
 ## SingleQuery

--- a/documentation/docs/en/guide/query/event-stream-aggregation.md
+++ b/documentation/docs/en/guide/query/event-stream-aggregation.md
@@ -23,6 +23,19 @@ Without Elements, one record is one root `DomainEventStream` document. Root filt
 
 `body` is the event array. After `expand("body")`, one record becomes one expanded event. Element filters, groups, metrics, and expression fields are relative to that event, so use `name`, `revision`, `bodyType`, and `body.data`, not the repeated root-prefixed forms `body.name` or `body.body.data`. The root filter still uses absolute root-document paths. `COUNT` counts the current scope, so root event-stream count and expanded event count are different metrics.
 
+```mermaid
+flowchart TB
+    Unit{"Counting unit"} --> Root["Root event-stream document"]
+    Unit --> Event["Expanded body event"]
+    Root --> S3["3 Creation trend"]
+    Root --> S4["4 Tenant / owner activity"]
+    Root --> S5Root["5 Event-stream count"]
+    Event --> S1["1 Event-name frequency"]
+    Event --> S2["2 Revision × bodyType"]
+    Event --> S5Event["5 Event count"]
+    Event --> S6["6 Payload analysis"]
+```
+
 ## Scenario 1: Event Name Frequency
 
 **Business question**

--- a/documentation/docs/en/guide/query/filter-expression.md
+++ b/documentation/docs/en/guide/query/filter-expression.md
@@ -142,6 +142,14 @@ val filter = filterExpression {
 
 `pathState` expands its inner fields to `state.*`, while `items.elementMatch` creates an independent single-element scope, so `quantity` is not expanded to `state.items.quantity`. Multiple expressions in `path { ... }` likewise form one implicit `AND`.
 
+```mermaid
+flowchart TB
+    And["AND: root scope"] --> Tenant["TENANT_ID = tenant-a"]
+    And --> Status["EQ state.status = PAID"]
+    And --> Items["ELEMENT_MATCH state.items"]
+    Items --> Quantity["GT quantity &gt; 1: element scope"]
+```
+
 ## Field Path Rules
 
 `field` is a logical path, not an arbitrary backend physical field name. The root depends on the query model: snapshot business fields are under `state`; event-stream root fields and expanded event fields are different, and event payload is under `body.body`. Do not copy snapshot `state.*` paths into event-stream queries or infer logical fields from physical mappings.

--- a/documentation/docs/en/guide/query/query-backend.md
+++ b/documentation/docs/en/guide/query/query-backend.md
@@ -9,6 +9,19 @@ description: Learn how QueryService, Spring typed Beans, Factory caching, and st
 
 `QueryService<R>` is the aggregate query-backend contract. It provides typed and dynamic single, list, paged, count, and aggregation operations. `SnapshotQueryService<S>` returns `MaterializedSnapshot<S>`, while `EventStreamQueryService` returns `DomainEventStream`. Aggregation always returns dynamic-document rows; the default `aggregate` fails when a backend does not support it.
 
+```mermaid
+flowchart TB
+    SnapshotRegistrar["SnapshotQueryServiceRegistrar"] --> SnapshotBean["Typed SnapshotQueryService&lt;STATE&gt; Bean"]
+    EventRegistrar["EventStreamQueryServiceRegistrar"] --> EventBean["EventStreamQueryService Bean"]
+    SnapshotBean --> Proxy["QueryServiceProxy"]
+    EventBean --> Proxy
+    Proxy --> Gateway["QueryGateway"]
+    Gateway --> Factory["QueryServiceFactory cache and routing"]
+    Factory --> Mongo["MongoDB QueryService"]
+    Factory --> Elastic["Elasticsearch QueryService"]
+    Infra["Trusted infrastructure"] -. "Direct call bypasses Gateway" .-> Factory
+```
+
 ## Injecting a typed SnapshotQueryService Bean
 
 Spring can inject a snapshot query service by its state type:

--- a/documentation/docs/en/guide/query/query-gateway.md
+++ b/documentation/docs/en/guide/query/query-gateway.md
@@ -15,14 +15,24 @@ Business code should not normally bypass the Gateway. Use a Factory directly onl
 
 The complete chain is:
 
-```text
-QueryServiceProxy / WebFlux Handler
-  -> SnapshotQueryGateway / EventStreamQueryGateway
-  -> QueryContext + QueryType
-  -> model-specific QueryFilter chain
-  -> Tail Filter
-  -> raw QueryServiceFactory
-  -> backend QueryService
+```mermaid
+sequenceDiagram
+    participant Caller as Caller
+    participant Entry as Proxy / WebFlux Handler
+    participant Gateway as QueryGateway
+    participant Filters as QueryFilter chain
+    participant Tail as Tail Filter
+    participant Factory as QueryServiceFactory
+    participant Backend as Backend QueryService
+    Caller->>Entry: Query DTO / DSL
+    Entry->>Gateway: Query after scope rewriting
+    Gateway->>Gateway: Create QueryContext + QueryType
+    Gateway->>Filters: Run model-specific filters
+    Filters->>Tail: Pass the final query
+    Tail->>Factory: Resolve the aggregate-scoped raw service
+    Factory->>Backend: Execute query
+    Backend-->>Gateway: Mono / Flux result
+    Gateway-->>Caller: Policy-processed result
 ```
 
 `QueryServiceProxy` serves in-process typed Beans; a WebFlux Handler calls the same kind of service after deserialization and request rewriting. The Tail Filter creates the raw aggregate service, stores the result, and the Gateway returns the corresponding `Mono` or `Flux`.

--- a/documentation/docs/en/guide/query/query-model-schema.md
+++ b/documentation/docs/en/guide/query/query-model-schema.md
@@ -15,16 +15,18 @@ It differs from [general JSON Schema](../advanced/schema.md): JSON Schema descri
 
 The runtime source chain is below. A larger number means a higher priority:
 
-```text
-System
- + JsonQuerySchemaSource (100)
- + ClasspathQuerySchemaSource (200)
- + BeanQuerySchemaSource (300)
- + WorkingDirectoryQuerySchemaSource (400)
- -> QuerySchemaMerger
- -> MongoDB / Elasticsearch Adapter
- -> QueryModelSchema
- -> QuerySchemaResolver
+```mermaid
+flowchart LR
+    System["System fields"] --> Merger["QuerySchemaMerger"]
+    Json["JSON Schema 100"] --> Merger
+    Classpath["Classpath 200"] --> Merger
+    Bean["Bean 300"] --> Merger
+    Working["Working Directory 400"] --> Merger
+    Merger --> Adapter["MongoDB / Elasticsearch Adapter"]
+    Adapter --> Schema["QueryModelSchema"]
+    Schema --> Resolver["QuerySchemaResolver"]
+    Resolver --> Query["Filter / Sort / Aggregation"]
+    Schema --> HTTP["Schema / refresh HTTP"]
 ```
 
 - `System` supplies model-specific fields for Snapshot and EventStream. Extensions must remain under the Snapshot `state` root or the EventStream `body.body` root; a field leaf already set by System cannot be overwritten.

--- a/documentation/docs/en/guide/query/snapshot-aggregation.md
+++ b/documentation/docs/en/guide/query/snapshot-aggregation.md
@@ -21,6 +21,20 @@ Without `elements`, the root filter, groups, and metrics use absolute snapshot l
 
 After `expand("state.items")`, the counting unit becomes one expanded order item. The first Element path remains absolute, while its filter and all following group, metric, and expression fields are relative to that element. Use `quantity`, `productId`, and `price`, not `state.items.quantity`. Groups only bucket records and do not change the counting unit; `COUNT` always counts the current innermost scope.
 
+```mermaid
+flowchart TB
+    Unit{"Counting unit"} --> Root["Root snapshot document"]
+    Unit --> Item["Expanded state.items"]
+    Root --> S1["1 Status breakdown"]
+    Root --> S2["2 Filtered KPIs"]
+    Root --> S3["3 Numeric ranges"]
+    Root --> S4["4 Business-time trend"]
+    Root --> S7["7 Multidimensional analysis"]
+    Item --> S5["5 Line-item Top-N"]
+    Item --> S6["6 Derived amount"]
+    Item --> S8["8 ANY display field"]
+```
+
 ## Scenario 1: Status Breakdown
 
 **Business question**

--- a/documentation/docs/zh/guide/query.md
+++ b/documentation/docs/zh/guide/query.md
@@ -30,8 +30,17 @@ Wow 的“查询”覆盖查询模型、服务端 Query Gateway、JVM 查询后�
 
 ## 执行链
 
-```text
-查询 DTO / DSL -> QueryServiceProxy -> QueryGateway -> QueryFilter chain -> QueryServiceFactory -> Backend
+```mermaid
+flowchart LR
+    Local["JVM 类型化 Bean"] --> Proxy["QueryServiceProxy"]
+    Client["远程 API Client"] --> HTTP["WebFlux / OpenAPI"]
+    HTTP --> Rewrite["请求作用域重写"]
+    Proxy --> Gateway["Query Gateway"]
+    Rewrite --> Gateway
+    Gateway --> Filters["QueryFilter 链"]
+    Filters --> Backend["查询后端"]
+    Models["快照 / 投影 / 事件流"] --> Backend
+    Backend --> Storage["MongoDB / Elasticsearch"]
 ```
 
 Gateway 是受管查询的策略边界；直接调用 Factory 会绕过它。过滤器适用范围、WebFlux 请求上下文和绕过条件见[查询网关](./query/query-gateway.md)。

--- a/documentation/docs/zh/guide/query/aggregation-query.md
+++ b/documentation/docs/zh/guide/query/aggregation-query.md
@@ -11,12 +11,16 @@ description: 定义 AggregationQuery 的公共 AST、统计单位和动态表格
 
 ```mermaid
 flowchart LR
-    Q[AggregationQuery] --> F[filter]
-    Q --> E[elements]
-    Q --> G[groupBy]
-    Q --> M[metrics]
-    Q --> S[sort]
-    Q --> L[limit]
+    Q["AggregationQuery"] --> F["filter：根过滤"]
+    F --> E{"elements？"}
+    E -->|不展开| RootUnit["统计单位：根文档"]
+    E -->|展开集合| ElementUnit["统计单位：最内层元素"]
+    RootUnit --> G["groupBy：分桶"]
+    ElementUnit --> G
+    G --> M["metrics：计算指标"]
+    M --> Rows["动态结果行"]
+    Rows --> S["sort"]
+    S --> L["limit"]
 ```
 
 `filter`、有序的 `elements`、`groupBy`、`metrics`、`sort` 与 `limit` 共同决定结果。`metrics` 不可为空；`elements`、`groupBy` 与 `sort` 可为空。没有 group 时，结果是整体汇总而非按维度分桶。

--- a/documentation/docs/zh/guide/query/data-query.md
+++ b/documentation/docs/zh/guide/query/data-query.md
@@ -16,6 +16,22 @@ description: 使用统一的查询形态读取快照或事件流数据。
 | `PagedQuery` | `filter`、`projection`、`sort`、`pagination` | 当前页数据和总数 |
 | Count | 直接提交 `FilterExpression` | 精确计数（`Long`） |
 
+```mermaid
+flowchart LR
+    Source{"选择数据源"} --> Snapshot["Snapshot：当前 state"]
+    Source --> Event["EventStream：历史 body"]
+    Shape{"选择返回形态"} --> Single["SingleQuery：至多一条"]
+    Shape --> List["ListQuery：列表"]
+    Shape --> Paged["PagedQuery：当前页 + total"]
+    Shape --> Count["FilterExpression：计数"]
+    Snapshot --> Execute["查询入口"]
+    Event --> Execute
+    Single --> Execute
+    List --> Execute
+    Paged --> Execute
+    Count --> Execute
+```
+
 这些形态可以作用于不同的数据模型；字段路径和模型默认行为分别见[快照查询](./snapshot-query.md)与[事件流查询](./event-stream-query.md)。本页不预设 `state.*` 或 `body.*` 路径。
 
 ## SingleQuery

--- a/documentation/docs/zh/guide/query/event-stream-aggregation.md
+++ b/documentation/docs/zh/guide/query/event-stream-aggregation.md
@@ -23,6 +23,19 @@ HTTP handler 严格解码请求后，`RewriteRequestFilter` 会依据 aggregate 
 
 `body` 是事件数组。调用 `expand("body")` 后，一条记录变为展开后的单个事件；Element filter、group、metric 与表达式字段都相对该事件，因此使用 `name`、`revision`、`bodyType` 和 `body.data`，不能重复根前缀写成 `body.name` 或 `body.body.data`。根 filter 仍使用根文档的绝对路径。`COUNT` 统计当前作用域，所以根事件流数量与展开后的事件数量不是同一指标。
 
+```mermaid
+flowchart TB
+    Unit{"统计单位"} --> Root["事件流根文档"]
+    Unit --> Event["展开后的 body 事件"]
+    Root --> S3["3 创建趋势"]
+    Root --> S4["4 租户 / Owner 活跃度"]
+    Root --> S5Root["5 事件流数量"]
+    Event --> S1["1 事件名称频次"]
+    Event --> S2["2 Revision × BodyType"]
+    Event --> S5Event["5 事件数量"]
+    Event --> S6["6 Payload 分析"]
+```
+
 ## 场景 1：事件名称频次
 
 **业务问题**

--- a/documentation/docs/zh/guide/query/filter-expression.md
+++ b/documentation/docs/zh/guide/query/filter-expression.md
@@ -142,6 +142,14 @@ val filter = filterExpression {
 
 `pathState` 将内部字段补为 `state.*`，而 `items.elementMatch` 创建独立的单元素作用域，所以 `quantity` 不会被补成 `state.items.quantity`。`path { ... }` 内的多个表达式同样形成一个隐式 `AND`。
 
+```mermaid
+flowchart TB
+    And["AND：根作用域"] --> Tenant["TENANT_ID = tenant-a"]
+    And --> Status["EQ state.status = PAID"]
+    And --> Items["ELEMENT_MATCH state.items"]
+    Items --> Quantity["GT quantity &gt; 1：元素作用域"]
+```
+
 ## 字段路径规则
 
 `field` 是逻辑路径，不是任意后端的物理字段名。根路径取决于查询模型：快照的业务字段位于 `state`；事件流的根字段与展开后的事件字段不同，事件 payload 位于 `body.body`。因此不要把快照的 `state.*` 路径复制到事件流查询，也不要从物理 mapping 猜测逻辑字段。

--- a/documentation/docs/zh/guide/query/query-backend.md
+++ b/documentation/docs/zh/guide/query/query-backend.md
@@ -9,6 +9,19 @@ description: 了解 QueryService、Spring 类型化 Bean、Factory 缓存与存�
 
 `QueryService<R>` 是聚合查询后端契约，提供类型化（typed）与动态（dynamic）的单条（single）、列表（list）、分页（paged）、计数（count）和聚合（aggregation）操作。`SnapshotQueryService<S>` 返回 `MaterializedSnapshot<S>`，而 `EventStreamQueryService` 返回 `DomainEventStream`。聚合始终返回动态文档行；后端未支持时，默认 `aggregate` 会失败。
 
+```mermaid
+flowchart TB
+    SnapshotRegistrar["SnapshotQueryServiceRegistrar"] --> SnapshotBean["SnapshotQueryService&lt;STATE&gt; 类型化 Bean"]
+    EventRegistrar["EventStreamQueryServiceRegistrar"] --> EventBean["EventStreamQueryService Bean"]
+    SnapshotBean --> Proxy["QueryServiceProxy"]
+    EventBean --> Proxy
+    Proxy --> Gateway["QueryGateway"]
+    Gateway --> Factory["QueryServiceFactory 缓存与路由"]
+    Factory --> Mongo["MongoDB QueryService"]
+    Factory --> Elastic["Elasticsearch QueryService"]
+    Infra["受信基础设施"] -. "直接调用，绕过 Gateway" .-> Factory
+```
+
 ## 注入类型化的 SnapshotQueryService Bean
 
 Spring 可按状态类型注入快照查询服务：

--- a/documentation/docs/zh/guide/query/query-gateway.md
+++ b/documentation/docs/zh/guide/query/query-gateway.md
@@ -15,14 +15,24 @@ description: 理解查询请求如何经过上下文、过滤器链、权限与�
 
 完整链路如下：
 
-```text
-QueryServiceProxy / WebFlux Handler
-  -> SnapshotQueryGateway / EventStreamQueryGateway
-  -> QueryContext + QueryType
-  -> model-specific QueryFilter chain
-  -> Tail Filter
-  -> raw QueryServiceFactory
-  -> backend QueryService
+```mermaid
+sequenceDiagram
+    participant Caller as 调用方
+    participant Entry as Proxy / WebFlux Handler
+    participant Gateway as QueryGateway
+    participant Filters as QueryFilter 链
+    participant Tail as Tail Filter
+    participant Factory as QueryServiceFactory
+    participant Backend as Backend QueryService
+    Caller->>Entry: Query DTO / DSL
+    Entry->>Gateway: 作用域重写后的查询
+    Gateway->>Gateway: 创建 QueryContext + QueryType
+    Gateway->>Filters: 执行模型专属过滤链
+    Filters->>Tail: 传递最终查询
+    Tail->>Factory: 获取聚合级原始服务
+    Factory->>Backend: 执行查询
+    Backend-->>Gateway: Mono / Flux 结果
+    Gateway-->>Caller: 策略处理后的结果
 ```
 
 `QueryServiceProxy` 供进程内的类型化 Bean 使用；WebFlux Handler 在反序列化和请求重写后调用同一类服务。Tail Filter 按聚合创建原始服务并写入结果，随后由 Gateway 返回对应的 `Mono` 或 `Flux`。

--- a/documentation/docs/zh/guide/query/query-model-schema.md
+++ b/documentation/docs/zh/guide/query/query-model-schema.md
@@ -15,16 +15,18 @@ Query Model Schema 是运行时查询能力合同，分别描述 `QueryModel.SNA
 
 运行时来源链如下，括号内数字越大，优先级越高：
 
-```text
-System
- + JsonQuerySchemaSource (100)
- + ClasspathQuerySchemaSource (200)
- + BeanQuerySchemaSource (300)
- + WorkingDirectoryQuerySchemaSource (400)
- -> QuerySchemaMerger
- -> MongoDB / Elasticsearch Adapter
- -> QueryModelSchema
- -> QuerySchemaResolver
+```mermaid
+flowchart LR
+    System["System 字段"] --> Merger["QuerySchemaMerger"]
+    Json["JSON Schema 100"] --> Merger
+    Classpath["Classpath 200"] --> Merger
+    Bean["Bean 300"] --> Merger
+    Working["Working Directory 400"] --> Merger
+    Merger --> Adapter["MongoDB / Elasticsearch Adapter"]
+    Adapter --> Schema["QueryModelSchema"]
+    Schema --> Resolver["QuerySchemaResolver"]
+    Resolver --> Query["Filter / Sort / Aggregation"]
+    Schema --> HTTP["Schema / refresh HTTP"]
 ```
 
 - `System` 为 Snapshot 和 EventStream 提供各自的系统字段。扩展只能位于 Snapshot 的 `state` 或 EventStream 的 `body.body` 根下；已经由系统设置的字段叶不能被覆盖。

--- a/documentation/docs/zh/guide/query/snapshot-aggregation.md
+++ b/documentation/docs/zh/guide/query/snapshot-aggregation.md
@@ -21,6 +21,20 @@ description: 用八个业务场景说明快照根文档与集合元素的聚合�
 
 调用 `expand("state.items")` 后，统计单位变为展开后的单个订单项。首个 Element 路径仍是绝对路径；它的 filter 以及后续 group、metric 和表达式字段都相对该元素，因此使用 `quantity`、`productId`、`price`，不能再写成 `state.items.quantity`。Group 只负责分桶，不改变统计单位；`COUNT` 始终统计当前最内层作用域。
 
+```mermaid
+flowchart TB
+    Unit{"统计单位"} --> Root["快照根文档"]
+    Unit --> Item["展开后的 state.items"]
+    Root --> S1["1 状态分类"]
+    Root --> S2["2 过滤 KPI"]
+    Root --> S3["3 数值区间"]
+    Root --> S4["4 业务时间趋势"]
+    Root --> S7["7 多维交叉分析"]
+    Item --> S5["5 明细项 Top-N"]
+    Item --> S6["6 派生金额"]
+    Item --> S8["8 ANY 展示字段"]
+```
+
 ## 场景 1：状态分类统计
 
 **业务问题**


### PR DESCRIPTION
## Goal

Improve the readability of the reorganized query documentation by visualizing core execution flows and aggregation scenario maps.

## Changes

- Add mirrored Chinese and English Mermaid diagrams to the query overview, gateway, backend, filter-expression, and data-query guides.
- Visualize aggregation counting units and the snapshot/event-stream analysis scenarios.
- Visualize the Query Model Schema source and resolution pipeline.
- Reuse VitePress Mermaid support without adding assets or dependencies.

## Verification

- `cd documentation && pnpm docs:build` — passed; only the existing Rollup chunk-size warning remains.
- `git diff --check origin/main...HEAD` — passed.
- Node assertion verified exactly 9 bilingual Mermaid diagrams with mirrored structures.

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

Documentation-only change. No migration, deployment, runtime, data, performance, or concurrency impact. Rollback is the single documentation commit.
