### PR TITLE
perf(query): normalize filters in one pass

### DIFF
--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/query/FilterNormalizerBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/query/FilterNormalizerBenchmark.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.benchmark.query
+
+import me.ahoo.wow.api.query.AndFilter
+import me.ahoo.wow.api.query.DeletionState
+import me.ahoo.wow.api.query.EqualFilter
+import me.ahoo.wow.api.query.FilterExpression
+import me.ahoo.wow.api.query.LogicalField
+import me.ahoo.wow.api.query.MatchAllFilter
+import me.ahoo.wow.query.FilterNormalizer
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Threads
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+import tools.jackson.databind.node.JsonNodeFactory
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(3)
+@Threads(1)
+open class FilterNormalizerBenchmark {
+    @Param("matchAll", "and1", "and8", "and32")
+    lateinit var shape: String
+
+    private val normalizer = FilterNormalizer(
+        clock = Clock.fixed(Instant.parse("2026-08-31T00:00:00Z"), ZoneOffset.UTC),
+        defaultZoneId = ZoneOffset.UTC,
+        defaultDeletionState = DeletionState.ACTIVE,
+    )
+    private lateinit var filter: FilterExpression
+
+    @Setup(Level.Trial)
+    fun setup() {
+        filter = when (shape) {
+            "matchAll" -> MatchAllFilter
+            "and1" -> filter(1)
+            "and8" -> filter(8)
+            "and32" -> filter(32)
+            else -> error("Unsupported filter shape: $shape")
+        }
+    }
+
+    @Benchmark
+    fun normalize(blackhole: Blackhole) {
+        blackhole.consume(normalizer.normalize(filter))
+    }
+
+    private fun filter(size: Int): FilterExpression = AndFilter(
+        List(size) { index ->
+            EqualFilter(
+                LogicalField("state.field$index"),
+                JsonNodeFactory.instance.numberNode(index),
+            )
+        },
+    )
+}

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/FilterNormalizer.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/FilterNormalizer.kt
@@ -64,45 +64,30 @@ class FilterNormalizer(
     private val defaultDeletionState: DeletionState? = DeletionState.ACTIVE,
 ) {
     fun normalize(expression: FilterExpression): FilterExpression {
-        val structural = normalizeStructural(expression)
-        val scoped = if (defaultDeletionState == null || structural.hasExplicitDeletionScope()) {
-            structural
+        val hasDeletionScope = defaultDeletionState == null || expression.hasExplicitDeletionScope()
+        val normalized = normalize(expression, clock.instant())
+        return if (hasDeletionScope) {
+            normalized
         } else {
-            AndFilter(listOf(DeletionFilter(defaultDeletionState), structural))
+            simplifyAnd(listOf(DeletionFilter(checkNotNull(defaultDeletionState)), normalized))
         }
-        val now = clock.instant()
-        return simplify(expandRelativeTime(scoped, now))
     }
 
-    private fun normalizeStructural(expression: FilterExpression): FilterExpression = when (expression) {
+    @Suppress("CyclomaticComplexMethod")
+    private fun normalize(expression: FilterExpression, now: Instant): FilterExpression = when (expression) {
         is EqualFilter -> if (expression.value.isNull) IsNullFilter(expression.field) else expression
         is NotEqualFilter -> if (expression.value.isNull) IsNotNullFilter(expression.field) else expression
         is IsEmptyStringFilter -> EqualFilter(expression.field, JsonNodeFactory.instance.stringNode(""))
-        is IsNotEmptyStringFilter -> AndFilter(
+        is IsNotEmptyStringFilter -> simplifyAnd(
             listOf(
                 IsNotNullFilter(expression.field),
                 NotEqualFilter(expression.field, JsonNodeFactory.instance.stringNode("")),
             ),
         )
-        is AndFilter -> AndFilter(expression.operands.map(::normalizeStructural))
-        is OrFilter -> OrFilter(expression.operands.map(::normalizeStructural))
-        is NorFilter -> NorFilter(expression.operands.map(::normalizeStructural))
-        is ElementMatchFilter -> ElementMatchFilter(expression.field, normalizeStructural(expression.predicate))
-        else -> expression
-    }
-
-    private fun FilterExpression.hasExplicitDeletionScope(): Boolean = when (this) {
-        is DeletionFilter -> true
-        is AndFilter -> operands.any { it.hasExplicitDeletionScope() }
-        else -> false
-    }
-
-    @Suppress("CyclomaticComplexMethod")
-    private fun expandRelativeTime(expression: FilterExpression, now: Instant): FilterExpression = when (expression) {
-        is AndFilter -> AndFilter(expression.operands.map { expandRelativeTime(it, now) })
-        is OrFilter -> OrFilter(expression.operands.map { expandRelativeTime(it, now) })
-        is NorFilter -> NorFilter(expression.operands.map { expandRelativeTime(it, now) })
-        is ElementMatchFilter -> ElementMatchFilter(expression.field, expandRelativeTime(expression.predicate, now))
+        is AndFilter -> simplifyAnd(expression.operands.map { normalize(it, now) })
+        is OrFilter -> simplifyOr(expression.operands.map { normalize(it, now) })
+        is NorFilter -> simplifyNor(expression.operands.map { normalize(it, now) })
+        is ElementMatchFilter -> ElementMatchFilter(expression.field, normalize(expression.predicate, now))
         is YesterdayFilter -> expression.dayRange(now, -1)
         is TodayFilter -> expression.dayRange(now, 0)
         is TomorrowFilter -> expression.dayRange(now, 1)
@@ -145,6 +130,12 @@ class FilterNormalizer(
         }
 
         else -> expression
+    }
+
+    private fun FilterExpression.hasExplicitDeletionScope(): Boolean = when (this) {
+        is DeletionFilter -> true
+        is AndFilter -> operands.any { it.hasExplicitDeletionScope() }
+        else -> false
     }
 
     private fun RelativeTimeFilter.dayRange(now: Instant, offset: Long): FilterExpression =
@@ -233,18 +224,16 @@ class FilterNormalizer(
 
     private fun zone(zoneId: String?): ZoneId = zoneId?.let(ZoneId::of) ?: defaultZoneId
 
-    private fun simplify(expression: FilterExpression): FilterExpression = when (expression) {
-        is AndFilter -> simplifyAnd(expression.operands.map(::simplify))
-        is OrFilter -> simplifyOr(expression.operands.map(::simplify))
-        is NorFilter -> simplifyNor(expression.operands.map(::simplify))
-        is ElementMatchFilter -> ElementMatchFilter(expression.field, simplify(expression.predicate))
-        else -> expression
-    }
-
     private fun simplifyAnd(operands: List<FilterExpression>): FilterExpression {
-        if (operands.any { it === MatchNoneFilter }) return MatchNoneFilter
-        val flattened = operands.flatMap { if (it is AndFilter) it.operands else listOf(it) }
-            .filterNot { it === MatchAllFilter }
+        val flattened = ArrayList<FilterExpression>(operands.size)
+        operands.forEach { operand ->
+            when {
+                operand === MatchNoneFilter -> return MatchNoneFilter
+                operand === MatchAllFilter -> Unit
+                operand is AndFilter -> flattened.addAll(operand.operands)
+                else -> flattened += operand
+            }
+        }
         return when (flattened.size) {
             0 -> MatchAllFilter
             1 -> flattened.first()
@@ -253,9 +242,15 @@ class FilterNormalizer(
     }
 
     private fun simplifyOr(operands: List<FilterExpression>): FilterExpression {
-        if (operands.any { it === MatchAllFilter }) return MatchAllFilter
-        val flattened = operands.flatMap { if (it is OrFilter) it.operands else listOf(it) }
-            .filterNot { it === MatchNoneFilter }
+        val flattened = ArrayList<FilterExpression>(operands.size)
+        operands.forEach { operand ->
+            when {
+                operand === MatchAllFilter -> return MatchAllFilter
+                operand === MatchNoneFilter -> Unit
+                operand is OrFilter -> flattened.addAll(operand.operands)
+                else -> flattened += operand
+            }
+        }
         return when (flattened.size) {
             0 -> MatchNoneFilter
             1 -> flattened.first()
@@ -264,8 +259,13 @@ class FilterNormalizer(
     }
 
     private fun simplifyNor(operands: List<FilterExpression>): FilterExpression {
-        if (operands.any { it === MatchAllFilter }) return MatchNoneFilter
-        val filtered = operands.filterNot { it === MatchNoneFilter }
+        val filtered = ArrayList<FilterExpression>(operands.size)
+        operands.forEach { operand ->
+            when {
+                operand === MatchAllFilter -> return MatchNoneFilter
+                operand !== MatchNoneFilter -> filtered += operand
+            }
+        }
         return if (filtered.isEmpty()) MatchAllFilter else NorFilter(filtered)
     }
 }


### PR DESCRIPTION
## Goal

Reduce filter-normalization CPU time and allocation without changing query semantics or public contracts.

## Changes

- Combine structural rewrites, relative-time expansion, and logical simplification into one recursive traversal.
- Preserve the explicit deletion-scope scan and the `defaultDeletionState = null` short circuit.
- Flatten AND/OR/NOR operands with a single collection pass.
- Add a focused JMH benchmark for MatchAll and 1, 8, and 32-condition filters.

## Verification

- `./gradlew :wow-query:check :wow-benchmarks:check :wow-benchmarks:jmhJar --no-parallel` — BUILD SUCCESSFUL.
- `FilterNormalizerTest` — 11/11 tests passed, covering deletion scope, relative time, time zones, formatter/time units, null and empty-string rewrites, and logical simplification.
- `FilterNormalizerBenchmark.normalize -prof gc`, 3 forks and 30 measurements per shape:
  - MatchAll: 53.450 ns/op, 400 B/op → 10.736 ns/op, 96 B/op.
  - AND × 1: 97.808 ns/op, 880 B/op → 27.214 ns/op, 296 B/op.
  - AND × 8: 444.146 ns/op, 1384 B/op → 90.479 ns/op, 472 B/op.
  - AND × 32: 1055.960 ns/op, 4080 B/op → 278.009 ns/op, 856 B/op.
- Independent read-only review found no critical, important, or minor issues.

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

Relative-time calculation, date formatting, time units, deletion-scope semantics, and MongoDB/Elasticsearch converter boundaries are unchanged. The JMH results are local hot-path evidence, not a production-capacity claim.