### PR TITLE
ci: cache Gradle pull request builds

### DIFF
--- a/.github/workflows/benchmark-smoke.yml
+++ b/.github/workflows/benchmark-smoke.yml
@@ -51,8 +51,10 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           server-id: github
-          cache: gradle
           settings-path: ${{ github.workspace }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Run benchmark tests and smoke
         run: ./gradlew :wow-benchmarks:test :wow-benchmarks:benchmarkSmoke --stacktrace

--- a/.github/workflows/compensation-test.yml
+++ b/.github/workflows/compensation-test.yml
@@ -53,8 +53,10 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           server-id: github
-          cache: gradle
           settings-path: ${{ github.workspace }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Test Compensation-Core
         run: ./gradlew wow-compensation-core:check --stacktrace
@@ -71,8 +73,10 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           server-id: github
-          cache: gradle
           settings-path: ${{ github.workspace }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Test Compensation-Domain
         run: ./gradlew wow-compensation-domain:check --stacktrace

--- a/.github/workflows/contract-test.yml
+++ b/.github/workflows/contract-test.yml
@@ -53,8 +53,10 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           server-id: github
-          cache: gradle
           settings-path: ${{ github.workspace }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Run contract tests with coverage
         run: ./gradlew allContractTest :code-coverage-report:contractCoverageReport --stacktrace

--- a/.github/workflows/example-java-test.yml
+++ b/.github/workflows/example-java-test.yml
@@ -49,8 +49,10 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           server-id: github
-          cache: gradle
           settings-path: ${{ github.workspace }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Test example-transfer-api
         run: ./gradlew example-transfer-api:build --stacktrace

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -58,8 +58,10 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           server-id: github
-          cache: gradle
           settings-path: ${{ github.workspace }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Run integration tests with coverage
         run: ./gradlew allIntegrationTest :code-coverage-report:integrationCoverageReport --stacktrace

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -46,8 +46,10 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           server-id: github
-          cache: gradle
           settings-path: ${{ github.workspace }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Run static analysis
         run: ./gradlew detekt --stacktrace


### PR DESCRIPTION
## Goal

Speed up Gradle-based pull request workflows by reusing the trusted build cache already produced on `main`.

## Changes

- migrate Integration Test, Contract Test, Compensation Test, Benchmark Smoke, Example Java Test, and Static Analysis to `gradle/actions/setup-gradle@v6`
- remove the overlapping `cache: gradle` option from `actions/setup-java`
- keep the default PR read-only cache policy
- keep triggers, paths, permissions, concurrency, test commands, and coverage uploads unchanged
- leave release-sensitive `package-deploy.yml` unchanged

## Validation

- semantic YAML cache contract: PASS (RED before implementation, GREEN after)
- `actionlint` for all six workflows
- `git diff --check origin/main...HEAD`
- exact Gradle task union for all six workflows: `BUILD SUCCESSFUL in 2m 28s`
- fresh verification rerun: `BUILD SUCCESSFUL in 23s`
- independent review: no Critical, Important, or Minor findings

## Evidence boundary

The PR itself triggers all six workflows and provides the first GitHub-hosted cache-read evidence. PR caches remain read-only, so untrusted pull requests cannot populate shared cache entries.
