### PR TITLE
perf(query): streamline composite filter resolution

### DIFF
--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/query/QuerySchemaResolverBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/query/QuerySchemaResolverBenchmark.kt
@@ -13,7 +13,9 @@
 
 package me.ahoo.wow.benchmark.query
 
+import me.ahoo.wow.api.query.AndFilter
 import me.ahoo.wow.api.query.CursorQuery
+import me.ahoo.wow.api.query.EqualFilter
 import me.ahoo.wow.api.query.LogicalField
 import me.ahoo.wow.api.query.MatchAllFilter
 import me.ahoo.wow.api.query.SingleQuery
@@ -43,10 +45,12 @@ import org.openjdk.jmh.annotations.Threads
 import org.openjdk.jmh.annotations.Warmup
 import org.openjdk.jmh.infra.Blackhole
 import reactor.core.publisher.Mono
+import tools.jackson.databind.node.JsonNodeFactory
 import java.util.concurrent.TimeUnit
 import kotlin.reflect.jvm.javaField
 
 private const val MASKED_FIELD_COUNT = 64
+private const val FILTER_OPERAND_COUNT = 8
 
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.AverageTime)
@@ -64,6 +68,16 @@ open class QuerySchemaResolverBenchmark {
             putAll(
                 List(MASKED_FIELD_COUNT) { index ->
                     LogicalField("state.secret$index") to maskedFieldSchema()
+                },
+            )
+            putAll(
+                List(FILTER_OPERAND_COUNT) { index ->
+                    LogicalField("state.filter$index") to maskedFieldSchema().copy(
+                        bindings = mapOf(
+                            QueryCapability.EXACT_MATCH to QueryFieldBinding("document.filter$index", null),
+                        ),
+                        maskRule = null,
+                    )
                 },
             )
             put(
@@ -85,6 +99,16 @@ open class QuerySchemaResolverBenchmark {
         override fun refresh(): Mono<QueryModelSchema> = schemaMono
     }
     private val query = SingleQuery(MatchAllFilter)
+    private val compositeFilterQuery = SingleQuery(
+        AndFilter(
+            List(FILTER_OPERAND_COUNT) { index ->
+                EqualFilter(
+                    LogicalField("state.filter$index"),
+                    JsonNodeFactory.instance.stringNode(index.toString()),
+                )
+            },
+        ),
+    )
     private val cursorQuery = CursorQuery(
         MatchAllFilter,
         sort = listOf(Sort(sortableField.value, Sort.Direction.ASC)),
@@ -93,6 +117,11 @@ open class QuerySchemaResolverBenchmark {
     @Benchmark
     fun resolve(blackhole: Blackhole) {
         blackhole.consume(provider.resolve(query, QuerySchemaValidationMode.COMPATIBLE).block())
+    }
+
+    @Benchmark
+    fun resolveCompositeFilter(blackhole: Blackhole) {
+        blackhole.consume(provider.resolve(compositeFilterQuery, QuerySchemaValidationMode.COMPATIBLE).block())
     }
 
     @Benchmark

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QueryFieldSchemaResolver.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QueryFieldSchemaResolver.kt
@@ -32,6 +32,14 @@ internal data class QueryFieldResolution(
 internal class QueryFieldSchemaResolver(
     private val schema: QueryModelSchema,
 ) {
+    private val elementScopePaths = buildSet {
+        schema.fields.forEach { (field, fieldSchema) ->
+            if (QueryCapability.ELEMENT_SCOPE in fieldSchema.bindings) {
+                add(field.value)
+            }
+        }
+    }
+
     fun resolveProjectionPath(path: String): QuerySchemaResolution<String> {
         val logicalField = try {
             LogicalField(path)
@@ -116,11 +124,12 @@ internal class QueryFieldSchemaResolver(
     }
 
     private fun LogicalField.isInElementScope(parent: LogicalField?): Boolean {
+        if (elementScopePaths.isEmpty()) return true
         var separator = value.lastIndexOf('.')
         while (separator > 0) {
-            val ancestor = LogicalField(value.substring(0, separator))
-            if (schema.fields[ancestor]?.bindings?.containsKey(QueryCapability.ELEMENT_SCOPE) == true) {
-                return ancestor == parent
+            val ancestorPath = value.substring(0, separator)
+            if (ancestorPath in elementScopePaths) {
+                return ancestorPath == parent?.value
             }
             separator = value.lastIndexOf('.', separator - 1)
         }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QueryFilterSchemaResolver.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QueryFilterSchemaResolver.kt
@@ -261,11 +261,14 @@ internal class QueryFilterSchemaResolver(
         physicalParent: String?,
         create: (List<FilterExpression>) -> FilterExpression,
     ): QuerySchemaResolution<FilterExpression> {
-        val resolved = operands.map { resolve(it, logicalParent, physicalParent) }
-        return QuerySchemaResolution(
-            create(resolved.map { it.value }),
-            resolved.map { it.compatibility }.combined(),
-        )
+        val values = ArrayList<FilterExpression>(operands.size)
+        var compatibility = QueryCompatibilityLevel.EXACT
+        operands.forEach { operand ->
+            val resolved = resolve(operand, logicalParent, physicalParent)
+            values += resolved.value
+            compatibility = maxOf(compatibility, resolved.compatibility)
+        }
+        return QuerySchemaResolution(create(values), compatibility)
     }
 
     private inline fun resolveFieldFilter(

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QueryModelSchemaProviderResolution.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QueryModelSchemaProviderResolution.kt
@@ -26,21 +26,21 @@ fun QueryModelSchemaProvider.resolve(
     mode: QuerySchemaValidationMode,
 ): Mono<ISingleQuery> = schemaForQuery()
     .map { it.resolver.resolve(query).requireAccepted(mode) }
-    .fallbackUnavailable(mode, query, !query.filter.referencesSystemTags())
+    .fallbackUnavailable(mode, query, query.filter)
 
 fun QueryModelSchemaProvider.resolve(
     query: IListQuery,
     mode: QuerySchemaValidationMode,
 ): Mono<IListQuery> = schemaForQuery()
     .map { it.resolver.resolve(query).requireAccepted(mode) }
-    .fallbackUnavailable(mode, query, !query.filter.referencesSystemTags())
+    .fallbackUnavailable(mode, query, query.filter)
 
 fun QueryModelSchemaProvider.resolve(
     query: IPagedQuery,
     mode: QuerySchemaValidationMode,
 ): Mono<IPagedQuery> = schemaForQuery()
     .map { it.resolver.resolve(query).requireAccepted(mode) }
-    .fallbackUnavailable(mode, query, !query.filter.referencesSystemTags())
+    .fallbackUnavailable(mode, query, query.filter)
 
 fun QueryModelSchemaProvider.resolve(
     query: ICursorQuery,
@@ -52,7 +52,7 @@ fun QueryModelSchemaProvider.resolve(
     mode: QuerySchemaValidationMode,
 ): Mono<FilterExpression> = schemaForQuery()
     .map { it.resolver.resolve(filter).requireAccepted(mode) }
-    .fallbackUnavailable(mode, filter, !filter.referencesSystemTags())
+    .fallbackUnavailable(mode, filter, filter)
 
 fun QueryModelSchemaProvider.resolve(
     query: AggregationQuery,
@@ -114,7 +114,11 @@ private fun LogicalField.isSystemTags(): Boolean =
 private fun <T : Any> Mono<T>.fallbackUnavailable(
     mode: QuerySchemaValidationMode,
     fallback: T,
-    allowFallback: Boolean,
+    filter: FilterExpression,
 ): Mono<T> = onErrorResume(QuerySchemaUnavailableException::class.java) { error ->
-    if (mode == QuerySchemaValidationMode.COMPATIBLE && allowFallback) Mono.just(fallback) else Mono.error(error)
+    if (mode == QuerySchemaValidationMode.COMPATIBLE && !filter.referencesSystemTags()) {
+        Mono.just(fallback)
+    } else {
+        Mono.error(error)
+    }
 }


### PR DESCRIPTION
## Goal

Remove schema-derived and error-only work from successful composite-filter resolution without changing query compatibility or fallback semantics.

## Changes

- Resolve composite filter operands in one pass with one pre-sized result list.
- Evaluate system-tags fallback eligibility only after QuerySchemaUnavailableException.
- Precompute ELEMENT_SCOPE string paths once per cached schema resolver.
- Fast-path schemas without element scopes and avoid per-field ancestor LogicalField allocation.
- Add an AndFilter(8) provider-to-resolver JMH scenario.

## Verification

- ./gradlew :wow-query:check :wow-benchmarks:check :wow-benchmarks:jmhJar --no-parallel — BUILD SUCCESSFUL before and after rebasing onto current main.
- git diff origin/main...HEAD --check — clean.
- JMH 1.37 on local macOS / JDK 17, 5×200 ms warmup, 10×200 ms measurement, 3 forks, gc profiler:
  - latency: 2061.914 ± 59.007 ns/op → 1107.514 ± 27.650 ns/op, about 46.3% lower.
  - allocation: 9392.006 B/op → 5208.003 ± 7.688 B/op, about 44.6% lower.
- Independent review: Ready to merge, no Critical, Important, or Minor findings.

## Compatibility and risks

- [x] This change preserves public API compatibility.
- [x] This change preserves wire compatibility.
- [x] This change preserves filter order and compatibility semantics.
- [x] Schema-unavailable system-tags fallback behavior remains unchanged.
- [x] Nested and dynamic element-scope enforcement remains unchanged.

Cold indexes are rebuilt with each immutable QueryModelSchema resolver after refresh. No request-derived dynamic paths are cached.