### PR TITLE
perf(mongo): prepare cursor cleanup paths once per page

### DIFF
--- a/wow-benchmarks/src/jmh/java/me/ahoo/wow/benchmark/query/MongoCursorPageBenchmark.java
+++ b/wow-benchmarks/src/jmh/java/me/ahoo/wow/benchmark/query/MongoCursorPageBenchmark.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.benchmark.query;
+
+import me.ahoo.wow.api.query.CursorPage;
+import me.ahoo.wow.api.query.CursorQuery;
+import me.ahoo.wow.api.query.MatchAllFilter;
+import me.ahoo.wow.api.query.Projection;
+import me.ahoo.wow.api.query.QueryField;
+import me.ahoo.wow.api.query.Sort;
+import me.ahoo.wow.mongo.query.MongoCursorCodec;
+import me.ahoo.wow.mongo.query.MongoCursorDocumentsKt;
+import me.ahoo.wow.mongo.query.MongoCursorProjection;
+import org.bson.Document;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(3)
+@Threads(1)
+public class MongoCursorPageBenchmark {
+    @Param({"10", "1000"}) public int pageSize;
+    @Param({"all_fields", "hidden_nested"}) public String shape;
+    private final List<String> sortFields = List.of(
+            "state.a.rank", "state.a.weight", "state.b.rank", "state.b.weight");
+    private CursorQuery query;
+    private MongoCursorProjection projection;
+
+    @Setup
+    public void setup() {
+        Projection requestedProjection = switch (shape) {
+            case "all_fields" -> Projection.Companion.getALL();
+            case "hidden_nested" -> new Projection(List.of(new QueryField("name")), List.of());
+            default -> throw new IllegalArgumentException(shape);
+        };
+        query = new CursorQuery(MatchAllFilter.INSTANCE, requestedProjection,
+                sortFields.stream().map(path -> new Sort(new QueryField(path), Sort.Direction.ASC)).toList(),
+                pageSize, null);
+        projection = MongoCursorDocumentsKt.withCursorFields(requestedProjection, sortFields);
+
+        CursorPage<Document> page = toCursorPage();
+        if (page.getList().size() != pageSize
+                || !("name-" + pageSize).equals(page.getList().get(pageSize - 1).getString("name"))) {
+            throw new IllegalStateException("wrong returned rows");
+        }
+        List<?> values = MongoCursorCodec.INSTANCE.decode(page.getNextCursor(), 4);
+        if (!values.equals(List.of(pageSize, pageSize + 1, pageSize + 2, pageSize + 3))) {
+            throw new IllegalStateException("cursor must use the last returned row");
+        }
+        Document expected = new Document("name", "name-1");
+        if (shape.equals("all_fields")) {
+            expected.append("state", new Document("a", new Document("rank", 1).append("weight", 2))
+                    .append("b", new Document("rank", 3).append("weight", 4)));
+        }
+        if (!expected.equals(page.getList().get(0))) {
+            throw new IllegalStateException("wrong payload or hidden field cleanup");
+        }
+    }
+
+    @Benchmark
+    public CursorPage<Document> toCursorPage() {
+        List<Document> documents = new ArrayList<>(pageSize + 1);
+        for (int row = 1; row <= pageSize + 1; row++) {
+            documents.add(new Document("name", "name-" + row).append("state",
+                    new Document("a", new Document("rank", row).append("weight", row + 1))
+                            .append("b", new Document("rank", row + 2).append("weight", row + 3))));
+        }
+        return MongoCursorDocumentsKt.toCursorPage(documents, query, projection, sortFields, Set.of(), document -> document);
+    }
+}

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/MongoCursorDocuments.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/MongoCursorDocuments.kt
@@ -90,20 +90,17 @@ internal fun Projection.withCursorFields(sortFields: List<String>): MongoCursorP
 private fun Document.valueAt(path: String): Any? =
     path.split('.').fold(this as Any?) { current, part -> (current as? Document)?.get(part) }
 
-private fun Document.removeAt(path: String, removeEmptyParents: Boolean) {
-    fun Document.removePath(parts: List<String>) {
-        if (parts.size == 1) {
-            remove(parts.single())
-            return
-        }
-        val child = get(parts.first()) as? Document ?: return
-        child.removePath(parts.drop(1))
-        if (removeEmptyParents && child.isEmpty()) {
-            remove(parts.first())
-        }
+private fun Document.removeAt(parts: List<String>, index: Int, removeEmptyParents: Boolean) {
+    val field = parts[index]
+    if (index == parts.lastIndex) {
+        remove(field)
+        return
     }
-
-    removePath(path.split('.'))
+    val child = get(field) as? Document ?: return
+    child.removeAt(parts, index + 1, removeEmptyParents)
+    if (removeEmptyParents && child.isEmpty()) {
+        remove(field)
+    }
 }
 
 internal fun <T : Any> List<Document>.toCursorPage(
@@ -119,10 +116,16 @@ internal fun <T : Any> List<Document>.toCursorPage(
     } else {
         null
     }
+    val removablePaths = if (returned.isEmpty() || projection.internalFields.isEmpty()) {
+        emptyList()
+    } else {
+        projection.internalFields.filterNot(deferredInternalFields::contains).map { it.split('.') }
+    }
+    val removeEmptyParents = projection.queryProjection.include.isNotEmpty()
     return CursorPage(
         list = returned.map { document ->
-            projection.internalFields.filterNot(deferredInternalFields::contains).forEach { field ->
-                document.removeAt(field, removeEmptyParents = projection.queryProjection.include.isNotEmpty())
+            removablePaths.forEach { parts ->
+                document.removeAt(parts, 0, removeEmptyParents)
             }
             mapper(document)
         },

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/MongoCursorDocumentsTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/MongoCursorDocumentsTest.kt
@@ -130,6 +130,79 @@ class MongoCursorDocumentsTest {
         page.list.single().get("state", Document::class.java).isEmpty().assert().isTrue()
     }
 
+    @Test
+    fun `included projection should clean each returned row and preserve shared payload and lookahead`() {
+        val sortFields = listOf("state.a.hidden.rank", "state.a.hidden.weight", "state.b.hidden.rank")
+        val projection = Projection(
+            include = listOf(QueryField("name"), QueryField("state.a.payload"), QueryField("state.empty")),
+        ).withCursorFields(sortFields)
+        val documents = (1..3).map { rank ->
+            Document("name", "row-$rank").append(
+                "state",
+                Document(
+                    "a",
+                    Document("hidden", Document("rank", rank).append("weight", rank + 10))
+                        .append("payload", "keep-$rank"),
+                ).append("b", Document("hidden", Document("rank", rank + 20)))
+                    .append("empty", Document()),
+            )
+        }
+        val query = CursorQuery(MatchAllFilter, sort = sortFields.map { Sort(QueryField(it), Sort.Direction.ASC) }, size = 2)
+
+        val page = documents.toCursorPage(query, projection) { it }
+
+        page.list.assert().containsExactly(
+            Document("name", "row-1").append(
+                "state", Document("a", Document("payload", "keep-1")).append("empty", Document()),
+            ),
+            Document("name", "row-2").append(
+                "state", Document("a", Document("payload", "keep-2")).append("empty", Document()),
+            ),
+        )
+        MongoCursorCodec.decode(page.nextCursor!!, 3).assert().isEqualTo(listOf(2, 12, 22))
+        documents.last().assert().isEqualTo(
+            Document("name", "row-3").append(
+                "state",
+                Document("a", Document("hidden", Document("rank", 3).append("weight", 13)).append("payload", "keep-3"))
+                    .append("b", Document("hidden", Document("rank", 23)))
+                    .append("empty", Document()),
+            ),
+        )
+    }
+
+    @Test
+    fun `deferred identity should remain native for cursor and reach mapper once in row order`() {
+        val sortFields = listOf("_id", "state.rank")
+        val projection = Projection(include = listOf(QueryField("name"))).withCursorFields(sortFields)
+        val documents = (1..3).map { rank ->
+            Document("_id", 100L + rank).append("name", "row-$rank").append("state", Document("rank", rank))
+        }
+        val query = CursorQuery(MatchAllFilter, sort = sortFields.map { Sort(QueryField(it), Sort.Direction.ASC) }, size = 2)
+        val mappedIds = mutableListOf<Long>()
+
+        val page = documents.toCursorPage(query, projection, deferredInternalFields = setOf("_id")) { document ->
+            document.containsKey("state").assert().isFalse()
+            mappedIds += document.remove("_id") as Long
+            document.getString("name")
+        }
+
+        mappedIds.assert().containsExactly(101L, 102L)
+        page.list.assert().containsExactly("row-1", "row-2")
+        MongoCursorCodec.decode(page.nextCursor!!, 2).assert().isEqualTo(listOf<Any>(102L, 2))
+    }
+
+    @Test
+    fun `empty terminal page should not invoke mapper or return a token`() {
+        val projection = Projection(include = listOf(QueryField("name"))).withCursorFields(listOf("rank"))
+
+        val page = emptyList<Document>().toCursorPage(cursorQuery(), projection) {
+            error("Mapper must not run for an empty page.")
+        }
+
+        page.list.assert().isEmpty()
+        page.nextCursor.assert().isNull()
+    }
+
     private fun cursorQuery(sortField: String = "rank") = CursorQuery(
         MatchAllFilter,
         sort = listOf(Sort(QueryField(sortField), Sort.Direction.ASC)),

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/MongoCursorDocumentsTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/MongoCursorDocumentsTest.kt
@@ -147,16 +147,19 @@ class MongoCursorDocumentsTest {
                     .append("empty", Document()),
             )
         }
-        val query = CursorQuery(MatchAllFilter, sort = sortFields.map { Sort(QueryField(it), Sort.Direction.ASC) }, size = 2)
+        val query =
+            CursorQuery(MatchAllFilter, sort = sortFields.map { Sort(QueryField(it), Sort.Direction.ASC) }, size = 2)
 
         val page = documents.toCursorPage(query, projection) { it }
 
         page.list.assert().containsExactly(
             Document("name", "row-1").append(
-                "state", Document("a", Document("payload", "keep-1")).append("empty", Document()),
+                "state",
+                Document("a", Document("payload", "keep-1")).append("empty", Document()),
             ),
             Document("name", "row-2").append(
-                "state", Document("a", Document("payload", "keep-2")).append("empty", Document()),
+                "state",
+                Document("a", Document("payload", "keep-2")).append("empty", Document()),
             ),
         )
         MongoCursorCodec.decode(page.nextCursor!!, 3).assert().isEqualTo(listOf(2, 12, 22))
@@ -177,7 +180,8 @@ class MongoCursorDocumentsTest {
         val documents = (1..3).map { rank ->
             Document("_id", 100L + rank).append("name", "row-$rank").append("state", Document("rank", rank))
         }
-        val query = CursorQuery(MatchAllFilter, sort = sortFields.map { Sort(QueryField(it), Sort.Direction.ASC) }, size = 2)
+        val query =
+            CursorQuery(MatchAllFilter, sort = sortFields.map { Sort(QueryField(it), Sort.Direction.ASC) }, size = 2)
         val mappedIds = mutableListOf<Long>()
 
         val page = documents.toCursorPage(query, projection, deferredInternalFields = setOf("_id")) { document ->


### PR DESCRIPTION
查询重构 stack 第 5/7 层，基于 `stack/query-04-elasticsearch-summary`。本层阶段提交为 `6feae9e85`。

## Goal

Mongo 游标每条返回记录都会重新过滤隐藏字段和拆分路径。本层将这些准备工作移到每页一次，递归清理使用路径索引。

## Changes

- 复用本页隐藏字段路径，删除递归中的 `drop` 子列表构造。
- 保留先生成 token 再清理、延后身份转换、mapper 次序和预读记录不变的合同。
- 增加共享父路径、空页、投影语义测试与 `MongoCursorPageBenchmark`。

## Verification

178项Mongo查询单元测试、11项真实cursor集成测试及Detekt通过，共189项，零失败、错误或跳过。相同基准源码/class、3forks、单线程：4个嵌套隐藏字段下，10/1000行耗时减少44.5%/48.6%，分配减少45.5%/58.1%。

以上为该阶段已有的本地验证记录。GitHub CI 由本 PR 触发，状态以当前 checks 为准。

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

唯一生产改动在页内清理。基准包含新Document构造与token编码，不包含MongoDB、网络或ObjectNode转换；无隐藏字段的耗时区间重叠，不能将该结果解释为真实Mongo查询加速。
