### PR TITLE
feat(compensation): support Chinese dashboard

### DIFF
--- a/compensation/dashboard/src/components/CopyButton.tsx
+++ b/compensation/dashboard/src/components/CopyButton.tsx
@@ -21,14 +21,17 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { copyTextToClipboard } from "@/utils/clipboard.ts";
+import { useI18n, type Message } from "@/i18n.tsx";
 
 interface CopyButtonProps {
   value: string;
-  label?: string;
+  label?: Message;
 }
 
 export function CopyButton({ value, label = "value" }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
+  const { t } = useI18n();
+  const translatedLabel = t(label);
 
   useEffect(() => {
     if (!copied) {
@@ -40,7 +43,7 @@ export function CopyButton({ value, label = "value" }: CopyButtonProps) {
 
   const copy = async () => {
     if (!(await copyTextToClipboard(value))) {
-      toast.error(`Unable to copy ${label}`);
+      toast.error(t("Unable to copy {label}", { label: translatedLabel }));
       return;
     }
     setCopied(true);
@@ -54,14 +57,18 @@ export function CopyButton({ value, label = "value" }: CopyButtonProps) {
             type="button"
             variant="ghost"
             size="icon-xs"
-            aria-label={`Copy ${label}`}
+            aria-label={t("Copy {label}", { label: translatedLabel })}
             onClick={copy}
           />
         }
       >
         {copied ? <Check /> : <Copy />}
       </TooltipTrigger>
-      <TooltipContent>{copied ? "Copied" : `Copy ${label}`}</TooltipContent>
+      <TooltipContent>
+        {copied
+          ? t("Copied")
+          : t("Copy {label}", { label: translatedLabel })}
+      </TooltipContent>
     </Tooltip>
   );
 }

--- a/compensation/dashboard/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/compensation/dashboard/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -14,6 +14,7 @@
 import * as React from "react";
 import { CircleAlert } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useI18n } from "@/i18n.tsx";
 
 interface ErrorBoundaryProps {
   children: React.ReactNode;
@@ -22,6 +23,33 @@ interface ErrorBoundaryProps {
 interface ErrorBoundaryState {
   hasError: boolean;
   error?: Error;
+}
+
+function ErrorFallback({ error, retry }: { error?: Error; retry: () => void }) {
+  const { t } = useI18n();
+
+  return (
+    <div role="alert" className="flex min-h-svh items-center justify-center bg-slate-50 p-6">
+      <div className="w-full max-w-md rounded-xl border border-red-200 bg-white p-6 text-center shadow-sm">
+        <CircleAlert aria-hidden="true" className="mx-auto size-8 text-red-600" />
+        <h2 className="mt-3 font-heading text-lg font-semibold text-slate-950">
+          {t("Something went wrong.")}
+        </h2>
+        <p className="mt-1 text-sm text-slate-600">
+          {t("The dashboard could not render this view. Try again to recover from a temporary problem.")}
+        </p>
+        <Button type="button" className="mt-5" onClick={retry}>
+          {t("Try again")}
+        </Button>
+        <details className="mt-5 text-left text-xs text-slate-500">
+          <summary className="cursor-pointer font-medium">{t("Technical details")}</summary>
+          <pre className="mt-2 overflow-auto whitespace-pre-wrap rounded-lg bg-slate-100 p-3">
+            {error?.toString()}
+          </pre>
+        </details>
+      </div>
+    </div>
+  );
 }
 
 export class ErrorBoundary extends React.Component<
@@ -47,37 +75,7 @@ export class ErrorBoundary extends React.Component<
 
   render() {
     if (this.state.hasError) {
-      return (
-        <div
-          role="alert"
-          className="flex min-h-svh items-center justify-center bg-slate-50 p-6"
-        >
-          <div className="w-full max-w-md rounded-xl border border-red-200 bg-white p-6 text-center shadow-sm">
-            <CircleAlert
-              aria-hidden="true"
-              className="mx-auto size-8 text-red-600"
-            />
-            <h2 className="mt-3 font-heading text-lg font-semibold text-slate-950">
-              Something went wrong.
-            </h2>
-            <p className="mt-1 text-sm text-slate-600">
-              The dashboard could not render this view. Try again to recover
-              from a temporary problem.
-            </p>
-            <Button type="button" className="mt-5" onClick={this.retry}>
-              Try again
-            </Button>
-            <details className="mt-5 text-left text-xs text-slate-500">
-              <summary className="cursor-pointer font-medium">
-                Technical details
-              </summary>
-              <pre className="mt-2 overflow-auto whitespace-pre-wrap rounded-lg bg-slate-100 p-3">
-                {this.state.error?.toString()}
-              </pre>
-            </details>
-          </div>
-        </div>
-      );
+      return <ErrorFallback error={this.state.error} retry={this.retry} />;
     }
 
     return this.props.children;

--- a/compensation/dashboard/src/components/ui/sheet.tsx
+++ b/compensation/dashboard/src/components/ui/sheet.tsx
@@ -17,6 +17,7 @@ import { Dialog as SheetPrimitive } from "@base-ui/react/dialog";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { XIcon } from "lucide-react";
+import { useI18n } from "@/i18n.tsx";
 
 function Sheet({ ...props }: SheetPrimitive.Root.Props) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />;
@@ -57,6 +58,7 @@ function SheetContent({
   side?: "top" | "right" | "bottom" | "left";
   showCloseButton?: boolean;
 }) {
+  const { t } = useI18n();
   return (
     <SheetPortal>
       <SheetOverlay />
@@ -82,7 +84,7 @@ function SheetContent({
             }
           >
             <XIcon />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">{t("Close")}</span>
           </SheetPrimitive.Close>
         )}
       </SheetPrimitive.Popup>

--- a/compensation/dashboard/src/components/ui/sidebar.tsx
+++ b/compensation/dashboard/src/components/ui/sidebar.tsx
@@ -19,6 +19,7 @@ import { useRender } from "@base-ui/react/use-render"
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { useIsMobile } from "@/hooks/use-mobile"
+import { useI18n } from "@/i18n.tsx"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
@@ -171,6 +172,7 @@ function Sidebar({
   collapsible?: "offcanvas" | "icon" | "none"
 }) {
   const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
+  const { t } = useI18n()
 
   if (collapsible === "none") {
     return (
@@ -204,8 +206,8 @@ function Sidebar({
           side={side}
         >
           <SheetHeader className="sr-only">
-            <SheetTitle>Sidebar</SheetTitle>
-            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+            <SheetTitle>{t("Sidebar")}</SheetTitle>
+            <SheetDescription>{t("Displays the mobile sidebar.")}</SheetDescription>
           </SheetHeader>
           <div className="flex h-full w-full flex-col">{children}</div>
         </SheetContent>
@@ -265,6 +267,7 @@ function SidebarTrigger({
   ...props
 }: React.ComponentProps<typeof Button>) {
   const { toggleSidebar } = useSidebar()
+  const { t } = useI18n()
 
   return (
     <Button
@@ -280,22 +283,23 @@ function SidebarTrigger({
       {...props}
     >
       <PanelLeftIcon />
-      <span className="sr-only">Toggle Sidebar</span>
+      <span className="sr-only">{t("Toggle Sidebar")}</span>
     </Button>
   )
 }
 
 function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
   const { toggleSidebar } = useSidebar()
+  const { t } = useI18n()
 
   return (
     <button
       data-sidebar="rail"
       data-slot="sidebar-rail"
-      aria-label="Toggle Sidebar"
+      aria-label={t("Toggle Sidebar")}
       tabIndex={-1}
       onClick={toggleSidebar}
-      title="Toggle Sidebar"
+      title={t("Toggle Sidebar")}
       className={cn(
         "absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2",
         "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",

--- a/compensation/dashboard/src/features/Analytics/AnalyticsCharts.tsx
+++ b/compensation/dashboard/src/features/Analytics/AnalyticsCharts.tsx
@@ -21,6 +21,7 @@ import {
 } from "../../components/ui/chart.tsx";
 import { formatDate } from "../../utils/dates.ts";
 import { summarizeTrend, type TrendPoint } from "./analyticsQueries.ts";
+import { useI18n } from "@/i18n.tsx";
 
 interface DistributionDatum {
   color: string;
@@ -48,6 +49,7 @@ export function DistributionChart({
   description,
   title,
 }: DistributionChartProps): ReactElement {
+  const { t } = useI18n();
   const total = data.reduce((sum, { count }) => sum + count, 0);
   const labels = data.map(
     ({ count, label }) =>
@@ -93,7 +95,7 @@ export function DistributionChart({
           );
         })}
       </dl>
-      <p className="dashboard-chart-total">Total {total.toLocaleString()}</p>
+      <p className="dashboard-chart-total">{t("Total {total}", { total: total.toLocaleString() })}</p>
     </section>
   );
 }
@@ -105,6 +107,7 @@ export function RetryDistributionChart({
   data: DistributionDatum[];
   description?: string;
 }): ReactElement {
+  const { t } = useI18n();
   const total = data.reduce((sum, { count }) => sum + count, 0);
   const rows = data.map((datum) => ({
     ...datum,
@@ -113,16 +116,16 @@ export function RetryDistributionChart({
   const maxCount = Math.max(...rows.map(({ count }) => count), 1);
 
   return (
-    <section aria-label="Retry distribution">
-      <h3 className="font-medium">Retry distribution</h3>
+    <section aria-label={t("Retry distribution")}>
+      <h3 className="font-medium">{t("Retry distribution")}</h3>
       {description ? (
         <p className="text-sm text-muted-foreground">{description}</p>
       ) : null}
       <div
         role="img"
-        aria-label={`Retry distribution: ${rows
-          .map(({ display, label }) => `${label} ${display}`)
-          .join(", ")}`}
+        aria-label={t("Retry distribution: {rows}", {
+          rows: rows.map(({ display, label }) => `${label} ${display}`).join(", "),
+        })}
         className="mt-2 grid gap-1.5"
       >
         {rows.map(({ color, count, display, key, label }) => (
@@ -145,7 +148,7 @@ export function RetryDistributionChart({
           </div>
         ))}
       </div>
-      <p className="dashboard-chart-total">Total {total.toLocaleString()}</p>
+      <p className="dashboard-chart-total">{t("Total {total}", { total: total.toLocaleString() })}</p>
     </section>
   );
 }
@@ -162,49 +165,56 @@ export function CompensationTrendChart({
 }: {
   points: TrendPoint[];
 }): ReactElement {
+  const { locale, t } = useI18n();
+  const localizedTrendConfig = {
+    newFailures: { color: trendConfig.newFailures.color, label: t("New failures") },
+    prepared: { color: trendConfig.prepared.color, label: t("Prepared") },
+    retriedFailed: { color: trendConfig.retriedFailed.color, label: t("Retried failed") },
+    succeeded: { color: trendConfig.succeeded.color, label: t("Succeeded") },
+  } satisfies ChartConfig;
   const totals = summarizeTrend(points);
   const outcomeFlow = [
     {
       color: trendConfig.prepared.color,
       count: totals.prepared,
       key: "prepared",
-      label: trendConfig.prepared.label,
+      label: localizedTrendConfig.prepared.label,
     },
     {
       color: trendConfig.retriedFailed.color,
       count: totals.retriedFailed,
       key: "retriedFailed",
-      label: trendConfig.retriedFailed.label,
+      label: localizedTrendConfig.retriedFailed.label,
     },
     {
       color: trendConfig.succeeded.color,
       count: totals.succeeded,
       key: "succeeded",
-      label: trendConfig.succeeded.label,
+      label: localizedTrendConfig.succeeded.label,
     },
   ];
   const maxOutcome = Math.max(...outcomeFlow.map(({ count }) => count), 1);
 
   return (
     <section
-      aria-label="Compensation activity"
+      aria-label={t("Compensation activity")}
       className="dashboard-activity-chart"
     >
       <section className="dashboard-failure-inflow">
         <h3>
-          Failure inflow (new failures)
-          {points.length > 1 ? " — daily trend" : ""}
+          {t("Failure inflow (new failures)")}
+          {points.length > 1 ? t(" — daily trend") : ""}
         </h3>
         <p className="dashboard-series-label">
           <span
             aria-hidden="true"
             style={{ backgroundColor: trendConfig.newFailures.color }}
           />
-          New failures
+          {t("New failures")}
         </p>
         {points.length > 1 ? (
           <ChartContainer
-            config={trendConfig}
+            config={localizedTrendConfig}
             className="min-h-0 flex-1 w-full py-2 text-sm aspect-auto"
           >
             <LineChart
@@ -218,7 +228,9 @@ export function CompensationTrendChart({
                 axisLine={false}
                 tickLine={false}
                 tickMargin={8}
-                tickFormatter={(bucket: number) => formatDate(bucket, "MM-DD")}
+                tickFormatter={(bucket: number) =>
+                  formatDate(bucket, "MM-DD", locale)
+                }
               />
               <YAxis allowDecimals={false} axisLine={false} tickLine={false} />
               <ChartTooltip
@@ -228,6 +240,7 @@ export function CompensationTrendChart({
                       formatDate(
                         Number(payload[0]?.payload.bucket),
                         "MM-DD HH:mm",
+                        locale,
                       )
                     }
                   />
@@ -236,7 +249,7 @@ export function CompensationTrendChart({
               <Line
                 dataKey="newFailures"
                 dot={{ r: 2.5 }}
-                name={trendConfig.newFailures.label}
+                name={localizedTrendConfig.newFailures.label}
                 stroke={trendConfig.newFailures.color}
                 strokeWidth={2}
                 type="monotone"
@@ -245,17 +258,17 @@ export function CompensationTrendChart({
           </ChartContainer>
         ) : (
           <p className="dashboard-inflow-single">
-            {totals.newFailures.toLocaleString()} new failures
+            {t("{count} new failures", { count: totals.newFailures.toLocaleString() })}
           </p>
         )}
       </section>
       <section className="dashboard-outcome-flow">
-        <h3>Outcome flow (total in selected range)</h3>
+        <h3>{t("Outcome flow (total in selected range)")}</h3>
         <div
           role="img"
-          aria-label={`Outcome flow: ${outcomeFlow
-            .map(({ count, label }) => `${label} ${count}`)
-            .join(", ")}`}
+          aria-label={t("Outcome flow: {rows}", {
+            rows: outcomeFlow.map(({ count, label }) => `${label} ${count}`).join(", "),
+          })}
           className="dashboard-outcome-flow-bars"
         >
           {outcomeFlow.map(({ color, count, key, label }) => (
@@ -280,20 +293,20 @@ export function CompensationTrendChart({
           ))}
         </div>
       </section>
-      <table className="sr-only" aria-label="Compensation outcomes data">
+      <table className="sr-only" aria-label={t("Compensation outcomes data")}>
         <thead>
           <tr>
-            <th>Time</th>
-            <th>New failures</th>
-            <th>Prepared</th>
-            <th>Retried failed</th>
-            <th>Succeeded</th>
+            <th>{t("Time")}</th>
+            <th>{t("New failures")}</th>
+            <th>{t("Prepared")}</th>
+            <th>{t("Retried failed")}</th>
+            <th>{t("Succeeded")}</th>
           </tr>
         </thead>
         <tbody>
           {points.map((point) => (
             <tr key={point.bucket}>
-              <td>{formatDate(point.bucket)}</td>
+              <td>{formatDate(point.bucket, undefined, locale)}</td>
               <td>{point.newFailures}</td>
               <td>{point.prepared}</td>
               <td>{point.retriedFailed}</td>

--- a/compensation/dashboard/src/features/Analytics/DashboardSkeleton.tsx
+++ b/compensation/dashboard/src/features/Analytics/DashboardSkeleton.tsx
@@ -13,12 +13,14 @@
 
 import { Skeleton } from "@/components/ui/skeleton";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { useI18n } from "@/i18n.tsx";
 
 export default function DashboardSkeleton() {
+  const { t } = useI18n();
   return (
     <div
       role="status"
-      aria-label="Loading dashboard"
+      aria-label={t("Loading dashboard")}
       className="dashboard-view dashboard-skeleton"
     >
       <div className="dashboard-toolbar">
@@ -27,7 +29,7 @@ export default function DashboardSkeleton() {
       </div>
       <Card size="sm" className="dashboard-overview">
         <CardHeader className="sr-only">
-          <span>Loading compensation overview</span>
+          <span>{t("Loading compensation overview")}</span>
         </CardHeader>
         <CardContent className="dashboard-overview-content">
           <section className="dashboard-stock">
@@ -42,7 +44,7 @@ export default function DashboardSkeleton() {
       </Card>
       <Card size="sm" className="dashboard-activity">
         <CardHeader className="sr-only">
-          <span>Loading dashboard activity</span>
+          <span>{t("Loading dashboard activity")}</span>
         </CardHeader>
         <CardContent>
           <Skeleton className="h-56 w-full" />

--- a/compensation/dashboard/src/features/Analytics/DashboardView.test.tsx
+++ b/compensation/dashboard/src/features/Analytics/DashboardView.test.tsx
@@ -7,6 +7,7 @@ import type {
   SnapshotAnalyticsResult,
 } from "./useSnapshotAnalytics.ts";
 import DashboardView from "./DashboardView.tsx";
+import { I18nProvider } from "@/i18n.tsx";
 
 const mocks = vi.hoisted(() => ({
   eventResult: undefined as unknown as AnalyticsSection<TrendPoint[]>,
@@ -130,6 +131,22 @@ beforeEach(() => {
 afterEach(() => vi.restoreAllMocks());
 
 describe("DashboardView", () => {
+  it("renders the dashboard key path in Chinese", () => {
+    localStorage.setItem("wow-dashboard-locale", "zh-CN");
+
+    render(
+      <I18nProvider>
+        <DashboardView />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByRole("region", { name: "补偿概览" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "刷新仪表盘" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /时间范围：2026年/ }),
+    ).toBeInTheDocument();
+  });
+
   it("composes the dashboard from shadcn cards", () => {
     render(<DashboardView />);
 

--- a/compensation/dashboard/src/features/Analytics/DashboardView.tsx
+++ b/compensation/dashboard/src/features/Analytics/DashboardView.tsx
@@ -17,6 +17,7 @@ import { useEffect, useMemo, useState } from "react";
 import { ExchangeError } from "@ahoo-wang/fetcher";
 import { RecoverableType } from "@ahoo-wang/fetcher-wow";
 import type { DateRange } from "react-day-picker";
+import { zhCN } from "react-day-picker/locale";
 import { formatAge, formatDate } from "../../utils/dates.ts";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -63,6 +64,7 @@ import {
   type AnalyticsSection,
   useSnapshotAnalytics,
 } from "./useSnapshotAnalytics.ts";
+import { useI18n, type Locale, type Message } from "@/i18n.tsx";
 
 interface CompleteDateRange {
   from: Date;
@@ -74,7 +76,14 @@ function createDefaultDateRange(): CompleteDateRange {
   return { from: to.subtract(6, "day").toDate(), to: to.toDate() };
 }
 
-function formatDateRange({ from, to }: CompleteDateRange): string {
+function formatDateRange(
+  { from, to }: CompleteDateRange,
+  locale: Locale,
+): string {
+  if (locale === "zh-CN") {
+    const formatter = new Intl.DateTimeFormat(locale, { dateStyle: "medium" });
+    return `${formatter.format(from)} – ${formatter.format(to)}`;
+  }
   return `${dayjs(from).format("YYYY-MM-DD")} – ${dayjs(to).format("YYYY-MM-DD")}`;
 }
 
@@ -88,7 +97,7 @@ const recoverabilityDisplay = {
     color: "var(--chart-1)",
     label: "Unrecoverable",
   },
-} satisfies Record<RecoverableType, { color: string; label: string }>;
+} satisfies Record<RecoverableType, { color: string; label: Message }>;
 const retryBucketColors = {
   "0": "var(--chart-5)",
   "1–2": "var(--chart-2)",
@@ -131,17 +140,16 @@ function formatStatusShare(count: number, total: number): string {
   return `${count} (${percentage}%)`;
 }
 
-const percentageFormatter = new Intl.NumberFormat("en-US", {
-  maximumFractionDigits: 1,
-  style: "percent",
-});
-
-function formatPercentage(value: number): string {
-  const formatted = percentageFormatter.format(value);
+function formatPercentage(value: number, locale: Locale): string {
+  const formatted = new Intl.NumberFormat(locale, {
+    maximumFractionDigits: 1,
+    style: "percent",
+  }).format(value);
   return value > 0 && formatted === "0%" ? "<0.1%" : formatted;
 }
 
 function PressureStatusShare({ cluster }: { cluster: PressureCluster }) {
+  const { t } = useI18n();
   const failed = formatStatusShare(cluster.failedCount, cluster.currentCount);
   const prepared = formatStatusShare(
     cluster.preparedCount,
@@ -157,7 +165,7 @@ function PressureStatusShare({ cluster }: { cluster: PressureCluster }) {
       : (cluster.preparedCount / cluster.currentCount) * 100;
 
   return (
-    <div aria-label={`Failed ${failed}; Prepared ${prepared}`}>
+    <div aria-label={t("Failed {failed}; Prepared {prepared}", { failed, prepared })}>
       <div className="flex items-center gap-2 text-xs tabular-nums">
         <span>{failed}</span>
         <span>{prepared}</span>
@@ -175,15 +183,16 @@ function PressureStatusShare({ cluster }: { cluster: PressureCluster }) {
 
 function PressureTable({ clusters }: { clusters: PressureCluster[] }) {
   const now = useNow();
+  const { locale, t } = useI18n();
   return (
-    <Table aria-label="Current failure pressure" className="min-w-[48rem]">
+    <Table aria-label={t("Current failure pressure")} className="min-w-[48rem]">
       <TableHeader>
         <TableRow>
-          <TableHead>Cluster</TableHead>
-          <TableHead className="text-right">Current</TableHead>
-          <TableHead>Failed / Prepared</TableHead>
-          <TableHead>Oldest</TableHead>
-          <TableHead>Next retry</TableHead>
+          <TableHead>{t("Cluster")}</TableHead>
+          <TableHead className="text-right">{t("Current")}</TableHead>
+          <TableHead>{t("Failed / Prepared")}</TableHead>
+          <TableHead>{t("Oldest")}</TableHead>
+          <TableHead>{t("Next retry")}</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -193,7 +202,7 @@ function PressureTable({ clusters }: { clusters: PressureCluster[] }) {
               colSpan={5}
               className="h-24 text-center text-muted-foreground"
             >
-              No active failure clusters
+              {t("No active failure clusters")}
             </TableCell>
           </TableRow>
         ) : (
@@ -202,7 +211,7 @@ function PressureTable({ clusters }: { clusters: PressureCluster[] }) {
               key={`${cluster.errorCode}:${cluster.contextName}:${cluster.processorName}:${cluster.functionName}:${cluster.functionKind}`}
               data-dominant={index === 0 ? "true" : undefined}
             >
-              <TableCell data-label="Cluster">
+              <TableCell data-label={t("Cluster")}>
                 <div className="font-medium">{cluster.errorCode}</div>
                 <div className="text-xs text-muted-foreground">
                   {cluster.contextName} · {cluster.processorName}/
@@ -211,24 +220,24 @@ function PressureTable({ clusters }: { clusters: PressureCluster[] }) {
                 </div>
               </TableCell>
               <TableCell
-                data-label="Current"
+                data-label={t("Current")}
                 className="text-right tabular-nums"
               >
                 {cluster.currentCount}
               </TableCell>
-              <TableCell data-label="Failed / Prepared">
+              <TableCell data-label={t("Failed / Prepared")}>
                 <PressureStatusShare cluster={cluster} />
               </TableCell>
               <TableCell
-                data-label="Oldest"
-                title={formatDate(cluster.oldestExecuteAt ?? undefined)}
+                data-label={t("Oldest")}
+                title={formatDate(cluster.oldestExecuteAt ?? undefined, undefined, locale)}
               >
                 {cluster.oldestExecuteAt
-                  ? formatAge(cluster.oldestExecuteAt, now)
+                  ? formatAge(cluster.oldestExecuteAt, now, locale)
                   : "-"}
               </TableCell>
-              <TableCell data-label="Next retry">
-                {formatDate(cluster.nextRetryAt ?? undefined)}
+              <TableCell data-label={t("Next retry")}>
+                {formatDate(cluster.nextRetryAt ?? undefined, undefined, locale)}
               </TableCell>
             </TableRow>
           ))
@@ -239,6 +248,7 @@ function PressureTable({ clusters }: { clusters: PressureCluster[] }) {
 }
 
 export default function DashboardView() {
+  const { locale, t } = useI18n();
   const [appliedRange, setAppliedRange] = useState<CompleteDateRange>(
     createDefaultDateRange,
   );
@@ -253,7 +263,7 @@ export default function DashboardView() {
     () => createTrendWindow(appliedRange.from, appliedRange.to, timeZone),
     [appliedRange, timeZone],
   );
-  const rangeLabel = formatDateRange(appliedRange);
+  const rangeLabel = formatDateRange(appliedRange, locale);
   const snapshot = useSnapshotAnalytics(window, refreshToken);
   const trend = useEventTrend(window, refreshToken);
   const sections = [
@@ -324,8 +334,10 @@ export default function DashboardView() {
     ? snapshot.pressure.data![0].currentCount / selectedActive!
     : 0;
   const pressureTitle = pressureInsightsReady
-    ? `Failure concentration · Top cluster ${formatPercentage(pressureShare)}`
-    : "Current failure pressure — Top 5 clusters";
+    ? t("Failure concentration · Top cluster {percentage}", {
+        percentage: formatPercentage(pressureShare, locale),
+      })
+    : t("Current failure pressure — Top 5 clusters");
 
   const applyRecentDays = (days: number) => {
     const to = dayjs(Date.now()).startOf("day");
@@ -339,12 +351,12 @@ export default function DashboardView() {
   return (
     <div className="dashboard-view">
       {initialLoading ? (
-        <span role="status" aria-label="Loading dashboard" className="sr-only">
-          Loading dashboard
+        <span role="status" aria-label={t("Loading dashboard")} className="sr-only">
+          {t("Loading dashboard")}
         </span>
       ) : null}
       <div className="dashboard-toolbar">
-        <span className="dashboard-time-range-label">Time range</span>
+        <span className="dashboard-time-range-label">{t("Time range")}</span>
         <Popover
           open={rangeOpen}
           onOpenChange={(open) => {
@@ -360,7 +372,7 @@ export default function DashboardView() {
                 type="button"
                 variant="outline"
                 className="dashboard-time-range-button"
-                aria-label={`Time range: ${rangeLabel}`}
+                aria-label={t("Time range: {range}", { range: rangeLabel })}
               />
             }
           >
@@ -373,16 +385,16 @@ export default function DashboardView() {
           >
             <div className="border-b p-2">
               <ToggleGroup
-                aria-label="Date range presets"
+                aria-label={t("Date range presets")}
                 variant="outline"
                 spacing={0}
                 className="w-full"
               >
-                {[
+                {([
                   ["Today", 1],
                   ["Last 7 days", 7],
                   ["Last 30 days", 30],
-                ].map(([label, days]) => (
+                ] satisfies [Message, number][]).map(([label, days]) => (
                   <ToggleGroupItem
                     key={label}
                     value={String(days)}
@@ -390,7 +402,7 @@ export default function DashboardView() {
                     className="flex-1"
                     onClick={() => applyRecentDays(Number(days))}
                   >
-                    {label}
+                    {t(label)}
                   </ToggleGroupItem>
                 ))}
               </ToggleGroup>
@@ -404,10 +416,11 @@ export default function DashboardView() {
               onSelect={setDraftRange}
               defaultMonth={draftRange.from}
               timeZone={timeZone}
+              locale={locale === "zh-CN" ? zhCN : undefined}
             />
             {draftRange.from && !draftRange.to ? (
               <p className="px-3 pb-2 text-sm text-muted-foreground">
-                Select an end date.
+                {t("Select an end date.")}
               </p>
             ) : null}
             <div className="flex justify-end gap-2 border-t p-2">
@@ -419,7 +432,7 @@ export default function DashboardView() {
                   setRangeOpen(false);
                 }}
               >
-                Cancel
+                {t("Cancel")}
               </Button>
               <Button
                 type="button"
@@ -434,23 +447,27 @@ export default function DashboardView() {
                   }
                 }}
               >
-                Apply
+                {t("Apply")}
               </Button>
             </div>
           </PopoverContent>
         </Popover>
         {dashboardUpdatedAt ? (
-          <span>Updated {formatDate(dashboardUpdatedAt)}</span>
+          <span>
+            {t("Updated {date}", {
+              date: formatDate(dashboardUpdatedAt, undefined, locale),
+            })}
+          </span>
         ) : null}
         <Button
           type="button"
           variant="outline"
           aria-busy={refreshing}
-          aria-label={refreshing ? "Refreshing dashboard" : "Refresh dashboard"}
+          aria-label={refreshing ? t("Refreshing dashboard") : t("Refresh dashboard")}
           onClick={() => setRefreshToken((value) => value + 1)}
         >
           <RefreshCw className={refreshing ? "animate-spin" : undefined} />
-          Refresh
+          {t("Refresh")}
         </Button>
       </div>
 
@@ -462,68 +479,72 @@ export default function DashboardView() {
       >
         <CardHeader className="sr-only">
           <CardTitle>
-            <h2 id="dashboard-overview-title">Compensation overview</h2>
+            <h2 id="dashboard-overview-title">{t("Compensation overview")}</h2>
           </CardTitle>
         </CardHeader>
         <CardContent className="dashboard-overview-content">
           <section
             role="region"
-            aria-label="Backlog exposure"
+            aria-label={t("Backlog exposure")}
             className="dashboard-stock"
           >
-            <h3 id="dashboard-stock-title">STOCK / Backlog exposure</h3>
+            <h3 id="dashboard-stock-title">{t("STOCK / Backlog exposure")}</h3>
             <SectionMeta section={snapshot.summary} />
             {scopeInsightsReady && snapshot.summary.data ? (
               <>
                 <dl className="dashboard-stock-metrics">
                   <div>
-                    <dt>Selected active</dt>
+                    <dt>{t("Selected active")}</dt>
                     <dd>{selectedActive.toLocaleString()}</dd>
                   </div>
                   <div>
-                    <dt>Older backlog</dt>
+                    <dt>{t("Older backlog")}</dt>
                     <dd>
                       {snapshot.summary.data.olderThanRange.toLocaleString()}
                     </dd>
                   </div>
                   <div>
-                    <dt>Unrecoverable</dt>
+                    <dt>{t("Unrecoverable")}</dt>
                     <dd>
                       {snapshot.summary.data.unrecoverable.toLocaleString()}
                     </dd>
                   </div>
                   <div>
-                    <dt>Coverage</dt>
-                    <dd>{formatPercentage(selectedCoverage)}</dd>
+                    <dt>{t("Coverage")}</dt>
+                    <dd>{formatPercentage(selectedCoverage, locale)}</dd>
                   </div>
                 </dl>
                 <Progress
-                  aria-label="Selected active coverage"
-                  aria-valuetext={formatPercentage(selectedCoverage)}
+                  aria-label={t("Selected active coverage")}
+                  aria-valuetext={formatPercentage(selectedCoverage, locale)}
                   value={selectedCoverage * 100}
                   className="dashboard-stock-progress"
                 />
                 <div className="dashboard-stock-scale">
                   <span>
-                    {selectedActive.toLocaleString()} selected (
-                    {formatPercentage(selectedCoverage)})
+                    {t("{count} selected ({percentage})", {
+                      count: selectedActive.toLocaleString(),
+                      percentage: formatPercentage(selectedCoverage, locale),
+                    })}
                   </span>
                   <span>
-                    {snapshot.summary.data.olderThanRange.toLocaleString()} older
+                    {t("{count} older", {
+                      count: snapshot.summary.data.olderThanRange.toLocaleString(),
+                    })}
                   </span>
-                  <span>{newerThanRange.toLocaleString()} newer</span>
-                  <span>{activeTotal.toLocaleString()} total</span>
+                  <span>{t("{count} newer", { count: newerThanRange.toLocaleString() })}</span>
+                  <span>{t("{count} total", { count: activeTotal.toLocaleString() })}</span>
                 </div>
                 <Separator />
                 <dl className="dashboard-stock-secondary">
                   <div>
-                    <dt>Actionable now</dt>
+                    <dt>{t("Actionable now")}</dt>
                     <dd>
                       {snapshot.summary.data.actionableNow.toLocaleString()}
                     </dd>
                   </div>
                   <div>
-                    <dt>Timed out</dt>
+                    <dt>{t("Timed out")}</dt>
                     <dd>{snapshot.summary.data.timedOut.toLocaleString()}</dd>
                   </div>
                 </dl>
@@ -532,37 +553,37 @@ export default function DashboardView() {
               <Skeleton className="h-44 w-full" />
             ) : (
               <p className="text-sm text-muted-foreground">
-                Backlog exposure unavailable.
+                {t("Backlog exposure unavailable.")}
               </p>
             )}
           </section>
           <section
             role="region"
-            aria-label="Compensation effectiveness"
+            aria-label={t("Compensation effectiveness")}
             className="dashboard-flow"
           >
-            <h3 id="dashboard-flow-title">FLOW / Compensation effectiveness</h3>
+            <h3 id="dashboard-flow-title">{t("FLOW / Compensation effectiveness")}</h3>
             <SectionMeta section={trend} />
             {trend.data ? (
               <>
                 <dl className="dashboard-flow-primary">
                   <div>
-                    <dt>New failures</dt>
+                    <dt>{t("New failures")}</dt>
                     <dd>{trendSummary.newFailures.toLocaleString()}</dd>
                   </div>
                   <div>
-                    <dt>Net backlog</dt>
+                    <dt>{t("Net backlog")}</dt>
                     <dd>
                       {trendSummary.netBacklog >= 0 ? "+" : ""}
                       {trendSummary.netBacklog.toLocaleString()}
                     </dd>
                   </div>
                   <div>
-                    <dt>Retry success</dt>
+                    <dt>{t("Retry success")}</dt>
                     <dd>
                       {trendSummary.retrySuccess === null
                         ? "—"
-                        : formatPercentage(trendSummary.retrySuccess)}
+                        : formatPercentage(trendSummary.retrySuccess, locale)}
                     </dd>
                   </div>
                 </dl>
@@ -571,21 +592,21 @@ export default function DashboardView() {
                   <div>
                     <dt>
                       <span aria-hidden="true" className="bg-chart-2" />
-                      Prepared
+                      {t("Prepared")}
                     </dt>
                     <dd>{trendSummary.prepared.toLocaleString()}</dd>
                   </div>
                   <div>
                     <dt>
                       <span aria-hidden="true" className="bg-chart-3" />
-                      Retried failed
+                      {t("Retried failed")}
                     </dt>
                     <dd>{trendSummary.retriedFailed.toLocaleString()}</dd>
                   </div>
                   <div>
                     <dt>
                       <span aria-hidden="true" className="bg-chart-4" />
-                      Succeeded
+                      {t("Succeeded")}
                     </dt>
                     <dd>{trendSummary.succeeded.toLocaleString()}</dd>
                   </div>
@@ -595,7 +616,7 @@ export default function DashboardView() {
               <Skeleton className="h-44 w-full" />
             ) : (
               <p className="text-sm text-muted-foreground">
-                Compensation effectiveness unavailable.
+                {t("Compensation effectiveness unavailable.")}
               </p>
             )}
           </section>
@@ -610,7 +631,7 @@ export default function DashboardView() {
       >
         <CardHeader className="sr-only">
           <CardTitle>
-            <h2 id="dashboard-activity-title">Dashboard activity</h2>
+            <h2 id="dashboard-activity-title">{t("Dashboard activity")}</h2>
           </CardTitle>
         </CardHeader>
         <CardContent>
@@ -620,7 +641,7 @@ export default function DashboardView() {
             <CompensationTrendChart points={trend.data} />
           ) : (
             <p className="text-sm text-muted-foreground">
-              Compensation activity unavailable.
+              {t("Compensation activity unavailable.")}
             </p>
           )}
         </CardContent>
@@ -635,7 +656,7 @@ export default function DashboardView() {
         <CardHeader>
           <CardTitle>
             <h2 id="dashboard-health-title">
-              Current health for selected execution range
+              {t("Current health for selected execution range")}
             </h2>
           </CardTitle>
         </CardHeader>
@@ -647,10 +668,11 @@ export default function DashboardView() {
               <Skeleton className="h-24 w-full" />
             ) : snapshot.recoverability.data ? (
               <DistributionChart
-                title="Recoverability composition"
+                title={t("Recoverability composition")}
                 data={snapshot.recoverability.data.map(
                   ({ count, recoverable }) => ({
                     ...recoverabilityDisplay[recoverable],
+                    label: t(recoverabilityDisplay[recoverable].label),
                     count,
                     key: recoverable,
                   }),
@@ -669,7 +691,7 @@ export default function DashboardView() {
             ) : snapshot.retries.data?.truncated ? (
               <Alert>
                 <AlertDescription>
-                  Retry distribution is truncated and is not charted.
+                  {t("Retry distribution is truncated and is not charted.")}
                 </AlertDescription>
               </Alert>
             ) : snapshot.retries.data ? (
@@ -678,7 +700,7 @@ export default function DashboardView() {
                   color: retryBucketColors[key],
                   count,
                   key,
-                  label: `${key} retries`,
+                  label: t("{key} retries", { key }),
                 }))}
               />
             ) : null}
@@ -700,11 +722,15 @@ export default function DashboardView() {
             <CardAction className="max-sm:col-span-2 max-sm:row-start-2 max-sm:justify-self-start">
               <Badge variant="outline">
                 {snapshot.pressure.data!.length === 1
-                  ? "1 cluster"
+                  ? t("{count} cluster", { count: 1 })
                   : snapshot.pressure.data!.length === 5
-                    ? "Top 5 clusters"
-                    : `${snapshot.pressure.data!.length} clusters`}{" "}
-                · Top cluster {formatPercentage(pressureShare)}
+                    ? t("Top 5 clusters")
+                    : t("{count} clusters", {
+                        count: snapshot.pressure.data!.length,
+                      })}{" "}
+                · {t("Top cluster {percentage}", {
+                  percentage: formatPercentage(pressureShare, locale),
+                })}
               </Badge>
             </CardAction>
           ) : null}

--- a/compensation/dashboard/src/features/App/App.tsx
+++ b/compensation/dashboard/src/features/App/App.tsx
@@ -18,6 +18,7 @@ import {
   ChartNoAxesCombined,
   Clock3,
   GitCommitHorizontal,
+  Languages,
   PanelLeftClose,
   PanelLeftOpen,
   Play,
@@ -44,6 +45,15 @@ import {
   SidebarTrigger,
   useSidebar,
 } from "@/components/ui/sidebar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useI18n } from "@/i18n.tsx";
+import { Button } from "@/components/ui/button";
 
 interface AppProps {
   navItems: readonly NavItem[];
@@ -72,9 +82,10 @@ function PrimaryNavigation({
   pathname: string;
 }) {
   const { isMobile, setOpenMobile } = useSidebar();
+  const { t } = useI18n();
 
   return (
-    <nav aria-label="Primary navigation">
+    <nav aria-label={t("Primary navigation")}>
       <SidebarMenu>
         {navItems.map((item) => {
           const Icon = navIcons[item.path] ?? CircleAlert;
@@ -88,12 +99,12 @@ function PrimaryNavigation({
               <SidebarMenuButton
                 isActive={isActive}
                 size="lg"
-                tooltip={item.label}
+                tooltip={t(item.label)}
                 render={
                   <NavLink
                     to={item.path}
                     end={item.path === NavItemPaths.Dashboard}
-                    aria-label={item.label}
+                    aria-label={t(item.label)}
                     onClick={() => {
                       if (isMobile) {
                         setOpenMobile(false);
@@ -103,7 +114,7 @@ function PrimaryNavigation({
                 }
               >
                 <Icon />
-                <span>{item.label}</span>
+                <span>{t(item.label)}</span>
               </SidebarMenuButton>
             </SidebarMenuItem>
           );
@@ -115,26 +126,27 @@ function PrimaryNavigation({
 
 function SidebarBrand() {
   const { setOpenMobile } = useSidebar();
+  const { t } = useI18n();
 
   return (
     <SidebarMenu>
       <SidebarMenuItem>
         <SidebarMenuButton
           size="lg"
-          tooltip="Compensation Control Plane"
+          tooltip={t("Compensation Control Plane")}
           render={
             <Link
               to={NavItemPaths.Dashboard}
-              aria-label="Wow compensation dashboard"
+              aria-label={t("Wow compensation dashboard")}
               onClick={() => setOpenMobile(false)}
             />
           }
         >
           <img className="size-9 object-contain" src="/logo.svg" alt="" />
           <span className="grid min-w-0 text-left leading-tight">
-            <span className="truncate font-medium">Compensation</span>
+            <span className="truncate font-medium">{t("Compensation")}</span>
             <span className="truncate text-xs text-sidebar-foreground/70">
-              Control Plane
+              {t("Control Plane")}
             </span>
           </span>
         </SidebarMenuButton>
@@ -145,17 +157,18 @@ function SidebarBrand() {
 
 function NavigationToggle({ mobile }: { mobile: boolean }) {
   const { isMobile, openMobile, state, toggleSidebar } = useSidebar();
+  const { t } = useI18n();
   if (mobile !== isMobile) {
     return null;
   }
   const expanded = mobile ? openMobile : state === "expanded";
   const label = mobile
     ? expanded
-      ? "Close navigation"
-      : "Open navigation"
+      ? t("Close navigation")
+      : t("Open navigation")
     : expanded
-      ? "Collapse navigation"
-      : "Expand navigation";
+      ? t("Collapse navigation")
+      : t("Expand navigation");
 
   if (mobile) {
     return (
@@ -179,21 +192,61 @@ function NavigationToggle({ mobile }: { mobile: boolean }) {
           onClick={toggleSidebar}
         >
           <Icon />
-          <span>{expanded ? "Collapse" : "Expand"}</span>
+          <span>{expanded ? t("Collapse") : t("Expand")}</span>
         </SidebarMenuButton>
       </SidebarMenuItem>
     </SidebarMenu>
   );
 }
 
+function LanguageMenu() {
+  const { locale, setLocale, t } = useI18n();
+  const language = locale === "zh-CN" ? "中文" : "English";
+  const label = t("Current language: {language}", { language });
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="app-language-trigger"
+            aria-label={label}
+          />
+        }
+      >
+        <Languages />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuRadioGroup
+          value={locale}
+          onValueChange={(value) => {
+            if (value === "en" || value === "zh-CN") {
+              setLocale(value);
+            }
+          }}
+        >
+          <DropdownMenuRadioItem value="en">English</DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="zh-CN">中文</DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
 export default function App({ navItems }: AppProps) {
   const location = useLocation();
+  const { t } = useI18n();
 
   const activeTitle = useMemo(
     () =>
-      navItems.find((item) => item.path === location.pathname)?.label ??
-      "To Retry",
-    [location.pathname, navItems],
+      t(
+        navItems.find((item) => item.path === location.pathname)?.label ??
+          "To Retry",
+      ),
+    [location.pathname, navItems, t],
   );
 
   return (
@@ -207,19 +260,19 @@ export default function App({ navItems }: AppProps) {
         }
       >
         <a className="skip-link" href="#main-content">
-          Skip to main content
+          {t("Skip to main content")}
         </a>
         <Sidebar
           collapsible="icon"
           role="complementary"
-          aria-label="Application sidebar"
+          aria-label={t("Application sidebar")}
         >
           <SidebarHeader>
             <SidebarBrand />
           </SidebarHeader>
           <SidebarContent>
             <SidebarGroup>
-              <SidebarGroupLabel>Navigation</SidebarGroupLabel>
+              <SidebarGroupLabel>{t("Navigation")}</SidebarGroupLabel>
               <SidebarGroupContent>
                 <PrimaryNavigation
                   navItems={navItems}
@@ -238,10 +291,10 @@ export default function App({ navItems }: AppProps) {
             <NavigationToggle mobile />
             <h1>{activeTitle}</h1>
             <div className="app-topbar-actions">
-              <div className="app-build-info" aria-label="Build information">
+              <div className="app-build-info" aria-label={t("Build information")}>
                 <span
                   className="app-build-info-item"
-                  title={`Version ${buildVersion}`}
+                  title={t("Version {version}", { version: buildVersion })}
                 >
                   <Tag />
                   <span>v{buildVersion}</span>
@@ -251,16 +304,21 @@ export default function App({ navItems }: AppProps) {
                   href={buildCommitUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  aria-label={`GitHub commit ${buildCommitSha}`}
-                  title={`GitHub commit ${buildCommitSha}`}
+                  aria-label={t("GitHub commit {commit}", {
+                    commit: buildCommitSha,
+                  })}
+                  title={t("GitHub commit {commit}", {
+                    commit: buildCommitSha,
+                  })}
                 >
                   <GitCommitHorizontal />
                   <code>{buildCommitShort}</code>
                 </a>
               </div>
+              <LanguageMenu />
               <nav
                 className="app-project-links"
-                aria-label="Project repositories"
+                aria-label={t("Project repositories")}
               >
                 <a
                   className="app-project-link is-github"

--- a/compensation/dashboard/src/features/App/__tests__/App.test.tsx
+++ b/compensation/dashboard/src/features/App/__tests__/App.test.tsx
@@ -1,8 +1,9 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { FindCategory } from "../../Failed/FindCategory.ts";
 import App from "../App.tsx";
+import { I18nProvider } from "../../../i18n.tsx";
+import type { NavItem } from "../../../routes/constants.tsx";
 
 const mocks = vi.hoisted(() => ({
   outletContext: undefined as unknown,
@@ -55,7 +56,7 @@ vi.mock("react-router", () => ({
   useLocation: () => ({ pathname: mocks.pathname }),
 }));
 
-const navItems = [
+const navItems: readonly NavItem[] = [
   {
     label: "Dashboard",
     path: "/",
@@ -63,14 +64,10 @@ const navItems = [
   {
     label: "To Retry",
     path: "/to-retry",
-    category: FindCategory.ToRetry,
-    component: () => null,
   },
   {
     label: "Executing",
     path: "/executing",
-    category: FindCategory.Executing,
-    component: () => null,
   },
 ];
 
@@ -165,6 +162,32 @@ describe("App", () => {
     );
     expect(version.closest(".app-topbar")).not.toBeNull();
     expect(version.closest("[data-slot='sidebar-footer']")).toBeNull();
+  });
+
+  it("switches the interface language from the topbar", async () => {
+    localStorage.setItem("wow-dashboard-locale", "en");
+    render(
+      <I18nProvider>
+        <App navItems={navItems} />
+      </I18nProvider>,
+    );
+
+    const languageButton = screen.getByRole("button", {
+      name: "Current language: English",
+    });
+    expect(languageButton.closest(".app-topbar")).not.toBeNull();
+    expect(languageButton.closest("[data-slot='sidebar-footer']")).toBeNull();
+
+    fireEvent.mouseDown(languageButton, { button: 0, ctrlKey: false });
+    expect(
+      await screen.findByRole("menuitemradio", { name: "English" }),
+    ).toHaveAttribute("aria-checked", "true");
+    fireEvent.click(screen.getByRole("menuitemradio", { name: "中文" }));
+
+    expect(
+      screen.getByRole("heading", { name: "执行中" }),
+    ).toBeInTheDocument();
+    expect(localStorage.getItem("wow-dashboard-locale")).toBe("zh-CN");
   });
 
   it("collapses and expands the desktop navigation", () => {

--- a/compensation/dashboard/src/features/Failed/Actions.tsx
+++ b/compensation/dashboard/src/features/Failed/Actions.tsx
@@ -51,6 +51,7 @@ import { copyTextToClipboard } from "@/utils/clipboard.ts";
 import type { OnChangedCapable } from "./types.ts";
 import { commandErrorMessage } from "./commandErrors.ts";
 import { getCompensationCapabilities } from "./compensationCapabilities.ts";
+import { useI18n } from "@/i18n.tsx";
 
 export interface ActionsProps
   extends StateCapable<ExecutionFailedState>, OnChangedCapable {
@@ -58,6 +59,7 @@ export interface ActionsProps
 }
 
 export function Actions({ state, onChanged, disabled }: ActionsProps) {
+  const { t } = useI18n();
   const [forceDialogOpen, setForceDialogOpen] = useState(false);
   const unavailableReasonId = useId();
   const stateCapabilities = getCompensationCapabilities(state);
@@ -65,17 +67,17 @@ export function Actions({ state, onChanged, disabled }: ActionsProps) {
     ? {
         canForcePrepare: false,
         canPrepare: false,
-        unavailableReason: "Refreshing current execution state.",
+        unavailableReason: "Refreshing current execution state." as const,
       }
     : stateCapabilities;
 
   const prepareState = useExecutePromise<CommandResult, ExchangeError>({
     onSuccess: () => {
-      toast.success("Compensation prepared");
+      toast.success(t("Compensation prepared"));
       onChanged?.();
     },
     onError: async (error) => {
-      toast.error("Prepare failed", {
+      toast.error(t("Prepare failed"), {
         description: await commandErrorMessage(error),
       });
     },
@@ -84,11 +86,11 @@ export function Actions({ state, onChanged, disabled }: ActionsProps) {
   const forcePrepareState = useExecutePromise<CommandResult, ExchangeError>({
     onSuccess: () => {
       setForceDialogOpen(false);
-      toast.success("Compensation force prepared");
+      toast.success(t("Compensation force prepared"));
       onChanged?.();
     },
     onError: async (error) => {
-      toast.error("Force prepare failed", {
+      toast.error(t("Force prepare failed"), {
         description: await commandErrorMessage(error),
       });
     },
@@ -112,17 +114,17 @@ export function Actions({ state, onChanged, disabled }: ActionsProps) {
 
   const copyExecutionId = async () => {
     if (!(await copyTextToClipboard(state.id))) {
-      toast.error("Unable to copy execution ID");
+      toast.error(t("Unable to copy execution ID"));
       return;
     }
-    toast.success("Execution ID copied");
+    toast.success(t("Execution ID copied"));
   };
   const busy = prepareState.loading || forcePrepareState.loading;
   const unavailableAction = disabled
-    ? { label: "Refreshing state", icon: <LoaderCircle /> }
+    ? { label: t("Refreshing state"), icon: <LoaderCircle /> }
     : state.status === ExecutionFailedStatus.SUCCEEDED
-      ? { label: "Already succeeded", icon: <CircleCheck /> }
-      : { label: "Retry limit reached", icon: <ShieldAlert /> };
+      ? { label: t("Already succeeded"), icon: <CircleCheck /> }
+      : { label: t("Retry limit reached"), icon: <ShieldAlert /> };
 
   return (
     <>
@@ -150,7 +152,7 @@ export function Actions({ state, onChanged, disabled }: ActionsProps) {
               <Play />
             )}
             {capabilities.canPrepare
-              ? "Prepare compensation"
+              ? t("Prepare compensation")
               : unavailableAction.label}
           </Button>
           <DropdownMenu>
@@ -161,7 +163,7 @@ export function Actions({ state, onChanged, disabled }: ActionsProps) {
                   variant="outline"
                   size="icon-lg"
                   className="h-11 w-12"
-                  aria-label="More actions"
+                  aria-label={t("More actions")}
                   disabled={busy}
                 />
               }
@@ -176,11 +178,11 @@ export function Actions({ state, onChanged, disabled }: ActionsProps) {
                 onClick={() => setForceDialogOpen(true)}
               >
                 <ShieldAlert />
-                Force prepare
+                {t("Force prepare")}
               </DropdownMenuItem>
               <DropdownMenuItem className="py-2" onClick={copyExecutionId}>
                 <Clipboard />
-                Copy execution ID
+                {t("Copy execution ID")}
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
@@ -190,7 +192,7 @@ export function Actions({ state, onChanged, disabled }: ActionsProps) {
             id={unavailableReasonId}
             className="max-w-72 text-right text-xs text-slate-500"
           >
-            {capabilities.unavailableReason}
+            {t(capabilities.unavailableReason)}
           </p>
         ) : null}
       </div>
@@ -201,21 +203,22 @@ export function Actions({ state, onChanged, disabled }: ActionsProps) {
             <AlertDialogMedia className="bg-red-50 text-red-600">
               <ShieldAlert />
             </AlertDialogMedia>
-            <AlertDialogTitle>Force prepare this execution?</AlertDialogTitle>
+            <AlertDialogTitle>{t("Force prepare this execution?")}</AlertDialogTitle>
             <AlertDialogDescription>
-              This bypasses the retry limit for {state.id}. The server still
-              validates the current execution state. Use it only after verifying
-              the failure context.
+              {t(
+                "This bypasses the retry limit for {id}. The server still validates the current execution state. Use it only after verifying the failure context.",
+                { id: state.id },
+              )}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel>{t("Cancel")}</AlertDialogCancel>
             <AlertDialogAction
               variant="destructive"
               onClick={forcePrepare}
               disabled={busy || !capabilities.canForcePrepare}
             >
-              Force prepare
+              {t("Force prepare")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/compensation/dashboard/src/features/Failed/ApplyRetrySpec.tsx
+++ b/compensation/dashboard/src/features/Failed/ApplyRetrySpec.tsx
@@ -29,6 +29,7 @@ import { Label } from "@/components/ui/label";
 import { commandErrorMessage } from "./commandErrors.ts";
 import { CopyButton } from "@/components/CopyButton";
 import { formatSeconds } from "@/utils/durations.ts";
+import { useI18n } from "@/i18n.tsx";
 
 const INT32_MAX = 2_147_483_647;
 
@@ -48,6 +49,7 @@ export function ApplyRetrySpec({
   retrySpec,
   onChanged,
 }: ApplyRetrySpecProps) {
+  const { locale, t } = useI18n();
   const [draft, setDraft] = useState<RetrySpecDraft>({
     maxRetries: String(retrySpec.maxRetries),
     minBackoff: String(retrySpec.minBackoff),
@@ -56,12 +58,12 @@ export function ApplyRetrySpec({
   const { closeDrawer } = useGlobalDrawer();
   const promiseState = useExecutePromise<CommandResult, ExchangeError>({
     onSuccess: () => {
-      toast.success("Retry specification updated");
+      toast.success(t("Retry specification updated"));
       closeDrawer();
       onChanged?.();
     },
     onError: async (error) => {
-      toast.error("Failed to apply retry specification", {
+      toast.error(t("Failed to apply retry specification"), {
         description: await commandErrorMessage(error),
       });
     },
@@ -99,7 +101,7 @@ export function ApplyRetrySpec({
   return (
     <form className="space-y-5" onSubmit={submit}>
       <div className="space-y-2">
-        <Label htmlFor="retry-id">Execution ID</Label>
+        <Label htmlFor="retry-id">{t("Execution ID")}</Label>
         <div className="relative">
           <Input
             id="retry-id"
@@ -113,7 +115,7 @@ export function ApplyRetrySpec({
         </div>
       </div>
       <div className="space-y-2">
-        <Label htmlFor="max-retries">Max retries</Label>
+        <Label htmlFor="max-retries">{t("Max retries")}</Label>
         <Input
           id="max-retries"
           name="maxRetries"
@@ -132,7 +134,7 @@ export function ApplyRetrySpec({
         />
       </div>
       <div className="space-y-2">
-        <Label htmlFor="min-backoff">Min backoff (s)</Label>
+        <Label htmlFor="min-backoff">{t("Min backoff (s)")}</Label>
         <Input
           id="min-backoff"
           name="minBackoff"
@@ -152,12 +154,12 @@ export function ApplyRetrySpec({
         />
         <p id="min-backoff-preview" className="text-xs text-slate-500">
           {draft.minBackoff
-            ? formatSeconds(Number(draft.minBackoff))
-            : "Enter a duration"}
+            ? formatSeconds(Number(draft.minBackoff), locale)
+            : t("Enter a duration")}
         </p>
       </div>
       <div className="space-y-2">
-        <Label htmlFor="execution-timeout">Execution timeout (s)</Label>
+        <Label htmlFor="execution-timeout">{t("Execution timeout (s)")}</Label>
         <Input
           id="execution-timeout"
           name="executionTimeout"
@@ -177,8 +179,8 @@ export function ApplyRetrySpec({
         />
         <p id="execution-timeout-preview" className="text-xs text-slate-500">
           {draft.executionTimeout
-            ? formatSeconds(Number(draft.executionTimeout))
-            : "Enter a duration"}
+            ? formatSeconds(Number(draft.executionTimeout), locale)
+            : t("Enter a duration")}
         </p>
       </div>
       <Button
@@ -186,7 +188,7 @@ export function ApplyRetrySpec({
         className="w-full"
         disabled={promiseState.loading || !dirty || !valid}
       >
-        {promiseState.loading ? "Applying…" : "Apply retry spec"}
+        {promiseState.loading ? t("Applying…") : t("Apply retry spec")}
       </Button>
     </form>
   );

--- a/compensation/dashboard/src/features/Failed/ChangeFunction.tsx
+++ b/compensation/dashboard/src/features/Failed/ChangeFunction.tsx
@@ -33,6 +33,7 @@ import {
 } from "@/components/ui/select";
 import { commandErrorMessage } from "./commandErrors.ts";
 import { CopyButton } from "@/components/CopyButton";
+import { useI18n } from "@/i18n.tsx";
 
 export interface ChangeFunctionProps extends OnChangedCapable {
   id: string;
@@ -51,16 +52,17 @@ export function ChangeFunction({
   functionInfo,
   onChanged,
 }: ChangeFunctionProps) {
+  const { t } = useI18n();
   const { closeDrawer } = useGlobalDrawer();
   const [draft, setDraft] = useState<FunctionDraft>({ ...functionInfo });
   const promiseState = useExecutePromise<CommandResult, ExchangeError>({
     onSuccess: () => {
-      toast.success("Function updated");
+      toast.success(t("Function updated"));
       closeDrawer();
       onChanged?.();
     },
     onError: async (error) => {
-      toast.error("Failed to change function", {
+      toast.error(t("Failed to change function"), {
         description: await commandErrorMessage(error),
       });
     },
@@ -100,7 +102,7 @@ export function ChangeFunction({
   return (
     <form className="space-y-5" onSubmit={submit}>
       <div className="space-y-2">
-        <Label htmlFor="function-id">Execution ID</Label>
+        <Label htmlFor="function-id">{t("Execution ID")}</Label>
         <div className="relative">
           <Input
             id="function-id"
@@ -114,7 +116,7 @@ export function ChangeFunction({
         </div>
       </div>
       <div className="space-y-2">
-        <Label htmlFor="context-name">Context name</Label>
+        <Label htmlFor="context-name">{t("Context name")}</Label>
         <Input
           id="context-name"
           name="contextName"
@@ -129,7 +131,7 @@ export function ChangeFunction({
         />
       </div>
       <div className="space-y-2">
-        <Label htmlFor="processor-name">Processor name</Label>
+        <Label htmlFor="processor-name">{t("Processor name")}</Label>
         <Input
           id="processor-name"
           name="processorName"
@@ -144,7 +146,7 @@ export function ChangeFunction({
         />
       </div>
       <div className="space-y-2">
-        <Label htmlFor="function-name">Function name</Label>
+        <Label htmlFor="function-name">{t("Function name")}</Label>
         <Input
           id="function-name"
           name="name"
@@ -159,7 +161,7 @@ export function ChangeFunction({
         />
       </div>
       <div className="space-y-2">
-        <Label htmlFor="function-kind">Function kind</Label>
+        <Label htmlFor="function-kind">{t("Function kind")}</Label>
         <Select
           name="functionKind"
           value={draft.functionKind}
@@ -186,7 +188,7 @@ export function ChangeFunction({
         className="w-full"
         disabled={promiseState.loading || !dirty || !valid}
       >
-        {promiseState.loading ? "Saving…" : "Save function"}
+        {promiseState.loading ? t("Saving…") : t("Save function")}
       </Button>
     </form>
   );

--- a/compensation/dashboard/src/features/Failed/FailedPagination.tsx
+++ b/compensation/dashboard/src/features/Failed/FailedPagination.tsx
@@ -22,6 +22,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
+import { useI18n } from "@/i18n.tsx";
 
 interface FailedPaginationProps {
   loading?: boolean;
@@ -41,6 +42,7 @@ export function FailedPagination({
   total,
 }: FailedPaginationProps) {
   const [jumpPage, setJumpPage] = useState("");
+  const { t } = useI18n();
   const firstItem = total === 0 ? 0 : (pageIndex - 1) * pageSize + 1;
   const lastItem = Math.min((pageIndex - 1) * pageSize + rowCount, total);
   const pageCount = Math.ceil(total / pageSize);
@@ -75,7 +77,7 @@ export function FailedPagination({
         aria-live="polite"
         className="text-sm text-slate-600 tabular-nums"
       >
-        {firstItem}–{lastItem} of {total}
+        {t("{first}–{last} of {total}", { first: firstItem, last: lastItem, total })}
       </span>
       <div className="flex items-center gap-1.5">
         <Button
@@ -83,7 +85,7 @@ export function FailedPagination({
           variant="outline"
           size="icon"
           className="failed-pagination-control"
-          aria-label="Previous page"
+          aria-label={t("Previous page")}
           disabled={pageCount === 0 || pageIndex <= 1 || loading}
           onClick={() => onPaginationChange?.(pageIndex - 1, pageSize)}
         >
@@ -95,7 +97,7 @@ export function FailedPagination({
             type="button"
             variant="outline"
             size="icon"
-            aria-label={`Page ${page}`}
+            aria-label={t("Page {page}", { page })}
             aria-current={page === pageIndex ? "page" : undefined}
             className={cn(
               "failed-pagination-control failed-table-page-button",
@@ -113,7 +115,7 @@ export function FailedPagination({
           variant="outline"
           size="icon"
           className="failed-pagination-control"
-          aria-label="Next page"
+          aria-label={t("Next page")}
           disabled={pageCount === 0 || pageIndex >= pageCount || loading}
           onClick={() => onPaginationChange?.(pageIndex + 1, pageSize)}
         >
@@ -127,7 +129,7 @@ export function FailedPagination({
                 variant="outline"
                 size="icon"
                 className="failed-pagination-control"
-                aria-label="Pagination options"
+                aria-label={t("Pagination options")}
                 disabled={loading}
               />
             }
@@ -137,7 +139,7 @@ export function FailedPagination({
           <PopoverContent align="end" className="w-64">
             <form className="space-y-4" onSubmit={submitPageJump}>
               <div className="space-y-2">
-                <Label htmlFor="page-jump">Go to page</Label>
+                <Label htmlFor="page-jump">{t("Go to page")}</Label>
                 <div className="flex gap-2">
                   <Input
                     id="page-jump"
@@ -148,15 +150,15 @@ export function FailedPagination({
                     onChange={(event) => setJumpPage(event.target.value)}
                   />
                   <Button type="submit" disabled={pageCount === 0 || !jumpPage}>
-                    Go
+                    {t("Go")}
                   </Button>
                 </div>
               </div>
               <div className="space-y-2">
-                <Label htmlFor="rows-per-page">Rows per page</Label>
+                <Label htmlFor="rows-per-page">{t("Rows per page")}</Label>
                 <select
                   id="rows-per-page"
-                  aria-label="Rows per page"
+                  aria-label={t("Rows per page")}
                   className="h-9 w-full rounded-lg border border-input bg-white px-2.5 text-sm outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50"
                   value={pageSize}
                   onChange={(event) =>

--- a/compensation/dashboard/src/features/Failed/FailedSearch.tsx
+++ b/compensation/dashboard/src/features/Failed/FailedSearch.tsx
@@ -24,6 +24,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { ExecutionFailedAggregatedFields } from "@/generated";
+import { useI18n, type Message } from "@/i18n.tsx";
 
 interface FailedSearchProps {
   onSearch?: (filterExpression: FilterExpression, hasFilters: boolean) => void;
@@ -32,8 +33,8 @@ interface FailedSearchProps {
 
 interface SearchField {
   key: string;
-  label: string;
-  placeholder: string;
+  label: Message;
+  placeholder: Message;
   filter: (value: string) => FilterExpression;
 }
 
@@ -106,6 +107,7 @@ const searchFields: SearchField[] = [
 export function FailedSearch({ onSearch, loading }: FailedSearchProps) {
   const [activeKeys, setActiveKeys] = useState<string[]>(["_id"]);
   const [values, setValues] = useState<Record<string, string>>({});
+  const { t } = useI18n();
 
   const activeFields = useMemo(
     () => searchFields.filter((field) => activeKeys.includes(field.key)),
@@ -155,16 +157,16 @@ export function FailedSearch({ onSearch, loading }: FailedSearchProps) {
   return (
     <form
       className="border-b bg-white px-5 py-[22px]"
-      aria-label="Search executions"
+      aria-label={t("Search executions")}
       aria-busy={loading}
       onSubmit={submit}
     >
       <div className="flex items-center gap-2">
         <div className="relative min-w-0 flex-1">
           <Input
-            aria-label="Execution ID"
+            aria-label={t("Execution ID")}
             className="h-11 pr-11 text-[15px]"
-            placeholder="Search by ID…"
+            placeholder={t("Search by ID…")}
             value={values._id ?? ""}
             onChange={(event) =>
               setValues((current) => ({ ...current, _id: event.target.value }))
@@ -175,7 +177,7 @@ export function FailedSearch({ onSearch, loading }: FailedSearchProps) {
             variant="ghost"
             size="icon"
             className="absolute top-0 right-0 size-11"
-            aria-label="Search"
+            aria-label={t("Search")}
             disabled={loading}
           >
             {loading ? (
@@ -192,18 +194,18 @@ export function FailedSearch({ onSearch, loading }: FailedSearchProps) {
                 type="button"
                 variant="outline"
                 className="h-11 px-4"
-                aria-label="Add filter"
+                aria-label={t("Add filter")}
               />
             }
           >
             <Filter />
             {appliedFilterCount > 0
-              ? `Filters (${appliedFilterCount})`
-              : "Add filter"}
+              ? t("Filters ({count})", { count: appliedFilterCount })
+              : t("Add filter")}
           </PopoverTrigger>
           <PopoverContent align="end" className="w-64 p-2">
             <div className="px-2 pb-2 text-xs font-medium text-muted-foreground">
-              Search fields
+              {t("Search fields")}
             </div>
             {searchFields.slice(1).map((field) => {
               const checked = activeKeys.includes(field.key);
@@ -218,7 +220,7 @@ export function FailedSearch({ onSearch, loading }: FailedSearchProps) {
                       setFieldActive(field.key, value === true)
                     }
                   />
-                  {field.label}
+                  {t(field.label)}
                 </Label>
               );
             })}
@@ -231,12 +233,12 @@ export function FailedSearch({ onSearch, loading }: FailedSearchProps) {
           {activeFields.slice(1).map((field) => (
             <div key={field.key} className="flex items-center gap-2">
               <Label className="w-28 shrink-0 text-xs text-muted-foreground">
-                {field.label}
+                {t(field.label)}
               </Label>
               <Input
-                aria-label={field.label}
+                aria-label={t(field.label)}
                 className="h-9"
-                placeholder={field.placeholder}
+                placeholder={t(field.placeholder)}
                 value={values[field.key] ?? ""}
                 onChange={(event) =>
                   setValues((current) => ({
@@ -249,7 +251,7 @@ export function FailedSearch({ onSearch, loading }: FailedSearchProps) {
                 type="button"
                 variant="ghost"
                 size="icon-sm"
-                aria-label={`Remove ${field.label}`}
+                aria-label={t("Remove {label}", { label: t(field.label) })}
                 onClick={() => setFieldActive(field.key, false)}
               >
                 <X />
@@ -259,16 +261,16 @@ export function FailedSearch({ onSearch, loading }: FailedSearchProps) {
         </div>
       ) : null}
       <div className="mt-2 flex min-h-5 items-center justify-between gap-3 text-xs text-slate-500">
-        <span>Exact match across all fields</span>
+        <span>{t("Exact match across all fields")}</span>
         {appliedFilterCount > 0 ? (
           <Button
             type="button"
             variant="link"
             className="h-auto px-0 text-xs"
-            aria-label="Clear all filters"
+            aria-label={t("Clear all filters")}
             onClick={clearAll}
           >
-            Clear all
+            {t("Clear all")}
           </Button>
         ) : null}
       </div>

--- a/compensation/dashboard/src/features/Failed/FailedTable.tsx
+++ b/compensation/dashboard/src/features/Failed/FailedTable.tsx
@@ -36,6 +36,7 @@ import { cn } from "@/lib/utils";
 import { useNow } from "@/hooks/useNow.ts";
 import { FailedPagination } from "./FailedPagination.tsx";
 import { StatusBadge } from "./StatusBadge.tsx";
+import { useI18n } from "@/i18n.tsx";
 
 const columnHelper = createColumnHelper<ExecutionFailedState>();
 
@@ -69,14 +70,15 @@ export function FailedTable({
   staleError,
 }: FailedTableProps) {
   const now = useNow();
+  const { locale, t } = useI18n();
   const columns = useMemo(
     () => [
       columnHelper.accessor("status", {
-        header: "Status",
+        header: t("Status"),
         cell: (info) => <StatusBadge status={info.getValue()} />,
       }),
       columnHelper.accessor("id", {
-        header: "Execution ID",
+        header: t("Execution ID"),
         cell: (info) => (
           <div className="min-w-0">
             <StatusBadge
@@ -86,7 +88,7 @@ export function FailedTable({
             <button
               type="button"
               disabled={loading}
-              aria-label={`View execution ${info.getValue()}`}
+              aria-label={t("View execution {id}", { id: info.getValue() })}
               className="block w-full truncate text-left font-medium text-slate-800 outline-none hover:text-blue-700 focus-visible:underline disabled:cursor-wait disabled:text-slate-700"
               onClick={(event) => {
                 event.stopPropagation();
@@ -104,7 +106,7 @@ export function FailedTable({
         ),
       }),
       columnHelper.accessor("function", {
-        header: "Processor / Function",
+        header: t("Processor / Function"),
         cell: (info) => (
           <div className="min-w-0">
             <div className="truncate text-sm text-slate-700">
@@ -118,7 +120,7 @@ export function FailedTable({
       }),
       columnHelper.display({
         id: "retry",
-        header: "Retry",
+        header: t("Retry"),
         cell: ({ row }) => (
           <span className="tabular-nums text-slate-700">
             {row.original.retryState.retries} /{" "}
@@ -127,18 +129,18 @@ export function FailedTable({
         ),
       }),
       columnHelper.accessor("executeAt", {
-        header: "Age",
+        header: t("Age"),
         cell: (info) => (
           <span
             className="text-xs tabular-nums text-slate-700"
-            title={formatDate(info.getValue())}
+            title={formatDate(info.getValue(), undefined, locale)}
           >
-            {formatAge(info.getValue(), now)}
+            {formatAge(info.getValue(), now, locale)}
           </span>
         ),
       }),
     ],
-    [loading, now, onSelect],
+    [loading, locale, now, onSelect, t],
   );
 
   // eslint-disable-next-line react-hooks/incompatible-library -- TanStack Table keeps its headless state local to this component.
@@ -158,12 +160,14 @@ export function FailedTable({
           className="flex items-center justify-between gap-3 border-b border-amber-200 bg-amber-50 px-4 py-2 text-xs text-amber-900"
         >
           <span>
-            Refresh failed: {staleError.message}. Showing the last loaded page;
-            changes are disabled until refresh succeeds.
+            {t(
+              "Refresh failed: {message}. Showing the last loaded page; changes are disabled until refresh succeeds.",
+              { message: staleError.message },
+            )}
           </span>
           <Button type="button" variant="outline" size="sm" onClick={onRetry}>
             <RefreshCw />
-            Retry
+            {t("Retry")}
           </Button>
         </div>
       ) : null}
@@ -171,7 +175,7 @@ export function FailedTable({
         {loading && pagedList.list.length > 0 ? (
           <div
             role="status"
-            aria-label="Loading page"
+            aria-label={t("Loading page")}
             className="pointer-events-none sticky top-[42px] z-20 h-0.5 overflow-hidden bg-blue-100"
           >
             <div className="h-full w-full animate-pulse bg-blue-500 motion-reduce:animate-none" />
@@ -226,7 +230,7 @@ export function FailedTable({
                   <div role="alert" className="mx-auto max-w-sm">
                     <AlertCircle className="mx-auto size-5 text-red-600" />
                     <div className="mt-2 text-sm font-medium text-red-700">
-                      Failed to load executions
+                      {t("Failed to load executions")}
                     </div>
                     <div className="mt-1 text-xs text-muted-foreground">
                       {error.message}
@@ -238,7 +242,7 @@ export function FailedTable({
                       onClick={onRetry}
                     >
                       <RefreshCw />
-                      Retry
+                      {t("Retry")}
                     </Button>
                   </div>
                 </TableCell>
@@ -251,20 +255,20 @@ export function FailedTable({
                   className="h-56 whitespace-normal break-words text-center"
                 >
                   <div className="text-sm font-medium text-slate-700">
-                    No failed executions found
+                    {t("No failed executions found")}
                   </div>
                   <div className="mt-1 text-xs text-muted-foreground">
-                    Try another queue or adjust the filters.
+                    {t("Try another queue or adjust the filters.")}
                   </div>
                   {hasActiveFilters ? (
                     <Button
                       type="button"
                       variant="outline"
                       className="mt-4"
-                      aria-label="Clear search filters"
+                      aria-label={t("Clear search filters")}
                       onClick={onClearFilters}
                     >
-                      Clear search
+                      {t("Clear search")}
                     </Button>
                   ) : null}
                 </TableCell>

--- a/compensation/dashboard/src/features/Failed/FailedView.tsx
+++ b/compensation/dashboard/src/features/Failed/FailedView.tsx
@@ -20,20 +20,22 @@ import { FailedTable } from "./FailedTable.tsx";
 import { FailedWorkspace } from "./FailedWorkspace.tsx";
 import type { FindCategory } from "./FindCategory.ts";
 import { useFailedQueueController } from "./useFailedQueueController.ts";
+import { useI18n } from "@/i18n.tsx";
 
 interface FailedViewProps {
   category: FindCategory;
 }
 
 function EmptyDetails() {
+  const { t } = useI18n();
   return (
     <div className="flex h-full items-center justify-center bg-slate-50 p-8 text-center">
       <div>
         <p className="text-sm font-medium text-slate-700">
-          Select an execution
+          {t("Select an execution")}
         </p>
         <p className="mt-1 text-xs text-slate-500">
-          Failure context and compensation actions will appear here.
+          {t("Failure context and compensation actions will appear here.")}
         </p>
       </div>
     </div>
@@ -41,16 +43,17 @@ function EmptyDetails() {
 }
 
 function LoadingPageDetails() {
+  const { t } = useI18n();
   return (
     <div
       role="status"
-      aria-label="Loading page details"
+      aria-label={t("Loading page details")}
       className="flex h-full items-center justify-center bg-slate-50 p-8 text-center"
     >
       <div>
-        <p className="text-sm font-medium text-slate-700">Loading page</p>
+        <p className="text-sm font-medium text-slate-700">{t("Loading page")}</p>
         <p className="mt-1 text-xs text-slate-500">
-          The next executions will appear here shortly.
+          {t("The next executions will appear here shortly.")}
         </p>
       </div>
     </div>
@@ -58,6 +61,7 @@ function LoadingPageDetails() {
 }
 
 export default function FailedView({ category }: FailedViewProps) {
+  const { t } = useI18n();
   const desktop = useMediaQuery("(min-width: 960px)");
   const { isOpen: isDrawerOpen } = useGlobalDrawer();
   const controller = useFailedQueueController({
@@ -69,7 +73,7 @@ export default function FailedView({ category }: FailedViewProps) {
   const master = (
     <section
       className="flex h-full min-h-0 flex-col border-r bg-white"
-      aria-label="Failed executions"
+      aria-label={t("Failed executions")}
     >
       <FailedSearch
         key={controller.searchResetToken}

--- a/compensation/dashboard/src/features/Failed/FailedWorkspace.tsx
+++ b/compensation/dashboard/src/features/Failed/FailedWorkspace.tsx
@@ -24,6 +24,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
+import { useI18n } from "@/i18n.tsx";
 
 const SPLIT_LAYOUT_KEY = "compensation-dashboard:failed-view-layout";
 const DEFAULT_SPLIT_LAYOUT = {
@@ -78,6 +79,7 @@ export function FailedWorkspace({
   master,
   onCloseDetails,
 }: FailedWorkspaceProps) {
+  const { t } = useI18n();
   const mobileDetailsFocusRef = useRef<HTMLDivElement>(null);
   const [splitLayout] = useState(loadSplitLayout);
 
@@ -100,15 +102,15 @@ export function FailedWorkspace({
             initialFocus={mobileDetailsFocusRef}
           >
             <SheetHeader className="sr-only">
-              <SheetTitle>Execution failed details</SheetTitle>
+              <SheetTitle>{t("Execution failed details")}</SheetTitle>
               <SheetDescription>
-                Inspect context and prepare compensation.
+                {t("Inspect context and prepare compensation.")}
               </SheetDescription>
             </SheetHeader>
             <div
               ref={mobileDetailsFocusRef}
               tabIndex={-1}
-              aria-label="Execution details panel"
+              aria-label={t("Execution details panel")}
               className="min-h-0 flex-1 overflow-hidden outline-none"
             >
               {details}
@@ -136,7 +138,7 @@ export function FailedWorkspace({
       </ResizablePanel>
       <ResizableHandle
         withHandle
-        aria-label="Resize execution list and details"
+        aria-label={t("Resize execution list and details")}
         className="z-20 bg-slate-200"
       />
       <ResizablePanel id="execution-details" minSize="48">

--- a/compensation/dashboard/src/features/Failed/MarkRecoverable.tsx
+++ b/compensation/dashboard/src/features/Failed/MarkRecoverable.tsx
@@ -40,6 +40,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { commandErrorMessage } from "./commandErrors.ts";
+import { useI18n } from "@/i18n.tsx";
 
 export interface MarkRecoverableProps
   extends Identifier, MarkRecoverable, OnChangedCapable {
@@ -52,15 +53,24 @@ export function MarkRecoverable({
   onChanged,
   disabled,
 }: MarkRecoverableProps) {
+  const { t } = useI18n();
+  const label = (value: RecoverableType) =>
+    t(
+      value === RecoverableType.RECOVERABLE
+        ? "Recoverable"
+        : value === RecoverableType.UNRECOVERABLE
+          ? "Unrecoverable"
+          : "Unknown",
+    );
   const [pending, setPending] = useState<RecoverableType>();
   const promiseState = useExecutePromise<CommandResult, ExchangeError>({
     onSuccess: () => {
-      toast.success("Recoverability updated");
+      toast.success(t("Recoverability updated"));
       setPending(undefined);
       onChanged?.();
     },
     onError: async (error) => {
-      toast.error("Failed to update recoverability", {
+      toast.error(t("Failed to update recoverability"), {
         description: await commandErrorMessage(error),
       });
     },
@@ -81,15 +91,15 @@ export function MarkRecoverable({
         onValueChange={(value) => setPending(value as RecoverableType)}
         disabled={disabled || promiseState.loading}
       >
-        <SelectTrigger size="sm" className="min-w-28" aria-label="Recoverable">
+        <SelectTrigger size="sm" className="min-w-28" aria-label={t("Recoverable")}>
           <SelectValue>
-            {recoverable.charAt(0) + recoverable.slice(1).toLowerCase()}
+            {label(recoverable)}
           </SelectValue>
         </SelectTrigger>
         <SelectContent>
           {Object.values(RecoverableType).map((value) => (
             <SelectItem key={value} value={value}>
-              {value.charAt(0) + value.slice(1).toLowerCase()}
+              {label(value)}
             </SelectItem>
           ))}
         </SelectContent>
@@ -107,14 +117,16 @@ export function MarkRecoverable({
             <AlertDialogMedia className="bg-amber-50 text-amber-700">
               <ShieldAlert />
             </AlertDialogMedia>
-            <AlertDialogTitle>Change recoverability?</AlertDialogTitle>
+            <AlertDialogTitle>{t("Change recoverability?")}</AlertDialogTitle>
             <AlertDialogDescription>
-              This changes execution eligibility from{" "}
-              {recoverable.toLowerCase()} to {pending?.toLowerCase()}.
+              {t("This changes execution eligibility from {from} to {to}.", {
+                from: label(recoverable),
+                to: pending ? label(pending) : "",
+              })}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel>{t("Cancel")}</AlertDialogCancel>
             <AlertDialogAction
               onClick={(event) => {
                 event.preventDefault();
@@ -124,7 +136,7 @@ export function MarkRecoverable({
               }}
               disabled={disabled || !pending || promiseState.loading}
             >
-              Confirm change
+              {t("Confirm change")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/compensation/dashboard/src/features/Failed/StatusBadge.tsx
+++ b/compensation/dashboard/src/features/Failed/StatusBadge.tsx
@@ -14,6 +14,7 @@
 import { ExecutionFailedStatus } from "@/generated";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
+import { useI18n, type Message } from "@/i18n.tsx";
 
 interface StatusBadgeProps {
   className?: string;
@@ -21,7 +22,8 @@ interface StatusBadgeProps {
 }
 
 export function StatusBadge({ className, status }: StatusBadgeProps) {
-  const labels: Record<ExecutionFailedStatus, string> = {
+  const { t } = useI18n();
+  const labels: Record<ExecutionFailedStatus, Message> = {
     [ExecutionFailedStatus.FAILED]: "Failed",
     [ExecutionFailedStatus.PREPARED]: "Prepared",
     [ExecutionFailedStatus.SUCCEEDED]: "Succeeded",
@@ -41,12 +43,13 @@ export function StatusBadge({ className, status }: StatusBadgeProps) {
         className,
       )}
     >
-      {labels[status]}
+      {t(labels[status])}
     </Badge>
   );
 }
 
 export function BooleanBadge({ value }: { value: boolean }) {
+  const { t } = useI18n();
   return (
     <Badge
       variant="outline"
@@ -57,7 +60,7 @@ export function BooleanBadge({ value }: { value: boolean }) {
           : "border-slate-300 bg-slate-50 text-slate-600",
       )}
     >
-      {value ? "Yes" : "No"}
+      {value ? t("Yes") : t("No")}
     </Badge>
   );
 }

--- a/compensation/dashboard/src/features/Failed/compensationCapabilities.ts
+++ b/compensation/dashboard/src/features/Failed/compensationCapabilities.ts
@@ -15,11 +15,12 @@ import {
   ExecutionFailedStatus,
   type ExecutionFailedState,
 } from "../../generated";
+import type { Message } from "@/i18n.tsx";
 
 export interface CompensationCapabilities {
   canForcePrepare: boolean;
   canPrepare: boolean;
-  unavailableReason?: string;
+  unavailableReason?: Message;
 }
 
 export function getCompensationCapabilities(

--- a/compensation/dashboard/src/features/Failed/details/ErrorDetails.tsx
+++ b/compensation/dashboard/src/features/Failed/details/ErrorDetails.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/components/ui/tooltip";
 import { copyTextToClipboard } from "@/utils/clipboard.ts";
 import { StackTraceEditor } from "./StackTraceEditor.tsx";
+import { useI18n } from "@/i18n.tsx";
 
 export interface ErrorDetailsProps {
   error: ErrorDetailsModel;
@@ -43,6 +44,7 @@ export function ErrorDetails({
   historical = false,
   defaultExpanded,
 }: ErrorDetailsProps) {
+  const { locale, t } = useI18n();
   const panelRef = useRef<HTMLDivElement>(null);
   const expandedContentRef = useRef<HTMLDivElement>(null);
   const [expanded, setExpanded] = useState(defaultExpanded ?? !historical);
@@ -77,7 +79,7 @@ export function ErrorDetails({
       try {
         await document.exitFullscreen();
       } catch {
-        toast.error("Unable to change fullscreen mode");
+        toast.error(t("Unable to change fullscreen mode"));
         return;
       }
     }
@@ -92,16 +94,16 @@ export function ErrorDetails({
         await panelRef.current?.requestFullscreen();
       }
     } catch {
-      toast.error("Unable to change fullscreen mode");
+      toast.error(t("Unable to change fullscreen mode"));
     }
   };
 
   const copy = async () => {
     if (!(await copyTextToClipboard(error.stackTrace))) {
-      toast.error("Unable to copy stack trace");
+      toast.error(t("Unable to copy stack trace"));
       return;
     }
-    toast.success("Stack trace copied");
+    toast.success(t("Stack trace copied"));
   };
   const normalizedQuery = searchQuery.trim().toLocaleLowerCase();
   const matchCount = normalizedQuery
@@ -110,7 +112,8 @@ export function ErrorDetails({
         .filter((line) => line.toLocaleLowerCase().includes(normalizedQuery))
         .length
     : 0;
-  const title = historical ? "Last failure" : "Stack trace";
+  const title = historical ? t("Last failure") : t("Stack trace");
+  const actionTitle = locale === "en" ? title.toLowerCase() : title;
   const collapsible = historical || defaultExpanded !== undefined;
 
   return (
@@ -132,8 +135,8 @@ export function ErrorDetails({
               size="icon-sm"
               aria-label={
                 expanded
-                  ? `Collapse ${title.toLowerCase()}`
-                  : `Expand ${title.toLowerCase()}`
+                  ? t("Collapse {title}", { title: actionTitle })
+                  : t("Expand {title}", { title: actionTitle })
               }
               aria-expanded={expanded}
               onClick={() => void toggleExpanded()}
@@ -161,14 +164,14 @@ export function ErrorDetails({
                   type="button"
                   variant="ghost"
                   size="icon-sm"
-                  aria-label="Copy stack trace"
+                  aria-label={t("Copy stack trace")}
                   onClick={copy}
                 />
               }
             >
               <Clipboard />
             </TooltipTrigger>
-            <TooltipContent>Copy stack trace</TooltipContent>
+            <TooltipContent>{t("Copy stack trace")}</TooltipContent>
           </Tooltip>
           {expanded ? (
             <Tooltip>
@@ -179,7 +182,7 @@ export function ErrorDetails({
                     variant="ghost"
                     size="icon-sm"
                     aria-label={
-                      fullscreen ? "Exit fullscreen" : "Open fullscreen"
+                      fullscreen ? t("Exit fullscreen") : t("Open fullscreen")
                     }
                     onClick={toggleFullscreen}
                   />
@@ -188,7 +191,7 @@ export function ErrorDetails({
                 {fullscreen ? <Minimize2 /> : <Maximize2 />}
               </TooltipTrigger>
               <TooltipContent>
-                {fullscreen ? "Exit fullscreen" : "Open fullscreen"}
+                {fullscreen ? t("Exit fullscreen") : t("Open fullscreen")}
               </TooltipContent>
             </Tooltip>
           ) : null}
@@ -200,9 +203,9 @@ export function ErrorDetails({
             <div className="min-w-[180px] flex-1">
               <Input
                 type="search"
-                aria-label="Search stack trace"
+                aria-label={t("Search stack trace")}
                 aria-describedby={matchStatusId}
-                placeholder="Search stack trace…"
+                placeholder={t("Search stack trace…")}
                 className="h-8 bg-white"
                 value={searchQuery}
                 onChange={(event) => setSearchQuery(event.target.value)}
@@ -215,7 +218,9 @@ export function ErrorDetails({
               className="text-xs text-slate-500 tabular-nums"
             >
               {normalizedQuery
-                ? `${matchCount} ${matchCount === 1 ? "match" : "matches"}`
+                ? t(matchCount === 1 ? "{count} match" : "{count} matches", {
+                    count: matchCount,
+                  })
                 : ""}
             </span>
             <Button
@@ -223,7 +228,9 @@ export function ErrorDetails({
               variant={wrapLongLines ? "secondary" : "ghost"}
               size="icon-sm"
               aria-label={
-                wrapLongLines ? "Disable line wrapping" : "Enable line wrapping"
+                wrapLongLines
+                  ? t("Disable line wrapping")
+                  : t("Enable line wrapping")
               }
               aria-pressed={wrapLongLines}
               onClick={() => setWrapLongLines((current) => !current)}

--- a/compensation/dashboard/src/features/Failed/details/ExecutionContext.tsx
+++ b/compensation/dashboard/src/features/Failed/details/ExecutionContext.tsx
@@ -20,6 +20,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { ChangeFunction } from "../ChangeFunction.tsx";
 import type { OnChangedCapable } from "../types.ts";
+import { useI18n } from "@/i18n.tsx";
 
 type ExecutionContextState = Pick<
   ExecutionFailedState,
@@ -58,13 +59,14 @@ export function ExecutionContext({
   onChanged,
   mutationsDisabled,
 }: ExecutionContextProps) {
+  const { t } = useI18n();
   const { openDrawer } = useGlobalDrawer();
   const aggregate = state.eventId.aggregateId;
 
   const editFunction = () =>
     openDrawer({
-      title: "Change function",
-      description: "Update the handler identity for this failed execution.",
+      title: t("Change function"),
+      description: t("Update the handler identity for this failed execution."),
       width: 500,
       children: (
         <ChangeFunction
@@ -78,29 +80,29 @@ export function ExecutionContext({
   return (
     <section
       className="overflow-hidden rounded-lg border bg-white shadow-sm"
-      aria-label="Execution context"
+      aria-label={t("Execution context")}
     >
       <div className="flex min-h-14 items-center gap-3 border-b bg-slate-50/70 px-4 py-3">
         <Workflow className="size-4 shrink-0 text-slate-500" />
         <div className="min-w-0">
           <h2 className="text-sm font-semibold text-slate-900">
-            Execution context
+            {t("Execution context")}
           </h2>
           <p className="text-xs text-slate-500">
-            Handler and source event identifiers
+            {t("Handler and source event identifiers")}
           </p>
         </div>
       </div>
       <dl className="grid grid-cols-1 gap-x-6 p-3 xl:grid-cols-2">
         <div className="space-y-1 xl:border-r xl:pr-6">
           <DetailRow
-            label="Processor"
+            label={t("Processor")}
             action={
               <Button
                 type="button"
                 variant="ghost"
                 size="icon-xs"
-                aria-label="Edit function"
+                aria-label={t("Edit function")}
                 disabled={mutationsDisabled}
                 onClick={editFunction}
               >
@@ -112,21 +114,21 @@ export function ExecutionContext({
               {state.function.processorName}
             </span>
           </DetailRow>
-          <DetailRow label="Function kind">
+          <DetailRow label={t("Function kind")}>
             {state.function.contextName} / {state.function.functionKind}
           </DetailRow>
-          <DetailRow label="Aggregate">
+          <DetailRow label={t("Aggregate")}>
             {aggregate.contextName} / {aggregate.aggregateName}
           </DetailRow>
-          <DetailRow label="Tenant">
+          <DetailRow label={t("Tenant")}>
             <span className="truncate">{aggregate.tenantId}</span>
           </DetailRow>
         </div>
 
         <div className="mt-4 space-y-1 border-t pt-4 xl:mt-0 xl:border-t-0 xl:pl-6 xl:pt-0">
-          <DetailRow label="Event version">{state.eventId.version}</DetailRow>
+          <DetailRow label={t("Event version")}>{state.eventId.version}</DetailRow>
           <DetailRow
-            label="Event ID"
+            label={t("Event ID")}
             action={<CopyButton value={state.eventId.id} label="event ID" />}
           >
             <span className="block truncate font-mono text-xs">
@@ -134,7 +136,7 @@ export function ExecutionContext({
             </span>
           </DetailRow>
           <DetailRow
-            label="Aggregate ID"
+            label={t("Aggregate ID")}
             action={
               <CopyButton value={aggregate.aggregateId} label="aggregate ID" />
             }

--- a/compensation/dashboard/src/features/Failed/details/FailureSummary.tsx
+++ b/compensation/dashboard/src/features/Failed/details/FailureSummary.tsx
@@ -16,6 +16,7 @@ import type { ExecutionFailedState } from "../../../generated";
 import { ExecutionFailedStatus } from "../../../generated";
 import { cn } from "@/lib/utils";
 import { formatDate } from "@/utils/dates";
+import { useI18n } from "@/i18n.tsx";
 
 export interface FailureSummaryProps {
   state: Pick<ExecutionFailedState, "error" | "executeAt" | "status">;
@@ -23,6 +24,7 @@ export interface FailureSummaryProps {
 
 export function FailureSummary({ state }: FailureSummaryProps) {
   const historical = state.status === ExecutionFailedStatus.SUCCEEDED;
+  const { locale, t } = useI18n();
 
   return (
     <section
@@ -30,7 +32,7 @@ export function FailureSummary({ state }: FailureSummaryProps) {
         "overflow-hidden rounded-lg border bg-white shadow-sm",
         historical ? "border-slate-200" : "border-red-200",
       )}
-      aria-label={historical ? "Last failure summary" : "Failure summary"}
+      aria-label={historical ? t("Last failure summary") : t("Failure summary")}
     >
       <div
         className={cn(
@@ -47,12 +49,12 @@ export function FailureSummary({ state }: FailureSummaryProps) {
           />
           <div className="min-w-0">
             <h2 className="text-sm font-semibold text-slate-900">
-              {historical ? "Last failure" : "Failure summary"}
+              {historical ? t("Last failure") : t("Failure summary")}
             </h2>
             <p className="text-xs text-slate-500">
               {historical
-                ? "Most recent recorded failure"
-                : "Current processing failure"}
+                ? t("Most recent recorded failure")
+                : t("Current processing failure")}
             </p>
           </div>
         </div>
@@ -73,10 +75,10 @@ export function FailureSummary({ state }: FailureSummaryProps) {
         <dl className="mt-4 border-t pt-3">
           <div>
             <dt className="text-xs text-slate-500">
-              {historical ? "Succeeded at" : "Failed at"}
+              {historical ? t("Succeeded at") : t("Failed at")}
             </dt>
             <dd className="mt-1 text-sm tabular-nums text-slate-800">
-              {formatDate(state.executeAt)}
+              {formatDate(state.executeAt, undefined, locale)}
             </dd>
           </div>
         </dl>

--- a/compensation/dashboard/src/features/Failed/details/FetchingFailedDetails.tsx
+++ b/compensation/dashboard/src/features/Failed/details/FetchingFailedDetails.tsx
@@ -23,6 +23,7 @@ import { RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { OnChangedCapable } from "../types.ts";
+import { useI18n } from "@/i18n.tsx";
 
 export interface FetchingFailedDetailsProps extends OnChangedCapable {
   id: string;
@@ -34,6 +35,7 @@ export function FetchingFailedDetails({
   onChanged,
   mutationsDisabled,
 }: FetchingFailedDetailsProps) {
+  const { t } = useI18n();
   const query = useMemo(
     () =>
       singleQuery<ExecutionFailedAggregatedFields>({
@@ -63,7 +65,7 @@ export function FetchingFailedDetails({
     return (
       <div
         role="status"
-        aria-label="Loading execution details"
+        aria-label={t("Loading execution details")}
         className="h-full space-y-4 bg-slate-50 p-5"
       >
         <Skeleton className="h-20 w-full" />
@@ -81,7 +83,7 @@ export function FetchingFailedDetails({
       >
         <div>
           <p className="text-sm font-medium text-red-600">
-            Failed to load execution
+            {t("Failed to load execution")}
           </p>
           <p className="mt-1 text-xs text-slate-500">{error.message}</p>
           <Button
@@ -91,7 +93,7 @@ export function FetchingFailedDetails({
             onClick={() => void refreshDetails()}
           >
             <RefreshCw />
-            Retry
+            {t("Retry")}
           </Button>
         </div>
       </div>
@@ -102,7 +104,7 @@ export function FetchingFailedDetails({
     return (
       <div
         role="status"
-        aria-label="Loading execution details"
+        aria-label={t("Loading execution details")}
         className="h-full space-y-4 bg-slate-50 p-5"
       >
         <Skeleton className="h-20 w-full" />
@@ -117,10 +119,10 @@ export function FetchingFailedDetails({
       <div className="flex h-full min-h-60 items-center justify-center bg-slate-50 p-6 text-center">
         <div>
           <p className="text-sm font-medium text-slate-700">
-            Execution not found
+            {t("Execution not found")}
           </p>
           <p className="mt-1 text-xs text-slate-500">
-            No compensation execution matches {id}.
+            {t("No compensation execution matches {id}.", { id })}
           </p>
         </div>
       </div>

--- a/compensation/dashboard/src/features/Failed/details/RecoveryStatus.tsx
+++ b/compensation/dashboard/src/features/Failed/details/RecoveryStatus.tsx
@@ -21,6 +21,7 @@ import { ApplyRetrySpec } from "../ApplyRetrySpec.tsx";
 import { MarkRecoverable } from "../MarkRecoverable.tsx";
 import { BooleanBadge } from "../StatusBadge.tsx";
 import type { OnChangedCapable } from "../types.ts";
+import { useI18n } from "@/i18n.tsx";
 
 type RecoveryState = Pick<
   ExecutionFailedState,
@@ -38,11 +39,12 @@ export function RecoveryStatus({
   mutationsDisabled,
 }: RecoveryStatusProps) {
   const { openDrawer } = useGlobalDrawer();
+  const { locale, t } = useI18n();
 
   const editRetry = () =>
     openDrawer({
-      title: "Apply retry specification",
-      description: "Tune retry limits and timing for this execution.",
+      title: t("Apply retry specification"),
+      description: t("Tune retry limits and timing for this execution."),
       width: 440,
       children: (
         <ApplyRetrySpec
@@ -56,17 +58,17 @@ export function RecoveryStatus({
   return (
     <section
       className="overflow-hidden rounded-lg border border-blue-200 bg-white shadow-sm"
-      aria-label="Recovery status"
+      aria-label={t("Recovery status")}
     >
       <div className="flex min-h-14 items-center justify-between gap-3 border-b bg-blue-50/60 px-4 py-3">
         <div className="flex min-w-0 items-center gap-3">
           <RotateCcw className="size-4 shrink-0 text-blue-600" />
           <div className="min-w-0">
             <h2 className="text-sm font-semibold text-slate-900">
-              Recovery status
+              {t("Recovery status")}
             </h2>
             <p className="text-xs text-slate-500">
-              Retry eligibility and timing
+              {t("Retry eligibility and timing")}
             </p>
           </div>
         </div>
@@ -74,7 +76,7 @@ export function RecoveryStatus({
           type="button"
           variant="ghost"
           size="icon-sm"
-          aria-label="Edit retry specification"
+          aria-label={t("Edit retry specification")}
           disabled={mutationsDisabled}
           onClick={editRetry}
         >
@@ -83,24 +85,29 @@ export function RecoveryStatus({
       </div>
       <dl className="grid grid-cols-1 gap-x-4 gap-y-4 p-4 sm:grid-cols-2 xl:grid-cols-1 2xl:grid-cols-2">
         <div>
-          <dt className="text-xs text-slate-500">Retry progress</dt>
+          <dt className="text-xs text-slate-500">{t("Retry progress")}</dt>
           <dd className="mt-1 text-sm tabular-nums text-slate-800">
             <span className="font-semibold">
-              {state.retryState.retries} of {state.retrySpec.maxRetries}
+              {t("{current} of {total}", {
+                current: state.retryState.retries,
+                total: state.retrySpec.maxRetries,
+              })}
             </span>
             <span className="mt-0.5 block text-xs text-slate-500">
-              Last: {formatDate(state.retryState.retryAt)}
+              {t("Last: {date}", {
+                date: formatDate(state.retryState.retryAt, undefined, locale),
+              })}
             </span>
           </dd>
         </div>
         <div>
-          <dt className="text-xs text-slate-500">Next retry at</dt>
+          <dt className="text-xs text-slate-500">{t("Next retry at")}</dt>
           <dd className="mt-1 text-sm tabular-nums text-slate-800">
-            {formatDate(state.retryState.nextRetryAt)}
+            {formatDate(state.retryState.nextRetryAt, undefined, locale)}
           </dd>
         </div>
         <div>
-          <dt className="text-xs text-slate-500">Recoverable</dt>
+          <dt className="text-xs text-slate-500">{t("Recoverable")}</dt>
           <dd className="mt-1">
             <MarkRecoverable
               id={state.id}
@@ -111,7 +118,7 @@ export function RecoveryStatus({
           </dd>
         </div>
         <div>
-          <dt className="text-xs text-slate-500">Retryable</dt>
+          <dt className="text-xs text-slate-500">{t("Retryable")}</dt>
           <dd className="mt-1">
             <BooleanBadge value={state.isRetryable} />
           </dd>
@@ -119,16 +126,16 @@ export function RecoveryStatus({
       </dl>
       <dl className="grid grid-cols-2 gap-4 border-t bg-slate-50/70 px-4 py-3">
         <div>
-          <dt className="text-[11px] text-slate-500">Min backoff</dt>
+          <dt className="text-[11px] text-slate-500">{t("Min backoff")}</dt>
           <dd className="mt-0.5 text-xs tabular-nums text-slate-700">
-            {formatSeconds(state.retrySpec.minBackoff)} (
+            {formatSeconds(state.retrySpec.minBackoff, locale)} (
             {state.retrySpec.minBackoff.toLocaleString()} s)
           </dd>
         </div>
         <div>
-          <dt className="text-[11px] text-slate-500">Timeout</dt>
+          <dt className="text-[11px] text-slate-500">{t("Timeout")}</dt>
           <dd className="mt-0.5 text-xs tabular-nums text-slate-700">
-            {formatSeconds(state.retrySpec.executionTimeout)} (
+            {formatSeconds(state.retrySpec.executionTimeout, locale)} (
             {state.retrySpec.executionTimeout.toLocaleString()} s)
           </dd>
         </div>

--- a/compensation/dashboard/src/features/Failed/details/StackTraceEditor.tsx
+++ b/compensation/dashboard/src/features/Failed/details/StackTraceEditor.tsx
@@ -15,6 +15,7 @@ import { PrismLight as SyntaxHighlighter } from "react-syntax-highlighter";
 import java from "react-syntax-highlighter/dist/esm/languages/prism/java";
 import vscDarkPlus from "react-syntax-highlighter/dist/esm/styles/prism/vsc-dark-plus";
 import { useMemo } from "react";
+import { useI18n } from "@/i18n.tsx";
 
 SyntaxHighlighter.registerLanguage("java-stack-trace", java);
 
@@ -29,6 +30,7 @@ export function StackTraceEditor({
   value,
   wrapLongLines = true,
 }: StackTraceEditorProps) {
+  const { t } = useI18n();
   const matchingLines = useMemo(() => {
     const query = searchQuery.trim().toLocaleLowerCase();
     if (!query) {
@@ -47,7 +49,7 @@ export function StackTraceEditor({
   return (
     <div
       role="region"
-      aria-label="Stack trace content"
+      aria-label={t("Stack trace content")}
       className="h-full overflow-auto bg-[#1e1e1e]"
       tabIndex={0}
     >

--- a/compensation/dashboard/src/features/Failed/history/ExecutionHistory.tsx
+++ b/compensation/dashboard/src/features/Failed/history/ExecutionHistory.tsx
@@ -29,6 +29,7 @@ import {
   type ExecutionEventStream,
   useExecutionHistory,
 } from "./useExecutionHistory.ts";
+import { useI18n } from "@/i18n.tsx";
 
 interface ExecutionHistoryProps {
   executionId: string;
@@ -36,31 +37,33 @@ interface ExecutionHistoryProps {
 }
 
 function EventStreamCard({ stream }: { stream: ExecutionEventStream }) {
+  const { locale, t } = useI18n();
   return (
     <article
       className="overflow-hidden rounded-lg border border-slate-200 bg-white"
-      aria-label={`Event stream version ${stream.version}`}
+      aria-label={t("Event stream version {version}", { version: stream.version })}
     >
       <header className="flex flex-wrap items-start justify-between gap-3 border-b bg-slate-50/80 px-4 py-3">
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
             <span className="rounded-md bg-blue-50 px-2 py-1 text-xs font-semibold text-blue-700 ring-1 ring-blue-200 ring-inset">
-              Version {stream.version}
+              {t("Version {version}", { version: stream.version })}
             </span>
             <span className="text-xs text-slate-500">
-              {stream.body.length}{" "}
-              {stream.body.length === 1 ? "event" : "events"}
+              {t(stream.body.length === 1 ? "{count} event" : "{count} events", {
+                count: stream.body.length,
+              })}
             </span>
           </div>
           <p
             className="mt-2 truncate font-mono text-[11px] text-slate-500"
             title={stream.id}
           >
-            Stream {stream.id}
+            {t("Stream {id}", { id: stream.id })}
           </p>
         </div>
         <time className="shrink-0 text-xs tabular-nums text-slate-500">
-          {formatDate(stream.createTime)}
+          {formatDate(stream.createTime, undefined, locale)}
         </time>
       </header>
 
@@ -75,7 +78,7 @@ function EventStreamCard({ stream }: { stream: ExecutionEventStream }) {
                     {event.name}
                   </span>
                   <span className="text-[11px] text-slate-500">
-                    revision {event.revision}
+                    {t("revision {revision}", { revision: event.revision })}
                   </span>
                 </div>
                 <p
@@ -86,7 +89,7 @@ function EventStreamCard({ stream }: { stream: ExecutionEventStream }) {
                 </p>
                 <details className="group mt-2 rounded-md border border-slate-200 bg-slate-50/60">
                   <summary className="cursor-pointer px-3 py-2 text-xs font-medium text-slate-700 outline-none hover:text-blue-700 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-inset">
-                    Event payload
+                    {t("Event payload")}
                   </summary>
                   <pre className="max-h-72 overflow-auto border-t border-slate-200 bg-slate-950 p-3 text-[11px] leading-relaxed whitespace-pre-wrap text-slate-100">
                     {JSON.stringify(event.body, null, 2) ?? "null"}
@@ -105,6 +108,7 @@ export function ExecutionHistory({
   executionId,
   refreshToken = 0,
 }: ExecutionHistoryProps) {
+  const { t } = useI18n();
   const [expanded, setExpanded] = useState(false);
   const { error, loadPage, loading, page, retry, settledPageIndex } =
     useExecutionHistory({
@@ -133,10 +137,10 @@ export function ExecutionHistory({
               id="execution-history-title"
               className="text-sm font-semibold text-slate-900"
             >
-              History
+              {t("History")}
             </h2>
             <p className="truncate text-xs text-slate-500">
-              EventStream lifecycle records, newest first
+              {t("EventStream lifecycle records, newest first")}
             </p>
           </div>
         </div>
@@ -146,7 +150,7 @@ export function ExecutionHistory({
               type="button"
               variant="ghost"
               size="icon-sm"
-              aria-label="Refresh history"
+              aria-label={t("Refresh history")}
               disabled={loading}
               onClick={() => loadPage(settledPageIndex)}
             >
@@ -157,11 +161,11 @@ export function ExecutionHistory({
             type="button"
             variant="ghost"
             size="sm"
-            aria-label={expanded ? "Collapse history" : "Expand history"}
+            aria-label={expanded ? t("Collapse history") : t("Expand history")}
             aria-expanded={expanded}
             onClick={() => setExpanded((current) => !current)}
           >
-            {expanded ? "Hide" : "View"}
+            {expanded ? t("Hide") : t("View")}
             {expanded ? <ChevronDown /> : <ChevronRight />}
           </Button>
         </div>
@@ -172,7 +176,7 @@ export function ExecutionHistory({
           {loading && page.list.length === 0 ? (
             <div
               role="status"
-              aria-label="Loading execution history"
+              aria-label={t("Loading execution history")}
               className="space-y-3"
             >
               <Skeleton className="h-28 w-full" />
@@ -187,7 +191,7 @@ export function ExecutionHistory({
             >
               <AlertCircle className="mx-auto size-5 text-red-600" />
               <p className="mt-2 text-sm font-medium text-red-700">
-                Failed to load history
+                {t("Failed to load history")}
               </p>
               <p className="mt-1 text-xs text-red-700/80">{error.message}</p>
               <Button
@@ -195,11 +199,11 @@ export function ExecutionHistory({
                 variant="outline"
                 size="sm"
                 className="mt-4 bg-white"
-                aria-label="Retry history"
+                aria-label={t("Retry history")}
                 onClick={retry}
               >
                 <RefreshCw />
-                Retry
+                {t("Retry")}
               </Button>
             </div>
           ) : null}
@@ -208,12 +212,12 @@ export function ExecutionHistory({
             <div className="rounded-lg border border-amber-200 bg-amber-50 p-8 text-center">
               <AlertCircle className="mx-auto size-5 text-amber-700" />
               <p className="mt-2 text-sm font-medium text-amber-900">
-                History unavailable
+                {t("History unavailable")}
               </p>
               <p className="mt-1 text-xs text-amber-800">
-                The configured event storage did not expose EventStream records
-                for this existing execution. Verify that it supports EventStream
-                queries.
+                {t(
+                  "The configured event storage did not expose EventStream records for this existing execution. Verify that it supports EventStream queries.",
+                )}
               </p>
             </div>
           ) : null}
@@ -227,10 +231,13 @@ export function ExecutionHistory({
                 <AlertCircle className="mt-0.5 size-4 shrink-0 text-amber-700" />
                 <div className="min-w-0">
                   <p className="text-sm font-medium text-amber-900">
-                    Failed to load history page
+                    {t("Failed to load history page")}
                   </p>
                   <p className="text-xs text-amber-800">
-                    Showing page {settledPageIndex}. {error.message}
+                    {t("Showing page {page}. {message}", {
+                      page: settledPageIndex,
+                      message: error.message,
+                    })}
                   </p>
                 </div>
               </div>
@@ -239,11 +246,11 @@ export function ExecutionHistory({
                 variant="outline"
                 size="sm"
                 className="bg-white"
-                aria-label="Retry history"
+                aria-label={t("Retry history")}
                 onClick={retry}
               >
                 <RefreshCw />
-                Retry
+                {t("Retry")}
               </Button>
             </div>
           ) : null}
@@ -253,7 +260,7 @@ export function ExecutionHistory({
               {loading ? (
                 <div
                   role="status"
-                  aria-label="Loading history page"
+                  aria-label={t("Loading history page")}
                   className="h-0.5 overflow-hidden bg-blue-100"
                 >
                   <div className="h-full w-full animate-pulse bg-blue-500 motion-reduce:animate-none" />
@@ -268,14 +275,18 @@ export function ExecutionHistory({
           {page.total > 0 ? (
             <div className="mt-4 flex items-center justify-between gap-3 border-t pt-3">
               <span className="text-xs tabular-nums text-slate-500">
-                {firstItem}–{lastItem} of {page.total}
+                {t("{first}–{last} of {total}", {
+                  first: firstItem,
+                  last: lastItem,
+                  total: page.total,
+                })}
               </span>
               <div className="flex items-center gap-1.5">
                 <Button
                   type="button"
                   variant="outline"
                   size="icon-sm"
-                  aria-label="Previous history page"
+                  aria-label={t("Previous history page")}
                   disabled={loading || settledPageIndex <= 1}
                   onClick={() => loadPage(settledPageIndex - 1)}
                 >
@@ -288,7 +299,7 @@ export function ExecutionHistory({
                   type="button"
                   variant="outline"
                   size="icon-sm"
-                  aria-label="Next history page"
+                  aria-label={t("Next history page")}
                   disabled={loading || settledPageIndex >= pageCount}
                   onClick={() => loadPage(settledPageIndex + 1)}
                 >

--- a/compensation/dashboard/src/i18n.test.tsx
+++ b/compensation/dashboard/src/i18n.test.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  I18nProvider,
+  resolveLocale,
+  translate,
+  useI18n,
+} from "./i18n.tsx";
+
+function LanguageProbe() {
+  const { locale, setLocale, t } = useI18n();
+
+  return (
+    <>
+      <output>{`${locale}:${t("Dashboard")}`}</output>
+      <button type="button" onClick={() => setLocale("en")}>
+        English
+      </button>
+      <button type="button" onClick={() => setLocale("zh-CN")}>
+        中文
+      </button>
+    </>
+  );
+}
+
+describe("i18n", () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("prefers a saved locale over the browser language", () => {
+    expect(resolveLocale("en", ["zh-CN"])).toBe("en");
+    expect(resolveLocale("zh-CN", ["en-US"])).toBe("zh-CN");
+  });
+
+  it("uses Chinese for Chinese browser language variants", () => {
+    expect(resolveLocale(null, ["zh-Hans-CN", "en-US"])).toBe("zh-CN");
+    expect(resolveLocale(null, ["en-US", "zh-CN"])).toBe("en");
+  });
+
+  it("translates messages and interpolates values", () => {
+    expect(translate("zh-CN", "Page {page}", { page: 3 })).toBe("第 3 页");
+    expect(translate("en", "Page {page}", { page: 3 })).toBe("Page 3");
+  });
+
+  it("persists language changes and updates the document language", () => {
+    localStorage.setItem("wow-dashboard-locale", "zh-CN");
+
+    render(
+      <I18nProvider>
+        <LanguageProbe />
+      </I18nProvider>,
+    );
+
+    expect(screen.getByText("zh-CN:仪表盘")).toBeInTheDocument();
+    expect(document.documentElement.lang).toBe("zh-CN");
+    expect(document.title).toBe("Wow 补偿仪表盘");
+
+    fireEvent.click(screen.getByRole("button", { name: "English" }));
+
+    expect(screen.getByText("en:Dashboard")).toBeInTheDocument();
+    expect(localStorage.getItem("wow-dashboard-locale")).toBe("en");
+    expect(document.documentElement.lang).toBe("en");
+  });
+
+  it("does not persist an automatically detected locale", () => {
+    render(
+      <I18nProvider>
+        <LanguageProbe />
+      </I18nProvider>,
+    );
+
+    expect(localStorage.getItem("wow-dashboard-locale")).toBeNull();
+  });
+
+  it("keeps rendering and switching when browser storage is unavailable", () => {
+    vi.spyOn(localStorage, "getItem").mockImplementation(() => {
+      throw new DOMException("blocked", "SecurityError");
+    });
+    vi.spyOn(localStorage, "setItem").mockImplementation(() => {
+      throw new DOMException("blocked", "SecurityError");
+    });
+
+    render(
+      <I18nProvider>
+        <LanguageProbe />
+      </I18nProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "中文" }));
+
+    expect(screen.getByText("zh-CN:仪表盘")).toBeInTheDocument();
+  });
+});

--- a/compensation/dashboard/src/i18n.tsx
+++ b/compensation/dashboard/src/i18n.tsx
@@ -1,0 +1,418 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-disable react-refresh/only-export-components -- The tiny locale API and provider intentionally live together. */
+
+import {
+  createContext,
+  useContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type PropsWithChildren,
+} from "react";
+
+export type Locale = "en" | "zh-CN";
+
+const zhCN = {
+  Dashboard: "仪表盘",
+  "To Retry": "待重试",
+  Executing: "执行中",
+  "Next Retry": "下次重试",
+  "Next retry": "下次重试",
+  "Non Retryable": "不可重试",
+  Succeeded: "已成功",
+  Unrecoverable: "不可恢复",
+  Failed: "失败",
+  Prepared: "已准备",
+  Unknown: "未知",
+  Recoverable: "可恢复",
+  Yes: "是",
+  No: "否",
+  Language: "语言",
+  English: "English",
+  Chinese: "中文",
+  "Current language: {language}": "当前语言：{language}",
+  "Primary navigation": "主导航",
+  "Application sidebar": "应用侧栏",
+  Navigation: "导航",
+  "Compensation Control Plane": "补偿控制台",
+  "Wow compensation dashboard": "Wow 补偿仪表盘",
+  "Wow Compensation Dashboard": "Wow 补偿仪表盘",
+  Compensation: "补偿",
+  "Control Plane": "控制台",
+  "Close navigation": "关闭导航",
+  "Open navigation": "打开导航",
+  "Collapse navigation": "收起导航",
+  "Expand navigation": "展开导航",
+  Collapse: "收起",
+  Expand: "展开",
+  Close: "关闭",
+  Sidebar: "侧栏",
+  "Displays the mobile sidebar.": "显示移动端侧栏。",
+  "Toggle Sidebar": "切换侧栏",
+  "Skip to main content": "跳到主要内容",
+  "Build information": "构建信息",
+  "GitHub commit {commit}": "GitHub 提交 {commit}",
+  "Project repositories": "项目仓库",
+  "Page {page}": "第 {page} 页",
+  "Previous page": "上一页",
+  "Next page": "下一页",
+  "Pagination options": "分页选项",
+  "Go to page": "跳转到页",
+  Go: "跳转",
+  "Rows per page": "每页行数",
+  "{first}–{last} of {total}": "第 {first}–{last} 条，共 {total} 条",
+  "Search executions": "搜索执行记录",
+  "Execution ID": "执行 ID",
+  "Event ID": "事件 ID",
+  "Aggregate ID": "聚合根 ID",
+  "Aggregate context": "聚合上下文",
+  "Aggregate name": "聚合名称",
+  "Processor context": "处理器上下文",
+  "Processor name": "处理器名称",
+  "Search by ID…": "按 ID 搜索…",
+  "Filter by event ID…": "按事件 ID 筛选…",
+  "Filter by aggregate ID…": "按聚合根 ID 筛选…",
+  "Filter by aggregate context…": "按聚合上下文筛选…",
+  "Filter by aggregate name…": "按聚合名称筛选…",
+  "Filter by processor context…": "按处理器上下文筛选…",
+  "Filter by processor name…": "按处理器名称筛选…",
+  Search: "搜索",
+  "Add filter": "添加筛选条件",
+  "Filters ({count})": "筛选条件（{count}）",
+  "Search fields": "搜索字段",
+  "Remove {label}": "移除{label}",
+  "Exact match across all fields": "所有字段均使用精确匹配",
+  "Clear all filters": "清除全部筛选条件",
+  "Clear all": "全部清除",
+  Status: "状态",
+  "Processor / Function": "处理器 / 函数",
+  Retry: "重试",
+  Age: "已等待",
+  "View execution {id}": "查看执行记录 {id}",
+  "Loading page": "正在加载页面",
+  "Refresh failed: {message}. Showing the last loaded page; changes are disabled until refresh succeeds.":
+    "刷新失败：{message}。当前显示上次加载的页面；刷新成功前无法进行变更。",
+  "Failed to load executions": "加载执行记录失败",
+  "No failed executions found": "未找到失败执行记录",
+  "Try another queue or adjust the filters.": "请切换队列或调整筛选条件。",
+  "Clear search filters": "清除搜索筛选条件",
+  "Clear search": "清除搜索",
+  "Select an execution": "请选择一条执行记录",
+  "Failure context and compensation actions will appear here.":
+    "失败上下文和补偿操作将显示在这里。",
+  "Loading page details": "正在加载页面详情",
+  "The next executions will appear here shortly.": "稍后将在这里显示执行记录。",
+  "Failed executions": "失败执行记录",
+  "Execution failed details": "执行失败详情",
+  "Inspect context and prepare compensation.": "检查上下文并准备补偿。",
+  "Execution details panel": "执行详情面板",
+  "Resize execution list and details": "调整执行列表和详情的大小",
+  "Loading execution details": "正在加载执行详情",
+  "Failed to load execution": "加载执行记录失败",
+  "Execution not found": "未找到执行记录",
+  "No compensation execution matches {id}.": "没有与 {id} 匹配的补偿执行记录。",
+  "Prepare compensation": "准备补偿",
+  "Refreshing state": "正在刷新状态",
+  "Already succeeded": "已经成功",
+  "Retry limit reached": "已达到重试上限",
+  "Refreshing current execution state.": "正在刷新当前执行状态。",
+  "This execution has already succeeded.": "此执行记录已成功。",
+  "Retry limit reached; force prepare remains available.":
+    "已达到重试上限；仍可使用强制准备。",
+  "Compensation prepared": "补偿已准备",
+  "Prepare failed": "准备失败",
+  "Compensation force prepared": "补偿已强制准备",
+  "Force prepare failed": "强制准备失败",
+  "Unable to copy execution ID": "无法复制执行 ID",
+  "Execution ID copied": "执行 ID 已复制",
+  "More actions": "更多操作",
+  "Force prepare": "强制准备",
+  "Copy execution ID": "复制执行 ID",
+  "Force prepare this execution?": "强制准备此执行记录？",
+  "This bypasses the retry limit for {id}. The server still validates the current execution state. Use it only after verifying the failure context.":
+    "这将绕过 {id} 的重试上限。服务端仍会验证当前执行状态，请仅在确认失败上下文后使用。",
+  Cancel: "取消",
+  "Retry specification updated": "重试规格已更新",
+  "Failed to apply retry specification": "应用重试规格失败",
+  "Max retries": "最大重试次数",
+  "Min backoff (s)": "最小退避时间（秒）",
+  "Execution timeout (s)": "执行超时（秒）",
+  "Enter a duration": "请输入时长",
+  "Applying…": "正在应用…",
+  "Apply retry spec": "应用重试规格",
+  "Function updated": "函数已更新",
+  "Failed to change function": "变更函数失败",
+  "Context name": "上下文名称",
+  "Function name": "函数名称",
+  "Function kind": "函数类型",
+  "Saving…": "正在保存…",
+  "Save function": "保存函数",
+  "Recoverability updated": "可恢复性已更新",
+  "Failed to update recoverability": "更新可恢复性失败",
+  "Change recoverability?": "变更可恢复性？",
+  "This changes execution eligibility from {from} to {to}.":
+    "这会将执行资格从{from}变更为{to}。",
+  "Confirm change": "确认变更",
+  "Apply retry specification": "应用重试规格",
+  "Tune retry limits and timing for this execution.": "调整此执行记录的重试上限和时间。",
+  "Recovery status": "恢复状态",
+  "Retry eligibility and timing": "重试资格与时间",
+  "Edit retry specification": "编辑重试规格",
+  "Retry progress": "重试进度",
+  "{current} of {total}": "{current} / {total}",
+  "Last: {date}": "上次：{date}",
+  "Next retry at": "下次重试时间",
+  Retryable: "可重试",
+  "Min backoff": "最小退避时间",
+  Timeout: "超时时间",
+  "Change function": "变更函数",
+  "Update the handler identity for this failed execution.": "更新此失败执行记录的处理器标识。",
+  "Execution context": "执行上下文",
+  "Handler and source event identifiers": "处理器和源事件标识",
+  Processor: "处理器",
+  Aggregate: "聚合根",
+  Tenant: "租户",
+  "Event version": "事件版本",
+  "Edit function": "编辑函数",
+  "Failure summary": "失败摘要",
+  "Last failure summary": "最近一次失败摘要",
+  "Last failure": "最近一次失败",
+  "Most recent recorded failure": "最近记录的失败",
+  "Current processing failure": "当前处理失败",
+  "Succeeded at": "成功时间",
+  "Failed at": "失败时间",
+  "Stack trace": "堆栈跟踪",
+  "Unable to change fullscreen mode": "无法切换全屏模式",
+  "Unable to copy stack trace": "无法复制堆栈跟踪",
+  "Stack trace copied": "堆栈跟踪已复制",
+  "Collapse {title}": "收起{title}",
+  "Expand {title}": "展开{title}",
+  "Copy stack trace": "复制堆栈跟踪",
+  "Exit fullscreen": "退出全屏",
+  "Open fullscreen": "进入全屏",
+  "Search stack trace": "搜索堆栈跟踪",
+  "Search stack trace…": "搜索堆栈跟踪…",
+  "{count} match": "{count} 个匹配项",
+  "{count} matches": "{count} 个匹配项",
+  "Disable line wrapping": "关闭自动换行",
+  "Enable line wrapping": "启用自动换行",
+  "Stack trace content": "堆栈跟踪内容",
+  "Unable to copy {label}": "无法复制{label}",
+  "Copy {label}": "复制{label}",
+  Copied: "已复制",
+  value: "内容",
+  "execution ID": "执行 ID",
+  "event ID": "事件 ID",
+  "aggregate ID": "聚合根 ID",
+  History: "历史记录",
+  "EventStream lifecycle records, newest first": "EventStream 生命周期记录，最新的在前",
+  "Refresh history": "刷新历史记录",
+  "Collapse history": "收起历史记录",
+  "Expand history": "展开历史记录",
+  Hide: "隐藏",
+  View: "查看",
+  "Loading execution history": "正在加载执行历史",
+  "Failed to load history": "加载历史记录失败",
+  "Retry history": "重试加载历史记录",
+  "History unavailable": "历史记录不可用",
+  "The configured event storage did not expose EventStream records for this existing execution. Verify that it supports EventStream queries.":
+    "当前事件存储未提供此执行记录的 EventStream 数据，请确认其支持 EventStream 查询。",
+  "Failed to load history page": "加载历史页失败",
+  "Showing page {page}. {message}": "当前显示第 {page} 页。{message}",
+  "Loading history page": "正在加载历史页",
+  "Previous history page": "上一页历史记录",
+  "Next history page": "下一页历史记录",
+  "Event stream version {version}": "事件流版本 {version}",
+  "Version {version}": "版本 {version}",
+  "{count} event": "{count} 个事件",
+  "{count} events": "{count} 个事件",
+  "Stream {id}": "事件流 {id}",
+  "revision {revision}": "修订版本 {revision}",
+  "Event payload": "事件载荷",
+  "Something went wrong.": "出现错误。",
+  "The dashboard could not render this view. Try again to recover from a temporary problem.":
+    "仪表盘无法呈现此视图，请重试以恢复临时故障。",
+  "Try again": "重试",
+  "Technical details": "技术详情",
+  "Loading dashboard": "正在加载仪表盘",
+  "Loading compensation overview": "正在加载补偿概览",
+  "Loading dashboard activity": "正在加载仪表盘活动",
+  "Time range": "时间范围",
+  "Time range: {range}": "时间范围：{range}",
+  "Date range presets": "日期范围预设",
+  Today: "今天",
+  "Last 7 days": "最近 7 天",
+  "Last 30 days": "最近 30 天",
+  "Select an end date.": "请选择结束日期。",
+  Apply: "应用",
+  "Updated {date}": "更新于 {date}",
+  "Refreshing dashboard": "正在刷新仪表盘",
+  "Refresh dashboard": "刷新仪表盘",
+  Refresh: "刷新",
+  "Compensation overview": "补偿概览",
+  "Backlog exposure": "积压暴露",
+  "STOCK / Backlog exposure": "存量 / 积压暴露",
+  "Selected active": "所选活跃记录",
+  "Older backlog": "更早的积压",
+  Coverage: "覆盖率",
+  "Selected active coverage": "所选活跃记录覆盖率",
+  "{count} selected ({percentage})": "所选 {count} 条（{percentage}）",
+  "{count} older": "更早 {count} 条",
+  "{count} newer": "更新 {count} 条",
+  "{count} total": "共 {count} 条",
+  "Actionable now": "当前可操作",
+  "Timed out": "已超时",
+  "Backlog exposure unavailable.": "积压暴露数据不可用。",
+  "Compensation effectiveness": "补偿效果",
+  "FLOW / Compensation effectiveness": "流量 / 补偿效果",
+  "New failures": "新增失败",
+  "Net backlog": "净积压",
+  "Retry success": "重试成功率",
+  "Retried failed": "重试失败",
+  "Compensation effectiveness unavailable.": "补偿效果数据不可用。",
+  "Dashboard activity": "仪表盘活动",
+  "Compensation activity unavailable.": "补偿活动数据不可用。",
+  "Current health for selected execution range": "所选执行时间范围的当前健康状况",
+  "Recoverability composition": "可恢复性构成",
+  "Retry distribution is truncated and is not charted.": "重试分布数据已截断，因此不绘制图表。",
+  "Failure concentration · Top cluster {percentage}": "失败集中度 · 首位集群 {percentage}",
+  "Current failure pressure — Top 5 clusters": "当前失败压力 — 前 5 个集群",
+  "{count} cluster": "{count} 个集群",
+  "{count} clusters": "{count} 个集群",
+  "Top 5 clusters": "前 5 个集群",
+  "Top cluster {percentage}": "首位集群 {percentage}",
+  "Current failure pressure": "当前失败压力",
+  Cluster: "集群",
+  Current: "当前",
+  "Failed / Prepared": "失败 / 已准备",
+  Oldest: "最早",
+  "No active failure clusters": "没有活跃的失败集群",
+  "Failed {failed}; Prepared {prepared}": "失败 {failed}；已准备 {prepared}",
+  "Retry distribution": "重试分布",
+  "Retry distribution: {rows}": "重试分布：{rows}",
+  "Total {total}": "总计 {total}",
+  "Compensation activity": "补偿活动",
+  "Failure inflow (new failures)": "失败流入（新增失败）",
+  " — daily trend": " — 每日趋势",
+  "{count} new failures": "新增失败 {count} 条",
+  "Outcome flow (total in selected range)": "结果流（所选范围内总计）",
+  "Outcome flow: {rows}": "结果流：{rows}",
+  "Compensation outcomes data": "补偿结果数据",
+  Time: "时间",
+  "{key} retries": "重试 {key} 次",
+} as const;
+
+export type Message = keyof typeof zhCN;
+export type TranslationValues = Record<string, string | number>;
+export type Translate = (
+  message: Message,
+  values?: TranslationValues,
+) => string;
+
+interface I18nContextValue {
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+  t: Translate;
+}
+
+const localeStorageKey = "wow-dashboard-locale";
+
+function loadSavedLocale(): string | null {
+  try {
+    return localStorage.getItem(localeStorageKey);
+  } catch {
+    return null;
+  }
+}
+
+function saveLocale(locale: Locale) {
+  try {
+    localStorage.setItem(localeStorageKey, locale);
+  } catch {
+    // A blocked UI preference must not prevent the dashboard from working.
+  }
+}
+
+export function translate(
+  locale: Locale,
+  message: Message,
+  values: TranslationValues = {},
+): string {
+  const template = locale === "zh-CN" ? zhCN[message] : message;
+  return template.replace(/\{(\w+)}/g, (placeholder, name: string) =>
+    Object.hasOwn(values, name) ? String(values[name]) : placeholder,
+  );
+}
+
+const I18nContext = createContext<I18nContextValue>({
+  locale: "en",
+  setLocale: () => undefined,
+  t: (message, values) => translate("en", message, values),
+});
+
+export function resolveLocale(
+  savedLocale: string | null,
+  languages: readonly string[],
+): Locale {
+  if (savedLocale === "en" || savedLocale === "zh-CN") {
+    return savedLocale;
+  }
+  for (const language of languages) {
+    const normalized = language.toLowerCase();
+    if (normalized.startsWith("zh")) {
+      return "zh-CN";
+    }
+    if (normalized.startsWith("en")) {
+      return "en";
+    }
+  }
+  return "en";
+}
+
+export function I18nProvider({ children }: PropsWithChildren) {
+  const [locale, setCurrentLocale] = useState<Locale>(() =>
+    resolveLocale(
+      loadSavedLocale(),
+      navigator.languages ?? [navigator.language],
+    ),
+  );
+  const setLocale = useCallback((nextLocale: Locale) => {
+    setCurrentLocale(nextLocale);
+    saveLocale(nextLocale);
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.lang = locale;
+    document.title = translate(locale, "Wow Compensation Dashboard");
+  }, [locale]);
+
+  const value = useMemo<I18nContextValue>(
+    () => ({
+      locale,
+      setLocale,
+      t: (message, values) => translate(locale, message, values),
+    }),
+    [locale, setLocale],
+  );
+
+  return (
+    <I18nContext value={value}>{children}</I18nContext>
+  );
+}
+
+export function useI18n() {
+  return useContext(I18nContext);
+}

--- a/compensation/dashboard/src/index.css
+++ b/compensation/dashboard/src/index.css
@@ -302,6 +302,12 @@ table.sr-only {
   border-left: 1px solid var(--border);
 }
 
+.app-language-trigger {
+  width: 34px;
+  height: 34px;
+  color: var(--muted-foreground);
+}
+
 .app-project-link {
   display: inline-flex;
   width: 34px;
@@ -868,6 +874,11 @@ table.sr-only {
   }
 
   .app-project-link {
+    width: 44px;
+    height: 44px;
+  }
+
+  .app-language-trigger {
     width: 44px;
     height: 44px;
   }

--- a/compensation/dashboard/src/main.test.tsx
+++ b/compensation/dashboard/src/main.test.tsx
@@ -15,6 +15,9 @@ vi.mock("react-dom/client", () => ({
   createRoot: mocks.createRoot,
 }));
 vi.mock("./index.css", () => ({}));
+vi.mock("@/i18n.tsx", () => ({
+  I18nProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
 vi.mock("react-router", () => ({
   RouterProvider: ({ router }: { router: unknown }) => (
     <div data-testid="router-provider">

--- a/compensation/dashboard/src/main.tsx
+++ b/compensation/dashboard/src/main.tsx
@@ -7,6 +7,7 @@ import { GlobalDrawerProvider } from "./components/GlobalDrawer";
 import "./services/compensationFetcher";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Toaster } from "@/components/ui/sonner";
+import { I18nProvider } from "@/i18n.tsx";
 
 const rootElement = document.getElementById("root");
 if (!rootElement) {
@@ -15,11 +16,13 @@ if (!rootElement) {
 
 createRoot(rootElement).render(
   <StrictMode>
-    <TooltipProvider>
-      <GlobalDrawerProvider>
-        <RouterProvider router={AppRouter} />
-        <Toaster position="bottom-right" richColors />
-      </GlobalDrawerProvider>
-    </TooltipProvider>
+    <I18nProvider>
+      <TooltipProvider>
+        <GlobalDrawerProvider>
+          <RouterProvider router={AppRouter} />
+          <Toaster position="bottom-right" richColors />
+        </GlobalDrawerProvider>
+      </TooltipProvider>
+    </I18nProvider>
   </StrictMode>,
 );

--- a/compensation/dashboard/src/routes/constants.tsx
+++ b/compensation/dashboard/src/routes/constants.tsx
@@ -14,6 +14,7 @@
 import type { ComponentType } from "react";
 import { FindCategory } from "../features/Failed/FindCategory.ts";
 import LazyFailedView from "./LazyFailedView.tsx";
+import type { Message } from "@/i18n.tsx";
 
 export const NavItemPaths = {
   Dashboard: "/",
@@ -27,7 +28,7 @@ export const NavItemPaths = {
 } as const;
 
 export interface NavItem {
-  readonly label: string;
+  readonly label: Message;
   readonly path: string;
 }
 

--- a/compensation/dashboard/src/utils/dates.test.ts
+++ b/compensation/dashboard/src/utils/dates.test.ts
@@ -43,6 +43,17 @@ describe("dates", () => {
       const formatted = formatDate(timestamp, "YYYY/MM/DD HH:mm");
       expect(formatted).toBe("2022/12/25 08:30");
     });
+
+    it("formats full dates in Chinese", () => {
+      const timestamp = new Date("2023-01-01 12:00:00").getTime();
+      expect(formatDate(timestamp, undefined, "zh-CN")).toBe(
+        "2023年1月1日 12:00:00",
+      );
+      expect(formatDate(timestamp, "MM-DD", "zh-CN")).toBe("1月1日");
+      expect(formatDate(timestamp, "MM-DD HH:mm", "zh-CN")).toBe(
+        "1月1日 12:00",
+      );
+    });
   });
 
   describe("formatAge", () => {
@@ -63,6 +74,12 @@ describe("dates", () => {
 
     it("clamps future timestamps to zero", () => {
       expect(formatAge(now + 5_000, now)).toBe("0s");
+    });
+
+    it("formats compact ages in Chinese", () => {
+      expect(formatAge(now - 2 * 60 * 60_000 - 12 * 60_000, now, "zh-CN")).toBe(
+        "2小时 12分",
+      );
     });
   });
 });

--- a/compensation/dashboard/src/utils/dates.ts
+++ b/compensation/dashboard/src/utils/dates.ts
@@ -12,37 +12,64 @@
  */
 
 import dayjs from "dayjs";
+import type { Locale } from "@/i18n.tsx";
 
 export function formatDate(
   timeAt: number | undefined,
-  template: string = "YYYY-MM-DD HH:mm:ss",
+  template?: string,
+  locale: Locale = "en",
 ): string {
   if (!timeAt) {
     return "-";
   }
-  return dayjs(timeAt).format(template);
+  if (locale === "zh-CN") {
+    if (!template) {
+      return new Intl.DateTimeFormat(locale, {
+        dateStyle: "medium",
+        timeStyle: "medium",
+      }).format(timeAt);
+    }
+    if (template === "MM-DD" || template === "MM-DD HH:mm") {
+      return new Intl.DateTimeFormat(locale, {
+        month: "short",
+        day: "numeric",
+        ...(template.includes("HH:mm")
+          ? { hour: "2-digit", minute: "2-digit", hour12: false }
+          : {}),
+      }).format(timeAt);
+    }
+  }
+  return dayjs(timeAt).format(template ?? "YYYY-MM-DD HH:mm:ss");
 }
 
-export function formatAge(timeAt: number, now: number = Date.now()): string {
+export function formatAge(
+  timeAt: number,
+  now: number = Date.now(),
+  locale: Locale = "en",
+): string {
   const elapsedSeconds = Math.max(0, Math.floor((now - timeAt) / 1_000));
   const seconds = elapsedSeconds % 60;
   const elapsedMinutes = Math.floor(elapsedSeconds / 60);
 
   if (elapsedMinutes === 0) {
-    return `${seconds}s`;
+    return `${seconds}${locale === "zh-CN" ? "秒" : "s"}`;
   }
 
   const minutes = elapsedMinutes % 60;
   const elapsedHours = Math.floor(elapsedMinutes / 60);
   if (elapsedHours === 0) {
-    return `${minutes}m ${seconds}s`;
+    return locale === "zh-CN"
+      ? `${minutes}分 ${seconds}秒`
+      : `${minutes}m ${seconds}s`;
   }
 
   const hours = elapsedHours % 24;
   const days = Math.floor(elapsedHours / 24);
   if (days === 0) {
-    return `${hours}h ${minutes}m`;
+    return locale === "zh-CN"
+      ? `${hours}小时 ${minutes}分`
+      : `${hours}h ${minutes}m`;
   }
 
-  return `${days}d ${hours}h`;
+  return locale === "zh-CN" ? `${days}天 ${hours}小时` : `${days}d ${hours}h`;
 }

--- a/compensation/dashboard/src/utils/durations.test.ts
+++ b/compensation/dashboard/src/utils/durations.test.ts
@@ -20,4 +20,8 @@ describe("formatSeconds", () => {
     expect(formatSeconds(120)).toBe("2 minutes");
     expect(formatSeconds(3_661)).toBe("1 hour 1 minute 1 second");
   });
+
+  it("formats durations in Chinese", () => {
+    expect(formatSeconds(3_661, "zh-CN")).toBe("1小时 1分钟 1秒");
+  });
 });

--- a/compensation/dashboard/src/utils/durations.ts
+++ b/compensation/dashboard/src/utils/durations.ts
@@ -11,7 +11,28 @@
  * limitations under the License.
  */
 
-export function formatSeconds(totalSeconds: number): string {
+import type { Locale } from "@/i18n.tsx";
+
+export function formatSeconds(
+  totalSeconds: number,
+  locale: Locale = "en",
+): string {
+  if (locale === "zh-CN") {
+    const hours = Math.floor(totalSeconds / 3_600);
+    const minutes = Math.floor((totalSeconds % 3_600) / 60);
+    const seconds = totalSeconds % 60;
+    if (totalSeconds < 60) {
+      return `${totalSeconds.toLocaleString()}秒`;
+    }
+    return [
+      hours > 0 ? `${hours.toLocaleString()}小时` : "",
+      minutes > 0 ? `${minutes.toLocaleString()}分钟` : "",
+      seconds > 0 ? `${seconds.toLocaleString()}秒` : "",
+    ]
+      .filter(Boolean)
+      .join(" ");
+  }
+
   if (totalSeconds < 60) {
     return `${totalSeconds.toLocaleString()} ${totalSeconds === 1 ? "second" : "seconds"}`;
   }


### PR DESCRIPTION
## Goal

为补偿 Dashboard 增加中文界面，并保留英文切换；语言入口放在顶栏右侧。

## Changes

- 增加轻量、类型安全的中英文文案层，支持浏览器语言检测与显式选择持久化
- 本地化仪表盘、失败队列、详情、历史、日期、时长、提示与无障碍标签
- 将语言切换从侧边栏移动到顶栏右侧，不新增依赖

## Verification

- `pnpm exec vitest run`：42 个测试文件、231 个测试通过
- `pnpm lint`：通过
- `pnpm build`：通过
- development 模式本地预览并连接 dev API 验证

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [ ] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

仅修改 Dashboard 前端展示与本地偏好；无 API、生成客户端、数据迁移或部署影响。界面内语言入口已覆盖该用户可见行为，无需额外文档。