### PR TITLE
ci: cache Gradle package builds

### DIFF
--- a/.github/workflows/package-deploy.yml
+++ b/.github/workflows/package-deploy.yml
@@ -32,7 +32,11 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: gradle
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: true
 
       - name: Verify release tag
         if: github.event_name == 'release'
@@ -79,8 +83,12 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           server-id: github
-          cache: gradle
           settings-path: ${{ github.workspace }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: true
 
       - name: Download release artifacts
         uses: actions/download-artifact@v4
@@ -119,7 +127,11 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: gradle
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: true
 
       - name: Download release artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Goal

Speed up release preflight by reusing trusted Gradle task outputs produced on `main`.

The v9.0.0 release preflight spent 15m14s in `build allIntegrationTest`; 344 of 350 tasks executed despite the dependency cache being restored.

## Changes

- migrate all three package deployment jobs to `gradle/actions/setup-gradle@v6`
- remove the overlapping `cache: gradle` option from `actions/setup-java`
- explicitly set `cache-read-only: true` for preflight, GitHub Packages, and Maven Central jobs
- keep release triggers, permissions, signing, secrets, artifacts, repositories, and publish commands unchanged

## Validation

- semantic YAML cache contract: PASS (RED before implementation, GREEN after)
- `actionlint .github/workflows/package-deploy.yml`
- `git diff --check origin/main...HEAD`
- actual `CI=GITHUB_ACTIONS ./gradlew build allIntegrationTest --stacktrace`: PASS
- dry-run task graphs: `publishToMavenLocal`, GitHub Packages publish, and Sonatype close/release: PASS
- independent release-safety review: no Critical, Important, or Minor findings

## Evidence boundary

No signing or publishing command was executed. This workflow only runs for a release or manual dispatch, so exact GitHub-hosted performance evidence will come from the next real release; this PR must not be validated by manually publishing packages.
