### PR TITLE
fix(webflux): correct query filter properties

### DIFF
--- a/documentation/docs/en/guide/extensions/webflux.md
+++ b/documentation/docs/en/guide/extensions/webflux.md
@@ -55,8 +55,8 @@ wow:
       max-list-size: 1000
       max-page-size: 100
       max-page-window: 10000
-      max-condition-nodes: 64
-      max-condition-values: 1000
+      max-filter-nodes: 128
+      max-filter-values: 1000
       allow-expensive-operators: true
       idle-timeout: 10s
 ```

--- a/documentation/docs/en/reference/config/infrastructure.md
+++ b/documentation/docs/en/reference/config/infrastructure.md
@@ -152,8 +152,8 @@ Configuration class: `WebFluxProperties`; required capability: `webflux-support`
 | `wow.webflux.query.max-list-size` | Int | `1000` | List/aggregation limit; `0` removes the cap and permits limit `0` |
 | `wow.webflux.query.max-page-size` | Int | `100` | Page-size cap; `0` disables it |
 | `wow.webflux.query.max-page-window` | Long | `10000` | `page.index * page.size` cap; `0` disables it |
-| `wow.webflux.query.max-condition-nodes` | Int | `64` | FilterExpression node cap; `0` disables it |
-| `wow.webflux.query.max-condition-values` | Int | `1000` | Value-count cap for collection filters; `0` disables it |
+| `wow.webflux.query.max-filter-nodes` | Int | `128` | FilterExpression node cap; `0` disables it |
+| `wow.webflux.query.max-filter-values` | Int | `1000` | Value-count cap for collection filters; `0` disables it |
 | `wow.webflux.query.allow-expensive-operators` | Boolean | `true` | Allows expensive filters, Elements, metric sorting/arithmetic, and match-all count/paged requests |
 | `wow.webflux.query.idle-timeout` | Duration | `10s` | Maximum idle wait for the next result or completion; `0s` disables it |
 | `wow.webflux.command.request.appender.agent.enabled` | Boolean | `true` | Adds `User-Agent` to command context |

--- a/documentation/docs/zh/guide/extensions/webflux.md
+++ b/documentation/docs/zh/guide/extensions/webflux.md
@@ -55,8 +55,8 @@ wow:
       max-list-size: 1000
       max-page-size: 100
       max-page-window: 10000
-      max-condition-nodes: 64
-      max-condition-values: 1000
+      max-filter-nodes: 128
+      max-filter-values: 1000
       allow-expensive-operators: true
       idle-timeout: 10s
 ```

--- a/documentation/docs/zh/reference/config/infrastructure.md
+++ b/documentation/docs/zh/reference/config/infrastructure.md
@@ -152,8 +152,8 @@ spring:
 | `wow.webflux.query.max-list-size` | Int | `1000` | list/aggregation limit；`0` 关闭上限并允许 limit `0` |
 | `wow.webflux.query.max-page-size` | Int | `100` | page size 上限；`0` 关闭 |
 | `wow.webflux.query.max-page-window` | Long | `10000` | `page.index * page.size` 上限；`0` 关闭 |
-| `wow.webflux.query.max-condition-nodes` | Int | `64` | FilterExpression 节点数上限；`0` 关闭 |
-| `wow.webflux.query.max-condition-values` | Int | `1000` | 集合型过滤条件的值数量上限；`0` 关闭 |
+| `wow.webflux.query.max-filter-nodes` | Int | `128` | FilterExpression 节点数上限；`0` 关闭 |
+| `wow.webflux.query.max-filter-values` | Int | `1000` | 集合型过滤条件的值数量上限；`0` 关闭 |
 | `wow.webflux.query.allow-expensive-operators` | Boolean | `true` | 允许 expensive filters、Elements、metric 排序/算术及 match-all count/paged |
 | `wow.webflux.query.idle-timeout` | Duration | `10s` | 等待下一结果或完成的最长空闲时间；`0s` 关闭 |
 | `wow.webflux.command.request.appender.agent.enabled` | Boolean | `true` | 把 `User-Agent` 写入命令上下文 |

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/query/QueryAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/query/QueryAutoConfiguration.kt
@@ -20,7 +20,6 @@ import me.ahoo.wow.filter.LogErrorHandler
 import me.ahoo.wow.query.event.DefaultEventStreamQueryGateway
 import me.ahoo.wow.query.event.EventStreamQueryGateway
 import me.ahoo.wow.query.event.EventStreamQueryServiceFactory
-import me.ahoo.wow.query.event.NoOpEventStreamQueryServiceFactory
 import me.ahoo.wow.query.event.filter.EventStreamQueryFilter
 import me.ahoo.wow.query.event.filter.MaskingEventStreamQueryFilter
 import me.ahoo.wow.query.event.filter.TailEventStreamQueryFilter
@@ -30,7 +29,6 @@ import me.ahoo.wow.query.mask.EventStreamMaskerRegistry
 import me.ahoo.wow.query.mask.StateDataMaskerRegistry
 import me.ahoo.wow.query.mask.StateDynamicDocumentMasker
 import me.ahoo.wow.query.snapshot.DefaultSnapshotQueryGateway
-import me.ahoo.wow.query.snapshot.NoOpSnapshotQueryServiceFactory
 import me.ahoo.wow.query.snapshot.SnapshotQueryGateway
 import me.ahoo.wow.query.snapshot.SnapshotQueryServiceFactory
 import me.ahoo.wow.query.snapshot.filter.MaskingSnapshotQueryFilter
@@ -161,10 +159,4 @@ class QueryAutoConfiguration {
     fun unavailableEventStreamQueryServiceFactory(): EventStreamQueryServiceFactory {
         return UnavailableEventStreamQueryServiceFactory
     }
-
-    @Deprecated("NoOp query services must be configured explicitly.")
-    fun noOpSnapshotQueryServiceFactory(): SnapshotQueryServiceFactory = NoOpSnapshotQueryServiceFactory
-
-    @Deprecated("NoOp query services must be configured explicitly.")
-    fun noOpEventStreamQueryServiceFactory(): EventStreamQueryServiceFactory = NoOpEventStreamQueryServiceFactory
 }

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfiguration.kt
@@ -133,8 +133,8 @@ class WebFluxAutoConfiguration {
             maxListSize = query.maxListSize,
             maxPageSize = query.maxPageSize,
             maxPageWindow = query.maxPageWindow,
-            maxFilterNodes = query.maxConditionNodes,
-            maxFilterValues = query.maxConditionValues,
+            maxFilterNodes = query.maxFilterNodes,
+            maxFilterValues = query.maxFilterValues,
             allowExpensiveOperators = query.allowExpensiveOperators,
             idleTimeout = query.idleTimeout,
         )
@@ -234,20 +234,6 @@ class WebFluxAutoConfiguration {
             tracingPolicy = tracingPolicy
         )
     }
-
-    fun queryRouteModule(
-        snapshotQueryGateway: SnapshotQueryGateway,
-        snapshotQueryServiceFactory: SnapshotQueryServiceFactory,
-        eventStreamQueryGateway: EventStreamQueryGateway,
-        rewriteRequestFilter: RewriteRequestFilter,
-        exceptionHandler: RequestExceptionHandler,
-    ): QueryRouteModule = QueryRouteModule(
-        snapshotQueryGateway = snapshotQueryGateway,
-        snapshotQueryServiceFactory = snapshotQueryServiceFactory,
-        eventStreamQueryGateway = eventStreamQueryGateway,
-        rewriteRequestFilter = rewriteRequestFilter,
-        exceptionHandler = exceptionHandler,
-    )
 
     @Bean("queryRouteModule")
     @Order(Ordered.HIGHEST_PRECEDENCE)

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxProperties.kt
@@ -16,6 +16,7 @@ package me.ahoo.wow.spring.boot.starter.webflux
 import me.ahoo.wow.api.Wow
 import me.ahoo.wow.api.naming.EnabledCapable
 import me.ahoo.wow.spring.boot.starter.ENABLED_SUFFIX_KEY
+import me.ahoo.wow.webflux.route.query.HttpQueryGuardFilter.Companion.DEFAULT_MAX_FILTER_NODES
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.bind.DefaultValue
@@ -56,10 +57,10 @@ constructor(
         var maxPageSize: Int = 100,
         @DefaultValue("10000")
         var maxPageWindow: Long = 10_000,
-        @DefaultValue("64")
-        var maxConditionNodes: Int = 64,
+        @DefaultValue("$DEFAULT_MAX_FILTER_NODES")
+        var maxFilterNodes: Int = DEFAULT_MAX_FILTER_NODES,
         @DefaultValue("1000")
-        var maxConditionValues: Int = 1000,
+        var maxFilterValues: Int = 1000,
         @DefaultValue("true")
         var allowExpensiveOperators: Boolean = true,
         @DefaultValue("10s")

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
@@ -82,7 +82,6 @@ import me.ahoo.wow.webflux.route.policy.BatchExecutionPolicy
 import me.ahoo.wow.webflux.route.policy.CommandWaitPolicy
 import me.ahoo.wow.webflux.route.policy.TracingPolicy
 import me.ahoo.wow.webflux.route.query.HttpQueryGuardFilter
-import me.ahoo.wow.webflux.route.query.RewriteRequestFilter
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.boot.test.context.FilteredClassLoader
@@ -110,18 +109,6 @@ import java.util.stream.Stream
 
 @Suppress("LargeClass")
 internal class WebFluxAutoConfigurationTest {
-
-    @Test
-    fun `should preserve query route module factory api`() {
-        WebFluxAutoConfiguration::class.java.getMethod(
-            "queryRouteModule",
-            SnapshotQueryGateway::class.java,
-            SnapshotQueryServiceFactory::class.java,
-            EventStreamQueryGateway::class.java,
-            RewriteRequestFilter::class.java,
-            RequestExceptionHandler::class.java,
-        ).assert().isNotNull()
-    }
     private val contextRunner = ApplicationContextRunner()
         .withBean(SnapshotQueryServiceFactory::class.java, { NoOpSnapshotQueryServiceFactory })
         .withPropertyValues(
@@ -175,7 +162,9 @@ internal class WebFluxAutoConfigurationTest {
                 val batchExecutionPolicy = context.getBean(BatchExecutionPolicy::class.java)
                 batchExecutionPolicy.concurrency.assert().isOne()
                 batchExecutionPolicy.prefetch.assert().isOne()
-                context.getBean(WebFluxProperties::class.java).query.allowExpensiveOperators.assert().isTrue()
+                val queryProperties = context.getBean(WebFluxProperties::class.java).query
+                queryProperties.maxFilterNodes.assert().isEqualTo(128)
+                queryProperties.allowExpensiveOperators.assert().isTrue()
 
                 context.assertDefaultRouteFactoriesRegistered()
             }
@@ -191,8 +180,8 @@ internal class WebFluxAutoConfigurationTest {
                 "${WebFluxProperties.PREFIX}.query.max-list-size=200",
                 "${WebFluxProperties.PREFIX}.query.max-page-size=20",
                 "${WebFluxProperties.PREFIX}.query.max-page-window=2000",
-                "${WebFluxProperties.PREFIX}.query.max-condition-nodes=32",
-                "${WebFluxProperties.PREFIX}.query.max-condition-values=50",
+                "${WebFluxProperties.PREFIX}.query.max-filter-nodes=32",
+                "${WebFluxProperties.PREFIX}.query.max-filter-values=50",
                 "${WebFluxProperties.PREFIX}.query.allow-expensive-operators=false",
                 "${WebFluxProperties.PREFIX}.query.idle-timeout=5s",
             )
@@ -226,8 +215,8 @@ internal class WebFluxAutoConfigurationTest {
                 properties.query.maxListSize.assert().isEqualTo(200)
                 properties.query.maxPageSize.assert().isEqualTo(20)
                 properties.query.maxPageWindow.assert().isEqualTo(2000)
-                properties.query.maxConditionNodes.assert().isEqualTo(32)
-                properties.query.maxConditionValues.assert().isEqualTo(50)
+                properties.query.maxFilterNodes.assert().isEqualTo(32)
+                properties.query.maxFilterValues.assert().isEqualTo(50)
                 properties.query.allowExpensiveOperators.assert().isFalse()
                 properties.query.idleTimeout.assert().isEqualTo(Duration.ofSeconds(5))
                 val batchExecutionPolicy = context.getBean(BatchExecutionPolicy::class.java)

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilter.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilter.kt
@@ -41,7 +41,7 @@ class HttpQueryGuardFilter(
     private val maxListSize: Int = 1000,
     private val maxPageSize: Int = 100,
     private val maxPageWindow: Long = 10_000,
-    private val maxFilterNodes: Int = 64,
+    private val maxFilterNodes: Int = DEFAULT_MAX_FILTER_NODES,
     private val maxFilterValues: Int = 1000,
     private val allowExpensiveOperators: Boolean = true,
     private val idleTimeout: Duration = Duration.ofSeconds(10),
@@ -230,8 +230,10 @@ class HttpQueryGuardFilter(
         }
     }
 
-    private companion object {
-        val EXPENSIVE_OPERATORS = setOf(
+    companion object {
+        const val DEFAULT_MAX_FILTER_NODES: Int = 128
+
+        private val EXPENSIVE_OPERATORS = setOf(
             FilterOperator.NE,
             FilterOperator.NOT_IN,
             FilterOperator.NOR,
@@ -242,6 +244,6 @@ class HttpQueryGuardFilter(
             FilterOperator.CONTAINS,
             FilterOperator.ENDS_WITH,
         )
-        val COUNTING_QUERY_TYPES = setOf(QueryType.PAGED, QueryType.DYNAMIC_PAGED, QueryType.COUNT)
+        private val COUNTING_QUERY_TYPES = setOf(QueryType.PAGED, QueryType.DYNAMIC_PAGED, QueryType.COUNT)
     }
 }

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
@@ -98,6 +98,29 @@ class HttpQueryGuardFilterTest {
     private val request = MockServerRequest.builder().build()
 
     @Test
+    fun `should allow 128 filter nodes by default`() {
+        val guard = HttpQueryGuardFilter(idleTimeout = Duration.ZERO)
+        val allowed = ListQuery(
+            filterExpression { repeat(127) { MessageRecords.AGGREGATE_ID eq it } },
+            limit = 1,
+        )
+        val rejected = ListQuery(
+            filterExpression { repeat(128) { MessageRecords.AGGREGATE_ID eq it } },
+            limit = 1,
+        )
+
+        guard.filter(listContext(allowed), FilterChain { Mono.empty() })
+            .writeRawRequest(request)
+            .test()
+            .verifyComplete()
+        guard.filter(listContext(rejected), unexpectedBackend())
+            .writeRawRequest(request)
+            .test()
+            .expectError(IllegalArgumentException::class.java)
+            .verify()
+    }
+
+    @Test
     fun `should reject unsafe list queries before backend invocation`() {
         listOf(
             ListQuery(MatchAllFilter),
@@ -123,7 +146,7 @@ class HttpQueryGuardFilterTest {
             ListQuery(filterExpression { MessageRecords.AGGREGATE_ID isIn List(1001) { it } }, limit = 1),
             ListQuery(IdsFilter(List(1001) { it.toString() }), limit = 1),
             ListQuery(AggregateIdsFilter(List(1001) { it.toString() }), limit = 1),
-            ListQuery(filterExpression { repeat(65) { MessageRecords.AGGREGATE_ID eq it } }, limit = 1),
+            ListQuery(filterExpression { repeat(128) { MessageRecords.AGGREGATE_ID eq it } }, limit = 1),
         ).forEach { query ->
             guard().filter(listContext(query), unexpectedBackend())
                 .writeRawRequest(request)
@@ -692,7 +715,7 @@ class HttpQueryGuardFilterTest {
         maxListSize: Int = 1000,
         maxPageSize: Int = 100,
         maxPageWindow: Long = 10_000,
-        maxFilterNodes: Int = 64,
+        maxFilterNodes: Int = HttpQueryGuardFilter.DEFAULT_MAX_FILTER_NODES,
         maxFilterValues: Int = 1000,
         allowExpensiveOperators: Boolean = false,
         idleTimeout: Duration = Duration.ofSeconds(10),


### PR DESCRIPTION
## Goal

Correct the WebFlux query guard property names, unify the default filter-node limit, and remove obsolete auto-configuration methods.

## Changes

- Rename `maxConditionNodes` / `maxConditionValues` to `maxFilterNodes` / `maxFilterValues`.
- Share `DEFAULT_MAX_FILTER_NODES = 128` between `HttpQueryGuardFilter` and Spring Boot properties.
- Remove the dead `queryRouteModule` factory and deprecated NoOp query-service factory helpers.
- Update regression tests and English/Chinese WebFlux documentation.

## Verification

- `./gradlew build` — BUILD SUCCESSFUL (334 actionable tasks).
- `cd documentation && pnpm docs:build` — build complete.
- `git diff --check` — clean.

## Compatibility and risks

- [ ] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

This intentionally renames the Spring configuration keys from `max-condition-*` to `max-filter-*`, renames the corresponding Kotlin properties, removes three obsolete methods, and raises the default filter-node limit from 64 to 128. Applications using the old keys or source APIs must migrate. No data, concurrency, or deployment workflow changes are involved; rollback is a commit revert.