### PR TITLE
feat(docs): add Mermaid diagram zoom controls

### DIFF
--- a/documentation/docs/.vitepress/theme/Mermaid.vue
+++ b/documentation/docs/.vitepress/theme/Mermaid.vue
@@ -39,6 +39,7 @@ const viewer = ref<HTMLElement>()
 const expandButton = ref<HTMLButtonElement>()
 const isExpanded = ref(false)
 let panZoom: PanZoomInstance | undefined
+let resizeObserver: ResizeObserver | undefined
 let previousBodyOverflow = ''
 
 const getSvg = () => viewer.value?.querySelector<SVGSVGElement>('.mermaid-content > svg')
@@ -50,6 +51,12 @@ const destroyPanZoom = () => {
 
 const fitPanZoom = () => {
     panZoom?.resize().fit().center()
+}
+
+const handleResize = () => {
+    if (!panZoom) return
+    if (isExpanded.value) fitPanZoom()
+    else panZoom.resize()
 }
 
 const initializePanZoom = async () => {
@@ -148,7 +155,6 @@ watch(isExpanded, async (expanded) => {
     if (typeof document === 'undefined') return
     if (expanded) {
         window.addEventListener('keydown', handleKeydown, true)
-        window.addEventListener('resize', fitPanZoom)
         previousBodyOverflow = document.body.style.overflow
         document.body.style.overflow = 'hidden'
         await nextTick()
@@ -158,7 +164,6 @@ watch(isExpanded, async (expanded) => {
         else viewer.value?.focus()
     } else {
         window.removeEventListener('keydown', handleKeydown, true)
-        window.removeEventListener('resize', fitPanZoom)
         await nextTick()
         fitPanZoom()
         document.body.style.overflow = previousBodyOverflow
@@ -166,13 +171,20 @@ watch(isExpanded, async (expanded) => {
     }
 })
 
-onMounted(() => void renderChart())
+onMounted(() => {
+    if (typeof ResizeObserver !== 'undefined' && viewer.value) {
+        resizeObserver = new ResizeObserver(handleResize)
+        resizeObserver.observe(viewer.value)
+    }
+    void renderChart()
+})
 watch(isDark, () => void renderChart())
 onBeforeUnmount(() => {
     destroyPanZoom()
+    resizeObserver?.disconnect()
+    resizeObserver = undefined
     if (typeof window !== 'undefined') {
         window.removeEventListener('keydown', handleKeydown, true)
-        window.removeEventListener('resize', fitPanZoom)
     }
     if (isExpanded.value && typeof document !== 'undefined') {
         document.body.style.overflow = previousBodyOverflow

--- a/documentation/docs/.vitepress/theme/Mermaid.vue
+++ b/documentation/docs/.vitepress/theme/Mermaid.vue
@@ -49,6 +49,11 @@ const initializePanZoom = async () => {
     await nextTick()
     const svgElement = getSvg()
     if (!svgElement) return
+    const viewBox = svgElement.getAttribute('viewBox')?.trim().split(/[\s,]+/).map(Number)
+    if (viewBox?.length === 4 && viewBox.every(Number.isFinite)) {
+        const [, , width, height] = viewBox
+        if (width > 0 && height > 0) svgElement.style.aspectRatio = `${width} / ${height}`
+    }
 
     const {default: createPanZoom} = await import('svg-pan-zoom')
     panZoom = createPanZoom(svgElement, {

--- a/documentation/docs/.vitepress/theme/Mermaid.vue
+++ b/documentation/docs/.vitepress/theme/Mermaid.vue
@@ -14,7 +14,10 @@
 <script setup lang="ts">
 import {nextTick, onBeforeUnmount, onMounted, ref, watch} from 'vue'
 import {useData} from 'vitepress'
-import {clampZoom, cycleFocus, stepZoom} from './mermaid-zoom.mjs'
+import type svgPanZoom from 'svg-pan-zoom'
+import {cycleFocus} from './mermaid-zoom.mjs'
+
+type PanZoomInstance = ReturnType<typeof svgPanZoom>
 
 const props = withDefaults(defineProps<{
     graph: string
@@ -27,11 +30,43 @@ const {isDark} = useData()
 const svg = ref('')
 const viewer = ref<HTMLElement>()
 const expandButton = ref<HTMLButtonElement>()
-const zoom = ref(1)
 const isExpanded = ref(false)
+let panZoom: PanZoomInstance | undefined
 let previousBodyOverflow = ''
 
+const getSvg = () => viewer.value?.querySelector<SVGSVGElement>('.mermaid-content > svg')
+
+const destroyPanZoom = () => {
+    panZoom?.destroy()
+    panZoom = undefined
+}
+
+const fitPanZoom = () => {
+    panZoom?.resize().fit().center()
+}
+
+const initializePanZoom = async () => {
+    await nextTick()
+    const svgElement = getSvg()
+    if (!svgElement) return
+
+    const {default: createPanZoom} = await import('svg-pan-zoom')
+    panZoom = createPanZoom(svgElement, {
+        controlIconsEnabled: false,
+        dblClickZoomEnabled: false,
+        fit: true,
+        maxZoom: 10,
+        minZoom: 0.1,
+        mouseWheelZoomEnabled: false,
+        panEnabled: isExpanded.value,
+        preventMouseEventsDefault: false,
+        zoomEnabled: true,
+    })
+    if (isExpanded.value) fitPanZoom()
+}
+
 const renderChart = async () => {
+    destroyPanZoom()
     const {default: mermaid} = await import('mermaid')
     mermaid.initialize({
         securityLevel: 'loose',
@@ -39,21 +74,19 @@ const renderChart = async () => {
         theme: isDark.value ? 'dark' : 'default',
     })
     svg.value = (await mermaid.render(props.id, decodeURIComponent(props.graph))).svg
-    zoom.value = 1
+    await initializePanZoom()
 }
 
-const setZoom = (value: number) => {
-    zoom.value = clampZoom(value)
+const resetZoom = () => {
+    if (isExpanded.value) fitPanZoom()
+    else panZoom?.reset()
 }
-
-const resetZoom = () => setZoom(1)
-
-const changeZoom = (direction: number) => setZoom(stepZoom(zoom.value, direction))
 
 const handleWheel = (event: WheelEvent) => {
-    if ((!event.ctrlKey && !event.metaKey) || event.deltaY === 0) return
+    if (!panZoom || (!event.ctrlKey && !event.metaKey) || event.deltaY === 0) return
     event.preventDefault()
-    changeZoom(event.deltaY < 0 ? 1 : -1)
+    if (event.deltaY < 0) panZoom.zoomIn()
+    else panZoom.zoomOut()
 }
 
 const openExpanded = () => {
@@ -72,6 +105,7 @@ const focusableControls = () => Array.from(
 
 const handleKeydown = (event: KeyboardEvent) => {
     if (event.key === 'Escape') {
+        event.preventDefault()
         closeExpanded()
         return
     }
@@ -87,25 +121,30 @@ const handleKeydown = (event: KeyboardEvent) => {
     }
 }
 
-watch(isExpanded, (expanded) => {
+watch(isExpanded, async (expanded) => {
     if (typeof document === 'undefined') return
     if (expanded) {
         previousBodyOverflow = document.body.style.overflow
         document.body.style.overflow = 'hidden'
-        void nextTick(() => {
-            const firstControl = focusableControls()[0]
-            if (firstControl) firstControl.focus()
-            else viewer.value?.focus()
-        })
+        await nextTick()
+        panZoom?.enablePan()
+        fitPanZoom()
+        const firstControl = focusableControls()[0]
+        if (firstControl) firstControl.focus()
+        else viewer.value?.focus()
     } else {
+        await nextTick()
+        panZoom?.disablePan()
+        panZoom?.reset()
         document.body.style.overflow = previousBodyOverflow
-        void nextTick(() => expandButton.value?.focus())
+        expandButton.value?.focus()
     }
 })
 
 onMounted(() => void renderChart())
 watch(isDark, () => void renderChart())
 onBeforeUnmount(() => {
+    destroyPanZoom()
     if (isExpanded.value && typeof document !== 'undefined') {
         document.body.style.overflow = previousBodyOverflow
     }
@@ -125,11 +164,11 @@ onBeforeUnmount(() => {
         @click.self="closeExpanded"
     >
         <div class="mermaid-viewport" @click.self="closeExpanded">
-            <div class="mermaid-content" :style="{zoom, width: `${zoom * 100}%`}" v-html="svg"></div>
+            <div class="mermaid-content" v-html="svg"></div>
         </div>
         <div class="mermaid-toolbar" role="toolbar" aria-label="Mermaid diagram controls">
-            <button type="button" aria-label="Zoom in" title="Zoom in" @click="changeZoom(1)">+</button>
-            <button type="button" aria-label="Zoom out" title="Zoom out" @click="changeZoom(-1)">−</button>
+            <button type="button" aria-label="Zoom in" title="Zoom in" @click="panZoom?.zoomIn()">+</button>
+            <button type="button" aria-label="Zoom out" title="Zoom out" @click="panZoom?.zoomOut()">−</button>
             <button type="button" aria-label="Reset zoom" title="Reset zoom" @click="resetZoom">↺</button>
             <button
                 v-if="!isExpanded"
@@ -171,7 +210,9 @@ onBeforeUnmount(() => {
 
 .mermaid-content > svg {
     display: block;
-    max-width: none !important;
+    width: 100%;
+    height: auto;
+    max-width: 100%;
     flex: 0 0 auto;
 }
 
@@ -237,8 +278,16 @@ onBeforeUnmount(() => {
 }
 
 .mermaid-viewer--expanded .mermaid-content {
-    min-width: max-content;
-    min-height: max-content;
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    min-height: 0;
+}
+
+.mermaid-viewer--expanded .mermaid-content > svg {
+    width: 100% !important;
+    height: 100% !important;
+    max-width: none !important;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/documentation/docs/.vitepress/theme/Mermaid.vue
+++ b/documentation/docs/.vitepress/theme/Mermaid.vue
@@ -12,8 +12,9 @@
 -->
 
 <script setup lang="ts">
-import {onMounted, ref, watch} from 'vue'
+import {nextTick, onBeforeUnmount, onMounted, ref, watch} from 'vue'
 import {useData} from 'vitepress'
+import {clampZoom, cycleFocus, stepZoom} from './mermaid-zoom.mjs'
 
 const props = withDefaults(defineProps<{
     graph: string
@@ -24,6 +25,11 @@ const props = withDefaults(defineProps<{
 })
 const {isDark} = useData()
 const svg = ref('')
+const viewer = ref<HTMLElement>()
+const expandButton = ref<HTMLButtonElement>()
+const zoom = ref(1)
+const isExpanded = ref(false)
+let previousBodyOverflow = ''
 
 const renderChart = async () => {
     const {default: mermaid} = await import('mermaid')
@@ -33,12 +39,217 @@ const renderChart = async () => {
         theme: isDark.value ? 'dark' : 'default',
     })
     svg.value = (await mermaid.render(props.id, decodeURIComponent(props.graph))).svg
+    zoom.value = 1
 }
+
+const setZoom = (value: number) => {
+    zoom.value = clampZoom(value)
+}
+
+const resetZoom = () => setZoom(1)
+
+const changeZoom = (direction: number) => setZoom(stepZoom(zoom.value, direction))
+
+const handleWheel = (event: WheelEvent) => {
+    if ((!event.ctrlKey && !event.metaKey) || event.deltaY === 0) return
+    event.preventDefault()
+    changeZoom(event.deltaY < 0 ? 1 : -1)
+}
+
+const openExpanded = () => {
+    isExpanded.value = true
+}
+
+const closeExpanded = () => {
+    isExpanded.value = false
+}
+
+const focusableControls = () => Array.from(
+    viewer.value?.querySelectorAll<HTMLElement>(
+        'button, a[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+    ) ?? []
+)
+
+const handleKeydown = (event: KeyboardEvent) => {
+    if (event.key === 'Escape') {
+        closeExpanded()
+        return
+    }
+    if (event.key !== 'Tab' || !isExpanded.value) return
+    const controls = focusableControls()
+    if (controls.length === 0) return
+    const currentIndex = controls.indexOf(document.activeElement as HTMLElement)
+    const atStart = currentIndex <= 0
+    const atEnd = currentIndex === controls.length - 1
+    if ((event.shiftKey && atStart) || (!event.shiftKey && (atEnd || currentIndex < 0))) {
+        event.preventDefault()
+        controls[cycleFocus(currentIndex, controls.length, event.shiftKey)]?.focus()
+    }
+}
+
+watch(isExpanded, (expanded) => {
+    if (typeof document === 'undefined') return
+    if (expanded) {
+        previousBodyOverflow = document.body.style.overflow
+        document.body.style.overflow = 'hidden'
+        void nextTick(() => {
+            const firstControl = focusableControls()[0]
+            if (firstControl) firstControl.focus()
+            else viewer.value?.focus()
+        })
+    } else {
+        document.body.style.overflow = previousBodyOverflow
+        void nextTick(() => expandButton.value?.focus())
+    }
+})
 
 onMounted(() => void renderChart())
 watch(isDark, () => void renderChart())
+onBeforeUnmount(() => {
+    if (isExpanded.value && typeof document !== 'undefined') {
+        document.body.style.overflow = previousBodyOverflow
+    }
+})
 </script>
 
 <template>
-    <div v-html="svg" :class="props.class"></div>
+    <div
+        ref="viewer"
+        :class="['mermaid-viewer', props.class, {'mermaid-viewer--expanded': isExpanded}]"
+        :tabindex="isExpanded ? 0 : undefined"
+        :role="isExpanded ? 'dialog' : undefined"
+        :aria-modal="isExpanded ? 'true' : undefined"
+        aria-label="Mermaid diagram"
+        @wheel="handleWheel"
+        @keydown="handleKeydown"
+        @click.self="closeExpanded"
+    >
+        <div class="mermaid-viewport" @click.self="closeExpanded">
+            <div class="mermaid-content" :style="{zoom, width: `${zoom * 100}%`}" v-html="svg"></div>
+        </div>
+        <div class="mermaid-toolbar" role="toolbar" aria-label="Mermaid diagram controls">
+            <button type="button" aria-label="Zoom in" title="Zoom in" @click="changeZoom(1)">+</button>
+            <button type="button" aria-label="Zoom out" title="Zoom out" @click="changeZoom(-1)">−</button>
+            <button type="button" aria-label="Reset zoom" title="Reset zoom" @click="resetZoom">↺</button>
+            <button
+                v-if="!isExpanded"
+                ref="expandButton"
+                type="button"
+                aria-label="Expand diagram"
+                title="Expand diagram"
+                @click="openExpanded"
+            >
+                ⛶
+            </button>
+            <button
+                v-else
+                type="button"
+                aria-label="Close expanded diagram"
+                title="Close expanded diagram"
+                @click="closeExpanded"
+            >
+                ×
+            </button>
+        </div>
+    </div>
 </template>
+
+<style>
+.mermaid-viewer {
+    position: relative;
+}
+
+.mermaid-viewport {
+    overflow: auto;
+}
+
+.mermaid-content {
+    display: flex;
+    justify-content: center;
+    min-width: 100%;
+}
+
+.mermaid-content > svg {
+    display: block;
+    max-width: none !important;
+    flex: 0 0 auto;
+}
+
+.mermaid-toolbar {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    z-index: 1;
+    display: flex;
+    gap: 0.25rem;
+    padding: 0.25rem;
+    border: 1px solid var(--vp-c-divider);
+    border-radius: 0.5rem;
+    background: var(--vp-c-bg-soft);
+    box-shadow: var(--vp-shadow-2);
+    opacity: 0;
+    transition: opacity 0.2s ease;
+}
+
+.mermaid-viewer:hover .mermaid-toolbar,
+.mermaid-viewer:focus-within .mermaid-toolbar,
+.mermaid-viewer--expanded .mermaid-toolbar {
+    opacity: 1;
+}
+
+.mermaid-toolbar button {
+    display: inline-flex;
+    width: 2rem;
+    height: 2rem;
+    align-items: center;
+    justify-content: center;
+    border: 0;
+    border-radius: 0.35rem;
+    background: transparent;
+    color: var(--vp-c-text-1);
+    cursor: pointer;
+    font-size: 1.1rem;
+}
+
+.mermaid-toolbar button:hover,
+.mermaid-toolbar button:focus-visible {
+    background: var(--vp-c-default-soft);
+}
+
+.mermaid-toolbar button:focus-visible {
+    outline: 2px solid var(--vp-c-brand-1);
+    outline-offset: 2px;
+}
+
+.mermaid-viewer--expanded {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    display: flex;
+    flex-direction: column;
+    padding: 4rem 1rem 1rem;
+    background: var(--vp-c-bg);
+}
+
+.mermaid-viewer--expanded .mermaid-viewport {
+    flex: 1;
+    min-height: 0;
+}
+
+.mermaid-viewer--expanded .mermaid-content {
+    min-width: max-content;
+    min-height: max-content;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .mermaid-toolbar {
+        transition: none;
+    }
+}
+
+@media (any-hover: none) {
+    .mermaid-toolbar {
+        opacity: 1;
+    }
+}
+</style>

--- a/documentation/docs/.vitepress/theme/Mermaid.vue
+++ b/documentation/docs/.vitepress/theme/Mermaid.vue
@@ -140,7 +140,7 @@ watch(isExpanded, async (expanded) => {
     } else {
         await nextTick()
         panZoom?.disablePan()
-        panZoom?.reset()
+        fitPanZoom()
         document.body.style.overflow = previousBodyOverflow
         expandButton.value?.focus()
     }

--- a/documentation/docs/.vitepress/theme/Mermaid.vue
+++ b/documentation/docs/.vitepress/theme/Mermaid.vue
@@ -16,7 +16,15 @@ import {nextTick, onBeforeUnmount, onMounted, ref, watch} from 'vue'
 import {useData} from 'vitepress'
 import {cycleFocus} from './mermaid-zoom.mjs'
 
-type PanZoomInstance = ReturnType<typeof import('svg-pan-zoom')>
+interface PanZoomInstance {
+    destroy(): void
+    resize(): PanZoomInstance
+    fit(): PanZoomInstance
+    center(): PanZoomInstance
+    zoomIn(): PanZoomInstance
+    zoomOut(): PanZoomInstance
+    reset(): PanZoomInstance
+}
 
 const props = withDefaults(defineProps<{
     graph: string
@@ -311,7 +319,7 @@ onBeforeUnmount(() => {
 .mermaid-viewer--expanded .mermaid-content > svg {
     width: 100% !important;
     height: 100% !important;
-    max-width: none !important;
+    max-width: 100% !important;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/documentation/docs/.vitepress/theme/Mermaid.vue
+++ b/documentation/docs/.vitepress/theme/Mermaid.vue
@@ -14,10 +14,9 @@
 <script setup lang="ts">
 import {nextTick, onBeforeUnmount, onMounted, ref, watch} from 'vue'
 import {useData} from 'vitepress'
-import type svgPanZoom from 'svg-pan-zoom'
 import {cycleFocus} from './mermaid-zoom.mjs'
 
-type PanZoomInstance = ReturnType<typeof svgPanZoom>
+type PanZoomInstance = ReturnType<typeof import('svg-pan-zoom')>
 
 const props = withDefaults(defineProps<{
     graph: string
@@ -63,7 +62,7 @@ const initializePanZoom = async () => {
         maxZoom: 10,
         minZoom: 0.1,
         mouseWheelZoomEnabled: false,
-        panEnabled: isExpanded.value,
+        panEnabled: true,
         preventMouseEventsDefault: false,
         zoomEnabled: true,
     })
@@ -109,12 +108,23 @@ const focusableControls = () => Array.from(
 )
 
 const handleKeydown = (event: KeyboardEvent) => {
+    if (!isExpanded.value) return
     if (event.key === 'Escape') {
         event.preventDefault()
         closeExpanded()
         return
     }
-    if (event.key !== 'Tab' || !isExpanded.value) return
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+        event.preventDefault()
+        event.stopImmediatePropagation()
+        return
+    }
+    if (event.key === '/') {
+        event.preventDefault()
+        event.stopImmediatePropagation()
+        return
+    }
+    if (event.key !== 'Tab') return
     const controls = focusableControls()
     if (controls.length === 0) return
     const currentIndex = controls.indexOf(document.activeElement as HTMLElement)
@@ -129,17 +139,19 @@ const handleKeydown = (event: KeyboardEvent) => {
 watch(isExpanded, async (expanded) => {
     if (typeof document === 'undefined') return
     if (expanded) {
+        window.addEventListener('keydown', handleKeydown, true)
+        window.addEventListener('resize', fitPanZoom)
         previousBodyOverflow = document.body.style.overflow
         document.body.style.overflow = 'hidden'
         await nextTick()
-        panZoom?.enablePan()
         fitPanZoom()
         const firstControl = focusableControls()[0]
         if (firstControl) firstControl.focus()
         else viewer.value?.focus()
     } else {
+        window.removeEventListener('keydown', handleKeydown, true)
+        window.removeEventListener('resize', fitPanZoom)
         await nextTick()
-        panZoom?.disablePan()
         fitPanZoom()
         document.body.style.overflow = previousBodyOverflow
         expandButton.value?.focus()
@@ -150,6 +162,10 @@ onMounted(() => void renderChart())
 watch(isDark, () => void renderChart())
 onBeforeUnmount(() => {
     destroyPanZoom()
+    if (typeof window !== 'undefined') {
+        window.removeEventListener('keydown', handleKeydown, true)
+        window.removeEventListener('resize', fitPanZoom)
+    }
     if (isExpanded.value && typeof document !== 'undefined') {
         document.body.style.overflow = previousBodyOverflow
     }
@@ -165,7 +181,6 @@ onBeforeUnmount(() => {
         :aria-modal="isExpanded ? 'true' : undefined"
         aria-label="Mermaid diagram"
         @wheel="handleWheel"
-        @keydown="handleKeydown"
         @click.self="closeExpanded"
     >
         <div class="mermaid-viewport" @click.self="closeExpanded">
@@ -234,6 +249,7 @@ onBeforeUnmount(() => {
     background: var(--vp-c-bg-soft);
     box-shadow: var(--vp-shadow-2);
     opacity: 0;
+    pointer-events: none;
     transition: opacity 0.2s ease;
 }
 
@@ -241,6 +257,7 @@ onBeforeUnmount(() => {
 .mermaid-viewer:focus-within .mermaid-toolbar,
 .mermaid-viewer--expanded .mermaid-toolbar {
     opacity: 1;
+    pointer-events: auto;
 }
 
 .mermaid-toolbar button {
@@ -280,6 +297,8 @@ onBeforeUnmount(() => {
 .mermaid-viewer--expanded .mermaid-viewport {
     flex: 1;
     min-height: 0;
+    overflow: hidden;
+    touch-action: none;
 }
 
 .mermaid-viewer--expanded .mermaid-content {
@@ -304,6 +323,7 @@ onBeforeUnmount(() => {
 @media (any-hover: none) {
     .mermaid-toolbar {
         opacity: 1;
+        pointer-events: auto;
     }
 }
 </style>

--- a/documentation/docs/.vitepress/theme/mermaid-zoom.mjs
+++ b/documentation/docs/.vitepress/theme/mermaid-zoom.mjs
@@ -1,3 +1,16 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export const cycleFocus = (index, size, reverse) => {
     if (size <= 0) return -1
     if (index < 0) return reverse ? size - 1 : 0

--- a/documentation/docs/.vitepress/theme/mermaid-zoom.mjs
+++ b/documentation/docs/.vitepress/theme/mermaid-zoom.mjs
@@ -1,14 +1,3 @@
-// ponytail: fixed 1–3x range; add adaptive fit/pan math only if real diagrams exceed it.
-const MIN_ZOOM = 1
-const MAX_ZOOM = 3
-const ZOOM_STEP = 0.25
-
-const roundZoom = (value) => Math.round(value * 100) / 100
-
-export const clampZoom = (value) => Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, roundZoom(value)))
-
-export const stepZoom = (value, direction) => clampZoom(value + ZOOM_STEP * direction)
-
 export const cycleFocus = (index, size, reverse) => {
     if (size <= 0) return -1
     if (index < 0) return reverse ? size - 1 : 0

--- a/documentation/docs/.vitepress/theme/mermaid-zoom.mjs
+++ b/documentation/docs/.vitepress/theme/mermaid-zoom.mjs
@@ -1,0 +1,16 @@
+// ponytail: fixed 1–3x range; add adaptive fit/pan math only if real diagrams exceed it.
+const MIN_ZOOM = 1
+const MAX_ZOOM = 3
+const ZOOM_STEP = 0.25
+
+const roundZoom = (value) => Math.round(value * 100) / 100
+
+export const clampZoom = (value) => Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, roundZoom(value)))
+
+export const stepZoom = (value, direction) => clampZoom(value + ZOOM_STEP * direction)
+
+export const cycleFocus = (index, size, reverse) => {
+    if (size <= 0) return -1
+    if (index < 0) return reverse ? size - 1 : 0
+    return (index + (reverse ? -1 : 1) + size) % size
+}

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "canvas-confetti": "^1.9.4",
-    "medium-zoom": "^1.1.0"
+    "medium-zoom": "^1.1.0",
+    "svg-pan-zoom": "^3.6.2"
   }
 }

--- a/documentation/pnpm-lock.yaml
+++ b/documentation/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       medium-zoom:
         specifier: ^1.1.0
         version: 1.1.0
+      svg-pan-zoom:
+        specifier: ^3.6.2
+        version: 3.6.2
     devDependencies:
       '@types/canvas-confetti':
         specifier: ^1.9.0
@@ -1391,6 +1394,9 @@ packages:
   superjson@2.2.6:
     resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
     engines: {node: '>=16'}
+
+  svg-pan-zoom@3.6.2:
+    resolution: {integrity: sha512-JwnvRWfVKw/Xzfe6jriFyfey/lWJLq4bUh2jwoR5ChWQuQoOH8FEh1l/bEp46iHHKHEJWIyFJETbazraxNWECg==}
 
   tabbable@6.5.0:
     resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
@@ -3036,6 +3042,8 @@ snapshots:
   superjson@2.2.6:
     dependencies:
       copy-anything: 4.0.5
+
+  svg-pan-zoom@3.6.2: {}
 
   tabbable@6.5.0: {}
 

--- a/documentation/test/mermaid-zoom.test.mjs
+++ b/documentation/test/mermaid-zoom.test.mjs
@@ -6,4 +6,6 @@ test('Mermaid expanded controls cycle focus at either edge', () => {
     assert.equal(cycleFocus(0, 4, true), 3)
     assert.equal(cycleFocus(3, 4, false), 0)
     assert.equal(cycleFocus(-1, 4, false), 0)
+    assert.equal(cycleFocus(-1, 4, true), 3)
+    assert.equal(cycleFocus(0, 0, false), -1)
 })

--- a/documentation/test/mermaid-zoom.test.mjs
+++ b/documentation/test/mermaid-zoom.test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict'
+import {test} from 'node:test'
+import {clampZoom, cycleFocus, stepZoom} from '../docs/.vitepress/theme/mermaid-zoom.mjs'
+
+test('Mermaid zoom stays within the supported range', () => {
+    assert.equal(clampZoom(0.5), 1)
+    assert.equal(clampZoom(3.5), 3)
+    assert.equal(stepZoom(1, 1), 1.25)
+    assert.equal(stepZoom(3, -1), 2.75)
+})
+
+test('Mermaid expanded controls cycle focus at either edge', () => {
+    assert.equal(cycleFocus(0, 4, true), 3)
+    assert.equal(cycleFocus(3, 4, false), 0)
+    assert.equal(cycleFocus(-1, 4, false), 0)
+})

--- a/documentation/test/mermaid-zoom.test.mjs
+++ b/documentation/test/mermaid-zoom.test.mjs
@@ -1,13 +1,6 @@
 import assert from 'node:assert/strict'
 import {test} from 'node:test'
-import {clampZoom, cycleFocus, stepZoom} from '../docs/.vitepress/theme/mermaid-zoom.mjs'
-
-test('Mermaid zoom stays within the supported range', () => {
-    assert.equal(clampZoom(0.5), 1)
-    assert.equal(clampZoom(3.5), 3)
-    assert.equal(stepZoom(1, 1), 1.25)
-    assert.equal(stepZoom(3, -1), 2.75)
-})
+import {cycleFocus} from '../docs/.vitepress/theme/mermaid-zoom.mjs'
 
 test('Mermaid expanded controls cycle focus at either edge', () => {
     assert.equal(cycleFocus(0, 4, true), 3)


### PR DESCRIPTION
## Goal
Improve Mermaid diagram readability in the documentation site with GitHub-style zoom interactions and adaptive expanded viewing.

## Changes
- Add hover/focus controls for zoom in, zoom out, reset, and expand.
- Replace custom CSS zoom state with the open-source `svg-pan-zoom` component for SVG pan/zoom and fit/center behavior.
- Fit diagrams to the available expanded viewport after layout, while keeping inline rendering and dark-mode behavior.
- Support Ctrl/Cmd + wheel zooming, touch/pan in expanded view, body scroll locking, backdrop/Esc/close handling, and keyboard focus trapping/restoration.
- Add the dependency and focused focus-cycle test.

## Verification
- `pnpm test` — VitePress build passed; 2 tests passed.
- Browser smoke check — Mermaid rendered without console errors; expanded diagrams fit the viewport, zoom controls worked, body lock and focus behavior passed.
- `git diff --check` passed.

## Compatibility and risks
- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

This is a documentation-theme-only change with no migration or data impact. `svg-pan-zoom` is loaded dynamically on the client to keep VitePress SSR safe.