### PR TITLE
fix(compensation): complete query temporal annotations

### DIFF
--- a/compensation/wow-compensation-api/src/main/kotlin/me/ahoo/wow/compensation/api/IExecutionFailedState.kt
+++ b/compensation/wow-compensation-api/src/main/kotlin/me/ahoo/wow/compensation/api/IExecutionFailedState.kt
@@ -24,6 +24,7 @@ import me.ahoo.wow.api.messaging.function.FunctionInfoData
 import me.ahoo.wow.api.modeling.AggregateId
 import me.ahoo.wow.api.modeling.AggregateIdCapable
 import me.ahoo.wow.api.naming.Materialized
+import me.ahoo.wow.api.query.schema.QueryTemporal
 
 data class ErrorDetails(
     override val errorCode: String,
@@ -116,18 +117,21 @@ data class RetryState(
      *
      * @see java.time.temporal.ChronoUnit.MILLIS
      */
+    @QueryTemporal
     val retryAt: Long,
     /**
      * Execution timeout deadline.
      *
      * @see java.time.temporal.ChronoUnit.MILLIS
      */
+    @QueryTemporal
     val timeoutAt: Long,
     /**
      * Timestamp of the next retry.
      *
      * @see java.time.temporal.ChronoUnit.MILLIS
      */
+    @QueryTemporal
     val nextRetryAt: Long,
 ) {
     fun timeout(): Boolean {

--- a/compensation/wow-compensation-domain/src/main/kotlin/me/ahoo/wow/compensation/domain/ExecutionFailedState.kt
+++ b/compensation/wow-compensation-domain/src/main/kotlin/me/ahoo/wow/compensation/domain/ExecutionFailedState.kt
@@ -41,7 +41,7 @@ class ExecutionFailedState(override val id: String) : IExecutionFailedState {
     override lateinit var error: ErrorDetails
         private set
 
-    @field:QueryTemporal
+    @QueryTemporal
     override var executeAt: Long = 0
         private set
     override lateinit var retrySpec: RetrySpec

--- a/compensation/wow-compensation-domain/src/test/kotlin/me/ahoo/wow/compensation/domain/ExecutionFailedTemporalTest.kt
+++ b/compensation/wow-compensation-domain/src/test/kotlin/me/ahoo/wow/compensation/domain/ExecutionFailedTemporalTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.compensation.domain
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.schema.QueryTemporal
+import me.ahoo.wow.compensation.api.RetryState
+import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
+
+class ExecutionFailedTemporalTest {
+    @Test
+    fun `execution and retry timestamps declare millisecond query semantics`() {
+        val timestampFields = listOf(
+            ExecutionFailedState::class.java.getDeclaredField("executeAt"),
+            RetryState::class.java.getDeclaredField("retryAt"),
+            RetryState::class.java.getDeclaredField("timeoutAt"),
+            RetryState::class.java.getDeclaredField("nextRetryAt"),
+        )
+        timestampFields.forEach { field ->
+            field.getAnnotation(QueryTemporal::class.java)?.timeUnit
+                .assert().isEqualTo(TimeUnit.MILLISECONDS)
+        }
+    }
+}


### PR DESCRIPTION
## Goal

Declare millisecond timestamp semantics for all execution-failure retry timestamps so query schemas can recognize them as temporal fields.

## Changes

- Add `@QueryTemporal` to `RetryState.retryAt`, `timeoutAt`, and `nextRetryAt`.
- Simplify `ExecutionFailedState.executeAt` to the same annotation syntax without an explicit use-site target.
- Add a regression test verifying that all four annotations are retained on JVM fields with `MILLISECONDS` units.

## Verification

- Regression test failed before the fix because retry timestamp annotations were absent, then passed after the fix.
- `./gradlew :wow-compensation-api:check :wow-compensation-domain:check` — passed; 55 tests, zero failures.
- `git diff --check` — passed.

## Compatibility and risks

Public Kotlin APIs and serialized values remain unchanged. Query schema metadata intentionally gains temporal semantics for the three retry timestamp fields. Retry durations remain ordinary numbers. No data migration or runtime scheduling change is required.

- [x] Tests cover the changed annotation contract.
- [x] Existing timestamp documentation remains accurate; no user workflow changes require documentation updates.
- [x] No credentials, generated build output, or local environment files are included.
