### PR TITLE
docs: add diagrams to domain command and event guides

### DIFF
--- a/document/design/2026-08-28-domain-command-event-diagrams-design.md
+++ b/document/design/2026-08-28-domain-command-event-diagrams-design.md
@@ -79,7 +79,7 @@
 | `domain/index` | 新增 | `flowchart TB` | 展示聚合边界如何连接事件溯源、事件演进、快照、生命周期与命令定义阅读入口。 |
 | `domain/aggregate` | 新增 | `flowchart TB` | 展示限界上下文、聚合边界、状态、命令处理、领域事件和不变量的关系。 |
 | `domain/event-sourcing` | 保留 | `flowchart LR` | 展示最新/历史版本恢复如何选择快照或空聚合，并从 `expectedNextVersion` 顺序溯源。 |
-| `domain/event-evolution` | 新增 | `flowchart LR` | 展示持久事件从旧 Revision 经过有序 Upgrader 链得到当前形态；DroppedEvent 是显式终点。 |
+| `domain/event-evolution` | 新增 | `flowchart LR` | 展示 `EventUpgraderFactory` 按 `@Order` 对每条记录恰好调用每个已注册 Upgrader 一次；每步可返回原样、升级或 DroppedEvent 记录，并验证最终记录可解析。 |
 | `domain/snapshot` | 重做 | `flowchart TB` | 对照完整事件回放与“快照 + 尾部事件”两条恢复路径，并汇聚到相同聚合状态。 |
 | `domain/lifecycle` | 新增 | `stateDiagram-v2` | 展示未初始化、活动、删除和恢复状态及其合法转换，不复制完整命令管线。 |
 

--- a/document/design/2026-08-28-domain-command-event-diagrams-design.md
+++ b/document/design/2026-08-28-domain-command-event-diagrams-design.md
@@ -1,0 +1,223 @@
+# 领域模型、命令、事件与协作文档图表设计
+
+## 背景
+
+“领域模型、命令、事件与协作”信息架构已经形成中英文各 20 个职责唯一的页面，但当前只有 6 个页面包含 Mermaid 图。其余 14 个页面主要依赖段落、表格和代码，读者必须先读完较长正文，才能建立组件关系、选择路径或状态转换的整体认知。
+
+查询文档已经在独立分支采用“页面主图 + 精确正文”的方式补充 Mermaid 图。本设计为另外三个区域建立相同的阅读体验，但不修改查询模块，也不引入新的视觉资产系统。
+
+## 已确认的决策
+
+- 覆盖中英文全部 20 个领域模型、命令、事件协作页面；每页恰好一张 Mermaid 主图。
+- 14 个纯文字页面新增主图。
+- 现有 6 张图中：重做与事件溯源图重复的快照图，扩充过于简略的事件分发图；其余 4 张保留。
+- 全部图使用内嵌 Mermaid，不新增 SVG、PNG、绘图依赖、生成脚本或主题配置。
+- 中英文图使用相同图类型、节点 ID、边和分组，只本地化显示标签。
+- 图是正文导航和关系摘要，不替代精确契约、错误边界、表格、代码或测试入口。
+- 不修改查询文档；查询图表由独立的 `docs/query-diagrams` 工作处理。
+
+## 范围
+
+### 包含
+
+- `documentation/docs/{zh,en}/guide/domain/` 的 6 个页面；
+- `documentation/docs/{zh,en}/guide/command/` 的 9 个页面；
+- `documentation/docs/{zh,en}/guide/event/` 的 5 个页面；
+- 新增 14 组双语 Mermaid 图；
+- 重构 `domain/snapshot` 与 `event/dispatch` 的双语现有图；
+- Mermaid 语法构建、双语结构、页面覆盖率和代表性桌面/窄屏视觉检查。
+
+### 不包含
+
+- `guide/query`、`guide/query/**`、`projection` 或 `data-access`；
+- 页面信息架构、URL、sidebar、章节职责或技术结论重写；
+- VitePress 主题、Mermaid 插件配置、颜色主题或全局 CSS；
+- 图片资产、图标库、截图、动画或交互图；
+- 框架源码、API、Schema、配置、示例行为、依赖、CI/CD 或发布流程。
+
+## 视觉语言
+
+### 图型选择
+
+- `flowchart LR`：线性调用、入口拓扑、处理链和左右对照；
+- `flowchart TB`：选择分支、层级关系和移动端更易阅读的复杂拓扑；
+- `sequenceDiagram`：跨组件调用、请求与响应、远程回调；
+- `stateDiagram-v2`：具有明确状态与转换条件的生命周期。
+
+不使用 Mermaid `mindmap`、自定义主题、颜色类或实验性语法，避免构建与主题兼容风险。
+
+### 复杂度限制
+
+- 一张图只回答一个核心问题；
+- 普通图通常不超过 8 个节点；
+- 运行时原理图最多 12 个节点或参与者；
+- 超过限制时通过 `subgraph` 分组、改变方向或删去非关键细节解决，不拆成第二张主图；
+- 节点标签使用短语，不把段落、完整签名、配置值或异常说明塞入图中。
+
+### 放置与正文关系
+
+- 图紧邻其核心概念第一次出现的位置，而不是机械地堆在 frontmatter 之后；
+- 图前用一句话说明“这张图回答什么问题”；
+- 图后正文继续解释保证、例外和失败边界；
+- 不删除正文中的关键表格或技术说明；只有已被图完整替代的纯文本 ASCII 流程可删除；
+- 不依赖颜色表达状态或选择，所有语义都必须出现在节点、边标签或正文中。
+
+### Mermaid 编写规则
+
+- 中英文对应图共享稳定的英文节点 ID，例如 `Gateway`、`Dispatcher`、`Store`；
+- 显示标签分别使用自然中文和英文；
+- 包含泛型、尖括号或特殊字符的标签必须加引号并使用 HTML 转义；
+- 边标签只用于真正的条件、结果或协议边界；
+- 避免一条边同时表达顺序、失败和保证三种含义。
+
+## 逐页图表职责
+
+### 领域模型
+
+| 页面 | 状态 | 图型 | 主图唯一职责 |
+| --- | --- | --- | --- |
+| `domain/index` | 新增 | `flowchart TB` | 展示聚合边界如何连接事件溯源、事件演进、快照、生命周期与命令定义阅读入口。 |
+| `domain/aggregate` | 新增 | `flowchart TB` | 展示限界上下文、聚合边界、状态、命令处理、领域事件和不变量的关系。 |
+| `domain/event-sourcing` | 保留 | `flowchart LR` | 展示最新/历史版本恢复如何选择快照或空聚合，并从 `expectedNextVersion` 顺序溯源。 |
+| `domain/event-evolution` | 新增 | `flowchart LR` | 展示持久事件从旧 Revision 经过有序 Upgrader 链得到当前形态；DroppedEvent 是显式终点。 |
+| `domain/snapshot` | 重做 | `flowchart TB` | 对照完整事件回放与“快照 + 尾部事件”两条恢复路径，并汇聚到相同聚合状态。 |
+| `domain/lifecycle` | 新增 | `stateDiagram-v2` | 展示未初始化、活动、删除和恢复状态及其合法转换，不复制完整命令管线。 |
+
+`domain/event-sourcing` 继续拥有权威历史与恢复主流程；`domain/snapshot` 只拥有恢复优化对照，避免维护两张几乎相同的恢复图。
+
+### 命令
+
+| 页面 | 状态 | 图型 | 主图唯一职责 |
+| --- | --- | --- | --- |
+| `command/index` | 新增 | `flowchart LR` | 展示意图从命令定义、发送、处理、事件追加到可观察完成与下游协作的全局路径。 |
+| `command/definition` | 新增 | `flowchart LR` | 展示命令载荷与元数据进入 Handler 后返回领域事件或 Void 的决策边界。 |
+| `command/sending` | 新增 | `flowchart TB` | 对照应用内 Gateway、聚合 HTTP 路由和全局命令门面三种入口。 |
+| `command/api-client` | 新增 | `sequenceDiagram` | 展示调用方、服务定位、CoApi、`/wow/command/send` 与最终结果之间的远程边界。 |
+| `command/completion` | 保留 | `flowchart LR` | 展示 `PROCESSED` 之后 SNAPSHOT、PROJECTED、EVENT_HANDLED、SAGA_HANDLED 是独立分支。 |
+| `command/reliability` | 新增 | `flowchart TB` | 展示失败或超时后如何查询权威结果、复用稳定 `requestId`、决定重试或停止。 |
+| `command/internals/pipeline` | 保留 | `flowchart LR` | 展示 Gateway 到 EventStore、Domain/State EventBus 与 PROCESSED 的内部顺序。 |
+| `command/internals/wait-runtime` | 新增 | `sequenceDiagram` | 展示 Wait Header、Coordinator、WaitState、Notifier 与 Handle 的注册、信号和清理闭环。 |
+| `command/internals/transport` | 新增 | `flowchart TB` | 对照 InMemory、Kafka、Redis、LocalFirst 的写入/准入位置与 `SENT` 证据边界。 |
+
+命令区的图按三个层级分工：`index` 是生命周期导航，`sending` 是入口选择，`internals/pipeline` 是运行时组件顺序。三者不能各自维护同一份完整调用链。
+
+### 事件与协作
+
+| 页面 | 状态 | 图型 | 主图唯一职责 |
+| --- | --- | --- | --- |
+| `event/index` | 新增 | `flowchart TB` | 根据普通副作用、跨聚合命令和持久失败恢复选择 Processor、Saga 或 Compensation。 |
+| `event/processor` | 新增 | `flowchart LR` | 展示事件匹配、Filter、响应式副作用、完成通知与失败入口。 |
+| `event/saga` | 新增 | `sequenceDiagram` | 展示源聚合事件触发 Saga，并顺序生成 0..N 条命令发送到目标聚合。 |
+| `event/compensation` | 保留 | `stateDiagram-v2` | 展示 `FAILED → PREPARED → FAILED/SUCCEEDED` 的持久恢复状态机。 |
+| `event/dispatch` | 扩充 | `flowchart TB` | 展示 Domain/State EventBus、Dispatcher、Notifier、Compensation/Retryable 与函数调用的相对位置。 |
+
+`event/index` 只负责选择；`event/processor` 与 `event/saga` 负责使用；`event/dispatch` 负责内部 Filter 顺序。补偿状态机只在 `event/compensation` 维护。
+
+## 技术事实边界
+
+- 图中所有顺序、状态、分支和保证必须与页面当前正文及其引用的源码/测试一致；
+- 不把 `PROCESSED` 画成所有下游阶段完成；
+- 不把 `SNAPSHOT` 无条件画成已写入新快照；
+- 不把 API Client 画成本地 Gateway 或完整 SSE 协议的等价实现；
+- 不把 Saga 业务补偿与事件函数失败后的持久补偿合并；
+- 不把 StateEvent 发布失败画成必然使命令失败；
+- 不把传输 `SENT` 画成命令已处理；
+- 不从旧图或旧文档继承未经当前源码、测试或已批准正文支持的承诺。
+
+## 双语一致性
+
+- 中英文每个对应页面必须拥有相同数量的 Mermaid 块；最终均为 1；
+- 对应图使用相同图型、方向、节点 ID、边、条件与 `subgraph`；
+- 只翻译显示标签和说明句，不翻译类名、阶段名、路由、Header、方法名和配置键；
+- 中文先作为事实基线，英文使用自然表达，不能靠逐词翻译改变技术语义；
+- 双语任一侧 Mermaid 解析失败、缺节点或边结构不同都阻塞验收。
+
+## 可读性与可访问性
+
+- 图不是唯一信息来源；页面正文必须能在 Mermaid 未渲染时继续表达完整契约；
+- 不使用颜色、线型粗细或空间位置作为唯一语义；
+- 节点和参与者名称必须可直接朗读并与正文术语一致；
+- 复杂图优先改为纵向或分组，而不是缩小字体或塞入长标签；
+- 页面在桌面和窄屏下都不能依赖横向拖动才能理解关键主路径。
+
+## 实施边界
+
+预计修改 32 个 Markdown 文件：
+
+- 28 个文件：14 个纯文字页面的中英文主图；
+- 4 个文件：双语 `domain/snapshot` 与 `event/dispatch` 现有图重构。
+
+以下 8 个文件中的 4 组现有图默认不改：
+
+- `domain/event-sourcing`；
+- `command/completion`；
+- `command/internals/pipeline`；
+- `event/compensation`。
+
+只有在实施验证发现双语结构不一致、Mermaid 语法失效或与当前正文冲突时，才允许对上述图做最小修正，并在提交说明中单独列出。
+
+## 验收标准
+
+### 结构
+
+- 中英文 20 个目标页面每页恰好包含 1 个 `mermaid` fenced block；
+- 20 组双语图的图型、方向、节点 ID、边和分组一致；
+- 不修改查询页面、sidebar、主题配置或图片目录；
+- 不新增依赖、脚本、生成文件或构建配置。
+
+### 内容
+
+- 每张图能用一句话说明唯一问题；
+- 不存在同一区域内重复维护的完整命令链、恢复链或补偿链；
+- 快照图与事件溯源图职责不同；
+- 命令概览、发送和内部管线图职责不同；
+- 事件选择、Processor、Saga、补偿和分发图职责不同；
+- 图中阶段、失败和协议边界与当前正文及源码一致。
+
+### 验证
+
+至少执行：
+
+```bash
+pnpm --dir documentation docs:build
+git diff --check
+```
+
+并完成以下无新增依赖检查：
+
+- 统计中英文 20 个目标页面的 Mermaid 块，确保每页恰好 1 个；
+- 比较双语页面路径集合和 Mermaid 图型集合；
+- 抽查节点 ID、边和分组结构一致；
+- 扫描目标目录，不存在第二张主图、未完成占位词或冲突标记；
+- 确认 Git diff 不包含 query、sidebar、主题、依赖、构建输出或图片资产；
+- 本地预览 `domain/lifecycle`、`command/api-client`、`command/internals/transport`、`event/index` 与扩充后的 `event/dispatch`；
+- 对上述代表页检查桌面与窄屏下的主路径、标签换行和横向宽度。
+
+## 实施分批
+
+1. **领域模型**：新增 4 组图，重做快照图，验证与事件溯源图不重复；
+2. **命令应用页**：新增概览、定义、发送、API Client、可靠性图；
+3. **命令原理页**：新增等待运行时与传输图，保留并核对现有管线/完成图；
+4. **事件与协作**：新增概览、Processor、Saga 图，扩充分发图，保留补偿状态机；
+5. **全站验收**：双语结构、VitePress 构建、代表页桌面/窄屏视觉检查。
+
+## 风险与控制
+
+| 风险 | 控制 |
+| --- | --- |
+| 图过宽导致移动端难读 | 优先 `TB`、短标签和 `subgraph`；代表页必须做窄屏检查。 |
+| 图与正文重复或冲突 | 每图只回答一个问题；正文继续拥有保证和例外。 |
+| 中英文结构漂移 | 先完成中文事实图，再按相同节点 ID 和边结构编写英文。 |
+| Mermaid 特殊字符导致构建失败 | 标签加引号，泛型和尖括号使用 HTML 转义，运行严格 VitePress 构建。 |
+| 图无意中扩大运行时承诺 | 对高风险阶段、失败、重试和传输边界重新核对当前源码/测试。 |
+| 与查询图表工作冲突 | 本任务完全排除 query、projection、data-access 与 sidebar 文件。 |
+
+## 明确不做
+
+- 不为了“视觉统一”给页面加入第二张装饰图；
+- 不把代码示例截图化；
+- 不用图取代错误说明、状态表、阶段表或能力限制；
+- 不创建共享 Mermaid include、宏、组件或生成器；
+- 不修改 VitePress 的 Mermaid 主题和全局颜色；
+- 不把查询图表合并进本任务；
+- 不在补图过程中顺带重写正文或修改运行时实现。

--- a/document/design/2026-08-29-domain-command-event-diagrams-implementation-plan.md
+++ b/document/design/2026-08-29-domain-command-event-diagrams-implementation-plan.md
@@ -1,0 +1,925 @@
+# 领域模型、命令、事件与协作文档图表 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为中英文“领域模型、命令、事件与协作”20 个页面建立每页一张、职责唯一的 Mermaid 主图，并保证技术事实、双语结构和桌面/窄屏可读性。
+
+**Architecture:** 直接在现有 Markdown 中维护 Mermaid，不增加资产、组件或生成器。按领域区域分批补齐 14 张缺失图，重构快照和事件分发两张现有图；其余 4 张已验证图保持不动。每批都先用覆盖率检查证明缺图，再增加最小图、构建 VitePress 并做代表页视觉检查。
+
+**Tech Stack:** VitePress 1.6.4、vitepress-plugin-mermaid、Markdown、Mermaid、pnpm、本地浏览器视觉检查。
+
+**Spec:** [`document/design/2026-08-28-domain-command-event-diagrams-design.md`](./2026-08-28-domain-command-event-diagrams-design.md)
+
+## Global Constraints
+
+- 最终中英文每个 `domain`、`command`、`event` 页面恰好包含 1 个 `mermaid` fenced block。
+- 中文是事实基线；英文使用完全相同的图型、方向、节点 ID、边、条件和 `subgraph`，只本地化显示标签。
+- 一张图只回答一个核心问题；普通图不超过 8 个节点，运行时图不超过 12 个节点或参与者。
+- 图前保留一句阅读目的；正文继续拥有精确保证、例外、错误边界、表格和代码。
+- 不依赖颜色、线宽或空间位置作为唯一语义；不增加 Mermaid 样式类或主题配置。
+- 不修改 `guide/query`、`guide/query/**`、`projection`、`data-access`、sidebar、主题、图片目录、依赖、构建配置、源码、API、Schema、CI/CD 或发布行为。
+- 不新增 SVG、PNG、图标、脚本、生成器、共享 include、宏或文档组件。
+- 不改变页面 URL、frontmatter、章节职责或已经审查通过的运行时承诺。
+- 只暂存当前任务列出的文件；不得提交 `node_modules`、构建输出、浏览器截图或本地状态。
+
+---
+
+### Task 1: 补齐领域模型图表
+
+**Files:**
+- Modify: `documentation/docs/zh/guide/domain/index.md`
+- Modify: `documentation/docs/en/guide/domain/index.md`
+- Modify: `documentation/docs/zh/guide/domain/aggregate.md`
+- Modify: `documentation/docs/en/guide/domain/aggregate.md`
+- Modify: `documentation/docs/zh/guide/domain/event-evolution.md`
+- Modify: `documentation/docs/en/guide/domain/event-evolution.md`
+- Modify: `documentation/docs/zh/guide/domain/snapshot.md`
+- Modify: `documentation/docs/en/guide/domain/snapshot.md`
+- Modify: `documentation/docs/zh/guide/domain/lifecycle.md`
+- Modify: `documentation/docs/en/guide/domain/lifecycle.md`
+- Read only: `documentation/docs/{zh,en}/guide/domain/event-sourcing.md`
+
+**Interfaces:**
+- Consumes: 已批准的领域模型六页职责，以及现有 `event-sourcing` 恢复主图。
+- Produces: 双语领域模型 6/6 页面每页一张主图；`snapshot` 图不再复制 `event-sourcing` 的恢复主流程。
+
+- [ ] **Step 1: 运行领域图覆盖契约并确认失败**
+
+```bash
+for locale in zh en; do
+  for page in index aggregate event-sourcing event-evolution snapshot lifecycle; do
+    test "$(rg -c '^```mermaid$' "documentation/docs/$locale/guide/domain/$page.md" || true)" = 1
+  done
+done
+```
+
+Expected: exit `1`，因为 `index`、`aggregate`、`event-evolution`、`lifecycle` 尚无 Mermaid 图。
+
+- [ ] **Step 2: 在双语 `domain/index` 增加能力地图**
+
+放在 lead 段落之后、第一个 `##` 之前。中文使用：
+
+```mermaid
+flowchart TB
+    Start["从领域边界开始"] --> Aggregate["聚合与不变量"]
+    Aggregate --> History["事件溯源：权威历史"]
+    History --> Evolution["事件演进：长期兼容"]
+    History --> Snapshot["快照：恢复优化"]
+    Aggregate --> Lifecycle["聚合生命周期"]
+    Aggregate --> Command["定义命令"]
+```
+
+英文保持相同结构，精确标签为：
+
+```text
+Start="Start with the domain boundary"
+Aggregate="Aggregate and invariants"
+History="Event sourcing: authoritative history"
+Evolution="Event evolution: long-term compatibility"
+Snapshot="Snapshots: recovery optimization"
+Lifecycle="Aggregate lifecycle"
+Command="Define commands"
+```
+
+图前说明句：
+
+```text
+下面的能力地图展示领域模型各页怎样从聚合边界展开。
+The capability map below shows how the domain-model pages grow from the aggregate boundary.
+```
+
+- [ ] **Step 3: 在双语 `domain/aggregate` 增加聚合边界图**
+
+放在 lead 段落之后、第一个 `##` 之前。中文使用：
+
+```mermaid
+flowchart TB
+    Context["限界上下文"] --> Aggregate["聚合边界"]
+    Intent["业务意图"] --> Decision["聚合决策"]
+    Aggregate --> State["当前状态"]
+    Aggregate --> Decision
+    State --> Decision
+    Decision --> Invariant{"不变量满足？"}
+    Invariant -->|是| Event["领域事件"]
+    Invariant -->|否| Reject["拒绝命令"]
+    Event --> State
+```
+
+英文标签：
+
+```text
+Context="Bounded context"
+Aggregate="Aggregate boundary"
+Intent="Business intent"
+Decision="Aggregate decision"
+State="Current state"
+Invariant="Invariants satisfied?"
+yes edge="Yes"
+Event="Domain event"
+no edge="No"
+Reject="Reject command"
+```
+
+图前说明句：
+
+```text
+聚合把状态、业务决策和不变量封装在同一个一致性边界中。
+An aggregate encloses state, business decisions, and invariants within one consistency boundary.
+```
+
+- [ ] **Step 4: 在双语 `domain/event-evolution` 增加升级链图**
+
+放在 lead 段落之后、第一个 `##` 之前。中文使用：
+
+```mermaid
+flowchart LR
+    Persisted["持久事件 Revision 1"] --> Lookup{"存在下一 Revision Upgrader？"}
+    Lookup -->|是| Upgrade["升级到下一 Revision"]
+    Upgrade --> Lookup
+    Lookup -->|否| Current["当前事件形态"]
+    Upgrade -. "显式删除" .-> Dropped["DroppedEvent"]
+```
+
+英文标签：
+
+```text
+Persisted="Persisted event Revision 1"
+Lookup="Next Revision Upgrader exists?"
+yes edge="Yes"
+Upgrade="Upgrade to the next Revision"
+no edge="No"
+Current="Current event shape"
+dotted edge="Explicitly drop"
+Dropped="DroppedEvent"
+```
+
+图前说明句：
+
+```text
+读取历史事件时，Upgrader 按 Revision 逐步推进，直到得到当前形态或显式丢弃事件。
+When historical events are read, Upgraders advance Revision by Revision until the current shape or an explicit drop is reached.
+```
+
+- [ ] **Step 5: 重做双语 `domain/snapshot` 主图**
+
+替换现有 Mermaid block，不增加第二张图。中文使用：
+
+```mermaid
+flowchart TB
+    Target["恢复最新聚合"] --> Choice{"存在可用快照？"}
+    Choice -->|否| All["加载全部事件"]
+    Choice -->|是| Snapshot["加载快照"]
+    Snapshot --> Tail["从 expectedNextVersion 加载尾部事件"]
+    All --> Source["按顺序 onSourcing"]
+    Tail --> Source
+    Source --> Ready["相同的当前聚合状态"]
+```
+
+英文标签：
+
+```text
+Target="Restore the latest aggregate"
+Choice="Usable snapshot exists?"
+no edge="No"
+All="Load all events"
+yes edge="Yes"
+Snapshot="Load snapshot"
+Tail="Load tail events from expectedNextVersion"
+Source="Apply onSourcing in order"
+Ready="Same current aggregate state"
+```
+
+保留现有图前后的正文，不把 `SNAPSHOT` 等同于一定写入新快照。
+
+- [ ] **Step 6: 在双语 `domain/lifecycle` 增加生命周期状态图**
+
+放在 lead 段落之后、第一个 `##` 之前。中文使用：
+
+```mermaid
+stateDiagram-v2
+    state "未初始化聚合" as Empty
+    state "活动聚合" as Active
+    state "已删除聚合" as Deleted
+    [*] --> Empty
+    Empty --> Active: 创建事件
+    Active --> Active: 普通领域事件
+    Active --> Deleted: 删除事件
+    Deleted --> Active: 恢复事件
+```
+
+英文标签与边标签：
+
+```text
+Empty="Uninitialized aggregate"
+Active="Active aggregate"
+Deleted="Deleted aggregate"
+Empty -> Active="Creation event"
+Active -> Active="Regular domain event"
+Active -> Deleted="Deletion event"
+Deleted -> Active="Recovery event"
+```
+
+图前说明句：
+
+```text
+生命周期由事件驱动；删除和恢复仍然是聚合状态演进的一部分。
+Events drive the lifecycle; deletion and recovery remain part of aggregate state evolution.
+```
+
+- [ ] **Step 7: 验证领域图并做代表页视觉检查**
+
+```bash
+for locale in zh en; do
+  for page in index aggregate event-sourcing event-evolution snapshot lifecycle; do
+    test "$(rg -c '^```mermaid$' "documentation/docs/$locale/guide/domain/$page.md")" = 1
+  done
+done
+pnpm --dir documentation docs:build
+git diff --check
+```
+
+启动本地文档站：
+
+```bash
+pnpm --dir documentation docs:dev --host 127.0.0.1
+```
+
+Expected: VitePress 输出本地访问地址并保持运行。使用浏览器分别检查：
+
+```text
+/guide/domain/lifecycle
+/zh/guide/domain/lifecycle
+/guide/domain/snapshot
+/zh/guide/domain/snapshot
+```
+
+每页检查桌面宽度约 1440px 和窄屏约 390px：标签不能截断，状态和两条恢复路径必须无需依赖颜色即可理解。若过宽，只缩短标签或把方向改为 `TB`，不得删除关键状态/分支。
+
+- [ ] **Step 8: 提交领域图表**
+
+```bash
+git add -- documentation/docs/{zh,en}/guide/domain/{index,aggregate,event-evolution,snapshot,lifecycle}.md
+git diff --cached --check
+git commit -m "docs: add domain model diagrams"
+```
+
+---
+### Task 2: 补齐命令应用页图表
+
+**Files:**
+- Modify: `documentation/docs/zh/guide/command/index.md`
+- Modify: `documentation/docs/en/guide/command/index.md`
+- Modify: `documentation/docs/zh/guide/command/definition.md`
+- Modify: `documentation/docs/en/guide/command/definition.md`
+- Modify: `documentation/docs/zh/guide/command/sending.md`
+- Modify: `documentation/docs/en/guide/command/sending.md`
+- Modify: `documentation/docs/zh/guide/command/api-client.md`
+- Modify: `documentation/docs/en/guide/command/api-client.md`
+- Modify: `documentation/docs/zh/guide/command/reliability.md`
+- Modify: `documentation/docs/en/guide/command/reliability.md`
+- Read only: `documentation/docs/{zh,en}/guide/command/completion.md`
+- Read: `wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/command/`
+
+**Interfaces:**
+- Consumes: 已有命令页面职责、API Client 当前能力边界和现有 completion 阶段分支图。
+- Produces: 命令应用层 6 页均有且仅有一张图；概览、定义、发送、远程客户端、完成和可靠性各自表达不同问题。
+
+- [ ] **Step 1: 运行命令应用图覆盖契约并确认失败**
+
+```bash
+for locale in zh en; do
+  for page in index definition sending api-client completion reliability; do
+    test "$(rg -c '^```mermaid$' "documentation/docs/$locale/guide/command/$page.md" || true)" = 1
+  done
+done
+```
+
+Expected: exit `1`，因为除 `completion` 外其余五页尚无图。
+
+- [ ] **Step 2: 在双语 `command/index` 增加生命周期导航图**
+
+放在 lead 段落之后、第一个 `##` 之前。中文使用：
+
+```mermaid
+flowchart LR
+    Intent["业务意图"] --> Definition["定义命令"]
+    Definition --> Send["发送命令"]
+    Send --> Process["聚合处理"]
+    Process --> Append["追加领域事件"]
+    Append --> Completion["观察完成阶段"]
+    Completion --> Collaboration["事件与协作"]
+```
+
+英文标签：
+
+```text
+Intent="Business intent"
+Definition="Define command"
+Send="Send command"
+Process="Process in aggregate"
+Append="Append domain events"
+Completion="Observe completion stages"
+Collaboration="Events and collaboration"
+```
+
+图前说明句：
+
+```text
+命令从业务意图开始，以持久事实和可观察的完成信号连接下游协作。
+A command starts as business intent and connects to downstream collaboration through durable facts and observable completion signals.
+```
+
+- [ ] **Step 3: 在双语 `command/definition` 增加处理结果边界图**
+
+放在 lead 段落之后、第一个 `##` 之前。中文使用：
+
+```mermaid
+flowchart LR
+    Command["命令载荷 + 元数据"] --> Void{"Void 命令？"}
+    Void -->|是| Ack["Dispatcher 确认，不进入聚合 Handler"]
+    Void -->|否| Handler["命令处理函数"]
+    State["当前聚合状态"] --> Handler
+    Handler --> Events["0..N 个领域事件"]
+    Events --> Sourcing["onSourcing 更新状态"]
+```
+
+英文标签：
+
+```text
+Command="Command payload + metadata"
+Void="Void command?"
+yes edge="Yes"
+Ack="Dispatcher acknowledges without aggregate Handler"
+no edge="No"
+Handler="Command handler"
+State="Current aggregate state"
+Events="0..N domain events"
+Sourcing="onSourcing updates state"
+```
+
+图前说明句：
+
+```text
+普通命令由聚合 Handler 根据当前状态产生事件；Void 命令在 Dispatcher 层直接确认。
+Regular commands let an aggregate Handler produce events from current state; Void commands are acknowledged at the Dispatcher layer.
+```
+
+- [ ] **Step 4: 在双语 `command/sending` 增加入口选择图**
+
+放在 lead 段落之后、第一个 `##` 之前。中文使用：
+
+```mermaid
+flowchart TB
+    Caller["调用方"] --> Entry{"选择入口"}
+    Entry -->|同进程| Gateway["CommandGateway"]
+    Entry -->|聚合专用 HTTP| AggregateRoute["生成的聚合命令路由"]
+    Entry -->|动态全局 HTTP| Facade["POST /wow/command/send"]
+    AggregateRoute --> WebFlux["WebFlux Command Handler"]
+    Facade --> WebFlux
+    WebFlux --> Gateway
+```
+
+英文标签：
+
+```text
+Caller="Caller"
+Entry="Choose an entry point"
+same-process edge="Same process"
+Gateway="CommandGateway"
+aggregate HTTP edge="Aggregate-specific HTTP"
+AggregateRoute="Generated aggregate command route"
+global HTTP edge="Dynamic global HTTP"
+Facade="POST /wow/command/send"
+WebFlux="WebFlux Command Handler"
+```
+
+图前说明句：
+
+```text
+三种入口最终进入同一 CommandGateway，但路由发现、协议能力和响应形式不同。
+All three entry points reach the same CommandGateway, but route discovery, protocol capabilities, and response forms differ.
+```
+
+- [ ] **Step 5: 在双语 `command/api-client` 增加远程调用时序图**
+
+放在 lead 段落之后、第一个 `##` 之前。中文使用：
+
+```mermaid
+sequenceDiagram
+    participant App as 调用方
+    participant Client as wow-apiclient.command
+    participant Resolver as 目标服务解析
+    participant CoApi as CoApi HTTP 客户端
+    participant Server as /wow/command/send
+    App->>Client: 同步或响应式调用
+    Client->>Resolver: 解析目标服务
+    Resolver-->>Client: serviceId
+    Client->>CoApi: CommandRequest + HTTP Headers
+    CoApi->>Server: POST JSON
+    Server-->>CoApi: 最终 CommandResult
+    CoApi-->>App: 成功结果或错误映射
+```
+
+英文参与者标签和消息：
+
+```text
+App="Caller"
+Client="wow-apiclient.command"
+Resolver="Target service resolution"
+CoApi="CoApi HTTP client"
+Server="/wow/command/send"
+App -> Client="Synchronous or reactive call"
+Client -> Resolver="Resolve target service"
+Resolver -> Client="serviceId"
+Client -> CoApi="CommandRequest + HTTP Headers"
+CoApi -> Server="POST JSON"
+Server -> CoApi="Final CommandResult"
+CoApi -> App="Successful result or mapped error"
+```
+
+图前说明句：
+
+```text
+API Client 是全局 JSON 门面的远程最终结果客户端，不是本地 Gateway 或 SSE 的等价实现。
+The API Client is a remote final-result client for the global JSON facade, not an equivalent of the local Gateway or SSE.
+```
+
+- [ ] **Step 6: 在双语 `command/reliability` 增加未知结果决策树**
+
+放在 lead 段落之后、第一个 `##` 之前。中文使用：
+
+```mermaid
+flowchart TB
+    Unknown["失败或超时：结果未知"] --> Check["查询权威结果"]
+    Check --> Exists{"相同 requestId 已产生事件？"}
+    Exists -->|是| Keep["接受既有结果，不重复发送"]
+    Exists -->|否| Valid{"业务意图仍然有效？"}
+    Valid -->|是| Retry["复用相同 requestId 重试"]
+    Valid -->|否| Stop["停止并人工处理"]
+```
+
+英文标签：
+
+```text
+Unknown="Failure or timeout: outcome unknown"
+Check="Query the authoritative result"
+Exists="Events already exist for this requestId?"
+yes edge="Yes"
+Keep="Accept the existing result; do not resend"
+no edge="No"
+Valid="Business intent still valid?"
+Retry="Retry with the same requestId"
+Stop="Stop and handle manually"
+```
+
+图前说明句：
+
+```text
+未知结果不能直接重发；先确认权威历史，再决定是否复用稳定 requestId 重试。
+Do not resend an unknown outcome immediately; confirm authoritative history before retrying with the stable requestId.
+```
+
+- [ ] **Step 7: 验证命令应用图并做代表页视觉检查**
+
+```bash
+for locale in zh en; do
+  for page in index definition sending api-client completion reliability; do
+    test "$(rg -c '^```mermaid$' "documentation/docs/$locale/guide/command/$page.md")" = 1
+  done
+done
+pnpm --dir documentation docs:build
+git diff --check
+```
+
+启动本地文档站并预览以下页面的桌面与窄屏：
+
+```bash
+pnpm --dir documentation docs:dev --host 127.0.0.1
+```
+
+Expected: VitePress 输出本地访问地址并保持运行。
+
+```text
+/guide/command/api-client
+/zh/guide/command/api-client
+/guide/command/reliability
+/zh/guide/command/reliability
+```
+
+时序图参与者和长消息不能截断；决策树的 Yes/No 分支必须无需依赖颜色即可区分。
+
+- [ ] **Step 8: 提交命令应用图表**
+
+```bash
+git add -- documentation/docs/{zh,en}/guide/command/{index,definition,sending,api-client,reliability}.md
+git diff --cached --check
+git commit -m "docs: add command guide diagrams"
+```
+
+---
+
+### Task 3: 补齐命令运行时图表
+
+**Files:**
+- Modify: `documentation/docs/zh/guide/command/internals/wait-runtime.md`
+- Modify: `documentation/docs/en/guide/command/internals/wait-runtime.md`
+- Modify: `documentation/docs/zh/guide/command/internals/transport.md`
+- Modify: `documentation/docs/en/guide/command/internals/transport.md`
+- Read only: `documentation/docs/{zh,en}/guide/command/internals/pipeline.md`
+- Read only: `documentation/docs/{zh,en}/guide/command/completion.md`
+- Read: `wow-core/src/main/kotlin/me/ahoo/wow/command/wait/`
+- Read: `wow-core/src/main/kotlin/me/ahoo/wow/messaging/`
+- Read: `wow-kafka/src/main/kotlin/`
+- Read: `wow-redis/src/main/kotlin/`
+
+**Interfaces:**
+- Consumes: 已有 completion 阶段图和 pipeline 组件图；当前 WaitState、Notifier 与 transport 实现。
+- Produces: 命令 9/9 页面每页一张图；等待信号闭环和 transport `SENT` 证据边界互不重复。
+
+- [ ] **Step 1: 运行完整命令区图覆盖契约并确认失败**
+
+```bash
+for locale in zh en; do
+  for file in $(cd "documentation/docs/$locale/guide" && rg --files command | sort); do
+    test "$(rg -c '^```mermaid$' "documentation/docs/$locale/guide/$file" || true)" = 1
+  done
+done
+```
+
+Expected: exit `1`，因为 `wait-runtime` 与 `transport` 尚无图。
+
+- [ ] **Step 2: 在双语 `wait-runtime` 增加信号闭环时序图**
+
+放在 lead 段落之后、第一个 `##` 之前。中文使用：
+
+```mermaid
+sequenceDiagram
+    participant Gateway as CommandGateway
+    participant Coordinator as WaitCoordinator
+    participant State as WaitState
+    participant Notifier as CommandWaitNotifier
+    participant Handle as WaitHandle
+    Gateway->>Coordinator: 注册 commandId + WaitPlan
+    Coordinator->>State: 创建阶段或链式状态
+    Coordinator-->>Gateway: 返回已注册 Handle
+    Notifier-->>Coordinator: WaitSignal（允许早到）
+    Coordinator->>State: 归约信号
+    State-->>Handle: acceptedSignal / finalSignal
+    Handle-->>Gateway: 结果流或最终结果
+    Handle->>Coordinator: 完成、取消或超时后清理
+```
+
+英文参与者标签和消息：
+
+```text
+Gateway="CommandGateway"
+Coordinator="WaitCoordinator"
+State="WaitState"
+Notifier="CommandWaitNotifier"
+Handle="WaitHandle"
+Gateway -> Coordinator="Register commandId + WaitPlan"
+Coordinator -> State="Create stage or chain state"
+Coordinator -> Gateway="Return registered Handle"
+Notifier -> Coordinator="WaitSignal (may arrive early)"
+Coordinator -> State="Reduce signal"
+State -> Handle="acceptedSignal / finalSignal"
+Handle -> Gateway="Result stream or final result"
+Handle -> Coordinator="Clean up after completion, cancellation, or timeout"
+```
+
+图前说明句：
+
+```text
+等待运行时先注册 Handle，再通过 Coordinator 把乱序 WaitSignal 归约到阶段或链式状态。
+The wait runtime registers a Handle first, then uses the Coordinator to reduce out-of-order WaitSignals into stage or chain state.
+```
+
+- [ ] **Step 3: 在双语 `transport` 增加 SENT 证据对照图**
+
+放在 lead 段落之后、第一个 `##` 之前。中文使用：
+
+```mermaid
+flowchart TB
+    Command["CommandMessage"] --> Transport{"CommandBus 实现"}
+    Transport --> InMemory["InMemory：本地 sink 准入"]
+    Transport --> Kafka["Kafka：producer result"]
+    Transport --> Redis["Redis：Stream XADD"]
+    Transport --> LocalFirst["LocalFirst：本地 receipt + 分布式准入"]
+    Void["Void 命令"] --> Distributed["强制分布式路径"]
+    Distributed --> LocalFirst
+    InMemory --> Sent["SENT"]
+    Kafka --> Sent
+    Redis --> Sent
+    LocalFirst --> Sent
+    Sent --> Boundary["只证明 transport 接受，不证明 PROCESSED"]
+```
+
+英文标签：
+
+```text
+Command="CommandMessage"
+Transport="CommandBus implementation"
+InMemory="InMemory: local sink admission"
+Kafka="Kafka: producer result"
+Redis="Redis: Stream XADD"
+LocalFirst="LocalFirst: local receipt + distributed admission"
+Void="Void command"
+Distributed="Force distributed path"
+Sent="SENT"
+Boundary="Proves transport acceptance, not PROCESSED"
+```
+
+图前说明句：
+
+```text
+不同传输对 SENT 的证据锚点不同，但都不代表命令已经完成处理。
+Each transport anchors SENT to different evidence, but none means the command has finished processing.
+```
+
+- [ ] **Step 4: 验证完整命令区并做密集图视觉检查**
+
+```bash
+for locale in zh en; do
+  test "$(cd "documentation/docs/$locale/guide" && rg --files command | wc -l | tr -d ' ')" = 9
+  for file in $(cd "documentation/docs/$locale/guide" && rg --files command | sort); do
+    test "$(rg -c '^```mermaid$' "documentation/docs/$locale/guide/$file")" = 1
+  done
+done
+pnpm --dir documentation docs:build
+git diff --check
+```
+
+启动本地文档站：
+
+```bash
+pnpm --dir documentation docs:dev --host 127.0.0.1
+```
+
+Expected: VitePress 输出本地访问地址并保持运行。本地预览：
+
+```text
+/guide/command/internals/wait-runtime
+/zh/guide/command/internals/wait-runtime
+/guide/command/internals/transport
+/zh/guide/command/internals/transport
+```
+
+检查 390px 窄屏下参与者标签与 transport 边界节点；不得通过删除 `Void` 或 `not PROCESSED` 边界来换取更短图。
+
+- [ ] **Step 5: 提交命令运行时图表**
+
+```bash
+git add -- documentation/docs/{zh,en}/guide/command/internals/{wait-runtime,transport}.md
+git diff --cached --check
+git commit -m "docs: add command runtime diagrams"
+```
+
+---
+
+### Task 4: 补齐事件与协作图表并完成全局验收
+
+**Files:**
+- Modify: `documentation/docs/zh/guide/event/index.md`
+- Modify: `documentation/docs/en/guide/event/index.md`
+- Modify: `documentation/docs/zh/guide/event/processor.md`
+- Modify: `documentation/docs/en/guide/event/processor.md`
+- Modify: `documentation/docs/zh/guide/event/saga.md`
+- Modify: `documentation/docs/en/guide/event/saga.md`
+- Modify: `documentation/docs/zh/guide/event/dispatch.md`
+- Modify: `documentation/docs/en/guide/event/dispatch.md`
+- Read only: `documentation/docs/{zh,en}/guide/event/compensation.md`
+- Read: `wow-core/src/main/kotlin/me/ahoo/wow/event/dispatcher/`
+- Read: `wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/`
+- Read: `wow-core/src/main/kotlin/me/ahoo/wow/command/wait/NotifierFilters.kt`
+- Read: `compensation/wow-compensation-core/src/main/kotlin/me/ahoo/wow/compensation/core/`
+
+**Interfaces:**
+- Consumes: 事件 Processor、Stateless Saga、Dispatcher Filter chain 和已有 Compensation 状态机。
+- Produces: 中英文全部 20 个目标页面每页恰好一张图，并通过全局构建、范围和代表页视觉验收。
+
+- [ ] **Step 1: 运行事件区图覆盖契约并确认失败**
+
+```bash
+for locale in zh en; do
+  for page in index processor saga compensation dispatch; do
+    test "$(rg -c '^```mermaid$' "documentation/docs/$locale/guide/event/$page.md" || true)" = 1
+  done
+done
+```
+
+Expected: exit `1`，因为 `index`、`processor`、`saga` 尚无图。
+
+- [ ] **Step 2: 在双语 `event/index` 增加选择流程图**
+
+放在 lead 段落之后、选择矩阵之前。中文使用：
+
+```mermaid
+flowchart TB
+    Need{"事实发生后需要什么？"}
+    Need -->|执行普通副作用| Processor["Event Processor"]
+    Need -->|生成跨聚合后续命令| Saga["Stateless Saga"]
+    Need -->|持久恢复处理失败| Compensation["Event Compensation"]
+    Processor --> Done["副作用完成"]
+    Saga --> Commands["0..N 条命令"]
+    Compensation --> Recovery["调度或人工恢复"]
+```
+
+英文标签：
+
+```text
+Need="What is needed after the fact occurs?"
+processor edge="Run an ordinary side effect"
+Processor="Event Processor"
+saga edge="Create cross-aggregate follow-up commands"
+Saga="Stateless Saga"
+compensation edge="Persistently recover handler failure"
+Compensation="Event Compensation"
+Done="Side effect completed"
+Commands="0..N commands"
+Recovery="Scheduled or manual recovery"
+```
+
+图前说明句：
+
+```text
+先按目标选择协作机制，再进入对应页面理解实现和失败边界。
+Choose the collaboration mechanism by goal before opening its implementation and failure boundaries.
+```
+
+- [ ] **Step 3: 在双语 `event/processor` 增加处理管线图**
+
+放在 lead 段落之后、第一个 `##` 之前。中文使用：
+
+```mermaid
+flowchart LR
+    Event["领域事件或状态事件"] --> Dispatcher["Event Dispatcher"]
+    Dispatcher --> Match["函数匹配与过滤"]
+    Match --> Filters["Dispatcher Filter chain"]
+    Filters --> Function["响应式事件函数"]
+    Function -->|完成| Signal["EVENT_HANDLED 信号"]
+    Function -->|失败| Recovery["重试或补偿入口"]
+```
+
+英文标签：
+
+```text
+Event="Domain event or state event"
+Dispatcher="Event Dispatcher"
+Match="Function matching and filtering"
+Filters="Dispatcher Filter chain"
+Function="Reactive event function"
+success edge="Complete"
+Signal="EVENT_HANDLED signal"
+failure edge="Fail"
+Recovery="Retry or compensation entry"
+```
+
+图前说明句：
+
+```text
+事件处理器只有在匹配函数的响应式工作完成后才产生完成信号；失败进入重试或补偿边界。
+An event processor emits completion only after the matched reactive function completes; failures enter retry or compensation boundaries.
+```
+
+- [ ] **Step 4: 在双语 `event/saga` 增加跨聚合时序图**
+
+放在 lead 段落之后、第一个 `##` 之前。中文使用：
+
+```mermaid
+sequenceDiagram
+    participant Source as 源聚合
+    participant EventBus as DomainEventBus
+    participant Saga as Stateless Saga
+    participant Gateway as CommandGateway
+    participant Target as 目标聚合
+    Source->>EventBus: 领域事件
+    EventBus->>Saga: 调用匹配的 Saga 函数
+    loop 0..N 条命令
+        Saga->>Gateway: 顺序发送后续命令
+        Gateway->>Target: 处理命令
+    end
+    Saga-->>EventBus: SAGA_HANDLED + commandIds
+```
+
+英文参与者标签和消息：
+
+```text
+Source="Source aggregate"
+EventBus="DomainEventBus"
+Saga="Stateless Saga"
+Gateway="CommandGateway"
+Target="Target aggregate"
+Source -> EventBus="Domain event"
+EventBus -> Saga="Invoke matching Saga function"
+loop="0..N commands"
+Saga -> Gateway="Send follow-up command in order"
+Gateway -> Target="Process command"
+Saga -> EventBus="SAGA_HANDLED + commandIds"
+```
+
+图前说明句：
+
+```text
+Stateless Saga 把一个已发生的事实转换为 0..N 条顺序发送的后续命令。
+A Stateless Saga converts an occurred fact into 0..N follow-up commands sent in order.
+```
+
+- [ ] **Step 5: 扩充双语 `event/dispatch` 现有图**
+
+替换现有 Mermaid block，不增加第二张图。中文使用：
+
+```mermaid
+flowchart TB
+    DomainBus["DomainEventBus"] --> DomainDispatcher["Domain / Saga Dispatcher"]
+    StateBus["StateEventBus"] --> StateDispatcher["State / Snapshot / Projection Dispatcher"]
+    DomainDispatcher --> Chain["Dispatcher-specific Filter chain"]
+    StateDispatcher --> Chain
+    Chain --> Notifier["Notifier Filter"]
+    Notifier --> Compensation["Compensation Filter（启用时）"]
+    Compensation --> Retryable["Retryable Filter（存在时）"]
+    Compensation --> Function["事件函数"]
+    Retryable --> Function
+    Function --> Ack["错误处理与 finallyAck"]
+```
+
+英文标签：
+
+```text
+DomainBus="DomainEventBus"
+DomainDispatcher="Domain / Saga Dispatcher"
+StateBus="StateEventBus"
+StateDispatcher="State / Snapshot / Projection Dispatcher"
+Chain="Dispatcher-specific Filter chain"
+Notifier="Notifier Filter"
+Compensation="Compensation Filter (when enabled)"
+Retryable="Retryable Filter (when present)"
+Function="Event function"
+Ack="Error handling and finallyAck"
+```
+
+保留图后正文对 Filter 进入/退出方向、失败信号、Snapshot 无即时 Retryable 层和 ACK 边界的精确解释。图中的直接 `Compensation --> Function` 表示某些链没有 Retryable Filter，不表示跳过 Compensation。
+
+- [ ] **Step 6: 运行 20/20 覆盖、双语与范围检查**
+
+```bash
+for locale in zh en; do
+  test "$(cd "documentation/docs/$locale/guide" && rg --files domain command event | wc -l | tr -d ' ')" = 20
+  for file in $(cd "documentation/docs/$locale/guide" && rg --files domain command event | sort); do
+    test "$(rg -c '^```mermaid$' "documentation/docs/$locale/guide/$file")" = 1
+  done
+done
+diff \
+  <(cd documentation/docs/zh/guide && rg --files domain command event | sort) \
+  <(cd documentation/docs/en/guide && rg --files domain command event | sort)
+! rg -n 'TO[D]O|TB[D]|^(<<<<<<<|=======|>>>>>>>)' documentation/docs/{zh,en}/guide/{domain,command,event} -g '*.md'
+diagram_base=$(git merge-base origin/main HEAD)
+test -z "$(git diff --name-only "$diagram_base"..HEAD | rg -v '^(document/design/2026-08-(28-domain-command-event-diagrams-design|29-domain-command-event-diagrams-implementation-plan)\.md|documentation/docs/(zh|en)/guide/(domain|command|event)/)' || true)"
+pnpm --dir documentation docs:build
+git diff --check
+```
+
+Expected: 40 个文件每个恰好 1 个 Mermaid block；query、sidebar、主题、依赖和图片资产不在 diff 中；VitePress 无 Mermaid 解析错误。
+
+- [ ] **Step 7: 做事件图和最终代表页视觉检查**
+
+启动本地文档站：
+
+```bash
+pnpm --dir documentation docs:dev --host 127.0.0.1
+```
+
+Expected: VitePress 输出本地访问地址并保持运行。本地预览以下中英文页面，桌面约 1440px、窄屏约 390px：
+
+```text
+/guide/event/
+/zh/guide/event/
+/guide/event/dispatch
+/zh/guide/event/dispatch
+/guide/domain/lifecycle
+/zh/guide/domain/lifecycle
+/guide/command/api-client
+/zh/guide/command/api-client
+/guide/command/internals/transport
+/zh/guide/command/internals/transport
+```
+
+逐页确认：
+
+- 主路径和分支无需依赖颜色即可理解；
+- 节点、参与者、边标签不截断；
+- 窄屏不因一个超长标签遮挡关键关系；
+- event chooser、state diagram、sequence diagram、dense transport/dispatch 五类图均可读；
+- 图后正文仍保留错误、失败和阶段边界。
+
+如需调整，只允许缩短显示标签、切换 `LR/TB` 或增加 `subgraph`；不得删除设计规定的节点、参与者或边。
+
+- [ ] **Step 8: 提交事件图和最终验收结果**
+
+```bash
+git add -- documentation/docs/{zh,en}/guide/event/{index,processor,saga,dispatch}.md
+git diff --cached --check
+git commit -m "docs: add event collaboration diagrams"
+git status --short
+```
+
+Expected: 最终工作树只包含计划/规格提交产生的已跟踪历史，无构建输出、截图或本地临时文件。

--- a/document/design/2026-08-29-domain-command-event-diagrams-implementation-plan.md
+++ b/document/design/2026-08-29-domain-command-event-diagrams-implementation-plan.md
@@ -133,31 +133,38 @@ An aggregate encloses state, business decisions, and invariants within one consi
 
 ```mermaid
 flowchart LR
-    Persisted["持久事件 Revision 1"] --> Lookup{"存在下一 Revision Upgrader？"}
-    Lookup -->|是| Upgrade["升级到下一 Revision"]
-    Upgrade --> Lookup
-    Lookup -->|否| Current["当前事件形态"]
-    Upgrade -. "显式删除" .-> Dropped["DroppedEvent"]
+    Persisted["持久事件记录"] --> Ordered["该事件的 Upgrader 列表<br/>按 @Order 排序一次"]
+    Ordered --> Apply["每个 Upgrader 恰好调用一次"]
+    Apply --> Result{"每次调用返回"}
+    Result -->|原样| Unchanged["记录不变"]
+    Result -->|升级| Upgraded["升级后的记录"]
+    Result -->|显式丢弃| Dropped["DroppedEvent 记录"]
+    Unchanged --> Final["最终记录<br/>必须验证可解析"]
+    Upgraded --> Final
+    Dropped --> Final
 ```
 
 英文标签：
 
 ```text
-Persisted="Persisted event Revision 1"
-Lookup="Next Revision Upgrader exists?"
-yes edge="Yes"
-Upgrade="Upgrade to the next Revision"
-no edge="No"
-Current="Current event shape"
-dotted edge="Explicitly drop"
-Dropped="DroppedEvent"
+Persisted="Persisted event record"
+Ordered="Upgrader list for this event<br/>sorted once by @Order"
+Apply="Invoke each Upgrader exactly once"
+Result="Each invocation returns"
+unchanged edge="Unchanged"
+Unchanged="Record unchanged"
+upgraded edge="Upgraded"
+Upgraded="Upgraded record"
+drop edge="Explicit drop"
+Dropped="DroppedEvent record"
+Final="Final record<br/>must be validated as resolvable"
 ```
 
 图前说明句：
 
 ```text
-读取历史事件时，Upgrader 按 Revision 逐步推进，直到得到当前形态或显式丢弃事件。
-When historical events are read, Upgraders advance Revision by Revision until the current shape or an explicit drop is reached.
+读取历史事件时，`EventUpgraderFactory` 按 `@Order` 调用该事件已注册的全部 Upgrader，每个恰好一次；每次调用都可返回原记录、升级记录或 `DroppedEvent` 记录，应用必须验证最终记录可解析。
+When historical events are read, `EventUpgraderFactory` invokes every Upgrader registered for that event once in `@Order` order. Each invocation may return the record unchanged, upgraded, or as a `DroppedEvent` record; the application must verify that the final record is resolvable.
 ```
 
 - [ ] **Step 5: 重做双语 `domain/snapshot` 主图**
@@ -555,43 +562,45 @@ Expected: exit `1`，因为 `wait-runtime` 与 `transport` 尚无图。
 ```mermaid
 sequenceDiagram
     participant Gateway as CommandGateway
-    participant Coordinator as WaitCoordinator
-    participant State as WaitState
     participant Notifier as CommandWaitNotifier
+    participant Coordinator as WaitCoordinator
     participant Handle as WaitHandle
-    Gateway->>Coordinator: 注册 commandId + WaitPlan
-    Coordinator->>State: 创建阶段或链式状态
+    participant State as WaitState
+    Gateway->>Coordinator: 注册 waitCommandId + WaitPlan
+    Coordinator->>Handle: 创建持有 WaitState 的 Handle
     Coordinator-->>Gateway: 返回已注册 Handle
     Notifier-->>Coordinator: WaitSignal（允许早到）
-    Coordinator->>State: 归约信号
+    Coordinator->>Handle: 按 waitCommandId 路由 next(signal)
+    Handle->>State: 在锁内归约信号
     State-->>Handle: acceptedSignal / finalSignal
     Handle-->>Gateway: 结果流或最终结果
-    Handle->>Coordinator: 完成、取消或超时后清理
+    Handle->>Coordinator: 完成、取消或超时后注销
 ```
 
 英文参与者标签和消息：
 
 ```text
 Gateway="CommandGateway"
-Coordinator="WaitCoordinator"
-State="WaitState"
 Notifier="CommandWaitNotifier"
+Coordinator="WaitCoordinator"
 Handle="WaitHandle"
-Gateway -> Coordinator="Register commandId + WaitPlan"
-Coordinator -> State="Create stage or chain state"
+State="WaitState"
+Gateway -> Coordinator="Register waitCommandId + WaitPlan"
+Coordinator -> Handle="Create Handle that owns WaitState"
 Coordinator -> Gateway="Return registered Handle"
 Notifier -> Coordinator="WaitSignal (may arrive early)"
-Coordinator -> State="Reduce signal"
+Coordinator -> Handle="Route next(signal) by waitCommandId"
+Handle -> State="Reduce signal under lock"
 State -> Handle="acceptedSignal / finalSignal"
 Handle -> Gateway="Result stream or final result"
-Handle -> Coordinator="Clean up after completion, cancellation, or timeout"
+Handle -> Coordinator="Unregister after completion, cancellation, or timeout"
 ```
 
 图前说明句：
 
 ```text
-等待运行时先注册 Handle，再通过 Coordinator 把乱序 WaitSignal 归约到阶段或链式状态。
-The wait runtime registers a Handle first, then uses the Coordinator to reduce out-of-order WaitSignals into stage or chain state.
+等待运行时先按 `waitCommandId` 注册 Handle。Notifier 把 WaitSignal 交给 Coordinator，Coordinator 路由到 Handle；Handle 持有并归约 WaitState。
+The wait runtime first registers a Handle by `waitCommandId`. A Notifier sends each WaitSignal to the Coordinator, which routes it to the Handle; the Handle owns and reduces its WaitState.
 ```
 
 - [ ] **Step 3: 在双语 `transport` 增加 SENT 证据对照图**
@@ -605,8 +614,8 @@ flowchart TB
     Transport --> Kafka["Kafka：producer result"]
     Transport --> Redis["Redis：Stream XADD"]
     Transport --> LocalFirst["LocalFirst：本地 receipt + 分布式准入"]
-    Void["Void 命令"] --> Distributed["强制分布式路径"]
-    Distributed --> LocalFirst
+    Void["Void + LocalFirst"] --> Distributed["强制分布式路径"]
+    Distributed --> Sent
     InMemory --> Sent["SENT"]
     Kafka --> Sent
     Redis --> Sent
@@ -623,7 +632,7 @@ InMemory="InMemory: local sink admission"
 Kafka="Kafka: producer result"
 Redis="Redis: Stream XADD"
 LocalFirst="LocalFirst: local receipt + distributed admission"
-Void="Void command"
+Void="Void + LocalFirst"
 Distributed="Force distributed path"
 Sent="SENT"
 Boundary="Proves transport acceptance, not PROCESSED"
@@ -791,14 +800,20 @@ sequenceDiagram
     participant EventBus as DomainEventBus
     participant Saga as Stateless Saga
     participant Gateway as CommandGateway
-    participant Target as 目标聚合
+    participant CommandBus as CommandBus
+    participant Notifier as SagaHandledNotifierFilter
+    participant WaitNotifier as CommandWaitNotifier
     Source->>EventBus: 领域事件
-    EventBus->>Saga: 调用匹配的 Saga 函数
+    EventBus->>Notifier: 分发到匹配 Saga
+    Notifier->>Saga: 调用 Saga 函数
     loop 0..N 条命令
         Saga->>Gateway: 顺序发送后续命令
-        Gateway->>Target: 处理命令
+        Gateway->>CommandBus: 发送命令
+        CommandBus-->>Gateway: 发送边界完成
     end
-    Saga-->>EventBus: SAGA_HANDLED + commandIds
+    Saga-->>Notifier: 函数完成并记录 commandIds
+    Notifier-->>WaitNotifier: SAGA_HANDLED + commandIds
+    Note over Gateway,CommandBus: 目标聚合处理不在<br/>SAGA_HANDLED 保证内
 ```
 
 英文参与者标签和消息：
@@ -808,13 +823,19 @@ Source="Source aggregate"
 EventBus="DomainEventBus"
 Saga="Stateless Saga"
 Gateway="CommandGateway"
-Target="Target aggregate"
+CommandBus="CommandBus"
+Notifier="SagaHandledNotifierFilter"
+WaitNotifier="CommandWaitNotifier"
 Source -> EventBus="Domain event"
-EventBus -> Saga="Invoke matching Saga function"
+EventBus -> Notifier="Dispatch to matching Saga"
+Notifier -> Saga="Invoke Saga function"
 loop="0..N commands"
 Saga -> Gateway="Send follow-up command in order"
-Gateway -> Target="Process command"
-Saga -> EventBus="SAGA_HANDLED + commandIds"
+Gateway -> CommandBus="Send command"
+CommandBus -> Gateway="Send boundary completed"
+Saga -> Notifier="Function completes and records commandIds"
+Notifier -> WaitNotifier="SAGA_HANDLED + commandIds"
+note="Target aggregate processing is outside the SAGA_HANDLED guarantee"
 ```
 
 图前说明句：
@@ -830,34 +851,37 @@ A Stateless Saga converts an occurred fact into 0..N follow-up commands sent in 
 
 ```mermaid
 flowchart TB
-    DomainBus["DomainEventBus"] --> DomainDispatcher["Domain / Saga Dispatcher"]
-    StateBus["StateEventBus"] --> StateDispatcher["State / Snapshot / Projection Dispatcher"]
-    DomainDispatcher --> Chain["Dispatcher-specific Filter chain"]
-    StateDispatcher --> Chain
-    Chain --> Notifier["Notifier Filter"]
-    Notifier --> Compensation["Compensation Filter（启用时）"]
-    Compensation --> Retryable["Retryable Filter（存在时）"]
-    Compensation --> Function["事件函数"]
-    Retryable --> Function
-    Function --> Ack["错误处理与 finallyAck"]
+    DomainBus["DomainEventBus"] --> EventStream["EventStreamDispatcher"]
+    StateBus["StateEventBus"] --> StateEvent["StateEventDispatcher"]
+    StateBus --> SnapshotDispatcher["SnapshotDispatcher"]
+    subgraph Composite["CompositeEventDispatcher"]
+        EventStream --> EventKind["FunctionKind.EVENT<br/>匹配 Processor / Saga /<br/>Projection<br/>&nbsp;"]
+        StateEvent --> StateKind["FunctionKind.STATE_EVENT<br/>匹配 Processor / Saga /<br/>Projection<br/>&nbsp;"]
+    end
+    EventKind --> EventChain["Processor / Saga /<br/>Projection<br/>Notifier → Retryable<br/>→ Function<br/>或<br/>Notifier<br/>→ Compensation<br/>→ Retryable<br/>→ Function<br/>&nbsp;"]
+    StateKind --> EventChain
+    SnapshotDispatcher --> SnapshotChain["Snapshot<br/>Notifier<br/>→ Function<br/>或<br/>Notifier<br/>→ Compensation<br/>→ Function<br/>&nbsp;"]
+    EventChain --> Boundary["错误处理与 finallyAck"]
+    SnapshotChain --> Boundary
 ```
 
 英文标签：
 
 ```text
 DomainBus="DomainEventBus"
-DomainDispatcher="Domain / Saga Dispatcher"
+EventStream="EventStreamDispatcher"
 StateBus="StateEventBus"
-StateDispatcher="State / Snapshot / Projection Dispatcher"
-Chain="Dispatcher-specific Filter chain"
-Notifier="Notifier Filter"
-Compensation="Compensation Filter (when enabled)"
-Retryable="Retryable Filter (when present)"
-Function="Event function"
-Ack="Error handling and finallyAck"
+StateEvent="StateEventDispatcher"
+SnapshotDispatcher="SnapshotDispatcher"
+Composite="CompositeEventDispatcher"
+EventKind="FunctionKind.EVENT<br/>match Processor / Saga /<br/>Projection<br/>&nbsp;"
+StateKind="FunctionKind.STATE_EVENT<br/>match Processor / Saga /<br/>Projection<br/>&nbsp;"
+EventChain="Processor / Saga /<br/>Projection<br/>Notifier → Retryable<br/>→ Function<br/>or<br/>Notifier<br/>→ Compensation<br/>→ Retryable<br/>→ Function<br/>&nbsp;"
+SnapshotChain="Snapshot<br/>Notifier<br/>→ Function<br/>or<br/>Notifier<br/>→ Compensation<br/>→ Function<br/>&nbsp;"
+Boundary="Error handling and finallyAck"
 ```
 
-保留图后正文对 Filter 进入/退出方向、失败信号、Snapshot 无即时 Retryable 层和 ACK 边界的精确解释。图中的直接 `Compensation --> Function` 表示某些链没有 Retryable Filter，不表示跳过 Compensation。
+两个链节点折叠显示四条可选路径，不改变 Filter 相对顺序：Processor / Saga / Projection 使用 `Notifier -> Retryable -> Function` 或 `Notifier -> Compensation -> Retryable -> Function`；Snapshot 使用 `Notifier -> Function` 或 `Notifier -> Compensation -> Function`。保留图后正文对 Filter 进入/退出方向、失败信号、Snapshot 无即时 Retryable 层和 ACK 边界的精确解释。
 
 - [ ] **Step 6: 运行 20/20 覆盖、双语与范围检查**
 

--- a/documentation/docs/en/guide/command/api-client.md
+++ b/documentation/docs/en/guide/command/api-client.md
@@ -8,6 +8,24 @@ outline: deep
 
 `wow-apiclient` provides hand-maintained CoApi command interfaces for Kotlin services calling a remote Wow application. The current implementation calls only global `POST /wow/command/send` and returns one final `CommandResult`.
 
+The API Client is a remote final-result client for the global JSON facade, not an equivalent of the local Gateway or SSE.
+
+```mermaid
+sequenceDiagram
+    participant App as Caller
+    participant Client as wow-apiclient.command
+    participant Resolver as Target service resolution
+    participant CoApi as CoApi HTTP client
+    participant Server as /wow/command/send
+    App->>Client: Synchronous or reactive call
+    Client->>Resolver: Resolve target service
+    Resolver-->>Client: serviceId
+    Client->>CoApi: CommandRequest + HTTP Headers
+    CoApi->>Server: POST JSON
+    Server-->>CoApi: Final CommandResult
+    CoApi-->>App: Successful result or mapped error
+```
+
 ## Capability Boundary
 
 `ReactiveRestCommandGateway` and `SyncRestCommandGateway` are HTTP transport adapters, not equivalents of the local `CommandGateway`:

--- a/documentation/docs/en/guide/command/definition.md
+++ b/documentation/docs/en/guide/command/definition.md
@@ -8,6 +8,18 @@ outline: deep
 
 A command is an imperative payload requesting a state change. It describes what a caller wants to happen; the [aggregate](../domain/aggregate.md) decides from current state whether it is allowed and represents the fact that happened as domain events.
 
+Regular commands let an aggregate Handler produce events from current state; Void commands are acknowledged at the Dispatcher layer.
+
+```mermaid
+flowchart LR
+    Command["Command payload + metadata"] --> Void{"Void command?"}
+    Void -->|Yes| Ack["Dispatcher acknowledges without aggregate Handler"]
+    Void -->|No| Handler["Command handler"]
+    State["Current aggregate state"] --> Handler
+    Handler --> Events["0..N domain events"]
+    Events --> Sourcing["onSourcing updates state"]
+```
+
 ## Command Payloads and Command Messages
 
 A command payload is usually a Kotlin `data class` or `object`. When sent, `toCommandMessage()` wraps the payload with a command ID, request ID, aggregate identity, owner, space, headers, expected version, and creation flags in `CommandMessage<C>`.

--- a/documentation/docs/en/guide/command/index.md
+++ b/documentation/docs/en/guide/command/index.md
@@ -8,6 +8,18 @@ outline: deep
 
 A command expresses one business intent to change aggregate state. Define its payload and target aggregate first, then send it through an in-process `CommandGateway`, an aggregate HTTP route, or the global command facade, and wait only for the completion stage the caller actually needs.
 
+A command starts as business intent and connects to downstream collaboration through durable facts and observable completion signals.
+
+```mermaid
+flowchart LR
+    Intent["Business intent"] --> Definition["Define command"]
+    Definition --> Send["Send command"]
+    Send --> Process["Process in aggregate"]
+    Process --> Append["Append domain events"]
+    Append --> Completion["Observe completion stages"]
+    Completion --> Collaboration["Events and collaboration"]
+```
+
 ## Quick Paths
 
 | Goal | Entry point |

--- a/documentation/docs/en/guide/command/internals/transport.md
+++ b/documentation/docs/en/guide/command/internals/transport.md
@@ -8,6 +8,24 @@ outline: deep
 
 Command transport routes a `CommandMessage` into a `ServerCommandExchange`; it does not execute aggregate business rules. Use each extension's documentation and the [Core Configuration Reference](../../../reference/config/core.md) to select and install a transport. This page does not duplicate dependency or configuration tables.
 
+Each transport anchors SENT to different evidence, but none means the command has finished processing.
+
+```mermaid
+flowchart TB
+    Command["CommandMessage"] --> Transport{"CommandBus implementation"}
+    Transport --> InMemory["InMemory: local sink admission"]
+    Transport --> Kafka["Kafka: producer result"]
+    Transport --> Redis["Redis: Stream XADD"]
+    Transport --> LocalFirst["LocalFirst: local receipt + distributed admission"]
+    Void["Void command"] --> Distributed["Force distributed path"]
+    Distributed --> LocalFirst
+    InMemory --> Sent["SENT"]
+    Kafka --> Sent
+    Redis --> Sent
+    LocalFirst --> Sent
+    Sent --> Boundary["Proves transport acceptance, not PROCESSED"]
+```
+
 ## CommandBus contract
 
 `CommandBus` is a `MessageBus<CommandMessage<*>, ServerCommandExchange<*>>` with `TopicKind.COMMAND`. Its three core operations expose different boundaries:

--- a/documentation/docs/en/guide/command/internals/transport.md
+++ b/documentation/docs/en/guide/command/internals/transport.md
@@ -17,7 +17,7 @@ flowchart TB
     Transport --> Kafka["Kafka: producer result"]
     Transport --> Redis["Redis: Stream XADD"]
     Transport --> LocalFirst["LocalFirst: local receipt + distributed admission"]
-    Void["Void command"] --> Distributed["Force distributed path"]
+    Void["Void + LocalFirst"] --> Distributed["Force distributed path"]
     Distributed --> Sent
     InMemory --> Sent["SENT"]
     Kafka --> Sent

--- a/documentation/docs/en/guide/command/internals/transport.md
+++ b/documentation/docs/en/guide/command/internals/transport.md
@@ -18,7 +18,7 @@ flowchart TB
     Transport --> Redis["Redis: Stream XADD"]
     Transport --> LocalFirst["LocalFirst: local receipt + distributed admission"]
     Void["Void command"] --> Distributed["Force distributed path"]
-    Distributed --> LocalFirst
+    Distributed --> Sent
     InMemory --> Sent["SENT"]
     Kafka --> Sent
     Redis --> Sent

--- a/documentation/docs/en/guide/command/internals/wait-runtime.md
+++ b/documentation/docs/en/guide/command/internals/wait-runtime.md
@@ -8,6 +8,25 @@ outline: deep
 
 The wait runtime models “how far processing got” as routable `WaitSignal` instances instead of blocking a command thread. See [Completion Semantics](../completion.md) for choosing a stage and [Send Commands](../sending.md) for Gateway APIs; this page explains signal production, transport, and reduction.
 
+The wait runtime registers a Handle first, then uses the Coordinator to reduce out-of-order WaitSignals into stage or chain state.
+
+```mermaid
+sequenceDiagram
+    participant Gateway as CommandGateway
+    participant Coordinator as WaitCoordinator
+    participant State as WaitState
+    participant Notifier as CommandWaitNotifier
+    participant Handle as WaitHandle
+    Gateway->>Coordinator: Register commandId + WaitPlan
+    Coordinator->>State: Create stage or chain state
+    Coordinator-->>Gateway: Return registered Handle
+    Notifier-->>Coordinator: WaitSignal (may arrive early)
+    Coordinator->>State: Reduce signal
+    State-->>Handle: acceptedSignal / finalSignal
+    Handle-->>Gateway: Result stream or final result
+    Handle->>Coordinator: Clean up after completion, cancellation, or timeout
+```
+
 ## WaitPlan Header
 
 A `WaitPlan` contains a `waitCommandId`, a `WaitTarget`, and `supportVoidCommand`. `DefaultCommandGateway` registers the local handle first and then uses `WaitPlan.propagate` to put three categories into the command Header:

--- a/documentation/docs/en/guide/command/internals/wait-runtime.md
+++ b/documentation/docs/en/guide/command/internals/wait-runtime.md
@@ -8,23 +8,24 @@ outline: deep
 
 The wait runtime models “how far processing got” as routable `WaitSignal` instances instead of blocking a command thread. See [Completion Semantics](../completion.md) for choosing a stage and [Send Commands](../sending.md) for Gateway APIs; this page explains signal production, transport, and reduction.
 
-The wait runtime registers a Handle first, then uses the Coordinator to reduce out-of-order WaitSignals into stage or chain state.
+The wait runtime first registers a Handle by `waitCommandId`. A Notifier sends each WaitSignal to the Coordinator, which routes it to the Handle; the Handle owns and reduces its WaitState.
 
 ```mermaid
 sequenceDiagram
     participant Gateway as CommandGateway
-    participant Coordinator as WaitCoordinator
-    participant State as WaitState
     participant Notifier as CommandWaitNotifier
+    participant Coordinator as WaitCoordinator
     participant Handle as WaitHandle
-    Gateway->>Coordinator: Register commandId + WaitPlan
-    Coordinator->>State: Create stage or chain state
+    participant State as WaitState
+    Gateway->>Coordinator: Register waitCommandId + WaitPlan
+    Coordinator->>Handle: Create Handle that owns WaitState
     Coordinator-->>Gateway: Return registered Handle
     Notifier-->>Coordinator: WaitSignal (may arrive early)
-    Coordinator->>State: Reduce signal
+    Coordinator->>Handle: Route next(signal) by waitCommandId
+    Handle->>State: Reduce signal under lock
     State-->>Handle: acceptedSignal / finalSignal
     Handle-->>Gateway: Result stream or final result
-    Handle->>Coordinator: Clean up after completion, cancellation, or timeout
+    Handle->>Coordinator: Unregister after completion, cancellation, or timeout
 ```
 
 ## WaitPlan Header

--- a/documentation/docs/en/guide/command/reliability.md
+++ b/documentation/docs/en/guide/command/reliability.md
@@ -8,6 +8,18 @@ outline: deep
 
 A reliable command call does not depend on “sending only once.” It makes the same business intent safe to identify, confirm, and retry. Preserve the aggregate identity, `commandId`, `requestId`, wait `stage`, error code, and caller timeout details when diagnosing an outcome.
 
+Do not resend an unknown outcome immediately; confirm authoritative history before retrying with the stable requestId.
+
+```mermaid
+flowchart TB
+    Unknown["Failure or timeout: outcome unknown"] --> Check["Query the authoritative result"]
+    Check --> Exists{"Events already exist for this requestId?"}
+    Exists -->|Yes| Keep["Accept the existing result; do not resend"]
+    Exists -->|No| Valid{"Business intent still valid?"}
+    Valid -->|Yes| Retry["Retry with the same requestId"]
+    Valid -->|No| Stop["Stop and handle manually"]
+```
+
 ## Where Failure Occurs
 
 | Layer | Typical result | Known boundary |

--- a/documentation/docs/en/guide/command/sending.md
+++ b/documentation/docs/en/guide/command/sending.md
@@ -8,6 +8,19 @@ outline: deep
 
 The same command can enter Wow through an in-process or HTTP boundary. The entry point does not change aggregate business rules, but it does change route metadata, response shape, and whether the caller can observe intermediate stages.
 
+All three entry points reach the same CommandGateway, but route discovery, protocol capabilities, and response forms differ.
+
+```mermaid
+flowchart TB
+    Caller["Caller"] --> Entry{"Choose an entry point"}
+    Entry -->|Same process| Gateway["CommandGateway"]
+    Entry -->|Aggregate-specific HTTP| AggregateRoute["Generated aggregate command route"]
+    Entry -->|Dynamic global HTTP| Facade["POST /wow/command/send"]
+    AggregateRoute --> WebFlux["WebFlux Command Handler"]
+    Facade --> WebFlux
+    WebFlux --> Gateway
+```
+
 ## Choose an Invocation Entry Point
 
 | Scenario | Entry point | Return |

--- a/documentation/docs/en/guide/domain/aggregate.md
+++ b/documentation/docs/en/guide/domain/aggregate.md
@@ -8,6 +8,21 @@ outline: deep
 
 An aggregate is the consistency boundary for one event stream. It separates a business change into two clear responsibilities: the command side decides from current state, while the state side reconstructs the result only from domain events that already happened. Every state change should be explainable by an event.
 
+An aggregate encloses state, business decisions, and invariants within one consistency boundary.
+
+```mermaid
+flowchart TB
+    Context["Bounded context"] --> Aggregate["Aggregate boundary"]
+    Intent["Business intent"] --> Decision["Aggregate decision"]
+    Aggregate --> State["Current state"]
+    Aggregate --> Decision
+    State --> Decision
+    Decision --> Invariant{"Invariants satisfied?"}
+    Invariant -->|Yes| Event["Domain event"]
+    Invariant -->|No| Reject["Reject command"]
+    Event --> State
+```
+
 ## Start With Business Boundaries
 
 Write invariants before code. For a cart, the business rules can first be expressed as a decision table:

--- a/documentation/docs/en/guide/domain/event-evolution.md
+++ b/documentation/docs/en/guide/domain/event-evolution.md
@@ -6,6 +6,17 @@ outline: deep
 
 # Event Evolution
 
+When historical events are read, Upgraders advance Revision by Revision until the current shape or an explicit drop is reached.
+
+```mermaid
+flowchart LR
+    Persisted["Persisted event Revision 1"] --> Lookup{"Next Revision Upgrader exists?"}
+    Lookup -->|Yes| Upgrade["Upgrade to the next Revision"]
+    Upgrade --> Lookup
+    Lookup -->|No| Current["Current event shape"]
+    Upgrade -. "Explicitly drop" .-> Dropped["DroppedEvent"]
+```
+
 ## Why Persisted Events Need Long-Term Compatibility
 
 A persisted domain event is a long-lived wire contract. Changing a Kotlin type affects new code only; old EventStore records retain their event name, `bodyType`, `revision`, and body. On reads, Wow upgrades each `DomainEventRecord` before resolving it to the current event type and passing it to state sourcing.

--- a/documentation/docs/en/guide/domain/event-evolution.md
+++ b/documentation/docs/en/guide/domain/event-evolution.md
@@ -6,15 +6,19 @@ outline: deep
 
 # Event Evolution
 
-When historical events are read, Upgraders advance Revision by Revision until the current shape or an explicit drop is reached.
+When historical events are read, `EventUpgraderFactory` invokes every Upgrader registered for that event once in `@Order` order. Each invocation may return the record unchanged, upgraded, or as a `DroppedEvent` record; the application must verify that the final record is resolvable.
 
 ```mermaid
 flowchart LR
-    Persisted["Persisted event Revision 1"] --> Lookup{"Next Revision Upgrader exists?"}
-    Lookup -->|Yes| Upgrade["Upgrade to the next Revision"]
-    Upgrade --> Lookup
-    Lookup -->|No| Current["Current event shape"]
-    Upgrade -. "Explicitly drop" .-> Dropped["DroppedEvent"]
+    Persisted["Persisted event record"] --> Ordered["Upgrader list for this event<br/>sorted once by @Order"]
+    Ordered --> Apply["Invoke each Upgrader exactly once"]
+    Apply --> Result{"Each invocation returns"}
+    Result -->|Unchanged| Unchanged["Record unchanged"]
+    Result -->|Upgraded| Upgraded["Upgraded record"]
+    Result -->|Explicit drop| Dropped["DroppedEvent record"]
+    Unchanged --> Final["Final record<br/>must be validated as resolvable"]
+    Upgraded --> Final
+    Dropped --> Final
 ```
 
 ## Why Persisted Events Need Long-Term Compatibility

--- a/documentation/docs/en/guide/domain/index.md
+++ b/documentation/docs/en/guide/domain/index.md
@@ -10,6 +10,18 @@ Wow uses an aggregate as a consistency boundary: the command side decides from c
 
 This section covers domain boundaries, state evolution, historical compatibility, and restoration cost. Complete Gateway, Dispatcher, Filter, and wait-stage behavior belongs to the [Command Processing Pipeline](../command/internals/pipeline.md), not to the domain model.
 
+The capability map below shows how the domain-model pages grow from the aggregate boundary.
+
+```mermaid
+flowchart TB
+    Start["Start with the domain boundary"] --> Aggregate["Aggregate and invariants"]
+    Aggregate --> History["Event sourcing: authoritative history"]
+    History --> Evolution["Event evolution: long-term compatibility"]
+    History --> Snapshot["Snapshots: recovery optimization"]
+    Aggregate --> Lifecycle["Aggregate lifecycle"]
+    Aggregate --> Command["Define commands"]
+```
+
 ## Choose a Reading Path
 
 ### First Modeling

--- a/documentation/docs/en/guide/domain/lifecycle.md
+++ b/documentation/docs/en/guide/domain/lifecycle.md
@@ -10,6 +10,7 @@ Events drive the lifecycle; deletion and recovery remain part of aggregate state
 
 ```mermaid
 stateDiagram-v2
+    direction LR
     state "Uninitialized aggregate" as Empty
     state "Active aggregate" as Active
     state "Deleted aggregate" as Deleted

--- a/documentation/docs/en/guide/domain/lifecycle.md
+++ b/documentation/docs/en/guide/domain/lifecycle.md
@@ -6,6 +6,20 @@ outline: deep
 
 # Aggregate Lifecycle
 
+Events drive the lifecycle; deletion and recovery remain part of aggregate state evolution.
+
+```mermaid
+stateDiagram-v2
+    state "Uninitialized aggregate" as Empty
+    state "Active aggregate" as Active
+    state "Deleted aggregate" as Deleted
+    [*] --> Empty
+    Empty --> Active: Creation event
+    Active --> Active: Regular domain event
+    Active --> Deleted: Deletion event
+    Deleted --> Active: Recovery event
+```
+
 ## Create or Restore State
 
 `StateAggregateFactory` creates an uninitialized state aggregate from state metadata and a complete `AggregateId`. Load an existing aggregate through `StateAggregateRepository`:

--- a/documentation/docs/en/guide/domain/snapshot.md
+++ b/documentation/docs/en/guide/domain/snapshot.md
@@ -17,11 +17,14 @@ A snapshot is a versioned aggregate-state checkpoint derived from event history.
 `EventSourcingStateAggregateRepository` reads a snapshot first only when loading the latest version: it materializes that snapshot into the aggregate and replays remaining events from `expectedNextVersion`; without one, it creates an empty aggregate and replays from the initial version.
 
 ```mermaid
-flowchart LR
-    Load[Load latest aggregate] --> Snapshot[Load snapshot or create empty aggregate]
-    Snapshot --> Events[Load events from expectedNextVersion]
-    Events --> Source[onSourcing in order]
-    Source --> Ready[Restored aggregate]
+flowchart TB
+    Target["Restore the latest aggregate"] --> Choice{"Usable snapshot exists?"}
+    Choice -->|No| All["Load all events"]
+    Choice -->|Yes| Snapshot["Load snapshot"]
+    Snapshot --> Tail["Load tail events from expectedNextVersion"]
+    All --> Source["Apply onSourcing in order"]
+    Tail --> Source
+    Source --> Ready["Same current aggregate state"]
 ```
 
 Application code should depend on `StateAggregateRepository`, rather than composing snapshot and event loading itself.

--- a/documentation/docs/en/guide/event/dispatch.md
+++ b/documentation/docs/en/guide/event/dispatch.md
@@ -22,13 +22,18 @@ Both implement `MessageBus`, but their topic kinds, subscriptions, and transport
 `DomainEventDispatcher`, `ProjectionDispatcher`, and `StatelessSagaDispatcher` are all based on `CompositeEventDispatcher`. One Composite Dispatcher creates two child dispatchers and shares an aggregate scheduler:
 
 ```mermaid
-flowchart LR
-    D[DomainEventBus] --> ED[EventStreamDispatcher]
-    S[StateEventBus] --> SD[StateEventDispatcher]
-    ED --> E[EVENT functions]
-    SD --> SE[STATE_EVENT functions]
-    E --> H[Dispatcher-specific FilterChain]
-    SE --> H
+flowchart TB
+    DomainBus["DomainEventBus"] --> DomainDispatcher["Domain / Saga Dispatcher"]
+    StateBus["StateEventBus"] --> StateDispatcher["State / Snapshot / Projection Dispatcher"]
+    DomainDispatcher --> Chain["Dispatcher-specific Filter chain"]
+    StateDispatcher --> Chain
+    Chain --> Notifier["Notifier Filter"]
+    Notifier --> Compensation["Compensation Filter (when enabled)"]
+    Notifier -. "No compensation Filter" .-> Function["Event function"]
+    Compensation --> Retryable["Retryable Filter (when present)"]
+    Compensation --> Function
+    Retryable --> Function
+    Function --> Ack["Error handling and finallyAck"]
 ```
 
 `EventStreamDispatcher` retains only `FunctionKind.EVENT`; `StateEventDispatcher` retains only `FunctionKind.STATE_EVENT`. Each creates subscriptions from the aggregate topics supported by its registered functions. An aggregate without a corresponding function does not get a consumption path for that dispatcher.

--- a/documentation/docs/en/guide/event/dispatch.md
+++ b/documentation/docs/en/guide/event/dispatch.md
@@ -23,17 +23,26 @@ Both implement `MessageBus`, but their topic kinds, subscriptions, and transport
 
 ```mermaid
 flowchart TB
-    DomainBus["DomainEventBus"] --> DomainDispatcher["Domain / Saga Dispatcher"]
-    StateBus["StateEventBus"] --> StateDispatcher["State / Snapshot / Projection Dispatcher"]
-    DomainDispatcher --> Chain["Dispatcher-specific Filter chain"]
-    StateDispatcher --> Chain
-    Chain --> Notifier["Notifier Filter"]
-    Notifier --> Compensation["Compensation Filter (when enabled)"]
-    Notifier -. "No compensation Filter" .-> Function["Event function"]
-    Compensation --> Retryable["Retryable Filter (when present)"]
-    Compensation --> Function
-    Retryable --> Function
-    Function --> Ack["Error handling and finallyAck"]
+    DomainBus["DomainEventBus"] --> EventStream["EventStreamDispatcher"]
+    StateBus["StateEventBus"] --> StateEvent["StateEventDispatcher"]
+    StateBus --> SnapshotDispatcher["SnapshotDispatcher"]
+    subgraph Composite["CompositeEventDispatcher"]
+        EventStream --> EventKind["FunctionKind.EVENT matching"]
+        StateEvent --> StateKind["FunctionKind.STATE_EVENT matching"]
+        EventKind --> Matched["Match Processor / Saga / Projection function"]
+        StateKind --> Matched
+    end
+    Matched --> EventNotifier["Notifier Filter"]
+    EventNotifier -->|"No Compensation"| Retryable["Retryable Filter"]
+    EventNotifier -->|"Compensation enabled"| DomainCompensation["Compensation Filter (domain event)"]
+    DomainCompensation --> Retryable
+    Retryable --> EventFunction["Invoke matched function"]
+    SnapshotDispatcher --> SnapshotNotifier["Notifier Filter"]
+    SnapshotNotifier -->|"No Compensation"| SnapshotFunction["Snapshot function"]
+    SnapshotNotifier -->|"Compensation enabled"| StateCompensation["Compensation Filter (state event)"]
+    StateCompensation --> SnapshotFunction
+    EventFunction --> EventBoundary["Handler error boundary and finallyAck"]
+    SnapshotFunction --> SnapshotBoundary["Snapshot error boundary and finallyAck"]
 ```
 
 `EventStreamDispatcher` retains only `FunctionKind.EVENT`; `StateEventDispatcher` retains only `FunctionKind.STATE_EVENT`. Each creates subscriptions from the aggregate topics supported by its registered functions. An aggregate without a corresponding function does not get a consumption path for that dispatcher.

--- a/documentation/docs/en/guide/event/dispatch.md
+++ b/documentation/docs/en/guide/event/dispatch.md
@@ -27,22 +27,14 @@ flowchart TB
     StateBus["StateEventBus"] --> StateEvent["StateEventDispatcher"]
     StateBus --> SnapshotDispatcher["SnapshotDispatcher"]
     subgraph Composite["CompositeEventDispatcher"]
-        EventStream --> EventKind["FunctionKind.EVENT matching"]
-        StateEvent --> StateKind["FunctionKind.STATE_EVENT matching"]
-        EventKind --> Matched["Match Processor / Saga / Projection function"]
-        StateKind --> Matched
+        EventStream --> EventKind["FunctionKind.EVENT<br/>match Processor / Saga /<br/>Projection<br/>&nbsp;"]
+        StateEvent --> StateKind["FunctionKind.STATE_EVENT<br/>match Processor / Saga /<br/>Projection<br/>&nbsp;"]
     end
-    Matched --> EventNotifier["Notifier Filter"]
-    EventNotifier -->|"No Compensation"| Retryable["Retryable Filter"]
-    EventNotifier -->|"Compensation enabled"| DomainCompensation["Compensation Filter (domain event)"]
-    DomainCompensation --> Retryable
-    Retryable --> EventFunction["Invoke matched function"]
-    SnapshotDispatcher --> SnapshotNotifier["Notifier Filter"]
-    SnapshotNotifier -->|"No Compensation"| SnapshotFunction["Snapshot function"]
-    SnapshotNotifier -->|"Compensation enabled"| StateCompensation["Compensation Filter (state event)"]
-    StateCompensation --> SnapshotFunction
-    EventFunction --> EventBoundary["Handler error boundary and finallyAck"]
-    SnapshotFunction --> SnapshotBoundary["Snapshot error boundary and finallyAck"]
+    EventKind --> EventChain["Processor / Saga /<br/>Projection<br/>Notifier → Retryable<br/>→ Function<br/>or<br/>Notifier<br/>→ Compensation<br/>→ Retryable<br/>→ Function<br/>&nbsp;"]
+    StateKind --> EventChain
+    SnapshotDispatcher --> SnapshotChain["Snapshot<br/>Notifier<br/>→ Function<br/>or<br/>Notifier<br/>→ Compensation<br/>→ Function<br/>&nbsp;"]
+    EventChain --> Boundary["Error handling and finallyAck"]
+    SnapshotChain --> Boundary
 ```
 
 `EventStreamDispatcher` retains only `FunctionKind.EVENT`; `StateEventDispatcher` retains only `FunctionKind.STATE_EVENT`. Each creates subscriptions from the aggregate topics supported by its registered functions. An aggregate without a corresponding function does not get a consumption path for that dispatcher.

--- a/documentation/docs/en/guide/event/index.md
+++ b/documentation/docs/en/guide/event/index.md
@@ -8,6 +8,19 @@ outline: deep
 
 After a domain event enters EventStore, it is authoritative history. The downstream collaboration in this section runs after the append. It consumes committed facts, but its effects are not part of the source aggregate transaction and cannot roll back an appended event.
 
+Choose the collaboration mechanism by goal before opening its implementation and failure boundaries.
+
+```mermaid
+flowchart TB
+    Need{"What is needed after the fact occurs?"}
+    Need -->|Run an ordinary side effect| Processor["Event Processor"]
+    Need -->|Create cross-aggregate follow-up commands| Saga["Stateless Saga"]
+    Need -->|Persistently recover handler failure| Compensation["Event Compensation"]
+    Processor --> Done["Side effect completed"]
+    Saga --> Commands["0..N commands"]
+    Compensation --> Recovery["Scheduled or manual recovery"]
+```
+
 ## Choose a Processing Mechanism
 
 | Need | Choose | Responsibility boundary |

--- a/documentation/docs/en/guide/event/processor.md
+++ b/documentation/docs/en/guide/event/processor.md
@@ -8,6 +8,18 @@ outline: deep
 
 An event processor runs ordinary application side effects after a domain event has been appended. It does not extend the source aggregate transaction: a processing failure cannot remove the event, and a successful side effect does not become authoritative event history.
 
+An event processor emits completion only after the matched reactive function completes; failures enter retry or compensation boundaries.
+
+```mermaid
+flowchart LR
+    Event["Domain event or state event"] --> Dispatcher["Event Dispatcher"]
+    Dispatcher --> Match["Function matching and filtering"]
+    Match --> Filters["Dispatcher Filter chain"]
+    Filters --> Function["Reactive event function"]
+    Function -->|Complete| Signal["EVENT_HANDLED signal"]
+    Function -->|Fail| Recovery["Retry or compensation entry"]
+```
+
 ## When to Use an Ordinary Event Processor
 
 Use a Processor to send notifications, write audit records, call external services, update integration state, or invalidate caches. Use a [Saga](../event/saga.md) when an event must generate follow-up commands for other aggregates.

--- a/documentation/docs/en/guide/event/saga.md
+++ b/documentation/docs/en/guide/event/saga.md
@@ -8,6 +8,24 @@ outline: deep
 
 Wow's `@StatelessSaga` is a stateless event orchestrator: it receives domain or state events and generates commands for the next step. Each target aggregate still handles its command in a local transaction. A Saga does not create a cross-aggregate ACID transaction.
 
+A Stateless Saga converts an occurred fact into 0..N follow-up commands sent in order.
+
+```mermaid
+sequenceDiagram
+    participant Source as Source aggregate
+    participant EventBus as DomainEventBus
+    participant Saga as Stateless Saga
+    participant Gateway as CommandGateway
+    participant Target as Target aggregate
+    Source->>EventBus: Domain event
+    EventBus->>Saga: Invoke matching Saga function
+    loop 0..N commands
+        Saga->>Gateway: Send follow-up command in order
+        Gateway->>Target: Process command
+    end
+    Saga-->>EventBus: SAGA_HANDLED + commandIds
+```
+
 ## When to Use a Saga
 
 Use a Saga when a committed event must drive business behavior in other aggregates, such as sending an entry command to a target account after a transfer is prepared. Use an [Event Processor](./processor.md) for notifications, audit, or external integrations. Do not wrap an ordinary side effect that generates no command in a Saga.

--- a/documentation/docs/en/guide/event/saga.md
+++ b/documentation/docs/en/guide/event/saga.md
@@ -16,14 +16,16 @@ sequenceDiagram
     participant EventBus as DomainEventBus
     participant Saga as Stateless Saga
     participant Gateway as CommandGateway
-    participant Target as Target aggregate
+    participant CommandBus as CommandBus
     Source->>EventBus: Domain event
     EventBus->>Saga: Invoke matching Saga function
     loop 0..N commands
         Saga->>Gateway: Send follow-up command in order
-        Gateway->>Target: Process command
+        Gateway->>CommandBus: Send command
+        CommandBus-->>Gateway: Send boundary completed
     end
     Saga-->>EventBus: SAGA_HANDLED + commandIds
+    Note over Gateway,CommandBus: Target aggregate processing is outside<br/>the SAGA_HANDLED guarantee
 ```
 
 ## When to Use a Saga

--- a/documentation/docs/en/guide/event/saga.md
+++ b/documentation/docs/en/guide/event/saga.md
@@ -17,14 +17,18 @@ sequenceDiagram
     participant Saga as Stateless Saga
     participant Gateway as CommandGateway
     participant CommandBus as CommandBus
+    participant Notifier as SagaHandledNotifierFilter
+    participant WaitNotifier as CommandWaitNotifier
     Source->>EventBus: Domain event
-    EventBus->>Saga: Invoke matching Saga function
+    EventBus->>Notifier: Dispatch to matching Saga
+    Notifier->>Saga: Invoke Saga function
     loop 0..N commands
         Saga->>Gateway: Send follow-up command in order
         Gateway->>CommandBus: Send command
         CommandBus-->>Gateway: Send boundary completed
     end
-    Saga-->>EventBus: SAGA_HANDLED + commandIds
+    Saga-->>Notifier: Function completes and records commandIds
+    Notifier-->>WaitNotifier: SAGA_HANDLED + commandIds
     Note over Gateway,CommandBus: Target aggregate processing is outside<br/>the SAGA_HANDLED guarantee
 ```
 

--- a/documentation/docs/zh/guide/command/api-client.md
+++ b/documentation/docs/zh/guide/command/api-client.md
@@ -8,6 +8,24 @@ outline: deep
 
 `wow-apiclient` 提供手工维护的 CoApi 命令接口，用于 Kotlin 服务调用远程 Wow 应用。当前实现只调用全局 `POST /wow/command/send`，并返回一个最终 `CommandResult`。
 
+API Client 是全局 JSON 门面的远程最终结果客户端，不是本地 Gateway 或 SSE 的等价实现。
+
+```mermaid
+sequenceDiagram
+    participant App as 调用方
+    participant Client as wow-apiclient.command
+    participant Resolver as 目标服务解析
+    participant CoApi as CoApi HTTP 客户端
+    participant Server as /wow/command/send
+    App->>Client: 同步或响应式调用
+    Client->>Resolver: 解析目标服务
+    Resolver-->>Client: serviceId
+    Client->>CoApi: CommandRequest + HTTP Headers
+    CoApi->>Server: POST JSON
+    Server-->>CoApi: 最终 CommandResult
+    CoApi-->>App: 成功结果或错误映射
+```
+
 ## 能力边界
 
 `ReactiveRestCommandGateway` 与 `SyncRestCommandGateway` 都是 HTTP 传输适配器，不是本地 `CommandGateway` 的等价替身：

--- a/documentation/docs/zh/guide/command/definition.md
+++ b/documentation/docs/zh/guide/command/definition.md
@@ -8,6 +8,18 @@ outline: deep
 
 命令是请求改变状态的祈使性载荷。它描述调用方想要发生什么；[聚合](../domain/aggregate.md)根据当前状态决定是否允许，并以领域事件表示已发生的事实。
 
+普通命令由聚合 Handler 根据当前状态产生事件；Void 命令在 Dispatcher 层直接确认。
+
+```mermaid
+flowchart LR
+    Command["命令载荷 + 元数据"] --> Void{"Void 命令？"}
+    Void -->|是| Ack["Dispatcher 确认，不进入聚合 Handler"]
+    Void -->|否| Handler["命令处理函数"]
+    State["当前聚合状态"] --> Handler
+    Handler --> Events["0..N 个领域事件"]
+    Events --> Sourcing["onSourcing 更新状态"]
+```
+
 ## 命令载荷与命令消息
 
 命令载荷通常是一个 Kotlin `data class` 或 `object`。发送时，`toCommandMessage()` 会将载荷与命令 ID、请求 ID、聚合身份、owner、space、header、期望版本以及创建标记封装为 `CommandMessage<C>`。

--- a/documentation/docs/zh/guide/command/index.md
+++ b/documentation/docs/zh/guide/command/index.md
@@ -8,6 +8,18 @@ outline: deep
 
 命令表达一次改变聚合状态的业务意图。应用先定义载荷和目标聚合，再选择应用内 `CommandGateway`、聚合 HTTP 路由或全局命令门面发送，并只等待调用方真正需要的完成阶段。
 
+命令从业务意图开始，以持久事实和可观察的完成信号连接下游协作。
+
+```mermaid
+flowchart LR
+    Intent["业务意图"] --> Definition["定义命令"]
+    Definition --> Send["发送命令"]
+    Send --> Process["聚合处理"]
+    Process --> Append["追加领域事件"]
+    Append --> Completion["观察完成阶段"]
+    Completion --> Collaboration["事件与协作"]
+```
+
 ## 快速入口
 
 | 目标 | 入口 |

--- a/documentation/docs/zh/guide/command/internals/transport.md
+++ b/documentation/docs/zh/guide/command/internals/transport.md
@@ -17,7 +17,7 @@ flowchart TB
     Transport --> Kafka["Kafka：producer result"]
     Transport --> Redis["Redis：Stream XADD"]
     Transport --> LocalFirst["LocalFirst：本地 receipt + 分布式准入"]
-    Void["Void 命令"] --> Distributed["强制分布式路径"]
+    Void["Void + LocalFirst"] --> Distributed["强制分布式路径"]
     Distributed --> Sent
     InMemory --> Sent["SENT"]
     Kafka --> Sent

--- a/documentation/docs/zh/guide/command/internals/transport.md
+++ b/documentation/docs/zh/guide/command/internals/transport.md
@@ -8,6 +8,24 @@ outline: deep
 
 命令传输负责把 `CommandMessage` 路由为 `ServerCommandExchange`，不负责执行聚合业务规则。如何选择和安装扩展以对应扩展文档与[核心配置参考](../../../reference/config/core.md)为准；本页不复制依赖或配置表。
 
+不同传输对 SENT 的证据锚点不同，但都不代表命令已经完成处理。
+
+```mermaid
+flowchart TB
+    Command["CommandMessage"] --> Transport{"CommandBus 实现"}
+    Transport --> InMemory["InMemory：本地 sink 准入"]
+    Transport --> Kafka["Kafka：producer result"]
+    Transport --> Redis["Redis：Stream XADD"]
+    Transport --> LocalFirst["LocalFirst：本地 receipt + 分布式准入"]
+    Void["Void 命令"] --> Distributed["强制分布式路径"]
+    Distributed --> LocalFirst
+    InMemory --> Sent["SENT"]
+    Kafka --> Sent
+    Redis --> Sent
+    LocalFirst --> Sent
+    Sent --> Boundary["只证明 transport 接受，不证明 PROCESSED"]
+```
+
 ## CommandBus 契约
 
 `CommandBus` 是 `MessageBus<CommandMessage<*>, ServerCommandExchange<*>>`，固定 `TopicKind.COMMAND`。三个核心动作具有不同边界：

--- a/documentation/docs/zh/guide/command/internals/transport.md
+++ b/documentation/docs/zh/guide/command/internals/transport.md
@@ -18,7 +18,7 @@ flowchart TB
     Transport --> Redis["Redis：Stream XADD"]
     Transport --> LocalFirst["LocalFirst：本地 receipt + 分布式准入"]
     Void["Void 命令"] --> Distributed["强制分布式路径"]
-    Distributed --> LocalFirst
+    Distributed --> Sent
     InMemory --> Sent["SENT"]
     Kafka --> Sent
     Redis --> Sent

--- a/documentation/docs/zh/guide/command/internals/wait-runtime.md
+++ b/documentation/docs/zh/guide/command/internals/wait-runtime.md
@@ -8,23 +8,24 @@ outline: deep
 
 等待运行时把“处理到哪里”建模为可路由的 `WaitSignal`，而不是阻塞命令线程。应用如何选择阶段见[完成语义](../completion.md)，如何调用 Gateway 见[发送命令](../sending.md)；本页只解释信号如何产生、传输和归约。
 
-等待运行时先注册 Handle，再通过 Coordinator 把乱序 WaitSignal 归约到阶段或链式状态。
+等待运行时先按 `waitCommandId` 注册 Handle。Notifier 把 WaitSignal 交给 Coordinator，Coordinator 路由到 Handle；Handle 持有并归约 WaitState。
 
 ```mermaid
 sequenceDiagram
     participant Gateway as CommandGateway
-    participant Coordinator as WaitCoordinator
-    participant State as WaitState
     participant Notifier as CommandWaitNotifier
+    participant Coordinator as WaitCoordinator
     participant Handle as WaitHandle
-    Gateway->>Coordinator: 注册 commandId + WaitPlan
-    Coordinator->>State: 创建阶段或链式状态
+    participant State as WaitState
+    Gateway->>Coordinator: 注册 waitCommandId + WaitPlan
+    Coordinator->>Handle: 创建持有 WaitState 的 Handle
     Coordinator-->>Gateway: 返回已注册 Handle
     Notifier-->>Coordinator: WaitSignal（允许早到）
-    Coordinator->>State: 归约信号
+    Coordinator->>Handle: 按 waitCommandId 路由 next(signal)
+    Handle->>State: 在锁内归约信号
     State-->>Handle: acceptedSignal / finalSignal
     Handle-->>Gateway: 结果流或最终结果
-    Handle->>Coordinator: 完成、取消或超时后清理
+    Handle->>Coordinator: 完成、取消或超时后注销
 ```
 
 ## WaitPlan Header

--- a/documentation/docs/zh/guide/command/internals/wait-runtime.md
+++ b/documentation/docs/zh/guide/command/internals/wait-runtime.md
@@ -8,6 +8,25 @@ outline: deep
 
 等待运行时把“处理到哪里”建模为可路由的 `WaitSignal`，而不是阻塞命令线程。应用如何选择阶段见[完成语义](../completion.md)，如何调用 Gateway 见[发送命令](../sending.md)；本页只解释信号如何产生、传输和归约。
 
+等待运行时先注册 Handle，再通过 Coordinator 把乱序 WaitSignal 归约到阶段或链式状态。
+
+```mermaid
+sequenceDiagram
+    participant Gateway as CommandGateway
+    participant Coordinator as WaitCoordinator
+    participant State as WaitState
+    participant Notifier as CommandWaitNotifier
+    participant Handle as WaitHandle
+    Gateway->>Coordinator: 注册 commandId + WaitPlan
+    Coordinator->>State: 创建阶段或链式状态
+    Coordinator-->>Gateway: 返回已注册 Handle
+    Notifier-->>Coordinator: WaitSignal（允许早到）
+    Coordinator->>State: 归约信号
+    State-->>Handle: acceptedSignal / finalSignal
+    Handle-->>Gateway: 结果流或最终结果
+    Handle->>Coordinator: 完成、取消或超时后清理
+```
+
 ## WaitPlan Header
 
 `WaitPlan` 包含 `waitCommandId`、`WaitTarget` 和 `supportVoidCommand`。`DefaultCommandGateway` 先注册本地 handle，再通过 `WaitPlan.propagate` 把三类信息写入命令 Header：

--- a/documentation/docs/zh/guide/command/reliability.md
+++ b/documentation/docs/zh/guide/command/reliability.md
@@ -8,6 +8,18 @@ outline: deep
 
 可靠的命令调用不依赖“只发送一次”，而是让同一业务意图可以被安全识别、确认和重试。诊断时同时保留聚合身份、`commandId`、`requestId`、等待 `stage`、错误码和调用方超时信息。
 
+未知结果不能直接重发；先确认权威历史，再决定是否复用稳定 requestId 重试。
+
+```mermaid
+flowchart TB
+    Unknown["失败或超时：结果未知"] --> Check["查询权威结果"]
+    Check --> Exists{"相同 requestId 已产生事件？"}
+    Exists -->|是| Keep["接受既有结果，不重复发送"]
+    Exists -->|否| Valid{"业务意图仍然有效？"}
+    Valid -->|是| Retry["复用相同 requestId 重试"]
+    Valid -->|否| Stop["停止并人工处理"]
+```
+
 ## 失败发生在哪一层
 
 | 层 | 常见结果 | 已知边界 |

--- a/documentation/docs/zh/guide/command/sending.md
+++ b/documentation/docs/zh/guide/command/sending.md
@@ -8,6 +8,19 @@ outline: deep
 
 同一条命令可以从进程内或 HTTP 边界进入 Wow。选择入口不会改变聚合业务规则，但会改变路由元数据、响应形状以及调用方能否观察中间阶段。
 
+三种入口最终进入同一 CommandGateway，但路由发现、协议能力和响应形式不同。
+
+```mermaid
+flowchart TB
+    Caller["调用方"] --> Entry{"选择入口"}
+    Entry -->|同进程| Gateway["CommandGateway"]
+    Entry -->|聚合专用 HTTP| AggregateRoute["生成的聚合命令路由"]
+    Entry -->|动态全局 HTTP| Facade["POST /wow/command/send"]
+    AggregateRoute --> WebFlux["WebFlux Command Handler"]
+    Facade --> WebFlux
+    WebFlux --> Gateway
+```
+
 ## 选择调用入口
 
 | 场景 | 入口 | 返回 |

--- a/documentation/docs/zh/guide/domain/aggregate.md
+++ b/documentation/docs/zh/guide/domain/aggregate.md
@@ -8,6 +8,21 @@ outline: deep
 
 聚合是一条事件流的一致性边界。它把一次业务变更分成两个明确职责：命令侧根据当前状态作出决策，状态侧只通过已发生的领域事件重建结果。每个状态变化都应能由事件解释。
 
+聚合把状态、业务决策和不变量封装在同一个一致性边界中。
+
+```mermaid
+flowchart TB
+    Context["限界上下文"] --> Aggregate["聚合边界"]
+    Intent["业务意图"] --> Decision["聚合决策"]
+    Aggregate --> State["当前状态"]
+    Aggregate --> Decision
+    State --> Decision
+    Decision --> Invariant{"不变量满足？"}
+    Invariant -->|是| Event["领域事件"]
+    Invariant -->|否| Reject["拒绝命令"]
+    Event --> State
+```
+
 ## 从业务边界开始
 
 先写不变量，再写代码。以购物车为例，业务规则可以先写成决策表：

--- a/documentation/docs/zh/guide/domain/event-evolution.md
+++ b/documentation/docs/zh/guide/domain/event-evolution.md
@@ -6,15 +6,19 @@ outline: deep
 
 # 事件演进
 
-读取历史事件时，Upgrader 按 Revision 逐步推进，直到得到当前形态或显式丢弃事件。
+读取历史事件时，`EventUpgraderFactory` 按 `@Order` 调用该事件已注册的全部 Upgrader，每个恰好一次；每次调用都可返回原记录、升级记录或 `DroppedEvent` 记录，应用必须验证最终记录可解析。
 
 ```mermaid
 flowchart LR
-    Persisted["持久事件 Revision 1"] --> Lookup{"存在下一 Revision Upgrader？"}
-    Lookup -->|是| Upgrade["升级到下一 Revision"]
-    Upgrade --> Lookup
-    Lookup -->|否| Current["当前事件形态"]
-    Upgrade -. "显式删除" .-> Dropped["DroppedEvent"]
+    Persisted["持久事件记录"] --> Ordered["该事件的 Upgrader 列表<br/>按 @Order 排序一次"]
+    Ordered --> Apply["每个 Upgrader 恰好调用一次"]
+    Apply --> Result{"每次调用返回"}
+    Result -->|原样| Unchanged["记录不变"]
+    Result -->|升级| Upgraded["升级后的记录"]
+    Result -->|显式丢弃| Dropped["DroppedEvent 记录"]
+    Unchanged --> Final["最终记录<br/>必须验证可解析"]
+    Upgraded --> Final
+    Dropped --> Final
 ```
 
 ## 为什么持久事件需要长期兼容

--- a/documentation/docs/zh/guide/domain/event-evolution.md
+++ b/documentation/docs/zh/guide/domain/event-evolution.md
@@ -6,6 +6,17 @@ outline: deep
 
 # 事件演进
 
+读取历史事件时，Upgrader 按 Revision 逐步推进，直到得到当前形态或显式丢弃事件。
+
+```mermaid
+flowchart LR
+    Persisted["持久事件 Revision 1"] --> Lookup{"存在下一 Revision Upgrader？"}
+    Lookup -->|是| Upgrade["升级到下一 Revision"]
+    Upgrade --> Lookup
+    Lookup -->|否| Current["当前事件形态"]
+    Upgrade -. "显式删除" .-> Dropped["DroppedEvent"]
+```
+
 ## 为什么持久事件需要长期兼容
 
 持久化领域事件是长期 wire 合同。修改 Kotlin 类型只影响新代码；EventStore 中的旧记录仍保留原来的事件名、`bodyType`、`revision` 和 body。读取时，Wow 先升级 `DomainEventRecord`，再把它解析为当前事件类型并交给状态溯源。

--- a/documentation/docs/zh/guide/domain/index.md
+++ b/documentation/docs/zh/guide/domain/index.md
@@ -10,6 +10,18 @@ Wow 的领域模型以聚合为一致性边界：命令侧根据当前状态作�
 
 本区域只回答领域边界、状态演进、历史兼容和恢复成本。完整 Gateway、Dispatcher、Filter 与等待阶段属于[命令处理管线](../command/internals/pipeline.md)，不在领域模型中展开。
 
+下面的能力地图展示领域模型各页怎样从聚合边界展开。
+
+```mermaid
+flowchart TB
+    Start["从领域边界开始"] --> Aggregate["聚合与不变量"]
+    Aggregate --> History["事件溯源：权威历史"]
+    History --> Evolution["事件演进：长期兼容"]
+    History --> Snapshot["快照：恢复优化"]
+    Aggregate --> Lifecycle["聚合生命周期"]
+    Aggregate --> Command["定义命令"]
+```
+
 ## 选择阅读路径
 
 ### 首次建模

--- a/documentation/docs/zh/guide/domain/lifecycle.md
+++ b/documentation/docs/zh/guide/domain/lifecycle.md
@@ -6,6 +6,20 @@ outline: deep
 
 # 聚合生命周期
 
+生命周期由事件驱动；删除和恢复仍然是聚合状态演进的一部分。
+
+```mermaid
+stateDiagram-v2
+    state "未初始化聚合" as Empty
+    state "活动聚合" as Active
+    state "已删除聚合" as Deleted
+    [*] --> Empty
+    Empty --> Active: 创建事件
+    Active --> Active: 普通领域事件
+    Active --> Deleted: 删除事件
+    Deleted --> Active: 恢复事件
+```
+
 ## 创建或恢复状态
 
 `StateAggregateFactory` 根据状态元数据和完整 `AggregateId` 创建未初始化的状态聚合。加载现有聚合应通过 `StateAggregateRepository`：

--- a/documentation/docs/zh/guide/domain/lifecycle.md
+++ b/documentation/docs/zh/guide/domain/lifecycle.md
@@ -10,6 +10,7 @@ outline: deep
 
 ```mermaid
 stateDiagram-v2
+    direction LR
     state "未初始化聚合" as Empty
     state "活动聚合" as Active
     state "已删除聚合" as Deleted

--- a/documentation/docs/zh/guide/domain/snapshot.md
+++ b/documentation/docs/zh/guide/domain/snapshot.md
@@ -17,11 +17,14 @@ outline: deep
 `EventSourcingStateAggregateRepository` 只在加载最新版本时先读取快照：有快照则将其物化为聚合，再从 `expectedNextVersion` 重放剩余事件；没有快照则创建空聚合并从初始版本重放。
 
 ```mermaid
-flowchart LR
-    Load[加载最新聚合] --> Snapshot[加载快照或创建空聚合]
-    Snapshot --> Events[从 expectedNextVersion 加载事件]
-    Events --> Source[按顺序 onSourcing]
-    Source --> Ready[恢复后的聚合]
+flowchart TB
+    Target["恢复最新聚合"] --> Choice{"存在可用快照？"}
+    Choice -->|否| All["加载全部事件"]
+    Choice -->|是| Snapshot["加载快照"]
+    Snapshot --> Tail["从 expectedNextVersion 加载尾部事件"]
+    All --> Source["按顺序 onSourcing"]
+    Tail --> Source
+    Source --> Ready["相同的当前聚合状态"]
 ```
 
 应用代码应依赖 `StateAggregateRepository`，不要自行拼接快照和事件加载逻辑。

--- a/documentation/docs/zh/guide/event/dispatch.md
+++ b/documentation/docs/zh/guide/event/dispatch.md
@@ -23,17 +23,26 @@ outline: deep
 
 ```mermaid
 flowchart TB
-    DomainBus["DomainEventBus"] --> DomainDispatcher["Domain / Saga Dispatcher"]
-    StateBus["StateEventBus"] --> StateDispatcher["State / Snapshot / Projection Dispatcher"]
-    DomainDispatcher --> Chain["Dispatcher-specific Filter chain"]
-    StateDispatcher --> Chain
-    Chain --> Notifier["Notifier Filter"]
-    Notifier --> Compensation["Compensation Filter（启用时）"]
-    Notifier -. "无补偿 Filter" .-> Function["事件函数"]
-    Compensation --> Retryable["Retryable Filter（存在时）"]
-    Compensation --> Function
-    Retryable --> Function
-    Function --> Ack["错误处理与 finallyAck"]
+    DomainBus["DomainEventBus"] --> EventStream["EventStreamDispatcher"]
+    StateBus["StateEventBus"] --> StateEvent["StateEventDispatcher"]
+    StateBus --> SnapshotDispatcher["SnapshotDispatcher"]
+    subgraph Composite["CompositeEventDispatcher"]
+        EventStream --> EventKind["FunctionKind.EVENT 匹配"]
+        StateEvent --> StateKind["FunctionKind.STATE_EVENT 匹配"]
+        EventKind --> Matched["匹配 Processor / Saga / Projection 函数"]
+        StateKind --> Matched
+    end
+    Matched --> EventNotifier["Notifier Filter"]
+    EventNotifier -->|"无 Compensation"| Retryable["Retryable Filter"]
+    EventNotifier -->|"启用 Compensation"| DomainCompensation["Compensation Filter（领域事件）"]
+    DomainCompensation --> Retryable
+    Retryable --> EventFunction["调用匹配函数"]
+    SnapshotDispatcher --> SnapshotNotifier["Notifier Filter"]
+    SnapshotNotifier -->|"无 Compensation"| SnapshotFunction["Snapshot 函数"]
+    SnapshotNotifier -->|"启用 Compensation"| StateCompensation["Compensation Filter（状态事件）"]
+    StateCompensation --> SnapshotFunction
+    EventFunction --> EventBoundary["Handler 错误边界与 finallyAck"]
+    SnapshotFunction --> SnapshotBoundary["Snapshot 错误边界与 finallyAck"]
 ```
 
 `EventStreamDispatcher` 只保留 `FunctionKind.EVENT`，`StateEventDispatcher` 只保留 `FunctionKind.STATE_EVENT`。各自按注册函数支持的聚合 topic 建立订阅；没有对应函数的聚合不会为该 dispatcher 创建消费路径。

--- a/documentation/docs/zh/guide/event/dispatch.md
+++ b/documentation/docs/zh/guide/event/dispatch.md
@@ -22,13 +22,18 @@ outline: deep
 `DomainEventDispatcher`、`ProjectionDispatcher` 与 `StatelessSagaDispatcher` 都基于 `CompositeEventDispatcher`。一个 Composite Dispatcher 创建两个子分发器，并共享聚合调度器：
 
 ```mermaid
-flowchart LR
-    D[DomainEventBus] --> ED[EventStreamDispatcher]
-    S[StateEventBus] --> SD[StateEventDispatcher]
-    ED --> E[EVENT functions]
-    SD --> SE[STATE_EVENT functions]
-    E --> H[Dispatcher-specific FilterChain]
-    SE --> H
+flowchart TB
+    DomainBus["DomainEventBus"] --> DomainDispatcher["Domain / Saga Dispatcher"]
+    StateBus["StateEventBus"] --> StateDispatcher["State / Snapshot / Projection Dispatcher"]
+    DomainDispatcher --> Chain["Dispatcher-specific Filter chain"]
+    StateDispatcher --> Chain
+    Chain --> Notifier["Notifier Filter"]
+    Notifier --> Compensation["Compensation Filter（启用时）"]
+    Notifier -. "无补偿 Filter" .-> Function["事件函数"]
+    Compensation --> Retryable["Retryable Filter（存在时）"]
+    Compensation --> Function
+    Retryable --> Function
+    Function --> Ack["错误处理与 finallyAck"]
 ```
 
 `EventStreamDispatcher` 只保留 `FunctionKind.EVENT`，`StateEventDispatcher` 只保留 `FunctionKind.STATE_EVENT`。各自按注册函数支持的聚合 topic 建立订阅；没有对应函数的聚合不会为该 dispatcher 创建消费路径。

--- a/documentation/docs/zh/guide/event/dispatch.md
+++ b/documentation/docs/zh/guide/event/dispatch.md
@@ -27,22 +27,14 @@ flowchart TB
     StateBus["StateEventBus"] --> StateEvent["StateEventDispatcher"]
     StateBus --> SnapshotDispatcher["SnapshotDispatcher"]
     subgraph Composite["CompositeEventDispatcher"]
-        EventStream --> EventKind["FunctionKind.EVENT 匹配"]
-        StateEvent --> StateKind["FunctionKind.STATE_EVENT 匹配"]
-        EventKind --> Matched["匹配 Processor / Saga / Projection 函数"]
-        StateKind --> Matched
+        EventStream --> EventKind["FunctionKind.EVENT<br/>匹配 Processor / Saga /<br/>Projection<br/>&nbsp;"]
+        StateEvent --> StateKind["FunctionKind.STATE_EVENT<br/>匹配 Processor / Saga /<br/>Projection<br/>&nbsp;"]
     end
-    Matched --> EventNotifier["Notifier Filter"]
-    EventNotifier -->|"无 Compensation"| Retryable["Retryable Filter"]
-    EventNotifier -->|"启用 Compensation"| DomainCompensation["Compensation Filter（领域事件）"]
-    DomainCompensation --> Retryable
-    Retryable --> EventFunction["调用匹配函数"]
-    SnapshotDispatcher --> SnapshotNotifier["Notifier Filter"]
-    SnapshotNotifier -->|"无 Compensation"| SnapshotFunction["Snapshot 函数"]
-    SnapshotNotifier -->|"启用 Compensation"| StateCompensation["Compensation Filter（状态事件）"]
-    StateCompensation --> SnapshotFunction
-    EventFunction --> EventBoundary["Handler 错误边界与 finallyAck"]
-    SnapshotFunction --> SnapshotBoundary["Snapshot 错误边界与 finallyAck"]
+    EventKind --> EventChain["Processor / Saga /<br/>Projection<br/>Notifier → Retryable<br/>→ Function<br/>或<br/>Notifier<br/>→ Compensation<br/>→ Retryable<br/>→ Function<br/>&nbsp;"]
+    StateKind --> EventChain
+    SnapshotDispatcher --> SnapshotChain["Snapshot<br/>Notifier<br/>→ Function<br/>或<br/>Notifier<br/>→ Compensation<br/>→ Function<br/>&nbsp;"]
+    EventChain --> Boundary["错误处理与 finallyAck"]
+    SnapshotChain --> Boundary
 ```
 
 `EventStreamDispatcher` 只保留 `FunctionKind.EVENT`，`StateEventDispatcher` 只保留 `FunctionKind.STATE_EVENT`。各自按注册函数支持的聚合 topic 建立订阅；没有对应函数的聚合不会为该 dispatcher 创建消费路径。

--- a/documentation/docs/zh/guide/event/index.md
+++ b/documentation/docs/zh/guide/event/index.md
@@ -8,6 +8,19 @@ outline: deep
 
 领域事件进入 EventStore 后成为权威历史。本区域的下游协作都发生在追加之后：它们消费已提交事实，但不把自己的副作用变成源聚合事务的一部分，也不能回滚已经追加的事件。
 
+先按目标选择协作机制，再进入对应页面理解实现和失败边界。
+
+```mermaid
+flowchart TB
+    Need{"事实发生后需要什么？"}
+    Need -->|执行普通副作用| Processor["Event Processor"]
+    Need -->|生成跨聚合后续命令| Saga["Stateless Saga"]
+    Need -->|持久恢复处理失败| Compensation["Event Compensation"]
+    Processor --> Done["副作用完成"]
+    Saga --> Commands["0..N 条命令"]
+    Compensation --> Recovery["调度或人工恢复"]
+```
+
 ## 选择处理机制
 
 | 需求 | 选择 | 责任边界 |

--- a/documentation/docs/zh/guide/event/processor.md
+++ b/documentation/docs/zh/guide/event/processor.md
@@ -8,6 +8,18 @@ outline: deep
 
 事件处理器在领域事件已经追加后执行普通应用副作用。它不是源聚合事务的延伸：处理失败不会撤销事件，处理成功也不会让副作用成为权威事件历史。
 
+事件处理器只有在匹配函数的响应式工作完成后才产生完成信号；失败进入重试或补偿边界。
+
+```mermaid
+flowchart LR
+    Event["领域事件或状态事件"] --> Dispatcher["Event Dispatcher"]
+    Dispatcher --> Match["函数匹配与过滤"]
+    Match --> Filters["Dispatcher Filter chain"]
+    Filters --> Function["响应式事件函数"]
+    Function -->|完成| Signal["EVENT_HANDLED 信号"]
+    Function -->|失败| Recovery["重试或补偿入口"]
+```
+
 ## 何时使用普通事件处理器
 
 适合使用 Processor 的工作包括发送通知、写审计记录、调用外部服务、更新集成状态或失效缓存。若事件需要生成其他聚合的后续命令，选择 [Saga](../event/saga.md)。

--- a/documentation/docs/zh/guide/event/saga.md
+++ b/documentation/docs/zh/guide/event/saga.md
@@ -16,14 +16,16 @@ sequenceDiagram
     participant EventBus as DomainEventBus
     participant Saga as Stateless Saga
     participant Gateway as CommandGateway
-    participant Target as 目标聚合
+    participant CommandBus as CommandBus
     Source->>EventBus: 领域事件
     EventBus->>Saga: 调用匹配的 Saga 函数
     loop 0..N 条命令
         Saga->>Gateway: 顺序发送后续命令
-        Gateway->>Target: 处理命令
+        Gateway->>CommandBus: 发送命令
+        CommandBus-->>Gateway: 发送边界完成
     end
     Saga-->>EventBus: SAGA_HANDLED + commandIds
+    Note over Gateway,CommandBus: 目标聚合处理不在<br/>SAGA_HANDLED 保证内
 ```
 
 ## 何时使用 Saga

--- a/documentation/docs/zh/guide/event/saga.md
+++ b/documentation/docs/zh/guide/event/saga.md
@@ -8,6 +8,24 @@ outline: deep
 
 Wow 的 `@StatelessSaga` 是无状态事件编排器：它接收领域事件或状态事件并生成下一步命令。每个目标聚合仍在自己的本地事务中处理命令；Saga 不创建跨聚合 ACID 事务。
 
+Stateless Saga 把一个已发生的事实转换为 0..N 条顺序发送的后续命令。
+
+```mermaid
+sequenceDiagram
+    participant Source as 源聚合
+    participant EventBus as DomainEventBus
+    participant Saga as Stateless Saga
+    participant Gateway as CommandGateway
+    participant Target as 目标聚合
+    Source->>EventBus: 领域事件
+    EventBus->>Saga: 调用匹配的 Saga 函数
+    loop 0..N 条命令
+        Saga->>Gateway: 顺序发送后续命令
+        Gateway->>Target: 处理命令
+    end
+    Saga-->>EventBus: SAGA_HANDLED + commandIds
+```
+
 ## 何时使用 Saga
 
 当一个已提交事件需要驱动其他聚合的业务行为时使用 Saga，例如转账准备完成后向目标账户发送入账命令。只需通知、审计或调用外部集成时使用[事件处理器](./processor.md)；不要用 Saga 包装一个不生成命令的普通副作用。

--- a/documentation/docs/zh/guide/event/saga.md
+++ b/documentation/docs/zh/guide/event/saga.md
@@ -17,14 +17,18 @@ sequenceDiagram
     participant Saga as Stateless Saga
     participant Gateway as CommandGateway
     participant CommandBus as CommandBus
+    participant Notifier as SagaHandledNotifierFilter
+    participant WaitNotifier as CommandWaitNotifier
     Source->>EventBus: 领域事件
-    EventBus->>Saga: 调用匹配的 Saga 函数
+    EventBus->>Notifier: 分发到匹配 Saga
+    Notifier->>Saga: 调用 Saga 函数
     loop 0..N 条命令
         Saga->>Gateway: 顺序发送后续命令
         Gateway->>CommandBus: 发送命令
         CommandBus-->>Gateway: 发送边界完成
     end
-    Saga-->>EventBus: SAGA_HANDLED + commandIds
+    Saga-->>Notifier: 函数完成并记录 commandIds
+    Notifier-->>WaitNotifier: SAGA_HANDLED + commandIds
     Note over Gateway,CommandBus: 目标聚合处理不在<br/>SAGA_HANDLED 保证内
 ```
 


### PR DESCRIPTION
## Goal

Improve the readability of the Domain Model, Commands, and Events and Collaboration guides by giving every bilingual page one focused Mermaid overview without replacing the precise prose contracts.

Completion criteria are 40/40 single-diagram coverage, matching Chinese and English topology, accurate runtime boundaries, readable desktop and narrow layouts, and a clean VitePress build.

## Changes

- Add 14 new bilingual Mermaid diagram groups.
- Rework the snapshot diagram to contrast full replay with snapshot plus tail events.
- Rework event dispatch into a 10-node overview covering both buses, composite dispatch, Snapshot, optional Compensation and Retryable paths, and finallyAck.
- Clarify event upgrader execution, WaitHandle ownership, Saga wait notifications, LocalFirst Void routing, and transport SENT boundaries.
- Keep four existing authoritative diagrams unchanged.
- Add the approved diagram design and implementation plan.
- Leave Query, Projection, Data Access, sidebar, theme, dependencies, source, and image assets unchanged.

## Verification

- `pnpm --dir documentation docs:build` — passed; 94 English Markdown pages processed.
- Diagram coverage — passed: 20 pages per language, 40/40 pages with exactly one Mermaid block.
- Bilingual topology — passed for all 20 page pairs.
- Complexity gates — passed: ordinary graphs at most 8 nodes; reviewed runtime graphs at 10 nodes.
- Scope and `git diff --check` — passed; exactly 32 product Markdown files plus the design and plan.
- Visual QA — passed for required state, sequence, chooser, transport, Saga, event-evolution, wait-runtime, and dispatch pages at 1440×900 and 390×844, with no clipping or horizontal overflow.
- Task reviews, final whole-branch review, and scoped final-fix review — passed.

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

This is a documentation-only change. It does not modify runtime behavior, URLs, storage, generated contracts, dependencies, deployment, or data.

Mermaid remains the existing rendering mechanism. Diagrams are supplementary: the full prose, tables, code, error boundaries, and accessibility-relevant textual meaning remain in each page. Query diagrams continue in their independent branch.