### PR TITLE
fix(core): preserve state metadata and saga recovery identities

### DIFF
--- a/documentation/docs/en/guide/event/saga.md
+++ b/documentation/docs/en/guide/event/saga.md
@@ -80,14 +80,24 @@ A function can synchronously, asynchronously, or reactively return these results
 
 For a command body or `CommandBuilder`, the framework fills only missing fields:
 
-- the default `requestId` is `${domainEvent.id}-${index}`, starting at index `0`;
+- the default `requestId` is `saga:${domainEvent.id}:${contextName}:${processorName}:${functionSignature}:${index}`, with URL-encoded function identity segments and index starting at `0`;
 - an explicit `requestId` is preserved;
 - missing `tenantId` and `spaceId` propagate from the source event;
 - the source event becomes upstream and its message header is propagated.
 
 A prebuilt `CommandMessage` keeps its message and `requestId` while receiving source-event header propagation.
 
-Replaying the same event with the same result order produces stable default request IDs that can cooperate with [command-gateway idempotency checks](../command/reliability.md). This does not make external side effects idempotent and does not deduplicate semantically repeated commands generated from different events.
+`functionSignature` contains the method name and every parameter's fully qualified type name, for example `onEvent(me.example.OrderCreated)`, to distinguish overloads. A custom `MessageFunction` without method metadata uses its name and `supportedType`. Changing the method name or parameter types, including injected parameters, changes the default ID. Set an explicit `requestId` when identity must remain stable across these refactors.
+
+Replaying the same event through the same function with the same result order produces stable default request IDs that can cooperate with [command-gateway idempotency checks](../command/reliability.md). This does not make external side effects idempotent and does not deduplicate semantically repeated commands generated from different events.
+
+Immediate retries retain the commands generated for the current exchange and their send progress. They reuse the original `commandId` values and continue with commands that have not been accepted.
+
+When the exchange's `ServiceProvider` supplies an `EventStore` that can read the target aggregate, each pending command checks the current request ID and the legacy `${domainEvent.id}-${index}` format through one `loadByRequestIds` call before sending. This also covers ordinary message redelivery after a restart without relying on compensation markers or gateway caches. A committed record for the current request ID takes priority and restores its `commandId/requestId`. Duplicate-request errors without committed evidence still propagate.
+
+If only a legacy record exists, the framework throws `DuplicateRequestIdException`: that record contains no function identity and cannot prove this function has completed. After business reconciliation, explicitly supplying the confirmed legacy `requestId` allows recovery of the original command identity.
+
+MongoDB and Elasticsearch query the candidate IDs. Redis checks its existing request index in bulk, reading no event history on a miss and reading history once on a hit. The default method for custom `EventStore` implementations scans aggregate history once; override it to use a backend index.
 
 ## Business Compensation
 
@@ -108,6 +118,8 @@ Do not conflate business compensation with processing-failure recovery. A Saga d
 The runtime produces `SAGA_HANDLED` after the Saga function completes and every generated `CommandGateway.send` completes. The signal carries the command-stream `commandId` values, but proves only the send boundary, not that the target aggregates processed those commands.
 
 Wait for the matching `SAGA_HANDLED` when the caller needs only to know that the Saga sent its commands. If every downstream command must reach another stage, use `CommandWait.chain(...)` with the Saga function and the tail stage/function. See [Completion Semantics](../command/completion.md) for stages, function matching, and early-arriving signals.
+
+Recovering a committed request confirms only `SENT`. `PROCESSED`, `PROJECTED`, and later stages still require actual notifications for the original command ID. The event store does not persist their completion records, so replay never fabricates them; missing notifications remain bounded by the original wait timeout. A parent Saga reports child send failures after its retries finish, so a failed individual send attempt does not prematurely terminate the chain.
 
 ## Testing and Failure Boundaries
 

--- a/documentation/docs/zh/guide/event/saga.md
+++ b/documentation/docs/zh/guide/event/saga.md
@@ -80,14 +80,24 @@ class CartSaga {
 
 对命令体或 `CommandBuilder`，框架只补充缺失字段：
 
-- 默认 `requestId` 为 `${domainEvent.id}-${index}`，索引从 `0` 开始；
+- 默认 `requestId` 为 `saga:${domainEvent.id}:${contextName}:${processorName}:${functionSignature}:${index}`，函数身份各段使用 URL 编码，索引从 `0` 开始；
 - 保留显式 `requestId`；
 - 缺失的 `tenantId`、`spaceId` 从源事件传播；
 - 设置源事件为 upstream，并传播消息 header。
 
 预构造的 `CommandMessage` 保留自己的消息与 `requestId`，同时传播源事件 header。
 
-同一事件以相同顺序重投时，默认 request ID 保持稳定，可与[命令网关的幂等检查](../command/reliability.md)协作。它不保证外部副作用幂等，也不能保护不同事件生成的语义重复命令。
+`functionSignature` 由方法名和全部参数的完整类型名组成，例如 `onEvent(me.example.OrderCreated)`，用于区分重载方法。自定义 `MessageFunction` 没有方法元数据时，使用函数名和 `supportedType`。修改方法名或参数类型（包括注入参数）会改变默认 ID；需要跨这些重构保持稳定时，应显式设置 `requestId`。
+
+同一事件由同一函数以相同顺序重投时，默认 request ID 保持稳定，可与[命令网关的幂等检查](../command/reliability.md)协作。它不保证外部副作用幂等，也不能保护不同事件生成的语义重复命令。
+
+即时重试保留本次处理已生成的命令和发送进度，沿用原 `commandId`，继续发送尚未成功的命令。
+
+处理上下文的 `ServiceProvider` 提供可读取目标聚合的 `EventStore` 时，每条待发送命令通过一次 `loadByRequestIds` 查询同时检查当前请求 ID 和旧格式 `${domainEvent.id}-${index}`。此检查也覆盖服务重启后的普通消息重投，不依赖补偿标记或网关缓存。当前请求 ID 有已提交记录时，优先复用其 `commandId/requestId`；缺乏已提交记录的重复请求错误仍会上抛。
+
+只找到旧格式记录时，由于记录缺少函数身份，框架抛出 `DuplicateRequestIdException`，不会把它视为当前函数已成功执行。完成业务核对后，可显式指定已确认的旧 `requestId` 来恢复原命令身份。
+
+MongoDB 和 Elasticsearch 使用候选 ID 查询；Redis 使用已有请求索引批量检查，未命中时不读取事件历史，命中时读取一次历史。自定义 `EventStore` 的默认实现会扫描一次聚合历史，可覆盖此方法使用后端索引。
 
 ## 业务补偿
 
@@ -108,6 +118,8 @@ fun onEntryFailed(event: EntryFailed): UnlockAmount =
 Saga 函数完成并且生成命令的 `CommandGateway.send` 全部完成后，运行时产生 `SAGA_HANDLED`。该信号包含本次命令流的 `commandId`，但只证明命令发送边界完成，不证明目标聚合已经处理命令。
 
 调用方只关心 Saga 已发出命令时等待匹配的 `SAGA_HANDLED`。若还必须等待每条后续命令的某个阶段，使用 `CommandWait.chain(...)` 指定 Saga 函数与 tail stage/function。完整阶段、函数匹配和提前到达信号处理见[完成语义](../command/completion.md)。
+
+恢复已提交请求只能确认 `SENT`；`PROCESSED`、`PROJECTED` 等阶段仍使用原命令 ID 对应的真实通知。事件存储没有保存这些阶段的完成记录，重投不会伪造完成信号；缺少通知时仍受原等待超时约束。Saga 子命令的发送失败由父 Saga 在重试结束后报告，单次发送失败不会提前终止等待链。
 
 ## 测试与失败边界
 

--- a/test/wow-mock/src/contractTest/kotlin/me/ahoo/wow/eventsourcing/mock/DelayEventStoreTest.kt
+++ b/test/wow-mock/src/contractTest/kotlin/me/ahoo/wow/eventsourcing/mock/DelayEventStoreTest.kt
@@ -13,16 +13,34 @@
 
 package me.ahoo.wow.eventsourcing.mock
 
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.eventsourcing.EventStore
 import me.ahoo.wow.eventsourcing.InMemoryEventStore
 import me.ahoo.wow.tck.eventsourcing.EventStoreSpec
 import me.ahoo.wow.tck.metrics.meteredForTck
 import org.junit.jupiter.api.Test
+import reactor.core.publisher.Flux
+import reactor.kotlin.test.test
 
 class DelayEventStoreTest : EventStoreSpec() {
     override fun createEventStore(): EventStore {
         return DelayEventStore().meteredForTck()
+    }
+
+    @Test
+    fun `delay decorator preserves native request lookup`() {
+        val stream = generateEventStream()
+        val candidates = setOf(stream.requestId)
+        val delegate = mockk<EventStore>()
+        every { delegate.loadByRequestIds(stream.aggregateId, candidates) } returns Flux.just(stream)
+
+        DelayEventStore(delegate = delegate).loadByRequestIds(stream.aggregateId, candidates)
+            .test().expectNext(stream).verifyComplete()
+        verify(exactly = 1) { delegate.loadByRequestIds(stream.aggregateId, candidates) }
+        verify(exactly = 0) { delegate.load(any(), any<Int>(), any<Int>()) }
     }
 
     @Test

--- a/test/wow-mock/src/main/kotlin/me/ahoo/wow/eventsourcing/mock/DelayEventStore.kt
+++ b/test/wow-mock/src/main/kotlin/me/ahoo/wow/eventsourcing/mock/DelayEventStore.kt
@@ -44,6 +44,9 @@ class DelayEventStore(
         return delegate.last(aggregateId).delaySubscription(delaySupplier())
     }
 
+    override fun loadByRequestIds(aggregateId: AggregateId, requestIds: Set<String>): Flux<DomainEventStream> =
+        delegate.loadByRequestIds(aggregateId, requestIds).delaySubscription(delaySupplier())
+
     override fun scanAggregateId(
         namedAggregate: NamedAggregate,
         afterId: String,

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/eventsourcing/EventStoreSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/eventsourcing/EventStoreSpec.kt
@@ -66,6 +66,34 @@ abstract class EventStoreSpec {
     }
 
     @Test
+    fun loadByRequestIds() {
+        val id = generateGlobalId()
+        val tenantA = namedAggregate.aggregateId(id, "tenant-a")
+        val tenantB = namedAggregate.aggregateId(generateGlobalId(), "tenant-b")
+        val first = MockAggregateCreated(
+            "first"
+        ).toDomainEventStream(GivenInitializationCommand(tenantA, requestId = "legacy"))
+        val second = MockAggregateCreated("second").toDomainEventStream(
+            GivenInitializationCommand(tenantA, requestId = "current"),
+            aggregateVersion = 1,
+        )
+        val foreign = MockAggregateCreated(
+            "foreign"
+        ).toDomainEventStream(GivenInitializationCommand(tenantB, requestId = "current"))
+        eventStore.append(
+            first
+        ).then(eventStore.append(second)).then(eventStore.append(foreign)).test().verifyComplete()
+        eventStore.loadByRequestIds(tenantA, setOf("legacy", "current", "missing"))
+            .map { it.id }.collectList().test()
+            .consumeNextWith { it.toSet().assert().isEqualTo(setOf(first.id, second.id)) }
+            .verifyComplete()
+        eventStore.loadByRequestIds(tenantA, setOf("missing")).test().verifyComplete()
+        eventStore.loadByRequestIds(tenantA, emptySet()).test().verifyComplete()
+        eventStore.loadByRequestIds(namedAggregate.aggregateId(id, "tenant-b"), setOf("legacy", "current"))
+            .test().verifyComplete()
+    }
+
+    @Test
     fun appendEventStream() {
         val eventStream = generateEventStream()
         eventStream.count().assert().isEqualTo(eventStream.size)

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
@@ -25,6 +25,7 @@ import me.ahoo.wow.command.wait.SkipsSuccessfulSentSignal
 import me.ahoo.wow.command.wait.WaitCoordinator
 import me.ahoo.wow.command.wait.WaitHandle
 import me.ahoo.wow.command.wait.WaitPlan
+import me.ahoo.wow.command.wait.chain.WaitingChainTail.Companion.COMMAND_WAIT_TAIL_STAGE
 import me.ahoo.wow.command.wait.extractWaitPlan
 import me.ahoo.wow.command.wait.notifyAndForget
 import me.ahoo.wow.command.wait.timeout
@@ -137,6 +138,10 @@ class DefaultCommandGateway(
                 commandWaitNotifier.notifyAndForget(waitPlan, waitSignal)
             }.doOnError {
                 val waitPlan = message.header.extractWaitPlan() ?: return@doOnError
+                // The parent saga reports a terminal send failure after its retries finish.
+                if (waitPlan.waitCommandId != message.commandId && message.header.containsKey(COMMAND_WAIT_TAIL_STAGE)) {
+                    return@doOnError
+                }
                 val waitSignal = message.commandSentSignal(waitPlan.waitCommandId, it)
                 commandWaitNotifier.notifyAndForget(waitPlan, waitSignal)
             }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/event/compensation/StateEventCompensator.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/event/compensation/StateEventCompensator.kt
@@ -24,7 +24,9 @@ import me.ahoo.wow.messaging.compensation.CompensationMatcher.withCompensation
 import me.ahoo.wow.messaging.compensation.CompensationTarget
 import me.ahoo.wow.messaging.compensation.EventCompensator
 import me.ahoo.wow.modeling.annotation.aggregateMetadata
+import me.ahoo.wow.modeling.state.StateAggregate
 import me.ahoo.wow.modeling.state.StateAggregateFactory
+import me.ahoo.wow.serialization.deepCopy
 import reactor.core.publisher.Mono
 
 /**
@@ -118,12 +120,10 @@ class StateEventCompensator(
                         return@concatMap Mono.empty<StateEvent<Any>>()
                     }
                     stateAggregate.onSourcing(eventStream)
-                    if (!stateAggregate.initialized) {
+                    if (!stateAggregate.initialized || eventStream.version !in headVersion..tailVersion) {
                         return@concatMap Mono.empty<StateEvent<Any>>()
                     }
-                    Mono.just(eventStream.toStateEvent(stateAggregate))
-                }.filter {
-                    it.version in headVersion..tailVersion
+                    Mono.just(eventStream.toStateEvent(stateAggregate.deepCopy(StateAggregate::class.java)))
                 }.concatMap {
                     compensate(it, target).thenReturn(it.aggregateId)
                 }.count()

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/EventStore.kt
@@ -67,6 +67,14 @@ interface EventStore :
         load(aggregateId).any { it.requestId == requestId }
 
     /**
+     * Loads records matching any candidate request ID for this aggregate.
+     * Result order is unspecified. Backends should use their request index; the
+     * default keeps existing implementations source-compatible with one scan.
+     */
+    fun loadByRequestIds(aggregateId: AggregateId, requestIds: Set<String>): Flux<DomainEventStream> =
+        if (requestIds.isEmpty()) Flux.empty() else load(aggregateId).filter { it.requestId in requestIds }
+
+    /**
      * Loads domain event streams for the specified aggregate within the given version range.
      * The range is inclusive: [headVersion, tailVersion].
      *

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/InMemoryEventStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/InMemoryEventStore.kt
@@ -125,6 +125,13 @@ class InMemoryEventStore : AbstractEventStore() {
         }
     }
 
+    override fun loadByRequestIds(aggregateId: AggregateId, requestIds: Set<String>): Flux<DomainEventStream> =
+        Flux.defer {
+            Flux.fromIterable(events[aggregateId].orEmpty())
+                .filter { it.requestId in requestIds }
+                .map { it.copy() }
+        }
+
     override fun last(aggregateId: AggregateId): Mono<DomainEventStream> {
         return Mono.fromSupplier {
             val eventsOfAgg = events[aggregateId] ?: return@fromSupplier null

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/RoutingEventStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/RoutingEventStore.kt
@@ -55,6 +55,9 @@ class RoutingEventStore(
     override fun existsRequestId(aggregateId: AggregateId, requestId: String): Mono<Boolean> =
         registry.get(aggregateId.namedAggregate).existsRequestId(aggregateId, requestId)
 
+    override fun loadByRequestIds(aggregateId: AggregateId, requestIds: Set<String>): Flux<DomainEventStream> =
+        registry.get(aggregateId.namedAggregate).loadByRequestIds(aggregateId, requestIds)
+
     override fun last(aggregateId: AggregateId): Mono<DomainEventStream> =
         registry.get(aggregateId.namedAggregate).last(aggregateId)
 

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotMaterializer.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotMaterializer.kt
@@ -37,7 +37,8 @@ fun <S : Any, D : Any> ReadOnlyStateAggregate<S>.toMedium(materialize: (S) -> D)
         operator = operator,
         firstEventTime = firstEventTime,
         eventTime = eventTime,
-        state = materialize(state)
+        state = materialize(state),
+        tags = tags,
     )
 }
 
@@ -48,6 +49,7 @@ fun <S : Any, D : Any> Snapshot<S>.materialize(materialize: (S) -> D): Materiali
         tenantId = aggregateId.tenantId,
         ownerId = ownerId,
         aggregateId = aggregateId.id,
+        spaceId = spaceId,
         version = version,
         eventId = eventId,
         firstOperator = firstOperator,
@@ -56,6 +58,7 @@ fun <S : Any, D : Any> Snapshot<S>.materialize(materialize: (S) -> D): Materiali
         eventTime = eventTime,
         state = materialize(state),
         snapshotTime = snapshotTime,
+        tags = tags,
         deleted = deleted
     )
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/StateEvent.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/eventsourcing/state/StateEvent.kt
@@ -15,6 +15,7 @@ package me.ahoo.wow.eventsourcing.state
 
 import me.ahoo.wow.api.abac.AbacTags
 import me.ahoo.wow.api.abac.EMPTY_ABAC_TAGS
+import me.ahoo.wow.api.modeling.SpaceId
 import me.ahoo.wow.command.CommandOperator.operator
 import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.infra.Decorator
@@ -97,6 +98,8 @@ interface StateEvent<S : Any> :
                 firstEventTime = stateAggregate.firstEventTime,
                 tags = stateAggregate.tags,
                 deleted = stateAggregate.deleted,
+                ownerId = stateAggregate.ownerId,
+                spaceId = stateAggregate.spaceId,
             )
     }
 }
@@ -111,6 +114,8 @@ interface StateEvent<S : Any> :
  * @param firstEventTime the first event time (default: from delegate)
  * @param tags the ABAC tags associated with the aggregate
  * @param deleted whether the aggregate is deleted (default: false)
+ * @param ownerId the owner after sourcing the event stream
+ * @param spaceId the space after sourcing the event stream
  */
 data class StateEventData<S : Any>(
     override val delegate: DomainEventStream,
@@ -118,10 +123,31 @@ data class StateEventData<S : Any>(
     override val firstOperator: String = delegate.header.operator.orEmpty(),
     override val firstEventTime: Long = delegate.createTime,
     override val tags: AbacTags = EMPTY_ABAC_TAGS,
-    override val deleted: Boolean = false
+    override val deleted: Boolean = false,
+    override val ownerId: String = delegate.ownerId,
+    override val spaceId: SpaceId = delegate.spaceId,
 ) : StateEvent<S>,
     Decorator<DomainEventStream>,
     DomainEventStream by delegate {
+    constructor(
+        delegate: DomainEventStream,
+        state: S,
+        firstOperator: String,
+        firstEventTime: Long,
+        tags: AbacTags,
+        deleted: Boolean,
+    ) : this(delegate, state, firstOperator, firstEventTime, tags, deleted, delegate.ownerId, delegate.spaceId)
+
+    /** Retains the existing Java copy signature, including the sourced ownership of this instance. */
+    fun copy(
+        delegate: DomainEventStream,
+        state: S,
+        firstOperator: String,
+        firstEventTime: Long,
+        tags: AbacTags,
+        deleted: Boolean,
+    ): StateEventData<S> = copy(delegate, state, firstOperator, firstEventTime, tags, deleted, ownerId, spaceId)
+
     /**
      * Creates a copy of this StateEventData with a copied delegate.
      *

--- a/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricEventStore.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/metrics/MetricEventStore.kt
@@ -67,6 +67,12 @@ internal class MetricEventStore(
             descriptor("last", aggregateId.contextName, aggregateId.aggregateName),
         )
 
+    override fun loadByRequestIds(aggregateId: AggregateId, requestIds: Set<String>): Flux<DomainEventStream> =
+        metrics.operation(
+            delegate.loadByRequestIds(aggregateId, requestIds),
+            descriptor("load_by_request_ids", aggregateId.contextName, aggregateId.aggregateName),
+        )
+
     override fun scanAggregateId(
         namedAggregate: NamedAggregate,
         afterId: String,

--- a/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunction.kt
@@ -18,17 +18,29 @@ import me.ahoo.wow.api.event.DomainEvent
 import me.ahoo.wow.api.messaging.function.FunctionKind
 import me.ahoo.wow.api.modeling.NamedAggregate
 import me.ahoo.wow.command.CommandGateway
+import me.ahoo.wow.command.DuplicateRequestIdException
+import me.ahoo.wow.command.SimpleCommandMessage
+import me.ahoo.wow.command.commandSentSignal
 import me.ahoo.wow.command.factory.CommandBuilder
 import me.ahoo.wow.command.factory.CommandBuilder.Companion.commandBuilder
 import me.ahoo.wow.command.factory.CommandMessageFactory
+import me.ahoo.wow.command.wait.CommandWaitNotifier
+import me.ahoo.wow.command.wait.extractWaitPlan
+import me.ahoo.wow.command.wait.notifyAndForget
 import me.ahoo.wow.event.DomainEventExchange
+import me.ahoo.wow.event.DomainEventStream
+import me.ahoo.wow.eventsourcing.EventStore
 import me.ahoo.wow.infra.Decorator
+import me.ahoo.wow.infra.Decorator.Companion.getOriginalDelegate
+import me.ahoo.wow.ioc.getService
 import me.ahoo.wow.messaging.function.MessageFunction
+import me.ahoo.wow.messaging.function.MessageFunctionAccessor
 import me.ahoo.wow.messaging.propagation.MessagePropagatorProvider.propagate
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
+import java.net.URLEncoder
 
 /**
  * A stateless saga function that processes domain events and generates command streams.
@@ -48,30 +60,110 @@ class StatelessSagaFunction(
     override val contextName: String = delegate.contextName
     override val name: String = delegate.name
     override val processor: Any = delegate.processor
+    override val processorName: String = delegate.processorName
     override val supportedType: Class<*> = delegate.supportedType
     override val supportedTopics: Set<NamedAggregate> = delegate.supportedTopics
     override val functionKind: FunctionKind = delegate.functionKind
+    private val method = (delegate.getOriginalDelegate() as? MessageFunctionAccessor<*, *, *>)?.metadata?.accessor?.method
+    private val signature = name + (method?.parameterTypes?.map { it.name } ?: listOf(supportedType.name))
+        .joinToString(",", "(", ")")
+    private val functionId = listOf(contextName, processorName, signature)
+        .joinToString(":") { URLEncoder.encode(it, Charsets.UTF_8) }
+    private val commandsKey = "__SAGA_COMMANDS__$functionId"
 
     override fun <A : Annotation> getAnnotation(annotationClass: Class<A>): A? = delegate.getAnnotation(annotationClass)
 
-    override fun invoke(exchange: DomainEventExchange<*>): Mono<CommandStream> =
-        delegate
-            .invoke(exchange)
-            .flatMapMany {
-                toCommandFlux(exchange.message, it)
-            }.concatMap {
-                commandGateway.send(it).thenReturn(it)
+    override fun invoke(exchange: DomainEventExchange<*>): Mono<CommandStream> = Mono.defer {
+        val commands = exchange.getAttribute<List<PendingCommand>>(commandsKey)?.toMono()
+            ?: delegate.invoke(exchange)
+                .flatMapMany { toCommandFlux(exchange.message, it) }
+                .collectList()
+                .doOnNext { exchange.setAttribute(commandsKey, it) }
+        commands.flatMapMany { Flux.fromIterable(it) }
+            .concatMap { pending ->
+                if (pending.sent) {
+                    Mono.just(pending.command)
+                } else {
+                    recoverStoredCommand(exchange, pending)
+                        .switchIfEmpty(
+                            Mono.defer {
+                                commandGateway.send(pending.command).thenReturn(pending.command)
+                                    .onErrorResume(DuplicateRequestIdException::class.java) { error ->
+                                        recoverStoredCommand(exchange, pending).switchIfEmpty(Mono.error(error))
+                                    }
+                            }
+                        ).doOnNext {
+                            pending.command = it
+                            pending.sent = true
+                        }
+                }
             }.collectList()
-            .map {
-                val commandStream = DefaultCommandStream(exchange.message.id, it)
-                exchange.setCommandStream(commandStream)
-                commandStream
-            }
+            .map { DefaultCommandStream(exchange.message.id, it).also(exchange::setCommandStream) }
+    }
 
+    private fun recoverStoredCommand(
+        exchange: DomainEventExchange<*>,
+        pending: PendingCommand,
+    ): Mono<CommandMessage<*>> {
+        val provider = exchange.getServiceProvider() ?: return Mono.empty()
+        val eventStore = provider.getService<EventStore>() ?: return Mono.empty()
+        val command = pending.command
+        return eventStore.loadByRequestIds(
+            command.aggregateId,
+            setOfNotNull(command.requestId, pending.legacyRequestId)
+        )
+            .collectList()
+            .flatMap { records ->
+                val stored = records.firstOrNull { it.requestId == command.requestId }
+                if (stored == null) {
+                    if (records.isEmpty()) return@flatMap Mono.empty()
+                    return@flatMap Mono.error(
+                        DuplicateRequestIdException(
+                            command.aggregateId,
+                            records.first().requestId,
+                            "Ambiguous legacy Saga request ID[${records.first().requestId}] for [$functionId]. " +
+                                "Reconcile the previous command before specifying an explicit requestId.",
+                        )
+                    )
+                }
+                val restored = command.restoreIdentity(stored)
+                notifyStoredCommand(restored, provider.getService<CommandWaitNotifier>())
+                Mono.just(restored)
+            }
+    }
+
+    private fun CommandMessage<*>.restoreIdentity(stored: DomainEventStream): CommandMessage<*> =
+        SimpleCommandMessage(
+            id = stored.commandId,
+            requestId = stored.requestId,
+            body = body,
+            aggregateId = aggregateId,
+            ownerId = ownerId,
+            spaceId = spaceId,
+            header = header.copy(),
+            aggregateVersion = aggregateVersion,
+            name = name,
+            isCreate = isCreate,
+            allowCreate = allowCreate,
+            isVoid = isVoid,
+            createTime = createTime,
+        )
+
+    private fun notifyStoredCommand(
+        command: CommandMessage<*>,
+        notifier: CommandWaitNotifier?,
+    ) {
+        notifier ?: return
+        val waitPlan = command.header.extractWaitPlan() ?: return
+        // A stored event proves acceptance. Later stages still require their actual notifications.
+        notifier.notifyAndForget(waitPlan, command.commandSentSignal(waitPlan.waitCommandId))
+    }
+
+    @Suppress("UNCHECKED_CAST")
     private fun toCommandFlux(
         domainEvent: DomainEvent<*>,
         handleResult: Any
-    ): Publisher<CommandMessage<*>> {
+    ): Publisher<PendingCommand> {
         if (handleResult !is Iterable<*>) {
             return toCommand(domainEvent = domainEvent, singleResult = handleResult)
         }
@@ -87,23 +179,29 @@ class StatelessSagaFunction(
         domainEvent: DomainEvent<*>,
         singleResult: Any,
         index: Int = 0
-    ): Mono<CommandMessage<*>> {
+    ): Mono<PendingCommand> {
         if (singleResult is CommandMessage<*>) {
             singleResult.header.propagate(domainEvent)
-            return singleResult.toMono()
+            return PendingCommand(singleResult).toMono()
         }
         val commandBuilder = singleResult as? CommandBuilder ?: singleResult.commandBuilder()
+        val legacyRequestId = "${domainEvent.id}-$index".takeIf { commandBuilder.requestId == null }
         commandBuilder
-            .requestIdIfAbsent("${domainEvent.id}-$index")
+            .requestIdIfAbsent("saga:${domainEvent.id}:$functionId:$index")
             .tenantIdIfAbsent(domainEvent.aggregateId.tenantId)
             .spaceIdIfAbsent(domainEvent.spaceId)
             .upstream(domainEvent)
             .header {
                 it.propagate(domainEvent)
             }
-        @Suppress("UNCHECKED_CAST")
-        return commandMessageFactory.create<Any>(commandBuilder) as Mono<CommandMessage<*>>
+        return commandMessageFactory.create<Any>(commandBuilder).map { PendingCommand(it, legacyRequestId) }
     }
+
+    private class PendingCommand(
+        var command: CommandMessage<*>,
+        val legacyRequestId: String? = null,
+        var sent: Boolean = false,
+    )
 
     override fun toString(): String = "StatelessSagaFunction(actual=$delegate)"
 }

--- a/wow-core/src/test/java/me/ahoo/wow/eventsourcing/state/StateEventDataSourceCompatibilityTest.java
+++ b/wow-core/src/test/java/me/ahoo/wow/eventsourcing/state/StateEventDataSourceCompatibilityTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.eventsourcing.state;
+
+import me.ahoo.wow.event.DomainEventStream;
+import me.ahoo.wow.modeling.DefaultAggregateId;
+import me.ahoo.wow.modeling.MaterializedNamedAggregate;
+import me.ahoo.wow.tck.event.MockDomainEventStreams;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class StateEventDataSourceCompatibilityTest {
+    @Test
+    void existingSixArgumentConstructionAndCopyRemainAvailable() {
+        var aggregateId = new DefaultAggregateId(new MaterializedNamedAggregate("test", "aggregate"), "id", "tenant");
+        DomainEventStream stream = MockDomainEventStreams.INSTANCE.generateEventStream(aggregateId);
+        var original = new StateEventData<>(stream, "state", "first", 1L, Map.of(), false);
+        assertEquals("copy", original.copy(stream, "copy", "first", 1L, Map.of(), false).getState());
+
+        var transferred = new StateEventData<>(stream, "state", "first", 1L, Map.of(), false, "new-owner", "new-space");
+        var copied = transferred.copy(stream, "copy", "first", 1L, Map.of(), false);
+        assertEquals("new-owner", copied.getOwnerId());
+        assertEquals("new-space", copied.getSpaceId());
+    }
+}

--- a/wow-core/src/test/kotlin/me/ahoo/wow/event/compensation/StateEventCompensatorTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/event/compensation/StateEventCompensatorTest.kt
@@ -15,15 +15,20 @@ package me.ahoo.wow.event.compensation
 
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.messaging.function.FunctionKind
+import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.eventsourcing.InMemoryEventStore
+import me.ahoo.wow.eventsourcing.state.InMemoryStateEventBus
 import me.ahoo.wow.eventsourcing.state.StateEvent
 import me.ahoo.wow.eventsourcing.state.StateEventBus
 import me.ahoo.wow.eventsourcing.state.StateEventExchange
 import me.ahoo.wow.messaging.MessageSubscription
 import me.ahoo.wow.messaging.compensation.COMPENSATION_ID
 import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.modeling.metadata.StateAggregateMetadata
 import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory
 import me.ahoo.wow.modeling.state.IgnoredErrorEvent
+import me.ahoo.wow.modeling.state.StateAggregate
+import me.ahoo.wow.modeling.state.StateAggregateFactory
 import me.ahoo.wow.tck.event.MockDomainEventStreams.generateEventStream
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import me.ahoo.wow.tck.mock.MockAggregateCreated
@@ -32,8 +37,78 @@ import org.junit.jupiter.api.Test
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.test.StepVerifier
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 class StateEventCompensatorTest {
+    @Test
+    fun `resending a narrow range copies only emitted versions`() {
+        val copies = AtomicInteger()
+        val aggregateId = MOCK_AGGREGATE_METADATA.aggregateId("copy-cost")
+        val store = InMemoryEventStore()
+        val factory = object : StateAggregateFactory {
+            override fun <S : Any> create(
+                metadata: StateAggregateMetadata<S>,
+                aggregateId: AggregateId
+            ): StateAggregate<S> {
+                val aggregate = ConstructorStateAggregateFactory.create(metadata, aggregateId)
+                return object : StateAggregate<S> by aggregate {
+                    override val state: S get() {
+                        copies.incrementAndGet()
+                        return aggregate.state
+                    }
+                }
+            }
+        }
+        for (version in 1..3) {
+            store.append(
+                generateEventStream(
+                    aggregateId,
+                    aggregateVersion = version - 1,
+                    eventCount = 1,
+                    createdEventSupplier = { MockAggregateCreated("v$version") }
+                )
+            ).block(Duration.ofSeconds(5))
+        }
+        val bus = InMemoryStateEventBus()
+        try {
+            val emitted = StateEventCompensator(factory, store, bus)
+                .resend(aggregateId, 3, 3, compensationTarget(FunctionKind.STATE_EVENT)).block(Duration.ofSeconds(5))
+            emitted.assert().isEqualTo(1L)
+            copies.get().assert().isEqualTo(1)
+        } finally { bus.close() }
+    }
+
+    @Test
+    fun `resend retains the state belonging to each version on the local bus`() {
+        val aggregateId = MOCK_AGGREGATE_METADATA.aggregateId("compensated-versions")
+        val eventStore = InMemoryEventStore()
+        val stateEventBus = InMemoryStateEventBus()
+        val received = stateEventBus.receive(MessageSubscription(aggregateId.namedAggregate))
+            .map { it.message }.take(2).collectList().toFuture()
+        try {
+            for (version in 1..2) {
+                val stream = generateEventStream(
+                    aggregateId,
+                    aggregateVersion = version - 1,
+                    eventCount = 1,
+                    createdEventSupplier = { MockAggregateCreated("state-v$version") },
+                )
+                StepVerifier.create(eventStore.append(stream)).verifyComplete()
+            }
+            val compensator = StateEventCompensator(ConstructorStateAggregateFactory, eventStore, stateEventBus)
+            StepVerifier.create(compensator.resend(aggregateId, 1, 2, compensationTarget(FunctionKind.STATE_EVENT)))
+                .expectNext(2).expectComplete().verify(Duration.ofSeconds(5))
+
+            val events = checkNotNull(received.get(5, TimeUnit.SECONDS))
+            events.map { it.version to (it.state as MockStateAggregate).data }
+                .assert().containsExactly(1 to "state-v1", 2 to "state-v2")
+        } finally {
+            received.cancel(true)
+            stateEventBus.close()
+        }
+    }
 
     @Test
     fun `resend rebuilds state and sends compensated state events in requested range`() {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/EventStoreTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/EventStoreTest.kt
@@ -48,6 +48,23 @@ class EventStoreTest {
     }
 
     @Test
+    fun `default request lookup filters candidates in one scan and skips empty candidates`() {
+        val aggregateId = MOCK_AGGREGATE_METADATA.aggregateId("aggregate-1")
+        val first = eventStream(aggregateId, "request-1")
+        val second = eventStream(aggregateId, "request-2")
+        val eventStore = ScanningEventStore(listOf(first, second, eventStream(aggregateId, "request-3")))
+
+        StepVerifier.create(eventStore.loadByRequestIds(aggregateId, setOf("request-1", "request-2")))
+            .expectNext(first, second)
+            .verifyComplete()
+        eventStore.loadCount.assert().isEqualTo(1)
+
+        StepVerifier.create(eventStore.loadByRequestIds(aggregateId, emptySet()))
+            .verifyComplete()
+        eventStore.loadCount.assert().isEqualTo(1)
+    }
+
+    @Test
     fun `default load uses full version range`() {
         val aggregateId = MOCK_AGGREGATE_METADATA.aggregateId("aggregate-1")
         val scanningEventStore = ScanningEventStore(emptyList())
@@ -117,6 +134,7 @@ class EventStoreTest {
     ) : EventStore {
         var lastHeadVersion: Int? = null
         var lastTailVersion: Int? = null
+        var loadCount: Int = 0
 
         override fun append(eventStream: DomainEventStream): Mono<Void> = Mono.empty()
 
@@ -125,6 +143,7 @@ class EventStoreTest {
             headVersion: Int,
             tailVersion: Int
         ): Flux<DomainEventStream> {
+            loadCount++
             lastHeadVersion = headVersion
             lastTailVersion = tailVersion
             return Flux.fromIterable(eventStreams)

--- a/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/RoutingEventStoreTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/RoutingEventStoreTest.kt
@@ -105,6 +105,17 @@ class RoutingEventStoreTest {
     }
 
     @Test
+    fun `request candidate lookup uses the routed native operation`() {
+        val defaultStore = RecordingEventStore()
+        val orderStore = RecordingEventStore()
+        val aggregateId = order.aggregateId("order-1")
+        val routingStore = routingEventStore(defaultStore, orderStore)
+        StepVerifier.create(routingStore.loadByRequestIds(aggregateId, setOf("request-1"))).verifyComplete()
+        orderStore.lastOperation.assert().isEqualTo("loadByRequestIds")
+        defaultStore.lastOperation.assert().isNull()
+    }
+
+    @Test
     fun `exists request id chooses configured store`() {
         val defaultStore = RecordingEventStore()
         val orderStore = RecordingEventStore()
@@ -285,6 +296,11 @@ class RoutingEventStoreTest {
         override fun last(aggregateId: AggregateId): Mono<DomainEventStream> {
             record("last", aggregateId)
             return failure?.let { Mono.error(it) } ?: Mono.empty()
+        }
+
+        override fun loadByRequestIds(aggregateId: AggregateId, requestIds: Set<String>): Flux<DomainEventStream> {
+            record("loadByRequestIds", aggregateId)
+            return failure?.let { Flux.error(it) } ?: Flux.empty()
         }
 
         override fun existsRequestId(aggregateId: AggregateId, requestId: String): Mono<Boolean> {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotMaterializerTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/snapshot/SnapshotMaterializerTest.kt
@@ -34,6 +34,7 @@ class SnapshotMaterializerTest {
         operator = "operator",
         firstEventTime = 100,
         eventTime = 200,
+        tags = mapOf("dept" to listOf("finance")),
         deleted = true,
     )
     private val snapshot = SimpleSnapshot(stateAggregate, snapshotTime = 300)
@@ -46,6 +47,8 @@ class SnapshotMaterializerTest {
         materialized.aggregateName.assert().isEqualTo(aggregateId.aggregateName)
         materialized.tenantId.assert().isEqualTo(aggregateId.tenantId)
         materialized.ownerId.assert().isEqualTo("owner-1")
+        materialized.spaceId.assert().isEqualTo("space-1")
+        materialized.tags.assert().isEqualTo(mapOf("dept" to listOf("finance")))
         materialized.aggregateId.assert().isEqualTo("snapshot-aggregate")
         materialized.version.assert().isEqualTo(7)
         materialized.eventId.assert().isEqualTo("event-1")
@@ -69,6 +72,7 @@ class SnapshotMaterializerTest {
         medium.tenantId.assert().isEqualTo(aggregateId.tenantId)
         medium.ownerId.assert().isEqualTo("owner-1")
         medium.spaceId.assert().isEqualTo(snapshot.spaceId)
+        medium.tags.assert().isEqualTo(mapOf("dept" to listOf("finance")))
         medium.version.assert().isEqualTo(7)
         medium.eventId.assert().isEqualTo("event-1")
         medium.firstOperator.assert().isEqualTo("first-operator")

--- a/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/state/StateEventMetadataTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/eventsourcing/state/StateEventMetadataTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.eventsourcing.state
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.event.OwnerTransferred
+import me.ahoo.wow.api.event.SpaceTransferred
+import me.ahoo.wow.command.toCommandMessage
+import me.ahoo.wow.event.toDomainEventStream
+import me.ahoo.wow.eventsourcing.EventSourcingStateAggregateRepository
+import me.ahoo.wow.eventsourcing.InMemoryEventStore
+import me.ahoo.wow.eventsourcing.snapshot.InMemorySnapshotStore
+import me.ahoo.wow.eventsourcing.snapshot.SimpleSnapshot
+import me.ahoo.wow.eventsourcing.state.StateEvent.Companion.toStateEvent
+import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory
+import me.ahoo.wow.serialization.toJsonString
+import me.ahoo.wow.serialization.toObject
+import me.ahoo.wow.tck.event.MockDomainEventStreams.generateEventStream
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
+import me.ahoo.wow.tck.mock.MockAggregateCreated
+import me.ahoo.wow.tck.mock.MockChangeAggregate
+import me.ahoo.wow.tck.mock.MockStateAggregate
+import org.junit.jupiter.api.Assertions.assertAll
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+class StateEventMetadataTest {
+    @Test
+    fun `state events preserve transferred ownership through copying serialization and snapshots`() {
+        val aggregateId = MOCK_AGGREGATE_METADATA.aggregateId("transferred-state-event")
+        val store = InMemoryEventStore()
+        val snapshots = InMemorySnapshotStore()
+        val state = ConstructorStateAggregateFactory.create(MOCK_AGGREGATE_METADATA.state, aggregateId)
+        val first = generateEventStream(
+            aggregateId,
+            aggregateVersion = 0,
+            eventCount = 1,
+            ownerId = "old-owner",
+            spaceId = "old-space",
+            createdEventSupplier = { MockAggregateCreated("v1") }
+        )
+        state.onSourcing(first)
+        store.append(first).block(Duration.ofSeconds(5))
+        val command = MockChangeAggregate(aggregateId.id, "transfer").toCommandMessage(
+            ownerId = "old-owner",
+            spaceId = "old-space",
+        )
+        val second = listOf(TransferredOwner("new-owner"), TransferredSpace("new-space"))
+            .toDomainEventStream(command, aggregateVersion = 1)
+        state.onSourcing(second)
+        state.ownerId.assert().isEqualTo("new-owner")
+        state.spaceId.assert().isEqualTo("new-space")
+        store.append(second).block(Duration.ofSeconds(5))
+        val stateEvent = second.toStateEvent(state)
+        for (event in listOf(
+            stateEvent,
+            stateEvent.copy(),
+            stateEvent.toJsonString().toObject<StateEvent<MockStateAggregate>>()
+        )) {
+            assertAll(
+                { event.ownerId.assert().isEqualTo("new-owner") },
+                { event.spaceId.assert().isEqualTo("new-space") },
+            )
+            snapshots.save(SimpleSnapshot(event)).block(Duration.ofSeconds(5))
+        }
+        val restored = EventSourcingStateAggregateRepository(ConstructorStateAggregateFactory, snapshots, store)
+            .load(aggregateId, MOCK_AGGREGATE_METADATA.state).block(Duration.ofSeconds(5))!!
+        assertAll(
+            { restored.ownerId.assert().isEqualTo("new-owner") },
+            { restored.spaceId.assert().isEqualTo("new-space") },
+        )
+    }
+}
+
+private data class TransferredOwner(override val toOwnerId: String) : OwnerTransferred
+private data class TransferredSpace(override val toSpaceId: String) : SpaceTransferred

--- a/wow-core/src/test/kotlin/me/ahoo/wow/metrics/MetricStorageDecoratorTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/metrics/MetricStorageDecoratorTest.kt
@@ -47,6 +47,7 @@ class MetricStorageDecoratorTest {
             every { load(aggregateId, 1, 10) } returns Flux.just(stream)
             every { load(aggregateId, 100L, 200L) } returns Flux.just(stream)
             every { existsRequestId(aggregateId, "request-1") } returns Mono.just(true)
+            every { loadByRequestIds(aggregateId, setOf("request-1")) } returns Flux.just(stream)
             every { last(aggregateId) } returns Mono.just(stream)
             every { scanAggregateId(aggregate, "after-id", 10) } returns Flux.just(aggregateId)
             every { close() } just Runs
@@ -57,6 +58,9 @@ class MetricStorageDecoratorTest {
         StepVerifier.create(eventStore.load(aggregateId, 1, 10)).expectNext(stream).verifyComplete()
         StepVerifier.create(eventStore.load(aggregateId, 100L, 200L)).expectNext(stream).verifyComplete()
         StepVerifier.create(eventStore.existsRequestId(aggregateId, "request-1")).expectNext(true).verifyComplete()
+        StepVerifier.create(
+            eventStore.loadByRequestIds(aggregateId, setOf("request-1"))
+        ).expectNext(stream).verifyComplete()
         StepVerifier.create(eventStore.last(aggregateId)).expectNext(stream).verifyComplete()
         StepVerifier.create(eventStore.scanAggregateId(aggregate, "after-id", 10))
             .expectNext(aggregateId)
@@ -70,6 +74,7 @@ class MetricStorageDecoratorTest {
                 "load_by_version",
                 "load_by_time",
                 "exists_request_id",
+                "load_by_request_ids",
                 "last",
                 "scan_aggregate_id",
             )
@@ -78,6 +83,7 @@ class MetricStorageDecoratorTest {
             delegate.load(aggregateId, 1, 10)
             delegate.load(aggregateId, 100L, 200L)
             delegate.existsRequestId(aggregateId, "request-1")
+            delegate.loadByRequestIds(aggregateId, setOf("request-1"))
             delegate.last(aggregateId)
             delegate.scanAggregateId(aggregate, "after-id", 10)
             delegate.close()

--- a/wow-core/src/test/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunctionCommandEmissionTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunctionCommandEmissionTest.kt
@@ -58,7 +58,9 @@ class StatelessSagaFunctionCommandEmissionTest {
                 stream.domainEventId.assert().isEqualTo(event.id)
                 stream.size.assert().isEqualTo(1)
                 commands[0].body.assert().isInstanceOf(MockCreateAggregate::class.java)
-                commands[0].requestId.assert().isEqualTo("${event.id}-0")
+                commands[0].requestId.assert().isEqualTo(
+                    "saga:${event.id}:fixture:String:onEvent%28me.ahoo.wow.tck.mock.MockAggregateCreated%29:0"
+                )
                 commands[0].aggregateId.tenantId.assert().isEqualTo(event.aggregateId.tenantId)
                 commands[0].spaceId.assert().isEqualTo(event.spaceId)
                 commands[0].header.traceId.assert().isEqualTo(event.header.traceId)
@@ -96,8 +98,8 @@ class StatelessSagaFunctionCommandEmissionTest {
                     MockChangeAggregate::class.java,
                 )
                 commands.map { it.requestId }.assert().containsExactly(
-                    "${event.id}-0",
-                    "${event.id}-1",
+                    "saga:${event.id}:fixture:String:onEvent%28me.ahoo.wow.tck.mock.MockAggregateCreated%29:0",
+                    "saga:${event.id}:fixture:String:onEvent%28me.ahoo.wow.tck.mock.MockAggregateCreated%29:1",
                 )
             }.verifyComplete()
 

--- a/wow-core/src/test/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunctionRequestIdTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaFunctionRequestIdTest.kt
@@ -28,7 +28,7 @@ import reactor.test.StepVerifier
 class StatelessSagaFunctionRequestIdTest {
 
     @Test
-    fun `command builder without request id uses domain event id and iterable index`() {
+    fun `command builder without request id uses event function identity and iterable index`() {
         val event = fixtureEvent()
         val function = StatelessSagaFunction(
             delegate = StubMessageFunction(
@@ -46,8 +46,8 @@ class StatelessSagaFunctionRequestIdTest {
         StepVerifier.create(function.invoke(SimpleDomainEventExchange(event)))
             .assertNext { stream ->
                 stream.map { it.requestId }.toList().assert().containsExactly(
-                    "${event.id}-0",
-                    "${event.id}-1",
+                    "saga:${event.id}:fixture:String:onEvent%28me.ahoo.wow.tck.mock.MockAggregateCreated%29:0",
+                    "saga:${event.id}:fixture:String:onEvent%28me.ahoo.wow.tck.mock.MockAggregateCreated%29:1",
                 )
             }.verifyComplete()
     }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaRecoveryTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/saga/stateless/StatelessSagaRecoveryTest.kt
@@ -1,0 +1,465 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.saga.stateless
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.annotation.StatelessSaga
+import me.ahoo.wow.api.command.CommandMessage
+import me.ahoo.wow.api.event.DomainEvent
+import me.ahoo.wow.api.messaging.function.FunctionInfoData
+import me.ahoo.wow.api.messaging.function.FunctionKind
+import me.ahoo.wow.api.messaging.function.NamedFunctionInfoData
+import me.ahoo.wow.api.modeling.AggregateId
+import me.ahoo.wow.command.CommandBus
+import me.ahoo.wow.command.DefaultCommandGateway
+import me.ahoo.wow.command.DefaultRequestIdChecker
+import me.ahoo.wow.command.DuplicateRequestIdException
+import me.ahoo.wow.command.ServerCommandExchange
+import me.ahoo.wow.command.factory.CommandBuilder.Companion.commandBuilder
+import me.ahoo.wow.command.toCommandMessage
+import me.ahoo.wow.command.validation.NoOpValidator
+import me.ahoo.wow.command.wait.CommandStage
+import me.ahoo.wow.command.wait.CommandWait
+import me.ahoo.wow.command.wait.CommandWaitNotifier
+import me.ahoo.wow.command.wait.DefaultWaitCoordinator
+import me.ahoo.wow.command.wait.SimpleCommandWaitEndpoint
+import me.ahoo.wow.command.wait.WaitSignal
+import me.ahoo.wow.command.wait.chain.WaitingChainTail.Companion.toWaitingChainTail
+import me.ahoo.wow.command.wait.testFunction
+import me.ahoo.wow.command.wait.testSignal
+import me.ahoo.wow.command.wait.thenNotifyAndForget
+import me.ahoo.wow.event.DomainEventExchange
+import me.ahoo.wow.event.DomainEventStream
+import me.ahoo.wow.event.SimpleDomainEventExchange
+import me.ahoo.wow.event.toDomainEventStream
+import me.ahoo.wow.eventsourcing.EventStore
+import me.ahoo.wow.eventsourcing.InMemoryEventStore
+import me.ahoo.wow.infra.idempotency.AggregateIdempotencyCheckerProvider
+import me.ahoo.wow.infra.idempotency.IdempotencyChecker
+import me.ahoo.wow.ioc.SimpleServiceProvider
+import me.ahoo.wow.ioc.register
+import me.ahoo.wow.messaging.MessageSubscription
+import me.ahoo.wow.messaging.compensation.CompensationMatcher.withCompensation
+import me.ahoo.wow.messaging.compensation.CompensationTarget
+import me.ahoo.wow.messaging.function.MessageFunction
+import me.ahoo.wow.tck.mock.MockAggregateCreated
+import me.ahoo.wow.tck.mock.MockChangeAggregate
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+import reactor.util.retry.Retry
+import java.time.Duration
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicInteger
+
+class StatelessSagaRecoveryTest {
+    @Test
+    fun `retry resumes remaining commands using their original identities`() {
+        val fixture = SagaRecoveryFixture()
+        var failedCommandId: String? = null
+        fixture.beforeSend = { command ->
+            if (command.aggregateId.id == "second" && failedCommandId == null) {
+                failedCommandId = command.commandId
+                Mono.error(TimeoutException("send failed"))
+            } else {
+                Mono.empty()
+            }
+        }
+        val function = fixture.function(
+            listOf(MockChangeAggregate("first", "one"), MockChangeAggregate("second", "two"))
+        )
+        val exchange = SimpleDomainEventExchange(fixture.event)
+        StepVerifier.create(function.invoke(exchange).retryWhen(Retry.max(1)))
+            .assertNext { stream ->
+                stream.toList()[1].commandId.assert().isEqualTo(failedCommandId)
+                fixture.attempts.map { it.aggregateId.id }.assert().containsExactly("first", "second", "second")
+            }.verifyComplete()
+    }
+
+    @Test
+    fun `different saga functions send distinct commands to the same aggregate`() {
+        val fixture = SagaRecoveryFixture()
+        val first = fixture.function(MockChangeAggregate("shared", "one"), name = "first")
+        val second = fixture.function(MockChangeAggregate("shared", "two"), name = "second")
+        StepVerifier.create(first.invoke(fixture.exchange()).then(second.invoke(fixture.exchange())))
+            .expectNextCount(1).verifyComplete()
+        fixture.attempts.map { it.requestId }.distinct().assert().hasSize(2)
+    }
+
+    @Test
+    fun `request identities distinguish contexts processors and delimiter characters`() {
+        val fixture = SagaRecoveryFixture()
+        val functions = listOf(
+            fixture.function(MockChangeAggregate("shared", "one"), contextName = "a:b", processorName = "c"),
+            fixture.function(MockChangeAggregate("shared", "two"), contextName = "a", processorName = "b:c"),
+            fixture.function(MockChangeAggregate("shared", "three"), contextName = "a", processorName = "c"),
+        )
+        StepVerifier.create(Flux.fromIterable(functions).concatMap { it.invoke(fixture.exchange()) })
+            .expectNextCount(3).verifyComplete()
+        fixture.attempts.map { it.requestId }.distinct().assert().hasSize(3)
+    }
+
+    @Test
+    fun `replayed event recovers the persisted command instead of emitting another one`() {
+        val fixture = SagaRecoveryFixture()
+        val body = MockChangeAggregate("replayed", "one")
+        val first = fixture.function(body).invoke(fixture.exchange()).block(Duration.ofSeconds(5))!!.single()
+        StepVerifier.create(fixture.function(body).invoke(fixture.exchange()))
+            .assertNext { it.single().commandId.assert().isEqualTo(first.commandId) }
+            .verifyComplete()
+        fixture.attempts.assert().hasSize(1)
+    }
+
+    @Test
+    fun `ordinary cold-cache redelivery restores identity before an asynchronous broker accepts another send`() {
+        val first = SagaRecoveryFixture()
+        val body = MockChangeAggregate("cold-replay", "one")
+        val original = first.function(body).invoke(first.exchange()).block(Duration.ofSeconds(5))!!.single()
+        val restarted = SagaRecoveryFixture(event = first.event, store = first.store).apply { brokerOnly = true }
+        StepVerifier.create(restarted.function(body).invoke(restarted.exchange()))
+            .assertNext { it.single().commandId.assert().isEqualTo(original.commandId) }
+            .verifyComplete()
+        restarted.attempts.assert().isEmpty()
+        restarted.recoveryReads.get().assert().isEqualTo(1)
+    }
+
+    @Test
+    fun `current signature record takes priority over an earlier ambiguous legacy record`() {
+        val fixture = SagaRecoveryFixture()
+        val body = MockChangeAggregate("legacy-target", "one")
+        val current = fixture.function(body).invoke(fixture.exchange()).block(Duration.ofSeconds(5))!!.single()
+        val history = InMemoryEventStore()
+        val older = body.toCommandMessage(
+            id = "legacy-command",
+            requestId = "${fixture.event.id}-0",
+            tenantId = fixture.event.aggregateId.tenantId,
+            spaceId = fixture.event.spaceId,
+        )
+        history.append(MockAggregateCreated("older").toDomainEventStream(older))
+            .then(history.append(MockAggregateCreated("current").toDomainEventStream(current, aggregateVersion = 1)))
+            .block(Duration.ofSeconds(5))
+        val restarted = SagaRecoveryFixture(fixture.event, history).apply { brokerOnly = true }
+        StepVerifier.create(restarted.function(body).invoke(restarted.exchange()))
+            .assertNext { it.single().commandId.assert().isEqualTo(current.commandId) }.verifyComplete()
+        restarted.attempts.assert().isEmpty()
+        restarted.recoveryReads.get().assert().isEqualTo(1)
+    }
+
+    @Test
+    fun `legacy requests report ambiguity even on ordinary cold-cache redelivery`() {
+        val fixture = SagaRecoveryFixture()
+        val original = fixture.storeLegacyCommand()
+        fixture.brokerOnly = true
+        val function = fixture.function(MockChangeAggregate("legacy-target", "from-another-function"), name = "another")
+        StepVerifier.create(function.invoke(fixture.exchange()))
+            .expectErrorSatisfies { error ->
+                error.assert().isInstanceOf(DuplicateRequestIdException::class.java)
+                (error as DuplicateRequestIdException).requestId.assert().isEqualTo(original.requestId)
+                error.message.assert().contains("legacy")
+            }.verify()
+        fixture.attempts.assert().isEmpty()
+    }
+
+    @Test
+    fun `fresh commands perform one candidate lookup without history scans`() {
+        val fixture = SagaRecoveryFixture()
+        StepVerifier.create(fixture.function(MockChangeAggregate("fresh", "one")).invoke(fixture.exchange()))
+            .expectNextCount(1).verifyComplete()
+        fixture.recoveryReads.get().assert().isEqualTo(1)
+        fixture.historyReads.get().assert().isEqualTo(0)
+    }
+
+    @Test
+    fun `explicit compensation uses one record read without existence probes`() {
+        val fixture = SagaRecoveryFixture()
+        val body = MockChangeAggregate("replayed", "one")
+        val function = fixture.function(body)
+        val original = function.invoke(fixture.exchange()).block(Duration.ofSeconds(5))!!.single()
+        fixture.recoveryReads.set(0)
+        StepVerifier.create(function.invoke(fixture.compensationExchange(function)))
+            .assertNext { it.single().commandId.assert().isEqualTo(original.commandId) }
+            .verifyComplete()
+        fixture.recoveryReads.get().assert().isEqualTo(1)
+        fixture.attempts.assert().hasSize(1)
+    }
+
+    @Test
+    fun `registered overloads have distinct stable request identities`() {
+        val fixture = SagaRecoveryFixture()
+        val registrar = StatelessSagaFunctionRegistrar(fixture.gateway, commandMessageFactory())
+        registrar.registerProcessor(OverloadedSaga())
+        val functions = registrar.supportedFunctions(fixture.event).toList()
+        functions.assert().hasSize(2)
+        StepVerifier.create(Flux.fromIterable(functions).concatMap { it.invoke(fixture.exchange()) })
+            .expectNextCount(2).verifyComplete()
+        fixture.attempts.map { it.requestId }.distinct().assert().hasSize(2)
+        val ids = fixture.attempts.map { it.commandId }.toSet()
+        val reloadedFunctions = StatelessSagaFunctionRegistrar(fixture.gateway, commandMessageFactory())
+            .resolveProcessor(OverloadedSaga())
+        StepVerifier.create(
+            Flux.fromIterable(reloadedFunctions).concatMap {
+                it.invoke(fixture.compensationExchange(it)).cast(CommandStream::class.java)
+            }.flatMapIterable { it }.map { it.commandId }.collectList()
+        )
+            .assertNext { it.toSet().assert().isEqualTo(ids) }.verifyComplete()
+        fixture.attempts.assert().hasSize(2)
+    }
+
+    @Test
+    fun `retry does not leave a failed sent signal in the waiting chain`() {
+        val fixture = SagaRecoveryFixture()
+        val plan = fixture.chainPlan(CommandStage.PROCESSED)
+        val handle = fixture.coordinator.createLast(plan)
+        fixture.signal(CommandStage.PROCESSED, fixture.event.commandId)
+        var failSecond = true
+        fixture.beforeSend = { command ->
+            if (command.aggregateId.id == "second" && failSecond) {
+                failSecond = false
+                Mono.error(TimeoutException("send failed"))
+            } else {
+                Mono.empty()
+            }
+        }
+        fixture.afterSend = { fixture.signal(CommandStage.PROCESSED, it.commandId) }
+        val function = fixture.function(
+            listOf(MockChangeAggregate("first", "one"), MockChangeAggregate("second", "two"))
+        )
+        val exchange = fixture.exchange().setFunction(function)
+        StepVerifier.create(
+            function.invoke(exchange).retryWhen(Retry.max(1)).then()
+                .thenNotifyAndForget(fixture.notifier, CommandStage.SAGA_HANDLED, exchange)
+                .then(handle.await())
+        ).assertNext { it.succeeded.assert().isTrue() }
+            .expectComplete().verify(Duration.ofSeconds(5))
+    }
+
+    @Test
+    fun `terminal saga send failure still completes the waiting chain with an error`() {
+        val fixture = SagaRecoveryFixture()
+        val handle = fixture.coordinator.createLast(fixture.chainPlan(CommandStage.PROCESSED))
+        fixture.signal(CommandStage.PROCESSED, fixture.event.commandId)
+        fixture.beforeSend = { Mono.error(TimeoutException("unavailable")) }
+        val function = fixture.function(MockChangeAggregate("failed", "one"))
+        val exchange = fixture.exchange().setFunction(function)
+        StepVerifier.create(
+            function.invoke(exchange).retryWhen(Retry.max(1)).then()
+                .thenNotifyAndForget(fixture.notifier, CommandStage.SAGA_HANDLED, exchange)
+        ).expectError(TimeoutException::class.java).verify()
+        StepVerifier.create(handle.await())
+            .assertNext { it.succeeded.assert().isFalse() }.verifyComplete()
+    }
+
+    @Test
+    fun `persisted recovery matches the original processed notification`() {
+        val fixture = SagaRecoveryFixture()
+        fixture.storeLegacyCommand()
+        val handle = fixture.coordinator.createLast(fixture.chainPlan(CommandStage.PROCESSED))
+        fixture.signal(CommandStage.PROCESSED, fixture.event.commandId)
+        fixture.signal(CommandStage.PROCESSED, "legacy-command")
+        val function = fixture.function(
+            MockChangeAggregate("legacy-target", "one").commandBuilder().requestId("${fixture.event.id}-0")
+        )
+        val exchange = fixture.exchange().setFunction(function)
+        StepVerifier.create(
+            function.invoke(exchange).then()
+                .thenNotifyAndForget(fixture.notifier, CommandStage.SAGA_HANDLED, exchange)
+                .then(handle.await())
+        ).assertNext {
+            it.succeeded.assert().isTrue()
+            it.commandId.assert().isEqualTo("legacy-command")
+        }.expectComplete().verify(Duration.ofSeconds(5))
+    }
+
+    @Test
+    fun `persisted recovery waits for actual projection completion`() {
+        val fixture = SagaRecoveryFixture()
+        fixture.storeLegacyCommand()
+        val handle = fixture.coordinator.createLast(fixture.chainPlan(CommandStage.PROJECTED))
+        fixture.signal(CommandStage.PROCESSED, fixture.event.commandId)
+        fixture.signal(CommandStage.PROCESSED, "legacy-command")
+        val function = fixture.function(
+            MockChangeAggregate("legacy-target", "one").commandBuilder().requestId("${fixture.event.id}-0")
+        )
+        val exchange = fixture.exchange().setFunction(function)
+        StepVerifier.create(
+            function.invoke(exchange).then()
+                .thenNotifyAndForget(fixture.notifier, CommandStage.SAGA_HANDLED, exchange)
+                .then(handle.await())
+        ).then {
+            (fixture.event.commandId in fixture.coordinator).assert().isTrue()
+            fixture.signal(CommandStage.PROJECTED, "legacy-command")
+        }.assertNext { it.succeeded.assert().isTrue() }
+            .expectComplete().verify(Duration.ofSeconds(5))
+    }
+
+    @Test
+    fun `stored events do not fabricate completion of command processing`() {
+        val fixture = SagaRecoveryFixture()
+        fixture.storeLegacyCommand()
+        val handle = fixture.coordinator.createLast(fixture.chainPlan(CommandStage.PROCESSED))
+        fixture.signal(CommandStage.PROCESSED, fixture.event.commandId)
+        val function = fixture.function(
+            MockChangeAggregate("legacy-target", "one").commandBuilder().requestId("${fixture.event.id}-0")
+        )
+        val exchange = fixture.exchange().setFunction(function)
+        StepVerifier.create(
+            function.invoke(exchange).then()
+                .thenNotifyAndForget(fixture.notifier, CommandStage.SAGA_HANDLED, exchange)
+                .then(handle.await())
+        ).then {
+            (fixture.event.commandId in fixture.coordinator).assert().isTrue()
+            fixture.signal(CommandStage.PROCESSED, "legacy-command")
+        }.assertNext { it.succeeded.assert().isTrue() }
+            .expectComplete().verify(Duration.ofSeconds(5))
+    }
+
+    @Test
+    fun `unverified duplicate failures are propagated`() {
+        val fixture = SagaRecoveryFixture()
+        fixture.beforeSend = { Mono.error(DuplicateRequestIdException(it.aggregateId, it.requestId)) }
+        StepVerifier.create(fixture.function(MockChangeAggregate("unknown", "one")).invoke(fixture.exchange()))
+            .expectError(DuplicateRequestIdException::class.java).verify()
+    }
+}
+
+private class SagaRecoveryFixture(
+    val event: DomainEvent<*> = fixtureEvent(),
+    val store: InMemoryEventStore = InMemoryEventStore(),
+) {
+    val recoveryReads = AtomicInteger()
+    val historyReads = AtomicInteger()
+    private val recoveryStore = object : EventStore by store {
+        override fun loadByRequestIds(aggregateId: AggregateId, requestIds: Set<String>): Flux<DomainEventStream> {
+            recoveryReads.incrementAndGet()
+            return store.loadByRequestIds(aggregateId, requestIds)
+        }
+        override fun existsRequestId(aggregateId: AggregateId, requestId: String): Mono<Boolean> {
+            recoveryReads.incrementAndGet()
+            return store.existsRequestId(aggregateId, requestId)
+        }
+        override fun load(aggregateId: AggregateId, headVersion: Int, tailVersion: Int): Flux<DomainEventStream> {
+            historyReads.incrementAndGet()
+            return store.load(aggregateId, headVersion, tailVersion)
+        }
+    }
+    val coordinator = DefaultWaitCoordinator()
+    val attempts = mutableListOf<CommandMessage<*>>()
+    var brokerOnly = false
+    var beforeSend: (CommandMessage<*>) -> Mono<Void> = { Mono.empty() }
+    var afterSend: (CommandMessage<*>) -> Unit = {}
+    val notifier = object : CommandWaitNotifier {
+        override fun notify(commandWaitEndpoint: String, waitSignal: WaitSignal): Mono<Void> =
+            Mono.fromRunnable { coordinator.signal(waitSignal) }
+    }
+    private val provider = SimpleServiceProvider().apply {
+        register<EventStore>(recoveryStore)
+        register<CommandWaitNotifier>(notifier)
+    }
+    private val bus = object : CommandBus {
+        override fun send(message: CommandMessage<*>): Mono<Void> = Mono.defer {
+            attempts += message
+            message.withReadOnly()
+            if (brokerOnly) {
+                return@defer beforeSend(message)
+            }
+            beforeSend(message).then(
+                store.last(message.aggregateId).map { it.version }.defaultIfEmpty(0)
+                    .flatMap { version ->
+                        store.append(
+                            MockAggregateCreated("stored").toDomainEventStream(message, version)
+                        )
+                    }
+            ).doOnSuccess { afterSend(message) }
+        }
+        override fun receive(subscription: MessageSubscription): Flux<ServerCommandExchange<*>> = Flux.empty()
+    }
+    private val seen = mutableSetOf<String>()
+    val gateway = DefaultCommandGateway(
+        SimpleCommandWaitEndpoint("local"),
+        bus,
+        NoOpValidator,
+        DefaultRequestIdChecker(AggregateIdempotencyCheckerProvider { IdempotencyChecker { seen.add(it) } }, store),
+        coordinator,
+        notifier,
+    )
+
+    fun exchange() = SimpleDomainEventExchange(event).setServiceProvider(provider)
+
+    fun compensationExchange(function: MessageFunction<*, *, *>) = exchange().also {
+        it.message.header.withCompensation(
+            CompensationTarget(
+                function = FunctionInfoData(
+                    FunctionKind.EVENT,
+                    function.contextName,
+                    function.processorName,
+                    function.name,
+                )
+            )
+        )
+    }
+
+    fun function(
+        result: Any,
+        name: String = "onEvent",
+        contextName: String = "fixture",
+        processorName: String = "test-saga",
+    ): StatelessSagaFunction = StatelessSagaFunction(
+        object : MessageFunction<Any, DomainEventExchange<*>, Mono<*>> by StubMessageFunction(Mono.just(result)) {
+            override val name = name
+            override val contextName = contextName
+            override val processorName = processorName
+        },
+        gateway,
+        commandMessageFactory(),
+    )
+
+    fun storeLegacyCommand(): CommandMessage<*> {
+        val command = MockChangeAggregate("legacy-target", "one").toCommandMessage(
+            id = "legacy-command",
+            requestId = "${event.id}-0",
+            tenantId = event.aggregateId.tenantId,
+            spaceId = event.spaceId,
+        )
+        store.append(MockAggregateCreated("stored").toDomainEventStream(command)).block(Duration.ofSeconds(5))
+        return command
+    }
+
+    fun chainPlan(stage: CommandStage) = CommandWait.chain(
+        event.commandId,
+        NamedFunctionInfoData("fixture", "test-saga", "onEvent"),
+        stage.toWaitingChainTail(NamedFunctionInfoData("projection", "projection", "onEvent")),
+    ).also { it.propagate(SimpleCommandWaitEndpoint("local"), event.header) }
+
+    fun signal(stage: CommandStage, commandId: String) {
+        coordinator.signal(
+            testSignal(
+                stage = stage,
+                waitCommandId = event.commandId,
+                commandId = commandId,
+                function = testFunction(contextName = "projection", processorName = "projection", name = "onEvent"),
+                isLastProjection = true,
+            )
+        )
+    }
+}
+
+@StatelessSaga
+private class OverloadedSaga {
+    @Suppress("UNUSED_PARAMETER")
+    fun onEvent(event: MockAggregateCreated) = MockChangeAggregate("shared", "body-overload")
+
+    @Suppress("UNUSED_PARAMETER")
+    fun onEvent(event: DomainEvent<MockAggregateCreated>) = MockChangeAggregate("shared", "message-overload")
+}

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchEventStore.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchEventStore.kt
@@ -111,6 +111,16 @@ class ElasticsearchEventStore(
         return searchEventStreams(aggregateId, filter)
     }
 
+    override fun loadByRequestIds(aggregateId: AggregateId, requestIds: Set<String>): Flux<DomainEventStream> {
+        if (requestIds.isEmpty()) return Flux.empty()
+        val filter = filter {
+            tenantId(aggregateId.tenantId)
+            aggregateId(aggregateId.id)
+            MessageRecords.REQUEST_ID isIn requestIds
+        }
+        return searchEventStreams(aggregateId, filter)
+    }
+
     private fun searchEventStreams(
         aggregateId: AggregateId,
         filter: FilterExpression,

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchEventStoreUnitTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/eventsourcing/ElasticsearchEventStoreUnitTest.kt
@@ -29,6 +29,7 @@ import me.ahoo.wow.event.DomainEventStream
 import me.ahoo.wow.modeling.MaterializedNamedAggregate
 import me.ahoo.wow.modeling.aggregateId
 import me.ahoo.wow.serialization.MessageRecords
+import me.ahoo.wow.tck.event.MockDomainEventStreams.generateEventStream
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.data.elasticsearch.client.elc.ReactiveElasticsearchClient
@@ -39,6 +40,32 @@ import java.util.function.Function
 class ElasticsearchEventStoreUnitTest {
     private val client = mockk<ReactiveElasticsearchClient>()
     private val aggregateId: AggregateId = MaterializedNamedAggregate("test", "aggregate").aggregateId("id")
+
+    @Test
+    fun `request lookup restricts the native query to candidate ids and tenant`() {
+        val target = aggregateId.namedAggregate.aggregateId("id", "tenant")
+        val stream = generateEventStream(target)
+        val search = slot<Function<SearchRequest.Builder, ObjectBuilder<SearchRequest>>>()
+        every { client.search(capture(search), DomainEventStream::class.java) } returns
+            Mono.just(searchResponse(stream, emptyList()))
+
+        ElasticsearchEventStore(client).loadByRequestIds(target, setOf(stream.requestId, "legacy"))
+            .test().expectNext(stream).verifyComplete()
+
+        val request = search.captured.apply(SearchRequest.Builder()).build()
+        request.routing().assert().containsExactly(target.id)
+        val query = request.query().toString()
+        listOf(
+            "terms",
+            MessageRecords.REQUEST_ID,
+            stream.requestId,
+            "legacy",
+            MessageRecords.TENANT_ID,
+            "tenant"
+        ).forEach {
+            query.assert().contains(it)
+        }
+    }
 
     @Test
     fun `batch size must be positive`() {

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoEventStore.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/MongoEventStore.kt
@@ -116,6 +116,14 @@ class MongoEventStore(
             .hasElement()
     }
 
+    override fun loadByRequestIds(aggregateId: AggregateId, requestIds: Set<String>): Flux<DomainEventStream> {
+        if (requestIds.isEmpty()) return Flux.empty()
+        return findStream(
+            aggregateId,
+            Filters.and(aggregateIdentityFilter(aggregateId), Filters.`in`(MessageRecords.REQUEST_ID, requestIds)),
+        )
+    }
+
     override fun last(aggregateId: AggregateId): Mono<DomainEventStream> {
         val eventStreamCollectionName = aggregateId.toEventStreamCollectionName()
         return database.getCollection(eventStreamCollectionName)

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/MongoEventStoreTenantFilterTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/MongoEventStoreTenantFilterTest.kt
@@ -33,6 +33,20 @@ import reactor.core.publisher.Mono
 
 class MongoEventStoreTenantFilterTest {
     @Test
+    fun `request candidate lookup uses tenant aggregate and indexed request filter`() {
+        val filterJson = captureFindFilter { eventStore, aggregateId ->
+            eventStore.loadByRequestIds(aggregateId, setOf("current", "legacy"))
+        }
+        filterJson.assert().contains("\$in")
+        filterJson.assert().contains(MessageRecords.REQUEST_ID)
+        filterJson.assert().contains(MessageRecords.TENANT_ID)
+        filterJson.assert().contains("tenant-1")
+        filterJson.assert().contains("order-1")
+        filterJson.assert().contains("current")
+        filterJson.assert().contains("legacy")
+    }
+
+    @Test
     fun `load stream by version should filter by tenant id`() {
         val filterJson = captureFindFilter { eventStore, aggregateId ->
             eventStore.load(aggregateId, headVersion = 1, tailVersion = 10)

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/eventsourcing/TracingEventStore.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/eventsourcing/TracingEventStore.kt
@@ -66,6 +66,14 @@ class TracingEventStore(override val delegate: EventStore) : Traced, EventStore,
         }
     }
 
+    override fun loadByRequestIds(aggregateId: AggregateId, requestIds: Set<String>): Flux<DomainEventStream> {
+        return Flux.deferContextual {
+            val parentContext = ReactorTraceContext.get(it)
+            val source = Flux.defer { delegate.loadByRequestIds(aggregateId, requestIds) }
+            TraceFlux(parentContext, EventStoreInstrumenter.LOAD_INSTRUMENTER, aggregateId, source)
+        }
+    }
+
     override fun scanAggregateId(
         namedAggregate: NamedAggregate,
         afterId: String,

--- a/wow-opentelemetry/src/test/kotlin/me/ahoo/wow/opentelemetry/eventsourcing/TracingEventStoreTest.kt
+++ b/wow-opentelemetry/src/test/kotlin/me/ahoo/wow/opentelemetry/eventsourcing/TracingEventStoreTest.kt
@@ -14,6 +14,10 @@
 package me.ahoo.wow.opentelemetry.eventsourcing
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.opentelemetry.api.GlobalOpenTelemetry
 import me.ahoo.test.asserts.assert
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.event.DomainEventStream
@@ -22,12 +26,33 @@ import me.ahoo.wow.eventsourcing.snapshot.NoOpSnapshotStore
 import me.ahoo.wow.eventsourcing.snapshot.SnapshotStore
 import me.ahoo.wow.metrics.WowMetrics
 import me.ahoo.wow.metrics.metered
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.modeling.aggregateId
 import me.ahoo.wow.opentelemetry.snapshot.TracingSnapshotStore
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import reactor.kotlin.test.test
 
 class TracingEventStoreTest {
+
+    @Test
+    fun `tracing and metrics preserve native request lookup`() {
+        val aggregateId = MaterializedNamedAggregate("test", "aggregate").aggregateId("id", "tenant")
+        val candidates = setOf("current", "legacy")
+        val stream = mockk<DomainEventStream>()
+        val delegate = mockk<EventStore>()
+        every { delegate.loadByRequestIds(aggregateId, candidates) } returns Flux.just(stream)
+        val store = TracingEventStore(delegate.metered(WowMetrics(SimpleMeterRegistry()), "eventStore"))
+
+        try {
+            store.loadByRequestIds(aggregateId, candidates).test().expectNext(stream).verifyComplete()
+            verify(exactly = 1) { delegate.loadByRequestIds(aggregateId, candidates) }
+            verify(exactly = 0) { delegate.load(any(), any<Int>(), any<Int>()) }
+        } finally {
+            GlobalOpenTelemetry.resetForTest()
+        }
+    }
 
     @Test
     fun `decorator chain should close the original EventStore exactly once`() {

--- a/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStore.kt
+++ b/wow-redis/src/main/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStore.kt
@@ -111,6 +111,20 @@ class RedisEventStore(
         return redisTemplate.opsForSet().isMember(requestIdxKey, requestId)
     }
 
+    override fun loadByRequestIds(aggregateId: AggregateId, requestIds: Set<String>): Flux<DomainEventStream> {
+        if (requestIds.isEmpty()) return Flux.empty()
+        return redisTemplate.opsForSet()
+            .isMember(EventStreamKeyLayout.requestIndexKey(aggregateId), *requestIds.toTypedArray())
+            .flatMapMany { matches ->
+                if (matches.values.none { it }) {
+                    Flux.empty()
+                } else {
+                    // ponytail: the existing set has no record offsets; add an offset index if duplicate recovery becomes costly.
+                    load(aggregateId).filter { matches[it.requestId] == true }
+                }
+            }
+    }
+
     override fun last(aggregateId: AggregateId): Mono<DomainEventStream> {
         val key = EventStreamKeyLayout.key(aggregateId)
         val range = Range.closed<Long>(0, 0)

--- a/wow-redis/src/test/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStoreRequestIdTest.kt
+++ b/wow-redis/src/test/kotlin/me/ahoo/wow/redis/eventsourcing/RedisEventStoreRequestIdTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.redis.eventsourcing
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import me.ahoo.wow.modeling.MaterializedNamedAggregate
+import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.serialization.toJsonString
+import me.ahoo.wow.tck.event.MockDomainEventStreams.generateEventStream
+import org.junit.jupiter.api.Test
+import org.springframework.data.redis.core.ReactiveSetOperations
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate
+import org.springframework.data.redis.core.ReactiveZSetOperations
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+
+class RedisEventStoreRequestIdTest {
+    private val aggregateId = MaterializedNamedAggregate("order-service", "order").aggregateId("order-1", "tenant-1")
+    private val template = mockk<ReactiveStringRedisTemplate>()
+    private val index = mockk<ReactiveSetOperations<String, String>>()
+    private val events = mockk<ReactiveZSetOperations<String, String>>()
+    private val store = RedisEventStore(template)
+
+    @Test
+    fun `missing candidates use one bulk membership check and no history read`() {
+        every { template.opsForSet() } returns index
+        every { template.opsForZSet() } returns events
+        every { index.isMember(EventStreamKeyLayout.requestIndexKey(aggregateId), "current", "legacy") } returns
+            Mono.just(mapOf<Any, Boolean>("current" to false, "legacy" to false))
+        every { events.rangeByScore(any<String>(), any(), any()) } returns Flux.error(AssertionError("Unexpected history read"))
+
+        StepVerifier.create(store.loadByRequestIds(aggregateId, linkedSetOf("current", "legacy"))).verifyComplete()
+        verify(exactly = 1) { index.isMember(EventStreamKeyLayout.requestIndexKey(aggregateId), "current", "legacy") }
+        verify(exactly = 0) { events.rangeByScore(any<String>(), any(), any()) }
+    }
+
+    @Test
+    fun `matching candidates load history once and return only matching records`() {
+        val wanted = generateEventStream(aggregateId, eventCount = 1)
+        val other = generateEventStream(aggregateId, aggregateVersion = 1, eventCount = 1)
+        every { template.opsForSet() } returns index
+        every { template.opsForZSet() } returns events
+        every { index.isMember(EventStreamKeyLayout.requestIndexKey(aggregateId), wanted.requestId, "missing") } returns
+            Mono.just(mapOf<Any, Boolean>(wanted.requestId to true, "missing" to false))
+        every {
+            events.rangeByScore(any<String>(), any(), any())
+        } returns Flux.just(wanted.toJsonString(), other.toJsonString())
+
+        StepVerifier.create(store.loadByRequestIds(aggregateId, linkedSetOf(wanted.requestId, "missing")))
+            .expectNextMatches { it.id == wanted.id }.verifyComplete()
+        verify(exactly = 1) { events.rangeByScore(any<String>(), any(), any()) }
+    }
+
+    @Test
+    fun `empty candidates skip Redis entirely`() {
+        StepVerifier.create(store.loadByRequestIds(aggregateId, emptySet())).verifyComplete()
+        verify(exactly = 0) {
+            template.opsForSet()
+            template.opsForZSet()
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Prevent state-event replay from exposing stale metadata or later state versions, and preserve command identity when a Saga retries or receives an event again after a restart. For example, if the first of two commands is accepted and the second send fails, retry resumes the remaining command with its original identity.

## Changes

- Carry sourced owner/space metadata into state events and preserve space/tags through snapshot materialization. Copy replay state only after sourcing and filtering the requested version range.
- Retain Saga command identities and send progress during retries. Include context, processor, and the full method parameter signature in default request IDs to distinguish overloaded functions.
- Recover committed commands before sending, including ordinary redelivery with a cold gateway cache. Prefer the current signature ID; report an ambiguous legacy-only match instead of treating another function's command as success. Preserve actual wait-stage notifications.
- Add a default `EventStore.loadByRequestIds` lookup, native MongoDB/Redis/Elasticsearch implementations, and forwarding through routing, metrics, tracing, and delay decorators. Update regression tests and both Saga guides.

## Verification

Verified the exact PR commit in a clean worktree based on `main`, excluding the separate query-mask commits and uncommitted schema work:

- `:wow-core:check :wow-mongo:check :wow-redis:check :wow-elasticsearch:check :wow-opentelemetry:check :wow-mock:check :wow-tck:detekt` — passed.
- MongoDB, Redis, and Elasticsearch `integrationTest --tests '*loadByRequestIds*'` — passed against Testcontainers backends, covering candidate matching and tenant isolation.
- `:wow-kafka:integrationTest --tests '*KafkaStateEventBusTest'` — passed.
- 1,982 tests passed across the selected local, contract, and integration tasks; no failures or skips.
- `pnpm docs:build` and `git diff --check origin/main...HEAD` — passed.
- Code review completed for Saga recovery, replay state isolation, backend queries, and decorator forwarding.

## Compatibility and risks

- [x] Existing public source calls remain supported, including the six-argument Java `StateEventData` constructor and `copy`; generated contracts are unchanged.
- [x] Tests cover the changed behavior.
- [x] Both Saga guides describe the identity and recovery behavior.
- [x] API documentation describes lookup behavior and backend limitations.
- [x] No credentials, generated build output, or local environment files are included.

Default Saga request IDs change to include the full function signature. A legacy `${domainEvent.id}-${index}` record without a current-ID match now raises `DuplicateRequestIdException`; after business reconciliation, an explicit confirmed legacy `requestId` can recover its command identity. Renaming a method or changing parameter types also changes its default ID.

Recovery requires access to the target aggregate's event store. Stored events prove SENT; later wait stages still require their actual notifications. Redis uses one bulk membership check and reads aggregate history once only on a hit. Custom stores without an override use one history scan. No storage-key migration or new dependency is introduced.
