### PR TITLE
refactor(query): consolidate metric filter validation and extract mongo guard translator

### DIFF
--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationCompiler.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationCompiler.kt
@@ -21,8 +21,6 @@ import co.elastic.clients.elasticsearch._types.mapping.RuntimeFieldType
 import co.elastic.clients.elasticsearch._types.query_dsl.Query
 import co.elastic.clients.json.JsonData
 import co.elastic.clients.util.NamedValue
-import me.ahoo.wow.api.query.AggregateIdFilter
-import me.ahoo.wow.api.query.AggregateIdsFilter
 import me.ahoo.wow.api.query.AggregationDateUnit
 import me.ahoo.wow.api.query.AggregationExpression
 import me.ahoo.wow.api.query.AggregationExpressionOperator
@@ -30,43 +28,9 @@ import me.ahoo.wow.api.query.AggregationFunction
 import me.ahoo.wow.api.query.AggregationGroup
 import me.ahoo.wow.api.query.AggregationMetric
 import me.ahoo.wow.api.query.AggregationQuery
-import me.ahoo.wow.api.query.AndFilter
-import me.ahoo.wow.api.query.BetweenFilter
-import me.ahoo.wow.api.query.ContainsAllFilter
-import me.ahoo.wow.api.query.ContainsFilter
-import me.ahoo.wow.api.query.DeletionFilter
-import me.ahoo.wow.api.query.ElementMatchFilter
-import me.ahoo.wow.api.query.EndsWithFilter
-import me.ahoo.wow.api.query.EqualFilter
-import me.ahoo.wow.api.query.ExistsFilter
-import me.ahoo.wow.api.query.FilterExpression
-import me.ahoo.wow.api.query.GreaterThanFilter
-import me.ahoo.wow.api.query.GreaterThanOrEqualFilter
-import me.ahoo.wow.api.query.IdFilter
-import me.ahoo.wow.api.query.IdsFilter
-import me.ahoo.wow.api.query.InFilter
-import me.ahoo.wow.api.query.IsEmptyFilter
-import me.ahoo.wow.api.query.IsEmptyStringFilter
-import me.ahoo.wow.api.query.IsNotEmptyStringFilter
-import me.ahoo.wow.api.query.IsNotNullFilter
-import me.ahoo.wow.api.query.IsNullFilter
-import me.ahoo.wow.api.query.LessThanFilter
-import me.ahoo.wow.api.query.LessThanOrEqualFilter
 import me.ahoo.wow.api.query.MatchAllFilter
-import me.ahoo.wow.api.query.MatchNoneFilter
-import me.ahoo.wow.api.query.NorFilter
-import me.ahoo.wow.api.query.NotEqualFilter
-import me.ahoo.wow.api.query.NotExistsFilter
-import me.ahoo.wow.api.query.NotInFilter
-import me.ahoo.wow.api.query.OrFilter
-import me.ahoo.wow.api.query.OwnerIdFilter
 import me.ahoo.wow.api.query.QueryField
-import me.ahoo.wow.api.query.RelativeTimeFilter
-import me.ahoo.wow.api.query.SearchFilter
 import me.ahoo.wow.api.query.Sort
-import me.ahoo.wow.api.query.SpaceIdFilter
-import me.ahoo.wow.api.query.StartsWithFilter
-import me.ahoo.wow.api.query.TenantIdFilter
 import me.ahoo.wow.api.query.schema.QueryCapability
 import me.ahoo.wow.api.query.schema.QueryCardinality
 import me.ahoo.wow.api.query.schema.QueryValueKind
@@ -78,6 +42,7 @@ import me.ahoo.wow.query.schema.QuerySchemaValidationException
 import me.ahoo.wow.query.schema.QueryValueSchema
 import me.ahoo.wow.query.schema.distinctCountCapability
 import me.ahoo.wow.query.schema.physicalField
+import me.ahoo.wow.query.schema.requireScalarMetricFilterFields
 import java.time.Instant
 import java.util.concurrent.TimeUnit
 
@@ -559,66 +524,3 @@ internal class ElasticsearchAggregationCompiler(
             TimeUnit.DAYS -> 86_400_000L to 1L
         }
 }
-
-/**
- * Filter aggregations keep Elasticsearch's element-matching semantics over array fields while
- * MongoDB metric guards compare whole values, so array-valued fields, [ElementMatchFilter],
- * and [SearchFilter] are rejected to mirror the MongoDB compiler's scalar-only metric filter contract.
- */
-@Suppress("CyclomaticComplexMethod", "LongMethod")
-private fun FilterExpression.requireScalarMetricFilterFields(
-    parent: QueryField?,
-    schema: QueryModelSchema,
-) {
-    when (this) {
-        MatchAllFilter, MatchNoneFilter,
-        is IdFilter, is IdsFilter, is AggregateIdFilter, is AggregateIdsFilter,
-        is TenantIdFilter, is OwnerIdFilter, is SpaceIdFilter, is DeletionFilter,
-        -> Unit
-
-        is AndFilter -> operands.forEach { it.requireScalarMetricFilterFields(parent, schema) }
-        is OrFilter -> operands.forEach { it.requireScalarMetricFilterFields(parent, schema) }
-        is NorFilter -> operands.forEach { it.requireScalarMetricFilterFields(parent, schema) }
-        is ElementMatchFilter -> throw QuerySchemaValidationException(
-            "Elasticsearch metric filters cannot translate [ELEMENT_MATCH] into a filter aggregation.",
-        )
-        is SearchFilter -> throw QuerySchemaValidationException(
-            "Aggregation metric filters do not support search filters.",
-        )
-        is RelativeTimeFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is EqualFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is NotEqualFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is GreaterThanFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is GreaterThanOrEqualFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is LessThanFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is LessThanOrEqualFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is BetweenFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is ContainsFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is StartsWithFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is EndsWithFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is InFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is NotInFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is ContainsAllFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is IsEmptyFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is IsEmptyStringFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is IsNotEmptyStringFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is IsNullFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is IsNotNullFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is ExistsFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is NotExistsFilter -> field.requireScalarMetricFilterField(parent, schema)
-    }
-}
-
-private fun QueryField.requireScalarMetricFilterField(parent: QueryField?, schema: QueryModelSchema) {
-    val logical = parent?.append(this) ?: this
-    val value = schema.field(logical)?.value ?: return
-    if (value.isArrayValued) {
-        throw QuerySchemaValidationException(
-            "Aggregation metric filter field [$logical] must be scalar; array fields are not supported in metric filters.",
-        )
-    }
-}
-
-private val QueryValueSchema.isArrayValued: Boolean
-    get() = kind == QueryValueKind.ARRAY ||
-        (kind == QueryValueKind.UNION && alternatives.any { it.kind == QueryValueKind.ARRAY })

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoAggregationCompiler.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoAggregationCompiler.kt
@@ -19,8 +19,6 @@ import com.mongodb.client.model.BsonField
 import com.mongodb.client.model.Filters
 import com.mongodb.client.model.Projections
 import com.mongodb.client.model.Sorts
-import me.ahoo.wow.api.query.AggregateIdFilter
-import me.ahoo.wow.api.query.AggregateIdsFilter
 import me.ahoo.wow.api.query.AggregationDateUnit
 import me.ahoo.wow.api.query.AggregationExpression
 import me.ahoo.wow.api.query.AggregationExpressionOperator
@@ -28,59 +26,19 @@ import me.ahoo.wow.api.query.AggregationFunction
 import me.ahoo.wow.api.query.AggregationGroup
 import me.ahoo.wow.api.query.AggregationMetric
 import me.ahoo.wow.api.query.AggregationQuery
-import me.ahoo.wow.api.query.AndFilter
-import me.ahoo.wow.api.query.BetweenFilter
-import me.ahoo.wow.api.query.ContainsAllFilter
-import me.ahoo.wow.api.query.ContainsFilter
-import me.ahoo.wow.api.query.DeletionFilter
-import me.ahoo.wow.api.query.ElementMatchFilter
-import me.ahoo.wow.api.query.EndsWithFilter
-import me.ahoo.wow.api.query.EqualFilter
-import me.ahoo.wow.api.query.ExistsFilter
-import me.ahoo.wow.api.query.FilterExpression
-import me.ahoo.wow.api.query.GreaterThanFilter
-import me.ahoo.wow.api.query.GreaterThanOrEqualFilter
-import me.ahoo.wow.api.query.IdFilter
-import me.ahoo.wow.api.query.IdsFilter
-import me.ahoo.wow.api.query.InFilter
-import me.ahoo.wow.api.query.IsEmptyFilter
-import me.ahoo.wow.api.query.IsEmptyStringFilter
-import me.ahoo.wow.api.query.IsNotEmptyStringFilter
-import me.ahoo.wow.api.query.IsNotNullFilter
-import me.ahoo.wow.api.query.IsNullFilter
-import me.ahoo.wow.api.query.LessThanFilter
-import me.ahoo.wow.api.query.LessThanOrEqualFilter
 import me.ahoo.wow.api.query.MatchAllFilter
-import me.ahoo.wow.api.query.MatchNoneFilter
-import me.ahoo.wow.api.query.NorFilter
-import me.ahoo.wow.api.query.NotEqualFilter
-import me.ahoo.wow.api.query.NotExistsFilter
-import me.ahoo.wow.api.query.NotInFilter
-import me.ahoo.wow.api.query.OrFilter
-import me.ahoo.wow.api.query.OwnerIdFilter
 import me.ahoo.wow.api.query.QueryField
-import me.ahoo.wow.api.query.RelativeTimeFilter
-import me.ahoo.wow.api.query.SearchFilter
 import me.ahoo.wow.api.query.Sort
-import me.ahoo.wow.api.query.SpaceIdFilter
-import me.ahoo.wow.api.query.StartsWithFilter
-import me.ahoo.wow.api.query.TenantIdFilter
 import me.ahoo.wow.api.query.schema.QueryCapability
 import me.ahoo.wow.api.query.schema.QueryValueKind
 import me.ahoo.wow.api.query.schema.Temporal
 import me.ahoo.wow.mongo.query.AbstractMongoFilterCompiler
 import me.ahoo.wow.query.schema.QueryModelSchema
 import me.ahoo.wow.query.schema.QuerySchemaValidationException
-import me.ahoo.wow.query.schema.QueryValueSchema
-import me.ahoo.wow.query.schema.absoluteLogicalField
 import me.ahoo.wow.query.schema.distinctCountCapability
 import me.ahoo.wow.query.schema.operationValues
 import me.ahoo.wow.query.schema.physicalField
-import org.bson.BsonArray
-import org.bson.BsonDocument
-import org.bson.BsonNull
-import org.bson.BsonRegularExpression
-import org.bson.BsonValue
+import me.ahoo.wow.query.schema.requireScalarMetricFilterFields
 import org.bson.Document
 import org.bson.conversions.Bson
 import java.time.Instant
@@ -705,210 +663,3 @@ internal class MongoAggregationCompiler(
     private val AggregationMetric.countAlias: String
         get() = "__wow_value_count_$alias"
 }
-
-/**
- * MongoDB evaluates a match document in expression position as a truthy object literal,
- * so a `$cond` guard must re-express the compiled predicate with aggregation operators.
- * The translation covers every shape [AbstractMongoFilterCompiler] emits and preserves
- * its null-versus-missing match semantics.
- */
-private fun Bson.toGuardCondition(): Any = toGuardCondition(toBsonDocument())
-
-/**
- * Guard expressions compare whole values while `$match` matches array elements,
- * so filters over array-valued fields are rejected instead of diverging silently.
- */
-@Suppress("CyclomaticComplexMethod", "LongMethod")
-private fun FilterExpression.requireScalarMetricFilterFields(
-    parent: QueryField?,
-    schema: QueryModelSchema,
-) {
-    when (this) {
-        MatchAllFilter, MatchNoneFilter,
-        is IdFilter, is IdsFilter, is AggregateIdFilter, is AggregateIdsFilter,
-        is TenantIdFilter, is OwnerIdFilter, is SpaceIdFilter, is DeletionFilter, is SearchFilter,
-        -> Unit
-
-        is AndFilter -> operands.forEach { it.requireScalarMetricFilterFields(parent, schema) }
-        is OrFilter -> operands.forEach { it.requireScalarMetricFilterFields(parent, schema) }
-        is NorFilter -> operands.forEach { it.requireScalarMetricFilterFields(parent, schema) }
-        is ElementMatchFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is RelativeTimeFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is EqualFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is NotEqualFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is GreaterThanFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is GreaterThanOrEqualFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is LessThanFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is LessThanOrEqualFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is BetweenFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is ContainsFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is StartsWithFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is EndsWithFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is InFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is NotInFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is ContainsAllFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is IsEmptyFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is IsEmptyStringFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is IsNotEmptyStringFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is IsNullFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is IsNotNullFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is ExistsFilter -> field.requireScalarMetricFilterField(parent, schema)
-        is NotExistsFilter -> field.requireScalarMetricFilterField(parent, schema)
-    }
-}
-
-private fun QueryField.requireScalarMetricFilterField(parent: QueryField?, schema: QueryModelSchema) {
-    val logical = absoluteLogicalField(this, parent)
-    val value = schema.field(logical)?.value ?: return
-    if (value.isArrayValued) {
-        throw QuerySchemaValidationException(
-            "Aggregation metric filter field [$logical] must be scalar; array fields are not supported in metric filters.",
-        )
-    }
-}
-
-private val QueryValueSchema.isArrayValued: Boolean
-    get() = kind == QueryValueKind.ARRAY ||
-        (kind == QueryValueKind.UNION && alternatives.any { it.kind == QueryValueKind.ARRAY })
-
-private fun toGuardCondition(document: BsonDocument): Any =
-    if (document.size == 0) {
-        Document("\$literal", true)
-    } else {
-        toGuardCondition(document.entries.single())
-    }
-
-private fun toGuardCondition(entry: Map.Entry<String, BsonValue>): Any {
-    val path = entry.key
-    val condition = entry.value
-    return when {
-        path == "\$and" || path == "\$or" ->
-            Document(path, condition.asArray().map { toGuardCondition(it.asDocument()) })
-
-        path == "\$nor" -> Document(
-            "\$not",
-            listOf(
-                Document(
-                    "\$or",
-                    condition.asArray().map { toGuardCondition(it.asDocument()) },
-                ),
-            ),
-        )
-
-        path.startsWith("\$") -> throw QuerySchemaValidationException(
-            "MongoDB metric filters cannot translate operator [$path] into a guard condition.",
-        )
-
-        else -> toGuardCondition(path, condition)
-    }
-}
-
-private fun toGuardCondition(path: String, condition: BsonValue): Any {
-    if (condition.isNull) {
-        return matchesNull(path)
-    }
-    if (condition.isRegularExpression) {
-        return regexGuard(path, condition.asRegularExpression())
-    }
-    if (!condition.isDocument) {
-        return Document("\$eq", listOf(fieldRef(path), condition.literalOperand()))
-    }
-    val document = condition.asDocument()
-    if (document.containsKey("\$elemMatch")) {
-        throw QuerySchemaValidationException(
-            "MongoDB metric filters cannot translate [\$elemMatch] into a guard condition.",
-        )
-    }
-    return document.entries.single().let { (operator, value) -> toGuardCondition(path, operator, value) }
-}
-
-@Suppress("CyclomaticComplexMethod")
-private fun toGuardCondition(path: String, operator: String, value: BsonValue): Any = when (operator) {
-    "\$ne" -> if (value.isNull) {
-        Document("\$and", listOf(Document("\$ne", listOf(fieldRef(path), null)), isPresent(path)))
-    } else {
-        Document("\$ne", listOf(fieldRef(path), value.literalOperand()))
-    }
-
-    "\$gt", "\$gte", "\$lt", "\$lte" -> Document(operator, listOf(fieldRef(path), value.literalOperand()))
-    "\$in" -> inGuard(path, value.asArray())
-    "\$nin" -> Document("\$not", listOf(inGuard(path, value.asArray())))
-    "\$exists" -> if (value.asBoolean().value) {
-        isPresent(path)
-    } else {
-        Document("\$eq", listOf(typeOf(path), "missing"))
-    }
-
-    "\$size" -> {
-        val size = value.asNumber().intValue()
-        Document(
-            "\$eq",
-            listOf(
-                Document(
-                    "\$size",
-                    Document(
-                        "\$cond",
-                        listOf(
-                            Document("\$isArray", listOf(fieldRef(path))),
-                            fieldRef(path),
-                            BsonArray(List(size + 1) { BsonNull.VALUE }),
-                        ),
-                    ),
-                ),
-                size,
-            ),
-        )
-    }
-
-    else -> throw QuerySchemaValidationException(
-        "MongoDB metric filters cannot translate operator [$operator] into a guard condition.",
-    )
-}
-
-private fun matchesNull(path: String): Any = Document(
-    "\$or",
-    listOf(
-        Document("\$eq", listOf(fieldRef(path), null)),
-        Document("\$eq", listOf(typeOf(path), "missing")),
-    ),
-)
-
-/**
- * A string operand starting with `$` would be parsed as a field reference in expression
- * position, so such operands are pinned with `$literal`; every other operand keeps its shape.
- */
-private fun BsonValue.literalOperand(): BsonValue =
-    if (isString && asString().value.startsWith("$")) {
-        BsonDocument("\$literal", this)
-    } else {
-        this
-    }
-
-private fun inGuard(path: String, values: BsonArray): Any = Document(
-    "\$in",
-    listOf(fieldRef(path), BsonArray(values.map { it.literalOperand() })),
-)
-
-/**
- * `$regexMatch` errors on non-string input while `$match` regex semantics never match one,
- * so the guard applies only to string values; null and missing inputs never match.
- */
-private fun regexGuard(path: String, regex: BsonRegularExpression): Document {
-    val input = fieldRef(path)
-    val condition = Document("input", input).append("regex", regex.pattern)
-    regex.options?.takeIf { it.isNotEmpty() }?.let { condition.append("options", it) }
-    return Document(
-        "\$cond",
-        listOf(
-            Document("\$eq", listOf(typeOf(path), "string")),
-            Document("\$regexMatch", condition),
-            false,
-        ),
-    )
-}
-
-private fun fieldRef(path: String): String = "\$$path"
-
-private fun typeOf(path: String): Document = Document("\$type", fieldRef(path))
-
-private fun isPresent(path: String): Document = Document("\$ne", listOf(typeOf(path), "missing"))

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoMetricFilterGuards.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoMetricFilterGuards.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.mongo.query.aggregation
+
+import me.ahoo.wow.query.schema.QuerySchemaValidationException
+import org.bson.BsonArray
+import org.bson.BsonDocument
+import org.bson.BsonNull
+import org.bson.BsonRegularExpression
+import org.bson.BsonValue
+import org.bson.Document
+import org.bson.conversions.Bson
+
+/**
+ * MongoDB evaluates a match document in expression position as a truthy object literal,
+ * so a `$cond` guard must re-express the compiled predicate with aggregation operators.
+ * The translation covers every shape [me.ahoo.wow.mongo.query.AbstractMongoFilterCompiler]
+ * emits — [me.ahoo.wow.query.schema.requireScalarMetricFilterFields] has already rejected
+ * the filters it cannot express — and preserves its null-versus-missing match semantics.
+ */
+internal fun Bson.toGuardCondition(): Any = toGuardCondition(toBsonDocument())
+
+private fun toGuardCondition(document: BsonDocument): Any =
+    if (document.size == 0) {
+        Document("\$literal", true)
+    } else {
+        toGuardCondition(document.entries.single())
+    }
+
+private fun toGuardCondition(entry: Map.Entry<String, BsonValue>): Any {
+    val path = entry.key
+    val condition = entry.value
+    return when {
+        path == "\$and" || path == "\$or" ->
+            Document(path, condition.asArray().map { toGuardCondition(it.asDocument()) })
+
+        path == "\$nor" -> Document(
+            "\$not",
+            listOf(
+                Document(
+                    "\$or",
+                    condition.asArray().map { toGuardCondition(it.asDocument()) },
+                ),
+            ),
+        )
+
+        path.startsWith("\$") -> throw QuerySchemaValidationException(
+            "MongoDB metric filters cannot translate operator [$path] into a guard condition.",
+        )
+
+        else -> toGuardCondition(path, condition)
+    }
+}
+
+private fun toGuardCondition(path: String, condition: BsonValue): Any {
+    if (condition.isNull) {
+        return matchesNull(path)
+    }
+    if (condition.isRegularExpression) {
+        return regexGuard(path, condition.asRegularExpression())
+    }
+    if (!condition.isDocument) {
+        return Document("\$eq", listOf(fieldRef(path), condition.literalOperand()))
+    }
+    return condition.asDocument().entries.single().let { (operator, value) -> toGuardCondition(path, operator, value) }
+}
+
+@Suppress("CyclomaticComplexMethod")
+private fun toGuardCondition(path: String, operator: String, value: BsonValue): Any = when (operator) {
+    "\$ne" -> if (value.isNull) {
+        Document("\$and", listOf(Document("\$ne", listOf(fieldRef(path), null)), isPresent(path)))
+    } else {
+        Document("\$ne", listOf(fieldRef(path), value.literalOperand()))
+    }
+
+    "\$gt", "\$gte", "\$lt", "\$lte" -> Document(operator, listOf(fieldRef(path), value.literalOperand()))
+    "\$in" -> inGuard(path, value.asArray())
+    "\$nin" -> Document("\$not", listOf(inGuard(path, value.asArray())))
+    "\$exists" -> if (value.asBoolean().value) {
+        isPresent(path)
+    } else {
+        Document("\$eq", listOf(typeOf(path), "missing"))
+    }
+
+    "\$size" -> {
+        val size = value.asNumber().intValue()
+        Document(
+            "\$eq",
+            listOf(
+                Document(
+                    "\$size",
+                    Document(
+                        "\$cond",
+                        listOf(
+                            Document("\$isArray", listOf(fieldRef(path))),
+                            fieldRef(path),
+                            BsonArray(List(size + 1) { BsonNull.VALUE }),
+                        ),
+                    ),
+                ),
+                size,
+            ),
+        )
+    }
+
+    else -> throw QuerySchemaValidationException(
+        "MongoDB metric filters cannot translate operator [$operator] into a guard condition.",
+    )
+}
+
+private fun matchesNull(path: String): Any = Document(
+    "\$or",
+    listOf(
+        Document("\$eq", listOf(fieldRef(path), null)),
+        Document("\$eq", listOf(typeOf(path), "missing")),
+    ),
+)
+
+/**
+ * A string operand starting with `$` would be parsed as a field reference in expression
+ * position, so such operands are pinned with `$literal`; every other operand keeps its shape.
+ */
+private fun BsonValue.literalOperand(): BsonValue =
+    if (isString && asString().value.startsWith("$")) {
+        BsonDocument("\$literal", this)
+    } else {
+        this
+    }
+
+private fun inGuard(path: String, values: BsonArray): Any = Document(
+    "\$in",
+    listOf(fieldRef(path), BsonArray(values.map { it.literalOperand() })),
+)
+
+/**
+ * `$regexMatch` errors on non-string input while `$match` regex semantics never match one,
+ * so the guard applies only to string values; null and missing inputs never match.
+ */
+private fun regexGuard(path: String, regex: BsonRegularExpression): Document {
+    val input = fieldRef(path)
+    val condition = Document("input", input).append("regex", regex.pattern)
+    regex.options?.takeIf { it.isNotEmpty() }?.let { condition.append("options", it) }
+    return Document(
+        "\$cond",
+        listOf(
+            Document("\$eq", listOf(typeOf(path), "string")),
+            Document("\$regexMatch", condition),
+            false,
+        ),
+    )
+}
+
+private fun fieldRef(path: String): String = "\$$path"
+
+private fun typeOf(path: String): Document = Document("\$type", fieldRef(path))
+
+private fun isPresent(path: String): Document = Document("\$ne", listOf(typeOf(path), "missing"))

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoMetricFilterGuards.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoMetricFilterGuards.kt
@@ -16,7 +16,6 @@ package me.ahoo.wow.mongo.query.aggregation
 import me.ahoo.wow.query.schema.QuerySchemaValidationException
 import org.bson.BsonArray
 import org.bson.BsonDocument
-import org.bson.BsonNull
 import org.bson.BsonRegularExpression
 import org.bson.BsonValue
 import org.bson.Document
@@ -55,10 +54,6 @@ private fun toGuardCondition(entry: Map.Entry<String, BsonValue>): Any {
             ),
         )
 
-        path.startsWith("\$") -> throw QuerySchemaValidationException(
-            "MongoDB metric filters cannot translate operator [$path] into a guard condition.",
-        )
-
         else -> toGuardCondition(path, condition)
     }
 }
@@ -76,7 +71,6 @@ private fun toGuardCondition(path: String, condition: BsonValue): Any {
     return condition.asDocument().entries.single().let { (operator, value) -> toGuardCondition(path, operator, value) }
 }
 
-@Suppress("CyclomaticComplexMethod")
 private fun toGuardCondition(path: String, operator: String, value: BsonValue): Any = when (operator) {
     "\$ne" -> if (value.isNull) {
         Document("\$and", listOf(Document("\$ne", listOf(fieldRef(path), null)), isPresent(path)))
@@ -91,27 +85,6 @@ private fun toGuardCondition(path: String, operator: String, value: BsonValue): 
         isPresent(path)
     } else {
         Document("\$eq", listOf(typeOf(path), "missing"))
-    }
-
-    "\$size" -> {
-        val size = value.asNumber().intValue()
-        Document(
-            "\$eq",
-            listOf(
-                Document(
-                    "\$size",
-                    Document(
-                        "\$cond",
-                        listOf(
-                            Document("\$isArray", listOf(fieldRef(path))),
-                            fieldRef(path),
-                            BsonArray(List(size + 1) { BsonNull.VALUE }),
-                        ),
-                    ),
-                ),
-                size,
-            ),
-        )
     }
 
     else -> throw QuerySchemaValidationException(

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
@@ -1250,6 +1250,34 @@ class MongoAggregationCompilerTest {
     }
 
     @Test
+    fun `and metric filters translate into and guards`() {
+        val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+            aggregation {
+                count("both") {
+                    and {
+                        "state.status" eq "PAID"
+                        "state.status" eq "SHIPPED"
+                    }
+                }
+            },
+            statusFilterSchema,
+        ).map { it.toBsonDocument() }
+
+        pipeline.single { it.containsKey("\$group") }.getDocument("\$group")
+            .getDocument("both").getDocument("\$sum").getArray("\$cond")[0].asDocument().assert().isEqualTo(
+            BsonDocument(
+                "\$and",
+                BsonArray(
+                    listOf(
+                        BsonDocument("\$eq", BsonArray(listOf(BsonString("\$state.status"), BsonString("PAID")))),
+                        BsonDocument("\$eq", BsonArray(listOf(BsonString("\$state.status"), BsonString("SHIPPED")))),
+                    ),
+                ),
+            ),
+        )
+    }
+
+    @Test
     fun `map keyed collection metric filters are rejected as array fields`() {
         assertThrows<QuerySchemaValidationException> {
             MongoAggregationCompiler(SnapshotFilterCompiler).compile(

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
@@ -1294,7 +1294,7 @@ class MongoAggregationCompilerTest {
                 mapCollectionSchema,
             )
         }.message.assert().isEqualTo(
-            "Aggregation metric filter field [state.groups.foo] must be scalar; array fields are not supported in metric filters.",
+            "Aggregation metric filters do not support [ELEMENT_MATCH].",
         )
     }
 

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/MetricFilterValidation.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/MetricFilterValidation.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.schema
+
+import me.ahoo.wow.api.query.AggregateIdFilter
+import me.ahoo.wow.api.query.AggregateIdsFilter
+import me.ahoo.wow.api.query.AndFilter
+import me.ahoo.wow.api.query.BetweenFilter
+import me.ahoo.wow.api.query.ContainsAllFilter
+import me.ahoo.wow.api.query.ContainsFilter
+import me.ahoo.wow.api.query.DeletionFilter
+import me.ahoo.wow.api.query.ElementMatchFilter
+import me.ahoo.wow.api.query.EndsWithFilter
+import me.ahoo.wow.api.query.EqualFilter
+import me.ahoo.wow.api.query.ExistsFilter
+import me.ahoo.wow.api.query.FilterExpression
+import me.ahoo.wow.api.query.GreaterThanFilter
+import me.ahoo.wow.api.query.GreaterThanOrEqualFilter
+import me.ahoo.wow.api.query.IdFilter
+import me.ahoo.wow.api.query.IdsFilter
+import me.ahoo.wow.api.query.InFilter
+import me.ahoo.wow.api.query.IsEmptyFilter
+import me.ahoo.wow.api.query.IsEmptyStringFilter
+import me.ahoo.wow.api.query.IsNotEmptyStringFilter
+import me.ahoo.wow.api.query.IsNotNullFilter
+import me.ahoo.wow.api.query.IsNullFilter
+import me.ahoo.wow.api.query.LessThanFilter
+import me.ahoo.wow.api.query.LessThanOrEqualFilter
+import me.ahoo.wow.api.query.MatchAllFilter
+import me.ahoo.wow.api.query.MatchNoneFilter
+import me.ahoo.wow.api.query.NorFilter
+import me.ahoo.wow.api.query.NotEqualFilter
+import me.ahoo.wow.api.query.NotExistsFilter
+import me.ahoo.wow.api.query.NotInFilter
+import me.ahoo.wow.api.query.OrFilter
+import me.ahoo.wow.api.query.OwnerIdFilter
+import me.ahoo.wow.api.query.QueryField
+import me.ahoo.wow.api.query.RelativeTimeFilter
+import me.ahoo.wow.api.query.SearchFilter
+import me.ahoo.wow.api.query.SpaceIdFilter
+import me.ahoo.wow.api.query.StartsWithFilter
+import me.ahoo.wow.api.query.TenantIdFilter
+import me.ahoo.wow.api.query.schema.QueryValueKind
+
+/**
+ * Validates that an aggregation metric filter references scalar fields only.
+ *
+ * Metric filters evaluate each record as a whole-value predicate: MongoDB re-expresses them as
+ * `$cond` guard conditions and Elasticsearch as filter aggregations. That differs from the
+ * element-matching evaluation of array fields in ordinary filters, so array-valued fields —
+ * including unions with an array alternative — are rejected, as are [ElementMatchFilter] and
+ * [SearchFilter], whose element-matching and full-text semantics have no whole-value translation.
+ *
+ * @param parent the enclosing element scope, or `null` for root-level metrics
+ * @param schema the schema that resolves logical fields to their value kinds
+ * @throws QuerySchemaValidationException when the filter is unsupported in metric position
+ */
+@Suppress("CyclomaticComplexMethod", "LongMethod")
+fun FilterExpression.requireScalarMetricFilterFields(
+    parent: QueryField?,
+    schema: QueryModelSchema,
+) {
+    when (this) {
+        MatchAllFilter, MatchNoneFilter,
+        is IdFilter, is IdsFilter, is AggregateIdFilter, is AggregateIdsFilter,
+        is TenantIdFilter, is OwnerIdFilter, is SpaceIdFilter, is DeletionFilter,
+        -> Unit
+
+        is SearchFilter -> throw QuerySchemaValidationException(
+            "Aggregation metric filters do not support search filters.",
+        )
+        is ElementMatchFilter -> throw QuerySchemaValidationException(
+            "Aggregation metric filters do not support [ELEMENT_MATCH].",
+        )
+        is AndFilter -> operands.forEach { it.requireScalarMetricFilterFields(parent, schema) }
+        is OrFilter -> operands.forEach { it.requireScalarMetricFilterFields(parent, schema) }
+        is NorFilter -> operands.forEach { it.requireScalarMetricFilterFields(parent, schema) }
+        is RelativeTimeFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is EqualFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is NotEqualFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is GreaterThanFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is GreaterThanOrEqualFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is LessThanFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is LessThanOrEqualFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is BetweenFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is ContainsFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is StartsWithFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is EndsWithFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is InFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is NotInFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is ContainsAllFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is IsEmptyFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is IsEmptyStringFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is IsNotEmptyStringFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is IsNullFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is IsNotNullFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is ExistsFilter -> field.requireScalarMetricFilterField(parent, schema)
+        is NotExistsFilter -> field.requireScalarMetricFilterField(parent, schema)
+    }
+}
+
+private fun QueryField.requireScalarMetricFilterField(parent: QueryField?, schema: QueryModelSchema) {
+    val logical = absoluteLogicalField(this, parent)
+    val value = schema.field(logical)?.value ?: return
+    if (value.isArrayValued) {
+        throw QuerySchemaValidationException(
+            "Aggregation metric filter field [$logical] must be scalar; array fields are not supported in metric filters.",
+        )
+    }
+}
+
+private val QueryValueSchema.isArrayValued: Boolean
+    get() = kind == QueryValueKind.ARRAY ||
+        (kind == QueryValueKind.UNION && alternatives.any { it.kind == QueryValueKind.ARRAY })

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/MetricFilterValidationTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/MetricFilterValidationTest.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.wow.query.schema
+
+import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.ContainsAllFilter
+import me.ahoo.wow.api.query.ContainsFilter
+import me.ahoo.wow.api.query.DeletionFilter
+import me.ahoo.wow.api.query.DeletionState
+import me.ahoo.wow.api.query.ElementMatchFilter
+import me.ahoo.wow.api.query.ExistsFilter
+import me.ahoo.wow.api.query.IsNotNullFilter
+import me.ahoo.wow.api.query.MatchAllFilter
+import me.ahoo.wow.api.query.MatchNoneFilter
+import me.ahoo.wow.api.query.OrFilter
+import me.ahoo.wow.api.query.QueryField
+import me.ahoo.wow.api.query.SearchFilter
+import me.ahoo.wow.api.query.schema.QueryValueKind
+import me.ahoo.wow.serialization.JsonSerializer
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import tools.jackson.databind.JsonNode
+
+class MetricFilterValidationTest {
+    private val schema = boundSchemaFixture(
+        objectFixture(
+            "status" to scalarFixture(),
+            "tags" to arrayFixture(scalarFixture()),
+            "notes" to QueryValueSchema(
+                QueryValueKind.UNION,
+                alternatives = listOf(scalarFixture(), arrayFixture(scalarFixture())),
+            ),
+            "orders" to arrayFixture(
+                objectFixture(
+                    "note" to scalarFixture(),
+                    "lines" to arrayFixture(objectFixture()),
+                ),
+            ),
+        )
+    )
+
+    @Test
+    fun `scalar and fieldless filters pass`() {
+        MatchAllFilter.requireScalarMetricFilterFields(null, schema)
+        MatchNoneFilter.requireScalarMetricFilterFields(null, schema)
+        DeletionFilter(DeletionState.ACTIVE).requireScalarMetricFilterFields(null, schema)
+        ExistsFilter(QueryField("status")).requireScalarMetricFilterFields(null, schema)
+        IsNotNullFilter(QueryField("status")).requireScalarMetricFilterFields(null, schema)
+        ContainsFilter(QueryField("status"), "PAID").requireScalarMetricFilterFields(null, schema)
+        ContainsAllFilter(QueryField("status"), listOf(json("PAID")))
+            .requireScalarMetricFilterFields(null, schema)
+    }
+
+    @Test
+    fun `unknown fields pass because the walker only guards known schema fields`() {
+        ExistsFilter(QueryField("unknown")).requireScalarMetricFilterFields(null, schema)
+    }
+
+    @Test
+    fun `array valued fields are rejected`() {
+        assertThrows<QuerySchemaValidationException> {
+            ExistsFilter(QueryField("tags")).requireScalarMetricFilterFields(null, schema)
+        }.message.assert().isEqualTo(
+            "Aggregation metric filter field [tags] must be scalar; " +
+                "array fields are not supported in metric filters.",
+        )
+    }
+
+    @Test
+    fun `union fields with an array alternative are rejected`() {
+        assertThrows<QuerySchemaValidationException> {
+            ExistsFilter(QueryField("notes")).requireScalarMetricFilterFields(null, schema)
+        }.message.assert().contains("[notes] must be scalar")
+    }
+
+    @Test
+    fun `element scoped filters resolve fields relative to their parent`() {
+        ExistsFilter(QueryField("note")).requireScalarMetricFilterFields(QueryField("orders"), schema)
+        assertThrows<QuerySchemaValidationException> {
+            ExistsFilter(QueryField("lines")).requireScalarMetricFilterFields(QueryField("orders"), schema)
+        }.message.assert().isEqualTo(
+            "Aggregation metric filter field [orders.lines] must be scalar; " +
+                "array fields are not supported in metric filters.",
+        )
+    }
+
+    @Test
+    fun `boolean operands walk their children`() {
+        assertThrows<QuerySchemaValidationException> {
+            OrFilter(
+                listOf(
+                    ExistsFilter(QueryField("status")),
+                    ExistsFilter(QueryField("tags")),
+                ),
+            ).requireScalarMetricFilterFields(null, schema)
+        }.message.assert().contains("[tags] must be scalar")
+    }
+
+    @Test
+    fun `element match filters are rejected before field inspection`() {
+        assertThrows<QuerySchemaValidationException> {
+            ElementMatchFilter(QueryField("tags"), ExistsFilter(QueryField("unknown")))
+                .requireScalarMetricFilterFields(null, schema)
+        }.message.assert().isEqualTo(
+            "Aggregation metric filters do not support [ELEMENT_MATCH].",
+        )
+    }
+
+    @Test
+    fun `search filters are rejected`() {
+        assertThrows<QuerySchemaValidationException> {
+            SearchFilter("premium").requireScalarMetricFilterFields(null, schema)
+        }.message.assert().isEqualTo(
+            "Aggregation metric filters do not support search filters.",
+        )
+    }
+
+    private fun json(value: Any?): JsonNode = JsonSerializer.valueToTree(value)
+}

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/MetricFilterValidationTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/MetricFilterValidationTest.kt
@@ -23,6 +23,7 @@ import me.ahoo.wow.api.query.ExistsFilter
 import me.ahoo.wow.api.query.IsNotNullFilter
 import me.ahoo.wow.api.query.MatchAllFilter
 import me.ahoo.wow.api.query.MatchNoneFilter
+import me.ahoo.wow.api.query.NotExistsFilter
 import me.ahoo.wow.api.query.OrFilter
 import me.ahoo.wow.api.query.QueryField
 import me.ahoo.wow.api.query.SearchFilter
@@ -40,6 +41,10 @@ class MetricFilterValidationTest {
             "notes" to QueryValueSchema(
                 QueryValueKind.UNION,
                 alternatives = listOf(scalarFixture(), arrayFixture(scalarFixture())),
+            ),
+            "flags" to QueryValueSchema(
+                QueryValueKind.UNION,
+                alternatives = listOf(scalarFixture(), scalarFixture()),
             ),
             "orders" to arrayFixture(
                 objectFixture(
@@ -60,6 +65,12 @@ class MetricFilterValidationTest {
         ContainsFilter(QueryField("status"), "PAID").requireScalarMetricFilterFields(null, schema)
         ContainsAllFilter(QueryField("status"), listOf(json("PAID")))
             .requireScalarMetricFilterFields(null, schema)
+        NotExistsFilter(QueryField("status")).requireScalarMetricFilterFields(null, schema)
+    }
+
+    @Test
+    fun `unions without an array alternative pass`() {
+        ExistsFilter(QueryField("flags")).requireScalarMetricFilterFields(null, schema)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Phase 2 (derived metrics) preparation refactor — zero functional change, two structural cleanups identified during the #3234 final review:

1. **Unify the scalar metric filter walker** into one shared helper `me.ahoo.wow.query.schema.requireScalarMetricFilterFields` (new `MetricFilterValidation.kt` in wow-query). The MongoDB and Elasticsearch compilers previously carried mirrored sealed-`when` walkers; they now enforce one contract from one place, with direct unit tests in wow-query (`MetricFilterValidationTest`, 8 scenarios).
2. **Extract the MongoDB match-document → guard-condition translator** into `MongoMetricFilterGuards.kt`, leaving `MongoAggregationCompiler.kt` with pipeline assembly only.

### Behavior notes

- `ElementMatchFilter` and `SearchFilter` are now rejected upfront by the shared walker with backend-neutral messages (the ES search message is kept verbatim). Previously MongoDB rejected them later at the translation layer — same `QuerySchemaValidationException`, different message. One Mongo test's expected message is updated accordingly.
- The Mongo translator's `$elemMatch` branch becomes unreachable (`$elemMatch` is emitted only by `ElementMatchFilter`, now rejected before compilation) and is pruned per the reachability doctrine.
- `ContainsAllFilter` keeps its existing per-backend behavior (Elasticsearch terms filter vs MongoDB untranslatable `$all`) — pre-existing divergence, intentionally unchanged.

## Test plan

- [x] `:wow-query:test` (incl. 8 new `MetricFilterValidationTest` scenarios)
- [x] `:wow-mongo:test` / `:wow-elasticsearch:test` (updated message assertion)
- [x] `detekt`
- [x] `:wow-query:check :wow-mongo:check :wow-elasticsearch:check`
- [x] `:wow-mongo:integrationTest :wow-elasticsearch:integrationTest` (live Testcontainers backends — TCK metric-filter scenarios unchanged and green)