### PR TITLE
perf(query): precompute dynamic field templates

### DIFF
--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/query/QuerySchemaResolverBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/query/QuerySchemaResolverBenchmark.kt
@@ -67,6 +67,8 @@ private const val FILTER_OPERAND_COUNT = 8
 open class QuerySchemaResolverBenchmark {
     private val sortableField = LogicalField("state.createdAt")
     private val aggregatableField = LogicalField("state.category")
+    private val dynamicField = LogicalField("state.dynamic")
+    private val dynamicChildField = LogicalField("state.dynamic.child.grandchild")
     private val eventSecretField = LogicalField("body.body.secret")
     private val eventBodyTypeField = LogicalField("body.bodyType")
     private val schema = QueryModelSchema(
@@ -106,6 +108,16 @@ open class QuerySchemaResolverBenchmark {
                     maskRule = null,
                 ),
             )
+            put(
+                dynamicField,
+                maskedFieldSchema().copy(
+                    bindings = mapOf(
+                        QueryCapability.EXACT_MATCH to QueryFieldBinding("document.dynamic", null),
+                    ),
+                    dynamicChildren = true,
+                    maskRule = null,
+                ),
+            )
         },
     )
     private val resolver = QuerySchemaResolver(schema)
@@ -138,6 +150,10 @@ open class QuerySchemaResolverBenchmark {
         ),
     )
     private val eventProjection = Projection(include = listOf(eventSecretField.value))
+    private val dynamicFilter = EqualFilter(
+        dynamicChildField,
+        JsonNodeFactory.instance.stringNode("value"),
+    )
     private val aggregationQuery = AggregationQuery(
         groupBy = listOf(AggregationGroup.Terms(aggregatableField, "category")),
         metrics = listOf(AggregationMetric.Count("count")),
@@ -181,6 +197,11 @@ open class QuerySchemaResolverBenchmark {
     @Benchmark
     fun resolveAggregation(blackhole: Blackhole) {
         blackhole.consume(resolver.resolve(aggregationQuery))
+    }
+
+    @Benchmark
+    fun resolveDynamicFilter(blackhole: Blackhole) {
+        blackhole.consume(resolver.resolve(dynamicFilter))
     }
 
     private fun maskedFieldSchema(): QueryFieldSchema {

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QueryModelSchema.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QueryModelSchema.kt
@@ -48,23 +48,33 @@ data class QueryModelSchema(
     @get:JsonIgnore
     internal val hasMaskedFields: Boolean = maskedFields.isNotEmpty()
 
+    private val dynamicFields = buildMap {
+        fields.forEach { (field, fieldSchema) ->
+            if (fieldSchema.dynamicChildren) {
+                put(
+                    field.value,
+                    fieldSchema.copy(bindings = fieldSchema.bindings - QueryCapability.ELEMENT_SCOPE),
+                )
+            }
+        }
+    }
+
     @get:JsonIgnore
     internal val resolver = QuerySchemaResolver(this)
 
     fun resolve(field: LogicalField): QueryFieldSchema? {
         fields[field]?.let { return it }
+        if (dynamicFields.isEmpty()) return null
         var separator = field.value.lastIndexOf('.')
         while (separator > 0) {
             val ancestorPath = field.value.substring(0, separator)
-            val ancestor = fields[LogicalField(ancestorPath)]
-            if (ancestor?.dynamicChildren == true) {
+            val ancestor = dynamicFields[ancestorPath]
+            if (ancestor != null) {
                 val suffix = field.value.substring(separator + 1)
                 return ancestor.copy(
-                    bindings = ancestor.bindings
-                        .filterKeys { it != QueryCapability.ELEMENT_SCOPE }
-                        .mapValues { (_, binding) ->
-                            binding.copy(physicalPath = "${binding.physicalPath}.$suffix")
-                        },
+                    bindings = ancestor.bindings.mapValues { (_, binding) ->
+                        binding.copy(physicalPath = "${binding.physicalPath}.$suffix")
+                    },
                     projectionPath = ancestor.projectionPath?.let { "$it.$suffix" },
                 )
             }


### PR DESCRIPTION
## Goal

Move schema-stable dynamic field preparation out of the request path while preserving dynamic resolution behavior.

## Changes

- Precompute `dynamicChildren` field templates keyed by their logical string path.
- Remove `ELEMENT_SCOPE` bindings once when the immutable schema is created.
- Return immediately when a schema has no dynamic templates.
- Keep request-derived suffix expansion local to each resolution.
- Add a focused JMH benchmark for a multi-level dynamic child filter.

## Verification

- `./gradlew :wow-query:check :wow-benchmarks:check :wow-benchmarks:jmhJar --no-parallel` — passed on current `origin/main`.
- `git diff --check` — passed.
- Independent read-only review of `32edb2742..3530b0525` — Ready to merge, no Critical, Important, or Minor findings.
- JMH 1.37, JDK 17, 3 forks, 5x200 ms warmup, 10x200 ms measurement:
  - latency: `630.979 ± 15.452 ns/op` → `366.865 ± 23.262 ns/op` (1.72x faster)
  - allocation: `2128.002 B/op` → `1008.001 B/op` (52.6% lower)

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

Declared fields still take precedence and dynamic ancestors are still checked nearest-first. Physical suffixes, storage types, projection paths, capability filtering, and unknown-field behavior remain unchanged. The template index is private schema-derived state and is rebuilt with every new schema or refresh; request-derived paths are never cached.