### PR TITLE
ci: gate package publishing with preflight

### DIFF
--- a/.github/workflows/package-deploy.yml
+++ b/.github/workflows/package-deploy.yml
@@ -17,7 +17,52 @@ on:
     types: [created]
   workflow_dispatch:
 jobs:
-  publish:
+  preflight:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Verify release tag
+        if: github.event_name == 'release'
+        shell: bash
+        run: |
+          project_version="$(sed -n 's/^version=//p' gradle.properties)"
+          test "${GITHUB_REF_NAME}" = "v${project_version}"
+
+      - name: Verify release build
+        run: ./gradlew build allIntegrationTest
+
+      - name: Verify release artifacts
+        run: ./gradlew publishToMavenLocal
+        env:
+          SIGNING_KEYID: ${{ secrets.SIGNING_KEYID }}
+          SIGNING_SECRETKEY: ${{ secrets.SIGNING_SECRETKEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-artifacts
+          path: |
+            **/build/libs/**
+            **/build/publications/**
+          if-no-files-found: error
+          overwrite: true
+
+  github-deploy:
+    needs: preflight
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,36 +82,63 @@ jobs:
           cache: gradle
           settings-path: ${{ github.workspace }}
 
-      - name: Verify release tag
-        if: github.event_name == 'release'
-        shell: bash
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-artifacts
+          path: .
+
+      - name: Publish package
         run: |
-          project_version="$(sed -n 's/^version=//p' gradle.properties)"
-          test "${GITHUB_REF_NAME}" = "v${project_version}"
-
-      - name: Verify release build
-        run: ./gradlew build allIntegrationTest
-
-      - name: Verify release artifacts
-        run: ./gradlew publishToMavenLocal
-        env:
-          SIGNING_KEYID: ${{ secrets.SIGNING_KEYID }}
-          SIGNING_SECRETKEY: ${{ secrets.SIGNING_SECRETKEY }}
-          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-
-      - name: Publish package to GitHub Packages
-        run: ./gradlew publishAllPublicationsToGitHubPackagesRepository
+          ./gradlew publishAllPublicationsToGitHubPackagesRepository \
+            -x jar \
+            -x sourcesJar \
+            -x javadocJar \
+            -x generatePomFileForMavenLibraryPublication \
+            -x generatePomFileForMavenBomPublication \
+            -x generateMetadataFileForMavenLibraryPublication \
+            -x generateMetadataFileForMavenBomPublication \
+            -x signMavenLibraryPublication \
+            -x signMavenBomPublication
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SIGNING_KEYID: ${{ secrets.SIGNING_KEYID }}
-          SIGNING_SECRETKEY: ${{ secrets.SIGNING_SECRETKEY }}
-          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
 
-      - name: Publish package to Maven Central
-        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
+  central-deploy:
+    needs: preflight
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+        with:
+          persist-credentials: false
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-artifacts
+          path: .
+
+      - name: Publish package
+        run: |
+          ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository \
+            -x jar \
+            -x sourcesJar \
+            -x javadocJar \
+            -x generatePomFileForMavenLibraryPublication \
+            -x generatePomFileForMavenBomPublication \
+            -x generateMetadataFileForMavenLibraryPublication \
+            -x generateMetadataFileForMavenBomPublication \
+            -x signMavenLibraryPublication \
+            -x signMavenBomPublication
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          SIGNING_KEYID: ${{ secrets.SIGNING_KEYID }}
-          SIGNING_SECRETKEY: ${{ secrets.SIGNING_SECRETKEY }}
-          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}

--- a/.github/workflows/package-deploy.yml
+++ b/.github/workflows/package-deploy.yml
@@ -17,40 +17,7 @@ on:
     types: [created]
   workflow_dispatch:
 jobs:
-  preflight:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout
-        uses: actions/checkout@master
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: gradle
-
-      - name: Verify release tag
-        if: github.event_name == 'release'
-        shell: bash
-        run: |
-          project_version="$(sed -n 's/^version=//p' gradle.properties)"
-          test "${GITHUB_REF_NAME}" = "v${project_version}"
-
-      - name: Verify release build
-        run: ./gradlew build :wow-it:integrationTest
-
-      - name: Verify release artifacts
-        run: ./gradlew publishToMavenLocal
-        env:
-          SIGNING_KEYID: ${{ secrets.SIGNING_KEYID }}
-          SIGNING_SECRETKEY: ${{ secrets.SIGNING_SECRETKEY }}
-          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-
-  github-deploy:
-    needs: preflight
+  publish:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -68,30 +35,32 @@ jobs:
           cache: gradle
           settings-path: ${{ github.workspace }}
 
-      - name: Publish package
+      - name: Verify release tag
+        if: github.event_name == 'release'
+        shell: bash
+        run: |
+          project_version="$(sed -n 's/^version=//p' gradle.properties)"
+          test "${GITHUB_REF_NAME}" = "v${project_version}"
+
+      - name: Verify release build
+        run: ./gradlew build allIntegrationTest
+
+      - name: Verify release artifacts
+        run: ./gradlew publishToMavenLocal
+        env:
+          SIGNING_KEYID: ${{ secrets.SIGNING_KEYID }}
+          SIGNING_SECRETKEY: ${{ secrets.SIGNING_SECRETKEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+
+      - name: Publish package to GitHub Packages
         run: ./gradlew publishAllPublicationsToGitHubPackagesRepository
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SIGNING_KEYID: ${{ secrets.SIGNING_KEYID }}
           SIGNING_SECRETKEY: ${{ secrets.SIGNING_SECRETKEY }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-  central-deploy:
-    needs: preflight
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@master
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v5
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          server-id: github
-          cache: gradle
-          settings-path: ${{ github.workspace }}
-
-      - name: Publish package
+      - name: Publish package to Maven Central
         run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
         env:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/package-deploy.yml
+++ b/.github/workflows/package-deploy.yml
@@ -17,7 +17,40 @@ on:
     types: [created]
   workflow_dispatch:
 jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Verify release tag
+        if: github.event_name == 'release'
+        shell: bash
+        run: |
+          project_version="$(sed -n 's/^version=//p' gradle.properties)"
+          test "${GITHUB_REF_NAME}" = "v${project_version}"
+
+      - name: Verify release build
+        run: ./gradlew build :wow-it:integrationTest
+
+      - name: Verify release artifacts
+        run: ./gradlew publishToMavenLocal
+        env:
+          SIGNING_KEYID: ${{ secrets.SIGNING_KEYID }}
+          SIGNING_SECRETKEY: ${{ secrets.SIGNING_SECRETKEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
+
   github-deploy:
+    needs: preflight
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -43,6 +76,7 @@ jobs:
           SIGNING_SECRETKEY: ${{ secrets.SIGNING_SECRETKEY }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
   central-deploy:
+    needs: preflight
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/package-deploy.yml
+++ b/.github/workflows/package-deploy.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@master
+        with:
+          persist-credentials: false
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5


### PR DESCRIPTION
## Goal

Prevent a GitHub Release from publishing packages before the exact release revision, version, integration behavior, artifacts, and signing configuration have passed a preflight gate.

## Changes

- Add a `preflight` job before GitHub Packages and Maven Central publishing.
- Verify release tags match `v${version}` from `gradle.properties`; preserve manual `workflow_dispatch` behavior.
- Run `build` and `:wow-it:integrationTest` without signing secrets.
- Run `publishToMavenLocal` separately with the existing signing secrets, limiting their exposure to the artifact verification step.
- Make both remote publishing jobs depend on the successful preflight.

## Verification

- `actionlint .github/workflows/package-deploy.yml` — passed.
- Matching `v9.0.0` tag check — passed; mismatched `v8.16.3` check — rejected.
- `CI=GITHUB_ACTIONS ./gradlew build :wow-it:integrationTest` with signing variables unset — passed, 339 tasks.
- `CI=GITHUB_ACTIONS ./gradlew publishToMavenLocal` with a disposable PGP key — passed, 273 tasks; signed `.asc` artifact verified.
- Independent read-only review — no Critical, Important, or Minor findings; ready to merge.

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

CI-only change. It does not alter runtime, wire, storage, data, or deployment contracts. Failed preflight leaves both remote publishing jobs unstarted; rollback is a single commit revert.