### PR TITLE
perf(core): reduce command processing and wait overhead

### DIFF
--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/component/IdempotencyComponentBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/component/IdempotencyComponentBenchmark.kt
@@ -28,17 +28,24 @@ open class IdempotencyComponentBenchmark {
         const val KNOWN_REQUEST_ID = "known-request-id"
     }
 
-    private lateinit var knownRequestChecker: BloomFilterIdempotencyChecker
+    private lateinit var requestChecker: BloomFilterIdempotencyChecker
+    private var requestSequence = 0L
 
     @Setup(Level.Iteration)
     fun setup() {
-        knownRequestChecker = BenchmarkIdempotency.bloomFilterChecker()
-        check(knownRequestChecker.check(KNOWN_REQUEST_ID))
+        requestChecker = BenchmarkIdempotency.bloomFilterChecker()
+        requestSequence = 0
+        check(requestChecker.check(KNOWN_REQUEST_ID))
     }
 
     @Benchmark
     fun checkKnownRequestId(blackhole: Blackhole) {
-        val result = knownRequestChecker.check(KNOWN_REQUEST_ID)
+        val result = requestChecker.check(KNOWN_REQUEST_ID)
         blackhole.consume(result)
+    }
+
+    @Benchmark
+    fun checkNewRequestId(blackhole: Blackhole) {
+        blackhole.consume(requestChecker.check("request-${requestSequence++}"))
     }
 }

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/e2e/BatchCommandWriteE2EBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/e2e/BatchCommandWriteE2EBenchmark.kt
@@ -44,9 +44,13 @@ open class BatchCommandWriteE2EBenchmark {
     )
     lateinit var scenario: String
 
+    @Param("4")
+    private var concurrency: Int = 4
+
     private lateinit var fixture: CommandWriteE2EFixture
     private lateinit var sequentialBatch: ConcurrentBatchWorkload
     private lateinit var concurrentBatch: ConcurrentBatchWorkload
+    private lateinit var largeConcurrentBatch: ConcurrentBatchWorkload
     private val failures = AtomicInteger()
 
     @Setup(Level.Iteration)
@@ -62,7 +66,11 @@ open class BatchCommandWriteE2EBenchmark {
         )
         concurrentBatch = ConcurrentBatchWorkload(
             size = COMMANDS_PER_INVOCATION,
-            concurrency = CONCURRENT_CONCURRENCY,
+            concurrency = concurrency,
+        )
+        largeConcurrentBatch = ConcurrentBatchWorkload(
+            size = LARGE_BATCH_COMMANDS,
+            concurrency = concurrency,
         )
     }
 
@@ -104,6 +112,12 @@ open class BatchCommandWriteE2EBenchmark {
         consumeBatch(concurrentBatch, blackhole)
     }
 
+    @Benchmark
+    @OperationsPerInvocation(LARGE_BATCH_COMMANDS)
+    fun sendLargeBatchConcurrentAndWaitProcessed(blackhole: Blackhole) {
+        consumeBatch(largeConcurrentBatch, blackhole)
+    }
+
     private fun consumeBatch(workload: ConcurrentBatchWorkload, blackhole: Blackhole) {
         blackhole.consumeWowResult(onError = { failures.incrementAndGet() }) {
             workload.execute {
@@ -114,7 +128,7 @@ open class BatchCommandWriteE2EBenchmark {
 
     companion object {
         const val COMMANDS_PER_INVOCATION = 32
+        private const val LARGE_BATCH_COMMANDS = 256
         private const val SEQUENTIAL_CONCURRENCY = 1
-        private const val CONCURRENT_CONCURRENCY = 4
     }
 }

--- a/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/infrastructure/mongo/MongoCommandWriteE2EBenchmark.kt
+++ b/wow-benchmarks/src/jmh/kotlin/me/ahoo/wow/benchmark/infrastructure/mongo/MongoCommandWriteE2EBenchmark.kt
@@ -13,22 +13,29 @@
 
 package me.ahoo.wow.benchmark.infrastructure.mongo
 
+import me.ahoo.wow.benchmark.fixture.BenchmarkAggregates
 import me.ahoo.wow.benchmark.fixture.BenchmarkCommands
 import me.ahoo.wow.benchmark.scenario.CommandDispatcherScenario
 import me.ahoo.wow.benchmark.scenario.SchedulerStrategy
 import me.ahoo.wow.benchmark.scenario.consumeWowResult
 import me.ahoo.wow.benchmark.scenario.toSchedulerSupplier
+import me.ahoo.wow.benchmark.workload.ConcurrentBatchWorkload
 import me.ahoo.wow.infrastructure.mongo.MongoBenchmarkFixture
+import me.ahoo.wow.mongo.AggregateSchemaInitializer.toEventStreamCollectionName
 import me.ahoo.wow.mongo.MongoEventStore
 import org.openjdk.jmh.annotations.Benchmark
 import org.openjdk.jmh.annotations.Level
+import org.openjdk.jmh.annotations.OperationsPerInvocation
 import org.openjdk.jmh.annotations.Param
 import org.openjdk.jmh.annotations.Scope
 import org.openjdk.jmh.annotations.Setup
 import org.openjdk.jmh.annotations.State
 import org.openjdk.jmh.annotations.TearDown
 import org.openjdk.jmh.infra.Blackhole
+import reactor.kotlin.core.publisher.toMono
+import java.time.Duration
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
 
 @State(Scope.Benchmark)
 @Suppress("VarCouldBeVal") // JMH injects @Param fields via reflection, so they must be `var`.
@@ -36,44 +43,93 @@ open class MongoCommandWriteE2EBenchmark {
     @Param("PARALLEL", "IMMEDIATE")
     private var schedulerStrategy: String = SchedulerStrategy.PARALLEL.name
 
+    @Param("4")
+    private var concurrency: Int = 4
+
     private lateinit var fixture: MongoBenchmarkFixture
     private lateinit var commandDispatcherScenario: CommandDispatcherScenario
+    private lateinit var concurrentBatch: ConcurrentBatchWorkload
+    private lateinit var largeConcurrentBatch: ConcurrentBatchWorkload
     private val failures = AtomicInteger()
+    private val expectedWrites = AtomicLong()
 
     @Setup(Level.Iteration)
     fun setup() {
         failures.set(0)
+        expectedWrites.set(0)
         fixture = MongoBenchmarkFixture()
+        val eventStore = MongoEventStore(fixture.database)
         commandDispatcherScenario = CommandDispatcherScenario.create(
-            eventStore = MongoEventStore(fixture.database),
+            eventStore = eventStore,
             schedulerSupplier = SchedulerStrategy.valueOf(schedulerStrategy).toSchedulerSupplier(),
         )
+        concurrentBatch = ConcurrentBatchWorkload(COMMANDS_PER_BATCH, concurrency)
+        largeConcurrentBatch = ConcurrentBatchWorkload(LARGE_BATCH_COMMANDS, concurrency)
+        println("Mongo E2E database=${fixture.database.name} writeConcern=${fixture.database.writeConcern} batchEnabled=${eventStore.batchOptions.enabled}")
     }
 
     @TearDown(Level.Iteration)
     fun tearDown() {
         val failureCount = failures.get()
         try {
+            commandDispatcherScenario.close()
             if (failureCount > 0) {
                 throw IllegalStateException(
                     "Mongo command write E2E recorded $failureCount failure(s).",
                 )
             }
-        } finally {
-            try {
-                commandDispatcherScenario.close()
-            } finally {
-                fixture.close()
+            val actualWrites = checkNotNull(
+                fixture.database.getCollection(BenchmarkAggregates.namedAggregate.toEventStreamCollectionName())
+                    .countDocuments().toMono().block(VERIFY_TIMEOUT)
+            )
+            check(actualWrites == expectedWrites.get()) {
+                "Mongo command write count mismatch: expected=${expectedWrites.get()}, actual=$actualWrites."
             }
+            println("Mongo E2E verified database=${fixture.database.name} completed=${expectedWrites.get()} stored=$actualWrites")
+        } finally {
+            fixture.close()
         }
     }
 
     @Benchmark
     fun sendAndWaitProcessed(blackHole: Blackhole) {
         blackHole.consumeWowResult(onError = { failures.incrementAndGet() }) {
-            commandDispatcherScenario.commandGateway
+            val result = commandDispatcherScenario.commandGateway
                 .sendAndWaitForProcessed(BenchmarkCommands.newAggregateAddCartItem())
                 .block()
+            checkNotNull(result)
+            expectedWrites.incrementAndGet()
+            result
         }
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(COMMANDS_PER_BATCH)
+    fun sendBatchConcurrentAndWaitProcessed(blackhole: Blackhole) {
+        consumeBatch(concurrentBatch, blackhole)
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(LARGE_BATCH_COMMANDS)
+    fun sendLargeBatchConcurrentAndWaitProcessed(blackhole: Blackhole) {
+        consumeBatch(largeConcurrentBatch, blackhole)
+    }
+
+    private fun consumeBatch(workload: ConcurrentBatchWorkload, blackhole: Blackhole) {
+        blackhole.consumeWowResult(onError = { failures.incrementAndGet() }) {
+            val completed = workload.execute {
+                commandDispatcherScenario.commandGateway
+                    .sendAndWaitForProcessed(BenchmarkCommands.commandPathAddCartItem())
+            }.block()
+            check(completed == workload.size.toLong())
+            expectedWrites.addAndGet(checkNotNull(completed))
+            completed
+        }
+    }
+
+    private companion object {
+        const val COMMANDS_PER_BATCH = 32
+        const val LARGE_BATCH_COMMANDS = 256
+        val VERIFY_TIMEOUT: Duration = Duration.ofSeconds(30)
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/command/DefaultCommandGateway.kt
@@ -63,6 +63,17 @@ class DefaultCommandGateway(
     CommandBus by commandBus {
     override val enforcesCommandWaitTimeout: Boolean = true
 
+    private val waitTimer by lazy { Schedulers.newSingle("wow-command-wait", true) }
+
+    override fun close() {
+        try {
+            commandBus.close()
+        } finally {
+            // Keep registered deadlines alive without retaining a shutdown-waiting thread.
+            waitTimer.disposeGracefully().subscribe().dispose()
+        }
+    }
+
     override fun receiver(
         subscription: MessageSubscription,
     ): MessageReceiver<ServerCommandExchange<*>> =
@@ -184,7 +195,7 @@ class DefaultCommandGateway(
                     ),
                     it,
                 )
-            }.withDeadline(DEFAULT_WAIT_TIMEOUT)
+            }.withDeadline(DEFAULT_WAIT_TIMEOUT, waitTimer)
 
     /**
      * Sends a command and returns a stream of command results as they become available.
@@ -263,7 +274,7 @@ class DefaultCommandGateway(
                         { handle -> handle.cancel() },
                     )
                 )
-        }.withDeadline(waitPlan.timeout)
+        }.withDeadline(waitPlan.timeout, waitTimer)
 
     /**
      * Sends a command with a specific wait plan.
@@ -329,8 +340,8 @@ class DefaultCommandGateway(
         }
 }
 
-private fun <T : Any> Mono<T>.withDeadline(timeout: Duration): Mono<T> =
-    timeout(timeout)
+private fun <T : Any> Mono<T>.withDeadline(timeout: Duration, timer: Scheduler): Mono<T> =
+    timeout(deadlineSignal(timeout, timer))
 
 private fun <T : Any> Flux<T>.withDeadline(timeout: Duration): Flux<T> =
     Flux.defer {
@@ -353,3 +364,8 @@ private fun deadlineSignal(
             .coerceAtLeast(Duration.ZERO),
         scheduler,
     )
+
+private fun deadlineSignal(timeout: Duration, timer: Scheduler): Mono<Long> =
+    Mono.delay(timeout, timer)
+        // Cancellation and user error callbacks must not run on the timer thread.
+        .publishOn(Schedulers.parallel())

--- a/wow-core/src/main/kotlin/me/ahoo/wow/infra/idempotency/BloomFilterIdempotencyChecker.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/infra/idempotency/BloomFilterIdempotencyChecker.kt
@@ -96,12 +96,7 @@ class BloomFilterIdempotencyChecker(
      */
     override fun check(element: String): Boolean {
         return elementLocks.get(element).withLock {
-            val currentBloomFilter = currentBloomFilter()
-            val contain = currentBloomFilter.mightContain(element)
-            if (!contain) {
-                currentBloomFilter.put(element)
-            }
-            !contain
+            currentBloomFilter().put(element)
         }
     }
 }

--- a/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/RetryableAggregateProcessor.kt
+++ b/wow-core/src/main/kotlin/me/ahoo/wow/modeling/command/RetryableAggregateProcessor.kt
@@ -42,22 +42,13 @@ class RetryableAggregateProcessor<C : Any, S : Any>(
 
     override val processorName: String = RetryableAggregateProcessor::class.simpleName!!
 
-    private val retryStrategy: Retry = Retry.backoff(MAX_RETRIES, MIN_BACKOFF)
-        .filter {
-            it.recoverable == RecoverableType.RECOVERABLE
-        }.doBeforeRetry {
-            log.warn(it.failure()) {
-                "[BeforeRetry] $aggregateId totalRetries[${it.totalRetries()}]."
-            }
-        }
-
     override fun process(exchange: ServerCommandExchange<*>): Mono<DomainEventStream> {
         val stateAggregateMono = if (exchange.message.isCreate) {
             aggregateFactory.createAsMono(aggregateMetadata.state, exchange.message.aggregateId)
         } else {
             stateAggregateRepository.load(aggregateId, aggregateMetadata.state)
         }
-        return stateAggregateMono.map {
+        val process = stateAggregateMono.map {
             commandAggregateFactory.create(aggregateMetadata, it)
         }
             .flatMap {
@@ -67,6 +58,26 @@ class RetryableAggregateProcessor<C : Any, S : Any>(
                 exchange.clearError()
                 it.process(exchange)
             }
-            .retryWhen(retryStrategy)
+        return process.onErrorResume { failure ->
+            var firstFailure = true
+            Mono.defer {
+                if (firstFailure) {
+                    firstFailure = false
+                    // Replay the failure so Reactor preserves the first backoff and the full retry budget.
+                    Mono.error(failure)
+                } else {
+                    process
+                }
+            }.retryWhen(
+                Retry.backoff(MAX_RETRIES, MIN_BACKOFF)
+                    .filter {
+                        it.recoverable == RecoverableType.RECOVERABLE
+                    }.doBeforeRetry {
+                        log.warn(it.failure()) {
+                            "[BeforeRetry] $aggregateId totalRetries[${it.totalRetries()}]."
+                        }
+                    }
+            )
+        }
     }
 }

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTest.kt
@@ -45,6 +45,7 @@ import me.ahoo.wow.infra.idempotency.AggregateIdempotencyCheckerProvider
 import me.ahoo.wow.infra.idempotency.IdempotencyChecker
 import me.ahoo.wow.infra.idempotency.NoOpIdempotencyChecker
 import me.ahoo.wow.messaging.MessageSubscription
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -52,6 +53,12 @@ import reactor.test.StepVerifier
 import java.util.concurrent.atomic.AtomicInteger
 
 class DefaultCommandGatewayTest {
+    private val gateways = mutableListOf<DefaultCommandGateway>()
+
+    @AfterEach
+    fun closeGateways() {
+        gateways.forEach(DefaultCommandGateway::close)
+    }
 
     @Test
     fun `send rejects duplicate request before delegating to command bus`() {
@@ -719,7 +726,7 @@ class DefaultCommandGatewayTest {
             requestIdChecker = requestIdChecker,
             waitCoordinator = waitCoordinator,
             commandWaitNotifier = notifier,
-        )
+        ).also { gateways += it }
 }
 
 private class RecordingCommandBus : CommandBus {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTimeoutTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/command/DefaultCommandGatewayTimeoutTest.kt
@@ -31,15 +31,158 @@ import me.ahoo.wow.command.wait.WaitStreamHandle
 import me.ahoo.wow.command.wait.testSignal
 import me.ahoo.wow.command.wait.withTimeout
 import me.ahoo.wow.messaging.MessageSubscription
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import reactor.core.scheduler.Scheduler
+import reactor.core.scheduler.Schedulers
 import reactor.test.StepVerifier
 import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
 
 class DefaultCommandGatewayTimeoutTest {
+    private val gateways = mutableListOf<DefaultCommandGateway>()
+
+    @AfterEach
+    fun closeGateways() {
+        gateways.forEach(DefaultCommandGateway::close)
+    }
+
+    @Test
+    fun `gateway close disposes its timer even when command bus close fails`() {
+        val timer = Schedulers.newSingle("test-command-timer")
+        val snapshot = Schedulers.setFactoryWithSnapshot(object : Schedulers.Factory {
+            override fun newSingle(threadFactory: ThreadFactory): Scheduler = timer
+        })
+        val failure = IllegalStateException("close failed")
+        val commandBus = object : CommandBus by TimeoutTestCommandBus() {
+            override fun close() = throw failure
+        }
+        val gateway = commandGateway(commandBus, DefaultWaitCoordinator())
+        try {
+            StepVerifier.create(gateway.sendAndWaitForSent(TestCommandMessage(id = "sent")))
+                .expectNextCount(1)
+                .verifyComplete()
+            runCatching { gateway.close() }.exceptionOrNull().assert().isSameAs(failure)
+            timer.isDisposed.assert().isTrue()
+        } finally {
+            gateways.remove(gateway)
+            Schedulers.resetFrom(snapshot)
+            timer.dispose()
+        }
+    }
+
+    @Test
+    fun `global single scheduler work does not delay command timeout`() {
+        val entered = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val finished = CountDownLatch(1)
+        val work = Schedulers.single().schedule {
+            try {
+                entered.countDown()
+                release.await(5, TimeUnit.SECONDS)
+            } finally {
+                finished.countDown()
+            }
+        }
+        val gateway = commandGateway(waitCoordinator = DefaultWaitCoordinator())
+        try {
+            entered.await(1, TimeUnit.SECONDS).assert().isTrue()
+            StepVerifier.create(
+                gateway.sendAndWait(
+                    TestCommandMessage(id = "independent-deadline"),
+                    CommandWait.processed("independent-deadline").withTimeout(Duration.ofMillis(50)),
+                )
+            )
+                .expectError(TimeoutException::class.java)
+                .verify(Duration.ofSeconds(1))
+        } finally {
+            release.countDown()
+            finished.await(1, TimeUnit.SECONDS).assert().isTrue()
+            work.dispose()
+        }
+    }
+
+    @Test
+    fun `slow timeout observer does not occupy the timer thread`() {
+        val delivery = Schedulers.newParallel("test-timeout-delivery", 2)
+        val snapshot = Schedulers.setFactoryWithSnapshot(object : Schedulers.Factory {
+            override fun newParallel(parallelism: Int, threadFactory: ThreadFactory): Scheduler = delivery
+        })
+        val entered = CountDownLatch(1)
+        val release = CountDownLatch(1)
+        val delivered = CountDownLatch(1)
+        val gateway = commandGateway(waitCoordinator = DefaultWaitCoordinator())
+        val first = gateway.sendAndWait(
+            TestCommandMessage(id = "slow-observer"),
+            CommandWait.processed("slow-observer").withTimeout(Duration.ofMillis(50)),
+        ).doOnError {
+            entered.countDown()
+            release.await(5, TimeUnit.SECONDS)
+        }.subscribe({}, { delivered.countDown() })
+        try {
+            entered.await(1, TimeUnit.SECONDS).assert().isTrue()
+            StepVerifier.create(
+                gateway.sendAndWait(
+                    TestCommandMessage(id = "next-deadline"),
+                    CommandWait.processed("next-deadline").withTimeout(Duration.ofMillis(50)),
+                )
+            )
+                .expectError(TimeoutException::class.java)
+                .verify(Duration.ofSeconds(1))
+        } finally {
+            release.countDown()
+            delivered.await(1, TimeUnit.SECONDS).assert().isTrue()
+            first.dispose()
+            Schedulers.resetFrom(snapshot)
+            delivery.dispose()
+        }
+    }
+
+    @Test
+    fun `closing gateway preserves the deadline of an active stream`() {
+        val coordinator = DefaultWaitCoordinator()
+        val gateway = commandGateway(waitCoordinator = coordinator)
+        val waitPlan = CommandWait.snapshot("closing-stream").withTimeout(Duration.ofMillis(200))
+
+        StepVerifier.create(gateway.sendAndWaitStream(TestCommandMessage(id = "closing-stream"), waitPlan))
+            .assertNext { it.stage.assert().isEqualTo(CommandStage.SENT) }
+            .then {
+                gateway.close()
+                coordinator.signal(
+                    testSignal(
+                        stage = CommandStage.PROCESSED,
+                        waitCommandId = "closing-stream",
+                        commandId = "closing-stream",
+                    ),
+                )
+            }
+            .assertNext { it.stage.assert().isEqualTo(CommandStage.PROCESSED) }
+            .expectError(TimeoutException::class.java)
+            .verify(Duration.ofSeconds(2))
+
+        coordinator.contains("closing-stream").assert().isFalse()
+    }
+
+    @Test
+    fun `closing gateway preserves the deadline of an active mono`() {
+        val coordinator = DefaultWaitCoordinator()
+        val gateway = commandGateway(waitCoordinator = coordinator)
+        val waitPlan = CommandWait.processed("closing-mono").withTimeout(Duration.ofMillis(200))
+
+        StepVerifier.create(gateway.sendAndWait(TestCommandMessage(id = "closing-mono"), waitPlan))
+            .then { gateway.close() }
+            .expectError(TimeoutException::class.java)
+            .verify(Duration.ofSeconds(2))
+
+        coordinator.contains("closing-mono").assert().isFalse()
+    }
+
     @Test
     fun `send and wait for sent default timeout bounds pending command bus`() {
         val gateway = commandGateway(
@@ -152,7 +295,7 @@ class DefaultCommandGatewayTimeoutTest {
             requestIdChecker = RequestIdChecker { _, _ -> Mono.just(true) },
             waitCoordinator = waitCoordinator,
             commandWaitNotifier = RecordingCommandWaitNotifier(),
-        )
+        ).also { gateways += it }
 }
 
 private class CountingWaitCoordinator : WaitCoordinator {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/infra/idempotency/BloomFilterIdempotencyCheckerTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/infra/idempotency/BloomFilterIdempotencyCheckerTest.kt
@@ -14,6 +14,7 @@
 package me.ahoo.wow.infra.idempotency
 
 import com.google.common.hash.BloomFilter
+import com.google.common.hash.Funnel
 import com.google.common.hash.Funnels
 import me.ahoo.test.asserts.assert
 import org.junit.jupiter.api.Test
@@ -27,6 +28,25 @@ import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
 
 class BloomFilterIdempotencyCheckerTest {
+
+    @Test
+    fun `should hash an element only once per check`() {
+        val hashCalls = AtomicInteger()
+        val checker = BloomFilterIdempotencyChecker(Duration.ofMinutes(1)) {
+            BloomFilter.create(
+                Funnel<String> { element, sink ->
+                    hashCalls.incrementAndGet()
+                    sink.putString(element, Charsets.UTF_8)
+                },
+                100,
+            )
+        }
+
+        checker.check("request-1").assert().isTrue()
+        hashCalls.get().assert().isEqualTo(1)
+        checker.check("request-1").assert().isFalse()
+        hashCalls.get().assert().isEqualTo(2)
+    }
 
     @Test
     fun `should allow first element and reject duplicate element in cached filter`() {

--- a/wow-core/src/test/kotlin/me/ahoo/wow/modeling/command/RetryableAggregateProcessorTest.kt
+++ b/wow-core/src/test/kotlin/me/ahoo/wow/modeling/command/RetryableAggregateProcessorTest.kt
@@ -25,11 +25,17 @@ import me.ahoo.wow.eventsourcing.InMemoryEventStore
 import me.ahoo.wow.eventsourcing.snapshot.InMemorySnapshotStore
 import me.ahoo.wow.ioc.SimpleServiceProvider
 import me.ahoo.wow.modeling.aggregateId
+import me.ahoo.wow.modeling.metadata.StateAggregateMetadata
 import me.ahoo.wow.modeling.state.ConstructorStateAggregateFactory
+import me.ahoo.wow.modeling.state.StateAggregate
+import me.ahoo.wow.modeling.state.StateAggregateFactory
 import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import me.ahoo.wow.tck.mock.MockChangeAggregate
 import me.ahoo.wow.tck.mock.MockCreateAggregate
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import reactor.core.Exceptions
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
@@ -39,6 +45,41 @@ import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicInteger
 
 class RetryableAggregateProcessorTest {
+
+    @Test
+    fun `processor defers state creation until requested and rebuilds on resubscription`() {
+        val created = AtomicInteger()
+        val aggregateFactory = object : StateAggregateFactory {
+            override fun <S : Any> create(
+                metadata: StateAggregateMetadata<S>,
+                aggregateId: AggregateId,
+            ): StateAggregate<S> {
+                created.incrementAndGet()
+                return ConstructorStateAggregateFactory.create(metadata, aggregateId)
+            }
+        }
+        val aggregateId = MOCK_AGGREGATE_METADATA.aggregateId("aggregate-1")
+        val processor = processor(aggregateId, InMemoryEventStore(), aggregateFactory)
+        val exchange = SimpleServerCommandExchange(MockCreateAggregate("aggregate-1", "created").toCommandMessage())
+            .setServiceProvider(SimpleServiceProvider())
+        val result = processor.process(exchange)
+        created.get().assert().isZero()
+
+        StepVerifier.create(result, 0)
+            .then { created.get().assert().isZero() }
+            .thenCancel()
+            .verify()
+
+        StepVerifier.create(result)
+            .expectNextCount(1)
+            .verifyComplete()
+        created.get().assert().isEqualTo(1)
+
+        StepVerifier.create(result)
+            .expectError(DuplicateAggregateIdException::class.java)
+            .verify()
+        created.get().assert().isEqualTo(2)
+    }
 
     @Test
     fun `processor creates state for create commands and loads state for changes`() {
@@ -92,14 +133,92 @@ class RetryableAggregateProcessorTest {
         exchange.getError().assert().isNull()
     }
 
+    @Test
+    fun `processor backs off before the first retry`() {
+        val eventStore = RetryableEventStore(listOf(TimeoutException("timeout")))
+        val aggregateId = MOCK_AGGREGATE_METADATA.aggregateId("aggregate-1")
+        val processor = processor(aggregateId, eventStore)
+        val exchange = SimpleServerCommandExchange(MockCreateAggregate("aggregate-1", "created").toCommandMessage())
+            .setServiceProvider(SimpleServiceProvider())
+
+        StepVerifier.withVirtualTime { processor.process(exchange) }
+            .expectSubscription()
+            .expectNoEvent(Duration.ofMillis(499))
+            .then { eventStore.attempts.get().assert().isEqualTo(1) }
+            .thenAwait(Duration.ofSeconds(1))
+            .expectNextCount(1)
+            .verifyComplete()
+
+        eventStore.attempts.get().assert().isEqualTo(2)
+    }
+
+    @Test
+    fun `processor preserves retry exhaustion and resets the budget for each subscription`() {
+        val failure = TimeoutException("timeout")
+        val eventStore = RetryableEventStore(List(8) { failure })
+        val aggregateId = MOCK_AGGREGATE_METADATA.aggregateId("aggregate-1")
+        val processor = processor(aggregateId, eventStore)
+        val exchange = SimpleServerCommandExchange(MockCreateAggregate("aggregate-1", "created").toCommandMessage())
+            .setServiceProvider(SimpleServiceProvider())
+        val result = processor.process(exchange)
+
+        repeat(2) { subscription ->
+            StepVerifier.withVirtualTime { result }
+                .thenAwait(Duration.ofSeconds(10))
+                .expectErrorMatches { Exceptions.isRetryExhausted(it) && it.cause === failure }
+                .verify()
+
+            eventStore.attempts.get().assert().isEqualTo((subscription + 1) * 4)
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [0, 1])
+    fun `processor stops at a non recoverable failure`(recoverableFailures: Int) {
+        val failure = IllegalArgumentException("invalid command")
+        val eventStore = RetryableEventStore(List(recoverableFailures) { TimeoutException("timeout") } + failure)
+        val aggregateId = MOCK_AGGREGATE_METADATA.aggregateId("aggregate-1")
+        val processor = processor(aggregateId, eventStore)
+        val exchange = SimpleServerCommandExchange(MockCreateAggregate("aggregate-1", "created").toCommandMessage())
+            .setServiceProvider(SimpleServiceProvider())
+
+        StepVerifier.withVirtualTime { processor.process(exchange) }
+            .thenAwait(Duration.ofSeconds(10))
+            .expectErrorMatches { it === failure }
+            .verify()
+
+        eventStore.attempts.get().assert().isEqualTo(recoverableFailures + 1)
+    }
+
+    @Test
+    fun `processor cancellation during backoff prevents another attempt`() {
+        val eventStore = RetryableEventStore()
+        val aggregateId = MOCK_AGGREGATE_METADATA.aggregateId("aggregate-1")
+        val processor = processor(aggregateId, eventStore)
+        val exchange = SimpleServerCommandExchange(MockCreateAggregate("aggregate-1", "created").toCommandMessage())
+            .setServiceProvider(SimpleServiceProvider())
+
+        StepVerifier.withVirtualTime {
+            processor.process(exchange)
+                .take(Duration.ofMillis(100))
+                .then(Mono.delay(Duration.ofSeconds(10)))
+        }
+            .thenAwait(Duration.ofSeconds(11))
+            .expectNext(0L)
+            .verifyComplete()
+
+        eventStore.attempts.get().assert().isEqualTo(1)
+    }
+
     private fun processor(
         aggregateId: AggregateId,
         eventStore: EventStore,
+        aggregateFactory: StateAggregateFactory = ConstructorStateAggregateFactory,
     ): RetryableAggregateProcessor<me.ahoo.wow.tck.mock.MockCommandAggregate, me.ahoo.wow.tck.mock.MockStateAggregate> =
         RetryableAggregateProcessor(
             aggregateId = aggregateId,
             aggregateMetadata = MOCK_AGGREGATE_METADATA,
-            aggregateFactory = ConstructorStateAggregateFactory,
+            aggregateFactory = aggregateFactory,
             stateAggregateRepository = EventSourcingStateAggregateRepository(
                 ConstructorStateAggregateFactory,
                 InMemorySnapshotStore(),
@@ -108,13 +227,16 @@ class RetryableAggregateProcessorTest {
             commandAggregateFactory = SimpleCommandAggregateFactory(eventStore),
         )
 
-    private class RetryableEventStore : EventStore {
+    private class RetryableEventStore(
+        private val failures: List<Throwable> = List(3) { TimeoutException("timeout") },
+    ) : EventStore {
         private val delegate = InMemoryEventStore()
         val attempts = AtomicInteger()
 
         override fun append(eventStream: DomainEventStream): Mono<Void> {
-            if (attempts.incrementAndGet() < 4) {
-                return TimeoutException("timeout").toMono()
+            val failure = failures.getOrNull(attempts.getAndIncrement())
+            if (failure != null) {
+                return failure.toMono()
             }
             return delegate.append(eventStream)
         }

--- a/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/wait/TracingCommandGateway.kt
+++ b/wow-opentelemetry/src/main/kotlin/me/ahoo/wow/opentelemetry/wait/TracingCommandGateway.kt
@@ -32,6 +32,8 @@ class TracingCommandGateway(override val delegate: CommandGateway) : Traced, Com
     override val enforcesCommandWaitTimeout: Boolean
         get() = delegate.enforcesCommandWaitTimeout
 
+    override fun close() = delegate.close()
+
     override fun <C : Any> sendAndWaitStream(
         command: CommandMessage<C>,
         waitPlan: WaitPlan

--- a/wow-opentelemetry/src/test/kotlin/me/ahoo/wow/opentelemetry/wait/TracingCommandGatewayWaitTest.kt
+++ b/wow-opentelemetry/src/test/kotlin/me/ahoo/wow/opentelemetry/wait/TracingCommandGatewayWaitTest.kt
@@ -42,6 +42,7 @@ import me.ahoo.wow.infra.idempotency.NoOpIdempotencyChecker
 import me.ahoo.wow.messaging.MessageReceiver
 import me.ahoo.wow.messaging.MessageSubscription
 import me.ahoo.wow.opentelemetry.Tracing.tracing
+import me.ahoo.wow.tck.mock.MOCK_AGGREGATE_METADATA
 import me.ahoo.wow.tck.mock.MockCreateAggregate
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
@@ -53,6 +54,32 @@ class TracingCommandGatewayWaitTest {
     @AfterEach
     fun resetOpenTelemetry() {
         GlobalOpenTelemetry.resetForTest()
+    }
+
+    @Test
+    fun `closing traced gateway releases its command bus`() {
+        val bus = InMemoryCommandBus()
+        val subscription = MessageSubscription(MOCK_AGGREGATE_METADATA.namedAggregate)
+        val receiver = bus.receive(subscription).subscribe()
+        val coordinator = DefaultWaitCoordinator()
+        val gateway = DefaultCommandGateway(
+            commandWaitEndpoint = SimpleCommandWaitEndpoint(""),
+            commandBus = bus,
+            validator = NoOpValidator,
+            requestIdChecker = DefaultRequestIdChecker(
+                AggregateIdempotencyCheckerProvider { NoOpIdempotencyChecker },
+            ),
+            waitCoordinator = coordinator,
+            commandWaitNotifier = LocalCommandWaitNotifier(coordinator),
+        ).tracing()
+        try {
+            bus.subscriberCount(subscription.namedAggregates.single()).assert().isOne()
+            gateway.close()
+            bus.subscriberCount(subscription.namedAggregates.single()).assert().isZero()
+        } finally {
+            receiver.dispose()
+            bus.close()
+        }
     }
 
     @Test
@@ -104,17 +131,18 @@ class TracingCommandGatewayWaitTest {
         ).toCommandMessage()
         val waitPlan = CommandWait.sent(command.commandId)
 
-        commandGateway
-            .sendAndWait(command, waitPlan)
-            .test()
-            .expectNextCount(1)
-            .verifyComplete()
-        tracerProvider.forceFlush().join(10, java.util.concurrent.TimeUnit.SECONDS)
+        commandGateway.use { gateway ->
+            gateway.sendAndWait(command, waitPlan)
+                .test()
+                .expectNextCount(1)
+                .verifyComplete()
+            tracerProvider.forceFlush().join(10, java.util.concurrent.TimeUnit.SECONDS)
 
-        spanExporter.spans
-            .any { it.name.endsWith(".waiting") }
-            .assert()
-            .isTrue()
+            spanExporter.spans
+                .any { it.name.endsWith(".waiting") }
+                .assert()
+                .isTrue()
+        }
     }
 }
 


### PR DESCRIPTION
## Goal

Reduce avoidable work on successful command writes: new request IDs are hashed twice, retry machinery is assembled before an error occurs, and Mono command deadlines add contention to shared Reactor scheduling. Keep command completion, cancellation, retry and timeout behavior intact.

## Changes

- Use `BloomFilter.put` to check and record an ID with one hash pass, retaining the existing per-element lock and filter expiry.
- Initialize the retry path only after the first failure. Replay that failure through Reactor's retry policy to preserve the first backoff, recoverability filtering and three-retry budget. Retain demand-aware state creation and fresh state on resubscription.
- Schedule Mono command deadlines on a private daemon timer and deliver timeout callbacks on the parallel scheduler. Preserve active deadlines during gateway shutdown and forward `TracingCommandGateway.close()` to its delegate.
- Cover these behaviors with regression tests; add configurable 32/256-command JMH workloads and real MongoDB event-count verification outside the timed section.

## Verification

- Passed on the current main-based tree, with the four test tasks explicitly rerun:

```shell
./gradlew :wow-core:test --rerun :wow-core:contractTest --rerun \
  :wow-opentelemetry:test --rerun :wow-benchmarks:test --rerun \
  :wow-core:check :wow-opentelemetry:check :wow-benchmarks:check \
  :wow-benchmarks:jmhJar --console=plain --no-parallel --max-workers=4
```

- Passed the current main gateway auto-configuration lifecycle tests:

```shell
./gradlew :wow-spring-boot-starter:test \
  --tests 'me.ahoo.wow.spring.boot.starter.command.CommandGatewayAutoConfigurationTest' \
  --rerun --console=plain --no-parallel --max-workers=4
```

- **1318 tests, zero failures/errors/skips**: wow-core:test 1134, wow-core:contractTest 131, wow-opentelemetry:test 24, wow-benchmarks:test 17, wow-spring-boot-starter:CommandGatewayAutoConfigurationTest 12.
- `git diff --check`: passed.
- Independent read-only review of all 12 changed files and the retry/timer/Spring lifecycle call paths found no blocking issues.
- Final head `4e15501fc51498bc1611601b0d50420fa5351dac` contains exactly the tested and reviewed diff.

### Local performance evidence

The following A/B measurements were collected on the original base `3cc8906915c808f24a9fe8629a3d810ad2afc65b` (a documentation-only descendant of v9.0.2 commit `fae60c655`), using identical benchmark definitions in the before/after JARs. This PR is based on current `main` (`8e01d5d73f2961ac03d279976a8ec4ba144785b3`); all 12 touched files had identical baseline contents at both commits. Functional checks are run on the PR tree. These are earlier local measurements, not a new performance measurement of current main.

| Workload | Before commands/s | After commands/s | Mean change | JMH 99.9% intervals |
| --- | ---: | ---: | ---: | --- |
| NoopEventStore, batch 32, concurrency 4 per sender | 232,577 ± 2,544 | 340,798 ± 5,495 | +46.53% | Separated |
| NoopEventStore, batch 256, concurrency 64 per sender | 399,359 ± 8,207 | 399,954 ± 3,985 | +0.15% | Overlap |
| Simulated asynchronous storage, 100 µs, reverse-order confirmation | 21,788 ± 84 | 22,282 ± 51 | +2.27% | Separated |
| MongoDB, single command per sender | 9,422 ± 1,462 | 9,996 ± 959 | +6.09% | Overlap |
| MongoDB, batch 32, concurrency 4 per sender | 20,088 ± 1,975 | 21,860 ± 689 | +8.82% | Overlap |
| MongoDB, batch 256, concurrency 64 per sender | 26,927 ± 4,235 | 27,487 ± 3,616 | +2.08% | Overlap |

**MongoDB improvements are not statistically established.** The framework result applies to the specified workload, not overall production throughput. The initial simulated-I/O run showed +11.45%, but that magnitude did not reproduce; the table uses the reverse-order confirmation.

<details>
<summary>Benchmark protocol, MongoDB verification and pairing</summary>

- JMH 1.37, Zulu Java 17.0.7, Apple M4 Pro / 24 GiB, four sender threads, 1 GiB heap, G1, GC profiler, PARALLEL aggregate scheduling.
- Each version/case uses three independent JVMs, each with 3 × 2 s warmup and 4 × 2 s measurement. Results are normalized to commands/s through `@OperationsPerInvocation` for batches.
- Framework cases run serially with matching options. Simulated I/O additionally has a reverse-order confirmation. MongoDB uses three interleaved A/B pairs per case, reversing the within-pair order.
- MongoDB 7.0.40, standalone WiredTiger, independent disk-backed Docker named volumes; container limit 4 CPU / 2 GiB and WiredTiger cache 0.5 GiB. Docker Desktop's 4 CPU / 5.78 GiB VM is shared with existing idle services.
- MongoEventStore uses default acknowledged writes with no explicit `j=true`; store-side batching is disabled (`insertOne` per event stream). A successful command is not claimed to wait for a journal fsync.
- Every command creates a new Cart aggregate. The completion boundary is `PROCESSED`; command/event buses and snapshot storage remain in memory. HTTP, projection/Saga completion, historical replay and long-duration steady-state capacity are outside the workload.
- Each Mongo iteration creates an isolated UUID database and normal event-stream indexes. Outside measurement, it checks `countDocuments == successful commands`, then drops that database.
- All **126 formal iterations** matched: **4,270,585 event streams including warmup**, of which **2,781,362** were written during measurement iterations. Four additional smoke runs only validate execution. The temporary container, volumes and credentials were removed afterwards.
- Mongo per-JVM paired changes: single `+1.92%, +22.05%, -3.66%`; batch 32 `+12.31%, +13.24%, +1.65%`; batch 256 `+9.08%, +6.22%, -7.94%`. All samples are retained; variation prevents a stable real-storage gain claim.
- JMH logs include post-measurement waits for remaining threads to exit. Every invocation returned successfully; JVMs and benchmarks did not run concurrently.

To reproduce, build both implementations with the same benchmark sources using `:wow-benchmarks:jmhJar`, then run the exact method with `-bm thrpt -tu s -t 4 -f 3 -wi 3 -w 2s -i 4 -r 2s -prof gc -jvmArgs '-Xms1g -Xmx1g -XX:+UseG1GC'`:

- Framework: `BatchCommandWriteE2EBenchmark.sendBatchConcurrentAndWaitProcessed`, `scenario=noop-store`, `concurrency=4`; large batches use `sendLargeBatchConcurrentAndWaitProcessed`, `concurrency=64`.
- Simulated I/O: `SimulatedIoCommandWriteBenchmark.sendAndWaitProcessed`, `ioDelay=100us`, `schedulerStrategy=PARALLEL`, `schedulerPoolSize=cpu`.
- MongoDB: `MongoCommandWriteE2EBenchmark.sendAndWaitProcessed`, `sendBatchConcurrentAndWaitProcessed` or `sendLargeBatchConcurrentAndWaitProcessed`, `schedulerStrategy=PARALLEL`, `concurrency=4/4/64`. Run three paired invocations of `-f 1` per version instead of one `-f 3` invocation, alternating their order. Supply Mongo connection credentials through `WOW_BENCHMARK_MONGO_*` environment variables and use an isolated `wow.benchmark.mongo.databasePrefix`.

</details>

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes (no new configuration or API workflow).
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

The main review point is timer ownership and shutdown: each gateway can own a daemon timer, existing deadlines must remain bounded after close, and timeout observers must not occupy the timer thread. The changes add no dependencies, storage schema changes or migration requirements. Commits separate Bloom, retry, and deadline/lifecycle changes for review and rollback.
