### PR TITLE
perf(elasticsearch): build cursor missing order in the sort compiler

### DIFF
--- a/wow-benchmarks/src/jmh/java/me/ahoo/wow/benchmark/query/ElasticsearchCursorSortBenchmark.java
+++ b/wow-benchmarks/src/jmh/java/me/ahoo/wow/benchmark/query/ElasticsearchCursorSortBenchmark.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.benchmark.query;
+
+import co.elastic.clients.elasticsearch._types.FieldSort;
+import co.elastic.clients.elasticsearch._types.SortOptions;
+import co.elastic.clients.elasticsearch._types.SortOrder;
+import me.ahoo.wow.api.modeling.NamedAggregate;
+import me.ahoo.wow.api.query.CursorPage;
+import me.ahoo.wow.api.query.CursorQuery;
+import me.ahoo.wow.api.query.ICursorQuery;
+import me.ahoo.wow.api.query.MatchAllFilter;
+import me.ahoo.wow.api.query.Projection;
+import me.ahoo.wow.api.query.QueryField;
+import me.ahoo.wow.api.query.Sort;
+import me.ahoo.wow.api.query.schema.QueryCapability;
+import me.ahoo.wow.api.query.schema.QueryCardinality;
+import me.ahoo.wow.api.query.schema.QueryModel;
+import me.ahoo.wow.elasticsearch.query.AbstractElasticsearchFilterCompiler;
+import me.ahoo.wow.elasticsearch.query.AbstractElasticsearchQueryBackend;
+import me.ahoo.wow.elasticsearch.query.ElasticsearchSortCompiler;
+import me.ahoo.wow.elasticsearch.query.event.EventStreamFilterCompiler;
+import me.ahoo.wow.elasticsearch.query.snapshot.SnapshotFilterCompiler;
+import me.ahoo.wow.modeling.MaterializedNamedAggregate;
+import me.ahoo.wow.query.ResolvedQuery;
+import me.ahoo.wow.query.schema.QueryFieldBinding;
+import me.ahoo.wow.query.schema.QueryFieldSchema;
+import me.ahoo.wow.query.schema.QueryModelSchema;
+import me.ahoo.wow.query.schema.QueryRewriteMode;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient;
+import reactor.core.publisher.Mono;
+import tools.jackson.databind.node.ObjectNode;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 200, timeUnit = TimeUnit.MILLISECONDS)
+@Fork(value = 3, jvmArgsAppend = {"-Xms256m", "-Xmx256m"})
+@Threads(1)
+public class ElasticsearchCursorSortBenchmark {
+    @Param({"flat", "nested"}) public String shape;
+    @Param({"2", "16"}) public int width;
+    private QueryModelSchema schema;
+    private List<Sort> sorts;
+    private ResolvedQuery<ICursorQuery> query;
+    private CursorBackend backend;
+
+    @Setup
+    public void setup() {
+        boolean nested = shape.equals("nested");
+        Map<QueryField, QueryFieldSchema> fields = new LinkedHashMap<>();
+        List<Sort> inputSorts = new ArrayList<>();
+        for (int index = 0; index < width; index++) {
+            QueryField logical = new QueryField("logical.field" + index);
+            QueryField resolved = new QueryField("document.field" + index);
+            QueryField physical = new QueryField((nested ? "body" : "state") + ".field" + index);
+            fields.put(logical, new QueryFieldSchema(
+                    null, null, null, Set.of(), true, false, QueryCardinality.SINGLE,
+                    null, false, Map.of(QueryCapability.Companion.getSORT(),
+                    new QueryFieldBinding(resolved, physical, null)),
+                    null, QueryRewriteMode.REQUIRED, null, null));
+            inputSorts.add(new Sort(logical, index % 2 == 0 ? Sort.Direction.ASC : Sort.Direction.DESC));
+        }
+        schema = new QueryModelSchema(nested ? QueryModel.Companion.getEVENT_STREAM()
+                : QueryModel.Companion.getSNAPSHOT(), Set.of(), Map.copyOf(fields));
+        sorts = List.copyOf(inputSorts);
+        query = new ResolvedQuery<>(new CursorQuery(
+                MatchAllFilter.INSTANCE, Projection.Companion.getALL(), sorts, 10, null), schema);
+        backend = new CursorBackend(nested ? EventStreamFilterCompiler.INSTANCE : SnapshotFilterCompiler.INSTANCE);
+
+        List<SortOptions> ordinary = ordinarySort();
+        if (ordinary.size() != width) throw new IllegalStateException("wrong sort count");
+        for (int index = 0; index < width; index++) {
+            FieldSort field = ordinary.get(index).field();
+            String expected = (nested ? "body" : "state") + ".field" + index;
+            SortOrder order = index % 2 == 0 ? SortOrder.Asc : SortOrder.Desc;
+            if (!field.field().equals(expected) || field.order() != order || field.missing() != null
+                    || (nested ? field.nested() == null || !field.nested().path().equals("body")
+                    : field.nested() != null)) {
+                throw new IllegalStateException("wrong ordinary sort at " + index);
+            }
+        }
+        cursorRequest();
+    }
+
+    @Benchmark
+    public List<SortOptions> ordinarySort() {
+        return ElasticsearchSortCompiler.INSTANCE.compile(sorts, schema);
+    }
+
+    // Includes filter compilation, request and Mono assembly; never subscribes or performs I/O.
+    @Benchmark
+    public Mono<CursorPage<ObjectNode>> cursorRequest() {
+        return backend.cursor(query);
+    }
+
+    private static final class CursorBackend extends AbstractElasticsearchQueryBackend {
+        private final NamedAggregate namedAggregate = new MaterializedNamedAggregate("benchmark", "cursor");
+        private final AbstractElasticsearchFilterCompiler filterCompiler;
+
+        private CursorBackend(AbstractElasticsearchFilterCompiler filterCompiler) {
+            this.filterCompiler = filterCompiler;
+        }
+
+        @Override
+        public NamedAggregate getNamedAggregate() {
+            return namedAggregate;
+        }
+
+        @Override
+        public AbstractElasticsearchFilterCompiler getFilterCompiler() {
+            return filterCompiler;
+        }
+
+        @Override
+        public String getIndexName() {
+            return "wow.benchmark.cursor";
+        }
+
+        @Override
+        public ReactiveElasticsearchClient getElasticsearchClient() {
+            throw new AssertionError("cursor assembly must not access the client");
+        }
+    }
+}

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryBackend.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/AbstractElasticsearchQueryBackend.kt
@@ -117,7 +117,10 @@ abstract class AbstractElasticsearchQueryBackend : QueryBackend {
         executePaged(query.query, query.schema)
 
     internal fun executeCursor(query: ICursorQuery, schema: QueryModelSchema): Mono<CursorPage<ObjectNode>> {
-        val compiled = compile(query.filter, query.sort, schema)
+        val compiled = CompiledQuery(
+            query = filterCompiler.compile(query.filter, schema),
+            sortOptions = ElasticsearchSortCompiler.compileCursor(query.sort, schema),
+        )
         val request = cursorSearchRequest(query, compiled, schema)
         return Mono.defer { elasticsearchClient.search(request, ObjectNode::class.java) }
             .map { response -> response.toCursorPage(query) }
@@ -134,7 +137,7 @@ abstract class AbstractElasticsearchQueryBackend : QueryBackend {
         it.index(indexName)
             .query(compiled.query)
             .size(query.size + 1)
-            .sort(compiled.sortOptions.withCursorMissing(query.sort))
+            .sort(compiled.sortOptions)
             .trackTotalHits { trackHits -> trackHits.enabled(false) }
         query.cursor?.let { cursor -> ElasticsearchCursorCodec.decode(cursor, query.sort.size) }
             ?.let(it::searchAfter)
@@ -186,20 +189,6 @@ abstract class AbstractElasticsearchQueryBackend : QueryBackend {
                     it.field { field -> field.field("_shard_doc").order(SortOrder.Asc) }
                 }
             )
-        }
-    }
-
-    private fun List<SortOptions>.withCursorMissing(sort: List<Sort>): List<SortOptions> {
-        require(size == sort.size)
-        return zip(sort) { sortOption, logicalSort ->
-            SortOptions.of {
-                it.field(
-                    sortOption.field().rebuild()
-                        .field(sortOption.field().field())
-                        .missing(if (logicalSort.direction == Sort.Direction.ASC) "_first" else "_last")
-                        .build(),
-                )
-            }
         }
     }
 

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchSortCompiler.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchSortCompiler.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.elasticsearch.query
 
+import co.elastic.clients.elasticsearch._types.FieldSort
 import co.elastic.clients.elasticsearch._types.SortOptions
 import co.elastic.clients.elasticsearch._types.SortOrder
 import me.ahoo.wow.api.query.Sort
@@ -27,19 +28,21 @@ object ElasticsearchSortCompiler {
 
     internal fun compileCursor(sort: List<Sort>, schema: QueryModelSchema): List<SortOptions> = compilePhysical(
         sort.map { it.copy(field = schema.resolvePhysicalField(it.field, QueryCapability.SORT)) },
-        cursor = true,
-    )
+    ) { logicalSort ->
+        missing(if (logicalSort.direction == Sort.Direction.ASC) "_first" else "_last")
+    }
 
-    internal fun compilePhysical(sort: List<Sort>): List<SortOptions> = compilePhysical(sort, cursor = false)
+    internal fun compilePhysical(sort: List<Sort>): List<SortOptions> = compilePhysical(sort) { }
 
-    private fun compilePhysical(sort: List<Sort>, cursor: Boolean): List<SortOptions> {
+    private inline fun compilePhysical(
+        sort: List<Sort>,
+        crossinline configure: FieldSort.Builder.(Sort) -> Unit,
+    ): List<SortOptions> {
         return sort.map {
             SortOptions.of { sortBuilder ->
                 sortBuilder.field { fieldBuilder ->
                     fieldBuilder.field(it.field.path).order(it.direction.toSortOrder())
-                    if (cursor) {
-                        fieldBuilder.missing(if (it.direction == Sort.Direction.ASC) "_first" else "_last")
-                    }
+                    fieldBuilder.configure(it)
                     if (it.field.path.startsWith("${MessageRecords.BODY}.")) {
                         fieldBuilder.nested { nested -> nested.path(MessageRecords.BODY) }
                     }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchSortCompiler.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchSortCompiler.kt
@@ -25,11 +25,21 @@ object ElasticsearchSortCompiler {
         sort.map { it.copy(field = schema.resolvePhysicalField(it.field, QueryCapability.SORT)) },
     )
 
-    internal fun compilePhysical(sort: List<Sort>): List<SortOptions> {
+    internal fun compileCursor(sort: List<Sort>, schema: QueryModelSchema): List<SortOptions> = compilePhysical(
+        sort.map { it.copy(field = schema.resolvePhysicalField(it.field, QueryCapability.SORT)) },
+        cursor = true,
+    )
+
+    internal fun compilePhysical(sort: List<Sort>): List<SortOptions> = compilePhysical(sort, cursor = false)
+
+    private fun compilePhysical(sort: List<Sort>, cursor: Boolean): List<SortOptions> {
         return sort.map {
             SortOptions.of { sortBuilder ->
                 sortBuilder.field { fieldBuilder ->
                     fieldBuilder.field(it.field.path).order(it.direction.toSortOrder())
+                    if (cursor) {
+                        fieldBuilder.missing(if (it.direction == Sort.Direction.ASC) "_first" else "_last")
+                    }
                     if (it.field.path.startsWith("${MessageRecords.BODY}.")) {
                         fieldBuilder.nested { nested -> nested.path(MessageRecords.BODY) }
                     }

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchSortCompilerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchSortCompilerTest.kt
@@ -14,13 +14,42 @@
 package me.ahoo.wow.elasticsearch.query
 
 import co.elastic.clients.elasticsearch._types.SortOrder
+import co.elastic.clients.elasticsearch.core.SearchRequest
+import co.elastic.clients.elasticsearch.core.SearchResponse
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.CursorQuery
+import me.ahoo.wow.api.query.MatchAllFilter
+import me.ahoo.wow.api.query.QueryField
 import me.ahoo.wow.api.query.Sort
+import me.ahoo.wow.api.query.schema.QueryCapability
+import me.ahoo.wow.api.query.schema.QueryCardinality
+import me.ahoo.wow.api.query.schema.QueryModel
+import me.ahoo.wow.elasticsearch.query.event.ElasticsearchEventStreamQueryBackend
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.query.ResolvedQuery
 import me.ahoo.wow.query.dsl.sort
+import me.ahoo.wow.query.schema.QueryFieldBinding
+import me.ahoo.wow.query.schema.QueryFieldSchema
+import me.ahoo.wow.query.schema.QueryModelSchema
+import me.ahoo.wow.query.schema.QueryRewriteMode
 import me.ahoo.wow.serialization.MessageRecords
 import org.junit.jupiter.api.Test
+import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
+import reactor.core.publisher.Mono
+import tools.jackson.databind.node.ObjectNode
 
 class ElasticsearchSortCompilerTest {
+    private val schema = QueryModelSchema(
+        model = QueryModel.EVENT_STREAM,
+        capabilities = emptySet(),
+        fields = mapOf(
+            QueryField("name") to sortFieldSchema(QueryField("document.name"), QueryField("body.name")),
+            QueryField("identity") to sortFieldSchema(QueryField("document.identity"), QueryField("id")),
+        ),
+    )
 
     @Test
     fun `should compile Sort to SortOptions`() {
@@ -34,10 +63,12 @@ class ElasticsearchSortCompilerTest {
         actual.first().let {
             it.field().field().assert().isEqualTo("field1")
             it.field().order().assert().isEqualTo(SortOrder.Asc)
+            it.field().missing().assert().isNull()
         }
         actual.last().let {
             it.field().field().assert().isEqualTo("field2")
             it.field().order().assert().isEqualTo(SortOrder.Desc)
+            it.field().missing().assert().isNull()
         }
     }
 
@@ -48,6 +79,61 @@ class ElasticsearchSortCompilerTest {
         val actual = ElasticsearchSortCompiler.compilePhysical(sort)
 
         actual.isEmpty().assert().isTrue()
+        ElasticsearchSortCompiler.compile(sort, schema).assert().isEmpty()
+    }
+
+    @Test
+    fun `should resolve logical sort fields without setting ordinary missing order`() {
+        val actual = ElasticsearchSortCompiler.compile(
+            sort {
+                "name".asc()
+                "name".desc()
+            },
+            schema,
+        ).map { it.field() }
+
+        actual.map { it.field() }.assert().containsExactly("body.name", "body.name")
+        actual.map { it.order() }.assert().containsExactly(SortOrder.Asc, SortOrder.Desc)
+        actual.forEach {
+            requireNotNull(it.nested()).path().assert().isEqualTo("body")
+            it.missing().assert().isNull()
+        }
+    }
+
+    @Test
+    fun `event cursor should preserve physical sorts nested context and missing order`() {
+        val client = mockk<ReactiveElasticsearchClient>()
+        val backend = ElasticsearchEventStreamQueryBackend(MaterializedNamedAggregate("test", "cursor"), client)
+        val request = slot<SearchRequest>()
+        every { client.search(capture(request), ObjectNode::class.java) } returns Mono.just(
+            SearchResponse.of<ObjectNode> {
+                it.took(1).timedOut(false)
+                    .shards { shards -> shards.failed(0).successful(1).total(1) }
+                    .hits { hits -> hits.hits(emptyList()) }
+            },
+        )
+
+        backend.cursor(
+            ResolvedQuery(
+                CursorQuery(
+                    MatchAllFilter,
+                    sort = sort {
+                        "name".asc()
+                        "identity".desc()
+                    },
+                    size = 1,
+                ),
+                schema,
+            ),
+        ).block()
+
+        request.captured.index().assert().containsExactly("wow.test.cursor.es")
+        val actual = request.captured.sort().map { it.field() }
+        actual.map { it.field() }.assert().containsExactly("body.name", "id")
+        actual.map { it.order() }.assert().containsExactly(SortOrder.Asc, SortOrder.Desc)
+        actual.map { requireNotNull(it.missing()).stringValue() }.assert().containsExactly("_first", "_last")
+        requireNotNull(actual.first().nested()).path().assert().isEqualTo("body")
+        actual.last().nested().assert().isNull()
     }
 
     @Test
@@ -57,5 +143,20 @@ class ElasticsearchSortCompilerTest {
         ).single().field()
 
         requireNotNull(actual.nested()).path().assert().isEqualTo(MessageRecords.BODY)
+        actual.missing().assert().isNull()
     }
+
+    private fun sortFieldSchema(resolved: QueryField, physical: QueryField) = QueryFieldSchema(
+        title = null,
+        description = null,
+        enumValues = null,
+        valueTypes = emptySet(),
+        nullable = true,
+        required = false,
+        cardinality = QueryCardinality.SINGLE,
+        semanticType = null,
+        dynamicChildren = false,
+        bindings = mapOf(QueryCapability.SORT to QueryFieldBinding(resolved, physical, null)),
+        rewriteMode = QueryRewriteMode.REQUIRED,
+    )
 }


### PR DESCRIPTION
查询重构 stack 第 6/7 层，基于 `stack/query-05-mongo-cursor-cleanup`。本层阶段提交为 `90467dd0f`。

## Goal

ES cursor 原先先构建普通排序，再逐项 rebuild 添加 missing 顺序。本层在第一次原生排序构造时完成 cursor 配置，减少组装工作。

## Changes

- 新增内部 compileCursor 入口，复用私有 inline/crossinline 构造模板；Backend 删除排序 rebuild。
- 保留普通排序入口、完整物理字段解析、nested、缺失值顺序及订阅时机。
- 增加请求合同与 `ElasticsearchCursorSortBenchmark` 普通排序控制组。

## Verification

157项ES查询单元、13项真实cursor集成及Detekt通过，共170项，零失败、错误或跳过。最终同源配对四组cursor组装耗时减少12.9%–34.3%，分配减少5.4%–29.7%；普通排序分配相同。

以上为该阶段已有的本地验证记录。GitHub CI 由本 PR 触发，状态以当前 checks 为准。

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

基准只构造请求和Publisher，没有订阅、数据库或网络耗时。初版普通nested排序曾回退约20%，一次私有inline细化后最终配对未再出现明确回退；原数据保留，不声称已证明动态JIT根因。
