### PR TITLE
docs: improve Mermaid diagram readability

### DIFF
--- a/documentation/docs/en/guide/command/index.md
+++ b/documentation/docs/en/guide/command/index.md
@@ -11,7 +11,7 @@ A command expresses one business intent to change aggregate state. Define its pa
 A command starts as business intent and connects to downstream collaboration through durable facts and observable completion signals.
 
 ```mermaid
-flowchart LR
+flowchart TB
     Intent["Business intent"] --> Definition["Define command"]
     Definition --> Send["Send command"]
     Send --> Process["Process in aggregate"]

--- a/documentation/docs/en/guide/command/internals/pipeline.md
+++ b/documentation/docs/en/guide/command/internals/pipeline.md
@@ -11,7 +11,7 @@ This page explains how a non-`Void` command crosses the Wow runtime. See [Send C
 ## Component map
 
 ```mermaid
-flowchart LR
+flowchart TB
     Caller --> Gateway[DefaultCommandGateway]
     Gateway --> Bus[CommandBus]
     Bus --> Dispatcher[CommandDispatcher]

--- a/documentation/docs/en/guide/command/internals/transport.md
+++ b/documentation/docs/en/guide/command/internals/transport.md
@@ -13,17 +13,11 @@ Each transport anchors SENT to different evidence, but none means the command ha
 ```mermaid
 flowchart TB
     Command["CommandMessage"] --> Transport{"CommandBus implementation"}
-    Transport --> InMemory["InMemory: local sink admission"]
-    Transport --> Kafka["Kafka: producer result"]
-    Transport --> Redis["Redis: Stream XADD"]
-    Transport --> LocalFirst["LocalFirst: local receipt + distributed admission"]
+    Transport --> Evidence["InMemory: local sink<br/>Kafka: producer result<br/>Redis: Stream XADD<br/>LocalFirst: local receipt + distributed admission"]
     Void["Void + LocalFirst"] --> Distributed["Force distributed path"]
     Distributed --> Sent
-    InMemory --> Sent["SENT"]
-    Kafka --> Sent
-    Redis --> Sent
-    LocalFirst --> Sent
-    Sent --> Boundary["Proves transport acceptance, not PROCESSED"]
+    Evidence --> Sent["SENT"]
+    Sent --> Boundary["SENT ≠ PROCESSED"]
 ```
 
 ## CommandBus contract

--- a/documentation/docs/en/guide/domain/event-evolution.md
+++ b/documentation/docs/en/guide/domain/event-evolution.md
@@ -9,7 +9,7 @@ outline: deep
 When historical events are read, `EventUpgraderFactory` invokes every Upgrader registered for that event once in `@Order` order. Each invocation may return the record unchanged, upgraded, or as a `DroppedEvent` record; the application must verify that the final record is resolvable.
 
 ```mermaid
-flowchart LR
+flowchart TB
     Persisted["Persisted event record"] --> Ordered["Upgrader list for this event<br/>sorted once by @Order"]
     Ordered --> Apply["Invoke each Upgrader exactly once"]
     Apply --> Result{"Each invocation returns"}

--- a/documentation/docs/en/guide/domain/event-sourcing.md
+++ b/documentation/docs/en/guide/domain/event-sourcing.md
@@ -86,7 +86,7 @@ Sourcing functions update state only from events; do not read the current time, 
 Applications restore aggregates through `StateAggregateRepository`. For a request for the latest version, `EventSourcingStateAggregateRepository` loads a snapshot first; when none exists, it creates an empty aggregate, loads streams from `expectedNextVersion`, and invokes `onSourcing` for each stream.
 
 ```mermaid
-flowchart LR
+flowchart TB
     Load[Load aggregate] --> Latest{Latest version?}
     Latest -->|yes| Snapshot[Load snapshot or create empty aggregate]
     Latest -->|no| Empty[Create empty aggregate]

--- a/documentation/docs/en/guide/domain/lifecycle.md
+++ b/documentation/docs/en/guide/domain/lifecycle.md
@@ -9,16 +9,16 @@ outline: deep
 Events drive the lifecycle; deletion and recovery remain part of aggregate state evolution.
 
 ```mermaid
-stateDiagram-v2
-    direction LR
-    state "Uninitialized aggregate" as Empty
-    state "Active aggregate" as Active
-    state "Deleted aggregate" as Deleted
-    [*] --> Empty
-    Empty --> Active: Creation event
-    Active --> Active: Regular domain event
-    Active --> Deleted: Deletion event
-    Deleted --> Active: Recovery event
+flowchart TB
+    Start((Start)) --> Empty["Uninitialized aggregate"]
+    Empty --> Created["Creation event"]
+    Created --> Active["Active aggregate"]
+    Active --> Regular["Regular domain event"]
+    Regular --> Active
+    Active --> DeletedEvent["Deletion event"]
+    DeletedEvent --> Deleted["Deleted aggregate"]
+    Deleted --> Recovery["Recovery event"]
+    Recovery --> Active
 ```
 
 ## Create or Restore State

--- a/documentation/docs/en/guide/event/compensation.md
+++ b/documentation/docs/en/guide/event/compensation.md
@@ -57,12 +57,16 @@ A replay exchange already carries `compensationId` in its header. Another failur
 ## The ExecutionFailed State Machine
 
 ```mermaid
-stateDiagram-v2
-    [*] --> FAILED: ExecutionFailedCreated
-    FAILED --> PREPARED: Prepare / ForcePrepare
-    PREPARED --> PREPARED: Prepare / ForcePrepare after timeout
-    PREPARED --> FAILED: ExecutionFailedApplied
-    PREPARED --> SUCCEEDED: ExecutionSuccessApplied
+flowchart TB
+    Start((Start)) --> Created["ExecutionFailedCreated"]
+    Created --> Failed["FAILED"]
+    Failed --> Prepare["Prepare / ForcePrepare"]
+    Prepare --> Prepared["PREPARED"]
+    Prepared --> FailedResult["ExecutionFailedApplied → FAILED"]
+    Prepared --> SuccessResult["ExecutionSuccessApplied → SUCCEEDED"]
+    Prepared --> Timeout["Timeout → Prepare / ForcePrepare → PREPARED"]
+    FailedResult ~~~ SuccessResult
+    SuccessResult ~~~ Timeout
 ```
 
 | State | Meaning | Accepted result commands |

--- a/documentation/docs/en/guide/event/dispatch.md
+++ b/documentation/docs/en/guide/event/dispatch.md
@@ -25,16 +25,16 @@ Both implement `MessageBus`, but their topic kinds, subscriptions, and transport
 flowchart TB
     DomainBus["DomainEventBus"] --> EventStream["EventStreamDispatcher"]
     StateBus["StateEventBus"] --> StateEvent["StateEventDispatcher"]
-    StateBus --> SnapshotDispatcher["SnapshotDispatcher"]
-    subgraph Composite["CompositeEventDispatcher"]
-        EventStream --> EventKind["FunctionKind.EVENT<br/>match Processor / Saga /<br/>Projection<br/>&nbsp;"]
-        StateEvent --> StateKind["FunctionKind.STATE_EVENT<br/>match Processor / Saga /<br/>Projection<br/>&nbsp;"]
-    end
-    EventKind --> EventChain["Processor / Saga /<br/>Projection<br/>Notifier → Retryable<br/>→ Function<br/>or<br/>Notifier<br/>→ Compensation<br/>→ Retryable<br/>→ Function<br/>&nbsp;"]
-    StateKind --> EventChain
-    SnapshotDispatcher --> SnapshotChain["Snapshot<br/>Notifier<br/>→ Function<br/>or<br/>Notifier<br/>→ Compensation<br/>→ Function<br/>&nbsp;"]
-    EventChain --> Boundary["Error handling and finallyAck"]
-    SnapshotChain --> Boundary
+    EventStream --> EventKind["FunctionKind.EVENT"]
+    EventKind ~~~ StateBus
+    StateEvent --> StateKind["FunctionKind.STATE_EVENT"]
+    EventKind --> Functions["Processor / Saga / Projection"]
+    StateKind --> Functions
+    Functions --> EventFilters["Notifier → [Compensation] → Retryable → Function"]
+    SnapshotPath["StateEventBus → SnapshotDispatcher"] --> SnapshotFilters["Notifier → [Compensation] → Function"]
+    EventFilters --> Boundary["Error handling and finallyAck"]
+    SnapshotFilters --> Boundary
+    EventFilters ~~~ SnapshotPath
 ```
 
 `EventStreamDispatcher` retains only `FunctionKind.EVENT`; `StateEventDispatcher` retains only `FunctionKind.STATE_EVENT`. Each creates subscriptions from the aggregate topics supported by its registered functions. An aggregate without a corresponding function does not get a consumption path for that dispatcher.

--- a/documentation/docs/en/guide/event/processor.md
+++ b/documentation/docs/en/guide/event/processor.md
@@ -11,7 +11,7 @@ An event processor runs ordinary application side effects after a domain event h
 An event processor emits completion only after the matched reactive function completes; failures enter retry or compensation boundaries.
 
 ```mermaid
-flowchart LR
+flowchart TB
     Event["Domain event or state event"] --> Dispatcher["Event Dispatcher"]
     Dispatcher --> Match["Function matching and filtering"]
     Match --> Filters["Dispatcher Filter chain"]

--- a/documentation/docs/en/guide/event/saga.md
+++ b/documentation/docs/en/guide/event/saga.md
@@ -11,25 +11,18 @@ Wow's `@StatelessSaga` is a stateless event orchestrator: it receives domain or 
 A Stateless Saga converts an occurred fact into 0..N follow-up commands sent in order.
 
 ```mermaid
-sequenceDiagram
-    participant Source as Source aggregate
-    participant EventBus as DomainEventBus
-    participant Saga as Stateless Saga
-    participant Gateway as CommandGateway
-    participant CommandBus as CommandBus
-    participant Notifier as SagaHandledNotifierFilter
-    participant WaitNotifier as CommandWaitNotifier
-    Source->>EventBus: Domain event
-    EventBus->>Notifier: Dispatch to matching Saga
-    Notifier->>Saga: Invoke Saga function
-    loop 0..N commands
-        Saga->>Gateway: Send follow-up command in order
-        Gateway->>CommandBus: Send command
-        CommandBus-->>Gateway: Send boundary completed
-    end
-    Saga-->>Notifier: Function completes and records commandIds
-    Notifier-->>WaitNotifier: SAGA_HANDLED + commandIds
-    Note over Gateway,CommandBus: Target aggregate processing is outside<br/>the SAGA_HANDLED guarantee
+flowchart TB
+    Source["Source aggregate"] -->|Domain event| EventBus["DomainEventBus"]
+    EventBus -->|Dispatch to matching Saga| Notifier["SagaHandledNotifierFilter"]
+    Notifier -->|Invoke Saga function| Saga["Stateless Saga"]
+    Saga --> Commands{"No follow-up command?"}
+    Commands -->|Yes| Done["Record commandIds"]
+    Commands -->|No: send in order| Gateway["CommandGateway"]
+    Gateway --> CommandBus["CommandBus"]
+    CommandBus --> Sent["Send complete; target processing pending"]
+    Sent --> Done
+    Done --> Signal["SAGA_HANDLED + commandIds"]
+    Signal --> WaitNotifier["CommandWaitNotifier"]
 ```
 
 ## When to Use a Saga

--- a/documentation/docs/zh/guide/command/index.md
+++ b/documentation/docs/zh/guide/command/index.md
@@ -11,7 +11,7 @@ outline: deep
 命令从业务意图开始，以持久事实和可观察的完成信号连接下游协作。
 
 ```mermaid
-flowchart LR
+flowchart TB
     Intent["业务意图"] --> Definition["定义命令"]
     Definition --> Send["发送命令"]
     Send --> Process["聚合处理"]

--- a/documentation/docs/zh/guide/command/internals/pipeline.md
+++ b/documentation/docs/zh/guide/command/internals/pipeline.md
@@ -11,7 +11,7 @@ outline: deep
 ## 组件地图
 
 ```mermaid
-flowchart LR
+flowchart TB
     Caller[调用方] --> Gateway[DefaultCommandGateway]
     Gateway --> Bus[CommandBus]
     Bus --> Dispatcher[CommandDispatcher]

--- a/documentation/docs/zh/guide/command/internals/transport.md
+++ b/documentation/docs/zh/guide/command/internals/transport.md
@@ -13,17 +13,11 @@ outline: deep
 ```mermaid
 flowchart TB
     Command["CommandMessage"] --> Transport{"CommandBus 实现"}
-    Transport --> InMemory["InMemory：本地 sink 准入"]
-    Transport --> Kafka["Kafka：producer result"]
-    Transport --> Redis["Redis：Stream XADD"]
-    Transport --> LocalFirst["LocalFirst：本地 receipt + 分布式准入"]
+    Transport --> Evidence["InMemory：本地 sink<br/>Kafka：producer result<br/>Redis：Stream XADD<br/>LocalFirst：本地 receipt + 分布式准入"]
     Void["Void + LocalFirst"] --> Distributed["强制分布式路径"]
     Distributed --> Sent
-    InMemory --> Sent["SENT"]
-    Kafka --> Sent
-    Redis --> Sent
-    LocalFirst --> Sent
-    Sent --> Boundary["只证明 transport 接受，不证明 PROCESSED"]
+    Evidence --> Sent["SENT"]
+    Sent --> Boundary["SENT ≠ PROCESSED"]
 ```
 
 ## CommandBus 契约

--- a/documentation/docs/zh/guide/domain/event-evolution.md
+++ b/documentation/docs/zh/guide/domain/event-evolution.md
@@ -9,7 +9,7 @@ outline: deep
 读取历史事件时，`EventUpgraderFactory` 按 `@Order` 调用该事件已注册的全部 Upgrader，每个恰好一次；每次调用都可返回原记录、升级记录或 `DroppedEvent` 记录，应用必须验证最终记录可解析。
 
 ```mermaid
-flowchart LR
+flowchart TB
     Persisted["持久事件记录"] --> Ordered["该事件的 Upgrader 列表<br/>按 @Order 排序一次"]
     Ordered --> Apply["每个 Upgrader 恰好调用一次"]
     Apply --> Result{"每次调用返回"}

--- a/documentation/docs/zh/guide/domain/event-sourcing.md
+++ b/documentation/docs/zh/guide/domain/event-sourcing.md
@@ -86,7 +86,7 @@ interface EventStore :
 应用通过 `StateAggregateRepository` 恢复聚合。`EventSourcingStateAggregateRepository` 在请求最新版本时先加载快照；没有快照则创建空聚合，再从 `expectedNextVersion` 加载事件流并逐条执行 `onSourcing`。
 
 ```mermaid
-flowchart LR
+flowchart TB
     Load[加载聚合] --> Latest{请求最新版本？}
     Latest -->|是| Snapshot[加载快照或创建空聚合]
     Latest -->|否| Empty[创建空聚合]

--- a/documentation/docs/zh/guide/domain/lifecycle.md
+++ b/documentation/docs/zh/guide/domain/lifecycle.md
@@ -9,16 +9,16 @@ outline: deep
 生命周期由事件驱动；删除和恢复仍然是聚合状态演进的一部分。
 
 ```mermaid
-stateDiagram-v2
-    direction LR
-    state "未初始化聚合" as Empty
-    state "活动聚合" as Active
-    state "已删除聚合" as Deleted
-    [*] --> Empty
-    Empty --> Active: 创建事件
-    Active --> Active: 普通领域事件
-    Active --> Deleted: 删除事件
-    Deleted --> Active: 恢复事件
+flowchart TB
+    Start((开始)) --> Empty["未初始化聚合"]
+    Empty --> Created["创建事件"]
+    Created --> Active["活动聚合"]
+    Active --> Regular["普通领域事件"]
+    Regular --> Active
+    Active --> DeletedEvent["删除事件"]
+    DeletedEvent --> Deleted["已删除聚合"]
+    Deleted --> Recovery["恢复事件"]
+    Recovery --> Active
 ```
 
 ## 创建或恢复状态

--- a/documentation/docs/zh/guide/event/compensation.md
+++ b/documentation/docs/zh/guide/event/compensation.md
@@ -57,12 +57,16 @@ ExecutionFailed -> 自动调度或人工准备 -> 原事件 + 原目标函数重
 ## ExecutionFailed 状态机
 
 ```mermaid
-stateDiagram-v2
-    [*] --> FAILED: ExecutionFailedCreated
-    FAILED --> PREPARED: Prepare / ForcePrepare
-    PREPARED --> PREPARED: 超时后再次 Prepare / ForcePrepare
-    PREPARED --> FAILED: ExecutionFailedApplied
-    PREPARED --> SUCCEEDED: ExecutionSuccessApplied
+flowchart TB
+    Start((开始)) --> Created["ExecutionFailedCreated"]
+    Created --> Failed["FAILED"]
+    Failed --> Prepare["Prepare / ForcePrepare"]
+    Prepare --> Prepared["PREPARED"]
+    Prepared --> FailedResult["ExecutionFailedApplied → FAILED"]
+    Prepared --> SuccessResult["ExecutionSuccessApplied → SUCCEEDED"]
+    Prepared --> Timeout["超时 → Prepare / ForcePrepare → PREPARED"]
+    FailedResult ~~~ SuccessResult
+    SuccessResult ~~~ Timeout
 ```
 
 | 状态 | 含义 | 可接受的结果命令 |

--- a/documentation/docs/zh/guide/event/dispatch.md
+++ b/documentation/docs/zh/guide/event/dispatch.md
@@ -25,16 +25,16 @@ outline: deep
 flowchart TB
     DomainBus["DomainEventBus"] --> EventStream["EventStreamDispatcher"]
     StateBus["StateEventBus"] --> StateEvent["StateEventDispatcher"]
-    StateBus --> SnapshotDispatcher["SnapshotDispatcher"]
-    subgraph Composite["CompositeEventDispatcher"]
-        EventStream --> EventKind["FunctionKind.EVENT<br/>匹配 Processor / Saga /<br/>Projection<br/>&nbsp;"]
-        StateEvent --> StateKind["FunctionKind.STATE_EVENT<br/>匹配 Processor / Saga /<br/>Projection<br/>&nbsp;"]
-    end
-    EventKind --> EventChain["Processor / Saga /<br/>Projection<br/>Notifier → Retryable<br/>→ Function<br/>或<br/>Notifier<br/>→ Compensation<br/>→ Retryable<br/>→ Function<br/>&nbsp;"]
-    StateKind --> EventChain
-    SnapshotDispatcher --> SnapshotChain["Snapshot<br/>Notifier<br/>→ Function<br/>或<br/>Notifier<br/>→ Compensation<br/>→ Function<br/>&nbsp;"]
-    EventChain --> Boundary["错误处理与 finallyAck"]
-    SnapshotChain --> Boundary
+    EventStream --> EventKind["FunctionKind.EVENT"]
+    EventKind ~~~ StateBus
+    StateEvent --> StateKind["FunctionKind.STATE_EVENT"]
+    EventKind --> Functions["Processor / Saga / Projection"]
+    StateKind --> Functions
+    Functions --> EventFilters["Notifier → [Compensation] → Retryable → Function"]
+    SnapshotPath["StateEventBus → SnapshotDispatcher"] --> SnapshotFilters["Notifier → [Compensation] → Function"]
+    EventFilters --> Boundary["错误处理与 finallyAck"]
+    SnapshotFilters --> Boundary
+    EventFilters ~~~ SnapshotPath
 ```
 
 `EventStreamDispatcher` 只保留 `FunctionKind.EVENT`，`StateEventDispatcher` 只保留 `FunctionKind.STATE_EVENT`。各自按注册函数支持的聚合 topic 建立订阅；没有对应函数的聚合不会为该 dispatcher 创建消费路径。

--- a/documentation/docs/zh/guide/event/processor.md
+++ b/documentation/docs/zh/guide/event/processor.md
@@ -11,7 +11,7 @@ outline: deep
 事件处理器只有在匹配函数的响应式工作完成后才产生完成信号；失败进入重试或补偿边界。
 
 ```mermaid
-flowchart LR
+flowchart TB
     Event["领域事件或状态事件"] --> Dispatcher["Event Dispatcher"]
     Dispatcher --> Match["函数匹配与过滤"]
     Match --> Filters["Dispatcher Filter chain"]

--- a/documentation/docs/zh/guide/event/saga.md
+++ b/documentation/docs/zh/guide/event/saga.md
@@ -11,25 +11,18 @@ Wow 的 `@StatelessSaga` 是无状态事件编排器：它接收领域事件或�
 Stateless Saga 把一个已发生的事实转换为 0..N 条顺序发送的后续命令。
 
 ```mermaid
-sequenceDiagram
-    participant Source as 源聚合
-    participant EventBus as DomainEventBus
-    participant Saga as Stateless Saga
-    participant Gateway as CommandGateway
-    participant CommandBus as CommandBus
-    participant Notifier as SagaHandledNotifierFilter
-    participant WaitNotifier as CommandWaitNotifier
-    Source->>EventBus: 领域事件
-    EventBus->>Notifier: 分发到匹配 Saga
-    Notifier->>Saga: 调用 Saga 函数
-    loop 0..N 条命令
-        Saga->>Gateway: 顺序发送后续命令
-        Gateway->>CommandBus: 发送命令
-        CommandBus-->>Gateway: 发送边界完成
-    end
-    Saga-->>Notifier: 函数完成并记录 commandIds
-    Notifier-->>WaitNotifier: SAGA_HANDLED + commandIds
-    Note over Gateway,CommandBus: 目标聚合处理不在<br/>SAGA_HANDLED 保证内
+flowchart TB
+    Source["源聚合"] -->|领域事件| EventBus["DomainEventBus"]
+    EventBus -->|分发到匹配 Saga| Notifier["SagaHandledNotifierFilter"]
+    Notifier -->|调用 Saga 函数| Saga["Stateless Saga"]
+    Saga --> Commands{"没有后续命令？"}
+    Commands -->|是| Done["记录 commandIds"]
+    Commands -->|否：顺序发送| Gateway["CommandGateway"]
+    Gateway --> CommandBus["CommandBus"]
+    CommandBus --> Sent["发送完成；目标聚合处理未保证"]
+    Sent --> Done
+    Done --> Signal["SAGA_HANDLED + commandIds"]
+    Signal --> WaitNotifier["CommandWaitNotifier"]
 ```
 
 ## 何时使用 Saga


### PR DESCRIPTION
## Goal

Fix Mermaid diagrams in the bilingual domain, command, and event guides that rendered as overly compressed horizontal strips, overlapping labels, or clipped text on desktop and narrow screens.

## Changes

- Reorient wide flowcharts into readable vertical layouts.
- Preserve Saga send-before-notify semantics and explicit zero-command handling.
- Present compensation transitions without overlapping state labels.
- Preserve the fixed DomainEventBus/StateEventBus dispatcher mappings and the independent Snapshot path.
- Keep Chinese and English diagram topology aligned across 20 Markdown files.

## Verification

- `pnpm docs:build` — passed.
- Browser rendering audit — 40/40 target pages rendered one Mermaid SVG without syntax/error nodes or detected text overflow.
- 390px visual regression checks — lifecycle, command pipeline/transport, Saga, compensation, and event dispatch diagrams are readable without clipping.
- `git diff --check` — passed.
- Independent semantic re-review — PASS.

The build retains the existing non-blocking Rollup large-chunk warning.

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

Documentation-only change. No migration, runtime, concurrency, data, or deployment impact. Rollback is a revert of the single documentation commit.