### PR TITLE
fix(query): align paged and cursor null ordering

### DIFF
--- a/documentation/docs/en/guide/query/data-query.md
+++ b/documentation/docs/en/guide/query/data-query.md
@@ -98,6 +98,8 @@ On the JVM, use `filter.count(queryGateway)`. Execution and exactness follow the
 
 Sort fields must be logical fields supported by the current query model, with direction `ASC` or `DESC`. Pagination changes the returned window but not `total`; when data can change between requests, use a stable ordering that sufficiently distinguishes records. `ListQuery.limit` and `PagedQuery.pagination` are alternative retrieval modes and should not be mixed in one shape.
 
+For the same backend, dataset, filter, and complete effective sort, paged and cursor queries preserve the same ordering semantics. Paged queries must explicitly include the unique sort field used by cursor queries. For single-valued sort fields supported by both query forms, when no null substitution such as `null_value` is configured, MongoDB and Elasticsearch place null or missing values before non-null values in ascending order and after them in descending order; subsequent sort fields break ties. This does not provide snapshot consistency across requests.
+
 ## Results and Empty Results
 
 Queries may return typed, state-only, or `ObjectNode` results; the concrete entry point determines which forms and unwrapping rules are available. After the Backend returns nodes, the Gateway masks them with the same Query Model Schema, then optionally uses Jackson for typed materialization. It skips masking immediately when the root Schema has no `masked` fields. Empty-result behavior is also entry-point-specific: JVM, WebFlux, and API Client 404, empty-value, or empty-list semantics are explained in their child pages and client page. This page does not generalize one transport semantic to every entry point.

--- a/documentation/docs/zh/guide/query/data-query.md
+++ b/documentation/docs/zh/guide/query/data-query.md
@@ -98,6 +98,8 @@ JVM 中可使用 `filter.count(queryGateway)`。计数是否可执行以及精�
 
 排序字段必须是当前查询模型支持的逻辑字段，方向为 `ASC` 或 `DESC`。分页只改变返回窗口，不改变 `total`；当数据可能在多次请求之间变化时，应使用稳定且足够区分记录的排序。`ListQuery.limit` 与 `PagedQuery.pagination` 是两种互斥的取数方式，不应在同一个形态中混用。
 
+同一后端、相同数据集、相同过滤条件和完整有效排序下，普通分页与游标分页保持相同排序语义；普通分页需显式提供游标使用的唯一排序字段。对于两种查询均支持的单值排序字段，未配置 `null_value` 等空值替代映射时，MongoDB 与 Elasticsearch 都将 null／缺失值在升序时放在非空值之前、降序时放在非空值之后，相同排序值再按后续字段排序。这不提供跨请求快照一致性。
+
 ## 返回值与空结果
 
 查询可以返回类型化（typed）、仅状态（state-only）或 `ObjectNode` 结果，具体入口决定可用形态和解包方式。Gateway 在 Backend 返回节点后固定按同一 Query Model Schema 脱敏，再按需用 Jackson 物化 typed 结果；根 Schema 没有 `masked` 字段时直接跳过。空结果也由具体入口决定：JVM、WebFlux 和 API Client 的 404、空值或空列表语义在各自子页面及客户端页面解释；本页不把一种传输语义推广到所有入口。

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/EventStreamQueryBackendSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/EventStreamQueryBackendSpec.kt
@@ -24,6 +24,8 @@ import me.ahoo.wow.api.query.IPagedQuery
 import me.ahoo.wow.api.query.ISingleQuery
 import me.ahoo.wow.api.query.MatchAllFilter
 import me.ahoo.wow.api.query.PagedList
+import me.ahoo.wow.api.query.PagedQuery
+import me.ahoo.wow.api.query.Pagination
 import me.ahoo.wow.api.query.Projection
 import me.ahoo.wow.api.query.QueryField
 import me.ahoo.wow.api.query.SingleQuery
@@ -339,7 +341,7 @@ abstract class EventStreamQueryBackendSpec {
     }
 
     @Test
-    fun `cursor should traverse null and missing sort values in both directions`() {
+    fun `paged and cursor should preserve null and missing sort order in both directions`() {
         val tenantId = generateGlobalId()
         val nullStream = generateEventStream(namedAggregate.aggregateId(tenantId = tenantId), ownerId = "null")
         val missingStream = generateEventStream(namedAggregate.aggregateId(tenantId = tenantId), ownerId = "missing")
@@ -357,6 +359,17 @@ abstract class EventStreamQueryBackendSpec {
                 sort = listOf(Sort(QueryField("ownerId"), direction)),
                 size = 2,
             )
+
+            val effectiveSort = query.withUniqueSort(QueryField("id")).sort
+            val pages = (1..3).map { index ->
+                queryBackendBinding.paged(
+                    PagedQuery(query.filter, sort = effectiveSort, pagination = Pagination(index, query.size)),
+                ).block()!!
+            }
+            pages.forEach { it.total.assert().isEqualTo(3L) }
+            pages.map { it.list.size }.assert().containsExactly(2, 1, 0)
+            pages.flatMap { it.list }.map { it.path("id").asString() }.assert()
+                .containsExactly(*expectedIds.toTypedArray())
 
             val first = queryBackendBinding.cursor(query).block()!!
             val second = queryBackendBinding.cursor(query.copy(cursor = first.nextCursor)).block()!!

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryBackendSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryBackendSpec.kt
@@ -27,6 +27,8 @@ import me.ahoo.wow.api.query.ISingleQuery
 import me.ahoo.wow.api.query.IdFilter
 import me.ahoo.wow.api.query.ListQuery
 import me.ahoo.wow.api.query.PagedList
+import me.ahoo.wow.api.query.PagedQuery
+import me.ahoo.wow.api.query.Pagination
 import me.ahoo.wow.api.query.Projection
 import me.ahoo.wow.api.query.QueryField
 import me.ahoo.wow.api.query.Sort
@@ -348,7 +350,7 @@ abstract class SnapshotQueryBackendSpec {
     }
 
     @Test
-    fun `cursor should traverse null and missing sort values in both directions`() {
+    fun `paged and cursor should preserve null and missing sort order in both directions`() {
         val nullId = "cursor-null"
         val missingId = "cursor-missing"
         val valueId = "cursor-value"
@@ -369,6 +371,17 @@ abstract class SnapshotQueryBackendSpec {
                 sort = listOf(Sort(QueryField("state.createdAt"), direction)),
                 size = 2,
             )
+
+            val effectiveSort = query.withUniqueSort(QueryField("aggregateId")).sort
+            val pages = (1..3).map { index ->
+                queryBackendBinding.paged(
+                    PagedQuery(query.filter, sort = effectiveSort, pagination = Pagination(index, query.size)),
+                ).block()!!
+            }
+            pages.forEach { it.total.assert().isEqualTo(3L) }
+            pages.map { it.list.size }.assert().containsExactly(2, 1, 0)
+            pages.flatMap { it.list }.map { it.path("aggregateId").asString() }.assert()
+                .containsExactly(*expectedIds.toTypedArray())
 
             val first = queryBackendBinding.cursor(query).block()!!
             val second = queryBackendBinding.cursor(query.copy(cursor = first.nextCursor)).block()!!

--- a/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchMappingFactsIntegrationTest.kt
+++ b/wow-elasticsearch/src/integrationTest/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchMappingFactsIntegrationTest.kt
@@ -24,8 +24,11 @@ import me.ahoo.wow.api.query.ElementMatchFilter
 import me.ahoo.wow.api.query.EqualFilter
 import me.ahoo.wow.api.query.ListQuery
 import me.ahoo.wow.api.query.MatchAllFilter
+import me.ahoo.wow.api.query.PagedQuery
 import me.ahoo.wow.api.query.Projection
 import me.ahoo.wow.api.query.QueryField
+import me.ahoo.wow.api.query.SingleQuery
+import me.ahoo.wow.api.query.Sort
 import me.ahoo.wow.api.query.StartsWithFilter
 import me.ahoo.wow.api.query.schema.QueryValueKind
 import me.ahoo.wow.api.query.schema.QueryValueType
@@ -122,6 +125,27 @@ class ElasticsearchMappingFactsIntegrationTest {
             backend.count(StartsWithFilter(QueryField("code"), "A"), schema).block().assert().isEqualTo(0L)
             backend.count(StartsWithFilter(QueryField("code"), "a"), schema).block().assert().isEqualTo(1L)
             assertThrows<QuerySchemaValidationException> { backend.count(StartsWithFilter(QueryField("normalized"), "A"), schema).block() }
+        }
+    }
+
+    @Test
+    fun `ordinary metadata sorts should execute without missing policy`() {
+        val metadata = mapOf(
+            "_score" to QueryValueSchema(QueryValueKind.SCALAR, valueTypes = setOf(QueryValueType.DECIMAL)),
+            "_doc" to QueryValueSchema(QueryValueKind.SCALAR, valueTypes = setOf(QueryValueType.INTEGER)),
+        )
+        withIndex("""{"properties":{"code":{"type":"keyword"}}}""", metadata + ("code" to string), """{"code":"A"}""") { backend, schema ->
+            metadata.keys.forEach { field ->
+                val sort = listOf(Sort(QueryField(field), Sort.Direction.DESC))
+                val single = SingleQuery(MatchAllFilter, sort = sort)
+                backend.single(validateQuery(single, schema), schema).block()!!.path("code").asString().assert().isEqualTo("A")
+                val list = ListQuery(MatchAllFilter, sort = sort, limit = 1)
+                backend.list(validateQuery(list, schema), schema).single().block()!!.path("code").asString().assert().isEqualTo("A")
+                val paged = PagedQuery(MatchAllFilter, sort = sort)
+                val page = backend.paged(validateQuery(paged, schema), schema).block()!!
+                page.total.assert().isEqualTo(1L)
+                page.list.single().path("code").asString().assert().isEqualTo("A")
+            }
         }
     }
 

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchSortCompiler.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchSortCompiler.kt
@@ -27,8 +27,10 @@ import me.ahoo.wow.serialization.MessageRecords
 object ElasticsearchSortCompiler {
     fun compile(sort: List<Sort>, schema: QueryModelSchema): List<SortOptions> = compilePhysical(
         sort.map { it.copy(field = schema.physicalField(it.field, QueryCapability.SORT)) },
-    ) { logicalSort ->
-        missing(if (logicalSort.direction == Sort.Direction.ASC) "_first" else "_last")
+    ) { physicalSort ->
+        if (physicalSort.field !in METADATA_SORT_FIELDS) {
+            missing(if (physicalSort.direction == Sort.Direction.ASC) "_first" else "_last")
+        }
     }
 
     @Suppress("ThrowsCount")
@@ -42,7 +44,7 @@ object ElasticsearchSortCompiler {
                 )
             }
             val physicalField = schema.physicalField(item.field, QueryCapability.CURSOR_SORT)
-            if (physicalField in UNSTABLE_CURSOR_SORT_FIELDS) {
+            if (physicalField in METADATA_SORT_FIELDS) {
                 throw QuerySchemaValidationException("Elasticsearch cursor sort field [$physicalField] is unstable.")
             }
             if (!physicalFields.add(physicalField)) {
@@ -83,7 +85,7 @@ object ElasticsearchSortCompiler {
     }
 }
 
-private val UNSTABLE_CURSOR_SORT_FIELDS = setOf(
+private val METADATA_SORT_FIELDS = setOf(
     QueryField("_score"),
     QueryField("_doc"),
     QueryField("_shard_doc"),

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchSortCompiler.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchSortCompiler.kt
@@ -27,7 +27,9 @@ import me.ahoo.wow.serialization.MessageRecords
 object ElasticsearchSortCompiler {
     fun compile(sort: List<Sort>, schema: QueryModelSchema): List<SortOptions> = compilePhysical(
         sort.map { it.copy(field = schema.physicalField(it.field, QueryCapability.SORT)) },
-    )
+    ) { logicalSort ->
+        missing(if (logicalSort.direction == Sort.Direction.ASC) "_first" else "_last")
+    }
 
     @Suppress("ThrowsCount")
     internal fun compileCursor(sort: List<Sort>, schema: QueryModelSchema): List<SortOptions> {

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchSortCompilerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchSortCompilerTest.kt
@@ -67,7 +67,7 @@ class ElasticsearchSortCompilerTest {
     }
 
     @Test
-    fun `should resolve logical sort fields without setting ordinary missing order`() {
+    fun `should resolve logical sort fields with the same missing order as cursor`() {
         val actual = ElasticsearchSortCompiler.compile(
             sort {
                 "name".asc()
@@ -78,10 +78,8 @@ class ElasticsearchSortCompilerTest {
 
         actual.map { it.field() }.assert().containsExactly("body.name", "body.name")
         actual.map { it.order() }.assert().containsExactly(SortOrder.Asc, SortOrder.Desc)
-        actual.forEach {
-            requireNotNull(it.nested()).path().assert().isEqualTo("body")
-            it.missing().assert().isNull()
-        }
+        actual.map { requireNotNull(it.missing()).stringValue() }.assert().containsExactly("_first", "_last")
+        actual.forEach { requireNotNull(it.nested()).path().assert().isEqualTo("body") }
     }
 
     @Test

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchSortCompilerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/ElasticsearchSortCompilerTest.kt
@@ -83,6 +83,27 @@ class ElasticsearchSortCompilerTest {
     }
 
     @Test
+    fun `logical aliases of metadata sorts should retain native missing policy`() {
+        listOf("_score", "_doc", "_shard_doc").forEach { physical ->
+            val logical = QueryField("rank")
+            val metadataSchema = nativeSchema(
+                model = QueryModel.SNAPSHOT,
+                capabilities = emptySet(),
+                fields = mapOf(logical to fieldSchema(QueryCapability.SORT to QueryField(physical))),
+            )
+            Sort.Direction.entries.forEach { direction ->
+                val actual = ElasticsearchSortCompiler.compile(
+                    listOf(Sort(logical, direction)),
+                    metadataSchema
+                ).single().field()
+                actual.field().assert().isEqualTo(physical)
+                actual.order().assert().isEqualTo(ElasticsearchSortCompiler.run { direction.toSortOrder() })
+                actual.missing().assert().isNull()
+            }
+        }
+    }
+
+    @Test
     fun `event cursor should preserve physical sorts nested context and missing order`() {
         val actual = ElasticsearchSortCompiler.compileCursor(
             sort {


### PR DESCRIPTION
## Goal

Elasticsearch paged queries placed null or missing sort values last in ascending order, while cursor queries placed them first. Switching pagination modes could therefore change row order for the same filter and effective sort.

## Changes

- Preserve native `_score`, `_doc`, and `_shard_doc` sorts (including logical aliases) without a `missing` option; real ES regression coverage exercises single/list/paged metadata sorting.
- Align ordinary logical query sorts with the existing cursor convention: missing values first for ASC and last for DESC. Single and list queries share this compiler; internal event-store physical sorts retain their current behavior.
- Extend Snapshot and EventStream TCK checks to verify page totals, ordered contents across pages, an empty out-of-range page, and cursor traversal for null/missing values in both directions.
- Document the ordering contract and its effective-sort and mapping constraints in English and Chinese.

## Verification

- Review regression reproduced on Elasticsearch 9.2.6: `[_score] unknown field [missing]` before the metadata-sort fix.
- After the review fix: `./gradlew :wow-elasticsearch:test :wow-elasticsearch:detekt :wow-elasticsearch:integrationTest --tests '*QueryBackendTest' --tests '*ElasticsearchMappingFactsIntegrationTest' --console=plain` — passed: 234 unit tests and 104 integration tests, no failures or skips; Detekt passed.

- Before the fix, the revised Elasticsearch sort unit test and both Snapshot/EventStream integration cases failed on the expected missing-order mismatch.
- `./gradlew :wow-elasticsearch:test :wow-mongo:integrationTest :wow-elasticsearch:integrationTest --tests '*QueryBackendTest' --tests '*ElasticsearchSortCompilerTest' --console=plain` — passed: 233 unit tests and 280 integration tests, no failures or skips. The filters apply to the final Elasticsearch integration task; MongoDB integration and Elasticsearch unit suites ran in full.
- `./gradlew :wow-elasticsearch:detekt :wow-tck:detekt --console=plain` — passed.
- `pnpm --dir documentation docs:build` — passed.
- `git diff --check` — passed.

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

Intentional behavior change: Elasticsearch single/list/paged ascending queries now place missing sort values first. This can change the first selected row or page contents when such values exist. Descending order and cursor behavior are unchanged. No data migration, new dependency, public configuration, or cross-request snapshot guarantee is introduced.
