### PR TITLE
perf(query): reuse known schema fields

### DIFF
--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QueryFieldSchemaResolver.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QueryFieldSchemaResolver.kt
@@ -32,6 +32,16 @@ internal data class QueryFieldResolution(
 internal class QueryFieldSchemaResolver(
     private val schema: QueryModelSchema,
 ) {
+    private val knownFields = buildMap {
+        schema.fields.forEach { (field, fieldSchema) ->
+            put(field.value, field)
+            fieldSchema.bindings.values.forEach { binding ->
+                runCatching { LogicalField(binding.physicalPath) }.getOrNull()?.let {
+                    putIfAbsent(it.value, it)
+                }
+            }
+        }
+    }
     private val elementScopePaths = buildSet {
         schema.fields.forEach { (field, fieldSchema) ->
             if (QueryCapability.ELEMENT_SCOPE in fieldSchema.bindings) {
@@ -39,6 +49,8 @@ internal class QueryFieldSchemaResolver(
             }
         }
     }
+
+    fun resolveLogicalField(path: String): LogicalField = knownFields[path] ?: LogicalField(path)
 
     fun resolveProjectionPath(path: String): QuerySchemaResolution<String> {
         val logicalField = try {

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QueryFilterSchemaResolver.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QueryFilterSchemaResolver.kt
@@ -214,11 +214,11 @@ internal class QueryFilterSchemaResolver(
         val value = if (container.physicalPath == null) {
             filter
         } else {
-            ElementMatchFilter(LogicalField(container.value), predicate.value)
+            ElementMatchFilter(fieldResolver.resolveLogicalField(container.value), predicate.value)
         }
         return QuerySchemaResolution(
             value,
-            listOf(container.compatibility, predicate.compatibility).combined(),
+            maxOf(container.compatibility, predicate.compatibility),
         )
     }
 
@@ -245,7 +245,7 @@ internal class QueryFilterSchemaResolver(
         }
         if (fields.all { it.compatibility == QueryCompatibilityLevel.EXACT }) {
             return QuerySchemaResolution(
-                filter.copy(fields = fields.mapTo(linkedSetOf()) { LogicalField(it.value) }),
+                filter.copy(fields = fields.mapTo(linkedSetOf()) { fieldResolver.resolveLogicalField(it.value) }),
                 QueryCompatibilityLevel.EXACT,
             )
         }
@@ -281,8 +281,8 @@ internal class QueryFilterSchemaResolver(
     ): QuerySchemaResolution<FilterExpression> {
         val resolved = fieldResolver.resolve(field, capability, logicalParent, physicalParent)
         return QuerySchemaResolution(
-            copy(LogicalField(resolved.value)),
-            listOf(resolved.compatibility, resolved.valueCompatibility(values)).combined(),
+            copy(fieldResolver.resolveLogicalField(resolved.value)),
+            maxOf(resolved.compatibility, resolved.valueCompatibility(values)),
         )
     }
 
@@ -300,12 +300,12 @@ internal class QueryFilterSchemaResolver(
         } else {
             QueryCompatibilityLevel.EXACT
         }
-        val compatibility = listOf(
+        val compatibility = maxOf(
             resolved.compatibility,
             cardinality,
             resolved.valueCompatibility(values),
-        ).combined()
-        return QuerySchemaResolution(copy(LogicalField(resolved.value)), compatibility)
+        )
+        return QuerySchemaResolution(copy(fieldResolver.resolveLogicalField(resolved.value)), compatibility)
     }
 
     private inline fun resolveStringFieldFilter(
@@ -321,11 +321,8 @@ internal class QueryFilterSchemaResolver(
                 resolved.fieldSchema.valueTypes == setOf(QueryValueType.STRING) -> QueryCompatibilityLevel.EXACT
             else -> QueryCompatibilityLevel.INCOMPATIBLE
         }
-        val compatibility = listOf(
-            resolved.compatibility,
-            stringField,
-        ).combined()
-        return QuerySchemaResolution(copy(LogicalField(resolved.value)), compatibility)
+        val compatibility = maxOf(resolved.compatibility, stringField)
+        return QuerySchemaResolution(copy(fieldResolver.resolveLogicalField(resolved.value)), compatibility)
     }
 
     private fun resolveRelativeTime(
@@ -340,7 +337,7 @@ internal class QueryFilterSchemaResolver(
         if (filter.dateFormatter != null) {
             return QuerySchemaResolution(filter, QueryCompatibilityLevel.INCOMPATIBLE)
         }
-        val physicalField = LogicalField(resolved.value)
+        val physicalField = fieldResolver.resolveLogicalField(resolved.value)
         val configured = when (val temporal = resolved.fieldSchema?.semanticType) {
             is Temporal.Epoch -> {
                 if (filter.datePattern != null) {


### PR DESCRIPTION
## Goal

Remove repeated schema-derived field validation and small compatibility collection allocation from filter resolution while preserving query behavior.

## Changes

- Precompute valid logical and physical `LogicalField` values in the immutable `QueryFieldSchemaResolver`.
- Reuse known fields across equality, collection, string, search, element-match, and relative-time filter rewriting.
- Keep unknown and request-derived dynamic paths uncached.
- Replace two- and three-item `listOf(...).combined()` calls with `maxOf`.

## Verification

- `./gradlew :wow-query:check :wow-benchmarks:check :wow-benchmarks:jmhJar --no-parallel` — passed on current `origin/main`.
- `git diff --check` — passed.
- Independent read-only review of `3fac7fa74..4f693c9cc` — Ready to merge, no Critical, Important, or Minor findings.
- JMH 1.37, JDK 17, 3 forks, 5x200 ms warmup, 10x200 ms measurement:
  - latency: `1071.260 ± 31.802 ns/op` → `246.117 ± 5.269 ns/op` (4.35x faster)
  - allocation: `5208.003 ± 7.688 B/op` → `1304.001 ± 7.688 B/op` (75.0% lower)

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

Filter values, order, wire format, compatibility strictness, nested element-scope enforcement, schema-unavailable behavior, and dynamic-field resolution remain unchanged. Invalid physical binding paths are not cached and retain request-time validation. Schema refresh publishes a new immutable schema with a new resolver and index.