### PR TITLE
refactor(spring): define query observer bean name contracts

### DIFF
--- a/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/query/QueryAutoConfiguration.kt
+++ b/wow-spring-boot-starter/src/main/kotlin/me/ahoo/wow/spring/boot/starter/query/QueryAutoConfiguration.kt
@@ -18,7 +18,9 @@ import me.ahoo.wow.query.event.EventStreamQueryBackendFactory
 import me.ahoo.wow.query.snapshot.SnapshotQueryBackendFactory
 import me.ahoo.wow.spring.boot.starter.ConditionalOnWowEnabled
 import me.ahoo.wow.spring.query.EventStreamQueryGatewayRegistrar
+import me.ahoo.wow.spring.query.EventStreamQueryGatewayRegistrar.Companion.EVENT_STREAM_QUERY_OBSERVER_BEAN_NAME
 import me.ahoo.wow.spring.query.SnapshotQueryGatewayRegistrar
+import me.ahoo.wow.spring.query.SnapshotQueryGatewayRegistrar.Companion.SNAPSHOT_QUERY_OBSERVER_BEAN_NAME
 import org.springframework.boot.autoconfigure.AutoConfiguration
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.context.annotation.Bean
@@ -33,12 +35,12 @@ import org.springframework.context.annotation.Import
 @Import(SnapshotQueryGatewayRegistrar::class, EventStreamQueryGatewayRegistrar::class)
 @ConditionalOnWowEnabled
 class QueryAutoConfiguration {
-    @Bean("snapshotQueryObserver")
-    @ConditionalOnMissingBean(name = ["snapshotQueryObserver"])
+    @Bean(SNAPSHOT_QUERY_OBSERVER_BEAN_NAME)
+    @ConditionalOnMissingBean(name = [SNAPSHOT_QUERY_OBSERVER_BEAN_NAME])
     fun snapshotQueryObserver(): QueryObserver = QueryLogObserver()
 
-    @Bean("eventStreamQueryObserver")
-    @ConditionalOnMissingBean(name = ["eventStreamQueryObserver"])
+    @Bean(EVENT_STREAM_QUERY_OBSERVER_BEAN_NAME)
+    @ConditionalOnMissingBean(name = [EVENT_STREAM_QUERY_OBSERVER_BEAN_NAME])
     fun eventStreamQueryObserver(): QueryObserver = QueryLogObserver()
 
     @Bean("noOpSnapshotQueryBackendFactory")

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/EventStreamQueryGatewayRegistrar.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/EventStreamQueryGatewayRegistrar.kt
@@ -27,6 +27,9 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry
 
 class EventStreamQueryGatewayRegistrar : QueryGatewayRegistrar() {
     companion object {
+        /** Bean name for the event stream observer shared by aggregate gateways; also used for custom overrides. */
+        const val EVENT_STREAM_QUERY_OBSERVER_BEAN_NAME = "eventStreamQueryObserver"
+
         private val log = KotlinLogging.logger {}
     }
 
@@ -51,7 +54,7 @@ class EventStreamQueryGatewayRegistrar : QueryGatewayRegistrar() {
 
             val filters = appContext.getBeanProvider(QueryFilter::class.java).toList()
             val policies = appContext.getBeanProvider(QueryPolicy::class.java).toList()
-            val observer = appContext.getBean("eventStreamQueryObserver", QueryObserver::class.java)
+            val observer = appContext.getBean(EVENT_STREAM_QUERY_OBSERVER_BEAN_NAME, QueryObserver::class.java)
             DefaultEventStreamQueryGateway(
                 namedAggregate = namedAggregate,
                 binding = binding,

--- a/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/SnapshotQueryGatewayRegistrar.kt
+++ b/wow-spring/src/main/kotlin/me/ahoo/wow/spring/query/SnapshotQueryGatewayRegistrar.kt
@@ -31,6 +31,9 @@ import org.springframework.core.ResolvableType
 
 class SnapshotQueryGatewayRegistrar : QueryGatewayRegistrar() {
     companion object {
+        /** Bean name for the snapshot observer shared by aggregate gateways; also used for custom overrides. */
+        const val SNAPSHOT_QUERY_OBSERVER_BEAN_NAME = "snapshotQueryObserver"
+
         private val log = KotlinLogging.logger {}
     }
 
@@ -57,7 +60,7 @@ class SnapshotQueryGatewayRegistrar : QueryGatewayRegistrar() {
 
             val filters = appContext.getBeanProvider(QueryFilter::class.java).toList()
             val policies = appContext.getBeanProvider(QueryPolicy::class.java).toList()
-            val observer = appContext.getBean("snapshotQueryObserver", QueryObserver::class.java)
+            val observer = appContext.getBean(SNAPSHOT_QUERY_OBSERVER_BEAN_NAME, QueryObserver::class.java)
             DefaultSnapshotQueryGateway<Any>(
                 namedAggregate = namedAggregate,
                 binding = binding,

--- a/wow-spring/src/test/kotlin/me/ahoo/wow/spring/query/QueryGatewayRegistrarTest.kt
+++ b/wow-spring/src/test/kotlin/me/ahoo/wow/spring/query/QueryGatewayRegistrarTest.kt
@@ -45,6 +45,8 @@ import me.ahoo.wow.query.snapshot.SnapshotQueryBackendFactory
 import me.ahoo.wow.query.snapshot.SnapshotQueryGateway
 import me.ahoo.wow.serialization.JsonSerializer
 import me.ahoo.wow.serialization.toJsonNode
+import me.ahoo.wow.spring.query.EventStreamQueryGatewayRegistrar.Companion.EVENT_STREAM_QUERY_OBSERVER_BEAN_NAME
+import me.ahoo.wow.spring.query.SnapshotQueryGatewayRegistrar.Companion.SNAPSHOT_QUERY_OBSERVER_BEAN_NAME
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.ObjectProvider
 import org.springframework.context.support.GenericApplicationContext
@@ -200,7 +202,7 @@ class QueryGatewayRegistrarTest {
             },
         )
         registerBean(
-            "snapshotQueryObserver",
+            SNAPSHOT_QUERY_OBSERVER_BEAN_NAME,
             QueryObserver::class.java,
             Supplier {
                 object : QueryObserver {
@@ -211,7 +213,7 @@ class QueryGatewayRegistrarTest {
             },
         )
         registerBean(
-            "eventStreamQueryObserver",
+            EVENT_STREAM_QUERY_OBSERVER_BEAN_NAME,
             QueryObserver::class.java,
             Supplier {
                 object : QueryObserver {


### PR DESCRIPTION
## Goal

Query gateway registrars and Boot auto-configuration repeated observer Bean names as string literals. Make these shared Spring integration names explicit contracts while preserving existing application configuration.

## Changes

- Expose documented `SNAPSHOT_QUERY_OBSERVER_BEAN_NAME` and `EVENT_STREAM_QUERY_OBSERVER_BEAN_NAME` constants from their registrars in `wow-spring`.
- Use the same constants for registrar lookups, `@Bean` definitions, `@ConditionalOnMissingBean` conditions and test Bean registration.
- Keep literal name assertions in the auto-configuration test to guard compatibility with the existing names.

## Verification

- `:wow-spring:test --tests me.ahoo.wow.spring.query.QueryGatewayRegistrarTest`: 2 tests passed.
- `:wow-spring-boot-starter:test --tests me.ahoo.wow.spring.boot.starter.query.QueryAutoConfigurationTest`: 5 tests passed.
- `:wow-spring:detekt :wow-spring-boot-starter:detekt` and `git diff --check`: passed.

## Compatibility and risks

- [x] QueryGateway API, Bean names and runtime behavior remain unchanged.
- [x] Registrar observer invocation and auto-configuration are covered by existing tests.
- [x] Public constant KDoc documents the names and custom override purpose.
- [x] No generated contracts, credentials, build output or local environment files are included.

No dependency, module boundary, deployment or data changes.
