### PR TITLE
docs: restore BI and event sourcing diagrams

### DIFF
--- a/documentation/docs/en/guide/bi.md
+++ b/documentation/docs/en/guide/bi.md
@@ -11,6 +11,10 @@ In a traditional reporting pipeline, an ETL job reads mutable business tables an
 instead projects immutable command and state-event Kafka topics into ClickHouse. The event store remains the source of
 truth; ClickHouse is a rebuildable analytical read model.
 
+<p align="center" style="text-align:center">
+  <img width="95%" src="/images/eventstore/eventsourcing.svg" alt="Event sourcing compared with traditional data storage"/>
+</p>
+
 That ownership boundary has operational consequences:
 
 - application metadata defines the desired schema and view graph;
@@ -20,6 +24,10 @@ That ownership boundary has operational consequences:
 
 Do not write domain state back from BI tables, and do not treat a successful SQL generation as proof that ClickHouse
 is current.
+
+<p align="center" style="text-align:center">
+  <img width="95%" src="/images/bi/bi.svg" alt="Wow business intelligence data flow"/>
+</p>
 
 ## Generate and Retrieve ETL Scripts
 

--- a/documentation/docs/en/guide/domain/event-sourcing.md
+++ b/documentation/docs/en/guide/domain/event-sourcing.md
@@ -8,6 +8,10 @@ outline: deep
 
 Event sourcing keeps an aggregate's facts that have already happened as ordered `DomainEventStream` values and restores state from those facts. Commands make decisions; an event becomes recoverable authoritative history only after `EventStore` appends it successfully.
 
+<p align="center" style="text-align:center">
+  <img width="95%" src="/images/eventstore/eventsourcing.svg" alt="Event sourcing compared with traditional data storage"/>
+</p>
+
 ## Authoritative History Model
 
 An event stream is the aggregate's consistency history. Snapshots, projections, and event-processor results cannot replace it. The complete command-execution phases are documented in the [Command Processing Pipeline](../command/internals/pipeline.md); this page defines only when history becomes authoritative and the boundaries used for recovery.

--- a/documentation/docs/zh/guide/bi.md
+++ b/documentation/docs/zh/guide/bi.md
@@ -10,6 +10,10 @@ description: 从 Wow 命令与状态事件流生成并运行 ClickHouse 读模�
 传统报表管线通常从可变业务表抽取数据，还要推断“发生了什么变化”。Wow BI 则把不可变命令与状态事件
 Kafka topic 投影到 ClickHouse。事件存储仍是事实源，ClickHouse 是可重建的分析读模型。
 
+<p align="center" style="text-align:center">
+  <img width="95%" src="/images/eventstore/eventsourcing.svg" alt="事件溯源与传统数据存储对比"/>
+</p>
+
 这一归属边界直接决定操作方式：
 
 - 应用元数据定义目标 schema 与 view graph；
@@ -18,6 +22,10 @@ Kafka topic 投影到 ClickHouse。事件存储仍是事实源，ClickHouse 是�
 - BI 行必须与事件/状态源完成对账，才能接受切换。
 
 不要从 BI 表反写领域状态，也不要把 SQL 生成成功当作 ClickHouse 已追平的证据。
+
+<p align="center" style="text-align:center">
+  <img width="95%" src="/images/bi/bi.svg" alt="Wow 商业智能数据链路"/>
+</p>
 
 ## 生成与获取 ETL 脚本
 

--- a/documentation/docs/zh/guide/domain/event-sourcing.md
+++ b/documentation/docs/zh/guide/domain/event-sourcing.md
@@ -8,6 +8,10 @@ outline: deep
 
 事件溯源把聚合的已发生事实保存为有序的 `DomainEventStream`，并从这些事实恢复状态。命令负责作出决策；事件一旦成功追加到 `EventStore`，才成为可恢复的权威历史。
 
+<p align="center" style="text-align:center">
+  <img width="95%" src="/images/eventstore/eventsourcing.svg" alt="事件溯源与传统数据存储对比"/>
+</p>
+
 ## 权威历史模型
 
 事件流是聚合的一致性历史；快照、投影和事件处理器的结果都不能替代它。命令执行的完整阶段见[命令处理管线](../command/internals/pipeline.md)；本页只定义历史何时成为权威，以及恢复所依赖的边界。


### PR DESCRIPTION
## Goal

Restore the existing event-sourcing and BI diagrams to the corresponding Chinese and English guides so the architecture explanations include their visual context.

## Changes

- add the event-sourcing comparison diagram to both BI guides
- add the BI data-flow diagram to both BI guides
- add the event-sourcing comparison diagram to both event-sourcing guides
- reuse the existing VitePress image paths, centered layout, and localized alt text

## Verification

- `cd documentation && pnpm docs:build` — passed after rebasing onto the latest `origin/main`
- `git diff --check origin/main..HEAD` — passed
- independent read-only review of the latest head — no findings

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

Documentation-only change. No runtime, API, schema, deployment, migration, performance, concurrency, or data impact. Rollback is a commit revert.
