### PR TITLE
fix(query): resolve metadata filters per query model

### DIFF
--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QueryFilterSchemaResolver.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QueryFilterSchemaResolver.kt
@@ -19,6 +19,7 @@ import me.ahoo.wow.api.query.*
 import me.ahoo.wow.api.query.schema.QueryCapability
 import me.ahoo.wow.api.query.schema.QueryCardinality
 import me.ahoo.wow.api.query.schema.QueryCompatibilityLevel
+import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.api.query.schema.QueryValueType
 import me.ahoo.wow.api.query.schema.Temporal
 import me.ahoo.wow.serialization.MessageRecords
@@ -46,6 +47,14 @@ internal class QueryFilterSchemaResolver(
 
         is IdFilter,
         is IdsFilter,
+        -> metadata(
+            filter,
+            if (schema.model == QueryModel.EVENT_STREAM) {
+                MessageRecords.ID
+            } else {
+                MessageRecords.AGGREGATE_ID
+            },
+        )
         is AggregateIdFilter,
         is AggregateIdsFilter,
         -> metadata(filter, MessageRecords.AGGREGATE_ID)

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolverTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaResolverTest.kt
@@ -669,6 +669,42 @@ class QuerySchemaResolverTest {
     }
 
     @Test
+    fun `event stream should keep deletion filters compatible without deletion metadata`() {
+        val filter = DeletionFilter(DeletionState.ACTIVE)
+        val resolver = QuerySchemaResolver(
+            QueryModelSchema(QueryModel.EVENT_STREAM, emptySet(), emptyMap()),
+        )
+
+        resolver.resolve(filter).assert().isEqualTo(
+            QuerySchemaResolution(filter, QueryCompatibilityLevel.COMPATIBLE),
+        )
+    }
+
+    @Test
+    fun `event stream id filters should use the stream id binding`() {
+        val filters = listOf(
+            IdFilter("stream-id"),
+            IdsFilter(listOf("stream-id")),
+        )
+        val resolver = QuerySchemaResolver(
+            QueryModelSchema(
+                QueryModel.EVENT_STREAM,
+                emptySet(),
+                mapOf(
+                    QueryField("id") to fieldSchema(QueryCapability.EXACT_MATCH to "document.id"),
+                    QueryField("aggregateId") to fieldSchema(),
+                ),
+            ),
+        )
+
+        filters.forEach { filter ->
+            resolver.resolve(filter).assert().isEqualTo(
+                QuerySchemaResolution(filter, QueryCompatibilityLevel.EXACT),
+            )
+        }
+    }
+
+    @Test
     fun `unknown field without dynamic ancestor should remain unchanged and compatible`() {
         val filter = EqualFilter(QueryField("state.unknown"), json("value"))
         val schema = schema(


### PR DESCRIPTION
## Summary

- Resolve IdFilter and IdsFilter against id for event streams and aggregateId for other models.
- Keep event-stream deletion filters COMPATIBLE when deletion metadata is unavailable.
- Add regression tests for both behaviors.

## Verification

- ./gradlew test --console=plain
- ./gradlew :wow-query:check --console=plain