### PR TITLE
ci: measure raw Local Test aggregation

### DIFF
--- a/.github/workflows/local-test.yml
+++ b/.github/workflows/local-test.yml
@@ -66,11 +66,9 @@ jobs:
       matrix:
         include:
           - shard: 1
-            coverage_task: localCoverageReportShard1
-            coverage_file: ./test/code-coverage-report/build/reports/jacoco/localCoverageReportShard1/localCoverageReportShard1.xml
+            test_task: localTestShard1
           - shard: 2
-            coverage_task: localCoverageReportShard2
-            coverage_file: ./test/code-coverage-report/build/reports/jacoco/localCoverageReportShard2/localCoverageReportShard2.xml
+            test_task: localTestShard2
     steps:
       - name: Checkout
         uses: actions/checkout@master
@@ -86,14 +84,17 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
 
-      - name: Run local test shard with coverage
-        run: ./gradlew :code-coverage-report:${{ matrix.coverage_task }} --stacktrace
+      - name: Run local test shard
+        run: ./gradlew :code-coverage-report:${{ matrix.test_task }} --rerun-tasks --stacktrace
 
-      - name: Upload local coverage shard
+      - name: Upload raw local coverage shard
         uses: actions/upload-artifact@v4
         with:
-          name: local-coverage-${{ matrix.shard }}
-          path: ${{ matrix.coverage_file }}
+          name: local-raw-coverage-${{ matrix.shard }}
+          path: |
+            **/build/classes/kotlin/main/**
+            **/build/classes/java/main/**
+            **/build/jacoco/test.exec
           if-no-files-found: error
 
   local-test:
@@ -110,17 +111,38 @@ jobs:
       - name: Checkout
         uses: actions/checkout@master
 
-      - name: Download local coverage shards
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          server-id: github
+          settings-path: ${{ github.workspace }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Download raw local coverage shard 1
         uses: actions/download-artifact@v4
         with:
-          pattern: local-coverage-*
-          path: ./coverage
-          merge-multiple: true
+          name: local-raw-coverage-1
+          path: .
 
-      - name: Verify complete local coverage
-        run: |
-          test -s ./coverage/localCoverageReportShard1.xml
-          test -s ./coverage/localCoverageReportShard2.xml
+      - name: Download raw local coverage shard 2
+        uses: actions/download-artifact@v4
+        with:
+          name: local-raw-coverage-2
+          path: .
+
+      - name: Aggregate raw local coverage
+        run: ./gradlew :code-coverage-report:localCoverageReportFromArtifacts --stacktrace
+
+      - name: Upload aggregated local coverage evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: local-raw-coverage-report
+          path: ./test/code-coverage-report/build/reports/jacoco/localCoverageReportFromArtifacts/localCoverageReportFromArtifacts.xml
+          if-no-files-found: error
 
       - name: Upload local coverage
         uses: codecov/codecov-action@v7
@@ -131,4 +153,72 @@ jobs:
           fail_ci_if_error: true
           verbose: true
           disable_search: true
-          files: ./coverage/localCoverageReportShard1.xml,./coverage/localCoverageReportShard2.xml
+          files: ./test/code-coverage-report/build/reports/jacoco/localCoverageReportFromArtifacts/localCoverageReportFromArtifacts.xml
+
+  local-coverage-baseline:
+    name: Local Coverage Baseline
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          server-id: github
+          settings-path: ${{ github.workspace }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Run unsharded local coverage baseline
+        run: ./gradlew allLocalTest :code-coverage-report:localCoverageReport --rerun-tasks --stacktrace
+
+      - name: Upload unsharded local coverage evidence
+        uses: actions/upload-artifact@v4
+        with:
+          name: local-unsharded-coverage-report
+          path: ./test/code-coverage-report/build/reports/jacoco/localCoverageReport/localCoverageReport.xml
+          if-no-files-found: error
+
+  local-coverage-parity:
+    name: Local Coverage Parity
+    needs:
+      - local-test
+      - local-coverage-baseline
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download aggregated local coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: local-raw-coverage-report
+          path: ./coverage/aggregated
+
+      - name: Download unsharded local coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: local-unsharded-coverage-report
+          path: ./coverage/unsharded
+
+      - name: Compare semantic JaCoCo coverage
+        shell: python
+        run: |
+          import hashlib
+          import sys
+          import xml.etree.ElementTree as ET
+
+          def normalize(path):
+              root = ET.parse(path).getroot()
+              for session in list(root.findall("sessioninfo")):
+                  root.remove(session)
+              return ET.tostring(root, encoding="utf-8")
+
+          aggregated = normalize("coverage/aggregated/localCoverageReportFromArtifacts.xml")
+          unsharded = normalize("coverage/unsharded/localCoverageReport.xml")
+          print(f"aggregated_sha256={hashlib.sha256(aggregated).hexdigest()}")
+          print(f"unsharded_sha256={hashlib.sha256(unsharded).hexdigest()}")
+          if aggregated != unsharded:
+              print("Semantic JaCoCo coverage differs.", file=sys.stderr)
+              raise SystemExit(1)

--- a/.github/workflows/local-test.yml
+++ b/.github/workflows/local-test.yml
@@ -59,9 +59,18 @@ env:
   CI: GITHUB_ACTIONS
 
 jobs:
-  local-test:
-    name: Local Test
+  local-test-shard:
+    name: Local Test Shard ${{ matrix.shard }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - shard: 1
+            coverage_task: localCoverageReportShard1
+            coverage_file: ./test/code-coverage-report/build/reports/jacoco/localCoverageReportShard1/localCoverageReportShard1.xml
+          - shard: 2
+            coverage_task: localCoverageReportShard2
+            coverage_file: ./test/code-coverage-report/build/reports/jacoco/localCoverageReportShard2/localCoverageReportShard2.xml
     steps:
       - name: Checkout
         uses: actions/checkout@master
@@ -77,12 +86,44 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
 
-      - name: Run local tests with coverage
-        run: ./gradlew allLocalTest :code-coverage-report:localCoverageReport --stacktrace
+      - name: Run local test shard with coverage
+        run: ./gradlew :code-coverage-report:${{ matrix.coverage_task }} --stacktrace
+
+      - name: Upload local coverage shard
+        uses: actions/upload-artifact@v4
+        with:
+          name: local-coverage-${{ matrix.shard }}
+          path: ${{ matrix.coverage_file }}
+          if-no-files-found: error
+
+  local-test:
+    name: Local Test
+    needs: local-test-shard
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require successful shards
+        env:
+          SHARD_RESULT: ${{ needs.local-test-shard.result }}
+        run: test "${SHARD_RESULT}" = "success"
+
+      - name: Checkout
+        uses: actions/checkout@master
+
+      - name: Download local coverage shards
+        uses: actions/download-artifact@v4
+        with:
+          pattern: local-coverage-*
+          path: ./coverage
+          merge-multiple: true
+
+      - name: Verify complete local coverage
+        run: |
+          test -s ./coverage/localCoverageReportShard1.xml
+          test -s ./coverage/localCoverageReportShard2.xml
 
       - name: Upload local coverage
         uses: codecov/codecov-action@v7
-        if: success()
         with:
           use_oidc: true
           flags: local
@@ -90,4 +131,4 @@ jobs:
           fail_ci_if_error: true
           verbose: true
           disable_search: true
-          files: ./test/code-coverage-report/build/reports/jacoco/localCoverageReport/localCoverageReport.xml
+          files: ./coverage/localCoverageReportShard1.xml,./coverage/localCoverageReportShard2.xml

--- a/documentation/docs/en/onboarding/contributor-guide.md
+++ b/documentation/docs/en/onboarding/contributor-guide.md
@@ -59,6 +59,81 @@ Pull-request workflows are the source of truth for CI:
 | Java example | `./gradlew :example-transfer-api:build :example-transfer-domain:build :example-transfer-server:build --stacktrace` | [`example-java-test.yml`](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/example-java-test.yml) |
 | Benchmark smoke | `./gradlew :wow-benchmarks:test :wow-benchmarks:benchmarkSmoke --stacktrace` | [`benchmark-smoke.yml`](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/benchmark-smoke.yml) |
 
+### Local Test two-shard contract
+
+Local Test reduces pull-request latency without changing tests, coverage, or the required-check name. It uses two Gradle shards with one fixed side and an automatic complement; it does not introduce a third shard, a larger runner, a new dependency, or a custom scheduler.
+
+#### Decision evidence
+
+The [original slow job](https://github.com/Ahoo-Wang/Wow/actions/runs/33380885897/job/99452754237?pr=3115) spent 9m29s in Gradle and executed 178 of 184 actionable tasks, with only 6 restored from cache. After correcting the Gradle cache topology, a [representative pull request](https://github.com/Ahoo-Wang/Wow/actions/runs/33451289472) still spent 9m29s in Gradle, but executed tasks fell to 135 and cached tasks rose to 49; the matching [`main` job](https://github.com/Ahoo-Wang/Wow/actions/runs/33455593795) took 6m09s. The cache works, but cold test and compilation work remains the critical path.
+
+The [forced full profile](https://github.com/Ahoo-Wang/Wow/actions/runs/33460101373/job/99708267226) ran all 184 tasks at commit `8651f2bbcb05fb48e23e24283dfa83e667df9516`: Gradle wall time was 8m57s and cumulative task time was 26m59s. Tests accounted for 17m18s, about 64%; compilation, KSP, and KAPT accounted for 9m27s, about 35%; effective parallelism was about 3.36. The profile came from closed, unmerged [PR #3134](https://github.com/Ahoo-Wang/Wow/pull/3134) and is measurement evidence only.
+
+#### Gradle shards
+
+`test/code-coverage-report/build.gradle.kts` defines `localCoverageReportShard1` and `localCoverageReportShard2`. Each task directly depends only on its shard's `test` tasks and emits one JaCoCo XML report. Both reports retain the full source/class scope of the existing `localCoverageReport`, but each uses execution data only from shard projects that intersect that scope. `wow-compensation-server` still runs its tests but, as today, does not enter the coverage report. The existing unsharded task remains the local regression baseline.
+
+Shard 1 is fixed to these 15 projects selected from the measured workload:
+
+```text
+:wow-core
+:wow-openapi
+:wow-bi
+:wow-elasticsearch
+:wow-query
+:wow-kafka
+:wow-opentelemetry
+:wow-cocache
+:wow-compensation-core
+:example-transfer-domain
+:wow-tck
+:wow-spring
+:wow-compensation-api
+:example-api
+:example-transfer-api
+```
+
+Shard 2 is `localTestTaskProjects - shard1`. Its initial set is:
+
+```text
+:wow-spring-boot-starter
+:wow-compiler
+:wow-mongo
+:wow-webflux
+:wow-schema
+:wow-redis
+:wow-compensation-server
+:example-domain
+:wow-models
+:wow-api
+:wow-compensation-domain
+:wow-cosec
+:wow-apiclient
+:wow-test
+:wow-mock
+:wow-it
+```
+
+Configuration-time guards require every shard-1 path to exist, both shards to be nonempty, no overlap, and an exact union with `localTestTaskProjects`. New Local Test projects therefore enter shard 2 automatically. If measurements later show imbalance, move one existing path instead of adding a configuration layer.
+
+#### Workflow and coverage
+
+`.github/workflows/local-test.yml` first runs a two-entry matrix. Each entry executes its Gradle coverage task and uploads a uniquely named XML artifact with `if-no-files-found: error`. The downstream job remains named `Local Test` to preserve the required check used by branch protection. It downloads both XML files and invokes the Codecov uploader once, retaining the `local` flag, OIDC, `disable_search: true`, and `fail_ci_if_error: true`. Codecov documents that one flag can accept multiple reports and merge them into that flag's total coverage; see [Flags](https://docs.codecov.com/docs/flags).
+
+The downstream job uses `if: always()` to inspect the aggregate matrix result, then requires that result to equal `success`. A test failure or missing XML fails its shard. If any shard fails or is cancelled, the guard fails before artifact download. If a successfully uploaded artifact later cannot be downloaded or is corrupt, the download step fails. No failure path reaches Codecov, so partial coverage is never uploaded. Both shards keep `gradle/actions/setup-gradle` and the existing `main` push, pull-request trigger, and cache-seeding semantics.
+
+#### Verification and acceptance
+
+Implementation must provide these results in order:
+
+1. Gradle's configuration-time partition guards pass, and each shard's `--dry-run` contains only the expected test tasks.
+2. `actionlint`, complete runs of both shards, and the original `allLocalTest :code-coverage-report:localCoverageReport` regression pass.
+3. At one commit, compare the unsharded XML with the two reports merged by Codecov under `local`. Line, branch, and per-file coverage must not drift. If Codecov merging changes coverage, stop rollout and use raw JaCoCo exec aggregation; do not weaken the coverage threshold.
+4. Temporary `--rerun-tasks` is allowed for one real-runner measurement only and must be absent from the final diff.
+5. Candidate workflow wall time is at most 7 minutes, shard wall times differ by no more than 15% of the slower shard, and cumulative runner-minutes stay at or below 125% of the former 8m51s Local Test median: 11m04s.
+
+After merge, observe the next 10 code pull requests that trigger Local Test. Use the ninth value after sorting durations in ascending order as the nearest-rank P90 and require it to stay at or below 7 minutes. If coverage drifts, the required check becomes unreliable, or runner cost exceeds the limit, revert the workflow and shard tasks in one commit. Revisit a third shard only if P90 still misses the target and a new profile proves it can improve the critical path within budget; this design adds no third-shard abstraction in advance.
+
 Run only the layers the change requires. Expand to aggregate tasks for shared runtime, TCK, or multi-backend changes; never report an unrun task as passing.
 
 The dashboard and documentation use their native commands:

--- a/documentation/docs/en/onboarding/contributor-guide.md
+++ b/documentation/docs/en/onboarding/contributor-guide.md
@@ -61,7 +61,7 @@ Pull-request workflows are the source of truth for CI:
 
 ### Local Test two-shard contract
 
-Local Test reduces pull-request latency without changing tests, coverage, or the required-check name. It uses two Gradle shards with one fixed side and an automatic complement; it does not introduce a third shard, a larger runner, a new dependency, or a custom scheduler.
+Local Test reduces pull-request latency without changing tests, coverage, or the required-check name. It uses two test-only Gradle shards, transfers raw JaCoCo execution data and compiled main classes, then emits one XML in a downstream job. It does not introduce a third shard, a larger runner, a new dependency, or a custom scheduler.
 
 #### Decision evidence
 
@@ -69,9 +69,11 @@ The [original slow job](https://github.com/Ahoo-Wang/Wow/actions/runs/3338088589
 
 The [forced full profile](https://github.com/Ahoo-Wang/Wow/actions/runs/33460101373/job/99708267226) ran all 184 tasks at commit `8651f2bbcb05fb48e23e24283dfa83e667df9516`: Gradle wall time was 8m57s and cumulative task time was 26m59s. Tests accounted for 17m18s, about 64%; compilation, KSP, and KAPT accounted for 9m27s, about 35%; effective parallelism was about 3.36. The profile came from closed, unmerged [PR #3134](https://github.com/Ahoo-Wang/Wow/pull/3134) and is measurement evidence only.
 
+The first two-XML candidate was force-measured in closed, unmerged [PR #3138](https://github.com/Ahoo-Wang/Wow/pull/3138) and its [diagnostic run](https://github.com/Ahoo-Wang/Wow/actions/runs/33467569094). The production path took 382 seconds and the shard gap was 7.65%, but cumulative runner time reached 714 seconds against a 664-second limit. Codecov coverage fell from the unsharded baseline's 88.20% to 88.15%. After excluding Codecov's zeroed complexity representation, 14 files and 15 line states still drifted. Separate XML files retain only aggregate branch/instruction counters, not complementary JaCoCo probe identity, so that architecture was rejected. This design merges raw execution data before emitting one XML.
+
 #### Gradle shards
 
-`test/code-coverage-report/build.gradle.kts` defines `localCoverageReportShard1` and `localCoverageReportShard2`. Each task directly depends only on its shard's `test` tasks and emits one JaCoCo XML report. Both reports retain the full source/class scope of the existing `localCoverageReport`, but each uses execution data only from shard projects that intersect that scope. `wow-compensation-server` still runs its tests but, as today, does not enter the coverage report. The existing unsharded task remains the local regression baseline.
+`test/code-coverage-report/build.gradle.kts` defines `localTestShard1` and `localTestShard2`. They depend only on their shard's `test` tasks, configure no JaCoCo report, and do not pull the other shard's compilation tasks through a full classDirectories collection. `wow-compensation-server:test` remains in shard 2 but, as today, does not enter the coverage report.
 
 Shard 1 is fixed to these 15 projects selected from the measured workload:
 
@@ -116,23 +118,26 @@ Shard 2 is `localTestTaskProjects - shard1`. Its initial set is:
 
 Configuration-time guards require every shard-1 path to exist, both shards to be nonempty, no overlap, and an exact union with `localTestTaskProjects`. New Local Test projects therefore enter shard 2 automatically. If measurements later show imbalance, move one existing path instead of adding a configuration layer.
 
+The same build script also defines `verifyLocalCoverageArtifacts` and `localCoverageReportFromArtifacts`. The verification task uses current source sets to require the raw `build/jacoco/test.exec` and main class files that should exist. The report task reads only explicit downloaded file paths, has no compilation or test dependencies, and reuses the complete source/class project scope of the existing `localCoverageReport`. The original `localCoverageReport` remains the unsharded baseline.
+
 #### Workflow and coverage
 
-`.github/workflows/local-test.yml` first runs a two-entry matrix. Each entry executes its Gradle coverage task and uploads a uniquely named XML artifact with `if-no-files-found: error`. The downstream job remains named `Local Test` to preserve the required check used by branch protection. It downloads both XML files and invokes the Codecov uploader once, retaining the `local` flag, OIDC, `disable_search: true`, and `fail_ci_if_error: true`. Codecov documents that one flag can accept multiple reports and merge them into that flag's total coverage; see [Flags](https://docs.codecov.com/docs/flags).
+`.github/workflows/local-test.yml` first runs a two-entry matrix. Each entry executes its test-only Gradle task and uses `actions/upload-artifact@v4` to upload the runner's existing `**/build/classes/kotlin/main/**`, `**/build/classes/java/main/**`, and `**/build/jacoco/test.exec`. A multi-path artifact keeps paths relative to the workspace's common ancestor, and `if-no-files-found: error` rejects an empty artifact. Current local outputs estimate 16.5 MiB and 14.2 MiB uncompressed by shard ownership; the hosted runner measurement remains authoritative.
 
-The downstream job uses `if: always()` to inspect the aggregate matrix result, then requires that result to equal `success`. A test failure or missing XML fails its shard. If any shard fails or is cancelled, the guard fails before artifact download. If a successfully uploaded artifact later cannot be downloaded or is corrupt, the download step fails. No failure path reaches Codecov, so partial coverage is never uploaded. Both shards keep `gradle/actions/setup-gradle` and the existing `main` push, pull-request trigger, and cache-seeding semantics.
+The downstream job remains named `Local Test` to preserve the required branch-protection check. It uses `if: always()` to inspect the aggregate matrix result and first requires `success`. It then downloads both artifacts by exact name into the workspace root, verifies the coverage inputs, runs the detached JaCoCo report, and uploads only that XML to Codecov while retaining the `local` flag, OIDC, `disable_search: true`, and `fail_ci_if_error: true`. A failed or cancelled shard, missing artifact, incomplete coverage input, report failure, or Codecov failure makes `Local Test` fail; partial coverage is never uploaded. Both shards retain `gradle/actions/setup-gradle` and the existing `main` push, pull-request trigger, and cache-seeding semantics.
 
 #### Verification and acceptance
 
 Implementation must provide these results in order:
 
-1. Gradle's configuration-time partition guards pass, and each shard's `--dry-run` contains only the expected test tasks.
-2. `actionlint`, complete runs of both shards, and the original `allLocalTest :code-coverage-report:localCoverageReport` regression pass.
-3. At one commit, compare the unsharded XML with the two reports merged by Codecov under `local`. Line, branch, and per-file coverage must not drift. If Codecov merging changes coverage, stop rollout and use raw JaCoCo exec aggregation; do not weaken the coverage threshold.
-4. Temporary `--rerun-tasks` is allowed for one real-runner measurement only and must be absent from the final diff.
-5. Candidate workflow wall time is at most 7 minutes, shard wall times differ by no more than 15% of the slower shard, and cumulative runner-minutes stay at or below 125% of the former 8m51s Local Test median: 11m04s.
+1. Gradle's configuration-time partition guards pass. Each test-only shard's `--dry-run` contains only its expected test tasks. The artifact report's `--dry-run` may contain only verification and report tasks—never compile, KSP, KAPT, or test tasks.
+2. `actionlint`, complete runs of both shards, raw artifact restoration, single-XML generation, and the original `allLocalTest :code-coverage-report:localCoverageReport` regression pass.
+3. A diagnostic PR runs the forced sharded production path and a separate forced unsharded baseline at the same SHA. A comparison job downloads both XML files, removes only non-semantic JaCoCo `sessioninfo`, then compares every package, class, method, source line, branch, and counter. Any drift fails. The unsharded baseline and comparison exist only in diagnostics, not the final workflow.
+4. Temporary `--rerun-tasks`, the baseline job, comparison job, and diagnostic XML artifacts are allowed only for one real-runner measurement and must be absent from the final diff.
+5. The production path from workflow `createdAt` through the final `Local Test` `completedAt` is at most 7 minutes. Shard wall times differ by no more than 15% of the slower shard. The two shards plus final `Local Test` consume at most 125% of the former 8m51s Local Test median: 11m04s. Diagnostic baseline and comparison jobs do not count toward production metrics.
+6. The final candidate has exactly one Codecov `local` session, whose only XML comes from raw execution-data aggregation.
 
-After merge, observe the next 10 code pull requests that trigger Local Test. Use the ninth value after sorting durations in ascending order as the nearest-rank P90 and require it to stay at or below 7 minutes. If coverage drifts, the required check becomes unreliable, or runner cost exceeds the limit, revert the workflow and shard tasks in one commit. Revisit a third shard only if P90 still misses the target and a new profile proves it can improve the critical path within budget; this design adds no third-shard abstraction in advance.
+After merge, observe the next 10 code pull requests that trigger Local Test. Use the ninth duration after ascending sort as the nearest-rank P90 and require it to stay at or below 7 minutes. If the raw design still drifts coverage, breaks the required check, or exceeds runner cost before merge, abandon sharding and restore the single job. If a post-merge continuous gate fails, revert the workflow, Gradle tasks, and this documentation section in one commit. This design adds no third-shard abstraction in advance.
 
 Run only the layers the change requires. Expand to aggregate tasks for shared runtime, TCK, or multi-backend changes; never report an unrun task as passing.
 

--- a/documentation/docs/zh/onboarding/contributor-guide.md
+++ b/documentation/docs/zh/onboarding/contributor-guide.md
@@ -59,6 +59,81 @@ Pull Request 工作流是 CI 事实来源：
 | Java 示例 | `./gradlew :example-transfer-api:build :example-transfer-domain:build :example-transfer-server:build --stacktrace` | [`example-java-test.yml`](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/example-java-test.yml) |
 | Benchmark smoke | `./gradlew :wow-benchmarks:test :wow-benchmarks:benchmarkSmoke --stacktrace` | [`benchmark-smoke.yml`](https://github.com/Ahoo-Wang/Wow/blob/main/.github/workflows/benchmark-smoke.yml) |
 
+### Local Test 两分片合同
+
+Local Test 的目标是在不改变测试、覆盖率或必需检查名称的前提下降低 Pull Request 等待时间。它采用两个固定起点、自动补齐的 Gradle 分片；不引入第三个分片、更大 runner、新依赖或自定义调度器。
+
+#### 决策证据
+
+[原始慢任务](https://github.com/Ahoo-Wang/Wow/actions/runs/33380885897/job/99452754237?pr=3115)的 Gradle 阶段为 9 分 29 秒，184 个 actionable task 中 178 个实际执行、6 个来自缓存。启用正确的 Gradle 缓存拓扑后，[代表性 Pull Request](https://github.com/Ahoo-Wang/Wow/actions/runs/33451289472) 的 Gradle 阶段仍需 9 分 29 秒，但执行数降为 135、缓存命中增为 49；对应 [`main` 任务](https://github.com/Ahoo-Wang/Wow/actions/runs/33455593795) 为 6 分 09 秒。这证明缓存有效，但冷执行的测试与编译仍是关键路径。
+
+[强制全量 Profile](https://github.com/Ahoo-Wang/Wow/actions/runs/33460101373/job/99708267226) 在 commit `8651f2bbcb05fb48e23e24283dfa83e667df9516` 上运行了全部 184 个 task：Gradle wall time 为 8 分 57 秒，累计 task time 为 26 分 59 秒。其中测试占 17 分 18 秒（约 64%），编译、KSP 与 KAPT 占 9 分 27 秒（约 35%），有效并行度约为 3.36。Profile 来自已关闭且未合并的 [PR #3134](https://github.com/Ahoo-Wang/Wow/pull/3134)，只作为本设计的测量证据。
+
+#### Gradle 分片
+
+`test/code-coverage-report/build.gradle.kts` 定义 `localCoverageReportShard1` 与 `localCoverageReportShard2`。每个任务只直接依赖所属分片的 `test` task，并生成一个 JaCoCo XML。两个报告都保留现有 `localCoverageReport` 的完整 source/class 范围，但各自只使用本分片与该范围相交项目的 execution data；`wow-compensation-server` 仍执行测试，但与现在一样不进入覆盖率报告。现有未分片任务继续作为本地回归基线。
+
+分片 1 固定为以下 15 个测量后较重或与其平衡的项目：
+
+```text
+:wow-core
+:wow-openapi
+:wow-bi
+:wow-elasticsearch
+:wow-query
+:wow-kafka
+:wow-opentelemetry
+:wow-cocache
+:wow-compensation-core
+:example-transfer-domain
+:wow-tck
+:wow-spring
+:wow-compensation-api
+:example-api
+:example-transfer-api
+```
+
+分片 2 是 `localTestTaskProjects - shard1`。初始集合为：
+
+```text
+:wow-spring-boot-starter
+:wow-compiler
+:wow-mongo
+:wow-webflux
+:wow-schema
+:wow-redis
+:wow-compensation-server
+:example-domain
+:wow-models
+:wow-api
+:wow-compensation-domain
+:wow-cosec
+:wow-apiclient
+:wow-test
+:wow-mock
+:wow-it
+```
+
+配置期守卫要求分片 1 的路径全部存在、两个分片非空、无交集，且并集严格等于 `localTestTaskProjects`。新 Local Test 项目因此自动进入分片 2；观察到失衡后再移动一个已有路径，而不是增加配置层。
+
+#### Workflow 与覆盖率
+
+`.github/workflows/local-test.yml` 先运行一个两项 matrix，每项执行对应的 Gradle coverage task，并用 `if-no-files-found: error` 上传唯一命名的 XML artifact。后置 job 的名称仍为 `Local Test`，以保持 branch protection 使用的必需检查名；它下载两个 XML，并只调用一次 Codecov uploader，继续使用 `local` flag、OIDC、`disable_search: true` 和 `fail_ci_if_error: true`。Codecov 文档明确说明同一 flag 可接收多个报告并合并贡献到该 flag 的总覆盖率，见 [Flags](https://docs.codecov.com/docs/flags)。
+
+后置 job 使用 `if: always()` 取得 matrix 汇总结果，但首先要求 matrix result 必须是 `success`。测试或 XML 缺失使所属分片失败；任何分片失败或取消时，守卫先失败且不下载 artifact。成功上传后若 artifact 无法下载或损坏，下载步骤失败。所有失败路径都不会运行 Codecov，禁止上传部分覆盖率。两个分片继续使用 `gradle/actions/setup-gradle`，并保留 `main` push 与 Pull Request 的现有触发和缓存种子语义。
+
+#### 验证与验收
+
+实现必须依次提供以下证据：
+
+1. Gradle 配置期分区守卫通过；两个分片的 `--dry-run` 均只包含预期 test task。
+2. `actionlint`、两个分片的完整执行以及原始 `allLocalTest :code-coverage-report:localCoverageReport` 回归通过。
+3. 在同一 commit 上比较未分片 XML 与两个分片经 Codecov 合并后的 `local` 覆盖率；line、branch 及文件级覆盖不得漂移。若 Codecov 合并语义产生漂移，停止上线并改用 raw JaCoCo exec 聚合，不接受放宽覆盖率。
+4. 临时 `--rerun-tasks` 仅用于一次真实 runner 测量，取得证据后必须从最终 diff 删除。
+5. 候选 workflow wall time 不超过 7 分钟，两个分片 wall time 差距不超过较慢分片的 15%，累计 runner-minutes 不超过旧 Local Test 8 分 51 秒中位数的 125%，即 11 分 04 秒。
+
+合并后观察接下来 10 个触发 Local Test 的代码 Pull Request；按耗时升序排列后的第 9 个值作为 nearest-rank P90，并要求它不超过 7 分钟。若覆盖率漂移、必需检查失真或 runner 成本越界，单 commit 回滚 workflow 与分片 task。只有 P90 仍超标且 profile 证明第三分片能在成本预算内改善关键路径时，才重新设计；本方案不预留第三分片抽象。
+
 只运行变化所需的层级。涉及共享运行时、TCK 或多个后端时再扩到聚合任务；不要把未运行的任务写成“已通过”。
 
 Dashboard 与文档使用各自的原生命令：

--- a/documentation/docs/zh/onboarding/contributor-guide.md
+++ b/documentation/docs/zh/onboarding/contributor-guide.md
@@ -61,7 +61,7 @@ Pull Request 工作流是 CI 事实来源：
 
 ### Local Test 两分片合同
 
-Local Test 的目标是在不改变测试、覆盖率或必需检查名称的前提下降低 Pull Request 等待时间。它采用两个固定起点、自动补齐的 Gradle 分片；不引入第三个分片、更大 runner、新依赖或自定义调度器。
+Local Test 的目标是在不改变测试、覆盖率或必需检查名称的前提下降低 Pull Request 等待时间。它采用两个 test-only Gradle 分片，传递 raw JaCoCo execution data 与已编译 main classes，再由后置 job 生成唯一 XML；不引入第三个分片、更大 runner、新依赖或自定义调度器。
 
 #### 决策证据
 
@@ -69,9 +69,11 @@ Local Test 的目标是在不改变测试、覆盖率或必需检查名称的前
 
 [强制全量 Profile](https://github.com/Ahoo-Wang/Wow/actions/runs/33460101373/job/99708267226) 在 commit `8651f2bbcb05fb48e23e24283dfa83e667df9516` 上运行了全部 184 个 task：Gradle wall time 为 8 分 57 秒，累计 task time 为 26 分 59 秒。其中测试占 17 分 18 秒（约 64%），编译、KSP 与 KAPT 占 9 分 27 秒（约 35%），有效并行度约为 3.36。Profile 来自已关闭且未合并的 [PR #3134](https://github.com/Ahoo-Wang/Wow/pull/3134)，只作为本设计的测量证据。
 
+首个双 XML 候选在已关闭且未合并的 [PR #3138](https://github.com/Ahoo-Wang/Wow/pull/3138) 上完成[强制测量](https://github.com/Ahoo-Wang/Wow/actions/runs/33467569094)：生产路径为 382 秒，分片差为 7.65%，但累计 runner time 为 714 秒，超过 664 秒上限；Codecov 总覆盖率从未分片基线的 88.20% 降为 88.15%。排除 Codecov 将 complexity 归零的表示差异后，仍有 14 个文件、15 个行状态漂移。两个分片 XML 只有 branch/instruction 汇总计数，无法保留互补 JaCoCo probe 身份，因此该架构被拒绝；本设计改为先合并 raw execution data，再生成单一 XML。
+
 #### Gradle 分片
 
-`test/code-coverage-report/build.gradle.kts` 定义 `localCoverageReportShard1` 与 `localCoverageReportShard2`。每个任务只直接依赖所属分片的 `test` task，并生成一个 JaCoCo XML。两个报告都保留现有 `localCoverageReport` 的完整 source/class 范围，但各自只使用本分片与该范围相交项目的 execution data；`wow-compensation-server` 仍执行测试，但与现在一样不进入覆盖率报告。现有未分片任务继续作为本地回归基线。
+`test/code-coverage-report/build.gradle.kts` 定义 `localTestShard1` 与 `localTestShard2`。它们只依赖所属分片的 `test` task，不配置 JaCoCo report，也不通过完整 classDirectories 拉入另一分片的编译任务。`wow-compensation-server:test` 仍属于分片 2，但与现在一样不进入覆盖率报告。
 
 分片 1 固定为以下 15 个测量后较重或与其平衡的项目：
 
@@ -116,23 +118,26 @@ Local Test 的目标是在不改变测试、覆盖率或必需检查名称的前
 
 配置期守卫要求分片 1 的路径全部存在、两个分片非空、无交集，且并集严格等于 `localTestTaskProjects`。新 Local Test 项目因此自动进入分片 2；观察到失衡后再移动一个已有路径，而不是增加配置层。
 
+同一 build script 另外定义 `verifyLocalCoverageArtifacts` 与 `localCoverageReportFromArtifacts`。验证任务按当前 source set 判断应存在的 raw `build/jacoco/test.exec` 与 main class 文件；报告任务只读取下载后的显式文件路径，不依赖任何编译或测试 task，并复用现有 `localCoverageReport` 的完整 source/class 项目范围。原始 `localCoverageReport` 保留为未分片基线。
+
 #### Workflow 与覆盖率
 
-`.github/workflows/local-test.yml` 先运行一个两项 matrix，每项执行对应的 Gradle coverage task，并用 `if-no-files-found: error` 上传唯一命名的 XML artifact。后置 job 的名称仍为 `Local Test`，以保持 branch protection 使用的必需检查名；它下载两个 XML，并只调用一次 Codecov uploader，继续使用 `local` flag、OIDC、`disable_search: true` 和 `fail_ci_if_error: true`。Codecov 文档明确说明同一 flag 可接收多个报告并合并贡献到该 flag 的总覆盖率，见 [Flags](https://docs.codecov.com/docs/flags)。
+`.github/workflows/local-test.yml` 先运行一个两项 matrix，每项执行对应的 test-only Gradle task，并用 `actions/upload-artifact@v4` 上传该 runner 已产生的 `**/build/classes/kotlin/main/**`、`**/build/classes/java/main/**` 与 `**/build/jacoco/test.exec`。多路径 artifact 以工作区公共祖先为根保留相对目录；`if-no-files-found: error` 禁止空 artifact。当前本地产物按分片归属估算为 16.5 MiB 与 14.2 MiB（未压缩），最终仍以托管 runner 实测为准。
 
-后置 job 使用 `if: always()` 取得 matrix 汇总结果，但首先要求 matrix result 必须是 `success`。测试或 XML 缺失使所属分片失败；任何分片失败或取消时，守卫先失败且不下载 artifact。成功上传后若 artifact 无法下载或损坏，下载步骤失败。所有失败路径都不会运行 Codecov，禁止上传部分覆盖率。两个分片继续使用 `gradle/actions/setup-gradle`，并保留 `main` push 与 Pull Request 的现有触发和缓存种子语义。
+后置 job 的名称仍为 `Local Test`，以保持 branch protection 使用的必需检查名。它使用 `if: always()` 读取 matrix 汇总结果，并首先要求 result 为 `success`；随后按精确名称分别下载两个 artifact 到工作区根目录，运行 artifact 验证与 detached JaCoCo report，最后只上传这一份 XML 到 Codecov，继续使用 `local` flag、OIDC、`disable_search: true` 和 `fail_ci_if_error: true`。任一分片失败、取消、artifact 缺失、覆盖输入不完整、报告失败或 Codecov 失败都会使 `Local Test` 失败；禁止上传部分覆盖率。两个分片继续使用 `gradle/actions/setup-gradle`，并保留 `main` push、Pull Request trigger 与现有缓存种子语义。
 
 #### 验证与验收
 
 实现必须依次提供以下证据：
 
-1. Gradle 配置期分区守卫通过；两个分片的 `--dry-run` 均只包含预期 test task。
-2. `actionlint`、两个分片的完整执行以及原始 `allLocalTest :code-coverage-report:localCoverageReport` 回归通过。
-3. 在同一 commit 上比较未分片 XML 与两个分片经 Codecov 合并后的 `local` 覆盖率；line、branch 及文件级覆盖不得漂移。若 Codecov 合并语义产生漂移，停止上线并改用 raw JaCoCo exec 聚合，不接受放宽覆盖率。
-4. 临时 `--rerun-tasks` 仅用于一次真实 runner 测量，取得证据后必须从最终 diff 删除。
-5. 候选 workflow wall time 不超过 7 分钟，两个分片 wall time 差距不超过较慢分片的 15%，累计 runner-minutes 不超过旧 Local Test 8 分 51 秒中位数的 125%，即 11 分 04 秒。
+1. Gradle 配置期分区守卫通过；两个 test-only 分片的 `--dry-run` 只包含预期 test task；artifact report 的 `--dry-run` 只能包含验证与报告 task，不能出现 compile、KSP、KAPT 或 test task。
+2. `actionlint`、两个分片的完整执行、raw artifact 恢复、单 XML 生成以及原始 `allLocalTest :code-coverage-report:localCoverageReport` 回归通过。
+3. 诊断 PR 在同一 SHA 同时运行 forced 分片生产路径与独立 forced 未分片基线。comparison job 下载两份 XML，只移除非语义性的 JaCoCo `sessioninfo` 后比较完整 package、class、method、source line、branch 与 counter；任何漂移都失败。未分片基线与 comparison 只属于诊断，不进入最终 workflow。
+4. 临时 `--rerun-tasks`、基线 job、comparison job 和诊断 XML artifact 只用于一次真实 runner 测量，取得证据后必须从最终 diff 删除。
+5. 生产路径从 workflow `createdAt` 到最终 `Local Test` 的 `completedAt` 不超过 7 分钟；两个分片 wall time 差距不超过较慢分片的 15%；两个分片与最终 `Local Test` 的累计 runner time 不超过旧 Local Test 8 分 51 秒中位数的 125%，即 11 分 04 秒。诊断基线与 comparison 不计入生产指标。
+6. 最终候选必须只有一个 Codecov `local` session，且其唯一 XML 来自 raw execution data 聚合。
 
-合并后观察接下来 10 个触发 Local Test 的代码 Pull Request；按耗时升序排列后的第 9 个值作为 nearest-rank P90，并要求它不超过 7 分钟。若覆盖率漂移、必需检查失真或 runner 成本越界，单 commit 回滚 workflow 与分片 task。只有 P90 仍超标且 profile 证明第三分片能在成本预算内改善关键路径时，才重新设计；本方案不预留第三分片抽象。
+合并后观察接下来 10 个触发 Local Test 的代码 Pull Request；按耗时升序排列后的第 9 个值作为 nearest-rank P90，并要求它不超过 7 分钟。若 raw 方案在合并前仍出现覆盖漂移、必需检查失真或 runner 成本越界，放弃分片并恢复单 job；合并后违反持续门禁时，用一个 commit 回滚 workflow、Gradle task 与本节文档。本方案不预留第三分片抽象。
 
 只运行变化所需的层级。涉及共享运行时、TCK 或多个后端时再扩到聚合任务；不要把未运行的任务写成“已通过”。
 

--- a/test/code-coverage-report/build.gradle.kts
+++ b/test/code-coverage-report/build.gradle.kts
@@ -85,11 +85,8 @@ fun registerLayerCoverageReport(
     taskName: String,
     projects: Iterable<Project>,
     testTaskName: String,
-    testProjects: Iterable<Project> = projects,
 ) {
-    val coverageProjects = projects.toSet()
-    val taskProjects = testProjects.toSet()
-    val coverageTestTasks = testTasks(taskProjects.intersect(coverageProjects), testTaskName)
+    val layerTestTasks = testTasks(projects, testTaskName)
     tasks.register<JacocoReport>(taskName) {
         description = "Generates the ${taskName.removeSuffix("CoverageReport")} coverage report."
         group = LifecycleBasePlugin.VERIFICATION_GROUP
@@ -99,8 +96,15 @@ fun registerLayerCoverageReport(
             csv.required.set(false)
             html.required.set(false)
         }
-        dependsOn(taskProjects.map { "${it.path}:$testTaskName" })
-        useCoverageData(coverageProjects, coverageTestTasks)
+        useCoverageData(projects, layerTestTasks)
+    }
+}
+
+fun registerLocalTestShard(taskName: String, projects: Iterable<Project>) {
+    tasks.register(taskName) {
+        description = "Runs $taskName tests."
+        group = LifecycleBasePlugin.VERIFICATION_GROUP
+        dependsOn(projects.map { "${it.path}:test" })
     }
 }
 
@@ -108,7 +112,8 @@ val localTestTasks = testTasks(localTestProjects, "test")
 val contractTestTasks = testTasks(localContractTestProjects, "contractTest")
 val integrationTestTasks = testTasks(integrationTestProjects, "integrationTest")
 val coveredTestTasks = localTestTasks + contractTestTasks + integrationTestTasks
-val localTestTaskProjects = localTestProjects.toSet() + project(":wow-compensation-server")
+val localCoverageProjects = localTestProjects.toSet()
+val localTestTaskProjects = localCoverageProjects + project(":wow-compensation-server")
 val localTestShard1Paths = setOf(
     ":wow-core",
     ":wow-openapi",
@@ -140,22 +145,73 @@ require(localTestShard1 + localTestShard2 == localTestTaskProjects) {
     "Local Test shards must cover every local test project."
 }
 
+fun Project.artifactClassDirectories() = listOf(
+    layout.buildDirectory.dir("classes/kotlin/main").get().asFile,
+    layout.buildDirectory.dir("classes/java/main").get().asFile,
+)
+
+fun Project.artifactExecutionData() = layout.buildDirectory.file("jacoco/test.exec").get().asFile
+
+fun Project.hasSource(sourceSetName: String): Boolean {
+    return extensions.getByType<SourceSetContainer>()
+        .named(sourceSetName)
+        .get()
+        .allSource.files
+        .any(File::isFile)
+}
+
+val artifactClassDirectories = localCoverageProjects.flatMap { it.artifactClassDirectories() }
+val artifactExecutionData = localCoverageProjects.map { it.artifactExecutionData() }
+val verifyLocalCoverageArtifacts = tasks.register("verifyLocalCoverageArtifacts") {
+    description = "Verifies downloaded Local Test coverage artifacts."
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    doLast {
+        val missingClassProjects = localCoverageProjects.filter { project ->
+            project.hasSource(SourceSet.MAIN_SOURCE_SET_NAME) &&
+                project.artifactClassDirectories().none { classDirectory ->
+                    classDirectory.walkTopDown().any { it.isFile && it.extension == "class" }
+                }
+        }
+        require(missingClassProjects.isEmpty()) {
+            "Missing Local Test main classes: ${missingClassProjects.map { it.path }}"
+        }
+        val missingExecutionDataProjects = localCoverageProjects.filter { project ->
+            project.hasSource(SourceSet.TEST_SOURCE_SET_NAME) && !project.artifactExecutionData().isFile
+        }
+        require(missingExecutionDataProjects.isEmpty()) {
+            "Missing Local Test execution data: ${missingExecutionDataProjects.map { it.path }}"
+        }
+    }
+}
+
 tasks.named<JacocoReport>("codeCoverageReport") {
     useCoverageData(libraryProjects, coveredTestTasks)
 }
 
 registerLayerCoverageReport("localCoverageReport", localTestProjects, "test")
-registerLayerCoverageReport(
-    taskName = "localCoverageReportShard1",
-    projects = localTestProjects,
-    testTaskName = "test",
-    testProjects = localTestShard1,
-)
-registerLayerCoverageReport(
-    taskName = "localCoverageReportShard2",
-    projects = localTestProjects,
-    testTaskName = "test",
-    testProjects = localTestShard2,
-)
+registerLocalTestShard("localTestShard1", localTestShard1)
+registerLocalTestShard("localTestShard2", localTestShard2)
+tasks.register<JacocoReport>("localCoverageReportFromArtifacts") {
+    description = "Generates Local Test coverage from downloaded artifacts."
+    group = LifecycleBasePlugin.VERIFICATION_GROUP
+    dependsOn(verifyLocalCoverageArtifacts)
+    reports {
+        xml.required.set(true)
+        xml.outputLocation.set(
+            layout.buildDirectory.file(
+                "reports/jacoco/localCoverageReportFromArtifacts/localCoverageReportFromArtifacts.xml",
+            ),
+        )
+        csv.required.set(false)
+        html.required.set(false)
+    }
+    sourceDirectories.setFrom(
+        mainSourceSets(localCoverageProjects).map { sourceSet ->
+            sourceSet.map { it.allSource.srcDirs }
+        },
+    )
+    classDirectories.setFrom(artifactClassDirectories.filter(File::isDirectory))
+    executionData.setFrom(artifactExecutionData.filter(File::isFile))
+}
 registerLayerCoverageReport("contractCoverageReport", localContractTestProjects, "contractTest")
 registerLayerCoverageReport("integrationCoverageReport", integrationTestProjects, "integrationTest")

--- a/test/code-coverage-report/build.gradle.kts
+++ b/test/code-coverage-report/build.gradle.kts
@@ -85,8 +85,11 @@ fun registerLayerCoverageReport(
     taskName: String,
     projects: Iterable<Project>,
     testTaskName: String,
+    testProjects: Iterable<Project> = projects,
 ) {
-    val layerTestTasks = testTasks(projects, testTaskName)
+    val coverageProjects = projects.toSet()
+    val taskProjects = testProjects.toSet()
+    val coverageTestTasks = testTasks(taskProjects.intersect(coverageProjects), testTaskName)
     tasks.register<JacocoReport>(taskName) {
         description = "Generates the ${taskName.removeSuffix("CoverageReport")} coverage report."
         group = LifecycleBasePlugin.VERIFICATION_GROUP
@@ -96,7 +99,8 @@ fun registerLayerCoverageReport(
             csv.required.set(false)
             html.required.set(false)
         }
-        useCoverageData(projects, layerTestTasks)
+        dependsOn(taskProjects.map { "${it.path}:$testTaskName" })
+        useCoverageData(coverageProjects, coverageTestTasks)
     }
 }
 
@@ -104,11 +108,54 @@ val localTestTasks = testTasks(localTestProjects, "test")
 val contractTestTasks = testTasks(localContractTestProjects, "contractTest")
 val integrationTestTasks = testTasks(integrationTestProjects, "integrationTest")
 val coveredTestTasks = localTestTasks + contractTestTasks + integrationTestTasks
+val localTestTaskProjects = localTestProjects.toSet() + project(":wow-compensation-server")
+val localTestShard1Paths = setOf(
+    ":wow-core",
+    ":wow-openapi",
+    ":wow-bi",
+    ":wow-elasticsearch",
+    ":wow-query",
+    ":wow-kafka",
+    ":wow-opentelemetry",
+    ":wow-cocache",
+    ":wow-compensation-core",
+    ":example-transfer-domain",
+    ":wow-tck",
+    ":wow-spring",
+    ":wow-compensation-api",
+    ":example-api",
+    ":example-transfer-api",
+)
+val localTestShard1 = localTestTaskProjects.filter { it.path in localTestShard1Paths }.toSet()
+val resolvedLocalTestShard1Paths = localTestShard1.map { it.path }.toSet()
+val missingLocalTestShard1Paths = localTestShard1Paths - resolvedLocalTestShard1Paths
+require(missingLocalTestShard1Paths.isEmpty()) {
+    "Local Test shard 1 contains unknown or non-local projects: $missingLocalTestShard1Paths"
+}
+val localTestShard2 = localTestTaskProjects - localTestShard1
+require(localTestShard1.isNotEmpty()) { "Local Test shard 1 must not be empty." }
+require(localTestShard2.isNotEmpty()) { "Local Test shard 2 must not be empty." }
+require(localTestShard1.intersect(localTestShard2).isEmpty()) { "Local Test shards must not overlap." }
+require(localTestShard1 + localTestShard2 == localTestTaskProjects) {
+    "Local Test shards must cover every local test project."
+}
 
 tasks.named<JacocoReport>("codeCoverageReport") {
     useCoverageData(libraryProjects, coveredTestTasks)
 }
 
 registerLayerCoverageReport("localCoverageReport", localTestProjects, "test")
+registerLayerCoverageReport(
+    taskName = "localCoverageReportShard1",
+    projects = localTestProjects,
+    testTaskName = "test",
+    testProjects = localTestShard1,
+)
+registerLayerCoverageReport(
+    taskName = "localCoverageReportShard2",
+    projects = localTestProjects,
+    testTaskName = "test",
+    testProjects = localTestShard2,
+)
 registerLayerCoverageReport("contractCoverageReport", localContractTestProjects, "contractTest")
 registerLayerCoverageReport("integrationCoverageReport", integrationTestProjects, "integrationTest")


### PR DESCRIPTION
## Purpose

Diagnostic-only PR to measure whether raw JaCoCo aggregation makes Local Test sharding both faster and coverage-equivalent.

**Do not merge.** This PR will be closed after collecting evidence; the measurement branch will remain available for audit.

## Experiment

- Run the 31 Local Test projects in two fixed test-only shards.
- Upload each shard's raw `test.exec` files and compiled main classes.
- Generate one detached JaCoCo XML in the final `Local Test` job and upload it once to Codecov.
- Run a same-SHA forced unsharded baseline and require exact semantic XML parity after removing JaCoCo session metadata.

## Acceptance gates

- Production-path wall time: `<= 420s`.
- Production runner time (shard 1 + shard 2 + final): `<= 664s`.
- Shard imbalance: `<= 15%`.
- Coverage: exact same-SHA semantic JaCoCo XML parity.

The baseline and parity jobs are diagnostic costs and are excluded from the proposed production-path timing.
