### PR TITLE
perf(query): index masked aggregation paths

### DIFF
--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/query/QuerySchemaResolverBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/query/QuerySchemaResolverBenchmark.kt
@@ -13,6 +13,9 @@
 
 package me.ahoo.wow.benchmark.query
 
+import me.ahoo.wow.api.query.AggregationGroup
+import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.AndFilter
 import me.ahoo.wow.api.query.CursorQuery
 import me.ahoo.wow.api.query.EqualFilter
@@ -63,6 +66,7 @@ private const val FILTER_OPERAND_COUNT = 8
 @Threads(1)
 open class QuerySchemaResolverBenchmark {
     private val sortableField = LogicalField("state.createdAt")
+    private val aggregatableField = LogicalField("state.category")
     private val eventSecretField = LogicalField("body.body.secret")
     private val eventBodyTypeField = LogicalField("body.bodyType")
     private val schema = QueryModelSchema(
@@ -93,8 +97,18 @@ open class QuerySchemaResolverBenchmark {
                     maskRule = null,
                 ),
             )
+            put(
+                aggregatableField,
+                maskedFieldSchema().copy(
+                    bindings = mapOf(
+                        QueryCapability.AGGREGATE_TERMS to QueryFieldBinding("document.category.keyword", null),
+                    ),
+                    maskRule = null,
+                ),
+            )
         },
     )
+    private val resolver = QuerySchemaResolver(schema)
     private val provider = object : QueryModelSchemaProvider {
         private val schemaMono = Mono.just(schema)
 
@@ -124,6 +138,10 @@ open class QuerySchemaResolverBenchmark {
         ),
     )
     private val eventProjection = Projection(include = listOf(eventSecretField.value))
+    private val aggregationQuery = AggregationQuery(
+        groupBy = listOf(AggregationGroup.Terms(aggregatableField, "category")),
+        metrics = listOf(AggregationMetric.Count("count")),
+    )
     private val query = SingleQuery(MatchAllFilter)
     private val compositeFilterQuery = SingleQuery(
         AndFilter(
@@ -158,6 +176,11 @@ open class QuerySchemaResolverBenchmark {
     @Benchmark
     fun resolveEventProjection(blackhole: Blackhole) {
         blackhole.consume(eventProjectionResolver.resolve(eventProjection))
+    }
+
+    @Benchmark
+    fun resolveAggregation(blackhole: Blackhole) {
+        blackhole.consume(resolver.resolve(aggregationQuery))
     }
 
     private fun maskedFieldSchema(): QueryFieldSchema {

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolver.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolver.kt
@@ -311,15 +311,24 @@ class QuerySchemaResolver(private val schema: QueryModelSchema) {
     ).let { resolved ->
         val logicalCandidate = resolved.logical.value
         val physicalCandidate = resolved.physicalPath ?: logicalCandidate
-        val matchesMaskedCandidate = maskedAggregationPaths.any { maskedPath ->
-            logicalCandidate == maskedPath || logicalCandidate.startsWith("$maskedPath.") ||
-                physicalCandidate == maskedPath || physicalCandidate.startsWith("$maskedPath.")
-        }
+        val matchesMaskedCandidate = isMaskedAggregationCandidate(logicalCandidate) ||
+            physicalCandidate != logicalCandidate && isMaskedAggregationCandidate(physicalCandidate)
         if (resolved.fieldSchema?.maskRule == null && !matchesMaskedCandidate) {
             resolved
         } else {
             resolved.copy(compatibility = QueryCompatibilityLevel.INCOMPATIBLE)
         }
+    }
+
+    private fun isMaskedAggregationCandidate(path: String): Boolean {
+        if (maskedAggregationPaths.isEmpty()) return false
+        if (path in maskedAggregationPaths) return true
+        var separator = path.lastIndexOf('.')
+        while (separator > 0) {
+            if (path.substring(0, separator) in maskedAggregationPaths) return true
+            separator = path.lastIndexOf('.', separator - 1)
+        }
+        return false
     }
 
     private fun QueryFieldResolution.matchesMaskedCandidate(): Boolean {


### PR DESCRIPTION
## Goal

Remove schema-size-dependent work from aggregation mask validation while preserving all existing compatibility semantics.

## Changes

- Replace the per-request linear scan of every masked aggregation path with exact and ancestor lookups in the resolver-owned path set.
- Skip mask lookup immediately when the schema has no masked aggregation paths.
- Avoid duplicate lookup when logical and physical candidates are identical.
- Add a focused JMH benchmark for an unrelated aggregation field beside 64 masked fields.

## Verification

- `./gradlew :wow-query:check :wow-benchmarks:check :wow-benchmarks:jmhJar --no-parallel` — passed on current `origin/main`.
- `git diff --check` — passed.
- Independent read-only review of `04d3c599f..70e98299e` — Ready to merge, no Critical, Important, or Minor findings.
- JMH 1.37, JDK 17, 3 forks, 5x200 ms warmup, 10x200 ms measurement:
  - latency: `609.944 ± 4.868 ns/op` → `137.318 ± 1.598 ns/op` (4.44x faster)
  - allocation: `5314.668 ± 10.251 B/op` → `1378.667 ± 10.251 B/op` (74.1% lower)

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

Direct logical masks, physical bindings, projection aliases, nested logical or physical parents, and unrelated-field compatibility remain unchanged. The indexed paths belong to the immutable `QuerySchemaResolver`; schema refresh creates a new resolver. No request-derived paths are cached.