### PR TITLE
ci: extend Gradle build caching

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -32,8 +32,10 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           server-id: github
-          cache: gradle
           settings-path: ${{ github.workspace }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build Code Coverage Report
         run: ./gradlew codeCoverageReport --stacktrace

--- a/.github/workflows/documentation-deploy.yml
+++ b/.github/workflows/documentation-deploy.yml
@@ -19,6 +19,7 @@ on:
     branches:
       - main
     paths:
+      - '.github/workflows/documentation-deploy.yml'
       - 'documentation/**'
   workflow_dispatch:
 
@@ -52,18 +53,10 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           server-id: github
-          cache: gradle
           settings-path: ${{ github.workspace }}
 
-      - name: Cache Gradle packages
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Setup Pages
         uses: actions/configure-pages@v6


### PR DESCRIPTION
## Goal

Extend the proven Local Test Gradle caching strategy to the two highest-value main-branch workflows without changing their build, coverage, documentation, or deployment behavior.

## Changes

- Replace setup-java Gradle caching with gradle/actions/setup-gradle@v6 in Codecov.
- Replace both overlapping Gradle cache mechanisms in Documentation with setup-gradle enhanced caching.
- Trigger Documentation when its workflow file changes so main can seed the updated cache immediately.

## Verification

- Cache workflow RED/GREEN contract assertions — passed.
- actionlint .github/workflows/codecov.yml .github/workflows/documentation-deploy.yml — passed.
- CI=GITHUB_ACTIONS ./gradlew codeCoverageReport dokkaGenerateHtml --stacktrace — BUILD SUCCESSFUL in 4m 43s.
- Independent read-only review found no Critical, Important, or Minor issues.

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

The first main runs may be cold and spend additional post-job time saving Gradle state. Later runs can restore compilation, test, coverage, and Dokka outputs from the main cache. Documentation now also deploys when this workflow file itself changes. The default setup-gradle v6 enhanced provider is used, consistent with Local Test.