### PR TITLE
perf(query): index schema mask paths

### DIFF
--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/query/SchemaMaskGatewayBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/query/SchemaMaskGatewayBenchmark.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.benchmark.query
+
+import me.ahoo.wow.api.query.IListQuery
+import me.ahoo.wow.api.query.ListQuery
+import me.ahoo.wow.api.query.LogicalField
+import me.ahoo.wow.api.query.MatchAllFilter
+import me.ahoo.wow.api.query.mask.FullMaskStrategy
+import me.ahoo.wow.api.query.mask.Mask
+import me.ahoo.wow.api.query.schema.QueryCardinality
+import me.ahoo.wow.api.query.schema.QueryModel
+import me.ahoo.wow.api.query.schema.QueryValueType
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.query.schema.MaskRule
+import me.ahoo.wow.query.schema.QueryFieldSchema
+import me.ahoo.wow.query.schema.QueryModelSchema
+import me.ahoo.wow.query.schema.QueryModelSchemaProvider
+import me.ahoo.wow.query.snapshot.DefaultSnapshotQueryGateway
+import me.ahoo.wow.query.snapshot.NoOpSnapshotQueryBackend
+import me.ahoo.wow.query.snapshot.SnapshotQueryBackend
+import me.ahoo.wow.query.snapshot.SnapshotQueryGateway
+import me.ahoo.wow.serialization.JsonSerializer
+import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.BenchmarkMode
+import org.openjdk.jmh.annotations.Fork
+import org.openjdk.jmh.annotations.Measurement
+import org.openjdk.jmh.annotations.Mode
+import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations.Param
+import org.openjdk.jmh.annotations.Scope
+import org.openjdk.jmh.annotations.Setup
+import org.openjdk.jmh.annotations.State
+import org.openjdk.jmh.annotations.Threads
+import org.openjdk.jmh.annotations.Warmup
+import org.openjdk.jmh.infra.Blackhole
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import tools.jackson.databind.node.JsonNodeFactory
+import tools.jackson.databind.node.ObjectNode
+import java.util.concurrent.TimeUnit
+import kotlin.reflect.jvm.javaField
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(3)
+@Threads(1)
+open class SchemaMaskGatewayBenchmark {
+    @Param("1", "64")
+    var maskedFieldCount: Int = 0
+
+    @Param("1", "1000")
+    var resultCount: Int = 0
+
+    private val namedAggregate = MaterializedNamedAggregate("benchmark-query", "schema-mask")
+    private lateinit var gateway: SnapshotQueryGateway<ObjectNode>
+    private lateinit var query: IListQuery
+
+    @Setup
+    fun setup() {
+        val schema = QueryModelSchema(
+            model = QueryModel.SNAPSHOT,
+            capabilities = emptySet(),
+            fields = (0 until maskedFieldCount).associate { index ->
+                LogicalField("state.secret$index") to maskedFieldSchema()
+            },
+        )
+        val results = List(resultCount) {
+            JsonNodeFactory.instance.objectNode().also { node ->
+                node.putObject("state").put("visible", "value")
+            }
+        }
+        val backend = object :
+            SnapshotQueryBackend by NoOpSnapshotQueryBackend(namedAggregate),
+            QueryModelSchemaProvider {
+            private val schemaMono = Mono.just(schema)
+
+            override fun schema(): Mono<QueryModelSchema> = schemaMono
+
+            override fun refresh(): Mono<QueryModelSchema> = schemaMono
+
+            override fun list(query: IListQuery): Flux<ObjectNode> = Flux.fromIterable(results)
+        }
+        gateway = DefaultSnapshotQueryGateway(
+            namedAggregate = namedAggregate,
+            backend = backend,
+            targetType = JsonSerializer.typeFactory.constructType(ObjectNode::class.java),
+        )
+        query = ListQuery(MatchAllFilter, limit = resultCount)
+    }
+
+    @Benchmark
+    fun maskMissingFields(blackhole: Blackhole) {
+        blackhole.consume(gateway.dynamicList(query).collectList().block())
+    }
+
+    private fun maskedFieldSchema(): QueryFieldSchema {
+        val annotation = Masked::secret.javaField!!.getAnnotation(Mask::class.java)
+        return QueryFieldSchema(
+            title = null,
+            description = null,
+            enumValues = null,
+            valueTypes = setOf(QueryValueType.STRING),
+            nullable = true,
+            required = false,
+            cardinality = QueryCardinality.SINGLE,
+            semanticType = null,
+            dynamicChildren = false,
+            bindings = emptyMap(),
+            maskRule = MaskRule(
+                FullMaskStrategy::class,
+                annotation,
+                FullMaskStrategy.compile(annotation),
+            ),
+        )
+    }
+
+    private data class Masked(@field:Mask val secret: String)
+}

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/SchemaMasker.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/mask/SchemaMasker.kt
@@ -26,12 +26,12 @@ import tools.jackson.databind.node.JsonNodeFactory
 import tools.jackson.databind.node.ObjectNode
 
 internal class SchemaMasker private constructor(
-    private val paths: List<MaskedPath>,
+    private val root: MaskNode,
     private val eventBodyTypes: Set<String>?,
 ) {
     fun mask(node: ObjectNode): ObjectNode {
         eventBodyTypes?.let { validateEventBodyTypes(node, it) }
-        paths.forEach { path -> maskAt(node, path.segments, 0, path.mask) }
+        maskAt(node, root)
         return node
     }
 
@@ -49,21 +49,34 @@ internal class SchemaMasker private constructor(
         }
     }
 
-    private fun maskAt(node: JsonNode, segments: List<String>, index: Int, mask: CompiledMask) {
+    private fun maskAt(node: JsonNode, maskNode: MaskNode) {
         if (node.isArray) {
-            node.forEach { child -> maskAt(child, segments, index, mask) }
+            node.forEach { child -> maskAt(child, maskNode) }
             return
         }
         if (!node.isObject) {
             if (node.isNull) return
             throw QuerySchemaValidationException("Masked query field has an invalid JSON wire shape.")
         }
-        val child = node.get(segments[index]) ?: return
-        if (index < segments.lastIndex) {
-            maskAt(child, segments, index + 1, mask)
-            return
+        val objectNode = node as ObjectNode
+        if (maskNode.children.size <= objectNode.size()) {
+            maskNode.children.forEach { (field, childMaskNode) ->
+                objectNode.get(field)?.let { child -> maskChild(objectNode, field, child, childMaskNode) }
+            }
+        } else {
+            objectNode.forEachEntry { field, child ->
+                maskNode.children[field]?.let { childMaskNode ->
+                    maskChild(objectNode, field, child, childMaskNode)
+                }
+            }
         }
-        maskValue(node as ObjectNode, segments[index], child, mask)
+    }
+
+    private fun maskChild(parent: ObjectNode, field: String, value: JsonNode, maskNode: MaskNode) {
+        maskNode.mask?.let { mask -> maskValue(parent, field, value, mask) }
+        if (maskNode.children.isNotEmpty()) {
+            maskAt(value, maskNode)
+        }
     }
 
     private fun maskValue(parent: ObjectNode, field: String, value: JsonNode, mask: CompiledMask) {
@@ -132,13 +145,13 @@ internal class SchemaMasker private constructor(
                 }
                 pathRules.add(responsePath, checkNotNull(fieldSchema.maskRule))
             }
-            val paths = pathRules.map { (path, rule) -> MaskedPath(path.split('.'), rule.compiled) }
+            val root = pathRules.map { (path, rule) -> MaskedPath(path.split('.'), rule.compiled) }.toMaskNode()
             val eventBodyTypes = if (schema.model == QueryModel.EVENT_STREAM) {
                 schema.requiredEventBodyTypes()
             } else {
                 null
             }
-            return SchemaMasker(paths, eventBodyTypes)
+            return SchemaMasker(root, eventBodyTypes)
         }
 
         private fun MutableMap<String, MaskRule>.add(path: String, rule: MaskRule) {
@@ -157,7 +170,19 @@ internal class SchemaMasker private constructor(
             }
             return bodyTypes
         }
+
+        private fun List<MaskedPath>.toMaskNode(index: Int = 0): MaskNode = MaskNode(
+            mask = firstOrNull { it.segments.size == index }?.mask,
+            children = filter { index < it.segments.size }
+                .groupBy { it.segments[index] }
+                .mapValues { (_, paths) -> paths.toMaskNode(index + 1) },
+        )
     }
+
+    private data class MaskNode(
+        val mask: CompiledMask?,
+        val children: Map<String, MaskNode>,
+    )
 
     private data class MaskedPath(val segments: List<String>, val mask: CompiledMask)
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/mask/SchemaMaskerTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/mask/SchemaMaskerTest.kt
@@ -32,6 +32,8 @@ import me.ahoo.wow.serialization.JsonSerializer
 import me.ahoo.wow.serialization.toJsonNode
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.node.JsonNodeFactory
 import tools.jackson.databind.node.ObjectNode
 import java.lang.reflect.Proxy
 import kotlin.reflect.jvm.javaField
@@ -46,6 +48,31 @@ class SchemaMaskerTest {
                 fields = emptyMap(),
             ),
         ).assert().isNull()
+    }
+
+    @Test
+    fun `sparse masked fields should read their shared branch once`() {
+        val masker = SchemaMasker.create(
+            QueryModelSchema(
+                model = QueryModel.SNAPSHOT,
+                capabilities = emptySet(),
+                fields = (0 until 64).associate { index ->
+                    LogicalField("state.secret$index") to fieldSchema(maskRule = fullMaskRule())
+                },
+            ),
+        )!!
+        val state = CountingObjectNode().also {
+            it.put("secret63", "value")
+        }
+        val node = CountingObjectNode().also {
+            it.set("state", state)
+        }
+
+        masker.mask(node)
+
+        node.path("state").path("secret63").stringValue().assert().isEqualTo("*****")
+        node.getCalls.assert().isOne()
+        state.getCalls.assert().isZero()
     }
 
     @Test
@@ -340,6 +367,15 @@ class SchemaMaskerTest {
             else -> error("Unexpected method: ${method.name}")
         }
     } as CompiledMask
+
+    private class CountingObjectNode : ObjectNode(JsonNodeFactory.instance) {
+        var getCalls: Int = 0
+
+        override fun get(propertyName: String): JsonNode? {
+            getCalls++
+            return super.get(propertyName)
+        }
+    }
 
     private data class Masked(
         @field:Mask val secret: String,


### PR DESCRIPTION
## Goal

Avoid scanning every masked schema path for every query result when most masked fields are absent.

## Changes

- Precompute an immutable segmented mask-path index for each cached `QueryModelSchema`.
- Traverse the smaller side of index children and returned JSON fields so missing branches are skipped early.
- Preserve in-place masking, nested-array traversal, projection aliases, event body-type validation, and fail-closed wire-shape behavior.
- Add a deterministic sparse-result complexity regression test and a database-free public QueryGateway JMH benchmark.

## Verification

- `./gradlew build` — passed, 337 actionable tasks, 0 failures.
- `./gradlew :wow-query:check :wow-benchmarks:check :wow-benchmarks:jmhClasses` — passed.
- Independent read-only code review — no remaining Critical, Important, or Minor findings.
- Same-host JMH, 1 fork, 3 warmup and 5 measurement iterations, 1000 missing-field results:

| Masked paths | Before | After |
| --- | ---: | ---: |
| 1 | 21.475 us/op | 22.036 us/op |
| 64 | 451.215 us/op | 24.073 us/op |

The 64-path workload is about 18.7x faster (94.7% lower average time); the 1-path control is effectively unchanged. Normalized allocation remained about 16.6 KiB/op.

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

There are no public API, wire, schema, storage, migration, or deployment changes. The private cold index is rebuilt with each immutable schema instance after refresh; no request-derived state is cached. Result nodes remain masked in place with the existing error and concurrency boundaries.
