### PR TITLE
perf(webflux): increase batch execution defaults

### DIFF
--- a/documentation/docs/en/guide/extensions/webflux.md
+++ b/documentation/docs/en/guide/extensions/webflux.md
@@ -49,8 +49,8 @@ wow:
     global-error:
       enabled: true
     batch:
-      concurrency: 1
-      prefetch: 1
+      concurrency: 128
+      prefetch: 4
     query:
       max-list-size: 1000
       max-page-size: 100
@@ -60,6 +60,8 @@ wow:
       allow-expensive-operators: true
       idle-timeout: 10s
 ```
+
+Batch concurrency applies per request and is shared by snapshot rebuild and StateEvent resend. Concurrent requests multiply downstream load; lower it to match application and storage capacity.
 
 `0` disables each numeric HTTP guard; `idle-timeout=0s` disables idle timeout. Do not duplicate backend field-type, mapping, or uniqueness checks. `HttpQueryGuardFilter` protects HTTP queries with WebFlux request context; programmatic `QueryGateway` calls retain their public behavior.
 

--- a/documentation/docs/en/reference/config/infrastructure.md
+++ b/documentation/docs/en/reference/config/infrastructure.md
@@ -147,8 +147,8 @@ Configuration class: `WebFluxProperties`; required capability: `webflux-support`
 | --- | --- | --- | --- |
 | `wow.webflux.enabled` | Boolean | `true` | Enables built-in Wow HTTP route wiring |
 | `wow.webflux.global-error.enabled` | Boolean | `true` | Registers Wow's global `WebExceptionHandler` |
-| `wow.webflux.batch.concurrency` | Int | `1` | Concurrency for batch operation/command tasks |
-| `wow.webflux.batch.prefetch` | Int | `1` | Batch-task prefetch |
+| `wow.webflux.batch.concurrency` | Int | `128` | Concurrency for batch snapshot regeneration and StateEvent resend tasks |
+| `wow.webflux.batch.prefetch` | Int | `4` | Batch-task prefetch |
 | `wow.webflux.query.max-list-size` | Int | `1000` | List/aggregation limit; `0` removes the cap and permits limit `0` |
 | `wow.webflux.query.max-page-size` | Int | `100` | Page-size cap; `0` disables it |
 | `wow.webflux.query.max-page-window` | Long | `10000` | `page.index * page.size` cap; `0` disables it |
@@ -160,5 +160,7 @@ Configuration class: `WebFluxProperties`; required capability: `webflux-support`
 | `wow.webflux.command.request.appender.ip.enabled` | Boolean | `true` | Adds the resolved remote IP to command context |
 
 All numeric query caps must be non-negative. Ordinary page size must still be at least `1`, and page offset cannot exceed `Int.MAX_VALUE`. `allow-expensive-operators=true` is the compatibility default, not capacity evidence. Test existing requests and the upgrade path before tightening it.
+
+Batch concurrency applies per request and is shared by snapshot rebuild and StateEvent resend. Concurrent requests multiply downstream load; lower it to match application and storage capacity.
 
 `webflux-support` wires built-in command, event, snapshot-query, rebuild, and compensation routes. It does not provide business authentication, authorization, or management-plane isolation. Read actual paths from the runtime OpenAPI and protect modifying operation routes with authorization, audit, rate limits, and a controlled network entry point.

--- a/documentation/docs/zh/guide/extensions/webflux.md
+++ b/documentation/docs/zh/guide/extensions/webflux.md
@@ -49,8 +49,8 @@ wow:
     global-error:
       enabled: true
     batch:
-      concurrency: 1
-      prefetch: 1
+      concurrency: 128
+      prefetch: 4
     query:
       max-list-size: 1000
       max-page-size: 100
@@ -60,6 +60,8 @@ wow:
       allow-expensive-operators: true
       idle-timeout: 10s
 ```
+
+批量并发度按请求生效，并由快照重建与 StateEvent 重发共享；多个并发请求会叠加下游负载，应按应用与存储容量下调。
 
 数值上限为 `0` 时关闭对应 HTTP guard；`idle-timeout=0s` 关闭 idle timeout。不要复制后端已负责的字段类型、mapping 或唯一性校验。`HttpQueryGuardFilter` 只保护带 WebFlux request context 的 HTTP 查询，程序内 `QueryGateway` 调用保持既有公共行为。
 

--- a/documentation/docs/zh/reference/config/infrastructure.md
+++ b/documentation/docs/zh/reference/config/infrastructure.md
@@ -147,8 +147,8 @@ spring:
 | --- | --- | --- | --- |
 | `wow.webflux.enabled` | Boolean | `true` | 启用内置 Wow HTTP route 装配 |
 | `wow.webflux.global-error.enabled` | Boolean | `true` | 注册 Wow 全局 `WebExceptionHandler` |
-| `wow.webflux.batch.concurrency` | Int | `1` | 批量运维/命令任务并发度 |
-| `wow.webflux.batch.prefetch` | Int | `1` | 批量任务 prefetch |
+| `wow.webflux.batch.concurrency` | Int | `128` | 批量快照重建与 StateEvent 重发任务并发度 |
+| `wow.webflux.batch.prefetch` | Int | `4` | 批量任务 prefetch |
 | `wow.webflux.query.max-list-size` | Int | `1000` | list/aggregation limit；`0` 关闭上限并允许 limit `0` |
 | `wow.webflux.query.max-page-size` | Int | `100` | page size 上限；`0` 关闭 |
 | `wow.webflux.query.max-page-window` | Long | `10000` | `page.index * page.size` 上限；`0` 关闭 |
@@ -160,5 +160,7 @@ spring:
 | `wow.webflux.command.request.appender.ip.enabled` | Boolean | `true` | 把解析出的远端 IP 写入命令上下文 |
 
 所有数值型查询上限必须非负；普通 page size 仍至少为 `1`，page offset 仍不得超过 `Int.MAX_VALUE`。`allow-expensive-operators=true` 是兼容性默认值，不是容量证明；收紧前需验证现有请求和升级路径。
+
+批量并发度按请求生效，并由快照重建与 StateEvent 重发共享；多个并发请求会叠加下游负载，应按应用与存储容量下调。
 
 `webflux-support` 注册命令、事件、快照查询以及重建/补偿等内置 route，但不自动提供业务认证、授权或管理面隔离。应用必须从运行时 OpenAPI 取得实际路径，并为修改性运维 route 配置鉴权、审计、限流和受控网络入口。

--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxProperties.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxProperties.kt
@@ -44,10 +44,10 @@ constructor(
     ) : EnabledCapable
 
     data class Batch(
-        @DefaultValue("1")
-        var concurrency: Int = 1,
-        @DefaultValue("1")
-        var prefetch: Int = 1
+        @DefaultValue("128")
+        var concurrency: Int = 128,
+        @DefaultValue("4")
+        var prefetch: Int = 4
     )
 
     data class Query(

--- a/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
+++ b/wow-spring-boot-starter/src/test/kotlin/me/ahoo/wow/spring/boot/starter/webflux/WebFluxAutoConfigurationTest.kt
@@ -269,8 +269,8 @@ internal class WebFluxAutoConfigurationTest {
                     .hasSingleBean(WebFluxProperties::class.java)
                     .hasSingleBean(BiScriptProperties::class.java)
                 val batchExecutionPolicy = context.getBean(BatchExecutionPolicy::class.java)
-                batchExecutionPolicy.concurrency.assert().isOne()
-                batchExecutionPolicy.prefetch.assert().isOne()
+                batchExecutionPolicy.concurrency.assert().isEqualTo(128)
+                batchExecutionPolicy.prefetch.assert().isEqualTo(4)
                 val queryProperties = context.getBean(WebFluxProperties::class.java).query
                 queryProperties.maxFilterNodes.assert().isEqualTo(128)
                 queryProperties.allowExpensiveOperators.assert().isTrue()

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/policy/BatchExecutionPolicy.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/policy/BatchExecutionPolicy.kt
@@ -17,8 +17,8 @@ import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
 
 class BatchExecutionPolicy(
-    val concurrency: Int = 1,
-    val prefetch: Int = 1
+    val concurrency: Int = 128,
+    val prefetch: Int = 4
 ) {
     init {
         require(concurrency > 0) {

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/policy/BatchExecutionPolicyTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/policy/BatchExecutionPolicyTest.kt
@@ -27,8 +27,8 @@ class BatchExecutionPolicyTest {
     fun `should use default execution options`() {
         val policy = BatchExecutionPolicy()
 
-        policy.concurrency.assert().isOne()
-        policy.prefetch.assert().isOne()
+        policy.concurrency.assert().isEqualTo(128)
+        policy.prefetch.assert().isEqualTo(4)
     }
 
     @Test


### PR DESCRIPTION
## Goal

Increase batch snapshot regeneration throughput by replacing the serial WebFlux batch defaults with the MongoDB-tested balance point.

## Changes

- Change `BatchExecutionPolicy` defaults from `concurrency=1`, `prefetch=1` to `128/4`.
- Keep Spring Boot property defaults aligned and preserve explicit configuration overrides.
- Update core and auto-configuration tests.
- Update English and Chinese WebFlux configuration documentation.
- Document that concurrency is per request, shared by snapshot regeneration and StateEvent resend, and multiplies across concurrent requests.

## Verification

- `./gradlew build --no-daemon` — passed on the rebased `origin/main` tree (337 tasks).
- `cd documentation && pnpm docs:build` — passed.
- `git diff --check origin/main..HEAD` — passed.
- Local MongoDB directional experiment covered `concurrency/prefetch` combinations across 10, 100, and 500 event streams per aggregate. `128/4` achieved 98.21%, 98.99%, and 100% of the measured peak respectively; raising concurrency to 256 or 512 added at most about 2% throughput.

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

This intentionally changes the default runtime concurrency for both snapshot regeneration and StateEvent resend. Concurrency is applied per request, so simultaneous batch requests multiply downstream load. Applications can restore the previous serial behavior with `wow.webflux.batch.concurrency=1` and `wow.webflux.batch.prefetch=1`.

The benchmark is local directional evidence, not a production capacity claim. It used MongoDB direct snapshot saves and did not validate multiple concurrent HTTP requests.
