### PR TITLE
feat(query): add record-level filters to aggregation metrics

### DIFF
--- a/documentation/designs/2026-09-12-aggregation-reporting-epic-design.md
+++ b/documentation/designs/2026-09-12-aggregation-reporting-epic-design.md
@@ -1,0 +1,164 @@
+# 聚合查询报表场景 Epic：指标级过滤、派生指标与后续阶段
+
+日期：2026-09-12
+
+状态：Phase 1-2 设计已获用户批准；Phase 3-6 为范围提纲（各阶段动手前细化）。
+
+基线：`main` `6cf8be185`（含 PR #3233：DISTINCT_COUNT / STDDEV / VARIANCE / MEDIAN / PERCENTILE 已交付）。前置设计：[2026-09-11 聚合指标函数扩展](2026-09-11-aggregation-metric-functions-design.md)。
+
+## 目标与范围
+
+补齐报表场景的服务端聚合能力。原始需求 9 项，其中：
+
+- **已交付（PR #3233）**：③ 去重计数（`DISTINCT_COUNT`）、⑧ 分位数/标准差（`PERCENTILE`/`MEDIAN`/`STDDEV`/`VARIANCE`）——移出本 Epic。
+- **本 Epic 剩余 7 项**：① 指标级过滤（漏斗）、② 派生指标（比率）、⑤ HAVING、⑥ 空桶补齐、⑦ TERMS 截断/缺失桶、⑨ 批量聚合端点、④ 子聚合。
+
+## 分期
+
+| 阶段 | 能力 | PR | 状态 |
+|---|---|---|---|
+| Phase 1 | 指标级过滤（漏斗/状态对比） | 独立 PR | 设计已批准，待实施计划 |
+| Phase 2 | 派生指标（客单价/毛利率/达成率） | 独立 PR | 设计已批准 |
+| Phase 3 | HAVING（按聚合值筛选分组） | 独立 PR | 范围提纲 |
+| Phase 4 | 分桶体验：空桶补齐 + TERMS 截断/缺失桶 | 独立 PR | 范围提纲 |
+| Phase 5 | 批量聚合端点（仪表盘一次加载） | 独立 PR | 范围提纲 |
+| Phase 6 | 子聚合（层级钻取） | 独立 Epic | 范围提纲（结构风险最高） |
+
+每个阶段独立可交付，不依赖未合并的后续阶段；各阶段动手前完成细化设计 → 实施计划 → PR。
+
+## 贯穿约束（承接 #3233 的设计原则）
+
+1. **不为存储端低版本做不支持或降级实现**：直接用原生算子，版本要求仅文档注明，运行时不做版本探测/门控。
+2. wire 兼容纯增量：不改既有字段/类型/JSON `type` 值与语义；无新能力的 JSON 与现状字节兼容。
+3. 跨后端语义由 TCK 锚定；确有差异的（近似、内存策略）以容差断言并文档化口径。
+4. 严格 TDD；测试用 fluent-assert；sealed `when` 全链路穷尽、无 `else`。
+5. HTTP 门控（HttpQueryGuard）：新增查询能力须评估 `allowExpensiveOperators=false` 与 `maxFilterValues` 的适用性。
+
+## Phase 1：指标级过滤（漏斗）
+
+### AST
+
+`AggregationMetric` 全部五个子类型（`Count`/`Numeric`/`Any`/`DistinctCount`/`Percentile`）各追加末位字段：
+
+```kotlin
+val filter: FilterExpression = MatchAllFilter
+```
+
+`@get:JsonInclude(NON_DEFAULT)` 省略默认值——无过滤的 JSON 与现状字节兼容，DSL 位置构造不受影响（`filter` 恒为最后参数）。`Derived`（Phase 2）同样携带该字段。
+
+### 语义
+
+- filter 作用于**当前作用域的记录**（根文档或最内层 element），不匹配的记录对该指标**零贡献**，不影响其他指标、分组与排序。
+- `COUNT + filter` = 条件计数，空匹配结果为 `0`（计数语义）。
+- `Numeric`/`DistinctCount`/`Percentile`/`Any` + filter：仅匹配记录的参与值/值参与；空匹配沿用各指标既有空语义（`null`；`DistinctCount` 仍为 `0`——它本就以 0 为空集语义）。
+
+### 验证（QuerySchemaValidation）
+
+- metric filter 复用 element-filter 的作用域校验（element 内不得含根级过滤器）；字段能力校验同常。
+- HttpQueryGuard：metric filter 不属昂贵算子；其过滤值数并入既有 `maxFilterValues` 计数。
+
+### 双后端
+
+- **Mongo**：参与值表达式外包 `$cond[filter, 参与, null/零贡献]`——`COUNT` → `$sum($cond(filter,1,0))`；`value_count` 守卫条件变为 `filter ∧ 参与`；`DistinctCount` 的 `$addToSet` 输入包 `$cond[filter, value, null]`（null 由投影过滤）；`Any` 用 `$max($cond(filter, field, null))`（`$max` 忽略 null）。
+- **Elasticsearch**：带 filter 的指标包一层 `filter` 子聚合（条件命中文档为其 `doc_count`），指标与 `valueCount` 守卫收在内层；`COUNT + filter` 读该 filter agg 的 `doc_count`；`value()` 导航为该类指标增加一层；分页/Top-N/`effectiveSort` 结构不变。
+
+### DSL
+
+```kotlin
+aggregation {
+    dateHistogram("createdAt", AggregationDateUnit.DAY, "day")
+    count("created")
+    count("paid") { "status" eq "PAID" }
+    sum("amount", "paidAmount") { "status" eq "PAID" }
+    distinctCount("customerId", "paidCustomers") { "status" eq "PAID" }
+    percentile("amount", 95.0, "paidP95") { "status" eq "PAID" }
+}
+```
+
+（带 `filter` 尾 lambda 的重载；无过滤重载签名不变。）
+
+### TCK 契约场景
+
+① 漏斗三环同图（created/paid/shipped 条件计数）② 条件 SUM/去重/百分位 ③ `COUNT+filter` 空匹配 = 0、数值类 = null ④ metric filter 与 element filter 叠加 ⑤ 按 filter 指标别名排序（Top-N）⑥ element 作用域内 metric filter 作用域正确性。
+
+## Phase 2：派生指标
+
+### AST
+
+新子类型：
+
+```kotlin
+data class Derived(
+    override val alias: String,
+    val expression: DerivedExpression,
+) : AggregationMetric
+
+sealed interface DerivedExpression {
+    data class MetricRef(val metric: String) : DerivedExpression
+    data class Constant(val value: Double) : DerivedExpression
+    data class Binary(
+        val operator: AggregationExpressionOperator,  // 复用 ADD/SUBTRACT/MULTIPLY/DIVIDE
+        val left: DerivedExpression,
+        val right: DerivedExpression,
+    ) : DerivedExpression
+}
+```
+
+不复用 `AggregationExpression`（记录级表达式），两者语义域不同，混用会误导 OpenAPI 与验证。深度/节点上限沿用 `MAX_EXPRESSION_DEPTH`/`MAX_EXPRESSION_NODES`。`Derived` **不携带 filter 字段**：filter 是记录级概念，派生在聚合之后计算，二者属不同语义层，不叠加。
+
+### 引用规则（构造期校验，AggregationQuery.init）
+
+- `MetricRef` 只能引用**声明序在前**的指标（无前向引用 → 结构上无环）；被引用别名必须存在、不得为分组别名、不得带 `__wow` 前缀。
+- 派生可引用非派生指标（含 `COUNT`，计数值作数值参与）与先声明的派生。
+
+### 语义
+
+- **null 传播**：任一操作数 `null` → 结果 `null`（被引用指标空语义随之传播）。
+- **除零 → null**、结果须有限 double——与既有 BINARY 口径一致。
+- 与 Phase 1 叠加：`filteredSum / filteredCount` = 已支付客单价等。
+
+### 双后端
+
+- **Mongo**：`$project` 不能引用同阶段输出 → 派生在**追加的第二个 `$project` 阶段**按声明序计算（读第一阶段已守卫的别名输出；`$cond` 实现 null 传播与除零守卫，模式同 `finiteDouble`）。
+- **Elasticsearch**：`bucket_script` 管道聚合置于 composite 桶内，`buckets_path` 引用兄弟聚合（`_count`、指标 value、percentiles 的 `alias[95.0]` 路径、先声明 bucket_script 的别名）；`gap_policy=skip` 产生 null，与 null 传播一致。
+- 按派生别名排序复用 Top-N 路径；ungrouped summary 同步支持。
+
+### DSL
+
+```kotlin
+aggregation {
+    terms("state.status", "status")
+    count("paid") { "status" eq "PAID" }
+    sum("amount", "paidAmount") { "status" eq "PAID" }
+    derived("paidAov") { ref("paidAmount") / ref("paid") }          // 已支付客单价
+    sum("targetAmount", "target")
+    derived("attainment") { ref("paidAmount") / ref("target") }     // 达成率
+    derived("margin") { (ref("paidAmount") - ref("target")) / ref("paidAmount") }
+    sort { "paidAov".desc() }
+}
+```
+
+（`ref(alias)` 引用先声明指标；`+ - * /` 运算符重载沿用 `AggregationQueryDsl` 既有模式；尾 lambda 为派生表达式块。）
+
+### TCK 契约场景
+
+① 客单价 `SUM/COUNT` ② 达成率 `SUM/SUM` ③ 毛利率（复合表达式）④ 除零 → null ⑤ null 传播（引用空语义指标）⑥ 派生链（引用先声明派生）⑦ 按派生别名排序 ⑧ filter × derived 叠加 ⑨ 前向引用/未知别名/分组别名引用构造期拒绝。
+
+## Phase 3-6 范围提纲（动手前细化）
+
+- **Phase 3 HAVING**：按聚合值过滤分组。引用语法直接复用 `MetricRef`（可引用派生）。Mongo：`$group` 后追加 `$match`（守卫字段须先落定，必要时三段式 project）。ES composite 无 bucket_selector：metric 排序路径在 Top-N 内存累积中过滤；分组排序路径按页超取直至满足 limit 或耗尽——`limit` 语义定义为**过滤后**行数。选择性与性能权衡文档化。
+- **Phase 4 分桶体验**：空桶补齐（`DATE_HISTOGRAM` 专用开关，窗口默认=实际数据首末桶；Mongo `$densify`、ES pager 补零——补零行的指标值遵循各指标空语义）；TERMS 截断（与 metric 排序 Top-N 的关系澄清：默认仍按分组序分页，`size` 语义独立定义）；缺失桶（ES `missing_bucket`、Mongo `$ifNull` 哨兵值归入声明的哨兵键）。
+- **Phase 5 批量聚合端点**：`POST .../aggregation:batch`（N 个 AggregationQuery）；ES `msearch`、Mongo `$facet`（内存受 100MB/阶段约束，超限回退服务端并发归并——细化时定案）；响应逐项对应；部分失败语义（逐项错误对象 vs 整体失败）细化时定案；HttpQueryGuard 按 N× 单查询限制收紧。
+- **Phase 6 子聚合**：ES composite 不可嵌套——需评估嵌套 terms 聚合/多级 composite 模拟/内存归并的结构方案及其对分页与 metric 排序契约的冲击；结构风险最高，独立 Epic 设计。
+
+## 测试与文档策略（每阶段相同）
+
+- wow-api AST 构造/JSON 往返单测 → wow-query DSL/验证单测 → 双编译器单测（结构化 Document/计划断言）→ TCK 跨后端契约（Docker 集成）→ OpenAPI 快照对齐 → 中英文档（场景各 1+）→ 全量回归 + detekt。
+- 版本要求（如出现新算子）仅文档注明。
+
+## 完成标准（每阶段）
+
+1. 新能力在双后端行为符合本设计语义，TCK 新场景全部通过且零回归。
+2. wire 纯增量（无新能力的 JSON 字节不变）；OpenAPI 快照纯增量对齐。
+3. DSL/验证/文档（中英）同步；HttpQueryGuard 适用性评估落地。
+4. 独立 PR、独立可交付；不依赖后续阶段。

--- a/documentation/designs/2026-09-12-metric-filter-implementation-plan.md
+++ b/documentation/designs/2026-09-12-metric-filter-implementation-plan.md
@@ -1,0 +1,590 @@
+# Phase 1 实施计划：指标级过滤（漏斗）
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为 `AggregationMetric` 全部子类型增加记录级 `filter` 字段（漏斗/状态对比：同一分组内按不同条件分别计数/聚合），MongoDB 与 Elasticsearch 双后端实现，含 DSL、验证、HttpQueryGuard、TCK 契约与中英文档。
+
+**Architecture:** 纯增量字段（默认 `MatchAllFilter`、`NON_DEFAULT` 序列化省略）——无过滤的 JSON 与现状字节兼容；不新增 sealed 子类型，全链路 `when` 不受穷尽性冲击，各模块任务独立。语义：当前作用域（根或最内层 element）内不匹配的记录对该指标零贡献。
+
+**Tech Stack:** Kotlin 2.x、JUnit 5、fluent-assert、Reactor、MongoDB Java Driver、elasticsearch-java 9.x、Testcontainers（mongo:7.0）。
+
+**Spec:** [2026-09-12-aggregation-reporting-epic-design.md](2026-09-12-aggregation-reporting-epic-design.md)「Phase 1」节（语义、验证、双后端、TCK 场景以该文档为准）。
+
+## Global Constraints
+
+- 基线：`main` `429970431`；不 bump 版本号。
+- wire 兼容纯增量：`filter` 为各子类型**末位**字段（位置构造兼容）、默认 `MatchAllFilter`、`@get:JsonInclude(NON_DEFAULT)` 省略——无过滤 JSON 字节不变。
+- 不为存储端低版本做降级/门控；本阶段无新版本要求。
+- 每个实现任务严格 TDD：先写失败测试、亲见 RED（失败在预期点）、再实现、GREEN。
+- 测试断言用 fluent-assert `.assert()`；核心路径 Reactor 非阻塞。
+- 不修改 CI workflow；OpenAPI 快照再生成属纯增量对齐（沿用 `-Dwow.snapshot.update=true` 机制）。
+- 提交信息 conventional commits（scope：`api`/`query`/`mongo`/`elasticsearch`/`webflux`/`tck`/`openapi`/`docs`）。
+- 设计语义锚点：`COUNT+filter` 空匹配 → `0`；数值/`Any`/`Percentile` → `null`；`DistinctCount` → `0`（既有空集语义）。metric filter 不属昂贵算子；其值数并入 `maxFilterValues`。
+
+---
+
+### Task 1: wow-api — 五个子类型的 filter 字段
+
+**Files:**
+- Modify: `wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt`（216-267 行区域的五个 data class）
+- Test: `wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt`
+
+**Interfaces:**
+- Produces（后续任务依赖）：每个子类型追加 `val filter: FilterExpression = MatchAllFilter`（**末位**，`Any` 的在 `alias` 之后、其余在现有参数之后）；JSON 属性名 `filter`，默认省略。`Count(alias, filter)` 与既有 `Count(alias)` 位置构造并存。
+
+- [ ] **Step 1: 写失败测试**（追加到 AggregationQueryTest）
+
+```kotlin
+@Test
+fun `metric filters should round trip and omit defaults`() {
+    val json = """
+        {
+          "metrics": [
+            {"type": "COUNT", "alias": "total"},
+            {"type": "COUNT", "filter": {"op": "EQ", "field": "status", "value": "PAID"}, "alias": "paid"},
+            {"type": "NUMERIC", "function": "SUM", "expression": {"field": "amount"},
+             "filter": {"op": "EQ", "field": "status", "value": "PAID"}, "alias": "paidAmount"}
+          ]
+        }
+    """.trimIndent()
+
+    val query = configuredMapper.readValue(json, AggregationQuery::class.java)
+    query.metrics.filterIsInstance<AggregationMetric.Count>().assert().hasSize(2)
+    query.metrics[1].filter.assert().isInstanceOf(EqualFilter::class.java)
+    query.metrics.filterIsInstance<AggregationMetric.Numeric>().single().filter.assert()
+        .isInstanceOf(EqualFilter::class.java)
+    query.metrics[0].filter.assert().isEqualTo(MatchAllFilter)
+    val wire = configuredMapper.writeValueAsString(query)
+    wire.assert()
+        .contains("\"type\":\"COUNT\",\"alias\":\"total\"")
+        .contains("\"filter\":{\"op\":\"EQ\"")
+}
+```
+
+注意：**不在**子类型 init 中校验 filter 内容——根级过滤器（如 `TenantIdFilter`）在根作用域的 metric filter 上是合法的，合法性取决于查询上下文，属 `QuerySchemaValidation` 职责（Task 3 经由 `filter(metric.filter, parent)` 的既有作用域校验强制执行）。
+
+- [ ] **Step 2: 运行确认 RED**
+
+```bash
+./gradlew :wow-api:test --tests "me.ahoo.wow.api.query.AggregationQueryTest"
+```
+
+预期：编译失败——`Count` 无第二参数、`filter` 属性不存在（失败点即预期点）。
+
+- [ ] **Step 3: 实现**
+
+五个子类型追加末位字段（`@get:JsonInclude(JsonInclude.Include.NON_DEFAULT)`，import 已在文件头）。示例（其余同款，无 init 校验——见 Step 1 注意）：
+
+```kotlin
+data class Count(
+    override val alias: String,
+    @get:JsonInclude(JsonInclude.Include.NON_DEFAULT)
+    val filter: FilterExpression = MatchAllFilter,
+) : AggregationMetric {
+    init {
+        requireAggregationAlias(alias)
+    }
+}
+```
+
+- [ ] **Step 4: GREEN**：`./gradlew :wow-api:test` 全绿（本任务后其他模块不受影响——纯增量字段，模块仍编译）。
+
+- [ ] **Step 5: 提交** `feat(api): add record-level filter to aggregation metrics`
+
+---
+
+### Task 2: wow-query — DSL 过滤重载
+
+**Files:**
+- Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDsl.kt`
+- Test: `wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt`
+
+**Interfaces:**
+- Consumes: Task 1 字段。
+- Produces: 既有方法各加一个尾 lambda 过滤重载（`init: FilterDsl.() -> Unit`，内部 `me.ahoo.wow.query.dsl.filter(init)` 转换）：`count(alias, init)`、`sum/avg/min/max/stddev/variance(field, alias, init)` 与 `(expression, alias, init)`、`percentile/median(field, p, alias, init)` 与 `(expression, p, alias, init)`、`distinctCount(field, alias, init)` 与 `(expression, alias, init)`、`any(field, alias, init)`。无过滤重载签名不变。
+
+- [ ] **Step 1: 写失败测试**
+
+```kotlin
+@Test
+fun `aggregation DSL should apply metric filters`() {
+    val query = aggregation {
+        terms("status", "status")
+        count("paid") { "status" eq "PAID" }
+        sum("amount", "paidAmount") { "status" eq "PAID" }
+        distinctCount(field("customerId"), "customers") { "amount" gt 0 }
+        percentile("amount", 95.0, "p95") { "status" eq "PAID" }
+    }
+
+    query.metrics.filterIsInstance<AggregationMetric.Count>().single().filter.assert()
+        .isInstanceOf(EqualFilter::class.java)
+    query.metrics.filterIsInstance<AggregationMetric.Numeric>().single().filter.assert()
+        .isInstanceOf(EqualFilter::class.java)
+    query.metrics.filterIsInstance<AggregationMetric.DistinctCount>().single().filter.assert()
+        .isInstanceOf(GreaterThanFilter::class.java)
+    query.metrics.filterIsInstance<AggregationMetric.Percentile>().single().filter.assert()
+        .isInstanceOf(EqualFilter::class.java)
+}
+```
+
+- [ ] **Step 2: RED**：`./gradlew :wow-query:test --tests "me.ahoo.wow.query.dsl.AggregationQueryDslTest"`——编译失败：重载不存在。
+
+- [ ] **Step 3: 实现**：每个方法追加重载，形如：
+
+```kotlin
+fun count(alias: String, init: FilterDsl.() -> Unit) {
+    metrics += AggregationMetric.Count(alias, me.ahoo.wow.query.dsl.filter(init))
+}
+
+fun sum(field: String, alias: String, init: FilterDsl.() -> Unit) = sum(field(field), alias, init)
+
+fun sum(expression: AggregationExpression, alias: String, init: FilterDsl.() -> Unit) {
+    metrics += AggregationMetric.Numeric(AggregationFunction.SUM, expression, me.ahoo.wow.query.dsl.filter(init), alias)
+}
+```
+
+（全部 21 个重载同款展开：count×1、sum/avg/min/max/stddev/variance×2、percentile×2、median×2、distinctCount×2、any×2；字段重载委托表达式重载。）
+
+- [ ] **Step 4: GREEN**：`./gradlew :wow-query:test`
+- [ ] **Step 5: 提交** `feat(query): add metric filter DSL overloads`
+
+---
+
+### Task 3: wow-query — 验证与 HttpQueryGuard
+
+**Files:**
+- Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaValidation.kt`（`aggregate()` metrics 循环）
+- Modify: `wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuard.kt`（110 行 `validateFilters` 列表）
+- Test: `wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaValidationTest.kt`、`wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardTest.kt`
+
+**Interfaces:**
+- Produces: `aggregate()` 在 metrics 循环前统一执行 `if (metric.filter !== MatchAllFilter) filter(metric.filter, parent)`（作用域=当前 parent，与 element.filter 同一校验路径）；guard 将非默认 metric filter 并入 `validateFilters` 列表（节点数与值数上限随之生效）。
+
+- [ ] **Step 1: 写失败测试**
+
+QuerySchemaValidationTest 追加：
+
+```kotlin
+@Test
+fun `metric filters follow the current scope for root and element contexts`() {
+    val schema = boundSchemaFixture(
+        objectFixture(
+            "tenantId" to scalarFixture(),
+            "orders" to arrayFixture(
+                objectFixture("status" to scalarFixture(), "amount" to scalarFixture(QueryValueType.DECIMAL))
+            )
+        )
+    )
+    // 根作用域：metric filter 可用根级过滤器（tenantId 在根声明）
+    validateQuery(
+        aggregation {
+            count("tenantOrders") { tenantId("tenant") }
+        },
+        schema,
+    ).assert().isNotNull()
+    // element 作用域：根级字段经 filter() 的 element-scope 校验拒绝
+    assertThrows<QuerySchemaValidationException> {
+        validateQuery(
+            aggregation {
+                expand("orders")
+                count("counted") { tenantId("tenant") }
+            },
+            schema,
+        )
+    }
+    // element 作用域：本作用域字段合法；未知字段拒绝
+    validateQuery(
+        aggregation {
+            expand("orders")
+            count("paid") { "status" eq "PAID" }
+        },
+        schema,
+    ).assert().isNotNull()
+    assertThrows<QuerySchemaValidationException> {
+        validateQuery(
+            aggregation {
+                expand("orders")
+                sum("missing", "total") { "status" eq "PAID" }
+            },
+            schema,
+        )
+    }
+}
+```
+
+（若 `tenantId` 的 FilterDsl 扩展在测试中不可用，以 `TenantIdFilter("tenant")` 直接构造；`boundSchemaFixture` 需给 `tenantId` 字段 EXACT_MATCH 能力——fixtures 默认全能力集已含 ✓。）
+
+HttpQueryGuardTest 追加（沿用既有 guard 测试构造助手）：
+
+```kotlin
+@Test
+fun `aggregation metric filters count toward filter value limits`() {
+    val guard = guard(maxFilterValues = 2)
+    assertThrows<IllegalArgumentException> {
+        guard.validateAggregation(
+            aggregation {
+                count("a") { "status" isIn listOf("PAID", "SHIPPED", "CANCELLED") } // 3 values > 2
+            }
+        )
+    }
+}
+```
+
+（guard 构造参数名按既有测试助手实况调整；断言消息含 `must not exceed` 可选加强。）
+
+- [ ] **Step 2: RED**
+
+```bash
+./gradlew :wow-query:test --tests "me.ahoo.wow.query.schema.QuerySchemaValidationTest"
+./gradlew :wow-webflux:test --tests "*HttpQueryGuard*"
+```
+
+预期失败点：guard 值计数断言（metric filter 未计数 → 3 值不超限 → 不抛）；validation 的 element-scope 拒绝段（filter 未被校验 → 通过 → assertThrows 失败）。根作用域通过段与未知字段段在实现前后均应通过（后者走 sum 字段校验，与 filter 无关）——执行者须核对每段实际失败点并在报告记录。
+
+- [ ] **Step 3: 实现**
+
+QuerySchemaValidation.aggregate()（metrics.forEach 之前）：
+
+```kotlin
+query.metrics.forEach { metric ->
+    if (metric.filter !== MatchAllFilter) {
+        filter(metric.filter, parent)
+    }
+}
+query.metrics.forEach { metric -> /* 既有 when 分支不动 */ }
+```
+
+（或并入既有循环开头，二选一，保持文件风格。）
+
+HttpQueryGuard 110 行：
+
+```kotlin
+validateFilters(
+    listOf(query.filter) +
+        query.elements.map(AggregationElement::filter) +
+        query.metrics.map(AggregationMetric::filter).filter { it !== MatchAllFilter } +
+        scopeFilters,
+    rejectMatchAll = false,
+)
+```
+
+（`AggregationMetric::filter` 属性引用；metric filter 不属昂贵算子——不加 expensive 判定。）
+
+- [ ] **Step 4: GREEN**：`./gradlew :wow-query:test :wow-webflux:test`
+- [ ] **Step 5: 提交** `feat(query): validate aggregation metric filters and count them in HTTP guards`
+
+---
+
+### Task 4: wow-mongo — 编译器守卫
+
+**Files:**
+- Modify: `wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoAggregationCompiler.kt`（`compile`/`group` 签名穿 `now`；`group` 五分支 + `numericParticipation`）
+- Test: `wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt`
+
+**Interfaces:**
+- Consumes: Task 1 字段；既有 `filterCompiler.compileScoped(filter, schema, logicalParent, physicalParent, now)`。
+- Produces:
+  - `group(query, id, parent, physicalParent, schema, now)`（`now` 由 `compile` 透传，供 metric filter 相对时间）。
+  - `metricFilter(metric, parent, physicalParent, schema, now): Bson?`（`MatchAllFilter → null`，否则 `compileScoped` 结果）。
+  - `Count+filter` → `Accumulators.sum(alias, {$cond: [filterDoc, 1, 0]})`。
+  - `Numeric/Percentile`：`input` 外包 `{$cond: [filterDoc, input, null]}`；`countAlias` 守卫变 `{$cond: [{$and: [filterDoc, contributes]}, 1, 0]}`。
+  - `DistinctCount`：`$addToSet` 输入外包 `{$cond: [filterDoc, value, null]}`（null 由投影过滤）。
+  - `Any+filter` → `Accumulators.max(alias, {$cond: [filterDoc, $field, null]})`。
+  - `project`/`toAggregationResult`/`emptySummary` 不变（空语义由上述守卫自然产生：COUNT 空 → 0、数值类 → null）。
+
+- [ ] **Step 1: 写失败测试**（结构化 Document 断言，沿用 Task 6 既有风格）
+
+```kotlin
+@Test
+fun `filtered count accumulates conditional ones`() {
+    val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+        aggregation { count("paid") { "status" eq "PAID" } },
+        schema(),
+    ).map { it.toBsonDocument() }
+
+    val group = pipeline.first { it.containsKey("\$group") }.getDocument("\$group")
+    val accumulator = group.getDocument("paid").getDocument("\$sum").getArray("\$cond")
+    accumulator.get(1).asInt32().value.assert().isEqualTo(1)
+    accumulator.get(0).asDocument().containsKey("\$eq").assert().isTrue()
+}
+
+@Test
+fun `filtered numeric metrics guard contributions with the filter`() {
+    val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+        aggregation {
+            sum("state.amount", "paidAmount") { "state.status" eq "PAID" }
+            percentile("state.amount", 50.0, "paidP50") { "state.status" eq "PAID" }
+        },
+        schema(),
+    ).map { it.toBsonDocument() }
+
+    val group = pipeline.first { it.containsKey("\$group") }.getDocument("\$group")
+    group.getDocument("paidAmount").getDocument("\$sum").getDocument("\$cond")
+        .containsKey("\$eq").assert().isTrue()
+    val countGuard = group.getDocument("__wow_value_count_paidAmount").getDocument("\$sum")
+        .getArray("\$cond").get(0).asDocument()
+    countGuard.getDocument("\$and").getArray(0).asDocument().containsKey("\$eq").assert().isTrue()
+    group.getDocument("paidP50").getDocument("\$percentile").getDocument("input")
+        .getDocument("\$cond").containsKey("\$eq").assert().isTrue()
+}
+
+@Test
+fun `filtered distinct count and any null non matching records`() {
+    val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+        aggregation {
+            distinctCount("state.productId", "paidProducts") { "state.status" eq "PAID" }
+            any("state.status", "anyStatus") { "deleted" eq false }
+        },
+        schema(),
+    ).map { it.toBsonDocument() }
+
+    val group = pipeline.first { it.containsKey("\$group") }.getDocument("\$group")
+    group.getDocument("paidProducts").getDocument("\$addToSet").getDocument("\$cond")
+        .containsKey("\$eq").assert().isTrue()
+    group.getDocument("anyStatus").getDocument("\$max").getDocument("\$cond")
+        .containsKey("\$eq").assert().isTrue()
+}
+```
+
+（`schema()` 的默认字段集含 `state.status` TERMS/`state.amount` NUMERIC/`state.productId` TERMS/`deleted` ✓；作用域内相对路径 `"status"` 在根作用域解析需绝对 `"state.status"`——测试用绝对路径。）
+
+- [ ] **Step 2: RED**：`./gradlew :wow-mongo:test --tests "me.ahoo.wow.mongo.query.snapshot.*"`——断言失败（当前 accumulator 无 `$cond`）。
+
+- [ ] **Step 3: 实现**（按 Interfaces 的六个产出点；`compile` 内 `group(query, groupId, logicalParent, physicalParent, schema)` 调用补 `now` 实参；既有无过滤路径输出**逐字节不变**——filter 为 null 时不包装）
+
+- [ ] **Step 4: GREEN**：`./gradlew :wow-mongo:test`
+- [ ] **Step 5: 提交** `feat(mongo): guard metric contributions with record-level filters`
+
+---
+
+### Task 5: wow-elasticsearch — filter 子聚合
+
+**Files:**
+- Modify: `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationCompiler.kt`（计划类型 + `toPlan` 五分支）
+- Modify: `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationPager.kt`（`metricAggregations`/`value()`）
+- Test: `wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt`
+
+**Interfaces:**
+- Produces:
+  - 计划类型追加 `filter: Query?`（默认 null）：`Count(alias, filter)`、`Numeric(alias, function, field, filter)`、`Any(alias, field, filter)`、`DistinctCount(alias, field, filter)`、`Percentile(alias, field, percentile, filter)`；`toPlan` 各分支编译 `metric.filter !== MatchAllFilter → filterCompiler.compileScoped(filter, schema, logicalParent, physicalParent, now)`。
+  - Pager：`Count+filter` → 名为 alias 的 `filter` 聚合（值 = 其 `doc_count`）；其余带 filter 指标 → 名为 `__wow_metric_filter_<alias>` 的 filter 聚合包裹原指标聚合与 valueCount；`value()` 对带 filter 指标先导航一层再走既有提取；无 filter 路径输出不变。
+
+- [ ] **Step 1: 写失败测试**
+
+```kotlin
+@Test
+fun `plan should compile metric filters into scoped queries`() {
+    val plan = ElasticsearchAggregationCompiler(SnapshotFilterCompiler).compile(
+        aggregation {
+            count("paid") { "status" eq "PAID" }
+            sum("amount", "paidAmount") { "status" eq "PAID" }
+        },
+        schema,
+    )
+
+    val count = plan.metrics.filterIsInstance<ElasticsearchAggregationMetric.Count>().single()
+    count.filter.assert().isNotNull()
+    plan.metrics.filterIsInstance<ElasticsearchAggregationMetric.Numeric>().single().filter.assert().isNotNull()
+}
+```
+
+（`schema` 为该测试类既有绑定 schema，`status` 为 keyword ✓。Pager 的 filter 包装与 value() 导航由 Task 6 集成契约覆盖——单元层断言计划携带 Query 即可，Pager 私有函数不可直测。）
+
+- [ ] **Step 2: RED**：编译失败（计划类型无 filter 参数）。
+- [ ] **Step 3: 实现**（按 Interfaces；`metricAggregations` 中带 filter 的非 COUNT 指标：
+
+```kotlin
+val metricAggregation = Aggregation.of { builder -> /* 既有 when(metric) 主体 */ }
+if (metric.filter == null) {
+    put(metric.alias, metricAggregation)
+} else {
+    put(
+        "__wow_metric_filter_${metric.alias}",
+        Aggregation.of { builder -> builder.filter(metric.filter).aggregations(metric.alias, metricAggregation) },
+    )
+}
+```
+
+COUNT 分支：`filter == null → Unit`（现状）；否则 `put(alias, filter agg)`。`value()`：COUNT+filter → `aggregations.getValue(alias).filter().docCount()`；其余带 filter 指标先把 `aggregations` 换为 `aggregations.getValue("__wow_metric_filter_$alias").filter().aggregations()` 再走既有提取——以局部函数/提前导航实现，避免分支复制。）
+
+- [ ] **Step 4: GREEN**：`./gradlew :wow-elasticsearch:test`
+- [ ] **Step 5: 提交** `feat(elasticsearch): wrap filtered metrics in filter aggregations`
+
+---
+
+### Task 6: TCK — 跨后端契约场景
+
+**Files:**
+- Modify: `test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryBackendSpec.kt`（874 行区域，`aggregation should support cancellation...` 之前）
+- Modify: `test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/EventStreamQueryBackendSpec.kt`
+
+**fixture 事实**（`aggregationStates()`）：stateA 订单 [PAID(lines: alpha@10, beta@20), CANCELLED(gamma@null)]；stateB [PAID(alpha@30, beta@20, delta@50)]。展开 `state.orders`+`lines` 后共 6 行：PAID 5 行（amounts 10/20/30/20/50）、CANCELLED 1 行。
+
+- [ ] **Step 1: Snapshot 场景**（设计文档 6 组；取材原则：metric filter 只能引用当前作用域自有字段——`status` 属 orders 层，lines 层条件用 `quantity`/`productName`）
+
+```kotlin
+@Test
+fun `aggregation should count a funnel of metric filtered counts`() {
+    saveAggregationStates(*aggregationStates().toTypedArray())
+    aggregation {
+        filter { deletion(DeletionState.ACTIVE) }
+        expand("state.orders")
+        count("all")                            // stateA 两单 + stateB 一单 = 3
+        count("paid") { "status" eq "PAID" }    // 2
+    }.query(queryBackendBinding)
+        .test()
+        .assertNext { it.assertWireEquals(mapOf("all" to 3L, "paid" to 2L)) }
+        .verifyComplete()
+}
+
+@Test
+fun `aggregation should filter numeric and distinct metrics by record filters`() {
+    saveAggregationStates(*aggregationStates().toTypedArray())
+    aggregation {
+        filter { deletion(DeletionState.ACTIVE) }
+        expand("state.orders")
+        expand("lines")
+        count("big") { "quantity" gte 2 }                               // beta,gamma,alpha,beta,delta = 5
+        sum("amount", "bigAmount") { "quantity" gte 2 }                 // 20+null+30+20+50 = 120.0
+        distinctCount("productId", "bigProducts") { "quantity" gte 2 }  // {alpha,beta,delta,gamma} = 4
+    }.query(queryBackendBinding)
+        .test()
+        .assertNext {
+            it.assertWireEquals(mapOf("big" to 5L, "bigAmount" to 120.0, "bigProducts" to 4L))
+        }.verifyComplete()
+}
+
+@Test
+fun `aggregation should return zero or null when a metric filter matches nothing`() {
+    saveAggregationStates(*aggregationStates().toTypedArray())
+    aggregation {
+        filter { deletion(DeletionState.ACTIVE) }
+        expand("state.orders")
+        expand("lines")
+        count("none") { "quantity" gt 100 }                            // 0L
+        sum("amount", "noneAmount") { "quantity" gt 100 }              // null
+        distinctCount("productId", "noneProducts") { "quantity" gt 100 } // 0L
+        percentile("amount", 95.0, "noneP95") { "quantity" gt 100 }    // null
+    }.query(queryBackendBinding)
+        .test()
+        .assertNext {
+            it.assertWireEquals(
+                mapOf("none" to 0L, "noneAmount" to null, "noneProducts" to 0L, "noneP95" to null),
+            )
+        }.verifyComplete()
+}
+
+@Test
+fun `aggregation should combine metric filters with element filters`() {
+    saveAggregationStates(*aggregationStates().toTypedArray())
+    aggregation {
+        filter { deletion(DeletionState.ACTIVE) }
+        expand("state.orders") { "status" eq "PAID" }
+        expand("lines")
+        count("all")                          // PAID 5 行
+        count("big") { "quantity" gte 2 }     // beta(2),alpha(4),beta(2),delta(5) = 4
+    }.query(queryBackendBinding)
+        .test()
+        .assertNext { it.assertWireEquals(mapOf("all" to 5L, "big" to 4L)) }
+        .verifyComplete()
+}
+
+@Test
+fun `aggregation should sort groups by a filtered metric`() {
+    saveAggregationStates(*aggregationStates().toTypedArray())
+    aggregation {
+        filter { deletion(DeletionState.ACTIVE) }
+        expand("state.orders")
+        expand("lines")
+        terms("productId", "product")
+        sum("amount", "bigAmount") { "quantity" gte 2 } // alpha=30(仅qty4行), beta=40, delta=50, gamma=null(amt空)
+        sort { "bigAmount".desc() }
+    }.query(queryBackendBinding)
+        .collectList()
+        .test()
+        .assertNext { rows ->
+            rows.map { it.path("product").textValue() }.assert().containsExactly("delta", "beta", "alpha")
+        }.verifyComplete()
+}
+
+@Test
+fun `aggregation should scope metric filters to the innermost element`() {
+    saveAggregationStates(*aggregationStates().toTypedArray())
+    aggregation {
+        filter { deletion(DeletionState.ACTIVE) }
+        expand("state.orders")
+        expand("lines")
+        count("byName") { "productName" eq "Alpha" } // 仅 stateA 的 alpha 行 = 1
+    }.query(queryBackendBinding)
+        .test()
+        .assertNext { it.path("byName").longValue().assert().isEqualTo(1L) }
+        .verifyComplete()
+}
+```
+
+（`productName` 在 lines 作用域已声明（既有 ANY 场景使用）；`productName eq "Alpha"` 精确匹配仅 stateA alpha 行——stateB alpha 行为 "Alpha 2026" 不等。）
+
+- [ ] **Step 2: EventStream 场景**
+
+```kotlin
+@Test
+fun aggregateFilteredEventCounts() {
+    val tenantId = generateGlobalId()
+    eventStore.append(generateEventStream(namedAggregate.aggregateId(tenantId = tenantId))).block()
+    aggregation {
+        filter { tenantId(tenantId) }
+        expand("body")
+        count("all")
+        count("first") { "revision" eq 1L } // 按 body.revision 条件计数；期望值执行时按 fixture 实况断言（事件流 revision 语义）
+    }.query(queryBackendBinding)
+        .test()
+        .assertNext { row ->
+            row.path("all").longValue().assert().isEqualTo(10L)
+            row.path("first").longValue().assert().isEqualTo(1L)
+        }.verifyComplete()
+}
+```
+
+（`revision` 的 JSON 值类型与比较语义执行时核对；若 revision 为数值需 `eq 1L` 的数值构造按 FilterDsl 惯例。）
+
+- [ ] **Step 3: 双后端集成确认 GREEN**（Docker）
+
+```bash
+./gradlew :wow-mongo:integrationTest :wow-elasticsearch:integrationTest --stacktrace
+```
+
+若后端行为与断言不符：以设计语义修正实现（守卫条件），不放宽断言；期望值算术错误则按 fixture 复推修正并记录。
+
+- [ ] **Step 4: 提交** `test(tck): add cross-backend contracts for metric filters`
+
+---
+
+### Task 7: OpenAPI 快照与中英文档
+
+**Files:**
+- Modify: `wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt`（如有 schema 形状断言需同步）+ 快照再生成
+- Modify: `documentation/docs/{zh,en}/guide/query/aggregation-query.md`（Metric 节 filter 语义）与 `snapshot-aggregation.md`（漏斗场景）
+
+- [ ] **Step 1**: `./gradlew :wow-openapi:test -Dwow.snapshot.update=true` 再生成；`./gradlew :wow-openapi:test` 干净复跑绿（快照差异须为纯增量：各 metric schema 增加 `filter` 属性引用）。
+- [ ] **Step 2**: zh Metric 表后追加段：指标级 `filter`（记录级零贡献语义、`COUNT+filter` 空匹配 0/数值类 null、element 作用域约束、值数计入 HTTP 限制）；en 镜像。`snapshot-aggregation.md` zh/en 各加漏斗场景（DSL 示例即 Task 2 形态）。
+- [ ] **Step 3**: `cd documentation && pnpm docs:build`。
+- [ ] **Step 4**: 提交 `feat(openapi): align metric filter schemas` 与 `docs(query): document aggregation metric filters`（可两提交）。
+
+---
+
+### Task 8: 全量回归与静态检查
+
+- [ ] **Step 1**: `./gradlew :wow-api:check :wow-query:check :wow-mongo:check :wow-elasticsearch:check :wow-webflux:check`
+- [ ] **Step 2**: `./gradlew :wow-mongo:integrationTest :wow-elasticsearch:integrationTest --stacktrace`
+- [ ] **Step 3**: `./gradlew allLocalTest allContractTest`
+- [ ] **Step 4**: `./gradlew detekt`
+- [ ] **Step 5**: `git log --oneline`、`git status` 收尾核对；如实汇报各层结果。
+
+---
+
+## 计划自审记录
+
+1. **规格覆盖**：设计「Phase 1」的 AST（Task 1）、语义（Tasks 4/5/6 断言锚定）、验证（Task 3）、双后端（Tasks 4/5）、DSL（Task 2）、HttpQueryGuard（Task 3）、TCK 六组场景（Task 6：漏斗/条件数值与去重/空匹配/叠加 element/按 filter 指标排序/最内层作用域 + EventStream 代表）、文档与快照（Task 7）、回归（Task 8）。覆盖完整。
+2. **自审修正记录**（写入时发现并已修正）：①原稿在 AST init 校验 filter 内容——错误：根级过滤器在根作用域 metric filter 上合法，合法性属查询上下文，移交 Task 3 验证层（`filter(metric.filter, parent)` 既有作用域路径）；②原稿测试取材 `"status"` 于 lines 层属跨层引用（相对解析仅一级，不合法）——漏斗移至 orders 层、lines 层条件改用自有字段 `quantity`/`productName`，期望值全部按 fixture 重推（含 gamma 含入 distinct=4、排序 delta>beta>alpha 无并列）。
+3. **类型一致性**：`filter: FilterExpression = MatchAllFilter` 末位字段（Task 1）与 DSL 重载（Task 2）、`metricFilter`/`compileScoped`（Task 4）、计划类型 `filter: Query?`（Task 5）签名一致；无新 sealed 子类型，无跨任务编译耦合（各任务独立 GREEN）。
+4. **风险注记**：ES `Count+filter` 复用 alias 作 filter 聚合名——与既有「COUNT 无子聚合」的 `value()` 路径以 `filter == null` 区分，零歧义；Mongo `now` 穿参为唯一签名变更（内部 private，无兼容影响）；Task 6 EventStream 的 `revision` 值类型按 FilterDsl 数值惯例核对后落定。

--- a/documentation/docs/en/guide/query/aggregation-query.md
+++ b/documentation/docs/en/guide/query/aggregation-query.md
@@ -66,6 +66,33 @@ Every Metric also has a unique alias, used as a result-column name.
 
 `ANY` is not a substitute for a deterministic group key: its selected non-null value is not guaranteed to be stable across executions or backends.
 
+### Metric Filter {#metric-filter}
+
+Every Metric also accepts an optional record-level `filter`, written in the DSL as a trailing lambda and defaulting to `MATCH_ALL`. It applies to the records of the current scope (root document or innermost Element): a record that fails the `filter` contributes nothing to that metric only, without affecting other metrics in the same query and without replacing the root `filter` or an Element `filter`. The JSON shape matches [Filter Expressions](./filter-expression.md):
+
+```kotlin
+count("paid") { "status" eq "PAID" }
+sum("total", "paidTotal") { "status" eq "PAID" }
+```
+
+```json
+{"type": "COUNT", "alias": "paid", "filter": {"op": "EQ", "field": "status", "value": "PAID"}}
+```
+
+An empty match keeps each metric's empty-set semantics: `COUNT` and `DISTINCT_COUNT` return `0`, while numeric metrics, `ANY`, and `PERCENTILE` return `null`.
+
+The following limits are shared by both backends and enforced at compile time:
+
+- fields referenced by a metric filter must be scalar; array fields and unions containing arrays are unsupported, and conditions that necessarily target array fields — such as `IS_EMPTY`/`$size` — are rejected as well: their semantics could be preserved, but they are refused in favor of one uniform contract;
+- full-text `SEARCH`, `ELEMENT_MATCH`, and `CONTAINS_ALL` (`$all` semantics) are unsupported;
+- scoping follows the Element filter rule: a metric filter inside an Element scope must not reference root-level fields or root-only filters.
+
+Versions and known boundaries:
+
+- metric filters on the MongoDB backend require server 5.0+ (`$not` inside the guard expression); the `PERCENTILE` metric itself still requires 7.0+. Older servers return their native error.
+- the `$gt`/`$lt` family in MongoDB guard expressions compares by the BSON total order rather than `$match` type bracketing, so counts over mixed-type data may run high; `$regex` raises an error on non-string input instead of silently not matching. Both are edge cases and do not promise bitwise cross-backend equality.
+- the HTTP query guard does not treat metric filters as expensive operators; their filter value counts feed the same `wow.webflux.query.max-filter-values` cap as other filters.
+
 ### Numeric Contributions and Precision {#numeric-contributions}
 
 `NUMERIC` contributes at most one value per current record, which is a root document or the innermost expanded Element. A direct `FIELD` and each field leaf in `BINARY` use the same rule: after ignoring null/missing entries, exactly one stored numeric value contributes; zero or multiple values contribute `null`. Duplicate numeric entries count separately; `[7,7]` is not a singleton.

--- a/documentation/docs/en/guide/query/aggregation-query.md
+++ b/documentation/docs/en/guide/query/aggregation-query.md
@@ -90,8 +90,8 @@ The following limits are shared by both backends and enforced at compile time:
 Versions and known boundaries:
 
 - metric filters on the MongoDB backend require server 5.0+ (`$not` inside the guard expression); the `PERCENTILE` metric itself still requires 7.0+. Older servers return their native error.
-- the `$gt`/`$lt` family in MongoDB guard expressions compares by the BSON total order rather than `$match` type bracketing, so counts over mixed-type data may run high; `$regex` raises an error on non-string input instead of silently not matching. Both are edge cases and do not promise bitwise cross-backend equality.
-- the HTTP query guard does not treat metric filters as expensive operators; their filter value counts feed the same `wow.webflux.query.max-filter-values` cap as other filters.
+- the `$gt`/`$lt` family in MongoDB guard expressions compares by the BSON total order rather than `$match` type bracketing, so counts over mixed-type data may run high; this is an edge case and does not promise bitwise cross-backend equality.
+- the HTTP query guard does not gate the metric filter construct itself as an expensive operator; operators inside a metric filter are subject to the same `wow.webflux.query.allow-expensive-operators` switch as root/element filters, and their filter value counts feed the same `wow.webflux.query.max-filter-values` cap as other filters.
 
 ### Numeric Contributions and Precision {#numeric-contributions}
 

--- a/documentation/docs/en/guide/query/snapshot-aggregation.md
+++ b/documentation/docs/en/guide/query/snapshot-aggregation.md
@@ -1,6 +1,6 @@
 ---
 title: Snapshot Aggregation
-description: Apply snapshot aggregation to root documents and collection elements through nine business scenarios.
+description: Apply snapshot aggregation to root documents and collection elements through ten business scenarios.
 ---
 
 # Snapshot Aggregation
@@ -33,6 +33,7 @@ flowchart TB
     Root --> S4["4 Business-time trend"]
     Root --> S7["7 Multidimensional analysis"]
     Root --> S9["9 Distinct customers and P95 amount"]
+    Root --> S10["10 Funnel conditional counts"]
     Item --> S5["5 Line-item Top-N"]
     Item --> S6["6 Derived amount"]
     Item --> S8["8 ANY display field"]
@@ -500,6 +501,44 @@ val query = aggregation {
 ```
 
 `customers` is the distinct customer count per group: `DISTINCT_COUNT` deduplicates non-null contribution values only, yields `0` for an empty set, and lets array fields participate element by element, which differs from the `NUMERIC` rule (see [numeric contributions and precision](./aggregation-query.md#numeric-contributions)). `p95Amount` and `amountStddev` follow the same numeric-contribution rule as `SUM`/`AVG` and are `null` when nothing contributes; `amountStddev` is population-standard-deviation and returns `0` for a single value; `p95Amount` is approximated by t-digest. `PERCENTILE` on the MongoDB backend requires server 7.0+. The explicit `deletion` filter matches the Gateway's default `DELETION = ACTIVE`.
+
+## Scenario 10: Funnel: Conditional Counts in One Chart
+
+**Business question**
+
+Without issuing multiple queries, how can one result table show the two-level funnel of "all orders → paid orders"?
+
+**Counting unit**
+
+Root snapshot documents; `orderCount` counts every current snapshot, while `paidCount` counts only snapshots with `state.status = PAID`.
+
+**Kotlin DSL**
+
+```kotlin
+val query = aggregation {
+    count("orderCount")
+    count("paidCount") { "state.status" eq "PAID" }
+}
+```
+
+**HTTP JSON and result interpretation**
+
+```json
+{
+  "metrics": [
+    {"type": "COUNT", "alias": "orderCount"},
+    {"type": "COUNT", "alias": "paidCount", "filter": {"op": "EQ", "field": "state.status", "value": "PAID"}}
+  ]
+}
+```
+
+```json
+[
+  {"orderCount": 50, "paidCount": 42}
+]
+```
+
+Both metrics share the same counting unit and root filter; each metric filter applies to its own metric only, so `paidCount ≤ orderCount` always holds. Each funnel level is one independent filtered COUNT — append more levels instead of splitting the funnel into multiple queries. See [Metric Filter](./aggregation-query.md#metric-filter) for empty-match semantics, limits, and version requirements.
 
 ## Backend Capabilities and Stability Boundaries
 

--- a/documentation/docs/zh/guide/query/aggregation-query.md
+++ b/documentation/docs/zh/guide/query/aggregation-query.md
@@ -66,6 +66,33 @@ flowchart LR
 
 `ANY` 不能替代确定性的 group key：所选的非 null 值不保证在不同执行或后端间稳定。
 
+### 指标级过滤 {#metric-filter}
+
+每种 Metric 还可以带一个可选的记录级 `filter`，DSL 以尾 lambda 表达，省略时为 `MATCH_ALL`。它作用于当前作用域（根文档或最内层 Element）的记录：不满足该 `filter` 的记录只对这个指标零贡献，不影响同查询的其他指标，也不替代根 `filter` 或 Element `filter`。过滤器的 JSON 形状与[过滤条件](./filter-expression.md)一致：
+
+```kotlin
+count("paid") { "status" eq "PAID" }
+sum("total", "paidTotal") { "status" eq "PAID" }
+```
+
+```json
+{"type": "COUNT", "alias": "paid", "filter": {"op": "EQ", "field": "status", "value": "PAID"}}
+```
+
+空匹配沿用各指标的空集语义：`COUNT` 与 `DISTINCT_COUNT` 返回 `0`，数值 metric、`ANY` 与 `PERCENTILE` 返回 `null`。
+
+以下限制在两个后端一致，并在编译期拒绝：
+
+- metric filter 引用的字段必须为标量；数组及含数组的联合字段不受支持，`IS_EMPTY`/`$size` 一类必然指向数组字段的条件也一并拒绝——尽管其语义本可保真，为保持统一契约不再单独放行；
+- `SEARCH` 全文、`ELEMENT_MATCH` 与 `CONTAINS_ALL`（`$all` 语义）不受支持；
+- 作用域规则与 Element filter 相同：处于 Element 作用域内的 metric filter 不得引用根级字段或 root-only 过滤器。
+
+版本与已知边界：
+
+- MongoDB 后端使用 metric filter 需要服务端 5.0+（守卫表达式中的 `$not`）；`PERCENTILE` 指标本身仍需 7.0+。旧版本服务端返回其原生错误。
+- MongoDB 守卫表达式的 `$gt`/`$lt` 族比较遵循 BSON 全序而非 `$match` 的类型分档，类型混杂数据下计数可能偏多；`$regex` 遇到非字符串输入会报错而不是静默不匹配。两者均为边界情形，不构成后端间逐位一致的承诺。
+- HTTP 查询保护不把 metric filter 视为高成本操作符；其过滤值数与其他 filter 一起计入 `wow.webflux.query.max-filter-values` 上限。
+
 ### 数值参与值与精度 {#numeric-contributions}
 
 `NUMERIC` 每条当前记录至多贡献一个值；当前记录由根文档或最内层 Elements 决定。直接 `FIELD` 与 `BINARY` 中的每个字段叶子使用相同口径：忽略 null/缺失后，恰好一个存储数值参与计算，零个或多个数值均贡献 `null`。重复数值分别计数；`[7,7]` 不是单值。

--- a/documentation/docs/zh/guide/query/aggregation-query.md
+++ b/documentation/docs/zh/guide/query/aggregation-query.md
@@ -90,8 +90,8 @@ sum("total", "paidTotal") { "status" eq "PAID" }
 版本与已知边界：
 
 - MongoDB 后端使用 metric filter 需要服务端 5.0+（守卫表达式中的 `$not`）；`PERCENTILE` 指标本身仍需 7.0+。旧版本服务端返回其原生错误。
-- MongoDB 守卫表达式的 `$gt`/`$lt` 族比较遵循 BSON 全序而非 `$match` 的类型分档，类型混杂数据下计数可能偏多；`$regex` 遇到非字符串输入会报错而不是静默不匹配。两者均为边界情形，不构成后端间逐位一致的承诺。
-- HTTP 查询保护不把 metric filter 视为高成本操作符；其过滤值数与其他 filter 一起计入 `wow.webflux.query.max-filter-values` 上限。
+- MongoDB 守卫表达式的 `$gt`/`$lt` 族比较遵循 BSON 全序而非 `$match` 的类型分档，类型混杂数据下计数可能偏多；这是边界情形，不构成后端间逐位一致的承诺。
+- HTTP 查询保护不把 metric filter 构造本身单独视为高成本操作符；metric filter 内的算子与根/element 过滤一样受 `wow.webflux.query.allow-expensive-operators` 昂贵算子开关约束，过滤值数与其他 filter 一起计入 `wow.webflux.query.max-filter-values` 上限。
 
 ### 数值参与值与精度 {#numeric-contributions}
 

--- a/documentation/docs/zh/guide/query/snapshot-aggregation.md
+++ b/documentation/docs/zh/guide/query/snapshot-aggregation.md
@@ -1,6 +1,6 @@
 ---
 title: 快照聚合
-description: 用九个业务场景说明快照根文档与集合元素的聚合查询。
+description: 用十个业务场景说明快照根文档与集合元素的聚合查询。
 ---
 
 # 快照聚合
@@ -33,6 +33,7 @@ flowchart TB
     Root --> S4["4 业务时间趋势"]
     Root --> S7["7 多维交叉分析"]
     Root --> S9["9 去重客户数与 P95 金额"]
+    Root --> S10["10 漏斗多条件计数"]
     Item --> S5["5 明细项 Top-N"]
     Item --> S6["6 派生金额"]
     Item --> S8["8 ANY 展示字段"]
@@ -500,6 +501,44 @@ val query = aggregation {
 ```
 
 `customers` 是组内去重客户数：`DISTINCT_COUNT` 只对非空参与值去重，空集为 `0`，数组字段按元素逐个参与，参与规则与 `NUMERIC` 不同（见[数值参与值与精度](./aggregation-query.md#numeric-contributions)）。`p95Amount` 与 `amountStddev` 遵循与 `SUM`/`AVG` 相同的数值参与规则，无有效贡献时为 `null`；`amountStddev` 为总体口径，单个贡献值为 `0`；`p95Amount` 由 t-digest 近似计算。`PERCENTILE` 在 MongoDB 后端需要服务端 7.0+。显式 `deletion` 过滤与 Gateway 默认追加的 `DELETION = ACTIVE` 一致。
+
+## 场景 10：漏斗：同图多条件计数
+
+**业务问题**
+
+不发起多次查询，如何在同一张结果表里得到“全部订单 → 已支付订单”两级漏斗的数量？
+
+**统计单位**
+
+快照根文档；`orderCount` 统计每份当前快照，`paidCount` 只统计 `state.status = PAID` 的快照。
+
+**Kotlin DSL**
+
+```kotlin
+val query = aggregation {
+    count("orderCount")
+    count("paidCount") { "state.status" eq "PAID" }
+}
+```
+
+**HTTP JSON 与结果解读**
+
+```json
+{
+  "metrics": [
+    {"type": "COUNT", "alias": "orderCount"},
+    {"type": "COUNT", "alias": "paidCount", "filter": {"op": "EQ", "field": "state.status", "value": "PAID"}}
+  ]
+}
+```
+
+```json
+[
+  {"orderCount": 50, "paidCount": 42}
+]
+```
+
+两个指标共享同一统计单位与根过滤，metric filter 只作用于各自的指标，因此 `paidCount ≤ orderCount` 恒成立。漏斗的每一级都是一个带 filter 的独立 COUNT，需要更多层级时继续追加即可，不必拆成多次查询。metric filter 的空集语义、限制与版本要求见[指标级过滤](./aggregation-query.md#metric-filter)。
 
 ## 后端能力与稳定性边界
 

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/EventStreamQueryBackendSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/EventStreamQueryBackendSpec.kt
@@ -498,6 +498,25 @@ abstract class EventStreamQueryBackendSpec {
                 row.path("names").longValue().assert().isEqualTo(2L)
             }.verifyComplete()
     }
+
+    @Test
+    fun aggregateFilteredEventCounts() {
+        val tenantId = generateGlobalId()
+        eventStore.append(generateEventStream(namedAggregate.aggregateId(tenantId = tenantId))).block()
+        aggregation {
+            filter { tenantId(tenantId) }
+            expand("body")
+            count("all")
+            // body.revision 是事件模式版本字符串（所有事件恒为 "0.0.1"），数值 eq 无法命中；
+            // 改按 body.name 精确匹配首个事件（事件名按 pascalToSnake 策略为 mock_aggregate_created，仅 1 个）
+            count("first") { "name" eq "mock_aggregate_created" }
+        }.query(queryBackendBinding)
+            .test()
+            .assertNext { row ->
+                row.path("all").longValue().assert().isEqualTo(10L)
+                row.path("first").longValue().assert().isEqualTo(1L)
+            }.verifyComplete()
+    }
 }
 
 private fun QueryBackendBinding<EventStreamQueryBackend>.single(query: ISingleQuery): Mono<ObjectNode> =

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryBackendSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryBackendSpec.kt
@@ -32,6 +32,7 @@ import me.ahoo.wow.api.query.Pagination
 import me.ahoo.wow.api.query.Projection
 import me.ahoo.wow.api.query.QueryField
 import me.ahoo.wow.api.query.Sort
+import me.ahoo.wow.api.query.StringComparison
 import me.ahoo.wow.api.query.schema.QueryCapability
 import me.ahoo.wow.api.query.schema.QueryCardinality
 import me.ahoo.wow.api.query.schema.QueryModel
@@ -1179,6 +1180,34 @@ abstract class SnapshotQueryBackendSpec {
         }.query(queryBackendBinding)
             .test()
             .assertNext { it.path("byName").longValue().assert().isEqualTo(1L) }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should count records matched by literal match metric filters`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+        aggregation {
+            filter { deletion(DeletionState.ACTIVE) }
+            expand("state.orders")
+            expand("lines")
+            count("contains") { "productName".containsText("Alpha") } // stateA "Alpha" + stateB "Alpha 2026" = 2
+            count("startsWith") { "productName".startsWithText("Alpha") } // 同上 = 2
+            count("endsWith") { "productName".endsWithText("2026") } // 仅 stateB "Alpha 2026" = 1
+            count("containsIgnoreCase") {
+                "productName".containsText("alpha", StringComparison.CASE_INSENSITIVE)
+            } // 大小写不敏感，同 contains = 2
+        }.query(queryBackendBinding)
+            .test()
+            .assertNext {
+                it.assertWireEquals(
+                    mapOf(
+                        "contains" to 2L,
+                        "startsWith" to 2L,
+                        "endsWith" to 1L,
+                        "containsIgnoreCase" to 2L,
+                    ),
+                )
+            }
             .verifyComplete()
     }
 

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryBackendSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryBackendSpec.kt
@@ -1088,8 +1088,8 @@ abstract class SnapshotQueryBackendSpec {
         aggregation {
             filter { deletion(DeletionState.ACTIVE) }
             expand("state.orders")
-            count("all")                            // stateA 两单 + stateB 一单 = 3
-            count("paid") { "status" eq "PAID" }    // 2
+            count("all") // stateA 两单 + stateB 一单 = 3
+            count("paid") { "status" eq "PAID" } // 2
         }.query(queryBackendBinding)
             .test()
             .assertNext { it.assertWireEquals(mapOf("all" to 3L, "paid" to 2L)) }
@@ -1103,9 +1103,9 @@ abstract class SnapshotQueryBackendSpec {
             filter { deletion(DeletionState.ACTIVE) }
             expand("state.orders")
             expand("lines")
-            count("big") { "quantity" gte 2 }                               // beta,gamma,alpha,beta,delta = 5
-            sum("amount", "bigAmount") { "quantity" gte 2 }                 // 20+null+30+20+50 = 120.0
-            distinctCount("productId", "bigProducts") { "quantity" gte 2 }  // {alpha,beta,delta,gamma} = 4
+            count("big") { "quantity" gte 2 } // beta,gamma,alpha,beta,delta = 5
+            sum("amount", "bigAmount") { "quantity" gte 2 } // 20+null+30+20+50 = 120.0
+            distinctCount("productId", "bigProducts") { "quantity" gte 2 } // {alpha,beta,delta,gamma} = 4
         }.query(queryBackendBinding)
             .test()
             .assertNext {
@@ -1120,10 +1120,10 @@ abstract class SnapshotQueryBackendSpec {
             filter { deletion(DeletionState.ACTIVE) }
             expand("state.orders")
             expand("lines")
-            count("none") { "quantity" gt 100 }                              // 0L
-            sum("amount", "noneAmount") { "quantity" gt 100 }                // null
+            count("none") { "quantity" gt 100 } // 0L
+            sum("amount", "noneAmount") { "quantity" gt 100 } // null
             distinctCount("productId", "noneProducts") { "quantity" gt 100 } // 0L
-            percentile("amount", 95.0, "noneP95") { "quantity" gt 100 }      // null
+            percentile("amount", 95.0, "noneP95") { "quantity" gt 100 } // null
         }.query(queryBackendBinding)
             .test()
             .assertNext {
@@ -1140,8 +1140,8 @@ abstract class SnapshotQueryBackendSpec {
             filter { deletion(DeletionState.ACTIVE) }
             expand("state.orders") { "status" eq "PAID" }
             expand("lines")
-            count("all")                          // PAID 5 行
-            count("big") { "quantity" gte 2 }     // beta(2),alpha(4),beta(2),delta(5) = 4
+            count("all") // PAID 5 行
+            count("big") { "quantity" gte 2 } // beta(2),alpha(4),beta(2),delta(5) = 4
         }.query(queryBackendBinding)
             .test()
             .assertNext { it.assertWireEquals(mapOf("all" to 5L, "big" to 4L)) }

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryBackendSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryBackendSpec.kt
@@ -1183,6 +1183,34 @@ abstract class SnapshotQueryBackendSpec {
     }
 
     @Test
+    fun `aggregation metric filters should preserve null versus missing semantics`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+        aggregation {
+            filter { deletion(DeletionState.ACTIVE) }
+            expand("state.orders")
+            expand("lines")
+            count("all") // 6 行
+            count("withAmount") { "amount" ne null } // 非 null 非 missing：仅 gamma 行 amount=null 被排除 = 5
+            count("nullishAmount") { "amount" eq null } // null 与 missing 均命中：仅 gamma = 1
+            count("hasMissing") { "missing".exists() } // missing 字段从未写入任何行 = 0
+            count("missingOrNull") { "missing" eq null } // 全部行缺失该字段 = 6
+        }.query(queryBackendBinding)
+            .test()
+            .assertNext {
+                it.assertWireEquals(
+                    mapOf(
+                        "all" to 6L,
+                        "withAmount" to 5L,
+                        "nullishAmount" to 1L,
+                        "hasMissing" to 0L,
+                        "missingOrNull" to 6L,
+                    ),
+                )
+            }
+            .verifyComplete()
+    }
+
+    @Test
     fun `aggregation should support cancellation after a real result`() {
         saveAggregationStates(*aggregationStates().toTypedArray())
 

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryBackendSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryBackendSpec.kt
@@ -1083,6 +1083,106 @@ abstract class SnapshotQueryBackendSpec {
     }
 
     @Test
+    fun `aggregation should count a funnel of metric filtered counts`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+        aggregation {
+            filter { deletion(DeletionState.ACTIVE) }
+            expand("state.orders")
+            count("all")                            // stateA 两单 + stateB 一单 = 3
+            count("paid") { "status" eq "PAID" }    // 2
+        }.query(queryBackendBinding)
+            .test()
+            .assertNext { it.assertWireEquals(mapOf("all" to 3L, "paid" to 2L)) }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should filter numeric and distinct metrics by record filters`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+        aggregation {
+            filter { deletion(DeletionState.ACTIVE) }
+            expand("state.orders")
+            expand("lines")
+            count("big") { "quantity" gte 2 }                               // beta,gamma,alpha,beta,delta = 5
+            sum("amount", "bigAmount") { "quantity" gte 2 }                 // 20+null+30+20+50 = 120.0
+            distinctCount("productId", "bigProducts") { "quantity" gte 2 }  // {alpha,beta,delta,gamma} = 4
+        }.query(queryBackendBinding)
+            .test()
+            .assertNext {
+                it.assertWireEquals(mapOf("big" to 5L, "bigAmount" to 120.0, "bigProducts" to 4L))
+            }.verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should return zero or null when a metric filter matches nothing`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+        aggregation {
+            filter { deletion(DeletionState.ACTIVE) }
+            expand("state.orders")
+            expand("lines")
+            count("none") { "quantity" gt 100 }                              // 0L
+            sum("amount", "noneAmount") { "quantity" gt 100 }                // null
+            distinctCount("productId", "noneProducts") { "quantity" gt 100 } // 0L
+            percentile("amount", 95.0, "noneP95") { "quantity" gt 100 }      // null
+        }.query(queryBackendBinding)
+            .test()
+            .assertNext {
+                it.assertWireEquals(
+                    mapOf("none" to 0L, "noneAmount" to null, "noneProducts" to 0L, "noneP95" to null),
+                )
+            }.verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should combine metric filters with element filters`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+        aggregation {
+            filter { deletion(DeletionState.ACTIVE) }
+            expand("state.orders") { "status" eq "PAID" }
+            expand("lines")
+            count("all")                          // PAID 5 行
+            count("big") { "quantity" gte 2 }     // beta(2),alpha(4),beta(2),delta(5) = 4
+        }.query(queryBackendBinding)
+            .test()
+            .assertNext { it.assertWireEquals(mapOf("all" to 5L, "big" to 4L)) }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should sort groups by a filtered metric`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+        aggregation {
+            filter { deletion(DeletionState.ACTIVE) }
+            expand("state.orders")
+            expand("lines")
+            terms("productId", "product")
+            sum("amount", "bigAmount") { "quantity" gte 2 } // alpha=30(仅qty4行), beta=40, delta=50, gamma=null(amt空)
+            sort { "bigAmount".desc() }
+        }.query(queryBackendBinding)
+            .collectList()
+            .test()
+            .assertNext { rows ->
+                // gamma 组通过过滤条件（quantity=3）但 amount 为 null，bigAmount=null 保留并按 DESC 置于末尾
+                rows.map { it.path("product").textValue() }.assert()
+                    .containsExactly("delta", "beta", "alpha", "gamma")
+            }.verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should scope metric filters to the innermost element`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+        aggregation {
+            filter { deletion(DeletionState.ACTIVE) }
+            expand("state.orders")
+            expand("lines")
+            count("byName") { "productName" eq "Alpha" } // 仅 stateA 的 alpha 行 = 1
+        }.query(queryBackendBinding)
+            .test()
+            .assertNext { it.path("byName").longValue().assert().isEqualTo(1L) }
+            .verifyComplete()
+    }
+
+    @Test
     fun `aggregation should support cancellation after a real result`() {
         saveAggregationStates(*aggregationStates().toTypedArray())
 

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryBackendSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryBackendSpec.kt
@@ -1185,7 +1185,8 @@ abstract class SnapshotQueryBackendSpec {
 
     @Test
     fun `aggregation should count records matched by literal match metric filters`() {
-        saveAggregationStates(*aggregationStates().toTypedArray())
+        // 含 aggregationAnyNullState：其 alpha 行 productName 为显式 null，regex 守卫必须视为不匹配而不是报错
+        saveAggregationStates(*(aggregationStates() + aggregationAnyNullState()).toTypedArray())
         aggregation {
             filter { deletion(DeletionState.ACTIVE) }
             expand("state.orders")

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
@@ -217,7 +217,14 @@ sealed interface AggregationMetric {
     @get:Schema(accessMode = Schema.AccessMode.READ_WRITE)
     val alias: String
 
-    data class Count(override val alias: String) : AggregationMetric {
+    @get:Schema(accessMode = Schema.AccessMode.READ_WRITE)
+    val filter: FilterExpression
+
+    data class Count(
+        override val alias: String,
+        @get:JsonInclude(JsonInclude.Include.CUSTOM, valueFilter = MatchAllFilterValueFilter::class)
+        override val filter: FilterExpression = MatchAllFilter,
+    ) : AggregationMetric {
         init {
             requireAggregationAlias(alias)
         }
@@ -227,6 +234,8 @@ sealed interface AggregationMetric {
         val function: AggregationFunction,
         val expression: AggregationExpression,
         override val alias: String,
+        @get:JsonInclude(JsonInclude.Include.CUSTOM, valueFilter = MatchAllFilterValueFilter::class)
+        override val filter: FilterExpression = MatchAllFilter,
     ) : AggregationMetric {
         init {
             requireAggregationAlias(alias)
@@ -236,6 +245,8 @@ sealed interface AggregationMetric {
     data class Any(
         val field: QueryField,
         override val alias: String,
+        @get:JsonInclude(JsonInclude.Include.CUSTOM, valueFilter = MatchAllFilterValueFilter::class)
+        override val filter: FilterExpression = MatchAllFilter,
     ) : AggregationMetric {
         init {
             requireAggregationAlias(alias)
@@ -245,6 +256,8 @@ sealed interface AggregationMetric {
     data class DistinctCount(
         val expression: AggregationExpression,
         override val alias: String,
+        @get:JsonInclude(JsonInclude.Include.CUSTOM, valueFilter = MatchAllFilterValueFilter::class)
+        override val filter: FilterExpression = MatchAllFilter,
     ) : AggregationMetric {
         init {
             requireAggregationAlias(alias)
@@ -256,6 +269,8 @@ sealed interface AggregationMetric {
         @get:Schema(minimum = "0", exclusiveMinimum = true, maximum = "100", exclusiveMaximum = true)
         val percentile: Double,
         override val alias: String,
+        @get:JsonInclude(JsonInclude.Include.CUSTOM, valueFilter = MatchAllFilterValueFilter::class)
+        override val filter: FilterExpression = MatchAllFilter,
     ) : AggregationMetric {
         init {
             requireAggregationAlias(alias)
@@ -279,6 +294,22 @@ private fun requireAggregationAlias(alias: String) {
     require('.' !in alias) { "aggregation alias must contain one segment." }
     require(!alias.startsWith("__wow")) { "aggregation alias must not use the reserved __wow prefix." }
     QueryField(alias)
+}
+
+/**
+ * Omits the [MatchAllFilter] default of metric-level `filter` properties so unfiltered queries
+ * keep their original JSON shape.
+ *
+ * Jackson 3 resolves `JsonInclude.Include.CUSTOM` value filters through
+ * `valueFilterInstance.equals(propertyValue)` (see `BeanPropertyWriter.serializeAsProperty`),
+ * so the omission predicate is expressed via [equals]. Kotlin constructor defaults cannot be
+ * honored by `JsonInclude.Include.NON_DEFAULT` here: `jackson-module-kotlin` does not expose
+ * creator defaults to inclusion checks.
+ */
+internal class MatchAllFilterValueFilter {
+    override fun equals(other: Any?): Boolean = other === MatchAllFilter
+
+    override fun hashCode(): Int = MatchAllFilterValueFilter::class.hashCode()
 }
 
 private data class PendingExpression(

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt
@@ -464,4 +464,38 @@ class AggregationQueryTest {
             .contains("\"op\":\"EQ\"")
             .doesNotContain("\"alias\":\"total\",\"filter\"")
     }
+
+    @Test
+    fun `explicit MATCH_ALL metric filters should deserialize and re-serialize omitted`() {
+        val json = """
+            {
+              "metrics": [
+                {"type": "COUNT", "alias": "total", "filter": {"op": "MATCH_ALL"}},
+                {"type": "NUMERIC", "function": "SUM", "expression": {"field": "amount"}, "alias": "sumAmount",
+                 "filter": {"op": "MATCH_ALL"}}
+              ]
+            }
+        """.trimIndent()
+
+        val explicit = configuredMapper.readValue(json, AggregationQuery::class.java)
+        explicit.metrics.forEach { metric ->
+            metric.filter.assert().isEqualTo(MatchAllFilter)
+        }
+        val omitted = AggregationQuery(
+            metrics = listOf(
+                AggregationMetric.Count("total"),
+                AggregationMetric.Numeric(
+                    AggregationFunction.SUM,
+                    AggregationExpression.Field(QueryField("amount")),
+                    "sumAmount",
+                ),
+            ),
+        )
+
+        configuredMapper.writeValueAsString(explicit).assert()
+            .isEqualTo(configuredMapper.writeValueAsString(omitted))
+        configuredMapper.writeValueAsString(explicit).assert()
+            .doesNotContain("\"alias\":\"total\",\"filter\"")
+            .doesNotContain("\"alias\":\"sumAmount\",\"filter\"")
+    }
 }

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt
@@ -438,4 +438,30 @@ class AggregationQueryTest {
             bareMapper.readValue(json, AggregationQuery::class.java)
         }
     }
+
+    @Test
+    fun `metric filters should round trip and omit defaults`() {
+        val json = """
+            {
+              "metrics": [
+                {"type": "COUNT", "alias": "total"},
+                {"type": "COUNT", "filter": {"op": "EQ", "field": "status", "value": "PAID"}, "alias": "paid"},
+                {"type": "NUMERIC", "function": "SUM", "expression": {"field": "amount"},
+                 "filter": {"op": "EQ", "field": "status", "value": "PAID"}, "alias": "paidAmount"}
+              ]
+            }
+        """.trimIndent()
+
+        val query = configuredMapper.readValue(json, AggregationQuery::class.java)
+        query.metrics.filterIsInstance<AggregationMetric.Count>().assert().hasSize(2)
+        query.metrics[1].filter.assert().isInstanceOf(EqualFilter::class.java)
+        query.metrics.filterIsInstance<AggregationMetric.Numeric>().single().filter.assert()
+            .isInstanceOf(EqualFilter::class.java)
+        query.metrics[0].filter.assert().isEqualTo(MatchAllFilter)
+        val wire = configuredMapper.writeValueAsString(query)
+        wire.assert()
+            .contains("\"type\":\"COUNT\",\"alias\":\"total\"")
+            .contains("\"op\":\"EQ\"")
+            .doesNotContain("\"alias\":\"total\",\"filter\"")
+    }
 }

--- a/wow-benchmarks/src/jmh/java/me/ahoo/wow/benchmark/query/AggregationCompilerBenchmark.java
+++ b/wow-benchmarks/src/jmh/java/me/ahoo/wow/benchmark/query/AggregationCompilerBenchmark.java
@@ -103,12 +103,15 @@ public class AggregationCompilerBenchmark {
                 case "known_epoch" -> groups.add(new AggregationGroup.DateHistogram(
                         input, alias, AggregationDateUnit.DAY, "UTC"));
                 case "known_metric" -> metrics.add(new AggregationMetric.Numeric(
-                        AggregationFunction.SUM, new AggregationExpression.Field(input), "metric" + index));
-                case "count_only" -> metrics.add(new AggregationMetric.Count("count" + index));
+                        AggregationFunction.SUM,
+                        new AggregationExpression.Field(input),
+                        "metric" + index,
+                        MatchAllFilter.INSTANCE));
+                case "count_only" -> metrics.add(new AggregationMetric.Count("count" + index, MatchAllFilter.INSTANCE));
                 default -> throw new IllegalArgumentException(shape);
             }
         }
-        if (!groups.isEmpty()) metrics.add(new AggregationMetric.Count("count"));
+        if (!groups.isEmpty()) metrics.add(new AggregationMetric.Count("count", MatchAllFilter.INSTANCE));
         schema = BenchmarkQuerySchemas.create(QueryModel.Companion.getSNAPSHOT(), fields, bindings);
         query = new AggregationQuery(MatchAllFilter.INSTANCE, List.of(), groups, metrics, List.of(), 100);
         verifyPlan(compile());

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationCompiler.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationCompiler.kt
@@ -21,6 +21,8 @@ import co.elastic.clients.elasticsearch._types.mapping.RuntimeFieldType
 import co.elastic.clients.elasticsearch._types.query_dsl.Query
 import co.elastic.clients.json.JsonData
 import co.elastic.clients.util.NamedValue
+import me.ahoo.wow.api.query.AggregateIdFilter
+import me.ahoo.wow.api.query.AggregateIdsFilter
 import me.ahoo.wow.api.query.AggregationDateUnit
 import me.ahoo.wow.api.query.AggregationExpression
 import me.ahoo.wow.api.query.AggregationExpressionOperator
@@ -28,8 +30,43 @@ import me.ahoo.wow.api.query.AggregationFunction
 import me.ahoo.wow.api.query.AggregationGroup
 import me.ahoo.wow.api.query.AggregationMetric
 import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.AndFilter
+import me.ahoo.wow.api.query.BetweenFilter
+import me.ahoo.wow.api.query.ContainsAllFilter
+import me.ahoo.wow.api.query.ContainsFilter
+import me.ahoo.wow.api.query.DeletionFilter
+import me.ahoo.wow.api.query.ElementMatchFilter
+import me.ahoo.wow.api.query.EndsWithFilter
+import me.ahoo.wow.api.query.EqualFilter
+import me.ahoo.wow.api.query.ExistsFilter
+import me.ahoo.wow.api.query.FilterExpression
+import me.ahoo.wow.api.query.GreaterThanFilter
+import me.ahoo.wow.api.query.GreaterThanOrEqualFilter
+import me.ahoo.wow.api.query.IdFilter
+import me.ahoo.wow.api.query.IdsFilter
+import me.ahoo.wow.api.query.InFilter
+import me.ahoo.wow.api.query.IsEmptyFilter
+import me.ahoo.wow.api.query.IsEmptyStringFilter
+import me.ahoo.wow.api.query.IsNotEmptyStringFilter
+import me.ahoo.wow.api.query.IsNotNullFilter
+import me.ahoo.wow.api.query.IsNullFilter
+import me.ahoo.wow.api.query.LessThanFilter
+import me.ahoo.wow.api.query.LessThanOrEqualFilter
+import me.ahoo.wow.api.query.MatchAllFilter
+import me.ahoo.wow.api.query.MatchNoneFilter
+import me.ahoo.wow.api.query.NorFilter
+import me.ahoo.wow.api.query.NotEqualFilter
+import me.ahoo.wow.api.query.NotExistsFilter
+import me.ahoo.wow.api.query.NotInFilter
+import me.ahoo.wow.api.query.OrFilter
+import me.ahoo.wow.api.query.OwnerIdFilter
 import me.ahoo.wow.api.query.QueryField
+import me.ahoo.wow.api.query.RelativeTimeFilter
+import me.ahoo.wow.api.query.SearchFilter
 import me.ahoo.wow.api.query.Sort
+import me.ahoo.wow.api.query.SpaceIdFilter
+import me.ahoo.wow.api.query.StartsWithFilter
+import me.ahoo.wow.api.query.TenantIdFilter
 import me.ahoo.wow.api.query.schema.QueryCapability
 import me.ahoo.wow.api.query.schema.QueryCardinality
 import me.ahoo.wow.api.query.schema.QueryValueKind
@@ -62,26 +99,37 @@ internal data class ElasticsearchAggregationElement(
 
 internal sealed interface ElasticsearchAggregationMetric {
     val alias: String
+    val filter: Query?
 
-    data class Count(override val alias: String) : ElasticsearchAggregationMetric
+    data class Count(
+        override val alias: String,
+        override val filter: Query? = null,
+    ) : ElasticsearchAggregationMetric
 
     data class Numeric(
         override val alias: String,
         val function: AggregationFunction,
         val field: String,
+        override val filter: Query? = null,
     ) : ElasticsearchAggregationMetric
 
     data class Any(
         override val alias: String,
         val field: String,
+        override val filter: Query? = null,
     ) : ElasticsearchAggregationMetric
 
-    data class DistinctCount(override val alias: String, val field: String) : ElasticsearchAggregationMetric
+    data class DistinctCount(
+        override val alias: String,
+        val field: String,
+        override val filter: Query? = null,
+    ) : ElasticsearchAggregationMetric
 
     data class Percentile(
         override val alias: String,
         val field: String,
         val percentile: Double,
+        override val filter: Query? = null,
     ) : ElasticsearchAggregationMetric
 }
 
@@ -133,7 +181,7 @@ internal class ElasticsearchAggregationCompiler(
             }
         }
         val metrics = query.metrics.mapIndexed { index, metric ->
-            metric.toPlan(logicalParent, physicalParent, index, schema, runtimeMappings)
+            metric.toPlan(logicalParent, physicalParent, index, schema, runtimeMappings, now)
         }
         val metricAliases = query.metrics.mapTo(hashSetOf(), AggregationMetric::alias)
         return ElasticsearchAggregationPlan(
@@ -265,41 +313,75 @@ internal class ElasticsearchAggregationCompiler(
         index: Int,
         schema: QueryModelSchema,
         runtimeMappings: MutableMap<String, RuntimeField>,
-    ): ElasticsearchAggregationMetric = when (this) {
-        is AggregationMetric.Count -> ElasticsearchAggregationMetric.Count(alias)
-        is AggregationMetric.Any -> ElasticsearchAggregationMetric.Any(
-            alias,
-            field.resolve(parent, physicalParent, schema, QueryCapability.AGGREGATE_TERMS),
-        )
-        is AggregationMetric.Numeric -> {
-            val metricExpression = expression
-            val scalarField = (metricExpression as? AggregationExpression.Field)?.field?.takeIf { field ->
-                val logicalField = parent?.append(field) ?: field
-                schema.field(logicalField)?.value?.cardinality == QueryCardinality.SINGLE
-            }
-            val metricField = if (scalarField != null) {
-                scalarField.resolve(parent, physicalParent, schema, QueryCapability.AGGREGATE_NUMERIC)
-            } else {
-                "__wow_expression_$index".also { runtimeFieldName ->
-                    runtimeMappings[runtimeFieldName] = RuntimeExpressionCompiler(
-                        parent,
-                        physicalParent,
-                        schema,
-                    ).compile(metricExpression)
+        now: Instant,
+    ): ElasticsearchAggregationMetric {
+        val filter = metricFilter(parent, physicalParent, schema, now)
+        return when (this) {
+            is AggregationMetric.Count -> ElasticsearchAggregationMetric.Count(alias, filter)
+            is AggregationMetric.Any -> ElasticsearchAggregationMetric.Any(
+                alias,
+                field.resolve(parent, physicalParent, schema, QueryCapability.AGGREGATE_TERMS),
+                filter,
+            )
+            is AggregationMetric.Numeric -> {
+                val metricExpression = expression
+                val scalarField = (metricExpression as? AggregationExpression.Field)?.field?.takeIf { field ->
+                    val logicalField = parent?.append(field) ?: field
+                    schema.field(logicalField)?.value?.cardinality == QueryCardinality.SINGLE
                 }
+                val metricField = if (scalarField != null) {
+                    scalarField.resolve(parent, physicalParent, schema, QueryCapability.AGGREGATE_NUMERIC)
+                } else {
+                    "__wow_expression_$index".also { runtimeFieldName ->
+                        runtimeMappings[runtimeFieldName] = RuntimeExpressionCompiler(
+                            parent,
+                            physicalParent,
+                            schema,
+                        ).compile(metricExpression)
+                    }
+                }
+                ElasticsearchAggregationMetric.Numeric(alias, function, metricField, filter)
             }
-            ElasticsearchAggregationMetric.Numeric(alias, function, metricField)
+
+            is AggregationMetric.DistinctCount -> toDistinctCountPlan(
+                parent,
+                physicalParent,
+                index,
+                schema,
+                runtimeMappings,
+                filter,
+            )
+
+            is AggregationMetric.Percentile -> toPercentilePlan(
+                parent,
+                physicalParent,
+                index,
+                schema,
+                runtimeMappings,
+                filter,
+            )
         }
+    }
 
-        is AggregationMetric.DistinctCount -> toDistinctCountPlan(
-            parent,
-            physicalParent,
-            index,
-            schema,
-            runtimeMappings
-        )
-
-        is AggregationMetric.Percentile -> toPercentilePlan(parent, physicalParent, index, schema, runtimeMappings)
+    /**
+     * Compiles the record-level filter of this metric against its enclosing scope,
+     * or returns `null` for [MatchAllFilter] so unfiltered metrics keep their unwrapped aggregations.
+     */
+    private fun AggregationMetric.metricFilter(
+        parent: QueryField?,
+        physicalParent: QueryField?,
+        schema: QueryModelSchema,
+        now: Instant,
+    ): Query? {
+        val filter = this.filter
+        if (filter === MatchAllFilter) {
+            return null
+        }
+        filter.requireScalarMetricFilterFields(parent, schema)
+        if (parent == null || physicalParent == null) {
+            return filterCompiler.compile(filter, schema, now)
+        }
+        return filterCompiler.compileScoped(filter, schema, parent, physicalParent, now)
     }
 
     private fun AggregationMetric.DistinctCount.toDistinctCountPlan(
@@ -308,6 +390,7 @@ internal class ElasticsearchAggregationCompiler(
         index: Int,
         schema: QueryModelSchema,
         runtimeMappings: MutableMap<String, RuntimeField>,
+        filter: Query?,
     ): ElasticsearchAggregationMetric.DistinctCount {
         val metricField = (expression as? AggregationExpression.Field)?.field?.let { field ->
             field.resolve(parent, physicalParent, schema, schema.distinctCountCapability(field, parent))
@@ -318,7 +401,7 @@ internal class ElasticsearchAggregationCompiler(
                 schema,
             ).compile(expression)
         }
-        return ElasticsearchAggregationMetric.DistinctCount(alias, metricField)
+        return ElasticsearchAggregationMetric.DistinctCount(alias, metricField, filter)
     }
 
     private fun AggregationMetric.Percentile.toPercentilePlan(
@@ -327,6 +410,7 @@ internal class ElasticsearchAggregationCompiler(
         index: Int,
         schema: QueryModelSchema,
         runtimeMappings: MutableMap<String, RuntimeField>,
+        filter: Query?,
     ): ElasticsearchAggregationMetric.Percentile {
         val metricExpression = expression
         val scalarField = (metricExpression as? AggregationExpression.Field)?.field?.takeIf { field ->
@@ -344,7 +428,7 @@ internal class ElasticsearchAggregationCompiler(
                 ).compile(metricExpression)
             }
         }
-        return ElasticsearchAggregationMetric.Percentile(alias, metricField, percentile)
+        return ElasticsearchAggregationMetric.Percentile(alias, metricField, percentile, filter)
     }
 
     private inner class RuntimeExpressionCompiler(
@@ -475,3 +559,64 @@ internal class ElasticsearchAggregationCompiler(
             TimeUnit.DAYS -> 86_400_000L to 1L
         }
 }
+
+/**
+ * Filter aggregations keep Elasticsearch's element-matching semantics over array fields while
+ * MongoDB metric guards compare whole values, so array-valued fields and [ElementMatchFilter]
+ * are rejected to mirror the MongoDB compiler's scalar-only metric filter contract.
+ */
+@Suppress("CyclomaticComplexMethod", "LongMethod")
+private fun FilterExpression.requireScalarMetricFilterFields(
+    parent: QueryField?,
+    schema: QueryModelSchema,
+) {
+    when (this) {
+        MatchAllFilter, MatchNoneFilter,
+        is IdFilter, is IdsFilter, is AggregateIdFilter, is AggregateIdsFilter,
+        is TenantIdFilter, is OwnerIdFilter, is SpaceIdFilter, is DeletionFilter,
+        -> Unit
+
+        is AndFilter -> operands.forEach { it.requireScalarMetricFilterFields(parent, schema) }
+        is OrFilter -> operands.forEach { it.requireScalarMetricFilterFields(parent, schema) }
+        is NorFilter -> operands.forEach { it.requireScalarMetricFilterFields(parent, schema) }
+        is ElementMatchFilter -> throw QuerySchemaValidationException(
+            "Elasticsearch metric filters cannot translate [ELEMENT_MATCH] into a filter aggregation.",
+        )
+        is SearchFilter -> fields.forEach { it.requireScalarMetricFilterField(parent, schema) }
+        is RelativeTimeFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is EqualFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is NotEqualFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is GreaterThanFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is GreaterThanOrEqualFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is LessThanFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is LessThanOrEqualFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is BetweenFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is ContainsFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is StartsWithFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is EndsWithFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is InFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is NotInFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is ContainsAllFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is IsEmptyFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is IsEmptyStringFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is IsNotEmptyStringFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is IsNullFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is IsNotNullFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is ExistsFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is NotExistsFilter -> field.requireScalarMetricFilterField(parent, schema)
+    }
+}
+
+private fun QueryField.requireScalarMetricFilterField(parent: QueryField?, schema: QueryModelSchema) {
+    val logical = parent?.append(this) ?: this
+    val value = schema.field(logical)?.value ?: return
+    if (value.isArrayValued) {
+        throw QuerySchemaValidationException(
+            "Aggregation metric filter field [$logical] must be scalar; array fields are not supported in metric filters.",
+        )
+    }
+}
+
+private val QueryValueSchema.isArrayValued: Boolean
+    get() = kind == QueryValueKind.ARRAY ||
+        (kind == QueryValueKind.UNION && alternatives.any { it.kind == QueryValueKind.ARRAY })

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationCompiler.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationCompiler.kt
@@ -562,8 +562,8 @@ internal class ElasticsearchAggregationCompiler(
 
 /**
  * Filter aggregations keep Elasticsearch's element-matching semantics over array fields while
- * MongoDB metric guards compare whole values, so array-valued fields and [ElementMatchFilter]
- * are rejected to mirror the MongoDB compiler's scalar-only metric filter contract.
+ * MongoDB metric guards compare whole values, so array-valued fields, [ElementMatchFilter],
+ * and [SearchFilter] are rejected to mirror the MongoDB compiler's scalar-only metric filter contract.
  */
 @Suppress("CyclomaticComplexMethod", "LongMethod")
 private fun FilterExpression.requireScalarMetricFilterFields(
@@ -582,7 +582,9 @@ private fun FilterExpression.requireScalarMetricFilterFields(
         is ElementMatchFilter -> throw QuerySchemaValidationException(
             "Elasticsearch metric filters cannot translate [ELEMENT_MATCH] into a filter aggregation.",
         )
-        is SearchFilter -> fields.forEach { it.requireScalarMetricFilterField(parent, schema) }
+        is SearchFilter -> throw QuerySchemaValidationException(
+            "Aggregation metric filters do not support search filters.",
+        )
         is RelativeTimeFilter -> field.requireScalarMetricFilterField(parent, schema)
         is EqualFilter -> field.requireScalarMetricFilterField(parent, schema)
         is NotEqualFilter -> field.requireScalarMetricFilterField(parent, schema)

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationPager.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationPager.kt
@@ -174,55 +174,54 @@ internal class ElasticsearchAggregationPager(
     private fun ElasticsearchAggregationPlan.metricAggregations(): Map<String, Aggregation> = buildMap {
         metrics.forEach { metric ->
             when (metric) {
-                is ElasticsearchAggregationMetric.Count -> Unit
-                is ElasticsearchAggregationMetric.Any -> put(
-                    metric.alias,
-                    Aggregation.of { builder ->
+                is ElasticsearchAggregationMetric.Count -> metric.filter?.let { filter ->
+                    put(metric.alias, Aggregation.of { builder -> builder.filter(filter) })
+                }
+
+                is ElasticsearchAggregationMetric.Any -> putMetricAggregations(
+                    metric,
+                    metric.alias to Aggregation.of { builder ->
                         builder.terms { terms -> terms.field(metric.field).size(1) }
                     },
                 )
 
-                is ElasticsearchAggregationMetric.Numeric -> {
-                    put(
-                        metric.alias,
-                        Aggregation.of { builder ->
-                            when (metric.function) {
-                                AggregationFunction.SUM -> builder.sum { it.field(metric.field) }
-                                AggregationFunction.AVG -> builder.avg { it.field(metric.field) }
-                                AggregationFunction.MIN -> builder.min { it.field(metric.field) }
-                                AggregationFunction.MAX -> builder.max { it.field(metric.field) }
-                                AggregationFunction.STDDEV, AggregationFunction.VARIANCE ->
-                                    builder.extendedStats { it.field(metric.field) }
-                            }
-                        },
-                    )
-                    put(
-                        metric.valueCountAlias,
-                        Aggregation.of { builder -> builder.valueCount { it.field(metric.field) } },
-                    )
-                }
-
-                is ElasticsearchAggregationMetric.DistinctCount -> put(
-                    metric.alias,
-                    Aggregation.of { builder -> builder.cardinality { it.field(metric.field) } },
+                is ElasticsearchAggregationMetric.Numeric -> putMetricAggregations(
+                    metric,
+                    metric.alias to Aggregation.of { builder ->
+                        when (metric.function) {
+                            AggregationFunction.SUM -> builder.sum { it.field(metric.field) }
+                            AggregationFunction.AVG -> builder.avg { it.field(metric.field) }
+                            AggregationFunction.MIN -> builder.min { it.field(metric.field) }
+                            AggregationFunction.MAX -> builder.max { it.field(metric.field) }
+                            AggregationFunction.STDDEV, AggregationFunction.VARIANCE ->
+                                builder.extendedStats { it.field(metric.field) }
+                        }
+                    },
+                    metric.valueCountAlias to Aggregation.of { builder ->
+                        builder.valueCount { it.field(metric.field) }
+                    },
                 )
 
-                is ElasticsearchAggregationMetric.Percentile -> {
-                    put(
-                        metric.alias,
-                        Aggregation.of { builder ->
-                            builder.percentiles {
-                                it.field(metric.field)
-                                    .percents(listOf(metric.percentile))
-                                    .keyed(false)
-                            }
-                        },
-                    )
-                    put(
-                        metric.valueCountAlias,
-                        Aggregation.of { builder -> builder.valueCount { it.field(metric.field) } },
-                    )
-                }
+                is ElasticsearchAggregationMetric.DistinctCount -> putMetricAggregations(
+                    metric,
+                    metric.alias to Aggregation.of { builder ->
+                        builder.cardinality { it.field(metric.field) }
+                    },
+                )
+
+                is ElasticsearchAggregationMetric.Percentile -> putMetricAggregations(
+                    metric,
+                    metric.alias to Aggregation.of { builder ->
+                        builder.percentiles {
+                            it.field(metric.field)
+                                .percents(listOf(metric.percentile))
+                                .keyed(false)
+                        }
+                    },
+                    metric.valueCountAlias to Aggregation.of { builder ->
+                        builder.valueCount { it.field(metric.field) }
+                    },
+                )
             }
         }
     }
@@ -280,11 +279,17 @@ internal class ElasticsearchAggregationPager(
         docCount: Long,
         aggregations: Map<String, Aggregate>,
     ): Any? = when (this) {
-        is ElasticsearchAggregationMetric.Count -> docCount
-        is ElasticsearchAggregationMetric.Any -> aggregations.getValue(alias).anyValue(alias)
-        is ElasticsearchAggregationMetric.Numeric -> numericValue(aggregations)
-        is ElasticsearchAggregationMetric.DistinctCount -> aggregations.getValue(alias).cardinality().value()
-        is ElasticsearchAggregationMetric.Percentile -> percentileValue(aggregations)
+        is ElasticsearchAggregationMetric.Count -> if (filter == null) {
+            docCount
+        } else {
+            aggregations.getValue(alias).filter().docCount()
+        }
+
+        is ElasticsearchAggregationMetric.Any -> aggregations.filtered(this).getValue(alias).anyValue(alias)
+        is ElasticsearchAggregationMetric.Numeric -> numericValue(aggregations.filtered(this))
+        is ElasticsearchAggregationMetric.DistinctCount ->
+            aggregations.filtered(this).getValue(alias).cardinality().value()
+        is ElasticsearchAggregationMetric.Percentile -> percentileValue(aggregations.filtered(this))
     }
 
     private fun Aggregate.anyValue(alias: String): Any? = when {
@@ -436,3 +441,33 @@ private fun incomparableValues(left: JsonNode?, right: JsonNode?): Nothing =
 private fun nestedAggregationName(index: Int): String = "__wow_element_$index"
 
 private fun filterAggregationName(index: Int): String = "__wow_element_filter_$index"
+
+private fun metricFilterAggregationName(alias: String): String = "__wow_metric_filter_$alias"
+
+/**
+ * Publishes a metric's aggregations directly, or nested under one filter aggregation
+ * so only records accepted by the metric filter contribute to it.
+ */
+private fun MutableMap<String, Aggregation>.putMetricAggregations(
+    metric: ElasticsearchAggregationMetric,
+    vararg subAggregations: Pair<String, Aggregation>,
+) {
+    val filter = metric.filter
+    if (filter == null) {
+        subAggregations.forEach { (name, aggregation) -> put(name, aggregation) }
+        return
+    }
+    put(
+        metricFilterAggregationName(metric.alias),
+        Aggregation.of { builder ->
+            builder.filter(filter)
+            subAggregations.forEach { (name, aggregation) -> builder.aggregations(name, aggregation) }
+            builder
+        },
+    )
+}
+
+private fun Map<String, Aggregate>.filtered(metric: ElasticsearchAggregationMetric): Map<String, Aggregate> {
+    val filter = metric.filter ?: return this
+    return getValue(metricFilterAggregationName(metric.alias)).filter().aggregations()
+}

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationPager.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationPager.kt
@@ -99,7 +99,8 @@ internal class ElasticsearchAggregationPager(
     }
 
     private fun ElasticsearchAggregationPlan.pageSize(fetched: Int): Int {
-        val bucketWidth = 1 + metrics.count { it is ElasticsearchAggregationMetric.Any }
+        val bucketWidth = 1 + metrics.count { it is ElasticsearchAggregationMetric.Any } +
+            metrics.count { it.filter != null }
         val pageCapacity = (batchSize / bucketWidth).coerceAtLeast(1)
         return if (metricSorted) pageCapacity else min(pageCapacity, limit - fetched)
     }

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchSummaryExecutionTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchSummaryExecutionTest.kt
@@ -46,6 +46,7 @@ class ElasticsearchSummaryExecutionTest {
         val staticFailure = IllegalArgumentException("invalid static metric")
         val metric = mockk<ElasticsearchAggregationMetric.Numeric> {
             every { alias } returns "total"
+            every { filter } returns null
             every { function } throws staticFailure
         }
         val plan = compile(

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
@@ -248,6 +248,61 @@ class ElasticsearchAggregationCompilerTest {
     }
 
     @Test
+    fun `element scoped and union array metric filter fields are rejected`() {
+        val tags = array(text)
+        val bound = ElasticsearchQuerySchemaAdapter.bind(
+            LogicalQuerySchema(
+                obj(
+                    mapOf(
+                        "deleted" to QueryValueSchema(
+                            QueryValueKind.SCALAR,
+                            valueTypes = setOf(QueryValueType.BOOLEAN),
+                        ),
+                        "notes" to QueryValueSchema(QueryValueKind.UNION, alternatives = listOf(text, tags)),
+                        "orders" to array(obj(mapOf("lines" to array(obj(mapOf("tags" to tags)))))),
+                    )
+                )
+            ),
+            ElasticsearchIndexMapping.from(
+                "test",
+                TypeMapping.of { mapping ->
+                    mapping.properties("deleted") { deleted -> deleted.boolean_ { it } }
+                        .properties("notes") { notes -> notes.keyword { it } }
+                        .properties("orders") { orders ->
+                            orders.nested { ordersNested ->
+                                ordersNested.properties("lines") { lines ->
+                                    lines.nested { linesNested ->
+                                        linesNested.properties("tags") { tags -> tags.keyword { it } }
+                                    }
+                                }
+                            }
+                        }
+                }
+            ),
+        )
+
+        assertThrows<QuerySchemaValidationException> {
+            compiler.compile(
+                aggregation {
+                    expand("orders")
+                    expand("lines")
+                    count("tagged") { "tags" eq "promo" }
+                },
+                bound,
+            )
+        }.message.assert().isEqualTo(
+            "Aggregation metric filter field [orders.lines.tags] must be scalar; " +
+                "array fields are not supported in metric filters.",
+        )
+        assertThrows<QuerySchemaValidationException> {
+            compiler.compile(aggregation { count("noted") { "notes" eq "premium" } }, bound)
+        }.message.assert().isEqualTo(
+            "Aggregation metric filter field [notes] must be scalar; " +
+                "array fields are not supported in metric filters.",
+        )
+    }
+
+    @Test
     fun `search filters in metric filters are rejected`() {
         val exception = assertThrows<QuerySchemaValidationException> {
             compiler.compile(aggregation { count("hits") { "name" search "premium" } }, schema)

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
@@ -20,6 +20,7 @@ import me.ahoo.wow.api.query.AggregationDateUnit
 import me.ahoo.wow.api.query.AggregationExpression
 import me.ahoo.wow.api.query.AggregationExpressionOperator
 import me.ahoo.wow.api.query.AggregationFunction
+import me.ahoo.wow.api.query.DeletionState
 import me.ahoo.wow.api.query.QueryField
 import me.ahoo.wow.api.query.schema.QueryValueKind
 import me.ahoo.wow.api.query.schema.QueryValueType
@@ -49,6 +50,9 @@ class ElasticsearchAggregationCompilerTest {
         obj(
             mapOf(
                 "deleted" to QueryValueSchema(QueryValueKind.SCALAR, valueTypes = setOf(QueryValueType.BOOLEAN)),
+                "tenantId" to text,
+                "ownerId" to text,
+                "spaceId" to text,
                 "amount" to scalar,
                 "createdAt" to temporal,
                 "name" to text,
@@ -72,6 +76,9 @@ class ElasticsearchAggregationCompilerTest {
             "test",
             TypeMapping.of {
                 it.properties("deleted") { it.boolean_ { it } }
+                    .properties("tenantId") { it.keyword { it } }
+                    .properties("ownerId") { it.keyword { it } }
+                    .properties("spaceId") { it.keyword { it } }
                     .properties("amount") { it.long_ { it } }
                     .properties("createdAt") { it.long_ { it } }
                     .properties("name") { it.text { it.fields("keyword") { it.keyword { it } } } }
@@ -310,6 +317,113 @@ class ElasticsearchAggregationCompilerTest {
         exception.message.assert().contains("do not support search filters")
         assertThrows<QuerySchemaValidationException> {
             compiler.compile(aggregation { count("hits") { search("premium") } }, schema)
+        }
+    }
+
+    @Test
+    fun `metric plan models default to unfiltered`() {
+        ElasticsearchAggregationMetric.Count("count").filter.assert().isNull()
+        ElasticsearchAggregationMetric.Any("sample", "name").filter.assert().isNull()
+        ElasticsearchAggregationMetric.Numeric("sum", AggregationFunction.SUM, "amount").filter.assert().isNull()
+        ElasticsearchAggregationMetric.DistinctCount("customers", "customerId").filter.assert().isNull()
+        ElasticsearchAggregationMetric.Percentile("p95", "amount", 95.0).filter.assert().isNull()
+    }
+
+    @Test
+    fun `every scalar filter leaf type compiles a non-null metric filter query`() {
+        val plan = compiler.compile(
+            aggregation {
+                count("equal") { "deleted" eq false }
+                count("notEqual") { "name" ne "Alpha" }
+                count("inList") { "name" isIn listOf("Alpha", "Beta") }
+                count("notInList") { "name" notIn listOf("Alpha") }
+                count("greater") { "amount" gt 1 }
+                count("greaterOrEqual") { "amount" gte 1 }
+                count("less") { "amount" lt 9 }
+                count("lessOrEqual") { "amount" lte 9 }
+                count("between") { "amount".between(1, 5) }
+                count("contains") { "name".containsText("Alp") }
+                count("startsWith") { "name".startsWithText("Alp") }
+                count("endsWith") { "name".endsWithText("pha") }
+                count("nullName") { "name".isNull() }
+                count("notNullName") { "name".isNotNull() }
+                count("present") { "name".exists() }
+                count("absent") { "name".notExists() }
+                count("emptyString") { "name".isEmptyString() }
+                count("notEmptyString") { "name".isNotEmptyString() }
+                count("allTerms") { "customerId" containsAll listOf("premium") }
+                count("emptyCollection") { "name".isEmptyCollection() }
+                count("today") { "createdAt".today() }
+            },
+            schema,
+        )
+
+        plan.metrics.associateBy { it.alias }.forEach { (alias, metric) ->
+            metric.filter.assert().isNotNull()
+        }
+        val metrics = plan.metrics.associateBy { it.alias }
+        metrics.getValue("equal").filter!!.isTerm.assert().isTrue()
+        metrics.getValue("greater").filter!!.isRange.assert().isTrue()
+        metrics.getValue("inList").filter!!.isTerms.assert().isTrue()
+        metrics.getValue("contains").filter!!.isWildcard.assert().isTrue()
+        metrics.getValue("today").filter!!.isBool.assert().isTrue()
+    }
+
+    @Test
+    fun `metadata and logical metric filters compile scoped queries`() {
+        val plan = compiler.compile(
+            aggregation {
+                count("byId") { id("order-1") }
+                count("byIds") { ids("order-1", "order-2") }
+                count("byAggregateId") { aggregateId("order-1") }
+                count("byAggregateIds") { aggregateIds("order-1", "order-2") }
+                count("byTenant") { tenantId("tenant-1") }
+                count("byOwner") { ownerId("owner-1") }
+                count("bySpace") { spaceId("space-1") }
+                count("active") { deletion(DeletionState.ACTIVE) }
+                count("anyState") { deletion(DeletionState.ALL) }
+                count("none") { matchNone() }
+                count("composed") {
+                    and {
+                        "deleted" eq false
+                        "amount" gt 0
+                    }
+                }
+                count("either") {
+                    or {
+                        "deleted" eq false
+                        "amount" gt 0
+                    }
+                }
+                count("neither") {
+                    nor {
+                        "deleted" eq false
+                        "amount" gt 0
+                    }
+                }
+                count("nested") {
+                    and {
+                        or {
+                            "deleted" eq false
+                            "name".exists()
+                        }
+                    }
+                }
+            },
+            schema,
+        )
+
+        val metrics = plan.metrics.associateBy { it.alias }
+        metrics.forEach { (alias, metric) ->
+            metric.filter.assert().isNotNull()
+        }
+        metrics.getValue("byIds").filter!!.isIds.assert().isTrue()
+        metrics.getValue("none").filter!!.isMatchNone.assert().isTrue()
+        metrics.getValue("anyState").filter!!.isMatchAll.assert().isTrue()
+        metrics.getValue("composed").filter!!.isBool.assert().isTrue()
+
+        assertThrows<QuerySchemaValidationException> {
+            compiler.compile(aggregation { count("unknown") { "unknown" eq "value" } }, schema)
         }
     }
 

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
@@ -53,6 +53,7 @@ class ElasticsearchAggregationCompilerTest {
                 "createdAt" to temporal,
                 "name" to text,
                 "customerId" to text,
+                "tags" to array(text),
                 "orders" to array(
                     obj(
                         mapOf(
@@ -75,6 +76,7 @@ class ElasticsearchAggregationCompilerTest {
                     .properties("createdAt") { it.long_ { it } }
                     .properties("name") { it.text { it.fields("keyword") { it.keyword { it } } } }
                     .properties("customerId") { it.text { it.fields("keyword") { it.keyword { it } } } }
+                    .properties("tags") { it.keyword { it } }
                     .properties("orders") {
                         it.nested { orders ->
                             orders.properties("status") { it.keyword { it } }
@@ -226,6 +228,53 @@ class ElasticsearchAggregationCompilerTest {
                 schema
             )
         }
+    }
+
+    @Test
+    fun `array valued metric filter fields are rejected`() {
+        val exception = assertThrows<QuerySchemaValidationException> {
+            compiler.compile(aggregation { count("tagged") { "tags" eq "premium" } }, schema)
+        }
+        exception.message.assert().contains("must be scalar")
+        assertThrows<QuerySchemaValidationException> {
+            compiler.compile(
+                aggregation {
+                    expand("orders")
+                    count("recent") { "lines".elementMatch { "quantity" gt 0 } }
+                },
+                schema,
+            )
+        }
+    }
+
+    @Test
+    fun `plan should compile metric filters into scoped queries`() {
+        val plan = compiler.compile(
+            aggregation {
+                count("paid") { "deleted" eq false }
+                sum("amount", "paidAmount") { "deleted" eq false }
+            },
+            schema,
+        )
+
+        val count = plan.metrics.filterIsInstance<ElasticsearchAggregationMetric.Count>().single()
+        count.filter.assert().isNotNull()
+        count.filter!!.term().field().assert().isEqualTo("deleted")
+        val numeric = plan.metrics.filterIsInstance<ElasticsearchAggregationMetric.Numeric>().single()
+        numeric.filter.assert().isNotNull()
+        numeric.filter!!.term().field().assert().isEqualTo("deleted")
+
+        val scoped = compiler.compile(
+            aggregation {
+                expand("orders")
+                count("paidOrders") { "status" eq "PAID" }
+            },
+            schema,
+        )
+        (scoped.metrics.single() as ElasticsearchAggregationMetric.Count).filter!!.term().field()
+            .assert().isEqualTo("orders.status")
+
+        compiler.compile(aggregation { count("count") }, schema).metrics.single().filter.assert().isNull()
     }
 
     @Test

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
@@ -248,6 +248,17 @@ class ElasticsearchAggregationCompilerTest {
     }
 
     @Test
+    fun `search filters in metric filters are rejected`() {
+        val exception = assertThrows<QuerySchemaValidationException> {
+            compiler.compile(aggregation { count("hits") { "name" search "premium" } }, schema)
+        }
+        exception.message.assert().contains("do not support search filters")
+        assertThrows<QuerySchemaValidationException> {
+            compiler.compile(aggregation { count("hits") { search("premium") } }, schema)
+        }
+    }
+
+    @Test
     fun `plan should compile metric filters into scoped queries`() {
         val plan = compiler.compile(
             aggregation {

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
@@ -85,6 +85,7 @@ private fun ReactiveElasticsearchClient.verifyNoPointInTimeCalls() {
     verify(exactly = 0) { closePointInTime(any<ClosePointInTimeRequest>()) }
 }
 
+@Suppress("LargeClass")
 class ElasticsearchAggregationPagerTest {
     private val client = mockk<ReactiveElasticsearchClient>()
 
@@ -441,6 +442,28 @@ class ElasticsearchAggregationPagerTest {
 
         pager(batchSize = 10).execute(plan).test().verifyComplete()
 
+        requests.single().aggregations().values.single().composite().size().assert().isEqualTo(3)
+    }
+
+    @Test
+    fun `filtered metrics should bound composite page size by filter wrappers`() {
+        val requests = mutableListOf<SearchRequest>()
+        stubPointInTime()
+        every { client.search(capture(requests), Map::class.java) } returns Mono.just(
+            groupResponse("pit-2", emptyList()),
+        )
+        val plan = compileAggregation(
+            aggregation {
+                terms("state.productId", "product")
+                count("active") { "deleted" eq false }
+                sum("state.amount", "total") { "deleted" eq false }
+                sort { "total".desc() }
+            },
+        )
+
+        pager(batchSize = 10).execute(plan).test().verifyComplete()
+
+        // each filtered metric adds one filter-aggregation bucket per composite bucket
         requests.single().aggregations().values.single().composite().size().assert().isEqualTo(3)
     }
 

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoAggregationCompiler.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoAggregationCompiler.kt
@@ -19,6 +19,8 @@ import com.mongodb.client.model.BsonField
 import com.mongodb.client.model.Filters
 import com.mongodb.client.model.Projections
 import com.mongodb.client.model.Sorts
+import me.ahoo.wow.api.query.AggregateIdFilter
+import me.ahoo.wow.api.query.AggregateIdsFilter
 import me.ahoo.wow.api.query.AggregationDateUnit
 import me.ahoo.wow.api.query.AggregationExpression
 import me.ahoo.wow.api.query.AggregationExpressionOperator
@@ -26,17 +28,51 @@ import me.ahoo.wow.api.query.AggregationFunction
 import me.ahoo.wow.api.query.AggregationGroup
 import me.ahoo.wow.api.query.AggregationMetric
 import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.AndFilter
+import me.ahoo.wow.api.query.BetweenFilter
+import me.ahoo.wow.api.query.ContainsAllFilter
+import me.ahoo.wow.api.query.ContainsFilter
+import me.ahoo.wow.api.query.DeletionFilter
+import me.ahoo.wow.api.query.ElementMatchFilter
+import me.ahoo.wow.api.query.EndsWithFilter
+import me.ahoo.wow.api.query.EqualFilter
+import me.ahoo.wow.api.query.ExistsFilter
+import me.ahoo.wow.api.query.FilterExpression
+import me.ahoo.wow.api.query.GreaterThanFilter
+import me.ahoo.wow.api.query.GreaterThanOrEqualFilter
+import me.ahoo.wow.api.query.IdFilter
+import me.ahoo.wow.api.query.IdsFilter
+import me.ahoo.wow.api.query.InFilter
+import me.ahoo.wow.api.query.IsEmptyFilter
+import me.ahoo.wow.api.query.IsEmptyStringFilter
+import me.ahoo.wow.api.query.IsNotEmptyStringFilter
+import me.ahoo.wow.api.query.IsNotNullFilter
+import me.ahoo.wow.api.query.IsNullFilter
+import me.ahoo.wow.api.query.LessThanFilter
+import me.ahoo.wow.api.query.LessThanOrEqualFilter
 import me.ahoo.wow.api.query.MatchAllFilter
+import me.ahoo.wow.api.query.MatchNoneFilter
+import me.ahoo.wow.api.query.NorFilter
+import me.ahoo.wow.api.query.NotEqualFilter
+import me.ahoo.wow.api.query.NotExistsFilter
+import me.ahoo.wow.api.query.NotInFilter
+import me.ahoo.wow.api.query.OrFilter
+import me.ahoo.wow.api.query.OwnerIdFilter
 import me.ahoo.wow.api.query.QueryField
+import me.ahoo.wow.api.query.RelativeTimeFilter
+import me.ahoo.wow.api.query.SearchFilter
 import me.ahoo.wow.api.query.Sort
+import me.ahoo.wow.api.query.SpaceIdFilter
+import me.ahoo.wow.api.query.StartsWithFilter
+import me.ahoo.wow.api.query.TenantIdFilter
 import me.ahoo.wow.api.query.schema.QueryCapability
 import me.ahoo.wow.api.query.schema.QueryValueKind
 import me.ahoo.wow.api.query.schema.Temporal
 import me.ahoo.wow.mongo.query.AbstractMongoFilterCompiler
 import me.ahoo.wow.query.schema.QueryModelSchema
-import me.ahoo.wow.query.schema.QueryPathSegment
 import me.ahoo.wow.query.schema.QuerySchemaValidationException
 import me.ahoo.wow.query.schema.QueryValueSchema
+import me.ahoo.wow.query.schema.absoluteLogicalField
 import me.ahoo.wow.query.schema.distinctCountCapability
 import me.ahoo.wow.query.schema.operationValues
 import me.ahoo.wow.query.schema.physicalField
@@ -116,7 +152,7 @@ internal class MongoAggregationCompiler(
         val accumulators = buildList {
             query.metrics.forEach { metric ->
                 val guard = metricFilter(metric, parent, physicalParent, schema, now)
-                    ?.toGuardCondition(schema)
+                    ?.toGuardCondition()
                 when (metric) {
                     is AggregationMetric.Count -> add(
                         if (guard == null) {
@@ -216,6 +252,7 @@ internal class MongoAggregationCompiler(
         if (filter === MatchAllFilter) {
             return null
         }
+        filter.requireScalarMetricFilterFields(parent, schema)
         if (parent == null) {
             return filterCompiler.compile(filter, schema, now)
         }
@@ -675,48 +712,85 @@ internal class MongoAggregationCompiler(
  * The translation covers every shape [AbstractMongoFilterCompiler] emits and preserves
  * its null-versus-missing match semantics.
  */
-private fun Bson.toGuardCondition(schema: QueryModelSchema): Any =
-    toGuardCondition(toBsonDocument(), schema.arrayValuedPhysicalFields())
+private fun Bson.toGuardCondition(): Any = toGuardCondition(toBsonDocument())
 
 /**
  * Guard expressions compare whole values while `$match` matches array elements,
  * so filters over array-valued fields are rejected instead of diverging silently.
  */
-private fun QueryModelSchema.arrayValuedPhysicalFields(): Set<String> =
-    bindings.entries.flatMapTo(mutableSetOf()) { (logical, native) ->
-        val value = definition.values[logical] ?: return@flatMapTo emptyList()
-        if (!value.isArrayValued) {
-            return@flatMapTo emptyList()
-        }
-        native.bindings.values
-            .filterNot { template -> template.physicalPath.segments.any { it is QueryPathSegment.Key } }
-            .map { template -> template.physicalPath.field(emptyList()).path }
+@Suppress("CyclomaticComplexMethod", "LongMethod")
+private fun FilterExpression.requireScalarMetricFilterFields(
+    parent: QueryField?,
+    schema: QueryModelSchema,
+) {
+    when (this) {
+        MatchAllFilter, MatchNoneFilter,
+        is IdFilter, is IdsFilter, is AggregateIdFilter, is AggregateIdsFilter,
+        is TenantIdFilter, is OwnerIdFilter, is SpaceIdFilter, is DeletionFilter, is SearchFilter,
+        -> Unit
+
+        is AndFilter -> operands.forEach { it.requireScalarMetricFilterFields(parent, schema) }
+        is OrFilter -> operands.forEach { it.requireScalarMetricFilterFields(parent, schema) }
+        is NorFilter -> operands.forEach { it.requireScalarMetricFilterFields(parent, schema) }
+        is ElementMatchFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is RelativeTimeFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is EqualFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is NotEqualFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is GreaterThanFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is GreaterThanOrEqualFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is LessThanFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is LessThanOrEqualFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is BetweenFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is ContainsFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is StartsWithFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is EndsWithFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is InFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is NotInFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is ContainsAllFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is IsEmptyFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is IsEmptyStringFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is IsNotEmptyStringFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is IsNullFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is IsNotNullFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is ExistsFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is NotExistsFilter -> field.requireScalarMetricFilterField(parent, schema)
     }
+}
+
+private fun QueryField.requireScalarMetricFilterField(parent: QueryField?, schema: QueryModelSchema) {
+    val logical = absoluteLogicalField(this, parent)
+    val value = schema.field(logical)?.value ?: return
+    if (value.isArrayValued) {
+        throw QuerySchemaValidationException(
+            "Aggregation metric filter field [$logical] must be scalar; array fields are not supported in metric filters.",
+        )
+    }
+}
 
 private val QueryValueSchema.isArrayValued: Boolean
     get() = kind == QueryValueKind.ARRAY ||
         (kind == QueryValueKind.UNION && alternatives.any { it.kind == QueryValueKind.ARRAY })
 
-private fun toGuardCondition(document: BsonDocument, arrayValuedFields: Set<String>): Any =
+private fun toGuardCondition(document: BsonDocument): Any =
     if (document.size == 0) {
         Document("\$literal", true)
     } else {
-        toGuardCondition(document.entries.single(), arrayValuedFields)
+        toGuardCondition(document.entries.single())
     }
 
-private fun toGuardCondition(entry: Map.Entry<String, BsonValue>, arrayValuedFields: Set<String>): Any {
+private fun toGuardCondition(entry: Map.Entry<String, BsonValue>): Any {
     val path = entry.key
     val condition = entry.value
     return when {
         path == "\$and" || path == "\$or" ->
-            Document(path, condition.asArray().map { toGuardCondition(it.asDocument(), arrayValuedFields) })
+            Document(path, condition.asArray().map { toGuardCondition(it.asDocument()) })
 
         path == "\$nor" -> Document(
             "\$not",
             listOf(
                 Document(
                     "\$or",
-                    condition.asArray().map { toGuardCondition(it.asDocument(), arrayValuedFields) },
+                    condition.asArray().map { toGuardCondition(it.asDocument()) },
                 ),
             ),
         )
@@ -725,16 +799,11 @@ private fun toGuardCondition(entry: Map.Entry<String, BsonValue>, arrayValuedFie
             "MongoDB metric filters cannot translate operator [$path] into a guard condition.",
         )
 
-        else -> toGuardCondition(path, condition, arrayValuedFields)
+        else -> toGuardCondition(path, condition)
     }
 }
 
-private fun toGuardCondition(path: String, condition: BsonValue, arrayValuedFields: Set<String>): Any {
-    if (path in arrayValuedFields) {
-        throw QuerySchemaValidationException(
-            "Aggregation metric filter field [$path] must be scalar; array fields are not supported in metric filters.",
-        )
-    }
+private fun toGuardCondition(path: String, condition: BsonValue): Any {
     if (condition.isNull) {
         return matchesNull(path)
     }
@@ -742,7 +811,7 @@ private fun toGuardCondition(path: String, condition: BsonValue, arrayValuedFiel
         return regexGuard(path, condition.asRegularExpression())
     }
     if (!condition.isDocument) {
-        return Document("\$eq", listOf(fieldRef(path), condition))
+        return Document("\$eq", listOf(fieldRef(path), condition.literalOperand()))
     }
     val document = condition.asDocument()
     if (document.containsKey("\$elemMatch")) {
@@ -758,10 +827,10 @@ private fun toGuardCondition(path: String, operator: String, value: BsonValue): 
     "\$ne" -> if (value.isNull) {
         Document("\$and", listOf(Document("\$ne", listOf(fieldRef(path), null)), isPresent(path)))
     } else {
-        Document("\$ne", listOf(fieldRef(path), value))
+        Document("\$ne", listOf(fieldRef(path), value.literalOperand()))
     }
 
-    "\$gt", "\$gte", "\$lt", "\$lte" -> Document(operator, listOf(fieldRef(path), value))
+    "\$gt", "\$gte", "\$lt", "\$lte" -> Document(operator, listOf(fieldRef(path), value.literalOperand()))
     "\$in" -> inGuard(path, value.asArray())
     "\$nin" -> Document("\$not", listOf(inGuard(path, value.asArray())))
     "\$exists" -> if (value.asBoolean().value) {
@@ -804,12 +873,38 @@ private fun matchesNull(path: String): Any = Document(
     ),
 )
 
-private fun inGuard(path: String, values: BsonArray): Any = Document("\$in", listOf(fieldRef(path), values))
+/**
+ * A string operand starting with `$` would be parsed as a field reference in expression
+ * position, so such operands are pinned with `$literal`; every other operand keeps its shape.
+ */
+private fun BsonValue.literalOperand(): BsonValue =
+    if (isString && asString().value.startsWith("$")) {
+        BsonDocument("\$literal", this)
+    } else {
+        this
+    }
 
+private fun inGuard(path: String, values: BsonArray): Any = Document(
+    "\$in",
+    listOf(fieldRef(path), BsonArray(values.map { it.literalOperand() })),
+)
+
+/**
+ * `$regexMatch` errors on non-string input while `$match` regex semantics never match one,
+ * so the guard applies only to string values; null and missing inputs never match.
+ */
 private fun regexGuard(path: String, regex: BsonRegularExpression): Document {
-    val condition = Document("input", fieldRef(path)).append("regex", regex.pattern)
+    val input = fieldRef(path)
+    val condition = Document("input", input).append("regex", regex.pattern)
     regex.options?.takeIf { it.isNotEmpty() }?.let { condition.append("options", it) }
-    return Document("\$regexMatch", condition)
+    return Document(
+        "\$cond",
+        listOf(
+            Document("\$eq", listOf(typeOf(path), "string")),
+            Document("\$regexMatch", condition),
+            false,
+        ),
+    )
 }
 
 private fun fieldRef(path: String): String = "\$$path"

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoAggregationCompiler.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoAggregationCompiler.kt
@@ -38,6 +38,10 @@ import me.ahoo.wow.query.schema.QuerySchemaValidationException
 import me.ahoo.wow.query.schema.distinctCountCapability
 import me.ahoo.wow.query.schema.operationValues
 import me.ahoo.wow.query.schema.physicalField
+import org.bson.BsonArray
+import org.bson.BsonDocument
+import org.bson.BsonNull
+import org.bson.BsonValue
 import org.bson.Document
 import org.bson.conversions.Bson
 import java.time.Instant
@@ -91,7 +95,7 @@ internal class MongoAggregationCompiler(
             id
         }
 
-        add(group(query, groupId, logicalParent, physicalParent, schema))
+        add(group(query, groupId, logicalParent, physicalParent, schema, now))
         add(project(query))
         query.effectiveSort().takeIf { it.isNotEmpty() }?.let { add(Aggregates.sort(it.toBson())) }
         add(Aggregates.limit(query.limit))
@@ -104,11 +108,19 @@ internal class MongoAggregationCompiler(
         parent: QueryField?,
         physicalParent: String?,
         schema: QueryModelSchema,
+        now: Instant,
     ): Bson {
         val accumulators = buildList {
             query.metrics.forEach { metric ->
+                val guard = metricFilter(metric, parent, physicalParent, schema, now)?.toGuardCondition()
                 when (metric) {
-                    is AggregationMetric.Count -> add(Accumulators.sum(metric.alias, 1))
+                    is AggregationMetric.Count -> add(
+                        if (guard == null) {
+                            Accumulators.sum(metric.alias, 1)
+                        } else {
+                            Accumulators.sum(metric.alias, Document("\$cond", listOf(guard, 1, 0)))
+                        },
+                    )
                     is AggregationMetric.Any -> {
                         val field = metric.field.resolve(
                             parent,
@@ -116,7 +128,13 @@ internal class MongoAggregationCompiler(
                             schema,
                             QueryCapability.AGGREGATE_TERMS,
                         )
-                        add(Accumulators.max(metric.alias, "\$$field"))
+                        add(
+                            if (guard == null) {
+                                Accumulators.max(metric.alias, "\$$field")
+                            } else {
+                                Accumulators.max(metric.alias, Document("\$cond", listOf(guard, "\$$field", null)))
+                            },
+                        )
                     }
                     is AggregationMetric.Numeric -> {
                         val nullGuarded = metric.function == AggregationFunction.MIN ||
@@ -128,11 +146,12 @@ internal class MongoAggregationCompiler(
                             physicalParent,
                             schema,
                         )
-                        add(metric.function.accumulate(metric.alias, input))
+                        val guardedInput = guard.wrapParticipation(input)
+                        add(metric.function.accumulate(metric.alias, guardedInput))
                         add(
                             Accumulators.sum(
                                 metric.countAlias,
-                                Document("\$cond", listOf(contributes, 1, 0)),
+                                Document("\$cond", listOf(guard.wrapContribution(contributes), 1, 0)),
                             ),
                         )
                     }
@@ -149,7 +168,7 @@ internal class MongoAggregationCompiler(
                                 metric.alias,
                                 Document(
                                     "\$percentile",
-                                    Document("input", input)
+                                    Document("input", guard.wrapParticipation(input))
                                         .append("p", listOf(metric.percentile / 100.0))
                                         .append("method", "approximate"),
                                 ),
@@ -158,7 +177,7 @@ internal class MongoAggregationCompiler(
                         add(
                             Accumulators.sum(
                                 metric.countAlias,
-                                Document("\$cond", listOf(contributes, 1, 0)),
+                                Document("\$cond", listOf(guard.wrapContribution(contributes), 1, 0)),
                             ),
                         )
                     }
@@ -166,7 +185,9 @@ internal class MongoAggregationCompiler(
                         add(
                             Accumulators.addToSet(
                                 metric.alias,
-                                distinctCountInput(metric.expression, parent, physicalParent, schema),
+                                guard.wrapParticipation(
+                                    distinctCountInput(metric.expression, parent, physicalParent, schema),
+                                ),
                             ),
                         )
                     }
@@ -174,6 +195,51 @@ internal class MongoAggregationCompiler(
             }
         }
         return Aggregates.group(id, accumulators)
+    }
+
+    /**
+     * Compiles the record-level filter of [metric] against its enclosing scope,
+     * or returns `null` for [MatchAllFilter] so unfiltered metrics keep their unwrapped accumulators.
+     */
+    private fun metricFilter(
+        metric: AggregationMetric,
+        parent: QueryField?,
+        physicalParent: String?,
+        schema: QueryModelSchema,
+        now: Instant,
+    ): Bson? {
+        val filter = metric.filter
+        if (filter === MatchAllFilter) {
+            return null
+        }
+        if (parent == null) {
+            return filterCompiler.compile(filter, schema, now)
+        }
+        return filterCompiler.compileScoped(
+            filter,
+            schema,
+            logicalParent = parent,
+            physicalParent = QueryField(requireNotNull(physicalParent)),
+            now = now,
+        )
+    }
+
+    /**
+     * Wraps a participating value so records rejected by the filter contribute `null` instead.
+     */
+    private fun Any?.wrapParticipation(input: Any): Any = if (this == null) {
+        input
+    } else {
+        Document("\$cond", listOf(this, input, null))
+    }
+
+    /**
+     * Extends a contribution predicate with the filter so rejected records add zero to the value count.
+     */
+    private fun Any?.wrapContribution(contributes: Any): Any = if (this == null) {
+        contributes
+    } else {
+        Document("\$and", listOf(this, contributes))
     }
 
     @Suppress("LongMethod")
@@ -598,3 +664,126 @@ internal class MongoAggregationCompiler(
     private val AggregationMetric.countAlias: String
         get() = "__wow_value_count_$alias"
 }
+
+/**
+ * MongoDB evaluates a match document in expression position as a truthy object literal,
+ * so a `$cond` guard must re-express the compiled predicate with aggregation operators.
+ * The translation covers every shape [AbstractMongoFilterCompiler] emits and preserves
+ * its null-versus-missing match semantics.
+ */
+private fun Bson.toGuardCondition(): Any = toGuardCondition(toBsonDocument())
+
+private fun toGuardCondition(document: BsonDocument): Any = when (document.size) {
+    0 -> Document("\$literal", true)
+    1 -> toGuardCondition(document.entries.first())
+    else -> Document("\$and", document.entries.map(::toGuardCondition))
+}
+
+private fun toGuardCondition(entry: Map.Entry<String, BsonValue>): Any {
+    val path = entry.key
+    val condition = entry.value
+    return when {
+        path == "\$and" || path == "\$or" ->
+            Document(path, condition.asArray().map { toGuardCondition(it.asDocument()) })
+
+        path == "\$nor" -> Document(
+            "\$not",
+            listOf(Document("\$or", condition.asArray().map { toGuardCondition(it.asDocument()) })),
+        )
+
+        path.startsWith("\$") -> throw QuerySchemaValidationException(
+            "MongoDB metric filters cannot translate operator [$path] into a guard condition.",
+        )
+
+        else -> toGuardCondition(path, condition)
+    }
+}
+
+private fun toGuardCondition(path: String, condition: BsonValue): Any {
+    if (condition.isNull) {
+        return matchesNull(path)
+    }
+    if (!condition.isDocument) {
+        return Document("\$eq", listOf(fieldRef(path), condition))
+    }
+    val document = condition.asDocument()
+    return when {
+        document.containsKey("\$elemMatch") -> throw QuerySchemaValidationException(
+            "MongoDB metric filters cannot translate [\$elemMatch] into a guard condition.",
+        )
+
+        document.containsKey("\$regex") -> regexGuard(path, document)
+
+        else -> document.entries.map { (operator, value) -> toGuardCondition(path, operator, value) }
+            .let { conditions -> conditions.singleOrNull() ?: Document("\$and", conditions) }
+    }
+}
+
+@Suppress("CyclomaticComplexMethod")
+private fun toGuardCondition(path: String, operator: String, value: BsonValue): Any = when (operator) {
+    "\$eq" -> if (value.isNull) matchesNull(path) else Document("\$eq", listOf(fieldRef(path), value))
+    "\$ne" -> if (value.isNull) {
+        Document("\$and", listOf(Document("\$ne", listOf(fieldRef(path), null)), isPresent(path)))
+    } else {
+        Document("\$ne", listOf(fieldRef(path), value))
+    }
+
+    "\$gt", "\$gte", "\$lt", "\$lte" -> Document(operator, listOf(fieldRef(path), value))
+    "\$in" -> inGuard(path, value.asArray())
+    "\$nin" -> Document("\$not", listOf(inGuard(path, value.asArray())))
+    "\$exists" -> if (value.asBoolean().value) {
+        isPresent(path)
+    } else {
+        Document("\$eq", listOf(typeOf(path), "missing"))
+    }
+
+    "\$size" -> Document(
+        "\$eq",
+        listOf(
+            Document(
+                "\$size",
+                Document(
+                    "\$cond",
+                    listOf(
+                        Document("\$isArray", listOf(fieldRef(path))),
+                        fieldRef(path),
+                        BsonArray(List(value.asNumber().intValue() + 1) { BsonNull.VALUE }),
+                    ),
+                ),
+            ),
+            value.asNumber().intValue(),
+        ),
+    )
+
+    else -> throw QuerySchemaValidationException(
+        "MongoDB metric filters cannot translate operator [$operator] into a guard condition.",
+    )
+}
+
+private fun matchesNull(path: String): Any = Document(
+    "\$or",
+    listOf(
+        Document("\$eq", listOf(fieldRef(path), null)),
+        Document("\$eq", listOf(typeOf(path), "missing")),
+    ),
+)
+
+private fun inGuard(path: String, values: BsonArray): Any {
+    val condition = Document("\$in", listOf(fieldRef(path), values))
+    if (values.none(BsonValue::isNull)) {
+        return condition
+    }
+    return Document("\$or", listOf(condition, Document("\$eq", listOf(typeOf(path), "missing"))))
+}
+
+private fun regexGuard(path: String, document: BsonDocument): Document {
+    val regex = Document("input", fieldRef(path)).append("regex", document.getString("\$regex"))
+    document.getString("\$options")?.let { regex.append("options", it) }
+    return Document("\$regexMatch", regex)
+}
+
+private fun fieldRef(path: String): String = "\$$path"
+
+private fun typeOf(path: String): Document = Document("\$type", fieldRef(path))
+
+private fun isPresent(path: String): Document = Document("\$ne", listOf(typeOf(path), "missing"))

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoAggregationCompiler.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoAggregationCompiler.kt
@@ -34,7 +34,9 @@ import me.ahoo.wow.api.query.schema.QueryValueKind
 import me.ahoo.wow.api.query.schema.Temporal
 import me.ahoo.wow.mongo.query.AbstractMongoFilterCompiler
 import me.ahoo.wow.query.schema.QueryModelSchema
+import me.ahoo.wow.query.schema.QueryPathSegment
 import me.ahoo.wow.query.schema.QuerySchemaValidationException
+import me.ahoo.wow.query.schema.QueryValueSchema
 import me.ahoo.wow.query.schema.distinctCountCapability
 import me.ahoo.wow.query.schema.operationValues
 import me.ahoo.wow.query.schema.physicalField
@@ -112,7 +114,8 @@ internal class MongoAggregationCompiler(
     ): Bson {
         val accumulators = buildList {
             query.metrics.forEach { metric ->
-                val guard = metricFilter(metric, parent, physicalParent, schema, now)?.toGuardCondition()
+                val guard = metricFilter(metric, parent, physicalParent, schema, now)
+                    ?.toGuardCondition(schema)
                 when (metric) {
                     is AggregationMetric.Count -> add(
                         if (guard == null) {
@@ -671,35 +674,65 @@ internal class MongoAggregationCompiler(
  * The translation covers every shape [AbstractMongoFilterCompiler] emits and preserves
  * its null-versus-missing match semantics.
  */
-private fun Bson.toGuardCondition(): Any = toGuardCondition(toBsonDocument())
+private fun Bson.toGuardCondition(schema: QueryModelSchema): Any =
+    toGuardCondition(toBsonDocument(), schema.arrayValuedPhysicalFields())
 
-private fun toGuardCondition(document: BsonDocument): Any = when (document.size) {
+/**
+ * Guard expressions compare whole values while `$match` matches array elements,
+ * so filters over array-valued fields are rejected instead of diverging silently.
+ */
+private fun QueryModelSchema.arrayValuedPhysicalFields(): Set<String> =
+    bindings.entries.flatMapTo(mutableSetOf()) { (logical, native) ->
+        val value = definition.values[logical] ?: return@flatMapTo emptyList()
+        if (!value.isArrayValued) {
+            return@flatMapTo emptyList()
+        }
+        native.bindings.values
+            .filterNot { template -> template.physicalPath.segments.any { it is QueryPathSegment.Key } }
+            .map { template -> template.physicalPath.field(emptyList()).path }
+    }
+
+private val QueryValueSchema.isArrayValued: Boolean
+    get() = kind == QueryValueKind.ARRAY ||
+        (kind == QueryValueKind.UNION && alternatives.any { it.kind == QueryValueKind.ARRAY })
+
+private fun toGuardCondition(document: BsonDocument, arrayValuedFields: Set<String>): Any = when (document.size) {
     0 -> Document("\$literal", true)
-    1 -> toGuardCondition(document.entries.first())
-    else -> Document("\$and", document.entries.map(::toGuardCondition))
+    1 -> toGuardCondition(document.entries.first(), arrayValuedFields)
+    else -> Document("\$and", document.entries.map { toGuardCondition(it, arrayValuedFields) })
 }
 
-private fun toGuardCondition(entry: Map.Entry<String, BsonValue>): Any {
+private fun toGuardCondition(entry: Map.Entry<String, BsonValue>, arrayValuedFields: Set<String>): Any {
     val path = entry.key
     val condition = entry.value
     return when {
         path == "\$and" || path == "\$or" ->
-            Document(path, condition.asArray().map { toGuardCondition(it.asDocument()) })
+            Document(path, condition.asArray().map { toGuardCondition(it.asDocument(), arrayValuedFields) })
 
         path == "\$nor" -> Document(
             "\$not",
-            listOf(Document("\$or", condition.asArray().map { toGuardCondition(it.asDocument()) })),
+            listOf(
+                Document(
+                    "\$or",
+                    condition.asArray().map { toGuardCondition(it.asDocument(), arrayValuedFields) },
+                ),
+            ),
         )
 
         path.startsWith("\$") -> throw QuerySchemaValidationException(
             "MongoDB metric filters cannot translate operator [$path] into a guard condition.",
         )
 
-        else -> toGuardCondition(path, condition)
+        else -> toGuardCondition(path, condition, arrayValuedFields)
     }
 }
 
-private fun toGuardCondition(path: String, condition: BsonValue): Any {
+private fun toGuardCondition(path: String, condition: BsonValue, arrayValuedFields: Set<String>): Any {
+    if (path in arrayValuedFields) {
+        throw QuerySchemaValidationException(
+            "Aggregation metric filter field [$path] must be scalar; array fields are not supported in metric filters.",
+        )
+    }
     if (condition.isNull) {
         return matchesNull(path)
     }
@@ -737,23 +770,26 @@ private fun toGuardCondition(path: String, operator: String, value: BsonValue): 
         Document("\$eq", listOf(typeOf(path), "missing"))
     }
 
-    "\$size" -> Document(
-        "\$eq",
-        listOf(
-            Document(
-                "\$size",
+    "\$size" -> {
+        val size = value.asNumber().intValue()
+        Document(
+            "\$eq",
+            listOf(
                 Document(
-                    "\$cond",
-                    listOf(
-                        Document("\$isArray", listOf(fieldRef(path))),
-                        fieldRef(path),
-                        BsonArray(List(value.asNumber().intValue() + 1) { BsonNull.VALUE }),
+                    "\$size",
+                    Document(
+                        "\$cond",
+                        listOf(
+                            Document("\$isArray", listOf(fieldRef(path))),
+                            fieldRef(path),
+                            BsonArray(List(size + 1) { BsonNull.VALUE }),
+                        ),
                     ),
                 ),
+                size,
             ),
-            value.asNumber().intValue(),
-        ),
-    )
+        )
+    }
 
     else -> throw QuerySchemaValidationException(
         "MongoDB metric filters cannot translate operator [$operator] into a guard condition.",

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoAggregationCompiler.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoAggregationCompiler.kt
@@ -697,11 +697,12 @@ private val QueryValueSchema.isArrayValued: Boolean
     get() = kind == QueryValueKind.ARRAY ||
         (kind == QueryValueKind.UNION && alternatives.any { it.kind == QueryValueKind.ARRAY })
 
-private fun toGuardCondition(document: BsonDocument, arrayValuedFields: Set<String>): Any = when (document.size) {
-    0 -> Document("\$literal", true)
-    1 -> toGuardCondition(document.entries.first(), arrayValuedFields)
-    else -> Document("\$and", document.entries.map { toGuardCondition(it, arrayValuedFields) })
-}
+private fun toGuardCondition(document: BsonDocument, arrayValuedFields: Set<String>): Any =
+    if (document.size == 0) {
+        Document("\$literal", true)
+    } else {
+        toGuardCondition(document.entries.single(), arrayValuedFields)
+    }
 
 private fun toGuardCondition(entry: Map.Entry<String, BsonValue>, arrayValuedFields: Set<String>): Any {
     val path = entry.key
@@ -744,30 +745,20 @@ private fun toGuardCondition(path: String, condition: BsonValue, arrayValuedFiel
         return Document("\$eq", listOf(fieldRef(path), condition))
     }
     val document = condition.asDocument()
-    return when {
-        document.containsKey("\$elemMatch") -> throw QuerySchemaValidationException(
+    if (document.containsKey("\$elemMatch")) {
+        throw QuerySchemaValidationException(
             "MongoDB metric filters cannot translate [\$elemMatch] into a guard condition.",
         )
-
-        document.containsKey("\$regex") -> regexGuard(path, document)
-
-        else -> document.entries.map { (operator, value) -> toGuardCondition(path, operator, value) }
-            .let { conditions -> conditions.singleOrNull() ?: Document("\$and", conditions) }
     }
+    return document.entries.single().let { (operator, value) -> toGuardCondition(path, operator, value) }
 }
 
 @Suppress("CyclomaticComplexMethod")
 private fun toGuardCondition(path: String, operator: String, value: BsonValue): Any = when (operator) {
-    "\$eq" -> when {
-        value.isNull -> matchesNull(path)
-        value.isRegularExpression -> regexGuard(path, value.asRegularExpression())
-        else -> Document("\$eq", listOf(fieldRef(path), value))
-    }
-
-    "\$ne" -> when {
-        value.isNull -> Document("\$and", listOf(Document("\$ne", listOf(fieldRef(path), null)), isPresent(path)))
-        value.isRegularExpression -> Document("\$not", listOf(regexGuard(path, value.asRegularExpression())))
-        else -> Document("\$ne", listOf(fieldRef(path), value))
+    "\$ne" -> if (value.isNull) {
+        Document("\$and", listOf(Document("\$ne", listOf(fieldRef(path), null)), isPresent(path)))
+    } else {
+        Document("\$ne", listOf(fieldRef(path), value))
     }
 
     "\$gt", "\$gte", "\$lt", "\$lte" -> Document(operator, listOf(fieldRef(path), value))
@@ -813,32 +804,7 @@ private fun matchesNull(path: String): Any = Document(
     ),
 )
 
-private fun inGuard(path: String, values: BsonArray): Any {
-    if (values.none { it.isRegularExpression }) {
-        val condition = Document("\$in", listOf(fieldRef(path), values))
-        if (values.none(BsonValue::isNull)) {
-            return condition
-        }
-        return Document("\$or", listOf(condition, Document("\$eq", listOf(typeOf(path), "missing"))))
-    }
-    val conditions = values.mapTo(mutableListOf()) { value ->
-        when {
-            value.isRegularExpression -> regexGuard(path, value.asRegularExpression())
-            value.isNull -> Document("\$eq", listOf(fieldRef(path), null))
-            else -> Document("\$eq", listOf(fieldRef(path), value))
-        }
-    }
-    if (values.any(BsonValue::isNull)) {
-        conditions += Document("\$eq", listOf(typeOf(path), "missing"))
-    }
-    return conditions.singleOrNull() ?: Document("\$or", conditions)
-}
-
-private fun regexGuard(path: String, document: BsonDocument): Document {
-    val regex = Document("input", fieldRef(path)).append("regex", document.getString("\$regex"))
-    document.getString("\$options")?.let { regex.append("options", it) }
-    return Document("\$regexMatch", regex)
-}
+private fun inGuard(path: String, values: BsonArray): Any = Document("\$in", listOf(fieldRef(path), values))
 
 private fun regexGuard(path: String, regex: BsonRegularExpression): Document {
     val condition = Document("input", fieldRef(path)).append("regex", regex.pattern)

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoAggregationCompiler.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoAggregationCompiler.kt
@@ -43,6 +43,7 @@ import me.ahoo.wow.query.schema.physicalField
 import org.bson.BsonArray
 import org.bson.BsonDocument
 import org.bson.BsonNull
+import org.bson.BsonRegularExpression
 import org.bson.BsonValue
 import org.bson.Document
 import org.bson.conversions.Bson
@@ -736,6 +737,9 @@ private fun toGuardCondition(path: String, condition: BsonValue, arrayValuedFiel
     if (condition.isNull) {
         return matchesNull(path)
     }
+    if (condition.isRegularExpression) {
+        return regexGuard(path, condition.asRegularExpression())
+    }
     if (!condition.isDocument) {
         return Document("\$eq", listOf(fieldRef(path), condition))
     }
@@ -754,11 +758,16 @@ private fun toGuardCondition(path: String, condition: BsonValue, arrayValuedFiel
 
 @Suppress("CyclomaticComplexMethod")
 private fun toGuardCondition(path: String, operator: String, value: BsonValue): Any = when (operator) {
-    "\$eq" -> if (value.isNull) matchesNull(path) else Document("\$eq", listOf(fieldRef(path), value))
-    "\$ne" -> if (value.isNull) {
-        Document("\$and", listOf(Document("\$ne", listOf(fieldRef(path), null)), isPresent(path)))
-    } else {
-        Document("\$ne", listOf(fieldRef(path), value))
+    "\$eq" -> when {
+        value.isNull -> matchesNull(path)
+        value.isRegularExpression -> regexGuard(path, value.asRegularExpression())
+        else -> Document("\$eq", listOf(fieldRef(path), value))
+    }
+
+    "\$ne" -> when {
+        value.isNull -> Document("\$and", listOf(Document("\$ne", listOf(fieldRef(path), null)), isPresent(path)))
+        value.isRegularExpression -> Document("\$not", listOf(regexGuard(path, value.asRegularExpression())))
+        else -> Document("\$ne", listOf(fieldRef(path), value))
     }
 
     "\$gt", "\$gte", "\$lt", "\$lte" -> Document(operator, listOf(fieldRef(path), value))
@@ -805,17 +814,36 @@ private fun matchesNull(path: String): Any = Document(
 )
 
 private fun inGuard(path: String, values: BsonArray): Any {
-    val condition = Document("\$in", listOf(fieldRef(path), values))
-    if (values.none(BsonValue::isNull)) {
-        return condition
+    if (values.none { it.isRegularExpression }) {
+        val condition = Document("\$in", listOf(fieldRef(path), values))
+        if (values.none(BsonValue::isNull)) {
+            return condition
+        }
+        return Document("\$or", listOf(condition, Document("\$eq", listOf(typeOf(path), "missing"))))
     }
-    return Document("\$or", listOf(condition, Document("\$eq", listOf(typeOf(path), "missing"))))
+    val conditions = values.mapTo(mutableListOf()) { value ->
+        when {
+            value.isRegularExpression -> regexGuard(path, value.asRegularExpression())
+            value.isNull -> Document("\$eq", listOf(fieldRef(path), null))
+            else -> Document("\$eq", listOf(fieldRef(path), value))
+        }
+    }
+    if (values.any(BsonValue::isNull)) {
+        conditions += Document("\$eq", listOf(typeOf(path), "missing"))
+    }
+    return conditions.singleOrNull() ?: Document("\$or", conditions)
 }
 
 private fun regexGuard(path: String, document: BsonDocument): Document {
     val regex = Document("input", fieldRef(path)).append("regex", document.getString("\$regex"))
     document.getString("\$options")?.let { regex.append("options", it) }
     return Document("\$regexMatch", regex)
+}
+
+private fun regexGuard(path: String, regex: BsonRegularExpression): Document {
+    val condition = Document("input", fieldRef(path)).append("regex", regex.pattern)
+    regex.options?.takeIf { it.isNotEmpty() }?.let { condition.append("options", it) }
+    return Document("\$regexMatch", condition)
 }
 
 private fun fieldRef(path: String): String = "\$$path"

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
@@ -1042,6 +1042,81 @@ class MongoAggregationCompilerTest {
     }
 
     @Test
+    fun `dollar prefixed string operands are compared as literals`() {
+        val rangeStringSchema = schema(
+            field(
+                "state.productName",
+                QueryCapability.RANGE,
+                "state.productName",
+                additionalCapabilities = setOf(QueryCapability.EXACT_MATCH),
+            ),
+        )
+        val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+            aggregation {
+                count("pending") { "state.productName" eq "\$pending" }
+                count("notPending") { "state.productName" ne "\$pending" }
+                count("pendingList") { "state.productName" isIn listOf("\$pending", "Alpha") }
+                count("missingList") { "state.productName" notIn listOf("\$pending") }
+                count("above") { "state.productName" gt "\$pending" }
+            },
+            rangeStringSchema,
+        ).map { it.toBsonDocument() }
+
+        val group = pipeline.first { it.containsKey("\$group") }.getDocument("\$group")
+        group.getDocument("pending").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            BsonDocument("\$eq", BsonArray(listOf(BsonString("\$state.productName"), literalString("\$pending")))),
+        )
+        group.getDocument("notPending").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            BsonDocument("\$ne", BsonArray(listOf(BsonString("\$state.productName"), literalString("\$pending")))),
+        )
+        group.getDocument("pendingList").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            BsonDocument(
+                "\$in",
+                BsonArray(
+                    listOf(
+                        BsonString("\$state.productName"),
+                        BsonArray(listOf(literalString("\$pending"), BsonString("Alpha"))),
+                    ),
+                ),
+            ),
+        )
+        group.getDocument("missingList").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            BsonDocument(
+                "\$not",
+                BsonArray(
+                    listOf(
+                        BsonDocument(
+                            "\$in",
+                            BsonArray(
+                                listOf(
+                                    BsonString("\$state.productName"),
+                                    BsonArray(listOf(literalString("\$pending"))),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        group.getDocument("above").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            BsonDocument("\$gt", BsonArray(listOf(BsonString("\$state.productName"), literalString("\$pending")))),
+        )
+    }
+
+    @Test
+    fun `dollar prefixed literal match values stay escaped regex patterns`() {
+        val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+            aggregation { count("startsWith") { "state.productName".startsWithText("\$pending") } },
+            guardFilterSchema,
+        ).map { it.toBsonDocument() }
+
+        pipeline.first { it.containsKey("\$group") }.getDocument("\$group")
+            .getDocument("startsWith").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            regexMatchGuard("^\\\$pending"),
+        )
+    }
+
+    @Test
     fun `element scoped metric filters compile guards relative to their element`() {
         val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
             aggregation {
@@ -1175,35 +1250,39 @@ class MongoAggregationCompilerTest {
     }
 
     @Test
-    fun `map keyed collection metric filters translate size guards`() {
+    fun `map keyed collection metric filters are rejected as array fields`() {
+        assertThrows<QuerySchemaValidationException> {
+            MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+                aggregation { count("empty") { "state.labels.foo".isEmptyCollection() } },
+                mapCollectionSchema,
+            )
+        }.message.assert().isEqualTo(
+            "Aggregation metric filter field [state.labels.foo] must be scalar; array fields are not supported in metric filters.",
+        )
+    }
+
+    @Test
+    fun `map keyed array metric filter fields are rejected`() {
+        assertThrows<QuerySchemaValidationException> {
+            MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+                aggregation { count("labeled") { "state.labels.foo" eq "premium" } },
+                mapCollectionSchema,
+            )
+        }.message.assert().isEqualTo(
+            "Aggregation metric filter field [state.labels.foo] must be scalar; array fields are not supported in metric filters.",
+        )
+    }
+
+    @Test
+    fun `map keyed scalar metric filter fields keep equality guards`() {
         val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
-            aggregation { count("empty") { "state.labels.foo".isEmptyCollection() } },
+            aggregation { count("prod") { "state.env.stage" eq "prod" } },
             mapCollectionSchema,
         ).map { it.toBsonDocument() }
 
         pipeline.single { it.containsKey("\$group") }.getDocument("\$group")
-            .getDocument("empty").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
-            BsonDocument(
-                "\$eq",
-                BsonArray(
-                    listOf(
-                        BsonDocument(
-                            "\$size",
-                            BsonDocument(
-                                "\$cond",
-                                BsonArray(
-                                    listOf(
-                                        BsonDocument("\$isArray", BsonArray(listOf(BsonString("\$state.labels.foo")))),
-                                        BsonString("\$state.labels.foo"),
-                                        BsonArray(listOf(BsonNull.VALUE)),
-                                    ),
-                                ),
-                            ),
-                        ),
-                        BsonInt32(0),
-                    ),
-                ),
-            ),
+            .getDocument("prod").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            BsonDocument("\$eq", BsonArray(listOf(BsonString("\$state.env.stage"), BsonString("prod")))),
         )
     }
 
@@ -1215,7 +1294,7 @@ class MongoAggregationCompilerTest {
                 mapCollectionSchema,
             )
         }.message.assert().isEqualTo(
-            "MongoDB metric filters cannot translate [\$elemMatch] into a guard condition.",
+            "Aggregation metric filter field [state.groups.foo] must be scalar; array fields are not supported in metric filters.",
         )
     }
 
@@ -1349,10 +1428,30 @@ private val paidStatusGuard = BsonDocument(
     BsonArray(listOf(BsonString("\$state.status"), BsonString("PAID"))),
 )
 
+private fun literalString(value: String): BsonDocument = BsonDocument("\$literal", BsonString(value))
+
 private fun regexMatchGuard(pattern: String, options: String? = null): BsonDocument {
-    val condition = BsonDocument("input", BsonString("\$state.productName")).append("regex", BsonString(pattern))
+    val condition = BsonDocument("input", BsonString("\$state.productName"))
+        .append("regex", BsonString(pattern))
     options?.let { condition.append("options", BsonString(it)) }
-    return BsonDocument("\$regexMatch", condition)
+    return BsonDocument(
+        "\$cond",
+        BsonArray(
+            listOf(
+                BsonDocument(
+                    "\$eq",
+                    BsonArray(
+                        listOf(
+                            BsonDocument("\$type", BsonString("\$state.productName")),
+                            BsonString("string"),
+                        ),
+                    ),
+                ),
+                BsonDocument("\$regexMatch", condition),
+                BsonBoolean(false),
+            ),
+        ),
+    )
 }
 
 private val guardFilterSchema = schema(
@@ -1367,7 +1466,7 @@ private val guardFilterSchema = schema(
 /**
  * A map-of-lists schema: concrete map keys resolve to array values whose physical paths
  * carry [me.ahoo.wow.query.schema.QueryPathSegment.Key] templates, so metric filters over
- * them are not rejected by the plain array-field guard.
+ * them must be rejected by the scalar-field walk like any other array field.
  */
 private val mapCollectionSchema = run {
     fun template(segments: List<QueryPathSegment>) = QueryPathTemplate(segments)
@@ -1375,6 +1474,13 @@ private val mapCollectionSchema = run {
         listOf(
             QueryPathSegment.Property("state"),
             QueryPathSegment.Property("labels"),
+            QueryPathSegment.Key(0),
+        ),
+    )
+    val envKey = template(
+        listOf(
+            QueryPathSegment.Property("state"),
+            QueryPathSegment.Property("env"),
             QueryPathSegment.Key(0),
         ),
     )
@@ -1416,6 +1522,13 @@ private val mapCollectionSchema = run {
                                 ),
                             ),
                         ),
+                        "env" to QueryValueSchema(
+                            QueryValueKind.OBJECT,
+                            additionalProperties = QueryValueSchema(
+                                QueryValueKind.SCALAR,
+                                valueTypes = setOf(QueryValueType.STRING),
+                            ),
+                        ),
                         "groups" to QueryValueSchema(
                             QueryValueKind.OBJECT,
                             additionalProperties = QueryValueSchema(
@@ -1441,7 +1554,8 @@ private val mapCollectionSchema = run {
         emptySet(),
         definition,
         mapOf(
-            labelsKey to bindings(labelsKey, setOf(QueryCapability.PRESENCE)),
+            labelsKey to bindings(labelsKey, setOf(QueryCapability.PRESENCE, QueryCapability.EXACT_MATCH)),
+            envKey to bindings(envKey, setOf(QueryCapability.EXACT_MATCH)),
             groupsKey to bindings(groupsKey, setOf(QueryCapability.ELEMENT_SCOPE, QueryCapability.PRESENCE)),
             groupName to bindings(groupName, setOf(QueryCapability.EXACT_MATCH)),
         ),

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
@@ -33,7 +33,10 @@ import me.ahoo.wow.query.dsl.aggregation
 import me.ahoo.wow.query.schema.QuerySchemaValidationException
 import me.ahoo.wow.query.schema.QueryValueSchema
 import me.ahoo.wow.serialization.MessageRecords
+import org.bson.BsonArray
+import org.bson.BsonBoolean
 import org.bson.BsonDocument
+import org.bson.BsonInt32
 import org.bson.BsonString
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -760,6 +763,81 @@ class MongoAggregationCompilerTest {
     }
 
     @Test
+    fun `filtered count accumulates conditional ones`() {
+        val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+            aggregation { count("paid") { "state.status" eq "PAID" } },
+            statusFilterSchema,
+        ).map { it.toBsonDocument() }
+
+        val group = pipeline.first { it.containsKey("\$group") }.getDocument("\$group")
+        val accumulator = group.getDocument("paid").getDocument("\$sum").getArray("\$cond")
+        accumulator.get(1).asInt32().value.assert().isEqualTo(1)
+        accumulator.get(2).asInt32().value.assert().isEqualTo(0)
+        accumulator.get(0).asDocument().assert().isEqualTo(paidStatusGuard)
+    }
+
+    @Test
+    fun `filtered numeric metrics guard contributions with the filter`() {
+        val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+            aggregation {
+                sum("state.amount", "paidAmount") { "state.status" eq "PAID" }
+                percentile("state.amount", 50.0, "paidP50") { "state.status" eq "PAID" }
+            },
+            statusFilterSchema,
+        ).map { it.toBsonDocument() }
+
+        val group = pipeline.first { it.containsKey("\$group") }.getDocument("\$group")
+        group.getDocument("paidAmount").getDocument("\$sum").getArray("\$cond").get(0).asDocument()
+            .assert().isEqualTo(paidStatusGuard)
+        val countGuard = group.getDocument("__wow_value_count_paidAmount").getDocument("\$sum")
+            .getArray("\$cond").get(0).asDocument()
+        countGuard.getArray("\$and").get(0).asDocument().assert().isEqualTo(paidStatusGuard)
+        countGuard.getArray("\$and").get(1).asDocument().containsKey("\$isNumber").assert().isTrue()
+        group.getDocument("paidP50").getDocument("\$percentile").getDocument("input")
+            .getArray("\$cond").get(0).asDocument().assert().isEqualTo(paidStatusGuard)
+    }
+
+    @Test
+    fun `filtered distinct count and any null non matching records`() {
+        val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+            aggregation {
+                distinctCount("state.productId", "paidProducts") { "state.status" eq "PAID" }
+                any("state.status", "anyStatus") { "deleted" eq false }
+            },
+            statusFilterSchema,
+        ).map { it.toBsonDocument() }
+
+        val group = pipeline.first { it.containsKey("\$group") }.getDocument("\$group")
+        group.getDocument("paidProducts").getDocument("\$addToSet").getArray("\$cond").get(0).asDocument()
+            .assert().isEqualTo(paidStatusGuard)
+        val anyGuard = group.getDocument("anyStatus").getDocument("\$max").getArray("\$cond")
+        anyGuard.get(0).asDocument().assert().isEqualTo(
+            BsonDocument("\$eq", BsonArray(listOf(BsonString("\$deleted"), BsonBoolean(false)))),
+        )
+        anyGuard.get(1).asString().value.assert().isEqualTo("\$state.status")
+        anyGuard.get(2).isNull.assert().isTrue()
+    }
+
+    @Test
+    fun `unfiltered metrics keep their unwrapped accumulators`() {
+        val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+            aggregation {
+                count("count")
+                sum("state.amount", "total")
+            },
+            schema(),
+        ).map { it.toBsonDocument() }
+
+        val group = pipeline.first { it.containsKey("\$group") }.getDocument("\$group")
+        group.getDocument("count").get("\$sum").assert().isEqualTo(BsonInt32(1))
+        group.getDocument("total").getDocument("\$sum").getArray("\$cond").get(0).asDocument()
+            .containsKey("\$isArray").assert().isTrue()
+        val countGuard = group.getDocument("__wow_value_count_total").getDocument("\$sum").getArray("\$cond")
+        countGuard.get(0).asDocument().containsKey("\$isNumber").assert().isTrue()
+        countGuard.get(0).asDocument().containsKey("\$and").assert().isFalse()
+    }
+
+    @Test
     fun `schema bindings should apply to root and element filters without element deletion scope`() {
         val query = aggregation {
             filter { "state.status" eq "PAID" }
@@ -786,6 +864,20 @@ class MongoAggregationCompilerTest {
             .doesNotContain("deleted")
     }
 }
+
+private val statusFilterSchema = schema(
+    field(
+        "state.status",
+        QueryCapability.EXACT_MATCH,
+        "state.status",
+        additionalCapabilities = setOf(QueryCapability.AGGREGATE_TERMS),
+    ),
+)
+
+private val paidStatusGuard = BsonDocument(
+    "\$eq",
+    BsonArray(listOf(BsonString("\$state.status"), BsonString("PAID"))),
+)
 
 private fun schema(vararg fields: Pair<QueryField, MongoTestField>) = mongoTestSchema(
     model = QueryModel.SNAPSHOT,

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
@@ -31,13 +31,21 @@ import me.ahoo.wow.mongo.query.aggregation.MongoAggregationCompiler
 import me.ahoo.wow.mongo.query.event.EventStreamFilterCompiler
 import me.ahoo.wow.mongo.query.mongoTestSchema
 import me.ahoo.wow.query.dsl.aggregation
+import me.ahoo.wow.query.schema.LogicalQuerySchema
+import me.ahoo.wow.query.schema.QueryFieldBindingTemplate
+import me.ahoo.wow.query.schema.QueryModelSchema
+import me.ahoo.wow.query.schema.QueryPathSegment
+import me.ahoo.wow.query.schema.QueryPathTemplate
 import me.ahoo.wow.query.schema.QuerySchemaValidationException
+import me.ahoo.wow.query.schema.QueryValueBindings
 import me.ahoo.wow.query.schema.QueryValueSchema
 import me.ahoo.wow.serialization.MessageRecords
 import org.bson.BsonArray
 import org.bson.BsonBoolean
 import org.bson.BsonDocument
+import org.bson.BsonDouble
 import org.bson.BsonInt32
+import org.bson.BsonInt64
 import org.bson.BsonNull
 import org.bson.BsonString
 import org.junit.jupiter.api.Test
@@ -1034,6 +1042,219 @@ class MongoAggregationCompilerTest {
     }
 
     @Test
+    fun `element scoped metric filters compile guards relative to their element`() {
+        val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+            aggregation {
+                expand("state.orders")
+                count("paid") { "status" eq "PAID" }
+            },
+            schema(),
+        ).map { it.toBsonDocument() }
+
+        val group = pipeline.single { it.containsKey("\$group") }.getDocument("\$group")
+        group.getDocument("paid").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            BsonDocument("\$eq", BsonArray(listOf(BsonString("\$state.orders.status"), BsonString("PAID")))),
+        )
+    }
+
+    @Test
+    fun `range metric filters translate into comparison guards`() {
+        val rangeSchema = schema(
+            field(
+                "state.amount",
+                QueryCapability.RANGE,
+                "state.amount",
+                QueryValueType.DECIMAL,
+                additionalCapabilities = setOf(QueryCapability.AGGREGATE_NUMERIC),
+            ),
+        )
+        val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+            aggregation {
+                count("above") { "state.amount" gt 10.0 }
+                count("within") { "state.amount".between(1.0, 5.0) }
+            },
+            rangeSchema,
+        ).map { it.toBsonDocument() }
+
+        val group = pipeline.single { it.containsKey("\$group") }.getDocument("\$group")
+        group.getDocument("above").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            BsonDocument("\$gt", BsonArray(listOf(BsonString("\$state.amount"), BsonDouble(10.0)))),
+        )
+        group.getDocument("within").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            BsonDocument(
+                "\$and",
+                BsonArray(
+                    listOf(
+                        BsonDocument("\$gte", BsonArray(listOf(BsonString("\$state.amount"), BsonDouble(1.0)))),
+                        BsonDocument("\$lte", BsonArray(listOf(BsonString("\$state.amount"), BsonDouble(5.0)))),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `relative time metric filters normalize into one shared range instant`() {
+        val temporalSchema = schema(
+            field(
+                "state.createdAt",
+                QueryCapability.RANGE,
+                "state.createdAt",
+                QueryValueType.INTEGER,
+                Temporal.Epoch(TimeUnit.SECONDS),
+                additionalCapabilities = setOf(QueryCapability.AGGREGATE_TEMPORAL),
+            ),
+        )
+        val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+            aggregation { count("today") { "state.createdAt".today(ZoneId.of("UTC")) } },
+            temporalSchema,
+            java.time.Instant.parse("1970-01-02T12:00:00Z"),
+        ).map { it.toBsonDocument() }
+
+        val guard = pipeline.single { it.containsKey("\$group") }.getDocument("\$group")
+            .getDocument("today").getDocument("\$sum").getArray("\$cond")[0].asDocument()
+        guard.getArray("\$and")[0].asDocument().assert().isEqualTo(
+            BsonDocument("\$gte", BsonArray(listOf(BsonString("\$state.createdAt"), BsonInt64(86400)))),
+        )
+        guard.getArray("\$and")[1].asDocument().assert().isEqualTo(
+            BsonDocument("\$lt", BsonArray(listOf(BsonString("\$state.createdAt"), BsonInt64(172800)))),
+        )
+    }
+
+    @Test
+    fun `match none metric filters guard with an empty in list`() {
+        val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+            aggregation { count("none") { matchNone() } },
+            schema(),
+        ).map { it.toBsonDocument() }
+
+        pipeline.single { it.containsKey("\$group") }.getDocument("\$group")
+            .getDocument("none").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            BsonDocument("\$in", BsonArray(listOf(BsonString("\$_id"), BsonArray()))),
+        )
+    }
+
+    @Test
+    fun `all state deletion metric filters guard with literal true`() {
+        val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+            aggregation { count("every") { deletion(DeletionState.ALL) } },
+            schema(),
+        ).map { it.toBsonDocument() }
+
+        pipeline.single { it.containsKey("\$group") }.getDocument("\$group")
+            .getDocument("every").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert()
+            .isEqualTo(BsonDocument("\$literal", BsonBoolean(true)))
+    }
+
+    @Test
+    fun `or metric filters translate into or guards`() {
+        val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+            aggregation {
+                count("either") {
+                    or {
+                        "state.status" eq "PAID"
+                        "state.status" eq "SHIPPED"
+                    }
+                }
+            },
+            statusFilterSchema,
+        ).map { it.toBsonDocument() }
+
+        pipeline.single { it.containsKey("\$group") }.getDocument("\$group")
+            .getDocument("either").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            BsonDocument(
+                "\$or",
+                BsonArray(
+                    listOf(
+                        BsonDocument("\$eq", BsonArray(listOf(BsonString("\$state.status"), BsonString("PAID")))),
+                        BsonDocument("\$eq", BsonArray(listOf(BsonString("\$state.status"), BsonString("SHIPPED")))),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `map keyed collection metric filters translate size guards`() {
+        val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+            aggregation { count("empty") { "state.labels.foo".isEmptyCollection() } },
+            mapCollectionSchema,
+        ).map { it.toBsonDocument() }
+
+        pipeline.single { it.containsKey("\$group") }.getDocument("\$group")
+            .getDocument("empty").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            BsonDocument(
+                "\$eq",
+                BsonArray(
+                    listOf(
+                        BsonDocument(
+                            "\$size",
+                            BsonDocument(
+                                "\$cond",
+                                BsonArray(
+                                    listOf(
+                                        BsonDocument("\$isArray", BsonArray(listOf(BsonString("\$state.labels.foo")))),
+                                        BsonString("\$state.labels.foo"),
+                                        BsonArray(listOf(BsonNull.VALUE)),
+                                    ),
+                                ),
+                            ),
+                        ),
+                        BsonInt32(0),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `map keyed element match metric filters are rejected`() {
+        assertThrows<QuerySchemaValidationException> {
+            MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+                aggregation { count("grouped") { "state.groups.foo".elementMatch { "name" eq "A" } } },
+                mapCollectionSchema,
+            )
+        }.message.assert().isEqualTo(
+            "MongoDB metric filters cannot translate [\$elemMatch] into a guard condition.",
+        )
+    }
+
+    @Test
+    fun `union array metric filter fields are rejected`() {
+        val schema = schema(
+            QueryField("state.notes") to MongoTestField(
+                QueryValueSchema(
+                    QueryValueKind.UNION,
+                    alternatives = listOf(
+                        QueryValueSchema(
+                            QueryValueKind.SCALAR,
+                            valueTypes = setOf(QueryValueType.STRING),
+                        ),
+                        QueryValueSchema(
+                            QueryValueKind.ARRAY,
+                            items = QueryValueSchema(
+                                QueryValueKind.SCALAR,
+                                valueTypes = setOf(QueryValueType.STRING),
+                            ),
+                        ),
+                    ),
+                ),
+                setOf(QueryCapability.EXACT_MATCH),
+                "state.notes",
+            ),
+        )
+
+        assertThrows<QuerySchemaValidationException> {
+            MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+                aggregation { count("noted") { "state.notes" eq "premium" } },
+                schema,
+            )
+        }.message.assert().isEqualTo(
+            "Aggregation metric filter field [state.notes] must be scalar; array fields are not supported in metric filters.",
+        )
+    }
+
+    @Test
     fun `metric filters cannot use text search`() {
         assertThrows<QuerySchemaValidationException> {
             MongoAggregationCompiler(SnapshotFilterCompiler).compile(
@@ -1142,6 +1363,90 @@ private val guardFilterSchema = schema(
         additionalCapabilities = setOf(QueryCapability.EXACT_MATCH, QueryCapability.PRESENCE),
     ),
 )
+
+/**
+ * A map-of-lists schema: concrete map keys resolve to array values whose physical paths
+ * carry [me.ahoo.wow.query.schema.QueryPathSegment.Key] templates, so metric filters over
+ * them are not rejected by the plain array-field guard.
+ */
+private val mapCollectionSchema = run {
+    fun template(segments: List<QueryPathSegment>) = QueryPathTemplate(segments)
+    val labelsKey = template(
+        listOf(
+            QueryPathSegment.Property("state"),
+            QueryPathSegment.Property("labels"),
+            QueryPathSegment.Key(0),
+        ),
+    )
+    val groupsKey = template(
+        listOf(
+            QueryPathSegment.Property("state"),
+            QueryPathSegment.Property("groups"),
+            QueryPathSegment.Key(0),
+        ),
+    )
+    val groupName = template(
+        listOf(
+            QueryPathSegment.Property("state"),
+            QueryPathSegment.Property("groups"),
+            QueryPathSegment.Key(0),
+            QueryPathSegment.Item,
+            QueryPathSegment.Property("name"),
+        ),
+    )
+    fun bindings(path: QueryPathTemplate, capabilities: Set<QueryCapability>) = QueryValueBindings(
+        bindings = capabilities.associateWith { QueryFieldBindingTemplate(path, storageTypes = null) },
+        projectionPath = path,
+        responsePath = path,
+    )
+    val definition = LogicalQuerySchema(
+        QueryValueSchema(
+            QueryValueKind.OBJECT,
+            properties = mapOf(
+                "state" to QueryValueSchema(
+                    QueryValueKind.OBJECT,
+                    properties = mapOf(
+                        "labels" to QueryValueSchema(
+                            QueryValueKind.OBJECT,
+                            additionalProperties = QueryValueSchema(
+                                QueryValueKind.ARRAY,
+                                items = QueryValueSchema(
+                                    QueryValueKind.SCALAR,
+                                    valueTypes = setOf(QueryValueType.STRING),
+                                ),
+                            ),
+                        ),
+                        "groups" to QueryValueSchema(
+                            QueryValueKind.OBJECT,
+                            additionalProperties = QueryValueSchema(
+                                QueryValueKind.ARRAY,
+                                items = QueryValueSchema(
+                                    QueryValueKind.OBJECT,
+                                    properties = mapOf(
+                                        "name" to QueryValueSchema(
+                                            QueryValueKind.SCALAR,
+                                            valueTypes = setOf(QueryValueType.STRING),
+                                        ),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+    QueryModelSchema(
+        QueryModel.SNAPSHOT,
+        emptySet(),
+        definition,
+        mapOf(
+            labelsKey to bindings(labelsKey, setOf(QueryCapability.PRESENCE)),
+            groupsKey to bindings(groupsKey, setOf(QueryCapability.ELEMENT_SCOPE, QueryCapability.PRESENCE)),
+            groupName to bindings(groupName, setOf(QueryCapability.EXACT_MATCH)),
+        ),
+    )
+}
 
 private fun schema(vararg fields: Pair<QueryField, MongoTestField>) = mongoTestSchema(
     model = QueryModel.SNAPSHOT,

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
@@ -20,6 +20,7 @@ import me.ahoo.wow.api.query.AggregationDateUnit
 import me.ahoo.wow.api.query.DeletionFilter
 import me.ahoo.wow.api.query.DeletionState
 import me.ahoo.wow.api.query.QueryField
+import me.ahoo.wow.api.query.StringComparison
 import me.ahoo.wow.api.query.schema.QueryCapability
 import me.ahoo.wow.api.query.schema.QueryModel
 import me.ahoo.wow.api.query.schema.QueryValueKind
@@ -1005,6 +1006,34 @@ class MongoAggregationCompilerTest {
     }
 
     @Test
+    fun `metric filters should translate literal match regex leaves into regexMatch guards`() {
+        val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+            aggregation {
+                count("contains") { "state.productName".containsText("Alpha") }
+                count("startsWith") { "state.productName".startsWithText("Alpha") }
+                count("endsWith") { "state.productName".endsWithText("2026") }
+                count("containsIgnoreCase") {
+                    "state.productName".containsText("alpha", StringComparison.CASE_INSENSITIVE)
+                }
+            },
+            guardFilterSchema,
+        ).map { it.toBsonDocument() }
+
+        val group = pipeline.first { it.containsKey("\$group") }.getDocument("\$group")
+        group.getDocument("contains").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            regexMatchGuard("Alpha"),
+        )
+        group.getDocument("startsWith").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            regexMatchGuard("^Alpha"),
+        )
+        group.getDocument("endsWith").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            regexMatchGuard("2026\$"),
+        )
+        group.getDocument("containsIgnoreCase").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert()
+            .isEqualTo(regexMatchGuard("alpha", "i"))
+    }
+
+    @Test
     fun `metric filters cannot use text search`() {
         assertThrows<QuerySchemaValidationException> {
             MongoAggregationCompiler(SnapshotFilterCompiler).compile(
@@ -1098,6 +1127,12 @@ private val paidStatusGuard = BsonDocument(
     "\$eq",
     BsonArray(listOf(BsonString("\$state.status"), BsonString("PAID"))),
 )
+
+private fun regexMatchGuard(pattern: String, options: String? = null): BsonDocument {
+    val condition = BsonDocument("input", BsonString("\$state.productName")).append("regex", BsonString(pattern))
+    options?.let { condition.append("options", BsonString(it)) }
+    return BsonDocument("\$regexMatch", condition)
+}
 
 private val guardFilterSchema = schema(
     field(

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
@@ -37,6 +37,7 @@ import org.bson.BsonArray
 import org.bson.BsonBoolean
 import org.bson.BsonDocument
 import org.bson.BsonInt32
+import org.bson.BsonNull
 import org.bson.BsonString
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -839,6 +840,171 @@ class MongoAggregationCompilerTest {
     }
 
     @Test
+    fun `metric filters should guard null equality and inequality with type conditions`() {
+        val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+            aggregation {
+                count("notAlpha") { "state.productName" ne "Alpha" }
+                count("nullName") { "state.productName" eq null }
+                count("notNullName") { "state.productName" ne null }
+            },
+            guardFilterSchema,
+        ).map { it.toBsonDocument() }
+
+        val group = pipeline.first { it.containsKey("\$group") }.getDocument("\$group")
+        group.getDocument("notAlpha").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert()
+            .isEqualTo(BsonDocument("\$ne", BsonArray(listOf(BsonString("\$state.productName"), BsonString("Alpha")))))
+        group.getDocument("nullName").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            BsonDocument(
+                "\$or",
+                BsonArray(
+                    listOf(
+                        BsonDocument(
+                            "\$eq",
+                            BsonArray(listOf(BsonString("\$state.productName"), BsonNull.VALUE)),
+                        ),
+                        BsonDocument(
+                            "\$eq",
+                            BsonArray(
+                                listOf(BsonDocument("\$type", BsonString("\$state.productName")), BsonString("missing"))
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        group.getDocument("notNullName").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            BsonDocument(
+                "\$and",
+                BsonArray(
+                    listOf(
+                        BsonDocument(
+                            "\$ne",
+                            BsonArray(listOf(BsonString("\$state.productName"), BsonNull.VALUE)),
+                        ),
+                        BsonDocument(
+                            "\$ne",
+                            BsonArray(
+                                listOf(
+                                    BsonDocument("\$type", BsonString("\$state.productName")),
+                                    BsonString("missing"),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `metric filters should translate nin and nor into not guards`() {
+        val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+            aggregation {
+                count("notInList") { "state.productName" notIn listOf("Alpha", "Beta") }
+                count("neither") {
+                    nor {
+                        "state.productName" eq "Alpha"
+                        "state.productName" eq "Beta"
+                    }
+                }
+            },
+            guardFilterSchema,
+        ).map { it.toBsonDocument() }
+
+        val group = pipeline.first { it.containsKey("\$group") }.getDocument("\$group")
+        group.getDocument("notInList").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            BsonDocument(
+                "\$not",
+                BsonArray(
+                    listOf(
+                        BsonDocument(
+                            "\$in",
+                            BsonArray(
+                                listOf(
+                                    BsonString("\$state.productName"),
+                                    BsonArray(listOf(BsonString("Alpha"), BsonString("Beta"))),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        group.getDocument("neither").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            BsonDocument(
+                "\$not",
+                BsonArray(
+                    listOf(
+                        BsonDocument(
+                            "\$or",
+                            BsonArray(
+                                listOf(
+                                    BsonDocument(
+                                        "\$eq",
+                                        BsonArray(listOf(BsonString("\$state.productName"), BsonString("Alpha"))),
+                                    ),
+                                    BsonDocument(
+                                        "\$eq",
+                                        BsonArray(listOf(BsonString("\$state.productName"), BsonString("Beta"))),
+                                    ),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `metric filters should translate exists checks into type guards`() {
+        val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+            aggregation {
+                count("present") { "state.productName".exists() }
+                count("absent") { "state.productName".notExists() }
+            },
+            guardFilterSchema,
+        ).map { it.toBsonDocument() }
+
+        val group = pipeline.first { it.containsKey("\$group") }.getDocument("\$group")
+        group.getDocument("present").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            BsonDocument(
+                "\$ne",
+                BsonArray(listOf(BsonDocument("\$type", BsonString("\$state.productName")), BsonString("missing"))),
+            ),
+        )
+        group.getDocument("absent").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            BsonDocument(
+                "\$eq",
+                BsonArray(listOf(BsonDocument("\$type", BsonString("\$state.productName")), BsonString("missing"))),
+            ),
+        )
+    }
+
+    @Test
+    fun `metric filters should translate in-lists into expression in guards`() {
+        val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+            aggregation {
+                count("inList") { "state.productName" isIn listOf("Alpha", "Beta") }
+            },
+            guardFilterSchema,
+        ).map { it.toBsonDocument() }
+
+        pipeline.first { it.containsKey("\$group") }.getDocument("\$group")
+            .getDocument("inList").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            BsonDocument(
+                "\$in",
+                BsonArray(
+                    listOf(
+                        BsonString("\$state.productName"),
+                        BsonArray(listOf(BsonString("Alpha"), BsonString("Beta"))),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
     fun `metric filters cannot use text search`() {
         assertThrows<QuerySchemaValidationException> {
             MongoAggregationCompiler(SnapshotFilterCompiler).compile(
@@ -931,6 +1097,15 @@ private val statusFilterSchema = schema(
 private val paidStatusGuard = BsonDocument(
     "\$eq",
     BsonArray(listOf(BsonString("\$state.status"), BsonString("PAID"))),
+)
+
+private val guardFilterSchema = schema(
+    field(
+        "state.productName",
+        QueryCapability.LITERAL_MATCH,
+        "state.productName",
+        additionalCapabilities = setOf(QueryCapability.EXACT_MATCH, QueryCapability.PRESENCE),
+    ),
 )
 
 private fun schema(vararg fields: Pair<QueryField, MongoTestField>) = mongoTestSchema(

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
@@ -234,6 +234,7 @@ class MongoAggregationCompilerInputTest {
     }
 }
 
+@Suppress("LargeClass")
 class MongoAggregationCompilerTest {
 
     @Test
@@ -835,6 +836,59 @@ class MongoAggregationCompilerTest {
         val countGuard = group.getDocument("__wow_value_count_total").getDocument("\$sum").getArray("\$cond")
         countGuard.get(0).asDocument().containsKey("\$isNumber").assert().isTrue()
         countGuard.get(0).asDocument().containsKey("\$and").assert().isFalse()
+    }
+
+    @Test
+    fun `metric filters cannot use text search`() {
+        assertThrows<QuerySchemaValidationException> {
+            MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+                aggregation { count("found") { "state.status" search "PAID" } },
+                statusFilterSchema,
+            )
+        }
+    }
+
+    @Test
+    fun `metric filters cannot use element match`() {
+        assertThrows<QuerySchemaValidationException> {
+            MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+                aggregation { count("orders") { "state.orders".elementMatch { "status" eq "PAID" } } },
+                schema(),
+            )
+        }
+    }
+
+    @Test
+    fun `metric filters cannot use contains all`() {
+        assertThrows<QuerySchemaValidationException> {
+            MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+                aggregation { count("tagged") { "state.status" containsAll listOf("A", "B") } },
+                statusFilterSchema,
+            )
+        }
+    }
+
+    @Test
+    fun `metric filters cannot filter on array valued fields`() {
+        val schema = schema(
+            QueryField("state.tags") to MongoTestField(
+                QueryValueSchema(
+                    kind = QueryValueKind.ARRAY,
+                    items = QueryValueSchema(QueryValueKind.SCALAR, valueTypes = setOf(QueryValueType.STRING)),
+                ),
+                setOf(QueryCapability.EXACT_MATCH),
+                "state.tags",
+            ),
+        )
+
+        assertThrows<QuerySchemaValidationException> {
+            MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+                aggregation { count("tagged") { "state.tags" eq "promo" } },
+                schema,
+            )
+        }.message.assert().isEqualTo(
+            "Aggregation metric filter field [state.tags] must be scalar; array fields are not supported in metric filters.",
+        )
     }
 
     @Test

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt
@@ -182,9 +182,20 @@ internal class ExampleDomainOpenAPITest {
             )
             metricSchema.discriminator.propertyName.assert().isEqualTo("type")
             (metricSchema.properties.getValue("alias").readOnly == true).assert().isFalse()
+            assertMetricFilterSchema(metricSchema)
             val anySchema = openAPI.components.schemas.getValue("wow.api.query.AggregationMetric.Any")
             anySchema.required.assert().containsExactlyInAnyOrder("field", "alias", "type")
             anySchema.properties.getValue("field").`$ref`.assert().isEqualTo(logicalFieldRef)
+        }
+
+        private fun assertMetricFilterSchema(metricSchema: Schema<*>) {
+            val filterRef = "#/components/schemas/wow.api.query.FilterExpression"
+            metricSchema.properties.getValue("filter").`$ref`.assert().isEqualTo(filterRef)
+            metricSchema.oneOf.mapNotNull { it.`$ref` }.forEach { metricRef ->
+                val concreteSchema = openAPI.components.schemas.getValue(metricRef.substringAfterLast('/'))
+                concreteSchema.properties.getValue("filter").`$ref`.assert().isEqualTo(filterRef)
+                concreteSchema.required.assert().doesNotContain("filter")
+            }
         }
 
         private fun assertFilterExpressionQueryFieldDefinition() {

--- a/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
@@ -4858,6 +4858,9 @@
         "properties" : {
           "alias" : {
             "type" : "string"
+          },
+          "filter" : {
+            "$ref" : "#/components/schemas/wow.api.query.FilterExpression"
           }
         }
       },
@@ -4868,6 +4871,9 @@
           },
           "field" : {
             "$ref" : "#/components/schemas/wow.api.query.QueryField"
+          },
+          "filter" : {
+            "$ref" : "#/components/schemas/wow.api.query.FilterExpression"
           },
           "type" : {
             "const" : "ANY"
@@ -4880,6 +4886,9 @@
         "properties" : {
           "alias" : {
             "type" : "string"
+          },
+          "filter" : {
+            "$ref" : "#/components/schemas/wow.api.query.FilterExpression"
           },
           "type" : {
             "const" : "COUNT"
@@ -4896,6 +4905,9 @@
           "expression" : {
             "$ref" : "#/components/schemas/wow.api.query.AggregationExpression"
           },
+          "filter" : {
+            "$ref" : "#/components/schemas/wow.api.query.FilterExpression"
+          },
           "type" : {
             "const" : "DISTINCT_COUNT"
           }
@@ -4910,6 +4922,9 @@
           },
           "expression" : {
             "$ref" : "#/components/schemas/wow.api.query.AggregationExpression"
+          },
+          "filter" : {
+            "$ref" : "#/components/schemas/wow.api.query.FilterExpression"
           },
           "function" : {
             "$ref" : "#/components/schemas/wow.api.query.AggregationFunction"
@@ -4928,6 +4943,9 @@
           },
           "expression" : {
             "$ref" : "#/components/schemas/wow.api.query.AggregationExpression"
+          },
+          "filter" : {
+            "$ref" : "#/components/schemas/wow.api.query.FilterExpression"
           },
           "percentile" : {
             "exclusiveMaximum" : 100,

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDsl.kt
@@ -72,8 +72,16 @@ class AggregationQueryDsl {
         metrics += AggregationMetric.Count(alias)
     }
 
+    fun count(alias: String, init: FilterDsl.() -> Unit) {
+        metrics += AggregationMetric.Count(alias, me.ahoo.wow.query.dsl.filter(init))
+    }
+
     fun any(field: String, alias: String) {
         metrics += AggregationMetric.Any(QueryField(field), alias)
+    }
+
+    fun any(field: String, alias: String, init: FilterDsl.() -> Unit) {
+        metrics += AggregationMetric.Any(QueryField(field), alias, me.ahoo.wow.query.dsl.filter(init))
     }
 
     fun field(name: String): AggregationExpression = AggregationExpression.Field(QueryField(name))
@@ -99,49 +107,101 @@ class AggregationQueryDsl {
 
     fun sum(field: String, alias: String) = sum(field(field), alias)
 
+    fun sum(field: String, alias: String, init: FilterDsl.() -> Unit) = sum(field(field), alias, init)
+
     fun avg(field: String, alias: String) = avg(field(field), alias)
+
+    fun avg(field: String, alias: String, init: FilterDsl.() -> Unit) = avg(field(field), alias, init)
 
     fun min(field: String, alias: String) = min(field(field), alias)
 
+    fun min(field: String, alias: String, init: FilterDsl.() -> Unit) = min(field(field), alias, init)
+
     fun max(field: String, alias: String) = max(field(field), alias)
+
+    fun max(field: String, alias: String, init: FilterDsl.() -> Unit) = max(field(field), alias, init)
 
     fun sum(expression: AggregationExpression, alias: String) =
         numeric(AggregationFunction.SUM, expression, alias)
 
+    fun sum(expression: AggregationExpression, alias: String, init: FilterDsl.() -> Unit) =
+        numeric(AggregationFunction.SUM, expression, alias, init)
+
     fun avg(expression: AggregationExpression, alias: String) =
         numeric(AggregationFunction.AVG, expression, alias)
+
+    fun avg(expression: AggregationExpression, alias: String, init: FilterDsl.() -> Unit) =
+        numeric(AggregationFunction.AVG, expression, alias, init)
 
     fun min(expression: AggregationExpression, alias: String) =
         numeric(AggregationFunction.MIN, expression, alias)
 
+    fun min(expression: AggregationExpression, alias: String, init: FilterDsl.() -> Unit) =
+        numeric(AggregationFunction.MIN, expression, alias, init)
+
     fun max(expression: AggregationExpression, alias: String) =
         numeric(AggregationFunction.MAX, expression, alias)
 
+    fun max(expression: AggregationExpression, alias: String, init: FilterDsl.() -> Unit) =
+        numeric(AggregationFunction.MAX, expression, alias, init)
+
     fun distinctCount(field: String, alias: String) = distinctCount(field(field), alias)
+
+    fun distinctCount(field: String, alias: String, init: FilterDsl.() -> Unit) =
+        distinctCount(field(field), alias, init)
 
     fun distinctCount(expression: AggregationExpression, alias: String) {
         metrics += AggregationMetric.DistinctCount(expression, alias)
     }
 
+    fun distinctCount(expression: AggregationExpression, alias: String, init: FilterDsl.() -> Unit) {
+        metrics += AggregationMetric.DistinctCount(expression, alias, me.ahoo.wow.query.dsl.filter(init))
+    }
+
     fun stddev(field: String, alias: String) = stddev(field(field), alias)
+
+    fun stddev(field: String, alias: String, init: FilterDsl.() -> Unit) =
+        stddev(field(field), alias, init)
 
     fun stddev(expression: AggregationExpression, alias: String) =
         numeric(AggregationFunction.STDDEV, expression, alias)
 
+    fun stddev(expression: AggregationExpression, alias: String, init: FilterDsl.() -> Unit) =
+        numeric(AggregationFunction.STDDEV, expression, alias, init)
+
     fun variance(field: String, alias: String) = variance(field(field), alias)
+
+    fun variance(field: String, alias: String, init: FilterDsl.() -> Unit) =
+        variance(field(field), alias, init)
 
     fun variance(expression: AggregationExpression, alias: String) =
         numeric(AggregationFunction.VARIANCE, expression, alias)
 
+    fun variance(expression: AggregationExpression, alias: String, init: FilterDsl.() -> Unit) =
+        numeric(AggregationFunction.VARIANCE, expression, alias, init)
+
     fun percentile(field: String, p: Double, alias: String) = percentile(field(field), p, alias)
+
+    fun percentile(field: String, p: Double, alias: String, init: FilterDsl.() -> Unit) =
+        percentile(field(field), p, alias, init)
 
     fun percentile(expression: AggregationExpression, p: Double, alias: String) {
         metrics += AggregationMetric.Percentile(expression, p, alias)
     }
 
+    fun percentile(expression: AggregationExpression, p: Double, alias: String, init: FilterDsl.() -> Unit) {
+        metrics += AggregationMetric.Percentile(expression, p, alias, me.ahoo.wow.query.dsl.filter(init))
+    }
+
     fun median(field: String, alias: String) = median(field(field), alias)
 
+    fun median(field: String, alias: String, init: FilterDsl.() -> Unit) =
+        median(field(field), alias, init)
+
     fun median(expression: AggregationExpression, alias: String) = percentile(expression, 50.0, alias)
+
+    fun median(expression: AggregationExpression, alias: String, init: FilterDsl.() -> Unit) =
+        percentile(expression, 50.0, alias, init)
 
     private fun numeric(
         function: AggregationFunction,
@@ -149,6 +209,15 @@ class AggregationQueryDsl {
         alias: String,
     ) {
         metrics += AggregationMetric.Numeric(function, expression, alias)
+    }
+
+    private fun numeric(
+        function: AggregationFunction,
+        expression: AggregationExpression,
+        alias: String,
+        init: FilterDsl.() -> Unit,
+    ) {
+        metrics += AggregationMetric.Numeric(function, expression, alias, me.ahoo.wow.query.dsl.filter(init))
     }
 
     fun sort(sort: List<Sort>) {

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaValidation.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaValidation.kt
@@ -141,13 +141,14 @@ private class QueryValidator(private val schema: QueryModelSchema) {
         when (expression) {
             MatchAllFilter, MatchNoneFilter -> Unit
             is IdFilter, is IdsFilter -> metadata(
-                if (schema.model == QueryModel.EVENT_STREAM) MessageRecords.ID else MessageRecords.AGGREGATE_ID
+                if (schema.model == QueryModel.EVENT_STREAM) MessageRecords.ID else MessageRecords.AGGREGATE_ID,
+                parent
             )
-            is AggregateIdFilter, is AggregateIdsFilter -> metadata(MessageRecords.AGGREGATE_ID)
-            is TenantIdFilter -> metadata(MessageRecords.TENANT_ID)
-            is OwnerIdFilter -> metadata(MessageRecords.OWNER_ID)
-            is SpaceIdFilter -> metadata(MessageRecords.SPACE_ID)
-            is DeletionFilter -> metadata(StateAggregateRecords.DELETED)
+            is AggregateIdFilter, is AggregateIdsFilter -> metadata(MessageRecords.AGGREGATE_ID, parent)
+            is TenantIdFilter -> metadata(MessageRecords.TENANT_ID, parent)
+            is OwnerIdFilter -> metadata(MessageRecords.OWNER_ID, parent)
+            is SpaceIdFilter -> metadata(MessageRecords.SPACE_ID, parent)
+            is DeletionFilter -> metadata(StateAggregateRecords.DELETED, parent)
             is AndFilter -> expression.operands.forEach { filter(it, parent) }
             is OrFilter -> expression.operands.forEach { filter(it, parent) }
             is NorFilter -> expression.operands.forEach { filter(it, parent) }
@@ -205,7 +206,13 @@ private class QueryValidator(private val schema: QueryModelSchema) {
         }
     }
 
-    private fun metadata(name: String) { field(QueryField(name), QueryCapability.EXACT_MATCH) }
+    private fun metadata(name: String, parent: QueryField?) {
+        field(
+            QueryField(name),
+            QueryCapability.EXACT_MATCH,
+            parent
+        )
+    }
 
     private fun equality(name: QueryField, value: JsonNode, parent: QueryField?) {
         if (value.isNull) {
@@ -287,6 +294,9 @@ private class QueryValidator(private val schema: QueryModelSchema) {
             aggregationField(group.field, setOf(capability), parent)
         }
         query.metrics.forEach { metric ->
+            if (metric.filter !== MatchAllFilter) {
+                filter(metric.filter, parent)
+            }
             when (metric) {
                 is AggregationMetric.Count -> Unit
                 is AggregationMetric.Any -> requireSchema(

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt
@@ -20,6 +20,8 @@ import me.ahoo.wow.api.query.AggregationExpressionOperator
 import me.ahoo.wow.api.query.AggregationFunction
 import me.ahoo.wow.api.query.AggregationGroup
 import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.EqualFilter
+import me.ahoo.wow.api.query.GreaterThanFilter
 import me.ahoo.wow.api.query.QueryField
 import org.junit.jupiter.api.Test
 import java.time.ZoneId
@@ -156,5 +158,64 @@ class AggregationQueryDslTest {
                 "amtMedian",
             ),
         )
+    }
+
+    @Test
+    fun `aggregation DSL should apply metric filters`() {
+        val query = aggregation {
+            terms("status", "status")
+            count("paid") { "status" eq "PAID" }
+            sum("amount", "paidAmount") { "status" eq "PAID" }
+            distinctCount(field("customerId"), "customers") { "amount" gt 0 }
+            percentile("amount", 95.0, "p95") { "status" eq "PAID" }
+        }
+
+        query.metrics.filterIsInstance<AggregationMetric.Count>().single().filter.assert()
+            .isInstanceOf(EqualFilter::class.java)
+        query.metrics.filterIsInstance<AggregationMetric.Numeric>().single().filter.assert()
+            .isInstanceOf(EqualFilter::class.java)
+        query.metrics.filterIsInstance<AggregationMetric.DistinctCount>().single().filter.assert()
+            .isInstanceOf(GreaterThanFilter::class.java)
+        query.metrics.filterIsInstance<AggregationMetric.Percentile>().single().filter.assert()
+            .isInstanceOf(EqualFilter::class.java)
+    }
+
+    @Test
+    fun `aggregation DSL should apply metric filters to every metric overload`() {
+        val query = aggregation {
+            terms("status", "status")
+            any("productName", "anyName") { "status" eq "PAID" }
+            avg("amount", "avgAmount") { "status" eq "PAID" }
+            min("amount", "minAmount") { "status" eq "PAID" }
+            max("amount", "maxAmount") { "status" eq "PAID" }
+            stddev("amount", "stddevAmount") { "status" eq "PAID" }
+            variance("amount", "varianceAmount") { "status" eq "PAID" }
+            median("amount", "medianAmount") { "amount" gt 0 }
+            sum(field("amount"), "sumExprAmount") { "status" eq "PAID" }
+            avg(field("amount"), "avgExprAmount") { "status" eq "PAID" }
+            min(field("amount"), "minExprAmount") { "status" eq "PAID" }
+            max(field("amount"), "maxExprAmount") { "status" eq "PAID" }
+            stddev(field("amount"), "stddevExprAmount") { "status" eq "PAID" }
+            variance(field("amount"), "varianceExprAmount") { "status" eq "PAID" }
+            distinctCount("customerId", "fieldCustomers") { "amount" gt 0 }
+            percentile(field("amount"), 95.0, "exprP95") { "status" eq "PAID" }
+            median(field("amount"), "exprMedian") { "amount" gt 0 }
+        }
+
+        val metricsByAlias = query.metrics.associateBy { it.alias }
+        metricsByAlias.keys.assert().hasSize(16)
+        val greaterThanAliases = setOf("medianAmount", "fieldCustomers", "exprMedian")
+        metricsByAlias.values.forEach { metric ->
+            val expectedType = if (metric.alias in greaterThanAliases) {
+                GreaterThanFilter::class.java
+            } else {
+                EqualFilter::class.java
+            }
+            metric.filter.assert().isInstanceOf(expectedType)
+        }
+        query.metrics.filterIsInstance<AggregationMetric.Percentile>()
+            .map(AggregationMetric.Percentile::percentile)
+            .assert()
+            .containsExactly(50.0, 95.0, 50.0)
     }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaValidationTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaValidationTest.kt
@@ -417,6 +417,52 @@ class QuerySchemaValidationTest {
     }
 
     @Test
+    fun `metric filters follow the current scope for root and element contexts`() {
+        val schema = boundSchemaFixture(
+            objectFixture(
+                "tenantId" to scalarFixture(),
+                "orders" to arrayFixture(
+                    objectFixture("status" to scalarFixture(), "amount" to scalarFixture(QueryValueType.DECIMAL))
+                )
+            )
+        )
+        // Root scope: metric filters may use root-level filters (tenantId is declared at the root).
+        validateQuery(
+            aggregation {
+                count("tenantOrders") { tenantId("tenant") }
+            },
+            schema,
+        ).assert().isNotNull()
+        // Element scope: root-level fields are rejected through filter()'s element-scope validation.
+        assertThrows<QuerySchemaValidationException> {
+            validateQuery(
+                aggregation {
+                    expand("orders")
+                    count("counted") { tenantId("tenant") }
+                },
+                schema,
+            )
+        }
+        // Element scope: fields of the current scope are legal; unknown fields are rejected.
+        validateQuery(
+            aggregation {
+                expand("orders")
+                count("paid") { "status" eq "PAID" }
+            },
+            schema,
+        ).assert().isNotNull()
+        assertThrows<QuerySchemaValidationException> {
+            validateQuery(
+                aggregation {
+                    expand("orders")
+                    sum("missing", "total") { "status" eq "PAID" }
+                },
+                schema,
+            )
+        }
+    }
+
+    @Test
     fun `distinct count accepts terms or numeric fields and rejects others while percentile follows numeric rules`() {
         val both = boundSchemaFixture(
             objectFixture(

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaValidationTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaValidationTest.kt
@@ -460,6 +460,15 @@ class QuerySchemaValidationTest {
                 schema,
             )
         }
+        // Unfiltered metrics (MatchAllFilter) skip metric filter validation inside element scope.
+        validateQuery(
+            aggregation {
+                expand("orders")
+                count("all")
+                sum("amount", "total")
+            },
+            schema,
+        ).assert().isNotNull()
     }
 
     @Test

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuard.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuard.kt
@@ -105,7 +105,10 @@ class HttpQueryGuard(
             is AggregationQuery -> {
                 validateResultSize(query.limit, "aggregation")
                 validateFilters(
-                    listOf(query.filter) + query.elements.map(AggregationElement::filter) + scopeFilters,
+                    listOf(query.filter) +
+                        query.elements.map(AggregationElement::filter) +
+                        query.metrics.map(AggregationMetric::filter).filter { it !== MatchAllFilter } +
+                        scopeFilters,
                     rejectMatchAll = false,
                 )
                 require(allowExpensiveOperators || query.elements.isEmpty()) {

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardTest.kt
@@ -45,6 +45,7 @@ import me.ahoo.wow.api.query.Sort
 import me.ahoo.wow.api.query.StringComparison
 import me.ahoo.wow.api.query.TenantIdFilter
 import me.ahoo.wow.query.QueryGateway
+import me.ahoo.wow.query.dsl.aggregation
 import me.ahoo.wow.query.dsl.filterExpression
 import me.ahoo.wow.query.filter.QueryType
 import me.ahoo.wow.serialization.MessageRecords
@@ -214,6 +215,17 @@ class HttpQueryGuardTest {
             QueryType.AGGREGATION,
             valueHeavy,
             guard(maxFilterValues = 1, allowExpensiveOperators = true),
+        )
+    }
+
+    @Test
+    fun `aggregation metric filters count toward filter value limits`() {
+        expectRejected(
+            QueryType.AGGREGATION,
+            aggregation {
+                count("statuses") { "status" isIn listOf("PAID", "SHIPPED", "CANCELLED") }
+            },
+            guard(maxFilterValues = 2),
         )
     }
 


### PR DESCRIPTION
## Goal

报表场景 Phase 1（漏斗/状态对比）：同一分组内按不同条件分别计数/聚合，如趋势图上同图叠加「创建数 / 支付数 / 发货数」。Epic 总设计见 `documentation/designs/2026-09-12-aggregation-reporting-epic-design.md`（本 PR 为其 Phase 1，含实施计划）。

## Changes

- **wow-api**：`AggregationMetric` 五个子类型新增记录级 `filter: FilterExpression = MatchAllFilter`（sealed 接口级声明、末位参数、Jackson 3 CUSTOM valueFilter 省略默认值——无过滤的 JSON 与现状字节兼容）
- **wow-query**：20 个 DSL 尾 lambda 过滤重载（`count("paid") { "status" eq "PAID" }`）
- **验证**：metric filter 走既有作用域校验（根作用域根级过滤器合法 / element 作用域拒绝）；修复 `metadata()` 丢弃 parent 的潜在验证缺口（行为保持，由两处 AST 构造期守卫证明）
- **wow-webflux**：metric filter 并入 `validateFilters`（节点数/`maxFilterValues` 值数/昂贵算子门控一致适用；本身不属昂贵算子）
- **wow-mongo**：match 文档→聚合表达式翻译器（`$cond` 守卫包裹参与值；null/missing 保真；`BsonRegularExpression`→`$regexMatch`；算子层 fail-closed）；`COUNT+filter` → 条件计数
- **wow-elasticsearch**：filter 子聚合包裹（`COUNT+filter` 复用 alias 名读 `doc_count`；其余指标 `__wow_metric_filter_<alias>` 包裹含 valueCount 守卫）
- **跨后端一致限制**（编译期拒绝）：metric filter 字段必须标量；`SearchFilter`/`$elemMatch`/`$all` 不支持
- **TCK**：9 个跨后端契约场景（漏斗、条件数值/去重/百分位、空匹配 0/null 分类法、element 叠加、按 filter 指标排序含 null 行居末、最内层作用域、null-vs-missing、literal-match）
- **OpenAPI/文档**：快照纯增量（六处 `filter` ref）；中英文档（语义、限制、MongoDB 5.0+ 版本要求、近似边界注记）+ 漏斗场景

## Verification

- `./gradlew :wow-api:check :wow-query:check :wow-mongo:check :wow-elasticsearch:check :wow-webflux:check :wow-openapi:check` — 全绿
- `./gradlew :wow-mongo:integrationTest :wow-elasticsearch:integrationTest`（Testcontainers）— Mongo 199/0、ES 176/0
- `./gradlew allLocalTest allContractTest` — 3,600+ / 191，0 失败
- `./gradlew detekt` — 通过；`documentation` `pnpm docs:build` — 无死链
- 全程严格 TDD；过程中发现并修复三个真实缺陷（数组字段语义静默分歧、SearchFilter 跨后端分歧、翻译器 regex 分支死代码——末者活库双重 RED 复现后修复并钉死测试）

## Compatibility and risks

- [x] This change preserves public API and generated contract compatibility.（wire 纯增量：无过滤 JSON 字节不变；OpenAPI 快照纯增量；位置构造兼容）
- [x] Tests cover the changed behavior or the verification alternative is explained.
- [x] Documentation is updated when user-visible behavior changes.
- [x] Comments and API documentation explain non-obvious constraints and remain accurate after this change.
- [x] No credentials, generated build output, or local environment files are included.

- **版本要求**：metric filter 在 MongoDB 后端需 5.0+（守卫表达式 `$not`；`PERCENTILE` 指标仍需 7.0+），仅文档注明，不做运行时门控
- **已知近似边界**（文档注明）：Mongo `$gt/$lt` 族按 BSON 全序而非 match 类型分档；`$regex` 遇非字符串输入报错而非静默不匹配
- **能力子集**：数组值字段与 `SearchFilter`/`$elemMatch`/`$all` 在 metric filter 中双后端一致拒绝（编译期清晰报错）
- 旧查询与旧客户端完全不受影响；无数据/迁移影响