### PR TITLE
perf(query): index masked cursor sort paths

### DIFF
--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/query/QuerySchemaResolverBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/query/QuerySchemaResolverBenchmark.kt
@@ -13,15 +13,19 @@
 
 package me.ahoo.wow.benchmark.query
 
+import me.ahoo.wow.api.query.CursorQuery
 import me.ahoo.wow.api.query.LogicalField
 import me.ahoo.wow.api.query.MatchAllFilter
 import me.ahoo.wow.api.query.SingleQuery
+import me.ahoo.wow.api.query.Sort
 import me.ahoo.wow.api.query.mask.FullMaskStrategy
 import me.ahoo.wow.api.query.mask.Mask
+import me.ahoo.wow.api.query.schema.QueryCapability
 import me.ahoo.wow.api.query.schema.QueryCardinality
 import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.api.query.schema.QueryValueType
 import me.ahoo.wow.query.schema.MaskRule
+import me.ahoo.wow.query.schema.QueryFieldBinding
 import me.ahoo.wow.query.schema.QueryFieldSchema
 import me.ahoo.wow.query.schema.QueryModelSchema
 import me.ahoo.wow.query.schema.QueryModelSchemaProvider
@@ -52,12 +56,26 @@ private const val MASKED_FIELD_COUNT = 64
 @Fork(3)
 @Threads(1)
 open class QuerySchemaResolverBenchmark {
+    private val sortableField = LogicalField("state.createdAt")
     private val schema = QueryModelSchema(
         model = QueryModel.SNAPSHOT,
         capabilities = emptySet(),
-        fields = List(MASKED_FIELD_COUNT) { index ->
-            LogicalField("state.secret$index") to maskedFieldSchema()
-        }.toMap(),
+        fields = buildMap {
+            putAll(
+                List(MASKED_FIELD_COUNT) { index ->
+                    LogicalField("state.secret$index") to maskedFieldSchema()
+                },
+            )
+            put(
+                sortableField,
+                maskedFieldSchema().copy(
+                    bindings = mapOf(
+                        QueryCapability.SORT to QueryFieldBinding("document.createdAt", null),
+                    ),
+                    maskRule = null,
+                ),
+            )
+        },
     )
     private val provider = object : QueryModelSchemaProvider {
         private val schemaMono = Mono.just(schema)
@@ -67,10 +85,19 @@ open class QuerySchemaResolverBenchmark {
         override fun refresh(): Mono<QueryModelSchema> = schemaMono
     }
     private val query = SingleQuery(MatchAllFilter)
+    private val cursorQuery = CursorQuery(
+        MatchAllFilter,
+        sort = listOf(Sort(sortableField.value, Sort.Direction.ASC)),
+    )
 
     @Benchmark
     fun resolve(blackhole: Blackhole) {
         blackhole.consume(provider.resolve(query, QuerySchemaValidationMode.COMPATIBLE).block())
+    }
+
+    @Benchmark
+    fun resolveCursorSort(blackhole: Blackhole) {
+        blackhole.consume(provider.resolve(cursorQuery, QuerySchemaValidationMode.COMPATIBLE).block())
     }
 
     private fun maskedFieldSchema(): QueryFieldSchema {

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolver.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolver.kt
@@ -78,6 +78,12 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
     private val maskedAggregationPaths = schema.maskedFields.flatMapTo(linkedSetOf()) { (logical, field) ->
         listOfNotNull(logical.value, field.projectionPath) + field.bindings.values.map { it.physicalPath }
     }
+    private val maskedProjectionPaths = schema.maskedFields.values.mapNotNullTo(hashSetOf()) { field ->
+        field.projectionPath?.takeIf { it.isNotEmpty() }
+    }
+    private val maskedPhysicalPaths = schema.maskedFields.values.flatMapTo(hashSetOf()) { field ->
+        field.bindings.values.map { it.physicalPath }
+    }
 
     fun resolve(query: ISingleQuery): QuerySchemaResolution<ISingleQuery> {
         val filter = resolve(query.filter)
@@ -314,13 +320,9 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
         val logicalCandidate = logical.value
         val projectionCandidate = fieldSchema?.projectionPath
         val physicalCandidate = physicalPath ?: logicalCandidate
-        return schema.maskedFields.values.any { maskedField ->
-            val projectionPath = maskedField.projectionPath
-            val matchesProjection = !projectionPath.isNullOrEmpty() &&
-                (projectionPath == logicalCandidate || projectionPath == projectionCandidate)
-            matchesProjection ||
-                maskedField.bindings.values.any { binding -> binding.physicalPath == physicalCandidate }
-        }
+        return logicalCandidate in maskedProjectionPaths ||
+            projectionCandidate != null && projectionCandidate in maskedProjectionPaths ||
+            physicalCandidate in maskedPhysicalPaths
     }
 
     private val AggregationGroup.capability: QueryCapability


### PR DESCRIPTION
## Goal

Reduce cursor query schema-resolution latency for schemas with masked fields without changing cursor-sort validation semantics.

## Changes

- Pre-index masked projection paths and physical bindings once per cached QuerySchemaResolver.
- Replace the per-sort linear masked-field scan with Set membership checks.
- Extend the existing QuerySchemaResolver JMH benchmark with 64 masked fields and one valid Cursor sort.

## Verification

- ./gradlew :wow-query:check :wow-benchmarks:check :wow-benchmarks:jmhJar --no-parallel — BUILD SUCCESSFUL.
- git diff --check — clean.
- JMH: 372.121 ± 4.051 ns/op → 275.644 ± 7.047 ns/op, about 25.9% lower latency.
- Allocation remained 1888 B/op; no allocation improvement is claimed.
- Independent review: Ready to merge, no Critical, Important, or Minor findings.

## Compatibility and risks

- [x] This change preserves public API compatibility.
- [x] This change preserves wire compatibility.
- [x] This change preserves existing cursor-sort validation semantics.

The cursor-sort pipeline is unchanged. Direct masks, dynamic masked descendants, projection and physical aliases, multi-valued fields, unstable metadata fields, and duplicate resolved physical sorts retain their existing rejection behavior.