### PR TITLE
perf(query): fast-path default schema resolution

### DIFF
--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolver.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolver.kt
@@ -49,6 +49,20 @@ data class ResolvedAggregationQuery(
     val schema: QueryModelSchema?,
 )
 
+private fun combined(
+    first: QueryCompatibilityLevel,
+    second: QueryCompatibilityLevel,
+    third: QueryCompatibilityLevel,
+): QueryCompatibilityLevel = when {
+    first == QueryCompatibilityLevel.INCOMPATIBLE ||
+        second == QueryCompatibilityLevel.INCOMPATIBLE ||
+        third == QueryCompatibilityLevel.INCOMPATIBLE -> QueryCompatibilityLevel.INCOMPATIBLE
+    first == QueryCompatibilityLevel.COMPATIBLE ||
+        second == QueryCompatibilityLevel.COMPATIBLE ||
+        third == QueryCompatibilityLevel.COMPATIBLE -> QueryCompatibilityLevel.COMPATIBLE
+    else -> QueryCompatibilityLevel.EXACT
+}
+
 fun <T> QuerySchemaResolution<T>.requireAccepted(mode: QuerySchemaValidationMode): T {
     if (!mode.accepts(compatibility)) {
         throw QuerySchemaValidationException(
@@ -71,7 +85,7 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
         val sort = resolve(query.sort)
         return QuerySchemaResolution(
             SingleQuery(filter.value, projection.value, sort.value),
-            listOf(filter.compatibility, projection.compatibility, sort.compatibility).combined(),
+            combined(filter.compatibility, projection.compatibility, sort.compatibility),
         )
     }
 
@@ -81,7 +95,7 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
         val sort = resolve(query.sort)
         return QuerySchemaResolution(
             ListQuery(filter.value, projection.value, sort.value, query.limit),
-            listOf(filter.compatibility, projection.compatibility, sort.compatibility).combined(),
+            combined(filter.compatibility, projection.compatibility, sort.compatibility),
         )
     }
 
@@ -91,7 +105,7 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
         val sort = resolve(query.sort)
         return QuerySchemaResolution(
             PagedQuery(filter.value, projection.value, sort.value, query.pagination),
-            listOf(filter.compatibility, projection.compatibility, sort.compatibility).combined(),
+            combined(filter.compatibility, projection.compatibility, sort.compatibility),
         )
     }
 
@@ -101,7 +115,7 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
         val sort = resolveCursorSort(query.sort)
         return QuerySchemaResolution(
             CursorQuery(filter.value, projection.value, sort.value, query.size, query.cursor),
-            listOf(filter.compatibility, projection.compatibility, sort.compatibility).combined(),
+            combined(filter.compatibility, projection.compatibility, sort.compatibility),
         )
     }
 
@@ -110,6 +124,9 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
 
     fun resolve(projection: Projection): QuerySchemaResolution<Projection> {
         val maskedEventProjection = schema.model == QueryModel.EVENT_STREAM && schema.hasMaskedFields
+        if (!maskedEventProjection && projection.isEmpty()) {
+            return QuerySchemaResolution(Projection.ALL, QueryCompatibilityLevel.EXACT)
+        }
         val include = projection.include.map {
             fieldResolver.resolveProjectionPath(it)
         }
@@ -158,6 +175,9 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
     }
 
     fun resolve(sort: List<Sort>): QuerySchemaResolution<List<Sort>> {
+        if (sort.isEmpty()) {
+            return QuerySchemaResolution(emptyList(), QueryCompatibilityLevel.EXACT)
+        }
         val resolved = sort.map { item ->
             fieldResolver.resolvePath(item.field, QueryCapability.SORT).let { field ->
                 item.copy(field = field.value) to field.compatibility
@@ -170,6 +190,9 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
     }
 
     private fun resolveCursorSort(sort: List<Sort>): QuerySchemaResolution<List<Sort>> {
+        if (sort.isEmpty()) {
+            return QuerySchemaResolution(emptyList(), QueryCompatibilityLevel.EXACT)
+        }
         val resolved = sort.map { item ->
             val field = runCatching { LogicalField(item.field) }.getOrNull()?.let { logical ->
                 fieldResolver.resolve(logical, QueryCapability.SORT, null, null)

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolverTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolverTest.kt
@@ -1050,6 +1050,77 @@ class QuerySchemaResolverTest {
     }
 
     @Test
+    fun `query should combine component compatibility by the strictest level`() {
+        val compatible = LogicalField("state.unknown")
+        val incompatible = LogicalField("state.declared")
+        val resolver = QuerySchemaResolver(schema(mapOf(incompatible to fieldSchema())))
+        val filters = mapOf(
+            QueryCompatibilityLevel.EXACT to MatchAllFilter,
+            QueryCompatibilityLevel.COMPATIBLE to EqualFilter(compatible, json(1)),
+            QueryCompatibilityLevel.INCOMPATIBLE to EqualFilter(incompatible, json(1)),
+        )
+        val projections = mapOf(
+            QueryCompatibilityLevel.EXACT to Projection.ALL,
+            QueryCompatibilityLevel.COMPATIBLE to Projection(include = listOf(compatible.value)),
+            QueryCompatibilityLevel.INCOMPATIBLE to Projection(include = listOf(incompatible.value)),
+        )
+        val sorts = mapOf(
+            QueryCompatibilityLevel.EXACT to emptyList(),
+            QueryCompatibilityLevel.COMPATIBLE to listOf(Sort(compatible.value, Sort.Direction.ASC)),
+            QueryCompatibilityLevel.INCOMPATIBLE to listOf(Sort(incompatible.value, Sort.Direction.ASC)),
+        )
+
+        QueryCompatibilityLevel.entries.forEach { filterLevel ->
+            QueryCompatibilityLevel.entries.forEach { projectionLevel ->
+                QueryCompatibilityLevel.entries.forEach { sortLevel ->
+                    val expected = maxOf(filterLevel, projectionLevel, sortLevel)
+                    resolver.resolve(
+                        ListQuery(
+                            filter = filters.getValue(filterLevel),
+                            projection = projections.getValue(projectionLevel),
+                            sort = sorts.getValue(sortLevel),
+                            limit = 1,
+                        ),
+                    ).compatibility.assert().isEqualTo(expected)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `empty projection and cursor sort should preserve masking contracts`() {
+        val snapshotResolver = QuerySchemaResolver(
+            schema(
+                mapOf(
+                    LogicalField("state.secret") to fieldSchema(maskRule = fullMaskRule()),
+                ),
+            ),
+        )
+        snapshotResolver.resolve(Projection()).assert().isEqualTo(
+            QuerySchemaResolution(Projection.ALL, QueryCompatibilityLevel.EXACT),
+        )
+
+        val eventResolver = QuerySchemaResolver(
+            QueryModelSchema(
+                QueryModel.EVENT_STREAM,
+                emptySet(),
+                mapOf(
+                    LogicalField("body.body.secret") to fieldSchema(maskRule = fullMaskRule()),
+                    LogicalField("body.bodyType") to fieldSchema(
+                        QueryCapability.PRESENCE to "document.events.type",
+                    ),
+                ),
+            ),
+        )
+        eventResolver.resolve(Projection()).assert().isEqualTo(
+            QuerySchemaResolution(Projection.ALL, QueryCompatibilityLevel.EXACT),
+        )
+        eventResolver.resolve(CursorQuery(MatchAllFilter)).assert().isEqualTo(
+            QuerySchemaResolution(CursorQuery(MatchAllFilter), QueryCompatibilityLevel.EXACT),
+        )
+    }
+
+    @Test
     fun `aggregation should validate relative elements groups and numeric expression fields`() {
         val query = AggregationQuery(
             filter = EqualFilter(LogicalField("state.status"), json("OPEN")),


### PR DESCRIPTION
## Goal

Reduce default query schema resolution allocation and latency without changing public, wire, or query semantics.

## Changes

- Canonicalize empty projections to Projection.ALL outside masked EventStream.
- Fast-path empty normal and cursor sorts.
- Combine component compatibility levels without temporary lists.
- Add public regression coverage for all 27 compatibility combinations and masking/cursor empty paths.

## Verification

- ./gradlew :wow-query:check :wow-benchmarks:check :wow-benchmarks:jmhJar --no-parallel — BUILD SUCCESSFUL.
- Existing JMH scenario: 58.17 ± 2.64 ns/op and 728 B/op → 42.87 ± 2.36 ns/op and 504 B/op (about 26.3% lower latency and 30.8% lower allocation).
- Independent review completed with no remaining findings.

## Compatibility and risks

- [x] This change preserves public API compatibility.
- [x] This change preserves wire compatibility.
- [x] This change preserves existing query semantics.

Only empty/default paths are canonicalized. The masked EventStream projection branch remains unchanged, and caller Query instances are not reused. Benchmark evidence is local and limited to the existing masked snapshot SingleQuery default-path scenario.