### PR TITLE
perf(compensation): replace full-history stock histogram

### DIFF
--- a/compensation/dashboard/e2e/dashboard.spec.ts
+++ b/compensation/dashboard/e2e/dashboard.spec.ts
@@ -18,6 +18,43 @@ type AggregationQueryBody = {
   groupBy?: Array<{ alias: string }>;
 };
 
+const activeStockFilter = {
+  op: "IN",
+  field: "state.status",
+  values: ["FAILED", "PREPARED"],
+};
+
+function stockCountKind(query: AggregationQueryBody) {
+  if (JSON.stringify(query.filter) === JSON.stringify(activeStockFilter)) {
+    return "activeTotal";
+  }
+  const root = query.filter as
+    | { op?: string; operands?: Array<{ field?: string; op?: string }> }
+    | undefined;
+  if (root?.op !== "AND" || !root.operands) {
+    return undefined;
+  }
+  const hasActiveFilter = root.operands.some(
+    (operand) => JSON.stringify(operand) === JSON.stringify(activeStockFilter),
+  );
+  if (!hasActiveFilter) {
+    return undefined;
+  }
+  const hasLowerBound = root.operands.some(
+    ({ field, op }) => field === "state.executeAt" && op === "GTE",
+  );
+  const hasUpperBound = root.operands.some(
+    ({ field, op }) => field === "state.executeAt" && op === "LT",
+  );
+  if (hasLowerBound && hasUpperBound) {
+    return "selectedInRange";
+  }
+  if (hasLowerBound) {
+    return "newerThanRange";
+  }
+  return hasUpperBound ? "olderThanRange" : undefined;
+}
+
 function queryWindow(query: AggregationQueryBody, field: string) {
   const matches: Array<{ field?: string; op?: string; value?: number }> = [];
   const visit = (value: unknown) => {
@@ -232,13 +269,6 @@ async function mockAnalyticsAggregations(
             nextRetryAt: 1_787_932_800_000,
           }),
         );
-      } else if (aliases.includes("executeAtBucket")) {
-        const today = new Date();
-        today.setHours(0, 0, 0, 0);
-        rows = [
-          { count: 680, executeAtBucket: today.getTime() - 365 * 86_400_000 },
-          { count: 320, executeAtBucket: today.getTime() },
-        ];
       } else if (aliases.includes("recoverable")) {
         rows = [
           { recoverable: "RECOVERABLE", count: 300 },
@@ -252,6 +282,14 @@ async function mockAnalyticsAggregations(
           { retries: 3, count: 2 },
           { retries: 6, count: 1 },
         ];
+      } else if (stockCountKind(query) === "activeTotal") {
+        rows = [{ count: 1_000 }];
+      } else if (stockCountKind(query) === "selectedInRange") {
+        rows = [{ count: 320 }];
+      } else if (stockCountKind(query) === "newerThanRange") {
+        rows = [{ count: 0 }];
+      } else if (stockCountKind(query) === "olderThanRange") {
+        rows = [{ count: 680 }];
       } else if (serializedFilter.includes("nextRetryAt")) {
         rows = [{ count: 128 }];
       } else if (serializedFilter.includes("timeoutAt")) {
@@ -534,7 +572,7 @@ test("loads the root dashboard with natural Top 5 pressure height", async ({
   await expect(
     page.getByRole("heading", { name: "FLOW / Compensation effectiveness" }),
   ).toBeVisible();
-  await expect.poll(() => snapshotRequests).toBe(8);
+  await expect.poll(() => snapshotRequests).toBe(11);
   await expect.poll(() => eventRequests).toBe(4);
   const timeRange = page.getByRole("button", { name: /^Time range:/ });
   await expect(timeRange).toContainText("–");
@@ -573,29 +611,34 @@ test("loads the root dashboard with natural Top 5 pressure height", async ({
     ).toBeGreaterThanOrEqual(14);
   }
   await page.getByRole("button", { name: "Today", exact: true }).click();
-  await expect.poll(() => snapshotRequests).toBe(16);
+  await expect.poll(() => snapshotRequests).toBe(22);
   await expect.poll(() => eventRequests).toBe(8);
   await page.getByRole("button", { name: "Refresh dashboard" }).click();
-  await expect.poll(() => snapshotRequests).toBe(24);
+  await expect.poll(() => snapshotRequests).toBe(33);
   await expect.poll(() => eventRequests).toBe(12);
 
   const appliedWindows: Array<{ end: number; start: number }> = [];
   for (const batch of [0, 1, 2]) {
     const batchSnapshotQueries = snapshotQueries.slice(
-      batch * 8,
-      batch * 8 + 8,
+      batch * 11,
+      batch * 11 + 11,
     );
-    const stockPartitionSnapshots = batchSnapshotQueries.filter((query) =>
-      query.groupBy?.some(({ alias }) => alias === "executeAtBucket"),
+    const stockCountSnapshots = batchSnapshotQueries.filter((query) =>
+      stockCountKind(query),
     );
-    const snapshotWindows = batchSnapshotQueries
-      .filter((query) => !stockPartitionSnapshots.includes(query))
-      .map((query) => queryWindow(query, "state.executeAt"));
+    const snapshotWindows = batchSnapshotQueries.map((query) =>
+      queryWindow(query, "state.executeAt"),
+    );
     const fullyWindowedSnapshots = snapshotWindows.filter(
       ({ end, start }) => Number.isFinite(start) && Number.isFinite(end),
     );
-    expect(fullyWindowedSnapshots).toHaveLength(7);
-    expect(stockPartitionSnapshots).toHaveLength(1);
+    expect(fullyWindowedSnapshots).toHaveLength(8);
+    expect(stockCountSnapshots.map(stockCountKind).sort()).toEqual([
+      "activeTotal",
+      "newerThanRange",
+      "olderThanRange",
+      "selectedInRange",
+    ]);
     const eventWindows = eventQueries
       .slice(batch * 4, batch * 4 + 4)
       .map((query) => queryWindow(query, "createTime"));
@@ -904,30 +947,36 @@ test("keeps zero-valued dashboard bars visually empty", async ({
     onEvent: () => undefined,
     onSnapshot: () => undefined,
   });
-  await page.route("**/execution_failed/snapshot/aggregation", async (route) => {
-    const query = route.request().postDataJSON() as AggregationQueryBody;
-    const aliases = query.groupBy?.map(({ alias }) => alias) ?? [];
-    if (aliases.includes("recoverable")) {
-      await route.fulfill({ json: [] });
-      return;
-    }
-    if (aliases.includes("executeAtBucket")) {
-      await route.fulfill({
-        json: [{ count: 680, executeAtBucket: Date.now() - 365 * 86_400_000 }],
-      });
-      return;
-    }
-    const serializedFilter = JSON.stringify(query.filter);
-    if (
-      aliases.length === 0 &&
-      serializedFilter.includes('"op":"GTE"') &&
-      serializedFilter.includes('"op":"LT"')
-    ) {
-      await route.fulfill({ json: [{ count: 0 }] });
-      return;
-    }
-    await route.fallback();
-  });
+  await page.route(
+    "**/execution_failed/snapshot/aggregation",
+    async (route) => {
+      const query = route.request().postDataJSON() as AggregationQueryBody;
+      const aliases = query.groupBy?.map(({ alias }) => alias) ?? [];
+      if (aliases.includes("recoverable")) {
+        await route.fulfill({ json: [] });
+        return;
+      }
+      const stockCount = stockCountKind(query);
+      if (stockCount === "activeTotal" || stockCount === "olderThanRange") {
+        await route.fulfill({ json: [{ count: 680 }] });
+        return;
+      }
+      if (stockCount === "selectedInRange" || stockCount === "newerThanRange") {
+        await route.fulfill({ json: [{ count: 0 }] });
+        return;
+      }
+      const serializedFilter = JSON.stringify(query.filter);
+      if (
+        aliases.length === 0 &&
+        serializedFilter.includes('"op":"GTE"') &&
+        serializedFilter.includes('"op":"LT"')
+      ) {
+        await route.fulfill({ json: [{ count: 0 }] });
+        return;
+      }
+      await route.fallback();
+    },
+  );
   await page.route("**/execution_failed/event/aggregation", async (route) => {
     const query = route.request().postDataJSON() as AggregationQueryBody;
     const { start } = queryWindow(query, "createTime");

--- a/compensation/dashboard/e2e/dashboard.spec.ts
+++ b/compensation/dashboard/e2e/dashboard.spec.ts
@@ -25,6 +25,9 @@ const activeStockFilter = {
 };
 
 function stockCountKind(query: AggregationQueryBody) {
+  if (query.groupBy?.length) {
+    return undefined;
+  }
   if (JSON.stringify(query.filter) === JSON.stringify(activeStockFilter)) {
     return "activeTotal";
   }

--- a/compensation/dashboard/src/features/Analytics/analyticsQueries.test.ts
+++ b/compensation/dashboard/src/features/Analytics/analyticsQueries.test.ts
@@ -76,24 +76,56 @@ describe("analyticsQueries", () => {
     [queries.actionableNow, queries.timedOut, queries.unrecoverable].forEach(
       expectSnapshotWindow,
     );
-    expect(queries).toHaveProperty("stockPartitions", {
-      filter: {
-        op: "IN",
-        field: "state.status",
-        values: [ExecutionFailedStatus.FAILED, ExecutionFailedStatus.PREPARED],
+    const activeFilter = {
+      op: "IN",
+      field: "state.status",
+      values: [ExecutionFailedStatus.FAILED, ExecutionFailedStatus.PREPARED],
+    };
+    expect(queries).toMatchObject({
+      activeTotal: {
+        filter: activeFilter,
+        metrics: [{ type: "COUNT", alias: "count" }],
       },
-      groupBy: [
-        {
-          alias: "executeAtBucket",
-          field: "state.executeAt",
-          timeZone: snapshotWindow.timeZone,
-          type: "DATE_HISTOGRAM",
-          unit: "DAY",
+      selectedInRange: {
+        filter: {
+          op: "AND",
+          operands: [
+            {
+              op: "GTE",
+              field: "state.executeAt",
+              value: snapshotWindow.start,
+            },
+            {
+              op: "LT",
+              field: "state.executeAt",
+              value: snapshotWindow.end,
+            },
+            activeFilter,
+          ],
         },
-      ],
-      metrics: [{ type: "COUNT", alias: "count" }],
-      limit: 1_000,
+        metrics: [{ type: "COUNT", alias: "count" }],
+      },
+      newerThanRange: {
+        filter: {
+          op: "AND",
+          operands: [
+            {
+              op: "GTE",
+              field: "state.executeAt",
+              value: snapshotWindow.end,
+            },
+            activeFilter,
+          ],
+        },
+        metrics: [{ type: "COUNT", alias: "count" }],
+      },
     });
+    expect(queries).not.toHaveProperty("stockPartitions");
+    [
+      queries.activeTotal,
+      queries.selectedInRange,
+      queries.newerThanRange,
+    ].forEach((query) => expect(query.groupBy).toBeUndefined());
     expect(queries.actionableNow.metrics).toEqual([
       { type: "COUNT", alias: "count" },
     ]);

--- a/compensation/dashboard/src/features/Analytics/analyticsQueries.test.ts
+++ b/compensation/dashboard/src/features/Analytics/analyticsQueries.test.ts
@@ -119,12 +119,27 @@ describe("analyticsQueries", () => {
         },
         metrics: [{ type: "COUNT", alias: "count" }],
       },
+      olderThanRange: {
+        filter: {
+          op: "AND",
+          operands: [
+            {
+              op: "LT",
+              field: "state.executeAt",
+              value: snapshotWindow.start,
+            },
+            activeFilter,
+          ],
+        },
+        metrics: [{ type: "COUNT", alias: "count" }],
+      },
     });
     expect(queries).not.toHaveProperty("stockPartitions");
     [
       queries.activeTotal,
       queries.selectedInRange,
       queries.newerThanRange,
+      queries.olderThanRange,
     ].forEach((query) => expect(query.groupBy).toBeUndefined());
     expect(queries.actionableNow.metrics).toEqual([
       { type: "COUNT", alias: "count" },

--- a/compensation/dashboard/src/features/Analytics/analyticsQueries.ts
+++ b/compensation/dashboard/src/features/Analytics/analyticsQueries.ts
@@ -273,6 +273,7 @@ export function createSnapshotSummaryQueries(
   | "actionableNow"
   | "activeTotal"
   | "newerThanRange"
+  | "olderThanRange"
   | "selectedInRange"
   | "timedOut"
   | "unrecoverable",
@@ -301,6 +302,16 @@ export function createSnapshotSummaryQueries(
         filter.gte(
           ExecutionFailedAggregatedFields.STATE_EXECUTE_AT,
           window.end,
+        ),
+        activeFilter,
+      ]),
+      metrics: [countMetric()],
+    },
+    olderThanRange: {
+      filter: filter.and([
+        filter.lt(
+          ExecutionFailedAggregatedFields.STATE_EXECUTE_AT,
+          window.start,
         ),
         activeFilter,
       ]),

--- a/compensation/dashboard/src/features/Analytics/analyticsQueries.ts
+++ b/compensation/dashboard/src/features/Analytics/analyticsQueries.ts
@@ -225,11 +225,6 @@ export interface SnapshotSummary {
   unrecoverable: number;
 }
 
-export interface StockPartitionRow {
-  count: number;
-  executeAtBucket: number;
-}
-
 export interface RecoverabilityRow {
   recoverable: RecoverableType;
   count: number;
@@ -276,7 +271,9 @@ export function createSnapshotSummaryQueries(
   window: TrendWindow,
 ): Record<
   | "actionableNow"
-  | "stockPartitions"
+  | "activeTotal"
+  | "newerThanRange"
+  | "selectedInRange"
   | "timedOut"
   | "unrecoverable",
   SnapshotAggregationQuery
@@ -291,20 +288,23 @@ export function createSnapshotSummaryQueries(
       ),
       metrics: [countMetric()],
     },
-    stockPartitions: {
+    activeTotal: {
       filter: activeFilter,
-      groupBy: [
-        aggregation.dateHistogram(
-          ExecutionFailedAggregatedFields.STATE_EXECUTE_AT,
-          {
-            alias: "executeAtBucket",
-            timeZone: window.timeZone,
-            unit: AggregationDateUnit.DAY,
-          },
-        ),
-      ],
       metrics: [countMetric()],
-      limit: MAX_TREND_DAYS,
+    },
+    selectedInRange: {
+      filter: withSnapshotWindow(window, activeFilter),
+      metrics: [countMetric()],
+    },
+    newerThanRange: {
+      filter: filter.and([
+        filter.gte(
+          ExecutionFailedAggregatedFields.STATE_EXECUTE_AT,
+          window.end,
+        ),
+        activeFilter,
+      ]),
+      metrics: [countMetric()],
     },
     timedOut: {
       filter: withSnapshotWindow(

--- a/compensation/dashboard/src/features/Analytics/useSnapshotAnalytics.test.ts
+++ b/compensation/dashboard/src/features/Analytics/useSnapshotAnalytics.test.ts
@@ -42,6 +42,35 @@ function isQuery(
   return query?.groupBy?.some((groupBy) => groupBy.alias === alias);
 }
 
+const activeFilter = {
+  op: "IN",
+  field: "state.status",
+  values: ["FAILED", "PREPARED"],
+};
+
+function stockCountKind(query: { filter?: unknown } | undefined) {
+  if (JSON.stringify(query?.filter) === JSON.stringify(activeFilter)) {
+    return "activeTotal";
+  }
+  const filter = query?.filter as
+    { op?: string; operands?: Array<{ op?: string }> } | undefined;
+  if (filter?.op !== "AND" || !filter.operands) {
+    return undefined;
+  }
+  const hasActiveFilter = filter.operands.some(
+    (operand) => JSON.stringify(operand) === JSON.stringify(activeFilter),
+  );
+  if (!hasActiveFilter) {
+    return undefined;
+  }
+  const hasLowerBound = filter.operands.some(({ op }) => op === "GTE");
+  const hasUpperBound = filter.operands.some(({ op }) => op === "LT");
+  if (hasLowerBound && hasUpperBound) {
+    return "selectedInRange";
+  }
+  return hasLowerBound ? "newerThanRange" : undefined;
+}
+
 const initialWindow: TrendWindow = {
   buckets: Array.from({ length: 7 }, (_, index) =>
     new Date(2026, 7, 22 + index).getTime(),
@@ -62,12 +91,10 @@ const nextWindow: TrendWindow = {
 };
 
 function summaryRows(
-  query: { groupBy?: Array<{ alias?: string }> },
+  query: { filter?: unknown; groupBy?: Array<{ alias?: string }> },
   count: number,
 ) {
-  return isQuery(query, "executeAtBucket")
-    ? [{ count, executeAtBucket: initialWindow.end - 86_400_000 }]
-    : [{ count }];
+  return [{ count: stockCountKind(query) === "newerThanRange" ? 0 : count }];
 }
 
 describe("useSnapshotAnalytics", () => {
@@ -80,7 +107,7 @@ describe("useSnapshotAnalytics", () => {
 
   afterEach(() => vi.restoreAllMocks());
 
-  it("starts seven snapshot requests and waits for top clusters before status mix", async () => {
+  it("starts nine snapshot requests and waits for top clusters before status mix", async () => {
     const pressure = deferred<PressureClusterRow[]>();
     mocks.aggregate.mockImplementation((query) => {
       if (isQuery(query, "errorCode")) {
@@ -91,7 +118,7 @@ describe("useSnapshotAnalytics", () => {
 
     renderHook(() => useSnapshotAnalytics(initialWindow, 0));
 
-    expect(mocks.aggregate).toHaveBeenCalledTimes(7);
+    expect(mocks.aggregate).toHaveBeenCalledTimes(9);
     pressure.resolve([
       {
         errorCode: "TEST",
@@ -104,7 +131,7 @@ describe("useSnapshotAnalytics", () => {
         nextRetryAt: 2_000,
       },
     ]);
-    await waitFor(() => expect(mocks.aggregate).toHaveBeenCalledTimes(8));
+    await waitFor(() => expect(mocks.aggregate).toHaveBeenCalledTimes(10));
   });
 
   it("settles independent sections while the stock pair remains deferred", async () => {
@@ -156,14 +183,17 @@ describe("useSnapshotAnalytics", () => {
     });
   });
 
-  it("partitions active stock from one aggregation response", async () => {
+  it("derives stock partitions from three count responses", async () => {
     mocks.aggregate.mockImplementation((query) => {
-      if (isQuery(query, "executeAtBucket")) {
-        return Promise.resolve([
-          { count: 3, executeAtBucket: initialWindow.start - 86_400_000 },
-          { count: 5, executeAtBucket: initialWindow.start },
-          { count: 7, executeAtBucket: initialWindow.end },
-        ]);
+      const stockCount = stockCountKind(query);
+      if (stockCount === "activeTotal") {
+        return Promise.resolve([{ count: 15 }]);
+      }
+      if (stockCount === "selectedInRange") {
+        return Promise.resolve([{ count: 5 }]);
+      }
+      if (stockCount === "newerThanRange") {
+        return Promise.resolve([{ count: 7 }]);
       }
       if (
         isQuery(query, "errorCode") ||
@@ -188,15 +218,17 @@ describe("useSnapshotAnalytics", () => {
     );
   });
 
-  it("marks stock unavailable when the aggregation reaches its limit", async () => {
+  it("marks stock unavailable when concurrent counts are inconsistent", async () => {
     mocks.aggregate.mockImplementation((query) => {
-      if (isQuery(query, "executeAtBucket")) {
-        return Promise.resolve(
-          Array.from({ length: 1_000 }, (_, index) => ({
-            count: 1,
-            executeAtBucket: initialWindow.start + index * 86_400_000,
-          })),
-        );
+      const stockCount = stockCountKind(query);
+      if (stockCount === "activeTotal") {
+        return Promise.resolve([{ count: 10 }]);
+      }
+      if (stockCount === "selectedInRange") {
+        return Promise.resolve([{ count: 8 }]);
+      }
+      if (stockCount === "newerThanRange") {
+        return Promise.resolve([{ count: 4 }]);
       }
       if (
         isQuery(query, "errorCode") ||
@@ -301,10 +333,10 @@ describe("useSnapshotAnalytics", () => {
     });
   });
 
-  it("aborts the old window and starts seven requests with the applied window", async () => {
+  it("aborts the old window and starts nine requests with the applied window", async () => {
     const controllers: AbortController[] = [];
     const queries: Array<{
-      filter: { operands: Array<{ op: string; value?: number }> };
+      filter: unknown;
     }> = [];
     mocks.aggregate.mockImplementation((query, _attributes, controller) => {
       if (!controller) {
@@ -328,8 +360,8 @@ describe("useSnapshotAnalytics", () => {
       await Promise.resolve();
     });
 
-    expect(mocks.aggregate).toHaveBeenCalledTimes(14);
-    expect(controllers.slice(0, 7).every(({ signal }) => signal.aborted)).toBe(
+    expect(mocks.aggregate).toHaveBeenCalledTimes(18);
+    expect(controllers.slice(0, 9).every(({ signal }) => signal.aborted)).toBe(
       true,
     );
     const fullyWindowedQueries = queries.filter((query) => {
@@ -339,29 +371,29 @@ describe("useSnapshotAnalytics", () => {
         serializedFilter.includes('"op":"LT"')
       );
     });
-    expect(fullyWindowedQueries).toHaveLength(12);
+    expect(fullyWindowedQueries).toHaveLength(14);
     expect(
       queries.filter(
         (query) =>
           JSON.stringify(query.filter).includes('"state.executeAt"') &&
           !fullyWindowedQueries.includes(query),
       ),
-    ).toHaveLength(0);
+    ).toHaveLength(2);
     expect(
       queries.filter(
         (query) => !JSON.stringify(query.filter).includes('"state.executeAt"'),
       ),
     ).toHaveLength(2);
-    expect(JSON.stringify(fullyWindowedQueries.slice(0, 6))).toContain(
+    expect(JSON.stringify(fullyWindowedQueries.slice(0, 7))).toContain(
       String(initialWindow.start),
     );
-    expect(JSON.stringify(fullyWindowedQueries.slice(6))).toContain(
+    expect(JSON.stringify(fullyWindowedQueries.slice(7))).toContain(
       String(nextWindow.start),
     );
   });
 
   it("does not let settled stale requests overwrite refreshed sections", async () => {
-    const firstLoads = Array.from({ length: 7 }, () => deferred<unknown[]>());
+    const firstLoads = Array.from({ length: 9 }, () => deferred<unknown[]>());
     let firstCall = 0;
     let refresh = 0;
     mocks.aggregate.mockImplementation((query) => {
@@ -384,7 +416,7 @@ describe("useSnapshotAnalytics", () => {
       ({ token }) => useSnapshotAnalytics(initialWindow, token),
       { initialProps: { token: 0 } },
     );
-    expect(mocks.aggregate).toHaveBeenCalledTimes(7);
+    expect(mocks.aggregate).toHaveBeenCalledTimes(9);
 
     refresh = 1;
     await act(async () => {
@@ -399,12 +431,12 @@ describe("useSnapshotAnalytics", () => {
       firstLoads[0].resolve([{ count: 1 }]);
       firstLoads[1].resolve([{ count: 1 }]);
       firstLoads[2].resolve([{ count: 1 }]);
-      firstLoads[3].resolve([
-        { count: 1, executeAtBucket: initialWindow.end - 86_400_000 },
-      ]);
-      firstLoads[4].resolve([]);
-      firstLoads[5].resolve([{ count: 1, recoverable: "true" }]);
-      firstLoads[6].resolve([{ count: 1, retries: 0 }]);
+      firstLoads[3].resolve([{ count: 1 }]);
+      firstLoads[4].resolve([{ count: 1 }]);
+      firstLoads[5].resolve([{ count: 0 }]);
+      firstLoads[6].resolve([]);
+      firstLoads[7].resolve([{ count: 1, recoverable: "true" }]);
+      firstLoads[8].resolve([{ count: 1, retries: 0 }]);
       await Promise.all(firstLoads.map(({ promise }) => promise));
     });
 

--- a/compensation/dashboard/src/features/Analytics/useSnapshotAnalytics.test.ts
+++ b/compensation/dashboard/src/features/Analytics/useSnapshotAnalytics.test.ts
@@ -68,7 +68,10 @@ function stockCountKind(query: { filter?: unknown } | undefined) {
   if (hasLowerBound && hasUpperBound) {
     return "selectedInRange";
   }
-  return hasLowerBound ? "newerThanRange" : undefined;
+  if (hasLowerBound) {
+    return "newerThanRange";
+  }
+  return hasUpperBound ? "olderThanRange" : undefined;
 }
 
 const initialWindow: TrendWindow = {
@@ -94,7 +97,15 @@ function summaryRows(
   query: { filter?: unknown; groupBy?: Array<{ alias?: string }> },
   count: number,
 ) {
-  return [{ count: stockCountKind(query) === "newerThanRange" ? 0 : count }];
+  const stockCount = stockCountKind(query);
+  return [
+    {
+      count:
+        stockCount === "newerThanRange" || stockCount === "olderThanRange"
+          ? 0
+          : count,
+    },
+  ];
 }
 
 describe("useSnapshotAnalytics", () => {
@@ -107,7 +118,7 @@ describe("useSnapshotAnalytics", () => {
 
   afterEach(() => vi.restoreAllMocks());
 
-  it("starts nine snapshot requests and waits for top clusters before status mix", async () => {
+  it("starts ten snapshot requests and waits for top clusters before status mix", async () => {
     const pressure = deferred<PressureClusterRow[]>();
     mocks.aggregate.mockImplementation((query) => {
       if (isQuery(query, "errorCode")) {
@@ -118,7 +129,7 @@ describe("useSnapshotAnalytics", () => {
 
     renderHook(() => useSnapshotAnalytics(initialWindow, 0));
 
-    expect(mocks.aggregate).toHaveBeenCalledTimes(9);
+    expect(mocks.aggregate).toHaveBeenCalledTimes(10);
     pressure.resolve([
       {
         errorCode: "TEST",
@@ -131,7 +142,7 @@ describe("useSnapshotAnalytics", () => {
         nextRetryAt: 2_000,
       },
     ]);
-    await waitFor(() => expect(mocks.aggregate).toHaveBeenCalledTimes(10));
+    await waitFor(() => expect(mocks.aggregate).toHaveBeenCalledTimes(11));
   });
 
   it("settles independent sections while the stock pair remains deferred", async () => {
@@ -183,7 +194,7 @@ describe("useSnapshotAnalytics", () => {
     });
   });
 
-  it("derives stock partitions from three count responses", async () => {
+  it("derives stock partitions from four count responses", async () => {
     mocks.aggregate.mockImplementation((query) => {
       const stockCount = stockCountKind(query);
       if (stockCount === "activeTotal") {
@@ -194,6 +205,9 @@ describe("useSnapshotAnalytics", () => {
       }
       if (stockCount === "newerThanRange") {
         return Promise.resolve([{ count: 7 }]);
+      }
+      if (stockCount === "olderThanRange") {
+        return Promise.resolve([{ count: 3 }]);
       }
       if (
         isQuery(query, "errorCode") ||
@@ -244,6 +258,42 @@ describe("useSnapshotAnalytics", () => {
 
     await waitFor(() =>
       expect(result.current.summary.data?.stockTruncated).toBe(true),
+    );
+  });
+
+  it("marks stock unavailable when total exceeds the partition counts", async () => {
+    mocks.aggregate.mockImplementation((query) => {
+      const stockCount = stockCountKind(query);
+      if (stockCount === "activeTotal") {
+        return Promise.resolve([{ count: 1 }]);
+      }
+      if (
+        stockCount === "selectedInRange" ||
+        stockCount === "newerThanRange" ||
+        stockCount === "olderThanRange"
+      ) {
+        return Promise.resolve([{ count: 0 }]);
+      }
+      if (
+        isQuery(query, "errorCode") ||
+        isQuery(query, "recoverable") ||
+        isQuery(query, "retries")
+      ) {
+        return Promise.resolve([]);
+      }
+      return Promise.resolve(summaryRows(query, 0));
+    });
+
+    const { result } = renderHook(() => useSnapshotAnalytics(initialWindow, 0));
+
+    await waitFor(() =>
+      expect(result.current.summary.data).toMatchObject({
+        activeTotal: 1,
+        newerThanRange: 0,
+        olderThanRange: 0,
+        selectedInRange: 0,
+        stockTruncated: true,
+      }),
     );
   });
 
@@ -333,7 +383,7 @@ describe("useSnapshotAnalytics", () => {
     });
   });
 
-  it("aborts the old window and starts nine requests with the applied window", async () => {
+  it("aborts the old window and starts ten requests with the applied window", async () => {
     const controllers: AbortController[] = [];
     const queries: Array<{
       filter: unknown;
@@ -360,8 +410,8 @@ describe("useSnapshotAnalytics", () => {
       await Promise.resolve();
     });
 
-    expect(mocks.aggregate).toHaveBeenCalledTimes(18);
-    expect(controllers.slice(0, 9).every(({ signal }) => signal.aborted)).toBe(
+    expect(mocks.aggregate).toHaveBeenCalledTimes(20);
+    expect(controllers.slice(0, 10).every(({ signal }) => signal.aborted)).toBe(
       true,
     );
     const fullyWindowedQueries = queries.filter((query) => {
@@ -378,7 +428,7 @@ describe("useSnapshotAnalytics", () => {
           JSON.stringify(query.filter).includes('"state.executeAt"') &&
           !fullyWindowedQueries.includes(query),
       ),
-    ).toHaveLength(2);
+    ).toHaveLength(4);
     expect(
       queries.filter(
         (query) => !JSON.stringify(query.filter).includes('"state.executeAt"'),
@@ -393,7 +443,7 @@ describe("useSnapshotAnalytics", () => {
   });
 
   it("does not let settled stale requests overwrite refreshed sections", async () => {
-    const firstLoads = Array.from({ length: 9 }, () => deferred<unknown[]>());
+    const firstLoads = Array.from({ length: 10 }, () => deferred<unknown[]>());
     let firstCall = 0;
     let refresh = 0;
     mocks.aggregate.mockImplementation((query) => {
@@ -416,7 +466,7 @@ describe("useSnapshotAnalytics", () => {
       ({ token }) => useSnapshotAnalytics(initialWindow, token),
       { initialProps: { token: 0 } },
     );
-    expect(mocks.aggregate).toHaveBeenCalledTimes(9);
+    expect(mocks.aggregate).toHaveBeenCalledTimes(10);
 
     refresh = 1;
     await act(async () => {
@@ -434,9 +484,10 @@ describe("useSnapshotAnalytics", () => {
       firstLoads[3].resolve([{ count: 1 }]);
       firstLoads[4].resolve([{ count: 1 }]);
       firstLoads[5].resolve([{ count: 0 }]);
-      firstLoads[6].resolve([]);
-      firstLoads[7].resolve([{ count: 1, recoverable: "true" }]);
-      firstLoads[8].resolve([{ count: 1, retries: 0 }]);
+      firstLoads[6].resolve([{ count: 0 }]);
+      firstLoads[7].resolve([]);
+      firstLoads[8].resolve([{ count: 1, recoverable: "true" }]);
+      firstLoads[9].resolve([{ count: 1, retries: 0 }]);
       await Promise.all(firstLoads.map(({ promise }) => promise));
     });
 

--- a/compensation/dashboard/src/features/Analytics/useSnapshotAnalytics.ts
+++ b/compensation/dashboard/src/features/Analytics/useSnapshotAnalytics.ts
@@ -21,7 +21,6 @@ import {
   createRetryHistogramQuery,
   createSnapshotSummaryQueries,
   mergePressureRows,
-  MAX_TREND_DAYS,
   trendWindowKey,
 } from "./analyticsQueries.ts";
 import type {
@@ -32,7 +31,6 @@ import type {
   RetryDistribution,
   RetryHistogramRow,
   SnapshotSummary,
-  StockPartitionRow,
   TrendWindow,
 } from "./analyticsQueries.ts";
 
@@ -190,52 +188,56 @@ async function loadSummary(
   abortController: AbortController,
 ): Promise<SnapshotSummary> {
   const queries = createSnapshotSummaryQueries(now, window);
-  const [actionableNow, timedOut, unrecoverable, stockPartitions] =
-    await Promise.all([
-      aggregateExecutionFailedSnapshots<CountRow>(
-        queries.actionableNow,
-        undefined,
-        abortController,
-      ),
-      aggregateExecutionFailedSnapshots<CountRow>(
-        queries.timedOut,
-        undefined,
-        abortController,
-      ),
-      aggregateExecutionFailedSnapshots<CountRow>(
-        queries.unrecoverable,
-        undefined,
-        abortController,
-      ),
-      aggregateExecutionFailedSnapshots<StockPartitionRow>(
-        queries.stockPartitions,
-        undefined,
-        abortController,
-      ),
-    ]);
-  const stock = stockPartitions.reduce(
-    (counts, { count, executeAtBucket }) => {
-      counts.activeTotal += count;
-      if (executeAtBucket < window.start) {
-        counts.olderThanRange += count;
-      } else if (executeAtBucket >= window.end) {
-        counts.newerThanRange += count;
-      } else {
-        counts.selectedInRange += count;
-      }
-      return counts;
-    },
-    {
-      activeTotal: 0,
-      newerThanRange: 0,
-      olderThanRange: 0,
-      selectedInRange: 0,
-    },
-  );
+  const [
+    actionableNow,
+    timedOut,
+    unrecoverable,
+    activeTotal,
+    selectedInRange,
+    newerThanRange,
+  ] = await Promise.all([
+    aggregateExecutionFailedSnapshots<CountRow>(
+      queries.actionableNow,
+      undefined,
+      abortController,
+    ),
+    aggregateExecutionFailedSnapshots<CountRow>(
+      queries.timedOut,
+      undefined,
+      abortController,
+    ),
+    aggregateExecutionFailedSnapshots<CountRow>(
+      queries.unrecoverable,
+      undefined,
+      abortController,
+    ),
+    aggregateExecutionFailedSnapshots<CountRow>(
+      queries.activeTotal,
+      undefined,
+      abortController,
+    ),
+    aggregateExecutionFailedSnapshots<CountRow>(
+      queries.selectedInRange,
+      undefined,
+      abortController,
+    ),
+    aggregateExecutionFailedSnapshots<CountRow>(
+      queries.newerThanRange,
+      undefined,
+      abortController,
+    ),
+  ]);
+  const activeTotalCount = activeTotal[0]?.count ?? 0;
+  const selectedInRangeCount = selectedInRange[0]?.count ?? 0;
+  const newerThanRangeCount = newerThanRange[0]?.count ?? 0;
+  const partitionedCount = selectedInRangeCount + newerThanRangeCount;
   return {
     actionableNow: actionableNow[0]?.count ?? 0,
-    ...stock,
-    stockTruncated: stockPartitions.length >= MAX_TREND_DAYS,
+    activeTotal: activeTotalCount,
+    newerThanRange: newerThanRangeCount,
+    olderThanRange: Math.max(activeTotalCount - partitionedCount, 0),
+    selectedInRange: selectedInRangeCount,
+    stockTruncated: partitionedCount > activeTotalCount,
     timedOut: timedOut[0]?.count ?? 0,
     unrecoverable: unrecoverable[0]?.count ?? 0,
   };

--- a/compensation/dashboard/src/features/Analytics/useSnapshotAnalytics.ts
+++ b/compensation/dashboard/src/features/Analytics/useSnapshotAnalytics.ts
@@ -195,6 +195,7 @@ async function loadSummary(
     activeTotal,
     selectedInRange,
     newerThanRange,
+    olderThanRange,
   ] = await Promise.all([
     aggregateExecutionFailedSnapshots<CountRow>(
       queries.actionableNow,
@@ -226,18 +227,25 @@ async function loadSummary(
       undefined,
       abortController,
     ),
+    aggregateExecutionFailedSnapshots<CountRow>(
+      queries.olderThanRange,
+      undefined,
+      abortController,
+    ),
   ]);
   const activeTotalCount = activeTotal[0]?.count ?? 0;
   const selectedInRangeCount = selectedInRange[0]?.count ?? 0;
   const newerThanRangeCount = newerThanRange[0]?.count ?? 0;
-  const partitionedCount = selectedInRangeCount + newerThanRangeCount;
+  const olderThanRangeCount = olderThanRange[0]?.count ?? 0;
+  const partitionedCount =
+    olderThanRangeCount + selectedInRangeCount + newerThanRangeCount;
   return {
     actionableNow: actionableNow[0]?.count ?? 0,
     activeTotal: activeTotalCount,
     newerThanRange: newerThanRangeCount,
-    olderThanRange: Math.max(activeTotalCount - partitionedCount, 0),
+    olderThanRange: olderThanRangeCount,
     selectedInRange: selectedInRangeCount,
-    stockTruncated: partitionedCount > activeTotalCount,
+    stockTruncated: partitionedCount !== activeTotalCount,
     timedOut: timedOut[0]?.count ?? 0,
     unrecoverable: unrecoverable[0]?.count ?? 0,
   };


### PR DESCRIPTION
## Summary
- replace the unbounded active-stock date histogram with four cancellable count aggregations
- preserve exact older/selected/newer totals and hide results unless their sum equals active total
- preserve stale-result, refresh, and AbortController behavior with unit and Playwright fixture coverage

## Performance evidence
- prod full-history histogram: 5.17-5.52s for 1,055,655 active snapshots and 416 buckets
- equivalent no-group aggregations: active 0.84s, selected 0.36s, newer 0.20s, older 2.47s
- the coherent replacement removes date conversion/grouping and reduces the slowest stock request by about half

## Verification
- `pnpm test --run` (41 files, 220 tests)
- `pnpm lint`
- `pnpm build`
- `pnpm exec playwright test --list` (30 browser cases parsed)
- independent code review completed; automated review feedback addressed in `147705ebf`

## Browser verification
- local Playwright Chromium 1234 installation stalled before download; the required Dashboard CI run is the browser-runtime gate