### PR TITLE
fix(query): harden V9 contracts and migration window

### DIFF
--- a/documentation/docs/en/guide/query/filter-expression.md
+++ b/documentation/docs/en/guide/query/filter-expression.md
@@ -48,7 +48,7 @@ Use these dedicated operators for system identities, tenant, owner, and space. D
 | --- | --- | --- |
 | `EQ` / `NE` | `{ "op": "EQ", "field": "state.status", "value": "PAID" }` | `"status" eq "PAID"` / `"status" ne "CANCELLED"` |
 | `GT` / `GTE` / `LT` / `LTE` | `{ "op": "GTE", "field": "state.total", "value": 100 }` | `"total" gte 100` |
-| `CONTAINS` / `STARTS_WITH` / `ENDS_WITH` | `{ "op": "CONTAINS", "field": "state.note", "value": "vip", "stringComparison": "CASE_INSENSITIVE" }` | `"note".contains("vip", StringComparison.CASE_INSENSITIVE)` |
+| `CONTAINS` / `STARTS_WITH` / `ENDS_WITH` | `{ "op": "CONTAINS", "field": "state.note", "value": "vip", "stringComparison": "CASE_INSENSITIVE" }` | `"note".containsText("vip", StringComparison.CASE_INSENSITIVE)` |
 
 String comparison defaults to `CASE_SENSITIVE`. Comparison and string capabilities depend on the backend and the Schema it publishes.
 

--- a/documentation/docs/zh/guide/query/filter-expression.md
+++ b/documentation/docs/zh/guide/query/filter-expression.md
@@ -48,7 +48,7 @@ description: 使用 FilterExpression、JSON 表达式和 Kotlin DSL 构造可组
 | --- | --- | --- |
 | `EQ` / `NE` | `{ "op": "EQ", "field": "state.status", "value": "PAID" }` | `"status" eq "PAID"` / `"status" ne "CANCELLED"` |
 | `GT` / `GTE` / `LT` / `LTE` | `{ "op": "GTE", "field": "state.total", "value": 100 }` | `"total" gte 100` |
-| `CONTAINS` / `STARTS_WITH` / `ENDS_WITH` | `{ "op": "CONTAINS", "field": "state.note", "value": "vip", "stringComparison": "CASE_INSENSITIVE" }` | `"note".contains("vip", StringComparison.CASE_INSENSITIVE)` |
+| `CONTAINS` / `STARTS_WITH` / `ENDS_WITH` | `{ "op": "CONTAINS", "field": "state.note", "value": "vip", "stringComparison": "CASE_INSENSITIVE" }` | `"note".containsText("vip", StringComparison.CASE_INSENSITIVE)` |
 
 字符串比较默认 `CASE_SENSITIVE`。比较和字符串能力由后端及其发布的 Schema 决定。
 

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/Condition.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/Condition.kt
@@ -23,7 +23,7 @@ import java.time.format.DateTimeFormatter
  * Marker interface for condition options.
  * Implementations can define additional configuration options for query conditions.
  */
-@Deprecated("Use typed FilterExpression properties.")
+@Deprecated("Scheduled for removal in 9.1.0. Use typed FilterExpression properties.")
 interface ConditionOptions
 
 /**
@@ -34,7 +34,7 @@ interface ConditionOptions
  *
  * @param C The type of the condition implementation, enabling self-referential types for nested conditions.
  */
-@Deprecated("Use FilterExpression.")
+@Deprecated("Scheduled for removal in 9.1.0. Use FilterExpression.")
 interface ICondition<C : ICondition<C>> {
     /**
      * The field name to apply the condition to.
@@ -101,7 +101,7 @@ interface ICondition<C : ICondition<C>> {
  * val searchCondition = Condition.contains("description", "kotlin", ignoreCase = true)
  * ```
  */
-@Deprecated("Use FilterExpression.")
+@Deprecated("Scheduled for removal in 9.1.0. Use FilterExpression.")
 data class Condition(
     override val field: String = EMPTY_VALUE,
     override val operator: Operator = Operator.ALL,

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/LegacyConditionAdapter.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/LegacyConditionAdapter.kt
@@ -23,7 +23,7 @@ private val LEGACY_VALUE_MAPPER = tools.jackson.databind.json.JsonMapper.builder
 private val LEGACY_NODE_FACTORY = tools.jackson.databind.node.JsonNodeFactory.instance
 
 @Suppress("CyclomaticComplexMethod", "LongMethod")
-@Deprecated("Use FilterExpression directly.")
+@Deprecated("Scheduled for removal in 9.1.0. Use FilterExpression directly.")
 fun Condition.toFilterExpression(): FilterExpression = when (operator) {
     Operator.ALL -> MatchAllFilter
     Operator.AND -> AndFilter(children.requireChildren("AND").map(Condition::toFilterExpression))

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/ListQuery.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/ListQuery.kt
@@ -61,7 +61,7 @@ data class ListQuery(
     override val sort: List<Sort> = emptyList(),
     override val limit: Int = 0
 ) : IListQuery {
-    @Deprecated("Use filter.")
+    @Deprecated("Scheduled for removal in 9.1.0. Use filter.")
     constructor(
         condition: Condition,
         projection: Projection = Projection.ALL,

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/Operator.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/Operator.kt
@@ -20,7 +20,7 @@ package me.ahoo.wow.api.query
  * applied to fields in database queries. Operators range from simple equality checks
  * to complex date range queries and array operations.
  */
-@Deprecated("Use FilterOperator.")
+@Deprecated("Scheduled for removal in 9.1.0. Use FilterOperator.")
 enum class Operator {
     /**
      * Logical AND operator.

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/PagedQuery.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/PagedQuery.kt
@@ -59,7 +59,7 @@ data class PagedQuery(
     override val sort: List<Sort> = emptyList(),
     override val pagination: Pagination = Pagination.DEFAULT
 ) : IPagedQuery {
-    @Deprecated("Use filter.")
+    @Deprecated("Scheduled for removal in 9.1.0. Use filter.")
     constructor(
         condition: Condition,
         projection: Projection = Projection.ALL,

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/QueryJsonDeserializer.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/QueryJsonDeserializer.kt
@@ -137,6 +137,9 @@ private fun JsonNode.removeUnknownLegacyConditionProperties() {
     if (this !is ObjectNode) {
         return
     }
+    require(!(has(QueryProtocol.FilterExpression.OP) && has(QueryProtocol.Condition.OPERATOR))) {
+        "op and operator cannot be used together."
+    }
     remove(propertyNames().filterNot(LEGACY_CONDITION_PROPERTIES::contains))
     get(QueryProtocol.Condition.CHILDREN)?.forEach(JsonNode::removeUnknownLegacyConditionProperties)
 }

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/SingleQuery.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/SingleQuery.kt
@@ -51,7 +51,7 @@ data class SingleQuery(
     override val projection: Projection = Projection.ALL,
     override val sort: List<Sort> = emptyList()
 ) : ISingleQuery {
-    @Deprecated("Use filter.")
+    @Deprecated("Scheduled for removal in 9.1.0. Use filter.")
     constructor(
         condition: Condition,
         projection: Projection = Projection.ALL,

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/query/FilterExpressionTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/query/FilterExpressionTest.kt
@@ -108,6 +108,18 @@ class FilterExpressionTest {
     }
 
     @Test
+    fun `legacy query condition should reject mixed discriminators`() {
+        val body = """{"condition":{"op":"MATCH_ALL","operator":"ALL"}}"""
+        val accepted = listOf(
+            runCatching { jsonMapper.readValue(body, ListQuery::class.java) }.isSuccess,
+            runCatching { jsonMapper.readValue(body, PagedQuery::class.java) }.isSuccess,
+            runCatching { jsonMapper.readValue(body, SingleQuery::class.java) }.isSuccess,
+        )
+
+        accepted.assert().containsExactly(false, false, false)
+    }
+
+    @Test
     fun `canonical filter tree should reject nested legacy condition`() {
         org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
             jsonMapper.readValue(

--- a/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/ReactiveSnapshotCountQueryApi.kt
+++ b/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/ReactiveSnapshotCountQueryApi.kt
@@ -23,7 +23,7 @@ fun FilterExpression.count(snapshotQueryApi: ReactiveSnapshotCountQueryApi): Mon
     return snapshotQueryApi.count(this)
 }
 
-@Deprecated("Use FilterExpression.count.")
+@Deprecated("Scheduled for removal in 9.1.0. Use FilterExpression.count.")
 fun Condition.count(snapshotQueryApi: ReactiveSnapshotCountQueryApi): Mono<Long> {
     return snapshotQueryApi.count(this)
 }

--- a/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SnapshotCountQueryApi.kt
+++ b/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SnapshotCountQueryApi.kt
@@ -27,7 +27,7 @@ interface SnapshotCountQueryApi<R> : SnapshotQueryApi {
     @PostExchange(SNAPSHOT_COUNT_RESOURCE_NAME)
     fun count(@RequestBody filter: FilterExpression): R
 
-    @Deprecated("Use count(FilterExpression).")
+    @Deprecated("Scheduled for removal in 9.1.0. Use count(FilterExpression).")
     @PostExchange(SNAPSHOT_COUNT_RESOURCE_NAME)
     fun count(@RequestBody condition: Condition): R = count(condition.toFilterExpression())
 }

--- a/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SynchronousSnapshotCountQueryApi.kt
+++ b/wow-apiclient/src/main/kotlin/me/ahoo/wow/apiclient/query/SynchronousSnapshotCountQueryApi.kt
@@ -22,7 +22,7 @@ fun FilterExpression.count(snapshotQueryApi: SynchronousSnapshotCountQueryApi): 
     return snapshotQueryApi.count(this)
 }
 
-@Deprecated("Use FilterExpression.count.")
+@Deprecated("Scheduled for removal in 9.1.0. Use FilterExpression.count.")
 fun Condition.count(snapshotQueryApi: SynchronousSnapshotCountQueryApi): Long {
     return snapshotQueryApi.count(this)
 }

--- a/wow-cosec/src/test/kotlin/me/ahoo/wow/cosec/query/CoSecRewriteRequestFilterTest.kt
+++ b/wow-cosec/src/test/kotlin/me/ahoo/wow/cosec/query/CoSecRewriteRequestFilterTest.kt
@@ -14,10 +14,10 @@
 package me.ahoo.wow.cosec.query
 
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.MatchAllFilter
 import me.ahoo.wow.api.query.SpaceIdFilter
 import me.ahoo.wow.cosec.extractor.CoSecCommandBuilderExtractor.SPACE_ID_KEY
 import me.ahoo.wow.id.generateGlobalId
-import me.ahoo.wow.query.dsl.filterExpression
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import org.junit.jupiter.api.Test
 import org.springframework.mock.web.reactive.function.server.MockServerRequest
@@ -28,7 +28,7 @@ class CoSecRewriteRequestFilterTest {
     fun `should resolve space id from request condition`() {
         val spaceId = generateGlobalId()
         val request = MockServerRequest.builder().header(SPACE_ID_KEY, spaceId).build()
-        val filter = CoSecRewriteRequestFilter.rewrite(MOCK_AGGREGATE_METADATA, request, filterExpression { })
+        val filter = CoSecRewriteRequestFilter.rewrite(MOCK_AGGREGATE_METADATA, request, MatchAllFilter)
         filter.assert().isInstanceOf(SpaceIdFilter::class.java)
         (filter as SpaceIdFilter).value.assert().isEqualTo(spaceId)
     }

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotMappingQueryTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchSnapshotMappingQueryTest.kt
@@ -305,7 +305,7 @@ class ElasticsearchSnapshotMappingQueryTest {
         val filter = filter {
             "state.name" eq "Wow"
             "state.name" search "Wow"
-            "state.name".contains("ow")
+            "state.name".containsText("ow")
             "state.age" gt 18
         }
 

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/QueryGateway.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/QueryGateway.kt
@@ -23,6 +23,7 @@ import me.ahoo.wow.api.query.IListQuery
 import me.ahoo.wow.api.query.IPagedQuery
 import me.ahoo.wow.api.query.ISingleQuery
 import me.ahoo.wow.api.query.PagedList
+import me.ahoo.wow.api.query.Queryable
 import me.ahoo.wow.filter.ErrorAccessor
 import me.ahoo.wow.filter.ErrorHandler
 import me.ahoo.wow.filter.FilterChain
@@ -113,14 +114,16 @@ abstract class AbstractQueryGateway<R : Any>(
             .onErrorResume { original -> observeError(context, original).thenMany(Flux.error(original)) }
     }
 
+    protected open fun prepareDynamicResult(query: Queryable<*>, result: ObjectNode): ObjectNode = result
+
     override fun single(query: ISingleQuery): Mono<R> =
         mono<ISingleQuery, Mono<ObjectNode>, R>(QueryType.SINGLE, query) { context ->
             context.getRequiredResult().map { it.toObject<R>(targetType) }
         }
 
     override fun dynamicSingle(query: ISingleQuery): Mono<ObjectNode> =
-        mono<ISingleQuery, Mono<ObjectNode>, ObjectNode>(QueryType.SINGLE, query) {
-            it.getRequiredResult()
+        mono<ISingleQuery, Mono<ObjectNode>, ObjectNode>(QueryType.SINGLE, query) { context ->
+            context.getRequiredResult().map { result -> prepareDynamicResult(context.getQuery(), result) }
         }
 
     override fun list(query: IListQuery): Flux<R> =
@@ -129,8 +132,8 @@ abstract class AbstractQueryGateway<R : Any>(
         }
 
     override fun dynamicList(query: IListQuery): Flux<ObjectNode> =
-        flux<IListQuery, Flux<ObjectNode>, ObjectNode>(QueryType.LIST, query) {
-            it.getRequiredResult()
+        flux<IListQuery, Flux<ObjectNode>, ObjectNode>(QueryType.LIST, query) { context ->
+            context.getRequiredResult().map { result -> prepareDynamicResult(context.getQuery(), result) }
         }
 
     override fun paged(query: IPagedQuery): Mono<PagedList<R>> =
@@ -141,8 +144,10 @@ abstract class AbstractQueryGateway<R : Any>(
         }
 
     override fun dynamicPaged(query: IPagedQuery): Mono<PagedList<ObjectNode>> =
-        mono<IPagedQuery, Mono<PagedList<ObjectNode>>, PagedList<ObjectNode>>(QueryType.PAGED, query) {
-            it.getRequiredResult()
+        mono<IPagedQuery, Mono<PagedList<ObjectNode>>, PagedList<ObjectNode>>(QueryType.PAGED, query) { context ->
+            context.getRequiredResult().map { page ->
+                page.copy(list = page.list.map { prepareDynamicResult(context.getQuery(), it) })
+            }
         }
 
     override fun cursor(query: ICursorQuery): Mono<CursorPage<R>> =
@@ -153,8 +158,10 @@ abstract class AbstractQueryGateway<R : Any>(
         }
 
     override fun dynamicCursor(query: ICursorQuery): Mono<CursorPage<ObjectNode>> =
-        mono<ICursorQuery, Mono<CursorPage<ObjectNode>>, CursorPage<ObjectNode>>(QueryType.CURSOR, query) {
-            it.getRequiredResult()
+        mono<ICursorQuery, Mono<CursorPage<ObjectNode>>, CursorPage<ObjectNode>>(QueryType.CURSOR, query) { context ->
+            context.getRequiredResult().map { page ->
+                page.copy(list = page.list.map { prepareDynamicResult(context.getQuery(), it) })
+            }
         }
 
     override fun count(filter: FilterExpression): Mono<Long> =

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/QueryGateway.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/QueryGateway.kt
@@ -23,7 +23,6 @@ import me.ahoo.wow.api.query.IListQuery
 import me.ahoo.wow.api.query.IPagedQuery
 import me.ahoo.wow.api.query.ISingleQuery
 import me.ahoo.wow.api.query.PagedList
-import me.ahoo.wow.api.query.Queryable
 import me.ahoo.wow.filter.ErrorAccessor
 import me.ahoo.wow.filter.ErrorHandler
 import me.ahoo.wow.filter.FilterChain
@@ -114,7 +113,7 @@ abstract class AbstractQueryGateway<R : Any>(
             .onErrorResume { original -> observeError(context, original).thenMany(Flux.error(original)) }
     }
 
-    protected open fun prepareDynamicResult(query: Queryable<*>, result: ObjectNode): ObjectNode = result
+    protected open fun prepareDynamicResult(context: QueryContext<*, *>, result: ObjectNode): ObjectNode = result
 
     override fun single(query: ISingleQuery): Mono<R> =
         mono<ISingleQuery, Mono<ObjectNode>, R>(QueryType.SINGLE, query) { context ->
@@ -123,7 +122,7 @@ abstract class AbstractQueryGateway<R : Any>(
 
     override fun dynamicSingle(query: ISingleQuery): Mono<ObjectNode> =
         mono<ISingleQuery, Mono<ObjectNode>, ObjectNode>(QueryType.SINGLE, query) { context ->
-            context.getRequiredResult().map { result -> prepareDynamicResult(context.getQuery(), result) }
+            context.getRequiredResult().map { result -> prepareDynamicResult(context, result) }
         }
 
     override fun list(query: IListQuery): Flux<R> =
@@ -133,7 +132,7 @@ abstract class AbstractQueryGateway<R : Any>(
 
     override fun dynamicList(query: IListQuery): Flux<ObjectNode> =
         flux<IListQuery, Flux<ObjectNode>, ObjectNode>(QueryType.LIST, query) { context ->
-            context.getRequiredResult().map { result -> prepareDynamicResult(context.getQuery(), result) }
+            context.getRequiredResult().map { result -> prepareDynamicResult(context, result) }
         }
 
     override fun paged(query: IPagedQuery): Mono<PagedList<R>> =
@@ -146,7 +145,7 @@ abstract class AbstractQueryGateway<R : Any>(
     override fun dynamicPaged(query: IPagedQuery): Mono<PagedList<ObjectNode>> =
         mono<IPagedQuery, Mono<PagedList<ObjectNode>>, PagedList<ObjectNode>>(QueryType.PAGED, query) { context ->
             context.getRequiredResult().map { page ->
-                page.copy(list = page.list.map { prepareDynamicResult(context.getQuery(), it) })
+                page.copy(list = page.list.map { prepareDynamicResult(context, it) })
             }
         }
 
@@ -160,7 +159,7 @@ abstract class AbstractQueryGateway<R : Any>(
     override fun dynamicCursor(query: ICursorQuery): Mono<CursorPage<ObjectNode>> =
         mono<ICursorQuery, Mono<CursorPage<ObjectNode>>, CursorPage<ObjectNode>>(QueryType.CURSOR, query) { context ->
             context.getRequiredResult().map { page ->
-                page.copy(list = page.list.map { prepareDynamicResult(context.getQuery(), it) })
+                page.copy(list = page.list.map { prepareDynamicResult(context, it) })
             }
         }
 

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/QueryLogErrorHandler.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/QueryLogErrorHandler.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import me.ahoo.wow.filter.ErrorHandler
+import me.ahoo.wow.query.filter.QueryContext
+import me.ahoo.wow.query.schema.QuerySchemaValidationException
+import reactor.core.publisher.Mono
+
+class QueryLogErrorHandler : ErrorHandler<QueryContext<*, *>> {
+    companion object {
+        private val log = KotlinLogging.logger { }
+    }
+
+    override fun handle(context: QueryContext<*, *>, throwable: Throwable): Mono<Void> {
+        if (throwable is QuerySchemaValidationException) {
+            log.error { throwable.message }
+        } else {
+            log.error(throwable) { throwable.message }
+        }
+        return Mono.error(throwable)
+    }
+}

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/ConditionDsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/ConditionDsl.kt
@@ -77,7 +77,7 @@ import kotlin.reflect.KCallable
  * - `String.tomorrow(datePattern: Any? = null)`: Adds a condition to check if the field is tomorrow.
  */
 @QueryDslMarker
-@Deprecated("Use FilterDsl.")
+@Deprecated("Scheduled for removal in 9.1.0. Use FilterDsl.")
 class ConditionDsl : NestedFieldDsl() {
 
     private var conditions: MutableList<Condition> = mutableListOf()

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/Dsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/Dsl.kt
@@ -88,7 +88,7 @@ fun aggregation(block: AggregationQueryDsl.() -> Unit): AggregationQuery {
  * @param block The DSL block to define the condition.
  * @return The constructed [Condition] object.
  */
-@Deprecated("Use filterExpression.")
+@Deprecated("Scheduled for removal in 9.1.0. Use filterExpression.")
 fun condition(block: ConditionDsl.() -> Unit): Condition {
     val dsl = ConditionDsl()
     dsl.block()

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/FilterDsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/FilterDsl.kt
@@ -137,16 +137,6 @@ class FilterDsl internal constructor(
         add(scoped.build())
     }
 
-    @Deprecated("Use path. Unlike nested, path groups multiple expressions with AND.")
-    fun String.nested(block: FilterDsl.() -> Unit) {
-        val nested = FilterDsl(
-            prefix = field(this).value,
-            allowScopedExpression = prefix == "" || allowScopedExpression,
-        ).apply(block)
-        require(nested.expressions.isNotEmpty()) { "nested block cannot be empty." }
-        nested.expressions.forEach(::add)
-    }
-
     fun String.elementMatch(block: FilterDsl.() -> Unit) {
         val nested = FilterDsl().apply(block)
         require(nested.expressions.isNotEmpty()) { "elementMatch block cannot be empty." }
@@ -173,13 +163,13 @@ class FilterDsl internal constructor(
 
     infix fun String.lte(value: Any?) = add(LessThanOrEqualFilter(field(this), value.literal()))
 
-    fun String.contains(value: String, comparison: StringComparison = StringComparison.CASE_SENSITIVE) =
+    fun String.containsText(value: String, comparison: StringComparison = StringComparison.CASE_SENSITIVE) =
         add(ContainsFilter(field(this), value, comparison))
 
-    fun String.startsWith(value: String, comparison: StringComparison = StringComparison.CASE_SENSITIVE) =
+    fun String.startsWithText(value: String, comparison: StringComparison = StringComparison.CASE_SENSITIVE) =
         add(StartsWithFilter(field(this), value, comparison))
 
-    fun String.endsWith(value: String, comparison: StringComparison = StringComparison.CASE_SENSITIVE) =
+    fun String.endsWithText(value: String, comparison: StringComparison = StringComparison.CASE_SENSITIVE) =
         add(EndsWithFilter(field(this), value, comparison))
 
     infix fun String.isIn(values: Iterable<*>) = add(InFilter(field(this), values.literals()))
@@ -301,10 +291,9 @@ class FilterDsl internal constructor(
         timeUnit: TimeUnit = TimeUnit.MILLISECONDS,
     ) = add(EarlierDaysFilter(field(this), days, zoneId?.id, datePattern, timeUnit = timeUnit))
 
-    internal fun build(): FilterExpression = when (expressions.size) {
-        0 -> MatchAllFilter
-        1 -> expressions.first()
-        else -> AndFilter(expressions.toList())
+    internal fun build(): FilterExpression {
+        require(expressions.isNotEmpty()) { "filter block cannot be empty." }
+        return expressions.singleOrNull() ?: AndFilter(expressions.toList())
     }
 
     private fun nestedLogical(

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/QueryDslMarker.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/QueryDslMarker.kt
@@ -50,14 +50,14 @@ package me.ahoo.wow.query.dsl
  * ```kotlin
  * @QueryDslMarker
  * interface FilterDsl {
- *     fun where(init: ConditionDsl.() -> Unit): FilterDsl
+ *     fun where(init: FilterDsl.() -> Unit): FilterExpression
  *     fun having(init: AggregateConditionDsl.() -> Unit): FilterDsl
  * }
  *
  * @QueryDslMarker
- * interface ConditionDsl {
- *     infix fun String.eq(value: Any): Condition
- *     infix fun String.gt(value: Any): Condition
+ * interface FilterDsl {
+ *     infix fun String.eq(value: Any): FilterExpression
+ *     infix fun String.gt(value: Any): FilterExpression
  *     // Methods from FilterDsl not accessible here
  * }
  * ```
@@ -83,8 +83,8 @@ package me.ahoo.wow.query.dsl
  * ```kotlin
  * val complexQuery = query {
  *     filter {                          // FilterDsl context
- *         where {                        // ConditionDsl context
- *             "status" eq "active"        // ConditionDsl methods only
+ *         where {                        // FilterDsl context
+ *             "status" eq "active"        // FilterDsl methods only
  *             "age" gt 18
  *             // filter.where() not accessible due to @QueryDslMarker
  *         }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/QueryableDsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/QueryableDsl.kt
@@ -53,12 +53,12 @@ abstract class QueryableDsl<Q : Queryable<Q>> {
         filter(me.ahoo.wow.query.dsl.filter(block))
     }
 
-    @Deprecated("Use filter.")
+    @Deprecated("Scheduled for removal in 9.1.0. Use filter.")
     fun condition(condition: Condition) {
         filter(condition.toFilterExpression())
     }
 
-    @Deprecated("Use filter.")
+    @Deprecated("Scheduled for removal in 9.1.0. Use filter.")
     fun condition(block: ConditionDsl.() -> Unit) {
         condition(me.ahoo.wow.query.dsl.condition(block))
     }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/event/EventStreamQueryGateway.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/event/EventStreamQueryGateway.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.query.event
 
 import me.ahoo.wow.api.modeling.NamedAggregate
+import me.ahoo.wow.api.query.Queryable
 import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.filter.ErrorHandler
 import me.ahoo.wow.query.AbstractQueryGateway
@@ -21,7 +22,10 @@ import me.ahoo.wow.query.QueryGateway
 import me.ahoo.wow.query.QueryLogErrorHandler
 import me.ahoo.wow.query.filter.QueryContext
 import me.ahoo.wow.query.filter.QueryFilter
+import me.ahoo.wow.query.mask.removeInternalEventBodyType
+import me.ahoo.wow.query.mask.requiresInternalEventBodyType
 import me.ahoo.wow.serialization.JsonSerializer
+import tools.jackson.databind.node.ObjectNode
 
 interface EventStreamQueryGateway : QueryGateway<DomainEventStream>
 
@@ -38,4 +42,7 @@ class DefaultEventStreamQueryGateway(
         filters,
         EventStreamQueryGateway::class,
         errorHandler,
-    )
+    ) {
+    override fun prepareDynamicResult(query: Queryable<*>, result: ObjectNode): ObjectNode =
+        if (query.projection.requiresInternalEventBodyType()) result.removeInternalEventBodyType() else result
+}

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/event/EventStreamQueryGateway.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/event/EventStreamQueryGateway.kt
@@ -14,7 +14,6 @@
 package me.ahoo.wow.query.event
 
 import me.ahoo.wow.api.modeling.NamedAggregate
-import me.ahoo.wow.api.query.Queryable
 import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.filter.ErrorHandler
 import me.ahoo.wow.query.AbstractQueryGateway
@@ -22,8 +21,8 @@ import me.ahoo.wow.query.QueryGateway
 import me.ahoo.wow.query.QueryLogErrorHandler
 import me.ahoo.wow.query.filter.QueryContext
 import me.ahoo.wow.query.filter.QueryFilter
+import me.ahoo.wow.query.mask.internalEventBodyTypeProjected
 import me.ahoo.wow.query.mask.removeInternalEventBodyType
-import me.ahoo.wow.query.mask.requiresInternalEventBodyType
 import me.ahoo.wow.serialization.JsonSerializer
 import tools.jackson.databind.node.ObjectNode
 
@@ -43,6 +42,6 @@ class DefaultEventStreamQueryGateway(
         EventStreamQueryGateway::class,
         errorHandler,
     ) {
-    override fun prepareDynamicResult(query: Queryable<*>, result: ObjectNode): ObjectNode =
-        if (query.projection.requiresInternalEventBodyType()) result.removeInternalEventBodyType() else result
+    override fun prepareDynamicResult(context: QueryContext<*, *>, result: ObjectNode): ObjectNode =
+        if (context.internalEventBodyTypeProjected) result.removeInternalEventBodyType() else result
 }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/event/EventStreamQueryGateway.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/event/EventStreamQueryGateway.kt
@@ -16,9 +16,9 @@ package me.ahoo.wow.query.event
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.filter.ErrorHandler
-import me.ahoo.wow.filter.LogErrorHandler
 import me.ahoo.wow.query.AbstractQueryGateway
 import me.ahoo.wow.query.QueryGateway
+import me.ahoo.wow.query.QueryLogErrorHandler
 import me.ahoo.wow.query.filter.QueryContext
 import me.ahoo.wow.query.filter.QueryFilter
 import me.ahoo.wow.serialization.JsonSerializer
@@ -29,7 +29,7 @@ class DefaultEventStreamQueryGateway(
     namedAggregate: NamedAggregate,
     backend: EventStreamQueryBackend,
     filters: List<QueryFilter<QueryContext<*, *>>> = emptyList(),
-    errorHandler: ErrorHandler<QueryContext<*, *>> = LogErrorHandler(),
+    errorHandler: ErrorHandler<QueryContext<*, *>> = QueryLogErrorHandler(),
 ) : EventStreamQueryGateway,
     AbstractQueryGateway<DomainEventStream>(
         namedAggregate,

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/event/QueryDsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/event/QueryDsl.kt
@@ -62,7 +62,7 @@ fun FilterExpression.count(queryGateway: EventStreamQueryGateway): Mono<Long> {
     return queryGateway.count(this)
 }
 
-@Deprecated("Use FilterExpression.count.")
+@Deprecated("Scheduled for removal in 9.1.0. Use FilterExpression.count.")
 fun Condition.count(queryGateway: EventStreamQueryGateway): Mono<Long> {
     return queryGateway.count(this.toFilterExpression())
 }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/EventMaskProjection.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/EventMaskProjection.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.mask
+
+import me.ahoo.wow.api.query.Projection
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.node.ObjectNode
+
+internal const val EVENT_BODY_TYPE_PATH = "body.bodyType"
+private const val EVENT_BODY_PATH = "body"
+
+internal fun Projection.requiresInternalEventBodyType(): Boolean {
+    val bodySelected = include.isEmpty() || include.any { it == EVENT_BODY_PATH || it.startsWith("$EVENT_BODY_PATH.") }
+    val bodyExcluded = EVENT_BODY_PATH in exclude
+    if (!bodySelected || bodyExcluded) return false
+
+    val bodyTypeSelected = include.isEmpty() || include.any {
+        it == EVENT_BODY_TYPE_PATH || EVENT_BODY_TYPE_PATH.startsWith("$it.")
+    }
+    return !bodyTypeSelected || EVENT_BODY_TYPE_PATH in exclude
+}
+
+internal fun Projection.withInternalEventBodyType(): Projection {
+    if (!requiresInternalEventBodyType()) return this
+    return if (include.isNotEmpty()) {
+        copy(include = include + EVENT_BODY_TYPE_PATH, exclude = exclude - EVENT_BODY_TYPE_PATH)
+    } else {
+        copy(exclude = exclude - EVENT_BODY_TYPE_PATH)
+    }
+}
+
+internal fun ObjectNode.removeInternalEventBodyType(): ObjectNode = apply {
+    get(EVENT_BODY_PATH)?.takeIf(JsonNode::isArray)?.forEach { event ->
+        (event as? ObjectNode)?.remove("bodyType")
+    }
+}

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/EventMaskProjection.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/EventMaskProjection.kt
@@ -14,37 +14,47 @@
 package me.ahoo.wow.query.mask
 
 import me.ahoo.wow.api.query.Projection
+import me.ahoo.wow.query.filter.QueryContext
 import tools.jackson.databind.JsonNode
 import tools.jackson.databind.node.ObjectNode
 
 internal const val EVENT_BODY_TYPE_PATH = "body.bodyType"
 private const val EVENT_BODY_PATH = "body"
 private const val EVENT_BODY_PAYLOAD_PATH = "body.body"
+private const val INTERNAL_EVENT_BODY_TYPE_PROJECTED = "wow.query.internal-event-body-type-projected"
 
-internal fun Projection.requiresInternalEventBodyType(): Boolean {
-    val bodySelected = include.isEmpty() || include.any {
-        EVENT_BODY_PATH.isSelectedBy(it) || it.startsWith("$EVENT_BODY_PATH.")
+internal var QueryContext<*, *>.internalEventBodyTypeProjected: Boolean
+    get() = getAttribute<Boolean>(INTERNAL_EVENT_BODY_TYPE_PROJECTED) == true
+    set(value) {
+        setAttribute(INTERNAL_EVENT_BODY_TYPE_PROJECTED, value)
     }
-    val bodyExcluded = exclude.any {
-        EVENT_BODY_PATH.matchesProjectionPattern(it) || EVENT_BODY_PAYLOAD_PATH.matchesProjectionPattern(it)
-    }
+
+internal fun Projection.requiresInternalEventBodyType(
+    bodyTypePath: String = EVENT_BODY_TYPE_PATH,
+): Boolean {
+    val bodySelected = include.isEmpty() || include.any(EVENT_BODY_PAYLOAD_PATH::intersectsSelection)
+    val bodyExcluded = exclude.any(EVENT_BODY_PAYLOAD_PATH::isSelectedBy)
     if (!bodySelected || bodyExcluded) return false
 
-    val bodyTypeSelected = include.isEmpty() || include.any(EVENT_BODY_TYPE_PATH::isSelectedBy)
-    return !bodyTypeSelected || exclude.any(EVENT_BODY_TYPE_PATH::isSelectedBy)
+    val bodyTypeSelected = include.isEmpty() || include.any(bodyTypePath::isSelectedBy)
+    return !bodyTypeSelected || exclude.any(bodyTypePath::isSelectedBy)
 }
 
-internal fun Projection.hasUnrestorableInternalEventBodyTypeExclusion(): Boolean =
-    requiresInternalEventBodyType() && exclude.any {
-        '*' in it && EVENT_BODY_TYPE_PATH.matchesProjectionPattern(it)
+internal fun Projection.hasUnrestorableInternalEventBodyTypeExclusion(
+    bodyTypePath: String = EVENT_BODY_TYPE_PATH,
+): Boolean =
+    requiresInternalEventBodyType(bodyTypePath) && exclude.any {
+        '*' in it && bodyTypePath.matchesProjectionPattern(it)
     }
 
-internal fun Projection.withInternalEventBodyType(): Projection {
-    if (!requiresInternalEventBodyType()) return this
+internal fun Projection.withInternalEventBodyType(
+    bodyTypePath: String = EVENT_BODY_TYPE_PATH,
+): Projection {
+    if (!requiresInternalEventBodyType(bodyTypePath)) return this
     return if (include.isNotEmpty()) {
-        copy(include = include + EVENT_BODY_TYPE_PATH, exclude = exclude - EVENT_BODY_TYPE_PATH)
+        copy(include = include + bodyTypePath, exclude = exclude - bodyTypePath)
     } else {
-        copy(exclude = exclude - EVENT_BODY_TYPE_PATH)
+        copy(exclude = exclude - bodyTypePath)
     }
 }
 
@@ -56,6 +66,9 @@ internal fun ObjectNode.removeInternalEventBodyType(): ObjectNode = apply {
 
 private fun String.isSelectedBy(pattern: String): Boolean =
     this == pattern || startsWith("$pattern.") || matchesProjectionPattern(pattern)
+
+private fun String.intersectsSelection(pattern: String): Boolean =
+    isSelectedBy(pattern) || pattern.startsWith("$this.")
 
 private fun String.matchesProjectionPattern(pattern: String): Boolean =
     pattern.split('*').joinToString(".*", "^", "$") { Regex.escape(it) }.toRegex().matches(this)

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/EventMaskProjection.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/EventMaskProjection.kt
@@ -19,17 +19,25 @@ import tools.jackson.databind.node.ObjectNode
 
 internal const val EVENT_BODY_TYPE_PATH = "body.bodyType"
 private const val EVENT_BODY_PATH = "body"
+private const val EVENT_BODY_PAYLOAD_PATH = "body.body"
 
 internal fun Projection.requiresInternalEventBodyType(): Boolean {
-    val bodySelected = include.isEmpty() || include.any { it == EVENT_BODY_PATH || it.startsWith("$EVENT_BODY_PATH.") }
-    val bodyExcluded = EVENT_BODY_PATH in exclude
+    val bodySelected = include.isEmpty() || include.any {
+        EVENT_BODY_PATH.isSelectedBy(it) || it.startsWith("$EVENT_BODY_PATH.")
+    }
+    val bodyExcluded = exclude.any {
+        EVENT_BODY_PATH.matchesProjectionPattern(it) || EVENT_BODY_PAYLOAD_PATH.matchesProjectionPattern(it)
+    }
     if (!bodySelected || bodyExcluded) return false
 
-    val bodyTypeSelected = include.isEmpty() || include.any {
-        it == EVENT_BODY_TYPE_PATH || EVENT_BODY_TYPE_PATH.startsWith("$it.")
-    }
-    return !bodyTypeSelected || EVENT_BODY_TYPE_PATH in exclude
+    val bodyTypeSelected = include.isEmpty() || include.any(EVENT_BODY_TYPE_PATH::isSelectedBy)
+    return !bodyTypeSelected || exclude.any(EVENT_BODY_TYPE_PATH::isSelectedBy)
 }
+
+internal fun Projection.hasUnrestorableInternalEventBodyTypeExclusion(): Boolean =
+    requiresInternalEventBodyType() && exclude.any {
+        '*' in it && EVENT_BODY_TYPE_PATH.matchesProjectionPattern(it)
+    }
 
 internal fun Projection.withInternalEventBodyType(): Projection {
     if (!requiresInternalEventBodyType()) return this
@@ -45,3 +53,9 @@ internal fun ObjectNode.removeInternalEventBodyType(): ObjectNode = apply {
         (event as? ObjectNode)?.remove("bodyType")
     }
 }
+
+private fun String.isSelectedBy(pattern: String): Boolean =
+    this == pattern || startsWith("$pattern.") || matchesProjectionPattern(pattern)
+
+private fun String.matchesProjectionPattern(pattern: String): Boolean =
+    pattern.split('*').joinToString(".*", "^", "$") { Regex.escape(it) }.toRegex().matches(this)

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/SchemaMaskQueryFilter.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/SchemaMaskQueryFilter.kt
@@ -15,9 +15,6 @@ package me.ahoo.wow.query.mask
 
 import me.ahoo.wow.api.query.CursorPage
 import me.ahoo.wow.api.query.PagedList
-import me.ahoo.wow.api.query.Projection
-import me.ahoo.wow.api.query.Queryable
-import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.filter.FilterChain
 import me.ahoo.wow.filter.SimpleFilterChain
 import me.ahoo.wow.query.QueryBackend
@@ -42,14 +39,13 @@ internal class SchemaMaskQueryFilter(
         context: QueryContext<*, *>,
         next: FilterChain<QueryContext<*, *>>,
     ): Mono<Void> {
-        val projection = (context.getQuery() as? Queryable<*>)?.projection ?: Projection.ALL
         return next.filter(context).then(
             Mono.fromRunnable {
                 when (context.queryType) {
-                    QueryType.SINGLE -> context.asSingleQuery().rewriteResult { it.maskResult(projection) }
-                    QueryType.LIST -> context.asListQuery().rewriteResult { it.maskResult(projection) }
-                    QueryType.PAGED -> context.asPagedQuery().rewriteResult { it.maskPagedResult(projection) }
-                    QueryType.CURSOR -> context.asCursorQuery().rewriteResult { it.maskCursorResult(projection) }
+                    QueryType.SINGLE -> context.asSingleQuery().rewriteResult { it.maskResult() }
+                    QueryType.LIST -> context.asListQuery().rewriteResult { it.maskResult() }
+                    QueryType.PAGED -> context.asPagedQuery().rewriteResult { it.maskPagedResult() }
+                    QueryType.CURSOR -> context.asCursorQuery().rewriteResult { it.maskCursorResult() }
                     QueryType.COUNT,
                     QueryType.AGGREGATION,
                     -> Unit
@@ -63,47 +59,37 @@ internal class SchemaMaskQueryFilter(
             .ofNullable(SchemaMasker.create(schema))
             .also { cached.set(schema to it) }
 
-    private fun Mono<ObjectNode>.maskResult(projection: Projection): Mono<ObjectNode> =
+    private fun Mono<ObjectNode>.maskResult(): Mono<ObjectNode> =
         Mono.defer(provider::schema).flatMap { schema ->
             val source = withQueryModelSchema(schema)
             masker(schema).map { schemaMasker ->
-                val removeBodyType = schema.requiresInternalEventBodyType(projection)
-                source.map { schemaMasker.mask(it, removeBodyType) }
+                source.map(schemaMasker::mask)
             }.orElse(source)
         }
 
-    private fun Flux<ObjectNode>.maskResult(projection: Projection): Flux<ObjectNode> =
+    private fun Flux<ObjectNode>.maskResult(): Flux<ObjectNode> =
         Mono.defer(provider::schema).flatMapMany { schema ->
             val source = withQueryModelSchema(schema)
             masker(schema).map { schemaMasker ->
-                val removeBodyType = schema.requiresInternalEventBodyType(projection)
-                source.map { schemaMasker.mask(it, removeBodyType) }
+                source.map(schemaMasker::mask)
             }.orElse(source)
         }
 
-    private fun Mono<PagedList<ObjectNode>>.maskPagedResult(projection: Projection): Mono<PagedList<ObjectNode>> =
+    private fun Mono<PagedList<ObjectNode>>.maskPagedResult(): Mono<PagedList<ObjectNode>> =
         Mono.defer(provider::schema).flatMap { schema ->
             val source = withQueryModelSchema(schema)
             masker(schema).map { schemaMasker ->
-                val removeBodyType = schema.requiresInternalEventBodyType(projection)
-                source.map { page -> PagedList(page.total, page.list.map { schemaMasker.mask(it, removeBodyType) }) }
+                source.map { page -> PagedList(page.total, page.list.map(schemaMasker::mask)) }
             }.orElse(source)
         }
 
-    private fun Mono<CursorPage<ObjectNode>>.maskCursorResult(projection: Projection): Mono<CursorPage<ObjectNode>> =
+    private fun Mono<CursorPage<ObjectNode>>.maskCursorResult(): Mono<CursorPage<ObjectNode>> =
         Mono.defer(provider::schema).flatMap { schema ->
             val source = withQueryModelSchema(schema)
             masker(schema).map { schemaMasker ->
-                val removeBodyType = schema.requiresInternalEventBodyType(projection)
-                source.map { page -> page.copy(list = page.list.map { schemaMasker.mask(it, removeBodyType) }) }
+                source.map { page -> page.copy(list = page.list.map(schemaMasker::mask)) }
             }.orElse(source)
         }
-
-    private fun SchemaMasker.mask(node: ObjectNode, removeBodyType: Boolean): ObjectNode =
-        mask(node).let { if (removeBodyType) it.removeInternalEventBodyType() else it }
-
-    private fun QueryModelSchema.requiresInternalEventBodyType(projection: Projection): Boolean =
-        model == QueryModel.EVENT_STREAM && projection.requiresInternalEventBodyType()
 }
 
 internal fun FilterChain<QueryContext<*, *>>.withSchemaMaskFilter(

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/SchemaMaskQueryFilter.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/SchemaMaskQueryFilter.kt
@@ -15,6 +15,9 @@ package me.ahoo.wow.query.mask
 
 import me.ahoo.wow.api.query.CursorPage
 import me.ahoo.wow.api.query.PagedList
+import me.ahoo.wow.api.query.Projection
+import me.ahoo.wow.api.query.Queryable
+import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.filter.FilterChain
 import me.ahoo.wow.filter.SimpleFilterChain
 import me.ahoo.wow.query.QueryBackend
@@ -38,50 +41,69 @@ internal class SchemaMaskQueryFilter(
     override fun filter(
         context: QueryContext<*, *>,
         next: FilterChain<QueryContext<*, *>>,
-    ): Mono<Void> = next.filter(context).then(
-        Mono.fromRunnable {
-            when (context.queryType) {
-                QueryType.SINGLE -> context.asSingleQuery().rewriteResult { it.maskResult() }
-                QueryType.LIST -> context.asListQuery().rewriteResult { it.maskResult() }
-                QueryType.PAGED -> context.asPagedQuery().rewriteResult { it.maskPagedResult() }
-                QueryType.CURSOR -> context.asCursorQuery().rewriteResult { it.maskCursorResult() }
-                QueryType.COUNT,
-                QueryType.AGGREGATION,
-                -> Unit
-            }
-        },
-    )
+    ): Mono<Void> {
+        val projection = (context.getQuery() as? Queryable<*>)?.projection ?: Projection.ALL
+        return next.filter(context).then(
+            Mono.fromRunnable {
+                when (context.queryType) {
+                    QueryType.SINGLE -> context.asSingleQuery().rewriteResult { it.maskResult(projection) }
+                    QueryType.LIST -> context.asListQuery().rewriteResult { it.maskResult(projection) }
+                    QueryType.PAGED -> context.asPagedQuery().rewriteResult { it.maskPagedResult(projection) }
+                    QueryType.CURSOR -> context.asCursorQuery().rewriteResult { it.maskCursorResult(projection) }
+                    QueryType.COUNT,
+                    QueryType.AGGREGATION,
+                    -> Unit
+                }
+            },
+        )
+    }
 
     private fun masker(schema: QueryModelSchema): Optional<SchemaMasker> =
         cached.get()?.takeIf { it.first === schema }?.second ?: Optional
             .ofNullable(SchemaMasker.create(schema))
             .also { cached.set(schema to it) }
 
-    private fun Mono<ObjectNode>.maskResult(): Mono<ObjectNode> = Mono.defer(provider::schema).flatMap { schema ->
-        val source = withQueryModelSchema(schema)
-        masker(schema).map { schemaMasker -> source.map(schemaMasker::mask) }.orElse(source)
-    }
-
-    private fun Flux<ObjectNode>.maskResult(): Flux<ObjectNode> = Mono.defer(provider::schema).flatMapMany { schema ->
-        val source = withQueryModelSchema(schema)
-        masker(schema).map { schemaMasker -> source.map(schemaMasker::mask) }.orElse(source)
-    }
-
-    private fun Mono<PagedList<ObjectNode>>.maskPagedResult(): Mono<PagedList<ObjectNode>> =
+    private fun Mono<ObjectNode>.maskResult(projection: Projection): Mono<ObjectNode> =
         Mono.defer(provider::schema).flatMap { schema ->
             val source = withQueryModelSchema(schema)
             masker(schema).map { schemaMasker ->
-                source.map { page -> PagedList(page.total, page.list.map(schemaMasker::mask)) }
+                val removeBodyType = schema.requiresInternalEventBodyType(projection)
+                source.map { schemaMasker.mask(it, removeBodyType) }
             }.orElse(source)
         }
 
-    private fun Mono<CursorPage<ObjectNode>>.maskCursorResult(): Mono<CursorPage<ObjectNode>> =
+    private fun Flux<ObjectNode>.maskResult(projection: Projection): Flux<ObjectNode> =
+        Mono.defer(provider::schema).flatMapMany { schema ->
+            val source = withQueryModelSchema(schema)
+            masker(schema).map { schemaMasker ->
+                val removeBodyType = schema.requiresInternalEventBodyType(projection)
+                source.map { schemaMasker.mask(it, removeBodyType) }
+            }.orElse(source)
+        }
+
+    private fun Mono<PagedList<ObjectNode>>.maskPagedResult(projection: Projection): Mono<PagedList<ObjectNode>> =
         Mono.defer(provider::schema).flatMap { schema ->
             val source = withQueryModelSchema(schema)
             masker(schema).map { schemaMasker ->
-                source.map { page -> page.copy(list = page.list.map(schemaMasker::mask)) }
+                val removeBodyType = schema.requiresInternalEventBodyType(projection)
+                source.map { page -> PagedList(page.total, page.list.map { schemaMasker.mask(it, removeBodyType) }) }
             }.orElse(source)
         }
+
+    private fun Mono<CursorPage<ObjectNode>>.maskCursorResult(projection: Projection): Mono<CursorPage<ObjectNode>> =
+        Mono.defer(provider::schema).flatMap { schema ->
+            val source = withQueryModelSchema(schema)
+            masker(schema).map { schemaMasker ->
+                val removeBodyType = schema.requiresInternalEventBodyType(projection)
+                source.map { page -> page.copy(list = page.list.map { schemaMasker.mask(it, removeBodyType) }) }
+            }.orElse(source)
+        }
+
+    private fun SchemaMasker.mask(node: ObjectNode, removeBodyType: Boolean): ObjectNode =
+        mask(node).let { if (removeBodyType) it.removeInternalEventBodyType() else it }
+
+    private fun QueryModelSchema.requiresInternalEventBodyType(projection: Projection): Boolean =
+        model == QueryModel.EVENT_STREAM && projection.requiresInternalEventBodyType()
 }
 
 internal fun FilterChain<QueryContext<*, *>>.withSchemaMaskFilter(

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/SchemaMaskQueryFilter.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/SchemaMaskQueryFilter.kt
@@ -15,6 +15,8 @@ package me.ahoo.wow.query.mask
 
 import me.ahoo.wow.api.query.CursorPage
 import me.ahoo.wow.api.query.PagedList
+import me.ahoo.wow.api.query.Projection
+import me.ahoo.wow.api.query.Queryable
 import me.ahoo.wow.filter.FilterChain
 import me.ahoo.wow.filter.SimpleFilterChain
 import me.ahoo.wow.query.QueryBackend
@@ -23,6 +25,7 @@ import me.ahoo.wow.query.filter.QueryFilter
 import me.ahoo.wow.query.filter.QueryType
 import me.ahoo.wow.query.schema.QueryModelSchema
 import me.ahoo.wow.query.schema.QueryModelSchemaProvider
+import me.ahoo.wow.query.schema.QuerySchemaResolver
 import me.ahoo.wow.query.schema.withQueryModelSchema
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -38,54 +41,56 @@ internal class SchemaMaskQueryFilter(
     override fun filter(
         context: QueryContext<*, *>,
         next: FilterChain<QueryContext<*, *>>,
-    ): Mono<Void> {
-        return next.filter(context).then(
-            Mono.fromRunnable {
+    ): Mono<Void> = next.filter(context).then(
+        Mono.defer {
+            when (context.queryType) {
+                QueryType.COUNT,
+                QueryType.AGGREGATION,
+                -> return@defer Mono.empty()
+                else -> Unit
+            }
+            Mono.defer(provider::schema).doOnNext { schema ->
+                context.internalEventBodyTypeProjected = QuerySchemaResolver(schema)
+                    .requiresInternalEventBodyType(
+                        (context.getQuery() as? Queryable<*>)?.projection ?: Projection.ALL,
+                    )
                 when (context.queryType) {
-                    QueryType.SINGLE -> context.asSingleQuery().rewriteResult { it.maskResult() }
-                    QueryType.LIST -> context.asListQuery().rewriteResult { it.maskResult() }
-                    QueryType.PAGED -> context.asPagedQuery().rewriteResult { it.maskPagedResult() }
-                    QueryType.CURSOR -> context.asCursorQuery().rewriteResult { it.maskCursorResult() }
+                    QueryType.SINGLE -> context.asSingleQuery().rewriteResult { it.maskResult(schema) }
+                    QueryType.LIST -> context.asListQuery().rewriteResult { it.maskResult(schema) }
+                    QueryType.PAGED -> context.asPagedQuery().rewriteResult { it.maskPagedResult(schema) }
+                    QueryType.CURSOR -> context.asCursorQuery().rewriteResult { it.maskCursorResult(schema) }
                     QueryType.COUNT,
                     QueryType.AGGREGATION,
                     -> Unit
                 }
-            },
-        )
-    }
+            }.then()
+        },
+    )
 
     private fun masker(schema: QueryModelSchema): Optional<SchemaMasker> =
         cached.get()?.takeIf { it.first === schema }?.second ?: Optional
             .ofNullable(SchemaMasker.create(schema))
             .also { cached.set(schema to it) }
 
-    private fun Mono<ObjectNode>.maskResult(): Mono<ObjectNode> =
-        Mono.defer(provider::schema).flatMap { schema ->
-            val source = withQueryModelSchema(schema)
-            masker(schema).map { schemaMasker ->
-                source.map(schemaMasker::mask)
-            }.orElse(source)
+    private fun Mono<ObjectNode>.maskResult(schema: QueryModelSchema): Mono<ObjectNode> =
+        withQueryModelSchema(schema).let { source ->
+            masker(schema).map { source.map(it::mask) }.orElse(source)
         }
 
-    private fun Flux<ObjectNode>.maskResult(): Flux<ObjectNode> =
-        Mono.defer(provider::schema).flatMapMany { schema ->
-            val source = withQueryModelSchema(schema)
-            masker(schema).map { schemaMasker ->
-                source.map(schemaMasker::mask)
-            }.orElse(source)
+    private fun Flux<ObjectNode>.maskResult(schema: QueryModelSchema): Flux<ObjectNode> =
+        withQueryModelSchema(schema).let { source ->
+            masker(schema).map { source.map(it::mask) }.orElse(source)
         }
 
-    private fun Mono<PagedList<ObjectNode>>.maskPagedResult(): Mono<PagedList<ObjectNode>> =
-        Mono.defer(provider::schema).flatMap { schema ->
-            val source = withQueryModelSchema(schema)
+    private fun Mono<PagedList<ObjectNode>>.maskPagedResult(schema: QueryModelSchema): Mono<PagedList<ObjectNode>> =
+        withQueryModelSchema(schema).let { source ->
             masker(schema).map { schemaMasker ->
                 source.map { page -> PagedList(page.total, page.list.map(schemaMasker::mask)) }
             }.orElse(source)
         }
 
-    private fun Mono<CursorPage<ObjectNode>>.maskCursorResult(): Mono<CursorPage<ObjectNode>> =
-        Mono.defer(provider::schema).flatMap { schema ->
-            val source = withQueryModelSchema(schema)
+    private fun Mono<CursorPage<ObjectNode>>.maskCursorResult(schema: QueryModelSchema): Mono<CursorPage<ObjectNode>> =
+        withQueryModelSchema(schema).let { source ->
             masker(schema).map { schemaMasker ->
                 source.map { page -> page.copy(list = page.list.map(schemaMasker::mask)) }
             }.orElse(source)

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolver.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolver.kt
@@ -23,6 +23,7 @@ import me.ahoo.wow.api.query.schema.QueryCardinality
 import me.ahoo.wow.api.query.schema.QueryCompatibilityLevel
 import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.query.FORBIDDEN_CURSOR_SORTS
+import me.ahoo.wow.query.mask.hasUnrestorableInternalEventBodyTypeExclusion
 import me.ahoo.wow.query.mask.withInternalEventBodyType
 
 enum class QuerySchemaValidationMode {
@@ -106,7 +107,8 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
         filterResolver.resolve(filter)
 
     fun resolve(projection: Projection): QuerySchemaResolution<Projection> {
-        val effectiveProjection = if (schema.model == QueryModel.EVENT_STREAM && schema.hasMaskedFields) {
+        val maskedEventProjection = schema.model == QueryModel.EVENT_STREAM && schema.hasMaskedFields
+        val effectiveProjection = if (maskedEventProjection) {
             projection.withInternalEventBodyType()
         } else {
             projection
@@ -122,7 +124,12 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
                 include.map { it.value },
                 exclude.map { it.value },
             ),
-            (include + exclude).map { it.compatibility }.combined(),
+            buildList {
+                addAll((include + exclude).map { it.compatibility })
+                if (maskedEventProjection && projection.hasUnrestorableInternalEventBodyTypeExclusion()) {
+                    add(QueryCompatibilityLevel.INCOMPATIBLE)
+                }
+            }.combined(),
         )
     }
 

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolver.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolver.kt
@@ -23,7 +23,9 @@ import me.ahoo.wow.api.query.schema.QueryCardinality
 import me.ahoo.wow.api.query.schema.QueryCompatibilityLevel
 import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.query.FORBIDDEN_CURSOR_SORTS
+import me.ahoo.wow.query.mask.EVENT_BODY_TYPE_PATH
 import me.ahoo.wow.query.mask.hasUnrestorableInternalEventBodyTypeExclusion
+import me.ahoo.wow.query.mask.requiresInternalEventBodyType
 import me.ahoo.wow.query.mask.withInternalEventBodyType
 
 enum class QuerySchemaValidationMode {
@@ -108,29 +110,51 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
 
     fun resolve(projection: Projection): QuerySchemaResolution<Projection> {
         val maskedEventProjection = schema.model == QueryModel.EVENT_STREAM && schema.hasMaskedFields
-        val effectiveProjection = if (maskedEventProjection) {
-            projection.withInternalEventBodyType()
+        val include = projection.include.map {
+            fieldResolver.resolveProjectionPath(it)
+        }
+        val exclude = projection.exclude.map {
+            fieldResolver.resolveProjectionPath(it)
+        }
+        val resolvedProjection = Projection(
+            include.map { it.value },
+            exclude.map { it.value },
+        )
+        val compatibility = (include + exclude).map { it.compatibility }
+        if (!maskedEventProjection) {
+            return QuerySchemaResolution(resolvedProjection, compatibility.combined())
+        }
+        val bodyType = fieldResolver.resolveProjectionPath(EVENT_BODY_TYPE_PATH)
+        val internalBodyType = resolvedProjection.requiresInternalEventBodyType(
+            bodyType.value,
+        )
+        val effectiveProjection = if (internalBodyType) {
+            resolvedProjection.withInternalEventBodyType(bodyType.value)
         } else {
-            projection
-        }
-        val include = effectiveProjection.include.map {
-            fieldResolver.resolveProjectionPath(it)
-        }
-        val exclude = effectiveProjection.exclude.map {
-            fieldResolver.resolveProjectionPath(it)
+            resolvedProjection
         }
         return QuerySchemaResolution(
-            Projection(
-                include.map { it.value },
-                exclude.map { it.value },
-            ),
+            effectiveProjection,
             buildList {
-                addAll((include + exclude).map { it.compatibility })
-                if (maskedEventProjection && projection.hasUnrestorableInternalEventBodyTypeExclusion()) {
+                addAll(compatibility)
+                if (internalBodyType) {
+                    add(bodyType.compatibility)
+                }
+                if (resolvedProjection.hasUnrestorableInternalEventBodyTypeExclusion(bodyType.value)) {
                     add(QueryCompatibilityLevel.INCOMPATIBLE)
                 }
             }.combined(),
         )
+    }
+
+    internal fun requiresInternalEventBodyType(projection: Projection): Boolean {
+        if (schema.model != QueryModel.EVENT_STREAM || !schema.hasMaskedFields) return false
+        val resolvedProjection = Projection(
+            include = projection.include.map { fieldResolver.resolveProjectionPath(it).value },
+            exclude = projection.exclude.map { fieldResolver.resolveProjectionPath(it).value },
+        )
+        val bodyTypePath = fieldResolver.resolveProjectionPath(EVENT_BODY_TYPE_PATH).value
+        return resolvedProjection.requiresInternalEventBodyType(bodyTypePath)
     }
 
     fun resolve(sort: List<Sort>): QuerySchemaResolution<List<Sort>> {

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolver.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolver.kt
@@ -21,7 +21,9 @@ import me.ahoo.wow.api.query.*
 import me.ahoo.wow.api.query.schema.QueryCapability
 import me.ahoo.wow.api.query.schema.QueryCardinality
 import me.ahoo.wow.api.query.schema.QueryCompatibilityLevel
+import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.query.FORBIDDEN_CURSOR_SORTS
+import me.ahoo.wow.query.mask.withInternalEventBodyType
 
 enum class QuerySchemaValidationMode {
     COMPATIBLE,
@@ -104,10 +106,15 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
         filterResolver.resolve(filter)
 
     fun resolve(projection: Projection): QuerySchemaResolution<Projection> {
-        val include = projection.include.map {
+        val effectiveProjection = if (schema.model == QueryModel.EVENT_STREAM && schema.hasMaskedFields) {
+            projection.withInternalEventBodyType()
+        } else {
+            projection
+        }
+        val include = effectiveProjection.include.map {
             fieldResolver.resolveProjectionPath(it)
         }
-        val exclude = projection.exclude.map {
+        val exclude = effectiveProjection.exclude.map {
             fieldResolver.resolveProjectionPath(it)
         }
         return QuerySchemaResolution(
@@ -143,9 +150,14 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
             item.copy(field = field?.value ?: item.field) to
                 if (accepted) QueryCompatibilityLevel.EXACT else QueryCompatibilityLevel.INCOMPATIBLE
         }
+        val values = resolved.map { it.first }
         return QuerySchemaResolution(
-            resolved.map { it.first },
-            resolved.map { it.second }.combined(),
+            values,
+            if (values.map(Sort::field).distinct().size == values.size) {
+                resolved.map { it.second }.combined()
+            } else {
+                QueryCompatibilityLevel.INCOMPATIBLE
+            },
         )
     }
 

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/QueryDsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/QueryDsl.kt
@@ -79,7 +79,7 @@ fun AggregationQuery.query(queryGateway: SnapshotQueryGateway<*>): Flux<ObjectNo
     return queryGateway.aggregate(this)
 }
 
-@Deprecated("Use FilterExpression.count.")
+@Deprecated("Scheduled for removal in 9.1.0. Use FilterExpression.count.")
 fun Condition.count(queryGateway: SnapshotQueryGateway<*>): Mono<Long> {
     return queryGateway.count(this.toFilterExpression())
 }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/SnapshotQueryGateway.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/snapshot/SnapshotQueryGateway.kt
@@ -16,9 +16,9 @@ package me.ahoo.wow.query.snapshot
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.api.query.MaterializedSnapshot
 import me.ahoo.wow.filter.ErrorHandler
-import me.ahoo.wow.filter.LogErrorHandler
 import me.ahoo.wow.query.AbstractQueryGateway
 import me.ahoo.wow.query.QueryGateway
+import me.ahoo.wow.query.QueryLogErrorHandler
 import me.ahoo.wow.query.filter.QueryContext
 import me.ahoo.wow.query.filter.QueryFilter
 import tools.jackson.databind.JavaType
@@ -30,7 +30,7 @@ class DefaultSnapshotQueryGateway<S : Any>(
     backend: SnapshotQueryBackend,
     targetType: JavaType,
     filters: List<QueryFilter<QueryContext<*, *>>> = emptyList(),
-    errorHandler: ErrorHandler<QueryContext<*, *>> = LogErrorHandler(),
+    errorHandler: ErrorHandler<QueryContext<*, *>> = QueryLogErrorHandler(),
 ) : SnapshotQueryGateway<S>,
     AbstractQueryGateway<MaterializedSnapshot<S>>(
         namedAggregate,

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/FilterDslTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/FilterDslTest.kt
@@ -25,6 +25,13 @@ import java.util.concurrent.TimeUnit
 
 class FilterDslTest {
     @Test
+    fun `should reject a filter block without expressions`() {
+        org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
+            filter { }
+        }
+    }
+
+    @Test
     fun `should build phrase search`() {
         val expression = filter {
             search("event sourcing", SearchMode.PHRASE, "title", "description")
@@ -180,22 +187,6 @@ class FilterDslTest {
     }
 
     @Test
-    @Suppress("DEPRECATION")
-    fun `should reject injected expression inside nested path scope`() {
-        val prebuilt = filter { "productId" eq "product-1" }
-
-        org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
-            filter {
-                "state".path {
-                    "items".nested {
-                        expression(prebuilt)
-                    }
-                }
-            }
-        }
-    }
-
-    @Test
     fun `should reject invalid path scope`() {
         org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
             filter {
@@ -240,84 +231,12 @@ class FilterDslTest {
     }
 
     @Test
-    @Suppress("DEPRECATION")
-    fun `should preserve deprecated nested source compatibility`() {
-        val expression = filter {
-            "state".nested {
-                "name" eq "Wow"
-            }
-        }
-
-        (expression as EqualFilter).field.assert().isEqualTo(LogicalField("state.name"))
-    }
-
-    @Test
-    @Suppress("DEPRECATION")
-    fun `should reject empty nested block`() {
-        org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
-            filter {
-                "state".nested { }
-            }
-        }
-    }
-
-    @Test
     fun `should reject empty element match block`() {
         org.junit.jupiter.api.assertThrows<IllegalArgumentException> {
             filter {
                 "items".elementMatch { }
             }
         }
-    }
-
-    @Test
-    @Suppress("DEPRECATION")
-    fun `should preserve deprecated nested logical semantics`() {
-        val expression = filter {
-            or {
-                "state".nested {
-                    "status" eq "CREATED"
-                    "ownerId" eq "owner-1"
-                }
-                "tenantId" eq "tenant-1"
-            }
-        } as OrFilter
-
-        expression.operands.assert().hasSize(3)
-    }
-
-    @Test
-    @Suppress("DEPRECATION")
-    fun `should preserve prebuilt expressions in deprecated nested logical blocks`() {
-        val prebuilt = filter { "name" eq "Wow" }
-
-        val expression = filter {
-            "state".nested {
-                or {
-                    expression(prebuilt)
-                    "status" eq "CREATED"
-                }
-            }
-        } as OrFilter
-
-        expression.operands[0].assert().isSameAs(prebuilt)
-        (expression.operands[1] as EqualFilter).field.assert().isEqualTo(LogicalField("state.status"))
-    }
-
-    @Test
-    @Suppress("DEPRECATION")
-    fun `should preserve prebuilt expressions in nested chains from root`() {
-        val prebuilt = filter { "name" eq "Wow" }
-
-        val expression = filter {
-            "state".nested {
-                "child".nested {
-                    expression(prebuilt)
-                }
-            }
-        }
-
-        expression.assert().isSameAs(prebuilt)
     }
 
     @Test
@@ -346,10 +265,10 @@ class FilterDslTest {
             "greaterThanOrEqual" gte 1
             "lessThan" lt 1
             "lessThanOrEqual" lte 1
-            "contains".contains("value", StringComparison.CASE_INSENSITIVE)
-            "containsDefault".contains("value")
-            "startsWith".startsWith("value")
-            "endsWith".endsWith("value")
+            "contains".containsText("value", StringComparison.CASE_INSENSITIVE)
+            "containsDefault".containsText("value")
+            "startsWith".startsWithText("value")
+            "endsWith".endsWithText("value")
             "in" isIn listOf(1, 2)
             "notIn" notIn listOf(1, 2)
             "between".between(1, 2)

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/event/DefaultEventStreamQueryGatewayTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/event/DefaultEventStreamQueryGatewayTest.kt
@@ -26,6 +26,7 @@ import me.ahoo.wow.api.query.ISingleQuery
 import me.ahoo.wow.api.query.LogicalField
 import me.ahoo.wow.api.query.MatchAllFilter
 import me.ahoo.wow.api.query.PagedList
+import me.ahoo.wow.api.query.Projection
 import me.ahoo.wow.api.query.Sort
 import me.ahoo.wow.api.query.mask.FullMaskStrategy
 import me.ahoo.wow.api.query.mask.Mask
@@ -142,6 +143,63 @@ class DefaultEventStreamQueryGatewayTest {
 
         event.path("body").path("data").stringValue().assert().isEqualTo("******")
         event.has("bodyType").assert().isFalse()
+    }
+
+    @Test
+    fun `typed event gateway should retain internally projected body type until materialization`() {
+        val eventStream = generateEventStream(
+            MOCK_AGGREGATE_METADATA.aggregateId(generateGlobalId()),
+            eventCount = 1,
+            createdEventSupplier = { MockAggregateCreated("secret") },
+        )
+        val raw = eventStream.toJsonNode<ObjectNode>()
+        val bodyType = raw.path("body").path(0).path("bodyType").stringValue()
+        val gateway = DefaultEventStreamQueryGateway(
+            MOCK_AGGREGATE_METADATA,
+            SchemaEventBackend(eventStream::toJsonNode, eventSchema(bodyType)),
+            errorHandler = ErrorHandler { _, error -> Mono.error(error) },
+        )
+
+        val result = gateway.single(
+            singleQuery {
+                projection { exclude("body.bodyType") }
+            },
+        ).block()!!
+
+        (result.body.single().body as MockAggregateCreated).data.assert().isEqualTo("******")
+    }
+
+    @Test
+    fun `dynamic event gateway should clean body type from rewritten projection`() {
+        val eventStream = generateEventStream(
+            MOCK_AGGREGATE_METADATA.aggregateId(generateGlobalId()),
+            eventCount = 1,
+            createdEventSupplier = { MockAggregateCreated("secret") },
+        )
+        val raw = eventStream.toJsonNode<ObjectNode>()
+        val bodyType = raw.path("body").path(0).path("bodyType").stringValue()
+        val rewriteProjection = object : EventStreamQueryFilter {
+            override fun filter(context: QueryContext<*, *>, next: FilterChain<QueryContext<*, *>>): Mono<Void> {
+                context.asSingleQuery().rewriteQuery {
+                    it.withProjection(Projection(exclude = listOf("body.bodyType")))
+                }
+                return next.filter(context)
+            }
+        }
+        val gateway = DefaultEventStreamQueryGateway(
+            MOCK_AGGREGATE_METADATA,
+            SchemaEventBackend(eventStream::toJsonNode, eventSchema(bodyType)),
+            filters = listOf(rewriteProjection),
+            errorHandler = ErrorHandler { _, error -> Mono.error(error) },
+        )
+
+        val result = gateway.dynamicSingle(
+            singleQuery {
+                projection { include("body.bodyType") }
+            },
+        ).block()!!
+
+        result.path("body").path(0).has("bodyType").assert().isFalse()
     }
 
     @Test

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/event/DefaultEventStreamQueryGatewayTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/event/DefaultEventStreamQueryGatewayTest.kt
@@ -203,6 +203,37 @@ class DefaultEventStreamQueryGatewayTest {
     }
 
     @Test
+    fun `dynamic event gateway should clean body type excluded through an alias`() {
+        val eventStream = generateEventStream(
+            MOCK_AGGREGATE_METADATA.aggregateId(generateGlobalId()),
+            eventCount = 1,
+            createdEventSupplier = { MockAggregateCreated("secret") },
+        )
+        val raw = eventStream.toJsonNode<ObjectNode>()
+        val bodyType = raw.path("body").path(0).path("bodyType").stringValue()
+        val schema = eventSchema(bodyType).let {
+            it.copy(
+                fields = it.fields + mapOf(
+                    LogicalField("eventTypeAlias") to fieldSchema(projectionPath = "body.bodyType"),
+                ),
+            )
+        }
+        val gateway = DefaultEventStreamQueryGateway(
+            MOCK_AGGREGATE_METADATA,
+            SchemaEventBackend(eventStream::toJsonNode, schema),
+            errorHandler = ErrorHandler { _, error -> Mono.error(error) },
+        )
+
+        val result = gateway.dynamicSingle(
+            singleQuery {
+                projection { exclude("eventTypeAlias") }
+            },
+        ).block()!!
+
+        result.path("body").path(0).has("bodyType").assert().isFalse()
+    }
+
+    @Test
     fun `event gateway should refresh masker when body type schema changes`() {
         val eventStream = generateEventStream(
             MOCK_AGGREGATE_METADATA.aggregateId(generateGlobalId()),
@@ -305,6 +336,7 @@ class DefaultEventStreamQueryGatewayTest {
         fun fieldSchema(
             enumValues: List<tools.jackson.databind.JsonNode>? = null,
             maskRule: MaskRule? = null,
+            projectionPath: String? = null,
         ) = QueryFieldSchema(
             title = null,
             description = null,
@@ -316,6 +348,7 @@ class DefaultEventStreamQueryGatewayTest {
             semanticType = null,
             dynamicChildren = false,
             bindings = emptyMap(),
+            projectionPath = projectionPath,
             maskRule = maskRule,
         )
     }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/event/DefaultEventStreamQueryGatewayTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/event/DefaultEventStreamQueryGatewayTest.kt
@@ -119,6 +119,32 @@ class DefaultEventStreamQueryGatewayTest {
     }
 
     @Test
+    fun `event gateway should remove internally projected body type`() {
+        val eventStream = generateEventStream(
+            MOCK_AGGREGATE_METADATA.aggregateId(generateGlobalId()),
+            eventCount = 1,
+            createdEventSupplier = { MockAggregateCreated("secret") },
+        )
+        val raw = eventStream.toJsonNode<ObjectNode>()
+        val bodyType = raw.path("body").path(0).path("bodyType").stringValue()
+        val gateway = DefaultEventStreamQueryGateway(
+            MOCK_AGGREGATE_METADATA,
+            SchemaEventBackend(eventStream::toJsonNode, eventSchema(bodyType)),
+            errorHandler = ErrorHandler { _, error -> Mono.error(error) },
+        )
+
+        val result = gateway.dynamicSingle(
+            singleQuery {
+                projection { include("body.body.data") }
+            },
+        ).block()!!
+        val event = result.path("body").path(0)
+
+        event.path("body").path("data").stringValue().assert().isEqualTo("******")
+        event.has("bodyType").assert().isFalse()
+    }
+
+    @Test
     fun `event gateway should refresh masker when body type schema changes`() {
         val eventStream = generateEventStream(
             MOCK_AGGREGATE_METADATA.aggregateId(generateGlobalId()),

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/mask/EventMaskProjectionTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/mask/EventMaskProjectionTest.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.mask
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.Projection
+import org.junit.jupiter.api.Test
+
+class EventMaskProjectionTest {
+    @Test
+    fun `wildcard include should preserve explicitly selected body type`() {
+        Projection(include = listOf("body.*")).requiresInternalEventBodyType().assert().isFalse()
+        Projection(include = listOf("body.bodyT*")).requiresInternalEventBodyType().assert().isFalse()
+    }
+}

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolverTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolverTest.kt
@@ -1637,7 +1637,7 @@ class QuerySchemaResolverTest {
                         maskRule = fullMaskRule(),
                     ),
                     LogicalField("body.bodyType") to fieldSchema(
-                        QueryCapability.PRESENCE to "document.events.type",
+                        QueryCapability.PRESENCE to "body.bodyType",
                     ),
                 ),
             ),
@@ -1645,6 +1645,31 @@ class QuerySchemaResolverTest {
 
         resolver.resolve(Projection(exclude = listOf("body.bodyT*"))).compatibility.assert()
             .isEqualTo(QueryCompatibilityLevel.INCOMPATIBLE)
+    }
+
+    @Test
+    fun `masked event projection should restore body type excluded through an alias`() {
+        val resolver = QuerySchemaResolver(
+            QueryModelSchema(
+                QueryModel.EVENT_STREAM,
+                emptySet(),
+                mapOf(
+                    LogicalField("body.body.secret") to fieldSchema(
+                        QueryCapability.PRESENCE to "body.body.secret",
+                        maskRule = fullMaskRule(),
+                    ),
+                    LogicalField("body.bodyType") to fieldSchema(
+                        QueryCapability.PRESENCE to "body.bodyType",
+                    ),
+                    LogicalField("eventTypeAlias") to fieldSchema(
+                        QueryCapability.PRESENCE to "body.bodyType",
+                    ),
+                ),
+            ),
+        )
+
+        resolver.resolve(Projection(exclude = listOf("eventTypeAlias"))).value.assert()
+            .isEqualTo(Projection.ALL)
     }
 
     private fun schema(

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolverTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolverTest.kt
@@ -1579,6 +1579,52 @@ class QuerySchemaResolverTest {
         }
     }
 
+    @Test
+    fun `cursor sort should reject distinct logical fields resolved to the same physical field`() {
+        val resolver = QuerySchemaResolver(
+            schema(
+                mapOf(
+                    LogicalField("state.idAlias") to fieldSchema(QueryCapability.SORT to "_id"),
+                    LogicalField("aggregateId") to fieldSchema(QueryCapability.SORT to "_id"),
+                ),
+            ),
+        )
+        val query = CursorQuery(
+            MatchAllFilter,
+            sort = listOf(
+                Sort("state.idAlias", Sort.Direction.DESC),
+                Sort("aggregateId", Sort.Direction.ASC),
+            ),
+        )
+
+        resolver.resolve(query).compatibility.assert().isEqualTo(QueryCompatibilityLevel.INCOMPATIBLE)
+    }
+
+    @Test
+    fun `masked event projection should include body type for internal validation`() {
+        val resolver = QuerySchemaResolver(
+            QueryModelSchema(
+                QueryModel.EVENT_STREAM,
+                emptySet(),
+                mapOf(
+                    LogicalField("body.body.secret") to fieldSchema(
+                        QueryCapability.PRESENCE to "body.body.secret",
+                        maskRule = fullMaskRule(),
+                    ),
+                    LogicalField("body.bodyType") to fieldSchema(
+                        QueryCapability.PRESENCE to "document.events.type",
+                    ),
+                ),
+            ),
+        )
+
+        val resolved = resolver.resolve(
+            Projection(include = listOf("body.body.secret")),
+        ).value
+
+        resolved.include.assert().containsExactly("body.body.secret", "document.events.type")
+    }
+
     private fun schema(
         fields: Map<LogicalField, QueryFieldSchema> = emptyMap(),
         capabilities: Set<QueryCapability> = emptySet(),

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolverTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolverTest.kt
@@ -1625,6 +1625,28 @@ class QuerySchemaResolverTest {
         resolved.include.assert().containsExactly("body.body.secret", "document.events.type")
     }
 
+    @Test
+    fun `masked event projection should reject wildcard exclusion of body type`() {
+        val resolver = QuerySchemaResolver(
+            QueryModelSchema(
+                QueryModel.EVENT_STREAM,
+                emptySet(),
+                mapOf(
+                    LogicalField("body.body.secret") to fieldSchema(
+                        QueryCapability.PRESENCE to "body.body.secret",
+                        maskRule = fullMaskRule(),
+                    ),
+                    LogicalField("body.bodyType") to fieldSchema(
+                        QueryCapability.PRESENCE to "document.events.type",
+                    ),
+                ),
+            ),
+        )
+
+        resolver.resolve(Projection(exclude = listOf("body.bodyT*"))).compatibility.assert()
+            .isEqualTo(QueryCompatibilityLevel.INCOMPATIBLE)
+    }
+
     private fun schema(
         fields: Map<LogicalField, QueryFieldSchema> = emptyMap(),
         capabilities: Set<QueryCapability> = emptySet(),

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/DefaultSnapshotQueryGatewayTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/DefaultSnapshotQueryGatewayTest.kt
@@ -13,6 +13,10 @@
 
 package me.ahoo.wow.query.snapshot
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.annotation.ORDER_FIRST
 import me.ahoo.wow.api.annotation.Order
@@ -61,6 +65,7 @@ import me.ahoo.wow.serialization.JsonSerializer
 import me.ahoo.wow.serialization.toJsonNode
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.kotlin.test.test
@@ -90,6 +95,22 @@ class DefaultSnapshotQueryGatewayTest {
         StepVerifier.create(result)
             .assertNext { it.stateValue().assert().isEqualTo("***********") }
             .verifyComplete()
+    }
+
+    @Test
+    fun `snapshot masking should not remove event body type fields`() {
+        val node = snapshotNode().also {
+            it.putArray("body").addObject().put("bodyType", "keep")
+        }
+        val backend = SchemaSnapshotBackend({ Mono.just(maskedSchema()) }, nodeSupplier = { node.deepCopy() })
+
+        val result = gateway(backend).dynamicSingle(
+            singleQuery {
+                projection { include("body.body.data") }
+            },
+        ).block()!!
+
+        result.path("body").path(0).has("bodyType").assert().isTrue()
     }
 
     @Test
@@ -263,6 +284,40 @@ class DefaultSnapshotQueryGatewayTest {
     }
 
     @Test
+    fun `default error handler should not log mask strategy cause`() {
+        val failure = IllegalStateException("secret-value")
+        val annotation = Masked::value.javaField!!.getAnnotation(Mask::class.java)
+        val schema = QueryModelSchema(
+            QueryModel.SNAPSHOT,
+            emptySet(),
+            mapOf(
+                LogicalField("state.value") to fieldSchema(
+                    MaskRule(FullMaskStrategy::class, annotation, CompiledMask { throw failure }),
+                ),
+            ),
+        )
+        val backend = SchemaSnapshotBackend(Mono.just(schema))
+        val errors = captureErrors {
+            DefaultSnapshotQueryGateway<TestState>(
+                namedAggregate = MOCK_AGGREGATE_METADATA,
+                backend = backend,
+                targetType = JsonSerializer.typeFactory.constructParametricType(
+                    MaterializedSnapshot::class.java,
+                    TestState::class.java,
+                ),
+            ).dynamicSingle(singleQuery { }).test()
+                .expectError(QuerySchemaValidationException::class.java)
+                .verify()
+        }
+
+        errors.assert().hasSize(1)
+        errors.single().formattedMessage.assert()
+            .isEqualTo("Mask strategy execution failed.")
+            .doesNotContain("secret-value")
+        errors.single().throwableProxy.assert().isNull()
+    }
+
+    @Test
     fun `gateway should retry schema loading after an earlier request fails`() {
         val failure = QuerySchemaUnavailableException("first")
         val attempts = AtomicInteger()
@@ -401,6 +456,19 @@ class DefaultSnapshotQueryGatewayTest {
         filters = filters,
         errorHandler = errorHandler,
     )
+
+    private fun captureErrors(block: () -> Unit): List<ILoggingEvent> {
+        val logger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME) as Logger
+        val appender = ListAppender<ILoggingEvent>().apply { start() }
+        logger.addAppender(appender)
+        return try {
+            block()
+            appender.list.filter { it.level == Level.ERROR }
+        } finally {
+            logger.detachAppender(appender)
+            appender.stop()
+        }
+    }
 
     private fun around(name: String, order: MutableList<String>) = object : QueryFilter<QueryContext<*, *>> {
         override fun filter(context: QueryContext<*, *>, next: FilterChain<QueryContext<*, *>>): Mono<Void> {

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/CountSnapshotQueryContextTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/snapshot/filter/CountSnapshotQueryContextTest.kt
@@ -16,6 +16,7 @@ package me.ahoo.wow.query.snapshot.filter
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.query.AndFilter
 import me.ahoo.wow.api.query.FilterExpression
+import me.ahoo.wow.api.query.MatchAllFilter
 import me.ahoo.wow.api.query.OwnerIdFilter
 import me.ahoo.wow.api.query.TenantIdFilter
 import me.ahoo.wow.query.dsl.filter
@@ -32,8 +33,7 @@ class CountSnapshotQueryContextTest {
             queryType = QueryType.COUNT,
             MOCK_AGGREGATE_METADATA
         )
-        val query = filter { }
-        context.setQuery(query)
+        context.setQuery(MatchAllFilter)
         context.appendFilter(TenantIdFilter("tenantId"))
         context.getQuery().assert().isEqualTo(TenantIdFilter("tenantId"))
     }

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/query/QueryAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/query/QueryAutoConfiguration.kt
@@ -13,7 +13,7 @@
 package me.ahoo.wow.spring.boot.starter.query
 
 import me.ahoo.wow.filter.ErrorHandler
-import me.ahoo.wow.filter.LogErrorHandler
+import me.ahoo.wow.query.QueryLogErrorHandler
 import me.ahoo.wow.query.event.EventStreamQueryBackendFactory
 import me.ahoo.wow.query.filter.QueryContext
 import me.ahoo.wow.query.snapshot.SnapshotQueryBackendFactory
@@ -36,11 +36,11 @@ import org.springframework.context.annotation.Import
 class QueryAutoConfiguration {
     @Bean("snapshotQueryErrorHandler")
     @ConditionalOnMissingBean(name = ["snapshotQueryErrorHandler"])
-    fun snapshotQueryErrorHandler(): ErrorHandler<QueryContext<*, *>> = LogErrorHandler()
+    fun snapshotQueryErrorHandler(): ErrorHandler<QueryContext<*, *>> = QueryLogErrorHandler()
 
     @Bean("eventStreamQueryErrorHandler")
     @ConditionalOnMissingBean(name = ["eventStreamQueryErrorHandler"])
-    fun eventStreamQueryErrorHandler(): ErrorHandler<QueryContext<*, *>> = LogErrorHandler()
+    fun eventStreamQueryErrorHandler(): ErrorHandler<QueryContext<*, *>> = QueryLogErrorHandler()
 
     @Bean("noOpSnapshotQueryBackendFactory")
     @ConditionalOnMissingBean(SnapshotQueryBackendFactory::class)

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardFilterTest.kt
@@ -127,12 +127,12 @@ class HttpQueryGuardFilterTest {
     fun `should reject unsafe list queries before backend invocation`() {
         listOf(
             ListQuery(MatchAllFilter),
-            ListQuery(filterExpression { MessageRecords.AGGREGATE_ID.contains("wow") }, limit = 1),
-            ListQuery(filterExpression { MessageRecords.AGGREGATE_ID.endsWith("wow") }, limit = 1),
-            ListQuery(filterExpression { MessageRecords.AGGREGATE_ID.startsWith("") }, limit = 1),
+            ListQuery(filterExpression { MessageRecords.AGGREGATE_ID.containsText("wow") }, limit = 1),
+            ListQuery(filterExpression { MessageRecords.AGGREGATE_ID.endsWithText("wow") }, limit = 1),
+            ListQuery(filterExpression { MessageRecords.AGGREGATE_ID.startsWithText("") }, limit = 1),
             ListQuery(
                 filterExpression {
-                    MessageRecords.AGGREGATE_ID.startsWith("wow", StringComparison.CASE_INSENSITIVE)
+                    MessageRecords.AGGREGATE_ID.startsWithText("wow", StringComparison.CASE_INSENSITIVE)
                 },
                 limit = 1,
             ),


### PR DESCRIPTION
## Goal

收口 V9 Query 核心合同，并为旧 `Condition` 调用方保留到 9.1.0 的明确迁移窗口。

## Changes

- 修复 EventStream Mask 在裁剪 projection 后缺失 `bodyType` 的问题，并在响应前移除内部补投影字段。
- 拒绝游标排序中多个逻辑字段映射到同一物理字段。
- Query Schema 校验错误默认不记录可能包含敏感值的 cause。
- 修复 `FilterDsl` 文本操作符与 Kotlin `String` 方法重名导致表达式被静默忽略的问题；空 Filter block 改为失败。
- 保留 `Condition`/`Operator`、DSL、查询构造器和 count client 重载，并统一标记 9.1.0 移除。

## Verification

- `CI=GITHUB_ACTIONS ./gradlew allLocalTest allContractTest allIntegrationTest --stacktrace`
- `./gradlew detekt build`
- Query、WebFlux、MongoDB、Elasticsearch 定向测试通过。

## Compatibility and risks

- [ ] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

`Condition` REST/JVM 兼容面保留到 9.1.0。V9 `FilterDsl` 的旧重名文本方法被替换为 `containsText`、`startsWithText`、`endsWithText`，空 block 不再隐式等价于 MatchAll。
