### PR TITLE
docs(query): clarify MongoDB ID projection exception

### DIFF
--- a/documentation/docs/en/guide/query/data-query.md
+++ b/documentation/docs/en/guide/query/data-query.md
@@ -70,6 +70,20 @@ Here, `index` is the 1-based page number and `size` is the page size; `sort` nam
 
 `projection` can use `include` or `exclude`; an empty projection returns all fields. Each QueryField selects one node and all of its descendants: selecting an object returns its whole subtree, while selecting a scalar is an exact field selection. Public Projection and Sort do not accept backend wildcard patterns. Select `state` itself for the whole state subtree instead of using a storage-side expression.
 
+### MongoDB ID projection exception
+
+MongoDB single/list/paged queries retain the native default of returning `_id`: even when include omits the ID, Snapshot results still contain `aggregateId` and EventStream results still contain `id`. This is an accepted backend difference; Elasticsearch does not add an unrequested ID.
+
+To return only `version`, explicitly exclude the logical ID. For Snapshot queries:
+
+```json
+{ "projection": { "include": ["version"], "exclude": ["aggregateId"] } }
+```
+
+For EventStream queries, change `exclude` to `["id"]`. MongoDB allows this ID exception when combining include and exclude; it does not permit arbitrary field combinations. Public requests use logical field names, not the physical `_id`.
+
+Cursor queries remove internal fields fetched only for sorting, including an ID not selected by the projection, so the default ID retention exception does not apply. With `include: ["version"]`, cursor results contain only `version` on both backends. State-only endpoints also unwrap `state` and do not return the snapshot's outer `aggregateId`.
+
 ## Count
 
 The count body is a `FilterExpression` directly, without an outer `filter` property:

--- a/documentation/docs/zh/guide/query/data-query.md
+++ b/documentation/docs/zh/guide/query/data-query.md
@@ -70,6 +70,20 @@ val query = PagedQuery(
 
 `projection` 可用 `include` 或 `exclude` 控制字段，空投影表示返回全部字段。每个 QueryField 选择一个节点及其全部后代：选择对象节点会返回整棵子树，选择标量节点等同于精确字段。公共 Projection 与 Sort 不接受后端通配 pattern；要选择整个 `state` 子树，应写 `state`，而不是存储侧表达式。
 
+### MongoDB 的 ID 投影例外
+
+MongoDB 的 single/list/paged 查询保留原生 `_id` 默认返回策略：即使 `include` 未选择 ID，Snapshot 结果仍包含 `aggregateId`，EventStream 结果仍包含 `id`。这是约定的后端差异；Elasticsearch 不额外返回未选择的 ID。
+
+若只需要 `version`，可显式排除逻辑 ID。Snapshot 使用：
+
+```json
+{ "projection": { "include": ["version"], "exclude": ["aggregateId"] } }
+```
+
+EventStream 将 `exclude` 改为 `["id"]`。这是 MongoDB 允许混用 include/exclude 的 ID 特例，不能推广到任意字段组合；公共请求使用逻辑字段名，不使用物理 `_id`。
+
+cursor 查询会清理仅为排序而读取的内部字段，包括未被投影选择的 ID，因此不适用上述默认保留 ID 的例外。`include: ["version"]` 在两种后端的 cursor 结果中都只返回 `version`。state-only 入口还会解包 `state`，不会返回快照外层的 `aggregateId`。
+
 ## Count
 
 Count 请求体直接是 `FilterExpression`，没有额外的 `filter` 包装：

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/Queryable.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/Queryable.kt
@@ -101,14 +101,19 @@ data class Pagination(
  * Data class representing field projection settings for queries.
  *
  * Projection controls which fields are included in or excluded from query results.
- * You can either specify fields to include (include list) or fields to exclude (exclude list),
- * but not both. If both lists are empty, all fields are included.
+ * Use include to select nodes and their descendants, or exclude to omit them.
+ * If both lists are empty, all fields are included. Combining include and exclude follows backend restrictions.
  *
- * @property include List of field names to include in the results. If non-empty, only these fields will be returned.
- * @property exclude List of field names to exclude from the results. Ignored if include list is non-empty.
+ * MongoDB single/list/paged queries retain the native `_id` field by default even when include omits it.
+ * It is returned as `aggregateId` for snapshots and `id` for event streams. Explicitly exclude that logical
+ * field to suppress it; MongoDB permits this ID exclusion alongside include. Elasticsearch does not add
+ * an unrequested ID. Cursor queries remove fields fetched only for sorting, including an unrequested ID.
+ *
+ * @property include Nodes to return, subject to the MongoDB ID exception above.
+ * @property exclude Nodes to omit, including the logical ID when it should not be returned.
  *
  * ```
- * val includeOnly = Projection(include = listOf(QueryField("name"), QueryField("email")))  // Only return name and email
+ * val includeOnly = Projection(include = listOf(QueryField("name"), QueryField("email")))  // MongoDB also retains ID
  * val excludeSome = Projection(exclude = listOf(QueryField("password"), QueryField("secret")))  // Return all except password and secret
  * val allFields = Projection.ALL  // Return all fields
  * ```


### PR DESCRIPTION
## Goal

Clarify the accepted MongoDB ID projection exception so callers can predict returned fields without changing query behavior.

## Changes

- Update the public `Projection` KDoc and Chinese/English query documentation: MongoDB single/list/paged queries retain the native ID by default (`aggregateId` for snapshots, `id` for event streams).
- Show explicit ID exclusion alongside inclusion, and distinguish cursor cleanup and state-only unwrapping.
- Remove contradictory claims that inclusion always returns only selected fields or ignores exclusion. QueryGateway signatures and runtime implementations are unchanged.

## Verification

- `pnpm --dir documentation test`: documentation build and documentation tests passed.
- `git diff --check`: passed.
- Focused REST revalidation against compensation-service 9.0.12: dev Elasticsearch 18/18 and prod MongoDB 18/18 passed, covering default ID retention, explicit ID exclusion, cursor projection and event payload type constraints. Requests were read-only; results remain local and are not included in this PR.
- JVM tests were not rerun for this documentation-only change; the Kotlin change is KDoc only.

## Compatibility and risks

- [x] Public API and generated contract compatibility are preserved.
- [x] Existing behavior was verified through focused REST requests; no runtime behavior changes.
- [x] Chinese and English documentation describe the backend difference.
- [x] Public API documentation explains the projection exception.
- [x] No credentials, generated output or local environment files are included.

No migration, deployment, data or performance changes.
