### PR TITLE
perf(query): resolve cursor sorts in one pass

### DIFF
--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolver.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolver.kt
@@ -199,7 +199,10 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
         if (sort.isEmpty()) {
             return QuerySchemaResolution(emptyList(), QueryCompatibilityLevel.EXACT)
         }
-        val resolved = sort.map { item ->
+        val values = ArrayList<Sort>(sort.size)
+        val fields = HashSet<String>(sort.size)
+        var compatibility = QueryCompatibilityLevel.EXACT
+        sort.forEach { item ->
             val field = runCatching { LogicalField(item.field) }.getOrNull()?.let { logical ->
                 fieldResolver.resolve(logical, QueryCapability.SORT, null, null)
             }
@@ -207,18 +210,13 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
                 field.fieldSchema != null && field.fieldSchema.cardinality == QueryCardinality.SINGLE &&
                 field.fieldSchema.maskRule == null && field.value !in FORBIDDEN_CURSOR_SORTS &&
                 !field.matchesMaskedCandidate()
-            item.copy(field = field?.value ?: item.field) to
-                if (accepted) QueryCompatibilityLevel.EXACT else QueryCompatibilityLevel.INCOMPATIBLE
+            val value = item.copy(field = field?.value ?: item.field)
+            values += value
+            if (!accepted || !fields.add(value.field)) {
+                compatibility = QueryCompatibilityLevel.INCOMPATIBLE
+            }
         }
-        val values = resolved.map { it.first }
-        return QuerySchemaResolution(
-            values,
-            if (values.map(Sort::field).distinct().size == values.size) {
-                resolved.map { it.second }.combined()
-            } else {
-                QueryCompatibilityLevel.INCOMPATIBLE
-            },
-        )
+        return QuerySchemaResolution(values, compatibility)
     }
 
     fun resolve(query: AggregationQuery): QuerySchemaResolution<AggregationQuery> {


### PR DESCRIPTION
## Goal

Reduce Cursor query schema-resolution latency and allocation without changing cursor-sort validation or output semantics.

## Changes

- Resolve non-empty Cursor sorts in one pass.
- Keep one pre-sized result list and one resolved-field set.
- Track compatibility while resolving instead of creating Pair and intermediate value, field, distinct, and compatibility collections.
- Leave ordinary sort resolution unchanged.

## Verification

- ./gradlew :wow-query:check :wow-benchmarks:check :wow-benchmarks:jmhJar --no-parallel — BUILD SUCCESSFUL.
- git diff --check — clean.
- Existing JMH scenario: 279.092 ± 7.303 ns/op → 231.295 ± 4.399 ns/op, about 17.1% lower latency.
- Allocation: 1906.667 ± 17.939 B/op → 1528.001 ± 0.001 B/op, about 19.9% lower.
- Independent review: Ready to merge, no Critical, Important, or Minor findings.

## Compatibility and risks

- [x] This change preserves public API compatibility.
- [x] This change preserves wire compatibility.
- [x] This change preserves cursor-sort output ordering, direction, field rewriting, and validation semantics.

Invalid sorts still make the complete resolution incompatible. Duplicate resolved physical fields are still rejected, and existing mask, cardinality, forbidden-field, and schema checks are unchanged.