### PR TITLE
fix(command): avoid command gateway self-reference

### DIFF
--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandGatewayAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandGatewayAutoConfiguration.kt
@@ -164,9 +164,6 @@ class CommandGatewayAutoConfiguration {
             }
             throw IllegalStateException(MISSING_COMMAND_BUS_MESSAGE)
         }
-        check(backingCommandBus !is CommandGateway) {
-            MISSING_COMMAND_BUS_MESSAGE
-        }
         return commandGateway(
             commandWaitEndpoint = commandWaitEndpoint,
             commandBus = backingCommandBus,

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandGatewayAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandGatewayAutoConfiguration.kt
@@ -40,7 +40,11 @@ import me.ahoo.wow.infra.idempotency.DefaultAggregateIdempotencyCheckerProvider
 import me.ahoo.wow.infra.idempotency.NoOpIdempotencyChecker
 import me.ahoo.wow.spring.boot.starter.ConditionalOnWowEnabled
 import me.ahoo.wow.spring.boot.starter.ENABLED_SUFFIX_KEY
+import org.springframework.beans.factory.BeanFactoryUtils
+import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.beans.factory.ObjectProvider
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.beans.factory.support.AbstractBeanDefinition
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass
@@ -48,7 +52,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
 
-@AutoConfiguration
+@AutoConfiguration(after = [CommandAutoConfiguration::class])
 @ConditionalOnWowEnabled
 class CommandGatewayAutoConfiguration {
 
@@ -141,9 +145,33 @@ class CommandGatewayAutoConfiguration {
     }
 
     @Suppress("LongParameterList")
-    @Bean
+    @Bean("commandGateway")
     @Primary
     @ConditionalOnMissingBean
+    fun commandGatewayBean(
+        commandWaitEndpoint: CommandWaitEndpoint,
+        commandBus: ObjectProvider<CommandBus>,
+        beanFactory: ConfigurableListableBeanFactory,
+        validator: Validator,
+        requestIdChecker: RequestIdChecker,
+        waitCoordinator: WaitCoordinator,
+        commandWaitNotifier: CommandWaitNotifier,
+    ): CommandGateway {
+        check(beanFactory.hasBackingCommandBus()) {
+            "A backing CommandBus is required to create CommandGateway."
+        }
+        return commandGateway(
+            commandWaitEndpoint = commandWaitEndpoint,
+            commandBus = commandBus.getObject(),
+            validator = validator,
+            requestIdChecker = requestIdChecker,
+            waitCoordinator = waitCoordinator,
+            commandWaitNotifier = commandWaitNotifier,
+        )
+    }
+
+    /** Retains the direct factory signature for source and binary compatibility. */
+    @Suppress("LongParameterList")
     fun commandGateway(
         commandWaitEndpoint: CommandWaitEndpoint,
         commandBus: CommandBus,
@@ -160,5 +188,24 @@ class CommandGatewayAutoConfiguration {
             waitCoordinator = waitCoordinator,
             commandWaitNotifier = commandWaitNotifier,
         )
+    }
+
+    private fun ConfigurableListableBeanFactory.hasBackingCommandBus(): Boolean {
+        return BeanFactoryUtils
+            .beanNamesForTypeIncludingAncestors(this, CommandBus::class.java, true, false)
+            .asSequence()
+            .filter { beanName -> isDefaultAutowireCandidate(beanName) }
+            .mapNotNull { beanName -> getType(beanName, false) }
+            .any { beanType -> !CommandGateway::class.java.isAssignableFrom(beanType) }
+    }
+
+    private fun ConfigurableListableBeanFactory.isDefaultAutowireCandidate(beanName: String): Boolean {
+        val beanDefinition = try {
+            getMergedBeanDefinition(beanName)
+        } catch (_: NoSuchBeanDefinitionException) {
+            return true
+        }
+        return beanDefinition.isAutowireCandidate &&
+            (beanDefinition !is AbstractBeanDefinition || beanDefinition.isDefaultCandidate)
     }
 }

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandGatewayAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandGatewayAutoConfiguration.kt
@@ -40,17 +40,17 @@ import me.ahoo.wow.infra.idempotency.DefaultAggregateIdempotencyCheckerProvider
 import me.ahoo.wow.infra.idempotency.NoOpIdempotencyChecker
 import me.ahoo.wow.spring.boot.starter.ConditionalOnWowEnabled
 import me.ahoo.wow.spring.boot.starter.ENABLED_SUFFIX_KEY
-import org.springframework.beans.factory.BeanFactoryUtils
-import org.springframework.beans.factory.NoSuchBeanDefinitionException
+import org.springframework.beans.factory.BeanCurrentlyInCreationException
 import org.springframework.beans.factory.ObjectProvider
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
-import org.springframework.beans.factory.support.AbstractBeanDefinition
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
+
+private const val COMMAND_GATEWAY_BEAN_NAME = "commandGateway"
+private const val MISSING_COMMAND_BUS_MESSAGE = "A backing CommandBus is required to create CommandGateway."
 
 @AutoConfiguration(after = [CommandAutoConfiguration::class])
 @ConditionalOnWowEnabled
@@ -145,24 +145,31 @@ class CommandGatewayAutoConfiguration {
     }
 
     @Suppress("LongParameterList")
-    @Bean("commandGateway")
+    @Bean(COMMAND_GATEWAY_BEAN_NAME)
     @Primary
     @ConditionalOnMissingBean
     fun commandGatewayBean(
         commandWaitEndpoint: CommandWaitEndpoint,
         commandBus: ObjectProvider<CommandBus>,
-        beanFactory: ConfigurableListableBeanFactory,
         validator: Validator,
         requestIdChecker: RequestIdChecker,
         waitCoordinator: WaitCoordinator,
         commandWaitNotifier: CommandWaitNotifier,
     ): CommandGateway {
-        check(beanFactory.hasBackingCommandBus()) {
-            "A backing CommandBus is required to create CommandGateway."
+        val backingCommandBus = try {
+            commandBus.getObject()
+        } catch (error: BeanCurrentlyInCreationException) {
+            if (error.beanName != COMMAND_GATEWAY_BEAN_NAME) {
+                throw error
+            }
+            throw IllegalStateException(MISSING_COMMAND_BUS_MESSAGE)
+        }
+        check(backingCommandBus !is CommandGateway) {
+            MISSING_COMMAND_BUS_MESSAGE
         }
         return commandGateway(
             commandWaitEndpoint = commandWaitEndpoint,
-            commandBus = commandBus.getObject(),
+            commandBus = backingCommandBus,
             validator = validator,
             requestIdChecker = requestIdChecker,
             waitCoordinator = waitCoordinator,
@@ -188,24 +195,5 @@ class CommandGatewayAutoConfiguration {
             waitCoordinator = waitCoordinator,
             commandWaitNotifier = commandWaitNotifier,
         )
-    }
-
-    private fun ConfigurableListableBeanFactory.hasBackingCommandBus(): Boolean {
-        return BeanFactoryUtils
-            .beanNamesForTypeIncludingAncestors(this, CommandBus::class.java, true, false)
-            .asSequence()
-            .filter { beanName -> isDefaultAutowireCandidate(beanName) }
-            .mapNotNull { beanName -> getType(beanName, false) }
-            .any { beanType -> !CommandGateway::class.java.isAssignableFrom(beanType) }
-    }
-
-    private fun ConfigurableListableBeanFactory.isDefaultAutowireCandidate(beanName: String): Boolean {
-        val beanDefinition = try {
-            getMergedBeanDefinition(beanName)
-        } catch (_: NoSuchBeanDefinitionException) {
-            return true
-        }
-        return beanDefinition.isAutowireCandidate &&
-            (beanDefinition !is AbstractBeanDefinition || beanDefinition.isDefaultCandidate)
     }
 }

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandGatewayAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandGatewayAutoConfigurationTest.kt
@@ -1,6 +1,7 @@
 package me.ahoo.wow.spring.boot.starter.command
 
 import io.mockk.mockk
+import io.mockk.verify
 import jakarta.validation.Validator
 import me.ahoo.cosid.machine.HostAddressSupplier
 import me.ahoo.cosid.machine.LocalHostAddressSupplier
@@ -207,12 +208,14 @@ class CommandGatewayAutoConfigurationTest {
 
     @Test
     fun `should select command bus by original parameter name`() {
+        val commandBus = mockk<CommandBus>(relaxed = true)
+        val otherCommandBus = mockk<CommandBus>(relaxed = true)
         contextRunner
             .enableWow()
             .withBean(CommandWaitNotifier::class.java, { mockk<CommandWaitNotifier>() })
             .withBean(HostAddressSupplier::class.java, { LocalHostAddressSupplier.INSTANCE })
-            .withBean("commandBus", CommandBus::class.java, { InMemoryCommandBus() })
-            .withBean("otherCommandBus", CommandBus::class.java, { InMemoryCommandBus() })
+            .withBean("commandBus", CommandBus::class.java, { commandBus })
+            .withBean("otherCommandBus", CommandBus::class.java, { otherCommandBus })
             .withUserConfiguration(
                 CommandAutoConfiguration::class.java,
                 CommandGatewayAutoConfiguration::class.java,
@@ -221,6 +224,9 @@ class CommandGatewayAutoConfigurationTest {
                 context.assert()
                     .hasNotFailed()
                     .hasSingleBean(CommandGateway::class.java)
+                context.getBean(CommandGateway::class.java).close()
+                verify(exactly = 1) { commandBus.close() }
+                verify(exactly = 0) { otherCommandBus.close() }
             }
     }
 

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandGatewayAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandGatewayAutoConfigurationTest.kt
@@ -180,6 +180,24 @@ class CommandGatewayAutoConfigurationTest {
     }
 
     @Test
+    fun `should accept a command gateway declared as command bus`() {
+        val backingGateway = mockk<CommandGateway>(relaxed = true)
+        contextRunner
+            .enableWow()
+            .withBean(CommandWaitNotifier::class.java, { mockk<CommandWaitNotifier>() })
+            .withBean(HostAddressSupplier::class.java, { LocalHostAddressSupplier.INSTANCE })
+            .withBean("commandBus", CommandBus::class.java, { backingGateway })
+            .withUserConfiguration(
+                CommandAutoConfiguration::class.java,
+                CommandGatewayAutoConfiguration::class.java,
+            ).run { context: AssertableApplicationContext ->
+                context.assert().hasNotFailed()
+                context.getBean("commandGateway", CommandGateway::class.java).close()
+                verify(exactly = 1) { backingGateway.close() }
+            }
+    }
+
+    @Test
     fun `should create prototype backing command bus only once`() {
         val creationCount = AtomicInteger()
         contextRunner

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandGatewayAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandGatewayAutoConfigurationTest.kt
@@ -161,6 +161,24 @@ class CommandGatewayAutoConfigurationTest {
     }
 
     @Test
+    fun `should create command gateway with resolvable command bus dependency`() {
+        contextRunner
+            .enableWow()
+            .withBean(CommandWaitNotifier::class.java, { mockk<CommandWaitNotifier>() })
+            .withBean(HostAddressSupplier::class.java, { LocalHostAddressSupplier.INSTANCE })
+            .withInitializer { context ->
+                context.beanFactory.registerResolvableDependency(CommandBus::class.java, InMemoryCommandBus())
+            }.withUserConfiguration(
+                CommandAutoConfiguration::class.java,
+                CommandGatewayAutoConfiguration::class.java,
+            ).run { context: AssertableApplicationContext ->
+                context.assert()
+                    .hasNotFailed()
+                    .hasSingleBean(CommandGateway::class.java)
+            }
+    }
+
+    @Test
     fun `should create prototype backing command bus only once`() {
         val creationCount = AtomicInteger()
         contextRunner

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandGatewayAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/command/CommandGatewayAutoConfigurationTest.kt
@@ -1,13 +1,18 @@
 package me.ahoo.wow.spring.boot.starter.command
 
 import io.mockk.mockk
+import jakarta.validation.Validator
 import me.ahoo.cosid.machine.HostAddressSupplier
 import me.ahoo.cosid.machine.LocalHostAddressSupplier
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.command.CommandBus
 import me.ahoo.wow.command.CommandGateway
+import me.ahoo.wow.command.InMemoryCommandBus
 import me.ahoo.wow.command.RequestIdChecker
+import me.ahoo.wow.command.wait.CommandWaitEndpoint
 import me.ahoo.wow.command.wait.CommandWaitNotifier
 import me.ahoo.wow.command.wait.LocalCommandWaitNotifier
+import me.ahoo.wow.command.wait.WaitCoordinator
 import me.ahoo.wow.eventsourcing.RequestIdExistenceChecker
 import me.ahoo.wow.id.GlobalIdGenerator
 import me.ahoo.wow.infra.idempotency.AggregateIdempotencyCheckerProvider
@@ -16,17 +21,190 @@ import me.ahoo.wow.infra.idempotency.IdempotencyChecker
 import me.ahoo.wow.modeling.aggregateId
 import me.ahoo.wow.spring.boot.starter.BusType
 import me.ahoo.wow.spring.boot.starter.enableWow
+import me.ahoo.wow.spring.boot.starter.kafka.KafkaAutoConfiguration
+import me.ahoo.wow.spring.boot.starter.kafka.KafkaProperties
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.config.ConfigurableBeanFactory
+import org.springframework.beans.factory.support.AbstractBeanDefinition
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.test.context.FilteredClassLoader
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext
 import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
 import reactor.core.publisher.Mono
 import reactor.test.StepVerifier
 import java.util.concurrent.atomic.AtomicInteger
 
 class CommandGatewayAutoConfigurationTest {
     private val contextRunner = ApplicationContextRunner()
+
+    @Test
+    fun `should retain direct command bus factory method`() {
+        val directFactoryMethod = CommandGatewayAutoConfiguration::class.java.methods.singleOrNull { method ->
+            method.name == "commandGateway" &&
+                method.parameterTypes.contentEquals(
+                    arrayOf(
+                        CommandWaitEndpoint::class.java,
+                        CommandBus::class.java,
+                        Validator::class.java,
+                        RequestIdChecker::class.java,
+                        WaitCoordinator::class.java,
+                        CommandWaitNotifier::class.java,
+                    ),
+                )
+        }
+
+        directFactoryMethod.assert().isNotNull()
+        directFactoryMethod!!.returnType.assert().isEqualTo(CommandGateway::class.java)
+    }
+
+    @Test
+    fun `should fail without self reference when no command bus is available`() {
+        contextRunner
+            .enableWow()
+            .withBean(CommandWaitNotifier::class.java, { mockk<CommandWaitNotifier>() })
+            .withBean(HostAddressSupplier::class.java, { LocalHostAddressSupplier.INSTANCE })
+            .withPropertyValues(
+                "${CommandProperties.BUS_TYPE}=${BusType.KAFKA_NAME}",
+                "${KafkaProperties.PREFIX}.enabled=false",
+            ).withConfiguration(
+                AutoConfigurations.of(
+                    KafkaAutoConfiguration::class.java,
+                    CommandAutoConfiguration::class.java,
+                    CommandGatewayAutoConfiguration::class.java,
+                ),
+            ).run { context: AssertableApplicationContext ->
+                context.startupFailure.assert().isNotNull()
+                generateSequence(context.startupFailure) { error -> error.cause }
+                    .mapNotNull { error -> error.message }
+                    .joinToString("\n")
+                    .assert()
+                    .contains("A backing CommandBus is required to create CommandGateway.")
+                    .doesNotContain("currently in creation")
+            }
+    }
+
+    @Test
+    fun `should fail without self reference when command bus is not an autowire candidate`() {
+        contextRunner
+            .enableWow()
+            .withBean(CommandWaitNotifier::class.java, { mockk<CommandWaitNotifier>() })
+            .withBean(HostAddressSupplier::class.java, { LocalHostAddressSupplier.INSTANCE })
+            .withBean(
+                "commandBus",
+                CommandBus::class.java,
+                { InMemoryCommandBus() },
+                { beanDefinition -> beanDefinition.isAutowireCandidate = false },
+            ).withUserConfiguration(
+                CommandAutoConfiguration::class.java,
+                CommandGatewayAutoConfiguration::class.java,
+            ).run { context: AssertableApplicationContext ->
+                context.startupFailure.assert().isNotNull()
+                generateSequence(context.startupFailure) { error -> error.cause }
+                    .mapNotNull { error -> error.message }
+                    .joinToString("\n")
+                    .assert()
+                    .contains("A backing CommandBus is required to create CommandGateway.")
+                    .doesNotContain("currently in creation")
+            }
+    }
+
+    @Test
+    fun `should fail without self reference when command bus is not a default candidate`() {
+        contextRunner
+            .enableWow()
+            .withBean(CommandWaitNotifier::class.java, { mockk<CommandWaitNotifier>() })
+            .withBean(HostAddressSupplier::class.java, { LocalHostAddressSupplier.INSTANCE })
+            .withBean(
+                "commandBus",
+                CommandBus::class.java,
+                { InMemoryCommandBus() },
+                { beanDefinition ->
+                    (beanDefinition as AbstractBeanDefinition).isDefaultCandidate = false
+                },
+            ).withUserConfiguration(
+                CommandAutoConfiguration::class.java,
+                CommandGatewayAutoConfiguration::class.java,
+            ).run { context: AssertableApplicationContext ->
+                context.startupFailure.assert().isNotNull()
+                generateSequence(context.startupFailure) { error -> error.cause }
+                    .mapNotNull { error -> error.message }
+                    .joinToString("\n")
+                    .assert()
+                    .contains("A backing CommandBus is required to create CommandGateway.")
+                    .doesNotContain("currently in creation")
+            }
+    }
+
+    @Test
+    fun `should create primary command gateway for command bus from later auto configuration`() {
+        contextRunner
+            .enableWow()
+            .withBean(CommandWaitNotifier::class.java, { mockk<CommandWaitNotifier>() })
+            .withBean(HostAddressSupplier::class.java, { LocalHostAddressSupplier.INSTANCE })
+            .withConfiguration(
+                AutoConfigurations.of(
+                    CommandAutoConfiguration::class.java,
+                    CommandGatewayAutoConfiguration::class.java,
+                    LateCommandBusAutoConfiguration::class.java,
+                ),
+            ).run { context: AssertableApplicationContext ->
+                context.assert()
+                    .hasNotFailed()
+                    .hasSingleBean(CommandGateway::class.java)
+                context.getBean(CommandBus::class.java)
+                    .assert()
+                    .isInstanceOf(CommandGateway::class.java)
+            }
+    }
+
+    @Test
+    fun `should create prototype backing command bus only once`() {
+        val creationCount = AtomicInteger()
+        contextRunner
+            .enableWow()
+            .withBean(CommandWaitNotifier::class.java, { mockk<CommandWaitNotifier>() })
+            .withBean(HostAddressSupplier::class.java, { LocalHostAddressSupplier.INSTANCE })
+            .withBean(
+                "commandBus",
+                CommandBus::class.java,
+                {
+                    creationCount.incrementAndGet()
+                    InMemoryCommandBus()
+                },
+                { beanDefinition -> beanDefinition.scope = ConfigurableBeanFactory.SCOPE_PROTOTYPE },
+            ).withUserConfiguration(
+                CommandAutoConfiguration::class.java,
+                CommandGatewayAutoConfiguration::class.java,
+            )
+            .run { context: AssertableApplicationContext ->
+                context.assert()
+                    .hasNotFailed()
+                    .hasSingleBean(CommandGateway::class.java)
+                creationCount.get().assert().isEqualTo(1)
+            }
+    }
+
+    @Test
+    fun `should select command bus by original parameter name`() {
+        contextRunner
+            .enableWow()
+            .withBean(CommandWaitNotifier::class.java, { mockk<CommandWaitNotifier>() })
+            .withBean(HostAddressSupplier::class.java, { LocalHostAddressSupplier.INSTANCE })
+            .withBean("commandBus", CommandBus::class.java, { InMemoryCommandBus() })
+            .withBean("otherCommandBus", CommandBus::class.java, { InMemoryCommandBus() })
+            .withUserConfiguration(
+                CommandAutoConfiguration::class.java,
+                CommandGatewayAutoConfiguration::class.java,
+            )
+            .run { context: AssertableApplicationContext ->
+                context.assert()
+                    .hasNotFailed()
+                    .hasSingleBean(CommandGateway::class.java)
+            }
+    }
 
     @Test
     fun `should load context with command gateway and idempotency checker`() {
@@ -124,4 +302,10 @@ class CommandGatewayAutoConfigurationTest {
                 existenceChecks.get().assert().isEqualTo(1)
             }
     }
+}
+
+@AutoConfiguration(after = [CommandGatewayAutoConfiguration::class])
+internal class LateCommandBusAutoConfiguration {
+    @Bean
+    fun lateCommandBus(): CommandBus = InMemoryCommandBus()
 }


### PR DESCRIPTION
## Summary

- prevent CommandGateway from resolving itself as the backing CommandBus when Kafka is disabled
- fail with an explicit missing backing CommandBus error instead of a circular dependency
- preserve the existing direct factory signature and support late, named, primary, and prototype bus candidates

## Testing

- ./gradlew test
- ./gradlew :wow-spring-boot-starter:check
- verified Kafka-disabled plus Kafka bus configuration fails explicitly without a self-reference
- verified Kafka-disabled plus in-memory buses starts example-server successfully