### PR TITLE
docs(query): explain SearchFilter backends

### DIFF
--- a/documentation/docs/en/guide/query/filter-expression.md
+++ b/documentation/docs/en/guide/query/filter-expression.md
@@ -94,7 +94,61 @@ An element predicate cannot contain the root-only `ID`, `IDS`, `AGGREGATE_ID`, `
 | `DELETION` | `{ "op": "DELETION", "state": "ACTIVE" }` | `deletion(DeletionState.ACTIVE)` |
 | `SEARCH` | `{ "op": "SEARCH", "query": "wireless", "fields": ["state.note"], "mode": "TERMS" }` | `search("wireless", "note")` |
 
-Use `DELETION` for deletion state instead of emulating it with a field path. Snapshot queries append `DELETION = ACTIVE` by default; event-stream queries retain the full history and do not append that guard. `SEARCH` requires a non-blank `query`; its `mode` is `TERMS` or `PHRASE`. Searchable fields, analysis, and result semantics depend on the backend.
+Use `DELETION` for deletion state instead of emulating it with a field path. Snapshot queries append `DELETION = ACTIVE` by default; event-stream queries retain the full history and do not append that guard.
+
+### SearchFilter
+
+`SearchFilter` represents full-text search, not a literal string `CONTAINS` match. The query is processed by the backend's full-text index and analyzer, so matching, analysis, and result ordering depend on the backend configuration.
+
+| Property | Description |
+| --- | --- |
+| `query` | Search text; it cannot be empty or blank. |
+| `fields` | Optional set of logical fields. When empty, the backend's default full-text fields are used; when present, the search requests those fields, subject to Schema validation. |
+| `mode` | `TERMS` or `PHRASE`; defaults to `TERMS`. |
+
+Construct it directly or with the DSL:
+
+```kotlin
+import me.ahoo.wow.api.query.QueryField
+import me.ahoo.wow.api.query.SearchFilter
+import me.ahoo.wow.api.query.SearchMode
+import me.ahoo.wow.query.dsl.filterExpression
+
+SearchFilter("wireless")
+
+SearchFilter(
+    query = "event sourcing",
+    fields = setOf(QueryField("state.description")),
+    mode = SearchMode.PHRASE,
+)
+
+filterExpression {
+    search("wireless", "state.title", "state.description")
+    search("event sourcing", SearchMode.PHRASE, "state.description")
+}
+```
+
+The corresponding JSON is:
+
+```json
+{
+  "op": "SEARCH",
+  "query": "event sourcing",
+  "fields": ["state.description"],
+  "mode": "PHRASE"
+}
+```
+
+`TERMS` is ordinary full-text search over analyzed terms; it does not require the original string to occur as one contiguous value. `event sourcing` can participate in matching as two terms. `PHRASE` is phrase search: analyzed terms must match in order and position, but the result still depends on the analyzer and is not raw-string equality.
+
+Before backend compilation, Query Schema resolves `fields`. When every field resolves exactly, the field scope is preserved, with a rewrite to physical backend paths when necessary. If fields cannot all resolve exactly but the model supports the requested full-text capability, compatible validation clears `fields`, falls back to the backend's default scope, and marks the result `COMPATIBLE`. This can broaden the search scope; strict validation accepts only `EXACT` and rejects that request.
+
+#### Backend implementation
+
+- **MongoDB**: Compiles to MongoDB `$text`. `TERMS` uses the query text directly; `PHRASE` wraps it in double quotes, so the query text itself cannot contain double quotes. The collection must have a text index, whose definition determines the searchable fields. The current MongoDB converter does not compile `fields` into a per-field restriction; explicit fields normally fall back to an unscoped `$text` query as `COMPATIBLE` at the Schema layer, while strict validation rejects it.
+- **Elasticsearch**: Compiles to `multi_match`. When `fields` is present and resolves exactly, they are mapped to Elasticsearch physical field paths; when it is empty, Elasticsearch's `index.query.default_field` determines the fields and Wow sets `lenient`. If explicit fields do not resolve exactly, compatible validation can clear them before compilation and search the default field scope instead. `TERMS` uses the default `best_fields` semantics: each field runs a `match` query and the best field supplies the relevance score. `PHRASE` sets `type: phrase`, equivalent to running `match_phrase` per field. Field support for term and phrase search is determined by the Elasticsearch mapping and Query Schema.
+
+`SEARCH` is a root-only filter and cannot be used inside an `ELEMENT_MATCH` predicate. For literal substring, prefix, or suffix matching, use `CONTAINS`, `STARTS_WITH`, or `ENDS_WITH` instead.
 
 ## Relative-time Operators
 

--- a/documentation/docs/zh/guide/query/filter-expression.md
+++ b/documentation/docs/zh/guide/query/filter-expression.md
@@ -94,7 +94,61 @@ description: 使用 FilterExpression、JSON 表达式和 Kotlin DSL 构造可组
 | `DELETION` | `{ "op": "DELETION", "state": "ACTIVE" }` | `deletion(DeletionState.ACTIVE)` |
 | `SEARCH` | `{ "op": "SEARCH", "query": "wireless", "fields": ["state.note"], "mode": "TERMS" }` | `search("wireless", "note")` |
 
-删除标记使用 `DELETION`，不要以字段路径模拟。快照查询默认追加 `DELETION = ACTIVE`；事件流查询保留完整历史，不追加该 guard。`SEARCH` 的 `query` 不可为空，`mode` 为 `TERMS` 或 `PHRASE`；可搜索字段、分词和结果语义取决于后端。
+删除标记使用 `DELETION`，不要以字段路径模拟。快照查询默认追加 `DELETION = ACTIVE`；事件流查询保留完整历史，不追加该 guard。
+
+### SearchFilter
+
+`SearchFilter` 表示全文搜索，不是普通字符串的 `CONTAINS` 匹配。搜索文本会交给后端的全文索引和 analyzer 处理，因此是否命中、如何分词以及结果如何排序取决于后端配置。
+
+| 属性 | 说明 |
+| --- | --- |
+| `query` | 搜索文本，不能是空字符串或全空白字符串。 |
+| `fields` | 可选的逻辑字段集合。为空时使用后端默认的全文搜索字段；不为空时请求限定到这些字段，但最终是否保留字段范围取决于 Schema 校验结果。 |
+| `mode` | `TERMS` 或 `PHRASE`，默认是 `TERMS`。 |
+
+直接构造或使用 DSL：
+
+```kotlin
+import me.ahoo.wow.api.query.QueryField
+import me.ahoo.wow.api.query.SearchFilter
+import me.ahoo.wow.api.query.SearchMode
+import me.ahoo.wow.query.dsl.filterExpression
+
+SearchFilter("wireless")
+
+SearchFilter(
+    query = "event sourcing",
+    fields = setOf(QueryField("state.description")),
+    mode = SearchMode.PHRASE,
+)
+
+filterExpression {
+    search("wireless", "state.title", "state.description")
+    search("event sourcing", SearchMode.PHRASE, "state.description")
+}
+```
+
+对应的 JSON：
+
+```json
+{
+  "op": "SEARCH",
+  "query": "event sourcing",
+  "fields": ["state.description"],
+  "mode": "PHRASE"
+}
+```
+
+`TERMS` 是分词后的普通全文搜索，不要求原始字符串完整连续出现；`event sourcing` 可能按两个 term 参与匹配。`PHRASE` 是短语搜索，要求分析后的词项按顺序和位置匹配，但仍受 analyzer 影响，并不等同于原始字符串相等。
+
+后端编译前，Query Schema 会先解析 `fields`。所有字段都能精确解析时，字段范围会保留（必要时改写为后端物理路径）；如果字段不能全部精确解析、但模型支持对应的全文能力，兼容校验模式会清空 `fields`，退化为后端默认范围，并将结果标记为 `COMPATIBLE`。这可能扩大搜索范围；严格校验模式只接受 `EXACT`，会拒绝这种请求。
+
+#### 后端实现
+
+- **MongoDB**：转换为 MongoDB 的 `$text` 查询。`TERMS` 直接使用查询文本；`PHRASE` 会将查询文本包装为双引号短语，查询文本本身不能包含双引号。collection 必须存在 text index，可搜索字段由该 text index 决定。当前 MongoDB 转换器不会把 `fields` 编译成逐字段限制；显式字段通常会在 Schema 层以 `COMPATIBLE` 方式降级为不带字段的 `$text` 查询，严格校验模式会拒绝它。
+- **Elasticsearch**：转换为 `multi_match` 查询。指定 `fields` 且精确解析时，字段会映射为 Elasticsearch 的物理字段路径；不指定时由 `index.query.default_field` 决定，并设置 `lenient`。如果显式字段没有精确解析，兼容校验模式同样可能先将其清空，再执行默认字段范围的搜索。`TERMS` 使用 `multi_match` 默认的 `best_fields` 语义，即各字段分别执行 `match`，使用最佳字段的相关性得分；`PHRASE` 设置 `type: phrase`，相当于对各字段执行 `match_phrase`。字段是否支持全文或短语搜索由 Elasticsearch mapping 和 Query Schema 决定。
+
+`SEARCH` 是 root-only 过滤器，不能放入 `ELEMENT_MATCH` 的元素谓词中。需要字面量的包含、前缀或后缀匹配时，应使用 `CONTAINS`、`STARTS_WITH` 或 `ENDS_WITH`。
 
 ## 相对时间操作符
 


### PR DESCRIPTION
## Goal

完善 SearchFilter 的使用契约和后端实现说明。

## Changes

- 补充 query、fields、mode 属性说明及 Kotlin DSL/JSON 示例。
- 说明 TERMS 与 PHRASE 的查询语义。
- 说明 MongoDB $text 与 Elasticsearch multi_match 的转换方式和差异。
- 说明 Query Schema 的 EXACT、COMPATIBLE、STRICT 行为，以及 root-only 限制。
- 同步更新中文和英文文档。

## Verification

- `pnpm docs:build`
- `git diff HEAD~1..HEAD --check`

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

Documentation-only change; no migration, rollback, performance, concurrency, data, or deployment impact.