### PR TITLE
feat(query): add derived aggregation metrics

### DIFF
--- a/documentation/designs/2026-09-12-derived-metrics-implementation-plan.md
+++ b/documentation/designs/2026-09-12-derived-metrics-implementation-plan.md
@@ -1,0 +1,801 @@
+# Phase 2 实施计划：派生指标（比率）
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 新增 `AggregationMetric.Derived` 子类型——在聚合结果之上按声明序计算比率/复合指标（客单价、达成率、毛利率），MongoDB 与 Elasticsearch 双后端实现，含 DSL、构造期引用校验、TCK 契约与中英文档。
+
+**Architecture:** 纯增量 sealed 子类型（wire 新增 `DERIVED` 判别类型，既有形状零变化）。派生表达式 `DerivedExpression`（`MetricRef`/`Constant`/`Binary`）只引用**声明序在前**的指标——结构上无环、无需拓扑排序，按声明序线性求值。语义：null 传播 + 除零→null + 结果必须有限 double。Mongo 在 `$group` 投影后追加**第二个 `$project`** 计算派生（复用既有 `$let`/`$cond`/`finiteDouble` 守卫模式）；ES 用 `bucket_script` 管道聚合（`gap_policy` 默认 skip 即 null 传播），引用路径由编译器从计划类型预生成。
+
+**Tech Stack:** Kotlin 2.x、JUnit 5、fluent-assert、Jackson 3、MongoDB Java Driver、elasticsearch-java 9.x（`bucket_script`）、Testcontainers。
+
+**Spec:** [2026-09-12-aggregation-reporting-epic-design.md](2026-09-12-aggregation-reporting-epic-design.md)「Phase 2」节。语义、引用规则、TCK 场景以该文档为准；本计划补充实现细节决策。
+
+## Global Constraints
+
+- 基线：`main`（含 #3233/#3234/#3235）。
+- wire 兼容纯增量：仅新增 `DERIVED` 子类型与 `DerivedExpression` 三态；既有子类型 JSON 形状与 DSL 签名零变化。
+- 只考虑源码级与 RESTful API 兼容，不考虑二进制兼容（用户既定裁决）。
+- 不为存储端低版本做降级/门控。本阶段无新存储版本要求：Mongo 第二 `$project` 与 ES `bucket_script` 均为远早于基线（Mongo 7.0 / ES 9.x）的能力。
+- 每个实现任务严格 TDD：先写失败测试、亲见 RED（失败在预期点）、再实现、GREEN。
+- 测试断言用 fluent-assert `.assert()`；核心路径 Reactor 非阻塞。
+- 提交信息 conventional commits（scope：`api`/`query`/`mongo`/`elasticsearch`/`webflux`/`tck`/`openapi`/`docs`）。
+- 语义锚点（与 Phase 1 空语义衔接）：`MetricRef` 引用空语义指标（Numeric/Percentile 空匹配→null）→ 派生 null；除零→null；任一操作数 null→null；结果必须有限（`±Infinity`/`NaN`→null）。
+- `Derived` **不携带 filter**（设计裁决：filter 是记录级概念，派生在聚合之后计算）。`Derived` 也不得被 `MetricRef` 引用 `Any` 指标（非数值，`$add`/painless 算术会运行期报错——构造期 fail-closed，见 Task 1）。
+
+---
+
+### Task 1: wow-api — Derived 子类型与构造期校验
+
+**Files:**
+- Modify: `wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt`
+- Test: `wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt`
+
+**Interfaces:**
+- Consumes: 既有 `requireAggregationAlias`、`MAX_EXPRESSION_DEPTH`/`MAX_EXPRESSION_NODES`、`MatchAllFilterValueFilter`。
+- Produces（后续任务全部依赖）：
+
+```kotlin
+// AggregationMetric 的 JsonSubTypes 追加 JsonSubTypes.Type(AggregationMetric.Derived::class, name = "DERIVED")
+// @Schema oneOf 数组同步追加 AggregationMetric.Derived::class
+
+data class Derived(
+    override val alias: String,
+    val expression: DerivedExpression,
+) : AggregationMetric {
+    @get:JsonInclude(JsonInclude.Include.CUSTOM, valueFilter = MatchAllFilterValueFilter::class)
+    override val filter: FilterExpression get() = MatchAllFilter
+    init {
+        requireAggregationAlias(alias)
+    }
+}
+
+@MissingTypeImpl 不适用（新类型无既有 wire 形态，所有形态显式携带 type）
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = QueryProtocol.Polymorphic.TYPE)
+@JsonSubTypes(
+    JsonSubTypes.Type(DerivedExpression.MetricRef::class, name = "METRIC_REF"),
+    JsonSubTypes.Type(DerivedExpression.Constant::class, name = "CONSTANT"),
+    JsonSubTypes.Type(DerivedExpression.Binary::class, name = "BINARY"),
+)
+@Schema(oneOf = [DerivedExpression.MetricRef::class, DerivedExpression.Constant::class, DerivedExpression.Binary::class], discriminatorProperty = QueryProtocol.Polymorphic.TYPE)
+sealed interface DerivedExpression {
+    data class MetricRef(val metric: String) : DerivedExpression
+    data class Constant(val value: Double) : DerivedExpression {
+        init {
+            require(value.isFinite()) { "derived constant must be finite." }
+        }
+    }
+    data class Binary(
+        val operator: AggregationExpressionOperator,  // 复用 ADD/SUBTRACT/MULTIPLY/DIVIDE
+        val left: DerivedExpression,
+        val right: DerivedExpression,
+    ) : DerivedExpression
+}
+```
+
+- 构造期校验：`AggregationQuery.init` 在 `metrics.requireValidExpressions()` 之后追加 `metrics.requireValidDerivedMetrics()`（新私有函数，同文件）：
+  - 按声明序遍历 metrics，维护 `declared = LinkedHashMap<String, Boolean /*isAny*/>`（alias → 是否 `Any`）。
+  - `Derived`：对 `expression` 做深度（≤`MAX_EXPRESSION_DEPTH`，根深度 1）/节点数（≤`MAX_EXPRESSION_NODES`）迭代校验（模式同 `requireValidExpressions` 的 `PendingExpression` 队列）。
+  - 每个 `MetricRef.metric`：`require(metric in declared)`——覆盖未知别名、前向引用、分组别名（分组别名与指标别名经既有唯一性检查互斥，不会出现在 declared 中）；错误消息：`"derived metric [$alias] must reference a metric declared before it, but was [$ref]."`。`require(!declared.getValue(ref) /*isAny*/)`——错误消息：`"derived metric [$alias] cannot reference ANY metric [$ref]."`。
+  - `DerivedExpression.Constant` 自校验 finite（init）；`Binary` 操作数入队。
+  - `requireValidExpressions()`（320-355 行）的 metric `when` 追加 `is AggregationMetric.Derived -> Unit`（派生树由新函数校验）。
+
+**注意**：`Derived.filter` 为 getter-only 覆写（非构造参数）——序列化经 `MatchAllFilterValueFilter` 省略（恒等于 `MatchAllFilter`）、反序列化无 creator 参数天然忽略；接口其余消费方（`HttpQueryGuard.validateFilters` 的 `filter { it !== MatchAllFilter }`、`metricFilter()` 短路）自动跳过。
+
+- [ ] **Step 1: 写失败测试**（追加到 AggregationQueryTest）
+
+```kotlin
+@Test
+fun `derived metrics should round trip with expression subtypes`() {
+    val json = """
+        {
+          "metrics": [
+            {"type": "COUNT", "alias": "paid"},
+            {"type": "SUM", "alias": "x"},
+            {"type": "DERIVED", "alias": "aov",
+             "expression": {"type": "BINARY", "operator": "DIVIDE",
+               "left": {"type": "METRIC_REF", "metric": "paid"},
+               "right": {"type": "CONSTANT", "value": 2.0}}}
+          ]
+        }
+    """.trimIndent()
+    val query = configuredMapper.readValue(json, AggregationQuery::class.java)
+    val derived = query.metrics.filterIsInstance<AggregationMetric.Derived>().single()
+    derived.filter.assert().isEqualTo(MatchAllFilter)
+    val wire = configuredMapper.writeValueAsString(query)
+    wire.assert().contains("\"type\":\"DERIVED\"")
+    // Derived 段不得出现 "filter"（getter-only 默认经 valueFilter 省略）
+    wire.substring(wire.indexOf("DERIVED"), wire.length).assert().doesNotContain("\"filter\"")
+}
+
+@Test
+fun `derived references must be declared earlier`() {
+    fun derivedOf(vararg metrics: AggregationMetric) = AggregationQuery(metrics = metrics.toList())
+    val paid = AggregationMetric.Count("paid")
+    val aov = AggregationMetric.Derived(
+        "aov",
+        DerivedExpression.Binary(ADD, DerivedExpression.MetricRef("paid"), DerivedExpression.Constant(1.0)),
+    )
+    // 前向引用：aov 在前引用其后声明的 paid
+    assertThrows<IllegalArgumentException> { derivedOf(aov, paid) }.message.assert()
+        .contains("must reference a metric declared before it")
+    assertThrows<IllegalArgumentException> {
+        derivedOf(paid, AggregationMetric.Derived("x", DerivedExpression.MetricRef("unknown")))
+    }.message.assert().contains("unknown")
+    // 单独 MetricRef 引用先声明指标——合法，不抛
+    derivedOf(paid, AggregationMetric.Derived("x", DerivedExpression.MetricRef("paid")))
+}
+
+@Test
+fun `derived references to any metrics and group aliases are rejected`() {
+    val any = AggregationMetric.Any(QueryField("status"), "sample")
+    assertThrows<IllegalArgumentException> {
+        AggregationQuery(
+            groupBy = listOf(AggregationGroup.Terms(QueryField("status"), "status")),
+            metrics = listOf(any, AggregationMetric.Derived("x", DerivedExpression.MetricRef("sample"))),
+        )
+    }.message.assert().contains("cannot reference ANY metric")
+    assertThrows<IllegalArgumentException> { // 引用分组别名 = 未知指标
+        AggregationQuery(
+            groupBy = listOf(AggregationGroup.Terms(QueryField("status"), "status")),
+            metrics = listOf(
+                AggregationMetric.Count("total"),
+                AggregationMetric.Derived("x", DerivedExpression.MetricRef("status")),
+            ),
+        )
+    }
+}
+
+@Test
+fun `derived expressions are depth and node bounded`() {
+    fun nest(depth: Int): DerivedExpression =
+        (1 until depth).fold(DerivedExpression.Constant(1.0) as DerivedExpression) { acc, _ ->
+            DerivedExpression.Binary(ADD, acc, DerivedExpression.Constant(1.0))
+        }
+    assertThrows<IllegalArgumentException> {
+        AggregationQuery(metrics = listOf(AggregationMetric.Count("c"), AggregationMetric.Derived("d", nest(9))))
+    }.message.assert().contains("depth")
+    assertThrows<IllegalArgumentException> {
+        DerivedExpression.Constant(Double.POSITIVE_INFINITY)
+    }
+}
+```
+
+（`DIVIDE`/`ADD`/`MetricRef` 为 `DerivedExpression`/`AggregationExpressionOperator` 嵌套类型的静态导入简写，按测试文件既有 import 风格展开；`configuredMapper` 为该测试类既有 mapper。）
+
+- [ ] **Step 2: RED**：`./gradlew :wow-api:test --tests "me.ahoo.wow.api.query.AggregationQueryTest"`——编译失败：`Derived`/`DerivedExpression` 不存在（失败点即预期点）。
+
+- [ ] **Step 3: 实现**（按 Interfaces；`DerivedExpression` 与注解块放在 `AggregationMetric` 之后、`AggregationFunction` 之前；`requireValidDerivedMetrics` 放在 `requireValidExpressions` 之后同文件私有）。
+
+- [ ] **Step 4: GREEN**：`./gradlew :wow-api:test` 全绿（其余模块因 sealed 穷尽性**预期编译失败**——不属本任务范围，Task 2-4 逐模块补臂；执行者在此步只跑 `:wow-api:test`）。
+
+- [ ] **Step 5: 提交** `feat(api): add derived aggregation metric type`
+
+---
+
+### Task 2: wow-query DSL + 验证臂 + wow-webflux Guard 臂
+
+**Files:**
+- Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDsl.kt`
+- Modify: `wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaValidation.kt:301`（aggregate() metric when）
+- Modify: `wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuard.kt:219`（hasArithmeticExpression）
+- Test: `wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt`、`wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaValidationTest.kt`、`wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardTest.kt`
+
+**Interfaces:**
+- Consumes: Task 1 的 `AggregationMetric.Derived`/`DerivedExpression`。
+- Produces:
+
+```kotlin
+// AggregationQueryDsl 内（@QueryDslMarker 同类）：
+fun derived(alias: String, expression: DerivedExpression) {
+    metrics += AggregationMetric.Derived(alias, expression)
+}
+
+fun derived(alias: String, init: DerivedExpressionDsl.() -> DerivedExpression) =
+    derived(alias, DerivedExpressionDsl().init())
+
+@QueryDslMarker
+class DerivedExpressionDsl {
+    fun ref(metric: String): DerivedExpression = DerivedExpression.MetricRef(metric)
+    fun constant(value: Double): DerivedExpression = DerivedExpression.Constant(value)
+
+    operator fun DerivedExpression.plus(other: DerivedExpression): DerivedExpression = binary(ADD, other)
+    operator fun DerivedExpression.minus(other: DerivedExpression): DerivedExpression = binary(SUBTRACT, other)
+    operator fun DerivedExpression.times(other: DerivedExpression): DerivedExpression = binary(MULTIPLY, other)
+    operator fun DerivedExpression.div(other: DerivedExpression): DerivedExpression = binary(DIVIDE, other)
+
+    private fun DerivedExpression.binary(operator: AggregationExpressionOperator, other: DerivedExpression) =
+        DerivedExpression.Binary(operator, this, other)
+}
+```
+
+（独立上下文类而非挂到 `AggregationQueryDsl`：`constant(Double)` 在同类中会与既有 `AggregationExpression` 版本签名冲突。`derived` 两个重载参数类型不同，无歧义。）
+
+- `QuerySchemaValidation.aggregate()` 追加臂：`is AggregationMetric.Derived -> Unit`（无 schema 字段；引用合法性已由 AST 构造期保证）。
+- `HttpQueryGuard.hasArithmeticExpression()` 追加臂：`is AggregationMetric.Derived -> true`（派生即算术——与既有"expensive operators 未允许时禁用指标算术表达式"口径一致）。
+
+- [ ] **Step 1: 写失败测试**
+
+```kotlin
+// AggregationQueryDslTest
+@Test
+fun `aggregation DSL should build derived metrics from refs and operators`() {
+    val query = aggregation {
+        count("paid")
+        sum("amount", "paidAmount") { "status" eq "PAID" }
+        derived("aov") { ref("paidAmount") / ref("paid") }
+        derived("target") { constant(120.0) }
+        derived("attainment") { ref("paidAmount") / ref("target") }
+    }
+    val derived = query.metrics.filterIsInstance<AggregationMetric.Derived>()
+    derived.assert().hasSize(3)
+    val aov = derived[0].expression as DerivedExpression.Binary
+    aov.operator.assert().isEqualTo(AggregationExpressionOperator.DIVIDE)
+    (aov.left as DerivedExpression.MetricRef).metric.assert().isEqualTo("paidAmount")
+    (derived[1].expression as DerivedExpression.Constant).value.assert().isEqualTo(120.0)
+    // attainment 引用先声明的派生 target —— 构造不抛即链合法
+}
+
+// QuerySchemaValidationTest
+@Test
+fun `derived metrics need no schema capability`() {
+    val schema = boundSchemaFixture(objectFixture("status" to scalarFixture()))
+    validateQuery(
+        aggregation {
+            count("total")
+            derived("half") { ref("total") / constant(2.0) }
+        },
+        schema,
+    ).assert().isNotNull()
+}
+
+// HttpQueryGuardTest（沿用既有 guard 测试构造助手）
+@Test
+fun `derived metrics count as arithmetic expressions`() {
+    val guard = guard(allowExpensiveOperators = false)
+    assertThrows<IllegalArgumentException> {
+        guard.validateAggregation(
+            aggregation {
+                count("total")
+                derived("half") { ref("total") / constant(2.0) }
+            },
+        )
+    }
+}
+```
+
+（`guard(...)` 参数按既有测试助手实况调整；`validateAggregation` 为 guard 的既有聚合入口，名称以实况为准。）
+
+- [ ] **Step 2: RED**：`./gradlew :wow-query:test --tests "*AggregationQueryDsl*" --tests "*QuerySchemaValidation*"` 与 `:wow-webflux:test --tests "*HttpQueryGuard*"`——编译失败（`derived` 不存在 / when 非穷尽）。
+
+- [ ] **Step 3: 实现**（按 Interfaces 三处）。
+
+- [ ] **Step 4: GREEN**：`./gradlew :wow-query:test :wow-webflux:test`
+
+- [ ] **Step 5: 提交** `feat(query): add derived metric DSL and guard arms`（可与 webflux 部分合并一提交；若分拆则 `feat(webflux): ...`）
+
+---
+
+### Task 3: wow-mongo — 第二 $project 派生阶段与结果映射
+
+**Files:**
+- Modify: `wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoAggregationCompiler.kt`（`compile` 138 行后、`group()`/`project()` when 臂、新增 `derivedProject` 与 `DerivedExpression` 编译）
+- Modify: `wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoQueryBackend.kt:185,201`（toAggregationResult/emptySummary 两处 when）
+- Test: `wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt`
+
+**Interfaces:**
+- Consumes: Task 1 AST；既有 `finiteDouble`、`toMongoExpression` 的 Binary `$let`/`$cond` 守卫模式、`mongoOperator`。
+- Produces:
+
+```kotlin
+// compile()：project 之后、sort 之前（sort 需读到派生别名）
+add(project(query))
+if (query.metrics.any { it is AggregationMetric.Derived }) {
+    add(derivedProject(query))
+}
+
+// group() 与 project() 的 metric when 各追加：is AggregationMetric.Derived -> Unit
+// （派生无 accumulator、无第一阶段投影——值由第二阶段补）
+
+private fun derivedProject(query: AggregationQuery): Bson {
+    val projections = buildList {
+        add(Projections.excludeId())
+        query.groupBy.forEach { add(Projections.include(it.alias)) }
+        query.metrics.forEach { metric ->
+            when (metric) {
+                is AggregationMetric.Derived -> add(Projections.computed(metric.alias, metric.expression.toDerivedDocument()))
+                else -> add(Projections.include(metric.alias))
+            }
+        }
+    }
+    return Aggregates.project(Projections.fields(projections))
+}
+
+// 声明序即求值序：$project 计算字段按序可见于同文档后续字段（文档内顺序求值），
+// 引用先声明派生读到的即是本阶段已计算的同名输出。
+private fun DerivedExpression.toDerivedDocument(): Any = when (this) {
+    is DerivedExpression.MetricRef -> "\$$metric"
+    is DerivedExpression.Constant -> value
+    is DerivedExpression.Binary -> {
+        val conditions = mutableListOf<Any>(
+            Document("\$ne", listOf("\$\$left", null)),
+            Document("\$ne", listOf("\$\$right", null)),
+        )
+        if (operator == AggregationExpressionOperator.DIVIDE) {
+            conditions += Document("\$ne", listOf("\$\$right", 0.0))
+        }
+        finiteDouble(
+            Document(
+                "\$let",
+                Document("vars", Document("left", left.toDerivedDocument()).append("right", right.toDerivedDocument()))
+                    .append(
+                        "in",
+                        Document(
+                            "\$cond",
+                            listOf(
+                                Document("\$and", conditions),
+                                Document(operator.mongoOperator, listOf("\$\$left", "\$\$right")),
+                                null,
+                            ),
+                        ),
+                    ),
+            ),
+        )
+    }
+}
+```
+
+（null 传播/除零/有限性与既有记录级 Binary 完全同构——被引用指标经第一阶段 project 已是守卫后的终值：`COUNT` 恒数、Numeric/Percentile 空贡献已改写 null。）
+
+- `AbstractMongoQueryBackend.toAggregationResult` 追加：`is AggregationMetric.Derived -> get(metric.alias).toFiniteDouble(metric.alias)`；`emptySummary` 追加：`is AggregationMetric.Derived -> null`（null 传播：空聚合引用指标为空语义）。
+
+- [ ] **Step 1: 写失败测试**（结构化 Document 断言，沿用本类既有风格）
+
+```kotlin
+@Test
+fun `derived metrics compile into a second project stage`() {
+    val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+        aggregation {
+            count("paid")
+            sum("state.amount", "paidAmount") { "state.status" eq "PAID" }
+            derived("aov") { ref("paidAmount") / ref("paid") }
+        },
+        schema(),
+    ).map { it.toBsonDocument() }
+
+    val projects = pipeline.filter { it.containsKey("\$project") }
+    projects.assert().hasSize(2)
+    val derived = projects[1].getDocument("\$project")
+    derived.containsKey("_id").assert().isTrue() // excludeId
+    val aov = derived.getDocument("aov").getDocument("\$let")
+    aov.getDocument("vars").getString("left").value.assert().isEqualTo("\$paidAmount")
+    // DIVIDE 守卫：$and 含 $ne right 0.0
+    val cond = aov.getDocument("in").getArray("\$cond")
+    cond.get(0).asDocument().getArray("\$and").assert().hasSize(3)
+    // 既有指标别名与分组别名在第二阶段保留
+    derived.containsKey("paid").assert().isTrue()
+    derived.containsKey("paidAmount").assert().isTrue()
+    // 排序阶段位于派生之后（sort 引用派生别名）
+    pipeline.indexOfLast { it.containsKey("\$project") }
+        .assert().isLessThan(pipeline.indexOfFirst { it.containsKey("\$sort") })
+}
+
+@Test
+fun `derived without derived metrics keeps a single project stage`() {
+    val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+        aggregation { count("total") },
+        schema(),
+    ).map { it.toBsonDocument() }
+    pipeline.filter { it.containsKey("\$project") }.assert().hasSize(1)
+}
+
+@Test
+fun `derived constants and chains compile leaves in order`() {
+    val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+        aggregation {
+            count("total")
+            derived("half") { ref("total") / constant(2.0) }
+            derived("quarter") { ref("half") / constant(2.0) }
+        },
+        schema(),
+    ).map { it.toBsonDocument() }
+    val derived = pipeline.last { it.containsKey("\$project") }.getDocument("\$project")
+    derived.containsKey("half").assert().isTrue()
+    derived.containsKey("quarter").assert().isTrue()
+    derived.keys.toList().indexOf("half").assert().isLessThan(derived.keys.toList().indexOf("quarter"))
+}
+```
+
+（`schema()` 默认字段集含 `state.status`/`state.amount` ✓；第二个测试中 `it as Bson` 的实际类型按 compile 返回 `List<Bson>` 直接用 `it.toBsonDocument()` 即可——以本类既有断言风格为准。）
+
+- [ ] **Step 2: RED**：`./gradlew :wow-mongo:test --tests "*MongoAggregationCompiler*"`——编译失败（when 非穷尽：`group`/`project`/`toAggregationResult`/`emptySummary`）。
+
+- [ ] **Step 3: 实现**（按 Interfaces；无派生查询的 pipeline **逐阶段不变**——`any { is Derived }` 守卫保证）。
+
+- [ ] **Step 4: GREEN**：`./gradlew :wow-mongo:test`
+
+- [ ] **Step 5: 提交** `feat(mongo): compute derived metrics in a second project stage`
+
+---
+
+### Task 4: wow-elasticsearch — bucket_script 计划与提取
+
+**Files:**
+- Modify: `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationCompiler.kt`（计划类型 + `compile()` prior 映射 + `toPlan` 臂 + bucketsPath/script 生成）
+- Modify: `wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationPager.kt`（`metricAggregations`/`value()` 臂）
+- Test: `wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt`
+
+**Interfaces:**
+- Consumes: Task 1 AST；既有计划类型、`metricFilterAggregationName`、`valueCountAlias`。
+- Produces:
+
+```kotlin
+// 计划类型追加：
+data class Derived(
+    override val alias: String,
+    val bucketsPath: Map<String, String>,
+    val script: Script,
+) : ElasticsearchAggregationMetric {
+    override val filter: Query? = null
+}
+
+// compile()：metrics 构建改为携带先声明计划映射（声明序天然由遍历序保证）：
+val metricPlans = mutableListOf<ElasticsearchAggregationMetric>()
+val priorByAlias = linkedMapOf<String, ElasticsearchAggregationMetric>()
+query.metrics.forEachIndexed { index, metric ->
+    val plan = metric.toPlan(logicalParent, physicalParent, index, schema, runtimeMappings, now, priorByAlias)
+    metricPlans += plan
+    priorByAlias[metric.alias] = plan
+}
+
+// toPlan 追加参数 prior: Map<String, ElasticsearchAggregationMetric>，追加臂：
+is AggregationMetric.Derived -> toDerivedPlan(metric.expression, priorByAlias)
+
+private fun toDerivedPlan(
+    expression: DerivedExpression,
+    prior: Map<String, ElasticsearchAggregationMetric>,
+): ElasticsearchAggregationMetric.Derived {
+    val bucketsPath = linkedMapOf<String, String>()
+    val source = "def value = ${expression.toScript(prior, bucketsPath)}; " +
+        "value == null || !Double.isFinite(value) ? null : value"
+    return ElasticsearchAggregationMetric.Derived(
+        alias,
+        bucketsPath,
+        Script.of { it.source { s -> s.scriptString(source) } },
+    )
+}
+
+// 叶子/节点序列化；MetricRef 顺带登记 bucketsPath 条目（vN=值路径，Numeric/Percentile 额外 cN=计数路径）
+private fun DerivedExpression.toScript(
+    prior: Map<String, ElasticsearchAggregationMetric>,
+    bucketsPath: MutableMap<String, String>,
+): String = when (this) {
+    is DerivedExpression.MetricRef -> {
+        val target = prior.getValue(metric)
+        val index = bucketsPath.size
+        val (valuePath, countPath) = target.referencePaths()
+        bucketsPath["v$index"] = valuePath
+        if (countPath == null) {
+            "params.v$index"
+        } else {
+            bucketsPath["c$index"] = countPath
+            "(params.c$index == 0.0 ? null : params.v$index)" // 空语义守卫：计数为 0 → null
+        }
+    }
+
+    is DerivedExpression.Constant -> value.toString()
+
+    is DerivedExpression.Binary -> when (operator) {
+        AggregationExpressionOperator.ADD ->
+            "(${left.toScript(prior, bucketsPath)} + ${right.toScript(prior, bucketsPath)})"
+        AggregationExpressionOperator.SUBTRACT ->
+            "(${left.toScript(prior, bucketsPath)} - ${right.toScript(prior, bucketsPath)})"
+        AggregationExpressionOperator.MULTIPLY ->
+            "(${left.toScript(prior, bucketsPath)} * ${right.toScript(prior, bucketsPath)})"
+        AggregationExpressionOperator.DIVIDE -> {
+            val rightScript = right.toScript(prior, bucketsPath)
+            val leftScript = left.toScript(prior, bucketsPath)
+            "($rightScript == 0.0 ? null : $leftScript / $rightScript)" // painless 除零抛异常 → 显式守卫
+        }
+    }
+}
+
+// 逐被引用指标解析 (valuePath, countPath?)；countPath 非空 = 脚本需要空语义守卫。
+// filtered 包装名基于被引用指标自身的 alias：metricFilterAggregationName(target.alias)。
+private fun ElasticsearchAggregationMetric.referencePaths(): Pair<String, String?> {
+    val scope = if (filter == null) "" else "${metricFilterAggregationName(alias)}."
+    return when (this) {
+        is ElasticsearchAggregationMetric.Count ->
+            // 未过滤：桶自身 doc_count；过滤：名为 alias 的 filter 聚合的 doc_count
+            (if (filter == null) "_count" else "$alias._count") to null
+
+        is ElasticsearchAggregationMetric.Numeric -> {
+            val value = when (function) {
+                AggregationFunction.SUM, AggregationFunction.AVG,
+                AggregationFunction.MIN, AggregationFunction.MAX,
+                -> "$alias.value"
+
+                AggregationFunction.STDDEV -> "$alias.std_deviation_population"
+                AggregationFunction.VARIANCE -> "$alias.variance_population"
+            }
+            "$scope$value" to "$scope${valueCountAlias}.value"
+        }
+
+        is ElasticsearchAggregationMetric.Percentile -> "$scope$alias[$percentile]" to "$scope${valueCountAlias}.value"
+        is ElasticsearchAggregationMetric.DistinctCount -> "$scope$alias.value" to null // cardinality 恒非 null（可为 0）
+        is ElasticsearchAggregationMetric.Derived -> "$alias.value" to null // 先声明 bucket_script 输出；null → gap → skip
+    }
+}
+```
+
+（`metricFilterAggregationName`/`valueCountAlias` 为 Pager 同包文件级既有声明——若声明于 Pager 文件为 private，则将 `referencePaths` 移至 Pager 文件或提升这两者为 internal 同包共享；执行者按现状选择最小改动。gap_policy 不显式设置：`bucket_script` 默认即 skip（缺路径/null 值 → 不执行 → null），与 null 传播一致。）
+
+- Pager `metricAggregations()` 追加臂：
+
+```kotlin
+is ElasticsearchAggregationMetric.Derived -> put(
+    metric.alias,
+    Aggregation.of { builder ->
+        builder.bucketScript { bs -> bs.bucketsPath(metric.bucketsPath).script(metric.script) }
+    },
+)
+```
+
+（`bucket_script` 引用兄弟聚合按名字解析，与 map 内声明序无关；引用先声明派生 → `${alias}.value` ✓。不增加 `bucketWidth` 预算——bucket_script 不产生桶。）
+
+- Pager `value()` 追加臂：`is ElasticsearchAggregationMetric.Derived -> aggregations.getValue(alias).simpleValue().value()`（`Double?`；ungrouped summary 与分组行同一路径——`summary()` 走 `metricAggregations()` 同一聚合集 ✓；按派生别名排序复用既有 metric-sorted Top-N 路径，行值经 `toRow` 自动携带 ✓）。
+
+- [ ] **Step 1: 写失败测试**
+
+```kotlin
+@Test
+fun `derived metrics plan bucket scripts with guarded paths`() {
+    val plan = ElasticsearchAggregationCompiler(SnapshotFilterCompiler).compile(
+        aggregation {
+            count("paid") { "status" eq "PAID" }
+            sum("amount", "paidAmount") { "status" eq "PAID" }
+            sum("amount", "totalAmount")
+            derived("aov") { ref("paidAmount") / ref("paid") }
+            derived("attainment") { ref("paidAmount") / ref("totalAmount") }
+        },
+        schema,
+    )
+    val derived = plan.metrics.filterIsInstance<ElasticsearchAggregationMetric.Derived>()
+    derived.assert().hasSize(2)
+    val aov = derived[0]
+    // 过滤 Numeric：value 走 wrapper、count 走 wrapper 内 valueCount；过滤 Count：alias._count
+    aov.bucketsPath.assert().containsKey("v0").containsKey("c0").containsKey("v1")
+    aov.bucketsPath["v0"].assert().isEqualTo("__wow_metric_filter_paidAmount.paidAmount.value")
+    aov.bucketsPath["c0"].assert().isEqualTo("__wow_metric_filter_paidAmount.__wow_value_count_paidAmount.value")
+    aov.bucketsPath["v1"].assert().isEqualTo("paid._count")
+    aov.script.source().scriptString().assert()
+        .contains("(params.c0 == 0.0 ? null : params.v0)").contains("params.v1 == 0.0 ? null")
+    val attainment = derived[1]
+    attainment.bucketsPath["v0"].assert().isEqualTo("__wow_metric_filter_paidAmount.paidAmount.value")
+    attainment.bucketsPath["v2"].assert().isEqualTo("totalAmount.value") // 未过滤 Numeric 无 wrapper
+    attainment.bucketsPath["c2"].assert().isEqualTo("__wow_value_count_totalAmount.value")
+    attainment.script.source().scriptString().assert().contains("Double.isFinite")
+}
+
+@Test
+fun `derived chains reference prior derived aliases`() {
+    val plan = ElasticsearchAggregationCompiler(SnapshotFilterCompiler).compile(
+        aggregation {
+            count("total")
+            derived("half") { ref("total") / constant(2.0) }
+            derived("quarter") { ref("half") / constant(2.0) }
+        },
+        schema,
+    )
+    val quarter = plan.metrics.filterIsInstance<ElasticsearchAggregationMetric.Derived>()[1]
+    quarter.bucketsPath.values.single().assert().isEqualTo("half.value")
+    quarter.script.source().scriptString().assert().contains("/ 2.0")
+}
+```
+
+（`script.source().scriptString()` 访问器名按 elasticsearch-java 9.x 实际 API 调整（如 `source().toString()` / `_get()`）；断言意图不变。`schema` 为本测试类既有绑定 schema。）
+
+- [ ] **Step 2: RED**：`./gradlew :wow-elasticsearch:test --tests "*ElasticsearchAggregationCompiler*"`——编译失败（when 非穷尽 + 计划类型无 Derived）。
+
+- [ ] **Step 3: 实现**（按 Interfaces；bucketsPath 键 `vN`/`cN` 按引用出现顺序编号，脚本与路径共用同一编号）。
+
+- [ ] **Step 4: GREEN**：`./gradlew :wow-elasticsearch:test`
+
+- [ ] **Step 5: 提交** `feat(elasticsearch): derive metrics with bucket scripts`
+
+---
+
+### Task 5: TCK — 跨后端契约场景
+
+**Files:**
+- Modify: `test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryBackendSpec.kt`（1215 行区域之后追加）
+- Modify: `test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/EventStreamQueryBackendSpec.kt`
+
+**fixture 事实**（`aggregationStates()`，展开 `state.orders`+`lines` 后 ACTIVE 共 6 行）：
+
+| 行 | quantity | amount |
+|---|---|---|
+| stateA alpha | 1 | 10 |
+| stateA beta | 2 | 20 |
+| stateA gamma（CANCELLED 单） | 3 | null |
+| stateB alpha | 4 | 30 |
+| stateB beta | 2 | 20 |
+| stateB delta | 5 | 50 |
+
+派生期望值推导：`big`(qty≥2)=5 行、`bigAmount`=120.0、`total`=全部 6 行、`totalAmount`=130.0（gamma null 不参与）。
+
+构造期拒绝类（前向引用/未知别名/分组别名/ANY 引用/深度超限）不进 TCK——AST 层规则与后端无关，已由 Task 1 单测锁定（设计场景 ⑨ 的落点说明，PR 描述中注明）。
+
+- [ ] **Step 1: Snapshot 场景（设计 ①-⑧）**
+
+```kotlin
+@Test
+fun `aggregation should derive ratios from filtered metrics`() { // ① 客单价 ⑧ filter×derived
+    saveAggregationStates(*aggregationStates().toTypedArray())
+    aggregation {
+        filter { deletion(DeletionState.ACTIVE) }
+        expand("state.orders")
+        expand("lines")
+        count("big") { "quantity" gte 2 }                // 5
+        sum("amount", "bigAmount") { "quantity" gte 2 }  // 120.0
+        derived("aov") { ref("bigAmount") / ref("big") } // 24.0
+    }.query(queryBackendBinding)
+        .test()
+        .assertNext { it.assertWireEquals(mapOf("big" to 5L, "bigAmount" to 120.0, "aov" to 24.0)) }
+        .verifyComplete()
+}
+
+@Test
+fun `aggregation should derive ratios between sums and constants`() { // ② 达成率 ③ 复合表达式
+    saveAggregationStates(*aggregationStates().toTypedArray())
+    aggregation {
+        filter { deletion(DeletionState.ACTIVE) }
+        expand("state.orders")
+        expand("lines")
+        sum("amount", "totalAmount")                                     // 130.0
+        sum("amount", "bigAmount") { "quantity" gte 2 }                  // 120.0
+        derived("margin") { (ref("totalAmount") - ref("bigAmount")) / constant(10.0) } // 1.0
+        derived("target") { constant(120.0) }
+        derived("attainment") { ref("bigAmount") / ref("target") }       // 1.0
+    }.query(queryBackendBinding)
+        .test()
+        .assertNext {
+            it.assertWireEquals(
+                mapOf("totalAmount" to 130.0, "bigAmount" to 120.0, "margin" to 1.0, "target" to 120.0, "attainment" to 1.0),
+            )
+        }.verifyComplete()
+}
+
+@Test
+fun `aggregation should derive null on division by zero`() { // ④
+    saveAggregationStates(*aggregationStates().toTypedArray())
+    aggregation {
+        filter { deletion(DeletionState.ACTIVE) }
+        expand("state.orders")
+        expand("lines")
+        count("none") { "quantity" gt 100 }                              // 0
+        sum("amount", "bigAmount") { "quantity" gte 2 }                  // 120.0
+        derived("ratio") { ref("bigAmount") / ref("none") }              // null
+    }.query(queryBackendBinding)
+        .test()
+        .assertNext { it.assertWireEquals(mapOf("none" to 0L, "bigAmount" to 120.0, "ratio" to null)) }
+        .verifyComplete()
+}
+
+@Test
+fun `aggregation should propagate null from empty metrics into derived`() { // ⑤
+    saveAggregationStates(*aggregationStates().toTypedArray())
+    aggregation {
+        filter { deletion(DeletionState.ACTIVE) }
+        expand("state.orders")
+        expand("lines")
+        sum("amount", "noneAmount") { "quantity" gt 100 }                // null
+        derived("scaled") { ref("noneAmount") * constant(2.0) }          // null
+    }.query(queryBackendBinding)
+        .test()
+        .assertNext { it.assertWireEquals(mapOf("noneAmount" to null, "scaled" to null)) }
+        .verifyComplete()
+}
+
+@Test
+fun `aggregation should derive from previously derived metrics`() { // ⑥ 派生链
+    saveAggregationStates(*aggregationStates().toTypedArray())
+    aggregation {
+        filter { deletion(DeletionState.ACTIVE) }
+        expand("state.orders")
+        expand("lines")
+        count("big") { "quantity" gte 2 }                                // 5
+        sum("amount", "bigAmount") { "quantity" gte 2 }                  // 120.0
+        derived("aov") { ref("bigAmount") / ref("big") }                 // 24.0
+        derived("aovDoubled") { ref("aov") * constant(2.0) }             // 48.0
+    }.query(queryBackendBinding)
+        .test()
+        .assertNext {
+            it.assertWireEquals(mapOf("big" to 5L, "bigAmount" to 120.0, "aov" to 24.0, "aovDoubled" to 48.0))
+        }.verifyComplete()
+}
+
+@Test
+fun `aggregation should sort groups by a derived metric`() { // ⑦（数据形态对齐 Phase 1 过滤排序场景）
+    saveAggregationStates(*aggregationStates().toTypedArray())
+    aggregation {
+        filter { deletion(DeletionState.ACTIVE) }
+        expand("state.orders")
+        expand("lines")
+        terms("productId", "product")
+        sum("amount", "bigAmount") { "quantity" gte 2 } // delta=50, beta=40, alpha=30, gamma=null
+        derived("share") { ref("bigAmount") / constant(50.0) } // 1.0 / 0.8 / 0.6 / null
+        sort { "share".desc() }
+    }.query(queryBackendBinding)
+        .collectList()
+        .test()
+        .assertNext { rows ->
+            rows.map { it.path("product").textValue() }.assert()
+                .containsExactly("delta", "beta", "alpha", "gamma") // null 置尾，与 Phase 1 排序口径一致
+        }.verifyComplete()
+}
+```
+
+- [ ] **Step 2: EventStream 场景**
+
+```kotlin
+@Test
+fun aggregateDerivedEventRatios() {
+    // 沿用本类既有事件流 fixture（Phase 1 aggregateFilteredEventCounts 同源）
+    aggregation {
+        filter { tenantId(tenantId) }
+        expand("body")
+        count("all")
+        count("first") { "revision" eq 1L }
+        derived("firstShare") { ref("first") / ref("all") }
+    }.query(queryBackendBinding)
+        .test()
+        .assertNext {
+            it.path("firstShare").doubleValue().assert().isEqualTo(/* all/first 按既有场景期望复推 */)
+        }.verifyComplete()
+}
+```
+
+（期望值按该类既有 aggregateFilteredEventCounts 的 all/first 实测值复推——若为 10/1 则 0.1；`revision` 构造沿用既有场景写法。）
+
+- [ ] **Step 3: 双后端集成确认 GREEN**（Docker）
+
+```bash
+./gradlew :wow-mongo:integrationTest :wow-elasticsearch:integrationTest --stacktrace
+```
+
+若后端行为与断言不符：以设计语义修正实现（如 ES `alias._count` 路径在目标版本的实际写法、`buckets_path` 对 extendedStats/percentiles 的键名），不放宽断言；期望值算术错误按 fixture 复推修正并记录。
+
+- [ ] **Step 4: 提交** `test(tck): add cross-backend contracts for derived metrics`
+
+---
+
+### Task 6: OpenAPI 快照与中英文档
+
+**Files:**
+- Modify: OpenAPI 快照再生成（`-Dwow.snapshot.update=true` 机制，差异须为纯增量：`AggregationMetric` oneOf 新增 `DERIVED`、`DerivedExpression` 新 schema）
+- Modify: `documentation/docs/zh/guide/query/aggregation-query.md`、`documentation/docs/en/guide/query/aggregation-query.md`（Derived 节：语义、引用规则、null 传播/除零、DSL 示例）
+- Modify: `documentation/docs/zh/guide/query/snapshot-aggregation.md` + en 镜像（达成率场景：DSL 示例即 Task 2 形态）
+
+- [ ] **Step 1**: `./gradlew :wow-openapi:test -Dwow.snapshot.update=true` 再生成；`./gradlew :wow-openapi:test` 干净复跑绿（差异纯增量核对）。
+- [ ] **Step 2**: 文档：zh `aggregation-query.md` Metric 节后追加「派生指标」小节——声明序引用规则（无前向引用/不可引用分组别名与 ANY）、null 传播与除零→null、filter×derived 叠加示例、ES `bucket_script`/Mongo 第二 `$project` 实现说明与版本要求（无新增要求）；en 镜像；`snapshot-aggregation.md` zh/en 各加达成率场景。
+- [ ] **Step 3**: `cd documentation && pnpm docs:build`
+- [ ] **Step 4**: 提交 `feat(openapi): align derived metric schemas` 与 `docs(query): document derived aggregation metrics`（可两提交）
+
+---
+
+### Task 7: 全量回归与静态检查
+
+- [ ] **Step 1**: `./gradlew :wow-api:check :wow-query:check :wow-mongo:check :wow-elasticsearch:check :wow-webflux:check :wow-openapi:check`
+- [ ] **Step 2**: `./gradlew :wow-mongo:integrationTest :wow-elasticsearch:integrationTest --stacktrace`
+- [ ] **Step 3**: `./gradlew allLocalTest allContractTest`
+- [ ] **Step 4**: `./gradlew detekt`
+- [ ] **Step 5**: `git log --oneline`、`git status` 收尾核对；如实汇报各层结果。
+
+---
+
+## 计划自审记录
+
+1. **规格覆盖**：AST 与构造期校验（Task 1）、DSL（Task 2）、验证/Guard（Task 2）、Mongo 第二 `$project`（Task 3）、ES `bucket_script` 与 gap_policy=skip（Task 4）、null 传播/除零/有限结果（Tasks 3/4 守卫 + Task 5 ④⑤）、按派生排序与 ungrouped summary（Tasks 3/4 路径 + Task 5 ⑦）、TCK ①-⑧（Task 5；⑨ 落 Task 1 单测——AST 层规则与后端无关）、文档与快照（Task 6）、回归（Task 7）。覆盖完整。
+2. **自审修正记录**：①原稿把派生运算符挂在 `AggregationQueryDsl` 上——`constant(Double)` 与既有 `AggregationExpression` 版本签名冲突，改为独立 `DerivedExpressionDsl` 上下文；②ES 引用空语义指标：`sum` 空集返回 0 而非 gap，直接引用会得到 0 而非 null——bucketsPath 为 Numeric/Percentile 引用同时收集 valueCount 路径并在脚本中 `(count == 0 ? null : value)` 守卫，与 Mongo 第一阶段 project 的 countAlias 改写对齐；③ES 脚本除零在 painless 中抛异常（非 null）——DIVIDE 节点显式 `right == 0.0 ? null` 守卫，整体包 `Double.isFinite` 守卫对齐 `finiteDouble`；④过滤 Count 引用路径 `alias._count`（filter 聚合 doc_count）与未过滤 `_count` 区分。
+3. **类型一致性**：`AggregationMetric.Derived(alias, expression)`（Task 1）↔ DSL `derived`/`ref`/`constant`（Task 2）↔ Mongo `toDerivedDocument`（Task 3）↔ ES 计划 `Derived(alias, bucketsPath, script)`（Task 4）↔ TCK 断言别名一致；6 处 sealed `when` 派发点（wow-api `requireValidExpressions`、wow-query 验证、webflux guard、Mongo `group`/`project`/backend 两处、ES `toPlan`/pager 两处）全部点名补臂，编译器穷尽性兜底。
+4. **风险注记**：①`$project` 计算字段文档内顺序求值——派生链依赖该语义（MongoDB 文档化行为：文档内按出现顺序求值，后续字段可引用先前计算字段）；若实测目标版本不满足，回退为每个派生单独一个 `$project` 阶段（计划允许，语义不变）；②ES `buckets_path` 对 extendedStats 键名（`std_deviation_population`）与 `alias._count` 写法以 Task 5 集成为准（本地无容器单测不覆盖），不符则改路径生成而非放宽断言；③`bucket_script` 脚本长度上限（`script.max_size_in_bytes`，默认 65535）远大于本阶段表达式上限产出的脚本，不构成约束；④裸 `MetricRef`（`derived("x") { ref("total") }`）合法——`Derived.expression` 即叶子，两后端直读 `"$total"` / `params.v0`，无需 Binary 包裹（Task 1 测试已含）。

--- a/documentation/docs/en/guide/query/aggregation-query.md
+++ b/documentation/docs/en/guide/query/aggregation-query.md
@@ -63,6 +63,7 @@ Every Metric also has a unique alias, used as a result-column name.
 | `DISTINCT_COUNT` | Counts the distinct non-null contribution values of an Expression as an integer; an empty set yields `0` |
 | `PERCENTILE` | Computes `PERCENTILE(p)` over a numeric Expression, `0 < p < 100`; the DSL's `median` equals `p=50` |
 | `ANY` | Selects one field value |
+| `DERIVED` | Computes arithmetic over declared metric results after aggregation (see [Derived Metrics](#derived-metrics)) |
 
 `ANY` is not a substitute for a deterministic group key: its selected non-null value is not guaranteed to be stable across executions or backends.
 
@@ -92,6 +93,55 @@ Versions and known boundaries:
 - metric filters on the MongoDB backend require server 5.0+ (`$not` inside the guard expression); the `PERCENTILE` metric itself still requires 7.0+. Older servers return their native error.
 - the `$gt`/`$lt` family in MongoDB guard expressions compares by the BSON total order rather than `$match` type bracketing, so counts over mixed-type data may run high; this is an edge case and does not promise bitwise cross-backend equality.
 - the HTTP query guard does not gate the metric filter construct itself as an expensive operator; operators inside a metric filter are subject to the same `wow.webflux.query.allow-expensive-operators` switch as root/element filters, and their filter value counts feed the same `wow.webflux.query.max-filter-values` cap as other filters.
+
+### Derived Metrics {#derived-metrics}
+
+A `DERIVED` metric computes arithmetic over the results of metrics declared in the same query, after aggregation finishes, producing one derived value per row (an AOV or an attainment ratio, for example). Its expression AST has only `METRIC_REF`, finite `CONSTANT`, and `BINARY`; the `BINARY` operators match the numeric expression set (`ADD`, `SUBTRACT`, `MULTIPLY`, `DIVIDE`) and can nest. The DSL is `derived(alias) { ... }`, with `ref(metric)` referencing a metric and `constant(value)` providing a constant:
+
+```kotlin
+aggregation {
+    terms("state.status", "status")
+    count("paid") { "status" eq "PAID" }
+    sum("amount", "paidAmount") { "status" eq "PAID" }
+    derived("paidAov") { ref("paidAmount") / ref("paid") }
+    sum("amount", "targetAmount")
+    derived("attainment") { ref("paidAmount") / ref("targetAmount") }
+    sort { "paidAov".desc() }
+}
+```
+
+`paidAov` divides two metric-filtered metrics into a paid AOV; `attainment` compares the paid amount against the target amount. A single derived metric has the following JSON shape, with `expression` reusing the recursive `DerivedExpression` schema:
+
+```json
+{
+  "type": "DERIVED",
+  "alias": "paidAov",
+  "expression": {
+    "type": "BINARY",
+    "operator": "DIVIDE",
+    "left": {"type": "METRIC_REF", "metric": "paidAmount"},
+    "right": {"type": "METRIC_REF", "metric": "paid"}
+  }
+}
+```
+
+Reference rules are enforced while constructing the `AggregationQuery`; violations throw `IllegalArgumentException`:
+
+- a `METRIC_REF` may reference only metrics declared before the derived metric in the same query (earlier derived metrics included); declaration order is evaluation order, so the reference graph is acyclic by construction. Unknown and group aliases are rejected;
+- referencing an `ANY` metric is rejected: its value is unstable across executions and backends;
+- constants must be finite; derived expressions share the numeric-expression depth cap of 8, and all derived expressions in one query share at most 256 nodes.
+
+Computation semantics:
+
+- null propagation: any null operand yields `null`; a reference to an empty-set `NUMERIC`/`PERCENTILE` (whose result is `null`) propagates `null` as well. `COUNT` references are never `null` (an empty set is `0`), but dividing by that `0` still yields `null`;
+- division by zero yields `null`, and the derived result must be finite;
+- a derived metric cannot carry a metric filter itself: filter is a record-level concept, and derived computes after aggregation. Its combination with the [Metric Filter](#metric-filter) is to reference filtered metrics — `paidAov` above is exactly "paid amount / paid count";
+- sort may reference a derived alias; the example sorts by `paidAov` descending.
+
+Implementation and guardrails:
+
+- MongoDB evaluates derived metrics in additional `$project` stages after the aggregation projection, one stage per derived metric in declaration order; Elasticsearch uses `bucket_script` pipeline aggregations inside the bucket. Neither adds storage version requirements (`$project` and `bucket_script` both predate the supported MongoDB 7.0 / Elasticsearch 9.x baselines);
+- the HTTP query guard treats derived metrics as arithmetic expressions: they are rejected when `wow.webflux.query.allow-expensive-operators=false`, consistent with the existing metric arithmetic gating.
 
 ### Numeric Contributions and Precision {#numeric-contributions}
 

--- a/documentation/docs/en/guide/query/aggregation-query.md
+++ b/documentation/docs/en/guide/query/aggregation-query.md
@@ -135,7 +135,7 @@ Computation semantics:
 
 - null propagation: any null operand yields `null`; a reference to an empty-set `NUMERIC`/`PERCENTILE` (whose result is `null`) propagates `null` as well. `COUNT` references are never `null` (an empty set is `0`), but dividing by that `0` still yields `null`;
 - division by zero yields `null`, and the derived result must be finite;
-- a derived metric cannot carry a metric filter itself: filter is a record-level concept, and derived computes after aggregation. Its combination with the [Metric Filter](#metric-filter) is to reference filtered metrics — `paidAov` above is exactly "paid amount / paid count";
+- a derived metric cannot carry a metric filter itself: filter is a record-level concept, and derived computes after aggregation. Its combination with the [Metric Filter](#metric-filter) is to reference filtered metrics — `paidAov` above is exactly "paid amount / paid count". The OpenAPI schema still shows the inherited optional `filter` property on `DERIVED` for shape compatibility — values sent there are ignored at deserialization, and the DSL/constructors cannot set it;
 - sort may reference a derived alias; the example sorts by `paidAov` descending.
 
 Implementation and guardrails:

--- a/documentation/docs/en/guide/query/snapshot-aggregation.md
+++ b/documentation/docs/en/guide/query/snapshot-aggregation.md
@@ -1,6 +1,6 @@
 ---
 title: Snapshot Aggregation
-description: Apply snapshot aggregation to root documents and collection elements through ten business scenarios.
+description: Apply snapshot aggregation to root documents and collection elements through eleven business scenarios.
 ---
 
 # Snapshot Aggregation
@@ -34,6 +34,7 @@ flowchart TB
     Root --> S7["7 Multidimensional analysis"]
     Root --> S9["9 Distinct customers and P95 amount"]
     Root --> S10["10 Funnel conditional counts"]
+    Root --> S11["11 Attainment and paid AOV"]
     Item --> S5["5 Line-item Top-N"]
     Item --> S6["6 Derived amount"]
     Item --> S8["8 ANY display field"]
@@ -539,6 +540,88 @@ val query = aggregation {
 ```
 
 Both metrics share the same counting unit and root filter; each metric filter applies to its own metric only, so `paidCount ≤ orderCount` always holds. Each funnel level is one independent filtered COUNT — append more levels instead of splitting the funnel into multiple queries. See [Metric Filter](./aggregation-query.md#metric-filter) for empty-match semantics, limits, and version requirements.
+
+## Scenario 11: Attainment Ratio and Paid AOV
+
+**Business question**
+
+In one result table, what is each order status's attainment ratio of paid amount against target amount, and which status has the highest paid AOV?
+
+**Counting unit**
+
+Root snapshot documents; `paid` and `paidAmount` count only snapshots with `state.status = PAID`, `targetAmount` sums every snapshot in the group, and the two derived metrics divide those results after aggregation finishes.
+
+**Kotlin DSL**
+
+```kotlin
+val query = aggregation {
+    terms("state.status", "status")
+    count("paid") { "state.status" eq "PAID" }
+    sum("state.totalAmount", "paidAmount") { "state.status" eq "PAID" }
+    derived("paidAov") { ref("paidAmount") / ref("paid") }
+    sum("state.targetAmount", "targetAmount")
+    derived("attainment") { ref("paidAmount") / ref("targetAmount") }
+    sort { "paidAov".desc() }
+}
+```
+
+**HTTP JSON and result interpretation**
+
+```json
+{
+  "groupBy": [
+    {"type": "TERMS", "field": "state.status", "alias": "status"}
+  ],
+  "metrics": [
+    {"type": "COUNT", "alias": "paid", "filter": {"op": "EQ", "field": "state.status", "value": "PAID"}},
+    {
+      "type": "NUMERIC",
+      "function": "SUM",
+      "expression": {"type": "FIELD", "field": "state.totalAmount"},
+      "alias": "paidAmount",
+      "filter": {"op": "EQ", "field": "state.status", "value": "PAID"}
+    },
+    {
+      "type": "DERIVED",
+      "alias": "paidAov",
+      "expression": {
+        "type": "BINARY",
+        "operator": "DIVIDE",
+        "left": {"type": "METRIC_REF", "metric": "paidAmount"},
+        "right": {"type": "METRIC_REF", "metric": "paid"}
+      }
+    },
+    {
+      "type": "NUMERIC",
+      "function": "SUM",
+      "expression": {"type": "FIELD", "field": "state.targetAmount"},
+      "alias": "targetAmount"
+    },
+    {
+      "type": "DERIVED",
+      "alias": "attainment",
+      "expression": {
+        "type": "BINARY",
+        "operator": "DIVIDE",
+        "left": {"type": "METRIC_REF", "metric": "paidAmount"},
+        "right": {"type": "METRIC_REF", "metric": "targetAmount"}
+      }
+    }
+  ],
+  "sort": [
+    {"field": "paidAov", "direction": "DESC"}
+  ]
+}
+```
+
+```json
+[
+  {"status": "PAID", "paid": 42, "paidAmount": 21420.0, "paidAov": 510.0, "targetAmount": 30000.0, "attainment": 0.714},
+  {"status": "FAILED", "paid": 0, "paidAmount": null, "paidAov": null, "targetAmount": 8000.0, "attainment": null}
+]
+```
+
+`paidAov = paidAmount / paid`, and `attainment = paidAmount / targetAmount`. The FAILED row demonstrates empty-set semantics: no PAID record exists in the group, so `paidAmount` is `null` on an empty set, and any null operand propagates `null` — both derived metrics are therefore `null` (dividing by `paid = 0` yields `null` as well). A derived metric cannot carry a metric filter itself; its combination with metric filtering is to reference filtered metrics, and sort can reference a derived alias directly. HTTP rejects derived metrics as arithmetic expressions when expensive operators are disabled. See [Derived Metrics](./aggregation-query.md#derived-metrics) for reference rules and semantics.
 
 ## Backend Capabilities and Stability Boundaries
 

--- a/documentation/docs/zh/guide/query/aggregation-query.md
+++ b/documentation/docs/zh/guide/query/aggregation-query.md
@@ -135,7 +135,7 @@ aggregation {
 
 - null 传播：任一操作数为 `null` 时结果为 `null`；引用空集的 `NUMERIC`/`PERCENTILE`（结果为 `null`）同样传播为 `null`。`COUNT` 引用不会为 `null`（空集为 `0`），但除以该 `0` 仍得到 `null`；
 - 除以零的结果为 `null`，派生结果必须有限；
-- 派生指标本身不能带 metric filter：filter 是记录级概念，派生在聚合之后计算。它与[指标级过滤](#metric-filter)的组合方式是引用带 filter 的 metric——上例 `paidAov` 即“已支付金额 / 已支付数量”；
+- 派生指标本身不能带 metric filter：filter 是记录级概念，派生在聚合之后计算。它与[指标级过滤](#metric-filter)的组合方式是引用带 filter 的 metric——上例 `paidAov` 即“已支付金额 / 已支付数量”。OpenAPI schema 为保持形状兼容仍在 `DERIVED` 上展示继承来的可选 `filter` 属性——反序列化时会忽略传入的取值，且 DSL 与构造器均无法设置它；
 - sort 可以引用派生 alias，上例即按 `paidAov` 降序。
 
 实现与护栏：

--- a/documentation/docs/zh/guide/query/aggregation-query.md
+++ b/documentation/docs/zh/guide/query/aggregation-query.md
@@ -63,6 +63,7 @@ flowchart LR
 | `DISTINCT_COUNT` | 统计 Expression 非空参与值的去重个数，结果为整数；空集为 `0` |
 | `PERCENTILE` | 对数值 Expression 计算 `PERCENTILE(p)`，`0 < p < 100`；DSL 的 `median` 等价 `p=50` |
 | `ANY` | 选择一个字段值 |
+| `DERIVED` | 聚合完成后对已声明 metric 的结果做算术运算（见[派生指标](#derived-metrics)） |
 
 `ANY` 不能替代确定性的 group key：所选的非 null 值不保证在不同执行或后端间稳定。
 
@@ -92,6 +93,55 @@ sum("total", "paidTotal") { "status" eq "PAID" }
 - MongoDB 后端使用 metric filter 需要服务端 5.0+（守卫表达式中的 `$not`）；`PERCENTILE` 指标本身仍需 7.0+。旧版本服务端返回其原生错误。
 - MongoDB 守卫表达式的 `$gt`/`$lt` 族比较遵循 BSON 全序而非 `$match` 的类型分档，类型混杂数据下计数可能偏多；这是边界情形，不构成后端间逐位一致的承诺。
 - HTTP 查询保护不把 metric filter 构造本身单独视为高成本操作符；metric filter 内的算子与根/element 过滤一样受 `wow.webflux.query.allow-expensive-operators` 昂贵算子开关约束，过滤值数与其他 filter 一起计入 `wow.webflux.query.max-filter-values` 上限。
+
+### 派生指标 {#derived-metrics}
+
+`DERIVED` Metric 在聚合完成后对同查询中已声明 metric 的结果做算术运算，为每行计算一个派生值（如客单价、达成率）。它的 Expression AST 只有 `METRIC_REF`、有限 `CONSTANT` 与 `BINARY`；`BINARY` 运算符与数值表达式一致（`ADD`、`SUBTRACT`、`MULTIPLY`、`DIVIDE`），可嵌套。DSL 为 `derived(alias) { ... }`，表达式内用 `ref(metric)` 引用 metric、`constant(value)` 给出常量：
+
+```kotlin
+aggregation {
+    terms("state.status", "status")
+    count("paid") { "status" eq "PAID" }
+    sum("amount", "paidAmount") { "status" eq "PAID" }
+    derived("paidAov") { ref("paidAmount") / ref("paid") }
+    sum("amount", "targetAmount")
+    derived("attainment") { ref("paidAmount") / ref("targetAmount") }
+    sort { "paidAov".desc() }
+}
+```
+
+`paidAov` 把两个带指标级过滤的 metric 相除，得到已支付客单价；`attainment` 把已支付金额与目标金额相比，得到达成率。单个派生指标的 JSON 形状如下，`expression` 递归复用 `DerivedExpression` schema：
+
+```json
+{
+  "type": "DERIVED",
+  "alias": "paidAov",
+  "expression": {
+    "type": "BINARY",
+    "operator": "DIVIDE",
+    "left": {"type": "METRIC_REF", "metric": "paidAmount"},
+    "right": {"type": "METRIC_REF", "metric": "paid"}
+  }
+}
+```
+
+引用规则在构造 `AggregationQuery` 时校验，违反即抛 `IllegalArgumentException`：
+
+- `METRIC_REF` 只能引用同一查询中先于该派生指标声明的 metric（含更早的派生指标）；声明序即求值序，引用图天然无环。未知别名与 group alias 一律拒绝；
+- 不能引用 `ANY` metric：其值跨执行与后端不稳定；
+- 常量必须有限；派生表达式与数值表达式共用 `depth ≤ 8` 的深度上限，同一查询的全部派生表达式共享至多 256 个节点。
+
+计算语义：
+
+- null 传播：任一操作数为 `null` 时结果为 `null`；引用空集的 `NUMERIC`/`PERCENTILE`（结果为 `null`）同样传播为 `null`。`COUNT` 引用不会为 `null`（空集为 `0`），但除以该 `0` 仍得到 `null`；
+- 除以零的结果为 `null`，派生结果必须有限；
+- 派生指标本身不能带 metric filter：filter 是记录级概念，派生在聚合之后计算。它与[指标级过滤](#metric-filter)的组合方式是引用带 filter 的 metric——上例 `paidAov` 即“已支付金额 / 已支付数量”；
+- sort 可以引用派生 alias，上例即按 `paidAov` 降序。
+
+实现与护栏：
+
+- MongoDB 在聚合投影之后追加额外的 `$project` 阶段计算派生值，每个派生指标一个阶段，按声明顺序执行；Elasticsearch 在桶内使用 `bucket_script` 管道聚合。两者均无新增存储版本要求（`$project` 与 `bucket_script` 都早于受支持的 MongoDB 7.0 / Elasticsearch 9.x 基线）；
+- HTTP 查询保护把派生指标视为算术表达式：`wow.webflux.query.allow-expensive-operators=false` 时会被拒绝，与既有 metric 算术表达式门槛一致。
 
 ### 数值参与值与精度 {#numeric-contributions}
 

--- a/documentation/docs/zh/guide/query/snapshot-aggregation.md
+++ b/documentation/docs/zh/guide/query/snapshot-aggregation.md
@@ -1,6 +1,6 @@
 ---
 title: 快照聚合
-description: 用十个业务场景说明快照根文档与集合元素的聚合查询。
+description: 用十一个业务场景说明快照根文档与集合元素的聚合查询。
 ---
 
 # 快照聚合
@@ -34,6 +34,7 @@ flowchart TB
     Root --> S7["7 多维交叉分析"]
     Root --> S9["9 去重客户数与 P95 金额"]
     Root --> S10["10 漏斗多条件计数"]
+    Root --> S11["11 达成率与客单价"]
     Item --> S5["5 明细项 Top-N"]
     Item --> S6["6 派生金额"]
     Item --> S8["8 ANY 展示字段"]
@@ -539,6 +540,88 @@ val query = aggregation {
 ```
 
 两个指标共享同一统计单位与根过滤，metric filter 只作用于各自的指标，因此 `paidCount ≤ orderCount` 恒成立。漏斗的每一级都是一个带 filter 的独立 COUNT，需要更多层级时继续追加即可，不必拆成多次查询。metric filter 的空集语义、限制与版本要求见[指标级过滤](./aggregation-query.md#metric-filter)。
+
+## 场景 11：达成率与客单价
+
+**业务问题**
+
+同一张结果表中，各订单状态的已支付金额相对目标金额的达成率是多少？已支付客单价最高的状态是哪个？
+
+**统计单位**
+
+快照根文档；`paid` 与 `paidAmount` 只统计 `state.status = PAID` 的快照，`targetAmount` 统计组内全部快照，两个派生指标在聚合完成后对三者做商。
+
+**Kotlin DSL**
+
+```kotlin
+val query = aggregation {
+    terms("state.status", "status")
+    count("paid") { "state.status" eq "PAID" }
+    sum("state.totalAmount", "paidAmount") { "state.status" eq "PAID" }
+    derived("paidAov") { ref("paidAmount") / ref("paid") }
+    sum("state.targetAmount", "targetAmount")
+    derived("attainment") { ref("paidAmount") / ref("targetAmount") }
+    sort { "paidAov".desc() }
+}
+```
+
+**HTTP JSON 与结果解读**
+
+```json
+{
+  "groupBy": [
+    {"type": "TERMS", "field": "state.status", "alias": "status"}
+  ],
+  "metrics": [
+    {"type": "COUNT", "alias": "paid", "filter": {"op": "EQ", "field": "state.status", "value": "PAID"}},
+    {
+      "type": "NUMERIC",
+      "function": "SUM",
+      "expression": {"type": "FIELD", "field": "state.totalAmount"},
+      "alias": "paidAmount",
+      "filter": {"op": "EQ", "field": "state.status", "value": "PAID"}
+    },
+    {
+      "type": "DERIVED",
+      "alias": "paidAov",
+      "expression": {
+        "type": "BINARY",
+        "operator": "DIVIDE",
+        "left": {"type": "METRIC_REF", "metric": "paidAmount"},
+        "right": {"type": "METRIC_REF", "metric": "paid"}
+      }
+    },
+    {
+      "type": "NUMERIC",
+      "function": "SUM",
+      "expression": {"type": "FIELD", "field": "state.targetAmount"},
+      "alias": "targetAmount"
+    },
+    {
+      "type": "DERIVED",
+      "alias": "attainment",
+      "expression": {
+        "type": "BINARY",
+        "operator": "DIVIDE",
+        "left": {"type": "METRIC_REF", "metric": "paidAmount"},
+        "right": {"type": "METRIC_REF", "metric": "targetAmount"}
+      }
+    }
+  ],
+  "sort": [
+    {"field": "paidAov", "direction": "DESC"}
+  ]
+}
+```
+
+```json
+[
+  {"status": "PAID", "paid": 42, "paidAmount": 21420.0, "paidAov": 510.0, "targetAmount": 30000.0, "attainment": 0.714},
+  {"status": "FAILED", "paid": 0, "paidAmount": null, "paidAov": null, "targetAmount": 8000.0, "attainment": null}
+]
+```
+
+`paidAov = paidAmount / paid`，`attainment = paidAmount / targetAmount`。FAILED 行演示空集语义：`paidAmount` 在组内无 PAID 记录、空集为 `null`，任一操作数为 `null` 即传播为 `null`，因此两个派生指标都是 `null`（除以 `paid = 0` 同样得到 `null`）。派生指标本身不能带 metric filter，它与指标级过滤的组合方式是引用带 filter 的 metric；sort 可以直接引用派生 alias。HTTP 禁用高成本操作符时会拒绝派生指标这类算术表达式。引用规则与语义详见[派生指标](./aggregation-query.md#derived-metrics)。
 
 ## 后端能力与稳定性边界
 

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/EventStreamQueryBackendSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/EventStreamQueryBackendSpec.kt
@@ -508,13 +508,32 @@ abstract class EventStreamQueryBackendSpec {
             expand("body")
             count("all")
             // body.revision 是事件模式版本字符串（所有事件恒为 "0.0.1"），数值 eq 无法命中；
-            // 改按 body.name 精确匹配首个事件（事件名按 pascalToSnake 策略为 mock_aggregate_created，仅 1 个）
+            // 改按 body.name 精确匹配首个事件（事件名按 pascalTo_snake 策略为 mock_aggregate_created，仅 1 个）
             count("first") { "name" eq "mock_aggregate_created" }
         }.query(queryBackendBinding)
             .test()
             .assertNext { row ->
                 row.path("all").longValue().assert().isEqualTo(10L)
                 row.path("first").longValue().assert().isEqualTo(1L)
+            }.verifyComplete()
+    }
+
+    @Test
+    fun aggregateDerivedEventRatios() {
+        val tenantId = generateGlobalId()
+        eventStore.append(generateEventStream(namedAggregate.aggregateId(tenantId = tenantId))).block()
+        aggregation {
+            filter { tenantId(tenantId) }
+            expand("body")
+            count("all") // aggregateFilteredEventCounts 的 all 实测值 = 10
+            count("first") { "name" eq "mock_aggregate_created" } // = 1
+            derived("firstShare") { ref("first") / ref("all") } // 1 / 10 = 0.1
+        }.query(queryBackendBinding)
+            .test()
+            .assertNext { row ->
+                row.path("all").longValue().assert().isEqualTo(10L)
+                row.path("first").longValue().assert().isEqualTo(1L)
+                row.path("firstShare").doubleValue().assert().isEqualTo(0.1)
             }.verifyComplete()
     }
 }

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/EventStreamQueryBackendSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/EventStreamQueryBackendSpec.kt
@@ -508,7 +508,7 @@ abstract class EventStreamQueryBackendSpec {
             expand("body")
             count("all")
             // body.revision 是事件模式版本字符串（所有事件恒为 "0.0.1"），数值 eq 无法命中；
-            // 改按 body.name 精确匹配首个事件（事件名按 pascalTo_snake 策略为 mock_aggregate_created，仅 1 个）
+            // 改按 body.name 精确匹配首个事件（事件名按 pascalToSnake 策略为 mock_aggregate_created，仅 1 个）
             count("first") { "name" eq "mock_aggregate_created" }
         }.query(queryBackendBinding)
             .test()

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryBackendSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryBackendSpec.kt
@@ -1241,6 +1241,121 @@ abstract class SnapshotQueryBackendSpec {
     }
 
     @Test
+    fun `aggregation should derive ratios from filtered metrics`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+        aggregation {
+            filter { deletion(DeletionState.ACTIVE) }
+            expand("state.orders")
+            expand("lines")
+            count("big") { "quantity" gte 2 } // 5
+            sum("amount", "bigAmount") { "quantity" gte 2 } // 120.0
+            derived("aov") { ref("bigAmount") / ref("big") } // 24.0
+        }.query(queryBackendBinding)
+            .test()
+            .assertNext { it.assertWireEquals(mapOf("big" to 5L, "bigAmount" to 120.0, "aov" to 24.0)) }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should derive ratios between sums and constants`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+        aggregation {
+            filter { deletion(DeletionState.ACTIVE) }
+            expand("state.orders")
+            expand("lines")
+            sum("amount", "totalAmount") // 130.0（gamma 的 null 不参与）
+            sum("amount", "bigAmount") { "quantity" gte 2 } // 120.0
+            derived("margin") { (ref("totalAmount") - ref("bigAmount")) / constant(10.0) } // 1.0
+            derived("target") { constant(120.0) }
+            derived("attainment") { ref("bigAmount") / ref("target") } // 1.0（派生引用派生）
+        }.query(queryBackendBinding)
+            .test()
+            .assertNext {
+                it.assertWireEquals(
+                    mapOf(
+                        "totalAmount" to 130.0,
+                        "bigAmount" to 120.0,
+                        "margin" to 1.0,
+                        "target" to 120.0,
+                        "attainment" to 1.0,
+                    ),
+                )
+            }.verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should derive null on division by zero`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+        aggregation {
+            filter { deletion(DeletionState.ACTIVE) }
+            expand("state.orders")
+            expand("lines")
+            count("none") { "quantity" gt 100 } // 0
+            sum("amount", "bigAmount") { "quantity" gte 2 } // 120.0
+            derived("ratio") { ref("bigAmount") / ref("none") } // 120/0 -> null
+        }.query(queryBackendBinding)
+            .test()
+            .assertNext { it.assertWireEquals(mapOf("none" to 0L, "bigAmount" to 120.0, "ratio" to null)) }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should propagate null from empty metrics into derived`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+        aggregation {
+            filter { deletion(DeletionState.ACTIVE) }
+            expand("state.orders")
+            expand("lines")
+            sum("amount", "noneAmount") { "quantity" gt 100 } // null（过滤后无参与值）
+            derived("scaled") { ref("noneAmount") * constant(2.0) } // null * 2 -> null
+        }.query(queryBackendBinding)
+            .test()
+            .assertNext { it.assertWireEquals(mapOf("noneAmount" to null, "scaled" to null)) }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should derive from previously derived metrics`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+        aggregation {
+            filter { deletion(DeletionState.ACTIVE) }
+            expand("state.orders")
+            expand("lines")
+            count("big") { "quantity" gte 2 } // 5
+            sum("amount", "bigAmount") { "quantity" gte 2 } // 120.0
+            derived("aov") { ref("bigAmount") / ref("big") } // 24.0
+            derived("aovDoubled") { ref("aov") * constant(2.0) } // 48.0（派生链）
+        }.query(queryBackendBinding)
+            .test()
+            .assertNext {
+                it.assertWireEquals(
+                    mapOf("big" to 5L, "bigAmount" to 120.0, "aov" to 24.0, "aovDoubled" to 48.0),
+                )
+            }.verifyComplete()
+    }
+
+    @Test
+    fun `aggregation should sort groups by a derived metric`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+        aggregation {
+            filter { deletion(DeletionState.ACTIVE) }
+            expand("state.orders")
+            expand("lines")
+            terms("productId", "product")
+            sum("amount", "bigAmount") { "quantity" gte 2 } // delta=50, beta=40, alpha=30, gamma=null
+            derived("share") { ref("bigAmount") / constant(50.0) } // 1.0 / 0.8 / 0.6 / null
+            sort { "share".desc() }
+        }.query(queryBackendBinding)
+            .collectList()
+            .test()
+            .assertNext { rows ->
+                // gamma 组通过过滤条件（quantity=3）但 amount 为 null，share=null 按_desc 置尾，与 Phase 1 排序口径一致
+                rows.map { it.path("product").textValue() }.assert()
+                    .containsExactly("delta", "beta", "alpha", "gamma")
+            }.verifyComplete()
+    }
+
+    @Test
     fun `aggregation should support cancellation after a real result`() {
         saveAggregationStates(*aggregationStates().toTypedArray())
 

--- a/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryBackendSpec.kt
+++ b/test/wow-tck/src/main/kotlin/me/ahoo/wow/tck/query/SnapshotQueryBackendSpec.kt
@@ -1300,6 +1300,22 @@ abstract class SnapshotQueryBackendSpec {
     }
 
     @Test
+    fun `aggregation should evaluate derived metrics over an empty ungrouped summary`() {
+        saveAggregationStates(*aggregationStates().toTypedArray())
+        aggregation {
+            filter { deletion(DeletionState.ACTIVE) }
+            expand("state.orders")
+            expand("lines") { "quantity" gt 10000 } // 元素过滤零匹配：空聚合摘要
+            count("c") // 0
+            derived("one") { constant(1.0) } // 常量可求值
+            derived("next") { ref("c") + constant(1.0) } // 引用计数空语义 0 -> 1.0
+        }.query(queryBackendBinding)
+            .test()
+            .assertNext { it.assertWireEquals(mapOf("c" to 0L, "one" to 1.0, "next" to 1.0)) }
+            .verifyComplete()
+    }
+
+    @Test
     fun `aggregation should propagate null from empty metrics into derived`() {
         saveAggregationStates(*aggregationStates().toTypedArray())
         aggregation {

--- a/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
+++ b/wow-api/src/main/kotlin/me/ahoo/wow/api/query/AggregationQuery.kt
@@ -47,6 +47,7 @@ data class AggregationQuery(
         require(limit in 1..MAX_LIMIT) { "limit must be between 1 and $MAX_LIMIT." }
         require(groupBy.isNotEmpty() || sort.isEmpty()) { "sort requires at least one groupBy." }
         metrics.requireValidExpressions()
+        metrics.requireValidDerivedMetrics()
 
         val aliases = groupBy.map(AggregationGroup::alias) + metrics.map(AggregationMetric::alias)
         require(aliases.distinct().size == aliases.size) { "aggregation aliases must be unique." }
@@ -202,6 +203,7 @@ enum class AggregationExpressionOperator {
     JsonSubTypes.Type(AggregationMetric.Any::class, name = "ANY"),
     JsonSubTypes.Type(AggregationMetric.DistinctCount::class, name = "DISTINCT_COUNT"),
     JsonSubTypes.Type(AggregationMetric.Percentile::class, name = "PERCENTILE"),
+    JsonSubTypes.Type(AggregationMetric.Derived::class, name = "DERIVED"),
 )
 @Schema(
     oneOf = [
@@ -210,6 +212,7 @@ enum class AggregationExpressionOperator {
         AggregationMetric.Any::class,
         AggregationMetric.DistinctCount::class,
         AggregationMetric.Percentile::class,
+        AggregationMetric.Derived::class,
     ],
     discriminatorProperty = QueryProtocol.Polymorphic.TYPE,
 )
@@ -279,6 +282,48 @@ sealed interface AggregationMetric {
             }
         }
     }
+
+    data class Derived(
+        override val alias: String,
+        val expression: DerivedExpression,
+    ) : AggregationMetric {
+        @get:JsonInclude(JsonInclude.Include.CUSTOM, valueFilter = MatchAllFilterValueFilter::class)
+        override val filter: FilterExpression get() = MatchAllFilter
+
+        init {
+            requireAggregationAlias(alias)
+        }
+    }
+}
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = QueryProtocol.Polymorphic.TYPE)
+@JsonSubTypes(
+    JsonSubTypes.Type(DerivedExpression.MetricRef::class, name = "METRIC_REF"),
+    JsonSubTypes.Type(DerivedExpression.Constant::class, name = "CONSTANT"),
+    JsonSubTypes.Type(DerivedExpression.Binary::class, name = "BINARY"),
+)
+@Schema(
+    oneOf = [
+        DerivedExpression.MetricRef::class,
+        DerivedExpression.Constant::class,
+        DerivedExpression.Binary::class,
+    ],
+    discriminatorProperty = QueryProtocol.Polymorphic.TYPE,
+)
+sealed interface DerivedExpression {
+    data class MetricRef(val metric: String) : DerivedExpression
+
+    data class Constant(val value: Double) : DerivedExpression {
+        init {
+            require(value.isFinite()) { "derived constant must be finite." }
+        }
+    }
+
+    data class Binary(
+        val operator: AggregationExpressionOperator,
+        val left: DerivedExpression,
+        val right: DerivedExpression,
+    ) : DerivedExpression
 }
 
 enum class AggregationFunction {
@@ -324,7 +369,7 @@ private fun List<AggregationMetric>.requireValidExpressions() {
             is AggregationMetric.Numeric -> pending.addLast(PendingExpression(metric.expression, 1))
             is AggregationMetric.DistinctCount -> pending.addLast(PendingExpression(metric.expression, 1))
             is AggregationMetric.Percentile -> pending.addLast(PendingExpression(metric.expression, 1))
-            is AggregationMetric.Count, is AggregationMetric.Any -> Unit
+            is AggregationMetric.Count, is AggregationMetric.Any, is AggregationMetric.Derived -> Unit
         }
     }
     var nodes = 0
@@ -352,4 +397,55 @@ private fun List<AggregationMetric>.requireValidExpressions() {
             )
         }
     }
+}
+
+private data class PendingDerivedExpression(
+    val expression: DerivedExpression,
+    val depth: Int,
+)
+
+private fun List<AggregationMetric>.requireValidDerivedMetrics() {
+    val declared = LinkedHashMap<String, Boolean>()
+    var nodes = 0
+    forEach { metric ->
+        if (metric is AggregationMetric.Derived) {
+            nodes = metric.requireValidDerivedExpression(declared, nodes)
+        }
+        declared[metric.alias] = metric is AggregationMetric.Any
+    }
+}
+
+private fun AggregationMetric.Derived.requireValidDerivedExpression(declared: Map<String, Boolean>, visitedNodes: Int): Int {
+    val pending = ArrayDeque<PendingDerivedExpression>()
+    pending.addLast(PendingDerivedExpression(expression, 1))
+    var nodes = visitedNodes
+    while (pending.isNotEmpty()) {
+        val (current, depth) = pending.removeLast()
+        require(depth <= AggregationQuery.MAX_EXPRESSION_DEPTH) {
+            "derived expression depth must be at most ${AggregationQuery.MAX_EXPRESSION_DEPTH}."
+        }
+        nodes++
+        require(nodes <= AggregationQuery.MAX_EXPRESSION_NODES) {
+            "derived expressions must contain at most ${AggregationQuery.MAX_EXPRESSION_NODES} nodes."
+        }
+        when (current) {
+            is DerivedExpression.MetricRef -> {
+                val reference = current.metric
+                require(reference in declared) {
+                    "derived metric [$alias] must reference a metric declared before it, but was [$reference]."
+                }
+                require(!declared.getValue(reference)) {
+                    "derived metric [$alias] cannot reference ANY metric [$reference]."
+                }
+            }
+
+            is DerivedExpression.Constant -> Unit
+
+            is DerivedExpression.Binary -> {
+                pending.addLast(PendingDerivedExpression(current.left, depth + 1))
+                pending.addLast(PendingDerivedExpression(current.right, depth + 1))
+            }
+        }
+    }
+    return nodes
 }

--- a/wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt
+++ b/wow-api/src/test/kotlin/me/ahoo/wow/api/query/AggregationQueryTest.kt
@@ -498,4 +498,99 @@ class AggregationQueryTest {
             .doesNotContain("\"alias\":\"total\",\"filter\"")
             .doesNotContain("\"alias\":\"sumAmount\",\"filter\"")
     }
+
+    @Test
+    fun `derived metrics should round trip with expression subtypes`() {
+        val json = """
+            {
+              "metrics": [
+                {"type": "COUNT", "alias": "paid"},
+                {"type": "NUMERIC", "function": "SUM", "expression": {"field": "amount"}, "alias": "x"},
+                {"type": "DERIVED", "alias": "aov",
+                 "expression": {"type": "BINARY", "operator": "DIVIDE",
+                   "left": {"type": "METRIC_REF", "metric": "paid"},
+                   "right": {"type": "CONSTANT", "value": 2.0}}}
+              ]
+            }
+        """.trimIndent()
+
+        val query = configuredMapper.readValue(json, AggregationQuery::class.java)
+        val derived = query.metrics.filterIsInstance<AggregationMetric.Derived>().single()
+
+        derived.expression.assert().isEqualTo(
+            DerivedExpression.Binary(
+                AggregationExpressionOperator.DIVIDE,
+                DerivedExpression.MetricRef("paid"),
+                DerivedExpression.Constant(2.0),
+            ),
+        )
+        derived.filter.assert().isEqualTo(MatchAllFilter)
+        val wire = configuredMapper.writeValueAsString(query)
+        wire.assert().contains("\"type\":\"DERIVED\"")
+        wire.substring(wire.indexOf("DERIVED")).assert().doesNotContain("\"filter\"")
+    }
+
+    @Test
+    fun `derived references must be declared earlier`() {
+        fun derivedOf(vararg metrics: AggregationMetric) = AggregationQuery(metrics = metrics.toList())
+        val paid = AggregationMetric.Count("paid")
+        val aov = AggregationMetric.Derived(
+            "aov",
+            DerivedExpression.Binary(
+                AggregationExpressionOperator.ADD,
+                DerivedExpression.MetricRef("paid"),
+                DerivedExpression.Constant(1.0),
+            ),
+        )
+
+        assertThrows<IllegalArgumentException> { derivedOf(aov, paid) }.message.assert()
+            .contains("must reference a metric declared before it")
+        assertThrows<IllegalArgumentException> {
+            derivedOf(paid, AggregationMetric.Derived("x", DerivedExpression.MetricRef("unknown")))
+        }.message.assert().contains("unknown")
+
+        derivedOf(paid, AggregationMetric.Derived("x", DerivedExpression.MetricRef("paid")))
+    }
+
+    @Test
+    fun `derived references to any metrics and group aliases are rejected`() {
+        val any = AggregationMetric.Any(QueryField("status"), "sample")
+        assertThrows<IllegalArgumentException> {
+            AggregationQuery(
+                groupBy = listOf(AggregationGroup.Terms(QueryField("status"), "status")),
+                metrics = listOf(any, AggregationMetric.Derived("x", DerivedExpression.MetricRef("sample"))),
+            )
+        }.message.assert().contains("cannot reference ANY metric")
+        assertThrows<IllegalArgumentException> {
+            AggregationQuery(
+                groupBy = listOf(AggregationGroup.Terms(QueryField("status"), "status")),
+                metrics = listOf(
+                    AggregationMetric.Count("total"),
+                    AggregationMetric.Derived("x", DerivedExpression.MetricRef("status")),
+                ),
+            )
+        }
+    }
+
+    @Test
+    fun `derived expressions are depth and node bounded`() {
+        fun nest(depth: Int): DerivedExpression =
+            (1 until depth).fold(DerivedExpression.Constant(1.0) as DerivedExpression) { acc, _ ->
+                DerivedExpression.Binary(AggregationExpressionOperator.ADD, acc, DerivedExpression.Constant(1.0))
+            }
+
+        assertThrows<IllegalArgumentException> {
+            AggregationQuery(metrics = listOf(AggregationMetric.Count("c"), AggregationMetric.Derived("d", nest(9))))
+        }.message.assert().contains("depth")
+        assertThrows<IllegalArgumentException> {
+            AggregationQuery(
+                metrics = List(AggregationQuery.MAX_METRICS) { index ->
+                    AggregationMetric.Derived("d$index", nest(AggregationQuery.MAX_EXPRESSION_DEPTH))
+                },
+            )
+        }.message.assert().contains("at most ${AggregationQuery.MAX_EXPRESSION_NODES} nodes")
+        assertThrows<IllegalArgumentException> {
+            DerivedExpression.Constant(Double.POSITIVE_INFINITY)
+        }
+    }
 }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationCompiler.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationCompiler.kt
@@ -463,10 +463,10 @@ internal class ElasticsearchAggregationCompiler(
      *
      * Guards use a NaN sentinel instead of null: Painless throws on null arithmetic operands, and an
      * empty-set sum is a value (0.0), not a gap, so the count guard must stay in double arithmetic
-     * (`Double.NaN`). Every reference is cast `as double` (plain `_count` paths arrive as Longs —
-     * Long/Long division is integer division), division relies on IEEE semantics (x / 0.0 → ±Infinity)
-     * instead of an explicit zero guard, and the final `!Double.isFinite` wrap unifies NaN and ±Infinity
-     * to null.
+     * (`Double.NaN`). Every reference is cast `(double)` — Painless has no `as` cast operator, and
+     * plain `_count` paths arrive as Longs (Long/Long division is integer division). Division relies
+     * on IEEE semantics (x / 0.0 → ±Infinity) instead of an explicit zero guard, and the final
+     * `!Double.isFinite` wrap unifies NaN and ±Infinity to null.
      */
     private fun DerivedExpression.toScript(
         prior: Map<String, ElasticsearchAggregationMetric>,
@@ -479,11 +479,11 @@ internal class ElasticsearchAggregationCompiler(
             val index = derivedRefIndexes.getOrPut(metric) { derivedRefIndexes.size }
             bucketsPath["v$index"] = valuePath
             if (countPath == null) {
-                "(params.v$index as double)"
+                "((double) params.v$index)"
             } else {
                 bucketsPath["c$index"] = countPath
                 // empty-set guard: zero count -> NaN sentinel (null would throw in Painless arithmetic)
-                "((params.c$index as double) == 0.0 ? Double.NaN : (params.v$index as double))"
+                "(((double) params.c$index) == 0.0 ? Double.NaN : ((double) params.v$index))"
             }
         }
 
@@ -520,10 +520,14 @@ internal class ElasticsearchAggregationCompiler(
     /**
      * Resolves (valuePath, countPath?) of a referenced metric plan; a non-null countPath means the
      * script needs the empty-set guard. Filtered wrapper names are based on the referenced metric's
-     * own alias: [metricFilterAggregationName] with that alias.
+     * own alias: [metricFilterAggregationName] with that alias. Metrics under that wrapper are
+     * referenced with the `>` separator — buckets_path resolves `a.b` against sibling aggregation
+     * *names* (a dot would look for a sibling literally named `a.b`), while `a>b` descends into the
+     * single-bucket wrapper [a]. Filtered Counts keep the filter aggregation named [alias] itself,
+     * so their doc_count is `alias._count`.
      */
     private fun ElasticsearchAggregationMetric.referencePaths(): Pair<String, String?> {
-        val scope = if (filter == null) "" else "${metricFilterAggregationName(alias)}."
+        val scope = if (filter == null) "" else "${metricFilterAggregationName(alias)}>"
         return when (this) {
             is ElasticsearchAggregationMetric.Count ->
                 // unfiltered: the bucket's own doc_count; filtered: the doc_count of the filter aggregation named alias

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationCompiler.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationCompiler.kt
@@ -28,6 +28,7 @@ import me.ahoo.wow.api.query.AggregationFunction
 import me.ahoo.wow.api.query.AggregationGroup
 import me.ahoo.wow.api.query.AggregationMetric
 import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.DerivedExpression
 import me.ahoo.wow.api.query.MatchAllFilter
 import me.ahoo.wow.api.query.QueryField
 import me.ahoo.wow.api.query.Sort
@@ -96,6 +97,14 @@ internal sealed interface ElasticsearchAggregationMetric {
         val percentile: Double,
         override val filter: Query? = null,
     ) : ElasticsearchAggregationMetric
+
+    data class Derived(
+        override val alias: String,
+        val bucketsPath: Map<String, String>,
+        val script: Script,
+    ) : ElasticsearchAggregationMetric {
+        override val filter: Query? = null
+    }
 }
 
 internal val ElasticsearchAggregationMetric.valueCountAlias: String
@@ -145,20 +154,51 @@ internal class ElasticsearchAggregationCompiler(
                 indexed.value.toSource(logicalParent, physicalParent, sort, indexed.index, schema, runtimeMappings)
             }
         }
-        val metrics = query.metrics.mapIndexed { index, metric ->
-            metric.toPlan(logicalParent, physicalParent, index, schema, runtimeMappings, now)
-        }
+        val metricPlans = compileMetrics(query, logicalParent, physicalParent, schema, runtimeMappings, now)
         val metricAliases = query.metrics.mapTo(hashSetOf(), AggregationMetric::alias)
         return ElasticsearchAggregationPlan(
             rootQuery = rootQuery,
             elements = elements,
             groupSources = groupSources,
-            metrics = metrics,
+            metrics = metricPlans,
             runtimeMappings = runtimeMappings,
             effectiveSort = effectiveSort,
             limit = query.limit,
             metricSorted = effectiveSort.any { it.field.path in metricAliases },
         )
+    }
+
+    /**
+     * Compiles the declared metrics in order. Declaration order (list iteration order) lets a
+     * [AggregationMetric.Derived] metric resolve the plans of metrics declared before it;
+     * referenced aliases keep one stable `vN`/`cN` param index across the whole compile.
+     */
+    private fun compileMetrics(
+        query: AggregationQuery,
+        logicalParent: QueryField?,
+        physicalParent: QueryField?,
+        schema: QueryModelSchema,
+        runtimeMappings: MutableMap<String, RuntimeField>,
+        now: Instant,
+    ): List<ElasticsearchAggregationMetric> {
+        val metricPlans = mutableListOf<ElasticsearchAggregationMetric>()
+        val priorByAlias = linkedMapOf<String, ElasticsearchAggregationMetric>()
+        val derivedRefIndexes = linkedMapOf<String, Int>()
+        query.metrics.forEachIndexed { index, metric ->
+            val plan = metric.toPlan(
+                logicalParent,
+                physicalParent,
+                index,
+                schema,
+                runtimeMappings,
+                now,
+                priorByAlias,
+                derivedRefIndexes,
+            )
+            metricPlans += plan
+            priorByAlias[metric.alias] = plan
+        }
+        return metricPlans
     }
 
     private fun AggregationGroup.toSource(
@@ -279,6 +319,8 @@ internal class ElasticsearchAggregationCompiler(
         schema: QueryModelSchema,
         runtimeMappings: MutableMap<String, RuntimeField>,
         now: Instant,
+        prior: Map<String, ElasticsearchAggregationMetric>,
+        derivedRefIndexes: MutableMap<String, Int>,
     ): ElasticsearchAggregationMetric {
         val filter = metricFilter(parent, physicalParent, schema, now)
         return when (this) {
@@ -325,6 +367,8 @@ internal class ElasticsearchAggregationCompiler(
                 runtimeMappings,
                 filter,
             )
+
+            is AggregationMetric.Derived -> toDerivedPlan(expression, prior, derivedRefIndexes)
         }
     }
 
@@ -394,6 +438,105 @@ internal class ElasticsearchAggregationCompiler(
             }
         }
         return ElasticsearchAggregationMetric.Percentile(alias, metricField, percentile, filter)
+    }
+
+    private fun AggregationMetric.Derived.toDerivedPlan(
+        expression: DerivedExpression,
+        prior: Map<String, ElasticsearchAggregationMetric>,
+        derivedRefIndexes: MutableMap<String, Int>,
+    ): ElasticsearchAggregationMetric.Derived {
+        val bucketsPath = linkedMapOf<String, String>()
+        val source = "def value = ${expression.toScript(prior, derivedRefIndexes, bucketsPath)}; " +
+            "value == null || !Double.isFinite(value) ? null : value"
+        return ElasticsearchAggregationMetric.Derived(
+            alias,
+            bucketsPath,
+            Script.of { it.source { s -> s.scriptString(source) } },
+        )
+    }
+
+    /**
+     * Serializes a derived expression to its bucket_script Painless body while registering the
+     * referenced sibling aggregations in [bucketsPath]. A [DerivedExpression.MetricRef] contributes
+     * a `vN` value entry and — for metrics whose empty-set semantics differ from a missing value —
+     * an additional `cN` value-count entry the script guards on.
+     */
+    private fun DerivedExpression.toScript(
+        prior: Map<String, ElasticsearchAggregationMetric>,
+        derivedRefIndexes: MutableMap<String, Int>,
+        bucketsPath: MutableMap<String, String>,
+    ): String = when (this) {
+        is DerivedExpression.MetricRef -> {
+            val target = prior.getValue(metric)
+            val (valuePath, countPath) = target.referencePaths()
+            val index = derivedRefIndexes.getOrPut(metric) { derivedRefIndexes.size }
+            bucketsPath["v$index"] = valuePath
+            if (countPath == null) {
+                "params.v$index"
+            } else {
+                bucketsPath["c$index"] = countPath
+                "(params.c$index == 0.0 ? null : params.v$index)" // empty-set guard: zero count -> null
+            }
+        }
+
+        is DerivedExpression.Constant -> value.toString()
+
+        is DerivedExpression.Binary -> when (operator) {
+            AggregationExpressionOperator.ADD ->
+                "(${left.toScript(
+                    prior,
+                    derivedRefIndexes,
+                    bucketsPath
+                )} + ${right.toScript(prior, derivedRefIndexes, bucketsPath)})"
+            AggregationExpressionOperator.SUBTRACT ->
+                "(${left.toScript(
+                    prior,
+                    derivedRefIndexes,
+                    bucketsPath
+                )} - ${right.toScript(prior, derivedRefIndexes, bucketsPath)})"
+            AggregationExpressionOperator.MULTIPLY ->
+                "(${left.toScript(
+                    prior,
+                    derivedRefIndexes,
+                    bucketsPath
+                )} * ${right.toScript(prior, derivedRefIndexes, bucketsPath)})"
+            AggregationExpressionOperator.DIVIDE -> {
+                val leftScript = left.toScript(prior, derivedRefIndexes, bucketsPath)
+                val rightScript = right.toScript(prior, derivedRefIndexes, bucketsPath)
+                "($rightScript == 0.0 ? null : $leftScript / $rightScript)" // painless division by zero throws -> explicit guard
+            }
+        }
+    }
+
+    /**
+     * Resolves (valuePath, countPath?) of a referenced metric plan; a non-null countPath means the
+     * script needs the empty-set guard. Filtered wrapper names are based on the referenced metric's
+     * own alias: [metricFilterAggregationName] with that alias.
+     */
+    private fun ElasticsearchAggregationMetric.referencePaths(): Pair<String, String?> {
+        val scope = if (filter == null) "" else "${metricFilterAggregationName(alias)}."
+        return when (this) {
+            is ElasticsearchAggregationMetric.Count ->
+                // unfiltered: the bucket's own doc_count; filtered: the doc_count of the filter aggregation named alias
+                (if (filter == null) "_count" else "$alias._count") to null
+
+            is ElasticsearchAggregationMetric.Numeric -> {
+                val value = when (function) {
+                    AggregationFunction.SUM, AggregationFunction.AVG,
+                    AggregationFunction.MIN, AggregationFunction.MAX,
+                    -> "$alias.value"
+
+                    AggregationFunction.STDDEV -> "$alias.std_deviation_population"
+                    AggregationFunction.VARIANCE -> "$alias.variance_population"
+                }
+                "$scope$value" to "$scope$valueCountAlias.value"
+            }
+
+            is ElasticsearchAggregationMetric.Percentile -> "$scope$alias[$percentile]" to "$scope$valueCountAlias.value"
+            is ElasticsearchAggregationMetric.DistinctCount -> "$scope$alias.value" to null // cardinality is never null (may be 0)
+            is ElasticsearchAggregationMetric.Derived -> "$alias.value" to null // prior bucket_script output; null -> gap -> skip
+            is ElasticsearchAggregationMetric.Any -> error("Derived metric cannot reference ANY metric [$alias].")
+        }
     }
 
     private inner class RuntimeExpressionCompiler(

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationCompiler.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationCompiler.kt
@@ -460,6 +460,13 @@ internal class ElasticsearchAggregationCompiler(
      * referenced sibling aggregations in [bucketsPath]. A [DerivedExpression.MetricRef] contributes
      * a `vN` value entry and — for metrics whose empty-set semantics differ from a missing value —
      * an additional `cN` value-count entry the script guards on.
+     *
+     * Guards use a NaN sentinel instead of null: Painless throws on null arithmetic operands, and an
+     * empty-set sum is a value (0.0), not a gap, so the count guard must stay in double arithmetic
+     * (`Double.NaN`). Every reference is cast `as double` (plain `_count` paths arrive as Longs —
+     * Long/Long division is integer division), division relies on IEEE semantics (x / 0.0 → ±Infinity)
+     * instead of an explicit zero guard, and the final `!Double.isFinite` wrap unifies NaN and ±Infinity
+     * to null.
      */
     private fun DerivedExpression.toScript(
         prior: Map<String, ElasticsearchAggregationMetric>,
@@ -472,10 +479,11 @@ internal class ElasticsearchAggregationCompiler(
             val index = derivedRefIndexes.getOrPut(metric) { derivedRefIndexes.size }
             bucketsPath["v$index"] = valuePath
             if (countPath == null) {
-                "params.v$index"
+                "(params.v$index as double)"
             } else {
                 bucketsPath["c$index"] = countPath
-                "(params.c$index == 0.0 ? null : params.v$index)" // empty-set guard: zero count -> null
+                // empty-set guard: zero count -> NaN sentinel (null would throw in Painless arithmetic)
+                "((params.c$index as double) == 0.0 ? Double.NaN : (params.v$index as double))"
             }
         }
 
@@ -503,7 +511,8 @@ internal class ElasticsearchAggregationCompiler(
             AggregationExpressionOperator.DIVIDE -> {
                 val leftScript = left.toScript(prior, derivedRefIndexes, bucketsPath)
                 val rightScript = right.toScript(prior, derivedRefIndexes, bucketsPath)
-                "($rightScript == 0.0 ? null : $leftScript / $rightScript)" // painless division by zero throws -> explicit guard
+                // all-double operands follow IEEE: x / 0.0 -> ±Infinity, unified to null by the final wrap
+                "($leftScript / $rightScript)"
             }
         }
     }

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationPager.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationPager.kt
@@ -223,6 +223,16 @@ internal class ElasticsearchAggregationPager(
                         builder.valueCount { it.field(metric.field) }
                     },
                 )
+
+                is ElasticsearchAggregationMetric.Derived -> put(
+                    metric.alias,
+                    Aggregation.of { builder ->
+                        builder.bucketScript { bucketScript ->
+                            bucketScript.bucketsPath { it.dict(metric.bucketsPath) }
+                                .script(metric.script)
+                        }
+                    },
+                )
             }
         }
     }
@@ -291,6 +301,12 @@ internal class ElasticsearchAggregationPager(
         is ElasticsearchAggregationMetric.DistinctCount ->
             aggregations.filtered(this).getValue(alias).cardinality().value()
         is ElasticsearchAggregationMetric.Percentile -> percentileValue(aggregations.filtered(this))
+
+        /**
+         * A skipped bucket_script (default gap_policy=skip: a referenced path is missing or null)
+         * is omitted from the response bucket, so the key itself may be absent — null either way.
+         */
+        is ElasticsearchAggregationMetric.Derived -> aggregations[alias]?.simpleValue()?.value()
     }
 
     private fun Aggregate.anyValue(alias: String): Any? = when {
@@ -443,7 +459,7 @@ private fun nestedAggregationName(index: Int): String = "__wow_element_$index"
 
 private fun filterAggregationName(index: Int): String = "__wow_element_filter_$index"
 
-private fun metricFilterAggregationName(alias: String): String = "__wow_metric_filter_$alias"
+internal fun metricFilterAggregationName(alias: String): String = "__wow_metric_filter_$alias"
 
 /**
  * Publishes a metric's aggregations directly, or nested under one filter aggregation

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationPager.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationPager.kt
@@ -46,8 +46,8 @@ private const val GROUP_AGGREGATION = "__wow_groups"
  * "Expected a multi bucket aggregation". One catch-all `filters` bucket provides the required
  * multi-bucket parent without changing any computed value.
  */
-private const val SUMMARY_BUCKET_AGGREGATION = "__wow_summary_bucket"
-private const val SUMMARY_BUCKET_KEY = "_wow"
+internal const val SUMMARY_BUCKET_AGGREGATION = "__wow_summary_bucket"
+internal const val SUMMARY_BUCKET_KEY = "_wow"
 
 internal class ElasticsearchAggregationPager(
     private val client: ReactiveElasticsearchClient,

--- a/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationPager.kt
+++ b/wow-elasticsearch/src/main/kotlin/me/ahoo/wow/elasticsearch/query/aggregation/ElasticsearchAggregationPager.kt
@@ -17,6 +17,7 @@ import co.elastic.clients.elasticsearch._types.FieldValue
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregate
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregation
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeBucket
+import co.elastic.clients.elasticsearch._types.query_dsl.Query
 import co.elastic.clients.elasticsearch.core.SearchRequest
 import co.elastic.clients.elasticsearch.core.search.ResponseBody
 import me.ahoo.wow.api.query.AggregationFunction
@@ -37,6 +38,16 @@ import kotlin.math.min
 
 private const val ROOT_AGGREGATION = "__wow_aggregation"
 private const val GROUP_AGGREGATION = "__wow_groups"
+
+/**
+ * A bucket_script pipeline requires a multi-bucket parent aggregation. Grouped queries nest the
+ * metrics under the composite [GROUP_AGGREGATION], but a summary (ungrouped) query would otherwise
+ * leave them under single-bucket scopes (`filter`/`nested`), which Elasticsearch rejects with
+ * "Expected a multi bucket aggregation". One catch-all `filters` bucket provides the required
+ * multi-bucket parent without changing any computed value.
+ */
+private const val SUMMARY_BUCKET_AGGREGATION = "__wow_summary_bucket"
+private const val SUMMARY_BUCKET_KEY = "_wow"
 
 internal class ElasticsearchAggregationPager(
     private val client: ReactiveElasticsearchClient,
@@ -141,7 +152,7 @@ internal class ElasticsearchAggregationPager(
         pageSize: Int,
     ): Aggregation {
         var aggregations = if (groupSources.isEmpty()) {
-            metricAggregations()
+            summaryMetricAggregations()
         } else {
             mapOf(GROUP_AGGREGATION to groupAggregation(afterKey, pageSize))
         }
@@ -237,9 +248,40 @@ internal class ElasticsearchAggregationPager(
         }
     }
 
+    /**
+     * Wraps summary (ungrouped) metric aggregations in one catch-all [SUMMARY_BUCKET_AGGREGATION]
+     * bucket whenever a derived metric requires a multi-bucket bucket_script parent.
+     */
+    private fun ElasticsearchAggregationPlan.summaryMetricAggregations(): Map<String, Aggregation> {
+        val aggregations = metricAggregations()
+        if (metrics.none { it is ElasticsearchAggregationMetric.Derived }) {
+            return aggregations
+        }
+        return mapOf(
+            SUMMARY_BUCKET_AGGREGATION to Aggregation.of { builder ->
+                builder.filters { filters ->
+                    filters.filters { buckets ->
+                        buckets.keyed(
+                            mapOf(SUMMARY_BUCKET_KEY to Query.of { it.matchAll { matchAll -> matchAll } }),
+                        )
+                    }
+                }.aggregations(aggregations)
+            },
+        )
+    }
+
     private fun ResponseBody<Map<*, *>>.summary(plan: ElasticsearchAggregationPlan): ObjectNode {
         val scope = aggregations().getValue(ROOT_AGGREGATION).let { root ->
             if (plan.elements.isEmpty()) root.filter() else root.innermostScope(plan)
+        }
+        if (plan.groupSources.isEmpty() && plan.metrics.any { it is ElasticsearchAggregationMetric.Derived }) {
+            val bucket = scope.aggregations()
+                .getValue(SUMMARY_BUCKET_AGGREGATION)
+                .filters()
+                .buckets()
+                .keyed()
+                .getValue(SUMMARY_BUCKET_KEY)
+            return plan.toRow(bucket.docCount(), bucket.aggregations())
         }
         return plan.toRow(scope.docCount(), scope.aggregations())
     }

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
@@ -479,21 +479,25 @@ class ElasticsearchAggregationCompilerTest {
         derived.assert().hasSize(2)
         val aov = derived[0]
         // filtered Numeric: value via the metric filter wrapper, count via the wrapper's value count;
+        // wrapper traversal uses the '>' separator — a dotted path would look up a sibling literally
+        // named "__wow_metric_filter_paidAmount.paidAmount" and fail request validation;
         // filtered Count: alias._count
         aov.bucketsPath.assert().containsKey("v0").containsKey("c0").containsKey("v1")
-        aov.bucketsPath["v0"].assert().isEqualTo("__wow_metric_filter_paidAmount.paidAmount.value")
-        aov.bucketsPath["c0"].assert().isEqualTo("__wow_metric_filter_paidAmount.__wow_value_count_paidAmount.value")
+        aov.bucketsPath["v0"].assert().isEqualTo("__wow_metric_filter_paidAmount>paidAmount.value")
+        aov.bucketsPath["c0"].assert().isEqualTo("__wow_metric_filter_paidAmount>__wow_value_count_paidAmount.value")
         aov.bucketsPath["v1"].assert().isEqualTo("paid._count")
         requireNotNull(aov.script.source()).scriptString().assert()
             // NaN sentinel: an empty-set sum is a value (0.0), not a gap, so the guard must stay
-            // in-double-arithmetic (Painless throws on null operands) and let NaN flow to the final wrap
-            .contains("((params.c0 as double) == 0.0 ? Double.NaN : (params.v0 as double))")
-            .contains("(params.v1 as double)")
+            // in-double-arithmetic (Painless throws on null operands) and let NaN flow to the final wrap;
+            // casts use the Painless `(double)` form — Painless has no `as` cast operator
+            .contains("(((double) params.c0) == 0.0 ? Double.NaN : ((double) params.v0))")
+            .contains("((double) params.v1)")
             .contains("Double.NaN")
             .contains("Double.isFinite")
             .doesNotContain("== 0.0 ? null")
+            .doesNotContain(" as double")
         val attainment = derived[1]
-        attainment.bucketsPath["v0"].assert().isEqualTo("__wow_metric_filter_paidAmount.paidAmount.value")
+        attainment.bucketsPath["v0"].assert().isEqualTo("__wow_metric_filter_paidAmount>paidAmount.value")
         attainment.bucketsPath["v2"].assert().isEqualTo("totalAmount.value") // unfiltered Numeric has no wrapper
         attainment.bucketsPath["c2"].assert().isEqualTo("__wow_value_count_totalAmount.value")
         requireNotNull(attainment.script.source()).scriptString().assert().contains("Double.isFinite")
@@ -512,7 +516,7 @@ class ElasticsearchAggregationCompilerTest {
         val quarter = plan.metrics.filterIsInstance<ElasticsearchAggregationMetric.Derived>()[1]
         quarter.bucketsPath.values.single().assert().isEqualTo("half.value")
         requireNotNull(quarter.script.source()).scriptString().assert()
-            .contains("(params.v1 as double)")
+            .contains("((double) params.v1)")
             .contains("/ 2.0")
     }
 

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
@@ -485,7 +485,13 @@ class ElasticsearchAggregationCompilerTest {
         aov.bucketsPath["c0"].assert().isEqualTo("__wow_metric_filter_paidAmount.__wow_value_count_paidAmount.value")
         aov.bucketsPath["v1"].assert().isEqualTo("paid._count")
         requireNotNull(aov.script.source()).scriptString().assert()
-            .contains("(params.c0 == 0.0 ? null : params.v0)").contains("params.v1 == 0.0 ? null")
+            // NaN sentinel: an empty-set sum is a value (0.0), not a gap, so the guard must stay
+            // in-double-arithmetic (Painless throws on null operands) and let NaN flow to the final wrap
+            .contains("((params.c0 as double) == 0.0 ? Double.NaN : (params.v0 as double))")
+            .contains("(params.v1 as double)")
+            .contains("Double.NaN")
+            .contains("Double.isFinite")
+            .doesNotContain("== 0.0 ? null")
         val attainment = derived[1]
         attainment.bucketsPath["v0"].assert().isEqualTo("__wow_metric_filter_paidAmount.paidAmount.value")
         attainment.bucketsPath["v2"].assert().isEqualTo("totalAmount.value") // unfiltered Numeric has no wrapper
@@ -505,7 +511,9 @@ class ElasticsearchAggregationCompilerTest {
         )
         val quarter = plan.metrics.filterIsInstance<ElasticsearchAggregationMetric.Derived>()[1]
         quarter.bucketsPath.values.single().assert().isEqualTo("half.value")
-        requireNotNull(quarter.script.source()).scriptString().assert().contains("/ 2.0")
+        requireNotNull(quarter.script.source()).scriptString().assert()
+            .contains("(params.v1 as double)")
+            .contains("/ 2.0")
     }
 
     @Test

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
@@ -13,6 +13,7 @@
 
 package me.ahoo.wow.elasticsearch.query.snapshot
 
+import co.elastic.clients.elasticsearch._types.Script
 import co.elastic.clients.elasticsearch._types.mapping.RuntimeFieldType
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping
 import me.ahoo.test.asserts.assert
@@ -327,6 +328,11 @@ class ElasticsearchAggregationCompilerTest {
         ElasticsearchAggregationMetric.Numeric("sum", AggregationFunction.SUM, "amount").filter.assert().isNull()
         ElasticsearchAggregationMetric.DistinctCount("customers", "customerId").filter.assert().isNull()
         ElasticsearchAggregationMetric.Percentile("p95", "amount", 95.0).filter.assert().isNull()
+        ElasticsearchAggregationMetric.Derived(
+            "aov",
+            emptyMap(),
+            Script.of { it.source { s -> s.scriptString("null") } },
+        ).filter.assert().isNull()
     }
 
     @Test
@@ -455,6 +461,51 @@ class ElasticsearchAggregationCompilerTest {
             .assert().isEqualTo("orders.status")
 
         compiler.compile(aggregation { count("count") }, schema).metrics.single().filter.assert().isNull()
+    }
+
+    @Test
+    fun `derived metrics plan bucket scripts with guarded paths`() {
+        val plan = compiler.compile(
+            aggregation {
+                count("paid") { "deleted" eq false }
+                sum("amount", "paidAmount") { "deleted" eq false }
+                sum("amount", "totalAmount")
+                derived("aov") { ref("paidAmount") / ref("paid") }
+                derived("attainment") { ref("paidAmount") / ref("totalAmount") }
+            },
+            schema,
+        )
+        val derived = plan.metrics.filterIsInstance<ElasticsearchAggregationMetric.Derived>()
+        derived.assert().hasSize(2)
+        val aov = derived[0]
+        // filtered Numeric: value via the metric filter wrapper, count via the wrapper's value count;
+        // filtered Count: alias._count
+        aov.bucketsPath.assert().containsKey("v0").containsKey("c0").containsKey("v1")
+        aov.bucketsPath["v0"].assert().isEqualTo("__wow_metric_filter_paidAmount.paidAmount.value")
+        aov.bucketsPath["c0"].assert().isEqualTo("__wow_metric_filter_paidAmount.__wow_value_count_paidAmount.value")
+        aov.bucketsPath["v1"].assert().isEqualTo("paid._count")
+        requireNotNull(aov.script.source()).scriptString().assert()
+            .contains("(params.c0 == 0.0 ? null : params.v0)").contains("params.v1 == 0.0 ? null")
+        val attainment = derived[1]
+        attainment.bucketsPath["v0"].assert().isEqualTo("__wow_metric_filter_paidAmount.paidAmount.value")
+        attainment.bucketsPath["v2"].assert().isEqualTo("totalAmount.value") // unfiltered Numeric has no wrapper
+        attainment.bucketsPath["c2"].assert().isEqualTo("__wow_value_count_totalAmount.value")
+        requireNotNull(attainment.script.source()).scriptString().assert().contains("Double.isFinite")
+    }
+
+    @Test
+    fun `derived chains reference prior derived aliases`() {
+        val plan = compiler.compile(
+            aggregation {
+                count("total")
+                derived("half") { ref("total") / constant(2.0) }
+                derived("quarter") { ref("half") / constant(2.0) }
+            },
+            schema,
+        )
+        val quarter = plan.metrics.filterIsInstance<ElasticsearchAggregationMetric.Derived>()[1]
+        quarter.bucketsPath.values.single().assert().isEqualTo("half.value")
+        requireNotNull(quarter.script.source()).scriptString().assert().contains("/ 2.0")
     }
 
     @Test

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationCompilerTest.kt
@@ -521,6 +521,46 @@ class ElasticsearchAggregationCompilerTest {
     }
 
     @Test
+    fun `derived metrics reference percentile distinct and deviation paths`() {
+        val plan = compiler.compile(
+            aggregation {
+                percentile("amount", 95.0, "p95")
+                distinctCount("customerId", "customers")
+                stddev("amount", "deviation")
+                variance("amount", "spread")
+                count("total")
+                derived("sharpness") { ref("p95") / ref("deviation") }
+                derived("spreadPerCustomer") { ref("spread") - ref("customers") }
+                derived("mixed") { (ref("total") + constant(1.0)) * constant(2.0) - constant(3.0) }
+            },
+            schema,
+        )
+        val derived = plan.metrics.filterIsInstance<ElasticsearchAggregationMetric.Derived>()
+
+        val sharpness = derived[0]
+        sharpness.bucketsPath["v0"].assert().isEqualTo("p95[95.0]")
+        sharpness.bucketsPath["c0"].assert().isEqualTo("__wow_value_count_p95.value")
+        sharpness.bucketsPath["v1"].assert().isEqualTo("deviation.std_deviation_population")
+        sharpness.bucketsPath["c1"].assert().isEqualTo("__wow_value_count_deviation.value")
+        requireNotNull(sharpness.script.source()).scriptString().assert().contains("/ ")
+
+        val spreadPerCustomer = derived[1]
+        // 引用编号为编译级首现共享：sharpness 已占用 v0/c0、v1/c1
+        spreadPerCustomer.bucketsPath["v2"].assert().isEqualTo("spread.variance_population")
+        spreadPerCustomer.bucketsPath["c2"].assert().isEqualTo("__wow_value_count_spread.value")
+        spreadPerCustomer.bucketsPath["v3"].assert().isEqualTo("customers.value")
+        spreadPerCustomer.bucketsPath.assert().doesNotContainKey("c3") // cardinality 恒非 null，无需空语义守卫
+        requireNotNull(spreadPerCustomer.script.source()).scriptString().assert().contains(" - ")
+
+        val mixed = derived[2]
+        mixed.bucketsPath.values.single().assert().isEqualTo("_count")
+        requireNotNull(mixed.script.source()).scriptString().assert()
+            .contains(" + 1.0")
+            .contains(" * 2.0")
+            .contains(" - 3.0")
+    }
+
+    @Test
     fun `two nested scopes keep predicates relative and native paths absolute`() {
         val query = aggregation {
             expand("orders") { "status" eq "PAID" }

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
@@ -16,6 +16,7 @@ package me.ahoo.wow.elasticsearch.query.snapshot
 import co.elastic.clients.elasticsearch._types.FieldValue
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregate
 import co.elastic.clients.elasticsearch._types.aggregations.Buckets
+import co.elastic.clients.elasticsearch._types.aggregations.FiltersBucket
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeBucket
 import co.elastic.clients.elasticsearch._types.aggregations.DoubleTermsBucket
 import co.elastic.clients.elasticsearch._types.aggregations.LongTermsBucket
@@ -40,6 +41,8 @@ import me.ahoo.wow.elasticsearch.query.AbstractElasticsearchFilterCompiler
 import me.ahoo.wow.elasticsearch.query.DEFAULT_SEARCH_BATCH_SIZE
 import me.ahoo.wow.elasticsearch.query.aggregation.ElasticsearchAggregationCompiler
 import me.ahoo.wow.elasticsearch.query.aggregation.ElasticsearchAggregationPager
+import me.ahoo.wow.elasticsearch.query.aggregation.SUMMARY_BUCKET_AGGREGATION
+import me.ahoo.wow.elasticsearch.query.aggregation.SUMMARY_BUCKET_KEY
 import me.ahoo.wow.elasticsearch.query.aggregation.selectTopRows
 import me.ahoo.wow.elasticsearch.query.toObjectNode
 import me.ahoo.wow.query.QueryBackendBinding
@@ -323,6 +326,36 @@ class ElasticsearchAggregationPagerTest {
         request.captured.assertSummaryRequest(plan)
         verify(exactly = 1) { client.search(any<SearchRequest>(), Map::class.java) }
         client.verifyNoPointInTimeCalls()
+    }
+
+    @Test
+    fun `derived summaries wrap metrics in a keyed filters bucket`() {
+        stubPointInTime()
+        val request = slot<SearchRequest>()
+        every { client.search(capture(request), Map::class.java) } returns Mono.just(derivedSummaryResponse())
+        val plan = compileAggregation(
+            aggregation {
+                count("count")
+                derived("one") { constant(1.0) }
+                derived("next") { ref("count") + constant(1.0) }
+            },
+        )
+
+        pager().execute(plan)
+            .test()
+            .assertNext {
+                it.path("count").longValue().assert().isEqualTo(0L)
+                it.path("one").doubleValue().assert().isEqualTo(1.0)
+                it.path("next").doubleValue().assert().isEqualTo(1.0)
+            }
+            .verifyComplete()
+
+        request.captured.aggregations().values.single().aggregations()
+            .getValue(SUMMARY_BUCKET_AGGREGATION)
+            .aggregations().apply {
+                getValue("one").bucketScript().assert().isNotNull()
+                getValue("next").bucketScript().assert().isNotNull()
+            }
     }
 
     @Test
@@ -760,6 +793,35 @@ class ElasticsearchAggregationPagerTest {
                     "__wow_value_count_total",
                     Aggregate.of { value -> value.valueCount { count -> count.value(0.0) } },
                 )
+        }
+    }
+
+    private fun derivedSummaryResponse(): SearchResponse<Map<*, *>> = response("pit-2") { aggregate ->
+        aggregate.filter { filter ->
+            filter.docCount(0).aggregations(
+                SUMMARY_BUCKET_AGGREGATION,
+                Aggregate.of { bucket ->
+                    bucket.filters { filters ->
+                        filters.buckets { buckets ->
+                            buckets.keyed(
+                                mapOf(
+                                    SUMMARY_BUCKET_KEY to FiltersBucket.of { keyed ->
+                                        keyed.docCount(0)
+                                            .aggregations(
+                                                "one",
+                                                Aggregate.of { value -> value.simpleValue { it.value(1.0) } },
+                                            )
+                                            .aggregations(
+                                                "next",
+                                                Aggregate.of { value -> value.simpleValue { it.value(1.0) } },
+                                            )
+                                    },
+                                ),
+                            )
+                        }
+                    }
+                },
+            )
         }
     }
 

--- a/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
+++ b/wow-elasticsearch/src/test/kotlin/me/ahoo/wow/elasticsearch/query/snapshot/ElasticsearchAggregationPagerTest.kt
@@ -16,9 +16,9 @@ package me.ahoo.wow.elasticsearch.query.snapshot
 import co.elastic.clients.elasticsearch._types.FieldValue
 import co.elastic.clients.elasticsearch._types.aggregations.Aggregate
 import co.elastic.clients.elasticsearch._types.aggregations.Buckets
-import co.elastic.clients.elasticsearch._types.aggregations.FiltersBucket
 import co.elastic.clients.elasticsearch._types.aggregations.CompositeBucket
 import co.elastic.clients.elasticsearch._types.aggregations.DoubleTermsBucket
+import co.elastic.clients.elasticsearch._types.aggregations.FiltersBucket
 import co.elastic.clients.elasticsearch._types.aggregations.LongTermsBucket
 import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket
 import co.elastic.clients.elasticsearch.core.ClosePointInTimeRequest

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoQueryBackend.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoQueryBackend.kt
@@ -201,6 +201,7 @@ abstract class AbstractMongoQueryBackend : QueryBackend {
         metric.alias to when (metric) {
             is AggregationMetric.Count, is AggregationMetric.DistinctCount -> 0L
             is AggregationMetric.Any, is AggregationMetric.Numeric, is AggregationMetric.Percentile -> null
+            // Deliberate empty-row semantics: constants are computed by the pipeline itself; this synthetic row only appears when the result flux is empty.
             is AggregationMetric.Derived -> null
         }
     }

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoQueryBackend.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoQueryBackend.kt
@@ -16,9 +16,11 @@ package me.ahoo.wow.mongo.query
 import com.mongodb.client.model.Filters
 import com.mongodb.reactivestreams.client.FindPublisher
 import com.mongodb.reactivestreams.client.MongoCollection
+import me.ahoo.wow.api.query.AggregationExpressionOperator
 import me.ahoo.wow.api.query.AggregationMetric
 import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.CursorPage
+import me.ahoo.wow.api.query.DerivedExpression
 import me.ahoo.wow.api.query.FilterExpression
 import me.ahoo.wow.api.query.ICursorQuery
 import me.ahoo.wow.api.query.IListQuery
@@ -197,12 +199,39 @@ abstract class AbstractMongoQueryBackend : QueryBackend {
     private fun Any?.toTermsValue(alias: String): Any? =
         if (this is Decimal128) toFiniteDouble(alias) else this
 
-    private fun AggregationQuery.emptySummary(): Document = metrics.associateTo(Document()) { metric ->
-        metric.alias to when (metric) {
-            is AggregationMetric.Count, is AggregationMetric.DistinctCount -> 0L
-            is AggregationMetric.Any, is AggregationMetric.Numeric, is AggregationMetric.Percentile -> null
-            // Deliberate empty-row semantics: constants are computed by the pipeline itself; this synthetic row only appears when the result flux is empty.
-            is AggregationMetric.Derived -> null
+    private fun AggregationQuery.emptySummary(): Document {
+        val values = LinkedHashMap<String, Any?>()
+        metrics.forEach { metric ->
+            values[metric.alias] = when (metric) {
+                is AggregationMetric.Count, is AggregationMetric.DistinctCount -> 0L
+                is AggregationMetric.Any, is AggregationMetric.Numeric, is AggregationMetric.Percentile -> null
+                // Mirrors the pipeline's derived stages: evaluate in declaration order over the
+                // synthetic empty values so constant and count-based deriveds match Elasticsearch.
+                is AggregationMetric.Derived -> metric.expression.evaluateOver(values)
+            }
+        }
+        return Document(values)
+    }
+
+    private fun DerivedExpression.evaluateOver(values: Map<String, Any?>): Double? = when (this) {
+        is DerivedExpression.MetricRef -> (values[metric] as? Number)?.toDouble()
+
+        is DerivedExpression.Constant -> value
+
+        is DerivedExpression.Binary -> {
+            val leftValue = left.evaluateOver(values) ?: return null
+            val rightValue = right.evaluateOver(values) ?: return null
+            when (operator) {
+                AggregationExpressionOperator.ADD -> leftValue + rightValue
+                AggregationExpressionOperator.SUBTRACT -> leftValue - rightValue
+                AggregationExpressionOperator.MULTIPLY -> leftValue * rightValue
+                AggregationExpressionOperator.DIVIDE ->
+                    if (rightValue == 0.0) {
+                        return null
+                    } else {
+                        leftValue / rightValue
+                    }
+            }.takeIf { it.isFinite() }
         }
     }
 

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoQueryBackend.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/AbstractMongoQueryBackend.kt
@@ -188,6 +188,7 @@ abstract class AbstractMongoQueryBackend : QueryBackend {
                 is AggregationMetric.Numeric -> get(metric.alias).toFiniteDouble(metric.alias)
                 is AggregationMetric.Percentile -> get(metric.alias).toFiniteDouble(metric.alias)
                 is AggregationMetric.DistinctCount -> (get(metric.alias) as Number).toLong()
+                is AggregationMetric.Derived -> get(metric.alias).toFiniteDouble(metric.alias)
             }
         }
         return this
@@ -200,6 +201,7 @@ abstract class AbstractMongoQueryBackend : QueryBackend {
         metric.alias to when (metric) {
             is AggregationMetric.Count, is AggregationMetric.DistinctCount -> 0L
             is AggregationMetric.Any, is AggregationMetric.Numeric, is AggregationMetric.Percentile -> null
+            is AggregationMetric.Derived -> null
         }
     }
 

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoAggregationCompiler.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoAggregationCompiler.kt
@@ -26,6 +26,7 @@ import me.ahoo.wow.api.query.AggregationFunction
 import me.ahoo.wow.api.query.AggregationGroup
 import me.ahoo.wow.api.query.AggregationMetric
 import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.DerivedExpression
 import me.ahoo.wow.api.query.MatchAllFilter
 import me.ahoo.wow.api.query.QueryField
 import me.ahoo.wow.api.query.Sort
@@ -46,6 +47,7 @@ import java.time.ZoneId
 import java.time.ZoneOffset
 import java.util.concurrent.TimeUnit
 
+@Suppress("LargeClass")
 internal class MongoAggregationCompiler(
     private val filterCompiler: AbstractMongoFilterCompiler,
 ) {
@@ -94,6 +96,11 @@ internal class MongoAggregationCompiler(
 
         add(group(query, groupId, logicalParent, physicalParent, schema, now))
         add(project(query))
+        query.metrics.forEach { metric ->
+            if (metric is AggregationMetric.Derived) {
+                add(derivedProject(query, metric))
+            }
+        }
         query.effectiveSort().takeIf { it.isNotEmpty() }?.let { add(Aggregates.sort(it.toBson())) }
         add(Aggregates.limit(query.limit))
     }
@@ -189,6 +196,7 @@ internal class MongoAggregationCompiler(
                             ),
                         )
                     }
+                    is AggregationMetric.Derived -> Unit
                 }
             }
         }
@@ -247,16 +255,17 @@ internal class MongoAggregationCompiler(
             add(Projections.excludeId())
             query.groupBy.forEach { add(Projections.computed(it.alias, "\$_id.${it.alias}")) }
             query.metrics.forEach { metric ->
-                add(
-                    when (metric) {
-                        is AggregationMetric.Count -> Projections.include(metric.alias)
-                        is AggregationMetric.Any -> Projections.include(metric.alias)
-                        is AggregationMetric.Numeric -> {
-                            val accumulated: Any = if (metric.function == AggregationFunction.VARIANCE) {
-                                Document("\$pow", listOf("\$${metric.alias}", 2))
-                            } else {
-                                "\$${metric.alias}"
-                            }
+                when (metric) {
+                    is AggregationMetric.Derived -> Unit
+                    is AggregationMetric.Count -> add(Projections.include(metric.alias))
+                    is AggregationMetric.Any -> add(Projections.include(metric.alias))
+                    is AggregationMetric.Numeric -> {
+                        val accumulated: Any = if (metric.function == AggregationFunction.VARIANCE) {
+                            Document("\$pow", listOf("\$${metric.alias}", 2))
+                        } else {
+                            "\$${metric.alias}"
+                        }
+                        add(
                             Projections.computed(
                                 metric.alias,
                                 Document(
@@ -267,9 +276,11 @@ internal class MongoAggregationCompiler(
                                         accumulated,
                                     ),
                                 ),
-                            )
-                        }
-                        is AggregationMetric.Percentile -> Projections.computed(
+                            ),
+                        )
+                    }
+                    is AggregationMetric.Percentile -> add(
+                        Projections.computed(
                             metric.alias,
                             Document(
                                 "\$cond",
@@ -279,8 +290,10 @@ internal class MongoAggregationCompiler(
                                     Document("\$arrayElemAt", listOf("\$${metric.alias}", 0)),
                                 ),
                             ),
-                        )
-                        is AggregationMetric.DistinctCount -> Projections.computed(
+                        ),
+                    )
+                    is AggregationMetric.DistinctCount -> add(
+                        Projections.computed(
                             metric.alias,
                             Document(
                                 "\$size",
@@ -328,9 +341,9 @@ internal class MongoAggregationCompiler(
                                     ),
                                 ),
                             ),
-                        )
-                    },
-                )
+                        ),
+                    )
+                }
             }
         }
         return Aggregates.project(Projections.fields(projections))
@@ -344,6 +357,65 @@ internal class MongoAggregationCompiler(
         AggregationFunction.STDDEV,
         AggregationFunction.VARIANCE,
         -> BsonField(field, Document("\$stdDevPop", input))
+    }
+
+    /**
+     * Compiles [derived] into its own `$project` stage: computed fields of one `$project`
+     * document cannot reference each other, so declaration order becomes evaluation order
+     * by staging every derived metric after the metrics it references. The stage carries
+     * the group aliases and every previously declared metric alias forward.
+     */
+    private fun derivedProject(query: AggregationQuery, derived: AggregationMetric.Derived): Bson {
+        val projections = buildList {
+            add(Projections.excludeId())
+            query.groupBy.forEach { add(Projections.include(it.alias)) }
+            query.metrics.takeWhile { it !== derived }.forEach { add(Projections.include(it.alias)) }
+            add(Projections.computed(derived.alias, derived.expression.toDerivedDocument()))
+        }
+        return Aggregates.project(Projections.fields(projections))
+    }
+
+    /**
+     * Null propagation, divide-by-zero, and finiteness mirror the record-level [AggregationExpression]
+     * guards: referenced metrics have already been projected to their guarded final values by
+     * [project] or an earlier [derivedProject] stage.
+     */
+    private fun DerivedExpression.toDerivedDocument(): Any = when (this) {
+        is DerivedExpression.MetricRef -> "\$$metric"
+
+        /**
+         * A bare number is an include flag in `$project`, so constants must be pinned with `$literal`
+         * to evaluate as values in computed fields and `$let` variables.
+         */
+        is DerivedExpression.Constant -> Document("\$literal", value)
+        is DerivedExpression.Binary -> {
+            val leftValue = left.toDerivedDocument()
+            val rightValue = right.toDerivedDocument()
+            val conditions = mutableListOf<Any>(
+                Document("\$ne", listOf("\$\$left", null)),
+                Document("\$ne", listOf("\$\$right", null)),
+            )
+            if (operator == AggregationExpressionOperator.DIVIDE) {
+                conditions += Document("\$ne", listOf("\$\$right", 0.0))
+            }
+            finiteDouble(
+                Document(
+                    "\$let",
+                    Document("vars", Document("left", leftValue).append("right", rightValue))
+                        .append(
+                            "in",
+                            Document(
+                                "\$cond",
+                                listOf(
+                                    Document("\$and", conditions),
+                                    Document(operator.mongoOperator, listOf("\$\$left", "\$\$right")),
+                                    null,
+                                ),
+                            ),
+                        ),
+                ),
+            )
+        }
     }
 
     private fun AggregationGroup.compile(

--- a/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoAggregationCompiler.kt
+++ b/wow-mongo/src/main/kotlin/me/ahoo/wow/mongo/query/aggregation/MongoAggregationCompiler.kt
@@ -363,14 +363,22 @@ internal class MongoAggregationCompiler(
      * Compiles [derived] into its own `$project` stage: computed fields of one `$project`
      * document cannot reference each other, so declaration order becomes evaluation order
      * by staging every derived metric after the metrics it references. The stage carries
-     * the group aliases and every previously declared metric alias forward.
+     * the group aliases and every other declared metric alias forward — inclusion-mode
+     * `$project` drops unlisted fields, and later stages never restore them.
      */
     private fun derivedProject(query: AggregationQuery, derived: AggregationMetric.Derived): Bson {
         val projections = buildList {
             add(Projections.excludeId())
             query.groupBy.forEach { add(Projections.include(it.alias)) }
-            query.metrics.takeWhile { it !== derived }.forEach { add(Projections.include(it.alias)) }
-            add(Projections.computed(derived.alias, derived.expression.toDerivedDocument()))
+            query.metrics.forEach { metric ->
+                add(
+                    if (metric === derived) {
+                        Projections.computed(metric.alias, metric.expression.toDerivedDocument())
+                    } else {
+                        Projections.include(metric.alias)
+                    },
+                )
+            }
         }
         return Aggregates.project(Projections.fields(projections))
     }

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
@@ -664,6 +664,31 @@ class MongoAggregationCompilerTest {
     }
 
     @Test
+    fun `metrics declared after a derived metric survive derived project stages`() {
+        val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+            aggregation {
+                count("total")
+                derived("half") { ref("total") / constant(2.0) }
+                sum("state.amount", "amount")
+                count("paid")
+            },
+            schema(),
+        ).map { it.toBsonDocument() }
+
+        val projects = pipeline.filter { it.containsKey("\$project") }
+        projects.assert().hasSize(2)
+        val derivedStage = projects[1].getDocument("\$project")
+        derivedStage.containsKey("total").assert().isTrue()
+        derivedStage.containsKey("half").assert().isTrue()
+        derivedStage.containsKey("amount").assert().isTrue()
+        derivedStage.containsKey("paid").assert().isTrue()
+        val keys = derivedStage.keys.toList()
+        keys.indexOf("total").assert().isLessThan(keys.indexOf("half"))
+        keys.indexOf("half").assert().isLessThan(keys.indexOf("amount"))
+        keys.indexOf("amount").assert().isLessThan(keys.indexOf("paid"))
+    }
+
+    @Test
     fun `plain field metric should normalize scalar or singleton values without conversion`() {
         val groupJson = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
             aggregation { sum("state.amount", "total") },

--- a/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
+++ b/wow-mongo/src/test/kotlin/me/ahoo/wow/mongo/query/snapshot/MongoAggregationCompilerTest.kt
@@ -585,6 +585,85 @@ class MongoAggregationCompilerTest {
     }
 
     @Test
+    fun `derived metrics compile into a second project stage`() {
+        val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+            aggregation {
+                terms("state.status", "status")
+                count("paid")
+                sum("state.amount", "paidAmount") { "state.status" eq "PAID" }
+                derived("aov") { ref("paidAmount") / ref("paid") }
+            },
+            statusFilterSchema,
+        ).map { it.toBsonDocument() }
+
+        val projects = pipeline.filter { it.containsKey("\$project") }
+        projects.assert().hasSize(2)
+        val derivedStage = projects[1].getDocument("\$project")
+        derivedStage.containsKey("_id").assert().isTrue()
+        val aov = derivedStage.getDocument("aov").getDocument("\$let")
+        val binary = aov.getDocument("vars").getDocument("value").getDocument("\$let")
+        binary.getDocument("vars").getString("left").value.assert().isEqualTo("\$paidAmount")
+        binary.getDocument("vars").getString("right").value.assert().isEqualTo("\$paid")
+        val cond = binary.getDocument("in").getArray("\$cond")
+        cond.get(0).asDocument().getArray("\$and").assert().hasSize(3)
+        cond.get(1).asDocument().getArray("\$divide").assert().hasSize(2)
+        aov.getDocument("in").getArray("\$cond").get(0).asDocument().getArray("\$and").assert().hasSize(3)
+        derivedStage.containsKey("paid").assert().isTrue()
+        derivedStage.containsKey("paidAmount").assert().isTrue()
+        pipeline.indexOfLast { it.containsKey("\$project") }
+            .assert().isLessThan(pipeline.indexOfFirst { it.containsKey("\$sort") })
+    }
+
+    @Test
+    fun `derived without derived metrics keeps a single project stage`() {
+        val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+            aggregation {
+                terms("state.status", "status")
+                count("total")
+                sum("state.amount", "totalAmount")
+                sort { "totalAmount".desc() }
+            },
+            schema(),
+        ).map { it.toBsonDocument() }
+
+        pipeline.map { it.keys.first() }.assert()
+            .containsExactly("\$match", "\$match", "\$group", "\$project", "\$sort", "\$limit")
+        pipeline.filter { it.containsKey("\$project") }.assert().hasSize(1)
+    }
+
+    @Test
+    fun `derived constants and chains compile leaves in order`() {
+        val pipeline = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
+            aggregation {
+                count("total")
+                derived("target") { constant(120.0) }
+                derived("half") { ref("total") / constant(2.0) }
+                derived("quarter") { ref("half") / constant(2.0) }
+            },
+            schema(),
+        ).map { it.toBsonDocument() }
+
+        val projects = pipeline.filter { it.containsKey("\$project") }
+        projects.assert().hasSize(4)
+        val targetStage = projects[1].getDocument("\$project")
+        targetStage.getDocument("target").getValue("\$literal").asDouble().value.assert().isEqualTo(120.0)
+
+        val halfStage = projects[2].getDocument("\$project")
+        val half = halfStage.getDocument("half").getDocument("\$let")
+            .getDocument("vars").getDocument("value").getDocument("\$let")
+        half.getDocument("vars").getString("left").value.assert().isEqualTo("\$total")
+        half.getDocument("vars").getDocument("right").getValue("\$literal").asDouble().value.assert().isEqualTo(2.0)
+
+        val quarterStage = projects[3].getDocument("\$project")
+        quarterStage.containsKey("half").assert().isTrue()
+        val quarter = quarterStage.getDocument("quarter").getDocument("\$let")
+            .getDocument("vars").getDocument("value").getDocument("\$let")
+        quarter.getDocument("vars").getString("left").value.assert().isEqualTo("\$half")
+        val keys = quarterStage.keys.toList()
+        keys.indexOf("half").assert().isLessThan(keys.indexOf("quarter"))
+    }
+
+    @Test
     fun `plain field metric should normalize scalar or singleton values without conversion`() {
         val groupJson = MongoAggregationCompiler(SnapshotFilterCompiler).compile(
             aggregation { sum("state.amount", "total") },

--- a/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt
+++ b/wow-openapi/src/test/kotlin/me/ahoo/wow/openapi/ExampleDomainOpenAPITest.kt
@@ -179,6 +179,7 @@ internal class ExampleDomainOpenAPITest {
                 "#/components/schemas/wow.api.query.AggregationMetric.Any",
                 "#/components/schemas/wow.api.query.AggregationMetric.DistinctCount",
                 "#/components/schemas/wow.api.query.AggregationMetric.Percentile",
+                "#/components/schemas/wow.api.query.AggregationMetric.Derived",
             )
             metricSchema.discriminator.propertyName.assert().isEqualTo("type")
             (metricSchema.properties.getValue("alias").readOnly == true).assert().isFalse()

--- a/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
+++ b/wow-openapi/src/test/resources/openapi/example-domain-openapi.snapshot.json
@@ -4838,6 +4838,7 @@
           "mapping" : {
             "ANY" : "#/components/schemas/wow.api.query.AggregationMetric.Any",
             "COUNT" : "#/components/schemas/wow.api.query.AggregationMetric.Count",
+            "DERIVED" : "#/components/schemas/wow.api.query.AggregationMetric.Derived",
             "DISTINCT_COUNT" : "#/components/schemas/wow.api.query.AggregationMetric.DistinctCount",
             "NUMERIC" : "#/components/schemas/wow.api.query.AggregationMetric.Numeric",
             "PERCENTILE" : "#/components/schemas/wow.api.query.AggregationMetric.Percentile"
@@ -4848,6 +4849,8 @@
           "$ref" : "#/components/schemas/wow.api.query.AggregationMetric.Any"
         }, {
           "$ref" : "#/components/schemas/wow.api.query.AggregationMetric.Count"
+        }, {
+          "$ref" : "#/components/schemas/wow.api.query.AggregationMetric.Derived"
         }, {
           "$ref" : "#/components/schemas/wow.api.query.AggregationMetric.DistinctCount"
         }, {
@@ -4895,6 +4898,24 @@
           }
         },
         "required" : [ "alias", "type" ],
+        "type" : "object"
+      },
+      "wow.api.query.AggregationMetric.Derived" : {
+        "properties" : {
+          "alias" : {
+            "type" : "string"
+          },
+          "expression" : {
+            "$ref" : "#/components/schemas/wow.api.query.DerivedExpression"
+          },
+          "filter" : {
+            "$ref" : "#/components/schemas/wow.api.query.FilterExpression"
+          },
+          "type" : {
+            "const" : "DERIVED"
+          }
+        },
+        "required" : [ "alias", "expression", "type" ],
         "type" : "object"
       },
       "wow.api.query.AggregationMetric.DistinctCount" : {
@@ -5046,6 +5067,66 @@
           }
         },
         "required" : [ "filter" ],
+        "type" : "object"
+      },
+      "wow.api.query.DerivedExpression" : {
+        "discriminator" : {
+          "mapping" : {
+            "BINARY" : "#/components/schemas/wow.api.query.DerivedExpression.Binary",
+            "CONSTANT" : "#/components/schemas/wow.api.query.DerivedExpression.Constant",
+            "METRIC_REF" : "#/components/schemas/wow.api.query.DerivedExpression.MetricRef"
+          },
+          "propertyName" : "type"
+        },
+        "oneOf" : [ {
+          "$ref" : "#/components/schemas/wow.api.query.DerivedExpression.Binary"
+        }, {
+          "$ref" : "#/components/schemas/wow.api.query.DerivedExpression.Constant"
+        }, {
+          "$ref" : "#/components/schemas/wow.api.query.DerivedExpression.MetricRef"
+        } ]
+      },
+      "wow.api.query.DerivedExpression.Binary" : {
+        "properties" : {
+          "left" : {
+            "$ref" : "#/components/schemas/wow.api.query.DerivedExpression"
+          },
+          "operator" : {
+            "$ref" : "#/components/schemas/wow.api.query.AggregationExpressionOperator"
+          },
+          "right" : {
+            "$ref" : "#/components/schemas/wow.api.query.DerivedExpression"
+          },
+          "type" : {
+            "const" : "BINARY"
+          }
+        },
+        "required" : [ "left", "operator", "right", "type" ],
+        "type" : "object"
+      },
+      "wow.api.query.DerivedExpression.Constant" : {
+        "properties" : {
+          "type" : {
+            "const" : "CONSTANT"
+          },
+          "value" : {
+            "format" : "double",
+            "type" : "number"
+          }
+        },
+        "required" : [ "type", "value" ],
+        "type" : "object"
+      },
+      "wow.api.query.DerivedExpression.MetricRef" : {
+        "properties" : {
+          "metric" : {
+            "type" : "string"
+          },
+          "type" : {
+            "const" : "METRIC_REF"
+          }
+        },
+        "required" : [ "metric", "type" ],
         "type" : "object"
       },
       "wow.api.query.FilterExpression" : {

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDsl.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDsl.kt
@@ -21,6 +21,7 @@ import me.ahoo.wow.api.query.AggregationFunction
 import me.ahoo.wow.api.query.AggregationGroup
 import me.ahoo.wow.api.query.AggregationMetric
 import me.ahoo.wow.api.query.AggregationQuery
+import me.ahoo.wow.api.query.DerivedExpression
 import me.ahoo.wow.api.query.FilterExpression
 import me.ahoo.wow.api.query.MatchAllFilter
 import me.ahoo.wow.api.query.QueryField
@@ -203,6 +204,13 @@ class AggregationQueryDsl {
     fun median(expression: AggregationExpression, alias: String, init: FilterDsl.() -> Unit) =
         percentile(expression, 50.0, alias, init)
 
+    fun derived(alias: String, expression: DerivedExpression) {
+        metrics += AggregationMetric.Derived(alias, expression)
+    }
+
+    fun derived(alias: String, init: DerivedExpressionDsl.() -> DerivedExpression) =
+        derived(alias, DerivedExpressionDsl().init())
+
     private fun numeric(
         function: AggregationFunction,
         expression: AggregationExpression,
@@ -233,4 +241,33 @@ class AggregationQueryDsl {
     }
 
     fun build(): AggregationQuery = AggregationQuery(filter, elements, groups, metrics, sort, limit)
+}
+
+/**
+ * Dedicated expression context for [AggregationQueryDsl.derived]: [constant] returns a
+ * [DerivedExpression.Constant] rather than the [AggregationExpression.Constant] built by
+ * [AggregationQueryDsl.constant], so the two scopes must not share a receiver type.
+ */
+@QueryDslMarker
+class DerivedExpressionDsl {
+    fun ref(metric: String): DerivedExpression = DerivedExpression.MetricRef(metric)
+
+    fun constant(value: Double): DerivedExpression = DerivedExpression.Constant(value)
+
+    operator fun DerivedExpression.plus(other: DerivedExpression): DerivedExpression =
+        binary(AggregationExpressionOperator.ADD, other)
+
+    operator fun DerivedExpression.minus(other: DerivedExpression): DerivedExpression =
+        binary(AggregationExpressionOperator.SUBTRACT, other)
+
+    operator fun DerivedExpression.times(other: DerivedExpression): DerivedExpression =
+        binary(AggregationExpressionOperator.MULTIPLY, other)
+
+    operator fun DerivedExpression.div(other: DerivedExpression): DerivedExpression =
+        binary(AggregationExpressionOperator.DIVIDE, other)
+
+    private fun DerivedExpression.binary(
+        operator: AggregationExpressionOperator,
+        other: DerivedExpression,
+    ): DerivedExpression = DerivedExpression.Binary(operator, this, other)
 }

--- a/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaValidation.kt
+++ b/wow-query/src/main/kotlin/me/ahoo/wow/query/schema/QuerySchemaValidation.kt
@@ -299,6 +299,7 @@ private class QueryValidator(private val schema: QueryModelSchema) {
             }
             when (metric) {
                 is AggregationMetric.Count -> Unit
+                is AggregationMetric.Derived -> Unit
                 is AggregationMetric.Any -> requireSchema(
                     aggregationField(
                         metric.field,

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt
@@ -259,4 +259,26 @@ class AggregationQueryDslTest {
             AggregationMetric.Derived("net", expression),
         )
     }
+
+    @Test
+    fun `derived expression operators build binary nodes for every operator`() {
+        val query = aggregation {
+            count("a")
+            count("b")
+            derived("plus") { ref("a") + ref("b") }
+            derived("minus") { ref("a") - ref("b") }
+            derived("times") { ref("a") * ref("b") }
+            derived("div") { ref("a") / ref("b") }
+        }
+
+        val derived = query.metrics.filterIsInstance<AggregationMetric.Derived>()
+        derived.assert().hasSize(4)
+        val operators = derived.map { (it.expression as DerivedExpression.Binary).operator }
+        operators.assert().containsExactly(
+            AggregationExpressionOperator.ADD,
+            AggregationExpressionOperator.SUBTRACT,
+            AggregationExpressionOperator.MULTIPLY,
+            AggregationExpressionOperator.DIVIDE,
+        )
+    }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/dsl/AggregationQueryDslTest.kt
@@ -20,6 +20,7 @@ import me.ahoo.wow.api.query.AggregationExpressionOperator
 import me.ahoo.wow.api.query.AggregationFunction
 import me.ahoo.wow.api.query.AggregationGroup
 import me.ahoo.wow.api.query.AggregationMetric
+import me.ahoo.wow.api.query.DerivedExpression
 import me.ahoo.wow.api.query.EqualFilter
 import me.ahoo.wow.api.query.GreaterThanFilter
 import me.ahoo.wow.api.query.QueryField
@@ -217,5 +218,45 @@ class AggregationQueryDslTest {
             .map(AggregationMetric.Percentile::percentile)
             .assert()
             .containsExactly(50.0, 95.0, 50.0)
+    }
+
+    @Test
+    fun `aggregation DSL should build derived metrics from refs and operators`() {
+        val query = aggregation {
+            count("paid")
+            sum("amount", "paidAmount") { "status" eq "PAID" }
+            derived("aov") { ref("paidAmount") / ref("paid") }
+            derived("target") { constant(120.0) }
+            derived("attainment") { ref("paidAmount") / ref("target") }
+        }
+
+        val derived = query.metrics.filterIsInstance<AggregationMetric.Derived>()
+        derived.assert().hasSize(3)
+        val aov = derived[0].expression as DerivedExpression.Binary
+        aov.operator.assert().isEqualTo(AggregationExpressionOperator.DIVIDE)
+        (aov.left as DerivedExpression.MetricRef).metric.assert().isEqualTo("paidAmount")
+        (aov.right as DerivedExpression.MetricRef).metric.assert().isEqualTo("paid")
+        (derived[1].expression as DerivedExpression.Constant).value.assert().isEqualTo(120.0)
+        val attainment = derived[2].expression as DerivedExpression.Binary
+        (attainment.left as DerivedExpression.MetricRef).metric.assert().isEqualTo("paidAmount")
+        (attainment.right as DerivedExpression.MetricRef).metric.assert().isEqualTo("target")
+    }
+
+    @Test
+    fun `aggregation DSL should accept a prebuilt derived expression`() {
+        val expression = DerivedExpression.Binary(
+            AggregationExpressionOperator.SUBTRACT,
+            DerivedExpression.MetricRef("total"),
+            DerivedExpression.Constant(1.0),
+        )
+        val query = aggregation {
+            count("total")
+            derived("net", expression)
+        }
+
+        query.metrics.assert().containsExactly(
+            AggregationMetric.Count("total"),
+            AggregationMetric.Derived("net", expression),
+        )
     }
 }

--- a/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaValidationTest.kt
+++ b/wow-query/src/test/kotlin/me/ahoo/wow/query/schema/QuerySchemaValidationTest.kt
@@ -518,6 +518,16 @@ class QuerySchemaValidationTest {
     }
 
     @Test
+    fun `derived metrics need no schema capability`() {
+        val schema = boundSchemaFixture(objectFixture("status" to scalarFixture()))
+        val query = aggregation {
+            count("total")
+            derived("half") { ref("total") / constant(2.0) }
+        }
+        validateQuery(query, schema).assert().isSameAs(query)
+    }
+
+    @Test
     fun `masked values stay queryable but public cursor and aggregate admission reject them`() {
         val annotation = Masked::secret.javaField!!.getAnnotation(Mask::class.java)
         val mask = MaskRule(FullMaskStrategy::class, annotation, FullMaskStrategy.compile(annotation))

--- a/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/query/FilterExpressionDefinitionProvider.kt
+++ b/wow-schema/src/main/kotlin/me/ahoo/wow/schema/typed/query/FilterExpressionDefinitionProvider.kt
@@ -25,6 +25,7 @@ import com.github.victools.jsonschema.generator.SchemaGenerationContext
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder
 import com.github.victools.jsonschema.generator.SchemaKeyword
 import me.ahoo.wow.api.query.AggregationExpression
+import me.ahoo.wow.api.query.DerivedExpression
 import me.ahoo.wow.api.query.FilterExpression
 import me.ahoo.wow.api.query.schema.QuerySemanticType
 import me.ahoo.wow.schema.WowSchemaLoader
@@ -72,6 +73,7 @@ object FilterExpressionDefinitionProvider : CustomDefinitionProviderV2, Module {
         when (scope.type.erasedType) {
             FilterExpression::class.java,
             AggregationExpression::class.java,
+            DerivedExpression::class.java,
             QuerySemanticType::class.java,
             -> emptyList()
 

--- a/wow-schema/src/test/kotlin/me/ahoo/wow/schema/typed/query/FilterExpressionDefinitionProviderTest.kt
+++ b/wow-schema/src/test/kotlin/me/ahoo/wow/schema/typed/query/FilterExpressionDefinitionProviderTest.kt
@@ -16,7 +16,9 @@ package me.ahoo.wow.schema.typed.query
 import com.networknt.schema.SchemaRegistry
 import com.networknt.schema.SpecificationVersion
 import me.ahoo.test.asserts.assert
+import me.ahoo.wow.api.query.AggregationQuery
 import me.ahoo.wow.api.query.FilterExpression
+import me.ahoo.wow.schema.SchemaGeneratorBuilder
 import me.ahoo.wow.schema.WowSchemaLoader
 import org.junit.jupiter.api.Test
 import tools.jackson.databind.json.JsonMapper
@@ -109,5 +111,31 @@ class FilterExpressionDefinitionProviderTest {
             )
             schema.validate(filter).assert().isEmpty()
         }
+    }
+
+    @Test
+    fun `recursive derived expression should generate a finite schema with references`() {
+        val generator = SchemaGeneratorBuilder().build()
+        val schema = generator.generateSchema(AggregationQuery::class.java)
+        val definitions = schema.path("definitions")
+
+        val derivedMetric = definitions.path("wow.api.query.AggregationMetric.Derived")
+        derivedMetric.path("properties").path("expression").path("\$ref").stringValue()
+            .assert().isEqualTo("#/definitions/wow.api.query.DerivedExpression")
+
+        val derivedExpression = definitions.path("wow.api.query.DerivedExpression")
+        derivedExpression.path("anyOf").toList()
+            .map { it.path("\$ref").stringValue() }
+            .assert()
+            .containsExactly(
+                "#/definitions/wow.api.query.DerivedExpression.MetricRef",
+                "#/definitions/wow.api.query.DerivedExpression.Constant",
+                "#/definitions/wow.api.query.DerivedExpression.Binary",
+            )
+        val derivedBinary = definitions.path("wow.api.query.DerivedExpression.Binary")
+        derivedBinary.path("properties").path("left").path("\$ref").stringValue()
+            .assert().isEqualTo("#/definitions/wow.api.query.DerivedExpression")
+        derivedBinary.path("properties").path("right").path("\$ref").stringValue()
+            .assert().isEqualTo("#/definitions/wow.api.query.DerivedExpression")
     }
 }

--- a/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuard.kt
+++ b/wow-webflux/src/main/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuard.kt
@@ -220,6 +220,7 @@ class HttpQueryGuard(
         is AggregationMetric.Numeric -> expression !is AggregationExpression.Field
         is AggregationMetric.DistinctCount -> expression !is AggregationExpression.Field
         is AggregationMetric.Percentile -> expression !is AggregationExpression.Field
+        is AggregationMetric.Derived -> true
         is AggregationMetric.Count, is AggregationMetric.Any -> false
     }
 

--- a/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardTest.kt
+++ b/wow-webflux/src/test/kotlin/me/ahoo/wow/webflux/route/query/HttpQueryGuardTest.kt
@@ -280,6 +280,16 @@ class HttpQueryGuardTest {
     }
 
     @Test
+    fun `derived metrics count as arithmetic expressions`() {
+        val derived = aggregation {
+            count("total")
+            derived("half") { ref("total") / constant(2.0) }
+        }
+        expectRejected(QueryType.AGGREGATION, derived, guard(allowExpensiveOperators = false))
+        expectAllowed(QueryType.AGGREGATION, derived, guard(allowExpensiveOperators = true))
+    }
+
+    @Test
     fun timesOutTheWholeMonoAndIdleFluxPublisher() {
         StepVerifier.withVirtualTime {
             guard(idleTimeout = Duration.ofSeconds(1)).mono(QueryType.SINGLE, IdFilter("id")) {


### PR DESCRIPTION
## Summary

Phase 2 of the aggregation reporting epic (follow-up to #3234): **derived metrics** — post-aggregation ratios (paid AOV, attainment, margin) computed over metrics declared earlier in the same query. Implements the approved design in `documentation/designs/2026-09-12-aggregation-reporting-epic-design.md` (Phase 2) via the plan in `documentation/designs/2026-09-12-derived-metrics-implementation-plan.md`.

```kotlin
aggregation {
    terms("state.status", "status")
    count("paid") { "status" eq "PAID" }
    sum("amount", "paidAmount") { "status" eq "PAID" }
    derived("paidAov") { ref("paidAmount") / ref("paid") }   // 已支付客单价
    sum("amount", "targetAmount")
    derived("attainment") { ref("paidAmount") / ref("targetAmount") }
    sort { "paidAov".desc() }
}
```

- **wow-api**: `AggregationMetric.Derived` (wire `DERIVED`) + `DerivedExpression` (`METRIC_REF`/`CONSTANT`/`BINARY` over ADD/SUBTRACT/MULTIPLY/DIVIDE). Construction-time validation: declaration-order references only (structurally acyclic), unknown/group-alias/`ANY` references rejected, depth ≤ 8, ≤ 256 nodes per query, finite constants. `Derived` carries no filter (getter-only default, omitted on the wire).
- **wow-query**: `derived(alias)` DSL with `ref()`/`constant()`/`+ - * /`; schema-validation arm. **wow-webflux**: derived counts as an arithmetic expression under the expensive-operators gate.
- **MongoDB**: one `$project` stage per derived metric, in declaration order — computed fields in a single `$project` cannot reference each other (verified on mongo:7; the plan pre-authorized this fallback). Constants wrap as `$literal`; null propagation / divide-by-zero → null / finite-result guards mirror the record-level expression compiler.
- **Elasticsearch**: one `bucket_script` per derived with **NaN-sentinel** painless scripts — every path param cast `(double)` (prevents Long integer division on `_count` refs), count-guarded refs emit `Double.NaN` on empty sets, divide-by-zero yields IEEE ±Infinity, and a single final `!Double.isFinite` wrap unifies NaN/±Infinity → null. Filter-wrapper `buckets_path` uses the `>` separator; ungrouped derived queries wrap metrics in a value-neutral catch-all `filters` bucket (bucket_script needs a multi-bucket parent).
- **TCK**: 7 cross-backend contract scenarios (AOV, attainment + composite, divide-by-zero → null, null propagation from empty metrics, derived chains, sort-by-derived with null last, EventStream ratio). Construction-rejection rules stay in wow-api unit tests (backend-independent — AST-level).
- **OpenAPI**: snapshot diff purely additive (+81/−0), includes a wow-schema fix — recursive `DerivedExpression` needed a `skipSubtypeLookup` entry or victools expands infinitely (TDD'd).
- **Docs**: zh/en 「派生指标 / Derived Metrics」 sections + Scenario 11 (达成率/attainment) in snapshot-aggregation.

**Wire compatibility: purely additive** — new discriminator type only; existing metric JSON shapes and DSL signatures unchanged.

## Notable findings baked into the implementation (all caught pre-merge by tests/review or live probing)

1. Painless (7.x+) throws on `null` arithmetic operands — in-script null sentinels crash the whole search; NaN propagates instead.
2. `$project` bare non-0/1 numbers are include flags — constant-only deriveds need `$literal`.
3. `buckets_path` filter-wrapper traversal needs the `>` separator, not `.`.
4. `bucket_script` requires a multi-bucket parent — ungrouped summary needs a wrapper bucket.
5. Per-derived `$project` stages must re-include every other metric alias (inclusion-mode `$project` drops unlisted fields) — caught by task review, regression-tested.

## Test plan

- [x] Module checks: `:wow-api:check :wow-query:check :wow-mongo:check :wow-elasticsearch:check :wow-webflux:check :wow-openapi:check :wow-schema:check`
- [x] `:wow-mongo:integrationTest` (13 suites, 0 failures) / `:wow-elasticsearch:integrationTest` aggregation suites (391 tests green incl. 7 new TCK scenarios on both backends)
- [x] `allLocalTest allContractTest`, `detekt`
- [x] OpenAPI snapshot clean re-run; `pnpm docs:build`

## CI note

`ElasticsearchEventStoreTest` flaked in one local full-suite run (a different test each time, each passes in isolation, suite green earlier on the same branch; this branch touches no event-store code) — ruled environmental (long Testcontainers session). If it flakes on CI, a re-run should clear it.

🤖 Generated with Woohoo Chat