### PR TITLE
perf(query): reduce KeepMask string allocations

### DIFF
--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/mask/Masking.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/mask/Masking.kt
@@ -60,19 +60,22 @@ object FullMaskStrategy : MaskStrategy<Mask> {
 
 object KeepMaskStrategy : MaskStrategy<KeepMask> {
     override fun compile(annotation: KeepMask): CompiledMask {
-        require(annotation.prefix >= 0 && annotation.suffix >= 0)
-        return CompiledMask { value -> keepMask(value, annotation.prefix, annotation.suffix) }
+        val prefix = annotation.prefix
+        val suffix = annotation.suffix
+        require(prefix >= 0 && suffix >= 0)
+        return CompiledMask { value -> keepMask(value, prefix, suffix) }
     }
 }
 
 private fun keepMask(value: String, prefix: Int, suffix: Int): String {
-    val codePoints = value.codePoints().toArray()
-    val size = codePoints.size
+    val size = value.codePointCount(0, value.length)
     if (prefix >= size || suffix >= size - prefix) return "*".repeat(size)
 
-    return buildString {
-        codePoints.take(prefix).forEach(::appendCodePoint)
-        "*".repeat(size - prefix - suffix).forEach(::append)
-        codePoints.takeLast(suffix).forEach(::appendCodePoint)
+    val prefixEnd = value.offsetByCodePoints(0, prefix)
+    val suffixStart = value.offsetByCodePoints(value.length, -suffix)
+    return buildString(prefixEnd + value.length - suffixStart + size - prefix - suffix) {
+        append(value, 0, prefixEnd)
+        repeat(size - prefix - suffix) { append('*') }
+        append(value, suffixStart, value.length)
     }
 }

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/query/mask/MaskingTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/query/mask/MaskingTest.kt
@@ -36,6 +36,12 @@ class MaskingTest {
             .mask("short").assert().isEqualTo("*****")
         KeepMaskStrategy.compile(UnicodeKept::value.javaField!!.getAnnotation(KeepMask::class.java))
             .mask("A中😀BCD").assert().isEqualTo("A中**CD")
+        KeepMaskStrategy.compile(UnicodeEdges::value.javaField!!.getAnnotation(KeepMask::class.java))
+            .mask("😀A中B😎").assert().isEqualTo("😀***😎")
+        KeepMaskStrategy.compile(ZeroPrefix::value.javaField!!.getAnnotation(KeepMask::class.java))
+            .mask("A😀B").assert().isEqualTo("**B")
+        KeepMaskStrategy.compile(ZeroSuffix::value.javaField!!.getAnnotation(KeepMask::class.java))
+            .mask("A😀B").assert().isEqualTo("A**")
     }
 
     @Test
@@ -51,4 +57,7 @@ class MaskingTest {
     private data class InvalidKeep(@field:KeepMask(prefix = -1) val value: String)
     private data class HugeKeep(@field:KeepMask(prefix = Int.MAX_VALUE, suffix = 1) val value: String)
     private data class UnicodeKept(@field:KeepMask(prefix = 2, suffix = 2) val value: String)
+    private data class UnicodeEdges(@field:KeepMask(prefix = 1, suffix = 1) val value: String)
+    private data class ZeroPrefix(@field:KeepMask(suffix = 1) val value: String)
+    private data class ZeroSuffix(@field:KeepMask(prefix = 1) val value: String)
 }


### PR DESCRIPTION
> 已由 #3191 完整替代。本 PR 的有效修复、测试和文档已整合至 #3191（目标 main），后续审查与合并仅在 #3191 进行。

## Goal

KeepMask 每次调用都构造完整 code-point 数组、保留两端的临时集合和中间星号字符串，增加逐字段分配。

## Changes

使用 `codePointCount` 和 `offsetByCodePoints` 定位边界，直接构造最终字符串并预分配容量；在 compile 时读取 prefix/suffix。保留短字符串全量遮蔽、空字符串及 Unicode code-point 语义。

## Verification

- `./gradlew :wow-api:check`：本层 115 项测试通过，Detekt 通过。
- 增补两端补充字符、prefix/suffix 为零的断言；冻结旧/新实现的 16,448 组输入对照输出一致，包含未配对 surrogate 和极大保留长度。
- 本机 JMH，1 thread / 3 forks / GC profiler / 256 MiB 堆：

| 输入 | ns/op 基线 → 候选 | B/op 基线 → 候选 |
| --- | ---: | ---: |
| 11 位手机号 | 50.20 → 34.30 | 400 → 88 |
| 含前后 emoji 的 Unicode | 108.01 → 45.06 | 725 → 184 |
| 900 code points 长字符串 | 3233.92 → 1006.95 | 18600 → 5512 |

FullMask 对照类字节码不变，三个输入的 B/op 均保持相同。基准源码、冻结 jar、JSON 和日志保存在本地，不作为仓库附件。

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

无公开 API 或行为变化。基准只测已编译字符串策略，不包含数据库、HTTP、typed 物化或生产并发；不能将局部结果换算成端到端吞吐收益。
