### PR TITLE
fix(docs): restore Chinese View as Markdown links

### DIFF
--- a/documentation/docs/.vitepress/config.mts
+++ b/documentation/docs/.vitepress/config.mts
@@ -14,9 +14,7 @@ const userConfig = defineConfig({
     // Keep VitePress dead-link validation enabled for every other link.
     ignoreDeadLinks: 'localhostLinks',
     head: head,
-    rewrites: {
-        'en/:rest*': ':rest*'
-    },
+    rewrites: (id) => id.startsWith('en/') ? id.slice(3) : id,
     transformHead({page, title, description}) {
         const isChinese = page.startsWith('zh/')
         const isArticle = (page.startsWith('articles/') || page.startsWith('zh/articles/')) &&
@@ -64,7 +62,13 @@ const userConfig = defineConfig({
         },
     },
     vite: {
-        plugins: [llmstxt({workDir: 'en', ignoreFiles: ['index.md']})],
+        plugins: [llmstxt({
+            ignoreFiles: ['index.md'],
+            ignoreFilesPerOutput: {
+                llmsTxt: ['zh.md', 'zh/**'],
+                llmsFullTxt: ['zh.md', 'zh/**']
+            }
+        })],
         optimizeDeps: {
             include: ['mermaid']
         }

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
-    "docs:preview": "vitepress preview docs"
+    "docs:preview": "vitepress preview docs",
+    "test": "pnpm docs:build && node --test test/*.test.mjs"
   },
   "keywords": [
     "Domain-Driven",

--- a/documentation/test/markdown-pages.test.mjs
+++ b/documentation/test/markdown-pages.test.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict'
+import {existsSync, readFileSync} from 'node:fs'
+import {test} from 'node:test'
+
+const pages = [
+    {html: 'articles/command-success-is-not-complete.html', markdown: 'articles/command-success-is-not-complete.md'},
+    {html: 'zh/articles/command-success-is-not-complete.html', markdown: 'zh/articles/command-success-is-not-complete.md'},
+    {html: 'zh/guide/getting-started.html', markdown: 'zh/guide/getting-started.md'},
+    {html: 'zh/articles/index.html', markdown: 'zh/articles.md'},
+    {html: 'zh/guide/index.html', markdown: 'zh/guide.md'},
+    {html: 'zh/index.html', markdown: 'zh.md'},
+]
+
+test('built pages expose their Markdown URLs', () => {
+    for (const page of pages) {
+        const markdownPath = new URL(`../docs/.vitepress/dist/${page.markdown}`, import.meta.url)
+        const htmlPath = new URL(`../docs/.vitepress/dist/${page.html}`, import.meta.url)
+        assert.ok(existsSync(markdownPath), `Missing Markdown page: ${page.markdown}`)
+        assert.ok(
+            readFileSync(htmlPath, 'utf8').includes(`at /${page.markdown} for this page in Markdown format`),
+            `HTML page does not reference ${page.markdown}`,
+        )
+    }
+})


### PR DESCRIPTION
## Goal
修复中文文档页面点击 View as Markdown 后返回 404 的问题。

## Changes
- 让 Markdown 生成插件同时处理英文和中文页面。
- 保留英文页面的无前缀 URL 与英文 llms.txt/llms-full.txt 汇总。
- 增加中文文章、指南和入口页的构建回归测试。

## Verification
- `cd documentation && pnpm test`：通过。
- 预览站点中英文 Markdown URL：HTTP 200。

## Compatibility and risks
- [x] 保持现有英文 URL 和生成汇总兼容。
- [x] 测试覆盖变更行为。
- [x] 未包含生成构建产物、凭据或本地环境文件。

仅调整文档构建配置，无运行时或数据迁移影响。