### PR TITLE
perf(query): optimize masked event projection resolution

### DIFF
--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/query/QuerySchemaResolverBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/query/QuerySchemaResolverBenchmark.kt
@@ -18,6 +18,7 @@ import me.ahoo.wow.api.query.CursorQuery
 import me.ahoo.wow.api.query.EqualFilter
 import me.ahoo.wow.api.query.LogicalField
 import me.ahoo.wow.api.query.MatchAllFilter
+import me.ahoo.wow.api.query.Projection
 import me.ahoo.wow.api.query.SingleQuery
 import me.ahoo.wow.api.query.Sort
 import me.ahoo.wow.api.query.mask.FullMaskStrategy
@@ -31,6 +32,7 @@ import me.ahoo.wow.query.schema.QueryFieldBinding
 import me.ahoo.wow.query.schema.QueryFieldSchema
 import me.ahoo.wow.query.schema.QueryModelSchema
 import me.ahoo.wow.query.schema.QueryModelSchemaProvider
+import me.ahoo.wow.query.schema.QuerySchemaResolver
 import me.ahoo.wow.query.schema.QuerySchemaValidationMode
 import me.ahoo.wow.query.schema.resolve
 import org.openjdk.jmh.annotations.Benchmark
@@ -61,6 +63,8 @@ private const val FILTER_OPERAND_COUNT = 8
 @Threads(1)
 open class QuerySchemaResolverBenchmark {
     private val sortableField = LogicalField("state.createdAt")
+    private val eventSecretField = LogicalField("body.body.secret")
+    private val eventBodyTypeField = LogicalField("body.bodyType")
     private val schema = QueryModelSchema(
         model = QueryModel.SNAPSHOT,
         capabilities = emptySet(),
@@ -98,6 +102,28 @@ open class QuerySchemaResolverBenchmark {
 
         override fun refresh(): Mono<QueryModelSchema> = schemaMono
     }
+    private val eventProjectionResolver = QuerySchemaResolver(
+        QueryModelSchema(
+            model = QueryModel.EVENT_STREAM,
+            capabilities = emptySet(),
+            fields = mapOf(
+                eventSecretField to maskedFieldSchema().copy(
+                    bindings = mapOf(
+                        QueryCapability.PRESENCE to QueryFieldBinding(eventSecretField.value, null),
+                    ),
+                    projectionPath = eventSecretField.value,
+                ),
+                eventBodyTypeField to maskedFieldSchema().copy(
+                    bindings = mapOf(
+                        QueryCapability.PRESENCE to QueryFieldBinding(eventBodyTypeField.value, null),
+                    ),
+                    projectionPath = eventBodyTypeField.value,
+                    maskRule = null,
+                ),
+            ),
+        ),
+    )
+    private val eventProjection = Projection(include = listOf(eventSecretField.value))
     private val query = SingleQuery(MatchAllFilter)
     private val compositeFilterQuery = SingleQuery(
         AndFilter(
@@ -127,6 +153,11 @@ open class QuerySchemaResolverBenchmark {
     @Benchmark
     fun resolveCursorSort(blackhole: Blackhole) {
         blackhole.consume(provider.resolve(cursorQuery, QuerySchemaValidationMode.COMPATIBLE).block())
+    }
+
+    @Benchmark
+    fun resolveEventProjection(blackhole: Blackhole) {
+        blackhole.consume(eventProjectionResolver.resolve(eventProjection))
     }
 
     private fun maskedFieldSchema(): QueryFieldSchema {

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/EventMaskProjection.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/EventMaskProjection.kt
@@ -42,21 +42,18 @@ internal fun Projection.requiresInternalEventBodyType(
 
 internal fun Projection.hasUnrestorableInternalEventBodyTypeExclusion(
     bodyTypePath: String = EVENT_BODY_TYPE_PATH,
-): Boolean =
-    requiresInternalEventBodyType(bodyTypePath) && exclude.any {
-        '*' in it && bodyTypePath.matchesProjectionPattern(it)
-    }
+): Boolean = exclude.any {
+    '*' in it && bodyTypePath.matchesProjectionPattern(it)
+}
 
 internal fun Projection.withInternalEventBodyType(
     bodyTypePath: String = EVENT_BODY_TYPE_PATH,
-): Projection {
-    if (!requiresInternalEventBodyType(bodyTypePath)) return this
-    return if (include.isNotEmpty()) {
+): Projection =
+    if (include.isNotEmpty()) {
         copy(include = include + bodyTypePath, exclude = exclude - bodyTypePath)
     } else {
         copy(exclude = exclude - bodyTypePath)
     }
-}
 
 internal fun ObjectNode.removeInternalEventBodyType(): ObjectNode = apply {
     get(EVENT_BODY_PATH)?.takeIf(JsonNode::isArray)?.forEach { event ->
@@ -70,5 +67,7 @@ private fun String.isSelectedBy(pattern: String): Boolean =
 private fun String.intersectsSelection(pattern: String): Boolean =
     isSelectedBy(pattern) || pattern.startsWith("$this.")
 
-private fun String.matchesProjectionPattern(pattern: String): Boolean =
-    pattern.split('*').joinToString(".*", "^", "$") { Regex.escape(it) }.toRegex().matches(this)
+private fun String.matchesProjectionPattern(pattern: String): Boolean {
+    if ('*' !in pattern) return false
+    return pattern.split('*').joinToString(".*", "^", "$") { Regex.escape(it) }.toRegex().matches(this)
+}

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolver.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolver.kt
@@ -75,6 +75,12 @@ fun <T> QuerySchemaResolution<T>.requireAccepted(mode: QuerySchemaValidationMode
 class QuerySchemaResolver(private val schema: QueryModelSchema) {
     private val fieldResolver = QueryFieldSchemaResolver(schema)
     private val filterResolver = QueryFilterSchemaResolver(schema, fieldResolver)
+    private val maskedEventProjection = schema.model == QueryModel.EVENT_STREAM && schema.hasMaskedFields
+    private val eventBodyType = if (maskedEventProjection) {
+        fieldResolver.resolveProjectionPath(EVENT_BODY_TYPE_PATH)
+    } else {
+        null
+    }
     private val maskedAggregationPaths = schema.maskedFields.flatMapTo(linkedSetOf()) { (logical, field) ->
         listOfNotNull(logical.value, field.projectionPath) + field.bindings.values.map { it.physicalPath }
     }
@@ -129,7 +135,6 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
         filterResolver.resolve(filter)
 
     fun resolve(projection: Projection): QuerySchemaResolution<Projection> {
-        val maskedEventProjection = schema.model == QueryModel.EVENT_STREAM && schema.hasMaskedFields
         if (!maskedEventProjection && projection.isEmpty()) {
             return QuerySchemaResolution(Projection.ALL, QueryCompatibilityLevel.EXACT)
         }
@@ -147,7 +152,7 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
         if (!maskedEventProjection) {
             return QuerySchemaResolution(resolvedProjection, compatibility.combined())
         }
-        val bodyType = fieldResolver.resolveProjectionPath(EVENT_BODY_TYPE_PATH)
+        val bodyType = checkNotNull(eventBodyType)
         val internalBodyType = resolvedProjection.requiresInternalEventBodyType(
             bodyType.value,
         )
@@ -163,7 +168,10 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
                 if (internalBodyType) {
                     add(bodyType.compatibility)
                 }
-                if (resolvedProjection.hasUnrestorableInternalEventBodyTypeExclusion(bodyType.value)) {
+                if (
+                    internalBodyType &&
+                    resolvedProjection.hasUnrestorableInternalEventBodyTypeExclusion(bodyType.value)
+                ) {
                     add(QueryCompatibilityLevel.INCOMPATIBLE)
                 }
             }.combined(),
@@ -171,12 +179,12 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
     }
 
     internal fun requiresInternalEventBodyType(projection: Projection): Boolean {
-        if (schema.model != QueryModel.EVENT_STREAM || !schema.hasMaskedFields) return false
+        if (!maskedEventProjection) return false
         val resolvedProjection = Projection(
             include = projection.include.map { fieldResolver.resolveProjectionPath(it).value },
             exclude = projection.exclude.map { fieldResolver.resolveProjectionPath(it).value },
         )
-        val bodyTypePath = fieldResolver.resolveProjectionPath(EVENT_BODY_TYPE_PATH).value
+        val bodyTypePath = checkNotNull(eventBodyType).value
         return resolvedProjection.requiresInternalEventBodyType(bodyTypePath)
     }
 

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolverTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolverTest.kt
@@ -1772,6 +1772,33 @@ class QuerySchemaResolverTest {
     }
 
     @Test
+    fun `masked event projection should allow body type wildcard exclusion when body is not selected`() {
+        val resolver = QuerySchemaResolver(
+            QueryModelSchema(
+                QueryModel.EVENT_STREAM,
+                emptySet(),
+                mapOf(
+                    LogicalField("body.body.secret") to fieldSchema(
+                        QueryCapability.PRESENCE to "body.body.secret",
+                        maskRule = fullMaskRule(),
+                    ),
+                    LogicalField("body.bodyType") to fieldSchema(
+                        QueryCapability.PRESENCE to "body.bodyType",
+                    ),
+                ),
+            ),
+        )
+        val projection = Projection(
+            include = listOf("body.aggregateId"),
+            exclude = listOf("body.bodyT*"),
+        )
+
+        resolver.resolve(projection).assert().isEqualTo(
+            QuerySchemaResolution(projection, QueryCompatibilityLevel.COMPATIBLE),
+        )
+    }
+
+    @Test
     fun `masked event projection should restore body type excluded through an alias`() {
         val resolver = QuerySchemaResolver(
             QueryModelSchema(


### PR DESCRIPTION
## Goal

Reduce per-request CPU work and allocation for masked EventStream projection resolution while preserving query behavior and compatibility.

## Changes

- Cache the masked EventStream flag and resolved `body.bodyType` path in the immutable `QuerySchemaResolver`.
- Compute the internal body-type requirement once per projection and reuse it.
- Skip regex construction for literal projection patterns.
- Add a focused JMH benchmark for masked EventStream projection resolution.

## Verification

- `./gradlew :wow-query:check :wow-benchmarks:check :wow-benchmarks:jmhJar --no-parallel` — passed after rebasing onto current `origin/main`.
- `git diff --check` — passed.
- JMH 1.37, JDK 17, 3 forks, 5x200 ms warmup, 10x200 ms measurement:
  - latency: `1195.005 ± 17.531 ns/op` → `281.775 ± 6.226 ns/op` (4.24x faster)
  - allocation: `10730.670 ± 33.315 B/op` → `1264.001 B/op` (88.2% lower)

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

Public API, wire format, filter ordering, masking semantics, schema-unavailable fallback behavior, and nested or dynamic element-scope enforcement remain unchanged. Cached values are derived only from the immutable `QueryModelSchema`; a refreshed schema receives a new resolver.