### PR TITLE
perf(query): reuse query schema resolver

### DIFF
--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/query/QuerySchemaResolverBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/query/QuerySchemaResolverBenchmark.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.benchmark.query
+
+import me.ahoo.wow.api.query.LogicalField
+import me.ahoo.wow.api.query.MatchAllFilter
+import me.ahoo.wow.api.query.SingleQuery
+import me.ahoo.wow.api.query.mask.FullMaskStrategy
+import me.ahoo.wow.api.query.mask.Mask
+import me.ahoo.wow.api.query.schema.QueryCardinality
+import me.ahoo.wow.api.query.schema.QueryModel
+import me.ahoo.wow.api.query.schema.QueryValueType
+import me.ahoo.wow.query.schema.MaskRule
+import me.ahoo.wow.query.schema.QueryFieldSchema
+import me.ahoo.wow.query.schema.QueryModelSchema
+import me.ahoo.wow.query.schema.QueryModelSchemaProvider
+import me.ahoo.wow.query.schema.QuerySchemaValidationMode
+import me.ahoo.wow.query.schema.resolve
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Threads
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+import reactor.core.publisher.Mono
+import java.util.concurrent.TimeUnit
+import kotlin.reflect.jvm.javaField
+
+private const val MASKED_FIELD_COUNT = 64
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(3)
+@Threads(1)
+open class QuerySchemaResolverBenchmark {
+    private val schema = QueryModelSchema(
+        model = QueryModel.SNAPSHOT,
+        capabilities = emptySet(),
+        fields = List(MASKED_FIELD_COUNT) { index ->
+            LogicalField("state.secret$index") to maskedFieldSchema()
+        }.toMap(),
+    )
+    private val provider = object : QueryModelSchemaProvider {
+        private val schemaMono = Mono.just(schema)
+
+        override fun schema(): Mono<QueryModelSchema> = schemaMono
+
+        override fun refresh(): Mono<QueryModelSchema> = schemaMono
+    }
+    private val query = SingleQuery(MatchAllFilter)
+
+    @Benchmark
+    fun resolve(blackhole: Blackhole) {
+        blackhole.consume(provider.resolve(query, QuerySchemaValidationMode.COMPATIBLE).block())
+    }
+
+    private fun maskedFieldSchema(): QueryFieldSchema {
+        val annotation = Masked::secret.javaField!!.getAnnotation(Mask::class.java)
+        return QueryFieldSchema(
+            title = null,
+            description = null,
+            enumValues = null,
+            valueTypes = setOf(QueryValueType.STRING),
+            nullable = true,
+            required = false,
+            cardinality = QueryCardinality.SINGLE,
+            semanticType = null,
+            dynamicChildren = false,
+            bindings = emptyMap(),
+            maskRule = MaskRule(
+                FullMaskStrategy::class,
+                annotation,
+                FullMaskStrategy.compile(annotation),
+            ),
+        )
+    }
+
+    private data class Masked(@field:Mask val secret: String)
+}

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/SchemaMaskQueryFilter.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/SchemaMaskQueryFilter.kt
@@ -25,7 +25,6 @@ import me.ahoo.wow.query.filter.QueryFilter
 import me.ahoo.wow.query.filter.QueryType
 import me.ahoo.wow.query.schema.QueryModelSchema
 import me.ahoo.wow.query.schema.QueryModelSchemaProvider
-import me.ahoo.wow.query.schema.QuerySchemaResolver
 import me.ahoo.wow.query.schema.withQueryModelSchema
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -50,7 +49,7 @@ internal class SchemaMaskQueryFilter(
                 else -> Unit
             }
             Mono.defer(provider::schema).doOnNext { schema ->
-                context.internalEventBodyTypeProjected = QuerySchemaResolver(schema)
+                context.internalEventBodyTypeProjected = schema.resolver
                     .requiresInternalEventBodyType(
                         (context.getQuery() as? Queryable<*>)?.projection ?: Projection.ALL,
                     )

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QueryModelSchema.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QueryModelSchema.kt
@@ -48,6 +48,9 @@ data class QueryModelSchema(
     @get:JsonIgnore
     internal val hasMaskedFields: Boolean = maskedFields.isNotEmpty()
 
+    @get:JsonIgnore
+    internal val resolver = QuerySchemaResolver(this)
+
     fun resolve(field: LogicalField): QueryFieldSchema? {
         fields[field]?.let { return it }
         var separator = field.value.lastIndexOf('.')

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QueryModelSchemaProviderResolution.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QueryModelSchemaProviderResolution.kt
@@ -25,33 +25,33 @@ fun QueryModelSchemaProvider.resolve(
     query: ISingleQuery,
     mode: QuerySchemaValidationMode,
 ): Mono<ISingleQuery> = schemaForQuery()
-    .map { QuerySchemaResolver(it).resolve(query).requireAccepted(mode) }
+    .map { it.resolver.resolve(query).requireAccepted(mode) }
     .fallbackUnavailable(mode, query, !query.filter.referencesSystemTags())
 
 fun QueryModelSchemaProvider.resolve(
     query: IListQuery,
     mode: QuerySchemaValidationMode,
 ): Mono<IListQuery> = schemaForQuery()
-    .map { QuerySchemaResolver(it).resolve(query).requireAccepted(mode) }
+    .map { it.resolver.resolve(query).requireAccepted(mode) }
     .fallbackUnavailable(mode, query, !query.filter.referencesSystemTags())
 
 fun QueryModelSchemaProvider.resolve(
     query: IPagedQuery,
     mode: QuerySchemaValidationMode,
 ): Mono<IPagedQuery> = schemaForQuery()
-    .map { QuerySchemaResolver(it).resolve(query).requireAccepted(mode) }
+    .map { it.resolver.resolve(query).requireAccepted(mode) }
     .fallbackUnavailable(mode, query, !query.filter.referencesSystemTags())
 
 fun QueryModelSchemaProvider.resolve(
     query: ICursorQuery,
     mode: QuerySchemaValidationMode,
-): Mono<ICursorQuery> = schemaForQuery().map { QuerySchemaResolver(it).resolve(query).requireAccepted(mode) }
+): Mono<ICursorQuery> = schemaForQuery().map { it.resolver.resolve(query).requireAccepted(mode) }
 
 fun QueryModelSchemaProvider.resolve(
     filter: FilterExpression,
     mode: QuerySchemaValidationMode,
 ): Mono<FilterExpression> = schemaForQuery()
-    .map { QuerySchemaResolver(it).resolve(filter).requireAccepted(mode) }
+    .map { it.resolver.resolve(filter).requireAccepted(mode) }
     .fallbackUnavailable(mode, filter, !filter.referencesSystemTags())
 
 fun QueryModelSchemaProvider.resolve(
@@ -60,7 +60,7 @@ fun QueryModelSchemaProvider.resolve(
 ): Mono<ResolvedAggregationQuery> = schemaForQuery()
     .map { schema ->
         ResolvedAggregationQuery(
-            QuerySchemaResolver(schema).resolve(query).requireAccepted(mode),
+            schema.resolver.resolve(query).requireAccepted(mode),
             schema,
         )
     }


### PR DESCRIPTION
## Goal

Eliminate repeated `QuerySchemaResolver` construction from the query hot path while preserving query behavior and public contracts.

## Changes

- Cache one internal resolver per immutable `QueryModelSchema` instance.
- Reuse it across all provider resolution overloads and the schema mask filter.
- Add a focused JMH benchmark for the masked-schema resolution path.

## Verification

- `./gradlew :wow-query:check :wow-benchmarks:check --no-parallel` — BUILD SUCCESSFUL.
- `QuerySchemaResolverBenchmark.resolve -prof gc`, 3 forks and 30 measurements:
  - Before: 2519.450 ns/op, 14160.007 B/op.
  - After: 59.110 ns/op, 728.000 B/op.
  - About 42.6x faster with 94.86% less allocation for this 64-masked-field microbenchmark.
- Independent read-only review found no critical, important, or minor issues.

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

The resolver and its collaborators contain no cross-call mutable state, so a schema instance can safely share it across concurrent requests. Schema refresh publishes a new schema instance and therefore a new resolver. The benchmark is local hot-path evidence, not a production capacity claim.