### PR TITLE
fix(schema): prioritize field descriptive metadata

### DIFF
--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/query/JsonSchemaDeclarationWalker.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/query/JsonSchemaDeclarationWalker.kt
@@ -90,7 +90,7 @@ private data class DescriptiveMetadataSource(
             label = "referenced-type",
         )
     } else {
-        DEEPER_METADATA_SOURCE
+        deeper()
     }
 
     fun composed(composition: String): DescriptiveMetadataSource = if (precedence == MEMBER_METADATA) {
@@ -99,13 +99,16 @@ private data class DescriptiveMetadataSource(
             label = "inline-$composition",
         )
     } else {
-        DEEPER_METADATA_SOURCE
+        deeper()
     }
+
+    private fun deeper(): DescriptiveMetadataSource = DescriptiveMetadataSource(
+        precedence = maxOf(DEEPER_COMPOSITION_METADATA, precedence + 1),
+        label = "deeper-composition",
+    )
 }
 
 private val MEMBER_METADATA_SOURCE = DescriptiveMetadataSource()
-private val DEEPER_METADATA_SOURCE =
-    DescriptiveMetadataSource(DEEPER_COMPOSITION_METADATA, "deeper-composition")
 
 private data class DescriptiveMetadataCandidate(
     val value: String,
@@ -228,7 +231,7 @@ internal class JsonSchemaWalker(
                 propertySchema.collectProperties(
                     fullName,
                     resolvingReferences,
-                    MEMBER_METADATA_SOURCE,
+                    source,
                 ),
             )
         }

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/query/JsonSchemaDeclarationWalker.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/query/JsonSchemaDeclarationWalker.kt
@@ -30,6 +30,7 @@ import me.ahoo.wow.query.schema.QuerySchemaDeclarationProperties.ENUM_VALUES
 import me.ahoo.wow.query.schema.QuerySchemaDeclarationProperties.SEMANTIC_TYPE
 import me.ahoo.wow.query.schema.QuerySchemaDeclarationProperties.TITLE
 import me.ahoo.wow.serialization.state.StateAggregateRecords
+import org.slf4j.LoggerFactory
 import tools.jackson.databind.JsonNode
 import java.util.concurrent.TimeUnit
 
@@ -72,6 +73,53 @@ private val ALTERNATIVE_COMPOSITIONS by lazy {
 private val COMPOSITIONS by lazy {
     listOf(JsonSchemaProperty.ALL_OF) + ALTERNATIVE_COMPOSITIONS
 }
+private val jsonSchemaWalkerLogger = LoggerFactory.getLogger(JsonSchemaWalker::class.java)
+
+private const val MEMBER_METADATA = 0
+private const val INLINE_METADATA = 1
+private const val REFERENCED_TYPE_METADATA = 2
+private const val DEEPER_COMPOSITION_METADATA = 3
+
+private data class DescriptiveMetadataSource(
+    val precedence: Int = MEMBER_METADATA,
+    val label: String = "member",
+) {
+    fun referenced(): DescriptiveMetadataSource = if (precedence <= INLINE_METADATA) {
+        DescriptiveMetadataSource(
+            precedence = REFERENCED_TYPE_METADATA,
+            label = "referenced-type",
+        )
+    } else {
+        DEEPER_METADATA_SOURCE
+    }
+
+    fun composed(composition: String): DescriptiveMetadataSource = if (precedence == MEMBER_METADATA) {
+        DescriptiveMetadataSource(
+            precedence = INLINE_METADATA,
+            label = "inline-$composition",
+        )
+    } else {
+        DEEPER_METADATA_SOURCE
+    }
+}
+
+private val MEMBER_METADATA_SOURCE = DescriptiveMetadataSource()
+private val DEEPER_METADATA_SOURCE =
+    DescriptiveMetadataSource(DEEPER_COMPOSITION_METADATA, "deeper-composition")
+
+private data class DescriptiveMetadataCandidate(
+    val value: String,
+    val localSource: DescriptiveMetadataSource,
+    val containerSource: DescriptiveMetadataSource,
+)
+
+private data class RankedDescriptiveMetadataCandidate(
+    val value: String,
+    val precedence: Int,
+    val label: String,
+)
+
+private data class SourcedJsonNode(val node: JsonNode, val source: DescriptiveMetadataSource)
 
 internal class JsonSchemaWalker(
     private val schema: JsonNode,
@@ -79,6 +127,8 @@ internal class JsonSchemaWalker(
     private val maskRuleResolver: (String) -> MaskRule,
 ) {
     private val fields = linkedMapOf<LogicalField, QueryFieldDeclaration>()
+    private val descriptiveMetadataCandidates =
+        mutableMapOf<Pair<LogicalField, String>, MutableList<DescriptiveMetadataCandidate>>()
 
     fun declaration(
         rootField: LogicalField = LogicalField(StateAggregateRecords.STATE),
@@ -86,31 +136,72 @@ internal class JsonSchemaWalker(
     ): QuerySchemaDeclaration {
         if (includeRoot) {
             val rootNodes = schema.effectiveNodes()
+            schema.collectDescriptiveMetadataCandidates(rootField, MEMBER_METADATA_SOURCE)
             fields[rootField] = QueryFieldDeclaration(
-                title = DeclarationValue.Set(
-                    rootNodes.consistentValue(rootField, TITLE) {
-                        it.textValueOrNull(JsonSchemaProperty.TITLE)
-                    },
-                ),
-                description = DeclarationValue.Set(
-                    rootNodes.consistentValue(rootField, DESCRIPTION) {
-                        it.textValueOrNull(JsonSchemaProperty.DESCRIPTION)
-                    },
-                ),
                 enumValues = DeclarationValue.Set(
                     rootNodes.consistentValue(rootField, ENUM_VALUES, JsonNode::enumValuesOrNull),
                 ),
                 dynamicChildren = DeclarationValue.Set(rootNodes.any(JsonNode::hasAdditionalProperties)),
             )
         }
-        fields.putAll(schema.collectProperties(rootField.value, setOf(ROOT_REFERENCE)))
-        return QuerySchemaDeclaration(fields)
+        fields.putAll(
+            schema.collectProperties(
+                parentName = rootField.value,
+                resolvingReferences = setOf(ROOT_REFERENCE),
+                source = MEMBER_METADATA_SOURCE,
+            ),
+        )
+        return QuerySchemaDeclaration(
+            fields.mapValuesTo(linkedMapOf()) { (field, declaration) ->
+                declaration.copy(
+                    title = DeclarationValue.Set(resolveDescriptiveMetadata(field, TITLE)),
+                    description = DeclarationValue.Set(resolveDescriptiveMetadata(field, DESCRIPTION)),
+                )
+            },
+        )
     }
 
     private fun JsonNode.collectProperties(
         parentName: String,
         resolvingReferences: Set<String>,
+        source: DescriptiveMetadataSource,
     ): Map<LogicalField, QueryFieldDeclaration> {
+        val collected = collectDirectProperties(parentName, resolvingReferences, source)
+        validateMaskedUnrepresentableDescendants(parentName, resolvingReferences)
+        reference()?.takeIf { it !in resolvingReferences }?.let { reference ->
+            rootSchema.at(reference.removePrefix(ROOT_REFERENCE))
+                .takeUnless(JsonNode::isMissingNode)
+                ?.collectProperties(parentName, resolvingReferences + reference, source.referenced())
+                ?.let(collected::mergeConjunctive)
+        }
+        get(JsonSchemaProperty.ALL_OF)?.forEach { branch ->
+            collected.mergeConjunctive(
+                branch.collectProperties(
+                    parentName,
+                    resolvingReferences,
+                    source.composed(JsonSchemaProperty.ALL_OF),
+                ),
+            )
+        }
+        ALTERNATIVE_COMPOSITIONS.forEach { composition ->
+            get(composition)?.asSequence()?.map { alternative ->
+                alternative.collectProperties(
+                    parentName,
+                    resolvingReferences,
+                    source.composed(composition),
+                )
+            }?.toList()?.mergeAlternatives()?.let(collected::mergeConjunctive)
+        }
+        get(JsonSchemaProperty.ITEMS)?.collectProperties(parentName, resolvingReferences, source)
+            ?.let(collected::mergeConjunctive)
+        return collected
+    }
+
+    private fun JsonNode.collectDirectProperties(
+        parentName: String,
+        resolvingReferences: Set<String>,
+        source: DescriptiveMetadataSource,
+    ): MutableMap<LogicalField, QueryFieldDeclaration> {
         val collected = linkedMapOf<LogicalField, QueryFieldDeclaration>()
         val parentRequired = get(JsonSchemaProperty.REQUIRED)?.asSequence()
             ?.filter(JsonNode::isString)
@@ -129,28 +220,18 @@ internal class JsonSchemaWalker(
                 return@forEach
             }
             val field = LogicalField(fullName)
+            propertySchema.collectDescriptiveMetadataCandidates(field, source)
             collected.mergeConjunctive(
                 mapOf(field to propertySchema.toDeclaration(field, propertyName in parentRequired)),
             )
-            collected.mergeConjunctive(propertySchema.collectProperties(fullName, resolvingReferences))
+            collected.mergeConjunctive(
+                propertySchema.collectProperties(
+                    fullName,
+                    resolvingReferences,
+                    MEMBER_METADATA_SOURCE,
+                ),
+            )
         }
-        validateMaskedUnrepresentableDescendants(parentName, resolvingReferences)
-        reference()?.takeIf { it !in resolvingReferences }?.let { reference ->
-            rootSchema.at(reference.removePrefix(ROOT_REFERENCE))
-                .takeUnless(JsonNode::isMissingNode)
-                ?.collectProperties(parentName, resolvingReferences + reference)
-                ?.let(collected::mergeConjunctive)
-        }
-        get(JsonSchemaProperty.ALL_OF)?.forEach { branch ->
-            collected.mergeConjunctive(branch.collectProperties(parentName, resolvingReferences))
-        }
-        ALTERNATIVE_COMPOSITIONS.forEach { composition ->
-            get(composition)?.asSequence()?.map { alternative ->
-                alternative.collectProperties(parentName, resolvingReferences)
-            }?.toList()?.mergeAlternatives()?.let(collected::mergeConjunctive)
-        }
-        get(JsonSchemaProperty.ITEMS)?.collectProperties(parentName, resolvingReferences)
-            ?.let(collected::mergeConjunctive)
         return collected
     }
 
@@ -186,14 +267,6 @@ internal class JsonSchemaWalker(
             Temporal.Epoch(TimeUnit.valueOf(unit))
         } ?: inferredTemporal
         return QueryFieldDeclaration(
-            title = DeclarationValue.Set(
-                nodes.consistentValue(field, TITLE) { it.textValueOrNull(JsonSchemaProperty.TITLE) },
-            ),
-            description = DeclarationValue.Set(
-                nodes.consistentValue(field, DESCRIPTION) {
-                    it.textValueOrNull(JsonSchemaProperty.DESCRIPTION)
-                },
-            ),
             enumValues = DeclarationValue.Set(
                 nodes.consistentValue(field, ENUM_VALUES, JsonNode::enumValuesOrNull),
             ),
@@ -207,6 +280,89 @@ internal class JsonSchemaWalker(
             dynamicChildren = DeclarationValue.Set(shapeNodes.any(JsonNode::hasAdditionalProperties)),
             maskRule = maskRuleId?.let { DeclarationValue.Set(maskRuleResolver(it)) } ?: DeclarationValue.Unset,
         )
+    }
+
+    private fun JsonNode.collectDescriptiveMetadataCandidates(
+        field: LogicalField,
+        containerSource: DescriptiveMetadataSource,
+    ) {
+        sourcedMetadataNodes().forEach { (node, localSource) ->
+            mapOf(
+                TITLE to node.textValueOrNull(JsonSchemaProperty.TITLE),
+                DESCRIPTION to node.textValueOrNull(JsonSchemaProperty.DESCRIPTION),
+            ).forEach { (property, value) ->
+                value?.let {
+                    descriptiveMetadataCandidates
+                        .getOrPut(field to property, ::mutableListOf)
+                        .add(DescriptiveMetadataCandidate(it, localSource, containerSource))
+                }
+            }
+        }
+    }
+
+    private fun JsonNode.sourcedMetadataNodes(
+        source: DescriptiveMetadataSource = MEMBER_METADATA_SOURCE,
+        resolvingReferences: Set<String> = emptySet(),
+    ): List<SourcedJsonNode> = buildList {
+        add(SourcedJsonNode(this@sourcedMetadataNodes, source))
+        reference()?.takeIf { it !in resolvingReferences }?.let { reference ->
+            rootSchema.at(reference.removePrefix(ROOT_REFERENCE))
+                .takeUnless(JsonNode::isMissingNode)
+                ?.let {
+                    addAll(it.sourcedMetadataNodes(source.referenced(), resolvingReferences + reference))
+                }
+        }
+        COMPOSITIONS.forEach { composition ->
+            get(composition)?.forEach { branch ->
+                addAll(branch.sourcedMetadataNodes(source.composed(composition), resolvingReferences))
+            }
+        }
+    }
+
+    private fun resolveDescriptiveMetadata(field: LogicalField, property: String): String? {
+        val candidates = descriptiveMetadataCandidates[field to property].orEmpty()
+        val containerBaseline = candidates.minOfOrNull { it.containerSource.precedence } ?: return null
+        val ranked = candidates.map { candidate ->
+            val containerPrecedence = candidate.containerSource.precedence
+                .takeUnless { it == containerBaseline } ?: MEMBER_METADATA
+            val effectiveSource = if (candidate.localSource.precedence >= containerPrecedence) {
+                candidate.localSource
+            } else {
+                candidate.containerSource
+            }
+            RankedDescriptiveMetadataCandidate(
+                value = candidate.value,
+                precedence = maxOf(candidate.localSource.precedence, containerPrecedence),
+                label = effectiveSource.label,
+            )
+        }
+            .sortedWith(
+                compareBy<RankedDescriptiveMetadataCandidate>(
+                    RankedDescriptiveMetadataCandidate::precedence,
+                    RankedDescriptiveMetadataCandidate::value,
+                    RankedDescriptiveMetadataCandidate::label,
+                ),
+            )
+        val selected = ranked.first()
+        val ignored = ranked.asSequence()
+            .filter { it.value != selected.value }
+            .distinctBy(RankedDescriptiveMetadataCandidate::value)
+            .toList()
+        if (ignored.isNotEmpty()) {
+            val hasSamePrecedence = ignored.any { it.precedence == selected.precedence }
+            val precedence = buildList {
+                add(selected.label + if (hasSamePrecedence) "(stable-value-order)" else "")
+                ignored.asSequence()
+                    .filter { it.precedence > selected.precedence }
+                    .mapTo(this, RankedDescriptiveMetadataCandidate::label)
+            }.distinct().joinToString(" > ")
+            jsonSchemaWalkerLogger.warn(
+                "Query schema descriptive metadata conflict: " +
+                    "field=$field, property=$property, selected=${selected.value}, " +
+                    "ignored=${ignored.map(RankedDescriptiveMetadataCandidate::value)}, precedence=$precedence",
+            )
+        }
+        return selected.value
     }
 
     private fun JsonNode.effectiveNodes(

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/query/JsonQuerySchemaFixtures.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/query/JsonQuerySchemaFixtures.kt
@@ -18,6 +18,8 @@ import com.fasterxml.jackson.annotation.JsonSubTypes
 import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonUnwrapped
 import io.swagger.v3.oas.annotations.media.Schema
+import me.ahoo.wow.api.annotation.Description
+import me.ahoo.wow.api.annotation.Summary
 import me.ahoo.wow.api.query.mask.CompiledMask
 import me.ahoo.wow.api.query.mask.FullMaskStrategy
 import me.ahoo.wow.api.query.mask.KeepMask
@@ -54,6 +56,26 @@ internal data class StructuralState(
 )
 
 internal enum class StructuralStatus { ACTIVE, INACTIVE }
+
+internal data class DescriptiveMetadataState(
+    @field:Schema(title = "Account status", description = "Account status description")
+    val status: ReferencedStatus,
+    @field:Schema(title = "Shared status", description = "Shared status description")
+    val equalStatus: EqualReferencedStatus,
+    val referencedStatus: ReferencedOnlyStatus,
+)
+
+@Summary("Bank account status enum")
+@Description("Bank account status enum description")
+internal enum class ReferencedStatus { OK, DISABLED }
+
+@Summary("Shared status")
+@Description("Shared status description")
+internal enum class EqualReferencedStatus { OK, DISABLED }
+
+@Summary("Referenced status")
+@Description("Referenced status description")
+internal enum class ReferencedOnlyStatus { OK, DISABLED }
 
 internal data class StructuralAddress(val city: String)
 

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/query/JsonQuerySchemaSourceTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/query/JsonQuerySchemaSourceTest.kt
@@ -438,9 +438,9 @@ class JsonQuerySchemaSourceTest {
                 selected = "Direct member title",
                 ignored = listOf(
                     "Nearest field title",
-                    "Deep referenced title",
                     "Deeper field composition title",
                     "Referenced composition title",
+                    "Deep referenced title",
                 ),
                 precedence = "member > inline-allOf > deeper-composition",
             )
@@ -501,6 +501,28 @@ class JsonQuerySchemaSourceTest {
                 precedence = "referenced-type > deeper-composition",
             )
         }
+    }
+
+    @Test
+    fun `should prefer the nearer declaration within deeper compositions`() {
+        assertTitleResolution(
+            schema = """{"properties":{"value":{"allOf":[{"allOf":[{"title":"Zulu nearer"}]},{"allOf":[{"allOf":[{"title":"Alpha farther"}]}]}]}}}""",
+            field = "state.value",
+            selected = "Zulu nearer",
+            ignored = listOf("Alpha farther"),
+            precedence = "deeper-composition",
+        )
+    }
+
+    @Test
+    fun `should preserve outer composition provenance for nested fields`() {
+        assertTitleResolution(
+            schema = """{"properties":{"container":{"type":"object","properties":{"name":{"type":"string","title":"Zulu member"}}}},"allOf":[{"properties":{"container":{"type":"object","properties":{"name":{"type":"string","title":"Alpha inline"}}}}}]}""",
+            field = "state.container.name",
+            selected = "Zulu member",
+            ignored = listOf("Alpha inline"),
+            precedence = "member > inline-allOf",
+        )
     }
 
     @Test

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/query/JsonQuerySchemaSourceTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/query/JsonQuerySchemaSourceTest.kt
@@ -13,6 +13,10 @@
 
 package me.ahoo.wow.schema.query
 
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import me.ahoo.test.asserts.assert
 import me.ahoo.test.asserts.assertThrownBy
 import me.ahoo.wow.api.query.LogicalField
@@ -47,6 +51,7 @@ import me.ahoo.wow.schema.query.maskfixture.privateMaskStrategyStateType
 import me.ahoo.wow.serialization.JsonSerializer
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.slf4j.LoggerFactory
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.core.scheduler.Schedulers
@@ -379,6 +384,164 @@ class JsonQuerySchemaSourceTest {
     }
 
     @Test
+    fun `should resolve generated descriptive metadata by source precedence`() {
+        val (declaration, warnings) = captureMetadataWarnings {
+            load(DescriptiveMetadataState::class.java)
+        }
+
+        declaration.field("state.status").let { status ->
+            status.title.assert().isEqualTo(DeclarationValue.Set("Account status"))
+            status.description.assert().isEqualTo(DeclarationValue.Set("Account status description"))
+            checkNotNull((status.enumValues as DeclarationValue.Set).value)
+                .map { it.stringValue() }
+                .assert().containsExactly("OK", "DISABLED")
+        }
+        declaration.field("state.equalStatus").let { status ->
+            status.title.assert().isEqualTo(DeclarationValue.Set("Shared status"))
+            status.description.assert().isEqualTo(DeclarationValue.Set("Shared status description"))
+        }
+        declaration.field("state.referencedStatus").let { status ->
+            status.title.assert().isEqualTo(DeclarationValue.Set("Referenced status"))
+            status.description.assert().isEqualTo(DeclarationValue.Set("Referenced status description"))
+        }
+        warnings.assert().hasSize(2)
+        warnings.first().assert()
+            .contains("field=state.status")
+            .contains("property=title")
+            .contains("selected=Account status")
+            .contains("ignored=[Bank account status enum]")
+            .contains("inline-allOf > referenced-type")
+        warnings.last().assert()
+            .contains("field=state.status")
+            .contains("property=description")
+            .contains("selected=Account status description")
+            .contains("ignored=[Bank account status enum description]")
+    }
+
+    @Test
+    fun `should deterministically prefer nearest metadata through nested refs and allOf`() {
+        val schema =
+            """
+            {"definitions":{
+              "BaseStatus":{"type":"string","enum":["OK","DISABLED"],"title":"Deep referenced title"},
+              "WrappedStatus":{"allOf":[{"${'$'}ref":"#/definitions/BaseStatus"},
+                {"title":"Referenced composition title"}]}},
+             "properties":{"status":{"title":"Direct member title","allOf":[
+               {"${'$'}ref":"#/definitions/WrappedStatus"},
+               {"allOf":[{"title":"Deeper field composition title"}]},{"title":"Nearest field title"}]}}}
+            """.trimIndent()
+
+        val inferences = (1..5).map {
+            assertTitleResolution(
+                schema = schema,
+                field = "state.status",
+                selected = "Direct member title",
+                ignored = listOf(
+                    "Nearest field title",
+                    "Deep referenced title",
+                    "Deeper field composition title",
+                    "Referenced composition title",
+                ),
+                precedence = "member > inline-allOf > deeper-composition",
+            )
+        }
+
+        inferences.forEach { (declaration) ->
+            checkNotNull((declaration.field("state.status").enumValues as DeclarationValue.Set).value)
+                .map { it.stringValue() }
+                .assert().containsExactly("OK", "DISABLED")
+        }
+        inferences.map { (_, warning) -> warning }.distinct().assert().hasSize(1)
+    }
+
+    @Test
+    fun `should preserve direct member precedence across outer compositions and refs`() {
+        mapOf(
+            "inline-allOf" to
+                """{"properties":{"value":{"type":"string","title":"Alpha inline"}}}""",
+            "referenced-type" to
+                """{"${'$'}ref":"#/definitions/Inherited"}""",
+        ).forEach { (ignoredSource, branch) ->
+            val schema =
+                """
+                {"definitions":{"Inherited":{"properties":{"value":{"type":"string","title":"Alpha referenced"}}}},
+                 "properties":{"value":{"type":"string","title":"Zulu member"}},"allOf":[$branch]}
+                """.trimIndent()
+
+            assertTitleResolution(
+                schema = schema,
+                field = "state.value",
+                selected = "Zulu member",
+                ignored = listOf(if (ignoredSource == "inline-allOf") "Alpha inline" else "Alpha referenced"),
+                precedence = "member > $ignoredSource",
+            )
+        }
+    }
+
+    @Test
+    fun `should prefer referenced type metadata over deeper compositions`() {
+        listOf(
+            """
+            {"definitions":{"Status":{"type":"string","title":"Zulu referenced title",
+             "allOf":[{"title":"Alpha deeper title"}]}},
+             "properties":{"status":{"${'$'}ref":"#/definitions/Status"}}}
+            """.trimIndent() to "state.status",
+            """
+            {"definitions":{"Value":{"type":"string","title":"Zulu referenced title"},
+             "State":{"properties":{"value":{"${'$'}ref":"#/definitions/Value"}},
+             "allOf":[{"properties":{"value":{"allOf":[{"title":"Alpha deeper title"}]}}}]}},
+             "${'$'}ref":"#/definitions/State"}
+            """.trimIndent() to "state.value",
+        ).forEach { (schema, field) ->
+            assertTitleResolution(
+                schema = schema,
+                field = field,
+                selected = "Zulu referenced title",
+                ignored = listOf("Alpha deeper title"),
+                precedence = "referenced-type > deeper-composition",
+            )
+        }
+    }
+
+    @Test
+    fun `should emit one canonical warning for all same precedence values independent of order`() {
+        val cases = listOf(
+            Triple(listOf("Charlie", "Bravo", "Alpha"), "Alpha", listOf("Bravo", "Charlie")),
+            Triple(listOf("Alpha", "Bravo", "Charlie"), "Alpha", listOf("Bravo", "Charlie")),
+            Triple(listOf("First", "Second", "Second"), "First", listOf("Second")),
+        )
+        val warnings = cases.map { (values, selected, ignored) ->
+            val branches = values.joinToString(",") { value ->
+                """{"properties":{"value":{"type":"string","title":"$value"}}}"""
+            }
+            assertTitleResolution(
+                schema = """{"oneOf":[$branches]}""",
+                field = "state.value",
+                selected = selected,
+                ignored = ignored,
+                precedence = "stable-value-order",
+            ).second
+        }
+        warnings.take(2).distinct().assert().hasSize(1)
+    }
+
+    @Test
+    fun `should keep structural and security metadata conflicts fail closed`() {
+        mapOf(
+            "enumValues" to
+                """{"properties":{"value":{"allOf":[{"type":"string","enum":["A"]},{"type":"string","enum":["B"]}]}}}""",
+            "maskRule" to
+                """{"properties":{"value":{"allOf":[{"type":"string","$MASK_RULE_ATTRIBUTE":"0"},{"type":"string","$MASK_RULE_ATTRIBUTE":"1"}]}}}""",
+            "semanticType" to
+                """{"properties":{"value":{"allOf":[{"type":"integer","$TEMPORAL_UNIT":"SECONDS"},{"type":"integer","$TEMPORAL_UNIT":"MILLISECONDS"}]}}}""",
+        ).forEach { (property, schema) ->
+            assertThrows<QuerySchemaConflictException> {
+                loadSchema(schema)
+            }.message.assert().contains("state.value.$property")
+        }
+    }
+
+    @Test
     fun `should reject masked illegal logical property names`() {
         val error = assertThrows<QuerySchemaConflictException> {
             load(MaskedInvalidLogicalFieldState::class.java)
@@ -503,17 +666,43 @@ class JsonQuerySchemaSourceTest {
     }
 
     @Test
-    fun `should reject conflicting composition metadata`() {
-        assertThrows<QuerySchemaConflictException> {
+    fun `should deterministically select conflicting composition metadata`() {
+        val (declaration, warnings) = captureMetadataWarnings {
             load(ConflictingCompositionState::class.java)
         }
+
+        declaration.field("state.union.value").title.assert()
+            .isEqualTo(DeclarationValue.Set("First"))
+        warnings.assert().hasSize(1)
+        warnings.single().assert()
+            .contains("field=state.union.value")
+            .contains("property=title")
+            .contains("selected=First")
+            .contains("ignored=[Second]")
+            .contains("member(stable-value-order)")
     }
 
     @Test
-    fun `should reject conflicting container metadata independent of branch order`() {
-        listOf(ForwardMetadataState::class.java, ReverseMetadataState::class.java).forEach { type ->
-            assertThrows<QuerySchemaConflictException> { load(type) }
+    fun `should select conflicting container metadata independent of branch order`() {
+        val inferences = listOf(ForwardMetadataState::class.java, ReverseMetadataState::class.java).map { type ->
+            captureMetadataWarnings { load(type) }
         }
+
+        inferences.forEach { (declaration, warnings) ->
+            declaration.field("state.value").let { value ->
+                value.title.assert().isEqualTo(DeclarationValue.Set("First title"))
+                value.description.assert().isEqualTo(DeclarationValue.Set("First description"))
+            }
+            warnings.assert().hasSize(2)
+            warnings.first().assert()
+                .contains("selected=First title")
+                .contains("ignored=[Second title]")
+                .contains("stable-value-order")
+            warnings.last().assert()
+                .contains("selected=First description")
+                .contains("ignored=[Second description]")
+        }
+        inferences.map { (_, warnings) -> warnings }.distinct().assert().hasSize(1)
     }
 
     @Test
@@ -832,6 +1021,48 @@ class JsonQuerySchemaSourceTest {
     }
 
     private fun load(type: Class<*>): QuerySchemaDeclaration = loadPublisher(type).single().block()!!
+
+    private fun loadSchema(schema: String): QuerySchemaDeclaration = JsonSchemaWalker(
+        schema = JsonSerializer.readTree(schema),
+        maskRuleResolver = { fullMaskRule() },
+    ).declaration()
+
+    private fun assertTitleResolution(
+        schema: String,
+        field: String,
+        selected: String,
+        ignored: List<String>,
+        precedence: String,
+    ): Pair<QuerySchemaDeclaration, String> {
+        val (declaration, warnings) = captureMetadataWarnings { loadSchema(schema) }
+        declaration.field(field).title.assert().isEqualTo(DeclarationValue.Set(selected))
+        warnings.assert().hasSize(1)
+        return declaration to warnings.single().also { warning ->
+            warning.assert()
+                .contains("field=$field")
+                .contains("property=title")
+                .contains("selected=$selected")
+                .contains("ignored=$ignored")
+                .contains(precedence)
+        }
+    }
+
+    private fun <T> captureMetadataWarnings(block: () -> T): Pair<T, List<String>> {
+        val logger = LoggerFactory.getLogger(JsonSchemaWalker::class.java) as Logger
+        val appender = ListAppender<ILoggingEvent>().apply {
+            context = logger.loggerContext
+            start()
+        }
+        logger.addAppender(appender)
+        return try {
+            block() to appender.list
+                .filter { it.level == Level.WARN }
+                .map { it.formattedMessage }
+        } finally {
+            logger.detachAppender(appender)
+            appender.stop()
+        }
+    }
 
     private fun loadPublisher(type: Class<*>): Flux<QuerySchemaDeclaration> =
         JsonQuerySchemaSource(typeResolver = { type }).load(context)


### PR DESCRIPTION
## Goal

Prevent Wow 9 query Schema inference from failing application startup when a field-level title or description differs from metadata declared on its referenced type.

Completion criteria:
- choose the descriptive declaration nearest to the query field;
- emit one deterministic WARN for title or description conflicts;
- retain referenced enum values;
- keep structural, semantic, mask, and cross-QuerySchemaSource conflicts fail closed.

## Changes

- Preserve member, inline composition, referenced type, and deeper composition provenance while walking one JSON Schema.
- Resolve title and description after structural traversal with deterministic precedence and stable tie-breaking.
- Emit one canonical WARN containing field, property, selected value, ignored values, and precedence.
- Keep the strict consistentValue path unchanged for enum values, mask rules, and temporal units.
- Consolidate real JsonQuerySchemaSource and JsonSchemaWalker regression coverage for generated schemas, nested refs/allOf, warning deduplication, determinism, and strict conflicts.

## Verification

- ./gradlew :wow-schema:test — passed, 241 tests and 0 failures.
- ./gradlew :wow-schema:detekt — passed.
- ./gradlew build — passed, 337 tasks.
- git diff --check — passed.

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

No storage structure, HTTP query protocol, FilterExpression contract, generated schema contract, or public API changes. The only runtime behavior change is that title and description conflicts within one JSON Schema are logged and resolved; security and query-semantic conflicts still throw QuerySchemaConflictException. Rollback is a single commit revert.
