### PR TITLE
ci: cache Gradle deploy builds

### DIFF
--- a/.github/workflows/compensation-deploy.yml
+++ b/.github/workflows/compensation-deploy.yml
@@ -80,8 +80,10 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           server-id: github
-          cache: gradle
           settings-path: ${{ github.workspace }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build Dist
         run: ./gradlew wow-compensation-server:installDist

--- a/.github/workflows/example-deploy.yml
+++ b/.github/workflows/example-deploy.yml
@@ -55,8 +55,10 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           server-id: github
-          cache: gradle
           settings-path: ${{ github.workspace }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build Dist
         run: ./gradlew example-server:installDist


### PR DESCRIPTION
## Goal

Speed up the Gradle `installDist` phase in the example and compensation image deployment workflows.

## Changes

- replace `actions/setup-java`'s dependency-only Gradle cache with `gradle/actions/setup-gradle@v6`
- keep JDK, pnpm, Docker, registry login, image metadata, triggers, and publish behavior unchanged

## Validation

- semantic YAML cache contract: PASS (RED before implementation, GREEN after)
- `actionlint .github/workflows/example-deploy.yml .github/workflows/compensation-deploy.yml`
- `git diff --check origin/main...HEAD`
- `CI=GITHUB_ACTIONS ./gradlew :example-server:installDist :wow-compensation-server:installDist --stacktrace`
  - `BUILD SUCCESSFUL`
- independent review: no Critical, Important, or Minor findings

## Risk / evidence boundary

The workflow change is limited to Gradle cache setup. Docker images were not built or pushed locally; the first exact GitHub Actions deployment evidence will be available after merge or manual dispatch.
